### PR TITLE
Fix async client `update_project` method

### DIFF
--- a/mem0/client/main.py
+++ b/mem0/client/main.py
@@ -769,10 +769,15 @@ class AsyncMemoryClient:
 
     @api_error_handler
     async def update_project(
-        self, custom_instructions: Optional[str], custom_categories: Optional[List[str]]
+        self, custom_instructions: Optional[str] = None, custom_categories: Optional[List[str]] = None
     ) -> Dict[str, Any]:
         if not (self.sync_client.org_id and self.sync_client.project_id):
             raise ValueError("org_id and project_id must be set to update instructions or categories")
+
+        if custom_instructions is None and custom_categories is None:
+            raise ValueError(
+                "Currently we only support updating custom_instructions or custom_categories, so you must provide at least one of them"
+            )
 
         payload = self.sync_client._prepare_params(
             {"custom_instructions": custom_instructions, "custom_categories": custom_categories}

--- a/mem0/client/main.py
+++ b/mem0/client/main.py
@@ -758,7 +758,7 @@ class AsyncMemoryClient:
         if not (self.sync_client.org_id and self.sync_client.project_id):
             raise ValueError("org_id and project_id must be set to access instructions or categories")
 
-        params = self._prepare_params({"fields": fields})
+        params = self.sync_client._prepare_params({"fields": fields})
         response = await self.async_client.get(
             f"/api/v1/orgs/organizations/{self.sync_client.org_id}/projects/{self.sync_client.project_id}/",
             params=params,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mem0ai"
-version = "0.1.44"
+version = "0.1.45"
 description = "Long-term memory for AI Agents"
 authors = ["Mem0 <founders@mem0.ai>"]
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mem0ai"
-version = "0.1.45"
+version = "0.1.45rc1"
 description = "Long-term memory for AI Agents"
 authors = ["Mem0 <founders@mem0.ai>"]
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mem0ai"
-version = "0.1.45rc1"
+version = "0.1.45"
 description = "Long-term memory for AI Agents"
 authors = ["Mem0 <founders@mem0.ai>"]
 exclude = [


### PR DESCRIPTION
## Description

Fixes the issue: 

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[24], [line 10](vscode-notebook-cell:?execution_count=24&line=10)
      [5](vscode-notebook-cell:?execution_count=24&line=5) print(mem0.__version__)
      [8](vscode-notebook-cell:?execution_count=24&line=8) client = AsyncMemoryClient(api_key=API_KEY, org_id=ORG_ID, project_id=PROJECT_ID)
---> [10](vscode-notebook-cell:?execution_count=24&line=10) response = await client.update_project(custom_instructions="Test prompt")
     [11](vscode-notebook-cell:?execution_count=24&line=11) print(response)

File ~/.pyenv/versions/3.12.8/lib/python3.12/site-packages/mem0/client/main.py:30, in api_error_handler.<locals>.wrapper(*args, **kwargs)
     [27](https://file+.vscode-resource.vscode-cdn.net/Users/deshraj/Projects/mem0-org/platform/notebooks/friday/~/.pyenv/versions/3.12.8/lib/python3.12/site-packages/mem0/client/main.py:27) @wraps(func)
     [28](https://file+.vscode-resource.vscode-cdn.net/Users/deshraj/Projects/mem0-org/platform/notebooks/friday/~/.pyenv/versions/3.12.8/lib/python3.12/site-packages/mem0/client/main.py:28) def wrapper(*args, **kwargs):
     [29](https://file+.vscode-resource.vscode-cdn.net/Users/deshraj/Projects/mem0-org/platform/notebooks/friday/~/.pyenv/versions/3.12.8/lib/python3.12/site-packages/mem0/client/main.py:29)     try:
---> [30](https://file+.vscode-resource.vscode-cdn.net/Users/deshraj/Projects/mem0-org/platform/notebooks/friday/~/.pyenv/versions/3.12.8/lib/python3.12/site-packages/mem0/client/main.py:30)         return func(*args, **kwargs)
     [31](https://file+.vscode-resource.vscode-cdn.net/Users/deshraj/Projects/mem0-org/platform/notebooks/friday/~/.pyenv/versions/3.12.8/lib/python3.12/site-packages/mem0/client/main.py:31)     except httpx.HTTPStatusError as e:
     [32](https://file+.vscode-resource.vscode-cdn.net/Users/deshraj/Projects/mem0-org/platform/notebooks/friday/~/.pyenv/versions/3.12.8/lib/python3.12/site-packages/mem0/client/main.py:32)         logger.error(f"HTTP error occurred: {e}")

TypeError: AsyncMemoryClient.update_project() missing 1 required positional argument: 'custom_categories'
```

- [x] Bug fix (non-breaking change which fixes an issue)