### PR TITLE
feat: Allow custom model and params with huggingface_base_url

### DIFF
--- a/mem0/embeddings/huggingface.py
+++ b/mem0/embeddings/huggingface.py
@@ -18,6 +18,7 @@ class HuggingFaceEmbedding(EmbeddingBase):
 
         if config.huggingface_base_url:
             self.client = OpenAI(base_url=config.huggingface_base_url)
+            self.config.model = self.config.model or "tei"
         else:
             self.config.model = self.config.model or "multi-qa-MiniLM-L6-cos-v1"
 
@@ -36,6 +37,8 @@ class HuggingFaceEmbedding(EmbeddingBase):
             list: The embedding vector.
         """
         if self.config.huggingface_base_url:
-            return self.client.embeddings.create(input=text, model="tei").data[0].embedding
+            return self.client.embeddings.create(
+                input=text, model=self.config.model, **self.config.model_kwargs
+            ).data[0].embedding
         else:
             return self.model.encode(text, convert_to_numpy=True).tolist()


### PR DESCRIPTION
## Description
This change addresses an issue where using huggingface_base_url would incorrectly restrict the embedding model to a hardcoded "tei" value and prevent the use of custom model parameters.

With this fix, users can now specify any model name and pass additional parameters (e.g., truncate=True) when connecting to a custom Hugging Face Text Embeddings Inference (TEI) endpoint or any other OpenAI-compatible API. This provides greater flexibility for users hosting their own embedding models.

Fixes #3553

## Type of change

Please delete options that are not relevant.

- This pull request enhances the flexibility and test coverage of the HuggingFace embedding integration. The main improvements are support for custom models and model parameters when using a HuggingFace endpoint, and the addition of a dedicated test for this functionality.

### HuggingFace embedding configuration and usage

* Ensured that when a custom HuggingFace base URL is provided, the model defaults to `"tei"` if not specified, and otherwise uses the provided model name. (`mem0/embeddings/huggingface.py`)
* Updated the embedding creation logic to use the configured model name and pass through any additional model keyword arguments from `model_kwargs`, allowing for greater customization. (`mem0/embeddings/huggingface.py`)

### Testing improvements

* Added a new test, `test_embed_with_huggingface_base_url`, to verify that custom HuggingFace endpoints, models, and model parameters are correctly handled and passed to the embedding client. (`tests/embeddings/test_huggingface_embeddings.py`)] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [x] Unit Test
- [x] Test Script (please provide)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
This pull request improves the flexibility and configurability of the HuggingFace embedding integration by allowing custom model names and model keyword arguments to be passed through when using a custom HuggingFace endpoint. It also adds a new test to ensure this functionality works as expected.

Enhancements to HuggingFace embedding configuration:

* The `HuggingFaceEmbedding` class now sets the model name to `"tei"` by default only if a custom HuggingFace base URL is provided and no model is explicitly specified, allowing users to override the model name as needed.
* The `embed` method now uses the model name and additional keyword arguments from the config when calling the HuggingFace endpoint, making it possible to customize embedding requests (e.g., to set truncation or other model-specific options).

Testing improvements:

* Added a new test, `test_embed_with_huggingface_base_url`, to verify that the embedding logic correctly passes the custom model name and keyword arguments to the HuggingFace endpoint when a base URL is provided.