### PR TITLE
Fix Azure AI Search get_all()

### DIFF
--- a/mem0/vector_stores/azure_ai_search.py
+++ b/mem0/vector_stores/azure_ai_search.py
@@ -337,7 +337,7 @@ class AzureAISearch(VectorStoreBase):
         for result in search_results:
             payload = json.loads(result["payload"])
             results.append(OutputData(id=result["id"], score=result["@search.score"], payload=payload))
-        return [results]
+        return results
 
     def __del__(self):
         """Close the search client when the object is deleted."""


### PR DESCRIPTION
## Description

get_all() should return a list of OutputData but it returns a list of a list of OutputData causing an error.

This bug was introduced in #2396 .

```bash
[[OutputData(id='9e3913e5-e33d-4e4e-8ba2-d7d79f5882e7''}), OutputData(id='7fd5dad4-84eb-4a52-aa27-f7c84ddabaa8''})]

File c:\Users\user\repo\.venv\Lib\site-packages\mem0\memory\main.py:581, in Memory._get_all_from_vector_store(self, filters, limit)
    578 for mem in actual_memories: 
    579     print(mem)
    580     memory_item_dict = MemoryItem(
--> 581         id=mem.id,
    582         memory=mem.payload["data"],
    583         hash=mem.payload.get("hash"),
    584         created_at=mem.payload.get("created_at"),
    585         updated_at=mem.payload.get("updated_at"),
    586     ).model_dump(exclude={"score"})
    588     for key in promoted_payload_keys:
    589         if key in mem.payload:

AttributeError: 'list' object has no attribute 'id'
```

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)
