### PR TITLE
feat(LM Studio): Add response_format param for LM Studio to config

### DIFF
--- a/mem0/configs/llms/base.py
+++ b/mem0/configs/llms/base.py
@@ -41,7 +41,7 @@ class BaseLlmConfig(ABC):
         xai_base_url: Optional[str] = None,
         # LM Studio specific
         lmstudio_base_url: Optional[str] = "http://localhost:1234/v1",
-        lmstduio_response_format: dict = None,
+        lmstudio_response_format: dict = None,
     ):
         """
         Initializes a configuration class instance for the LLM.
@@ -88,8 +88,8 @@ class BaseLlmConfig(ABC):
         :type xai_base_url: Optional[str], optional
         :param lmstudio_base_url: LM Studio base URL to be use, defaults to "http://localhost:1234/v1"
         :type lmstudio_base_url: Optional[str], optional
-        :param lmstduio_response_format: LM Studio response format to be use, defaults to None
-        :type mstduio_response_format: Optional[Dict], optional
+        :param lmstudio_response_format: LM Studio response format to be use, defaults to None
+        :type lmstudio_response_format: Optional[Dict], optional
         """
 
         self.model = model
@@ -126,4 +126,4 @@ class BaseLlmConfig(ABC):
 
         # LM Studio specific
         self.lmstudio_base_url = lmstudio_base_url
-        self.lmstudio_response_format = lmstduio_response_format
+        self.lmstudio_response_format = lmstudio_response_format

--- a/mem0/configs/llms/base.py
+++ b/mem0/configs/llms/base.py
@@ -41,6 +41,7 @@ class BaseLlmConfig(ABC):
         xai_base_url: Optional[str] = None,
         # LM Studio specific
         lmstudio_base_url: Optional[str] = "http://localhost:1234/v1",
+        lmstduio_response_format: dict = None,
     ):
         """
         Initializes a configuration class instance for the LLM.
@@ -87,6 +88,8 @@ class BaseLlmConfig(ABC):
         :type xai_base_url: Optional[str], optional
         :param lmstudio_base_url: LM Studio base URL to be use, defaults to "http://localhost:1234/v1"
         :type lmstudio_base_url: Optional[str], optional
+        :param lmstduio_response_format: LM Studio response format to be use, defaults to None
+        :type mstduio_response_format: Optional[Dict], optional
         """
 
         self.model = model
@@ -123,3 +126,4 @@ class BaseLlmConfig(ABC):
 
         # LM Studio specific
         self.lmstudio_base_url = lmstudio_base_url
+        self.lmstudio_response_format = lmstduio_response_format

--- a/mem0/llms/lmstudio.py
+++ b/mem0/llms/lmstudio.py
@@ -46,6 +46,8 @@ class LMStudioLLM(LLMBase):
         }
         if response_format:
             params["response_format"] = response_format
+        if self.config.lmstudio_response_format is not None:
+            params["response_format"] = self.config.lmstudio_response_format
 
         response = self.client.chat.completions.create(**params)
         return response.choices[0].message.content

--- a/tests/llms/test_lm_studio.py
+++ b/tests/llms/test_lm_studio.py
@@ -51,7 +51,7 @@ def test_generate_response_specifying_response_format(mock_lm_studio_client):
         temperature=0.7,
         max_tokens=100,
         top_p=1.0,
-        lmstduio_response_format={"type": "json_schema"},  # Specifying the response format in config
+        lmstudio_response_format={"type": "json_schema"},  # Specifying the response format in config
     )
     llm = LMStudioLLM(config)
     messages = [

--- a/tests/llms/test_lm_studio.py
+++ b/tests/llms/test_lm_studio.py
@@ -44,3 +44,30 @@ def test_generate_response_without_tools(mock_lm_studio_client):
     )
 
     assert response == "I'm doing well, thank you for asking!"
