### PR TITLE
fix: expose limit, threshold, and infer params in REST API models

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -76,6 +76,7 @@ class MemoryCreate(BaseModel):
     agent_id: Optional[str] = None
     run_id: Optional[str] = None
     metadata: Optional[Dict[str, Any]] = None
+    infer: Optional[bool] = Field(None, description="Whether to extract facts from messages. Defaults to True.")
 
 
 class SearchRequest(BaseModel):
@@ -84,6 +85,8 @@ class SearchRequest(BaseModel):
     run_id: Optional[str] = None
     agent_id: Optional[str] = None
     filters: Optional[Dict[str, Any]] = None
+    limit: Optional[int] = Field(None, description="Maximum number of results to return.")
+    threshold: Optional[float] = Field(None, description="Minimum similarity score for results.")
 
 
 @app.post("/configure", summary="Configure Mem0")


### PR DESCRIPTION
## Summary

The `SearchRequest` and `MemoryCreate` Pydantic models in `server/main.py` are missing fields that the underlying `Memory.search()` and `Memory.add()` methods already accept. Because Pydantic v2 silently drops extra fields (`extra='ignore'` by default), clients sending `limit`, `threshold`, or `infer` get no error — the parameters are just ignored.

## Changes

- `SearchRequest`: add `limit` (int) and `threshold` (float)
- `MemoryCreate`: add `infer` (bool)

No handler changes needed — the existing `model_dump()` + `**params` pattern forwards these to the underlying `Memory` methods automatically.

## Impact

| Parameter | Before | After |
|-----------|--------|-------|
| `limit` in search | Silently ignored, always returns 100 results | Respected, controls result count |
| `threshold` in search | Silently ignored, no score filtering | Respected, filters by similarity score |
| `infer` in add | Silently ignored, always runs LLM extraction | Respected, allows verbatim storage when `false` |

## Fixes

- Fixes #3976
- Fixes #3819
- Fixes #3813