### PR TITLE
fix: update retired default Anthropic model to claude-sonnet-4-5-20250929

### DIFF
--- a/mem0-ts/src/oss/src/llms/anthropic.ts
+++ b/mem0-ts/src/oss/src/llms/anthropic.ts
@@ -12,7 +12,7 @@ export class AnthropicLLM implements LLM {
       throw new Error("Anthropic API key is required");
     }
     this.client = new Anthropic({ apiKey });
-    this.model = config.model || "claude-3-sonnet-20240229";
+    this.model = config.model || "claude-sonnet-4-5-20250929";
   }
 
   async generateResponse(

--- a/mem0-ts/src/oss/tests/anthropic.test.ts
+++ b/mem0-ts/src/oss/tests/anthropic.test.ts
@@ -1,0 +1,59 @@
+/// <reference types="jest" />
+
+jest.mock("@anthropic-ai/sdk", () => {
+  const mockCreate = jest.fn().mockResolvedValue({
+    content: [{ type: "text", text: '{"result": "ok"}' }],
+    stop_reason: "end_turn",
+  });
+  return jest.fn().mockImplementation(() => ({
+    messages: { create: mockCreate },
+  }));
+});
+
+import Anthropic from "@anthropic-ai/sdk";
+import { AnthropicLLM } from "../src/llms/anthropic";
+
+describe("AnthropicLLM", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.ANTHROPIC_API_KEY = "test-key";
+  });
+
+  afterEach(() => {
+    delete process.env.ANTHROPIC_API_KEY;
+  });
+
+  describe("default model", () => {
+    it("should use claude-sonnet-4-5-20250929 when no model specified", () => {
+      const llm = new AnthropicLLM({ apiKey: "test-key" });
+
+      // Access private model field via type assertion
+      expect((llm as any).model).toBe("claude-sonnet-4-5-20250929");
+    });
+
+    it("should use custom model when specified", () => {
+      const llm = new AnthropicLLM({
+        apiKey: "test-key",
+        model: "claude-opus-4-6",
+      });
+
+      expect((llm as any).model).toBe("claude-opus-4-6");
+    });
+  });
+
+  describe("generateResponse", () => {
+    it("should pass model to SDK messages.create", async () => {
+      const llm = new AnthropicLLM({ apiKey: "test-key" });
+
+      await llm.generateResponse([{ role: "user", content: "Hello" }]);
+
+      const mockInstance = (Anthropic as unknown as jest.Mock).mock.results[0]
+        .value;
+      expect(mockInstance.messages.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: "claude-sonnet-4-5-20250929",
+        }),
+      );
+    });
+  });
+});

--- a/mem0/llms/anthropic.py
+++ b/mem0/llms/anthropic.py
@@ -35,7 +35,7 @@ class AnthropicLLM(LLMBase):
         super().__init__(config)
 
         if not self.config.model:
-            self.config.model = "claude-3-5-sonnet-20240620"
+            self.config.model = "claude-sonnet-4-5-20250929"
 
         api_key = self.config.api_key or os.getenv("ANTHROPIC_API_KEY")
         self.client = anthropic.Anthropic(api_key=api_key)


### PR DESCRIPTION
## Description

Updated the default Anthropic model in both TypeScript and Python SDKs from retired/deprecated models to `claude-sonnet-4-5-20250929`.

- TypeScript SDK: `claude-3-sonnet-20240229` → `claude-sonnet-4-5-20250929` (retired July 2025)
- Python SDK: `claude-3-5-sonnet-20240620` → `claude-sonnet-4-5-20250929` (deprecated)

The current TypeScript default `claude-3-sonnet-20240229` was [retired by Anthropic on July 21, 2025](https://docs.anthropic.com/en/docs/about-claude/model-deprecations). Users who rely on the default (no explicit model config) get API errors. The Python default is also deprecated. Both are updated to `claude-sonnet-4-5-20250929`, preserving the Sonnet-tier positioning of the original defaults.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit Test

Unit tests verify:
- Default model is `claude-sonnet-4-5-20250929` when no model specified
- Custom model is used when explicitly provided
- Default model is passed to SDK `messages.create()`

Run: `cd mem0-ts && npx jest --testPathPattern="anthropic.test"`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings