### PR TITLE
fix: conditional assetPrefix for dev mode to fix CSS loading

### DIFF
--- a/examples/mem0-demo/app/layout.tsx
+++ b/examples/mem0-demo/app/layout.tsx
@@ -5,11 +5,13 @@ import "./globals.css";
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
+  preload: false,
 });
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
+  preload: false,
 });
 
 export const metadata: Metadata = {

--- a/examples/mem0-demo/next.config.ts
+++ b/examples/mem0-demo/next.config.ts
@@ -1,10 +1,12 @@
 import type { NextConfig } from "next";
 
+const isProd = process.env.NODE_ENV === "production";
+
 const nextConfig: NextConfig = {
   /* config options here */
-  assetPrefix: "https://demo.mem0.ai",
+  assetPrefix: isProd ? "https://demo.mem0.ai" : undefined,
   images: {
-    path: "https://demo.mem0.ai",
+    path: isProd ? "https://demo.mem0.ai" : undefined,
   },
   async headers() {
     return [


### PR DESCRIPTION
## Description

When running the app in development mode, Next.js serves assets locally (http://localhost:3000/_next/static/...), but the `assetPrefix` config in `next.config.ts` is telling it to fetch them from `https://demo.mem0.ai`. This will make these requests fail with a 404, and the stylesheets don’t load.

This PR resolves this issue by adding a conditional check to avoid this. Plus, the `preload: false` is added to fonts, fixing the link preload warning in Next.js.

Fixes #2444

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested by `pnpm run dev`, all the assets can be found by Next.js, and the demo website works properly.

> https://docs.mem0.ai/examples/mem0-demo#enhancing-the-next-js-application

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
