### PR TITLE
fix cohere reranker

### DIFF
--- a/mem0/configs/rerankers/config.py
+++ b/mem0/configs/rerankers/config.py
@@ -2,13 +2,11 @@ from typing import Optional
 
 from pydantic import BaseModel, Field
 
-from mem0.configs.rerankers.base import BaseRerankerConfig
-
 
 class RerankerConfig(BaseModel):
     """Configuration for rerankers."""
 
     provider: str = Field(description="Reranker provider (e.g., 'cohere', 'sentence_transformer')", default="cohere")
-    config: Optional[BaseRerankerConfig] = Field(description="Provider-specific reranker configuration", default=None)
+    config: Optional[dict] = Field(description="Provider-specific reranker configuration", default=None)
 
     model_config = {"extra": "forbid"}

--- a/mem0/reranker/cohere_reranker.py
+++ b/mem0/reranker/cohere_reranker.py
@@ -64,7 +64,7 @@ class CohereReranker(BaseReranker):
                 model=self.model,
                 query=query,
                 documents=doc_texts,
-                top_k=top_k or self.config.top_k or len(documents),
+                top_n=top_k or self.config.top_k or len(documents),
                 return_documents=self.config.return_documents,
                 max_chunks_per_doc=self.config.max_chunks_per_doc,
             )


### PR DESCRIPTION
## Description

Fix cohere reranker. With the following config:

```
"reranker": {
        "provider": "cohere",
        "config": {
            "api_key": ...,
            "model": "rerank-multilingual-v3.0",
            "top_k": 5,
            "return_documents": True
        }
    },
```

It creates a BaseRerankerConfig instead of CohereRerankerConfig. Also, we should use top_n instead of top_k

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

The above config can work now.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
