### PR TITLE
Fixes slack link in documentation navbar

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -36,7 +36,7 @@
     {
       "name": "Slack",
       "icon": "slack",
-      "url": "https://mem0.ai/slack/"
+      "url": "https://embedchain.ai/slack/"
     },
     {
       "name": "Discord",


### PR DESCRIPTION
## Description

The slack link in the documentation navbar was broken. This PR fixes it. 
