### PR TITLE
The default ID is too large for qdrant

### DIFF
--- a/embedchain/vectordb/qdrant.py
+++ b/embedchain/vectordb/qdrant.py
@@ -1,6 +1,5 @@
 import copy
 import os
-import uuid
 from typing import Any, Optional, Union
 
 try:
@@ -146,7 +145,9 @@ class QdrantDB(BaseVectorDB):
         qdrant_ids = []
         for id, document, metadata in zip(ids, documents, metadatas):
             metadata["text"] = document
-            qdrant_ids.append(id)
+            # Qdrant supports using both 64-bit unsigned integers and UUID as ID for points.
+            # https://qdrant.tech/documentation/concepts/points/?q=ExtendedPointId
+            qdrant_ids.append(id[-32:])
             payloads.append({"identifier": id, "text": document, "metadata": copy.deepcopy(metadata)})
 
         for i in tqdm(range(0, len(qdrant_ids), self.BATCH_SIZE), desc="Adding data in batches"):


### PR DESCRIPTION
The default ID as below is too large for qdrant

https://qdrant.tech/documentation/concepts/points/?q=ExtendedPointId  Qdrant supports using both 64-bit unsigned integers and UUID as identifiers for points.

Here is an example of default ID
default-app-id--d5f90c9758d5ab25db9aae87e958bd77a9bcd0d35909a4e9aa3662c896b42961

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [ ] Unit Test
- [ ] Test Script (please provide)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
