### PR TITLE
fix(ollama): resolve IPv6 connection failures and url config being dropped

### DIFF
--- a/mem0-ts/src/oss/src/config/manager.ts
+++ b/mem0-ts/src/oss/src/config/manager.ts
@@ -82,6 +82,7 @@ export class ConfigManager {
 
           return {
             baseURL: userConf?.baseURL || defaultConf.baseURL,
+            url: userConf?.url,
             apiKey:
               userConf?.apiKey !== undefined
                 ? userConf.apiKey

--- a/mem0-ts/src/oss/src/embeddings/ollama.ts
+++ b/mem0-ts/src/oss/src/embeddings/ollama.ts
@@ -12,7 +12,7 @@ export class OllamaEmbedder implements Embedder {
 
   constructor(config: EmbeddingConfig) {
     this.ollama = new Ollama({
-      host: config.url || "http://localhost:11434",
+      host: config.url || "http://127.0.0.1:11434",
     });
     this.model = config.model || "nomic-embed-text:latest";
     this.embeddingDims = config.embeddingDims || 768;

--- a/mem0-ts/src/oss/src/llms/ollama.ts
+++ b/mem0-ts/src/oss/src/llms/ollama.ts
@@ -11,7 +11,7 @@ export class OllamaLLM implements LLM {
 
   constructor(config: LLMConfig) {
     this.ollama = new Ollama({
-      host: config.config?.url || "http://localhost:11434",
+      host: config.url || config.baseURL || config.config?.url || "http://127.0.0.1:11434",
     });
     this.model = config.model || "llama3.1:8b";
     this.ensureModelExists().catch((err) => {

--- a/mem0-ts/src/oss/src/types/index.ts
+++ b/mem0-ts/src/oss/src/types/index.ts
@@ -41,6 +41,7 @@ export interface HistoryStoreConfig {
 export interface LLMConfig {
   provider?: string;
   baseURL?: string;
+  url?: string;
   config?: Record<string, any>;
   apiKey?: string;
   model?: string | any;
@@ -140,6 +141,7 @@ export const MemoryConfigSchema = z.object({
       model: z.union([z.string(), z.any()]).optional(),
       modelProperties: z.record(z.string(), z.any()).optional(),
       baseURL: z.string().optional(),
+      url: z.string().optional(),
     }),
   }),
   historyDbPath: z.string().optional(),


### PR DESCRIPTION
## Problem

Ollama LLM/Embedder connections fail on systems where `localhost` resolves to IPv6 `::1` but Ollama only listens on IPv4 `127.0.0.1`. This is increasingly common in Node.js 18+ which prefers IPv6.

## Root Causes (4 bugs)

1. **OllamaLLM constructor** reads `config.config?.url` but receives a flat config object — `url` is never found
2. **Zod schema** (`MemoryConfigSchema`) strips `url` from LLM config during validation (field not declared)
3. **ConfigManager.mergeConfig()** explicitly constructs LLM config without `url`, dropping it even if provided
4. **Default fallback** uses `localhost` which resolves to `::1` on IPv6-enabled systems

## Fixes

- `OllamaLLM`: Read `url`/`baseURL` from flat config, default to `127.0.0.1`
- `OllamaEmbedder`: Default to `127.0.0.1` instead of `localhost`
- `MemoryConfigSchema`: Add `url` field to LLM config Zod schema
- `ConfigManager`: Preserve `url` in LLM config merge

## Testing

Tested with self-hosted Mem0 setup: Ollama (nomic-embed-text + qwen3) on 127.0.0.1:11434, Qdrant on 127.0.0.1:6333. All memory operations (add/search/list/get/delete) work correctly after patches.