### PR TITLE
Add support for API key configuration in LiteLLM

### DIFF
--- a/mem0/llms/litellm.py
+++ b/mem0/llms/litellm.py
@@ -1,4 +1,5 @@
 import json
+import os
 from typing import Dict, List, Optional
 
 try:
@@ -16,7 +17,8 @@ class LiteLLM(LLMBase):
 
         if not self.config.model:
             self.config.model = "gpt-4o-mini"
-
+        if not self.config.api_key:
+            self.config.api_key = os.environ["OPENAI_API_KEY"]
     def _parse_response(self, response, tools):
         """
         Process the response based on whether tools are used or not.
@@ -75,6 +77,7 @@ class LiteLLM(LLMBase):
             "temperature": self.config.temperature,
             "max_tokens": self.config.max_tokens,
             "top_p": self.config.top_p,
+            "api_key": self.config.api_key,
         }
         if response_format:
             params["response_format"] = response_format


### PR DESCRIPTION
## Description

Allow the LiteLLM integration to use an API key specified in the configuration object instead of requiring it to be set as an environment variable.

Fixes https://github.com/mem0ai/mem0/issues/1746

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [ ] Unit Test
- [ ] Test Script (please provide)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
