### PR TITLE
fix: neo4j _search_graph_db cypher query syntax error

### DIFF
--- a/mem0/memory/graph_memory.py
+++ b/mem0/memory/graph_memory.py
@@ -252,8 +252,10 @@ class MemoryGraph:
         """Search similar nodes among and their respective incoming and outgoing relations."""
         result_relations = []
         agent_filter = ""
+        agent_filter_for_call = ""
         if filters.get("agent_id"):
-            agent_filter = "AND n.agent_id = $agent_id AND m.agent_id = $agent_id"
+            agent_filter = "AND n.agent_id = $agent_id"
+            agent_filter_for_call = "AND m.agent_id = $agent_id"
 
         for node in node_list:
             n_embedding = self.embedding_model.embed(node)
@@ -266,11 +268,11 @@ class MemoryGraph:
             WHERE similarity >= $threshold
             CALL {{
                 MATCH (n)-[r]->(m)
-                WHERE m.user_id = $user_id {agent_filter.replace("n.", "m.")} 
+                WHERE m.user_id = $user_id {agent_filter_for_call} 
                 RETURN n.name AS source, elementId(n) AS source_id, type(r) AS relationship, elementId(r) AS relation_id, m.name AS destination, elementId(m) AS destination_id
                 UNION
                 MATCH (m)-[r]->(n)
-                WHERE m.user_id = $user_id {agent_filter.replace("n.", "m.")}
+                WHERE m.user_id = $user_id {agent_filter_for_call}
                 RETURN m.name AS source, elementId(m) AS source_id, type(r) AS relationship, elementId(r) AS relation_id, n.name AS destination, elementId(n) AS destination_id
             }}
             WITH distinct source, source_id, relationship, relation_id, destination, destination_id, similarity


### PR DESCRIPTION
## Description

neo4j _search_graph_db cypher query syntax error


When graph memory is enabled and the agent id is set, an error will be reported. The following are the examples used and the error stack

```python
    m = Memory.from_config(SERVER_CONFIG)

    messages = [
        { "role": "user", "content": "Hi, I'm GuoHao. I'm a vegetarian and I'm allergic to nuts." },
        { "role": "assistant", "content": "Hello GuoHao! I see that you're a vegetarian with a nut allergy." }
    ]

    add_result = m.add(messages, user_id="GuoHao", agent_id="agent01", run_id="session01")
```


