### PR TITLE
Making prompts clear for low parameter models.

### DIFF
--- a/mem0/configs/prompts.py
+++ b/mem0/configs/prompts.py
@@ -229,5 +229,5 @@ def get_update_memory_messages(retrieved_old_memory_dict, response_content):
     - If there is a deletion, the memory key-value pair should be removed from the memory.
     - If there is an update, the ID key should remain the same and only the value needs to be updated.
 
-    Only return the json format, do not add ``` around the json in the response. Start directly with {{ so I can load the response in json.loads() function. 
+    Only return the json format, do not add ``` around the json response. Start directly with {{ so I can load the json response with json.loads() function. 
     """

--- a/mem0/configs/prompts.py
+++ b/mem0/configs/prompts.py
@@ -229,5 +229,5 @@ def get_update_memory_messages(retrieved_old_memory_dict, response_content):
     - If there is a deletion, the memory key-value pair should be removed from the memory.
     - If there is an update, the ID key should remain the same and only the value needs to be updated.
 
-    Do not return anything except the JSON format.
+    Only return the json format, do not add ``` around the json in the response. Start directly with {{ so I can load the response in json.loads() function. 
     """


### PR DESCRIPTION
## Description

Current prompt for returning json output -
```
Do not return anything except the JSON format.
```

It has 2 negations and it didn't work for `meta-llama/Meta-Llama-3.1-70B-Instruct`

A better prompt that worked - 
```
Only return the json format, do not add ``` around the json in the response. Start directly with {{ so I can load the response in json.loads() function. 
```

This worked for the model.

Fixes #1885 #1854

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

This change requires more testing, I don't have access to all models you support.

I tested on the example using  `meta-llama/Meta-Llama-3.1-70B-Instruct` and `gpt 4o`

- [ ] Unit Test
- [ ] Test Script (please provide)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
