### PR TITLE
LiteLLM API key Config

### DIFF
--- a/mem0/llms/litellm.py
+++ b/mem0/llms/litellm.py
@@ -1,3 +1,4 @@
+import os
 import json
 from typing import Dict, List, Optional
 
@@ -68,6 +69,8 @@ class LiteLLM(LLMBase):
         """
         if not litellm.supports_function_calling(self.config.model):
             raise ValueError(f"Model '{self.config.model}' in litellm does not support function calling.")
+        
+        api_key = self.config.api_key or os.environ["OPENAI_API_KEY"]
 
         params = {
             "model": self.config.model,
@@ -75,6 +78,7 @@ class LiteLLM(LLMBase):
             "temperature": self.config.temperature,
             "max_tokens": self.config.max_tokens,
             "top_p": self.config.top_p,
+            "api_key": api_key,
         }
         if response_format:
             params["response_format"] = response_format


### PR DESCRIPTION
## Description

Adds support to provide `api_key` directly to `config` instead of setting in env variables. Since the model defaults to `gpt-4o-mini`, key also defaults to `OPENAI_API_KEY` if not provided.

Fixes #1746 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Tested by giving api_key directly to config instead of env variables

Please delete options that are not relevant.

- [ ] Unit Test
- [ ] Test Script (please provide)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [x] closes #1746 
- [ ] Made sure Checks passed
