### PR TITLE
updates to the category docs

### DIFF
--- a/docs/api-reference/memory/v2-search-memories.mdx
+++ b/docs/api-reference/memory/v2-search-memories.mdx
@@ -70,3 +70,39 @@ The v2 search API is powerful and flexible, allowing for more precise memory ret
   )
   ```
   </CodeGroup>
+
+  <CodeGroup>
+  ```python Categories Filter Examples
+  # Example 1: Using 'contains' for partial matching
+  finance_memories = m.search(
+      query="What are my financial goals?",
+      version="v2",
+      filters={
+          "AND": [
+              { "user_id": "alice" },
+              {
+                  "categories": {
+                      "contains": "finance"
+                  }
+              }
+          ]
+      },
+  )
+
+  # Example 2: Using 'in' for exact matching
+  personal_memories = m.search(
+      query="What personal information do you have?",
+      version="v2",
+      filters={
+          "AND": [
+              { "user_id": "alice" },
+              {
+                  "categories": {
+                      "in": ["personal_information"]
+                  }
+              }
+          ]
+      },
+  )
+  ```
+  </CodeGroup>

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1094,7 +1094,7 @@
 								}
 							}
 						},
-						"description": "Filters to apply to the memories. Available fields are: user_id, agent_id, app_id, run_id, created_at, updated_at, categories, keywords. Supports logical operators (AND, OR) and comparison operators (in, gte, lte, gt, lt, ne, contains, icontains)",
+						"description": "Filters to apply to the memories. Available fields are: user_id, agent_id, app_id, run_id, created_at, updated_at, categories, keywords. Supports logical operators (AND, OR) and comparison operators (in, gte, lte, gt, lt, ne, contains, icontains). For categories field, use 'contains' for partial matching (e.g., {\"categories\": {\"contains\": \"finance\"}}) or 'in' for exact matching (e.g., {\"categories\": {\"in\": [\"personal_information\"]}}).",
 						"style": "deepObject",
 						"explode": true
 					},
@@ -5083,7 +5083,7 @@
 					"filters": {
 						"title": "Filters",
 						"type": "object",
-						"description": "A dictionary of filters to apply to the search. Available fields are: user_id, agent_id, app_id, run_id, created_at, updated_at, categories, keywords. Supports logical operators (AND, OR) and comparison operators (in, gte, lte, gt, lt, ne, contains, icontains).",
+						"description": "A dictionary of filters to apply to the search. Available fields are: user_id, agent_id, app_id, run_id, created_at, updated_at, categories, keywords. Supports logical operators (AND, OR) and comparison operators (in, gte, lte, gt, lt, ne, contains, icontains). For categories field, use 'contains' for partial matching (e.g., {\"categories\": {\"contains\": \"finance\"}}) or 'in' for exact matching (e.g., {\"categories\": {\"in\": [\"personal_information\"]}}).",
 						"properties": {
 							"user_id": {"type": "string"},
 							"agent_id": {"type": "string"},

--- a/docs/platform/advanced-memory-operations.mdx
+++ b/docs/platform/advanced-memory-operations.mdx
@@ -285,6 +285,10 @@ curl -X POST "https://api.mem0.ai/v1/memories/" \
 
 Our advanced search allows you to set custom search filters. You can filter by user_id, agent_id, app_id, run_id, created_at, updated_at, categories, and text. The filters support logical operators (AND, OR) and comparison operators (in, gte, lte, gt, lt, ne, contains, icontains, `*`). The wildcard character (`*`) matches everything for a specific field.
 
+For the **categories** field specifically:
+- Use `contains` for partial matching (e.g., `{"categories": {"contains": "finance"}}`)
+- Use `in` for exact matching (e.g., `{"categories": {"in": ["personal_information"]}}`).
+
 Here you need to define `version` as `v2` in the search method.
 
 #### Example 1: Search using user_id and agent_id filters
@@ -407,58 +411,106 @@ curl -X POST "https://api.mem0.ai/v1/memories/search/?version=v2" \
 ```
 </CodeGroup>
 
