### PR TITLE
Fix TypeError: startswith first arg must be str or a tuple of str, no…

### DIFF
--- a/mem0/llms/ollama.py
+++ b/mem0/llms/ollama.py
@@ -4,7 +4,7 @@ from llm.base import LLMBase
 
 class OllamaLLM(LLMBase):
     def __init__(self, model="llama3"):
-        self.model = model
+        self.model = model.model
         self._ensure_model_exists()
 
     def _ensure_model_exists(self):


### PR DESCRIPTION
…t BaseLlmConfig

## Description

Fix the issue TypeError: startswith first arg must be str or a tuple of str, not BaseLlmConfig

Fixes #1620

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
