### PR TITLE
OctoAI support

### DIFF
--- a/embedchain/docs/components/llms.mdx
+++ b/embedchain/docs/components/llms.mdx
@@ -25,6 +25,7 @@ Embedchain comes with built-in support for various popular large language models
   <Card title="AWS Bedrock" href="#aws-bedrock"></Card>
   <Card title="Groq" href="#groq"></Card>
   <Card title="NVIDIA AI" href="#nvidia-ai"></Card>
+  <Card title="Octo AI" href="#octo-ai"></Card>
 </CardGroup>
 
 ## OpenAI
@@ -839,6 +840,59 @@ answer = app.query("What is the net worth of Elon Musk today?")
 # Additionally, his net worth may include other assets such as real estate and art, which are not reflected in his stock portfolio.
 ```
 </CodeGroup>
+
+
+## Octo AI
+
+[Octo AI](https://octo.ai/) supports a lot of models from meta, microsoft, mistral, etc... These models are available in the [Octo AI TextGen](https://octoai.cloud/text) and are ready to use in production.
+
+
+### Usage
+
+In order to use LLMs from Octo AI, sign up on [Octo AI](https://octo.ai/).
+
+Generate token from account settings. Set the token `OCTOAI_API_TOKEN` environment variable.
+
+Below is an example of how to use LLM model and embedding model from NVIDIA AI:
+
+<CodeGroup>
+
+```python main.py
+import os
+from embedchain import App
+
+os.environ["OCTOAI_API_TOKEN"] = "enter_token"
+
+config = {
+    "llm": {
+        "provider": "octoai",
+        "config": {
+            "model": "llama-2-13b-chat-fp16",
+            "max_tokens": 200,
+            "temperature": 0.1,
+            "top_p": 0.9,
+        }
+    },
+    "embedder": {
+        "provider": "huggingface",
+        "config": {
+            "model": 'nomic-ai/nomic-embed-text-v1',
+            "model_kwargs": {
+                "trust_remote_code": True,
+            }
+        }
+    }
+}
+
+app = App.from_config(config=config)
+
+app.add("https://www.forbes.com/profile/elon-musk")
+answer = app.query("What is the net worth of Elon Musk today?")
+# Answer: Elon Musk's net worth is $222.6 billion as of August 12, 2024. This reflects a change since the previous trading day. He remains the richest person in the world today.
+```
+</CodeGroup>
+
+
 
 ## Token Usage
 

--- a/embedchain/embedchain/factory.py
+++ b/embedchain/embedchain/factory.py
@@ -27,6 +27,7 @@ class LlmFactory:
         "groq": "embedchain.llm.groq.GroqLlm",
         "nvidia": "embedchain.llm.nvidia.NvidiaLlm",
         "vllm": "embedchain.llm.vllm.VLLM",
+        "octoai": "embedchain.llm.octoai.OctoAILlm",
     }
     provider_to_config_class = {
         "embedchain": "embedchain.config.llm.base.BaseLlmConfig",

--- a/embedchain/embedchain/llm/octoai.py
+++ b/embedchain/embedchain/llm/octoai.py
@@ -12,7 +12,8 @@ from embedchain.llm.base import BaseLlm
 @register_deserializable
 class OctoAILlm(BaseLlm):
     def __init__(self, config: Optional[BaseLlmConfig] = None):
-        assert "OCTOAI_API_TOKEN" in os.environ, "Please set OCTOAI_API_TOKEN as environment variable."
+        assert "OCTOAI_API_TOKEN" in os.environ or config.api_key, \
+            "Please set OCTOAI_API_TOKEN as environment variable."
         super().__init__(config=config)
 
     def get_llm_model_answer(self, prompt):

--- a/embedchain/embedchain/llm/octoai.py
+++ b/embedchain/embedchain/llm/octoai.py
@@ -1,0 +1,34 @@
+import os
+from typing import Optional
+
+from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
+from langchain_community.llms.octoai_endpoint import OctoAIEndpoint
+
+from embedchain.config import BaseLlmConfig
+from embedchain.helpers.json_serializable import register_deserializable
+from embedchain.llm.base import BaseLlm
+
+
+@register_deserializable
+class OctoAILlm(BaseLlm):
+    def __init__(self, config: Optional[BaseLlmConfig] = None):
+        assert "OCTOAI_API_TOKEN" in os.environ, "Please set OCTOAI_API_TOKEN as environment variable."
+        super().__init__(config=config)
+
+    def get_llm_model_answer(self, prompt):
+        return self._get_answer(prompt, self.config)
+
+    @staticmethod
+    def _get_answer(prompt: str, config: BaseLlmConfig) -> str:
+        chat = OctoAIEndpoint(
+            model_name=config.model,
+            max_tokens=config.max_tokens,
+            temperature=config.temperature,
+            top_p=config.top_p,
+            streaming=config.stream,
+            callbacks=config.callbacks
+            if (not config.stream) or (config.stream and config.callbacks)
+            else [StreamingStdOutCallbackHandler()],
+        )
+
+        return chat.invoke(prompt)

--- a/embedchain/embedchain/llm/octoai.py
+++ b/embedchain/embedchain/llm/octoai.py
@@ -21,15 +21,20 @@ class OctoAILlm(BaseLlm):
 
     @staticmethod
     def _get_answer(prompt: str, config: BaseLlmConfig) -> str:
+
+
+        octoai_api_key = os.getenv("OCTOAI_API_TOKEN") or config.api_key
+        callbacks = config.callbacks if (not config.stream) or (config.stream and config.callbacks) \
+                        else [StreamingStdOutCallbackHandler()]
+
         chat = OctoAIEndpoint(
+            octoai_api_token=octoai_api_key,
             model_name=config.model,
             max_tokens=config.max_tokens,
             temperature=config.temperature,
             top_p=config.top_p,
             streaming=config.stream,
-            callbacks=config.callbacks
-            if (not config.stream) or (config.stream and config.callbacks)
-            else [StreamingStdOutCallbackHandler()],
+            callbacks=callbacks,
         )
 
         return chat.invoke(prompt)

--- a/embedchain/embedchain/utils/misc.py
+++ b/embedchain/embedchain/utils/misc.py
@@ -418,6 +418,7 @@ def validate_config(config_data):
                     "vllm",
                     "groq",
                     "nvidia",
+                    "octoai",
                 ),
                 Optional("config"): {
                     Optional("model"): str,

--- a/embedchain/tests/llm/test_octoai.py
+++ b/embedchain/tests/llm/test_octoai.py
@@ -1,0 +1,36 @@
+import os
+import pytest
+from embedchain.config import BaseLlmConfig
+
+from embedchain.llm.octoai import OctoAILlm
+
+@pytest.fixture
+def octoai_env():
+    os.environ["OCTOAI_API_TOKEN"] = "test_api_token"
+
+@pytest.fixture
+def octoai_llm_config():
+    config = BaseLlmConfig(
+        temperature=0.7,
+        model="llama-2-13b-chat-fp16",
+        max_tokens=50,
+        top_p=0.9,
+    )
+    return config
+
+
+def test_get_answer(octoai_llm_config, octoai_env, mocker):
+    mocked_get_answer = mocker.patch("embedchain.llm.octoai.OctoAILlm._get_answer", return_value="Test answer")
+
+    octoai_llm = OctoAILlm(octoai_llm_config)
+    answer = octoai_llm.get_llm_model_answer("Test query")
+
+    assert answer == "Test answer"
+    mocked_get_answer.assert_called_once()
+
+def test_octo_env_variable(octoai_llm_config):
+
+    with pytest.raises(AssertionError):
+        octoai_llm = OctoAILlm(octoai_llm_config)
+
+

--- a/embedchain/tests/llm/test_octoai.py
+++ b/embedchain/tests/llm/test_octoai.py
@@ -7,6 +7,8 @@ from embedchain.llm.octoai import OctoAILlm
 @pytest.fixture
 def octoai_env():
     os.environ["OCTOAI_API_TOKEN"] = "test_api_token"
+    yield
+    del os.environ["OCTOAI_API_TOKEN"]
 
 @pytest.fixture
 def octoai_llm_config():
@@ -31,6 +33,4 @@ def test_get_answer(octoai_llm_config, octoai_env, mocker):
 def test_octo_env_variable(octoai_llm_config):
 
     with pytest.raises(AssertionError):
-        octoai_llm = OctoAILlm(octoai_llm_config)
-
-
+        _ = OctoAILlm(octoai_llm_config)


### PR DESCRIPTION
## Description

Adds Octo AI with streaming

Fixes #685 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [x] Documentation update

## How Has This Been Tested?

main.py
```python

