### PR TITLE
Fixes n_embeddings use and error for memgraph

### DIFF
--- a/mem0/vector_stores/qdrant.py
+++ b/mem0/vector_stores/qdrant.py
@@ -261,7 +261,7 @@ class Qdrant(VectorStoreBase):
             with_payload=True,
             with_vectors=False,
         )
-        return result.points
+        return result
 
     def reset(self):
         """Reset the index by deleting and recreating it."""

--- a/tests/vector_stores/test_qdrant.py
+++ b/tests/vector_stores/test_qdrant.py
@@ -231,7 +231,7 @@ class TestQdrant(unittest.TestCase):
             score=0.95, 
             payload={"user_id": "alice", "agent_id": "agent1", "run_id": "run1"}
         )
-        self.client_mock.scroll.return_value = MagicMock(points=[mock_point])
+        self.client_mock.scroll.return_value = [mock_point]
 
         filters = {"user_id": "alice", "agent_id": "agent1", "run_id": "run1"}
         results = self.qdrant.list(filters=filters, limit=10)
@@ -247,6 +247,7 @@ class TestQdrant(unittest.TestCase):
         self.assertIsInstance(scroll_filter, Filter)
         self.assertEqual(len(scroll_filter.must), 3)  # user_id, agent_id, run_id
 
+        # The list method returns the result directly
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].payload["user_id"], "alice")
         self.assertEqual(results[0].payload["agent_id"], "agent1")
@@ -259,7 +260,7 @@ class TestQdrant(unittest.TestCase):
             score=0.95, 
             payload={"user_id": "alice"}
         )
-        self.client_mock.scroll.return_value = MagicMock(points=[mock_point])
+        self.client_mock.scroll.return_value = [mock_point]
 
         filters = {"user_id": "alice"}
         results = self.qdrant.list(filters=filters, limit=10)
@@ -270,19 +271,21 @@ class TestQdrant(unittest.TestCase):
         self.assertIsInstance(scroll_filter, Filter)
         self.assertEqual(len(scroll_filter.must), 1)  # Only user_id
 
+        # The list method returns the result directly
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].payload["user_id"], "alice")
 
     def test_list_with_no_filters(self):
         """Test list with no filters."""
         mock_point = MagicMock(id=str(uuid.uuid4()), score=0.95, payload={"key": "value"})
-        self.client_mock.scroll.return_value = MagicMock(points=[mock_point])
+        self.client_mock.scroll.return_value = [mock_point]
 
         results = self.qdrant.list(filters=None, limit=10)
 
         call_args = self.client_mock.scroll.call_args[1]
         self.assertIsNone(call_args["scroll_filter"])
 
+        # The list method returns the result directly
         self.assertEqual(len(results), 1)
 
     def test_delete_col(self):


### PR DESCRIPTION
## Description

memgraph_memory _search_graph_db() the 'n_embedding' of the user query is not used for similarity calculation, which causes and throws error.

Fixes #3230 #3247 #3060 #2764 



## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit Test
- [x] Test Script (please provide)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [x] closes #3230 #3247  #3060 #2764 
- [x] Made sure Checks passed
