### PR TITLE
fix: close posthog clients and only create clients if telemtry is ena…

### DIFF
--- a/mem0/memory/telemetry.py
+++ b/mem0/memory/telemetry.py
@@ -28,9 +28,6 @@ class AnonymousTelemetry:
 
         self.user_id = get_or_create_user_id(vector_store)
 
-        if not MEM0_TELEMETRY:
-            self.posthog.disabled = True
-
     def capture_event(self, event_name, properties=None, user_email=None):
         if properties is None:
             properties = {}
@@ -56,6 +53,9 @@ client_telemetry = AnonymousTelemetry()
 
 
 def capture_event(event_name, memory_instance, additional_data=None):
+    if not MEM0_TELEMETRY:
+        return
+
     oss_telemetry = AnonymousTelemetry(
         vector_store=memory_instance._telemetry_vector_store
         if hasattr(memory_instance, "_telemetry_vector_store")
@@ -78,9 +78,13 @@ def capture_event(event_name, memory_instance, additional_data=None):
         event_data.update(additional_data)
 
     oss_telemetry.capture_event(event_name, event_data)
+    oss_telemetry.close()
 
 
 def capture_client_event(event_name, instance, additional_data=None):
+    if not MEM0_TELEMETRY:
+        return
+
     event_data = {
         "function": f"{instance.__class__.__module__}.{instance.__class__.__name__}",
     }


### PR DESCRIPTION
## Description

Every call to `memory/telemetry.py:capture_event` creates a new PostHog client, which internally creates a new thread to handle an internal message queue. This can lead to massive thread counts from idle PostHog clients.

The environment flag `MEM0_TELEMETRY=False` does not prevent this as it just pauses the PostHog client's internal queue processing.

This PR:
- adds an explicit call to `AnonymousTelemetry.close` shutdown the PostHog client
- honors the `MEM0_TELEMETRY` flag more conistently by not even creating a PostHog client.

See #3376

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