+
+def test_generate_response_specifying_response_format(mock_lm_studio_client):
+    config = BaseLlmConfig(
+        model="lmstudio-community/Meta-Llama-3.1-8B-Instruct-GGUF/Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
+        temperature=0.7,
+        max_tokens=100,
+        top_p=1.0,
+        lmstduio_response_format={"type": "json_schema"},  # Specifying the response format in config
+    )
+    llm = LMStudioLLM(config)
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello, how are you?"},
+    ]
+
+    response = llm.generate_response(messages)
+
+    mock_lm_studio_client.chat.completions.create.assert_called_once_with(
+        model="lmstudio-community/Meta-Llama-3.1-8B-Instruct-GGUF/Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
+        messages=messages,
+        temperature=0.7,
+        max_tokens=100,
+        top_p=1.0,
+        response_format={"type": "json_schema"},
+    )
+
+    assert response == "I'm doing well, thank you for asking!"


### PR DESCRIPTION
## Description
Thank you for checking this PR!
Added a “param” parameter to configure the response_format for LM Studio as desired.

Background:
LM Studio: 0.3.14
mem0: 0.1.81

I got the following error when using Mem0 with LMStudio. 
To avoid this error, I would like to be able to specify an arbitrary response_format in config's param.
```
Traceback (most recent call last):
  File "/Users/*************/workspace/py_prj/agent_practice/mem.py", line 77, in <module>
    m.add(messages, user_id="alice123", metadata={"category": "movies"})
  File "/Users/*************/workspace/py_prj/agent_practice/.venv/lib/python3.12/site-packages/mem0/memory/main.py", line 158, in add
    vector_store_result = future1.result()
                          ^^^^^^^^^^^^^^^^
  File "/Users/*************/.local/share/uv/python/cpython-3.12.7-macos-aarch64-none/lib/python3.12/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/*************/.local/share/uv/python/cpython-3.12.7-macos-aarch64-none/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/Users/*************/.local/share/uv/python/cpython-3.12.7-macos-aarch64-none/lib/python3.12/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/*************/workspace/py_prj/agent_practice/.venv/lib/python3.12/site-packages/mem0/memory/main.py", line 197, in _add_to_vector_store
    response = self.llm.generate_response(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/*************/workspace/py_prj/agent_practice/.venv/lib/python3.12/site-packages/mem0/llms/lmstudio.py", line 50, in generate_response
    response = self.client.chat.completions.create(**params)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/*************/workspace/py_prj/agent_practice/.venv/lib/python3.12/site-packages/openai/_utils/_utils.py", line 279, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/*************/workspace/py_prj/agent_practice/.venv/lib/python3.12/site-packages/openai/resources/chat/completions/completions.py", line 914, in create
    return self._post(
           ^^^^^^^^^^^
  File "/Users/*************/workspace/py_prj/agent_practice/.venv/lib/python3.12/site-packages/openai/_base_client.py", line 1242, in post
    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/*************/workspace/py_prj/agent_practice/.venv/lib/python3.12/site-packages/openai/_base_client.py", line 919, in request
    return self._request(
           ^^^^^^^^^^^^^^
  File "/Users/*************/workspace/py_prj/agent_practice/.venv/lib/python3.12/site-packages/openai/_base_client.py", line 1023, in _request
    raise self._make_status_error_from_response(err.response) from None
openai.BadRequestError: Error code: 400 - {'error': "'response_format.type' must be 'json_schema'"}
```

We would like to be able to specify in the following way
```
config = {
    "llm": {
        "provider": "lmstudio",
        "config": {
            "model": "meta-llama-3.1-70b-instruct",
            "temperature": 0.2,
            "max_tokens": 2000,
            "lmstudio_base_url": "http://127.0.0.1:1234/v1", # default LM Studio API URL
            "lmstudio_response_format": {"type": "json_schema", "json_schema": {"type": "object", "schema": {}}},
        }
    },
}
```

Thank you so much for considering this PR.

P.S.
We did not know where to find the documentation for the change.
Could you tell me where and how to change it.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Added test_generate_response_specifying_response_format.
This is a test case to verify that the specified response_format is reflected.
Conventional tests have also been performed to confirm that when response_format is not set in config, the same params as before are used.

- [x] Unit Test
- [x] Test Script (please provide)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed