### PR TITLE
fix: actually remove vectors from FAISS index in delete()

### DIFF
--- a/mem0/graphs/configs.py
+++ b/mem0/graphs/configs.py
@@ -99,6 +99,8 @@ class GraphStoreConfig(BaseModel):
         le=1.0,
     )
 
+    custom_search_prompt: Optional[str] = Field(None, description="Custom prompt for entity extraction during graph search")
+
     @field_validator("config")
     def validate_config(cls, v, values):
         provider = values.data.get("provider")

--- a/mem0/graphs/neptune/base.py
+++ b/mem0/graphs/neptune/base.py
@@ -80,11 +80,19 @@ class NeptuneBase(ABC):
         _tools = [EXTRACT_ENTITIES_TOOL]
         if self.llm_provider in ["azure_openai_structured", "openai_structured"]:
             _tools = [EXTRACT_ENTITIES_STRUCT_TOOL]
+        
+        default_search_prompt = f"You are a smart assistant who understands entities and their types in a given text. If user message contains self reference such as 'I', 'me', 'my' etc. then use {filters['user_id']} as the source entity. Extract all the entities from the text. ***DO NOT*** answer the question itself if the given text is a question."
+        
+        search_prompt = getattr(self.config.graph_store, 'custom_search_prompt', None) or default_search_prompt
+        
+        if "{user_id}" in search_prompt:
+            search_prompt = search_prompt.replace("{user_id}", str(filters.get("user_id", "USER")))
+        
         search_results = self.llm.generate_response(
             messages=[
                 {
                     "role": "system",
-                    "content": f"You are a smart assistant who understands entities and their types in a given text. If user message contains self reference such as 'I', 'me', 'my' etc. then use {filters['user_id']} as the source entity. Extract all the entities from the text. ***DO NOT*** answer the question itself if the given text is a question.",
+                    "content": search_prompt,
                 },
                 {"role": "user", "content": data},
             ],


### PR DESCRIPTION
## 🐛 Bug Fix

The `delete()` method in FAISS vector store was not actually removing vectors from the index - it only removed entries from `docstore` and `index_to_id` but left `self.index` unchanged.

## Changes
- Rebuild FAISS index with remaining vectors after deletion
- Preserve correct index type (IndexFlatL2 vs IndexFlatIP) based on distance_strategy

## Related Issue
Fixes the bug where deleted vectors would still appear in search results.