### PR TITLE
support dependency openai 2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ requires-python = ">=3.9,<4.0"
 dependencies = [
     "qdrant-client>=1.9.1",
     "pydantic>=2.7.3",
-    "openai>=1.90.0,<1.110.0",
+    "openai>=1.90.0",
     "posthog>=3.5.0",
     "pytz>=2024.1",
     "sqlalchemy>=2.0.31",
@@ -60,7 +60,7 @@ llms = [
     "groq>=0.3.0",
     "together>=0.2.10",
     "litellm>=1.74.0",
-    "openai>=1.90.0,<1.110.0",
+    "openai>=1.90.0",
     "ollama>=0.1.0",
     "vertexai>=0.1.0",
     "google-generativeai>=0.3.0",


### PR DESCRIPTION
## Description

Support OpenAI 2.x dependency by removing upper version constraint.

Fixes # (issue)
Closes #3529

## Type of change
- Updated `pyproject.toml` to remove `<1.110.0` constraint
- Allows OpenAI 2.x while maintaining backward compatibility

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- No code changes required (APIs are stable)
- Verified existing functionality remains intact
- All OpenAI tests pass (7/7) with OpenAI 2.1.0 
- All embedding tests pass (5/5) with OpenAI 2.1.0
- No breaking changes detected


## Checklist:
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
-  I have checked my code and corrected any misspellings

## Maintainer Checklist

- closes #3529 
