### PR TITLE
Integrate Portkey LLM Provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ install:
 
 install_all:
 	poetry install
-	poetry run pip install groq together boto3 litellm ollama portkey_ai
+	poetry run pip install groq together boto3 litellm ollama portkey-ai
 
 # Format code with ruff
 format:

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ install:
 
 install_all:
 	poetry install
-	poetry run pip install groq together boto3 litellm ollama
+	poetry run pip install groq together boto3 litellm ollama portkey
 
 # Format code with ruff
 format:

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ install:
 
 install_all:
 	poetry install
-	poetry run pip install groq together boto3 litellm ollama portkey
+	poetry run pip install groq together boto3 litellm ollama portkey_ai
 
 # Format code with ruff
 format:

--- a/docs/components/llms.mdx
+++ b/docs/components/llms.mdx
@@ -12,6 +12,8 @@ Mem0 includes built-in support for various popular large language models. Memory
   <Card title="Groq" href="#groq"></Card>
   <Card title="Together" href="#together"></Card>
   <Card title="AWS Bedrock" href="#aws-bedrock"></Card>
+  <Card title="AWS Bedrock" href="#aws_bedrock"></Card>
+  <Card title="Portkey" href="#portkey"></Card>
   <Card title="Litellm" href="#litellm"></Card>
   <Card title="Google AI" href="#google-ai"></Card>
   <Card title="Anthropic" href="#anthropic"></Card>
