### PR TITLE
Update personalized deep research example with GitHub link

### DIFF
--- a/docs/examples/personalized-deep-research.mdx
+++ b/docs/examples/personalized-deep-research.mdx
@@ -6,6 +6,8 @@ title: Personalized Deep Research
 
 Deep Research is an intelligent agent that synthesizes large amounts of online data and completes complex research tasks, customized to your unique preferences and insights. Built on Mem0's technology, it enhances AI-driven online exploration with personalized memories.
 
+You can checkout GitHub repositry here: [Personalized Deep Research](https://github.com/mem0ai/personalized-deep-research/tree/mem0)
+
 ## Overview
 
 Deep Research leverages Mem0's memory capabilities to:
@@ -29,13 +31,6 @@ Watch Deep Research in action:
   referrerpolicy="strict-origin-when-cross-origin" 
   allowfullscreen
 ></iframe>
-
-## Getting Started
-
-1. Visit [deep-research.mem0.ai](https://deep-research.mem0.ai/)
-2. Upload your resume (PDF or text) or manually enter information about yourself
-3. Enter your research topic
-4. Click "Start Research" to begin
 
 ## Features
 
@@ -69,4 +64,6 @@ Watch Deep Research in action:
 
 ## Try It Out
 
-Experience AI-powered research personalization at [deep-research.mem0.ai](https://deep-research.mem0.ai/)
+> To try it yourself, clone the repository and follow the instructions in the README to run it locally or deploy it.
+
+- [Personalized Deep Research GitHub](https://github.com/mem0ai/personalized-deep-research/tree/mem0)


### PR DESCRIPTION
Added a link to the GitHub repository for Personalized Deep Research and updated instructions to encourage cloning and running the project locally. Removed outdated 'Getting Started' steps and improved the 'Try It Out' section for clarity.