### PR TITLE
Change ping endpoint for validating api key

### DIFF
--- a/mem0/client/main.py
+++ b/mem0/client/main.py
@@ -94,7 +94,7 @@ class MemoryClient:
     def _validate_api_key(self):
         """Validate the API key by making a test request."""
         try:
-            response = self.client.get("/v1/memories/", params={"user_id": "test"})
+            response = self.client.get("/v1/ping/")
             response.raise_for_status()
         except httpx.HTTPStatusError:
             raise ValueError("Invalid API Key. Please get a valid API Key from https://app.mem0.ai")


### PR DESCRIPTION
## Description

Current endpoint creates a GET_ALL event in the Mem0 Platform. Hence, changing the route to ping endpoint so that it just validates the API key and doesn't do anything else. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested manually and works fine. 

```python
import requests
r = requests.get("https://api.mem0.ai/v1/ping/", headers={"Authorization": "Token m0-xxx"})
r.raise_for_status()
```