### PR TITLE
Doc: show output_format as param in API reference

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3676,6 +3676,12 @@
 						"type": "boolean",
 						"default": true
 					},
+					"output_format": {
+						"description": "It two output formats: `v1.0` (default) and `v1.1`. To enable the latest format, which provides enhanced detail for each memory operation, set the output_format parameter to `v1.1`. Note that `v1.0` will be deprecated in version 0.1.35.",
+						"title": "Output format",
+						"type": "string",
+						"nullable": true
+					},
 					"custom_categories": {
 						"description": "A list of categories with category name and it's description.",
 						"title": "Custom categories",
@@ -3763,6 +3769,12 @@
 						"type": "boolean",
 						"default": false,
 						"description": "Whether to rerank the memories."
+					},
+					"output_format": {
+						"title": "Output format",
+						"type": "string",
+						"nullable": true,
+						"description": "The search method supports two output formats: `v1.0` (default) and `v1.1`."
 					},
 					"org_name": {
 						"title": "Organization Name",

--- a/docs/platform/quickstart.mdx
+++ b/docs/platform/quickstart.mdx
@@ -108,7 +108,29 @@ curl -X POST "https://api.mem0.ai/v1/memories/" \
 ```
 
 ```json Output (v1.0)
-{'message': 'ok'}
+[
+  {
+    "id": "a1b2c3d4-e5f6-4g7h-8i9j-k0l1m2n3o4p5",
+    "data": {
+      "memory": "Name is Alex"
+    },
+    "event": "ADD"
+  },
+  {
+    "id": "b2c3d4e5-f6g7-8h9i-j0k1-l2m3n4o5p6q7",
+    "data": {
+      "memory": "Is a vegetarian"
+    },
+    "event": "ADD"
+  },
+  {
+    "id": "c3d4e5f6-g7h8-9i0j-k1l2-m3n4o5p6q7r8",
+    "data": {
+      "memory": "Is allergic to nuts"
+    },
+    "event": "ADD"
+  }
+]
 ```
 ```json Output (v1.1)
 {
@@ -186,7 +208,22 @@ curl -X POST "https://api.mem0.ai/v1/memories/" \
 ```
 
 ```json Output (v1.0)
-{'message': 'ok'}
+[
+  {
+    "id": "f2968654-5cd8-4d58-9f40-57ee339846b6",
+    "data": {
+      "memory": "Interested in vegetarian restaurants in Tokyo"
+    },
+    "event": "ADD"
+  },
+  {
+    "id": "f2968654-5cd8-4d58-9f40-57ee339846b6",
+    "data": {
+      "memory": "Planning a trip to Japan next month"
+    },
+    "event": "ADD"
+  }
+]
 ```
 
 ```json Output (v1.1)
@@ -249,7 +286,29 @@ curl -X POST "https://api.mem0.ai/v1/memories/" \
 ```
 
 ```json Output (v1.0)
-{'message': 'ok'}
+[
+    {
+        "id": "a1b2c3d4-e5f6-4g7h-8i9j-k0l1m2n3o4p5",
+        "data": {
+            "memory": "Name is Alex"
+        },
+        "event": "ADD"
+    },
+    {
+        "id": "b2c3d4e5-f6g7-8h9i-j0k1-l2m3n4o5p6q7",
+        "data": {
+            "memory": "Is a vegetarian"
+        },
+        "event": "ADD"
+    },
+    {
+        "id": "c3d4e5f6-g7h8-9i0j-k1l2-m3n4o5p6q7r8",
+        "data": {
+            "memory": "Is allergic to nuts"
+        },
+        "event": "ADD"
+    }
+]
 ```
 
 ```json Output (v1.1)


### PR DESCRIPTION
## Description

Doc: show output_format as param in API reference and also change the example showing the current response while using both output_format as `v1.0` and `v1.1`.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [x] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
