### PR TITLE
Load AWS config from environment variable

### DIFF
--- a/docs/components/llms/models/aws_bedrock.mdx
+++ b/docs/components/llms/models/aws_bedrock.mdx
@@ -7,7 +7,7 @@ title: AWS Bedrock
 ### Setup
 - Before using the AWS Bedrock LLM, make sure you have the appropriate model access from [Bedrock Console](https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/modelaccess).
 - You will also need to authenticate the `boto3` client by using a method in the [AWS documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials)
-- You will have to export `AWS_REGION`, `AWS_ACCESS_KEY`, and `AWS_SECRET_ACCESS_KEY` to set environment variables.
+- You will have to export `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY` to set environment variables.
 
 ### Usage
 

--- a/mem0/configs/embeddings/base.py
+++ b/mem0/configs/embeddings/base.py
@@ -1,3 +1,4 @@
+import os
 from abc import ABC
 from typing import Dict, Optional, Union
 
@@ -36,9 +37,10 @@ class BaseEmbedderConfig(ABC):
         # LM Studio specific
         lmstudio_base_url: Optional[str] = "http://localhost:1234/v1",
         # AWS Bedrock specific
-        aws_access_key_id: Optional[str] = None,
-        aws_secret_access_key: Optional[str] = None,
-        aws_region: Optional[str] = "us-west-2",
+        aws_access_key_id: Optional[str] = os.environ.get("AWS_ACCESS_KEY_ID", None),
+        aws_secret_access_key: Optional[str] = os.environ.get("AWS_SECRET_ACCESS_KEY", None),
+        aws_session_token: Optional[str] = os.environ.get("AWS_SESSION_TOKEN", None),
+        aws_region: Optional[str] = os.environ.get("AWS_REGION", "us-west-2"),
     ):
         """
         Initializes a configuration class instance for the Embeddings.
@@ -71,6 +73,14 @@ class BaseEmbedderConfig(ABC):
         :type memory_search_embedding_type: Optional[str], optional
         :param lmstudio_base_url: LM Studio base URL to be use, defaults to "http://localhost:1234/v1"
         :type lmstudio_base_url: Optional[str], optional
+        :param aws_access_key_id: AWS access key ID, defaults to None
+        :type aws_access_key_id: Optional[str], optional
+        :param aws_secret_access_key: AWS secret access key, defaults to None
+        :type aws_secret_access_key: Optional[str], optional
+        :param aws_session_token: AWS session token, defaults to None
+        :type aws_session_token: Optional[str], optional
+        :param aws_region: AWS region, defaults to "us-west-2"
+        :type aws_region: Optional[str], optional
         """
 
         self.model = model
@@ -105,4 +115,5 @@ class BaseEmbedderConfig(ABC):
         # AWS Bedrock specific
         self.aws_access_key_id = aws_access_key_id
         self.aws_secret_access_key = aws_secret_access_key
+        self.aws_session_token = aws_session_token
         self.aws_region = aws_region

--- a/mem0/configs/llms/base.py
+++ b/mem0/configs/llms/base.py
@@ -1,3 +1,4 @@
+import os
 from abc import ABC
 from typing import Dict, Optional, Union
 
@@ -47,9 +48,10 @@ class BaseLlmConfig(ABC):
         # vLLM specific
         vllm_base_url: Optional[str] = "http://localhost:8000/v1",
         # AWS Bedrock specific
-        aws_access_key_id: Optional[str] = None,
-        aws_secret_access_key: Optional[str] = None,
-        aws_region: Optional[str] = "us-west-2",
+        aws_access_key_id: Optional[str] = os.environ.get("AWS_ACCESS_KEY_ID", None),
+        aws_secret_access_key: Optional[str] = os.environ.get("AWS_SECRET_ACCESS_KEY", None),
+        aws_session_token: Optional[str] = os.environ.get("AWS_SESSION_TOKEN", None),
+        aws_region: Optional[str] = os.environ.get("AWS_REGION", "us-west-2"),
     ):
         """
         Initializes a configuration class instance for the LLM.
@@ -102,6 +104,14 @@ class BaseLlmConfig(ABC):
         :type lmstudio_response_format: Optional[Dict], optional
         :param vllm_base_url: vLLM base URL to be use, defaults to "http://localhost:8000/v1"
         :type vllm_base_url: Optional[str], optional
+        :param aws_access_key_id: AWS access key ID, defaults to None
+        :type aws_access_key_id: Optional[str], optional
+        :param aws_secret_access_key: AWS secret access key, defaults to None
+        :type aws_secret_access_key: Optional[str], optional
+        :param aws_session_token: AWS session token, defaults to None
+        :type aws_session_token: Optional[str], optional
+        :param aws_region: AWS region, defaults to "us-west-2"
+        :type aws_region: Optional[str], optional
         """
 
         self.model = model
