### PR TITLE
Fix bug  _search_graph_db() in memgraph_memeory.py

### DIFF
--- a/mem0/memory/graph_memory.py
+++ b/mem0/memory/graph_memory.py
@@ -81,6 +81,8 @@ class MemoryGraph:
         # TODO: Batch queries with APOC plugin
         # TODO: Add more filter support
         deleted_entities = self._delete_entities(to_be_deleted, filters)
+
+        # Add the new entities to the graph，with enbedding
         added_entities = self._add_entities(to_be_added, filters, entity_type_map)
 
         return {"deleted_entities": deleted_entities, "added_entities": added_entities}
@@ -248,7 +250,7 @@ class MemoryGraph:
         logger.debug(f"Extracted entities: {entities}")
         return entities
 
-    def _search_graph_db(self, node_list, filters, limit=100):
+    def  _search_graph_db(self, node_list, filters, limit=100):
         """Search similar nodes among and their respective incoming and outgoing relations."""
         result_relations = []
         agent_filter = ""
@@ -402,7 +404,6 @@ class MemoryGraph:
                 if agent_id:
                     merge_props.append("agent_id: $agent_id")
                 merge_props_str = ", ".join(merge_props)
-
                 cypher = f"""
                 MATCH (source)
                 WHERE elementId(source) = $source_id

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -646,6 +646,7 @@ class Memory(MemoryBase):
             raise ValueError("At least one of 'user_id', 'agent_id', or 'run_id' must be specified.")
 
         keys, encoded_ids = process_telemetry_filters(effective_filters)
+        # 请求的元信息
         capture_event(
             "mem0.search",
             self,
@@ -659,8 +660,11 @@ class Memory(MemoryBase):
             },
         )
 
+        # 启用线程池，同时进行两个搜索
         with concurrent.futures.ThreadPoolExecutor() as executor:
+            # 向量搜索
             future_memories = executor.submit(self._search_vector_store, query, effective_filters, limit, threshold)
+            # 图谱搜索
             future_graph_entities = (
                 executor.submit(self.graph.search, query, effective_filters, limit) if self.enable_graph else None
             )

--- a/mem0/memory/memgraph_memory.py
+++ b/mem0/memory/memgraph_memory.py
@@ -317,80 +317,6 @@ class MemoryGraph:
         return result_relations
 
 
-
-    # memgraph_memory _search_graph_db() the 'n_embedding' of the user query is not used for similarity calculation.
-    # github issue #3230
-    # def _search_graph_db(self, node_list, filters, limit=100):
-    #     """Search similar nodes among and their respective incoming and outgoing relations."""
-    #     result_relations = []
-
-    #     for node in node_list:
-    #         n_embedding = self.embedding_model.embed(node)
-
-    #         # Build query based on whether agent_id is provided
-    #         if filters.get("agent_id"):
-    #             cypher_query = """
-    #             MATCH (n:Entity {user_id: $user_id, agent_id: $agent_id})-[r]->(m:Entity)
-    #             WHERE n.embedding IS NOT NULL
-    #             WITH collect(n) AS nodes1, collect(m) AS nodes2, r
-    #             CALL node_similarity.cosine_pairwise("embedding", nodes1, nodes2)
-    #             YIELD node1, node2, similarity
-    #             WITH node1, node2, similarity, r
-    #             WHERE similarity >= $threshold
-    #             RETURN node1.name AS source, id(node1) AS source_id, type(r) AS relationship, id(r) AS relation_id, node2.name AS destination, id(node2) AS destination_id, similarity
-    #             UNION
-    #             MATCH (n:Entity {user_id: $user_id, agent_id: $agent_id})<-[r]-(m:Entity)
-    #             WHERE n.embedding IS NOT NULL
-    #             WITH collect(n) AS nodes1, collect(m) AS nodes2, r
-    #             CALL node_similarity.cosine_pairwise("embedding", nodes1, nodes2)
-    #             YIELD node1, node2, similarity
-    #             WITH node1, node2, similarity, r
-    #             WHERE similarity >= $threshold
-    #             RETURN node2.name AS source, id(node2) AS source_id, type(r) AS relationship, id(r) AS relation_id, node1.name AS destination, id(node1) AS destination_id, similarity
-    #             ORDER BY similarity DESC
-    #             LIMIT $limit;
-    #             """
-    #             params = {
-    #                 "n_embedding": n_embedding,
-    #                 "threshold": self.threshold,
-    #                 "user_id": filters["user_id"],
-    #                 "agent_id": filters["agent_id"],
-    #                 "limit": limit,
-    #             }
-    #         else:
-    #             cypher_query = """
-    #             MATCH (n:Entity {user_id: $user_id})-[r]->(m:Entity)
-    #             WHERE n.embedding IS NOT NULL
-    #             WITH collect(n) AS nodes1, collect(m) AS nodes2, r
-    #             CALL node_similarity.cosine_pairwise("embedding", nodes1, nodes2)
-    #             YIELD node1, node2, similarity
-    #             WITH node1, node2, similarity, r
-    #             WHERE similarity >= $threshold
-    #             RETURN node1.name AS source, id(node1) AS source_id, type(r) AS relationship, id(r) AS relation_id, node2.name AS destination, id(node2) AS destination_id, similarity
-    #             UNION
-    #             MATCH (n:Entity {user_id: $user_id})<-[r]-(m:Entity)
-    #             WHERE n.embedding IS NOT NULL
-    #             WITH collect(n) AS nodes1, collect(m) AS nodes2, r
-    #             CALL node_similarity.cosine_pairwise("embedding", nodes1, nodes2)
-    #             YIELD node1, node2, similarity
-    #             WITH node1, node2, similarity, r
-    #             WHERE similarity >= $threshold
-    #             RETURN node2.name AS source, id(node2) AS source_id, type(r) AS relationship, id(r) AS relation_id, node1.name AS destination, id(node1) AS destination_id, similarity
-    #             ORDER BY similarity DESC
-    #             LIMIT $limit;
-    #             """
-    #             params = {
-    #                 "n_embedding": n_embedding,
-    #                 "threshold": self.threshold,
-    #                 "user_id": filters["user_id"],
-    #                 "limit": limit,
-    #             }
-
-    #         ans = self.graph.query(cypher_query, params=params)
-    #         result_relations.extend(ans)
-
-    #     return result_relations
-
     def _get_delete_entities_from_search_output(self, search_output, data, filters):
         """Get the entities to be deleted from the search output."""
         search_output_string = format_entities(search_output)
@@ -506,7 +432,7 @@ class MemoryGraph:
                     """
 
                 params = {
-                    "sou rce_id": source_node_search_result[0]["id(source_candidate)"],
+                    "source_id": source_node_search_result[0]["id(source_candidate)"],
                     "destination_name": destination,
                     "destination_embedding": dest_embedding,
                     "user_id": user_id,


### PR DESCRIPTION
## Description

This function seems to want to implement a cypher query statement and get the results of the returned execution, but the query does not contain a placeholder $ for the ‘n_embedding’ parameter, and the similarity is not calculated against the similarity of the user's query, but rather is filtered by the user_id and agent_id, and then calculated two-by-two between the connected nodes. The result is that the final retrieved triples are not related to the user's query's entity_type_map, and the memory fails.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
I modified the query logic of cypher and verified the feasibility of cypher queries. By using the embedded vectors of user questions, I queried for similar nodes and then searched for relationships.

Please delete options that are not relevant.

- [ ] Unit Test

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
