### PR TITLE
Currently, the graph memory search is not filtering for the user

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -281,7 +281,7 @@ class Memory(MemoryBase):
         
         if self.version == "v1.1":
             if self.enable_graph:
-                graph_entities = self.graph.get_all()
+                graph_entities = self.graph.get_all(filters=filters)
                 return {"memories": all_memories, "entities": graph_entities}
             else:
                 return {"memories" : all_memories}

--- a/mem0/memory/main_graph.py
+++ b/mem0/memory/main_graph.py
@@ -214,7 +214,7 @@ class MemoryGraph:
         self.graph.query(cypher)
     
 
-    def get_all(self):
+    def get_all(self,filters):
         """
         Retrieves all nodes and relationships from the graph database based on optional filtering criteria.
 
@@ -228,10 +228,10 @@ class MemoryGraph:
 
         # return all nodes and relationships
         query = """
-        MATCH (n)-[r]->(m)
+        MATCH (n)-[r]->(m) WHERE toLower(n.name) = toLower($name)
         RETURN n.name AS source, type(r) AS relationship, m.name AS target
         """
-        results = self.graph.query(query)
+        results = self.graph.query(query,params={"name": filters["user_id"]})
 
         final_results = []
         for result in results:


### PR DESCRIPTION
## Description

Currently the graph memory search is not filtering for the user. It is returning the memory for all users irrespective of the user id filter. Made the change to ensure that only user specific graph memory is returend