### PR TITLE
Add support for Jina AI Chat API

### DIFF
--- a/docs/components/llms/models/jina.mdx
+++ b/docs/components/llms/models/jina.mdx
@@ -1,0 +1,174 @@
+---
+title: Jina AI
+description: Guide to use Mem0 with Jina AI Chat
+---
+
+# Jina AI
+
+Jina AI provides a powerful chat API with capabilities similar to other major LLM providers. The Jina AI Chat API allows for text generation, function/tool calling, and image input.
+
+## Getting Started
+
+To get started, you need to obtain an API key from Jina AI. You can get one from [chat.jina.ai/api](https://chat.jina.ai/api).
+
+### Installation
+
+Mem0 already includes the necessary dependencies to use Jina AI Chat. No additional installation is required.
+
+### Configuration
+
+Here's an example of how to configure Mem0 to use Jina AI:
+
+```python
+from mem0 import Memory
+
+config = {
+    "llm": {
+        "provider": "jina",
+        "config": {
+            "model": "jina-chat-v1",  # Default model
+            "temperature": 0.1,
+            "max_tokens": 2000,
+            "api_key": "your-jina-api-key",  # Replace with your API key or set JINA_API_KEY env variable
+        }
+    },
+    "embedder": {
+        "provider": "openai",  # You can use any supported embedding provider
+        "config": {
+            "model": "text-embedding-3-small"
+        }
+    },
+    "vector_store": {
+        "provider": "qdrant",  # You can use any supported vector store
+        "config": {
+            "collection_name": "mem0_jina_example",
+            "embedding_model_dims": 1536,
+        }
+    },
+    "version": "v1.1"
+}
+
+memory = Memory.from_config(config)
+```
+
+Alternatively, you can set the `JINA_API_KEY` environment variable instead of passing it in the config:
+
+```bash
+export JINA_API_KEY="your-jina-api-key"
+```
+
+## Configuration Options
+
+The Jina LLM provider supports the following configuration options:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `model` | `str` | The model to use. Default is `jina-chat-v1`. |
+| `temperature` | `float` | Controls the randomness of the output. Lower values make output more deterministic. Default is `0.1`. |
+| `max_tokens` | `int` | The maximum number of tokens to generate. Default is `2000`. |
+| `top_p` | `float` | An alternative to temperature sampling. Default is `0.1`. |
+| `api_key` | `str` | Your Jina AI API key. If not provided, it will try to use the `JINA_API_KEY` environment variable. |
+| `jina_base_url` | `str` | The base URL for the Jina AI API. Default is `https://api.chat.jina.ai/v1/chat`. |
+
+## Example Usage
+
+Here's a complete example of using Mem0 with Jina AI:
+
+```python
+import os
+from mem0 import Memory
+
+# Set your Jina API key
+api_key = os.environ.get("JINA_API_KEY")
+if not api_key:
+    print("Please set your JINA_API_KEY environment variable")
+    exit(1)
+
+# Define the configuration
+config = {
+    "llm": {
+        "provider": "jina",
+        "config": {
+            "model": "jina-chat-v1",
+            "temperature": 0.1,
+            "max_tokens": 2000,
+            "api_key": api_key,
+        }
+    },
+    "embedder": {
+        "provider": "openai",
+        "config": {
+            "model": "text-embedding-3-small"
+        }
+    },
+    "vector_store": {
+        "provider": "qdrant",
+        "config": {
+            "collection_name": "mem0_jina_example",
+            "embedding_model_dims": 1536,
+        }
+    },
+    "version": "v1.1"
+}
+
+# Initialize Memory with the configuration
+memory = Memory.from_config(config)
+
+# Add a memory
+user_id = "test-user-1"
+memory.add(
+    "Jina AI is a powerful LLM with a developer-friendly API.",
+    user_id=user_id,
+)
+
+# Search for a memory
+results = memory.search("What is Jina AI?", user_id=user_id)
+for result in results:
+    print(result.payload['data'])
+
+# Chat using the LLM
+response = memory.chat("Tell me about Jina AI and its features.")
+print(response)
+```
+
+## Advanced Features
+
+### Using Function/Tool Calling
+
+Jina AI supports function/tool calling, similar to other LLM providers. When using memory.add() with procedural memory types, Mem0 will automatically utilize this capability when appropriate.
+
+### Using Vision Features
+
+Jina AI supports vision features, allowing you to send images along with text prompts. You can enable this by setting `enable_vision` to `True` in your config:
+
+```python
+config = {
+    "llm": {
+        "provider": "jina",
+        "config": {
+            "model": "jina-chat-v1",
+            "enable_vision": True,
+            "vision_details": "auto",  # Options: "low", "high", "auto"
+            "api_key": "your-jina-api-key",
+        }
+    },
+    # ... other config options
+}
+```
+
+## Troubleshooting
+
+If you encounter issues with the Jina AI integration, here are some common solutions:
+
+- Make sure your API key is valid and correctly set.
+- Check if you're using the correct base URL if you've customized it.
+- Ensure you have an active internet connection to reach the Jina AI API.
+- If you encounter rate limits, consider adjusting your request frequency.
+
+For more information on the Jina AI Chat API, visit [chat.jina.ai/api](https://chat.jina.ai/api).
+
+## Further Resources
+
+- [Jina AI Documentation](https://jina.ai/docs/)
+- [Jina AI Chat](https://chat.jina.ai/)
+- [Mem0 Documentation](/) 

--- a/docs/components/llms/models/jina.mdx
+++ b/docs/components/llms/models/jina.mdx
@@ -7,9 +7,16 @@ description: Guide to use Mem0 with Jina AI Chat
 
 Jina AI provides a powerful chat API with capabilities similar to other major LLM providers. The Jina AI Chat API allows for text generation, function/tool calling, and image input.
 
+## Important API Key Distinction
+
+**Note:** Jina AI offers multiple API services including Chat API, Reader API, Search API, Embeddings API, etc. 
+- The **Jina Chat API** (used in this integration) requires its own specific API key from [chat.jina.ai/api](https://chat.jina.ai/api) 
+- This key is different from keys used for Jina's Reader API, Search API, or other Jina services
+- For this integration, you must set the `JINACHAT_API_KEY` environment variable or provide the key in the config
+
 ## Getting Started
 
-To get started, you need to obtain an API key from Jina AI. You can get one from [chat.jina.ai/api](https://chat.jina.ai/api).
+To get started, you need to obtain a Chat API key from Jina AI. You can get one from [chat.jina.ai/api](https://chat.jina.ai/api).
 
 ### Installation
 
@@ -29,7 +36,7 @@ config = {
             "model": "jina-chat-v1",  # Default model
             "temperature": 0.1,
             "max_tokens": 2000,
-            "api_key": "your-jina-api-key",  # Replace with your API key or set JINA_API_KEY env variable
+            "api_key": "your-jina-chat-api-key",  # Replace with your API key or set JINACHAT_API_KEY env variable
         }
     },
     "embedder": {
@@ -51,10 +58,10 @@ config = {
 memory = Memory.from_config(config)
 ```
 
-Alternatively, you can set the `JINA_API_KEY` environment variable instead of passing it in the config:
+Alternatively, you can set the `JINACHAT_API_KEY` environment variable instead of passing it in the config:
 
 ```bash
-export JINA_API_KEY="your-jina-api-key"
+export JINACHAT_API_KEY="your-jina-chat-api-key"
 ```
 
 ## Configuration Options
@@ -67,8 +74,8 @@ The Jina LLM provider supports the following configuration options:
 | `temperature` | `float` | Controls the randomness of the output. Lower values make output more deterministic. Default is `0.1`. |
 | `max_tokens` | `int` | The maximum number of tokens to generate. Default is `2000`. |
 | `top_p` | `float` | An alternative to temperature sampling. Default is `0.1`. |
-| `api_key` | `str` | Your Jina AI API key. If not provided, it will try to use the `JINA_API_KEY` environment variable. |
-| `jina_base_url` | `str` | The base URL for the Jina AI API. Default is `https://api.chat.jina.ai/v1/chat`. |
+| `api_key` | `str` | Your Jina Chat API key. If not provided, it will try to use the `JINACHAT_API_KEY` environment variable. |
+| `jina_base_url` | `str` | The base URL for the Jina Chat API. Default is `https://api.chat.jina.ai/v1/chat`. |
 
 ## Example Usage
 
@@ -78,10 +85,10 @@ Here's a complete example of using Mem0 with Jina AI:
 import os
 from mem0 import Memory
 
-# Set your Jina API key
-api_key = os.environ.get("JINA_API_KEY")
+# Set your Jina Chat API key
+api_key = os.environ.get("JINACHAT_API_KEY")
 if not api_key:
-    print("Please set your JINA_API_KEY environment variable")
+    print("Please set your JINACHAT_API_KEY environment variable")
     exit(1)
 
 # Define the configuration
@@ -149,7 +156,7 @@ config = {
             "model": "jina-chat-v1",
             "enable_vision": True,
             "vision_details": "auto",  # Options: "low", "high", "auto"
-            "api_key": "your-jina-api-key",
+            "api_key": "your-jina-chat-api-key",
         }
     },
     # ... other config options
@@ -160,6 +167,7 @@ config = {
 
 If you encounter issues with the Jina AI integration, here are some common solutions:
 
+- **API Key Confusion**: Make sure you're using a Jina Chat API key specifically (not a key for Reader API or other Jina services). The "Invalid token" error often occurs when using the wrong type of Jina API key.
 - Make sure your API key is valid and correctly set.
 - Check if you're using the correct base URL if you've customized it.
 - Ensure you have an active internet connection to reach the Jina AI API.

--- a/examples/mem0_with_jina.py
+++ b/examples/mem0_with_jina.py
@@ -1,0 +1,73 @@
+import os
+from mem0 import Memory
+
+# Set your Jina API key
+# You can get one from https://chat.jina.ai/api
+api_key = os.environ.get("JINA_API_KEY")
+if not api_key:
+    print("Please set your JINA_API_KEY environment variable")
+    print("You can get one from https://chat.jina.ai/api")
+    exit(1)
+
+# Define the configuration
+config = {
+    "llm": {
+        "provider": "jina",
+        "config": {
+            "model": "jina-chat-v1",  # This is the default model
+            "temperature": 0.1,       # Lower temperature for more deterministic responses
+            "max_tokens": 2000,       # Maximum number of tokens in the response
+            "api_key": api_key,       # Your Jina API key
+            # Optionally, you can specify a custom base URL if needed
+            # "jina_base_url": "https://custom.jina.ai/v1/chat",
+        }
+    },
+    "embedder": {
+        "provider": "openai",
+        "config": {
+            "model": "text-embedding-3-small"
+        }
+    },
+    "vector_store": {
+        "provider": "qdrant",
+        "config": {
+            "collection_name": "mem0_jina_example",
+            "embedding_model_dims": 1536,  # Dimensions of the OpenAI embedding model
+        }
+    },
+    "version": "v1.1"
+}
+
+# Initialize Memory with the configuration
+memory = Memory.from_config(config)
+
+# Test adding a memory
+user_id = "test-user-1"
+message = "Jina AI is a powerful LLM with a developer-friendly API."
+
+print(f"Adding memory: {message}")
+result = memory.add(
+    message,
+    user_id=user_id,
+    infer=True  # This will extract facts from the message
+)
+print("Added memory:")
+print(result)
+
+# Test searching for a memory
+query = "What is Jina AI?"
+print(f"\nSearching for: {query}")
+search_results = memory.search(query, user_id=user_id)
+print("Search results:")
+for result in search_results:
+    print(f"- {result.payload['data']}")
+
+# Test using the LLM to chat
+print("\nChatting with Jina AI:")
+response = memory.chat("Tell me about Jina AI and its features.")
+print(f"Response: {response}")
+
+# Clean up (optional)
+print("\nCleaning up...")
+memory.delete_all(user_id=user_id)
+print("Memories deleted.") 

--- a/examples/mem0_with_jina.py
+++ b/examples/mem0_with_jina.py
@@ -1,12 +1,14 @@
 import os
 from mem0 import Memory
 
-# Set your Jina API key
-# You can get one from https://chat.jina.ai/api
-api_key = os.environ.get("JINA_API_KEY")
+# Set your Jina Chat API key
+# IMPORTANT: This must be a Jina Chat API key from https://chat.jina.ai/api
+# This is NOT the same as Jina's Reader/Search API key or other Jina services
+api_key = os.environ.get("JINACHAT_API_KEY")
 if not api_key:
-    print("Please set your JINA_API_KEY environment variable")
+    print("Please set your JINACHAT_API_KEY environment variable")
     print("You can get one from https://chat.jina.ai/api")
+    print("Note: This must be a Chat API key, not a Reader/Search API key")
     exit(1)
 
 # Define the configuration

--- a/mem0/configs/llms/base.py
+++ b/mem0/configs/llms/base.py
@@ -41,6 +41,8 @@ class BaseLlmConfig(ABC):
         xai_base_url: Optional[str] = None,
         # LM Studio specific
         lmstudio_base_url: Optional[str] = "http://localhost:1234/v1",
+        # Jina specific
+        jina_base_url: Optional[str] = None,
     ):
         """
         Initializes a configuration class instance for the LLM.
@@ -87,6 +89,8 @@ class BaseLlmConfig(ABC):
         :type xai_base_url: Optional[str], optional
         :param lmstudio_base_url: LM Studio base URL to be use, defaults to "http://localhost:1234/v1"
         :type lmstudio_base_url: Optional[str], optional
+        :param jina_base_url: Jina AI Chat base URL to be use, defaults to None
+        :type jina_base_url: Optional[str], optional
         """
 
         self.model = model
@@ -123,3 +127,6 @@ class BaseLlmConfig(ABC):
 
         # LM Studio specific
         self.lmstudio_base_url = lmstudio_base_url
+        
+        # Jina specific
+        self.jina_base_url = jina_base_url

--- a/mem0/llms/jina.py
+++ b/mem0/llms/jina.py
@@ -15,11 +15,11 @@ class JinaLLM(LLMBase):
         if not self.config.model:
             self.config.model = "jina-chat-v1"  # Default model if not specified
 
-        self.api_key = self.config.api_key or os.getenv("JINA_API_KEY")
+        self.api_key = self.config.api_key or os.getenv("JINACHAT_API_KEY")
         if not self.api_key:
-            raise ValueError("Jina AI API key is required. Set it in the config or as JINA_API_KEY environment variable.")
+            raise ValueError("Jina Chat API key is required. Set it in the config or as JINACHAT_API_KEY environment variable.")
         
-        self.base_url = self.config.jina_base_url or os.getenv("JINA_API_BASE") or "https://api.chat.jina.ai/v1/chat"
+        self.base_url = self.config.jina_base_url or os.getenv("JINACHAT_API_BASE") or "https://api.chat.jina.ai/v1/chat"
         self.headers = {
             "Content-Type": "application/json",
             "Authorization": f"Bearer {self.api_key}"

--- a/mem0/llms/jina.py
+++ b/mem0/llms/jina.py
@@ -1,0 +1,119 @@
+import json
+import os
+from typing import Dict, List, Optional
+
+import requests
+
+from mem0.configs.llms.base import BaseLlmConfig
+from mem0.llms.base import LLMBase
+
+
+class JinaLLM(LLMBase):
+    def __init__(self, config: Optional[BaseLlmConfig] = None):
+        super().__init__(config)
+
+        if not self.config.model:
+            self.config.model = "jina-chat-v1"  # Default model if not specified
+
+        self.api_key = self.config.api_key or os.getenv("JINA_API_KEY")
+        if not self.api_key:
+            raise ValueError("Jina AI API key is required. Set it in the config or as JINA_API_KEY environment variable.")
+        
+        self.base_url = self.config.jina_base_url or os.getenv("JINA_API_BASE") or "https://api.chat.jina.ai/v1/chat"
+        self.headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.api_key}"
+        }
+
+    def _parse_response(self, response, tools):
+        """
+        Process the response based on whether tools are used or not.
+
+        Args:
+            response: The raw response from API.
+            tools: The list of tools provided in the request.
+
+        Returns:
+            str or dict: The processed response.
+        """
+        if tools:
+            processed_response = {
+                "content": response["choices"][0]["message"]["content"],
+                "tool_calls": [],
+            }
+
+            # Check if tool_calls exists in the response
+            if "tool_calls" in response["choices"][0]["message"]:
+                for tool_call in response["choices"][0]["message"]["tool_calls"]:
+                    processed_response["tool_calls"].append(
+                        {
+                            "name": tool_call["function"]["name"],
+                            "arguments": json.loads(tool_call["function"]["arguments"]),
+                        }
+                    )
+
+            return processed_response
+        else:
+            return response["choices"][0]["message"]["content"]
+
+    def generate_response(
+        self,
+        messages: List[Dict[str, str]],
+        response_format=None,
+        tools: Optional[List[Dict]] = None,
+        tool_choice: str = "auto",
+    ):
+        """
+        Generate a response based on the given messages using Jina AI Chat.
+
+        Args:
+            messages (list): List of message dicts containing 'role' and 'content'.
+            response_format (str or object, optional): Format of the response. Defaults to None.
+            tools (list, optional): List of tools that the model can call. Defaults to None.
+            tool_choice (str, optional): Tool choice method. Defaults to "auto".
+
+        Returns:
+            str or dict: The generated response.
+        """
+        # Build the request payload
+        payload = {
+            "model": self.config.model,
+            "messages": messages,
+            "temperature": self.config.temperature,
+            "max_tokens": self.config.max_tokens,
+            "top_p": self.config.top_p,
+        }
+
+        # Add tools if provided
+        if tools:
+            payload["tools"] = tools
+            payload["tool_choice"] = tool_choice
+
+        # Add response format if provided
+        if response_format:
+            payload["response_format"] = response_format
+
+        # Make the API request
+        try:
+            response = requests.post(
+                f"{self.base_url}/completions",
+                headers=self.headers,
+                json=payload
+            )
+            response.raise_for_status()
+            response_data = response.json()
+            
+            # Return parsed response
+            return self._parse_response(response_data, tools)
+            
+        except requests.exceptions.RequestException as e:
+            error_msg = f"Error making request to Jina AI Chat API: {str(e)}"
+            if hasattr(e, 'response') and e.response is not None:
+                try:
+                    error_response = e.response.json()
+                    if isinstance(error_response, dict) and 'error' in error_response:
+                        error_msg += f". API Error: {error_response['error']}"
+                except (ValueError, AttributeError, TypeError):
+                    if hasattr(e.response, 'status_code'):
+                        error_msg += f". Status code: {e.response.status_code}"
+            raise Exception(error_msg) 

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -26,6 +26,7 @@ class LlmFactory:
         "deepseek": "mem0.llms.deepseek.DeepSeekLLM",
         "xai": "mem0.llms.xai.XAILLM",
         "lmstudio": "mem0.llms.lmstudio.LMStudioLLM",
+        "jina": "mem0.llms.jina.JinaLLM",
     }
 
     @classmethod

--- a/test_with_lib.py
+++ b/test_with_lib.py
@@ -1,0 +1,17 @@
+from jinaai import JinaAI
+import os
+
+# Get API key from environment variable
+api_key = os.getenv("JINACHAT_API_KEY")
+print(f"API key length: {len(api_key) if api_key else 'Not found'}")
+print(f"First few chars: {api_key[:10] if api_key else 'None'}")
+
+# Initialize the Jina AI client
+client = JinaAI(secrets={"jinachat-secret": api_key})
+
+# Make a simple request
+try:
+    response = client.generate("Hello, how are you?")
+    print(f"Response: {response}")
+except Exception as e:
+    print(f"Error: {str(e)}")

--- a/tests/llms/test_jina.py
+++ b/tests/llms/test_jina.py
@@ -1,0 +1,201 @@
+from unittest.mock import Mock, patch
+import os
+import pytest
+from requests.exceptions import RequestException
+
+from mem0.configs.llms.base import BaseLlmConfig
+from mem0.llms.jina import JinaLLM
+
+
+@pytest.fixture
+def mock_jina_client():
+    with patch("mem0.llms.jina.requests.post") as mock_post:
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "chatId": "test-chat-id",
+            "inputMessageId": "test-input-message-id",
+            "responseMessageId": "test-response-message-id",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "This is a test response from Jina AI Chat."
+                    },
+                    "finish_reason": "stop"
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 20,
+                "total_tokens": 30
+            }
+        }
+        mock_response.raise_for_status = Mock()
+        mock_post.return_value = mock_response
+        yield mock_post
+
+
+def test_jina_llm_init():
+    # Test with explicit API key in config
+    config = BaseLlmConfig(model="jina-chat-v1", temperature=0.7, max_tokens=100, top_p=1.0, api_key="test-api-key")
+    with patch.dict(os.environ, {}, clear=True):
+        llm = JinaLLM(config)
+        assert llm.api_key == "test-api-key"
+        assert llm.base_url == "https://api.chat.jina.ai/v1/chat"
+        assert llm.headers == {"Content-Type": "application/json", "Authorization": "Bearer test-api-key"}
+
+    # Test with environment variable API key
+    with patch.dict(os.environ, {"JINA_API_KEY": "env-api-key"}, clear=True):
+        config = BaseLlmConfig(model="jina-chat-v1", temperature=0.7, max_tokens=100, top_p=1.0)
+        llm = JinaLLM(config)
+        assert llm.api_key == "env-api-key"
+
+    # Test with custom base URL
+    config = BaseLlmConfig(
+        model="jina-chat-v1", 
+        temperature=0.7, 
+        max_tokens=100, 
+        top_p=1.0, 
+        api_key="test-api-key", 
+        jina_base_url="https://custom.jina.ai/v1"
+    )
+    llm = JinaLLM(config)
+    assert llm.base_url == "https://custom.jina.ai/v1"
+
+    # Test with environment variable base URL
+    with patch.dict(os.environ, {"JINA_API_BASE": "https://env.jina.ai/v1"}, clear=True):
+        config = BaseLlmConfig(model="jina-chat-v1", temperature=0.7, max_tokens=100, top_p=1.0, api_key="test-api-key")
+        llm = JinaLLM(config)
+        assert llm.base_url == "https://env.jina.ai/v1"
+
+
+def test_generate_response_without_tools(mock_jina_client):
+    config = BaseLlmConfig(model="jina-chat-v1", temperature=0.7, max_tokens=100, top_p=1.0, api_key="test-api-key")
+    llm = JinaLLM(config)
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello, how are you?"},
+    ]
+
+    response = llm.generate_response(messages)
+    
+    # Verify the response is correctly parsed
+    assert response == "This is a test response from Jina AI Chat."
+    
+    # Verify the correct API call was made
+    mock_jina_client.assert_called_once_with(
+        f"{llm.base_url}/completions",
+        headers=llm.headers,
+        json={
+            "model": "jina-chat-v1",
+            "messages": messages,
+            "temperature": 0.7,
+            "max_tokens": 100,
+            "top_p": 1.0,
+        }
+    )
+
+
+def test_generate_response_with_tools(mock_jina_client):
+    config = BaseLlmConfig(model="jina-chat-v1", temperature=0.7, max_tokens=100, top_p=1.0, api_key="test-api-key")
+    llm = JinaLLM(config)
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Add a new memory: Today is a sunny day."},
+    ]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "add_memory",
+                "description": "Add a memory",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"data": {"type": "string", "description": "Data to add to memory"}},
+                    "required": ["data"],
+                },
+            },
+        }
+    ]
+
+    # Update mock_jina_client to include tool_calls in the response
+    mock_jina_client.return_value.json.return_value = {
+        "chatId": "test-chat-id",
+        "inputMessageId": "test-input-message-id",
+        "responseMessageId": "test-response-message-id",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "I've added the memory for you.",
+                    "tool_calls": [
+                        {
+                            "id": "call_abc123",
+                            "type": "function",
+                            "function": {
+                                "name": "add_memory",
+                                "arguments": '{"data": "Today is a sunny day."}'
+                            }
+                        }
+                    ]
+                },
+                "finish_reason": "tool_calls"
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 20,
+            "total_tokens": 30
+        }
+    }
+
+    response = llm.generate_response(messages, tools=tools)
+    
+    # Verify the response is correctly parsed
+    assert response["content"] == "I've added the memory for you."
+    assert len(response["tool_calls"]) == 1
+    assert response["tool_calls"][0]["name"] == "add_memory"
+    assert response["tool_calls"][0]["arguments"] == {"data": "Today is a sunny day."}
+    
+    # Verify the correct API call was made
+    mock_jina_client.assert_called_once_with(
+        f"{llm.base_url}/completions",
+        headers=llm.headers,
+        json={
+            "model": "jina-chat-v1",
+            "messages": messages,
+            "temperature": 0.7,
+            "max_tokens": 100,
+            "top_p": 1.0,
+            "tools": tools,
+            "tool_choice": "auto"
+        }
+    )
+
+
+def test_error_handling(mock_jina_client):
+    config = BaseLlmConfig(model="jina-chat-v1", temperature=0.7, max_tokens=100, top_p=1.0, api_key="test-api-key")
+    llm = JinaLLM(config)
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello, how are you?"},
+    ]
+    
+    # Make the request raise an exception
+    mock_error_response = Mock()
+    mock_error_response.json.return_value = {"error": "Invalid API key"}
+    mock_error_response.status_code = 401
+    
+    request_exception = RequestException("Error occurred")
+    request_exception.response = mock_error_response
+    
+    mock_jina_client.side_effect = request_exception
+    
+    # Try to generate a response, which should raise an exception
+    with pytest.raises(Exception) as excinfo:
+        llm.generate_response(messages)
+    
+    # Verify the exception message contains the API error
+    assert "API Error: Invalid API key" in str(excinfo.value) 

