### PR TITLE
fix: pass encoding_format='float' in OpenAI embeddings for proxy compatibility

### DIFF
--- a/mem0/embeddings/openai.py
+++ b/mem0/embeddings/openai.py
@@ -43,7 +43,12 @@ class OpenAIEmbedding(EmbeddingBase):
         """
         text = text.replace("\n", " ")
         return (
-            self.client.embeddings.create(input=[text], model=self.config.model, dimensions=self.config.embedding_dims)
+            self.client.embeddings.create(
+                input=[text],
+                model=self.config.model,
+                dimensions=self.config.embedding_dims,
+                encoding_format="float",
+            )
             .data[0]
             .embedding
         )

--- a/tests/embeddings/test_openai_embeddings.py
+++ b/tests/embeddings/test_openai_embeddings.py
@@ -24,7 +24,7 @@ def test_embed_default_model(mock_openai_client):
     result = embedder.embed("Hello world")
 
     mock_openai_client.embeddings.create.assert_called_once_with(
-        input=["Hello world"], model="text-embedding-3-small", dimensions=1536
+        input=["Hello world"], model="text-embedding-3-small", dimensions=1536, encoding_format="float"
     )
     assert result == [0.1, 0.2, 0.3]
 
@@ -39,7 +39,7 @@ def test_embed_custom_model(mock_openai_client):
     result = embedder.embed("Test embedding")
 
     mock_openai_client.embeddings.create.assert_called_once_with(
-        input=["Test embedding"], model="text-embedding-2-medium", dimensions=1024
+        input=["Test embedding"], model="text-embedding-2-medium", dimensions=1024, encoding_format="float"
     )
     assert result == [0.4, 0.5, 0.6]
 
@@ -54,7 +54,7 @@ def test_embed_removes_newlines(mock_openai_client):
     result = embedder.embed("Hello\nworld")
 
     mock_openai_client.embeddings.create.assert_called_once_with(
-        input=["Hello world"], model="text-embedding-3-small", dimensions=1536
+        input=["Hello world"], model="text-embedding-3-small", dimensions=1536, encoding_format="float"
     )
     assert result == [0.7, 0.8, 0.9]
 
@@ -69,7 +69,7 @@ def test_embed_without_api_key_env_var(mock_openai_client):
     result = embedder.embed("Testing API key")
 
     mock_openai_client.embeddings.create.assert_called_once_with(
-        input=["Testing API key"], model="text-embedding-3-small", dimensions=1536
+        input=["Testing API key"], model="text-embedding-3-small", dimensions=1536, encoding_format="float"
     )
     assert result == [1.0, 1.1, 1.2]
 
@@ -85,6 +85,25 @@ def test_embed_uses_environment_api_key(mock_openai_client, monkeypatch):
     result = embedder.embed("Environment key test")
 
     mock_openai_client.embeddings.create.assert_called_once_with(
-        input=["Environment key test"], model="text-embedding-3-small", dimensions=1536
+        input=["Environment key test"], model="text-embedding-3-small", dimensions=1536, encoding_format="float"
     )
     assert result == [1.3, 1.4, 1.5]
+
+
+def test_embed_passes_encoding_format_float(mock_openai_client):
+    """Verify encoding_format='float' is always passed to prevent base64 issues with proxies.
+
+    The OpenAI SDK defaults to encoding_format='base64' when not specified,
+    which breaks OpenAI-compatible proxies (OpenRouter, LiteLLM, vLLM, etc.)
+    that don't support base64 decoding. See #4057.
+    """
+    config = BaseEmbedderConfig()
+    embedder = OpenAIEmbedding(config)
+    mock_response = Mock()
+    mock_response.data = [Mock(embedding=[0.1, 0.2, 0.3])]
+    mock_openai_client.embeddings.create.return_value = mock_response
+
+    embedder.embed("Proxy compatibility test")
+
+    call_kwargs = mock_openai_client.embeddings.create.call_args
+    assert call_kwargs.kwargs.get("encoding_format") == "float" or call_kwargs[1].get("encoding_format") == "float"


### PR DESCRIPTION
Closes #4057

## Summary

- Added `encoding_format="float"` to `embeddings.create()` call in `mem0/embeddings/openai.py`
- The OpenAI Python SDK defaults to `encoding_format="base64"` when not specified ([confirmed by OpenAI](https://github.com/openai/openai-python/issues/1490)), which breaks OpenAI-compatible proxies (OpenRouter, LiteLLM, vLLM, Ollama) that don't support base64 decoding
- Users get intermittent `ValueError: No embedding data received` errors when using `openai_base_url` with non-OpenAI providers

## Changes

- `mem0/embeddings/openai.py` - added `encoding_format="float"` to the `embeddings.create()` call
- `tests/embeddings/test_openai_embeddings.py` - updated existing test assertions and added a new test verifying encoding format is always passed

## Test plan

- [x] All 6 OpenAI embedding tests pass
- [x] No breaking changes - `encoding_format="float"` works with all providers including direct OpenAI API
