### PR TITLE
fix(ts-sdk): use dynamic import for ollama to support optional dependency

### DIFF
--- a/mem0-ts/src/oss/src/embeddings/ollama.ts
+++ b/mem0-ts/src/oss/src/embeddings/ollama.ts
@@ -1,33 +1,55 @@
-import { Ollama } from "ollama";
+import type { Ollama } from "ollama";
 import { Embedder } from "./base";
 import { EmbeddingConfig } from "../types";
 import { logger } from "../utils/logger";
 
+let OllamaClient: typeof Ollama | null = null;
+
+async function getOllamaClient(): Promise<typeof Ollama> {
+  if (!OllamaClient) {
+    try {
+      const ollamaModule = await import("ollama");
+      OllamaClient = ollamaModule.Ollama;
+    } catch (error) {
+      throw new Error(
+        "The 'ollama' package is required to use Ollama provider. " +
+          "Please install it with: npm install ollama"
+      );
+    }
+  }
+  return OllamaClient;
+}
+
 export class OllamaEmbedder implements Embedder {
-  private ollama: Ollama;
+  private ollama: Ollama | null = null;
   private model: string;
   private embeddingDims?: number;
+  private host: string;
   // Using this variable to avoid calling the Ollama server multiple times
   private initialized: boolean = false;
 
   constructor(config: EmbeddingConfig) {
-    this.ollama = new Ollama({
-      host: config.url || "http://localhost:11434",
-    });
+    this.host = config.url || "http://localhost:11434";
     this.model = config.model || "nomic-embed-text:latest";
     this.embeddingDims = config.embeddingDims || 768;
-    this.ensureModelExists().catch((err) => {
-      logger.error(`Error ensuring model exists: ${err}`);
-    });
+  }
+
+  private async getClient(): Promise<Ollama> {
+    if (!this.ollama) {
+      const OllamaClass = await getOllamaClient();
+      this.ollama = new OllamaClass({ host: this.host });
+    }
+    return this.ollama;
   }
 
   async embed(text: string): Promise<number[]> {
+    const ollama = await this.getClient();
     try {
-      await this.ensureModelExists();
+      await this.ensureModelExists(ollama);
     } catch (err) {
       logger.error(`Error ensuring model exists: ${err}`);
     }
-    const response = await this.ollama.embeddings({
+    const response = await ollama.embeddings({
       model: this.model,
       prompt: text,
     });
@@ -39,14 +61,14 @@ export class OllamaEmbedder implements Embedder {
     return response;
   }
 
-  private async ensureModelExists(): Promise<boolean> {
+  private async ensureModelExists(ollama: Ollama): Promise<boolean> {
     if (this.initialized) {
       return true;
     }
-    const local_models = await this.ollama.list();
+    const local_models = await ollama.list();
     if (!local_models.models.find((m: any) => m.name === this.model)) {
       logger.info(`Pulling model ${this.model}...`);
-      await this.ollama.pull({ model: this.model });
+      await ollama.pull({ model: this.model });
     }
     this.initialized = true;
     return true;

--- a/mem0-ts/src/oss/src/llms/ollama.ts
+++ b/mem0-ts/src/oss/src/llms/ollama.ts
@@ -1,22 +1,43 @@
-import { Ollama } from "ollama";
+import type { Ollama } from "ollama";
 import { LLM, LLMResponse } from "./base";
 import { LLMConfig, Message } from "../types";
 import { logger } from "../utils/logger";
 
+let OllamaClient: typeof Ollama | null = null;
+
+async function getOllamaClient(): Promise<typeof Ollama> {
+  if (!OllamaClient) {
+    try {
+      const ollamaModule = await import("ollama");
+      OllamaClient = ollamaModule.Ollama;
+    } catch (error) {
+      throw new Error(
+        "The 'ollama' package is required to use Ollama provider. " +
+          "Please install it with: npm install ollama"
+      );
+    }
+  }
+  return OllamaClient;
+}
+
 export class OllamaLLM implements LLM {
-  private ollama: Ollama;
+  private ollama: Ollama | null = null;
   private model: string;
+  private host: string;
   // Using this variable to avoid calling the Ollama server multiple times
   private initialized: boolean = false;
 
   constructor(config: LLMConfig) {
-    this.ollama = new Ollama({
-      host: config.config?.url || "http://localhost:11434",
-    });
+    this.host = config.config?.url || "http://localhost:11434";
     this.model = config.model || "llama3.1:8b";
-    this.ensureModelExists().catch((err) => {
-      logger.error(`Error ensuring model exists: ${err}`);
-    });
+  }
+
+  private async getClient(): Promise<Ollama> {
+    if (!this.ollama) {
+      const OllamaClass = await getOllamaClient();
+      this.ollama = new OllamaClass({ host: this.host });
+    }
+    return this.ollama;
   }
 
   async generateResponse(
@@ -24,13 +45,14 @@ export class OllamaLLM implements LLM {
     responseFormat?: { type: string },
     tools?: any[],
   ): Promise<string | LLMResponse> {
+    const ollama = await this.getClient();
     try {
-      await this.ensureModelExists();
+      await this.ensureModelExists(ollama);
     } catch (err) {
       logger.error(`Error ensuring model exists: ${err}`);
     }
 
-    const completion = await this.ollama.chat({
+    const completion = await ollama.chat({
       model: this.model,
       messages: messages.map((msg) => {
         const role = msg.role as "system" | "user" | "assistant";
@@ -63,13 +85,14 @@ export class OllamaLLM implements LLM {
   }
 
   async generateChat(messages: Message[]): Promise<LLMResponse> {
+    const ollama = await this.getClient();
     try {
-      await this.ensureModelExists();
+      await this.ensureModelExists(ollama);
     } catch (err) {
       logger.error(`Error ensuring model exists: ${err}`);
     }
 
-    const completion = await this.ollama.chat({
+    const completion = await ollama.chat({
       messages: messages.map((msg) => {
         const role = msg.role as "system" | "user" | "assistant";
         return {
@@ -89,14 +112,14 @@ export class OllamaLLM implements LLM {
     };
   }
 
-  private async ensureModelExists(): Promise<boolean> {
+  private async ensureModelExists(ollama: Ollama): Promise<boolean> {
     if (this.initialized) {
       return true;
     }
-    const local_models = await this.ollama.list();
+    const local_models = await ollama.list();
     if (!local_models.models.find((m: any) => m.name === this.model)) {
       logger.info(`Pulling model ${this.model}...`);
-      await this.ollama.pull({ model: this.model });
+      await ollama.pull({ model: this.model });
     }
     this.initialized = true;
     return true;

--- a/mem0-ts/tests/ollama-lazy-import.test.ts
+++ b/mem0-ts/tests/ollama-lazy-import.test.ts
@@ -1,0 +1,62 @@
+/// <reference types="jest" />
+
+describe("Ollama Lazy Import", () => {
+  describe("OllamaLLM", () => {
+    it("should be importable without ollama package installed", async () => {
+      // This test verifies that the module can be imported without throwing
+      // The actual ollama import only happens when the class methods are called
+      const { OllamaLLM } = await import("../src/oss/src/llms/ollama");
+      expect(OllamaLLM).toBeDefined();
+    });
+
+    it("should instantiate without throwing", () => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { OllamaLLM } = require("../src/oss/src/llms/ollama");
+      const llm = new OllamaLLM({
+        model: "llama3.1:8b",
+        config: { url: "http://localhost:11434" },
+      });
+      expect(llm).toBeDefined();
+    });
+  });
+
+  describe("OllamaEmbedder", () => {
+    it("should be importable without ollama package installed", async () => {
+      // This test verifies that the module can be imported without throwing
+      const { OllamaEmbedder } = await import("../src/oss/src/embeddings/ollama");
+      expect(OllamaEmbedder).toBeDefined();
+    });
+
+    it("should instantiate without throwing", () => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { OllamaEmbedder } = require("../src/oss/src/embeddings/ollama");
+      const embedder = new OllamaEmbedder({
+        model: "nomic-embed-text:latest",
+        url: "http://localhost:11434",
+      });
+      expect(embedder).toBeDefined();
+    });
+  });
+
+  describe("Factory imports", () => {
+    it("should import factory without requiring ollama", async () => {
+      // The factory imports OllamaLLM and OllamaEmbedder, but since they use
+      // dynamic imports, this should not throw even if ollama is not installed
+      const { LLMFactory, EmbedderFactory } = await import(
+        "../src/oss/src/utils/factory"
+      );
+      expect(LLMFactory).toBeDefined();
+      expect(EmbedderFactory).toBeDefined();
+    });
+
+    it("should create non-ollama providers without ollama installed", () => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { VectorStoreFactory } = require("../src/oss/src/utils/factory");
+      const store = VectorStoreFactory.create("memory", {
+        collectionName: "test",
+        dimension: 1536,
+      });
+      expect(store).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Changed static `import { Ollama } from 'ollama'` to dynamic `await import('ollama')` 
- Ollama package is now only loaded when using Ollama provider
- Clear error message when ollama package is missing

## Test plan
- [x] Added tests to verify modules can be imported without ollama installed
- [x] Verified factory can create non-Ollama providers
- [x] Existing factory tests pass

Fixes #3857