### PR TITLE
[Bug Fix] Fix issue with chromadb not working with 0.6.0 and onwards

### DIFF
--- a/mem0/vector_stores/chroma.py
+++ b/mem0/vector_stores/chroma.py
@@ -105,10 +105,10 @@ class ChromaDB(VectorStoreBase):
             chromadb.Collection: The created or retrieved collection.
         """
         # Skip creating collection if already exists
-        collections = self.list_cols()
-        for collection in collections:
-            if collection.name == name:
-                logging.debug(f"Collection {name} already exists. Skipping creation.")
+        collection_info = self.client.get_collection(name=name)
+        if collection_info:
+            logging.debug(f"Collection {name} already exists. Skipping creation.")
+            return collection_info
 
         collection = self.client.get_or_create_collection(
             name=name,

--- a/mem0/vector_stores/qdrant.py
+++ b/mem0/vector_stores/qdrant.py
@@ -24,12 +24,12 @@ class Qdrant(VectorStoreBase):
         self,
         collection_name: str,
         embedding_model_dims: int,
-        client: QdrantClient = None,
-        host: str = None,
-        port: int = None,
-        path: str = None,
-        url: str = None,
-        api_key: str = None,
+        client: QdrantClient | None = None,
+        host: str | None = None,
+        port: int | None = None,
+        path: str | None = None,
+        url: str | None = None,
+        api_key: str | None = None,
         on_disk: bool = False,
     ):
         """

--- a/mem0/vector_stores/qdrant.py
+++ b/mem0/vector_stores/qdrant.py
@@ -24,12 +24,12 @@ class Qdrant(VectorStoreBase):
         self,
         collection_name: str,
         embedding_model_dims: int,
-        client: QdrantClient | None = None,
-        host: str | None = None,
-        port: int | None = None,
-        path: str | None = None,
-        url: str | None = None,
-        api_key: str | None = None,
+        client: QdrantClient = None,
+        host: str = None,
+        port: int = None,
+        path: str = None,
+        url: str = None,
+        api_key: str = None,
         on_disk: bool = False,
     ):
         """


### PR DESCRIPTION
## Description

Fixes the following issue when using chromadb with mem0 like this:

```python
import logging

logging.basicConfig(level=logging.ERROR, format='%(levelname)s - %(asctime)s - %(pathname)s - %(lineno)s - %(message)s')

from mem0 import Memory

config = {
    "vector_store": {
        "provider": "chroma",
        "config": {
            "collection_name": "test",
            "path": "db",
        }
    }
}

memory = Memory.from_config(config_dict=config)
memory.add("Remember my name is Deshraj and I am avid traveler. I like to stay in airbnb and travel to new places preferably in mountains", user_id="deshraj")
existing_memories = memory.get_all(user_id="deshraj")
```

Error:

```
Traceback (most recent call last):
  File "/Users/deshraj/Projects/test_v2.py", line 17, in <module>
    memory = Memory.from_config(config_dict=config)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/deshraj/Projects/.venv/lib/python3.11/site-packages/mem0/memory/main.py", line 64, in from_config
    return cls(config)
           ^^^^^^^^^^^
  File "/Users/deshraj/Projects/.venv/lib/python3.11/site-packages/mem0/memory/main.py", line 39, in __init__
    self.vector_store = VectorStoreFactory.create(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/deshraj/Projects/.venv/lib/python3.11/site-packages/mem0/utils/factory.py", line 82, in create
    return vector_store_instance(**config)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/deshraj/Projects/.venv/lib/python3.11/site-packages/mem0/vector_stores/chroma.py", line 61, in __init__
    self.collection = self.create_col(collection_name)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/deshraj/Projects/.venv/lib/python3.11/site-packages/mem0/vector_stores/chroma.py", line 110, in create_col
    if collection.name == name:
       ^^^^^^^^^^^^^^^
  File "/Users/deshraj/Projects/.venv/lib/python3.11/site-packages/chromadb/api/models/Collection.py", line 418, in __getattr__
    raise NotImplementedError(
NotImplementedError: In Chroma v0.6.0, list_collections only returns collection names. Use Client.get_collection(test) to access name. See https://docs.trychroma.com/deployment/migration for more information.
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)