### PR TITLE
Renamed unknown node type

### DIFF
--- a/mem0/memory/graph_memory.py
+++ b/mem0/memory/graph_memory.py
@@ -327,8 +327,8 @@ class MemoryGraph:
             relationship = item["relationship"]
 
             # types
-            source_type = entity_type_map.get(source, "unknown")
-            destination_type = entity_type_map.get(destination, "unknown")
+            source_type = entity_type_map.get(source, "__User__")
+            destination_type = entity_type_map.get(destination, "__User__")
 
             # embeddings
             source_embedding = self.embedding_model.embed(source)

--- a/mem0/memory/memgraph_memory.py
+++ b/mem0/memory/memgraph_memory.py
@@ -369,8 +369,8 @@ class MemoryGraph:
             relationship = item["relationship"]
 
             # types
-            source_type = entity_type_map.get(source, "unknown")
-            destination_type = entity_type_map.get(destination, "unknown")
+            source_type = entity_type_map.get(source, "__User__")
+            destination_type = entity_type_map.get(destination, "__User__")
 
             # embeddings
             source_embedding = self.embedding_model.embed(source)


### PR DESCRIPTION
Updated node type assignment: nodes without a specified type are now renamed to "__User__" instead of being set to 'Unknown'."