### PR TITLE
feat: add custom_search_prompt for graph entity extraction

### DIFF
--- a/mem0/graphs/configs.py
+++ b/mem0/graphs/configs.py
@@ -99,6 +99,8 @@ class GraphStoreConfig(BaseModel):
         le=1.0,
     )
 
+    custom_search_prompt: Optional[str] = Field(None, description="Custom prompt for entity extraction during graph search")
+
     @field_validator("config")
     def validate_config(cls, v, values):
         provider = values.data.get("provider")

--- a/mem0/graphs/neptune/base.py
+++ b/mem0/graphs/neptune/base.py
@@ -80,11 +80,19 @@ class NeptuneBase(ABC):
         _tools = [EXTRACT_ENTITIES_TOOL]
         if self.llm_provider in ["azure_openai_structured", "openai_structured"]:
             _tools = [EXTRACT_ENTITIES_STRUCT_TOOL]
+        
+        default_search_prompt = f"You are a smart assistant who understands entities and their types in a given text. If user message contains self reference such as 'I', 'me', 'my' etc. then use {filters['user_id']} as the source entity. Extract all the entities from the text. ***DO NOT*** answer the question itself if the given text is a question."
+        
+        search_prompt = getattr(self.config.graph_store, 'custom_search_prompt', None) or default_search_prompt
+        
+        if "{user_id}" in search_prompt:
+            search_prompt = search_prompt.replace("{user_id}", str(filters.get("user_id", "USER")))
+        
         search_results = self.llm.generate_response(
             messages=[
                 {
                     "role": "system",
-                    "content": f"You are a smart assistant who understands entities and their types in a given text. If user message contains self reference such as 'I', 'me', 'my' etc. then use {filters['user_id']} as the source entity. Extract all the entities from the text. ***DO NOT*** answer the question itself if the given text is a question.",
+                    "content": search_prompt,
                 },
                 {"role": "user", "content": data},
             ],


### PR DESCRIPTION
## Summary
Adds `custom_search_prompt` config option for customizing entity extraction during graph search.

## Problem
The search path uses a hardcoded prompt in `_retrieve_nodes_from_data()`. This doesn't work for domain-specific use cases where:
- Entity types need to be constrained (e.g., only `Medication`, `Condition`)
- Terminology mapping is needed (e.g., "heart attack" → "Myocardial Infarction")

## Solution
New config option `custom_search_prompt` parallel to existing `custom_prompt` (which is for add path).

## Usage
```python
config = {
    "graph_store": {
        "provider": "neo4j",
        "config": {...},
        "custom_search_prompt": "Extract medical entities: Medication, Condition, Allergy. Patient: {user_id}"
    }
}
```

## Changes
- `graphs/configs.py`: Added `custom_search_prompt` field to GraphStoreConfig
- `memory/graph_memory.py`: Use custom prompt in Neo4j implementation
- `memory/memgraph_memory.py`: Use custom prompt in Memgraph implementation  
- `graphs/neptune/base.py`: Use custom prompt in Neptune implementation

Fixes #3299