### PR TITLE
Fix `EmbedderFactory.create()` in  GraphMemory

### DIFF
--- a/mem0/memory/graph_memory.py
+++ b/mem0/memory/graph_memory.py
@@ -34,7 +34,11 @@ class MemoryGraph:
             self.config.graph_store.config.username,
             self.config.graph_store.config.password,
         )
-        self.embedding_model = EmbedderFactory.create(self.config.embedder.provider, self.config.embedder.config)
+        self.embedding_model = EmbedderFactory.create(
+            self.config.embedder.provider, 
+            self.config.embedder.config, 
+            self.config.vector_store.config
+        )
 
         self.llm_provider = "openai_structured"
         if self.config.llm.provider:


### PR DESCRIPTION
## Description

Fix `EmbedderFactory.create()` in  GraphMemory

Fixes #2532 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
