### PR TITLE
Add configurable custom_search_prompt for entity extraction during graph search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,7 @@ celerybeat.pid
 # Environments
 .env
 .venv
+.venv312
 env/
 venv/
 ENV/

--- a/docs/open-source/features/graph-memory.mdx
+++ b/docs/open-source/features/graph-memory.mdx
@@ -211,6 +211,15 @@ const config = {
 const memory = new Memory(config);
 ```
 </CodeGroup>
+
+    `custom_prompt` tunes relationship extraction on writes. Use `custom_search_prompt` when you want to control entity extraction during graph search.
+
+```python
+config["graph_store"]["custom_search_prompt"] = (
+    "Extract only organization entities mentioned by USER_ID. "
+    "Return only entities and their types."
+)
+```
   </Accordion>
   <Accordion title="Raise the confidence threshold">
     Keep noisy edges out of the graph by demanding higher extraction confidence.

--- a/mem0/graphs/configs.py
+++ b/mem0/graphs/configs.py
@@ -89,6 +89,9 @@ class GraphStoreConfig(BaseModel):
     custom_prompt: Optional[str] = Field(
         description="Custom prompt to fetch entities from the given text", default=None
     )
+    custom_search_prompt: Optional[str] = Field(
+        description="Custom prompt to extract entities during graph search", default=None
+    )
     threshold: float = Field(
         description="Threshold for embedding similarity when matching nodes during graph ingestion. "
                     "Range: 0.0 to 1.0. Higher values require closer matches. "

--- a/mem0/graphs/neptune/base.py
+++ b/mem0/graphs/neptune/base.py
@@ -80,11 +80,23 @@ class NeptuneBase(ABC):
         _tools = [EXTRACT_ENTITIES_TOOL]
         if self.llm_provider in ["azure_openai_structured", "openai_structured"]:
             _tools = [EXTRACT_ENTITIES_STRUCT_TOOL]
+        custom_search_prompt = getattr(self.config.graph_store, "custom_search_prompt", None)
+        if custom_search_prompt:
+            system_prompt = custom_search_prompt
+            if "USER_ID" in system_prompt:
+                system_prompt = system_prompt.replace("USER_ID", filters["user_id"])
+        else:
+            system_prompt = (
+                "You are a smart assistant who understands entities and their types in a given text. If user message "
+                f"contains self reference such as 'I', 'me', 'my' etc. then use {filters['user_id']} as the source "
+                "entity. Extract all the entities from the text. ***DO NOT*** answer the question itself if the given "
+                "text is a question."
+            )
         search_results = self.llm.generate_response(
             messages=[
                 {
                     "role": "system",
-                    "content": f"You are a smart assistant who understands entities and their types in a given text. If user message contains self reference such as 'I', 'me', 'my' etc. then use {filters['user_id']} as the source entity. Extract all the entities from the text. ***DO NOT*** answer the question itself if the given text is a question.",
+                    "content": system_prompt,
                 },
                 {"role": "user", "content": data},
             ],

--- a/mem0/memory/graph_memory.py
+++ b/mem0/memory/graph_memory.py
@@ -198,11 +198,23 @@ class MemoryGraph:
         _tools = [EXTRACT_ENTITIES_TOOL]
         if self.llm_provider in ["azure_openai_structured", "openai_structured"]:
             _tools = [EXTRACT_ENTITIES_STRUCT_TOOL]
+        custom_search_prompt = getattr(self.config.graph_store, "custom_search_prompt", None)
+        if custom_search_prompt:
+            system_prompt = custom_search_prompt
+            if "USER_ID" in system_prompt:
+                system_prompt = system_prompt.replace("USER_ID", filters["user_id"])
+        else:
+            system_prompt = (
+                "You are a smart assistant who understands entities and their types in a given text. If user message "
+                f"contains self reference such as 'I', 'me', 'my' etc. then use {filters['user_id']} as the source "
+                "entity. Extract all the entities from the text. ***DO NOT*** answer the question itself if the given "
+                "text is a question."
+            )
         search_results = self.llm.generate_response(
             messages=[
                 {
                     "role": "system",
-                    "content": f"You are a smart assistant who understands entities and their types in a given text. If user message contains self reference such as 'I', 'me', 'my' etc. then use {filters['user_id']} as the source entity. Extract all the entities from the text. ***DO NOT*** answer the question itself if the given text is a question.",
+                    "content": system_prompt,
                 },
                 {"role": "user", "content": data},
             ],

--- a/mem0/memory/memgraph_memory.py
+++ b/mem0/memory/memgraph_memory.py
@@ -201,11 +201,23 @@ class MemoryGraph:
         _tools = [EXTRACT_ENTITIES_TOOL]
         if self.llm_provider in ["azure_openai_structured", "openai_structured"]:
             _tools = [EXTRACT_ENTITIES_STRUCT_TOOL]
+        custom_search_prompt = getattr(self.config.graph_store, "custom_search_prompt", None)
+        if custom_search_prompt:
+            system_prompt = custom_search_prompt
+            if "USER_ID" in system_prompt:
+                system_prompt = system_prompt.replace("USER_ID", filters["user_id"])
+        else:
+            system_prompt = (
+                "You are a smart assistant who understands entities and their types in a given text. If user message "
+                f"contains self reference such as 'I', 'me', 'my' etc. then use {filters['user_id']} as the source "
+                "entity. Extract all the entities from the text. ***DO NOT*** answer the question itself if the given "
+                "text is a question."
+            )
         search_results = self.llm.generate_response(
             messages=[
                 {
                     "role": "system",
-                    "content": f"You are a smart assistant who understands entities and their types in a given text. If user message contains self reference such as 'I', 'me', 'my' etc. then use {filters['user_id']} as the source entity. Extract all the entities from the text. ***DO NOT*** answer the question itself if the given text is a question.",
+                    "content": system_prompt,
                 },
                 {"role": "user", "content": data},
             ],

--- a/tests/memory/test_graph_search_prompt.py
+++ b/tests/memory/test_graph_search_prompt.py
@@ -1,0 +1,66 @@
+import importlib
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+
+DEFAULT_PROMPT_TEMPLATE = (
+    "You are a smart assistant who understands entities and their types in a given text. "
+    "If user message contains self reference such as 'I', 'me', 'my' etc. then use {user_id} "
+    "as the source entity. Extract all the entities from the text. ***DO NOT*** answer the question "
+    "itself if the given text is a question."
+)
+
+
+def _install_stub(monkeypatch, module_name, is_package=False, **attrs):
+    module = types.ModuleType(module_name)
+    if is_package:
+        module.__path__ = []
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    return module
+
+
+@pytest.fixture
+def stub_graph_modules(monkeypatch):
+    _install_stub(monkeypatch, "langchain_neo4j", Neo4jGraph=object)
+    _install_stub(monkeypatch, "rank_bm25", BM25Okapi=object)
+    _install_stub(monkeypatch, "langchain_memgraph", is_package=True)
+    _install_stub(monkeypatch, "langchain_memgraph.graphs", is_package=True)
+    _install_stub(monkeypatch, "langchain_memgraph.graphs.memgraph", Memgraph=object)
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "mem0.memory.graph_memory",
+        "mem0.memory.memgraph_memory",
+    ],
+)
+def test_custom_search_prompt_overrides_default(stub_graph_modules, module_name):
+    module = importlib.import_module(module_name)
+    module = importlib.reload(module)
+    graph_cls = module.MemoryGraph
+
+    graph = graph_cls.__new__(graph_cls)
+    graph.llm_provider = "openai"
+    graph.llm = MagicMock()
+    graph.llm.generate_response.return_value = {"tool_calls": []}
+    graph.config = MagicMock()
+    graph.config.graph_store.custom_search_prompt = None
+
+    filters = {"user_id": "test-user"}
+    graph._retrieve_nodes_from_data("Hello", filters)
+
+    messages = graph.llm.generate_response.call_args.kwargs["messages"]
+    assert messages[0]["content"] == DEFAULT_PROMPT_TEMPLATE.format(user_id=filters["user_id"])
+
+    graph.llm.generate_response.reset_mock()
+    graph.config.graph_store.custom_search_prompt = "Custom search prompt for USER_ID only."
+    graph._retrieve_nodes_from_data("Hello", filters)
+
+    messages = graph.llm.generate_response.call_args.kwargs["messages"]
+    assert messages[0]["content"] == "Custom search prompt for test-user only."

--- a/tests/memory/test_neptune_analytics_memory.py
+++ b/tests/memory/test_neptune_analytics_memory.py
@@ -1,6 +1,27 @@
+import sys
+import types
 import unittest
 from unittest.mock import MagicMock, patch
 import pytest
+
+try:
+    import langchain_aws  # noqa: F401
+except ImportError:
+    stub = types.ModuleType("langchain_aws")
+    stub.NeptuneAnalyticsGraph = object
+    sys.modules["langchain_aws"] = stub
+
+try:
+    from botocore.config import Config  # noqa: F401
+except ImportError:
+    botocore_module = types.ModuleType("botocore")
+    botocore_module.__path__ = []
+    botocore_config = types.ModuleType("botocore.config")
+    botocore_config.Config = object
+    botocore_module.config = botocore_config
+    sys.modules["botocore"] = botocore_module
+    sys.modules["botocore.config"] = botocore_config
+
 from mem0.graphs.neptune.neptunegraph import MemoryGraph
 from mem0.graphs.neptune.base import NeptuneBase
 


### PR DESCRIPTION
## Summary
- Add `custom_search_prompt` to graph config and use it for entity extraction across Neo4j, Memgraph, and Neptune (with optional `USER_ID` substitution).
- Add unit tests covering default vs custom prompt behavior, including Neptune coverage.
- Document `custom_search_prompt` usage and how it differs from `custom_prompt`.

## Testing
- `./.venv312/bin/python -m pytest tests`

## Notes
- Full `pytest` (including `embedchain/`) not run due to separate dependency tree; can be executed in a dedicated env if needed.

Fixes #3299
