### PR TITLE
feat(openmemory): make OpenAI API key optional in run.sh

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1076,9 +1076,14 @@
 								"run_id": {"type": "string"},
 								"created_at": {"type": "string", "format": "date-time"},
 								"updated_at": {"type": "string", "format": "date-time"},
-								"categories": {"type": "array", "items": {"type": "string"}},
+								"categories": {"type": "object", "properties": {
+									"in": {"type": "array", "items": {"type": "string"}}
+								}},
 								"metadata": {"type": "object"},
-								"keywords": {"type": "string"}
+								"keywords": {"type": "object", "properties": {
+									"contains": {"type": "string"},
+									"icontains": {"type": "string"}
+								}}
 							},
 							"additionalProperties": {
 								"type": "object",
@@ -5091,8 +5096,13 @@
 							"run_id": {"type": "string"},
 							"created_at": {"type": "string", "format": "date-time"},
 							"updated_at": {"type": "string", "format": "date-time"},
-							"text": {"type": "string"},
-							"categories": {"type": "array", "items": {"type": "string"}},
+							"keywords": {"type": "object", "properties": {
+								"contains": {"type": "string"},
+								"icontains": {"type": "string"}
+							}},
+							"categories": {"type": "object", "properties": {
+								"in": {"type": "array", "items": {"type": "string"}}
+							}},
 							"metadata": {"type": "object"}
 						},
 						"additionalProperties": {


### PR DESCRIPTION
- Remove exit condition when OPENAI_API_KEY is not set
- Allow run.sh to continue with warning messages instead of failing and still be set through UI
- Maintain helpful instructions for setting the API key via environment variable or UI settings

## Description

This change makes the initial setup process more flexible by allowing users to
start OpenMemory without immediately requiring an OpenAI API key, which can
be configured later through the application interface.

Fixes #3445 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #3445
- [ ] Made sure Checks passed
