### PR TITLE
fix(google): :bug: google llm provider not generating graph entities

### DIFF
--- a/mem0-ts/src/oss/src/memory/graph_memory.ts
+++ b/mem0-ts/src/oss/src/memory/graph_memory.ts
@@ -226,8 +226,10 @@ export class MemoryGraph {
         for (const call of searchResults.toolCalls) {
           if (call.name === "extract_entities") {
             const args = JSON.parse(call.arguments);
-            for (const item of args.entities) {
-              entityTypeMap[item.entity] = item.entity_type;
+            if (args.entities && Array.isArray(args.entities)) {
+              for (const item of args.entities) {
+                entityTypeMap[item.entity] = item.entity_type;
+              }
             }
           }
         }
@@ -264,7 +266,8 @@ export class MemoryGraph {
             ).replace(
               "CUSTOM_PROMPT",
               `4. ${this.config.graphStore.customPrompt}`,
-            ) + "\nPlease provide your response in JSON format.",
+            ) +
+            "\nUse the establish_relationships tool to provide your response.",
         },
         { role: "user", content: data },
       ];
@@ -274,7 +277,7 @@ export class MemoryGraph {
           role: "system",
           content:
             EXTRACT_RELATIONS_PROMPT.replace("USER_ID", filters["userId"]) +
-            "\nPlease provide your response in JSON format.",
+            "\nUse the establish_relationships tool to provide your response.",
         },
         {
           role: "user",


### PR DESCRIPTION
## Description
Entities are not generated when using Google LLM. This PR fixes it by passing the tools to the google LLM provider.

This PR also includes a small change to `EXTRACT_RELATIONS_PROMPT` to ask the LLM to use the provided tool instead of returning JSON response.

Fixes https://github.com/mem0ai/mem0/issues/3431

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested locally via npm link

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
