### PR TITLE
fix: Ignore memgraph index duplicate creation errors

### DIFF
--- a/mem0/memory/memgraph_memory.py
+++ b/mem0/memory/memgraph_memory.py
@@ -54,12 +54,21 @@ class MemoryGraph:
         # 1. Create vector index (created Entity label on all nodes)
         # 2. Create label property index for performance optimizations
         embedding_dims = self.config.embedder.config["embedding_dims"]
-        create_vector_index_query = f"CREATE VECTOR INDEX memzero ON :Entity(embedding) WITH CONFIG {{'dimension': {embedding_dims}, 'capacity': 1000, 'metric': 'cos'}};"
-        self.graph.query(create_vector_index_query, params={})
-        create_label_prop_index_query = "CREATE INDEX ON :Entity(user_id);"
-        self.graph.query(create_label_prop_index_query, params={})
-        create_label_index_query = "CREATE INDEX ON :Entity;"
-        self.graph.query(create_label_index_query, params={})
+        try:
+            create_vector_index_query = f"CREATE VECTOR INDEX memzero ON :Entity(embedding) WITH CONFIG {{'dimension': {embedding_dims}, 'capacity': 1000, 'metric': 'cos'}};"
+            self.graph.query(create_vector_index_query, params={})
+        except Exception:
+            pass
+        try:
+            create_label_prop_index_query = "CREATE INDEX ON :Entity(user_id);"
+            self.graph.query(create_label_prop_index_query, params={})
+        except Exception:
+            pass
+        try:
+            create_label_index_query = "CREATE INDEX ON :Entity;"
+            self.graph.query(create_label_index_query, params={})
+        except Exception:
+            pass
 
     def add(self, data, filters):
         """

--- a/mem0/memory/memgraph_memory.py
+++ b/mem0/memory/memgraph_memory.py
@@ -54,21 +54,24 @@ class MemoryGraph:
         # 1. Create vector index (created Entity label on all nodes)
         # 2. Create label property index for performance optimizations
         embedding_dims = self.config.embedder.config["embedding_dims"]
-        try:
-            create_vector_index_query = f"CREATE VECTOR INDEX memzero ON :Entity(embedding) WITH CONFIG {{'dimension': {embedding_dims}, 'capacity': 1000, 'metric': 'cos'}};"
-            self.graph.query(create_vector_index_query, params={})
-        except Exception:
-            pass
-        try:
-            create_label_prop_index_query = "CREATE INDEX ON :Entity(user_id);"
-            self.graph.query(create_label_prop_index_query, params={})
-        except Exception:
-            pass
-        try:
-            create_label_index_query = "CREATE INDEX ON :Entity;"
-            self.graph.query(create_label_index_query, params={})
-        except Exception:
-            pass
+        index_info = self._fetch_existing_indexes()
+        # Create vector index if not exists
+        if not any(idx.get("index_name") == "memzero" for idx in index_info["vector_index_exists"]):
+            self.graph.query(
+            f"CREATE VECTOR INDEX memzero ON :Entity(embedding) WITH CONFIG {{'dimension': {embedding_dims}, 'capacity': 1000, 'metric': 'cos'}};"
+            )
+        # Create label+property index if not exists
+        if not any(
+            idx.get("index type") == "label+property" and idx.get("label") == "Entity"
+            for idx in index_info["index_exists"]
+        ):
+            self.graph.query("CREATE INDEX ON :Entity(user_id);")
+        # Create label index if not exists
+        if not any(
+            idx.get("index type") == "label" and idx.get("label") == "Entity"
+            for idx in index_info["index_exists"]
+        ):
+            self.graph.query("CREATE INDEX ON :Entity;")
 
     def add(self, data, filters):
         """
@@ -610,3 +613,18 @@ class MemoryGraph:
 
         result = self.graph.query(cypher, params=params)
         return result
+    
+    def _fetch_existing_indexes(self):
+        """
+        Retrieves information about existing indexes and vector indexes in the Memgraph database.
+
+        Returns:
+            dict: A dictionary containing lists of existing indexes and vector indexes.
+        """
+        
+        index_exists = list(self.graph.query("SHOW INDEX INFO;"))
+        vector_index_exists = list(self.graph.query("SHOW VECTOR INDEX INFO;"))
+        return {
+            "index_exists": index_exists,
+            "vector_index_exists": vector_index_exists
+        }


### PR DESCRIPTION
## Description

When I initialize Memory, I get an error message saying that the index is created repeatedly

```
File "/home/ubuntu/pyproject/.venv/lib/python3.12/site-packages/mem0/memory/main.py", line 146, in __init__
    self.graph = MemoryGraph(self.config)
                 ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/pyproject/.venv/lib/python3.12/site-packages/mem0/memory/memgraph_memory.py", line 58, in __init__
    self.graph.query(create_vector_index_query, params={})
  File "/home/ubuntu/pyproject/.venv/lib/python3.12/site-packages/memgraph_toolbox/api/memgraph.py", line 111, in query
    json_data = [r.data() for r in data]
                                   ^^^^
  File "/home/ubuntu/pyproject/.venv/lib/python3.12/site-packages/neo4j/_sync/work/result.py", line 398, in __iter__
    self._connection.fetch_message()
  File "/home/ubuntu/pyproject/.venv/lib/python3.12/site-packages/neo4j/_sync/io/_common.py", line 184, in inner
    func(*args, **kwargs)
  File "/home/ubuntu/pyproject/.venv/lib/python3.12/site-packages/neo4j/_sync/io/_bolt.py", line 864, in fetch_message
    res = self._process_message(tag, fields)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/pyproject/.venv/lib/python3.12/site-packages/neo4j/_sync/io/_bolt5.py", line 500, in _process_message
    response.on_failure(summary_metadata or {})
  File "/home/ubuntu/pyproject/.venv/lib/python3.12/site-packages/neo4j/_sync/io/_common.py", line 254, in on_failure
    raise self._hydrate_error(metadata)
neo4j.exceptions.ClientError: {code: Memgraph.ClientError.MemgraphError.MemgraphError} {message: Given vector index already exists.}
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Test Script (please provide)

```python
from mem0 import Memory

config = {
    "graph_store": {
        "provider": "memgraph",
        "config": {
            "url": "bolt://localhost:7687",
            "username": "testuser",
            "password": "test123",
        },
    },
}

m = Memory.from_config(config)

# Subsequent startup projects loading Memory will not fail due to duplicate creation of Memgraph indexes
m = Memory.from_config(config)
```

Repeatedly initialize Memory and you can observe that there will be no index duplication error causing mem0 to be unusable.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
