### PR TITLE
Fix: prevent double embedding in mem0.add (fixes #3723)

### DIFF
--- a/mem0/vector_stores/azure_ai_search.py
+++ b/mem0/vector_stores/azure_ai_search.py
@@ -222,7 +222,8 @@ class AzureAISearch(VectorStoreBase):
         if filters:
             filter_expression = self._build_filter_expression(filters)
 
-        vector_query = VectorizedQuery(vector=vectors, k_nearest_neighbors=limit, fields="vector")
+        # Azure VectorizedQuery uses `k` for nearest neighbors in current SDKs.
+        vector_query = VectorizedQuery(vector=vectors, k=limit, fields="vector")
         if self.hybrid_search:
             search_results = self.search_client.search(
                 search_text=query,

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -245,3 +245,35 @@ def test_get_all_handles_flat_list_from_postgres(mock_sqlite, mock_llm_factory, 
     assert len(result) == 2
     assert result[0]["memory"] == "Memory 1"
     assert result[1]["memory"] == "Memory 2" 
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+def test_add_infer_false_embeds_once(mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
+    """
+    Regression test: adding with infer=False should not trigger duplicate embedding calls.
+    """
+    embedder = MagicMock()
+    embedder.embed.return_value = [0.1, 0.2, 0.3]
+    embedder.config = MagicMock(embedding_dims=3)
+    mock_embedder_factory.return_value = embedder
+
+    mock_vector_store = MagicMock()
+    mock_vector_store.search.return_value = []
+    mock_vector_store.insert.return_value = None
+    mock_vector_store.get.return_value = None
+    telemetry_vector_store = MagicMock()
+    mock_vector_factory.side_effect = [mock_vector_store, telemetry_vector_store]
+
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+    memory = MemoryClass(MemoryConfig())
+
+    memory.add("foo", user_id="test_user", infer=False)
+
+    assert embedder.embed.call_count == 1
+    mock_vector_store.insert.assert_called_once()

--- a/tests/vector_stores/test_azure_ai_search.py
+++ b/tests/vector_stores/test_azure_ai_search.py
@@ -542,7 +542,7 @@ def test_search_basic(azure_ai_search_instance):
     # Check parameters
     assert len(kwargs["vector_queries"]) == 1
     assert kwargs["vector_queries"][0].vector == query_vector
-    assert kwargs["vector_queries"][0].k_nearest_neighbors == 5
+    assert kwargs["vector_queries"][0].k == 5
     assert kwargs["vector_queries"][0].fields == "vector"
     assert kwargs["filter"] is None  # No filters
     assert kwargs["top"] == 5


### PR DESCRIPTION
## Description

- Reuse precomputed embeddings when infer=False (sync/async) so mem0.add no longer calls the embedder twice.
- Allow _create_memory to accept provided embeddings; avoids redundant API calls.
- Update Azure AI Search vector query to use k (current SDK) and adjust the test accordingly.
- Add regression test to ensure infer=False embeds once and uses the main vector store.

Fixes #3723

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

MEM0_DIR=$PWD/.mem0 pytest -p no:rerunfailures tests/

Please delete options that are not relevant.

- [ ] Unit Test


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
