### PR TITLE
Fix mem0-migrations issue

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -67,7 +67,7 @@ class Memory(MemoryBase):
             self.graph = MemoryGraph(self.config)
             self.enable_graph = True
 
-        self.config.vector_store.config.collection_name = "mem0-migrations"
+        self.config.vector_store.config.collection_name = "mem0migrations"
         if self.config.vector_store.provider in ["faiss", "qdrant"]:
             provider_path = f"migrations_{self.config.vector_store.provider}"
             self.config.vector_store.config.path = os.path.join(mem0_dir, provider_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mem0ai"
-version = "0.1.94"
+version = "0.1.95"
 description = "Long-term memory for AI Agents"
 authors = ["Mem0 <founders@mem0.ai>"]
 exclude = [


### PR DESCRIPTION
## Description

Change the collection from `mem0-migrations` to `mem0migrations` in order to avoid error while creating collections. And version bump -> 0.1.95

Fixes #2577 #2589

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)