### PR TITLE
fix(mem0-ts): pass url config to OpenAI embedder constructor

### DIFF
--- a/mem0-ts/src/oss/src/embeddings/openai.ts
+++ b/mem0-ts/src/oss/src/embeddings/openai.ts
@@ -8,7 +8,7 @@ export class OpenAIEmbedder implements Embedder {
   private embeddingDims?: number;
 
   constructor(config: EmbeddingConfig) {
-    this.openai = new OpenAI({ apiKey: config.apiKey });
+    this.openai = new OpenAI({ apiKey: config.apiKey, baseURL: config.url });
     this.model = config.model || "text-embedding-3-small";
     this.embeddingDims = config.embeddingDims || 1536;
   }


### PR DESCRIPTION
## Problem

The `OpenAIEmbedder` constructor in the TypeScript OSS SDK accepts an `EmbeddingConfig` with a `url` field, but never passes it to the OpenAI SDK constructor. This causes all embedding requests to go to `api.openai.com` regardless of configuration.

This affects anyone running mem0 OSS with a custom embeddings endpoint (Infinity, vLLM, LiteLLM, TEI, etc.).

## Fix

One-line change: pass `config.url` as the OpenAI SDK's `baseURL` parameter, matching how `OpenAILLM` already handles `config.baseURL`.

## Context

- The `EmbeddingConfig` type already declares `url?: string`
- The config manager already passes `url` through from user config
- The `OllamaEmbedder` already uses `config.url` correctly
- Only `OpenAIEmbedder` was missing this

## Testing

Tested with Infinity (`nomic-embed-text-v1.5`) as a custom OpenAI-compatible embeddings server. Before fix: requests hit `api.openai.com` and fail with model ID errors. After fix: requests correctly route to the configured endpoint.