### PR TITLE
feat: add env varis for custom config

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -31,7 +31,12 @@ MEMGRAPH_USERNAME = os.environ.get("MEMGRAPH_USERNAME", "memgraph")
 MEMGRAPH_PASSWORD = os.environ.get("MEMGRAPH_PASSWORD", "mem0graph")
 
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
+OPENAI_COMPLETION_MODEL = os.environ.get("OPENAI_COMPLETION_MODEL","gpt-4.1-nano-2025-04-14")
+OPENAI_EMBEDDING_MODEL = os.environ.get("OPENAI_EMBEDDING_MODEL","text-embedding-3-small")
+OPENAI_BASE_URL = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
 HISTORY_DB_PATH = os.environ.get("HISTORY_DB_PATH", "/app/history/history.db")
+
+EMBEDIING_DIMS = os.environ.get("EMBEDIING_DIMS", "1536")
 
 DEFAULT_CONFIG = {
     "version": "v1.1",
@@ -44,14 +49,17 @@ DEFAULT_CONFIG = {
             "user": POSTGRES_USER,
             "password": POSTGRES_PASSWORD,
             "collection_name": POSTGRES_COLLECTION_NAME,
+            "embedding_model_dims": int(EMBEDIING_DIMS),
         },
     },
     "graph_store": {
         "provider": "neo4j",
         "config": {"url": NEO4J_URI, "username": NEO4J_USERNAME, "password": NEO4J_PASSWORD},
     },
-    "llm": {"provider": "openai", "config": {"api_key": OPENAI_API_KEY, "temperature": 0.2, "model": "gpt-4.1-nano-2025-04-14"}},
-    "embedder": {"provider": "openai", "config": {"api_key": OPENAI_API_KEY, "model": "text-embedding-3-small"}},
+    "llm": {"provider": "openai", "config": {"api_key": OPENAI_API_KEY, "temperature": 0.2, "model": OPENAI_COMPLETION_MODEL,
+                                             "openai_base_url": OPENAI_BASE_URL}},
+    "embedder": {"provider": "openai", "config": {"api_key": OPENAI_API_KEY, "model": OPENAI_EMBEDDING_MODEL,
+                                                  "openai_base_url": OPENAI_BASE_URL, "embedding_dims": EMBEDIING_DIMS}},
     "history_db_path": HISTORY_DB_PATH,
 }
 


### PR DESCRIPTION
## Description

1. in my use case, we only permit to use the inner ai model, which api is compatible with openai, so ,mem0 should allow user to cutom the openai_base_url.
2. we use pgvector as our embedding database, but when we use differenrt embedding model, the default embedding dimension is always 1536, which made our insert data failed, so embedding dimension also should allow use custom modify.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [ ] Unit Test
- [ ] Test Script (please provide)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