```python

2025-08-05 19:52:54,729 - INFO - NOOP for Memory.
Traceback (most recent call last):
  File "/Users/rosicky/code/code/python/python3-work-test/memory-layer/local2.py", line 129, in <module>
    mytest_memory()
    ~~~~~~~~~~~~~^^
  File "/Users/rosicky/code/code/python/python3-work-test/memory-layer/local2.py", line 91, in mytest_memory
    add_result = m.add(messages, user_id="GuoHao", agent_id="agent01", run_id="session01")
  File "/Users/rosicky/Library/Caches/pypoetry/virtualenvs/python3-work-test-XtBhgy6p-py3.13/lib/python3.13/site-packages/mem0/memory/main.py", line 264, in add
    graph_result = future2.result()
  File "/opt/homebrew/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ~~~~~~~~~~~~~~~~~^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/opt/homebrew/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/Users/rosicky/Library/Caches/pypoetry/virtualenvs/python3-work-test-XtBhgy6p-py3.13/lib/python3.13/site-packages/mem0/memory/main.py", line 460, in _add_to_graph
    added_entities = self.graph.add(data, filters)
  File "/Users/rosicky/Library/Caches/pypoetry/virtualenvs/python3-work-test-XtBhgy6p-py3.13/lib/python3.13/site-packages/mem0/memory/graph_memory.py", line 78, in add
    search_output = self._search_graph_db(node_list=list(entity_type_map.keys()), filters=filters)
  File "/Users/rosicky/Library/Caches/pypoetry/virtualenvs/python3-work-test-XtBhgy6p-py3.13/lib/python3.13/site-packages/mem0/memory/graph_memory.py", line 291, in _search_graph_db
    ans = self.graph.query(cypher_query, params=params)
  File "/Users/rosicky/Library/Caches/pypoetry/virtualenvs/python3-work-test-XtBhgy6p-py3.13/lib/python3.13/site-packages/langchain_neo4j/graphs/neo4j_graph.py", line 230, in query
    data, _, _ = self._driver.execute_query(
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~^
        Query(text=query, timeout=self.timeout),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        database_=self._database,
        ^^^^^^^^^^^^^^^^^^^^^^^^^
        parameters_=params,
        ^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/rosicky/Library/Caches/pypoetry/virtualenvs/python3-work-test-XtBhgy6p-py3.13/lib/python3.13/site-packages/neo4j/_sync/driver.py", line 978, in execute_query
    return session._run_transaction(
           ~~~~~~~~~~~~~~~~~~~~~~~~^
        access_mode,
        ^^^^^^^^^^^^
    ...<3 lines>...
        {},
        ^^^
    )
    ^
  File "/Users/rosicky/Library/Caches/pypoetry/virtualenvs/python3-work-test-XtBhgy6p-py3.13/lib/python3.13/site-packages/neo4j/_sync/work/session.py", line 588, in _run_transaction
    result = transaction_function(tx, *args, **kwargs)
  File "/Users/rosicky/Library/Caches/pypoetry/virtualenvs/python3-work-test-XtBhgy6p-py3.13/lib/python3.13/site-packages/neo4j/_work/query.py", line 144, in wrapped
    return f(*args, **kwargs)
  File "/Users/rosicky/Library/Caches/pypoetry/virtualenvs/python3-work-test-XtBhgy6p-py3.13/lib/python3.13/site-packages/neo4j/_sync/driver.py", line 1314, in _work
    res = tx.run(query, parameters)
  File "/Users/rosicky/Library/Caches/pypoetry/virtualenvs/python3-work-test-XtBhgy6p-py3.13/lib/python3.13/site-packages/neo4j/_sync/work/transaction.py", line 206, in run
    result._tx_ready_run(query, parameters)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/Users/rosicky/Library/Caches/pypoetry/virtualenvs/python3-work-test-XtBhgy6p-py3.13/lib/python3.13/site-packages/neo4j/_sync/work/result.py", line 177, in _tx_ready_run
    self._run(query, parameters, None, None, None, None, None, None)
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rosicky/Library/Caches/pypoetry/virtualenvs/python3-work-test-XtBhgy6p-py3.13/lib/python3.13/site-packages/neo4j/_sync/work/result.py", line 236, in _run
    self._attach()
    ~~~~~~~~~~~~^^
  File "/Users/rosicky/Library/Caches/pypoetry/virtualenvs/python3-work-test-XtBhgy6p-py3.13/lib/python3.13/site-packages/neo4j/_sync/work/result.py", line 430, in _attach
    self._connection.fetch_message()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/rosicky/Library/Caches/pypoetry/virtualenvs/python3-work-test-XtBhgy6p-py3.13/lib/python3.13/site-packages/neo4j/_sync/io/_common.py", line 193, in inner
    func(*args, **kwargs)
    ~~~~^^^^^^^^^^^^^^^^^
  File "/Users/rosicky/Library/Caches/pypoetry/virtualenvs/python3-work-test-XtBhgy6p-py3.13/lib/python3.13/site-packages/neo4j/_sync/io/_bolt.py", line 863, in fetch_message
    res = self._process_message(tag, fields)
  File "/Users/rosicky/Library/Caches/pypoetry/virtualenvs/python3-work-test-XtBhgy6p-py3.13/lib/python3.13/site-packages/neo4j/_sync/io/_bolt5.py", line 1208, in _process_message
    response.on_failure(summary_metadata or {})
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rosicky/Library/Caches/pypoetry/virtualenvs/python3-work-test-XtBhgy6p-py3.13/lib/python3.13/site-packages/neo4j/_sync/io/_common.py", line 263, in on_failure
    raise self._hydrate_error(metadata)
neo4j.exceptions.CypherSyntaxError: {code: Neo.ClientError.Statement.SyntaxError} {message: Variable `m` not defined (line 4, column 44 (offset: 134))
"            AND n.agent_id = $agent_id AND m.agent_id = $agent_id"
```




## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [ ] Unit Test
- [ ] Test Script (please provide)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
