### PR TITLE
OpenClaw plugin: Fix broken auto-recall memory injection

### DIFF
--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -1274,7 +1274,7 @@ const memoryPlugin = {
           );
 
           return {
-            systemContext: `<relevant-memories>\nThe following memories may be relevant to this conversation:\n${memoryContext}\n</relevant-memories>`,
+            prependContext: `<relevant-memories>\nThe following memories may be relevant to this conversation:\n${memoryContext}\n</relevant-memories>`,
           };
         } catch (err) {
           api.logger.warn(`openclaw-mem0: recall failed: ${String(err)}`);


### PR DESCRIPTION
Change systemContext to prependContext in before_agent_start hook to match OpenClaw's expected property name. Memories were being fetched but never injected into prompts.

## Description
Fixes a critical bug where auto-recall memory injection was silently broken. The `before_agent_start` hook returned `{ systemContext: ... }` but OpenClaw's hook runner only checks for `{ prependContext: ... }`. This caused memories to be fetched and logged but never actually injected into conversation prompts.

**Root Cause**: Property name mismatch in hook return object
**Impact**: Auto-recall appears to work (logs show injection) but memories never reach the LLM
**Fix**: One-line property rename from `systemContext` to `prependContext`

Fixes #4037

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
**Manual testing steps performed:**
- [x] Set OPENCLAW_CACHE_TRACE and OPENCLAW_ANTHROPIC_PAYLOAD_LOG to true
- [x] Enabled auto-recall in mem0 OpenClaw plugin
- [x] Restarted openclaw gateway
- [x] Started conversation triggering memory recall
- [x] Verified <relevant-memories> now appear in .openclaw/logs
- [x] Verified system prompt (agent.md, soul.md) remains unaffected

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings