### PR TITLE
AsyncMemory._add_to_vector_store bugfix when no facts found

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1219,6 +1219,8 @@ class AsyncMemory(MemoryBase):
             except Exception as e:
                 logger.error(f"Invalid JSON response: {e}")
                 new_memories_with_actions = {}
+        else:
+            new_memories_with_actions = {}
 
         returned_memories = []
         try:


### PR DESCRIPTION
## Description

Added missing else condition to fix an UnboundLocalError 

Bug: In the AsyncMemory._add_to_vector_store method (line
1203-1222), there's an UnboundLocalError when no new facts are
retrieved from the input. The variable new_memories_with_actions is
only defined inside the if new_retrieved_facts: block but is referenced
outside of it at line 1222.

Fix: Added else: new_memories_with_actions = {} to handle the case
when new_retrieved_facts is empty.

Error:
UnboundLocalError: cannot access local variable
'new_memories_with_actions' before assignment

This was causing memory processing to fail completely when the LLM
determined there were no new memorable facts to extract from
conversations


Fixes # (issue): N/A, didn't create an issue yet

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
None, I don't think this is covered by tests


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
