### PR TITLE
bug fix for async _add_to_vector_store method

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1221,6 +1221,8 @@ class AsyncMemory(MemoryBase):
             except Exception as e:
                 logger.error(f"Invalid JSON response: {e}")
                 new_memories_with_actions = {}
+        else:
+            new_memories_with_actions = {}
 
         returned_memories = []
         try:


### PR DESCRIPTION
## Description

Adds a default value for new_memories_with_actions when the variable new_retrieved_facts is None.

Fixes [# 3200](https://github.com/mem0ai/mem0/issues/3200)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The test script in the issue no longer returns an error when I install from my branch.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
