### PR TITLE
fix: convert cosine distance to similarity score in PGVector search

### DIFF
--- a/mem0/vector_stores/pgvector.py
+++ b/mem0/vector_stores/pgvector.py
@@ -241,7 +241,10 @@ class PGVector(VectorStoreBase):
             )
 
             results = cur.fetchall()
-        return [OutputData(id=str(r[0]), score=float(r[1]), payload=r[2]) for r in results]
+        # Convert cosine distance to similarity score (1 - distance)
+        # This ensures consistency with other vector stores (e.g., Weaviate)
+        # where higher scores indicate greater similarity
+        return [OutputData(id=str(r[0]), score=1.0 - float(r[1]), payload=r[2]) for r in results]
 
     def delete(self, vector_id: str) -> None:
         """


### PR DESCRIPTION

## Description

This PR applies the same fix that was done for Weaviate in #3521 to PGVector.

The `search` method in PGVector was returning raw cosine distance as the `score` field, which is inconsistent with other vector stores and causes `threshold` filtering to fail.

**Problem:**
- Cosine distance: 0 = identical, higher = less similar
- But `memory/main.py` threshold logic expects: higher score = more similar (`score >= threshold`)

**This caused:**
1. Exact matches to have `score=0.0` instead of `score=1.0`
2. `threshold` parameter to filter out the most relevant results (e.g., `threshold=0.1` filters out exact matches with `score=0.0`)
3. Inconsistency with Weaviate and other vector stores

**Solution:**
Convert cosine distance to similarity score using `1 - distance`, same as Weaviate (#3521).

Related to #3521 (Weaviate fix)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Test Script (please provide)

```python
from mem0 import Memory

config = {
    "vector_store": {
        "provider": "pgvector",
        "config": {
            "user": "your_user",
            "password": "your_password",
            "host": "localhost",
            "port": 5432,
            "dbname": "your_db",
        }
    }
}

m = Memory.from_config(config)
m.add("I am 20 years old", user_id="test")

# Test 1: Exact match should have score ≈ 1.0
results = m.search("20 years old", user_id="test")
assert results["results"][0]["score"] > 0.9, f"Expected high score, got {results['results'][0]['score']}"
print(f"✅ Exact match score: {results['results'][0]['score']}")

# Test 2: Threshold filtering should work correctly
results = m.search("20 years old", user_id="test", threshold=0.5)
assert len(results["results"]) > 0, "Expected results with threshold=0.5"
print(f"✅ Threshold filtering works: {len(results['results'])} results")
```

**Results before fix:**
- Exact match: `score=0.0` ❌
- `threshold=0.1` filters out exact matches ❌

**Results after fix:**
- Exact match: `score≈1.0` ✅
- `threshold=0.5` returns relevant results ✅

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number, or remove if no issue)
- [ ] Made sure Checks passed
