### PR TITLE
Add extra_headers support for observability and custom proxy headers

### DIFF
--- a/docs/components/embedders/config.mdx
+++ b/docs/components/embedders/config.mdx
@@ -84,6 +84,7 @@ Here's a comprehensive list of all parameters that can be used across different 
 | `memory_update_embedding_type` | The type of embedding to use for the update memory action                       | VertexAI            |
 | `memory_search_embedding_type` | The type of embedding to use for the search memory action                       | VertexAI            |
 | `lmstudio_base_url` | Base URL for LM Studio API                    | LM Studio         |
+| `extra_headers`      | Custom HTTP headers for observability/proxy   | OpenAI            |
 </Tab>
 <Tab title="TypeScript">
 | Parameter | Description | Provider |

--- a/docs/components/llms/config.mdx
+++ b/docs/components/llms/config.mdx
@@ -76,6 +76,32 @@ await memory.add("Your text here", { userId: "user123", metadata: { category: "e
 
 </CodeGroup>
 
+### Using Extra Headers for Observability
+
+You can pass custom HTTP headers to supported LLM providers using the `extra_headers` config option. This is useful for integrating with observability tools like Helicone or custom proxy servers:
+
+```python Python
+import os
+from mem0 import Memory
+
+os.environ["OPENAI_API_KEY"] = "sk-xx"
+
+config = {
+    "llm": {
+        "provider": "openai",
+        "config": {
+            "model": "gpt-4o-mini",
+            "extra_headers": {
+                "Helicone-Auth": "Bearer <your-helicone-key>",
+                "Helicone-Cache-Enabled": "true"
+            }
+        }
+    }
+}
+
+m = Memory.from_config(config)
+```
+
 ## Why is Config Needed?
 
 Config is essential for:
@@ -115,6 +141,7 @@ Here's a comprehensive list of all parameters that can be used across different 
     | `seed`               | Seed for deterministic sampling               | Sarvam            |
     | `stop`               | Stop sequences (max 4)                        | Sarvam            |
     | `lmstudio_base_url`  | Base URL for LM Studio API                    | LM Studio         |
+    | `extra_headers`      | Custom HTTP headers for observability/proxy   | All               |
     | `response_callback`  | LLM response callback function                | OpenAI            |
   </Tab>
   <Tab title="TypeScript">

--- a/mem0/configs/embeddings/base.py
+++ b/mem0/configs/embeddings/base.py
@@ -40,6 +40,8 @@ class BaseEmbedderConfig(ABC):
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
         aws_region: Optional[str] = None,
+        # Custom headers for API requests
+        extra_headers: Optional[Dict[str, str]] = None,
     ):
         """
         Initializes a configuration class instance for the Embeddings.
@@ -72,6 +74,8 @@ class BaseEmbedderConfig(ABC):
         :type memory_search_embedding_type: Optional[str], optional
         :param lmstudio_base_url: LM Studio base URL to be use, defaults to "http://localhost:1234/v1"
         :type lmstudio_base_url: Optional[str], optional
+        :param extra_headers: Custom HTTP headers to include in API requests, defaults to None
+        :type extra_headers: Optional[Dict[str, str]], optional
         """
 
         self.model = model
@@ -107,4 +111,7 @@ class BaseEmbedderConfig(ABC):
         self.aws_access_key_id = aws_access_key_id
         self.aws_secret_access_key = aws_secret_access_key
         self.aws_region = aws_region or os.environ.get("AWS_REGION") or "us-west-2"
+
+        # Custom headers
+        self.extra_headers = extra_headers
 

--- a/mem0/configs/llms/anthropic.py
+++ b/mem0/configs/llms/anthropic.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Dict, Optional
 
 from mem0.configs.llms.base import BaseLlmConfig
 
@@ -21,6 +21,7 @@ class AnthropicConfig(BaseLlmConfig):
         enable_vision: bool = False,
         vision_details: Optional[str] = "auto",
         http_client_proxies: Optional[dict] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
         # Anthropic-specific parameters
         anthropic_base_url: Optional[str] = None,
     ):
@@ -37,6 +38,7 @@ class AnthropicConfig(BaseLlmConfig):
             enable_vision: Enable vision capabilities, defaults to False
             vision_details: Vision detail level, defaults to "auto"
             http_client_proxies: HTTP client proxy settings, defaults to None
+            extra_headers: Custom HTTP headers for API requests, defaults to None
             anthropic_base_url: Anthropic API base URL, defaults to None
         """
         # Initialize base parameters
@@ -50,6 +52,7 @@ class AnthropicConfig(BaseLlmConfig):
             enable_vision=enable_vision,
             vision_details=vision_details,
             http_client_proxies=http_client_proxies,
+            extra_headers=extra_headers,
         )
 
         # Anthropic-specific parameters

--- a/mem0/configs/llms/azure.py
+++ b/mem0/configs/llms/azure.py
@@ -24,6 +24,7 @@ class AzureOpenAIConfig(BaseLlmConfig):
         http_client_proxies: Optional[dict] = None,
         # Azure OpenAI-specific parameters
         azure_kwargs: Optional[Dict[str, Any]] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
     ):
         """
         Initialize Azure OpenAI configuration.
@@ -51,6 +52,7 @@ class AzureOpenAIConfig(BaseLlmConfig):
             enable_vision=enable_vision,
             vision_details=vision_details,
             http_client_proxies=http_client_proxies,
+            extra_headers=extra_headers,
         )
 
         # Azure OpenAI-specific parameters

