### PR TITLE
fix: :bug: replace hardcoded llm provider with provider from config

### DIFF
--- a/mem0-ts/src/oss/src/memory/graph_memory.ts
+++ b/mem0-ts/src/oss/src/memory/graph_memory.ts
@@ -89,7 +89,7 @@ export class MemoryGraph {
 
     this.llm = LLMFactory.create(this.llmProvider, this.config.llm.config);
     this.structuredLlm = LLMFactory.create(
-      "openai_structured",
+      this.llmProvider,
       this.config.llm.config,
     );
     this.threshold = 0.7;


### PR DESCRIPTION
## Description

TS OSS Client Graph Memory is hardcoded to OpenAI. This should be replaced with the provider from llm config

Fixes https://github.com/mem0ai/mem0/issues/2872

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Have tested locally by adding a memory

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
