### PR TITLE
[graph_memory]: improve delete/add graph memory

### DIFF
--- a/docs/open-source/graph_memory/overview.mdx
+++ b/docs/open-source/graph_memory/overview.mdx
@@ -109,6 +109,10 @@ The Mem0's graph supports the following operations:
 
 ### Add Memories
 
+<Note>
+If you are using Mem0 with Graph Memory, it is recommended to pass `user_id`. The default value of `user_id` (in case of graph memory) is `user`.
+</Note>
+
 <CodeGroup>
 ```python Code
 m.add("I like pizza", user_id="alice")

--- a/mem0/graphs/tools.py
+++ b/mem0/graphs/tools.py
@@ -85,7 +85,7 @@ NOOP_TOOL = {
 RELATIONS_TOOL = {
     "type": "function",
     "function": {
-        "name": "establish_relations",
+        "name": "establish_relationships",
         "description": "Establish relationships among the entities based on the provided text.",
         "parameters": {
             "type": "object",
@@ -99,7 +99,7 @@ RELATIONS_TOOL = {
                                 "type": "string",
                                 "description": "The source entity of the relationship."
                             },
-                            "relation": {
+                            "relationship": {
                                 "type": "string",
                                 "description": "The relationship between the source and destination entities."
                             },
@@ -109,9 +109,9 @@ RELATIONS_TOOL = {
                             },
                         },
                         "required": [   
-                            "source_entity",
-                            "relation",
-                            "destination_entity",
+                            "source",
+                            "relationship",
+                            "destination",
                         ],
                         "additionalProperties": False,
                     },
@@ -262,7 +262,7 @@ RELATIONS_STRUCT_TOOL = {
                                 "type": "string",
                                 "description": "The source entity of the relationship."
                             },
-                            "relation": {
+                            "relatationship": {
                                 "type": "string",
                                 "description": "The relationship between the source and destination entities."
                             },
@@ -273,7 +273,7 @@ RELATIONS_STRUCT_TOOL = {
                         },
                         "required": [   
                             "source_entity",
-                            "relation",
+                            "relatationship",
                             "destination_entity",
                         ],
                         "additionalProperties": False,
@@ -320,4 +320,67 @@ EXTRACT_ENTITIES_STRUCT_TOOL = {
             "additionalProperties": False
         }
     }
+}
+
+DELETE_MEMORY_STRUCT_TOOL_GRAPH = {
+    "type": "function",
+    "function": {
+        "name": "delete_graph_memory",
+        "description": "Delete the relationship between two nodes. This function deletes the existing relationship.",
+        "strict": True,
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "source": {
+                    "type": "string",
+                    "description": "The identifier of the source node in the relationship.",
+                },
+                "relationship": {
+                    "type": "string",
+                    "description": "The existing relationship between the source and destination nodes that needs to be deleted.",
+                },
+                "destination": {
+                    "type": "string",
+                    "description": "The identifier of the destination node in the relationship.",
+                }
+            },
+            "required": [
+                "source",
+                "relationship",
+                "destination",
+            ],
+            "additionalProperties": False,
+        },
+    },
+}
+
+DELETE_MEMORY_TOOL_GRAPH = {
+    "type": "function",
+    "function": {
+        "name": "delete_graph_memory",
+        "description": "Delete the relationship between two nodes. This function deletes the existing relationship.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "source": {
+                    "type": "string",
+                    "description": "The identifier of the source node in the relationship.",
+                },
+                "relationship": {
+                    "type": "string",
+                    "description": "The existing relationship between the source and destination nodes that needs to be deleted.",
+                },
+                "destination": {
+                    "type": "string",
+                    "description": "The identifier of the destination node in the relationship.",
+                }
+            },
+            "required": [
+                "source",
+                "relationship",
+                "destination",
+            ],
+            "additionalProperties": False,
+        },
+    },
 }

--- a/mem0/graphs/utils.py
+++ b/mem0/graphs/utils.py
@@ -43,7 +43,7 @@ CUSTOM_PROMPT
 
 Relationships:
     - Use consistent, general, and timeless relationship types.
-    - Example: Prefer "PROFESSOR" over "BECAME_PROFESSOR."
+    - Example: Prefer "professor" over "became_professor."
     - Relationships should only be established among the entities explicitly mentioned in the user message.
 
 Entity Consistency:
@@ -54,15 +54,41 @@ Strive to construct a coherent and easily understandable knowledge graph by esht
 
 Adhere strictly to these guidelines to ensure high-quality knowledge graph extraction."""
 
+DELETE_RELATIONS_SYSTEM_PROMPT = """
+You are a graph memory manager specializing in identifying, managing, and optimizing relationships within graph-based memories. Your primary task is to analyze a list of existing relationships and determine which ones should be deleted based on the new information provided.
+Input:
+1. Existing Graph Memories: A list of current graph memories, each containing source, relationship, and destination information.
+2. New Text: The new information to be integrated into the existing graph structure.
+3. Use "USER_ID" as node for any self-references (e.g., "I," "me," "my," etc.) in user messages.
 
-def get_update_memory_prompt(existing_memories, new_memories, template):
-    return template.format(existing_memories=existing_memories, new_memories=new_memories)
+Guidelines:
+1. Identification: Use the new information to evaluate existing relationships in the memory graph.
+2. Deletion Criteria: Delete a relationship only if it meets at least one of these conditions:
+   - Outdated or Inaccurate: The new information is more recent or accurate.
+   - Contradictory: The new information conflicts with or negates the existing information.
+3. DO NOT DELETE if their is a possibility of same type of relationship but different destination nodes.
+4. Comprehensive Analysis:
+   - Thoroughly examine each existing relationship against the new information and delete as necessary.
+   - Multiple deletions may be required based on the new information.
+5. Semantic Integrity:
+   - Ensure that deletions maintain or improve the overall semantic structure of the graph.
+   - Avoid deleting relationships that are NOT contradictory/outdated to the new information.
+6. Temporal Awareness: Prioritize recency when timestamps are available.
+7. Necessity Principle: Only DELETE relationships that must be deleted and are contradictory/outdated to the new information to maintain an accurate and coherent memory graph.
 
+Note: DO NOT DELETE if their is a possibility of same type of relationship but different destination nodes. 
 
-def get_update_memory_messages(existing_memories, new_memories):
-    return [
-        {
-            "role": "user",
-            "content": get_update_memory_prompt(existing_memories, new_memories, UPDATE_GRAPH_PROMPT),
-        },
-    ]
+For example: 
+Existing Memory: alice -- loves_to_eat -- pizza
+New Information: Alice also loves to eat burger.
+
+Do not delete in the above example because there is a possibility that Alice loves to eat both pizza and burger.
+
+Memory Format:
+source -- relationship -- destination
+
+Provide a list of deletion instructions, each specifying the relationship to be deleted.
+"""
+
+def get_delete_messages(existing_memories_string, data, user_id):
+    return DELETE_RELATIONS_SYSTEM_PROMPT.replace("USER_ID", user_id), f"Here are the existing memories: {existing_memories_string} \n\n New Information: {data}"

--- a/mem0/memory/graph_memory.py
+++ b/mem0/memory/graph_memory.py
@@ -60,6 +60,7 @@ class MemoryGraph:
         to_be_deleted = self._get_delete_entities_from_search_output(search_output, data, filters)
         
         #TODO: Batch queries with APOC plugin
+        #TODO: Add more filter support
         deleted_entities = self._delete_entities(to_be_deleted, filters["user_id"])
         added_entities = self._add_entities(to_be_added, filters["user_id"], entity_type_map)
         
@@ -293,8 +294,8 @@ class MemoryGraph:
             DELETE r
             RETURN 
                 n.name AS source,
-                m.name AS destination,
-                type(r) AS deleted_relationship
+                m.name AS target,
+                type(r) AS relationship
             """
             params = {
                 "source_name": source,
@@ -338,7 +339,7 @@ class MemoryGraph:
                     MERGE (source)-[r:{relationship}]->(destination)
                     ON CREATE SET 
                         r.created = timestamp()
-                    RETURN source.name AS source, type(r) AS relationship, destination.name AS destination
+                    RETURN source.name AS source, type(r) AS relationship, destination.name AS target
                     """
 
                 params = {
@@ -363,7 +364,7 @@ class MemoryGraph:
                     MERGE (source)-[r:{relationship}]->(destination)
                     ON CREATE SET 
                         r.created = timestamp()
-                    RETURN source.name AS source, type(r) AS relationship, destination.name AS destination
+                    RETURN source.name AS source, type(r) AS relationship, destination.name AS target
                     """
                 
                 params = {
@@ -387,7 +388,7 @@ class MemoryGraph:
                     ON CREATE SET 
                         r.created_at = timestamp(),
                         r.updated_at = timestamp()
-                    RETURN source.name AS source, type(r) AS relationship, destination.name AS destination
+                    RETURN source.name AS source, type(r) AS relationship, destination.name AS target
                     """
                 params = {
                     "source_id": source_node_search_result[0]['elementId(source_candidate)'],
@@ -408,7 +409,7 @@ class MemoryGraph:
                     ON MATCH SET m.embedding = $dest_embedding
                     MERGE (n)-[rel:{relationship}]->(m)
                     ON CREATE SET rel.created = timestamp()
-                    RETURN n.name AS source, type(rel) AS relationship, m.name AS destination
+                    RETURN n.name AS source, type(rel) AS relationship, m.name AS target
                     """
                 params = {
                     "source_name": source,

--- a/mem0/memory/graph_memory.py
+++ b/mem0/memory/graph_memory.py
@@ -94,7 +94,7 @@ class MemoryGraph:
 
         search_results = []
         for item in reranked_results:
-            search_results.append({"source": item[0], "relationship": item[1], "target": item[2]})
+            search_results.append({"source": item[0], "relationship": item[1], "destination": item[2]})
 
         logger.info(f"Returned {len(search_results)} search results")
 

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -240,14 +240,11 @@ class Memory(MemoryBase):
     def _add_to_graph(self, messages, filters):
         added_entities = []
         if self.api_version == "v1.1" and self.enable_graph:
-            if filters["user_id"]:
-                self.graph.user_id = filters["user_id"]
-            elif filters["agent_id"]:
-                self.graph.agent_id = filters["agent_id"]
-            elif filters["run_id"]:
-                self.graph.run_id = filters["run_id"]
+            if filters.get("user_id"):
+                filters["user_id"] = filters["user_id"]
             else:
-                self.graph.user_id = "USER"
+                filters["user_id"] = "user"
+
             data = "\n".join([msg["content"] for msg in messages if "content" in msg and msg["role"] != "system"])
             added_entities = self.graph.add(data, filters)
 

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -240,11 +240,9 @@ class Memory(MemoryBase):
     def _add_to_graph(self, messages, filters):
         added_entities = []
         if self.api_version == "v1.1" and self.enable_graph:
-            if filters.get("user_id"):
-                filters["user_id"] = filters["user_id"]
-            else:
+            if filters.get("user_id") is None:
                 filters["user_id"] = "user"
-
+                
             data = "\n".join([msg["content"] for msg in messages if "content" in msg and msg["role"] != "system"])
             added_entities = self.graph.add(data, filters)
 

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -24,7 +24,7 @@ def format_entities(entities):
     
     formatted_lines = []
     for entity in entities:
-        simplified = f"{entity['source']} -- {entity['relation'].upper()} -- {entity['destination']}"
+        simplified = f"{entity['source']} -- {entity['relatationship']} -- {entity['destination']}"
         formatted_lines.append(simplified)
 
     return "\n".join(formatted_lines)

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -94,4 +94,4 @@ def test_completions_create_with_system_message(mock_memory_client, mock_litellm
 
     call_args = mock_litellm.completion.call_args[1]
     assert call_args["messages"][0]["role"] == "system"
-    assert call_args["messages"][0]["content"] == MEMORY_ANSWER_PROMPT
+    assert call_args["messages"][0]["content"] == "You are a helpful assistant."


### PR DESCRIPTION
### Description
Flow of graph memory addtion:

1. Extracts all the entities/nodes and their types mentioned in the query. (Returns: dictionary of {nodes:type})
2. Eshtablish relations among the extracted nodes. (Input: list of nodes(that does not contains types). Returns: list of source -- relationship -- destination)

_(Note: The above 2 LLM calls are made to ensure that all the facts are retrieved from the query/data. The single LLM seems to be overloaded if we expect source (and their types) -- relationship -- destination (and their types))_

3. Search similar nodes and their respective inbound and outbound relations. 
4. LLM call to find what relationship we want to delete based on the query/data. (it returns the relations that we have to delete 

Now we have a list of entities (source -- relationship -- destination) that we need to add and delete. 

5. Delete relationships
6. Add relationships
- Find whichever node is common (source and destination) via similarity search (0.9 threshold) and then  then merge it. 