### PR TITLE
fix: correct type mismatch in Langchain Vector Store Adapter update method

### DIFF
--- a/mem0/vector_stores/langchain.py
+++ b/mem0/vector_stores/langchain.py
@@ -115,7 +115,7 @@ class Langchain(VectorStoreBase):
         Update a vector and its payload.
         """
         self.delete(vector_id)
-        self.insert(vector, payload, [vector_id])
+        self.insert([vector], [payload], [vector_id])
 
     def get(self, vector_id):
         """


### PR DESCRIPTION
## Summary
Fixes #3767

- The `update` method in `mem0/vector_stores/langchain.py` passes `vector` and `payload` directly to `insert()`, but `insert()` expects `List[List[float]]` and `List[Dict]` respectively
- Wrapped `vector` and `payload` in lists (`[vector]` and `[payload]`) to match the expected parameter types

## Changes
- `mem0/vector_stores/langchain.py`: Changed `self.insert(vector, payload, [vector_id])` to `self.insert([vector], [payload], [vector_id])`

## Test Plan
- All 10 existing Langchain vector store tests pass