### PR TITLE
Enhance Docker Security: Run Container as a Non-Root User

### DIFF
--- a/embedchain/embedchain/deployment/fly.io/Dockerfile
+++ b/embedchain/embedchain/deployment/fly.io/Dockerfile
@@ -1,13 +1,29 @@
 FROM python:3.11-slim
 
+# Create a non-root user and group
+RUN groupadd -r appgroup && useradd -r -g appgroup appuser
+
+# Set the working directory
 WORKDIR /app
 
+# Copy application files and adjust permissions
 COPY requirements.txt /app/
+RUN chown -R appuser:appgroup /app
 
-RUN pip install -r requirements.txt
+# Install dependencies before switching to non-root user
+RUN pip install --no-cache-dir -r requirements.txt
 
+# Copy the rest of the application files
 COPY . /app
 
+# Ensure correct permissions
+RUN chown -R appuser:appgroup /app
+
+# Switch to non-root user
+USER appuser
+
+# Expose application port
 EXPOSE 8080
 
+# Run the application
 CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
This update modifies the Dockerfile to address a Trivy security warning

## Description

This PR updates the Dockerfile to improve security by running the container as a non-root user, preventing privilege escalation risks and addressing Trivy's HIGH severity warning (DS002).
Changes Implemented:

✅ Added a new system user (appuser) and group (appgroup).
✅ Set ownership of /app to the non-root user.
✅ Moved pip install before switching users to prevent permission issues.
✅ Switched to USER appuser to follow best security practices.

Why This Change?

🔹 Mitigates security risks associated with running containers as root.
🔹 Complies with Docker security best practices.
🔹 Fixes Trivy HIGH severity warning (DS002).
References:

📌 vulnerability database: [aquasec](https://avd.aquasec.com/misconfig/dockerfile/general/avd-ds-0002/)
Testing & Validation:

✅ Builds and runs successfully with uvicorn.
✅ Verified application runs correctly as appuser.
✅ Passed security scans without issues.

Please review and merge to enhance security. 🚀