### PR TITLE
Fix: Ollama checking model exists

### DIFF
--- a/mem0/embeddings/ollama.py
+++ b/mem0/embeddings/ollama.py
@@ -36,7 +36,7 @@ class OllamaEmbedding(EmbeddingBase):
         Ensure the specified model exists locally. If not, pull it from Ollama.
         """
         local_models = self.client.list()["models"]
-        if not any(model.get("name") == self.config.model for model in local_models):
+        if not any(model.get("name") == self.config.model or model.get("model") == self.config.model for model in local_models):
             self.client.pull(self.config.model)
 
     def embed(self, text, memory_action: Optional[Literal["add", "search", "update"]] = None):


### PR DESCRIPTION
## Description

Fix function `_ensure_model_exists` when checking model name from model list cause the object parsed from api /api/tags from base url of ollama may not have attribute "name". I added attribute "model"

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Keep passing test cases

- [x] Unit Test
- [x] Test Script (please provide)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings