### PR TITLE
fix(security): update axios to ^1.13.0 to resolve HIGH severity vulne…

### DIFF
--- a/mem0-ts/package.json
+++ b/mem0-ts/package.json
@@ -91,7 +91,7 @@
     "typescript": "5.5.4"
   },
   "dependencies": {
-    "axios": "1.7.7",
+    "axios": "^1.13.0",
     "openai": "^4.93.0",
     "uuid": "9.0.1",
     "zod": "^3.24.1"


### PR DESCRIPTION
Security: Update axios dependency
Summary
This PR updates axios from pinned version 1.7.7 to ^1.13.0 to address HIGH-severity security vulnerabilities in the TypeScript SDK.

Fixes #3941

Vulnerabilities Addressed
GHSA-jr5f-v2jv-69x6 — Axios Cross-Site Request Forgery (CSRF) vulnerability
Includes fixes from related axios security advisories resolved in v1.8.x+

Changes
Updated axios dependency in package.json from 1.7.7 to ^1.13.0
Why use a semver range?
Using ^1.13.0 instead of a pinned version allows downstream projects to receive future axios security fixes automatically through dependency resolution, without waiting for a new mem0 release.

Testing
✅ Confirmed npm install resolves to axios 1.13.4
✅ Ran npm test — results match the main branch
(existing test failures are unrelated to this change)
✅ No breaking changes expected (axios 1.x maintains backward compatibility)

Checklist
 Dependency updated
 Installation verified
 No regressions introduced