### PR TITLE
Added threshold to search

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mem0ai"
-version = "0.1.104"
+version = "0.1.105"
 description = "Long-term memory for AI Agents"
 authors = [
     { name = "Mem0", email = "founders@mem0.ai" }


### PR DESCRIPTION
## Feature: Add Score Threshold to Search Functionality

**Description:**

This PR introduces a `threshold` parameter to the memory search functionality. This allows users to filter search results based on a minimum relevance score, providing more control over the retrieved memories.

**Changes Implemented:**

-   Added an optional `threshold` (float) parameter to the `search()` method in both the `Memory` (synchronous) and `AsyncMemory` (asynchronous) classes.
-   Updated the internal `_search_vector_store()` methods in both classes to:
    -   Accept the `threshold` parameter.
    -   Filter the raw search results from the vector store, only returning memories whose score is greater than or equal to the provided `threshold`. If no threshold is provided, all results are returned (maintaining previous behavior).
-   Updated the `capture_event` calls within the `search` methods to include the `threshold` value for telemetry.
-   Updated docstrings for the affected methods to reflect the new `threshold` parameter.

**Reasoning:**

Previously, the search functionality returned all memories up to the specified `limit`, regardless of their relevance score. This change enables users to retrieve only those memories that meet a certain confidence level, making the search results more precise and useful for applications requiring higher relevance.

**Impact:**

-   Users can now fine-tune search queries to get more relevant results by specifying a `threshold`.
-   This is a backward-compatible change; if the `threshold` parameter is not provided, the search functionality behaves as before.