### PR TITLE
[docs]  graph memory docs fix 

### DIFF
--- a/docs/open-source/features/graph-memory.mdx
+++ b/docs/open-source/features/graph-memory.mdx
@@ -15,7 +15,7 @@ Graph Memory extends Mem0 by persisting nodes and edges alongside embeddings, so
 
 ## How Graph Memory Maps Context
 
-Mem0 extracts entities and relationships from every memory write, stores embeddings in your vector database, and mirrors relationships in a graph backend. On retrieval, vector search narrows candidates, then the graph supplies context and re-ranks results.
+Mem0 extracts entities and relationships from every memory write, stores embeddings in your vector database, and mirrors relationships in a graph backend. On retrieval, vector search narrows candidates while the graph returns related context alongside the results.
 
 ```mermaid
 graph LR
@@ -37,8 +37,8 @@ Mem0’s extraction LLM identifies entities, relationships, and timestamps from 
 <Step title="Store vectors and edges together">
 Embeddings land in your configured vector database while nodes and edges flow into a Bolt-compatible graph backend (Neo4j, Memgraph, Neptune, or Kuzu).
 </Step>
-<Step title="Blend graph context at search time">
-`memory.search` first performs vector similarity, then follows connected nodes to boost (or filter) answers before optionally handing results to a reranker.
+<Step title="Expose graph context at search time">
+`memory.search` performs vector similarity (optionally reranked by your configured reranker) and returns the results list. Graph Memory runs in parallel and adds related entities in the `relations` array—it does not reorder the vector hits automatically.
 </Step>
 </Steps>
 
@@ -161,6 +161,10 @@ results.results.forEach((hit) => {
 <Info icon="check">
 Expect to see **Alice met Bob at GraphConf 2025** in the output. In Neo4j Browser run `MATCH (p:Person)-[r]->(q:Person) RETURN p,r,q LIMIT 5;` to confirm the edge exists.
 </Info>
+
+<Note>
+Graph Memory enriches responses by adding related entities in the `relations` key. The ordering of `results` always comes from vector search (plus any reranker you configure); graph edges do not reorder those hits automatically.
+</Note>
 
 ## Operate Graph Memory Day-to-Day
 

--- a/docs/platform/features/graph-memory.mdx
+++ b/docs/platform/features/graph-memory.mdx
@@ -14,8 +14,8 @@ This feature allows your AI applications to understand connections between entit
 The Graph Memory feature analyzes how each entity connects and relates to each other. When enabled:
 
 1. Mem0 automatically builds a graph representation of entities
-2. Retrieval considers graph relationships between entities
-3. Results include entities that may be contextually important even if they're not direct semantic matches
+2. Vector search returns the top semantic matches (with any reranker you configure)
+3. Graph relations are returned alongside those results to provide additional context—they do not reorder the vector hits
 
 ## Using Graph Memory
 
@@ -179,6 +179,10 @@ console.log(results);
 
 </CodeGroup>
 
+<Note>
+`results` always reflects the vector search order (optionally reranked). Graph Memory augments that response by adding related entities in the `relations` array; it does not re-rank the vector results automatically.
+</Note>
+
 ### Retrieving All Memories with Graph Memory
 
 When retrieving all memories, Graph Memory provides additional relationship context:
@@ -339,4 +343,3 @@ Graph Memory requires additional processing and may increase response times slig
 If you have any questions, please feel free to reach out to us using one of the following methods:
 
 <Snippet file="get-help.mdx" />
-


### PR DESCRIPTION
## Description

This PR addresses a fault in docs where it says that graph=True influences the vector search list  

Fix Graph Memory docs to match current behavior. Vector search returns the results list (with optional reranker); Graph Memory simply adds relationship context in relations. The previous wording implied graph data reordered the vector hits, which isn’t accurate
 

  

Fixes # (issue)

https://github.com/mem0ai/mem0/issues/3713



## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [ ] Unit Test
- [ ] Test Script (please provide)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
