### PR TITLE
fix: bedrock llm, embeddings, tools, temporary creds

### DIFF
--- a/mem0/embeddings/aws_bedrock.py
+++ b/mem0/embeddings/aws_bedrock.py
@@ -11,7 +11,6 @@ import numpy as np
 
 from mem0.configs.embeddings.base import BaseEmbedderConfig
 from mem0.embeddings.base import EmbeddingBase
-from mem0.memory.utils import extract_json
 
 
 class AWSBedrockEmbedding(EmbeddingBase):
@@ -28,6 +27,7 @@ class AWSBedrockEmbedding(EmbeddingBase):
         # Get AWS config from environment variables or use defaults
         aws_access_key = os.environ.get("AWS_ACCESS_KEY_ID", "")
         aws_secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
+        aws_session_token = os.environ.get("AWS_SESSION_TOKEN", "")
         aws_region = os.environ.get("AWS_REGION", "us-west-2")
 
         # Check if AWS config is provided in the config
@@ -43,6 +43,7 @@ class AWSBedrockEmbedding(EmbeddingBase):
             region_name=aws_region,
             aws_access_key_id=aws_access_key if aws_access_key else None,
             aws_secret_access_key=aws_secret_key if aws_secret_key else None,
+            aws_session_token=aws_session_token if aws_session_token else None,
         )
 
     def _normalize_vector(self, embeddings):
@@ -75,7 +76,7 @@ class AWSBedrockEmbedding(EmbeddingBase):
                 contentType="application/json",
             )
 
-            response_body = json.loads(extract_json(response.get("body").read()))
+            response_body = json.loads(response.get("body").read())
 
             if provider == "cohere":
                 embeddings = response_body.get("embeddings")[0]

--- a/mem0/llms/aws_bedrock.py
+++ b/mem0/llms/aws_bedrock.py
@@ -10,7 +10,7 @@ except ImportError:
 
 from mem0.configs.llms.base import BaseLlmConfig
 from mem0.llms.base import LLMBase
-from mem0.memory.utils import extract_json
+
 
 PROVIDERS = ["ai21", "amazon", "anthropic", "cohere", "meta", "mistral", "stability", "writer"]
 
@@ -92,17 +92,15 @@ class AWSBedrockLLM(LLMBase):
             if response["output"]["message"]["content"]:
                 for item in response["output"]["message"]["content"]:
                     if "toolUse" in item:
-                        processed_response["tool_calls"].append(
-                            {
-                                "name": item["toolUse"]["name"],
-                                "arguments": item["toolUse"]["input"],
-                            }
-                        )
+                        processed_response["tool_calls"].append({
+                            "name": item["toolUse"]["name"],
+                            "arguments": item["toolUse"]["input"],
+                        })
 
             return processed_response
 
         response_body = response.get("body").read().decode()
-        response_json = json.loads(extract_json(response_body))
+        response_json = json.loads(response_body)
         return response_json.get("content", [{"text": ""}])[0].get("text", "")
 
     def _prepare_input(
@@ -190,10 +188,7 @@ class AWSBedrockLLM(LLMBase):
                 }
 
                 for prop, details in function["parameters"].get("properties", {}).items():
-                    new_tool["toolSpec"]["inputSchema"]["json"]["properties"][prop] = {
-                        "type": details.get("type", "string"),
-                        "description": details.get("description", ""),
-                    }
+                    new_tool["toolSpec"]["inputSchema"]["json"]["properties"][prop] = details
 
                 new_tools.append(new_tool)
 


### PR DESCRIPTION
## Description

This commit:
1. Removes the invalid `extract_json` from aws_bedrock embeddings and llm, added in #3013 
2. It adds support for temporary credentials (`AWS_SESSION_TOKEN`). 
3. It updates the tool parsing to properly support graph memory, where previously the `_convert_tool_format` previously dropped nested JSON Schema tool properties and parameters.


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [ ] Unit Test
- [x] Test Script (please provide)

```python
import boto3
import os
from .settings import config
from mem0 import Memory
from mem0.configs.base import GraphStoreConfig, MemoryConfig, VectorStoreConfig
from mem0.embeddings.configs import EmbedderConfig
from mem0.graphs.configs import Neo4jConfig
from mem0.llms.configs import LlmConfig


# get AWS access key, secret key, and session token from boto3 session with a named profile
session = boto3.Session(profile_name=config.aws_profile)

# get the default region from the boto3 session
region = session.region_name

# get the default access key from the boto3 session
os.environ["AWS_ACCESS_KEY_ID"] = session.get_credentials().access_key
os.environ["AWS_SECRET_ACCESS_KEY"] = session.get_credentials().secret_key
os.environ["AWS_SESSION_TOKEN"] = str(session.get_credentials().token)
os.environ["MEM0_TELEMETRY"] = "false"

llm_config = LlmConfig(
    provider="aws_bedrock", config={"model": config.amazon_bedrock_llm, "temperature": 0.2, "max_tokens": 2000}
)

mem_config = MemoryConfig(
    vector_store=VectorStoreConfig(
        provider="pgvector",
        config={
            "user": config.postgres_user,
            "password": config.postgres_password,
            "host": "host.docker.internal",
            "port": 5432,
            "embedding_model_dims": 1024,
            "collection_name": "memplex",
        },
    ),
    graph_store=GraphStoreConfig(
        provider="neo4j",
        config=Neo4jConfig(
            url="neo4j://host.docker.internal:7687", username=config.neo4j_user, password=config.neo4j_password
        ),  # type: ignore
    ),
    embedder=EmbedderConfig(provider="aws_bedrock", config={"model": config.amazon_bedrock_embed}),
    llm=llm_config,
)

mem = Memory(mem_config)

messages = [
    {"role": "user", "content": "I'm planning to watch a movie tonight. Any recommendations?"},
    {"role": "assistant", "content": "How about a thriller movies? They can be quite engaging."},
    {"role": "user", "content": "I'm not a big fan of thriller movies but I love sci-fi movies."},
    {
        "role": "assistant",
        "content": "Got it! I'll avoid thriller recommendations and suggest sci-fi movies in the future.",
    },
]

mem.delete_all(user_id="alice")

# Store inferred memories (default behavior)
result = mem.add(messages, user_id="alice", metadata={"category": "movie_recommendations"})
print(result)
# Retrieve memories
retrieved_memories = mem.search(query="What are the movie recommendations?", user_id="alice")

print(retrieved_memories)
# Delete memories
# mem.delete_all(user_id="alice")
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
