### PR TITLE
Remove tiktoken optional dependency

### DIFF
--- a/embedchain/pyproject.toml
+++ b/embedchain/pyproject.toml
@@ -104,7 +104,6 @@ pypdf = "^5.0.0"
 gptcache = "^0.1.43"
 pysbd = "^0.3.4"
 mem0ai = "^0.1.54"
-tiktoken = { version = "^0.7.0", optional = true }
 sentence-transformers = { version = "^2.2.2", optional = true }
 torch = { version = "2.3.0", optional = true }
 # Torch 2.0.1 is not compatible with poetry (https://github.com/pytorch/pytorch/issues/100974)
@@ -185,3 +184,4 @@ aws = ["langchain-aws"]
 
 [tool.poetry.scripts]
 ec = "embedchain.cli:cli"
+


### PR DESCRIPTION
## Description

This PR removes `tiktoken` from embedchain's optional dependencies.
That dependency is not used anywhere.
Tiktoken 0.7 doesn't have built binaries for Python 3.13 so tiktoken can't be used together with embedchain.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [ ] Unit Test
- [ ] Test Script (please provide)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
