### PR TITLE
fix: Inconsistent `created` and `updated` properties on graph

### DIFF
--- a/mem0/graphs/neptune/main.py
+++ b/mem0/graphs/neptune/main.py
@@ -114,7 +114,8 @@ class MemoryGraph(NeptuneBase):
                         destination.mentions = 1
                         {destination_extra_set}
                     ON MATCH SET
-                        destination.mentions = coalesce(destination.mentions, 0) + 1
+                        destination.mentions = coalesce(destination.mentions, 0) + 1,
+                        destination.updated = timestamp()
                     WITH source, destination, $dest_embedding as dest_embedding
                     CALL neptune.algo.vectors.upsert(destination, dest_embedding)
                     WITH source, destination
@@ -140,7 +141,7 @@ class MemoryGraph(NeptuneBase):
                     MATCH (destination)
                     WHERE id(destination) = $destination_id
                     SET 
-                        destination.mentions = coalesce(destination.mentions, 0) + 1
+                        destination.mentions = coalesce(destination.mentions, 0) + 1,
                         destination.updated = timestamp()
                     WITH destination
                     MERGE (source {source_label} {{name: $source_name, user_id: $user_id}})


### PR DESCRIPTION
## Description

This PR aims to fix what described over https://github.com/mem0ai/mem0/issues/3156 , to patch all insert / update queries for Neptune Analytics integration, to guarantee fields: `created` and `updated` are always present if applicable and accurate.  

Fixes # (issue)

https://github.com/mem0ai/mem0/issues/3156

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [x] Unit Test
- [x] Test Script (please provide)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
