### PR TITLE
Fixing base llm config for anthropic

### DIFF
--- a/mem0/configs/llms/anthropic.py
+++ b/mem0/configs/llms/anthropic.py
@@ -13,10 +13,10 @@ class AnthropicConfig(BaseLlmConfig):
         self,
         # Base parameters
         model: Optional[str] = None,
-        temperature: float = 0.1,
+        temperature: float = None,
         api_key: Optional[str] = None,
         max_tokens: int = 2000,
-        top_p: float = 0.1,
+        top_p: float = None,
         top_k: int = 1,
         enable_vision: bool = False,
         vision_details: Optional[str] = "auto",

--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -115,17 +115,24 @@ class LLMBase(ABC):
     def _get_common_params(self, **kwargs) -> Dict:
         """
         Get common parameters that most providers use.
+        Filters out None values to avoid API errors.
 
         Returns:
             Dict: Common parameters dictionary.
         """
-        params = {
-            "temperature": self.config.temperature,
-            "max_tokens": self.config.max_tokens,
-            "top_p": self.config.top_p,
-        }
+        params = {}
 
-        # Add provider-specific parameters from kwargs
-        params.update(kwargs)
+        # Only include parameters that are not None
+        if self.config.temperature is not None:
+            params["temperature"] = self.config.temperature
+        if self.config.max_tokens is not None:
+            params["max_tokens"] = self.config.max_tokens
+        if self.config.top_p is not None:
+            params["top_p"] = self.config.top_p
+
+        # Add provider-specific parameters from kwargs (also filter None values)
+        for key, value in kwargs.items():
+            if value is not None:
+                params[key] = value
 
         return params


### PR DESCRIPTION
## Description

When using anthropic LLM, the default configuration sets both `temperature` and `top_p`. However, this LLM API call fails with exception 
```
anthropic.BadRequestError: Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error', 'message': '`temperature` and `top_p` cannot both be specified for this model. Please use only one.'},

```
Hence setting the default value as None for both `temperature` and  `top_p`

Fixes # [3730](https://github.com/mem0ai/mem0/issues/3730)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Able to execute the code attached in issue with this fix and provides below output:

```
Added first memory.

--- Retrieving Memories ---

Searching for: 'What is my name and what do I do for work?'
{'results': [{'id': '70963f93-2cc5-4f67-be48-b47ee57e5ca7', 'memory': 'Name is John', 'hash': 'b411f2405087835e4ecef41b42f3f901', 'metadata': None, 'score': 0.5285094683899707, 'created_at': '2025-11-07T22:58:09.162766-08:00', 'updated_at': None, 'user_id': 'local-dev-user-123'}, {'id': 'a071bf47-c9dd-4a35-80a4-568f8abaad0b', 'memory': 'Is a software developer', 'hash': '62168cb21e558338c23fa7673637e358', 'metadata': None, 'score': 0.5033015147920743, 'created_at': '2025-11-07T22:58:09.164146-08:00', 'updated_at': None, 'user_id': 'local-dev-user-123'}]}

```

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [ ] Unit Test
- [x] Test Script (attached in the issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
