### PR TITLE
Add GitHub Action to automatically label potential security vulnerability reports

### DIFF
--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -1,0 +1,31 @@
+name: Label issues
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  scan-and-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Scan issue title and body for security keywords
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const triageLabel = 'maintainer-triage-p0';
+            const keywordRegex = /(vulnerability|exploit|RCE|privilege escalation|CVE)/gi;
+            const issueText = `${context.payload.issue.title || ''}\n${context.payload.issue.body || ''}`;
+            const matches = issueText.match(keywordRegex);
+            if (!matches) {
+              console.log("No security keywords detected.");
+              return;
+            }
+
+            console.log(`Detected keywords: ${[...new Set(matches)].join(', ')}`);
+            console.log(`Adding label '${triageLabel}'.`);
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              labels: [triageLabel]
+            });


### PR DESCRIPTION
## Description

Currently all vulnerabilities & security issues are being reported via public "Issues" rather than Private Security Advisories (https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/configure-vulnerability-reporting/configuring-private-vulnerability-reporting-for-a-repository). We need to set up the private issue reporting. However, there still could be instances where a vulnerability is still reported publicly.

This PR adds a GitHub Action that scans issue details (title & body for now) & labels the issue if it is suspected to be a vulnerability report. We could have another Action be triggered on this label to notify maintainers to act promptly by creating a private advisory with the user & removing the public issue. I can include the second action in a subsequent PR based on the notification preference (SMTP/SendGrid/Slack/etc.).

<!-- Fixes # (issue) -->

## Type of change

Please delete options that are not relevant.

- [x] Refactor (does not change functionality, e.g. code style improvements, linting)

## How Has This Been Tested?

Tested on my fork by creating a dummy issue: https://github.com/BhumikaSaini/mem0/issues/2

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
