### PR TITLE
fix: add OpenClaw to docs navigation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -404,6 +404,7 @@
                       "integrations/autogen",
                       "integrations/agno",
                       "integrations/camel-ai",
+                      "integrations/openclaw",
                       "integrations/openai-agents-sdk",
                       "integrations/google-ai-adk",
                       "integrations/mastra",


### PR DESCRIPTION
## Summary

- Adds missing `integrations/openclaw` entry to the Agent Frameworks section in `docs.json`