--- a/mem0/configs/llms/base.py
+++ b/mem0/configs/llms/base.py
@@ -24,6 +24,7 @@ class BaseLlmConfig(ABC):
         enable_vision: bool = False,
         vision_details: Optional[str] = "auto",
         http_client_proxies: Optional[Union[Dict, str]] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
     ):
         """
         Initialize a base configuration class instance for the LLM.
@@ -50,6 +51,8 @@ class BaseLlmConfig(ABC):
                 Options: "low", "high", "auto". Defaults to "auto"
             http_client_proxies: Proxy settings for HTTP client.
                 Can be a dict or string. Defaults to None
+            extra_headers: Custom HTTP headers to include in API requests.
+                Defaults to None
         """
         self.model = model
         self.temperature = temperature
@@ -60,3 +63,4 @@ class BaseLlmConfig(ABC):
         self.enable_vision = enable_vision
         self.vision_details = vision_details
         self.http_client = httpx.Client(proxies=http_client_proxies) if http_client_proxies else None
+        self.extra_headers = extra_headers

--- a/mem0/configs/llms/deepseek.py
+++ b/mem0/configs/llms/deepseek.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Dict, Optional
 
 from mem0.configs.llms.base import BaseLlmConfig
 
@@ -21,6 +21,7 @@ class DeepSeekConfig(BaseLlmConfig):
         enable_vision: bool = False,
         vision_details: Optional[str] = "auto",
         http_client_proxies: Optional[dict] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
         # DeepSeek-specific parameters
         deepseek_base_url: Optional[str] = None,
     ):
@@ -37,6 +38,7 @@ class DeepSeekConfig(BaseLlmConfig):
             enable_vision: Enable vision capabilities, defaults to False
             vision_details: Vision detail level, defaults to "auto"
             http_client_proxies: HTTP client proxy settings, defaults to None
