### PR TITLE
add psycopg2-binary to server/requirements.txt

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -3,3 +3,4 @@ uvicorn==0.34.0
 pydantic==2.10.4
 mem0ai>=0.1.48
 python-dotenv==1.0.1
+psycopg2-binary==2.9.9


### PR DESCRIPTION
## Description

Fix for runtime failure caused by a missing dependency: psycopg2 when running docker-compose file of the REST API server

Fixes #3123 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

By running the API server using docker-compose and verifying the dependency issue is reolved.

- [ ] Unit Test
- [ ] Test Script (please provide)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #3123 
- [ ] Made sure Checks passed