--- a/tests/llms/test_jina.py
+++ b/tests/llms/test_jina.py
@@ -46,7 +46,7 @@ def test_jina_llm_init():
         assert llm.headers == {"Content-Type": "application/json", "Authorization": "Bearer test-api-key"}
 
     # Test with environment variable API key
-    with patch.dict(os.environ, {"JINA_API_KEY": "env-api-key"}, clear=True):
+    with patch.dict(os.environ, {"JINACHAT_API_KEY": "env-api-key"}, clear=True):
         config = BaseLlmConfig(model="jina-chat-v1", temperature=0.7, max_tokens=100, top_p=1.0)
         llm = JinaLLM(config)
         assert llm.api_key == "env-api-key"
@@ -64,7 +64,7 @@ def test_jina_llm_init():
     assert llm.base_url == "https://custom.jina.ai/v1"
 
     # Test with environment variable base URL
-    with patch.dict(os.environ, {"JINA_API_BASE": "https://env.jina.ai/v1"}, clear=True):
+    with patch.dict(os.environ, {"JINACHAT_API_BASE": "https://env.jina.ai/v1"}, clear=True):
         config = BaseLlmConfig(model="jina-chat-v1", temperature=0.7, max_tokens=100, top_p=1.0, api_key="test-api-key")
         llm = JinaLLM(config)
         assert llm.base_url == "https://env.jina.ai/v1"


### PR DESCRIPTION
## Description

Add Jina AI Chat as an alternative LLM model. This is an EU hosted LLM, that can now be used as an alternative LLM with mem0.

## Type of change

Please delete options that are not relevant.

- [x ] New feature (non-breaking change which adds functionality)
- [ x] Documentation update

## How Has This Been Tested?

There are tests to the new feature in the PR, but this has also been tested manually within my own chat application as an LLM backend for mem0.

- [ x] Unit Test

## Checklist:

- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ x] Any dependent changes have been merged and published in downstream modules
- [ x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