+            extra_headers: Custom HTTP headers for API requests, defaults to None
             deepseek_base_url: DeepSeek API base URL, defaults to None
         """
         # Initialize base parameters
@@ -50,6 +52,7 @@ class DeepSeekConfig(BaseLlmConfig):
             enable_vision=enable_vision,
             vision_details=vision_details,
             http_client_proxies=http_client_proxies,
+            extra_headers=extra_headers,
         )
 
         # DeepSeek-specific parameters

--- a/mem0/configs/llms/lmstudio.py
+++ b/mem0/configs/llms/lmstudio.py
@@ -21,6 +21,7 @@ class LMStudioConfig(BaseLlmConfig):
         enable_vision: bool = False,
         vision_details: Optional[str] = "auto",
         http_client_proxies: Optional[dict] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
         # LM Studio-specific parameters
         lmstudio_base_url: Optional[str] = None,
         lmstudio_response_format: Optional[Dict[str, Any]] = None,
@@ -52,6 +53,7 @@ class LMStudioConfig(BaseLlmConfig):
             enable_vision=enable_vision,
             vision_details=vision_details,
             http_client_proxies=http_client_proxies,
+            extra_headers=extra_headers,
         )
 
         # LM Studio-specific parameters

--- a/mem0/configs/llms/openai.py
+++ b/mem0/configs/llms/openai.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from mem0.configs.llms.base import BaseLlmConfig
 
@@ -21,6 +21,7 @@ class OpenAIConfig(BaseLlmConfig):
         enable_vision: bool = False,
         vision_details: Optional[str] = "auto",
         http_client_proxies: Optional[dict] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
         # OpenAI-specific parameters
         openai_base_url: Optional[str] = None,
         models: Optional[List[str]] = None,
@@ -45,6 +46,7 @@ class OpenAIConfig(BaseLlmConfig):
             enable_vision: Enable vision capabilities, defaults to False
             vision_details: Vision detail level, defaults to "auto"
             http_client_proxies: HTTP client proxy settings, defaults to None
+            extra_headers: Custom HTTP headers for API requests, defaults to None
             openai_base_url: OpenAI API base URL, defaults to None
             models: List of models for OpenRouter, defaults to None
             route: OpenRouter route strategy, defaults to "fallback"
@@ -64,6 +66,7 @@ class OpenAIConfig(BaseLlmConfig):
             enable_vision=enable_vision,
             vision_details=vision_details,
             http_client_proxies=http_client_proxies,
+            extra_headers=extra_headers,
         )
 
         # OpenAI-specific parameters

--- a/mem0/configs/llms/vllm.py
+++ b/mem0/configs/llms/vllm.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Dict, Optional
 
 from mem0.configs.llms.base import BaseLlmConfig
 
@@ -21,6 +21,7 @@ class VllmConfig(BaseLlmConfig):
         enable_vision: bool = False,
         vision_details: Optional[str] = "auto",
         http_client_proxies: Optional[dict] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
         # vLLM-specific parameters
         vllm_base_url: Optional[str] = None,
     ):
@@ -50,6 +51,7 @@ class VllmConfig(BaseLlmConfig):
             enable_vision=enable_vision,
             vision_details=vision_details,
             http_client_proxies=http_client_proxies,
+            extra_headers=extra_headers,
         )
 
         # vLLM-specific parameters

--- a/mem0/embeddings/openai.py
+++ b/mem0/embeddings/openai.py
@@ -29,7 +29,11 @@ class OpenAIEmbedding(EmbeddingBase):
                 DeprecationWarning,
             )
 
-        self.client = OpenAI(api_key=api_key, base_url=base_url)
+        self.client = OpenAI(
+            api_key=api_key,
+            base_url=base_url,
+            default_headers=self.config.extra_headers,
+        )
 
     def embed(self, text, memory_action: Optional[Literal["add", "search", "update"]] = None):
         """

--- a/mem0/llms/anthropic.py
+++ b/mem0/llms/anthropic.py
@@ -38,7 +38,10 @@ class AnthropicLLM(LLMBase):
             self.config.model = "claude-3-5-sonnet-20240620"
 
         api_key = self.config.api_key or os.getenv("ANTHROPIC_API_KEY")
