### PR TITLE
Doc: add "memory" in EC "Custom config" section and fix typos in the json config sample

### DIFF
--- a/embedchain/docs/api-reference/advanced/configuration.mdx
+++ b/embedchain/docs/api-reference/advanced/configuration.mdx
@@ -70,6 +70,9 @@ cache:
   config:
     similarity_threshold: 0.8
     auto_flush: 50
+
+memory:
+  top_k: 10
 ```
 
 ```json config.json
@@ -90,9 +93,9 @@ cache:
       "prompt": "Use the following pieces of context to answer the query at the end.\nIf you don't know the answer, just say that you don't know, don't try to make up an answer.\n$context\n\nQuery: $query\n\nHelpful Answer:",
       "system_prompt": "Act as William Shakespeare. Answer the following questions in the style of William Shakespeare.",
       "api_key": "sk-xxx",
-      "model_kwargs": {"response_format": {"type": "json_object"}},
+      "model_kwargs": { "response_format": { "type": "json_object" } },
       "api_version": "2024-02-01",
-      "http_client_proxies": "http://testproxy.mem0.net:8000",
+      "http_client_proxies": "http://testproxy.mem0.net:8000"
     }
   },
   "vectordb": {
@@ -108,7 +111,7 @@ cache:
     "config": {
       "model": "text-embedding-ada-002",
       "api_key": "sk-xxx",
-      "http_client_proxies": "http://testproxy.mem0.net:8000",
+      "http_client_proxies": "http://testproxy.mem0.net:8000"
     }
   },
   "chunker": {
@@ -119,14 +122,17 @@ cache:
   },
   "cache": {
     "similarity_evaluation": {
-        "strategy": "distance",
-        "max_distance": 1.0,
+      "strategy": "distance",
+      "max_distance": 1.0
     },
     "config": {
-        "similarity_threshold": 0.8,
-        "auto_flush": 50,
-    },
+      "similarity_threshold": 0.8,
+      "auto_flush": 50
+    }
   },
+  "memory": {
+    "top_k": 10
+  }
 }
 ```
 
@@ -181,14 +187,17 @@ config = {
         'min_chunk_size': 0
     },
     'cache': {
-      'similarity_evaluation': {
-          'strategy': 'distance',
-          'max_distance': 1.0,
-      },
-      'config': {
-          'similarity_threshold': 0.8,
-          'auto_flush': 50,
-      },
+        'similarity_evaluation': {
+            'strategy': 'distance',
+            'max_distance': 1.0,
+        },
+        'config': {
+            'similarity_threshold': 0.8,
+            'auto_flush': 50,
+        },
+    },
+    'memory': {
+        'top_k': 10,
     },
 }
 ```

--- a/embedchain/docs/api-reference/advanced/configuration.mdx
+++ b/embedchain/docs/api-reference/advanced/configuration.mdx
@@ -93,7 +93,7 @@ memory:
       "prompt": "Use the following pieces of context to answer the query at the end.\nIf you don't know the answer, just say that you don't know, don't try to make up an answer.\n$context\n\nQuery: $query\n\nHelpful Answer:",
       "system_prompt": "Act as William Shakespeare. Answer the following questions in the style of William Shakespeare.",
       "api_key": "sk-xxx",
-      "model_kwargs": { "response_format": { "type": "json_object" } },
+      "model_kwargs": {"response_format": {"type": "json_object"}},
       "api_version": "2024-02-01",
       "http_client_proxies": "http://testproxy.mem0.net:8000"
     }


### PR DESCRIPTION
## Description

Update embedchain docs page: `/api-reference/advanced/configuration`

* Add the missing `memory` section in config samples (yaml, py, and json).
* Also, remove commas after the last elements in the JSON config sample. Regular JSON does not support trailing commas.

## Type of change

- [x] Documentation update

## How Has This Been Tested?

- Run `mintlify dev` and navigate to `/api-reference/advanced/configuration`.
- To verify JSON formatting, copy the config sample into a separate file and check for errors in the editor.

## Checklist:

* [ ]  My code follows the style guidelines of this project
* [x]  I have performed a self-review of my own code
* [ ]  I have commented my code, particularly in hard-to-understand areas
* [ ]  I have made corresponding changes to the documentation
* [ ]  My changes generate no new warnings
* [ ]  I have added tests that prove my fix is effective or that my feature works
* [ ]  New and existing unit tests pass locally with my changes
* [ ]  Any dependent changes have been merged and published in downstream modules
* [ ]  I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
