### PR TITLE
Make home and mem0 dirs configurable so that the service can work on AWS lambda.

### DIFF
--- a/mem0/memory/setup.py
+++ b/mem0/memory/setup.py
@@ -3,7 +3,7 @@ import os
 import uuid
 
 # Set up the directory path
-home_dir = os.environ.get("HOME_DIR") or os.path.expanduser("~")
+home_dir = os.path.expanduser("~")
 mem0_dir = os.environ.get("MEM0_DIR") or os.path.join(home_dir, ".mem0")
 os.makedirs(mem0_dir, exist_ok=True)
 

--- a/mem0/memory/setup.py
+++ b/mem0/memory/setup.py
@@ -3,8 +3,8 @@ import os
 import uuid
 
 # Set up the directory path
-home_dir = os.path.expanduser("~")
-mem0_dir = os.path.join(home_dir, ".mem0")
+home_dir = os.environ.get("HOME_DIR") or os.path.expanduser("~")
+mem0_dir = os.environ.get("MEM0_DIR") or os.path.join(home_dir, ".mem0")
 os.makedirs(mem0_dir, exist_ok=True)
 
 


### PR DESCRIPTION
## Description

If you try to use `mem0` in a lambda function, you'll get a nasty warning like
```
OSError: [Errno 30] Read-only file system: '/home/sbx_user1051'
bla bla bla
in <module>
from mem0.memory.main import Memory
in <module>
from mem0.memory.setup import setup_config\n/tmp/mem0/memory/setup.py:8:
in <module>
os.makedirs(mem0_dir, exist_ok=True)
<frozen os>
bla bla bla
[Errno 30] Read-only file system
```
This is because `~` is read-only on a lambda function.  However, `/tmp` is writeable, as is any mounted EFS directory.  Therefore, if we simply expose the home and `mem0` directories in the code to be injectable as environment variables, we can easily resolve this issue by injecting e.g., `/tmp/mem0`.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I tested the `or` logical locally but didn't actually test it in a lambda function to confirm that it resolves the bug.  That being said, I think the ability to configure these directories is broadly desirable for users, regardless of whether or not it fully resolves adding AWS lambda support.  (I discovered this issue while trying to get [Benchify](https://www.benchify.com) to work for a customer who uses `mem0` in their product.)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

