### PR TITLE
fix typo in the prompt of get_update_memory_messages

### DIFF
--- a/mem0/configs/prompts.py
+++ b/mem0/configs/prompts.py
@@ -120,7 +120,7 @@ def get_update_memory_messages(retrieved_old_memory_dict, response_content):
                         "text" : "User is a software engineer"
                     }},
                     {{
-                        "id" : "0a14d8f0-e364-4f5c-b305-10da1f0d0878",
+                        "id" : "b4229775-d860-4ccb-983f-0f628ca112f5",
                         "text" : "User likes to play cricket"
                     }}
                 ]
@@ -143,6 +143,7 @@ def get_update_memory_messages(retrieved_old_memory_dict, response_content):
                             "id" : "b4229775-d860-4ccb-983f-0f628ca112f5",
                             "text" : "Loves to play cricket with friends",
                             "event" : "UPDATE"
+                            "old_memory" : "User likes to play cricket"
                         }}
                     ]
                 }}


### PR DESCRIPTION
## Description

The uuid in get_update_memory_messages.Update prompt is wrong.
There is no old_memory neither.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [ ] Unit Test

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
