### PR TITLE
fix: allow protobuf 6.x to resolve CVE-2026-0994

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "posthog>=3.5.0",
     "pytz>=2024.1",
     "sqlalchemy>=2.0.31",
-    "protobuf>=5.29.0,<6.0.0",
+    "protobuf>=5.29.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Remove upper bound constraint on protobuf to allow upgrading to version 6.x which contains the fix for CVE-2026-0994.

The current constraint `protobuf>=5.29.0,<6.0.0` prevents users from upgrading to a secure protobuf release.

Closes #3963