### PR TITLE
fix: Use ConfigDict instead of class-based Config

### DIFF
--- a/mem0/client/project.py
+++ b/mem0/client/project.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 
 import httpx
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from mem0.client.utils import api_error_handler
 from mem0.memory.telemetry import capture_client_event
@@ -20,9 +20,10 @@ class ProjectConfig(BaseModel):
     project_id: Optional[str] = Field(default=None, description="Project ID")
     user_email: Optional[str] = Field(default=None, description="User email")
 
-    class Config:
-        validate_assignment = True
-        extra = "forbid"
+    model_config = ConfigDict(
+        validate_assignment=True,
+        extra="forbid",
+    )
 
 
 class BaseProject(ABC):

--- a/mem0/client/project.py
+++ b/mem0/client/project.py
@@ -20,10 +20,7 @@ class ProjectConfig(BaseModel):
     project_id: Optional[str] = Field(default=None, description="Project ID")
     user_email: Optional[str] = Field(default=None, description="User email")
 
-    model_config = ConfigDict(
-        validate_assignment=True,
-        extra="forbid",
-    )
+    model_config = ConfigDict(validate_assignment=True, extra="forbid")
 
 
 class BaseProject(ABC):

--- a/mem0/configs/vector_stores/azure_ai_search.py
+++ b/mem0/configs/vector_stores/azure_ai_search.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class AzureAISearchConfig(BaseModel):
@@ -54,6 +54,4 @@ class AzureAISearchConfig(BaseModel):
 
         return values
 
-    model_config = {
-        "arbitrary_types_allowed": True,
-    }
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/mem0/configs/vector_stores/baidu.py
+++ b/mem0/configs/vector_stores/baidu.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class BaiduDBConfig(BaseModel):
@@ -24,6 +24,4 @@ class BaiduDBConfig(BaseModel):
             )
         return values
 
-    model_config = {
-        "arbitrary_types_allowed": True,
-    }
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/mem0/configs/vector_stores/chroma.py
+++ b/mem0/configs/vector_stores/chroma.py
@@ -1,6 +1,6 @@
 from typing import Any, ClassVar, Dict, Optional
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class ChromaDbConfig(BaseModel):
@@ -35,6 +35,4 @@ class ChromaDbConfig(BaseModel):
             )
         return values
 
-    model_config = {
-        "arbitrary_types_allowed": True,
-    }
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/mem0/configs/vector_stores/databricks.py
+++ b/mem0/configs/vector_stores/databricks.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from databricks.sdk.service.vectorsearch import EndpointType, VectorIndexType, PipelineType
 
@@ -58,6 +58,4 @@ class DatabricksConfig(BaseModel):
 
         return self
 
-    model_config = {
-        "arbitrary_types_allowed": True,
-    }
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/mem0/configs/vector_stores/faiss.py
+++ b/mem0/configs/vector_stores/faiss.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class FAISSConfig(BaseModel):
@@ -34,6 +34,4 @@ class FAISSConfig(BaseModel):
             )
         return values
 
-    model_config = {
-        "arbitrary_types_allowed": True,
-    }
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/mem0/configs/vector_stores/langchain.py
+++ b/mem0/configs/vector_stores/langchain.py
@@ -1,6 +1,6 @@
 from typing import Any, ClassVar, Dict
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class LangchainConfig(BaseModel):
@@ -27,6 +27,4 @@ class LangchainConfig(BaseModel):
             )
         return values
 
-    model_config = {
-        "arbitrary_types_allowed": True,
-    }
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/mem0/configs/vector_stores/milvus.py
+++ b/mem0/configs/vector_stores/milvus.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Any, Dict
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class MetricType(str, Enum):
@@ -39,6 +39,4 @@ class MilvusDBConfig(BaseModel):
             )
         return values
 
-    model_config = {
-        "arbitrary_types_allowed": True,
-    }
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/mem0/configs/vector_stores/pinecone.py
+++ b/mem0/configs/vector_stores/pinecone.py
@@ -1,7 +1,7 @@
 import os
 from typing import Any, Dict, Optional
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class PineconeConfig(BaseModel):
@@ -52,6 +52,4 @@ class PineconeConfig(BaseModel):
             )
         return values
 
