### PR TITLE
fix: Preserve http_auth and connection_class in _safe_deepcopy_config

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -70,7 +70,12 @@ def _safe_deepcopy_config(config):
             clone_dict = {k: v for k, v in config.__dict__.items()}
         
         sensitive_tokens = ("auth", "credential", "password", "token", "secret", "key", "connection_class")
+        safe_fields = {"http_auth", "auth", "connection_class"}
+
         for field_name in list(clone_dict.keys()):
+            if field_name.lower() in safe_fields:
+                continue
+            
             if any(token in field_name.lower() for token in sensitive_tokens):
                 clone_dict[field_name] = None
         


### PR DESCRIPTION
Fixes #3580.
**Context**: Opensearch and other vector stores require 'http_auth' and 'connection_class' for runtime connection, but '_safe_deepcopy_config' was aggressively stripping them due to 'auth' substring matching.

**Fix**: Added an explicit allowlist for 'http_auth', 'auth', and 'connection_class' to preserve them during configuration deepcopy/reconstruction.