### PR TITLE
Fix loading env in openmemory api

### DIFF
--- a/openmemory/api/app/config.py
+++ b/openmemory/api/app/config.py
@@ -1,4 +1,6 @@
 import os
+from dotenv import load_dotenv, find_dotenv
+load_dotenv(find_dotenv())
 
 USER_ID = os.getenv("USER", "default_user")
 DEFAULT_APP_ID = "openmemory"


### PR DESCRIPTION
## Description

I couln't start the application, facing user not found error, when i debugged, found out that my `api/.env` has `USER=user` but it is not being loaded in config.py

## Type of change

- Bug Fix

## How Has This Been Tested?

To reproduce
```cmd
cd openmemory/api
python -m venv .venv
.venv/Scripts/Activate.ps1
pip install -r requirements.txt
uvicorn main:app --host 0.0.0.0 --port 8765
```
use a print statement for `USER_ID` in `api/app/config.py`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
