### PR TITLE
 fix: add dimensions parameter to Azure OpenAI embeddings

### DIFF
--- a/mem0/embeddings/azure_openai.py
+++ b/mem0/embeddings/azure_openai.py
@@ -52,4 +52,8 @@ class AzureOpenAIEmbedding(EmbeddingBase):
             list: The embedding vector.
         """
         text = text.replace("\n", " ")
-        return self.client.embeddings.create(input=[text], model=self.config.model).data[0].embedding
+        return (
+            self.client.embeddings.create(input=[text], model=self.config.model, dimensions=self.config.embedding_dims)
+            .data[0]
+            .embedding
+        )


### PR DESCRIPTION
  ## Description

  The `AzureOpenAIEmbedding` class does not pass the `embedding_dims` config to the Azure OpenAI API, even though:
  1. The documentation mentions `embedding_dims` as a configurable parameter
  2. The `BaseEmbedderConfig` class already supports `embedding_dims`
  3. The OpenAI embedder (`openai.py`) already implements this feature

  This prevents users from using dimension reduction with `text-embedding-3-large` or `text-embedding-3-small` models on Azure OpenAI.

  ## Current Behavior

  ```python
  # mem0/embeddings/azure_openai.py:55
  return self.client.embeddings.create(input=[text], model=self.config.model).data[0].embedding
  # ^ dimensions parameter is missing

  Expected Behavior

  # Should match openai.py:45-48
  return (
      self.client.embeddings.create(input=[text], model=self.config.model, dimensions=self.config.embedding_dims)
      .data[0]
      .embedding
  )

  Suggested Fix

  Add dimensions=self.config.embedding_dims to the embeddings.create() call in mem0/embeddings/azure_openai.py.

