### PR TITLE
[docs] Add Redirects to the new docs to fix broken links

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -860,11 +860,19 @@
       "destination": "/cookbooks/integrations/healthcare-google-adk"
     },
     {
+      "source": "/examples/mem0-google-adk-healthcare-assi",
+      "destination": "/cookbooks/integrations/healthcare-google-adk"
+    },
+    {
       "source": "/examples/aws_example",
       "destination": "/cookbooks/integrations/aws-bedrock"
     },
     {
       "source": "/examples/aws_neptune_analytics_hybrid_store",
+      "destination": "/cookbooks/integrations/neptune-analytics"
+    },
+    {
+      "source": "/examples/aws_neptune_analytics_hybrid_st",
       "destination": "/cookbooks/integrations/neptune-analytics"
     },
     {
@@ -878,6 +886,42 @@
     {
       "source": "/examples/llamaindex-multiagent-learning-system",
       "destination": "/cookbooks/frameworks/llamaindex-multiagent"
+    },
+    {
+      "source": "/examples/llamaindex-multiagent-learning-",
+      "destination": "/cookbooks/frameworks/llamaindex-multiagent"
+    },
+    {
+      "source": "/overview",
+      "destination": "/platform/overview"
+    },
+    {
+      "source": "/components/embedders/models/hugging_face",
+      "destination": "/components/embedders/models/huggingface"
+    },
+    {
+      "source": "/components/llms/models/azure_openai_structured",
+      "destination": "/components/llms/models/azure_openai"
+    },
+    {
+      "source": "/components/llms/models/openai_structured",
+      "destination": "/components/llms/models/openai"
+    },
+    {
+      "source": "/components/vectordbs/dbs/azure_ai_search",
+      "destination": "/components/vectordbs/dbs/azure"
+    },
+    {
+      "source": "/components/vectordbs/dbs/upstash_vector",
+      "destination": "/components/vectordbs/dbs/upstash-vector"
+    },
+    {
+      "source": "/components/vectordbs/dbs/vertex_ai_vector_search",
+      "destination": "/components/vectordbs/dbs/vertex_ai"
+    },
+    {
+      "source": "/platform/features/selective-memory",
+      "destination": "/platform/features/custom-instructions"
     },
     {
       "source": "/examples/multimodal-demo",


### PR DESCRIPTION
## Description

While creating new docs and restructuring the `docs.json` , the overall change broke the overall old links and SEO 

This PR redirects the old link to the new location  to fix 404 issues to docs

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [ ] Unit Test
- [ ] Test Script (please provide)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
