### PR TITLE
remove warnings and refresh schema from neo4j

### DIFF
--- a/mem0/memory/graph_memory.py
+++ b/mem0/memory/graph_memory.py
@@ -33,6 +33,8 @@ class MemoryGraph:
             self.config.graph_store.config.url,
             self.config.graph_store.config.username,
             self.config.graph_store.config.password,
+            refresh_schema=False,
+            driver_config={"notifications_min_severity":"OFF"}
         )
         self.embedding_model = EmbedderFactory.create(
             self.config.embedder.provider, self.config.embedder.config, self.config.vector_store.config


### PR DESCRIPTION
On the very first memory addition we get a lot of warnings, which might confuse the user:

<img width="1663" alt="Screenshot 2025-05-07 at 11 45 30" src="https://github.com/user-attachments/assets/b4db42b6-7ac4-49a3-b5f8-16d6e0c936ee" />



Additionally, since you never use the schema, we don't have to fetch it (faster init times)