### PR TITLE
fix: handle JSON parsing errors in prompts

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -241,9 +241,13 @@ export class Memory {
     }
     const parsedMessages = messages.map((m) => m.content).join("\n");
 
-    const [systemPrompt, userPrompt] = this.customPrompt
-      ? [this.customPrompt, `Input:\n${parsedMessages}`]
-      : getFactRetrievalMessages(parsedMessages);
+    let systemPrompt: string;
+    let userPrompt: string;
+
+    [systemPrompt, userPrompt] = getFactRetrievalMessages(
+      parsedMessages,
+      this.customPrompt
+    );
 
     const response = await this.llm.generateResponse(
       [

--- a/mem0-ts/src/oss/src/prompts/index.ts
+++ b/mem0-ts/src/oss/src/prompts/index.ts
@@ -34,6 +34,7 @@ export const MemoryUpdateSchema = z.object({
 
 export function getFactRetrievalMessages(
   parsedMessages: string,
+  customPrompt?: string,
 ): [string, string] {
   const systemPrompt = `You are a Personal Information Organizer, specialized in accurately storing facts, user memories, and preferences. Your primary role is to extract relevant pieces of information from conversations and organize them into distinct, manageable facts. This allows for easy retrieval and personalization in future interactions. Below are the types of information you need to focus on and the detailed instructions on how to handle the input data.
   
@@ -88,6 +89,13 @@ export function getFactRetrievalMessages(
   `;
 
   const userPrompt = `Following is a conversation between the user and the assistant. You have to extract the relevant facts and preferences about the user, if any, from the conversation and return them in the JSON format as shown above.\n\nInput:\n${parsedMessages}`;
+
+  const customPromptWithJsonHandling = customPrompt ? ` ${customPrompt} Your response must be a valid JSON.` : "";
+
+  // If custom prompt is provided, that will be your system prompt now and user prompt will be parsed message [ based on existing functionality ]
+    if (customPrompt) {
+        return [customPromptWithJsonHandling, "Input:\n" + parsedMessages];
+    }
 
   return [systemPrompt, userPrompt];
 }


### PR DESCRIPTION
This pull request updates how custom prompts are handled when generating fact retrieval messages in the memory module. The main change is to allow a custom prompt to fully override the default system prompt logic, while ensuring the response must be valid JSON. The logic for constructing prompts has been centralized in the `getFactRetrievalMessages` function.

**Prompt customization improvements:**

* The `getFactRetrievalMessages` function now accepts an optional `customPrompt` parameter. If provided, it becomes the system prompt (with a requirement for valid JSON responses), and the user prompt is set to the parsed conversation. [[1]](diffhunk://#diff-77102cd146d3b8fc5151eed83aca3e59ccda65d64fc67c5edccc2a3bdeba535eR37) [[2]](diffhunk://#diff-77102cd146d3b8fc5151eed83aca3e59ccda65d64fc67c5edccc2a3bdeba535eR93-R99)
* The `Memory` class has been updated to always use `getFactRetrievalMessages` for constructing prompts, passing in `customPrompt` if set, simplifying and unifying prompt handling.

Fixes #3559 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [ ] Unit Test
- [ ] Test Script (please provide)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
