### PR TITLE
fix: remove README.md from wheel shared-data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,9 +102,6 @@ exclude = [
 packages = ["mem0"]
 only-include = ["mem0"]
 
-[tool.hatch.build.targets.wheel.shared-data]
-"README.md" = "README.md"
-
 [tool.hatch.envs.dev_py_3_9]
 python = "3.9"
 features = [


### PR DESCRIPTION
## Description

Remove `README.md` from `[tool.hatch.build.targets.wheel.shared-data]`. This config causes `README.md` to be installed into users' Python environment at the top level (`sys.prefix`). The README is already included in `.dist-info/METADATA` via the `readme` field in `[project]`, so distributing it as shared data is unnecessary.

Fixes [#4024](https://github.com/mem0ai/mem0/issues/4024 ) 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Test Script (please provide)

python -m build
unzip -l dist/mem0ai-*.whl | grep -i readme

Confirmed README.md no longer appears under *.data/data/ and is still present in .dist-info/METADATA.
Checklist:
[x] My code follows the style guidelines of this project
[x] I have performed a self-review of my own code
[x] My changes generate no new warnings
[x] New and existing unit tests pass locally with my changes
[x] I have checked my code and corrected any misspellings