-    model_config = {
-        "arbitrary_types_allowed": True,
-    }
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/mem0/configs/vector_stores/qdrant.py
+++ b/mem0/configs/vector_stores/qdrant.py
@@ -1,6 +1,6 @@
 from typing import Any, ClassVar, Dict, Optional
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class QdrantConfig(BaseModel):
@@ -44,6 +44,4 @@ class QdrantConfig(BaseModel):
             )
         return values
 
-    model_config = {
-        "arbitrary_types_allowed": True,
-    }
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/mem0/configs/vector_stores/redis.py
+++ b/mem0/configs/vector_stores/redis.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 # TODO: Upgrade to latest pydantic version
@@ -21,6 +21,4 @@ class RedisDBConfig(BaseModel):
             )
         return values
 
-    model_config = {
-        "arbitrary_types_allowed": True,
-    }
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/mem0/configs/vector_stores/s3_vectors.py
+++ b/mem0/configs/vector_stores/s3_vectors.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class S3VectorsConfig(BaseModel):
@@ -29,6 +29,4 @@ class S3VectorsConfig(BaseModel):
             )
         return values
 
-    model_config = {
-        "arbitrary_types_allowed": True,
-    }
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/mem0/configs/vector_stores/upstash_vector.py
+++ b/mem0/configs/vector_stores/upstash_vector.py
@@ -1,7 +1,7 @@
 import os
 from typing import Any, ClassVar, Dict, Optional
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 try:
     from upstash_vector import Index
@@ -31,6 +31,4 @@ class UpstashVectorConfig(BaseModel):
             raise ValueError("Either a client or URL and token must be provided.")
         return values
 
-    model_config = {
-        "arbitrary_types_allowed": True,
-    }
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/mem0/configs/vector_stores/vertex_ai_vector_search.py
+++ b/mem0/configs/vector_stores/vertex_ai_vector_search.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class GoogleMatchingEngineConfig(BaseModel):
@@ -14,7 +14,7 @@ class GoogleMatchingEngineConfig(BaseModel):
     credentials_path: Optional[str] = Field(None, description="Path to service account credentials file")
     vector_search_api_endpoint: Optional[str] = Field(None, description="Vector search API endpoint")
 
-    model_config = {"extra": "forbid"}
+    model_config = ConfigDict(extra="forbid")
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/mem0/configs/vector_stores/weaviate.py
+++ b/mem0/configs/vector_stores/weaviate.py
@@ -1,6 +1,6 @@
 from typing import Any, ClassVar, Dict, Optional
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class WeaviateConfig(BaseModel):
@@ -38,6 +38,4 @@ class WeaviateConfig(BaseModel):
 
         return values
 
-    model_config = {
-        "arbitrary_types_allowed": True,
-    }
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/openmemory/api/app/schemas.py
+++ b/openmemory/api/app/schemas.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import List, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, ConfigDict, Field, validator
 
 
 class MemoryBase(BaseModel):
@@ -33,8 +33,7 @@ class Memory(MemoryBase):
     categories: Optional[List[Category]] = None
     app: App
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 class MemoryUpdate(BaseModel):
     content: Optional[str] = None


### PR DESCRIPTION
## Description

This updates the `openmemory.api.app.schemas.Memory` and `mem0.client.project.ProjectConfig` pydantic classes to use the modern `ConfigDict` style rather than `class Config:`.

Fixes #3408 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Before**

```sh
?> uv run python -Wd -c "import mem0"
# .venv/lib/python3.12/site-packages/pydantic/_internal/_config.py:323: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/
  warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)
```

**After**

```sh
?> uv run python -Wd -c "import mem0"
# no warning
```

**NOTE**: Since this is a small patch, I didn't get the full dev environment off the ground (I'm not normally a `hatch` user). If CI fails, I'm happy to put in the extra minutes to get it clean locally.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
