### PR TITLE
fix: use processed config in Memory.from_config method

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -159,8 +159,8 @@ class Memory(MemoryBase):
     @classmethod
     def from_config(cls, config_dict: Dict[str, Any]):
         try:
-            config = cls._process_config(config_dict)
-            config = MemoryConfig(**config_dict)
+            processed_config = cls._process_config(config_dict)
+            config = MemoryConfig(**processed_config)
         except ValidationError as e:
             logger.error(f"Configuration validation error: {e}")
             raise
@@ -999,8 +999,8 @@ class AsyncMemory(MemoryBase):
     @classmethod
     async def from_config(cls, config_dict: Dict[str, Any]):
         try:
-            config = cls._process_config(config_dict)
-            config = MemoryConfig(**config_dict)
+            processed_config = cls._process_config(config_dict)
+            config = MemoryConfig(**processed_config)
         except ValidationError as e:
             logger.error(f"Configuration validation error: {e}")
             raise


### PR DESCRIPTION
## Description

Fixes bug in Memory.from_config() and AsyncMemory.from_config() where the processed configuration was ignored.
The _process_config() method processes the config dict but the result was unused - the original config_dict was passed to MemoryConfig() instead of the processed_config.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [x] Test Script - Verified with config containing graph_store + embedder that previously failed with AttributeError
```py
config = {
    "graph_store": {"provider": "neo4j", "config": {...}},
    "embedder": {"provider": "ollama", "config": {"embedding_dims": 384}},
    # ... other config
}
Memory.from_config(config)  # Previously failed, now works
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
