### PR TITLE
Handle single vector case in query processing

### DIFF
--- a/mem0/vector_stores/upstash_vector.py
+++ b/mem0/vector_stores/upstash_vector.py
@@ -126,17 +126,22 @@ class UpstashVector(VectorStoreBase):
                 namespace=self.collection_name,
             )
         else:
+            # Check if vectors is a single vector (list of floats) or list of vectors
+            # A single vector will have float/int elements, while list of vectors will have list elements
+            if vectors and not isinstance(vectors[0], list):
+                # Single vector case - wrap it in a list
+                vectors = [vectors]
+
             queries = [
                 {
                     "vector": v,
                     "top_k": limit,
                     "filter": filters_str or "",
                     "include_metadata": True,
-                    "namespace": self.collection_name,
                 }
                 for v in vectors
             ]
-            responses = self.client.query_many(queries=queries)
+            responses = self.client.query_many(queries=queries, namespace=self.collection_name)
             # flatten
             response = [res for res_list in responses for res in res_list]
 


### PR DESCRIPTION
Added handling for single vector input by wrapping it in a list.

## Description

Upstash vector may a single vector instead of List of vectors

Fixes # (issue)
add type checking, if it's a single vector wrap it in a list

## Type of change

Please delete options that are not relevant.

- [v] Bug fix (non-breaking change which fixes an issue)
