### PR TITLE
fix: make Anthropic max_tokens configurable with higher default

### DIFF
--- a/mem0-ts/src/oss/src/llms/anthropic.ts
+++ b/mem0-ts/src/oss/src/llms/anthropic.ts
@@ -5,6 +5,7 @@ import { LLMConfig, Message } from "../types";
 export class AnthropicLLM implements LLM {
   private client: Anthropic;
   private model: string;
+  private maxTokens: number;
 
   constructor(config: LLMConfig) {
     const apiKey = config.apiKey || process.env.ANTHROPIC_API_KEY;
@@ -13,6 +14,7 @@ export class AnthropicLLM implements LLM {
     }
     this.client = new Anthropic({ apiKey });
     this.model = config.model || "claude-3-sonnet-20240229";
+    this.maxTokens = config.maxTokens || 16384;
   }
 
   async generateResponse(
@@ -36,7 +38,7 @@ export class AnthropicLLM implements LLM {
         typeof systemMessage?.content === "string"
           ? systemMessage.content
           : undefined,
-      max_tokens: 4096,
+      max_tokens: this.maxTokens,
     });
 
     const firstBlock = response.content[0];

--- a/mem0-ts/src/oss/src/types/index.ts
+++ b/mem0-ts/src/oss/src/types/index.ts
@@ -45,6 +45,7 @@ export interface LLMConfig {
   apiKey?: string;
   model?: string | any;
   modelProperties?: Record<string, any>;
+  maxTokens?: number;
 }
 
 export interface Neo4jConfig {
@@ -140,6 +141,7 @@ export const MemoryConfigSchema = z.object({
       model: z.union([z.string(), z.any()]).optional(),
       modelProperties: z.record(z.string(), z.any()).optional(),
       baseURL: z.string().optional(),
+      maxTokens: z.number().optional(),
     }),
   }),
   historyDbPath: z.string().optional(),

--- a/mem0-ts/src/oss/tests/anthropic-max-tokens.test.ts
+++ b/mem0-ts/src/oss/tests/anthropic-max-tokens.test.ts
@@ -1,0 +1,50 @@
+/// <reference types="jest" />
+
+const mockCreate = jest.fn().mockResolvedValue({
+  content: [{ type: "text", text: '{"result": "ok"}' }],
+  stop_reason: "end_turn",
+});
+
+jest.mock("@anthropic-ai/sdk", () => {
+  return jest.fn().mockImplementation(() => ({
+    messages: { create: mockCreate },
+  }));
+});
+
+import Anthropic from "@anthropic-ai/sdk";
+import { AnthropicLLM } from "../src/llms/anthropic";
+
+describe("AnthropicLLM maxTokens", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.ANTHROPIC_API_KEY = "test-key";
+  });
+
+  afterEach(() => {
+    delete process.env.ANTHROPIC_API_KEY;
+  });
+
+  it("should use default maxTokens of 16384 when not specified", async () => {
+    const llm = new AnthropicLLM({ apiKey: "test-key" });
+
+    await llm.generateResponse([{ role: "user", content: "Hello" }]);
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        max_tokens: 16384,
+      }),
+    );
+  });
+
+  it("should use custom maxTokens value when specified", async () => {
+    const llm = new AnthropicLLM({ apiKey: "test-key", maxTokens: 8192 });
+
+    await llm.generateResponse([{ role: "user", content: "Hello" }]);
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        max_tokens: 8192,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Description

Replace the hardcoded `max_tokens: 4096` in the Anthropic LLM provider with a configurable `maxTokens` field (default `16384`). The previous value was too low for memory operations involving large context, causing silent truncation and downstream JSON parse failures.

- Added `maxTokens?: number` to `LLMConfig` interface
- Added `maxTokens: z.number().optional()` to `MemoryConfigSchema` Zod validation
- `AnthropicLLM` constructor reads `maxTokens` from config with default `16384`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit Test

Unit tests verify:
- Default `16384` used when `maxTokens` not specified
- Custom `maxTokens` value passed through to SDK `messages.create()`

Run: `cd mem0-ts && npx jest --testPathPattern="anthropic-max-tokens"`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings