### PR TITLE
[Mem0] Add support for getting all users in python client

### DIFF
--- a/docs/platform/quickstart.mdx
+++ b/docs/platform/quickstart.mdx
@@ -230,6 +230,59 @@ curl -X POST "https://api.mem0.ai/v1/memories/search/" \
 ```
 </CodeGroup>
 
+
+### 4.3 Get all users
+
+Get all users, agents, and sessions for which memories exist.
+
+<CodeGroup>
+
+```python Python
+client.users()
+```
+
+```javascript JavaScript
+client.users()
+    .then(users => console.log(users))
+    .catch(error => console.error(error));
+```
+
+```bash cURL
+curl -X GET "https://api.mem0.ai/v1/entities/" \
+     -H "Authorization: Token your-api-key"
+```
+
+
+```json Output
+[
+    {
+        "id": "1",
+        "name": "user123",
+        "created_at": "2024-07-17T16:47:23.899900-07:00",
+        "updated_at": "2024-07-17T16:47:23.899918-07:00",
+        "total_memories": 5,
+        "owner": "alex",
+        "organization": "alex-org",
+        "metadata": {"foo": "bar"},
+        "type": "user"
+    },
+    {
+        "id": "2",
+        "name": "travel-agent",
+        "created_at": "2024-07-01T17:59:08.187250-07:00",
+        "updated_at": "2024-07-01T17:59:08.187266-07:00",
+        "total_memories": 10,
+        "owner": "alex",
+        "organization": "alex-org",
+        "metadata": {"agent_id": "123"},
+        "type": "agent"
+    }
+]
+```
+
+</CodeGroup>
+
+
 ### 4.3 Get All Memories
 
 Fetch all memories for a user, agent, or session using the getAll() method.

--- a/mem0/client/main.py
+++ b/mem0/client/main.py
@@ -237,6 +237,14 @@ class MemoryClient:
         capture_client_event("client.history", self)
         return response.json()
 
+    @api_error_handler
+    def users(self):
+        """Get all users, agents, and sessions for which memories exist."""
+        response = self.client.get("/entities/")
+        response.raise_for_status()
+        capture_client_event("client.users", self)
+        return response.json()
+
     def reset(self):
         """Reset the client. (Not implemented)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mem0ai"
-version = "0.0.14"
+version = "0.0.15"
 description = "Long-term memory for AI Agents"
 authors = ["Mem0 <founders@mem0.ai>"]
 exclude = [


### PR DESCRIPTION
## Description

Some of the users requested API endpoint to get all the users, agents, apps for which the memories are created.

This PR adds support for the same.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
