### PR TITLE
feat: add reasoning_effort parameter for reasoning models

### DIFF
--- a/mem0/configs/llms/azure.py
+++ b/mem0/configs/llms/azure.py
@@ -24,6 +24,8 @@ class AzureOpenAIConfig(BaseLlmConfig):
         http_client_proxies: Optional[dict] = None,
         # Azure OpenAI-specific parameters
         azure_kwargs: Optional[Dict[str, Any]] = None,
+        # Reasoning model parameters
+        reasoning_effort: Optional[str] = None,
     ):
         """
         Initialize Azure OpenAI configuration.
@@ -39,6 +41,9 @@ class AzureOpenAIConfig(BaseLlmConfig):
             vision_details: Vision detail level, defaults to "auto"
             http_client_proxies: HTTP client proxy settings, defaults to None
             azure_kwargs: Azure-specific configuration, defaults to None
+            reasoning_effort: Reasoning effort level for reasoning models (o1, o3, gpt-5).
+                Options: "low", "medium", "high". Only used with reasoning models.
+                Defaults to None
         """
         # Initialize base parameters
         super().__init__(
@@ -55,3 +60,6 @@ class AzureOpenAIConfig(BaseLlmConfig):
 
         # Azure OpenAI-specific parameters
         self.azure_kwargs = AzureConfig(**(azure_kwargs or {}))
+        
+        # Reasoning model parameters
+        self.reasoning_effort = reasoning_effort

--- a/mem0/configs/llms/openai.py
+++ b/mem0/configs/llms/openai.py
@@ -31,6 +31,8 @@ class OpenAIConfig(BaseLlmConfig):
         store: bool = False,
         # Response monitoring callback
         response_callback: Optional[Callable[[Any, dict, dict], None]] = None,
+        # Reasoning model parameters
+        reasoning_effort: Optional[str] = None,
     ):
         """
         Initialize OpenAI configuration.
@@ -52,6 +54,9 @@ class OpenAIConfig(BaseLlmConfig):
             site_url: Site URL for OpenRouter, defaults to None
             app_name: Application name for OpenRouter, defaults to None
             response_callback: Optional callback for monitoring LLM responses.
+            reasoning_effort: Reasoning effort level for reasoning models (o1, o3, gpt-5).
+                Options: "low", "medium", "high". Only used with reasoning models.
+                Defaults to None
         """
         # Initialize base parameters
         super().__init__(
@@ -77,3 +82,6 @@ class OpenAIConfig(BaseLlmConfig):
 
         # Response monitoring
         self.response_callback = response_callback
+        
+        # Reasoning model parameters
+        self.reasoning_effort = reasoning_effort

--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -88,6 +88,11 @@ class LLMBase(ABC):
                 supported_params["tools"] = kwargs["tools"]
             if "tool_choice" in kwargs:
                 supported_params["tool_choice"] = kwargs["tool_choice"]
+            
+            # Add reasoning_effort if configured (for o1, o3, gpt-5 models)
+            reasoning_effort = getattr(self.config, 'reasoning_effort', None)
+            if reasoning_effort:
+                supported_params["reasoning_effort"] = reasoning_effort
                 
             return supported_params
         else:


### PR DESCRIPTION
## Summary
Adds support for the `reasoning_effort` parameter to `OpenAIConfig` and `AzureOpenAIConfig`.

## Changes
- Added `reasoning_effort` parameter to `AzureOpenAIConfig` and `OpenAIConfig`
- Updated `_get_supported_params` in the base LLM class to include `reasoning_effort` when configured for reasoning models

## Usage
```python
from mem0 import Memory

config = {
    "llm": {
        "provider": "azure_openai",
        "config": {
            "model": "o1",
            "reasoning_effort": "low",  # or "medium", "high"
            "azure_kwargs": {...}
        }
    }
}

m = Memory.from_config(config)
```

Closes #3651