### PR TITLE
fix: Fix Docker run command syntax in REST API documentation

### DIFF
--- a/docs/open-source/features/rest-api.mdx
+++ b/docs/open-source/features/rest-api.mdx
@@ -79,7 +79,7 @@ Mem0 provides a REST API server (written using FastAPI). Users can perform all o
         3. Run the Docker container:
 
         ``` bash
-        docker run -p 8000:8000 mem0-api-server --env-file .env
+        docker run -p 8000:8000 --env-file .env mem0-api-server
         ```
 
         4. Access the API at http://localhost:8000.


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

- [X] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Running `docker run -p 8000:8000 mem0-api-server --env-file .env` results in `docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "--env-file": executable file not found in $PATH: unknown.`

Which means Docker is trying to treat --env-file as the command to run inside the container, rather than as a flag for docker run.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
