### PR TITLE
fix: fixed missing dependency in docker build

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -3,3 +3,4 @@ uvicorn==0.34.0
 pydantic==2.10.4
 mem0ai>=0.1.48
 python-dotenv==1.0.1
+psycopg2>=2.7


### PR DESCRIPTION
## Description

Added a missing dependency which triggered the following error on start up: https://github.com/natterstefan/mem0/blob/b70b17e6c11d63547587f5aa513bf399f012571e/mem0/vector_stores/pgvector.py#L7-L11

Version is taken from here: https://github.com/natterstefan/mem0/blob/b70b17e6c11d63547587f5aa513bf399f012571e/poetry.lock#L1911 and here

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Build and start docker prior to and with this change: `docker compose up --build`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