-        self.client = anthropic.Anthropic(api_key=api_key)
+        self.client = anthropic.Anthropic(
+            api_key=api_key,
+            default_headers=self.config.extra_headers,
+        )
 
     def generate_response(
         self,

--- a/mem0/llms/anthropic.py
+++ b/mem0/llms/anthropic.py
@@ -30,6 +30,7 @@ class AnthropicLLM(LLMBase):
                 enable_vision=config.enable_vision,
                 vision_details=config.vision_details,
                 http_client_proxies=config.http_client,
+                extra_headers=config.extra_headers,
             )
 
         super().__init__(config)

--- a/mem0/llms/azure_openai.py
+++ b/mem0/llms/azure_openai.py
@@ -44,7 +44,9 @@ class AzureOpenAILLM(LLMBase):
         azure_deployment = self.config.azure_kwargs.azure_deployment or os.getenv("LLM_AZURE_DEPLOYMENT")
         azure_endpoint = self.config.azure_kwargs.azure_endpoint or os.getenv("LLM_AZURE_ENDPOINT")
         api_version = self.config.azure_kwargs.api_version or os.getenv("LLM_AZURE_API_VERSION")
-        default_headers = self.config.azure_kwargs.default_headers
+        default_headers = self.config.extra_headers or {}
+        if self.config.azure_kwargs.default_headers:
+            default_headers = {**self.config.azure_kwargs.default_headers, **self.config.extra_headers}
 
         # If the API key is not provided or is a placeholder, use DefaultAzureCredential.
         if api_key is None or api_key == "" or api_key == "your-api-key":
@@ -126,12 +128,14 @@ class AzureOpenAILLM(LLMBase):
         messages[-1]["content"] = user_prompt
 
         params = self._get_supported_params(messages=messages, **kwargs)
-        
+
         # Add model and messages
-        params.update({
-            "model": self.config.model,
-            "messages": messages,
-        })
+        params.update(
+            {
+                "model": self.config.model,
+                "messages": messages,
+            }
+        )
 
         if tools:
             params["tools"] = tools

--- a/mem0/llms/azure_openai.py
+++ b/mem0/llms/azure_openai.py
@@ -46,7 +46,10 @@ class AzureOpenAILLM(LLMBase):
         api_version = self.config.azure_kwargs.api_version or os.getenv("LLM_AZURE_API_VERSION")
         default_headers = self.config.extra_headers or {}
         if self.config.azure_kwargs.default_headers:
-            default_headers = {**self.config.azure_kwargs.default_headers, **self.config.extra_headers}
+            default_headers = {
+                **self.config.azure_kwargs.default_headers,
+                **(self.config.extra_headers or {}),
+            }
 
         # If the API key is not provided or is a placeholder, use DefaultAzureCredential.
         if api_key is None or api_key == "" or api_key == "your-api-key":

--- a/mem0/llms/azure_openai.py
+++ b/mem0/llms/azure_openai.py
@@ -32,6 +32,7 @@ class AzureOpenAILLM(LLMBase):
                 enable_vision=config.enable_vision,
                 vision_details=config.vision_details,
                 http_client_proxies=config.http_client,
+                extra_headers=config.extra_headers,
             )
 
         super().__init__(config)

--- a/mem0/llms/deepseek.py
+++ b/mem0/llms/deepseek.py
@@ -38,7 +38,11 @@ class DeepSeekLLM(LLMBase):
 
         api_key = self.config.api_key or os.getenv("DEEPSEEK_API_KEY")
         base_url = self.config.deepseek_base_url or os.getenv("DEEPSEEK_API_BASE") or "https://api.deepseek.com"
