### PR TITLE
fix(mem0-ts): extract content from code blocks instead of removing them

### DIFF
--- a/mem0-ts/src/oss/src/prompts/index.ts
+++ b/mem0-ts/src/oss/src/prompts/index.ts
@@ -269,5 +269,10 @@ export function parseMessages(messages: string[]): string {
 }
 
 export function removeCodeBlocks(text: string): string {
-  return text.replace(/```[^`]*```/g, "");
+  // If the response contains a code block, extract its content rather than
+  // stripping it. Many local/open-source models wrap JSON in ```json fences
+  // even when response_format is set to json_object.
+  const match = text.match(/```(?:json)?\s*\n?([\s\S]*?)```/);
+  if (match) return match[1].trim();
+  return text.replace(/```[^`]*```/g, "").trim();
 }


### PR DESCRIPTION
## Problem

When an LLM wraps its JSON response in markdown code fences:

```
\`\`\`json
{"facts": ["The sky is blue."]}
\`\`\`

Explanation: I extracted one fact from the input.
```

The `removeCodeBlocks` function strips the fenced block entirely (`text.replace(/\`\`\`[^\`]*\`\`\`/g, "")`), leaving only the explanation text. The subsequent `JSON.parse` then fails with `SyntaxError: Unexpected end of JSON input` because it receives:

```
Explanation: I extracted one fact from the input.
```

…instead of the actual JSON.

This silently breaks `memory.add()` — facts are never extracted, and the response shows "No new memories extracted" even though the LLM produced valid output.

## Who this affects

Anyone using open-source/local models (Qwen, Llama, Mistral, Phi, etc.) which commonly wrap structured output in code fences even when `response_format: { type: "json_object" }` is set. This is one of the most common behaviors with local inference servers (llama.cpp, vLLM, Ollama, TabbyAPI, MLX).

## Fix

When a code fence is present, extract its content rather than deleting it. Falls back to the original strip behavior if no fenced block is found.

## Testing

Tested with Qwen2.5-32B via a local inference server. Before fix: all `memory.add()` calls silently fail ("no new memories extracted"). After fix: facts are correctly extracted and stored.