@@ -149,4 +159,5 @@ class BaseLlmConfig(ABC):
         # AWS Bedrock specific
         self.aws_access_key_id = aws_access_key_id
         self.aws_secret_access_key = aws_secret_access_key
+        self.aws_session_token = aws_session_token
         self.aws_region = aws_region

--- a/mem0/embeddings/aws_bedrock.py
+++ b/mem0/embeddings/aws_bedrock.py
@@ -1,5 +1,4 @@
 import json
-import os
 from typing import Literal, Optional
 
 try:
@@ -24,26 +23,13 @@ class AWSBedrockEmbedding(EmbeddingBase):
 
         self.config.model = self.config.model or "amazon.titan-embed-text-v1"
 
-        # Get AWS config from environment variables or use defaults
-        aws_access_key = os.environ.get("AWS_ACCESS_KEY_ID", "")
-        aws_secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
-        aws_session_token = os.environ.get("AWS_SESSION_TOKEN", "")
-        aws_region = os.environ.get("AWS_REGION", "us-west-2")
-
-        # Check if AWS config is provided in the config
-        if hasattr(self.config, "aws_access_key_id"):
-            aws_access_key = self.config.aws_access_key_id
-        if hasattr(self.config, "aws_secret_access_key"):
-            aws_secret_key = self.config.aws_secret_access_key
-        if hasattr(self.config, "aws_region"):
-            aws_region = self.config.aws_region
 
         self.client = boto3.client(
             "bedrock-runtime",
-            region_name=aws_region,
-            aws_access_key_id=aws_access_key if aws_access_key else None,
-            aws_secret_access_key=aws_secret_key if aws_secret_key else None,
-            aws_session_token=aws_session_token if aws_session_token else None,
+            region_name=self.config.aws_region,
+            aws_access_key_id=self.config.aws_access_key_id,
+            aws_secret_access_key=self.config.aws_secret_access_key,
+            aws_session_token=self.config.aws_session_token,
         )
 
     def _normalize_vector(self, embeddings):

--- a/mem0/llms/aws_bedrock.py
+++ b/mem0/llms/aws_bedrock.py
@@ -1,5 +1,4 @@
 import json
-import os
 import re
 from typing import Any, Dict, List, Optional
 
@@ -28,24 +27,12 @@ class AWSBedrockLLM(LLMBase):
         if not self.config.model:
             self.config.model = "anthropic.claude-3-5-sonnet-20240620-v1:0"
 
-        # Get AWS config from environment variables or use defaults
-        aws_access_key = os.environ.get("AWS_ACCESS_KEY_ID", "")
-        aws_secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
-        aws_region = os.environ.get("AWS_REGION", "us-west-2")
-
-        # Check if AWS config is provided in the config
-        if hasattr(self.config, "aws_access_key_id"):
-            aws_access_key = self.config.aws_access_key_id
-        if hasattr(self.config, "aws_secret_access_key"):
-            aws_secret_key = self.config.aws_secret_access_key
-        if hasattr(self.config, "aws_region"):
-            aws_region = self.config.aws_region
-
         self.client = boto3.client(
             "bedrock-runtime",
-            region_name=aws_region,
-            aws_access_key_id=aws_access_key if aws_access_key else None,
-            aws_secret_access_key=aws_secret_key if aws_secret_key else None,
+            region_name=self.config.aws_region,
+            aws_access_key_id=self.config.aws_access_key_id,
+            aws_secret_access_key=self.config.aws_secret_access_key,
+            aws_session_token=self.config.aws_session_token,
         )
 
         self.model_kwargs = {


### PR DESCRIPTION
## Description

This PR fixes AWS configuration loading from environment variables across the codebase.  The `AWS_REGION` is never used in the boto client config because the default config takes precedence.

## Type of change

- Fixed incorrect environment variable name in documentation (AWS_ACCESS_KEY → AWS_ACCESS_KEY_ID)
- Added support for AWS_SESSION_TOKEN for temporary credentials
- Simplified AWS client initialisation by removing duplicated environment variable logic

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (does not change functionality, e.g. code style improvements, linting)
- [x] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [x] Test as a lib on my project 
- [x] Run script (`make test`) 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
