### PR TITLE
Fix embedder config schema to support embeddingDims and url parameters

### DIFF
--- a/mem0-ts/src/oss/src/config/manager.ts
+++ b/mem0-ts/src/oss/src/config/manager.ts
@@ -27,6 +27,7 @@ export class ConfigManager {
                 : defaultConf.apiKey,
             model: finalModel,
             url: userConf?.url,
+            embeddingDims: userConf?.embeddingDims,
             modelProperties:
               userConf?.modelProperties !== undefined
                 ? userConf.modelProperties

--- a/mem0-ts/src/oss/src/types/index.ts
+++ b/mem0-ts/src/oss/src/types/index.ts
@@ -119,6 +119,8 @@ export const MemoryConfigSchema = z.object({
       apiKey: z.string().optional(),
       model: z.union([z.string(), z.any()]).optional(),
       baseURL: z.string().optional(),
+      embeddingDims: z.number().optional(),
+      url: z.string().optional(),
     }),
   }),
   vectorStore: z.object({


### PR DESCRIPTION
The Zod schema for embedder config was missing embeddingDims and url fields, causing these parameters to be stripped during validation.

* Added embeddingDims and url to MemoryConfigSchema.embedder.config
* Updated ConfigManager.mergeConfig to pass embeddingDims

Fixes - #3632 