### PR TITLE
Fix the configuration parameter of baidu_vector_store

### DIFF
--- a/mem0/configs/vector_stores/baidu.py
+++ b/mem0/configs/vector_stores/baidu.py
@@ -8,9 +8,10 @@ class BaiduDBConfig(BaseModel):
     account: str = Field("root", description="Account for Baidu VectorDB")
     api_key: str = Field(None, description="API Key for Baidu VectorDB")
     database_name: str = Field("mem0", description="Name of the database")
-    table_name: str = Field("mem0", description="Name of the table")
+    collection_name: str = Field("mem0", description="Name of the table")
     embedding_model_dims: int = Field(1536, description="Dimensions of the embedding model")
     metric_type: str = Field("L2", description="Metric type for similarity search")
+    replication: int = Field(3, description="Replication factor for the table")
 
     @model_validator(mode="before")
     @classmethod


### PR DESCRIPTION
## Description

fix baidu_vector_store:
- BaiduDBconfig used `table_name` while Memory class need `collection_name`
- Hardcode replicate=3 caused failures in resource-constrained environments
- Invalid filter formats triggered "bad parameter filter" exceptions

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [ ] Test Script (please provide)

```python
from mem0 import Memory

Memory.from_config({
    "vectore_store": {
        "collection_name": "xxx",
        # "not table_name": ""
        ...
        
    }
})

```

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
