### PR TITLE
Fix memory deletion not removing from vector store

### DIFF
--- a/openmemory/api/app/mcp_server.py
+++ b/openmemory/api/app/mcp_server.py
@@ -314,7 +314,7 @@ async def delete_all_memories() -> str:
             # delete the accessible memories only
             for memory_id in accessible_memory_ids:
                 try:
-                    memory_client.delete(memory_id)
+                    memory_client.delete(str(memory_id))
                 except Exception as delete_error:
                     logging.warning(f"Failed to delete memory {memory_id} from vector store: {delete_error}")
 

--- a/openmemory/api/app/routers/memories.py
+++ b/openmemory/api/app/routers/memories.py
@@ -350,8 +350,32 @@ async def delete_memories(
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
 
+    # Get memory client to delete from vector store
+    try:
+        memory_client = get_memory_client()
+        if not memory_client:
+            raise HTTPException(
+                status_code=503,
+                detail="Memory client is not available"
+            )
+    except HTTPException:
+        raise
+    except Exception as client_error:
+        logging.error(f"Memory client initialization failed: {client_error}")
+        raise HTTPException(
+            status_code=503,
+            detail=f"Memory service unavailable: {str(client_error)}"
+        )
+
+    # Delete from vector store then mark as deleted in database
     for memory_id in request.memory_ids:
+        try:
+            memory_client.delete(str(memory_id))
+        except Exception as delete_error:
+            logging.warning(f"Failed to delete memory {memory_id} from vector store: {delete_error}")
+
         update_memory_state(db, memory_id, MemoryState.deleted, user.id)
+
     return {"message": f"Successfully deleted {len(request.memory_ids)} memories"}
 
 


### PR DESCRIPTION
## Problem

Memory deletion endpoints only updated PostgreSQL state but never deleted from Qdrant vector store. This caused:
- Deleted memories still appearing in search results
- Vector store growing indefinitely
- Database and vector store getting out of sync

**What was broken:**
1. **REST API** (`DELETE /api/v1/memories/`): Only called `update_memory_state()` to mark as deleted in DB
2. **MCP API** (`delete_all_memories`): Called `memory_client.delete(memory_id)` but passed UUID instead of string

## How It Works Elsewhere

The `add_memories` flow (both REST and MCP) properly syncs:
1. Add to vector store via `memory_client.add()`
2. Store metadata in PostgreSQL

Deletion should mirror this - remove from both stores.

## The Fix

**MCP API** (`delete_all_memories` in mcp_server.py):
- Convert UUID to string: `memory_client.delete(str(memory_id))`
- Qdrant expects string IDs, not UUID objects

**REST API** (`delete_memories` in memories.py):
- Added vector store deletion before DB update:
  1. Get memory client
  2. Delete from Qdrant via `memory_client.delete(str(memory_id))`
  3. Mark as deleted in PostgreSQL

Both endpoints now properly sync deletions across storage layers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Test Script - verified memories deleted from both Qdrant and PostgreSQL
- Tested delete_all via MCP and bulk delete via REST API
- Confirmed deleted memories no longer appear in search results

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Follows existing pattern from add_memories workflow