### PR TITLE
Added mulit id filters support for all vectorstores

### DIFF
--- a/mem0/vector_stores/langchain.py
+++ b/mem0/vector_stores/langchain.py
@@ -160,8 +160,9 @@ class Langchain(VectorStoreBase):
             if hasattr(self.client, "_collection") and hasattr(self.client._collection, "get"):
                 # Convert mem0 filters to Chroma where clause if needed
                 where_clause = None
-                if filters and "user_id" in filters:
-                    where_clause = {"user_id": filters["user_id"]}
+                if filters:
+                    # Handle all filters, not just user_id
+                    where_clause = filters
 
                 result = self.client._collection.get(where=where_clause, limit=limit)
 

--- a/mem0/vector_stores/qdrant.py
+++ b/mem0/vector_stores/qdrant.py
@@ -148,6 +148,9 @@ class Qdrant(VectorStoreBase):
         Returns:
             Filter: The created Filter object.
         """
+        if not filters:
+            return None
+            
         conditions = []
         for key, value in filters.items():
             if isinstance(value, dict) and "gte" in value and "lte" in value:
@@ -258,7 +261,7 @@ class Qdrant(VectorStoreBase):
             with_payload=True,
             with_vectors=False,
         )
-        return result
+        return result.points
 
     def reset(self):
         """Reset the index by deleting and recreating it."""

--- a/tests/vector_stores/test_chroma.py
+++ b/tests/vector_stores/test_chroma.py
@@ -48,6 +48,73 @@ def test_search_vectors(chromadb_instance, mock_chromadb_client):
     assert results[0].payload == {"name": "vector1"}
 
 
+def test_search_vectors_with_filters(chromadb_instance, mock_chromadb_client):
+    """Test search with agent_id and run_id filters."""
+    mock_result = {
+        "ids": [["id1"]],
+        "distances": [[0.1]],
+        "metadatas": [[{"name": "vector1", "user_id": "alice", "agent_id": "agent1", "run_id": "run1"}]],
+    }
+    chromadb_instance.collection.query.return_value = mock_result
+
+    vectors = [[0.1, 0.2, 0.3]]
+    filters = {"user_id": "alice", "agent_id": "agent1", "run_id": "run1"}
+    results = chromadb_instance.search(query="", vectors=vectors, limit=2, filters=filters)
+
+    # Verify that _generate_where_clause was called with the filters
+    expected_where = {"$and": [{"user_id": "alice"}, {"agent_id": "agent1"}, {"run_id": "run1"}]}
+    chromadb_instance.collection.query.assert_called_once_with(
+        query_embeddings=vectors, where=expected_where, n_results=2
+    )
+
+    assert len(results) == 1
+    assert results[0].id == "id1"
+    assert results[0].payload["user_id"] == "alice"
+    assert results[0].payload["agent_id"] == "agent1"
+    assert results[0].payload["run_id"] == "run1"
+
+
+def test_search_vectors_with_single_filter(chromadb_instance, mock_chromadb_client):
+    """Test search with single filter (should not use $and)."""
+    mock_result = {
+        "ids": [["id1"]],
+        "distances": [[0.1]],
+        "metadatas": [[{"name": "vector1", "user_id": "alice"}]],
+    }
+    chromadb_instance.collection.query.return_value = mock_result
+
+    vectors = [[0.1, 0.2, 0.3]]
+    filters = {"user_id": "alice"}
+    results = chromadb_instance.search(query="", vectors=vectors, limit=2, filters=filters)
+
+    # Verify that single filter is passed as-is (no $and wrapper)
+    chromadb_instance.collection.query.assert_called_once_with(
+        query_embeddings=vectors, where=filters, n_results=2
+    )
+
+    assert len(results) == 1
+    assert results[0].payload["user_id"] == "alice"
+
+
+def test_search_vectors_with_no_filters(chromadb_instance, mock_chromadb_client):
+    """Test search with no filters."""
+    mock_result = {
+        "ids": [["id1"]],
+        "distances": [[0.1]],
+        "metadatas": [[{"name": "vector1"}]],
+    }
+    chromadb_instance.collection.query.return_value = mock_result
+
+    vectors = [[0.1, 0.2, 0.3]]
+    results = chromadb_instance.search(query="", vectors=vectors, limit=2, filters=None)
+
+    chromadb_instance.collection.query.assert_called_once_with(
+        query_embeddings=vectors, where=None, n_results=2
+    )
+
+    assert len(results) == 1
+
+
 def test_delete_vector(chromadb_instance):
     vector_id = "id1"
 
@@ -100,3 +167,81 @@ def test_list_vectors(chromadb_instance):
     assert len(results[0]) == 2
     assert results[0][0].id == "id1"
     assert results[0][1].id == "id2"
+
+
+def test_list_vectors_with_filters(chromadb_instance):
+    """Test list with agent_id and run_id filters."""
+    mock_result = {
+        "ids": [["id1"]],
+        "distances": [[0.1]],
+        "metadatas": [[{"name": "vector1", "user_id": "alice", "agent_id": "agent1", "run_id": "run1"}]],
+    }
+    chromadb_instance.collection.get.return_value = mock_result
+
+    filters = {"user_id": "alice", "agent_id": "agent1", "run_id": "run1"}
+    results = chromadb_instance.list(filters=filters, limit=2)
+
+    # Verify that _generate_where_clause was called with the filters
+    expected_where = {"$and": [{"user_id": "alice"}, {"agent_id": "agent1"}, {"run_id": "run1"}]}
+    chromadb_instance.collection.get.assert_called_once_with(where=expected_where, limit=2)
+
+    assert len(results[0]) == 1
+    assert results[0][0].payload["user_id"] == "alice"
+    assert results[0][0].payload["agent_id"] == "agent1"
+    assert results[0][0].payload["run_id"] == "run1"
+
+
+def test_list_vectors_with_single_filter(chromadb_instance):
+    """Test list with single filter (should not use $and)."""
+    mock_result = {
+        "ids": [["id1"]],
+        "distances": [[0.1]],
+        "metadatas": [[{"name": "vector1", "user_id": "alice"}]],
+    }
+    chromadb_instance.collection.get.return_value = mock_result
+
+    filters = {"user_id": "alice"}
+    results = chromadb_instance.list(filters=filters, limit=2)
+
+    # Verify that single filter is passed as-is (no $and wrapper)
+    chromadb_instance.collection.get.assert_called_once_with(where=filters, limit=2)
+
+    assert len(results[0]) == 1
+    assert results[0][0].payload["user_id"] == "alice"
+
+
+def test_generate_where_clause_multiple_filters():
+    """Test _generate_where_clause with multiple filters."""
+    filters = {"user_id": "alice", "agent_id": "agent1", "run_id": "run1"}
+    result = ChromaDB._generate_where_clause(filters)
+    
+    expected = {"$and": [{"user_id": "alice"}, {"agent_id": "agent1"}, {"run_id": "run1"}]}
+    assert result == expected
+
+
+def test_generate_where_clause_single_filter():
+    """Test _generate_where_clause with single filter."""
+    filters = {"user_id": "alice"}
+    result = ChromaDB._generate_where_clause(filters)
+    
+    # Single filter should be returned as-is
+    assert result == filters
+
+
+def test_generate_where_clause_no_filters():
+    """Test _generate_where_clause with no filters."""
+    result = ChromaDB._generate_where_clause(None)
+    assert result == {}
+
+    result = ChromaDB._generate_where_clause({})
+    assert result == {}
+
+
+def test_generate_where_clause_non_string_values():
+    """Test _generate_where_clause with non-string values."""
+    filters = {"user_id": "alice", "count": 5, "active": True}
+    result = ChromaDB._generate_where_clause(filters)
+    
+    # Only string values should be included in $and array
+    expected = {"$and": [{"user_id": "alice"}]}
+    assert result == expected

--- a/tests/vector_stores/test_langchain_vector_store.py
+++ b/tests/vector_stores/test_langchain_vector_store.py
@@ -64,6 +64,66 @@ def test_search_vectors(langchain_instance):
     langchain_instance.client.similarity_search_by_vector.assert_called_with(embedding=vectors, k=2, filter=filters)
 
 
+def test_search_vectors_with_agent_id_run_id_filters(langchain_instance):
+    """Test search with agent_id and run_id filters."""
+    # Mock search results
+    mock_docs = [
+        Mock(metadata={"user_id": "alice", "agent_id": "agent1", "run_id": "run1"}, id="id1"),
+        Mock(metadata={"user_id": "bob", "agent_id": "agent2", "run_id": "run2"}, id="id2")
+    ]
+    langchain_instance.client.similarity_search_by_vector.return_value = mock_docs
+
+    vectors = [[0.1, 0.2, 0.3]]
+    filters = {"user_id": "alice", "agent_id": "agent1", "run_id": "run1"}
+    results = langchain_instance.search(query="", vectors=vectors, limit=2, filters=filters)
+
+    # Verify that filters were passed to the underlying vector store
+    langchain_instance.client.similarity_search_by_vector.assert_called_once_with(
+        embedding=vectors, k=2, filter=filters
+    )
+
+    assert len(results) == 2
+    assert results[0].payload["user_id"] == "alice"
+    assert results[0].payload["agent_id"] == "agent1"
+    assert results[0].payload["run_id"] == "run1"
+
+
+def test_search_vectors_with_single_filter(langchain_instance):
+    """Test search with single filter."""
+    # Mock search results
+    mock_docs = [Mock(metadata={"user_id": "alice"}, id="id1")]
+    langchain_instance.client.similarity_search_by_vector.return_value = mock_docs
+
+    vectors = [[0.1, 0.2, 0.3]]
+    filters = {"user_id": "alice"}
+    results = langchain_instance.search(query="", vectors=vectors, limit=2, filters=filters)
+
+    # Verify that filters were passed to the underlying vector store
+    langchain_instance.client.similarity_search_by_vector.assert_called_once_with(
+        embedding=vectors, k=2, filter=filters
+    )
+
+    assert len(results) == 1
+    assert results[0].payload["user_id"] == "alice"
+
+
+def test_search_vectors_with_no_filters(langchain_instance):
+    """Test search with no filters."""
+    # Mock search results
+    mock_docs = [Mock(metadata={"name": "vector1"}, id="id1")]
+    langchain_instance.client.similarity_search_by_vector.return_value = mock_docs
+
+    vectors = [[0.1, 0.2, 0.3]]
+    results = langchain_instance.search(query="", vectors=vectors, limit=2, filters=None)
+
+    # Verify that no filters were passed to the underlying vector store
+    langchain_instance.client.similarity_search_by_vector.assert_called_once_with(
+        embedding=vectors, k=2
+    )
+
+    assert len(results) == 1
+
+
 def test_get_vector(langchain_instance):
     # Mock get result
     mock_doc = Mock(metadata={"name": "vector1"}, id="id1")
@@ -81,3 +141,86 @@ def test_get_vector(langchain_instance):
     langchain_instance.client.get_by_ids.return_value = []
     result = langchain_instance.get("non_existent_id")
     assert result is None
+
+
+def test_list_with_filters(langchain_instance):
+    """Test list with agent_id and run_id filters."""
+    # Mock the _collection.get method
+    mock_collection = Mock()
+    mock_collection.get.return_value = {
+        "ids": [["id1"]],
+        "metadatas": [[{"user_id": "alice", "agent_id": "agent1", "run_id": "run1"}]],
+        "documents": [["test document"]]
+    }
+    langchain_instance.client._collection = mock_collection
+
+    filters = {"user_id": "alice", "agent_id": "agent1", "run_id": "run1"}
+    results = langchain_instance.list(filters=filters, limit=10)
+
+    # Verify that the collection.get method was called with the correct filters
+    mock_collection.get.assert_called_once_with(where=filters, limit=10)
+
+    # Verify the results
+    assert len(results) == 1
+    assert len(results[0]) == 1
+    assert results[0][0].payload["user_id"] == "alice"
+    assert results[0][0].payload["agent_id"] == "agent1"
+    assert results[0][0].payload["run_id"] == "run1"
+
+
+def test_list_with_single_filter(langchain_instance):
+    """Test list with single filter."""
+    # Mock the _collection.get method
+    mock_collection = Mock()
+    mock_collection.get.return_value = {
+        "ids": [["id1"]],
+        "metadatas": [[{"user_id": "alice"}]],
+        "documents": [["test document"]]
+    }
+    langchain_instance.client._collection = mock_collection
+
+    filters = {"user_id": "alice"}
+    results = langchain_instance.list(filters=filters, limit=10)
+
+    # Verify that the collection.get method was called with the correct filter
+    mock_collection.get.assert_called_once_with(where=filters, limit=10)
+
+    # Verify the results
+    assert len(results) == 1
+    assert len(results[0]) == 1
+    assert results[0][0].payload["user_id"] == "alice"
+
+
+def test_list_with_no_filters(langchain_instance):
+    """Test list with no filters."""
+    # Mock the _collection.get method
+    mock_collection = Mock()
+    mock_collection.get.return_value = {
+        "ids": [["id1"]],
+        "metadatas": [[{"name": "vector1"}]],
+        "documents": [["test document"]]
+    }
+    langchain_instance.client._collection = mock_collection
+
+    results = langchain_instance.list(filters=None, limit=10)
+
+    # Verify that the collection.get method was called with no filters
+    mock_collection.get.assert_called_once_with(where=None, limit=10)
+
+    # Verify the results
+    assert len(results) == 1
+    assert len(results[0]) == 1
+    assert results[0][0].payload["name"] == "vector1"
+
+
+def test_list_with_exception(langchain_instance):
+    """Test list when an exception occurs."""
+    # Mock the _collection.get method to raise an exception
+    mock_collection = Mock()
+    mock_collection.get.side_effect = Exception("Test exception")
+    langchain_instance.client._collection = mock_collection
+
+    results = langchain_instance.list(filters={"user_id": "alice"}, limit=10)
+
+    # Verify that an empty list is returned when an exception occurs
+    assert results == []

--- a/tests/vector_stores/test_qdrant.py
+++ b/tests/vector_stores/test_qdrant.py
@@ -3,7 +3,13 @@ import uuid
 from unittest.mock import MagicMock
 
 from qdrant_client import QdrantClient
-from qdrant_client.models import Distance, PointIdsList, PointStruct, VectorParams
+from qdrant_client.models import (
+    Distance,
+    Filter,
+    PointIdsList,
+    PointStruct,
+    VectorParams,
+)
 
 from mem0.vector_stores.qdrant import Qdrant
 
@@ -64,6 +70,121 @@ class TestQdrant(unittest.TestCase):
         self.assertEqual(results[0].payload, {"key": "value"})
         self.assertEqual(results[0].score, 0.95)
 
+    def test_search_with_filters(self):
+        """Test search with agent_id and run_id filters."""
+        vectors = [[0.1, 0.2]]
+        mock_point = MagicMock(
+            id=str(uuid.uuid4()), 
+            score=0.95, 
+            payload={"user_id": "alice", "agent_id": "agent1", "run_id": "run1"}
+        )
+        self.client_mock.query_points.return_value = MagicMock(points=[mock_point])
+
+        filters = {"user_id": "alice", "agent_id": "agent1", "run_id": "run1"}
+        results = self.qdrant.search(query="", vectors=vectors, limit=1, filters=filters)
+
+        # Verify that _create_filter was called and query_filter was passed
+        self.client_mock.query_points.assert_called_once()
+        call_args = self.client_mock.query_points.call_args[1]
+        self.assertEqual(call_args["collection_name"], "test_collection")
+        self.assertEqual(call_args["query"], vectors)
+        self.assertEqual(call_args["limit"], 1)
+        
+        # Verify that a Filter object was created
+        query_filter = call_args["query_filter"]
+        self.assertIsInstance(query_filter, Filter)
+        self.assertEqual(len(query_filter.must), 3)  # user_id, agent_id, run_id
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].payload["user_id"], "alice")
+        self.assertEqual(results[0].payload["agent_id"], "agent1")
+        self.assertEqual(results[0].payload["run_id"], "run1")
+
+    def test_search_with_single_filter(self):
+        """Test search with single filter."""
+        vectors = [[0.1, 0.2]]
+        mock_point = MagicMock(
+            id=str(uuid.uuid4()), 
+            score=0.95, 
+            payload={"user_id": "alice"}
+        )
+        self.client_mock.query_points.return_value = MagicMock(points=[mock_point])
+
+        filters = {"user_id": "alice"}
+        results = self.qdrant.search(query="", vectors=vectors, limit=1, filters=filters)
+
+        # Verify that a Filter object was created with single condition
+        call_args = self.client_mock.query_points.call_args[1]
+        query_filter = call_args["query_filter"]
+        self.assertIsInstance(query_filter, Filter)
+        self.assertEqual(len(query_filter.must), 1)  # Only user_id
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].payload["user_id"], "alice")
+
+    def test_search_with_no_filters(self):
+        """Test search with no filters."""
+        vectors = [[0.1, 0.2]]
+        mock_point = MagicMock(id=str(uuid.uuid4()), score=0.95, payload={"key": "value"})
+        self.client_mock.query_points.return_value = MagicMock(points=[mock_point])
+
+        results = self.qdrant.search(query="", vectors=vectors, limit=1, filters=None)
+
+        call_args = self.client_mock.query_points.call_args[1]
+        self.assertIsNone(call_args["query_filter"])
+
+        self.assertEqual(len(results), 1)
+
+    def test_create_filter_multiple_filters(self):
+        """Test _create_filter with multiple filters."""
+        filters = {"user_id": "alice", "agent_id": "agent1", "run_id": "run1"}
+        result = self.qdrant._create_filter(filters)
+        
+        self.assertIsInstance(result, Filter)
+        self.assertEqual(len(result.must), 3)
+        
+        # Check that all conditions are present
+        conditions = [cond.key for cond in result.must]
+        self.assertIn("user_id", conditions)
+        self.assertIn("agent_id", conditions)
+        self.assertIn("run_id", conditions)
+
+    def test_create_filter_single_filter(self):
+        """Test _create_filter with single filter."""
+        filters = {"user_id": "alice"}
+        result = self.qdrant._create_filter(filters)
+        
+        self.assertIsInstance(result, Filter)
+        self.assertEqual(len(result.must), 1)
+        self.assertEqual(result.must[0].key, "user_id")
+        self.assertEqual(result.must[0].match.value, "alice")
+
+    def test_create_filter_no_filters(self):
+        """Test _create_filter with no filters."""
+        result = self.qdrant._create_filter(None)
+        self.assertIsNone(result)
+        
+        result = self.qdrant._create_filter({})
+        self.assertIsNone(result)
+
+    def test_create_filter_with_range_values(self):
+        """Test _create_filter with range values."""
+        filters = {"user_id": "alice", "count": {"gte": 5, "lte": 10}}
+        result = self.qdrant._create_filter(filters)
+        
+        self.assertIsInstance(result, Filter)
+        self.assertEqual(len(result.must), 2)
+        
+        # Check that range condition is created
+        range_conditions = [cond for cond in result.must if hasattr(cond, 'range') and cond.range is not None]
+        self.assertEqual(len(range_conditions), 1)
+        self.assertEqual(range_conditions[0].key, "count")
+        
+        # Check that string condition is created
+        string_conditions = [cond for cond in result.must if hasattr(cond, 'match') and cond.match is not None]
+        self.assertEqual(len(string_conditions), 1)
+        self.assertEqual(string_conditions[0].key, "user_id")
+
     def test_delete(self):
         vector_id = str(uuid.uuid4())
         self.qdrant.delete(vector_id=vector_id)
@@ -102,6 +223,67 @@ class TestQdrant(unittest.TestCase):
         self.client_mock.get_collections.return_value = MagicMock(collections=[{"name": "test_collection"}])
         result = self.qdrant.list_cols()
         self.assertEqual(result.collections[0]["name"], "test_collection")
+
+    def test_list_with_filters(self):
+        """Test list with agent_id and run_id filters."""
+        mock_point = MagicMock(
+            id=str(uuid.uuid4()), 
+            score=0.95, 
+            payload={"user_id": "alice", "agent_id": "agent1", "run_id": "run1"}
+        )
+        self.client_mock.scroll.return_value = MagicMock(points=[mock_point])
+
+        filters = {"user_id": "alice", "agent_id": "agent1", "run_id": "run1"}
+        results = self.qdrant.list(filters=filters, limit=10)
+
+        # Verify that _create_filter was called and scroll_filter was passed
+        self.client_mock.scroll.assert_called_once()
+        call_args = self.client_mock.scroll.call_args[1]
+        self.assertEqual(call_args["collection_name"], "test_collection")
+        self.assertEqual(call_args["limit"], 10)
+        
+        # Verify that a Filter object was created
+        scroll_filter = call_args["scroll_filter"]
+        self.assertIsInstance(scroll_filter, Filter)
+        self.assertEqual(len(scroll_filter.must), 3)  # user_id, agent_id, run_id
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].payload["user_id"], "alice")
+        self.assertEqual(results[0].payload["agent_id"], "agent1")
+        self.assertEqual(results[0].payload["run_id"], "run1")
+
+    def test_list_with_single_filter(self):
+        """Test list with single filter."""
+        mock_point = MagicMock(
+            id=str(uuid.uuid4()), 
+            score=0.95, 
+            payload={"user_id": "alice"}
+        )
+        self.client_mock.scroll.return_value = MagicMock(points=[mock_point])
+
+        filters = {"user_id": "alice"}
+        results = self.qdrant.list(filters=filters, limit=10)
+
+        # Verify that a Filter object was created with single condition
+        call_args = self.client_mock.scroll.call_args[1]
+        scroll_filter = call_args["scroll_filter"]
+        self.assertIsInstance(scroll_filter, Filter)
+        self.assertEqual(len(scroll_filter.must), 1)  # Only user_id
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].payload["user_id"], "alice")
+
+    def test_list_with_no_filters(self):
+        """Test list with no filters."""
+        mock_point = MagicMock(id=str(uuid.uuid4()), score=0.95, payload={"key": "value"})
+        self.client_mock.scroll.return_value = MagicMock(points=[mock_point])
+
+        results = self.qdrant.list(filters=None, limit=10)
+
+        call_args = self.client_mock.scroll.call_args[1]
+        self.assertIsNone(call_args["scroll_filter"])
+
+        self.assertEqual(len(results), 1)
 
     def test_delete_col(self):
         self.qdrant.delete_col()


### PR DESCRIPTION
## Description

This PR fixes the support for the multi id filters for all the vectorstores, also added tests with filters for vector stores.

Fixes #3260 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (does not change functionality, e.g. code style improvements, linting)

## How Has This Been Tested?

- [x] Unit Test
- [x] Test Script (please provide)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [x] closes #3260 
- [x] Made sure Checks passed