-        self.client = OpenAI(api_key=api_key, base_url=base_url)
+        self.client = OpenAI(
+            api_key=api_key,
+            base_url=base_url,
+            default_headers=self.config.extra_headers,
+        )
 
     def _parse_response(self, response, tools):
         """

--- a/mem0/llms/deepseek.py
+++ b/mem0/llms/deepseek.py
@@ -29,6 +29,7 @@ class DeepSeekLLM(LLMBase):
                 enable_vision=config.enable_vision,
                 vision_details=config.vision_details,
                 http_client_proxies=config.http_client,
+                extra_headers=config.extra_headers,
             )
 
         super().__init__(config)

--- a/mem0/llms/groq.py
+++ b/mem0/llms/groq.py
@@ -20,7 +20,10 @@ class GroqLLM(LLMBase):
             self.config.model = "llama3-70b-8192"
 
         api_key = self.config.api_key or os.getenv("GROQ_API_KEY")
-        self.client = Groq(api_key=api_key)
+        self.client = Groq(
+            api_key=api_key,
+            default_headers=self.config.extra_headers,
+        )
 
     def _parse_response(self, response, tools):
         """

--- a/mem0/llms/lmstudio.py
+++ b/mem0/llms/lmstudio.py
@@ -28,6 +28,7 @@ class LMStudioLLM(LLMBase):
                 enable_vision=config.enable_vision,
                 vision_details=config.vision_details,
                 http_client_proxies=config.http_client,
+                extra_headers=config.extra_headers,
             )
 
         super().__init__(config)
@@ -38,7 +39,11 @@ class LMStudioLLM(LLMBase):
         )
         self.config.api_key = self.config.api_key or "lm-studio"
 
-        self.client = OpenAI(base_url=self.config.lmstudio_base_url, api_key=self.config.api_key)
+        self.client = OpenAI(
+            base_url=self.config.lmstudio_base_url,
+            api_key=self.config.api_key,
+            default_headers=self.config.extra_headers,
+        )
 
     def _parse_response(self, response, tools):
         """

--- a/mem0/llms/openai.py
+++ b/mem0/llms/openai.py
@@ -30,6 +30,7 @@ class OpenAILLM(LLMBase):
                 enable_vision=config.enable_vision,
                 vision_details=config.vision_details,
                 http_client_proxies=config.http_client,
+                extra_headers=config.extra_headers,
             )
 
         super().__init__(config)
@@ -43,12 +44,17 @@ class OpenAILLM(LLMBase):
                 base_url=self.config.openrouter_base_url
                 or os.getenv("OPENROUTER_API_BASE")
                 or "https://openrouter.ai/api/v1",
+                default_headers=self.config.extra_headers,
             )
         else:
             api_key = self.config.api_key or os.getenv("OPENAI_API_KEY")
             base_url = self.config.openai_base_url or os.getenv("OPENAI_BASE_URL") or "https://api.openai.com/v1"
 
-            self.client = OpenAI(api_key=api_key, base_url=base_url)
+            self.client = OpenAI(
+                api_key=api_key,
+                base_url=base_url,
+                default_headers=self.config.extra_headers,
+            )
 
     def _parse_response(self, response, tools):
         """

--- a/mem0/llms/together.py
+++ b/mem0/llms/together.py
@@ -20,7 +20,10 @@ class TogetherLLM(LLMBase):
             self.config.model = "mistralai/Mixtral-8x7B-Instruct-v0.1"
 
         api_key = self.config.api_key or os.getenv("TOGETHER_API_KEY")
-        self.client = Together(api_key=api_key)
+        self.client = Together(
+            api_key=api_key,
+            default_headers=self.config.extra_headers,
+        )
 
     def _parse_response(self, response, tools):
         """

--- a/mem0/llms/vllm.py
+++ b/mem0/llms/vllm.py
@@ -29,6 +29,7 @@ class VllmLLM(LLMBase):
                 enable_vision=config.enable_vision,
                 vision_details=config.vision_details,
                 http_client_proxies=config.http_client,
+                extra_headers=config.extra_headers,
             )
 
         super().__init__(config)
@@ -38,7 +39,11 @@ class VllmLLM(LLMBase):
 
         self.config.api_key = self.config.api_key or os.getenv("VLLM_API_KEY") or "vllm-api-key"
         base_url = self.config.vllm_base_url or os.getenv("VLLM_BASE_URL")
-        self.client = OpenAI(api_key=self.config.api_key, base_url=base_url)
+        self.client = OpenAI(
+            api_key=self.config.api_key,
+            base_url=base_url,
+            default_headers=self.config.extra_headers,
+        )
 
     def _parse_response(self, response, tools):
         """

