### PR TITLE
fix: categorization uses configured LLM; MCP returns str; Unicode JSON preserved

### DIFF
--- a/openmemory/api/app/mcp_server.py
+++ b/openmemory/api/app/mcp_server.py
@@ -133,7 +133,9 @@ async def add_memories(text: str) -> str:
 
                 db.commit()
 
-            return response
+            if isinstance(response, (dict, list)):
+                return json.dumps(response, ensure_ascii=False, indent=2)
+            return str(response)
         finally:
             db.close()
     except Exception as e:
@@ -184,7 +186,7 @@ async def search_memory(query: str) -> str:
             for h in hits:
                 # All vector db search functions return OutputData class
                 id, score, payload = h.id, h.score, h.payload
-                if allowed and h.id is None or h.id not in allowed: 
+                if allowed and (h.id is None or h.id not in allowed):
                     continue
                 
                 results.append({
@@ -211,7 +213,7 @@ async def search_memory(query: str) -> str:
                     db.add(access_log)
             db.commit()
 
-            return json.dumps({"results": results}, indent=2)
+            return json.dumps({"results": results}, ensure_ascii=False, indent=2)
         finally:
             db.close()
     except Exception as e:
@@ -280,7 +282,7 @@ async def list_memories() -> str:
                         db.add(access_log)
                         filtered_memories.append(memory)
                 db.commit()
-            return json.dumps(filtered_memories, indent=2)
+            return json.dumps(filtered_memories, ensure_ascii=False, indent=2)
         finally:
             db.close()
     except Exception as e:

--- a/openmemory/api/app/mcp_server.py
+++ b/openmemory/api/app/mcp_server.py
@@ -382,14 +382,14 @@ async def handle_sse(request: Request):
 
 @mcp_router.post("/messages/")
 async def handle_get_message(request: Request):
-    return await handle_post_message(request)
+    return await _handle_post_message(request)
 
 
 @mcp_router.post("/{client_name}/sse/{user_id}/messages/")
 async def handle_post_message(request: Request):
-    return await handle_post_message(request)
+    return await _handle_post_message(request)
 
-async def handle_post_message(request: Request):
+async def _handle_post_message(request: Request):
     """Handle POST messages for SSE"""
     try:
         body = await request.body()

--- a/openmemory/api/app/utils/categorization.py
+++ b/openmemory/api/app/utils/categorization.py
@@ -1,22 +1,82 @@
+import json
 import logging
+import os
+import re
 from typing import List
 
+from app.database import SessionLocal
 from app.utils.prompts import MEMORY_CATEGORIZATION_PROMPT
 from dotenv import load_dotenv
 from openai import OpenAI
 from pydantic import BaseModel
-from tenacity import retry, stop_after_attempt, wait_exponential
+from tenacity import (
+    retry,
+    retry_if_not_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 load_dotenv()
 openai_client = OpenAI()
 
+deepseek_client = OpenAI(
+    api_key=os.environ.get("DEEPSEEK_API_KEY"),
+    base_url=os.environ.get("DEEPSEEK_BASE_URL")
+)
 
 class MemoryCategories(BaseModel):
     categories: List[str]
 
+class UnsupportedProviderError(Exception):
+    pass
 
-@retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=4, max=15))
-def get_categories_for_memory(memory: str) -> List[str]:
+def _get_categories_from_deepseek(memory: str, model: str = "deepseek-chat") -> List[str]:
+    try:
+        messages = [
+            {"role": "system", "content": MEMORY_CATEGORIZATION_PROMPT + "\n\nPlease respond with a JSON object containing a 'categories' array of strings."},
+            {"role": "user", "content": memory}
+        ]
+    
+        completion = deepseek_client.chat.completions.create(
+            model=model,
+            messages=messages,
+            temperature=0
+        )
+    
+        response_text = completion.choices[0].message.content
+        
+        # Try to extract JSON from response
+    
+        # Look for JSON in the response
+        json_match = re.search(r'\{.*\}', response_text, re.DOTALL)
+        if json_match:
+            json_str = json_match.group()
+            parsed_json = json.loads(json_str)
+            if "categories" in parsed_json:
+                return [cat.strip().lower() for cat in parsed_json["categories"]]
+        
+        # If no JSON found, try to parse as simple list
+        lines = response_text.strip().split('\n')
+        categories = []
+        for line in lines:
+            line = line.strip()
+            if line and not line.startswith('#') and not line.startswith('Categories:'):
+                # Remove bullet points, numbers, etc.
+                clean_line = re.sub(r'^[-*•\d\.]\s*', '', line).strip()
+                if clean_line:
+                    categories.append(clean_line.lower())
+        
+        # Limit to 10 categories or default
+        return categories[:10] if categories else ["general"]  
+    except Exception as e:
+        logging.error(f"[ERROR] Failed to get categories: {e}")
+        try:
+            logging.debug(f"[DEBUG] Raw response: {completion.choices[0].message.content}")
+        except Exception as debug_e:
+            logging.debug(f"[DEBUG] Could not extract raw response: {debug_e}")
+        raise
+
+def _get_categories_from_openai(memory: str, model: str = "gpt-4o-mini") -> List[str]:
     try:
         messages = [
             {"role": "system", "content": MEMORY_CATEGORIZATION_PROMPT},
@@ -25,7 +85,7 @@ def get_categories_for_memory(memory: str) -> List[str]:
 
         # Let OpenAI handle the pydantic parsing directly
         completion = openai_client.beta.chat.completions.parse(
-            model="gpt-4o-mini",
+            model=model,
             messages=messages,
             response_format=MemoryCategories,
             temperature=0
@@ -41,3 +101,52 @@ def get_categories_for_memory(memory: str) -> List[str]:
         except Exception as debug_e:
             logging.debug(f"[DEBUG] Could not extract raw response: {debug_e}")
         raise
+
+
+def get_llm_config() -> dict:
+    """Get LLM configuration from database."""
+    try:
+        # Import here to avoid circular import
+        from app.models import Config as ConfigModel
+        
+        db = SessionLocal()
+        db_config = db.query(ConfigModel).filter(ConfigModel.key == "main").first()
+        
+        if db_config and "mem0" in db_config.value and "llm" in db_config.value["mem0"]:
+            llm_config = db_config.value["mem0"]["llm"]
+            if llm_config:
+                db.close()
+                return llm_config
+        
+        db.close()
+        return {"provider": "unknown", "config": {"model": "unknown"}}
+        
+    except Exception as e:
+        logging.error(f"[ERROR] Failed to load LLM config from database: {e}")
+        return {"provider": "unknown", "config": {"model": "unknown"}}
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=4, max=15),
+    retry=retry_if_not_exception_type(UnsupportedProviderError),
+    reraise=True
+)
+def get_categories_for_memory(memory: str) -> List[str]:
+    llm_config = get_llm_config()
+    provider = llm_config.get("provider", "unknown")
+    config = llm_config.get("config", {})
+    model = config.get("model")
+    
+    if provider == "openai":
+        model = model or "gpt-4o-mini"
+        return _get_categories_from_openai(memory, model)
+    elif provider == "deepseek":
+        model = model or "deepseek-chat"
+        return _get_categories_from_deepseek(memory, model)
+    else:
+        supported = ("openai", "deepseek")
+        raise UnsupportedProviderError(
+            f"Unsupported LLM provider: '{provider or 'empty'}'. Supported: {', '.join(supported)}"
+        )
+
+


### PR DESCRIPTION
## Description

- Fix: Categorization now respects the configured LLM provider/model (DeepSeek or OpenAI). Previously it was hardcoded to an OpenAI model, so even when both the LLM and embeddings used non‑OpenAI providers, categorization still forced OpenAI. It now follows the configured provider/model for these two backends.

- Fix: Normalize MCP server tool-handler return type to str per the MCP interface specification (some handlers previously returned a Python dict).

- Enhancement: Preserve Unicode in JSON responses (no ASCII escaping, e.g., ensure_ascii=False), improving non‑ASCII handling.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor (does not change functionality, e.g. code style improvements, linting)

## How Has This Been Tested?

- [x] Test Script (manual verification using live provider APIs; no new unit tests were added)

Manual test setup:

- Environment variables:

  - OPENAI_BASE_URL = Aliyun DashScope’s OpenAI‑compatible endpoint
  - OPENAI_API_KEY = Aliyun DashScope’s OpenAI‑compatible endpoint API key
  - DEEPSEEK_BASE_URL = official DeepSeek API base URL
  - DEEPSEEK_API_KEY = official DeepSeek API key

- Models:

  - LLM: DeepSeek (model: deepseek-chat)
  - Embeddings: Qwen3 (model: text-embedding-v4, via DashScope)

- Note: At this time, categorization supports DeepSeek and OpenAI only; this run validates the DeepSeek path with Qwen3 embeddings.

Steps and expected results:

1. Categorization respects configured provider/model (DeepSeek)

   - Configure LLM provider = DeepSeek (deepseek-chat); embeddings = Qwen3 text-embedding-v4 via DashScope (through OPENAI_BASE_URL).
   - Trigger a memory entry categorization.
   - Expectation: categorization calls DeepSeek (no OpenAI fallback). Verify via request/trace logs that calls hit DEEPSEEK_BASE_URL; no requests are sent to api.openai.com.

2. Unicode JSON responses

   - Submit text containing non‑ASCII characters (e.g., “Unicode character test — mañana 🚀”).
   - Expectation: Unicode remains unescaped (no \uXXXX sequences); response encoding is UTF‑8.

2. MCP tool call return type is normalized to string

   - Invoke a tool handler that previously could return a Python dict.
   - Expectation: server now returns a string payload per the MCP spec; json.loads(response) succeeds and isinstance(response, str) is true.

4. Lint sanity (F811 fix)

   - Run pre‑commit hooks (e.g., pre-commit run -a).
   - Expectation: no F811 (“redefinition of unused name”) warning; checks pass.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] N/A — no associated GitHub issue for this PR
- [ ] Made sure Checks passed
