### PR TITLE
fix: use toCamelCase in redis get method for the payload

### DIFF
--- a/mem0-ts/src/oss/src/vector_stores/redis.ts
+++ b/mem0-ts/src/oss/src/vector_stores/redis.ts
@@ -510,7 +510,7 @@ export class RedisDB implements VectorStore {
 
       return {
         id: vectorId,
-        payload,
+        payload: toCamelCase(payload),
       };
     } catch (error) {
       console.error("Error getting vector:", error);


### PR DESCRIPTION
## Description

The redis vector store should reliably convert between snake_case and camelCase. In the get method of the redis implementation the payload was given back raw. I converted the payload back to camelCase like the search method does it?

As i do not have the time to go trough a complete process for a single line change I just opened this pull request so you can review the changes yourself. This is not a feature request but a critical bug fix.

Fixes #3171 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

I tested this is the node_modules folder in my current project.

- [ ] Unit Test
- [ ] Test Script (please provide)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [x] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
