### PR TITLE
fix(oss): propagate historyDbPath into historyStore config

### DIFF
--- a/mem0-ts/src/oss/src/config/manager.ts
+++ b/mem0-ts/src/oss/src/config/manager.ts
@@ -104,6 +104,14 @@ export class ConfigManager {
       historyStore: {
         ...DEFAULT_MEMORY_CONFIG.historyStore,
         ...userConfig.historyStore,
+        ...(userConfig.historyDbPath && !userConfig.historyStore
+          ? {
+              config: {
+                ...DEFAULT_MEMORY_CONFIG.historyStore.config,
+                historyDbPath: userConfig.historyDbPath,
+              },
+            }
+          : {}),
       },
       disableHistory:
         userConfig.disableHistory || DEFAULT_MEMORY_CONFIG.disableHistory,


### PR DESCRIPTION
## Summary

Fixes #4074

When a user provides `historyDbPath` in their config, it is silently ignored because `DEFAULT_MEMORY_CONFIG.historyStore` always populates `historyStore` with a hardcoded `historyDbPath: "memory.db"`. The `Memory` constructor then uses `historyStore` (always truthy from defaults) instead of the user's `historyDbPath`.

This change propagates the user-provided `historyDbPath` into `historyStore.config.historyDbPath` when no explicit `historyStore` override is provided.

## Changes

- `mem0-ts/src/oss/src/config/manager.ts`: When merging config, if `userConfig.historyDbPath` is set and `userConfig.historyStore` is not, inject the user's path into `historyStore.config.historyDbPath`

## Test plan

- Verify that `new Memory({ historyDbPath: "/custom/path.db" })` uses `/custom/path.db` instead of `memory.db`
- Verify that providing an explicit `historyStore` config still takes full precedence
- Verify that omitting both `historyDbPath` and `historyStore` still defaults to `memory.db`