### PR TITLE
Add structured_data_schema to MemoryOptions interface

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -409,6 +409,11 @@ mode: "wide"
 
 <Tab title="TypeScript">
 
+<Update label="2025-07-08" description="v2.1.36">
+**New Features:**
+- **Client:** Added `structured_data_schema` param to `add` method.
+</Update>
+
 <Update label="2025-07-08" description="v2.1.35">
 **New Features:**
 - **Client:** Added `createMemoryExport` and `getMemoryExport` methods.

--- a/mem0-ts/package.json
+++ b/mem0-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mem0ai",
-  "version": "2.1.35",
+  "version": "2.1.36",
   "description": "The Memory Layer For Your AI Apps",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/mem0-ts/src/client/mem0.types.ts
+++ b/mem0-ts/src/client/mem0.types.ts
@@ -31,6 +31,7 @@ export interface MemoryOptions {
   async_mode?: boolean;
   filter_memories?: boolean;
   immutable?: boolean;
+  structured_data_schema?: Record<string, any>;
 }
 
 export interface ProjectOptions {

--- a/mem0-ts/src/client/telemetry.ts
+++ b/mem0-ts/src/client/telemetry.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import type { TelemetryClient, TelemetryOptions } from "./telemetry.types";
 
-let version = "2.1.35";
+let version = "2.1.36";
 
 // Safely check for process.env in different environments
 let MEM0_TELEMETRY = true;


### PR DESCRIPTION
## Description

Introduces the structured_data_schema parameter to the MemoryOptions interface in the TypeScript client, allowing users to specify a schema for structured data. Changelog updated to reflect this new feature.
