### PR TITLE
fix: allow None vector in milvus updates

### DIFF
--- a/mem0/vector_stores/milvus.py
+++ b/mem0/vector_stores/milvus.py
@@ -178,9 +178,18 @@ class MilvusDB(VectorStoreBase):
 
         Args:
             vector_id (str): ID of the vector to update.
-            vector (List[float], optional): Updated vector.
+            vector (List[float], optional): Updated vector. If None, the existing vector will be preserved.
             payload (Dict, optional): Updated payload.
         """
+        # If vector is None, fetch the existing vector to preserve it
+        if vector is None:
+            existing_data = self.client.get(collection_name=self.collection_name, ids=vector_id)
+            if not existing_data:
+                raise ValueError(f"Vector with ID {vector_id} not found")
+            vector = existing_data[0].get("vectors")
+            if vector is None:
+                raise ValueError(f"Could not retrieve existing vector for ID {vector_id}")
+
         schema = {"id": vector_id, "vectors": vector, "metadata": payload}
         self.client.upsert(collection_name=self.collection_name, data=schema)
 


### PR DESCRIPTION
## Description

milvus api does not support update without vector at the moment, this fix enable update with vector = None by fetch the vector and upsert with the other updated fields.


Fixes # [(issue)](https://github.com/mem0ai/mem0/issues/3708)

## Type of change


- [ ] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

tested against milvus in docker

Please delete options that are not relevant.

- [x] Unit Test

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
