### PR TITLE
OpenClaw plugin: fix auto-recall injection and auto-capture message drop

### DIFF
--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -1318,8 +1318,6 @@ const memoryPlugin = {
                 if (
                   block &&
                   typeof block === "object" &&
-                  "type" in block &&
-                  (block as Record<string, unknown>).type === "text" &&
                   "text" in block &&
                   typeof (block as Record<string, unknown>).text === "string"
                 ) {
@@ -1331,8 +1329,11 @@ const memoryPlugin = {
             }
 
             if (!textContent) continue;
-            // Skip injected memory context
-            if (textContent.includes("<relevant-memories>")) continue;
+            // Strip injected memory context, keep the actual user text
+            if (textContent.includes("<relevant-memories>")) {
+              textContent = textContent.replace(/<relevant-memories>[\s\S]*?<\/relevant-memories>\s*/g, "").trim();
+              if (!textContent) continue;
+            }
 
             formattedMessages.push({
               role: role as string,


### PR DESCRIPTION
Fix OpenClaw auto-capture dropping valid user text when recall context is prepended, and include the prior recall injection key fix in the same patch set.

## Description
This PR consolidates two related OpenClaw plugin bug fixes in `openclaw/index.ts`:

1. **Auto-recall injection fix**  
   `before_agent_start` now returns `{ prependContext: ... }` (not `systemContext`) so recalled memories are actually injected into prompts.

2. **Auto-capture preservation fix**  
   In `agent_end`, messages containing `<relevant-memories>...</relevant-memories>` are no longer skipped wholesale.  
   Instead, injected recall context is stripped and the remaining real user/assistant text is captured if non-empty.

**Root Cause #1**: Hook return property mismatch (`systemContext` vs `prependContext`)  
**Impact #1**: Auto-recall looked successful in logs but memories never reached the LLM

**Root Cause #2**: Marker-based hard skip in capture path  
**Impact #2**: Valid user content was silently dropped whenever injected recall block was present

**Fix #1**: Rename `systemContext` → `prependContext`  
**Fix #2**: Replace skip-on-marker with strip-and-keep behavior; skip only empty leftovers

Fixes #4037  
Fixes #4063

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
**Manual testing steps performed:**
- [x] Set OPENCLAW_CACHE_TRACE and OPENCLAW_ANTHROPIC_PAYLOAD_LOG to true
- [x] Enabled auto-recall and auto-capture in mem0 OpenClaw plugin
- [x] Restarted openclaw gateway
- [x] Started conversation that triggers memory recall
- [x] Verified `<relevant-memories>` appears in effective prompt logs
- [x] Verified capture no longer drops entire message when recall block is present
- [x] Verified only injected block is removed and remaining user text is preserved/captured
- [x] Verified system prompt (agent.md, soul.md) remains unaffected

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
