### PR TITLE
fix: resolve URL field inconsistency between Zod Schema and Ollama providers

### DIFF
--- a/mem0-ts/src/oss/src/config/manager.ts
+++ b/mem0-ts/src/oss/src/config/manager.ts
@@ -26,7 +26,8 @@ export class ConfigManager {
                 ? userConf.apiKey
                 : defaultConf.apiKey,
             model: finalModel,
-            url: userConf?.url,
+            url: userConf?.url || userConf?.baseURL,
+            baseURL: userConf?.baseURL || userConf?.url,
             modelProperties:
               userConf?.modelProperties !== undefined
                 ? userConf.modelProperties
@@ -80,7 +81,8 @@ export class ConfigManager {
           }
 
           return {
-            baseURL: userConf?.baseURL || defaultConf.baseURL,
+            baseURL: userConf?.baseURL || userConf?.url || defaultConf.baseURL,
+            url: userConf?.url || userConf?.baseURL || defaultConf.baseURL,
             apiKey:
               userConf?.apiKey !== undefined
                 ? userConf.apiKey

--- a/mem0-ts/src/oss/src/embeddings/ollama.ts
+++ b/mem0-ts/src/oss/src/embeddings/ollama.ts
@@ -11,7 +11,7 @@ export class OllamaEmbedder implements Embedder {
 
   constructor(config: EmbeddingConfig) {
     this.ollama = new Ollama({
-      host: config.url || "http://localhost:11434",
+      host: config.url || config.baseURL || "http://localhost:11434",
     });
     this.model = config.model || "nomic-embed-text:latest";
     this.ensureModelExists().catch((err) => {

--- a/mem0-ts/src/oss/src/llms/anthropic.ts
+++ b/mem0-ts/src/oss/src/llms/anthropic.ts
@@ -39,7 +39,11 @@ export class AnthropicLLM implements LLM {
       max_tokens: 4096,
     });
 
-    return response.content[0].text;
+    const firstContent = response.content[0];
+    if (firstContent.type === "text") {
+      return firstContent.text;
+    }
+    throw new Error("Expected text content block but received different type");
   }
 
   async generateChat(messages: Message[]): Promise<LLMResponse> {

--- a/mem0-ts/src/oss/src/llms/ollama.ts
+++ b/mem0-ts/src/oss/src/llms/ollama.ts
@@ -11,7 +11,10 @@ export class OllamaLLM implements LLM {
 
   constructor(config: LLMConfig) {
     this.ollama = new Ollama({
-      host: config.config?.url || "http://localhost:11434",
+      host:
+        config.config?.url ||
+        config.config?.baseURL ||
+        "http://localhost:11434",
     });
     this.model = config.model || "llama3.1:8b";
     this.ensureModelExists().catch((err) => {

--- a/mem0-ts/src/oss/src/types/index.ts
+++ b/mem0-ts/src/oss/src/types/index.ts
@@ -16,6 +16,7 @@ export interface EmbeddingConfig {
   apiKey?: string;
   model?: string | any;
   url?: string;
+  baseURL?: string;
   modelProperties?: Record<string, any>;
 }
 
@@ -40,6 +41,7 @@ export interface HistoryStoreConfig {
 export interface LLMConfig {
   provider?: string;
   baseURL?: string;
+  url?: string;
   config?: Record<string, any>;
   apiKey?: string;
   model?: string | any;
@@ -118,6 +120,7 @@ export const MemoryConfigSchema = z.object({
       apiKey: z.string().optional(),
       model: z.union([z.string(), z.any()]).optional(),
       baseURL: z.string().optional(),
+      url: z.string().optional(),
     }),
   }),
   vectorStore: z.object({
@@ -137,6 +140,7 @@ export const MemoryConfigSchema = z.object({
       model: z.union([z.string(), z.any()]).optional(),
       modelProperties: z.record(z.string(), z.any()).optional(),
       baseURL: z.string().optional(),
+      url: z.string().optional(),
     }),
   }),
   historyDbPath: z.string().optional(),


### PR DESCRIPTION
###  Ollama Configuration Inconsistency

#### 🐛 Problem

An inconsistency in URL field naming across different parts of the codebase prevented users from correctly configuring Ollama providers.

- **Zod Schema**: The `MemoryConfigSchema` only supported the `baseURL` field for both embedder and LLM configurations.
- **Ollama Implementation**: The `OllamaEmbedder` and `OllamaLLM` classes expected a field named `url`.
- **ConfigManager**: The `ConfigManager` returned different field names, which led to Zod schema validation failures and caused the `url` configuration to be ignored.

This conflict resulted in validation errors and made it impossible to set the Ollama service URL correctly.

---

#### 🔧 Solution

To resolve this, the configuration handling was unified and made more flexible.

- **Updated Zod Schema**: The schema now accepts both `url` and `baseURL` fields in the embedder and LLM configurations, providing backward compatibility and flexibility.
- **Enhanced ConfigManager**: The manager was modified to handle both `url` and `baseURL` fields, implementing fallback logic to prioritize one while still recognizing the other.
- **Updated Ollama Providers**: The `OllamaEmbedder` and `OllamaLLM` classes were updated to support both `url` and `baseURL`, ensuring the correct endpoint is used regardless of which field is provided.
- **Improved Type Definitions**: The `url` field was added to the `EmbeddingConfig` and `LLMConfig` TypeScript interfaces to reflect the changes and improve type safety.