### PR TITLE
fix: Handle invalid memory IDs and prevent IndexError in Qdrant (fixe…

### DIFF
--- a/mem0/vector_stores/qdrant.py
+++ b/mem0/vector_stores/qdrant.py
@@ -128,6 +128,19 @@ class Qdrant(VectorStoreBase):
             ids (list, optional): List of IDs corresponding to vectors. Defaults to None.
         """
         logger.info(f"Inserting {len(vectors)} vectors into collection {self.collection_name}")
+        
+        # Issue 4 Fix: Validate list lengths to prevent IndexError during concurrent operations
+        if ids is not None and len(ids) != len(vectors):
+            raise ValueError(
+                f"Length mismatch: {len(ids)} IDs provided for {len(vectors)} vectors. "
+                f"This can occur during concurrent operations. Ensure IDs list matches vectors list length."
+            )
+        if payloads is not None and len(payloads) != len(vectors):
+            raise ValueError(
+                f"Length mismatch: {len(payloads)} payloads provided for {len(vectors)} vectors. "
+                f"Ensure payloads list matches vectors list length."
+            )
+        
         points = [
             PointStruct(
                 id=idx if ids is None else ids[idx],


### PR DESCRIPTION
Fixes #3945

## Description

This PR fixes two critical bugs reported in issue #3945 related to memory generation errors when processing the LoCoMo dataset:

**Issue 1: KeyError '16' when LLM returns invalid memory ID**
- **Problem**: When the LLM hallucinates an invalid memory ID (e.g., returns "16" when only memories with IDs 0-4 exist), the code crashes with `KeyError: '16'` when trying to access `temp_uuid_mapping[resp.get("id")]`.
- **Solution**: Added validation before accessing `temp_uuid_mapping`. If the ID is invalid:
  - For UPDATE operations: Treat as ADD (create new memory) with a warning log
  - For DELETE operations: Skip the operation with a warning log
- **Impact**: Prevents crashes and gracefully handles LLM hallucinations

**Issue 4: IndexError in Qdrant during concurrent operations**
- **Problem**: During concurrent write operations, if the `ids` list is shorter than the `vectors` list, accessing `ids[idx]` causes `IndexError: index 4494 is out of bounds for axis 0 with size 4494`.
- **Solution**: Added length validation in `Qdrant.insert()` to ensure all lists match before processing. Raises a clear `ValueError` with descriptive message if mismatch is detected.
- **Impact**: Prevents IndexError and provides clear error messages for debugging

Both fixes are applied to sync and async implementations to ensure consistency.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

**Unit Tests:**
- ✅ All 11 core memory tests pass (`tests/test_memory.py`)
- ✅ All 19 Qdrant vector store tests pass (`tests/vector_stores/test_qdrant.py`)
- ✅ No regressions in existing functionality

**Test Configuration:**
- Python 3.12.7
- pytest 7.4.4
- qdrant-client 1.16.2

**Manual Testing:**
The fixes handle edge cases that occur intermittently:
- Issue 1: When LLM returns invalid memory IDs during UPDATE/DELETE operations
- Issue 4: When concurrent operations cause list length mismatches

**Reproduction Steps (from issue):**
1. Process LoCoMo dataset with concurrent operations
2. LLM may return invalid memory IDs → Issue 1 fixed
3. Concurrent Qdrant writes may have mismatched list lengths → Issue 4 fixed

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [x] closes #3945
- [x] Made sure Checks passed

## Files Changed

- `mem0/memory/main.py`: Added ID validation in `_add_to_vector_store()` method (sync and async versions)
- `mem0/vector_stores/qdrant.py`: Added list length validation in `insert()` method

## Additional Notes

- The fixes are backward compatible and don't change the API
- Warning logs are added to help debug when LLM returns invalid IDs
- Error messages are descriptive to aid troubleshooting
- Both sync and async code paths are fixed for consistency