### PR TITLE
Fix: Enable Kuzu Concurrency

### DIFF
--- a/mem0/memory/kuzu_memory.py
+++ b/mem0/memory/kuzu_memory.py
@@ -1,4 +1,5 @@
 import logging
+from weakref import WeakValueDictionary
 
 from mem0.memory.utils import format_entities
 
@@ -27,8 +28,8 @@ logger = logging.getLogger(__name__)
 
 
 class MemoryGraph:
-    _db_objects: dict[str, kuzu.Database] = {}
-    
+    _db_objects: WeakValueDictionary[str, kuzu.Database] = WeakValueDictionary()
+
     def __init__(self, config):
         self.config = config
 
@@ -44,8 +45,9 @@ class MemoryGraph:
         # See https://docs.kuzudb.com/concurrency.
         kuzu_db_file = self.config.graph_store.config.db
         if kuzu_db_file != ":memory:" and kuzu_db_file not in self._db_objects:
-            self._db_objects[kuzu_db_file] = kuzu.Database(kuzu_db_file)
-        self.db = self._db_objects[self.config.graph_store.config.db]
+            self.db = kuzu.Database(kuzu_db_file)
+            self._db_objects[kuzu_db_file] = self.db
+        self.db = self._db_objects[kuzu_db_file]
         self.graph = kuzu.Connection(self.db)
 
         self.node_label = ":Entity"


### PR DESCRIPTION
## Description

Currently, creating multiple `[Async]Memory` instances pointing to the same Kuzu DB file will raise an error (`Could not set lock on file : /path/to/database/example.kuzu`). This is due to limitations in the way that Kuzu handles file locking and concurrency - see [Connections and Concurrency | Kuzu](https://docs.kuzudb.com/concurrency/). Specifically, in order to use the same Kuzu DB file, connections need to use the same `kuzu.Database` object. This PR ensures that `kuzu.Database` objects are reused when attempting to connect to the same `.kuzu` DB file. 

This allows multiple `[Async]Memory` instances to point to the same Kuzu DB file without error and function as expected. (This is often the case in Jupyter notebooks and async code, for example.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Small change - tested accessing the same Kuzu DB file from two separate mem0 `Memory` and `AsyncMemory` instances and validated that read/write operations to the same underlying Kuzu DB file works as expected. Previously an error related to file locking was raised when attempting to create the second mem0 `[Async]Memory` instance pointing to the same Kuzu DB.

Please delete options that are not relevant.

- [x] Test Script - [test_script.py](https://github.com/user-attachments/files/22519010/test_script.py)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
