### PR TITLE
Fix condition check for memories_result type in AsyncMemory class

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1753,7 +1753,7 @@ class AsyncMemory(MemoryBase):
         memories_result = await asyncio.to_thread(self.vector_store.list, filters=filters, limit=limit)
         actual_memories = (
             memories_result[0]
-            if isinstance(memories_result, (tuple, list)) and len(memories_result) > 0
+            if isinstance(memories_result, (tuple)) and len(memories_result) > 0
             else memories_result
         )
 


### PR DESCRIPTION
## Description

This fixes issue #3605 attribute error for MongoDB in async Memory class module for get_all

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

```python
async def main():
    # Initialize Memory with the configuration
    m = await AsyncMemory.from_config(config)

    memories = await m.get_all(user_id="john")

    print(memories)
    print(len(memories["results"]))
```


- [x] Test Script (please provide)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
