### PR TITLE
Async/MemoryClient: output type fixed in doc examples

### DIFF
--- a/docs/examples/mem0-agentic-tool.mdx
+++ b/docs/examples/mem0-agentic-tool.mdx
@@ -113,7 +113,7 @@ async def search_memory(
     """
     user_id = context.context.user_id or "default_user"
     memories = await client.search(query, user_id=user_id, output_format="v1.1")
-    results = '\n'.join([result["memory"] for result in memories["results"]])
+    results = '\n'.join([result["memory"] for result in memories])
     return str(results)
 ```
 

--- a/docs/examples/mem0-openai-voice-demo.mdx
+++ b/docs/examples/mem0-openai-voice-demo.mdx
@@ -134,10 +134,10 @@ async def search_memories(
     )
     
     # Format and return the results
-    if not results.get('results', []):
+    if not results:
         return "I don't have any relevant memories about this topic."
     
-    memories = [f"• {result['memory']}" for result in results.get('results', [])]
+    memories = [f"• {result['memory']}" for result in results]
     return "Here's what I remember that might be relevant:\n" + "\n".join(memories)
 ```
 
@@ -350,10 +350,10 @@ async def search_memories(
     )
     
     # Format and return the results
-    if not results.get('results', []):
+    if not results:
         return "I don't have any relevant memories about this topic."
     
-    memories = [f"• {result['memory']}" for result in results.get('results', [])]
+    memories = [f"• {result['memory']}" for result in results]
     return "Here's what I remember that might be relevant:\n" + "\n".join(memories)
 
 # Create the agent with memory-enabled tools

--- a/docs/integrations/elevenlabs.mdx
+++ b/docs/integrations/elevenlabs.mdx
@@ -150,11 +150,10 @@ Define the two key memory functions that will be registered as tools:
         )
 
         # Extract and join the memory texts
-        memories = ' '.join([result["memory"] for result in results.get('results', [])])
-        print("[ Memories ]", memories)
-
-        if memories:
-            return memories
+        if results:
+          memories = ' '.join([result["memory"] for result in results])
+          print("[ Memories ]", memories)
+          return memories
         return "No memories found"
 ```
 

--- a/docs/integrations/livekit.mdx
+++ b/docs/integrations/livekit.mdx
@@ -117,9 +117,9 @@ class MemoryEnabledAgent(Agent):
                 user_id=RAG_USER_ID,
             )
             logger.info(f"mem0_client.search returned: {search_results}")
-            if search_results and search_results.get('results', []):
+            if search_results:
                 context_parts = []
-                for result in search_results.get('results', []):
+                for result in search_results:
                     paragraph = result.get("memory") or result.get("text")
                     if paragraph:
                         source = "mem0 Memories"

--- a/docs/integrations/openai-agents-sdk.mdx
+++ b/docs/integrations/openai-agents-sdk.mdx
@@ -45,8 +45,8 @@ mem0 = MemoryClient()
 def search_memory(query: str, user_id: str) -> str:
     """Search through past conversations and memories"""
     memories = mem0.search(query, user_id=user_id, limit=3)
-    if memories and memories.get('results'):
-        return "\n".join([f"- {mem['memory']}" for mem in memories['results']])
+    if memories:
+        return "\n".join([f"- {mem['memory']}" for mem in memories])
     return "No relevant memories found."
 
 @function_tool


### PR DESCRIPTION
## Description

- fixed some integrations/examples in docs where `search` method of `MemoryClient` or `AsyncMemoryClient` was being used.
- previously, results were being interpreted as `dict` ; changed this to interpret them as `list`

Fixes #3381 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [x] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [ ] Unit Test
- [ ] Test Script (please provide)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
