### PR TITLE
ci: add install-only workflow for manual dependency install checks

### DIFF
--- a/.github/workflows/install-only.yml
+++ b/.github/workflows/install-only.yml
@@ -1,0 +1,42 @@
+name: Install-only CI
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  install-only:
+    name: Install-only
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.10, 3.11]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Upgrade pip tooling
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+
+      - name: Install project extras (install-only)
+        env:
+          PIP_DISABLE_PIP_VERSION_CHECK: '1'
+        run: |
+          # Install editable with the same extras used in the full CI
+          pip install -e ".[test,graph,vector_stores,llms,extras]"
+
+      - name: Run pip check
+        run: |
+          # Show any dependency conflicts (non-zero exit will mark job failed)
+          pip check
+
+      - name: Show installed packages summary
+        run: |
+          pip list --format=columns


### PR DESCRIPTION
Adds a small  GitHub Actions workflow that can be manually dispatched (or triggered on PR) to run the project dependency installation step for Python 3.10 and 3.11. This helps maintainers re-run the pip resolver quickly to debug 'resolution-too-deep' issues without running the full CI matrix. Workflow: 
How to use: go to the Actions tab or the workflow on the PR and click 'Run workflow' (choose a python version) to re-run the dependency install.This PR targets the parent repo so CI can be re-run on the branch; it's safe and only installs packages (no tests or deployments).