### PR TITLE
fix: allow graph_store.llm to fully override LLM configuration

### DIFF
--- a/mem0/memory/graph_memory.py
+++ b/mem0/memory/graph_memory.py
@@ -41,12 +41,16 @@ class MemoryGraph:
         self.embedding_model = EmbedderFactory.create(self.config.embedder.provider, self.config.embedder.config)
 
         self.llm_provider = "openai_structured"
+        self.llm_config = {}
         if self.config.llm.provider:
             self.llm_provider = self.config.llm.provider
+            self.llm_config = self.config.llm.config
         if self.config.graph_store.llm:
             self.llm_provider = self.config.graph_store.llm.provider
+            if self.config.graph_store.llm.config:
+                self.llm_config = self.config.graph_store.llm.config
 
-        self.llm = LlmFactory.create(self.llm_provider, self.config.llm.config)
+        self.llm = LlmFactory.create(self.llm_provider, self.llm_config)
         self.user_id = None
         self.threshold = 0.7
 


### PR DESCRIPTION
## Description

Allow graph_store.llm to fully override LLM configuration

Previously, graph_store.llm could only override the LLM provider but would still
use config.llm.config for configuration settings. This change allows graph_store.llm
to override both the provider and its configuration settings.

This enables more flexible LLM configuration when needed specifically for graph store operations.

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

