### PR TITLE
[fix]: DOC: Google deprecated the text-embedding-004 model replaced with gemini-embedding-001 

### DIFF
--- a/docs/components/embedders/models/google_AI.mdx
+++ b/docs/components/embedders/models/google_AI.mdx
@@ -18,7 +18,7 @@ config = {
     "embedder": {
         "provider": "gemini",
         "config": {
-            "model": "models/text-embedding-004",
+            "model": "models/gemini-embedding-001",
         }
     }
 }
@@ -65,7 +65,7 @@ Here are the parameters available for configuring Gemini embedder:
 <Tab title="Python">
 | Parameter        | Description                          | Default Value           |
 | ---------------- | ------------------------------------ | ----------------------- |
-| `model`          | The name of the embedding model to use| `models/text-embedding-004` |
+| `model`          | The name of the embedding model to use| `models/gemini-embedding-001` |
 | `embedding_dims` | Dimensions of the embedding model     | `1536`                  |
 | `api_key`        | The Google API key                   | `None`                  |
 </Tab>

--- a/docs/components/embedders/models/vertexai.mdx
+++ b/docs/components/embedders/models/vertexai.mdx
@@ -16,7 +16,7 @@ config = {
     "embedder": {
         "provider": "vertexai",
         "config": {
-            "model": "text-embedding-004",
+            "model": "gemini-embedding-001",
             "memory_add_embedding_type": "RETRIEVAL_DOCUMENT",
             "memory_update_embedding_type": "RETRIEVAL_DOCUMENT",
             "memory_search_embedding_type": "RETRIEVAL_QUERY"
@@ -47,7 +47,7 @@ Here are the parameters available for configuring the Vertex AI embedder:
 
 | Parameter                 | Description                                      | Default Value        |
 | ------------------------- | ------------------------------------------------ | -------------------- |
-| `model`                   | The name of the Vertex AI embedding model to use | `text-embedding-004` |
+| `model`                   | The name of the Vertex AI embedding model to use | `gemini-embedding-001` |
 | `vertex_credentials_json` | Path to the Google Cloud credentials JSON file   | `None`               |
 | `embedding_dims`          | Dimensions of the embedding model                | `256`                |
 | `memory_add_embedding_type` | The type of embedding to use for the add memory action | `RETRIEVAL_DOCUMENT` |

--- a/docs/v0x/components/embedders/models/google_AI.mdx
+++ b/docs/v0x/components/embedders/models/google_AI.mdx
@@ -18,7 +18,7 @@ config = {
     "embedder": {
         "provider": "gemini",
         "config": {
-            "model": "models/text-embedding-004",
+            "model": "models/gemini-embedding-001",
         }
     }
 }
@@ -66,7 +66,7 @@ Here are the parameters available for configuring Gemini embedder:
 <Tab title="Python">
 | Parameter        | Description                          | Default Value           |
 | ---------------- | ------------------------------------ | ----------------------- |
-| `model`          | The name of the embedding model to use| `models/text-embedding-004` |
+| `model`          | The name of the embedding model to use| `models/gemini-embedding-001` |
 | `embedding_dims` | Dimensions of the embedding model     | `1536`                  |
 | `api_key`        | The Google API key                   | `None`                  |
 </Tab>

--- a/docs/v0x/components/embedders/models/vertexai.mdx
+++ b/docs/v0x/components/embedders/models/vertexai.mdx
@@ -16,7 +16,7 @@ config = {
     "embedder": {
         "provider": "vertexai",
         "config": {
-            "model": "text-embedding-004",
+            "model": "gemini-embedding-001",
             "memory_add_embedding_type": "RETRIEVAL_DOCUMENT",
             "memory_update_embedding_type": "RETRIEVAL_DOCUMENT",
             "memory_search_embedding_type": "RETRIEVAL_QUERY"
@@ -47,7 +47,7 @@ Here are the parameters available for configuring the Vertex AI embedder:
 
 | Parameter                 | Description                                      | Default Value        |
 | ------------------------- | ------------------------------------------------ | -------------------- |
-| `model`                   | The name of the Vertex AI embedding model to use | `text-embedding-004` |
+| `model`                   | The name of the Vertex AI embedding model to use | `gemini-embedding-001` |
 | `vertex_credentials_json` | Path to the Google Cloud credentials JSON file   | `None`               |
 | `embedding_dims`          | Dimensions of the embedding model                | `256`                |
 | `memory_add_embedding_type` | The type of embedding to use for the add memory action | `RETRIEVAL_DOCUMENT` |

--- a/mem0/embeddings/gemini.py
+++ b/mem0/embeddings/gemini.py
@@ -12,7 +12,7 @@ class GoogleGenAIEmbedding(EmbeddingBase):
     def __init__(self, config: Optional[BaseEmbedderConfig] = None):
         super().__init__(config)
 
-        self.config.model = self.config.model or "models/text-embedding-004"
+        self.config.model = self.config.model or "models/gemini-embedding-001"
         self.config.embedding_dims = self.config.embedding_dims or self.config.output_dimensionality or 768
 
         api_key = self.config.api_key or os.getenv("GOOGLE_API_KEY")

--- a/mem0/embeddings/vertexai.py
+++ b/mem0/embeddings/vertexai.py
@@ -12,7 +12,7 @@ class VertexAIEmbedding(EmbeddingBase):
     def __init__(self, config: Optional[BaseEmbedderConfig] = None):
         super().__init__(config)
 
-        self.config.model = self.config.model or "text-embedding-004"
+        self.config.model = self.config.model or "gemini-embedding-001"
         self.config.embedding_dims = self.config.embedding_dims or 256
 
         self.embedding_types = {

--- a/tests/embeddings/test_gemini_emeddings.py
+++ b/tests/embeddings/test_gemini_emeddings.py
@@ -19,6 +19,12 @@ def config():
     return BaseEmbedderConfig(api_key="dummy_api_key", model="test_model", embedding_dims=786)
 
 
+@pytest.fixture
+def default_config():
+    """Fixture for testing default configuration (no model or embedding_dims specified)."""
+    return BaseEmbedderConfig(api_key="dummy_api_key")
+
+
 def test_embed_query(mock_genai, config):
     mock_embedding_response = type(
         "Response", (), {"embeddings": [type("Embedding", (), {"values": [0.1, 0.2, 0.3, 0.4]})]}
@@ -58,3 +64,18 @@ def test_config_initialization(config):
     assert embedder.config.api_key == "dummy_api_key"
     assert embedder.config.model == "test_model"
     assert embedder.config.embedding_dims == 786
+
+
+def test_default_model_is_gemini_embedding_001(mock_genai, default_config):
+    """Test that the default model is gemini-embedding-001 (replacing deprecated text-embedding-004).
+    """
+    mock_embedding_response = type(
+        "Response", (), {"embeddings": [type("Embedding", (), {"values": [0.1, 0.2, 0.3]})]}
+    )()
+    mock_genai.return_value = mock_embedding_response
+    
+    embedder = GoogleGenAIEmbedding(default_config)
+    
+    assert embedder.config.model == "models/gemini-embedding-001"
+    
+    assert embedder.config.embedding_dims == 768


### PR DESCRIPTION
## Description

The Default mode text-embedding-004 is depreciated on Jan 14, 2026 and hence replaced by gemini-embedding-001 as suggested by Google Community

Fixes #3942

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Particular tests for this change are present in files: _test_gemini_emeddings.py_ and _test_vertexai_embeddings.py_ where it checks the default model is "gemini-embedding-001" or not and along with default embeddding_dims. 
Can be tested using given instructions i.e., make test-py-3.11 (if using 3.11 python version)

<img width="824" height="23" alt="image" src="https://github.com/user-attachments/assets/628f6f4c-7e82-4c01-ac13-f31923bb6075" />

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [x] closes #3942
- [x] Made sure Checks passed