### PR TITLE
Refactor: remove deprecated `google-generativeai` from mem0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ install:
 
 install_all:
 	pip install ruff==0.6.9 groq together boto3 litellm ollama chromadb weaviate weaviate-client sentence_transformers vertexai \
-	            google-generativeai elasticsearch opensearch-py vecs "pinecone<7.0.0" pinecone-text faiss-cpu langchain-community \
+	            google-genai elasticsearch opensearch-py vecs "pinecone<7.0.0" pinecone-text faiss-cpu langchain-community \
 							upstash-vector azure-search-documents langchain-memgraph langchain-neo4j langchain-aws rank-bm25 pymochow pymongo psycopg kuzu databricks-sdk valkey
 
 # Format code with ruff

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ install:
 
 install_all:
 	pip install ruff==0.6.9 groq together boto3 litellm ollama chromadb weaviate weaviate-client sentence_transformers vertexai \
-	            google-genai elasticsearch opensearch-py vecs "pinecone<7.0.0" pinecone-text faiss-cpu langchain-community \
+	            google-generativeai google-genai elasticsearch opensearch-py vecs "pinecone<7.0.0" pinecone-text faiss-cpu langchain-community \
 							upstash-vector azure-search-documents langchain-memgraph langchain-neo4j langchain-aws rank-bm25 pymochow pymongo psycopg kuzu databricks-sdk valkey
 
 # Format code with ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ llms = [
     "openai>=1.90.0",
     "ollama>=0.1.0",
     "vertexai>=0.1.0",
-    "google-generativeai>=0.3.0",
+
     "google-genai>=1.0.0",
 ]
 extras = [


### PR DESCRIPTION
## Description

Removes dangling references to the `google-generativeai` package, which is deprecated, and has been migrated away from, but is still being installed. This should save some dependency bloat for your users as well as ensure it isn't accidentally used, e.g. by an agent.

## Type of change

- [x] Refactor (does not change functionality, e.g. code style improvements, linting)

## How Has This Been Tested?

- [x] Unit Test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
