### PR TITLE
Add support for custom prompt override in memory.add function

### DIFF
--- a/docs/features/custom-prompts.mdx
+++ b/docs/features/custom-prompts.mdx
@@ -107,3 +107,20 @@ m.add("I like going to hikes", user_id="alice")
 }
 ```
 </CodeGroup>
+
+
+## Customizing Prompts per Memory Addition
+
+In addition to setting a default prompt in the configuration, you can also override prompts for individual memory entries by using the prompt and graph_prompt parameters in m.add(). This allows you to tailor specific entries without changing the overall configuration.
+
+For example, to add a memory with a custom prompt:
+
+```python Code
+m.add("Yesterday, I ordered a laptop, the order id is 12345", user_id="alice", prompt=custom_prompt)
+```
+
+You can also use graph_prompt to customize the prompt specifically for graph memory entries:
+
+```python Code
+m.add("Yesterday, I ordered a laptop, the order id is 12345", user_id="alice", graph_prompt=graph_prompt)
+```

--- a/docs/open-source/graph_memory/features.mdx
+++ b/docs/open-source/graph_memory/features.mdx
@@ -33,6 +33,12 @@ config = {
 m = Memory.from_config(config_dict=config)
 ```
 
+You can also **override prompts** for individual memory additions by using the `graph_prompt` parameter in `m.add()`
+
+```python Code
+m.add("Yesterday, I ordered a laptop, the order id is 12345", user_id="alice", graph_prompt=graph_prompt)
+```
+
 If you want to use a managed version of Mem0, please check out [Mem0](https://mem0.dev/pd). If you have any questions, please feel free to reach out to us using one of the following methods:
 
 <Snippet file="get-help.mdx" />

--- a/mem0/memory/graph_memory.py
+++ b/mem0/memory/graph_memory.py
@@ -48,7 +48,7 @@ class MemoryGraph:
         self.user_id = None
         self.threshold = 0.7
 
-    def add(self, data, filters):
+    def add(self, data, filters, graph_prompt):
         """
         Adds data to the graph.
 
@@ -60,7 +60,8 @@ class MemoryGraph:
         # retrieve the search results
         search_output = self._search(data, filters)
 
-        if self.config.graph_store.custom_prompt:
+        custom_prompt = graph_prompt if graph_prompt else self.config.graph_store.custom_prompt
+        if custom_prompt:
             messages = [
                 {
                     "role": "system",

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -67,6 +67,7 @@ class Memory(MemoryBase):
         metadata=None,
         filters=None,
         prompt=None,
+        graph_prompt=None,
     ):
         """
         Create a new memory.
@@ -79,6 +80,7 @@ class Memory(MemoryBase):
             metadata (dict, optional): Metadata to store with the memory. Defaults to None.
             filters (dict, optional): Filters to apply to the search. Defaults to None.
             prompt (str, optional): Prompt to use for memory deduction. Defaults to None.
+            prompt (str, optional): Prompt to use for graph memory deduction. Defaults to None.
 
         Returns:
             dict: A dictionary containing the result of the memory addition operation.
@@ -111,8 +113,8 @@ class Memory(MemoryBase):
             messages = [{"role": "user", "content": messages}]
 
         with concurrent.futures.ThreadPoolExecutor() as executor:
-            future1 = executor.submit(self._add_to_vector_store, messages, metadata, filters)
-            future2 = executor.submit(self._add_to_graph, messages, filters)
+            future1 = executor.submit(self._add_to_vector_store, messages, metadata, filters, prompt)
+            future2 = executor.submit(self._add_to_graph, messages, filters, graph_prompt)
 
             concurrent.futures.wait([future1, future2])
 
@@ -134,11 +136,12 @@ class Memory(MemoryBase):
             )
             return {"message": "ok"}
 
-    def _add_to_vector_store(self, messages, metadata, filters):
+    def _add_to_vector_store(self, messages, metadata, filters, prompt):
         parsed_messages = parse_messages(messages)
 
-        if self.custom_prompt:
-            system_prompt = self.custom_prompt
+        custom_prompt = prompt if prompt else self.custom_prompt
+        if custom_prompt:
+            system_prompt = custom_prompt
             user_prompt = f"Input: {parsed_messages}"
         else:
             system_prompt, user_prompt = get_fact_retrieval_messages(parsed_messages)
@@ -230,7 +233,7 @@ class Memory(MemoryBase):
 
         return returned_memories
 
-    def _add_to_graph(self, messages, filters):
+    def _add_to_graph(self, messages, filters, graph_prompt):
         added_entities = []
         if self.api_version == "v1.1" and self.enable_graph:
             if filters["user_id"]:
@@ -242,7 +245,7 @@ class Memory(MemoryBase):
             else:
                 self.graph.user_id = "USER"
             data = "\n".join([msg["content"] for msg in messages if "content" in msg and msg["role"] != "system"])
-            added_entities = self.graph.add(data, filters)
+            added_entities = self.graph.add(data, filters, graph_prompt)
 
         return added_entities
 

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -80,7 +80,7 @@ class Memory(MemoryBase):
             metadata (dict, optional): Metadata to store with the memory. Defaults to None.
             filters (dict, optional): Filters to apply to the search. Defaults to None.
             prompt (str, optional): Prompt to use for memory deduction. Defaults to None.
