### PR TITLE
[improvement]: system message added

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -161,7 +161,8 @@ class Memory(MemoryBase):
 
         function_calling_prompt = get_update_memory_messages(retrieved_old_memory, new_retrieved_facts)
         new_memories_with_actions = self.llm.generate_response(
-            messages=[{"role": "user", "content": function_calling_prompt}],
+            messages=[{"role": "system", "content": "You are a helpful assistant designed to output JSON."}, 
+                      {"role": "user", "content": function_calling_prompt}],
             response_format={"type": "json_object"},
         )
         new_memories_with_actions = json.loads(new_memories_with_actions)


### PR DESCRIPTION
resolves issue: #1841 

This llm call contains a system message:
https://github.com/mem0ai/mem0/blob/bbddb98aca3bbe8f544b0e0faeb55f69b6691104/mem0/memory/main.py#L136-L139

mentioning to give output in json format
https://github.com/mem0ai/mem0/blob/bbddb98aca3bbe8f544b0e0faeb55f69b6691104/mem0/configs/prompts.py#L57

But here system message is not present, which sometimes give non-JSON output
https://github.com/mem0ai/mem0/blob/bbddb98aca3bbe8f544b0e0faeb55f69b6691104/mem0/memory/main.py#L163-L166

Refrence: https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/json-mode?tabs=python