### PR TITLE
fix(oss): propagate historyDbPath into historyStore config

### DIFF
--- a/mem0-ts/src/oss/src/config/manager.ts
+++ b/mem0-ts/src/oss/src/config/manager.ts
@@ -104,6 +104,14 @@ export class ConfigManager {
       historyStore: {
         ...DEFAULT_MEMORY_CONFIG.historyStore,
         ...userConfig.historyStore,
+        ...(userConfig.historyDbPath && !userConfig.historyStore
+          ? {
+              config: {
+                ...DEFAULT_MEMORY_CONFIG.historyStore.config,
+                historyDbPath: userConfig.historyDbPath,
+              },
+            }
+          : {}),
       },
       disableHistory:
         userConfig.disableHistory || DEFAULT_MEMORY_CONFIG.disableHistory,


### PR DESCRIPTION
## Summary

- Fixes #4074
- When a user provides `historyDbPath` but not a custom `historyStore`, the top-level path was silently ignored because `DEFAULT_MEMORY_CONFIG.historyStore` always populated `historyStore` with `historyDbPath: "memory.db"`
- The `Memory` constructor checks `this.config.historyStore` first (always truthy from defaults), so the user's `historyDbPath` was never used
- This propagates the user-provided `historyDbPath` into `historyStore.config.historyDbPath` when no explicit `historyStore` is provided

## Test plan

- [x] Verify that `new Memory({ historyDbPath: "/custom/path.db" })` uses `/custom/path.db` instead of `memory.db`
- [x] Verify that providing an explicit `historyStore` config still takes full precedence
- [x] Verify that omitting both `historyDbPath` and `historyStore` still defaults to `memory.db`