### PR TITLE
fix: preserve runtime authentication objects in _safe_deepcopy_config

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -69,7 +69,7 @@ def _safe_deepcopy_config(config):
         else:
             clone_dict = {k: v for k, v in config.__dict__.items()}
         
-        sensitive_tokens = ("auth", "credential", "password", "token", "secret", "key", "connection_class")
+        sensitive_tokens = ("credential", "password", "token", "secret", "key")
         for field_name in list(clone_dict.keys()):
             if any(token in field_name.lower() for token in sensitive_tokens):
                 clone_dict[field_name] = None


### PR DESCRIPTION
Fixes #3580. The current sanitizer in _safe_deepcopy_config is overly broad and removes 'http_auth' which is required for OpenSearch AWS-signed clients. This PR narrows the sensitive tokens list to preserve runtime auth objects while still stripping genuinely sensitive data like passwords and tokens.