### PR TITLE
Fix database parameter assignment in graph_memory.py

### DIFF
--- a/mem0/memory/graph_memory.py
+++ b/mem0/memory/graph_memory.py
@@ -33,7 +33,7 @@ class MemoryGraph:
             self.config.graph_store.config.url,
             self.config.graph_store.config.username,
             self.config.graph_store.config.password,
-            self.config.graph_store.config.database,
+            database=self.config.graph_store.config.database,
             refresh_schema=False,
             driver_config={"notifications_min_severity": "OFF"},
         )


### PR DESCRIPTION
## Description

Due to an update in the langchain-neo4j library, a new field, `token`, has been added between the `password` and `database` parameters when instantiating the Neo4jGraph class. This causes the current code to assign the value of the `database` variable to the `token` variable. The input parameters need to be explicitly specified.

You can find code here: [langchain-neo4j](https://github.com/langchain-ai/langchain-neo4j/blob/main/libs/neo4j/langchain_neo4j/graphs/neo4j_graph.py#L98)

**Before**
<img width="758" height="411" alt="image" src="https://github.com/user-attachments/assets/009333ef-5be5-4620-aa51-bda84d790cf1" />


**Now**
<img width="705" height="409" alt="image" src="https://github.com/user-attachments/assets/ede9c9b6-a532-40f7-8aa5-8ac0327579bd" />


## Type of change

Please delete options that are not relevant.

- [-] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

My Langchain-Neo4j version is 0.8.0, and I tested it with Neo4j Azure without any issues. I also believe that changing from implicit to explicit parameters shouldn't introduce any significant problems.
