### PR TITLE
fix: broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
   ·
   <a href="https://mem0.dev/DiG">Join Discord</a>
   ·
-  <a href="https://mem0.dev/demo">Demo</a>
+  <a href="https://mem0.ai/demo">Demo</a>
   ·
-  <a href="https://mem0.dev/openmemory">OpenMemory</a>
+  <a href="https://mem0.ai/openmemory">OpenMemory</a>
 </p>
 
 <p align="center">
@@ -142,7 +142,7 @@ For detailed integration steps, see the [Quickstart](https://docs.mem0.ai/quicks
 
 ## 🔗 Integrations & Demos
 
-- **ChatGPT with Memory**: Personalized chat powered by Mem0 ([Live Demo](https://mem0.dev/demo))
+- **ChatGPT with Memory**: Personalized chat powered by Mem0 ([Live Demo](https://mem0.ai/demo))
 - **Browser Extension**: Store memories across ChatGPT, Perplexity, and Claude ([Chrome Extension](https://chromewebstore.google.com/detail/onihkkbipkfeijkadecaafbgagkhglop?utm_source=item-share-cb))
 - **Langgraph Support**: Build a customer bot with Langgraph + Mem0 ([Guide](https://docs.mem0.ai/integrations/langgraph))
 - **CrewAI Integration**: Tailor CrewAI outputs with Mem0 ([Example](https://docs.mem0.ai/integrations/crewai))


### PR DESCRIPTION
## Description

Fix broken `mem0.dev` (which lead to 404s) links (that redirect to incorrect `.ai` webpages equivalents) w/ `.ai` ones.

- https://mem0.dev/demo redirects to auth/login (which leads to dashboard)
- https://mem0.dev/openmemory redirects to https://mem0.ai/openmemory-mcp (404).

## Type of change

Please delete options that are not relevant.

- [x] Documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
