### PR TITLE
fix(oss): validate LLM fact output via FactRetrievalSchema before embedding

### DIFF
--- a/mem0-ts/src/oss/src/embeddings/ollama.ts
+++ b/mem0-ts/src/oss/src/embeddings/ollama.ts
@@ -27,9 +27,12 @@ export class OllamaEmbedder implements Embedder {
     } catch (err) {
       logger.error(`Error ensuring model exists: ${err}`);
     }
+    // Ollama's Go server requires prompt to be a string. Coerce defensively
+    // since callers may pass values parsed from untrusted LLM JSON output.
+    const prompt = typeof text === "string" ? text : JSON.stringify(text);
     const response = await this.ollama.embeddings({
       model: this.model,
-      prompt: text,
+      prompt,
     });
     return response.embedding;
   }

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -15,6 +15,7 @@ import {
   HistoryManagerFactory,
 } from "../utils/factory";
 import {
+  FactRetrievalSchema,
   getFactRetrievalMessages,
   getUpdateMemoryMessages,
   parseMessages,
@@ -261,7 +262,8 @@ export class Memory {
     const cleanResponse = removeCodeBlocks(response as string);
     let facts: string[] = [];
     try {
-      facts = JSON.parse(cleanResponse).facts || [];
+      const parsed = FactRetrievalSchema.parse(JSON.parse(cleanResponse));
+      facts = parsed.facts;
     } catch (e) {
       console.error(
         "Failed to parse facts from LLM response:",

--- a/mem0-ts/src/oss/src/prompts/index.ts
+++ b/mem0-ts/src/oss/src/prompts/index.ts
@@ -1,9 +1,18 @@
 import { z } from "zod";
 
+// Accepts a string directly, or an object with a "fact" or "text" key
+// (common malformed shapes from smaller LLMs like llama3.1:8b).
+const factItem = z.union([
+  z.string(),
+  z.object({ fact: z.string() }).transform((o) => o.fact),
+  z.object({ text: z.string() }).transform((o) => o.text),
+]);
+
 // Define Zod schema for fact retrieval output
 export const FactRetrievalSchema = z.object({
   facts: z
-    .array(z.string())
+    .array(factItem)
+    .transform((arr) => arr.filter((s) => s.length > 0))
     .describe("An array of distinct facts extracted from the conversation."),
 });
 


### PR DESCRIPTION
## Summary

Fixes #4081

`addToVectorStore` passes raw LLM-extracted facts directly to `embedder.embed()` without validating they are strings. Local/smaller LLMs (e.g. `llama3.1:8b` via Ollama) sometimes return facts as objects instead of plain strings:

```json
// Expected
{"facts": ["User prefers dark mode", "Name is Alice"]}

// What llama3.1:8b sometimes returns
{"facts": [{"fact": "User prefers dark mode"}, {"fact": "Name is Alice"}]}
```

This causes Ollama's Go server to crash with:
```
ResponseError: json: cannot unmarshal object into Go struct field EmbeddingRequest.prompt of type string
```

## Approach

`FactRetrievalSchema` already exists in `prompts/index.ts` but was never used at the parse site. This PR:

1. **`prompts/index.ts`** — Extends `FactRetrievalSchema` with a `z.union` transform that accepts `string | { fact: string } | { text: string }` and normalizes to `string[]`, filtering empties.

2. **`memory/index.ts`** — Replaces raw `JSON.parse().facts` with `FactRetrievalSchema.parse()` so the schema is actually used.

3. **`embeddings/ollama.ts`** — One-line safety net (`typeof text === "string" ? text : JSON.stringify(text)`) in case non-string values reach the embedder from other callers.

## Test plan

- [ ] `memory.add()` with `llama3.1:8b` returning `[{ fact: "..." }]` — normalizes and stores correctly
- [ ] `memory.add()` with models returning `["string"]` — no behavior change
- [ ] Zod `.parse()` catches completely invalid JSON and falls through to `facts = []`
- [ ] Empty facts are filtered out and don't enter the vector store

🤖 Generated with [Claude Code](https://claude.com/claude-code)