### PR TITLE
Bugfix: Pick AWS region from the environment variable correctly

### DIFF
--- a/mem0/configs/embeddings/base.py
+++ b/mem0/configs/embeddings/base.py
@@ -1,3 +1,4 @@
+import os
 from abc import ABC
 from typing import Dict, Optional, Union
 
@@ -38,7 +39,7 @@ class BaseEmbedderConfig(ABC):
         # AWS Bedrock specific
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
-        aws_region: Optional[str] = "us-west-2",
+        aws_region: Optional[str] = None,
     ):
         """
         Initializes a configuration class instance for the Embeddings.
@@ -105,4 +106,5 @@ class BaseEmbedderConfig(ABC):
         # AWS Bedrock specific
         self.aws_access_key_id = aws_access_key_id
         self.aws_secret_access_key = aws_secret_access_key
-        self.aws_region = aws_region
+        self.aws_region = aws_region or os.environ.get("AWS_REGION") or "us-west-2"
+

--- a/mem0/configs/llms/aws_bedrock.py
+++ b/mem0/configs/llms/aws_bedrock.py
@@ -1,6 +1,7 @@
-from typing import Optional, Dict, Any, List
-from mem0.configs.llms.base import BaseLlmConfig
 import os
+from typing import Any, Dict, List, Optional
+
+from mem0.configs.llms.base import BaseLlmConfig
 
 
 class AWSBedrockConfig(BaseLlmConfig):
@@ -19,7 +20,7 @@ class AWSBedrockConfig(BaseLlmConfig):
         top_k: int = 1,
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
-        aws_region: str = "us-west-2",
+        aws_region: str = "",
         aws_session_token: Optional[str] = None,
         aws_profile: Optional[str] = None,
         model_kwargs: Optional[Dict[str, Any]] = None,
@@ -53,7 +54,7 @@ class AWSBedrockConfig(BaseLlmConfig):
 
         self.aws_access_key_id = aws_access_key_id
         self.aws_secret_access_key = aws_secret_access_key
-        self.aws_region = aws_region
+        self.aws_region = aws_region or os.getenv("AWS_REGION", "us-west-2")
         self.aws_session_token = aws_session_token
         self.aws_profile = aws_profile
         self.model_kwargs = model_kwargs or {}

--- a/mem0/embeddings/aws_bedrock.py
+++ b/mem0/embeddings/aws_bedrock.py
@@ -28,15 +28,15 @@ class AWSBedrockEmbedding(EmbeddingBase):
         aws_access_key = os.environ.get("AWS_ACCESS_KEY_ID", "")
         aws_secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
         aws_session_token = os.environ.get("AWS_SESSION_TOKEN", "")
-        aws_region = os.environ.get("AWS_REGION", "us-west-2")
 
         # Check if AWS config is provided in the config
         if hasattr(self.config, "aws_access_key_id"):
             aws_access_key = self.config.aws_access_key_id
         if hasattr(self.config, "aws_secret_access_key"):
             aws_secret_key = self.config.aws_secret_access_key
-        if hasattr(self.config, "aws_region"):
-            aws_region = self.config.aws_region
+        
+        # AWS region is always set in config - see BaseEmbedderConfig
+        aws_region = self.config.aws_region or "us-west-2"
 
         self.client = boto3.client(
             "bedrock-runtime",

--- a/tests/test_memory_integration.py
+++ b/tests/test_memory_integration.py
@@ -136,6 +136,40 @@ def test_azure_config_structure():
     assert azure_config["embedder"]["provider"] == "azure_openai"
     assert "azure_kwargs" in azure_config["embedder"]["config"]
 
+def test_aws_bedrock_region(monkeypatch):
+    """Test that AWS Bedrock configuration structure is properly formatted"""
+
+    # Test AWS Bedrock configuration structure (without actual credentials)
+    monkeypatch.setenv("AWS_REGION", "ap-south-1")
+    aws_bedrock_config = {
+        "llm": {
+            "provider": "aws_bedrock",
+            "config": {
+                "model": "amazon.titan-embed-text-v1",
+                "temperature": 0.1,
+                "max_tokens": 1500,
+            },
+        },
+        "vector_store": {
+            "provider": "chroma",
+            "config": {
+                "collection_name": "test_collection",
+                "path": "./test_db",
+            },
+        },
+        "embedder": {
+            "provider": "aws_bedrock",
+            "config": {
+                "model": "amazon.titan-embed-text-v1",
+            },
+        },
+    }
+    
+    memory = Memory.from_config(aws_bedrock_config)
+
+    assert memory.embedding_model.client.meta.region_name == "ap-south-1"
+    assert memory.llm.client.meta.region_name == "ap-south-1"
+
 
 def test_memory_messages_format():
     """Test that memory messages are properly formatted"""


### PR DESCRIPTION
## Description

The changes make sure that we also check the environment variable `AWS_REGION` while setting the variable `aws_region` rather than just setting the default if it's not present in the config.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Added relevant tests; all passing.

Please delete options that are not relevant.

- [X] Unit Test
- [ ] Test Script (please provide)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
