### PR TITLE
fix: appropriately handle overriding for aws LLM and embedding configurations

### DIFF
--- a/mem0/configs/embeddings/base.py
+++ b/mem0/configs/embeddings/base.py
@@ -1,3 +1,4 @@
+import os
 from abc import ABC
 from typing import Dict, Optional, Union
 
@@ -36,7 +37,7 @@ class BaseEmbedderConfig(ABC):
         # AWS Bedrock specific
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
-        aws_region: Optional[str] = "us-west-2",
+        aws_region: Optional[str] = None,
     ):
         """
         Initializes a configuration class instance for the Embeddings.
@@ -98,6 +99,6 @@ class BaseEmbedderConfig(ABC):
         self.lmstudio_base_url = lmstudio_base_url
 
         # AWS Bedrock specific
-        self.aws_access_key_id = aws_access_key_id
-        self.aws_secret_access_key = aws_secret_access_key
-        self.aws_region = aws_region
+        self.aws_access_key_id = aws_access_key_id or os.environ.get("AWS_ACCESS_KEY_ID")
+        self.aws_secret_access_key = aws_secret_access_key or os.environ.get("AWS_SECRET_ACCESS_KEY")
+        self.aws_region = aws_region or os.environ.get("AWS_REGION", "us-west-2")

--- a/mem0/configs/llms/base.py
+++ b/mem0/configs/llms/base.py
@@ -1,3 +1,4 @@
+import os
 from abc import ABC
 from typing import Dict, Optional, Union
 
@@ -44,7 +45,7 @@ class BaseLlmConfig(ABC):
         # AWS Bedrock specific
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
-        aws_region: Optional[str] = "us-west-2",
+        aws_region: Optional[str] = None,
     ):
         """
         Initializes a configuration class instance for the LLM.
@@ -129,6 +130,6 @@ class BaseLlmConfig(ABC):
         self.lmstudio_base_url = lmstudio_base_url
 
         # AWS Bedrock specific
-        self.aws_access_key_id = aws_access_key_id
-        self.aws_secret_access_key = aws_secret_access_key
-        self.aws_region = aws_region
+        self.aws_access_key_id = aws_access_key_id or os.environ.get("AWS_ACCESS_KEY_ID", None)
+        self.aws_secret_access_key = aws_secret_access_key or os.environ.get("AWS_SECRET_ACCESS_KEY", None)
+        self.aws_region = aws_region or os.environ.get("AWS_REGION", "us-west-2")

--- a/mem0/embeddings/aws_bedrock.py
+++ b/mem0/embeddings/aws_bedrock.py
@@ -1,5 +1,4 @@
 import json
-import os
 from typing import Literal, Optional
 
 try:
@@ -24,17 +23,12 @@ class AWSBedrockEmbedding(EmbeddingBase):
 
         self.config.model = self.config.model or "amazon.titan-embed-text-v1"
 
-        # Get AWS config from environment variables or use defaults
-        aws_access_key = os.environ.get("AWS_ACCESS_KEY_ID", "")
-        aws_secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
-        aws_region = os.environ.get("AWS_REGION", "us-west-2")
-
         # Check if AWS config is provided in the config
-        if hasattr(self.config, "aws_access_key_id"):
+        if self.config.aws_access_key_id:
             aws_access_key = self.config.aws_access_key_id
-        if hasattr(self.config, "aws_secret_access_key"):
+        if self.config.aws_secret_access_key:
             aws_secret_key = self.config.aws_secret_access_key
-        if hasattr(self.config, "aws_region"):
+        if self.config.aws_region:
             aws_region = self.config.aws_region
 
         self.client = boto3.client(

--- a/mem0/llms/aws_bedrock.py
+++ b/mem0/llms/aws_bedrock.py
@@ -1,5 +1,4 @@
 import json
-import os
 import re
 from typing import Any, Dict, List, Optional
 
@@ -28,17 +27,12 @@ class AWSBedrockLLM(LLMBase):
         if not self.config.model:
             self.config.model = "anthropic.claude-3-5-sonnet-20240620-v1:0"
 
-        # Get AWS config from environment variables or use defaults
-        aws_access_key = os.environ.get("AWS_ACCESS_KEY_ID", "")
-        aws_secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
-        aws_region = os.environ.get("AWS_REGION", "us-west-2")
-
         # Check if AWS config is provided in the config
-        if hasattr(self.config, "aws_access_key_id"):
+        if self.config.aws_access_key_id:
             aws_access_key = self.config.aws_access_key_id
-        if hasattr(self.config, "aws_secret_access_key"):
+        if self.config.aws_secret_access_key:
             aws_secret_key = self.config.aws_secret_access_key
-        if hasattr(self.config, "aws_region"):
+        if self.config.aws_region:
             aws_region = self.config.aws_region
 
         self.client = boto3.client(


### PR DESCRIPTION
## Description
I noticed the logic for aws bedrock is causing the configurations to not be respected. 

`AWSBedrockLLM` will check if the attribute exists, which it does, and it will set the value from the environment variables to None. Same goes for `AWSBedrockEmbedding`. 

Additionally the default to us-west-2 so the base configs (`BaseEmbedderConfig`, `BaseLlmConfig`) will default to us-west-2, so environment settings don't seem to be respected. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Tested locally using the following configuration. Testing with the PR updates seems to work. Testing without causes some issues - you can trace the logs of what values end up looking like to see the overriding.

```python
import os

from mem0 import Memory
from mem0.configs.base import MemoryConfig
from mem0.llms.configs import LlmConfig
from mem0.embeddings.configs import EmbedderConfig

# os.environ['AWS_REGION'] = 'us-east-1'
# os.environ["AWS_ACCESS_KEY_ID"] = ""
# os.environ["AWS_SECRET_ACCESS_KEY"] = ""

llm_config = LlmConfig(
    provider="aws_bedrock",
    config={
        "model": "arn:aws:bedrock:us-east-1:{your-account-id}:inference-profile/us.anthropic.claude-3-5-sonnet-20241022-v2:0",
        "temperature": 0.2,
        "max_tokens": 2000,
    }
)

embedder_config = EmbedderConfig(
    provider="aws_bedrock",
    config={
        "model": "amazon.titan-embed-text-v1",
    }
)

mem_config = MemoryConfig(
    llm=llm_config,
    embedder=embedder_config
)

m = Memory(mem_config)
```

Please delete options that are not relevant.

- [ ] Unit Test
- [x] Test Script (please provide) 

See above.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