--- a/mem0/llms/xai.py
+++ b/mem0/llms/xai.py
@@ -16,7 +16,11 @@ class XAILLM(LLMBase):
 
         api_key = self.config.api_key or os.getenv("XAI_API_KEY")
         base_url = self.config.xai_base_url or os.getenv("XAI_API_BASE") or "https://api.x.ai/v1"
-        self.client = OpenAI(api_key=api_key, base_url=base_url)
+        self.client = OpenAI(
+            api_key=api_key,
+            base_url=base_url,
+            default_headers=self.config.extra_headers,
+        )
 
     def generate_response(
         self,

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -96,6 +96,7 @@ class LlmFactory:
                     "enable_vision": config.enable_vision,
                     "vision_details": config.vision_details,
                     "http_client_proxies": config.http_client,
+                    "extra_headers": getattr(config, "extra_headers", None),
                 }
                 config_dict.update(kwargs)
                 config = config_class(**config_dict)
@@ -238,7 +239,10 @@ class RerankerFactory:
     # Provider mappings with their config classes
     provider_to_class = {
         "cohere": ("mem0.reranker.cohere_reranker.CohereReranker", CohereRerankerConfig),
-        "sentence_transformer": ("mem0.reranker.sentence_transformer_reranker.SentenceTransformerReranker", SentenceTransformerRerankerConfig),
+        "sentence_transformer": (
+            "mem0.reranker.sentence_transformer_reranker.SentenceTransformerReranker",
+            SentenceTransformerRerankerConfig,
+        ),
         "zero_entropy": ("mem0.reranker.zero_entropy_reranker.ZeroEntropyReranker", ZeroEntropyRerankerConfig),
         "llm_reranker": ("mem0.reranker.llm_reranker.LLMReranker", LLMRerankerConfig),
         "huggingface": ("mem0.reranker.huggingface_reranker.HuggingFaceReranker", HuggingFaceRerankerConfig),

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -207,3 +207,40 @@ def test_callback_with_tools(mock_openai_client):
     mock_callback.assert_called_once()
     # Check that tool_calls exists in the message
     assert hasattr(mock_callback.call_args[0][1].choices[0].message, 'tool_calls')
+
+
+def test_openai_llm_extra_headers():
+    """Test that extra_headers are passed to OpenAI client."""
+    custom_headers = {
+        "Helicone-Auth": "Bearer test-token",
+        "Custom-Header": "custom-value"
+    }
+    
+    with patch("mem0.llms.openai.OpenAI") as mock_openai:
+        config = OpenAIConfig(
+            model="gpt-4.1-nano-2025-04-14",
+            api_key="test-key",
+            extra_headers=custom_headers
+        )
+        llm = OpenAILLM(config)
+        
+        # Verify OpenAI client was initialized with default_headers
+        mock_openai.assert_called_once()
+        call_kwargs = mock_openai.call_args[1]
+        assert call_kwargs.get("default_headers") == custom_headers
+
+
+def test_openai_llm_no_extra_headers():
+    """Test that OpenAI client works without extra_headers."""
+    with patch("mem0.llms.openai.OpenAI") as mock_openai:
+        config = OpenAIConfig(
+            model="gpt-4.1-nano-2025-04-14",
+            api_key="test-key"
+        )
+        llm = OpenAILLM(config)
+        
+        # Verify OpenAI client was initialized without default_headers or with None
+        mock_openai.assert_called_once()
+        call_kwargs = mock_openai.call_args[1]
+        assert call_kwargs.get("default_headers") is None
+

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -17,7 +17,9 @@ def mock_openai_client():
 
 def test_openai_llm_base_url():
     # case1: default config: with openai official base url
-    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key")
+    config = OpenAIConfig(
+        model="gpt-4.1-nano-2025-04-14", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key"
+    )
     llm = OpenAILLM(config)
     # Note: openai client will parse the raw base_url into a URL object, which will have a trailing slash
     assert str(llm.client.base_url) == "https://api.openai.com/v1/"
@@ -25,7 +27,9 @@ def test_openai_llm_base_url():
     # case2: with env variable OPENAI_API_BASE
     provider_base_url = "https://api.provider.com/v1"
     os.environ["OPENAI_BASE_URL"] = provider_base_url
-    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key")
+    config = OpenAIConfig(
+        model="gpt-4.1-nano-2025-04-14", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key"
+    )
     llm = OpenAILLM(config)
     # Note: openai client will parse the raw base_url into a URL object, which will have a trailing slash
     assert str(llm.client.base_url) == provider_base_url + "/"
@@ -33,7 +37,12 @@ def test_openai_llm_base_url():
     # case3: with config.openai_base_url
     config_base_url = "https://api.config.com/v1"
     config = OpenAIConfig(
-        model="gpt-4.1-nano-2025-04-14", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key", openai_base_url=config_base_url
+        model="gpt-4.1-nano-2025-04-14",
+        temperature=0.7,
+        max_tokens=100,
+        top_p=1.0,
+        api_key="api_key",
+        openai_base_url=config_base_url,
     )
     llm = OpenAILLM(config)
     # Note: openai client will parse the raw base_url into a URL object, which will have a trailing slash
@@ -97,7 +106,14 @@ def test_generate_response_with_tools(mock_openai_client):
     response = llm.generate_response(messages, tools=tools)
 
     mock_openai_client.chat.completions.create.assert_called_once_with(
-        model="gpt-4.1-nano-2025-04-14", messages=messages, temperature=0.7, max_tokens=100, top_p=1.0, tools=tools, tool_choice="auto", store=False
+        model="gpt-4.1-nano-2025-04-14",
+        messages=messages,
+        temperature=0.7,
+        max_tokens=100,
+        top_p=1.0,
+        tools=tools,
+        tool_choice="auto",
+        store=False,
     )
 
     assert response["content"] == "I've added the memory for you."
@@ -109,19 +125,19 @@ def test_generate_response_with_tools(mock_openai_client):
 def test_response_callback_invocation(mock_openai_client):
     # Setup mock callback
     mock_callback = Mock()
-    
+
     config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", response_callback=mock_callback)
     llm = OpenAILLM(config)
     messages = [{"role": "user", "content": "Test callback"}]
-    
+
     # Mock response
     mock_response = Mock()
     mock_response.choices = [Mock(message=Mock(content="Response"))]
     mock_openai_client.chat.completions.create.return_value = mock_response
-    
+
     # Call method
     llm.generate_response(messages)
-    
+
     # Verify callback called with correct arguments
     mock_callback.assert_called_once()
     args = mock_callback.call_args[0]
@@ -134,16 +150,16 @@ def test_no_response_callback(mock_openai_client):
     config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14")
     llm = OpenAILLM(config)
     messages = [{"role": "user", "content": "Test no callback"}]
-    
+
     # Mock response
     mock_response = Mock()
     mock_response.choices = [Mock(message=Mock(content="Response"))]
     mock_openai_client.chat.completions.create.return_value = mock_response
-    
+
     # Should complete without calling any callback
     response = llm.generate_response(messages)
     assert response == "Response"
-    
+
     # Verify no callback is set
     assert llm.config.response_callback is None
 
@@ -152,20 +168,20 @@ def test_callback_exception_handling(mock_openai_client):
     # Callback that raises exception
     def faulty_callback(*args):
         raise ValueError("Callback error")
-    
+
     config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", response_callback=faulty_callback)
     llm = OpenAILLM(config)
     messages = [{"role": "user", "content": "Test exception"}]
-    
+
     # Mock response
     mock_response = Mock()
     mock_response.choices = [Mock(message=Mock(content="Expected response"))]
     mock_openai_client.chat.completions.create.return_value = mock_response
-    
+
     # Should complete without raising
     response = llm.generate_response(messages)
     assert response == "Expected response"
-    
+
     # Verify callback was called (even though it raised an exception)
     assert llm.config.response_callback is faulty_callback
 
@@ -186,10 +202,10 @@ def test_callback_with_tools(mock_openai_client):
                     "properties": {"param1": {"type": "string"}},
                     "required": ["param1"],
                 },
