### PR TITLE
Fixed a bug with the _ensure_model_exists method

### DIFF
--- a/mem0/embeddings/ollama.py
+++ b/mem0/embeddings/ollama.py
@@ -36,7 +36,7 @@ class OllamaEmbedding(EmbeddingBase):
         Ensure the specified model exists locally. If not, pull it from Ollama.
         """
         local_models = self.client.list()["models"]
-        if not any(model.get("name") == self.config.model for model in local_models):
+        if not any(model.get("model") == self.config.model for model in local_models):
             self.client.pull(self.config.model)
 
     def embed(self, text, memory_action: Optional[Literal["add", "search", "update"]] = None):


### PR DESCRIPTION
ListResponse Model doesn't have a field called 'name', only 'model'.
```
class ListResponse(SubscriptableBaseModel):
  class Model(SubscriptableBaseModel):
    model: Optional[str] = None
    modified_at: Optional[datetime] = None
    digest: Optional[str] = None
    size: Optional[ByteSize] = None
    details: Optional[ModelDetails] = None
```

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [x] Locally validated to match the expected results.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
