### PR TITLE
fix: `_get_all_from_vector_store` by correctly handling 2D array check

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -560,7 +560,7 @@ class Memory(MemoryBase):
     def _get_all_from_vector_store(self, filters, limit):
         memories_result = self.vector_store.list(filters=filters, limit=limit)
         actual_memories = (
-            memories_result[0] if isinstance(memories_result, tuple) and len(memories_result) > 0 else memories_result
+            memories_result[0] if isinstance(memories_result,  (list,tuple)) and len(memories_result) > 0 else memories_result
         )
 
         promoted_payload_keys = [


### PR DESCRIPTION


## Description

Fix bug in `_get_all_from_vector_store`: Ensure correct handling of vector store result structure

when the `memories_result` is 2D array:[[]],there is an error

  File "D:\Application\Anaconda3\envs\llm\Lib\site-packages\mem0\memory\main.py", line 580, in _get_all_from_vector_store
    id=mem.id,
       ^^^^^^
AttributeError: 'list' object has no attribute 'id'

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ - ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [ ] Unit Test
- [ ] Test Script (please provide)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