-#### Example 3: Search using metadata and categories
+#### Example 3: Search using categories filters
 
 <CodeGroup>
 ```python Python
-query = "What do you know about me?"
+# Example 3a: Using 'contains' for partial matching
+query = "What are my financial goals?"
 filters = {
     "AND": [
-        {"metadata": {"food": "vegan"}},
+        { "user_id": "alice" },
         {
-         "categories":{
-            "contains": "food_preferences"
-         }
-    }
+            "categories": {
+                "contains": "finance"
+            }
+        }
+    ]
+}
+client.search(query, version="v2", filters=filters)
+
+# Example 3b: Using 'in' for exact matching
+query = "What personal information do you have?"
+filters = {
+    "AND": [
+        { "user_id": "alice" },
+        {
+            "categories": {
+                "in": ["personal_information"]
+            }
+        }
     ]
 }
 client.search(query, version="v2", filters=filters)
 ```
 
 ```javascript JavaScript
-const query = "What do you know about me?";
-const filters = {
+// Example 3a: Using 'contains' for partial matching
+const query1 = "What are my financial goals?";
+const filters1 = {
     "AND": [
-        {"metadata": {"food": "vegan"}},
+        { "user_id": "alice" },
         {
             "categories": {
-                "contains": "food_preferences"
+                "contains": "finance"
             }
         }
     ]
 };
 
-client.search(query, { version: "v2", filters })
+client.search(query1, { version: "v2", filters: filters1 })
+    .then(results => console.log(results))
+    .catch(error => console.error(error));
+
+// Example 3b: Using 'in' for exact matching
+const query2 = "What personal information do you have?";
+const filters2 = {
+    "AND": [
+        { "user_id": "alice" },
+        {
+            "categories": {
+                "in": ["personal_information"]
+            }
+        }
+    ]
+};
+
+client.search(query2, { version: "v2", filters: filters2 })
     .then(results => console.log(results))
     .catch(error => console.error(error));
 ```
 
 ```bash cURL
+# Example 3a: Using 'contains' for partial matching
 curl -X POST "https://api.mem0.ai/v1/memories/search/?version=v2" \
      -H "Authorization: Token your-api-key" \
      -H "Content-Type: application/json" \
      -d '{
-         "query": "What do you know about me?",
+         "query": "What are my financial goals?",
          "filters": {
              "AND": [
-                 {
-                     "metadata": {
-                         "food": "vegan"
-                     }
-                 },
+                 { "user_id": "alice" },
                  {
                      "categories": {
-                         "contains": "food_preferences"
+                         "contains": "finance"
+                     }
+                 }
+             ]
+         }
+     }'
+
+# Example 3b: Using 'in' for exact matching
+curl -X POST "https://api.mem0.ai/v1/memories/search/?version=v2" \
+     -H "Authorization: Token your-api-key" \
+     -H "Content-Type: application/json" \
+     -d '{
+         "query": "What personal information do you have?",
+         "filters": {
+             "AND": [
+                 { "user_id": "alice" },
+                 {
+                     "categories": {
+                         "in": ["personal_information"]
                      }
                  }
              ]
@@ -692,6 +744,10 @@ curl -X GET "https://api.mem0.ai/v1/memories/?user_id=alex&keywords=to play&page
 #### Get all memories using custom filters
 
 Our advanced retrieval allows you to set custom filters when fetching memories. You can filter by user_id, agent_id, app_id, run_id, created_at, updated_at, categories, and keywords. The filters support logical operators (AND, OR) and comparison operators (in, gte, lte, gt, lt, ne, contains, icontains, `*`). The wildcard character (`*`) matches everything for a specific field.
+
+For the **categories** field specifically:
+- Use `contains` for partial matching (e.g., `{"categories": {"contains": "finance"}}`)
+- Use `in` for exact matching (e.g., `{"categories": {"in": ["personal_information"]}}`).
 
 Here you need to define `version` as `v2` in the get_all method.
 


### PR DESCRIPTION
## 📚 Update documentation for categories filter usage

### Summary
Updated documentation across multiple files to clarify the proper usage of the `categories` field in memory search and retrieval filters. The documentation now provides clear examples showing the correct syntax for both partial and exact matching.

### Changes Made

#### 1. **OpenAPI Specification** (`docs/openapi.json`)
- Enhanced filter descriptions to include specific guidance for categories usage
- Added examples showing `contains` for partial matching and `in` for exact matching
- Updated both search and retrieval endpoint descriptions

#### 2. **V2 Search Memories API Reference** (`docs/api-reference/memory/v2-search-memories.mdx`)
- Added new code example section dedicated to categories filtering
- Included Python examples demonstrating both filter patterns:
  - `{"categories": {"contains": "finance"}}` for partial matching
  - `{"categories": {"in": ["personal_information"]}}` for exact matching

#### 3. **Advanced Memory Operations Guide** (`docs/platform/advanced-memory-operations.mdx`)
- Updated general filter descriptions to highlight categories-specific usage
- Replaced existing Example 3 with comprehensive categories filtering examples
- Added consistent examples across all supported languages (Python, JavaScript, cURL)
- Updated both search and retrieval sections with the same guidance

### Key Improvements

✅ **Clear Usage Patterns**: Documentation now explicitly shows two main approaches:
- `contains` operator for partial string matching within categories
- `in` operator for exact category matching from a list

✅ **Consistent Examples**: All code examples use consistent user_id (`alice`) and realistic category values

✅ **Multi-Language Support**: Examples provided in Python, JavaScript, and cURL formats

✅ **Comprehensive Coverage**: Updated descriptions in both search and retrieval operations

### Before/After

**Before**: Generic mention that categories field supports various operators
**After**: Specific guidance with concrete examples:
```python
# Partial matching
{"categories": {"contains": "finance"}}

# Exact matching  
{"categories": {"in": ["personal_information"]}}
```

### Impact
- Reduces developer confusion about categories filter syntax
- Provides copy-pasteable examples for common use cases
- Ensures consistency across all API documentation
- Improves developer experience when implementing memory filtering

### Files Modified
- `docs/openapi.json`
- `docs/api-reference/memory/v2-search-memories.mdx` 
- `docs/platform/advanced-memory-operations.mdx`