### PR TITLE
fix(graph): use keyword arguments when initializing Neo4jGraph to pre…

### DIFF
--- a/mem0/memory/graph_memory.py
+++ b/mem0/memory/graph_memory.py
@@ -30,10 +30,11 @@ class MemoryGraph:
     def __init__(self, config):
         self.config = config
         self.graph = Neo4jGraph(
-            self.config.graph_store.config.url,
-            self.config.graph_store.config.username,
-            self.config.graph_store.config.password,
-            self.config.graph_store.config.database,
+            url= self.config.graph_store.config.url,
+            username= self.config.graph_store.config.username,
+            password= self.config.graph_store.config.password,
+            database= self.config.graph_store.config.database,
+            token= getattr(self.config.graph_store.config, "token", None),
             refresh_schema=False,
             driver_config={"notifications_min_severity": "OFF"},
         )


### PR DESCRIPTION
fix(graph): use keyword arguments when initializing Neo4jGraph to prevent token misassignment

Previously, positional arguments were used when initializing Neo4jGraph.
Due to the constructor signature (url, username, password, token, database),
the database argument was incorrectly passed as `token`, causing Neo4j to use
bearer authentication instead of basic authentication.

This change switches to explicit keyword arguments to ensure correct parameter
mapping and prevent authentication errors.