### PR TITLE
Add metadata field to memory update schema

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1699,6 +1699,10 @@
 									"text": {
 										"type": "string",
 										"description": "The updated text content of the memory"
+									},
+									"metadata": {
+										"type": "object",
+										"description": "Additional metadata associated with the memory"
 									}
 								}
 							}


### PR DESCRIPTION
## Description

Introduces an optional 'metadata' object to the memory update schema in the OpenAPI specification, allowing additional metadata to be associated with a memory.

## Type of change
- [x] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
