### PR TITLE
docs: add memory_categorize webhook event type

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4539,7 +4539,7 @@
 				"x-code-samples": [
 					{
 						"lang": "Python",
-						"source": "# To use the Python SDK, install the package:\n# pip install mem0ai\n\nfrom mem0 import MemoryClient\nclient = MemoryClient(api_key=\"your_api_key\")\n\n# Get all webhooks\nwebhooks = client.get_webhooks(project_id=\"your_project_id\")\nprint(webhooks)\n\n# Create a webhook\nwebhook = client.create_webhook(\n    url=\"https://your-webhook-url.com\",\n    name=\"My Webhook\",\n    project_id=\"your_project_id\",\n    event_types=[\"memory:add\"]\n)\nprint(webhook)"
+						"source": "# To use the Python SDK, install the package:\n# pip install mem0ai\n\nfrom mem0 import MemoryClient\nclient = MemoryClient(api_key=\"your_api_key\")\n\n# Get all webhooks\nwebhooks = client.get_webhooks(project_id=\"your_project_id\")\nprint(webhooks)\n\n# Create a webhook\nwebhook = client.create_webhook(\n    url=\"https://your-webhook-url.com\",\n    name=\"My Webhook\",\n    project_id=\"your_project_id\",\n    event_types=[\"memory:add\", \"memory:categorize\"]\n)\nprint(webhook)"
 					},
 					{
 						"lang": "JavaScript",
@@ -4606,7 +4606,8 @@
 											"enum": [
 												"memory:add",
 												"memory:update",
-												"memory:delete"
+												"memory:delete",
+												"memory:categorize"
 											]
 										},
 										"description": "List of event types to subscribe to."
@@ -4701,7 +4702,7 @@
 				"x-code-samples": [
 					{
 						"lang": "Python",
-						"source": "# To use the Python SDK, install the package:\n# pip install mem0ai\n\nfrom mem0 import MemoryClient\nclient = MemoryClient(api_key=\"your_api_key\", org_id=\"your_org_id\", project_id=\"your_project_id\")\n\n# Create a webhook\nwebhook = client.create_webhook(\n    url=\"https://your-webhook-url.com\",\n    name=\"My Webhook\",\n    project_id=\"your_project_id\",\n    event_types=[\"memory:add\"]\n)\nprint(webhook)"
+						"source": "# To use the Python SDK, install the package:\n# pip install mem0ai\n\nfrom mem0 import MemoryClient\nclient = MemoryClient(api_key=\"your_api_key\", org_id=\"your_org_id\", project_id=\"your_project_id\")\n\n# Create a webhook\nwebhook = client.create_webhook(\n    url=\"https://your-webhook-url.com\",\n    name=\"My Webhook\",\n    project_id=\"your_project_id\",\n    event_types=[\"memory:add\", \"memory:categorize\"]\n)\nprint(webhook)"
 					},
 					{
 						"lang": "JavaScript",
@@ -4767,7 +4768,8 @@
 											"enum": [
 												"memory:add",
 												"memory:update",
-												"memory:delete"
+												"memory:delete",
+												"memory:categorize"
 											]
 										},
 										"description": "New list of event types to subscribe to"
@@ -4845,11 +4847,11 @@
 				"x-code-samples": [
 					{
 						"lang": "Python",
-						"source": "# To use the Python SDK, install the package:\n# pip install mem0ai\n\nfrom mem0 import MemoryClient\nclient = MemoryClient(api_key=\"your_api_key\")\n\n# Update a webhook\nwebhook = client.update_webhook(\n    webhook_id=\"your_webhook_id\",\n    name=\"Updated Webhook\",\n    url=\"https://new-webhook-url.com\",\n    event_types=[\"memory:add\"]\n)\nprint(webhook)\n\n# Delete a webhook\nresponse = client.delete_webhook(webhook_id=\"your_webhook_id\")\nprint(response)"
+						"source": "# To use the Python SDK, install the package:\n# pip install mem0ai\n\nfrom mem0 import MemoryClient\nclient = MemoryClient(api_key=\"your_api_key\")\n\n# Update a webhook\nwebhook = client.update_webhook(\n    webhook_id=\"your_webhook_id\",\n    name=\"Updated Webhook\",\n    url=\"https://new-webhook-url.com\",\n    event_types=[\"memory:add\", \"memory:categorize\"]\n)\nprint(webhook)\n\n# Delete a webhook\nresponse = client.delete_webhook(webhook_id=\"your_webhook_id\")\nprint(response)"
 					},
 					{
 						"lang": "JavaScript",
-						"source": "// To use the JavaScript SDK, install the package:\n// npm i mem0ai\n\nimport MemoryClient from 'mem0ai';\nconst client = new MemoryClient({ apiKey: 'your-api-key' });\n\n// Update a webhook\nclient.updateWebhook('your_webhook_id', {\n  name: 'Updated Webhook',\n  url: 'https://new-webhook-url.com',\n  event_types: ['memory:add']\n})\n  .then(webhook => console.log(webhook))\n  .catch(err => console.error(err));\n\n// Delete a webhook\nclient.deleteWebhook('your_webhook_id')\n  .then(response => console.log(response))\n  .catch(err => console.error(err));"
+						"source": "// To use the JavaScript SDK, install the package:\n// npm i mem0ai\n\nimport MemoryClient from 'mem0ai';\nconst client = new MemoryClient({ apiKey: 'your-api-key' });\n\n// Update a webhook\nclient.updateWebhook('your_webhook_id', {\n  name: 'Updated Webhook',\n  url: 'https://new-webhook-url.com',\n  event_types: ['memory:add', 'memory:categorize']\n})\n  .then(webhook => console.log(webhook))\n  .catch(err => console.error(err));\n\n// Delete a webhook\nclient.deleteWebhook('your_webhook_id')\n  .then(response => console.log(response))\n  .catch(err => console.error(err));"
 					},
 					{
 						"lang": "cURL",

--- a/docs/platform/features/webhooks.mdx
+++ b/docs/platform/features/webhooks.mdx
@@ -5,7 +5,7 @@ description: 'Configure and manage webhooks to receive real-time notifications a
 
 ## Overview
 
-Webhooks enable real-time notifications for memory events in your Mem0 project. Webhooks are configured at the project level, meaning each webhook is tied to a specific project and receives events solely from that project. You can configure webhooks to send HTTP POST requests to your specified URLs whenever memories are created, updated, or deleted.
+Webhooks enable real-time notifications for memory events in your Mem0 project. Webhooks are configured at the project level, meaning each webhook is tied to a specific project and receives events solely from that project. You can configure webhooks to send HTTP POST requests to your specified URLs whenever memories are created, updated, deleted, or categorized.
 
 ## Managing Webhooks
 
@@ -27,7 +27,7 @@ webhook = client.create_webhook(
     url="https://your-app.com/webhook",
     name="Memory Logger",
     project_id="proj_123",
-    event_types=["memory_add"]
+    event_types=["memory_add", "memory_categorize"]
 )
 print(webhook)
 ```
@@ -41,7 +41,7 @@ const webhook = await client.createWebhook({
     url: "https://your-app.com/webhook",
     name: "Memory Logger",
     projectId: "proj_123",
-    eventTypes: ["memory_add"]
+    eventTypes: ["memory_add", "memory_categorize"]
 });
 console.log(webhook);
 ```
@@ -167,11 +167,13 @@ Mem0 supports the following event types for webhooks:
 - `memory_add`: Triggered when a memory is added.
 - `memory_update`: Triggered when an existing memory is updated.
 - `memory_delete`: Triggered when a memory is deleted.
+- `memory_categorize`: Triggered when a memory is categorized.
 
 ## Webhook Payload
 
 When a memory event occurs, Mem0 sends an HTTP POST request to your webhook URL with the following payload:
 
+**Memory add/update/delete payload:**
 ```json
 {
     "event_details": {
@@ -180,6 +182,17 @@ When a memory event occurs, Mem0 sends an HTTP POST request to your webhook URL 
             "memory": "Name is Alex"
             },
         "event": "ADD"
+    }
+}
+```
+
+**Memory categorize payload:**
+```json
+{
+    "event_details": {
+        "event": "CATEGORIZE",
+        "memory_id": "a1b2c3d4-e5f6-4g7h-8i9j-k0l1m2n3o4p5",
+        "categories": ["hobbies", "travel"]
     }
 }
 ```


### PR DESCRIPTION
## Summary
- Adds `memory_categorize` to the documented webhook event types in the feature guide and OpenAPI spec
- Includes the categorize event payload format (with `categories` array)
- Updates code examples to show `memory_categorize` as an available option

## Context
The platform backend already supports `memory_categorize` as a 4th webhook event type (added in [mem0ai/platform#2368](https://github.com/mem0ai/platform/pull/2368)). This PR brings the public docs in sync.

## Test plan
- [ ] Verify rendered docs show the new event type in the Event Types list
- [ ] Verify the categorize payload example renders correctly
- [ ] Confirm openapi.json is valid JSON