### PR TITLE
fix: incorrect database param

### DIFF
--- a/mem0/memory/graph_memory.py
+++ b/mem0/memory/graph_memory.py
@@ -30,10 +30,10 @@ class MemoryGraph:
     def __init__(self, config):
         self.config = config
         self.graph = Neo4jGraph(
-            self.config.graph_store.config.url,
-            self.config.graph_store.config.username,
-            self.config.graph_store.config.password,
-            self.config.graph_store.config.database,
+            url=self.config.graph_store.config.url,
+            username=self.config.graph_store.config.username,
+            password=self.config.graph_store.config.password,
+            database=self.config.graph_store.config.database,
             refresh_schema=False,
             driver_config={"notifications_min_severity": "OFF"},
         )


### PR DESCRIPTION
## Description

Fix incorrect parameter order in Neo4jGraph initialization in MemoryGraph

Fixes #3906 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Verified the params in Neo4jGraph
<img width="1728" height="1084" alt="Screenshot 2026-01-15 at 11 56 06 PM" src="https://github.com/user-attachments/assets/dd7a80e5-dbbe-43cf-8bef-78eab494cc24" />

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #3906
- [ ] Made sure Checks passed
