### PR TITLE
DOC: Fix missing Neptune Analytics mention on doc

### DIFF
--- a/docs/open-source/graph_memory/overview.mdx
+++ b/docs/open-source/graph_memory/overview.mdx
@@ -50,8 +50,8 @@ allowfullscreen
 ## Initialize Graph Memory
 
 To initialize Graph Memory you'll need to set up your configuration with graph
-store providers. Currently, we support [Neo4j](#initialize-neo4j) and
-[Memgraph](#initialize-memgraph) as graph store providers. 
+store providers. Currently, we support [Neo4j](#initialize-neo4j), [Memgraph](#initialize-memgraph)
+and [Neptune Analytics](#initialize-neptune-analytics) as graph store providers.
 
 
 ### Initialize Neo4j

--- a/docs/open-source/graph_memory/overview.mdx
+++ b/docs/open-source/graph_memory/overview.mdx
@@ -50,7 +50,7 @@ allowfullscreen
 ## Initialize Graph Memory
 
 To initialize Graph Memory you'll need to set up your configuration with graph
-store providers. Currently, we support [Neo4j](#initialize-neo4j), [Memgraph](#initialize-memgraph)
+store providers. Currently, we support [Neo4j](#initialize-neo4j), [Memgraph](#initialize-memgraph),
 and [Neptune Analytics](#initialize-neptune-analytics) as graph store providers.
 
 


### PR DESCRIPTION
## Description

This is a proposed fix to add the missing mention of `Neptune Analytics` on the heading paragraph for graph memory page. 

Fixes # https://github.com/mem0ai/mem0/issues/3263


## Type of change

Please delete options that are not relevant.

- [x] Documentation update

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
