### PR TITLE
allowing field-level updates without overwriting the entire payload d…

### DIFF
--- a/mem0/vector_stores/mongodb.py
+++ b/mem0/vector_stores/mongodb.py
@@ -188,17 +188,25 @@ class MongoDB(VectorStoreBase):
     def update(self, vector_id: str, vector: Optional[List[float]] = None, payload: Optional[Dict] = None) -> None:
         """
         Update a vector and its payload.
+        
+        This performs a partial update (merge) for the payload. Existing fields in the
+        payload that are not included in the update will be preserved.
 
         Args:
             vector_id (str): ID of the vector to update.
             vector (List[float], optional): Updated vector.
-            payload (Dict, optional): Updated payload.
+            payload (Dict, optional): Updated payload fields to merge.
         """
         update_fields = {}
+        
         if vector is not None:
             update_fields["embedding"] = vector
+            
         if payload is not None:
-            update_fields["payload"] = payload
+            # FIX: Use dot notation to update specific fields within the payload dictionary
+            # instead of overwriting the entire 'payload' field.
+            for key, value in payload.items():
+                update_fields[f"payload.{key}"] = value
 
         if update_fields:
             try:
@@ -209,7 +217,6 @@ class MongoDB(VectorStoreBase):
                     logger.warning(f"No document found with ID '{vector_id}' to update.")
             except PyMongoError as e:
                 logger.error(f"Error updating document: {e}")
-
     def get(self, vector_id: str) -> Optional[OutputData]:
         """
         Retrieve a vector by ID.


### PR DESCRIPTION
## Description

This PR fixes the MongoDB vector store `update` method to use dot notation for payload field updates, allowing field-level updates without overwriting the entire payload dictionary. Previously, updating any payload field would replace the entire payload object, causing data loss for fields not included in the update.

**Key Changes:**
- Modified `update()` method in `mem0/vector_stores/mongodb.py` to use MongoDB dot notation (`payload.field_name`) for partial payload updates
- Updated existing test to match the new implementation
- Added comprehensive test coverage for all update scenarios

**Benefits:**
- Preserves existing payload fields when updating specific fields
- Enables partial updates without requiring the full payload to be provided
- Maintains backward compatibility with the API

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Comprehensive unit tests have been added and updated to verify the fix. The test suite includes:

**Updated Tests:**
- `test_update_vector_and_payload` - Verifies updating both vector and payload fields uses dot notation

**New Test Cases Added:**
- `test_update_vector_only` - Tests updating only the vector
- `test_update_payload_only` - Tests updating only payload fields
- `test_update_payload_partial_merge` - Verifies partial payload updates preserve existing fields
- `test_update_no_fields` - Edge case when no fields are provided
- `test_update_document_not_found` - Handles missing documents gracefully
- `test_update_payload_with_nested_fields` - Tests multiple payload fields (user_id, agent_id, run_id, etc.)

**Test Results:**
All 22 tests in the MongoDB test suite pass successfully:

pytest tests/vector_stores/test_mongodb.py -v
