### PR TITLE
Sets up metadata db for every llm class

### DIFF
--- a/embedchain/embedchain/app.py
+++ b/embedchain/embedchain/app.py
@@ -20,7 +20,7 @@ from embedchain.cache import (
 )
 from embedchain.client import Client
 from embedchain.config import AppConfig, CacheConfig, ChunkerConfig, Mem0Config
-from embedchain.core.db.database import get_session, init_db, setup_engine
+from embedchain.core.db.database import get_session
 from embedchain.core.db.models import DataSource
 from embedchain.embedchain import EmbedChain
 from embedchain.embedder.base import BaseEmbedder
@@ -88,10 +88,6 @@ class App(EmbedChain):
 
         if name and config:
             raise Exception("Cannot provide both name and config. Please provide only one of them.")
-
-        # Initialize the metadata db for the app
-        setup_engine(database_uri=os.environ.get("EMBEDCHAIN_DB_URI"))
-        init_db()
 
         self.auto_deploy = auto_deploy
         # Store the dict config as an attribute to be able to send it
@@ -389,10 +385,6 @@ class App(EmbedChain):
         vector_db = VectorDBFactory.create(vector_db_provider, vector_db_config_data.get("config", {}))
 
         if llm_config_data:
-            # Initialize the metadata db for the app here since llmfactory needs it for initialization of
-            # the llm memory
-            setup_engine(database_uri=os.environ.get("EMBEDCHAIN_DB_URI"))
-            init_db()
             llm_provider = llm_config_data.get("provider", "openai")
             llm = LlmFactory.create(llm_provider, llm_config_data.get("config", {}))
         else:

--- a/embedchain/embedchain/config/llm/base.py
+++ b/embedchain/embedchain/config/llm/base.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 import re

--- a/embedchain/embedchain/config/llm/base.py
+++ b/embedchain/embedchain/config/llm/base.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import re
 from string import Template
 from typing import Any, Mapping, Optional, Dict, Union
@@ -8,7 +9,9 @@ from pathlib import Path
 import httpx
 
 from embedchain.config.base_config import BaseConfig
+from embedchain.core.db.database import init_db, setup_engine
 from embedchain.helpers.json_serializable import register_deserializable
+
 
 logger = logging.getLogger(__name__)
 
@@ -209,6 +212,11 @@ class BaseLlmConfig(BaseConfig):
 
         if prompt is None:
             prompt = DEFAULT_PROMPT_TEMPLATE
+
+        # Initialize the metadata db for the app here since llmfactory needs it for initialization of
+        # the llm memory
+        setup_engine(database_uri=os.environ.get("EMBEDCHAIN_DB_URI"))
+        init_db()
 
         self.number_documents = number_documents
         self.temperature = temperature

--- a/embedchain/embedchain/config/llm/base.py
+++ b/embedchain/embedchain/config/llm/base.py
@@ -10,7 +10,6 @@ import httpx
 from embedchain.config.base_config import BaseConfig
 from embedchain.helpers.json_serializable import register_deserializable
 
