### PR TITLE
feat(elasticsearch): Add API key authentication for self-hosted instances

### DIFF
--- a/mem0/vector_stores/elasticsearch.py
+++ b/mem0/vector_stores/elasticsearch.py
@@ -33,6 +33,13 @@ class ElasticsearchDB(VectorStoreBase):
                 verify_certs=config.verify_certs,
                 headers= config.headers or {},
             )
+        elif config.api_key:
+            self.client = Elasticsearch(
+                hosts=[f"{config.host}" if config.port is None else f"{config.host}:{config.port}"],
+                api_key=config.api_key,
+                verify_certs=config.verify_certs,
+                headers= config.headers or {},
+            )
         else:
             self.client = Elasticsearch(
                 hosts=[f"{config.host}" if config.port is None else f"{config.host}:{config.port}"],

--- a/tests/vector_stores/test_elasticsearch.py
+++ b/tests/vector_stores/test_elasticsearch.py
@@ -9,8 +9,8 @@ try:
 except ImportError:
     raise ImportError("Elasticsearch requires extra dependencies. Install with `pip install elasticsearch`") from None
 
-from mem0.vector_stores.elasticsearch import ElasticsearchDB, OutputData
 from mem0.configs.vector_stores.elasticsearch import ElasticsearchConfig
+from mem0.vector_stores.elasticsearch import ElasticsearchDB, OutputData
 
 
 class TestElasticsearchDB(unittest.TestCase):
@@ -324,6 +324,31 @@ class TestElasticsearchDB(unittest.TestCase):
         self.assertEqual(es_config.port, 9200)
         self.assertEqual(es_config.user, "elastic")
         self.assertEqual(es_config.password, "password")
+
+    def test_es_config_with_api_key(self):
+        config = {"host": "localhost", "port": 9200, "api_key": "test-api-key"}
+        es_config = ElasticsearchConfig(**config)
+
+        # Assert that the config object was created successfully
+        self.assertIsNotNone(es_config)
+        self.assertIsInstance(es_config, ElasticsearchConfig)
+
+        # Assert that the configuration values are correctly set
+        self.assertEqual(es_config.host, "localhost")
+        self.assertEqual(es_config.port, 9200)
+        self.assertEqual(es_config.api_key, "test-api-key")
+
+    def test_es_config_with_cloud_id(self):
+        config = {"cloud_id": "test-cloud-id", "api_key": "test-api-key"}
+        es_config = ElasticsearchConfig(**config)
+
+        # Assert that the config object was created successfully
+        self.assertIsNotNone(es_config)
+        self.assertIsInstance(es_config, ElasticsearchConfig)
+
+        # Assert that the configuration values are correctly set
+        self.assertEqual(es_config.cloud_id, "test-cloud-id")
+        self.assertEqual(es_config.api_key, "test-api-key")
 
     def test_es_valid_headers(self):
         config = {


### PR DESCRIPTION
## Description

Add support for connecting to Elasticsearch using API key authentication without requiring cloud_id.

Previously, API key auth was only available for Elastic Cloud (via cloud_id). This change enables API key authentication for self-hosted Elasticsearch instances by allowing `(host, api_key)` configuration.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [x] Unit Test
- [x] Test Script (please provide)

Test script
```python
from mem0.vector_stores.elasticsearch import ElasticsearchDB
config = {
     "host": "https://host",
     "port": 443,
     "api_key": "api-key",
    }
es_db = ElasticsearchDB(**config)
print(es_db.list_cols())
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
