### PR TITLE
fix(docs): Correct API authentication header from Bearer to Token

### DIFF
--- a/docs/api-reference/memory/add-memories.mdx
+++ b/docs/api-reference/memory/add-memories.mdx
@@ -17,7 +17,7 @@ Memories are processed asynchronously by default. The response contains queued e
 
 | Header | Required | Description |
 | --- | --- | --- |
-| `Authorization: Bearer <MEM0_API_KEY>` | Yes | API key scoped to your workspace. |
+| `Authorization: Token <MEM0_API_KEY>` | Yes | API key scoped to your workspace. |
 | `Accept: application/json` | Yes | Ensures a JSON response. |
 
 ## Request body

--- a/docs/platform/quickstart.mdx
+++ b/docs/platform/quickstart.mdx
@@ -69,7 +69,7 @@ await client.add(messages, { user_id: "user123" });
 
 ```bash cURL
 curl -X POST https://api.mem0.ai/v1/memories/add \
-  -H "Authorization: Bearer $MEM0_API_KEY" \
+  -H "Authorization: Token $MEM0_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "messages": [
@@ -97,7 +97,7 @@ console.log(results);
 
 ```bash cURL
 curl -X POST https://api.mem0.ai/v1/memories/search \
-  -H "Authorization: Bearer $MEM0_API_KEY" \
+  -H "Authorization: Token $MEM0_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "query": "What are my dietary restrictions?",

--- a/docs/templates/api_reference_template.mdx
+++ b/docs/templates/api_reference_template.mdx
@@ -35,7 +35,7 @@ path: "/v1/memories"
 
 | Method | Path | Auth | Rate Limit |
 | --- | --- | --- | --- |
-| [METHOD] | `[path]` | Bearer (`mem0-api-key`) | [X req/min] |
+| [METHOD] | `[path]` | Token (`mem0-api-key`) | [X req/min] |
 
 <Info>
   Use this endpoint when [brief scenario]. Prefer [alternative endpoint] for [other scenario].
@@ -51,7 +51,7 @@ path: "/v1/memories"
 
 | Name | Required | Description |
 | --- | --- | --- |
-| `Authorization` | Yes | `Bearer YOUR_API_KEY` |
+| `Authorization` | Yes | `Token YOUR_API_KEY` |
 | `Content-Type` | Yes | `application/json` |
 
 ### Body
@@ -65,7 +65,7 @@ path: "/v1/memories"
 <CodeGroup>
 ```bash Shell
 curl https://api.mem0.ai/v1/memories \
-  -H "Authorization: Bearer $MEM0_API_KEY" \
+  -H "Authorization: Token $MEM0_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{ "user_id": "alex", "memory": "Prefers email follow-ups." }'
 ```
@@ -75,7 +75,7 @@ import requests
 
 resp = requests.post(
     "https://api.mem0.ai/v1/memories",
-    headers={"Authorization": f"Bearer {API_KEY}"},
+    headers={"Authorization": f"Token {API_KEY}"},
     json={"user_id": "alex", "memory": "Prefers email follow-ups."},
 )
 resp.raise_for_status()
@@ -85,7 +85,7 @@ resp.raise_for_status()
 const response = await fetch("https://api.mem0.ai/v1/memories", {
   method: "POST",
   headers: {
-    Authorization: `Bearer ${process.env.MEM0_API_KEY}`,
+    Authorization: `Token ${process.env.MEM0_API_KEY}`,
     "Content-Type": "application/json",
   },
   body: JSON.stringify({ user_id: "alex", memory: "Prefers email follow-ups." }),


### PR DESCRIPTION
## Description

Customers were getting 401 authentication errors when following the API documentation examples. The docs showed `Authorization: Bearer <token>` but the API actually expects `Authorization: Token <token>`.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [ ] Unit Test
- [ ] Test Script (please provide)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
