### PR TITLE
[Misc] Clean up unnecessary checks in chromadb vector store integration

### DIFF
--- a/mem0/vector_stores/chroma.py
+++ b/mem0/vector_stores/chroma.py
@@ -104,12 +104,6 @@ class ChromaDB(VectorStoreBase):
         Returns:
             chromadb.Collection: The created or retrieved collection.
         """
-        # Skip creating collection if already exists
-        collection_info = self.client.get_collection(name=name)
-        if collection_info:
-            logging.debug(f"Collection {name} already exists. Skipping creation.")
-            return collection_info
-
         collection = self.client.get_or_create_collection(
             name=name,
             embedding_function=embedding_fn,


### PR DESCRIPTION
## Description

We don't need to check whether the collection already exists or not since we use the `client.get_or_create_collection()` which already takes care of this. 

Tested locally and it work fine.

## Type of change

- [x] Refactor (does not change functionality, e.g. code style improvements, linting)
