### PR TITLE
Azure embedding support

### DIFF
--- a/mem0/embeddings/azure_openai.py
+++ b/mem0/embeddings/azure_openai.py
@@ -16,7 +16,7 @@ class AzureOpenAIEmbedding(EmbeddingBase):
         self.api_key=None
         self.azure_endpoint=None
         self.api_version = None
-        
+
         if os.getenv("EMBED_AZURE_OPENAI_API_KEY") and os.getenv("EMBED_AZURE_OPENAI_ENDPOINT") and os.getenv("EMBED_OPENAI_API_VERSION"):
             
             self.api_key = os.getenv("EMBED_AZURE_OPENAI_API_KEY")
@@ -26,7 +26,6 @@ class AzureOpenAIEmbedding(EmbeddingBase):
             self.api_key = os.getenv("AZURE_OPENAI_API_KEY")
             self.azure_endpoint = os.getenv("AZURE_OPENAI_ENDPOINT")
             self.api_version = os.getenv("AZURE_OPENAI_ENDPOINT")
-        print(self.api_key, self.azure_endpoint, self.api_version)
         self.client = AzureOpenAI(api_version=self.api_version, api_key=self.api_key, azure_endpoint=self.azure_endpoint)
 
     def embed(self, text):

--- a/mem0/embeddings/azure_openai.py
+++ b/mem0/embeddings/azure_openai.py
@@ -1,0 +1,48 @@
+from typing import Optional
+from openai import AzureOpenAI
+import os
+from mem0.embeddings.base import EmbeddingBase
+from mem0.configs.embeddings.base import BaseEmbedderConfig
+
+class AzureOpenAIEmbedding(EmbeddingBase):
+    def __init__(self, config: Optional[BaseEmbedderConfig] = None):
+        super().__init__(config)
+
+        if not self.config.model:
+            self.config.model="text-embedding-ada-002"
+        if not self.config.embedding_dims:
+            self.config.embedding_dims=1536
+
+        self.api_key=None
+        self.azure_endpoint=None
+        self.api_version = None
+        
+        if os.getenv("EMBED_AZURE_OPENAI_API_KEY") and os.getenv("EMBED_AZURE_OPENAI_ENDPOINT") and os.getenv("EMBED_OPENAI_API_VERSION"):
+            
+            self.api_key = os.getenv("EMBED_AZURE_OPENAI_API_KEY")
+            self.azure_endpoint = os.getenv("EMBED_AZURE_OPENAI_ENDPOINT")
+            self.api_version = os.getenv("EMBED_OPENAI_API_VERSION")
+        else:
+            self.api_key = os.getenv("AZURE_OPENAI_API_KEY")
+            self.azure_endpoint = os.getenv("AZURE_OPENAI_ENDPOINT")
+            self.api_version = os.getenv("AZURE_OPENAI_ENDPOINT")
+        print(self.api_key, self.azure_endpoint, self.api_version)
+        self.client = AzureOpenAI(api_version=self.api_version, api_key=self.api_key, azure_endpoint=self.azure_endpoint)
+
+    def embed(self, text):
+        """
+        Get the embedding for the given text using OpenAI.
+
+        Args:
+            text (str): The text to embed.
+
+        Returns:
+            list: The embedding vector.
+        """
+        text = text.replace("\n", " ")
+
+        return (
+            self.client.embeddings.create(input=[text], model=self.config.model)
+            .data[0]
+            .embedding
+        )

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -34,7 +34,8 @@ class LlmFactory:
 class EmbedderFactory:
     provider_to_class = {
         "openai": "mem0.embeddings.openai.OpenAIEmbedding",
-        "ollama": "mem0.embeddings.ollama.OllamaEmbedding"
+        "ollama": "mem0.embeddings.ollama.OllamaEmbedding",
+        "azure_openai":"mem0.embeddings.azure_openai.AzureOpenAIEmbedding"
     }
 
     @classmethod

--- a/tests/Azure_embedding_test.py
+++ b/tests/Azure_embedding_test.py
@@ -4,13 +4,13 @@ import os, time,sys
 sys.path.append("../")
 from mem0 import Memory
 # We tested the scenario where embedding and LLM are provided by different interfaces from azure_openai. If an interface can provide both embedding and LLM simultaneously, then it is sufficient to set the three environment variables: “AZURE_OPENAI_API_KEY”, “AZURE_OPENAI_ENDPOINT”, and “OPENAI_API_VERSION”.
