### PR TITLE
Fix REST API infer parameter ignored

### DIFF
--- a/openmemory/api/app/routers/memories.py
+++ b/openmemory/api/app/routers/memories.py
@@ -252,7 +252,8 @@ async def create_memory(
             metadata={
                 "source_app": "openmemory",
                 "mcp_client": request.app,
-            }
+            },
+            infer=request.infer
         )
         
         # Log the response for debugging


### PR DESCRIPTION
Simple fix - forgot to pass infer parameter to memory_client.add().

## Description

REST API endpoint accepts `infer` parameter in request schema but wasn't passing it to `memory_client.add()` call. One line fix.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Test Script (verified infer=False stores verbatim, infer=True transforms via LLM)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings