### PR TITLE
Fix: Add missing OpenAI import in vLLM module

### DIFF
--- a/mem0/llms/vllm.py
+++ b/mem0/llms/vllm.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Optional
 from mem0.configs.llms.base import BaseLlmConfig
 from mem0.llms.base import LLMBase
 from mem0.memory.utils import extract_json
+from openai import OpenAI
 
 
 class VllmLLM(LLMBase):


### PR DESCRIPTION
## Description

This PR adds the missing `import openai` statement in the `vllm.py` file. The absence of this import was causing runtime issues when using vLLM, as noted in [Issue #3057]

Fixes   #3057

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

This is a minor fix (missing import). No tests were run, but the fix aligns with the usage context and should resolve the import error mentioned in Issue #3057.

Please feel free to run tests or suggest improvements if necessary.


Please delete options that are not relevant.
Not tested – minor import fix only.


## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [x ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
