### PR TITLE
fix: wrap vector and payload in lists in langchain adapter update method

### DIFF
--- a/mem0/vector_stores/langchain.py
+++ b/mem0/vector_stores/langchain.py
@@ -115,7 +115,7 @@ class Langchain(VectorStoreBase):
         Update a vector and its payload.
         """
         self.delete(vector_id)
-        self.insert(vector, payload, [vector_id])
+        self.insert([vector], [payload], [vector_id])
 
     def get(self, vector_id):
         """


### PR DESCRIPTION
The `insert` method expects lists for `vectors` and `payloads` parameters, but the `update` method was passing single values. This caused type mismatch errors when updating vectors in the Langchain vector store adapter.

Closes #3767