-os.environ["AZURE_OPENAI_API_KEY"] = "702acd8694634c4abce4223479d0bcf8"
-os.environ["AZURE_OPENAI_ENDPOINT"] = "https://yuaiweiwu-gpt4o.openai.azure.com/"
-os.environ["OPENAI_API_VERSION"] = "2024-05-01-preview"
+os.environ["AZURE_OPENAI_API_KEY"] = ""
+os.environ["AZURE_OPENAI_ENDPOINT"] = ""
+os.environ["OPENAI_API_VERSION"] = ""
 
-os.environ["EMBED_AZURE_OPENAI_API_KEY"] = "c70302f0120b4a99b54886a3b1e12610"
-os.environ["EMBED_AZURE_OPENAI_ENDPOINT"] = "https://aitogether-japan.openai.azure.com/"
-os.environ["EMBED_OPENAI_API_VERSION"] = "2023-08-01-preview"
+os.environ["EMBED_AZURE_OPENAI_API_KEY"] = ""
+os.environ["EMBED_AZURE_OPENAI_ENDPOINT"] = ""
+os.environ["EMBED_OPENAI_API_VERSION"] = ""
 
 config = {
     "llm": {

--- a/tests/Azure_embedding_test.py
+++ b/tests/Azure_embedding_test.py
@@ -1,0 +1,38 @@
+
+import openai
+import os, time,sys
+sys.path.append("../")
+from mem0 import Memory
+# We tested the scenario where embedding and LLM are provided by different interfaces from azure_openai. If an interface can provide both embedding and LLM simultaneously, then it is sufficient to set the three environment variables: “AZURE_OPENAI_API_KEY”, “AZURE_OPENAI_ENDPOINT”, and “OPENAI_API_VERSION”.
+os.environ["AZURE_OPENAI_API_KEY"] = "702acd8694634c4abce4223479d0bcf8"
+os.environ["AZURE_OPENAI_ENDPOINT"] = "https://yuaiweiwu-gpt4o.openai.azure.com/"
+os.environ["OPENAI_API_VERSION"] = "2024-05-01-preview"
+
+os.environ["EMBED_AZURE_OPENAI_API_KEY"] = "c70302f0120b4a99b54886a3b1e12610"
+os.environ["EMBED_AZURE_OPENAI_ENDPOINT"] = "https://aitogether-japan.openai.azure.com/"
+os.environ["EMBED_OPENAI_API_VERSION"] = "2023-08-01-preview"
+
+config = {
+    "llm": {
+        "provider": "azure_openai",
+        "config": {
+            "model": "gpt-4o",
+            "temperature": 0.1,
+            "max_tokens": 2000,
+        }
+    },
+    "embedder":{
+        "provider":"azure_openai"
+    }
+    
+}
+
+m = Memory.from_config(config)
+m.add("Likes to play cricket on weekends", user_id="alice", metadata={"category": "hobbies"})
+
+related_memories = m.search(query="What are Alice's hobbies?", user_id="alice")
+print(related_memories)
+all_memories = m.get_all()
+memory_id = all_memories[0]["id"] 
+history = m.history(memory_id=memory_id)
+print(history)


### PR DESCRIPTION
## Description

We have found that the updated mem0 now supports the Azure LLM provider, but does not support the Azure embedding provider. Now, you can easily configure `AZURE_OPENAI_API_KEY` , `AZURE_OPENAI_ENDPOINT` , and `OPENAI_API_VERSION`  with one click. And in the config, just specify that the provider for the embedder is azure_openai. If the embedder's API is not inconsistent, then simply configure the three environment variables `EMBED_AZURE_OPENAI_API_KEY` , `EMBED_AZURE_OPENAI_ENDPOINT` , and `EMBED_OPENAI_API_VERSION`  separately.

Fixes #1604 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Running the Azure-embedding-test.py file will do the trick. The prerequisite is to provide the relevant API key. If it responds normally, it indicates that the functionality is complete.

- [x] Unit Test
- [ ] Test Script (please provide)

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [x] closes #1604 (Replace 1604 with the GitHub issue number)
- [x] Made sure Checks passed