### PR TITLE
fix: adjust markdown spacing to prevent text overlap

### DIFF
--- a/examples/mem0-demo/components/mem0/markdown.css
+++ b/examples/mem0-demo/components/mem0/markdown.css
@@ -6,7 +6,7 @@
   }
 
   .prose li p {
-    margin-top: -19px;
+    margin-top: 0;
   }
 
   @keyframes highlightSweep {

--- a/examples/mem0-demo/components/mem0/markdown.tsx
+++ b/examples/mem0-demo/components/mem0/markdown.tsx
@@ -178,8 +178,14 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
     span: ({ children, ...props }: React.HTMLAttributes<HTMLSpanElement>) => (
       <span {...props}>{processChildren(children)}</span>
     ),
+    ul: ({ children, ...props }: React.HTMLAttributes<HTMLUListElement>) => (
+      <ul className="my-4 ml-6 list-disc" {...props}>{processChildren(children)}</ul>
+    ),
+    ol: ({ children, ...props }: React.HTMLAttributes<HTMLOListElement>) => (
+      <ol className="my-4 ml-6 list-decimal" {...props}>{processChildren(children)}</ol>
+    ),
     li: ({ children, ...props }: React.HTMLAttributes<HTMLLIElement>) => (
-      <li {...props}>{processChildren(children)}</li>
+      <li className="my-2" {...props}>{processChildren(children)}</li>
     ),
     strong: ({ children, ...props }: React.HTMLAttributes<HTMLElement>) => (
       <strong {...props}>{processChildren(children)}</strong>


### PR DESCRIPTION
## Description

In the markdown component, the parent `<div>` in `markdown.tsx` applies the classes `prose-ul:-my-2 prose-ol:-my-2 prose-li:-my-2`, which set negative margins on HTML list elements.

In `markdown.css`, the rule `.prose li p { margin-top: -19px; }` reduces the space between the `<p>` inside a `<li>` and the preceding content, causing overlap.

This PR tries to fix these problems, and so resolves #2451.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested by running the `mem0` demo, and chatting with the bots. The markdown rendering works properly now, as shown in the pic.

<img width="520" alt="image" src="https://github.com/user-attachments/assets/6b33f5b0-9a3f-4988-b266-ac89a0039c3d" />

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
