### PR TITLE
feat: add support for custom providers in memory configuration and embedding

### DIFF
--- a/mem0-ts/src/oss/README.md
+++ b/mem0-ts/src/oss/README.md
@@ -89,6 +89,35 @@ const memory = new Memory({
   },
 });
 
+// Or with an OpenAI-compatible custom provider (e.g. Scaleway)
+const memory = new Memory({
+  embedder: {
+    provider: "custom",
+    config: {
+      baseURL: process.env.SCALEWAY_API_URL,
+      apiKey: process.env.SCALEWAY_API_KEY,
+      model: "bge-multilingual-gemma2",
+    },
+  },
+  vectorStore: {
+    provider: "memory",
+    config: {
+      collectionName: "memories",
+      dimension: 3584
+    }
+  },
+  llm: {
+    provider: "custom",
+    config: {
+      baseURL: process.env.SCALEWAY_API_URL,
+      apiKey: process.env.SCALEWAY_API_KEY,
+      model: "gpt-oss-120b",
+    },
+  },
+});
+
+// `url` also works for backward compatibility if you prefer that field name.
+
 // Add a memory
 await memory.add("The sky is blue", "user123");
 

--- a/mem0-ts/src/oss/src/config/manager.ts
+++ b/mem0-ts/src/oss/src/config/manager.ts
@@ -27,6 +27,10 @@ export class ConfigManager {
                 : defaultConf.apiKey,
             model: finalModel,
             url: userConf?.url,
+            baseURL:
+              userConf?.baseURL !== undefined
+                ? userConf.baseURL
+                : defaultConf.baseURL,
             embeddingDims: userConf?.embeddingDims,
             modelProperties:
               userConf?.modelProperties !== undefined

--- a/mem0-ts/src/oss/src/embeddings/openai.ts
+++ b/mem0-ts/src/oss/src/embeddings/openai.ts
@@ -8,7 +8,10 @@ export class OpenAIEmbedder implements Embedder {
   private embeddingDims?: number;
 
   constructor(config: EmbeddingConfig) {
-    this.openai = new OpenAI({ apiKey: config.apiKey });
+    this.openai = new OpenAI({
+      apiKey: config.apiKey,
+      baseURL: config.baseURL || config.url,
+    });
     this.model = config.model || "text-embedding-3-small";
     this.embeddingDims = config.embeddingDims || 1536;
   }

--- a/mem0-ts/src/oss/src/types/index.ts
+++ b/mem0-ts/src/oss/src/types/index.ts
@@ -16,6 +16,7 @@ export interface EmbeddingConfig {
   apiKey?: string;
   model?: string | any;
   url?: string;
+  baseURL?: string;
   embeddingDims?: number;
   modelProperties?: Record<string, any>;
 }

--- a/mem0-ts/src/oss/src/utils/factory.ts
+++ b/mem0-ts/src/oss/src/utils/factory.ts
@@ -37,6 +37,7 @@ export class EmbedderFactory {
   static create(provider: string, config: EmbeddingConfig): Embedder {
     switch (provider.toLowerCase()) {
       case "openai":
+      case "custom":
         return new OpenAIEmbedder(config);
       case "ollama":
         return new OllamaEmbedder(config);
@@ -57,6 +58,7 @@ export class LLMFactory {
   static create(provider: string, config: LLMConfig): LLM {
     switch (provider.toLowerCase()) {
       case "openai":
+      case "custom":
         return new OpenAILLM(config);
       case "openai_structured":
         return new OpenAIStructuredLLM(config);


### PR DESCRIPTION
## Description

Adds first-class support for custom OpenAI-compatible providers in the TypeScript SDK (mem0-ts).  
- Allows `provider: "custom"` for LLMs and embedders, reusing the OpenAI clients with user-supplied `baseURL`/`url`.  
- Passes those URLs through config merging so they reach the SDK constructors.  
- Normalizes non-string LLM responses (some providers return structured objects) before parsing memories, fixing `text.replace is not a function`.  
- Updates the OSS README with a sample custom-provider configuration; if this direction looks good we can add a dedicated documentation section afterwards.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [ ] Unit Test
- [x] Test Script – manual test: run `memory.add`/`search` with a Scaleway OpenAI-compatible endpoint using the new `provider: "custom"` config to confirm memories are saved without errors.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed


If this change looks good, we can follow up by adding a dedicated documentation section about custom providers.

