### PR TITLE
fix: 🔧 default llm config being used for graph store instead of root llm config provided by the user

### DIFF
--- a/mem0-ts/src/oss/src/config/defaults.ts
+++ b/mem0-ts/src/oss/src/config/defaults.ts
@@ -34,12 +34,6 @@ export const DEFAULT_MEMORY_CONFIG: MemoryConfig = {
       username: process.env.NEO4J_USERNAME || "neo4j",
       password: process.env.NEO4J_PASSWORD || "password",
     },
-    llm: {
-      provider: "openai",
-      config: {
-        model: "gpt-4-turbo-preview",
-      },
-    },
   },
   historyStore: {
     provider: "sqlite",

--- a/mem0-ts/src/oss/src/llms/anthropic.ts
+++ b/mem0-ts/src/oss/src/llms/anthropic.ts
@@ -39,7 +39,11 @@ export class AnthropicLLM implements LLM {
       max_tokens: 4096,
     });
 
-    return response.content[0].text;
+    const firstContent = response.content[0];
+    if (firstContent.type === "text") {
+      return firstContent.text;
+    }
+    throw new Error("Unexpected response type from Anthropic API");
   }
 
   async generateChat(messages: Message[]): Promise<LLMResponse> {

--- a/mem0-ts/src/oss/src/memory/graph_memory.ts
+++ b/mem0-ts/src/oss/src/memory/graph_memory.ts
@@ -89,7 +89,7 @@ export class MemoryGraph {
 
     this.llm = LLMFactory.create(this.llmProvider, this.config.llm.config);
     this.structuredLlm = LLMFactory.create(
-      "openai_structured",
+      this.llmProvider,
       this.config.llm.config,
     );
     this.threshold = 0.7;


### PR DESCRIPTION
## Description

If the user has provided a config with llm in the main config then that should be used for graph store but instead the default open ai config is used.

The user-provided llm config works for graph store only if it is provided in the graphStore config.

Fixes https://github.com/mem0ai/mem0/issues/3425

This also includes a small change in `anthropic.ts` because the build fails without this change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested locally using npm link

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
