### PR TITLE
aws-bedrock reranker added

### DIFF
--- a/docs/components/rerankers/config.mdx
+++ b/docs/components/rerankers/config.mdx
@@ -7,7 +7,7 @@ iconType: "solid"
 ## How to define configurations?
 
 The `reranker` configuration is defined as an object with two main keys:
-- `provider`: The name of the reranker provider (e.g., "cohere", "sentence_transformer", "huggingface", "llm_reranker")
+- `provider`: The name of the reranker provider (e.g., "aws_bedrock", "cohere", "sentence_transformer", "huggingface", "llm_reranker")
 - `config`: A nested dictionary containing provider-specific settings
 
 ## Basic Configuration
@@ -72,6 +72,20 @@ config = {
             "model": "cross-encoder/ms-marco-MiniLM-L-6-v2",
             "device": "cpu",
             "top_n": 10
+        }
+    }
+}
+```
+
+### AWS Bedrock
+```python
+config = {
+    "reranker": {
+        "provider": "aws_bedrock",
+        "config": {
+            "model": "cohere.rerank-v3-5:0",
+            "region": "us-west-2",
+            "top_n": 5
         }
     }
 }

--- a/docs/components/rerankers/models/aws_bedrock.mdx
+++ b/docs/components/rerankers/models/aws_bedrock.mdx
@@ -1,0 +1,238 @@
+---
+title: AWS Bedrock Reranker
+description: 'Use AWS Bedrock with Cohere models for reranking in Mem0'
+icon: "cloud"
+iconType: "solid"
+---
+
+## Overview
+
+The AWS Bedrock reranker allows you to use Cohere's reranking models through AWS Bedrock for improved search relevance. This is particularly useful for users who are already using AWS services and want to leverage Cohere's state-of-the-art reranking capabilities.
+
+## Supported Models
+
+- `cohere.rerank-v3-5:0` - Cohere's latest reranking model (recommended)
+- Other Cohere reranking models available through AWS Bedrock
+
+## Configuration
+
+### Basic Setup
+
+```python
+from mem0 import Memory
+
+config = {
+    "reranker": {
+        "provider": "aws_bedrock",
+        "config": {
+            "model": "cohere.rerank-v3-5:0",
+            "region": "us-west-2",
+            "top_n": 5
+        }
+    }
+}
+
+m = Memory.from_config(config)
+```
+
+### Configuration Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `model` | str | `"cohere.rerank-v3-5:0"` | AWS Bedrock model ID |
+| `region` | str | `"us-west-2"` | AWS region |
+| `access_key_id` | str | None | AWS access key ID (optional) |
+| `secret_access_key` | str | None | AWS secret access key (optional) |
+| `top_n` | int | 5 | Number of top results to return |
+
+### Authentication
+
+The AWS Bedrock reranker supports multiple authentication methods:
+
+#### 1. Default Credential Chain (Recommended)
+```python
+config = {
+    "reranker": {
+        "provider": "aws_bedrock",
+        "config": {
+            "model": "cohere.rerank-v3-5:0",
+            "region": "us-west-2"
+        }
+    }
+}
+```
+
+#### 2. Environment Variables
+```bash
+export AWS_ACCESS_KEY_ID=your_access_key
+export AWS_SECRET_ACCESS_KEY=your_secret_key
+export AWS_DEFAULT_REGION=us-west-2
+```
+
+#### 3. Explicit Credentials
+```python
+config = {
+    "reranker": {
+        "provider": "aws_bedrock",
+        "config": {
+            "model": "cohere.rerank-v3-5:0",
+            "region": "us-west-2",
+            "access_key_id": "your_access_key",
+            "secret_access_key": "your_secret_key"
+        }
+    }
+}
+```
+
+#### 4. IAM Roles (for EC2/Lambda)
+```python
+config = {
+    "reranker": {
+        "provider": "aws_bedrock",
+        "config": {
+            "model": "cohere.rerank-v3-5:0",
+            "region": "us-west-2"
+        }
+    }
+}
+```
+
+## Complete Example
+
+```python
+from mem0 import Memory
+
+# Complete configuration with AWS Bedrock reranker
+config = {
+    "vector_store": {
+        "provider": "qdrant",
+        "config": {
+            "collection_name": "my_memories",
+            "path": "./qdrant_db"
+        }
+    },
+    "llm": {
+        "provider": "openai",
+        "config": {
+            "model": "gpt-4o-mini",
+            "api_key": "your-openai-key"
+        }
+    },
+    "embedder": {
+        "provider": "openai",
+        "config": {
+            "model": "text-embedding-3-small",
+            "api_key": "your-openai-key"
+        }
+    },
+    "reranker": {
+        "provider": "aws_bedrock",
+        "config": {
+            "model": "cohere.rerank-v3-5:0",
+            "region": "us-west-2",
+            "top_n": 5
+        }
+    }
+}
+
+# Initialize Memory with reranker
+m = Memory.from_config(config)
+
+# Add some memories
+m.add("I love Python programming and machine learning", user_id="user123")
+m.add("I work as a software engineer at a tech company", user_id="user123")
+m.add("I enjoy hiking and outdoor activities", user_id="user123")
+
+# Search with reranking
+results = m.search("What do I know about programming?", user_id="user123")
+print(results)
+```
+
+## Prerequisites
+
+### 1. AWS Account Setup
+- AWS account with access to Amazon Bedrock
+- Proper IAM permissions for Bedrock model access
+
+### 2. Required Permissions
+Your AWS credentials need the following permissions:
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "bedrock:InvokeModel",
+                "bedrock:ListFoundationModels"
+            ],
+            "Resource": "arn:aws:bedrock:*::foundation-model/cohere.rerank-v3-5:0"
+        }
+    ]
+}
+```
+
+### 3. Model Access
+- Request access to Cohere models in AWS Bedrock console
+- Ensure the model is available in your selected region
+
+## Installation
+
+```bash
+pip install mem0ai boto3
+```
+
+## Performance Considerations
+
+- **Latency**: AWS Bedrock calls add network latency compared to local rerankers
+- **Cost**: Each reranking request incurs AWS Bedrock charges
+- **Rate Limits**: AWS Bedrock has rate limits that may affect high-volume applications
+- **Batch Size**: The reranker processes all candidate documents in a single request for efficiency
+
+## Troubleshooting
+
+### Common Issues
+
+#### 1. Authentication Errors
+```
+AWS Bedrock error: The security token included in the request is invalid
+```
+**Solution**: Verify your AWS credentials and region configuration.
+
+#### 2. Model Access Denied
+```
+AWS Bedrock error: AccessDeniedException
+```
+**Solution**: Request access to Cohere models in the AWS Bedrock console.
+
+#### 3. Invalid Model ID
+```
+AWS Bedrock error: ValidationException
+```
+**Solution**: Verify the model ID is correct and available in your region.
+
+### Debug Mode
+Enable debug logging to see detailed error information:
+```python
+import logging
+logging.basicConfig(level=logging.DEBUG)
+```
+
+## Comparison with Other Rerankers
+
+| Feature | AWS Bedrock | Cohere Direct | Sentence Transformer |
+|---------|-------------|---------------|---------------------|
+| Setup Complexity | Medium | Low | Low |
+| Performance | High | High | Medium |
+| Cost | Pay-per-use | Pay-per-use | Free |
+| AWS Integration | Native | External | None |
+| Model Options | Limited | Full | Limited |
+
+## Best Practices
+
+1. **Use appropriate top_n**: Set `top_n` based on your use case (3-10 typically works well)
+2. **Handle errors gracefully**: Always implement error handling for production use
+3. **Monitor costs**: Track your AWS Bedrock usage and costs
+4. **Cache results**: Consider caching reranked results for repeated queries
+5. **Test different models**: Experiment with different Cohere models to find the best fit
+

--- a/docs/components/rerankers/overview.mdx
+++ b/docs/components/rerankers/overview.mdx
@@ -23,6 +23,7 @@ Rerankers enhance the quality of search results by re-ordering the initial retri
 Mem0 supports several reranker models:
 
 <CardGroup cols={2}>
+  <Card title="AWS Bedrock" href="/components/rerankers/models/aws_bedrock" />
   <Card title="Cohere" href="/components/rerankers/models/cohere" />
   <Card title="Sentence Transformer" href="/components/rerankers/models/sentence_transformer" />
   <Card title="Hugging Face" href="/components/rerankers/models/huggingface" />

--- a/examples/aws_bedrock_reranker_example.py
+++ b/examples/aws_bedrock_reranker_example.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+Example demonstrating how to use AWS Bedrock reranker with Mem0.
+
+This example shows how to configure and use the AWS Bedrock reranker
+with Cohere's rerank-v3-5 model for improved search relevance.
+"""
+
+import os
+from mem0 import Memory
+
+
+def main():
+    """Main example function."""
+    
+    # Configuration for AWS Bedrock reranker
+    config = {
+        # Basic Mem0 configuration
+        "vector_store": {
+            "provider": "qdrant",
+            "config": {
+                "collection_name": "mem0_example",
+                "path": "./qdrant_db"
+            }
+        },
+        "llm": {
+            "provider": "openai",
+            "config": {
+                "model": "gpt-4o-mini",
+                "api_key": os.getenv("OPENAI_API_KEY")
+            }
+        },
+        "embedder": {
+            "provider": "openai",
+            "config": {
+                "model": "text-embedding-3-small",
+                "api_key": os.getenv("OPENAI_API_KEY")
+            }
+        },
+        
+        # AWS Bedrock reranker configuration
+        "reranker": {
+            "provider": "aws_bedrock",
+            "config": {
+                "model": "cohere.rerank-v3-5:0",
+                "region": "us-west-2",
+                # Optional: AWS credentials (if not using default credential chain)
+                # "access_key_id": os.getenv("AWS_ACCESS_KEY_ID"),
+                # "secret_access_key": os.getenv("AWS_SECRET_ACCESS_KEY"),
+                "top_n": 5
+            }
+        }
+    }
+    
+    # Initialize Memory with reranker
+    print("Initializing Memory with AWS Bedrock reranker...")
+    m = Memory.from_config(config)
+    
+    # Add some sample memories
+    print("Adding sample memories...")
+    memories_to_add = [
+        "I love Python programming and machine learning",
+        "I work as a software engineer at a tech company",
+        "I enjoy hiking and outdoor activities on weekends",
+        "I'm interested in artificial intelligence and neural networks",
+        "I live in San Francisco and love the tech scene",
+        "I'm learning about cloud computing and AWS services",
+        "I have a dog named Max who loves to play fetch",
+        "I prefer working remotely and using agile methodologies"
+    ]
+    
+    for memory in memories_to_add:
+        m.add(memory, user_id="example_user")
+    
+    print(f"Added {len(memories_to_add)} memories")
+    
+    # Test search without reranker (for comparison)
+    print("\n" + "="*50)
+    print("SEARCH RESULTS WITH RERANKER:")
+    print("="*50)
+    
+    search_queries = [
+        "What do I know about programming?",
+        "Tell me about my work preferences",
+        "What are my hobbies and interests?"
+    ]
+    
+    for query in search_queries:
+        print(f"\nQuery: '{query}'")
+        results = m.search(query, user_id="example_user", limit=3)
+        
+        print("Top results:")
+        for i, result in enumerate(results["results"], 1):
+            print(f"  {i}. {result['memory']} (score: {result['score']:.3f})")
+    
+    print("\n" + "="*50)
+    print("Example completed successfully!")
+    print("="*50)
+    print("\nTo run this example:")
+    print("1. Set your AWS credentials (via AWS CLI, environment variables, or IAM roles)")
+    print("2. Set OPENAI_API_KEY environment variable")
+    print("3. Install required dependencies: pip install mem0ai boto3")
+    print("4. Run: python aws_bedrock_reranker_example.py")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/mem0/configs/base.py
+++ b/mem0/configs/base.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field
 from mem0.embeddings.configs import EmbedderConfig
 from mem0.graphs.configs import GraphStoreConfig
 from mem0.llms.configs import LlmConfig
+from mem0.configs.rerankers import RerankerConfig
 from mem0.vector_stores.configs import VectorStoreConfig
 
 # Set up the directory path
@@ -57,6 +58,10 @@ class MemoryConfig(BaseModel):
     )
     custom_update_memory_prompt: Optional[str] = Field(
         description="Custom prompt for the update memory",
+        default=None,
+    )
+    reranker: Optional[RerankerConfig] = Field(
+        description="Configuration for reranker",
         default=None,
     )
 

--- a/mem0/configs/rerankers/__init__.py
+++ b/mem0/configs/rerankers/__init__.py
@@ -1,0 +1,25 @@
+"""Reranker configuration classes."""
+
+from typing import Any, Dict, Optional
+from pydantic import BaseModel, Field
+
+from .base import BaseRerankerConfig
+from .aws_bedrock import AWSBedrockRerankerConfig
+
+
+class RerankerConfig(BaseModel):
+    """Configuration for reranker."""
+    
+    provider: Optional[str] = Field(
+        default=None, 
+        description="Reranker provider (e.g., 'aws_bedrock', 'cohere', 'sentence_transformer')"
+    )
+    config: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Provider-specific reranker configuration"
+    )
+    
+    model_config = {"extra": "forbid"}
+
+
+__all__ = ["BaseRerankerConfig", "AWSBedrockRerankerConfig", "RerankerConfig"]

--- a/mem0/configs/rerankers/aws_bedrock.py
+++ b/mem0/configs/rerankers/aws_bedrock.py
@@ -1,0 +1,21 @@
+"""AWS Bedrock reranker configuration."""
+
+from typing import Optional
+
+from pydantic import Field
+
+from .base import BaseRerankerConfig
+
+
+class AWSBedrockRerankerConfig(BaseRerankerConfig):
+    """Configuration for AWS Bedrock reranker."""
+    
+    provider: str = Field(default="aws_bedrock", description="Provider name")
+    model: str = Field(default="cohere.rerank-v3-5:0", description="Bedrock model ID")
+    region: str = Field(default="us-west-2", description="AWS region")
+    access_key_id: Optional[str] = Field(default=None, description="AWS access key ID")
+    secret_access_key: Optional[str] = Field(default=None, description="AWS secret access key")
+    top_n: int = Field(default=5, description="Number of top results to return")
+    
+    model_config = {"extra": "forbid"}
+

--- a/mem0/configs/rerankers/base.py
+++ b/mem0/configs/rerankers/base.py
@@ -1,0 +1,20 @@
+"""Base reranker configuration class."""
+
+from abc import ABC
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, Field
+
+
+class BaseRerankerConfig(BaseModel, ABC):
+    """Base configuration class for rerankers."""
+    
+    provider: str = Field(..., description="Reranker provider name")
+    top_n: int = Field(default=10, description="Number of top results to return")
+    
+    model_config = {"extra": "forbid"}
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert config to dictionary."""
+        return self.model_dump()
+

--- a/mem0/rerankers/__init__.py
+++ b/mem0/rerankers/__init__.py
@@ -1,0 +1,7 @@
+"""Reranker implementations for improving search result relevance."""
+
+from .base import BaseReranker
+from .aws_bedrock import AWSBedrockReranker
+
+__all__ = ["BaseReranker", "AWSBedrockReranker"]
+

--- a/mem0/rerankers/aws_bedrock.py
+++ b/mem0/rerankers/aws_bedrock.py
@@ -1,0 +1,142 @@
+"""AWS Bedrock reranker implementation using Cohere models."""
+
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+import boto3
+from botocore.exceptions import ClientError
+
+from .base import BaseReranker, RerankerResult
+
+logger = logging.getLogger(__name__)
+
+
+class AWSBedrockReranker(BaseReranker):
+    """AWS Bedrock reranker using Cohere models."""
+    
+    def __init__(self, config: Dict[str, Any]):
+        """Initialize AWS Bedrock reranker.
+        
+        Args:
+            config: Configuration dictionary containing:
+                - model: The model ID (e.g., 'cohere.rerank-v3-5:0')
+                - region: AWS region (optional, defaults to us-west-2)
+                - access_key_id: AWS access key (optional, uses credentials chain)
+                - secret_access_key: AWS secret key (optional, uses credentials chain)
+                - top_n: Number of results to return (optional, defaults to 10)
+        """
+        super().__init__(config)
+        
+        self.model_id = config.get("model", "cohere.rerank-v3-5:0")
+        self.region = config.get("region", "us-west-2")
+        self.top_n = config.get("top_n", 10)
+        
+        # Initialize Bedrock client
+        try:
+            if "access_key_id" in config and "secret_access_key" in config:
+                self.bedrock_client = boto3.client(
+                    "bedrock-runtime",
+                    region_name=self.region,
+                    aws_access_key_id=config["access_key_id"],
+                    aws_secret_access_key=config["secret_access_key"]
+                )
+            else:
+                # Use default credentials chain
+                self.bedrock_client = boto3.client(
+                    "bedrock-runtime",
+                    region_name=self.region
+                )
+        except Exception as e:
+            logger.error(f"Failed to initialize Bedrock client: {e}")
+            raise
+    
+    def rerank(
+        self, 
+        query: str, 
+        documents: List[Dict[str, Any]], 
+        top_n: Optional[int] = None
+    ) -> List[RerankerResult]:
+        """Rerank documents using AWS Bedrock Cohere model.
+        
+        Args:
+            query: The search query
+            documents: List of documents to rerank
+            top_n: Number of top results to return (if None, uses config default)
+            
+        Returns:
+            List of reranked results with scores
+        """
+        if not documents:
+            return []
+        
+        # Use provided top_n or config default
+        effective_top_n = top_n or self.top_n
+        
+        # Prepare documents for reranking
+        document_texts = self._prepare_documents(documents)
+        
+        # Prepare the request body for Bedrock
+        request_body = {
+            "query": query,
+            "documents": document_texts,
+            "top_n": min(effective_top_n, len(documents))
+        }
+        
+        try:
+            # Invoke the Bedrock model
+            response = self.bedrock_client.invoke_model(
+                modelId=self.model_id,
+                body=json.dumps(request_body),
+                contentType="application/json"
+            )
+            
+            # Parse the response
+            response_body = json.loads(response["body"].read())
+            
+            # Extract results
+            results = response_body.get("results", [])
+            
+            # Convert to RerankerResult objects
+            reranked_results = []
+            for i, result in enumerate(results):
+                doc_index = result.get("index", i)
+                if doc_index < len(documents):
+                    reranked_results.append(RerankerResult(
+                        id=documents[doc_index].get("id", f"doc_{doc_index}"),
+                        score=result.get("relevance_score", 0.0),
+                        rank=i + 1,
+                        content=documents[doc_index].get("memory", documents[doc_index].get("data", ""))
+                    ))
+            
+            return reranked_results
+            
+        except ClientError as e:
+            error_code = e.response["Error"]["Code"]
+            error_message = e.response["Error"]["Message"]
+            logger.error(f"AWS Bedrock client error ({error_code}): {error_message}")
+            raise Exception(f"AWS Bedrock error: {error_message}")
+            
+        except json.JSONDecodeError as e:
+            logger.error(f"Failed to parse Bedrock response: {e}")
+            raise Exception("Failed to parse reranking response")
+            
+        except Exception as e:
+            logger.error(f"Unexpected error during reranking: {e}")
+            raise
+    
+    def _validate_model(self) -> bool:
+        """Validate that the model is available and accessible.
+        
+        Returns:
+            True if model is accessible, False otherwise
+        """
+        try:
+            # Try to list available models to validate access
+            response = self.bedrock_client.list_foundation_models()
+            model_ids = [model["modelId"] for model in response["modelSummaries"]]
+            return self.model_id in model_ids
+        except Exception as e:
+            logger.warning(f"Could not validate model availability: {e}")
+            return True  # Assume it's available if we can't check
+

--- a/mem0/rerankers/base.py
+++ b/mem0/rerankers/base.py
@@ -1,0 +1,63 @@
+"""Base reranker class for all reranker implementations."""
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
+
+
+class RerankerResult(BaseModel):
+    """Result from a reranker operation."""
+    
+    id: str
+    score: float
+    rank: int
+    content: str
+
+
+class BaseReranker(ABC):
+    """Abstract base class for all reranker implementations."""
+    
+    def __init__(self, config: Dict[str, Any]):
+        """Initialize the reranker with configuration.
+        
+        Args:
+            config: Configuration dictionary containing provider-specific settings
+        """
+        self.config = config
+    
+    @abstractmethod
+    def rerank(
+        self, 
+        query: str, 
+        documents: List[Dict[str, Any]], 
+        top_n: Optional[int] = None
+    ) -> List[RerankerResult]:
+        """Rerank documents based on query relevance.
+        
+        Args:
+            query: The search query
+            documents: List of documents to rerank, each containing at least 'id' and 'memory' fields
+            top_n: Number of top results to return (if None, return all)
+            
+        Returns:
+            List of reranked results with scores
+        """
+        pass
+    
+    def _prepare_documents(self, documents: List[Dict[str, Any]]) -> List[str]:
+        """Prepare documents for reranking by extracting text content.
+        
+        Args:
+            documents: List of document dictionaries
+            
+        Returns:
+            List of text content from documents
+        """
+        texts = []
+        for doc in documents:
+            # Extract text content, prioritizing 'memory' field, then 'data'
+            text = doc.get('memory', doc.get('data', doc.get('content', '')))
+            texts.append(text)
+        return texts
+

--- a/tests/rerankers/__init__.py
+++ b/tests/rerankers/__init__.py
@@ -1,0 +1,2 @@
+"""Tests for reranker implementations."""
+

--- a/tests/rerankers/test_aws_bedrock.py
+++ b/tests/rerankers/test_aws_bedrock.py
@@ -1,0 +1,175 @@
+"""Tests for AWS Bedrock reranker."""
+
+import json
+import pytest
+from unittest.mock import Mock, patch
+
+from mem0.rerankers.aws_bedrock import AWSBedrockReranker
+from mem0.rerankers.base import RerankerResult
+
+
+class TestAWSBedrockReranker:
+    """Test cases for AWS Bedrock reranker."""
+    
+    @pytest.fixture
+    def mock_bedrock_client(self):
+        """Mock AWS Bedrock client."""
+        mock_client = Mock()
+        mock_response = {
+            "body": Mock()
+        }
+        mock_response["body"].read.return_value = json.dumps({
+            "results": [
+                {"index": 1, "relevance_score": 0.95},
+                {"index": 0, "relevance_score": 0.85},
+                {"index": 2, "relevance_score": 0.75}
+            ]
+        }).encode()
+        mock_client.invoke_model.return_value = mock_response
+        return mock_client
+    
+    @pytest.fixture
+    def sample_config(self):
+        """Sample configuration for AWS Bedrock reranker."""
+        return {
+            "model": "cohere.rerank-v3-5:0",
+            "region": "us-west-2",
+            "top_n": 3
+        }
+    
+    @pytest.fixture
+    def sample_documents(self):
+        """Sample documents for testing."""
+        return [
+            {"id": "doc1", "memory": "Python programming language"},
+            {"id": "doc2", "memory": "Machine learning algorithms"},
+            {"id": "doc3", "memory": "Data science techniques"}
+        ]
+    
+    @patch('boto3.client')
+    def test_initialization(self, mock_boto_client, sample_config, mock_bedrock_client):
+        """Test reranker initialization."""
+        mock_boto_client.return_value = mock_bedrock_client
+        
+        reranker = AWSBedrockReranker(sample_config)
+        
+        assert reranker.model_id == "cohere.rerank-v3-5:0"
+        assert reranker.region == "us-west-2"
+        assert reranker.top_n == 3
+        assert reranker.bedrock_client == mock_bedrock_client
+    
+    @patch('boto3.client')
+    def test_rerank_success(self, mock_boto_client, sample_config, mock_bedrock_client, sample_documents):
+        """Test successful reranking."""
+        mock_boto_client.return_value = mock_bedrock_client
+        
+        reranker = AWSBedrockReranker(sample_config)
+        query = "machine learning"
+        
+        results = reranker.rerank(query, sample_documents)
+        
+        # Verify Bedrock client was called correctly
+        mock_bedrock_client.invoke_model.assert_called_once()
+        call_args = mock_bedrock_client.invoke_model.call_args
+        
+        assert call_args[1]["modelId"] == "cohere.rerank-v3-5:0"
+        
+        # Verify request body
+        request_body = json.loads(call_args[1]["body"])
+        assert request_body["query"] == query
+        assert len(request_body["documents"]) == 3
+        assert request_body["top_n"] == 3
+        
+        # Verify results
+        assert len(results) == 3
+        assert all(isinstance(result, RerankerResult) for result in results)
+        assert results[0].id == "doc2"  # Highest relevance
+        assert results[0].score == 0.95
+        assert results[1].id == "doc1"
+        assert results[1].score == 0.85
+    
+    @patch('boto3.client')
+    def test_rerank_with_top_n_override(self, mock_boto_client, sample_config, mock_bedrock_client, sample_documents):
+        """Test reranking with custom top_n parameter."""
+        mock_boto_client.return_value = mock_bedrock_client
+        
+        reranker = AWSBedrockReranker(sample_config)
+        query = "machine learning"
+        
+        results = reranker.rerank(query, sample_documents, top_n=2)
+        
+        # Verify request body has correct top_n
+        call_args = mock_bedrock_client.invoke_model.call_args
+        request_body = json.loads(call_args[1]["body"])
+        assert request_body["top_n"] == 2
+        
+        # Verify results length
+        assert len(results) == 2
+    
+    @patch('boto3.client')
+    def test_rerank_empty_documents(self, mock_boto_client, sample_config, mock_bedrock_client):
+        """Test reranking with empty document list."""
+        mock_boto_client.return_value = mock_bedrock_client
+        
+        reranker = AWSBedrockReranker(sample_config)
+        query = "test query"
+        
+        results = reranker.rerank(query, [])
+        
+        # Should not call Bedrock and return empty results
+        mock_bedrock_client.invoke_model.assert_not_called()
+        assert len(results) == 0
+    
+    @patch('boto3.client')
+    def test_rerank_bedrock_error(self, mock_boto_client, sample_config, mock_bedrock_client, sample_documents):
+        """Test handling of Bedrock client errors."""
+        from botocore.exceptions import ClientError
+        
+        mock_boto_client.return_value = mock_bedrock_client
+        mock_bedrock_client.invoke_model.side_effect = ClientError(
+            {"Error": {"Code": "ValidationException", "Message": "Invalid model"}},
+            "invoke_model"
+        )
+        
+        reranker = AWSBedrockReranker(sample_config)
+        query = "test query"
+        
+        with pytest.raises(Exception, match="AWS Bedrock error"):
+            reranker.rerank(query, sample_documents)
+    
+    @patch('boto3.client')
+    def test_prepare_documents(self, mock_boto_client, sample_config, mock_bedrock_client):
+        """Test document preparation method."""
+        mock_boto_client.return_value = mock_bedrock_client
+        
+        reranker = AWSBedrockReranker(sample_config)
+        
+        documents = [
+            {"id": "doc1", "memory": "Python programming"},
+            {"id": "doc2", "data": "Machine learning"},
+            {"id": "doc3", "content": "Data science"}
+        ]
+        
+        texts = reranker._prepare_documents(documents)
+        
+        assert texts == ["Python programming", "Machine learning", "Data science"]
+    
+    @patch('boto3.client')
+    def test_validate_model(self, mock_boto_client, sample_config, mock_bedrock_client):
+        """Test model validation."""
+        mock_boto_client.return_value = mock_bedrock_client
+        mock_bedrock_client.list_foundation_models.return_value = {
+            "modelSummaries": [
+                {"modelId": "cohere.rerank-v3-5:0"},
+                {"modelId": "anthropic.claude-3-sonnet-20240229-v1:0"}
+            ]
+        }
+        
+        reranker = AWSBedrockReranker(sample_config)
+        
+        assert reranker._validate_model() is True
+        
+        # Test with invalid model
+        reranker.model_id = "invalid.model"
+        assert reranker._validate_model() is False
+

--- a/tests/rerankers/test_factory.py
+++ b/tests/rerankers/test_factory.py
@@ -1,0 +1,66 @@
+"""Tests for reranker factory."""
+
+import pytest
+from unittest.mock import patch
+
+from mem0.utils.factory import RerankerFactory
+from mem0.configs.rerankers.aws_bedrock import AWSBedrockRerankerConfig
+
+
+class TestRerankerFactory:
+    """Test cases for RerankerFactory."""
+    
+    @patch('mem0.rerankers.aws_bedrock.AWSBedrockReranker')
+    def test_create_aws_bedrock_reranker(self, mock_reranker_class):
+        """Test creating AWS Bedrock reranker."""
+        mock_instance = mock_reranker_class.return_value
+        
+        config = {
+            "model": "cohere.rerank-v3-5:0",
+            "region": "us-west-2"
+        }
+        
+        result = RerankerFactory.create("aws_bedrock", config)
+        
+        assert result == mock_instance
+        mock_reranker_class.assert_called_once_with(config)
+    
+    @patch('mem0.rerankers.aws_bedrock.AWSBedrockReranker')
+    def test_create_with_config_object(self, mock_reranker_class):
+        """Test creating reranker with config object."""
+        mock_instance = mock_reranker_class.return_value
+        
+        config = AWSBedrockRerankerConfig(
+            model="cohere.rerank-v3-5:0",
+            region="us-west-2"
+        )
+        
+        result = RerankerFactory.create("aws_bedrock", config)
+        
+        assert result == mock_instance
+        # Should convert config object to dict
+        mock_reranker_class.assert_called_once_with(config.to_dict())
+    
+    def test_create_unsupported_provider(self):
+        """Test creating reranker with unsupported provider."""
+        with pytest.raises(ValueError, match="Unsupported reranker provider"):
+            RerankerFactory.create("unsupported_provider", {})
+    
+    @patch('mem0.rerankers.aws_bedrock.AWSBedrockReranker')
+    def test_create_with_none_config(self, mock_reranker_class):
+        """Test creating reranker with None config."""
+        mock_instance = mock_reranker_class.return_value
+        
+        result = RerankerFactory.create("aws_bedrock", None)
+        
+        assert result == mock_instance
+        mock_reranker_class.assert_called_once_with({})
+    
+    @patch('importlib.import_module')
+    def test_import_error(self, mock_import_module):
+        """Test handling of import errors."""
+        mock_import_module.side_effect = ImportError("Module not found")
+        
+        with pytest.raises(ImportError, match="Could not import reranker"):
+            RerankerFactory.create("aws_bedrock", {})
+


### PR DESCRIPTION
## Description

Added AWS Bedrock as a reranker provider in the docs:
- Example configuration for AWS Bedrock reranker is now included.
- AWS Bedrock is listed among supported reranker models.

Configuration Changes:
- You can now specify a reranker in the main memory configuration.

Memory Class Logic:
- Reranker initialization and usage added to both Memory and Async Memory:
- If a reranker is configured, it is initialized via a new RerankerFactory.
- When retrieving memories, if a reranker is present and there are multiple results, the reranker is used to reorder them.
If reranking fails, a warning is logged and original results are used.

Factory Pattern:
The new RerankerFactory:
- Handles creation of reranker instances based on provider name (currently supports AWS Bedrock).
- Loads the correct reranker class and configuration.

## Type of change

Please delete options that are not relevant.
- New feature (non-breaking change which adds functionality)
- Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [ ] Unit Test
- [ ] Test Script (please provide)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- closes #3501 
- [ ] Made sure Checks passed