@@ -167,6 +169,59 @@ config = {
 
 m = Memory.from_config(config)
 m.add("Likes to play cricket on weekends", user_id="alice", metadata={"category": "hobbies"})
+```
+
+## Portkey
+
+[Portkey](https://docs.portkey.ai/docs/welcome/integration-guides) Allows you to switch between models from [30+ providers (OpenAI, Vertex, Bedrock, Zhipu, Together, Anthropic, ...)](https://docs.portkey.ai/docs/provider-endpoints/supported-providers) with a single line.
+Teams also use Portkey to improve the cost, performance, and accuracy of their Gen AI apps.
+It takes <2 mins to integrate and with that, it already starts monitoring all of your LLM requests and also makes your app resilient, secure, performant, and more accurate at the same time.
+
+### Open source
+```python
+import os
+from mem0 import Memory
+
+os.environ["PORTKEY_API_KEY"] = "your-api-key"
+
+config = {
+    "llm": {
+        "provider": "portkey",
+        "config": {
+            "provider": "openai",
+            "model": "gpt-3.5-turbo",
+            "Authorization": "{YOUR_OPENAI_API_KEY}"
+            "temperature": 0.2,
+            "max_tokens": 1500,
+        }
+    }
+}
+
+m = Memory.from_config(config)
+m.add("Likes to play cricket on weekends", user_id="alice", metadata={"category": "hobbies"})
+```
+
+### Enterprise
+```python
+import os
+from mem0 import Memory
+
+os.environ["PORTKEY_API_KEY"] = "your-api-key"
+
+config = {
+    "llm": {
+        "provider": "portkey",
+        "config": {
+            "config":"{PORTKEY_CONFIG_ID}",
+        }
+    }
+}
+
+m = Memory.from_config(config)
+m.add("Likes to play cricket on weekends", user_id="alice", metadata={"category": "hobbies"})
+```
+
+
 ```
 
 ## Litellm

--- a/docs/components/llms.mdx
+++ b/docs/components/llms.mdx
@@ -177,7 +177,6 @@ m.add("Likes to play cricket on weekends", user_id="alice", metadata={"category"
 Teams also use Portkey to improve the cost, performance, and accuracy of their Gen AI apps.
 It takes <2 mins to integrate and with that, it already starts monitoring all of your LLM requests and also makes your app resilient, secure, performant, and more accurate at the same time.
 
-### Open source
 ```python
 import os
 from mem0 import Memory
@@ -199,29 +198,6 @@ config = {
 
 m = Memory.from_config(config)
 m.add("Likes to play cricket on weekends", user_id="alice", metadata={"category": "hobbies"})
-```
-
-### Enterprise
-```python
-import os
-from mem0 import Memory
-
-os.environ["PORTKEY_API_KEY"] = "your-api-key"
-
-config = {
-    "llm": {
-        "provider": "portkey",
-        "config": {
-            "config":"{PORTKEY_CONFIG_ID}",
-        }
-    }
-}
-
-m = Memory.from_config(config)
-m.add("Likes to play cricket on weekends", user_id="alice", metadata={"category": "hobbies"})
-```
-
-
 ```
 
 ## Litellm

--- a/mem0/llms/aws_bedrock.py
+++ b/mem0/llms/aws_bedrock.py
@@ -11,8 +11,8 @@ from mem0.llms.base import LLMBase
 from mem0.configs.llms.base import BaseLlmConfig
 
 class AWSBedrockLLM(LLMBase):    
-    def __init__(self, config: Optional[BaseLlmConfig] = None):
-        super().__init__(config)
+    def __init__(self, configDict: Optional[Dict] = None):
+        super().__init__(configDict)
 
         if not self.config.model:
             self.config.model="anthropic.claude-3-5-sonnet-20240620-v1:0"

--- a/mem0/llms/aws_bedrock.py
+++ b/mem0/llms/aws_bedrock.py
@@ -8,7 +8,6 @@ except ImportError:
     raise ImportError("AWS Bedrock requires extra dependencies. Install with `pip install boto3`") from None
 
 from mem0.llms.base import LLMBase
-from mem0.configs.llms.base import BaseLlmConfig
 
 class AWSBedrockLLM(LLMBase):    
     def __init__(self, configDict: Optional[Dict] = None):

--- a/mem0/llms/azure_openai.py
+++ b/mem0/llms/azure_openai.py
@@ -7,8 +7,8 @@ from mem0.llms.base import LLMBase
 from mem0.configs.llms.base import BaseLlmConfig
 
 class AzureOpenAILLM(LLMBase):
-    def __init__(self, config: Optional[BaseLlmConfig] = None):
-        super().__init__(config)
+    def __init__(self, configDict: Optional[Dict] = None):
+        super().__init__(configDict)
 
         # Model name should match the custom deployment name chosen for it.
         if not self.config.model:

--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -1,20 +1,20 @@
-from typing import Optional
+from typing import Optional, Dict
 from abc import ABC, abstractmethod
 
 from mem0.configs.llms.base import BaseLlmConfig
 
 
 class LLMBase(ABC):
-    def __init__(self, config: Optional[BaseLlmConfig] = None):
+    def __init__(self, configDict: Optional[Dict] = None):
         """Initialize a base LLM class
 
         :param config: LLM configuration option class, defaults to None
         :type config: Optional[BaseLlmConfig], optional
         """
-        if config is None:
+        if configDict is None:
             self.config = BaseLlmConfig()
         else:
-            self.config = config
+            self.config = BaseLlmConfig(**configDict)
 
     @abstractmethod
     def generate_response(self, messages):

--- a/mem0/llms/configs.py
+++ b/mem0/llms/configs.py
@@ -14,7 +14,7 @@ class LlmConfig(BaseModel):
     @field_validator("config")
     def validate_config(cls, v, values):
         provider = values.data.get("provider")
-        if provider in ("openai", "ollama", "groq", "together", "aws_bedrock", "litellm", "azure_openai"):
+        if provider in ("openai", "ollama", "groq", "together", "aws_bedrock", "litellm", "azure_openai", "portkey"):
             return v
         else:
             raise ValueError(f"Unsupported LLM provider: {provider}")

--- a/mem0/llms/litellm.py
+++ b/mem0/llms/litellm.py
@@ -8,8 +8,8 @@ from mem0.configs.llms.base import BaseLlmConfig
 
 
 class LiteLLM(LLMBase):
-    def __init__(self, config: Optional[BaseLlmConfig] = None):
-        super().__init__(config)
+    def __init__(self, configDict: Optional[Dict] = None):
+        super().__init__(configDict)
 
         if not self.config.model:
             self.config.model="gpt-4o"

--- a/mem0/llms/litellm.py
+++ b/mem0/llms/litellm.py
@@ -4,7 +4,6 @@ from typing import Dict, List, Optional
 import litellm
 
 from mem0.llms.base import LLMBase
-from mem0.configs.llms.base import BaseLlmConfig
 
 
 class LiteLLM(LLMBase):

--- a/mem0/llms/ollama.py
+++ b/mem0/llms/ollama.py
@@ -9,8 +9,8 @@ from mem0.llms.base import LLMBase
 from mem0.configs.llms.base import BaseLlmConfig
 
 class OllamaLLM(LLMBase):
-    def __init__(self, config: Optional[BaseLlmConfig] = None):
-        super().__init__(config)
+    def __init__(self, configDict: Optional[Dict] = None):
+        super().__init__(configDict)
 
         if not self.config.model:
             self.config.model="llama3.1:70b"

--- a/mem0/llms/openai.py
+++ b/mem0/llms/openai.py
@@ -5,7 +5,6 @@ from typing import Dict, List, Optional
 from openai import OpenAI
 
 from mem0.llms.base import LLMBase
-from mem0.configs.llms.base import BaseLlmConfig
 
 class OpenAILLM(LLMBase):
     def __init__(self, configDict: Optional[Dict] = None):

--- a/mem0/llms/openai.py
+++ b/mem0/llms/openai.py
@@ -96,5 +96,4 @@ class OpenAILLM(LLMBase):
             params["tool_choice"] = tool_choice
 
         response = self.client.chat.completions.create(**params)
-        print(response)
         return self._parse_response(response, tools)

--- a/mem0/llms/openai.py
+++ b/mem0/llms/openai.py
@@ -8,8 +8,8 @@ from mem0.llms.base import LLMBase
 from mem0.configs.llms.base import BaseLlmConfig
 
 class OpenAILLM(LLMBase):
-    def __init__(self, config: Optional[BaseLlmConfig] = None):
-        super().__init__(config)
+    def __init__(self, configDict: Optional[Dict] = None):
+        super().__init__(BaseLlmConfig(**configDict))
 
         if not self.config.model:
             self.config.model="gpt-4o"
@@ -97,4 +97,5 @@ class OpenAILLM(LLMBase):
             params["tool_choice"] = tool_choice
 
         response = self.client.chat.completions.create(**params)
+        print(response)
         return self._parse_response(response, tools)

--- a/mem0/llms/openai.py
+++ b/mem0/llms/openai.py
@@ -9,7 +9,7 @@ from mem0.configs.llms.base import BaseLlmConfig
 
 class OpenAILLM(LLMBase):
     def __init__(self, configDict: Optional[Dict] = None):
-        super().__init__(BaseLlmConfig(**configDict))
+        super().__init__(configDict)
 
         if not self.config.model:
             self.config.model="gpt-4o"

--- a/mem0/llms/portkey.py
+++ b/mem0/llms/portkey.py
@@ -79,7 +79,7 @@ class PortkeyConfig(BaseLlmConfig):
 
 
 class PortkeyLLM(LLMBase):
-    def __init__(self, configDict: dict):
+    def __init__(self, configDict: Optional[Dict]):
         self.config = PortkeyConfig(**configDict)
         self.client = Portkey(**configDict)
 

--- a/mem0/llms/portkey.py
+++ b/mem0/llms/portkey.py
@@ -46,6 +46,7 @@ class PortkeyConfig(BaseLlmConfig):
         azure_api_version: Optional[str] = None,
         http_client: Optional[httpx.Client] = None,
         request_timeout: Optional[int] = None,
+        Authorization: Optional[str] = None,
     ):
 
         super().__init__(model, temperature, max_tokens, top_p)
@@ -76,6 +77,7 @@ class PortkeyConfig(BaseLlmConfig):
         self.azure_api_version = azure_api_version
         self.http_client = http_client
         self.request_timeout = request_timeout
+        self.Authorization = Authorization
 
 
 class PortkeyLLM(LLMBase):

--- a/mem0/llms/portkey.py
+++ b/mem0/llms/portkey.py
@@ -1,0 +1,150 @@
+from typing import Optional, Dict, List, Union, Mapping
+import json
+import httpx
+
+from mem0.llms.base import LLMBase
+from mem0.configs.llms.base import BaseLlmConfig
+
+try:
+    from portkey_ai import Portkey
+except ImportError:
+    raise ImportError(
+        "Portkey requires extra dependencies. Install with `pip install portkey-ai`"
+    ) from None
+
+
+class PortkeyConfig(BaseLlmConfig):
+    def __init__(
+        self,
+        model: Optional[str] = None,
+        temperature: float = 0,
+        max_tokens: int = 3000,
+        top_p: float = 1,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        virtual_key: Optional[str] = None,
+        config: Optional[Union[Mapping, str]] = None,
+        provider: Optional[str] = None,
+        trace_id: Optional[str] = None,
+        metadata: Union[Optional[dict[str, str]], str] = None,
+        cache_namespace: Optional[str] = None,
+        debug: Optional[bool] = None,
+        cache_force_refresh: Optional[bool] = None,
+        custom_host: Optional[str] = None,
+        forward_headers: Optional[List[str]] = None,
+        openai_project: Optional[str] = None,
+        openai_organization: Optional[str] = None,
+        aws_secret_access_key: Optional[str] = None,
+        aws_access_key_id: Optional[str] = None,
+        aws_session_token: Optional[str] = None,
+        aws_region: Optional[str] = None,
+        vertex_project_id: Optional[str] = None,
+        vertex_region: Optional[str] = None,
+        workers_ai_account_id: Optional[str] = None,
+        azure_resource_name: Optional[str] = None,
+        azure_deployment_id: Optional[str] = None,
+        azure_api_version: Optional[str] = None,
+        http_client: Optional[httpx.Client] = None,
+        request_timeout: Optional[int] = None,
+    ):
+
+        super().__init__(model, temperature, max_tokens, top_p)
+
+        self.provider = provider
+        self.api_key = api_key
+        self.base_url = base_url
+        self.virtual_key = virtual_key
+        self.config = config
+        self.trace_id = trace_id
+        self.metadata = metadata
+        self.cache_namespace = cache_namespace
+        self.debug = debug
+        self.cache_force_refresh = cache_force_refresh
+        self.custom_host = custom_host
+        self.forward_headers = forward_headers
+        self.openai_project = openai_project
+        self.openai_organization = openai_organization
+        self.aws_secret_access_key = aws_secret_access_key
+        self.aws_access_key_id = aws_access_key_id
+        self.aws_session_token = aws_session_token
+        self.aws_region = aws_region
+        self.vertex_project_id = vertex_project_id
+        self.vertex_region = vertex_region
+        self.workers_ai_account_id = workers_ai_account_id
+        self.azure_resource_name = azure_resource_name
+        self.azure_deployment_id = azure_deployment_id
+        self.azure_api_version = azure_api_version
+        self.http_client = http_client
+        self.request_timeout = request_timeout
+
+
+class PortkeyLLM(LLMBase):
+    def __init__(self, configDict: dict):
+        self.config = PortkeyConfig(**configDict)
+        self.client = Portkey(**configDict)
+
+    def _parse_response(self, response, tools):
+        """
+        Process the response based on whether tools are used or not.
+
+        Args:
+            response: The raw response from API.
+            tools: The list of tools provided in the request.
+
+        Returns:
+            str or dict: The processed response.
+        """
+        if tools:
+            processed_response = {
+                "content": response.choices[0].message.content,
+                "tool_calls": [],
+            }
+
+            if response.choices[0].message.tool_calls:
+                for tool_call in response.choices[0].message.tool_calls:
+                    processed_response["tool_calls"].append(
+                        {
+                            "name": tool_call.function.name,
+                            "arguments": json.loads(tool_call.function.arguments),
+                        }
+                    )
+
+            return processed_response
+        else:
+            return response.choices[0].message.content
+
+    def generate_response(
+        self,
+        messages: List[Dict[str, str]],
+        response_format=None,
+        tools: Optional[List[Dict]] = None,
+        tool_choice: str = "auto",
+    ):
+        """
+        Generate a response based on the given messages using Litellm.
+
+        Args:
+            messages (list): List of message dicts containing 'role' and 'content'.
+            response_format (str or object, optional): Format of the response. Defaults to "text".
+            tools (list, optional): List of tools that the model can call. Defaults to None.
+            tool_choice (str, optional): Tool choice method. Defaults to "auto".
+
+        Returns:
+            str: The generated response.
+        """
+        params = {
+            "messages": messages,
+            "temperature": self.config.temperature,
+            "max_tokens": self.config.max_tokens,
+            "top_p": self.config.top_p,
+        }
+        if response_format:
+            params["response_format"] = response_format
+        if tools:
+            params["tools"] = tools
+            params["tool_choice"] = tool_choice
+        if self.config.model:
+            params["model"] = self.config.model
+
+        response = self.client.chat.completions.create(**params)
+        return self._parse_response(response, tools)

--- a/mem0/llms/portkey.py
+++ b/mem0/llms/portkey.py
@@ -123,7 +123,7 @@ class PortkeyLLM(LLMBase):
         tool_choice: str = "auto",
     ):
         """
-        Generate a response based on the given messages using Litellm.
+        Generate a response based on the given messages using Portkey.
 
         Args:
             messages (list): List of message dicts containing 'role' and 'content'.

--- a/mem0/llms/together.py
+++ b/mem0/llms/together.py
@@ -10,8 +10,8 @@ from mem0.llms.base import LLMBase
 from mem0.configs.llms.base import BaseLlmConfig
 
 class TogetherLLM(LLMBase):
-    def __init__(self, config: Optional[BaseLlmConfig] = None):
-        super().__init__(config)
+    def __init__(self, configDict: Optional[Dict] = None):
+        super().__init__(configDict)
 
         if not self.config.model:
             self.config.model="mistralai/Mixtral-8x7B-Instruct-v0.1"

--- a/mem0/llms/together.py
+++ b/mem0/llms/together.py
@@ -7,7 +7,6 @@ except ImportError:
     raise ImportError("Together requires extra dependencies. Install with `pip install together`") from None
 
 from mem0.llms.base import LLMBase
-from mem0.configs.llms.base import BaseLlmConfig
 
 class TogetherLLM(LLMBase):
     def __init__(self, configDict: Optional[Dict] = None):

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -18,6 +18,7 @@ class LlmFactory:
         "aws_bedrock": "mem0.llms.aws_bedrock.AWSBedrockLLM",
         "litellm": "mem0.llms.litellm.LiteLLM",
         "azure_openai": "mem0.llms.azure_openai.AzureOpenAILLM",
+        "portkey": "mem0.llms.portkey.PortkeyLLM",
     }
 
     @classmethod
@@ -25,8 +26,7 @@ class LlmFactory:
         class_type = cls.provider_to_class.get(provider_name)
         if class_type:
             llm_instance = load_class(class_type)
-            base_config = BaseLlmConfig(**config)
-            return llm_instance(base_config)
+            return llm_instance(config)
         else:
             raise ValueError(f"Unsupported Llm provider: {provider_name}")
         

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -1,6 +1,5 @@
 import importlib
 
-from mem0.configs.llms.base import BaseLlmConfig
 
 
 def load_class(class_type):

--- a/tests/llms/test_azure_openai.py
+++ b/tests/llms/test_azure_openai.py
@@ -16,7 +16,7 @@ def mock_openai_client():
         yield mock_client
 
 def test_generate_response_without_tools(mock_openai_client):
-    config = BaseLlmConfig(model=MODEL, temperature=TEMPERATURE, max_tokens=MAX_TOKENS, top_p=TOP_P)
+    config = {"model":MODEL, "temperature":TEMPERATURE, "max_tokens":MAX_TOKENS, "top_p":TOP_P}
     llm = AzureOpenAILLM(config)
     messages = [
         {"role": "system", "content": "You are a helpful assistant."},
@@ -40,7 +40,7 @@ def test_generate_response_without_tools(mock_openai_client):
 
 
 def test_generate_response_with_tools(mock_openai_client):
-    config = BaseLlmConfig(model=MODEL, temperature=TEMPERATURE, max_tokens=MAX_TOKENS, top_p=TOP_P)
+    config = {"model":MODEL, "temperature":TEMPERATURE, "max_tokens":MAX_TOKENS, "top_p":TOP_P}
     llm = AzureOpenAILLM(config)
     messages = [
         {"role": "system", "content": "You are a helpful assistant."},

--- a/tests/llms/test_groq.py
+++ b/tests/llms/test_groq.py
@@ -1,7 +1,6 @@
 import pytest
 from unittest.mock import Mock, patch
 from mem0.llms.groq import GroqLLM
-from mem0.configs.llms.base import BaseLlmConfig
 
 @pytest.fixture
 def mock_groq_client():
@@ -12,7 +11,7 @@ def mock_groq_client():
 
 
 def test_generate_response_without_tools(mock_groq_client):
-    config = BaseLlmConfig(model="llama3-70b-8192", temperature=0.7, max_tokens=100, top_p=1.0)
+    config = {"model":"llama3-70b-8192", "temperature":0.7, "max_tokens":100, "top_p":1.0}
     llm = GroqLLM(config)
     messages = [
         {"role": "system", "content": "You are a helpful assistant."},
@@ -36,7 +35,7 @@ def test_generate_response_without_tools(mock_groq_client):
 
 
 def test_generate_response_with_tools(mock_groq_client):
-    config = BaseLlmConfig(model="llama3-70b-8192", temperature=0.7, max_tokens=100, top_p=1.0)
+    config = {"model":"llama3-70b-8192", "temperature":0.7, "max_tokens":100, "top_p":1.0}
     llm = GroqLLM(config)
     messages = [
         {"role": "system", "content": "You are a helpful assistant."},

--- a/tests/llms/test_litellm.py
+++ b/tests/llms/test_litellm.py
@@ -2,7 +2,6 @@ import pytest
 from unittest.mock import Mock, patch
 
 from mem0.llms import litellm
-from mem0.configs.llms.base import BaseLlmConfig
 
 @pytest.fixture
 def mock_litellm():
@@ -10,7 +9,7 @@ def mock_litellm():
         yield mock_litellm
 
 def test_generate_response_with_unsupported_model(mock_litellm):
-    config = BaseLlmConfig(model="unsupported-model", temperature=0.7, max_tokens=100, top_p=1)
+    config = {"model":"unsupported-model", "temperature":0.7, "max_tokens":100, "top_p":1.0}
     llm = litellm.LiteLLM(config)
     messages = [{"role": "user", "content": "Hello"}]
     
@@ -21,7 +20,7 @@ def test_generate_response_with_unsupported_model(mock_litellm):
 
 
 def test_generate_response_without_tools(mock_litellm):
-    config = BaseLlmConfig(model="gpt-4o", temperature=0.7, max_tokens=100, top_p=1)
+    config = {"model":"gpt-4o", "temperature":0.7, "max_tokens":100, "top_p":1.0}
     llm = litellm.LiteLLM(config)
     messages = [
         {"role": "system", "content": "You are a helpful assistant."},
@@ -46,7 +45,7 @@ def test_generate_response_without_tools(mock_litellm):
 
 
 def test_generate_response_with_tools(mock_litellm):
-    config = BaseLlmConfig(model="gpt-4o", temperature=0.7, max_tokens=100, top_p=1)
+    config = {"model":"gpt-4o", "temperature":0.7, "max_tokens":100, "top_p":1.0}
     llm = litellm.LiteLLM(config)
     messages = [
         {"role": "system", "content": "You are a helpful assistant."},

--- a/tests/llms/test_ollama.py
+++ b/tests/llms/test_ollama.py
@@ -13,7 +13,7 @@ def mock_ollama_client():
         yield mock_client
 
 def test_generate_response_without_tools(mock_ollama_client):
-    config = BaseLlmConfig(model="llama3.1:70b", temperature=0.7, max_tokens=100, top_p=1.0)
+    config = {"model":"llama3.1:70b", "temperature":0.7, "max_tokens":100, "top_p":1.0}
     llm = OllamaLLM(config)
     messages = [
         {"role": "system", "content": "You are a helpful assistant."},
@@ -39,7 +39,7 @@ def test_generate_response_without_tools(mock_ollama_client):
     assert response == "I'm doing well, thank you for asking!"
 
 def test_generate_response_with_tools(mock_ollama_client):
-    config = BaseLlmConfig(model="llama3.1:70b", temperature=0.7, max_tokens=100, top_p=1.0)
+    config = {"model":"llama3.1:70b", "temperature":0.7, "max_tokens":100, "top_p":1.0}
     llm = OllamaLLM(config)
     messages = [
         {"role": "system", "content": "You are a helpful assistant."},

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -1,7 +1,6 @@
 import pytest
 from unittest.mock import Mock, patch
 from mem0.llms.openai import OpenAILLM
-from mem0.configs.llms.base import BaseLlmConfig
 
 @pytest.fixture
 def mock_openai_client():
@@ -12,7 +11,7 @@ def mock_openai_client():
 
 
 def test_generate_response_without_tools(mock_openai_client):
-    config = BaseLlmConfig(model="gpt-4o", temperature=0.7, max_tokens=100, top_p=1.0)
+    config = {"model":"gpt-4o", "temperature":0.7, "max_tokens":100, "top_p":1.0}
     llm = OpenAILLM(config)
     messages = [
         {"role": "system", "content": "You are a helpful assistant."},
@@ -36,7 +35,7 @@ def test_generate_response_without_tools(mock_openai_client):
 
 
 def test_generate_response_with_tools(mock_openai_client):
-    config = BaseLlmConfig(model="gpt-4o", temperature=0.7, max_tokens=100, top_p=1.0)
+    config = {"model":"gpt-4o", "temperature":0.7, "max_tokens":100, "top_p":1.0}
     llm = OpenAILLM(config)
     messages = [
         {"role": "system", "content": "You are a helpful assistant."},

--- a/tests/llms/test_portkey.py
+++ b/tests/llms/test_portkey.py
@@ -1,0 +1,89 @@
+import pytest
+from unittest.mock import Mock, patch
+from mem0.llms.portkey import PortkeyLLM
+
+@pytest.fixture
+def mock_portkey_client():
+    with patch('mem0.llms.portkey.Portkey') as mock_portkey:
+        mock_client = Mock()
+        mock_portkey.return_value = mock_client
+        yield mock_client
+
+
+def test_generate_response_without_tools(mock_portkey_client):
+    config = {"model":"gpt-4o", "temperature":0.7, "max_tokens":100, "top_p":1.0}
+    llm = PortkeyLLM(config)
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello, how are you?"}
+    ]
+    
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="I'm doing well, thank you for asking!"))]
+    mock_portkey_client.chat.completions.create.return_value = mock_response
+
+    response = llm.generate_response(messages)
+
+    mock_portkey_client.chat.completions.create.assert_called_once_with(
+        model="gpt-4o",
+        messages=messages,
+        temperature=0.7,
+        max_tokens=100,
+        top_p=1.0
+    )
+    assert response == "I'm doing well, thank you for asking!"
+
+
+def test_generate_response_with_tools(mock_portkey_client):
+    config = {"model":"gpt-4o", "temperature":0.7, "max_tokens":100, "top_p":1.0}
+    llm = PortkeyLLM(config)
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Add a new memory: Today is a sunny day."}
+    ]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "add_memory",
+                "description": "Add a memory",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "data": {"type": "string", "description": "Data to add to memory"}
+                    },
+                    "required": ["data"],
+                },
+            },
+        }
+    ]
+    
+    mock_response = Mock()
+    mock_message = Mock()
+    mock_message.content = "I've added the memory for you."
+    
+    mock_tool_call = Mock()
+    mock_tool_call.function.name = "add_memory"
+    mock_tool_call.function.arguments = '{"data": "Today is a sunny day."}'
+    
+    mock_message.tool_calls = [mock_tool_call]
+    mock_response.choices = [Mock(message=mock_message)]
+    mock_portkey_client.chat.completions.create.return_value = mock_response
+
+    response = llm.generate_response(messages, tools=tools)
+
+    mock_portkey_client.chat.completions.create.assert_called_once_with(
+        model="gpt-4o",
+        messages=messages,
+        temperature=0.7,
+        max_tokens=100,
+        top_p=1.0,
+        tools=tools,
+        tool_choice="auto"
+    )
+    
+    assert response["content"] == "I've added the memory for you."
+    assert len(response["tool_calls"]) == 1
+    assert response["tool_calls"][0]["name"] == "add_memory"
+    assert response["tool_calls"][0]["arguments"] == {'data': 'Today is a sunny day.'}
+    

--- a/tests/llms/test_together.py
+++ b/tests/llms/test_together.py
@@ -12,7 +12,7 @@ def mock_together_client():
 
 
 def test_generate_response_without_tools(mock_together_client):
-    config = BaseLlmConfig(model="mistralai/Mixtral-8x7B-Instruct-v0.1", temperature=0.7, max_tokens=100, top_p=1.0)
+    config = {"model":"mistralai/Mixtral-8x7B-Instruct-v0.1", "temperature":0.7, "max_tokens":100, "top_p":1.0}
     llm = TogetherLLM(config)
     messages = [
         {"role": "system", "content": "You are a helpful assistant."},
@@ -36,7 +36,7 @@ def test_generate_response_without_tools(mock_together_client):
 
 
 def test_generate_response_with_tools(mock_together_client):
-    config = BaseLlmConfig(model="mistralai/Mixtral-8x7B-Instruct-v0.1", temperature=0.7, max_tokens=100, top_p=1.0)
+    config = {"model":"mistralai/Mixtral-8x7B-Instruct-v0.1", "temperature":0.7, "max_tokens":100, "top_p":1.0}
     llm = TogetherLLM(config)
     messages = [
         {"role": "system", "content": "You are a helpful assistant."},

--- a/tests/llms/test_together.py
+++ b/tests/llms/test_together.py
@@ -1,7 +1,6 @@
 import pytest
 from unittest.mock import Mock, patch
 from mem0.llms.together import TogetherLLM
-from mem0.configs.llms.base import BaseLlmConfig
 
 @pytest.fixture
 def mock_together_client():


### PR DESCRIPTION
## Description

Add support for Portkey

Notes:
- Refactored to move initialisation of the LLM Config object inside the LLM Providers. This is to allow extensibility depending on Provider, the previous setup restricts Providers to use BaseConfig only.

Fixes https://github.com/mem0ai/mem0/issues/1586

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] Refactor (does not change functionality, e.g. code style improvements, linting)
- [X] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [X] Unit Test

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
