### PR TITLE
fix: remove vector_store.reset() from delete_all() to prevent deleting all users' memories

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -214,6 +214,12 @@ def test_delete_all(memory_instance, version, enable_graph):
     assert result["message"] == "Memories deleted successfully!"
 
 
+def test_delete_all_requires_filter(memory_instance):
+    """delete_all() without any filter must raise ValueError."""
+    with pytest.raises(ValueError, match="At least one filter is required"):
+        memory_instance.delete_all()
+
+
 @pytest.mark.parametrize(
     "version, enable_graph, expected_result",
     [


### PR DESCRIPTION
## Summary
- `delete_all()` called `self.vector_store.reset()` after deleting filtered memories
- `reset()` drops and recreates the entire collection, destroying ALL memories for ALL users
- The filtered deletion via `self._delete_memory()` loop was already sufficient

## Changes
- Remove `self.vector_store.reset()` call from `delete_all()` in `mem0/memory/main.py`
- Verified async `adelete_all()` was already correct (no reset call)
- Added test assertion that `vector_store.reset` is never called
- Added test that `delete_all` requires filter parameters

## Test plan
- [x] Existing `test_delete_all` updated with `reset.assert_not_called()`
- [x] New `test_delete_all_requires_filter` added

Fixes #3928