### PR TITLE
fix request mem0 without org_id raise error

### DIFF
--- a/mem0/client/main.py
+++ b/mem0/client/main.py
@@ -145,7 +145,8 @@ class MemoryClient:
         Raises:
             APIError: If the API request fails.
         """
-        response = self.client.get(f"/v1/memories/{memory_id}/")
+        params = self._prepare_params()
+        response = self.client.get(f"/v1/memories/{memory_id}/", params=params)
         response.raise_for_status()
         capture_client_event("client.get", self, {"memory_id": memory_id})
         return response.json()
@@ -219,7 +220,8 @@ class MemoryClient:
             Dict[str, Any]: The response from the server.
         """
         capture_client_event("client.update", self, {"memory_id": memory_id})
-        response = self.client.put(f"/v1/memories/{memory_id}/", json={"text": data})
+        params = self._prepare_params()
+        response = self.client.put(f"/v1/memories/{memory_id}/", json={"text": data}, params=params)
         response.raise_for_status()
         return response.json()
 
@@ -236,7 +238,8 @@ class MemoryClient:
         Raises:
             APIError: If the API request fails.
         """
-        response = self.client.delete(f"/v1/memories/{memory_id}/")
+        params = self._prepare_params()
+        response = self.client.delete(f"/v1/memories/{memory_id}/", params=params)
         response.raise_for_status()
         capture_client_event("client.delete", self, {"memory_id": memory_id})
         return response.json()
@@ -273,7 +276,8 @@ class MemoryClient:
         Raises:
             APIError: If the API request fails.
         """
-        response = self.client.get(f"/v1/memories/{memory_id}/history/")
+        params = self._prepare_params()
+        response = self.client.get(f"/v1/memories/{memory_id}/history/", params=params)
         response.raise_for_status()
         capture_client_event("client.history", self, {"memory_id": memory_id})
         return response.json()
@@ -454,7 +458,8 @@ class AsyncMemoryClient:
 
     @api_error_handler
     async def get(self, memory_id: str) -> Dict[str, Any]:
-        response = await self.async_client.get(f"/v1/memories/{memory_id}/")
+        params = self.sync_client._prepare_params()
+        response = await self.async_client.get(f"/v1/memories/{memory_id}/", params=params)
         response.raise_for_status()
         capture_client_event("async_client.get", self.sync_client, {"memory_id": memory_id})
         return response.json()
@@ -489,14 +494,16 @@ class AsyncMemoryClient:
 
     @api_error_handler
     async def update(self, memory_id: str, data: str) -> Dict[str, Any]:
-        response = await self.async_client.put(f"/v1/memories/{memory_id}/", json={"text": data})
+        params = self.sync_client._prepare_params()
+        response = await self.async_client.put(f"/v1/memories/{memory_id}/", json={"text": data}, params=params)
         response.raise_for_status()
         capture_client_event("async_client.update", self.sync_client, {"memory_id": memory_id})
         return response.json()
 
     @api_error_handler
     async def delete(self, memory_id: str) -> Dict[str, Any]:
-        response = await self.async_client.delete(f"/v1/memories/{memory_id}/")
+        params = self.sync_client._prepare_params()
+        response = await self.async_client.delete(f"/v1/memories/{memory_id}/", params=params)
         response.raise_for_status()
         capture_client_event("async_client.delete", self.sync_client, {"memory_id": memory_id})
         return response.json()
@@ -511,7 +518,8 @@ class AsyncMemoryClient:
 
     @api_error_handler
     async def history(self, memory_id: str) -> List[Dict[str, Any]]:
-        response = await self.async_client.get(f"/v1/memories/{memory_id}/history/")
+        params = self.sync_client._prepare_params()
+        response = await self.async_client.get(f"/v1/memories/{memory_id}/history/", params=params)
         response.raise_for_status()
         capture_client_event("async_client.history", self.sync_client, {"memory_id": memory_id})
         return response.json()


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Hi everyone, whenever I send a request to perform operations on a specific memory, such as `get`, `update`, or `delete`, I consistently encounter the following error:
```
{
  "detail": "Invalid API key for this organization."
}
```
Upon investigation, I noticed that the request was missing some parameters. To address this, I added all the required parameters.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

I test it in my local python environment.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
