### PR TITLE
MongoDB Vector Store misaligned strings and classes

### DIFF
--- a/docs/components/vectordbs/dbs/mongodb.mdx
+++ b/docs/components/vectordbs/dbs/mongodb.mdx
@@ -16,8 +16,7 @@ config = {
         "config": {
             "db_name": "mem0-db",
             "collection_name": "mem0-collection",
-            "user": "my-user",
-            "password": "my-password",
+            "mongo_uri":"mongodb://username:password@localhost:27017"
         }
     }
 }
@@ -41,9 +40,6 @@ Here are the parameters available for configuring MongoDB:
 | db_name | Name of the MongoDB database | `"mem0_db"` |
 | collection_name | Name of the MongoDB collection | `"mem0_collection"` |
 | embedding_model_dims | Dimensions of the embedding vectors | `1536` |
-| user | MongoDB user for authentication | `None` |
-| password | Password for the MongoDB user | `None` |
-| host | MongoDB host | `"localhost"` |
-| port | MongoDB port | `27017` |
+| mongo_uri | The mongo URI connection string | mongodb://username:password@localhost:27017 |
 
-> **Note**: `user` and `password` must either be provided together or omitted together.
+> **Note**: If Mongo_uri is not provided it will default to mongodb://username:password@localhost:27017.

--- a/mem0/configs/vector_stores/mongodb.py
+++ b/mem0/configs/vector_stores/mongodb.py
@@ -1,6 +1,6 @@
-from typing import Any, Dict, Optional, Callable, List
+from typing import Any, Dict, Optional
 
-from pydantic import BaseModel, Field, root_validator
+from pydantic import BaseModel, Field, model_validator
 
 
 class MongoDBConfig(BaseModel):
@@ -9,29 +9,12 @@ class MongoDBConfig(BaseModel):
     db_name: str = Field("mem0_db", description="Name of the MongoDB database")
     collection_name: str = Field("mem0", description="Name of the MongoDB collection")
     embedding_model_dims: Optional[int] = Field(1536, description="Dimensions of the embedding vectors")
-    user: Optional[str] = Field(None, description="MongoDB user for authentication")
-    password: Optional[str] = Field(None, description="Password for the MongoDB user")
-    host: Optional[str] = Field("localhost", description="MongoDB host. Default is 'localhost'")
-    port: Optional[int] = Field(27017, description="MongoDB port. Default is 27017")
+    mongo_uri: str = Field("mongodb://localhost:27017", description="MongoDB URI. Default is mongodb://localhost:27017")
 
-    @root_validator(pre=True)
-    def check_auth_and_connection(cls, values):
-        user = values.get("user")
-        password = values.get("password")
-        if (user is None) != (password is None):
-            raise ValueError("Both 'user' and 'password' must be provided together or omitted together.")
-
-        host = values.get("host")
-        port = values.get("port")
-        if host is None:
-            raise ValueError("The 'host' must be provided.")
-        if port is None:
-            raise ValueError("The 'port' must be provided.")
-        return values
-
-    @root_validator(pre=True)
+    @model_validator(mode='before')
+    @classmethod
     def validate_extra_fields(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        allowed_fields = set(cls.__fields__)
+        allowed_fields = set(cls.model_fields.keys())
         input_fields = set(values.keys())
         extra_fields = input_fields - allowed_fields
         if extra_fields:

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -80,7 +80,7 @@ class VectorStoreFactory:
         "upstash_vector": "mem0.vector_stores.upstash_vector.UpstashVector",
         "azure_ai_search": "mem0.vector_stores.azure_ai_search.AzureAISearch",
         "pinecone": "mem0.vector_stores.pinecone.PineconeDB",
-        "mongodb": "mem0.vector_stores.mongodb.MongoVector",
+        "mongodb": "mem0.vector_stores.mongodb.MongoDB",
         "redis": "mem0.vector_stores.redis.RedisDB",
         "elasticsearch": "mem0.vector_stores.elasticsearch.ElasticsearchDB",
         "vertex_ai_vector_search": "mem0.vector_stores.vertex_ai_vector_search.GoogleMatchingEngine",

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -80,7 +80,7 @@ class VectorStoreFactory:
         "upstash_vector": "mem0.vector_stores.upstash_vector.UpstashVector",
         "azure_ai_search": "mem0.vector_stores.azure_ai_search.AzureAISearch",
         "pinecone": "mem0.vector_stores.pinecone.PineconeDB",
-        "mongodb": "mem0.vector_stores.mongodb.MongoDB",
+        "mongodb": "mem0.vector_stores.mongodb.MongoVector",
         "redis": "mem0.vector_stores.redis.RedisDB",
         "elasticsearch": "mem0.vector_stores.elasticsearch.ElasticsearchDB",
         "vertex_ai_vector_search": "mem0.vector_stores.vertex_ai_vector_search.GoogleMatchingEngine",

--- a/mem0/vector_stores/mongodb.py
+++ b/mem0/vector_stores/mongodb.py
@@ -22,7 +22,7 @@ class OutputData(BaseModel):
     payload: Optional[dict]
 
 
-class MongoVector(VectorStoreBase):
+class MongoDB(VectorStoreBase):
     VECTOR_TYPE = "knnVector"
     SIMILARITY_METRIC = "cosine"
 

--- a/tests/vector_stores/test_mongodb.py
+++ b/tests/vector_stores/test_mongodb.py
@@ -1,4 +1,3 @@
-import time
 import pytest
 from unittest.mock import MagicMock, patch
 from mem0.vector_stores.mongodb import MongoVector
@@ -20,8 +19,7 @@ def mongo_vector_fixture(mock_mongo_client):
         db_name="test_db",
         collection_name="test_collection",
         embedding_model_dims=1536,
-        user="username",
-        password="password",
+        mongo_uri="mongodb://username:password@localhost:27017"
     )
     return mongo_vector, mock_collection, mock_db
 
@@ -48,7 +46,7 @@ def test_initalize_create_col(mongo_vector_fixture):
                 "fields": {
                     "embedding": {
                         "type": "knnVector",
-                        "d": 1536,
+                        "dimensions": 1536,
                         "similarity": "cosine",
                     }
                 }

--- a/tests/vector_stores/test_mongodb.py
+++ b/tests/vector_stores/test_mongodb.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import MagicMock, patch
-from mem0.vector_stores.mongodb import MongoVector
+from mem0.vector_stores.mongodb import MongoDB
 from pymongo.operations import SearchIndexModel
 
 @pytest.fixture
@@ -15,7 +15,7 @@ def mongo_vector_fixture(mock_mongo_client):
     mock_collection.find.return_value = []
     mock_db.list_collection_names.return_value = []
 
-    mongo_vector = MongoVector(
+    mongo_vector = MongoDB(
         db_name="test_db",
         collection_name="test_collection",
         embedding_model_dims=1536,


### PR DESCRIPTION
- Fixed MongoDBs string in the vector store factory to match the name of the class. 
- Removed check_auth_and_connection in mongoDB config as its not needed anymore. 
- Added mongo_uri to the mongoDBConfig to replace the host, port, password, and user to match the mongoVector class. This also simplifies the logic and allows users to connect with just the mongo URI. 
- Updated to use pydantic V2 syntax on mongos validation. 
- Updated the test_mongo.py to match the new structure. 
- Fixed the search index model to use dimensions instead of d.