### PR TITLE
Fix MCP search_memory NoneType iteration error

### DIFF
--- a/openmemory/api/app/mcp_server.py
+++ b/openmemory/api/app/mcp_server.py
@@ -184,7 +184,7 @@ async def search_memory(query: str) -> str:
             for h in hits:
                 # All vector db search functions return OutputData class
                 id, score, payload = h.id, h.score, h.payload
-                if allowed and h.id is None or h.id not in allowed: 
+                if allowed is not None and h.id not in allowed:
                     continue
                 
                 results.append({


### PR DESCRIPTION
## Problem

MCP `search_memory` endpoint crashed with `TypeError: argument of type 'NoneType' is not iterable` when filtering search results by ACL permissions.

**Root cause:** Boolean logic error in filter condition (line 187):
```python
if allowed and h.id is None or h.id not in allowed:  # Wrong
```

This evaluates as `(allowed and h.id is None) or (h.id not in allowed)`, causing crash when `allowed` is a non-empty set.

## Fix

Corrected the boolean logic:
```python
if allowed is not None and h.id not in allowed:  # Correct
```

Now properly checks: "If ACL filter exists AND memory ID not in allowed set, skip it"

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Test Script - MCP search now returns results without TypeError
- Verified with populated memory database and ACL filtering

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings