### PR TITLE
feat: add reasoning_effort parameter support for reasoning models

### DIFF
--- a/mem0/configs/llms/azure.py
+++ b/mem0/configs/llms/azure.py
@@ -22,6 +22,7 @@ class AzureOpenAIConfig(BaseLlmConfig):
         enable_vision: bool = False,
         vision_details: Optional[str] = "auto",
         http_client_proxies: Optional[dict] = None,
+        reasoning_effort: Optional[str] = None,
         # Azure OpenAI-specific parameters
         azure_kwargs: Optional[Dict[str, Any]] = None,
     ):
@@ -38,6 +39,8 @@ class AzureOpenAIConfig(BaseLlmConfig):
             enable_vision: Enable vision capabilities, defaults to False
             vision_details: Vision detail level, defaults to "auto"
             http_client_proxies: HTTP client proxy settings, defaults to None
+            reasoning_effort: Controls reasoning effort for reasoning models (o1, o3, gpt-5).
+                Options: "low", "medium", "high". Defaults to None
             azure_kwargs: Azure-specific configuration, defaults to None
         """
         # Initialize base parameters
@@ -51,6 +54,7 @@ class AzureOpenAIConfig(BaseLlmConfig):
             enable_vision=enable_vision,
             vision_details=vision_details,
             http_client_proxies=http_client_proxies,
+            reasoning_effort=reasoning_effort,
         )
 
         # Azure OpenAI-specific parameters

--- a/mem0/configs/llms/base.py
+++ b/mem0/configs/llms/base.py
@@ -24,6 +24,7 @@ class BaseLlmConfig(ABC):
         enable_vision: bool = False,
         vision_details: Optional[str] = "auto",
         http_client_proxies: Optional[Union[Dict, str]] = None,
+        reasoning_effort: Optional[str] = None,
     ):
         """
         Initialize a base configuration class instance for the LLM.
@@ -50,6 +51,9 @@ class BaseLlmConfig(ABC):
                 Options: "low", "high", "auto". Defaults to "auto"
             http_client_proxies: Proxy settings for HTTP client.
                 Can be a dict or string. Defaults to None
+            reasoning_effort: Controls the effort level for reasoning models (e.g., o1, o3, gpt-5).
+                Options: "low", "medium", "high". Only applicable to reasoning models.
+                Defaults to None (uses provider default)
         """
         self.model = model
         self.temperature = temperature
@@ -59,4 +63,5 @@ class BaseLlmConfig(ABC):
         self.top_k = top_k
         self.enable_vision = enable_vision
         self.vision_details = vision_details
+        self.reasoning_effort = reasoning_effort
         self.http_client = httpx.Client(proxies=http_client_proxies) if http_client_proxies else None

--- a/mem0/configs/llms/openai.py
+++ b/mem0/configs/llms/openai.py
@@ -21,6 +21,7 @@ class OpenAIConfig(BaseLlmConfig):
         enable_vision: bool = False,
         vision_details: Optional[str] = "auto",
         http_client_proxies: Optional[dict] = None,
+        reasoning_effort: Optional[str] = None,
         # OpenAI-specific parameters
         openai_base_url: Optional[str] = None,
         models: Optional[List[str]] = None,
@@ -45,6 +46,8 @@ class OpenAIConfig(BaseLlmConfig):
             enable_vision: Enable vision capabilities, defaults to False
             vision_details: Vision detail level, defaults to "auto"
             http_client_proxies: HTTP client proxy settings, defaults to None
+            reasoning_effort: Controls reasoning effort for reasoning models (o1, o3, gpt-5).
+                Options: "low", "medium", "high". Defaults to None
             openai_base_url: OpenAI API base URL, defaults to None
             models: List of models for OpenRouter, defaults to None
             route: OpenRouter route strategy, defaults to "fallback"
@@ -64,6 +67,7 @@ class OpenAIConfig(BaseLlmConfig):
             enable_vision=enable_vision,
             vision_details=vision_details,
             http_client_proxies=http_client_proxies,
+            reasoning_effort=reasoning_effort,
         )
 
         # OpenAI-specific parameters

--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -88,6 +88,11 @@ class LLMBase(ABC):
                 supported_params["tools"] = kwargs["tools"]
             if "tool_choice" in kwargs:
                 supported_params["tool_choice"] = kwargs["tool_choice"]
+            
+            # Include reasoning_effort for reasoning models if configured
+            reasoning_effort = getattr(self.config, 'reasoning_effort', None)
+            if reasoning_effort:
+                supported_params["reasoning_effort"] = reasoning_effort
                 
             return supported_params
         else:


### PR DESCRIPTION
## Summary

Closes #3651

Adds support for the `reasoning_effort` parameter for reasoning models (o1, o3, gpt-5) in `AzureOpenAIConfig` and `OpenAIConfig`.

## Problem

When `reasoning_effort` is included in the `llm.config` section (e.g., when initializing via `Memory.from_config`), the following error is raised:

```
TypeError: AzureOpenAIConfig.__init__() got an unexpected keyword argument 'reasoning_effort'
```

## Changes

- **`mem0/configs/llms/base.py`**: Added `reasoning_effort: Optional[str] = None` to `BaseLlmConfig.__init__()`
- **`mem0/configs/llms/azure.py`**: Added `reasoning_effort` parameter to `AzureOpenAIConfig` and forward to `super().__init__()`
- **`mem0/configs/llms/openai.py`**: Added `reasoning_effort` parameter to `OpenAIConfig` and forward to `super().__init__()`
- **`mem0/llms/base.py`**: Updated `_get_supported_params()` to include `reasoning_effort` when the model is a reasoning model
- **`tests/llms/test_azure_openai.py`**: Added 2 new tests:
  - Verify `reasoning_effort` is passed through for reasoning models (`o3-mini`)
  - Verify `reasoning_effort` is correctly ignored for non-reasoning models

## Testing

All 10 tests pass (8 existing + 2 new):

```
tests/llms/test_azure_openai.py::test_generate_response_reasoning_model_with_reasoning_effort PASSED
tests/llms/test_azure_openai.py::test_generate_response_non_reasoning_model_ignores_reasoning_effort PASSED
```

## Usage

```python
from mem0 import Memory

config = {
    "llm": {
        "provider": "azure_openai",
        "config": {
            "model": "o3-mini",
            "reasoning_effort": "low",
            "azure_kwargs": {
                "api_key": "...",
                "azure_endpoint": "...",
                "azure_deployment": "...",
            }
        }
    }
}

m = Memory.from_config(config)
```