-            }
+            },
         }
     ]
-    
+
     # Mock tool response
     mock_response = Mock()
     mock_message = Mock()
@@ -200,30 +216,23 @@ def test_callback_with_tools(mock_openai_client):
     mock_message.tool_calls = [mock_tool_call]
     mock_response.choices = [Mock(message=mock_message)]
     mock_openai_client.chat.completions.create.return_value = mock_response
-    
+
     llm.generate_response(messages, tools=tools)
-    
+
     # Verify callback called with tool response
     mock_callback.assert_called_once()
     # Check that tool_calls exists in the message
-    assert hasattr(mock_callback.call_args[0][1].choices[0].message, 'tool_calls')
+    assert hasattr(mock_callback.call_args[0][1].choices[0].message, "tool_calls")
 
 
 def test_openai_llm_extra_headers():
     """Test that extra_headers are passed to OpenAI client."""
-    custom_headers = {
-        "Helicone-Auth": "Bearer test-token",
-        "Custom-Header": "custom-value"
-    }
-    
+    custom_headers = {"Helicone-Auth": "Bearer test-token", "Custom-Header": "custom-value"}
+
     with patch("mem0.llms.openai.OpenAI") as mock_openai:
-        config = OpenAIConfig(
-            model="gpt-4.1-nano-2025-04-14",
-            api_key="test-key",
-            extra_headers=custom_headers
-        )
-        llm = OpenAILLM(config)
-        
+        config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", api_key="test-key", extra_headers=custom_headers)
+        OpenAILLM(config)
+
         # Verify OpenAI client was initialized with default_headers
         mock_openai.assert_called_once()
         call_kwargs = mock_openai.call_args[1]
