### PR TITLE
fix: add Token prefix in code samples for event API endpoints

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -457,7 +457,33 @@
 							}
 						}
 					}
-				}
+				},
+				"x-code-samples": [
+					{
+						"lang": "Python",
+						"source": "import requests\n\nurl = \"https://api.mem0.ai/v1/events/\"\n\nheaders = {\"Authorization\": \"Token <api-key>\"}\n\nresponse = requests.get(url, headers=headers)\n\nprint(response.json())"
+					},
+					{
+						"lang": "JavaScript",
+						"source": "const url = 'https://api.mem0.ai/v1/events/';\n\nconst options = {\n  method: 'GET',\n  headers: {\n    'Authorization': 'Token <api-key>'\n  }\n};\n\nfetch(url, options)\n  .then(response => response.json())\n  .then(data => console.log(data))\n  .catch(error => console.error(error));"
+					},
+					{
+						"lang": "cURL",
+						"source": "curl --request GET \\\n  --url https://api.mem0.ai/v1/events/ \\\n  --header 'Authorization: Token <api-key>'"
+					},
+					{
+						"lang": "Go",
+						"source": "package main\n\nimport (\n\t\"fmt\"\n\t\"net/http\"\n\t\"io/ioutil\"\n)\n\nfunc main() {\n\n\turl := \"https://api.mem0.ai/v1/events/\"\n\n\treq, _ := http.NewRequest(\"GET\", url, nil)\n\n\treq.Header.Add(\"Authorization\", \"Token <api-key>\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
+					},
+					{
+						"lang": "PHP",
+						"source": "<?php\n\n$curl = curl_init();\n\ncurl_setopt_array($curl, [\n  CURLOPT_URL => \"https://api.mem0.ai/v1/events/\",\n  CURLOPT_RETURNTRANSFER => true,\n  CURLOPT_ENCODING => \"\",\n  CURLOPT_MAXREDIRS => 10,\n  CURLOPT_TIMEOUT => 30,\n  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,\n  CURLOPT_CUSTOMREQUEST => \"GET\",\n  CURLOPT_HTTPHEADER => [\n    \"Authorization: Token <api-key>\"\n  ],\n]);\n\n$response = curl_exec($curl);\n$err = curl_error($curl);\n\ncurl_close($curl);\n\nif ($err) {\n  echo \"cURL Error #:\" . $err;\n} else {\n  echo $response;\n}"
+					},
+					{
+						"lang": "Java",
+						"source": "HttpResponse<String> response = Unirest.get(\"https://api.mem0.ai/v1/events/\")\n  .header(\"Authorization\", \"Token <api-key>\")\n  .asString();"
+					}
+				]
 			}
 		},
 		"/v1/event/{event_id}/": {
@@ -563,7 +589,33 @@
 							}
 						}
 					}
-				}
+				},
+				"x-code-samples": [
+					{
+						"lang": "Python",
+						"source": "import requests\n\nevent_id = \"your-event-id\"\nurl = f\"https://api.mem0.ai/v1/event/{event_id}/\"\n\nheaders = {\"Authorization\": \"Token <api-key>\"}\n\nresponse = requests.get(url, headers=headers)\n\nprint(response.json())"
+					},
+					{
+						"lang": "JavaScript",
+						"source": "const eventId = 'your-event-id';\nconst url = `https://api.mem0.ai/v1/event/${eventId}/`;\n\nconst options = {\n  method: 'GET',\n  headers: {\n    'Authorization': 'Token <api-key>'\n  }\n};\n\nfetch(url, options)\n  .then(response => response.json())\n  .then(data => console.log(data))\n  .catch(error => console.error(error));"
+					},
+					{
+						"lang": "cURL",
+						"source": "curl --request GET \\\n  --url https://api.mem0.ai/v1/event/{event_id}/ \\\n  --header 'Authorization: Token <api-key>'"
+					},
+					{
+						"lang": "Go",
+						"source": "package main\n\nimport (\n\t\"fmt\"\n\t\"net/http\"\n\t\"io/ioutil\"\n)\n\nfunc main() {\n\n\turl := \"https://api.mem0.ai/v1/event/{event_id}/\"\n\n\treq, _ := http.NewRequest(\"GET\", url, nil)\n\n\treq.Header.Add(\"Authorization\", \"Token <api-key>\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
+					},
+					{
+						"lang": "PHP",
+						"source": "<?php\n\n$curl = curl_init();\n\ncurl_setopt_array($curl, [\n  CURLOPT_URL => \"https://api.mem0.ai/v1/event/{event_id}/\",\n  CURLOPT_RETURNTRANSFER => true,\n  CURLOPT_ENCODING => \"\",\n  CURLOPT_MAXREDIRS => 10,\n  CURLOPT_TIMEOUT => 30,\n  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,\n  CURLOPT_CUSTOMREQUEST => \"GET\",\n  CURLOPT_HTTPHEADER => [\n    \"Authorization: Token <api-key>\"\n  ],\n]);\n\n$response = curl_exec($curl);\n$err = curl_error($curl);\n\ncurl_close($curl);\n\nif ($err) {\n  echo \"cURL Error #:\" . $err;\n} else {\n  echo $response;\n}"
+					},
+					{
+						"lang": "Java",
+						"source": "HttpResponse<String> response = Unirest.get(\"https://api.mem0.ai/v1/event/{event_id}/\")\n  .header(\"Authorization\", \"Token <api-key>\")\n  .asString();"
+					}
+				]
 			}
 		},
 		"/v1/exports/": {


### PR DESCRIPTION
## Description

The Get Event (`/v1/event/{event_id}/`) and Get Events (`/v1/events/`) API documentation pages had code examples that omitted the required `Token` prefix in the `Authorization` header, causing authentication errors for developers copying the examples. The example code in the docs doesn't match what's required internally.

I fixed the code examples in the docs by adding explicit `x-code-samples` to both endpoints in `docs/openapi.json`, following the same pattern used by other endpoints like `/v1/entities/`. All samples include the correct Authorization: Token <api-key> header.

Fixes #3926

## Type of change

- [x] Documentation update

## How Has This Been Tested?

I ran `mintlify dev` locally and verified that the `Get Event` and `Get Events` API reference pages now display code samples with the correct `Authorization: Token <api-key>` header.

Here's what the docs look with these changes:

<img width="1045" height="310" alt="Screenshot 2026-02-17 at 6 04 37 PM" src="https://github.com/user-attachments/assets/3f4092e4-378c-4684-b041-966993ee67ff" />

<img width="1040" height="237" alt="Screenshot 2026-02-17 at 6 01 53 PM" src="https://github.com/user-attachments/assets/29d62db3-c0b4-4c63-8c2a-6dd6cc4aae28" />

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Maintainer Checklist

- [ ] closes #3926 
- [ ] Made sure Checks passed
