### PR TITLE
  Register `PGVector` class in the TypeScript SDK's `VectorStoreFactory` to enable pgvector support.

### DIFF
--- a/mem0-ts/src/oss/src/utils/factory.ts
+++ b/mem0-ts/src/oss/src/utils/factory.ts
@@ -32,6 +32,7 @@ import { LangchainLLM } from "../llms/langchain";
 import { LangchainEmbedder } from "../embeddings/langchain";
 import { LangchainVectorStore } from "../vector_stores/langchain";
 import { AzureAISearch } from "../vector_stores/azure_ai_search";
+import { PGVector } from "../vector_stores/pgvector";
 
 export class EmbedderFactory {
   static create(provider: string, config: EmbeddingConfig): Embedder {
@@ -96,6 +97,8 @@ export class VectorStoreFactory {
         return new LangchainVectorStore(config as any);
       case "vectorize":
         return new VectorizeDB(config as any);
+      case "pgvector":
+        return new PGVector(config as any);
       case "azure-ai-search":
         return new AzureAISearch(config as any);
       default:


### PR DESCRIPTION
 ## Description

  Fixes #3782 
  Register `PGVector` class in the TypeScript SDK's `VectorStoreFactory` to enable pgvector support.

  The `PGVector` class was already fully implemented in `mem0-ts/src/oss/src/vector_stores/pgvector.ts` but was never registered in the factory (`mem0-ts/src/oss/src/utils/factory.ts`), making it unusable despite being
  documented.

  **Changes:**
  - Added import for `PGVector` from `../vector_stores/pgvector`
  - Added `case "pgvector"` in `VectorStoreFactory.create()` switch statement

  Fixes # (issue)

  ## Type of change

  -  Bug fix (non-breaking change which fixes an issue)

  ## How Has This Been Tested?

  - [ ] Unit Test

  ```typescript
  import { Memory } from "mem0ai/oss";

  const memory = new Memory({
    vectorStore: {
      provider: "pgvector",
      config: {
        user: "postgres",
        password: "password",
        host: "localhost",
        port: 5432,
        embeddingModelDims: 1536,
      }
    },
    // ... other config
  });

  // Previously threw: Error: Unsupported vector store provider: pgvector
  // Now initializes correctly

  Checklist:

  - My code follows the style guidelines of this project
  - I have performed a self-review of my own code
  - I have commented my code, particularly in hard-to-understand areas
  - I have made corresponding changes to the documentation
  - My changes generate no new warnings
  - I have added tests that prove my fix is effective or that my feature works
  - New and existing unit tests pass locally with my changes
  - Any dependent changes have been merged and published in downstream modules
  - I have checked my code and corrected any misspellings

  Maintainer Checklist

  - closes #xxxx (Replace xxxx with the GitHub issue number)
  - Made sure Checks passed