### PR TITLE
[FIX] Graph Docs page was missing on the side bar

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -58,6 +58,7 @@
                       "platform/features/platform-overview",
                       "platform/features/contextual-add",
                       "platform/features/async-client",
+                      "platform/features/graph-memory",
                       "platform/features/advanced-retrieval",
                       "platform/features/criteria-retrieval",
                       "platform/features/multimodal-support",

--- a/docs/platform/features/platform-overview.mdx
+++ b/docs/platform/features/platform-overview.mdx
@@ -36,7 +36,7 @@ Learn about the key features and capabilities that make Mem0 a powerful platform
   <Card title="Memory Export" icon="file-export" href="memory-export">
     Export memories in structured formats using customizable Pydantic schemas.
   </Card>
-  <Card title="Graph Memory" icon="graph" href="graph-memory">
+  <Card title="Graph Memory" icon="circle-nodes" href="graph-memory">
     Add memories in the form of nodes and edges in a graph database and search for related memories.
   </Card>
 </CardGroup>


### PR DESCRIPTION
Added Graph memory to the features list in docs.