### PR TITLE
Vercel AI SDK / Graph Memory

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -462,5 +462,15 @@ mode: "wide"
 </Update>
 
 </Tab>
+
+<Tab title="Vercel AI SDK">
+
+<Update label="2025-05-01" description="v1.0.1">
+**New Features:**
+- **Vercel AI SDK:** Added support for graph
+</Update>
+
+</Tab>
+
 </Tabs>
 

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -467,7 +467,7 @@ mode: "wide"
 
 <Update label="2025-05-01" description="v1.0.1">
 **New Features:**
-- **Vercel AI SDK:** Added support for graph
+- **Vercel AI SDK:** Added support for graph memories
 </Update>
 
 </Tab>

--- a/docs/integrations/vercel-ai-sdk.mdx
+++ b/docs/integrations/vercel-ai-sdk.mdx
@@ -7,7 +7,7 @@ title: Vercel AI SDK
 The [**Mem0 AI SDK Provider**](https://www.npmjs.com/package/@mem0/vercel-ai-provider) is a library developed by **Mem0** to integrate with the Vercel AI SDK. This library brings enhanced AI interaction capabilities to your applications by introducing persistent memory functionality.
 
 <Note type="info">
-  🎉 Exciting news! Mem0 AI SDK now supports <strong>Tools Call</strong>.
+  🎉 Exciting news! Mem0 AI SDK now supports <strong>Graph Memory</strong>.
 </Note>
 
 ## Overview
@@ -80,6 +80,8 @@ npm install @mem0/vercel-ai-provider
      > For standalone features, such as `addMemories`, `retrieveMemories`, and `getMemories`, you must either set `MEM0_API_KEY` as an environment variable or pass it directly in the function call.
 
      > `getMemories` will return raw memories in the form of an array of objects, while `retrieveMemories` will return a response in string format with a system prompt ingested with the retrieved memories.
+
+     > `getMemories` is an object with two keys: `results` and `relations` if `graph_memory` is enabled. Otherwise, it will return an array of objects.
 
 ### 1. Basic Text Generation with Memory Context
 
@@ -204,6 +206,24 @@ console.log(sources);
 ```
 
 The same can be done for `streamText` as well.
+
+## Graph Memory
+
+Mem0 AI SDK now supports Graph Memory. You can enable it by setting `enable_graph` to `true` in the `mem0Config` object.
+
+```typescript
+const mem0 = createMem0({
+  mem0Config: { enable_graph: true },
+});
+```
+
+You can also pass `enable_graph` in the standalone functions. This includes `getMemories`, `retrieveMemories`, and `addMemories`.
+
+```typescript
+const memories = await getMemories(prompt, { user_id: "borat", mem0ApiKey: "m0-xxx", enable_graph: true });
+```
+
+The `getMemories` function will return an object with two keys: `results` and `relations`, if `enable_graph` is set to `true`. Otherwise, it will return an array of objects.
 
 
 ## Key Features

--- a/docs/integrations/vercel-ai-sdk.mdx
+++ b/docs/integrations/vercel-ai-sdk.mdx
@@ -81,7 +81,7 @@ npm install @mem0/vercel-ai-provider
 
      > `getMemories` will return raw memories in the form of an array of objects, while `retrieveMemories` will return a response in string format with a system prompt ingested with the retrieved memories.
 
-     > `getMemories` is an object with two keys: `results` and `relations` if `graph_memory` is enabled. Otherwise, it will return an array of objects.
+     > `getMemories` is an object with two keys: `results` and `relations` if `enable_graph` is enabled. Otherwise, it will return an array of objects.
 
 ### 1. Basic Text Generation with Memory Context
 

--- a/vercel-ai-sdk/package.json
+++ b/vercel-ai-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mem0/vercel-ai-provider",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Vercel AI Provider for providing memory to LLMs",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/vercel-ai-sdk/src/mem0-generic-language-model.ts
+++ b/vercel-ai-sdk/src/mem0-generic-language-model.ts
@@ -37,7 +37,7 @@ export class Mem0GenericLanguageModel implements LanguageModelV1 {
     });
 
     // Get Memories
-    const memories = await getMemories(messagesPrompts, mem0Config);
+    let memories = await getMemories(messagesPrompts, mem0Config);
 
     const mySystemPrompt = "These are the memories I have stored. Give more weightage to the question by users and try to answer that first. You have to modify your answer based on the memories I have provided. If the memories are irrelevant you can ignore them. Also don't reply to this section of the prompt, or the memories, they are only for your reference. The System prompt starts after text System Message: \n\n";
 
@@ -80,6 +80,10 @@ export class Mem0GenericLanguageModel implements LanguageModelV1 {
     // Add the system prompt to the beginning of the messages if there are memories
     if (memories.length > 0) {
       messagesPrompts.unshift(systemPrompt);
+    }
+
+    if (isGraphEnabled) {
+      memories = memories.results;
     }
 
     return { memories, messagesPrompts };

--- a/vercel-ai-sdk/src/mem0-types.ts
+++ b/vercel-ai-sdk/src/mem0-types.ts
@@ -28,6 +28,7 @@ export interface Mem0ConfigSettings {
   top_k?: number;
   threshold?: number;
   rerank?: boolean;
+  enable_graph?: boolean;
 }
 
 export interface Mem0ChatConfig extends Mem0ConfigSettings, Mem0ProviderSettings {}


### PR DESCRIPTION
This PR adds support for Graph Memory in the Mem0 AI SDK.

Changes:
- Added support for Graph Memory in the Mem0 AI SDK.
- Added support for standalone functions.
- Added support for `enable_graph` in the `mem0Config` object.
- Added support for `enable_graph` in the standalone functions.

Any Major Changes:
- In `getMemories`, the return type is now an object with two keys: `results` and `relations`, if `enable_graph` is set to `true`. Otherwise, it will return an array of objects.