-            prompt (str, optional): Prompt to use for graph memory deduction. Defaults to None.
+            graph_prompt (str, optional): Prompt to use for graph memory deduction. Defaults to None.
 
         Returns:
             dict: A dictionary containing the result of the memory addition operation.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -32,14 +32,27 @@ def memory_instance():
         return Memory(config)
 
 
-@pytest.mark.parametrize("version, enable_graph", [("v1.0", False), ("v1.1", True)])
-def test_add(memory_instance, version, enable_graph):
+@pytest.mark.parametrize(
+    "version, enable_graph, custom_prompt",
+    [
+        ("v1.0", False, None),
+        ("v1.1", True, None),
+        ("v1.0", False, "CustomPrompt"),
+        ("v1.1", True, "CustomPrompt"),
+    ]
+)
+def test_add(memory_instance, version, enable_graph, custom_prompt):
     memory_instance.config.version = version
     memory_instance.enable_graph = enable_graph
     memory_instance._add_to_vector_store = Mock(return_value=[{"memory": "Test memory", "event": "ADD"}])
     memory_instance._add_to_graph = Mock(return_value=[])
 
-    result = memory_instance.add(messages=[{"role": "user", "content": "Test message"}], user_id="test_user")
+    result = memory_instance.add(
+        messages=[{"role": "user", "content": "Test message"}],
+        user_id="test_user",
+        prompt=custom_prompt,
+        graph_prompt=custom_prompt
+    )
 
     assert "results" in result
     assert result["results"] == [{"memory": "Test memory", "event": "ADD"}]
@@ -47,12 +60,12 @@ def test_add(memory_instance, version, enable_graph):
     assert result["relations"] == []
 
     memory_instance._add_to_vector_store.assert_called_once_with(
-        [{"role": "user", "content": "Test message"}], {"user_id": "test_user"}, {"user_id": "test_user"}
+        [{"role": "user", "content": "Test message"}], {"user_id": "test_user"}, {"user_id": "test_user"}, custom_prompt
     )
 
     # Remove the conditional assertion for _add_to_graph
     memory_instance._add_to_graph.assert_called_once_with(
-        [{"role": "user", "content": "Test message"}], {"user_id": "test_user"}
+        [{"role": "user", "content": "Test message"}], {"user_id": "test_user"}, custom_prompt
     )
 
 


### PR DESCRIPTION
## Description

Add support for overriding the custom prompt by using the prompt argument in the `memory.add` function.

Originally, the prompt argument existed in `memory.add` but was not utilized. I have implemented functionality to allow it to override the global `custom_prompt` setting from the configuration.

Users can now easily override the default prompt when adding individual entries, without needing to change the global configuration. This makes memory management more flexible and adaptable to specific needs.

```python

from mem0 import Memory

config = {
    "llm": {
        "provider": "openai",
        "config": {
            "model": "gpt-4o",
            "temperature": 0.2,
            "max_tokens": 1500,
        }
    },
    "custom_prompt": custom_prompt,
    "version": "v1.1"
}

# This use the custom_prompt from config
m = Memory.from_config(config_dict=config)

# Use second_custom_prompt to override the default prompt for this memory entry
second_custom_prompt = "Prompt...."
m.add("Yesterday, I ordered a laptop, the order id is 12345", user_id="alice", prompt=second_custom_prompt)

# Use third_custom_prompt to override the default prompt for this memory entry
third_custom_prompt = "Prompt...."
m.add("I like to eat pasta!", user_id="alice", prompt=third_custom_prompt)
```

Fixes # (No related issue, this is a new feature)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [x] Documentation update

## How Has This Been Tested?

- [x] Unit Test
- [x] Test Script

Unitest has been added, you can also test the functionality by the following code snippet:

```python
import os
from mem0 import Memory

os.environ["OPENAI_API_KEY"] = "your-api-key"

custom_prompt = """
Add "User likes to play video games" to memory only.

Example:
Output: {"facts": ["User likes to play video games"]}

Return the facts and preferences in JSON format as shown above.
"""

config = {
    "llm": {
        "provider": "openai",
        "config": {
            "model": "gpt-4o",
            "temperature": 0.2,
            "max_tokens": 1500,
        }
    },
    "custom_prompt": custom_prompt,
    "version": "v1.1"
}

mem0 = Memory.from_config(config)

prompt = """
Add "User likes to eat cookie" to memory only.

Example:
Output: {"facts": ["User likes to eat cookie"]}

Return the facts and preferences in JSON format as shown above.
"""

# Add memory using the gloable custom_prompt configuration
# Output {'results': [{'id': '047f379f-e66e-4a31-b3c1-3cc65cad8233', 'memory': 'User likes to play video games', 'event': 'ADD'}], 'relations': []}
memory = mem0.add("My name is Zncl2222", user_id='zncl2222')
print(memory)

# Add memory using the specific prompt override
# Output{'results': [{'id': '639353d4-dc28-45cc-a3a6-5141f1daa7d7', 'memory': 'User likes to eat cookie', 'event': 'ADD'}], 'relations': []}
memory2 = mem0.add("My name is Zncl2222", user_id='zncl2222', prompt=prompt)
print(memory2)
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
