### PR TITLE
fix: add truncation detection warnings for Anthropic and OpenAI

### DIFF
--- a/mem0-ts/src/oss/src/llms/anthropic.ts
+++ b/mem0-ts/src/oss/src/llms/anthropic.ts
@@ -39,6 +39,12 @@ export class AnthropicLLM implements LLM {
       max_tokens: 4096,
     });
 
+    if (response.stop_reason === "max_tokens") {
+      console.warn(
+        `[mem0] Anthropic response truncated (stop_reason: "max_tokens", max_tokens: ${4096}). Consider increasing maxTokens in your LLM config.`,
+      );
+    }
+
     const firstBlock = response.content[0];
     if (firstBlock.type === "text") {
       return firstBlock.text;

--- a/mem0-ts/src/oss/src/llms/openai.ts
+++ b/mem0-ts/src/oss/src/llms/openai.ts
@@ -35,6 +35,12 @@ export class OpenAILLM implements LLM {
       ...(tools && { tools, tool_choice: "auto" }),
     });
 
+    if (completion.choices[0].finish_reason === "length") {
+      console.warn(
+        `[mem0] OpenAI response truncated (finish_reason: "length"). Consider increasing maxTokens in your LLM config.`,
+      );
+    }
+
     const response = completion.choices[0].message;
 
     if (response.tool_calls) {

--- a/mem0-ts/src/oss/tests/truncation-detection.test.ts
+++ b/mem0-ts/src/oss/tests/truncation-detection.test.ts
@@ -1,0 +1,112 @@
+/// <reference types="jest" />
+
+// --- Anthropic mock ---
+const mockAnthropicCreate = jest.fn();
+jest.mock("@anthropic-ai/sdk", () => {
+  return jest.fn().mockImplementation(() => ({
+    messages: { create: mockAnthropicCreate },
+  }));
+});
+
+// --- OpenAI mock ---
+const mockOpenAICreate = jest.fn();
+jest.mock("openai", () => {
+  return jest.fn().mockImplementation(() => ({
+    chat: { completions: { create: mockOpenAICreate } },
+  }));
+});
+
+import { AnthropicLLM } from "../src/llms/anthropic";
+import { OpenAILLM } from "../src/llms/openai";
+
+describe("Truncation Detection", () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    warnSpy = jest.spyOn(console, "warn").mockImplementation();
+    process.env.ANTHROPIC_API_KEY = "test-key";
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    delete process.env.ANTHROPIC_API_KEY;
+  });
+
+  describe("Anthropic", () => {
+    it('should warn when stop_reason is "max_tokens"', async () => {
+      mockAnthropicCreate.mockResolvedValue({
+        content: [{ type: "text", text: '{"partial": true' }],
+        stop_reason: "max_tokens",
+      });
+
+      const llm = new AnthropicLLM({ apiKey: "test-key" });
+      const result = await llm.generateResponse([
+        { role: "user", content: "Hello" },
+      ]);
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("[mem0]"));
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("max_tokens"),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Consider increasing maxTokens"),
+      );
+      // Response should still be returned
+      expect(result).toBe('{"partial": true');
+    });
+
+    it('should not warn when stop_reason is "end_turn"', async () => {
+      mockAnthropicCreate.mockResolvedValue({
+        content: [{ type: "text", text: '{"result": "ok"}' }],
+        stop_reason: "end_turn",
+      });
+
+      const llm = new AnthropicLLM({ apiKey: "test-key" });
+      await llm.generateResponse([{ role: "user", content: "Hello" }]);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("OpenAI", () => {
+    it('should warn when finish_reason is "length"', async () => {
+      mockOpenAICreate.mockResolvedValue({
+        choices: [
+          {
+            message: { content: '{"partial": true', role: "assistant" },
+            finish_reason: "length",
+          },
+        ],
+      });
+
+      const llm = new OpenAILLM({ apiKey: "test-key" });
+      const result = await llm.generateResponse([
+        { role: "user", content: "Hello" },
+      ]);
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("[mem0]"));
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Consider increasing maxTokens"),
+      );
+      // Response should still be returned
+      expect(result).toBe('{"partial": true');
+    });
+
+    it('should not warn when finish_reason is "stop"', async () => {
+      mockOpenAICreate.mockResolvedValue({
+        choices: [
+          {
+            message: { content: '{"result": "ok"}', role: "assistant" },
+            finish_reason: "stop",
+          },
+        ],
+      });
+
+      const llm = new OpenAILLM({ apiKey: "test-key" });
+      await llm.generateResponse([{ role: "user", content: "Hello" }]);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Description

Added `console.warn` when LLM responses are truncated due to token limits. This surfaces the root cause of downstream JSON parse failures that are otherwise difficult to debug.

- Anthropic: warns when `stop_reason === "max_tokens"`
- OpenAI: warns when `finish_reason === "length"`

Truncated responses are still returned unchanged — no behavior change, only added visibility. The warning message suggests increasing `maxTokens` in the LLM config.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit Test

Unit tests verify:
- Anthropic: warning logged on `stop_reason: "max_tokens"`
- Anthropic: no warning on `stop_reason: "end_turn"`
- OpenAI: warning logged on `finish_reason: "length"`
- OpenAI: no warning on `finish_reason: "stop"`

Run: `cd mem0-ts && npx jest --testPathPattern="truncation-detection"`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings