### PR TITLE
[enhancement] Add reasoning_effort parameter support for Azure/OpenAI configs

### DIFF
--- a/mem0/configs/llms/azure.py
+++ b/mem0/configs/llms/azure.py
@@ -22,6 +22,7 @@ class AzureOpenAIConfig(BaseLlmConfig):
         enable_vision: bool = False,
         vision_details: Optional[str] = "auto",
         http_client_proxies: Optional[dict] = None,
+        reasoning_effort: Optional[str] = None,
         # Azure OpenAI-specific parameters
         azure_kwargs: Optional[Dict[str, Any]] = None,
     ):
@@ -38,6 +39,7 @@ class AzureOpenAIConfig(BaseLlmConfig):
             enable_vision: Enable vision capabilities, defaults to False
             vision_details: Vision detail level, defaults to "auto"
             http_client_proxies: HTTP client proxy settings, defaults to None
+            reasoning_effort: Reasoning level (low, medium, high), defaults to None
             azure_kwargs: Azure-specific configuration, defaults to None
         """
         # Initialize base parameters
@@ -54,4 +56,5 @@ class AzureOpenAIConfig(BaseLlmConfig):
         )
 
         # Azure OpenAI-specific parameters
+        self.reasoning_effort = reasoning_effort
         self.azure_kwargs = AzureConfig(**(azure_kwargs or {}))

--- a/mem0/configs/llms/openai.py
+++ b/mem0/configs/llms/openai.py
@@ -21,6 +21,7 @@ class OpenAIConfig(BaseLlmConfig):
         enable_vision: bool = False,
         vision_details: Optional[str] = "auto",
         http_client_proxies: Optional[dict] = None,
+        reasoning_effort: Optional[str] = None,
         # OpenAI-specific parameters
         openai_base_url: Optional[str] = None,
         models: Optional[List[str]] = None,
@@ -45,12 +46,14 @@ class OpenAIConfig(BaseLlmConfig):
             enable_vision: Enable vision capabilities, defaults to False
             vision_details: Vision detail level, defaults to "auto"
             http_client_proxies: HTTP client proxy settings, defaults to None
+            reasoning_effort: Reasoning level (low, medium, high), defaults to None
             openai_base_url: OpenAI API base URL, defaults to None
             models: List of models for OpenRouter, defaults to None
             route: OpenRouter route strategy, defaults to "fallback"
             openrouter_base_url: OpenRouter base URL, defaults to None
             site_url: Site URL for OpenRouter, defaults to None
             app_name: Application name for OpenRouter, defaults to None
+            store: Store conversation, defaults to False
             response_callback: Optional callback for monitoring LLM responses.
         """
         # Initialize base parameters
@@ -67,6 +70,7 @@ class OpenAIConfig(BaseLlmConfig):
         )
 
         # OpenAI-specific parameters
+        self.reasoning_effort = reasoning_effort
         self.openai_base_url = openai_base_url
         self.models = models
         self.route = route

--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -88,6 +88,8 @@ class LLMBase(ABC):
                 supported_params["tools"] = kwargs["tools"]
             if "tool_choice" in kwargs:
                 supported_params["tool_choice"] = kwargs["tool_choice"]
+            if hasattr(self.config, 'reasoning_effort') and self.config.reasoning_effort:
+                supported_params["reasoning_effort"] = self.config.reasoning_effort
                 
             return supported_params
         else:


### PR DESCRIPTION
## Description

Added support for the `reasoning_effort` parameter in `AzureOpenAIConfig` and `OpenAIConfig` classes to enable testing and comparison of different reasoning effort levels ("low", "medium", "high") supported by OpenAI's reasoning models (o1, o3, gpt-5).

The parameter was recently added to OpenAI SDK but was not implemented in Mem0's configuration classes, causing a `TypeError` when users tried to pass `reasoning_effort` in their config.

This change enables users to evaluate performance and latency trade-offs across reasoning models directly within Mem0.

Fixes #3651

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Tested by initializing both config classes with the `reasoning_effort` parameter and verifying:
1. Parameter is accepted and stored correctly
2. Parameter is included in API params for reasoning models (o1, o3, gpt-5)
3. Parameter is excluded for non-reasoning models (gpt-4, etc.)
4. All existing unit tests pass

- [x] Unit Test
- [x] Test Script (please provide)

```python
# Test script used
from mem0.configs.llms.azure import AzureOpenAIConfig
from mem0.configs.llms.openai import OpenAIConfig

# Test AzureOpenAIConfig
azure_config = AzureOpenAIConfig(
    model="o1-preview",
    reasoning_effort="medium"
)
assert azure_config.reasoning_effort == "medium"

# Test OpenAIConfig
openai_config = OpenAIConfig(
    model="o1-mini",
    reasoning_effort="low"
)
assert openai_config.reasoning_effort == "low"


Fixes #3651 