### PR TITLE
fix: preserve http_auth in _safe_deepcopy_config

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -69,9 +69,16 @@ def _safe_deepcopy_config(config):
         else:
             clone_dict = {k: v for k, v in config.__dict__.items()}
         
-        sensitive_tokens = ("auth", "credential", "password", "token", "secret", "key", "connection_class")
+        # Fields that should be excluded from telemetry but preserved for runtime
+        # Note: we use specific patterns to avoid matching runtime fields like http_auth
+        sensitive_tokens = ("credential", "password", "secret", "api_key", "access_key")
+        # Fields with non-serializable objects that should be nulled for telemetry
+        runtime_tokens = ("connection_class",)
         for field_name in list(clone_dict.keys()):
-            if any(token in field_name.lower() for token in sensitive_tokens):
+            field_lower = field_name.lower()
+            if any(token in field_lower for token in sensitive_tokens):
+                clone_dict[field_name] = None
+            elif any(token in field_lower for token in runtime_tokens):
                 clone_dict[field_name] = None
         
         try:


### PR DESCRIPTION
## Summary
Fixes #3580

The `_safe_deepcopy_config` function was using `'auth'` as a sensitive token, which incorrectly matched `http_auth` and broke AWS-signed OpenSearch client authentication.

## Changes
- Updated sensitive token patterns to be more specific
- Split into `sensitive_tokens` (truly sensitive data like passwords, secrets, api_keys) and `runtime_tokens` (non-serializable objects like connection_class)
- Preserves `http_auth` and similar runtime authentication objects required for vector store connections

## Testing
Verified the change preserves `http_auth` field while still sanitizing truly sensitive fields like `password`, `secret`, and `api_key`.