### PR TITLE
Fix duplicated metadata issue while adding or updating memories

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -7,6 +7,7 @@ import logging
 import os
 import uuid
 import warnings
+from copy import deepcopy
 from datetime import datetime
 from typing import Any, Dict
 
@@ -290,7 +291,7 @@ class Memory(MemoryBase):
                         memory_id = self._create_memory(
                             data=resp.get("text"),
                             existing_embeddings=new_message_embeddings,
-                            metadata=metadata,
+                            metadata=deepcopy(metadata),
                         )
                         returned_memories.append(
                             {
@@ -304,7 +305,7 @@ class Memory(MemoryBase):
                             memory_id=temp_uuid_mapping[resp["id"]],
                             data=resp.get("text"),
                             existing_embeddings=new_message_embeddings,
-                            metadata=metadata,
+                            metadata=deepcopy(metadata),
                         )
                         returned_memories.append(
                             {
@@ -1035,7 +1036,9 @@ class AsyncMemory(MemoryBase):
                     elif resp.get("event") == "ADD":
                         task = asyncio.create_task(
                             self._create_memory(
-                                data=resp.get("text"), existing_embeddings=new_message_embeddings, metadata=metadata
+                                data=resp.get("text"),
+                                existing_embeddings=new_message_embeddings,
+                                metadata=deepcopy(metadata),
                             )
                         )
                         memory_tasks.append((task, resp, "ADD", None))
@@ -1045,7 +1048,7 @@ class AsyncMemory(MemoryBase):
                                 memory_id=temp_uuid_mapping[resp["id"]],
                                 data=resp.get("text"),
                                 existing_embeddings=new_message_embeddings,
-                                metadata=metadata,
+                                metadata=deepcopy(metadata),
                             )
                         )
                         memory_tasks.append((task, resp, "UPDATE", temp_uuid_mapping[resp["id"]]))


### PR DESCRIPTION
## Description
I figured out that the async memory system shares same metadata object between all create memory actions.  
I guess this is the reason of the issue 2578. 
  
In AsyncMemory, `_add_to_vector_store` method gets parameter named `metadata`, 
and exact same metadata object is passed to `_create_memory` method which modifies the metadata object and do async await.  
  
This causes modification on metadata(because all `_create_memory` references on same metadata object) before finishing asyncio job, if the method is called multiple times from `_add_to_vector_store` method.  
  
I tested my code in local, and it solved the problem(duplicating last metadata for all memories).  
  
I also added deepcopy to sync memory mechanism for making sure that the system separates metadata between memories.  
  
Fixes #2578

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [x] Unit Test
- [ ] Test Script (please provide)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
