### PR TITLE
support `store` for openai

### DIFF
--- a/mem0/configs/llms/openai.py
+++ b/mem0/configs/llms/openai.py
@@ -28,6 +28,7 @@ class OpenAIConfig(BaseLlmConfig):
         openrouter_base_url: Optional[str] = None,
         site_url: Optional[str] = None,
         app_name: Optional[str] = None,
+        store: bool = False,
         # Response monitoring callback
         response_callback: Optional[Callable[[Any, dict, dict], None]] = None,
     ):
@@ -72,5 +73,7 @@ class OpenAIConfig(BaseLlmConfig):
         self.openrouter_base_url = openrouter_base_url
         self.site_url = site_url
         self.app_name = app_name
+        self.store = store
+
         # Response monitoring
         self.response_callback = response_callback

--- a/mem0/llms/openai.py
+++ b/mem0/llms/openai.py
@@ -123,7 +123,13 @@ class OpenAILLM(LLMBase):
                 openrouter_params["extra_headers"] = extra_headers
 
             params.update(**openrouter_params)
-
+        
+        else:
+            openai_specific_generation_params = ["store"]
+            for param in openai_specific_generation_params:
+                if hasattr(self.config, param):
+                    params[param] = getattr(self.config, param)
+            
         if response_format:
             params["response_format"] = response_format
         if tools:  # TODO: Remove tools if no issues found with new memory addition logic

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -55,7 +55,7 @@ def test_generate_response_without_tools(mock_openai_client):
     response = llm.generate_response(messages)
 
     mock_openai_client.chat.completions.create.assert_called_once_with(
-        model="gpt-4o", messages=messages, temperature=0.7, max_tokens=100, top_p=1.0
+        model="gpt-4o", messages=messages, temperature=0.7, max_tokens=100, top_p=1.0, store=False
     )
     assert response == "I'm doing well, thank you for asking!"
 
@@ -97,7 +97,7 @@ def test_generate_response_with_tools(mock_openai_client):
     response = llm.generate_response(messages, tools=tools)
 
     mock_openai_client.chat.completions.create.assert_called_once_with(
-        model="gpt-4o", messages=messages, temperature=0.7, max_tokens=100, top_p=1.0, tools=tools, tool_choice="auto"
+        model="gpt-4o", messages=messages, temperature=0.7, max_tokens=100, top_p=1.0, tools=tools, tool_choice="auto", store=False
     )
 
     assert response["content"] == "I've added the memory for you."


### PR DESCRIPTION
## Description
Adds support for an additional parameter `store` in the llm config.
(Not a crucial parameter though as it seem to affect the user in anyway. See [this](https://platform.openai.com/docs/api-reference/responses/create#responses_create-store).)

Fixes #3306 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?
Locally tested if `store` is being correcly passed to `.generate_response` of `OpenAILLM` and it succeeds.

Please delete options that are not relevant.

- [ ] Unit Test
- [ ] Test Script (please provide)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #3306  (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
