### PR TITLE
fix: evaluate prompt dates at runtime instead of import time

### DIFF
--- a/mem0/configs/prompts.py
+++ b/mem0/configs/prompts.py
@@ -11,7 +11,9 @@ Guidelines:
 Here are the details of the task:
 """
 
-FACT_RETRIEVAL_PROMPT = f"""You are a Personal Information Organizer, specialized in accurately storing facts, user memories, and preferences. Your primary role is to extract relevant pieces of information from conversations and organize them into distinct, manageable facts. This allows for easy retrieval and personalization in future interactions. Below are the types of information you need to focus on and the detailed instructions on how to handle the input data.
+def get_fact_retrieval_prompt() -> str:
+    """Generates the fact retrieval prompt with the current date."""
+    return f"""You are a Personal Information Organizer, specialized in accurately storing facts, user memories, and preferences. Your primary role is to extract relevant pieces of information from conversations and organize them into distinct, manageable facts. This allows for easy retrieval and personalization in future interactions. Below are the types of information you need to focus on and the detailed instructions on how to handle the input data.
 
 Types of Information to Remember:
 
@@ -59,7 +61,9 @@ You should detect the language of the user input and record the facts in the sam
 """
 
 # USER_MEMORY_EXTRACTION_PROMPT - Enhanced version based on platform implementation
-USER_MEMORY_EXTRACTION_PROMPT = f"""You are a Personal Information Organizer, specialized in accurately storing facts, user memories, and preferences. 
+def get_user_memory_extraction_prompt() -> str:
+    """Generates the user memory extraction prompt with the current date."""
+    return f"""You are a Personal Information Organizer, specialized in accurately storing facts, user memories, and preferences. 
 Your primary role is to extract relevant pieces of information from conversations and organize them into distinct, manageable facts. 
 This allows for easy retrieval and personalization in future interactions. Below are the types of information you need to focus on and the detailed instructions on how to handle the input data.
 
@@ -120,7 +124,9 @@ Following is a conversation between the user and the assistant. You have to extr
 """
 
 # AGENT_MEMORY_EXTRACTION_PROMPT - Enhanced version based on platform implementation
-AGENT_MEMORY_EXTRACTION_PROMPT = f"""You are an Assistant Information Organizer, specialized in accurately storing facts, preferences, and characteristics about the AI assistant from conversations. 
+def get_agent_memory_extraction_prompt() -> str:
+    """Generates the agent memory extraction prompt with the current date."""
+    return f"""You are an Assistant Information Organizer, specialized in accurately storing facts, preferences, and characteristics about the AI assistant from conversations. 
 Your primary role is to extract relevant pieces of information about the assistant from conversations and organize them into distinct, manageable facts. 
 This allows for easy retrieval and characterization of the assistant in future interactions. Below are the types of information you need to focus on and the detailed instructions on how to handle the input data.
 

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -2,9 +2,9 @@ import hashlib
 import re
 
 from mem0.configs.prompts import (
-    FACT_RETRIEVAL_PROMPT,
-    USER_MEMORY_EXTRACTION_PROMPT,
-    AGENT_MEMORY_EXTRACTION_PROMPT,
+    get_fact_retrieval_prompt,
+    get_user_memory_extraction_prompt,
+    get_agent_memory_extraction_prompt,
 )
 
 
@@ -19,14 +19,14 @@ def get_fact_retrieval_messages(message, is_agent_memory=False):
         tuple: (system_prompt, user_prompt)
     """
     if is_agent_memory:
-        return AGENT_MEMORY_EXTRACTION_PROMPT, f"Input:\n{message}"
+        return get_agent_memory_extraction_prompt(), f"Input:\n{message}"
     else:
-        return USER_MEMORY_EXTRACTION_PROMPT, f"Input:\n{message}"
+        return get_user_memory_extraction_prompt(), f"Input:\n{message}"
 
 
 def get_fact_retrieval_messages_legacy(message):
     """Legacy function for backward compatibility."""
-    return FACT_RETRIEVAL_PROMPT, f"Input:\n{message}"
+    return get_fact_retrieval_prompt(), f"Input:\n{message}"
 
 
 def parse_messages(messages):


### PR DESCRIPTION
## Description

This PR fixes a bug where prompt constants containing `datetime.now()` were evaluated once at module import time, causing stale dates to be used in long-running processes (e.g., servers running for days/weeks).

**Problem:** 
- Prompts like `FACT_RETRIEVAL_PROMPT` used f-strings with `datetime.now().strftime("%Y-%m-%d")`
- These were evaluated once when the module was imported
- A server starting on Nov 11 would continue showing "Today's date is 2025-11-11" even weeks later

**Solution:**
- Converted static prompt constants to factory functions (`get_fact_retrieval_prompt()`, etc.)
- Updated all callers in `mem0/memory/utils.py` to invoke these functions
- Now `datetime.now()` is evaluated at runtime, ensuring prompts always contain the current date

This ensures temporal accuracy for LLM-based memory operations in production deployments.

Fixes #3755

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manual verification: Python syntax validation passed (`python -m py_compile`)
- [x] Code inspection: Verified all imports and function calls updated correctly
- [x] No references to old constants remain (confirmed via `findstr`)


- Files modified: `mem0/configs/prompts.py`, `mem0/memory/utils.py`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
