### PR TITLE
fix: update license information in README and pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,4 +166,4 @@ We now have a paper you can cite:
 
 ## ⚖️ License
 
-Apache 2.0 — see the [LICENSE](LICENSE) file for details.
+Apache 2.0 — see the [LICENSE](https://github.com/mem0ai/mem0/blob/main/LICENSE) file for details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ authors = [
     { name = "Mem0", email = "founders@mem0.ai" }
 ]
 readme = "README.md"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 requires-python = ">=3.9,<4.0"
 dependencies = [
     "qdrant-client>=1.9.1",


### PR DESCRIPTION
Fix broken LICENSE link on PyPI package page by updating both README and pyproject.toml files.

- Add license field to pyproject.toml for proper PyPI display
- Fix relative LICENSE link in README to absolute GitHub URL

Fixes #3326

## Description

The PyPI package page at https://pypi.org/project/mem0ai/ displays the README.md content, but the relative LICENSE link `[LICENSE](LICENSE)` becomes broken (404 error). This fix addresses the issue by:

1. Adding proper license metadata to pyproject.toml using PEP 639 standard
2. Converting the relative LICENSE link to an absolute GitHub URL

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## How Has This Been Tested?

**Verification performed:**
- Confirmed LICENSE file exists at repository root
- Verified GitHub LICENSE URL is accessible and points to correct file
- Validated pyproject.toml syntax follows PEP 639 standard
- Checked that license metadata format is compatible with PyPI display

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [x] closes #3326