### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,10 +11,10 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
       mem0_changed: ${{ steps.filter.outputs.mem0 }}
       embedchain_changed: ${{ steps.filter.outputs.embedchain }}
     steps:
-    - uses: actions/checkout@v3
-    - uses: dorny/paths-filter@v2
+    - uses: actions/checkout@v6
+    - uses: dorny/paths-filter@v3
       id: filter
       with:
         filters: |
@@ -43,9 +43,9 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Clean up disk space
@@ -59,7 +59,7 @@ jobs:
         run: pip install hatch
       - name: Load cached venv
         id: cached-hatch-dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: .venv
           key: venv-mem0-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
@@ -84,16 +84,16 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Hatch
         run: pip install hatch
       - name: Load cached venv
         id: cached-hatch-dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: .venv
           key: venv-embedchain-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
@@ -109,7 +109,7 @@ jobs:
       - name: Run tests and generate coverage report
         run: cd embedchain && make coverage
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           file: coverage.xml
         env:


### PR DESCRIPTION
## Description

This PR updates outdated GitHub Action versions to ensure compatibility and security. The changes include updating `actions/checkout` from `v2` to `v6`, `actions/cache` from `v3` to `v5`, and other dependencies to their latest stable versions. These updates are non-breaking and do not affect existing functionality.  

Fixes #  

## Type of change

- [ ] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Refactor  
- [ ] Documentation update  

## How Has This Been Tested?

The changes will be tested in the CI pipeline of the pull request.  

## Checklist:

- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my own code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have made corresponding changes to the documentation  
- [ ] My changes generate no new warnings  
- [ ] I have added tests that prove my fix is effective or that my feature works  
- [ ] New and existing unit tests pass locally with my changes  
- [ ] Any dependent changes have been merged and published in downstream modules  
- [ ] I have checked my code and corrected any misspellings  

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)  
- [ ] Made sure Checks passed