### PR TITLE
feat(openmemory): add OPENAI_BASE_URL to run.sh

### DIFF
--- a/openmemory/run.sh
+++ b/openmemory/run.sh
@@ -108,6 +108,7 @@ create_compose_file() {
     image: mem0/openmemory-mcp:latest
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - OPENAI_BASE_URL=${OPENAI_BASE_URL}
       - USER=${USER}
 EOF
 


### PR DESCRIPTION
This PR adds support for `OPENAI_BASE_URL` in the `openmemory/run.sh` script. This allows users to specify a custom base URL for the OpenAI API, for example, when using a proxy or a self-hosted solution.