### PR TITLE
fix: Ensure metadata IDs are mapped as keyword

### DIFF
--- a/mem0/vector_stores/elasticsearch.py
+++ b/mem0/vector_stores/elasticsearch.py
@@ -64,7 +64,15 @@ class ElasticsearchDB(VectorStoreBase):
                         "index": True,
                         "similarity": "cosine",
                     },
-                    "metadata": {"type": "object", "properties": {"user_id": {"type": "keyword"}}},
+                    "metadata": {
+                        "type": "object",
+                        "properties": {
+                            "user_id": {"type": "keyword"},
+                            "run_id": {"type": "keyword"},
+                            "agent_id": {"type": "keyword"},
+                            "actor_id": {"type": "keyword"},
+                        },
+                    },
                 }
             },
         }


### PR DESCRIPTION
## Description

Searches for specific `run_id` values (e.g., "test-curl") in Elasticsearch were failing. This was caused by `run_id`, `agent_id`, and `actor_id` being auto-mapped by Elasticsearch as the `text` type, which tokenized the values.
This commit explicitly maps these fields to the `keyword` type during index creation to prevent tokenization and enable exact term matching.
![c31b78b5-03ee-471a-abaf-69131bf27a00](https://github.com/user-attachments/assets/255f1abb-b069-4953-9c92-7c87afee3906)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [ ] Unit Test
- [ ] Test Script (please provide)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