@@ -233,14 +242,10 @@ def test_openai_llm_extra_headers():
 def test_openai_llm_no_extra_headers():
     """Test that OpenAI client works without extra_headers."""
     with patch("mem0.llms.openai.OpenAI") as mock_openai:
-        config = OpenAIConfig(
-            model="gpt-4.1-nano-2025-04-14",
-            api_key="test-key"
-        )
-        llm = OpenAILLM(config)
-        
+        config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", api_key="test-key")
+        OpenAILLM(config)
+
         # Verify OpenAI client was initialized without default_headers or with None
         mock_openai.assert_called_once()
         call_kwargs = mock_openai.call_args[1]
         assert call_kwargs.get("default_headers") is None
-


### PR DESCRIPTION
# feat: add extra_headers support for LLM and Embedding providers

## Description

This PR implements support for `extra_headers` across multiple LLM and Embedding providers to support observability tools (like Helicone), custom proxies, and additional authentication requirements.

Key changes include:
- Added `extra_headers` field to `BaseLlmConfig` and `BaseEmbedderConfig`.
- Implemented header propagation in `OpenAI`, `Anthropic`, `Groq`, `Together`, `DeepSeek`, `xAI`, `Azure OpenAI`, `LM Studio`, and `vLLM`.
- Updated `factory.py` to support `extra_headers` in configuration generation.
- Added unit tests for OpenAI to ensure custom headers are correctly passed to the provider clients.
- Updated documentation with `extra_headers` parameter and usage example for Helicone integration.

Fixes #3851

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## How Has This Been Tested?

- [x] Unit Test: Verified `OpenAI` client initialization with `extra_headers` in `tests/llms/test_openai.py`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [x] closes #3851
- [ ] Made sure Checks passed
