### PR TITLE
fix: preserve all metadata fields when updating memory

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1150,24 +1150,17 @@ class Memory(MemoryBase):
 
         prev_value = existing_memory.payload.get("data")
 
-        new_metadata = deepcopy(metadata) if metadata is not None else {}
+        # Start with existing payload to preserve all metadata fields (including custom ones)
+        new_metadata = deepcopy(existing_memory.payload)
 
+        # Override with any explicitly provided metadata
+        if metadata is not None:
+            new_metadata.update(metadata)
+
+        # Update managed fields
         new_metadata["data"] = data
         new_metadata["hash"] = hashlib.md5(data.encode()).hexdigest()
-        new_metadata["created_at"] = existing_memory.payload.get("created_at")
         new_metadata["updated_at"] = datetime.now(pytz.timezone("US/Pacific")).isoformat()
-
-        # Preserve session identifiers from existing memory only if not provided in new metadata
-        if "user_id" not in new_metadata and "user_id" in existing_memory.payload:
-            new_metadata["user_id"] = existing_memory.payload["user_id"]
-        if "agent_id" not in new_metadata and "agent_id" in existing_memory.payload:
-            new_metadata["agent_id"] = existing_memory.payload["agent_id"]
-        if "run_id" not in new_metadata and "run_id" in existing_memory.payload:
-            new_metadata["run_id"] = existing_memory.payload["run_id"]
-        if "actor_id" not in new_metadata and "actor_id" in existing_memory.payload:
-            new_metadata["actor_id"] = existing_memory.payload["actor_id"]
-        if "role" not in new_metadata and "role" in existing_memory.payload:
-            new_metadata["role"] = existing_memory.payload["role"]
 
         if data in existing_embeddings:
             embeddings = existing_embeddings[data]


### PR DESCRIPTION
## Summary
Fixes #3966

## Problem
When updating a memory via `memory.update()`, custom metadata fields like `bucket_id`, `context_id`, `category`, `source`, etc. are lost because `_update_memory` only preserves a whitelist of known fields (`user_id`, `agent_id`, `run_id`, `actor_id`, `role`).

## Solution
Instead of starting with an empty dict and selectively copying known fields, start with the existing payload (preserving all metadata) and then update only the managed fields (`data`, `hash`, `updated_at`).

This is simpler, more maintainable, and correctly preserves all custom metadata fields.

## Changes
- Start `new_metadata` from `deepcopy(existing_memory.payload)` instead of empty dict
- Merge in any explicitly provided metadata
- Remove the per-field preservation logic (no longer needed)