### PR TITLE
fix: ensure prompts include 'json' for json_object response format

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -424,6 +424,8 @@ class Memory(MemoryBase):
 
         if self.config.custom_fact_extraction_prompt:
             system_prompt = self.config.custom_fact_extraction_prompt
+            if "json" not in system_prompt.lower():
+                system_prompt += "\nYou must respond with a valid JSON object containing a 'facts' key with an array of strings."
             user_prompt = f"Input:\n{parsed_messages}"
         else:
             # Determine if this should use agent memory extraction based on agent_id presence
@@ -1453,6 +1455,8 @@ class AsyncMemory(MemoryBase):
         parsed_messages = parse_messages(messages)
         if self.config.custom_fact_extraction_prompt:
             system_prompt = self.config.custom_fact_extraction_prompt
+            if "json" not in system_prompt.lower():
+                system_prompt += "\nYou must respond with a valid JSON object containing a 'facts' key with an array of strings."
             user_prompt = f"Input:\n{parsed_messages}"
         else:
             # Determine if this should use agent memory extraction based on agent_id presence

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -278,9 +278,12 @@ def test_custom_prompts(memory_custom_instance):
             ##
             mock_parse_messages.assert_called_once_with(messages)
 
+            expected_system_prompt = memory_custom_instance.config.custom_fact_extraction_prompt
+            if "json" not in expected_system_prompt.lower():
+                expected_system_prompt += "\nYou must respond with a valid JSON object containing a 'facts' key with an array of strings."
             memory_custom_instance.llm.generate_response.assert_any_call(
                 messages=[
-                    {"role": "system", "content": memory_custom_instance.config.custom_fact_extraction_prompt},
+                    {"role": "system", "content": expected_system_prompt},
                     {"role": "user", "content": f"Input:\n{mock_parse_messages.return_value}"},
                 ],
                 response_format={"type": "json_object"},


### PR DESCRIPTION
## Summary
Fixes #3559

When using `custom_fact_extraction_prompt` with `response_format: { type: "json_object" }`, OpenAI's API requires that the messages contain the word "json" in some form. If a user provides a custom prompt that doesn't include this word, the API returns:

> Error 400: 'messages' must contain the word 'json' in some form, to use 'response_format' of type 'json_object'.

This fix adds a check in the Python SDK (both sync `Memory` and async `AsyncMemory`) to detect when the custom fact extraction prompt doesn't contain "json" (case-insensitive) and automatically appends a JSON format instruction. This matches the fix already applied in the TypeScript SDK in commit 394203d1.

## Changes
- **`mem0/memory/main.py`**: Added check in both `Memory._add_to_vector_store` and `AsyncMemory._add_to_vector_store` to append JSON format instruction to `custom_fact_extraction_prompt` when "json" is not already present in the prompt
- **`tests/test_main.py`**: Updated `test_custom_prompts` to expect the appended JSON instruction when the custom prompt doesn't contain "json"

## Test Plan
- [x] Existing `test_custom_prompts` test updated and passes
- [x] All 13 tests in `tests/test_main.py` pass
- [x] Custom prompts containing "json" are not modified (no-op)
- [x] Custom prompts without "json" get the instruction appended