-
 logger = logging.getLogger(__name__)
 
 DEFAULT_PROMPT = """

--- a/embedchain/embedchain/config/llm/base.py
+++ b/embedchain/embedchain/config/llm/base.py
@@ -1,5 +1,5 @@
+import json
 import logging
-import os
 import re
 from string import Template
 from typing import Any, Mapping, Optional, Dict, Union
@@ -8,7 +8,6 @@ from pathlib import Path
 import httpx
 
 from embedchain.config.base_config import BaseConfig
-from embedchain.core.db.database import init_db, setup_engine
 from embedchain.helpers.json_serializable import register_deserializable
 
 
@@ -211,11 +210,6 @@ class BaseLlmConfig(BaseConfig):
 
         if prompt is None:
             prompt = DEFAULT_PROMPT_TEMPLATE
-
-        # Initialize the metadata db for the app here since llmfactory needs it for initialization of
-        # the llm memory
-        setup_engine(database_uri=os.environ.get("EMBEDCHAIN_DB_URI"))
-        init_db()
 
         self.number_documents = number_documents
         self.temperature = temperature

--- a/embedchain/embedchain/llm/base.py
+++ b/embedchain/embedchain/llm/base.py
@@ -1,9 +1,11 @@
 import logging
+import os
 from collections.abc import Generator
 from typing import Any, Optional
 
 from langchain.schema import BaseMessage as LCBaseMessage
 
+from embedchain.constants import SQLITE_PATH
 from embedchain.config import BaseLlmConfig
 from embedchain.config.llm.base import (
     DEFAULT_PROMPT,
@@ -11,6 +13,7 @@ from embedchain.config.llm.base import (
     DEFAULT_PROMPT_WITH_MEM0_MEMORY_TEMPLATE,
     DOCS_SITE_PROMPT_TEMPLATE,
 )
+from embedchain.core.db.database import init_db, setup_engine
 from embedchain.helpers.json_serializable import JSONSerializable
 from embedchain.memory.base import ChatHistory
 from embedchain.memory.message import ChatMessage
@@ -29,6 +32,11 @@ class BaseLlm(JSONSerializable):
             self.config = BaseLlmConfig()
         else:
             self.config = config
+
+        # Initialize the metadata db for the app here since llmfactory needs it for initialization of
+        # the llm memory
+        setup_engine(database_uri=os.environ.get("EMBEDCHAIN_DB_URI", f"sqlite:///{SQLITE_PATH}"))
+        init_db()
 
         self.memory = ChatHistory()
         self.is_docs_site_instance = False

--- a/embedchain/poetry.lock
+++ b/embedchain/poetry.lock
@@ -2390,6 +2390,22 @@ SQLAlchemy = ">=1.4,<3"
 tenacity = ">=8.1.0,<8.4.0 || >8.4.0,<9.0.0"
 
 [[package]]
+name = "langchain-aws"
+version = "0.1.13"
+description = "An integration package connecting AWS and LangChain"
+optional = true
+python-versions = "<4.0,>=3.8.1"
+files = [
+    {file = "langchain_aws-0.1.13-py3-none-any.whl", hash = "sha256:c4db60c8a83b8ff3e66170e0bd646739176fcd1a20a9d0a10828a1e21339af1d"},
+    {file = "langchain_aws-0.1.13.tar.gz", hash = "sha256:fda790732a72de4ccec3760dba24db5f9fa5cb8724dfd9676a7d5cf87a9f1a98"},
+]
+
+[package.dependencies]
+boto3 = ">=1.34.131,<1.35.0"
+langchain-core = ">=0.2.17,<0.3"
+numpy = ">=1,<2"
+
+[[package]]
 name = "langchain-cohere"
 version = "0.1.9"
 description = "An integration package connecting Cohere and LangChain"
@@ -6565,6 +6581,7 @@ doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linke
 test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
 
 [extras]
+aws = ["langchain-aws"]
 elasticsearch = ["elasticsearch"]
 gmail = ["google-api-core", "google-api-python-client", "google-auth", "google-auth-httplib2", "google-auth-oauthlib", "requests"]
 google = ["google-generativeai"]
@@ -6585,4 +6602,4 @@ weaviate = ["weaviate-client"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<=3.13"
-content-hash = "8197f676b36fed2bf02f33cd15e83c3e6640ae5ba216210af5777ab2dc139480"
+content-hash = "9a57a07f9a60c51a2f8765f31d5d768f7d6ff67b63c0d419648a2b8d668527ad"

--- a/embedchain/poetry.lock
+++ b/embedchain/poetry.lock
@@ -2390,22 +2390,6 @@ SQLAlchemy = ">=1.4,<3"
 tenacity = ">=8.1.0,<8.4.0 || >8.4.0,<9.0.0"
 
 [[package]]
-name = "langchain-aws"
-version = "0.1.10"
-description = "An integration package connecting AWS and LangChain"
-optional = true
-python-versions = "<4.0,>=3.8.1"
-files = [
-    {file = "langchain_aws-0.1.10-py3-none-any.whl", hash = "sha256:2cba72efaa9f0dc406d8e06a1fbaa3762678d489cbc5147cf64a7012189c161c"},
-    {file = "langchain_aws-0.1.10.tar.gz", hash = "sha256:7f01dacbf8345a28192cec4ef31018cc33a91de0b82122f913eec09a76d64fd5"},
-]
-
-[package.dependencies]
-boto3 = ">=1.34.131,<1.35.0"
-langchain-core = ">=0.2.6,<0.3"
-numpy = ">=1,<2"
-
-[[package]]
 name = "langchain-cohere"
 version = "0.1.9"
 description = "An integration package connecting Cohere and LangChain"
@@ -3255,6 +3239,7 @@ description = "Nvidia JIT LTO Library"
 optional = true
 python-versions = ">=3"
 files = [
+    {file = "nvidia_nvjitlink_cu12-12.5.82-py3-none-manylinux2014_aarch64.whl", hash = "sha256:98103729cc5226e13ca319a10bbf9433bbbd44ef64fe72f45f067cacc14b8d27"},
     {file = "nvidia_nvjitlink_cu12-12.5.82-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f9b37bc5c8cf7509665cb6ada5aaa0ce65618f2332b7d3e78e9790511f111212"},
     {file = "nvidia_nvjitlink_cu12-12.5.82-py3-none-win_amd64.whl", hash = "sha256:e782564d705ff0bf61ac3e1bf730166da66dd2fe9012f111ede5fc49b64ae697"},
 ]
@@ -4614,6 +4599,7 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
+    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -4621,8 +4607,16 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
+    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
+    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -4639,6 +4633,7 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
+    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -4646,6 +4641,7 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -6569,7 +6565,6 @@ doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linke
 test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
 
 [extras]
-aws = ["langchain-aws"]
 elasticsearch = ["elasticsearch"]
 gmail = ["google-api-core", "google-api-python-client", "google-auth", "google-auth-httplib2", "google-auth-oauthlib", "requests"]
 google = ["google-generativeai"]
@@ -6590,4 +6585,4 @@ weaviate = ["weaviate-client"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<=3.13"
-content-hash = "9a57a07f9a60c51a2f8765f31d5d768f7d6ff67b63c0d419648a2b8d668527ad"
+content-hash = "8197f676b36fed2bf02f33cd15e83c3e6640ae5ba216210af5777ab2dc139480"

--- a/embedchain/tests/conftest.py
+++ b/embedchain/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+from unittest import mock
 
 import pytest
 from sqlalchemy import MetaData, create_engine
@@ -33,3 +34,9 @@ def disable_telemetry():
     os.environ["EC_TELEMETRY"] = "false"
     yield
     del os.environ["EC_TELEMETRY"]
+
+
+@pytest.fixture(autouse=True)
+def mock_alembic_command():
+    with mock.patch("alembic.command.upgrade") as mock_alembic:
+        yield

--- a/embedchain/tests/conftest.py
+++ b/embedchain/tests/conftest.py
@@ -1,5 +1,4 @@
 import os
-from unittest import mock
 
 import pytest
 from sqlalchemy import MetaData, create_engine
@@ -34,9 +33,3 @@ def disable_telemetry():
     os.environ["EC_TELEMETRY"] = "false"
     yield
     del os.environ["EC_TELEMETRY"]
-
-
-@pytest.fixture(autouse=True)
-def mock_alembic_command_upgrade():
-    with mock.patch("alembic.command.upgrade"):
-        yield

--- a/embedchain/tests/conftest.py
+++ b/embedchain/tests/conftest.py
@@ -37,6 +37,6 @@ def disable_telemetry():
 
 
 @pytest.fixture(autouse=True)
-def mock_alembic_command():
-    with mock.patch("alembic.command.upgrade") as mock_alembic:
+def mock_alembic_command_upgrade():
+    with mock.patch("alembic.command.upgrade"):
         yield

--- a/embedchain/tests/llm/conftest.py
+++ b/embedchain/tests/llm/conftest.py
@@ -1,0 +1,8 @@
+
+from unittest import mock
+import pytest
+
+@pytest.fixture(autouse=True)
+def mock_alembic_command_upgrade():
+    with mock.patch("alembic.command.upgrade"):
+        yield


### PR DESCRIPTION
## Description

The metadata database for storing chat history is a sqllite3 db. It is setup up in the app class by using `setup_engine`. 

But running individual tests in llm folder fails because we don't create any app for tests. Individual llm classes are called independently. Thus, `setup_engine` is never called.

This change moves the setup to BaseLlmConfig, which is called every time we load an llm.

Fixes #1400 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Tested individual tests in llm folder, and also tested running my demo app.

- [X] Unit Test
- [ ] Test Script (please provide)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
