### PR TITLE
fix: aws bedrock provider invoke_model raise error when use Amazon Nova Model  

### DIFF
--- a/mem0/llms/aws_bedrock.py
+++ b/mem0/llms/aws_bedrock.py
@@ -99,10 +99,11 @@ class AWSBedrockLLM(LLMBase):
                         )
 
             return processed_response
-
-        response_body = response.get("body").read().decode()
-        response_json = json.loads(response_body)
-        return response_json.get("content", [{"text": ""}])[0].get("text", "")
+        else:
+            if response["output"]["message"]["content"]:
+                return response["output"]["message"]["content"][0].get("text", "")
+            else:
+                return ""
 
     def _prepare_input(
         self,


### PR DESCRIPTION
## Description
The previous implementation method within the invoke_model API was constrained to supporting the older Titan models. Consequently, the newer Nova models are incompatible, leading to errors. Presently, AWSBedrock supports for the Converse API. Therefore, it is imperative to uniformly update to the Converse API.

Fixes # (issue)
when use "us.amazon.nova-pro-v1:0", it raise errors:
botocore.errorfactory.ValidationException: An error occurred (ValidationException) when calling the InvokeModel operation: Malformed input request: #: required key [messages] not found, please reformat your input and try again.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?
Just use model id: us.amazon.nova-pro-v1:0 to verify it

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
