### PR TITLE
Fix: Remove duplicate entity triples in format_entities output

### DIFF
--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -45,10 +45,13 @@ def format_entities(entities):
     if not entities:
         return ""
 
+    seen = set()
     formatted_lines = []
     for entity in entities:
         simplified = f"{entity['source']} -- {entity['relationship']} -- {entity['destination']}"
-        formatted_lines.append(simplified)
+        if simplified not in seen:
+            seen.add(simplified)
+            formatted_lines.append(simplified)
 
     return "\n".join(formatted_lines)
 


### PR DESCRIPTION
Remove duplicate entity triples in format_entities output

## Description

The current implementation of `format_entities` does not handle duplicate `(source, relationship, destination)` triples. When the input `entities` list contains duplicates, the formatted output also includes repeated lines, which is redundant and may mislead downstream LLM generation processing (e.g., causing the model to overemphasize repeated facts or generate inconsistent summaries).

The duplications originally come form function `_search_graph_db`, however the output list items have similarity score, it is not able to reduce the duplication there.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manual verification using the official graph example
- [x] Unit Test

When running this [neo4j-example notebook](https://github.com/mem0ai/mem0/blob/main/examples/graph-db-demo/neo4j-example.ipynb), the original output contained repeated triples:

user_id:_alice -- loves -- thriller_movies
user_id:_alice -- not_a_fan_of -- thriller_movies
user_id:_alice -- loves -- thriller_movies
user_id:_alice -- not_a_fan_of -- thriller_movies
user_id:_alice -- loves -- thriller_movies
user_id:_alice -- not_a_fan_of -- thriller_movies

With the new update, the result becomes:

user_id:_alice -- loves -- thriller_movies
user_id:_alice -- not_a_fan_of -- thriller_movies


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist


- [x] Made sure Checks passed
