### PR TITLE
Support API key in config for LiteLLM

### DIFF
--- a/mem0/llms/litellm.py
+++ b/mem0/llms/litellm.py
@@ -79,6 +79,7 @@ class LiteLLM(LLMBase):
             "temperature": self.config.temperature,
             "max_tokens": self.config.max_tokens,
             "top_p": self.config.top_p,
+            "api_key": self.config.api_key,
         }
         if response_format:
             params["response_format"] = response_format


### PR DESCRIPTION
Added support for specifying the API key via the configuration object (`self.config.api_key`) instead of relying solely on environment variables. This change provides more flexibility in managing API keys.

## Description

This update adds the ability to set the API key directly in the configuration object (`self.config.api_key`), instead of being limited to using environment variables. This enhancement offers more flexibility for developers by allowing API keys to be managed within their application's configuration files. This change is especially beneficial for those who prefer or require configuration-based management for sensitive information.

Fixes #1746 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

The changes were tested by updating the configuration object to include the API key (`self.config.api_key`) and verifying that the application correctly uses this key for API calls.

- [ ] Unit Test
- [ ] Test Script

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [x] closes #1746 *(If this is linked to an issue, replace with the correct issue number)*
- [ ] Made sure Checks passed