### PR TITLE
fix: rename vector_stores to vector-stores for Hatch 1.16+ compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ graph = [
     "rank-bm25>=0.2.2",
     "kuzu>=0.11.0",
 ]
-vector_stores = [
+vector-stores = [
     "vecs>=0.4.0",
     "chromadb>=0.4.24",
     "cassandra-driver>=3.29.0",
@@ -110,7 +110,7 @@ python = "3.9"
 features = [
   "test",
   "graph",
-  "vector_stores",
+  "vector-stores",
   "llms",
   "extras",
 ]
@@ -120,7 +120,7 @@ python = "3.10"
 features = [
   "test",
   "graph",
-  "vector_stores",
+  "vector-stores",
   "llms",
   "extras",
 ]
@@ -130,7 +130,7 @@ python = "3.11"
 features = [
   "test",
   "graph",
-  "vector_stores",
+  "vector-stores",
   "llms",
   "extras",
 ]
@@ -140,7 +140,7 @@ python = "3.12"
 features = [
   "test",
   "graph",
-  "vector_stores",
+  "vector-stores",
   "llms",
   "extras",
 ]


### PR DESCRIPTION
Hatch 1.16+ enforces PEP 503 normalization, which converts underscores to hyphens in extra names. This causes a mismatch when looking up `vector_stores` in project.optional-dependencies.

Rename `vector_stores` to `vector-stores` in:
- [project.optional-dependencies] section
- [tool.hatch.envs.dev_py_3_9] features
- [tool.hatch.envs.dev_py_3_10] features
- [tool.hatch.envs.dev_py_3_11] features
- [tool.hatch.envs.dev_py_3_12] features

Fixes #3800

## Description

**Root Cause:** [PEP 503](https://peps.python.org/pep-0503/#normalized-names) specifies that extra names should be normalized by replacing underscores with hyphens. Hatch 1.16+ enforces this normalization, converting `vector_stores` to `vector-stores` during feature lookup, but the original name `vector_stores` in `project.optional-dependencies` doesn't match.

**Solution:** Rename `vector_stores` to `vector-stores` in all relevant locations in `pyproject.toml`.

Fixes #3800

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

After applying this change, `hatch shell dev_py_3_*` commands work correctly with Hatch 1.16.1.

**Test steps:**

1. Upgrade hatch to latest version:
  ` pipx upgrade hatch`
2. Enter the dev shell:
   `hatch shell dev_py_3_9`
3. Result: Successfully enters the environment without `ValueError`

- [x] Test Script (please provide)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist


- [x] closes #3800
