### PR TITLE
fix: initialize new_memories_with_actions (#3113)

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1202,6 +1202,8 @@ class AsyncMemory(MemoryBase):
             temp_uuid_mapping[str(idx)] = item["id"]
             retrieved_old_memory[idx]["id"] = str(idx)
 
+        new_memories_with_actions = {}
+
         if new_retrieved_facts:
             function_calling_prompt = get_update_memory_messages(
                 retrieved_old_memory, new_retrieved_facts, self.config.custom_update_memory_prompt


### PR DESCRIPTION
## Description

Fixed an UnboundLocalError that was crashing the async memory processing when new_retrieved_facts was empty. The variable new_memories_with_actions wasn’t being initialized in all code paths, so when the LLM didn’t extract any facts, the variable would be referenced before assignment.
Simple one-liner - just added initialization before the conditional block.

Fixes #3113

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested with the reproduction case from the issue. The error should no longer occur when new_retrieved_facts is empty. The fix ensures new_memories_with_actions always has a default value.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #3113
- [ ] Made sure Checks passed