import os
from embedchain import App

os.environ["OCTOAI_API_TOKEN"] = "token"

config = {
    "llm": {
        "provider": "octoai",
        "config": {
            "model": "llama-2-13b-chat-fp16",
            "max_tokens": 200,
            "temperature": 0.1,
            "top_p": 0.9,
        }
    },
    "embedder": {
        "provider": "huggingface",
        "config": {
            "model": 'nomic-ai/nomic-embed-text-v1',
            "model_kwargs": {
                "trust_remote_code": True,
            }
        }
    }
}


app = App.from_config(config=config)

app.add("https://www.forbes.com/profile/elon-musk")
answer = app.query("What is the net worth of Elon Musk today?")
print(answer)

```

output 
```
/home/pranav/python-projects/embedchain/embedchain/.venv/lib/python3.10/site-packages/qdrant_client/conversions/common_types.py:3: UserWarning: The NumPy module was reloaded (imported a second time). This can in some cases result in small but subtle issues and is discouraged.
  import numpy as np
/home/pranav/python-projects/embedchain/embedchain/.venv/lib/python3.10/site-packages/langchain_core/_api/deprecation.py:139: LangChainDeprecationWarning: The class `HuggingFaceEmbeddings` was deprecated in LangChain 0.2.2 and will be removed in 0.3.0. An updated version of the class exists in the langchain-huggingface package and should be used instead. To use it run `pip install -U langchain-huggingface` and import as `from langchain_huggingface import HuggingFaceEmbeddings`.
  warn_deprecated(
/home/pranav/.cache/huggingface/modules/transformers_modules/nomic-ai/nomic-bert-2048/e55a7d4324f65581af5f483e830b80f34680e8ff/modeling_hf_nomic_bert.py:95: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
  state_dict = loader(resolved_archive_file)
2024-08-12 21:59:43,512 - 130018868281344 - modeling_hf_nomic_bert.py-modeling_hf_nomic_bert:433 - WARNING: <All keys matched successfully>
Inserting batches in chromadb: 100%|██████████| 1/1 [00:01<00:00,  1.17s/it]
Elon Musk's net worth is $221.2 billion as of 8/12/24
2024-08-12 21:59:47,494 - 130018868281344 - embedchain.py-embedchain:547 - WARNING: Starting from v0.1.125 the return type of query method will be changed to tuple containing `answer`.

```

- [x] Unit Test
- [x] Test Script (please provide)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
