### PR TITLE
chore: do a disk cleanup in gh actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,12 @@ on:
       - 'mem0/**'
       - 'tests/**'
       - 'embedchain/**'
+      - '.github/workflows/**'
   pull_request:
     paths:
       - 'mem0/**'
       - 'tests/**'
       - 'embedchain/**'
-      - '.github/**'
 
 jobs:
   check_changes:
@@ -29,6 +29,7 @@ jobs:
           mem0:
             - 'mem0/**'
             - 'tests/**'
+            - '.github/workflows/**'
           embedchain:
             - 'embedchain/**'
 


### PR DESCRIPTION
## Description

In GitHub CI: ERROR: Could not install packages due to an OSError: [Errno 28] No space left on device
Fixes the above issue