### PR TITLE
Fixed issue 1520 - the collect_metrics options for the app is now taken into account for all actions

### DIFF
--- a/embedchain/embedchain/embedchain.py
+++ b/embedchain/embedchain/embedchain.py
@@ -535,7 +535,8 @@ class EmbedChain(JSONSerializable):
                 )
 
         # Send anonymous telemetry
-        self.telemetry.capture(event_name="query", properties=self._telemetry_props)
+        if self.config.collect_metrics:
+            self.telemetry.capture(event_name="query", properties=self._telemetry_props)
 
         if citations:
             if self.llm.config.token_usage:
@@ -647,7 +648,8 @@ class EmbedChain(JSONSerializable):
         self.llm.add_history(self.config.id, input_query, answer, session_id=session_id)
 
         # Send anonymous telemetry
-        self.telemetry.capture(event_name="chat", properties=self._telemetry_props)
+        if self.config.collect_metrics:
+            self.telemetry.capture(event_name="chat", properties=self._telemetry_props)
 
         if citations:
             if self.llm.config.token_usage:
@@ -679,7 +681,8 @@ class EmbedChain(JSONSerializable):
             list[dict]: A list of dictionaries, each containing the 'context' and 'metadata' of a document.
         """
         # Send anonymous telemetry
-        self.telemetry.capture(event_name="search", properties=self._telemetry_props)
+        if self.config.collect_metrics:
+            self.telemetry.capture(event_name="search", properties=self._telemetry_props)
 
         if raw_filter and where:
             raise ValueError("You can't use both `raw_filter` and `where` together.")
@@ -729,7 +732,8 @@ class EmbedChain(JSONSerializable):
         self.db.reset()
         self.delete_all_chat_history(app_id=self.config.id)
         # Send anonymous telemetry
-        self.telemetry.capture(event_name="reset", properties=self._telemetry_props)
+        if self.config.collect_metrics:
+            self.telemetry.capture(event_name="reset", properties=self._telemetry_props)
 
     def get_history(
         self,


### PR DESCRIPTION
Fix Issue #1520 - The collect_metrics option for the app is not taken into account in all actions. 

Describe the bug
According to the docs, collect_metrics app option allows to turn off sending telemetry data.
However looking at file: (https://github.com/mem0ai/mem0/blob/main/embedchain/embedchain/embedchain.py) this is correct only for add and delete methods.

## Description

For each action/method, checked if the collect_metrics was checked before collecting metrics, where it was not the checked it has now been added.

Fixes # 1520

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please advise how this should be tested.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] New and existing unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [X] closes #1520 
- [X] Made sure Checks passed
