### PR TITLE
feat: Add db_name field to MilvusDBConfig and MilvusDB initialization

### DIFF
--- a/mem0/configs/vector_stores/milvus.py
+++ b/mem0/configs/vector_stores/milvus.py
@@ -25,6 +25,7 @@ class MilvusDBConfig(BaseModel):
     collection_name: str = Field("mem0", description="Name of the collection")
     embedding_model_dims: int = Field(1536, description="Dimensions of the embedding model")
     metric_type: str = Field("L2", description="Metric type for similarity search")
+    db_name: str = Field("", description="Name of the database")
 
     @model_validator(mode="before")
     @classmethod

--- a/mem0/vector_stores/milvus.py
+++ b/mem0/vector_stores/milvus.py
@@ -30,6 +30,7 @@ class MilvusDB(VectorStoreBase):
         collection_name: str,
         embedding_model_dims: int,
         metric_type: MetricType,
+        db_name: str,
     ) -> None:
         """Initialize the MilvusDB database.
 
@@ -39,11 +40,12 @@ class MilvusDB(VectorStoreBase):
             collection_name (str): Name of the collection (defaults to mem0).
             embedding_model_dims (int): Dimensions of the embedding model (defaults to 1536).
             metric_type (MetricType): Metric type for similarity search (defaults to L2).
+            db_name (str): Name of the database (defaults to "").
         """
         self.collection_name = collection_name
         self.embedding_model_dims = embedding_model_dims
         self.metric_type = metric_type
-        self.client = MilvusClient(uri=url, token=token)
+        self.client = MilvusClient(uri=url, token=token, db_name=db_name)
         self.create_col(
             collection_name=self.collection_name,
             vector_size=self.embedding_model_dims,


### PR DESCRIPTION
## Description

In my project, db_name must be specified to use different databases. This is a very simple change with no additional dependencies. If set to "", it uses the default Milvus database. I have tested this.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [x] Unit Test
- [ ] Test Script (please provide)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
