### PR TITLE
fix(ts): lazy-load SQLite3 to prevent import time crashes

### DIFF
--- a/mem0-ts/src/oss/examples/lazy-load-sqlite.ts
+++ b/mem0-ts/src/oss/examples/lazy-load-sqlite.ts
@@ -5,29 +5,29 @@ import { Memory } from "../src";
 console.log("\nImport succeeded , sqlite3 was not eagerly loaded\n");
 
 try {
-    const memory = new Memory({
-        embedder: {
-            provider: "openai",
-            config: {
-                apiKey: ''
-            }
-        },
-        vectorStore: {
-            provider: "qdrant",
-            config: {
-                collectionName: "test",
-                url: "http://localhost:6333"
-            }
-        },
-        llm: {
-            provider: 'openai',
-            config: {
-                apiKey: ''
-            }
-        }
-    })
+  const memory = new Memory({
+    embedder: {
+      provider: "openai",
+      config: {
+        apiKey: "",
+      },
+    },
+    vectorStore: {
+      provider: "qdrant",
+      config: {
+        collectionName: "test",
+        url: "http://localhost:6333",
+      },
+    },
+    llm: {
+      provider: "openai",
+      config: {
+        apiKey: "",
+      },
+    },
+  });
 
-    console.log('\nMemory instantiated , no sqlite3 needed\n');
+  console.log("\nMemory instantiated , no sqlite3 needed\n");
 } catch (err) {
-    console.error('\nError: ', err);
+  console.error("\nError: ", err);
 }

--- a/mem0-ts/src/oss/src/storage/SQLiteManager.ts
+++ b/mem0-ts/src/oss/src/storage/SQLiteManager.ts
@@ -11,7 +11,7 @@ export class SQLiteManager implements HistoryManager {
     } catch (error: any) {
       throw new Error(
         `Failed to load sqlite3: ${error.message}\n` +
-        `Make sure sqlite3 is installed`,
+          `Make sure sqlite3 is installed`,
       );
     }
     this.db = new sqlite3.Database(dbPath);

--- a/mem0-ts/src/oss/src/vector_stores/memory.ts
+++ b/mem0-ts/src/oss/src/vector_stores/memory.ts
@@ -27,7 +27,7 @@ export class MemoryVectorStore implements VectorStore {
     } catch (error: any) {
       throw new Error(
         `Failed to load sqlite3: ${error.message}\n` +
-        `Make sure sqlite3 is installed`
+          `Make sure sqlite3 is installed`,
       );
     }
     this.db = new sqlite3.Database(this.dbPath);


### PR DESCRIPTION
## Description

Currently the sdk import `sqlite3` at module load time, even when users doesn't configure it. This causes the package to fail in environment where sqlite3 native bindings cannot compile.

Future Work : Current used sqlite package doesn't compile under environments like Bun. While this PR fixes the issue for users who doesn't need sqlite in their configuration , we still need a way to make sure it works in every envs.

Fixes #3882 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (does not change functionality, e.g. code style improvements, linting)

## How Has This Been Tested?

- Added an example file `/mem0-ts/src/oss/examples/lazy-load-sqlite.ts` , running this file crashes the process without the fix when not using sqlite3.

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [x] Test Script (please provide)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
