### PR TITLE
feat: add reasoning_effort parameter for reasoning models

### DIFF
--- a/mem0/configs/llms/azure.py
+++ b/mem0/configs/llms/azure.py
@@ -22,6 +22,7 @@ class AzureOpenAIConfig(BaseLlmConfig):
         enable_vision: bool = False,
         vision_details: Optional[str] = "auto",
         http_client_proxies: Optional[dict] = None,
+        reasoning_effort: Optional[str] = None,
         # Azure OpenAI-specific parameters
         azure_kwargs: Optional[Dict[str, Any]] = None,
     ):
@@ -38,6 +39,7 @@ class AzureOpenAIConfig(BaseLlmConfig):
             enable_vision: Enable vision capabilities, defaults to False
             vision_details: Vision detail level, defaults to "auto"
             http_client_proxies: HTTP client proxy settings, defaults to None
+            reasoning_effort: Reasoning effort for reasoning models ("low", "medium", "high"), defaults to None
             azure_kwargs: Azure-specific configuration, defaults to None
         """
         # Initialize base parameters
@@ -51,6 +53,7 @@ class AzureOpenAIConfig(BaseLlmConfig):
             enable_vision=enable_vision,
             vision_details=vision_details,
             http_client_proxies=http_client_proxies,
+            reasoning_effort=reasoning_effort,
         )
 
         # Azure OpenAI-specific parameters

--- a/mem0/configs/llms/base.py
+++ b/mem0/configs/llms/base.py
@@ -24,6 +24,7 @@ class BaseLlmConfig(ABC):
         enable_vision: bool = False,
         vision_details: Optional[str] = "auto",
         http_client_proxies: Optional[Union[Dict, str]] = None,
+        reasoning_effort: Optional[str] = None,
     ):
         """
         Initialize a base configuration class instance for the LLM.
@@ -50,6 +51,8 @@ class BaseLlmConfig(ABC):
                 Options: "low", "high", "auto". Defaults to "auto"
             http_client_proxies: Proxy settings for HTTP client.
                 Can be a dict or string. Defaults to None
+            reasoning_effort: Reasoning effort level for reasoning models (o1, o3, gpt-5 series).
+                Options: "low", "medium", "high". Defaults to None (not sent)
         """
         self.model = model
         self.temperature = temperature
@@ -60,3 +63,4 @@ class BaseLlmConfig(ABC):
         self.enable_vision = enable_vision
         self.vision_details = vision_details
         self.http_client = httpx.Client(proxies=http_client_proxies) if http_client_proxies else None
+        self.reasoning_effort = reasoning_effort

--- a/mem0/configs/llms/openai.py
+++ b/mem0/configs/llms/openai.py
@@ -21,6 +21,7 @@ class OpenAIConfig(BaseLlmConfig):
         enable_vision: bool = False,
         vision_details: Optional[str] = "auto",
         http_client_proxies: Optional[dict] = None,
+        reasoning_effort: Optional[str] = None,
         # OpenAI-specific parameters
         openai_base_url: Optional[str] = None,
         models: Optional[List[str]] = None,
@@ -45,6 +46,7 @@ class OpenAIConfig(BaseLlmConfig):
             enable_vision: Enable vision capabilities, defaults to False
             vision_details: Vision detail level, defaults to "auto"
             http_client_proxies: HTTP client proxy settings, defaults to None
+            reasoning_effort: Reasoning effort for reasoning models ("low", "medium", "high"), defaults to None
             openai_base_url: OpenAI API base URL, defaults to None
             models: List of models for OpenRouter, defaults to None
             route: OpenRouter route strategy, defaults to "fallback"
@@ -64,6 +66,7 @@ class OpenAIConfig(BaseLlmConfig):
             enable_vision=enable_vision,
             vision_details=vision_details,
             http_client_proxies=http_client_proxies,
+            reasoning_effort=reasoning_effort,
         )
 
         # OpenAI-specific parameters

--- a/mem0/llms/azure_openai_structured.py
+++ b/mem0/llms/azure_openai_structured.py
@@ -77,6 +77,11 @@ class AzureOpenAIStructuredLLM(LLMBase):
             "max_tokens": self.config.max_tokens,
             "top_p": self.config.top_p,
         }
+
+        reasoning_effort = getattr(self.config, 'reasoning_effort', None)
+        if reasoning_effort:
+            params["reasoning_effort"] = reasoning_effort
+
         if response_format:
             params["response_format"] = response_format
         if tools:

--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -79,7 +79,7 @@ class LLMBase(ABC):
         
         if self._is_reasoning_model(model):
             supported_params = {}
-            
+
             if "messages" in kwargs:
                 supported_params["messages"] = kwargs["messages"]
             if "response_format" in kwargs:
@@ -88,7 +88,11 @@ class LLMBase(ABC):
                 supported_params["tools"] = kwargs["tools"]
             if "tool_choice" in kwargs:
                 supported_params["tool_choice"] = kwargs["tool_choice"]
-                
+
+            reasoning_effort = getattr(self.config, 'reasoning_effort', None)
+            if reasoning_effort:
+                supported_params["reasoning_effort"] = reasoning_effort
+
             return supported_params
         else:
             # For regular models, include all common parameters

--- a/tests/llms/test_azure_openai.py
+++ b/tests/llms/test_azure_openai.py
@@ -256,3 +256,66 @@ def test_init_with_placeholder_api_key(monkeypatch):
             http_client=None,
             default_headers=None,
         )
+
+
+@pytest.mark.parametrize("model_name", ["o1", "o3-mini", "gpt-5"])
+def test_generate_response_reasoning_model_with_reasoning_effort(mock_openai_client, model_name):
+    config = AzureOpenAIConfig(model=model_name, reasoning_effort="low")
+    llm = AzureOpenAILLM(config)
+    messages = [
+        {"role": "user", "content": "Hello, how are you?"},
+    ]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="I'm doing well!"))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    response = llm.generate_response(messages)
+
+    # For reasoning models, temperature/max_tokens/top_p should be excluded,
+    # but reasoning_effort should be included
+    mock_openai_client.chat.completions.create.assert_called_once_with(
+        model=model_name, messages=messages, reasoning_effort="low"
+    )
+    assert response == "I'm doing well!"
+
+
+def test_generate_response_reasoning_model_without_reasoning_effort(mock_openai_client):
+    config = AzureOpenAIConfig(model="o3-mini")
+    llm = AzureOpenAILLM(config)
+    messages = [
+        {"role": "user", "content": "Hello"},
+    ]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Hi!"))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    response = llm.generate_response(messages)
+
+    # reasoning_effort should NOT be in params when not configured
+    mock_openai_client.chat.completions.create.assert_called_once_with(
+        model="o3-mini", messages=messages
+    )
+    assert response == "Hi!"
+
+
+def test_generate_response_non_reasoning_model_ignores_reasoning_effort(mock_openai_client):
+    config = AzureOpenAIConfig(model=MODEL, temperature=TEMPERATURE, max_tokens=MAX_TOKENS, top_p=TOP_P, reasoning_effort="high")
+    llm = AzureOpenAILLM(config)
+    messages = [
+        {"role": "user", "content": "Hello"},
+    ]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Hi!"))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    response = llm.generate_response(messages)
+
+    # For non-reasoning models, reasoning_effort should NOT be included,
+    # but temperature/max_tokens/top_p should be
+    mock_openai_client.chat.completions.create.assert_called_once_with(
+        model=MODEL, messages=messages, temperature=TEMPERATURE, max_tokens=MAX_TOKENS, top_p=TOP_P
+    )
+    assert response == "Hi!"


### PR DESCRIPTION
## Summary

- Adds `reasoning_effort` parameter to `BaseLlmConfig`, `OpenAIConfig`, and `AzureOpenAIConfig`
- Passes `reasoning_effort` through to the OpenAI SDK for reasoning models (o1, o3, gpt-5 series) via `_get_supported_params()`
- Also supports `reasoning_effort` in `AzureOpenAIStructuredLLM`

Closes #3651

## Changes

| File | Change |
|------|--------|
| `mem0/configs/llms/base.py` | Added `reasoning_effort` optional parameter |
| `mem0/configs/llms/openai.py` | Added `reasoning_effort` to `OpenAIConfig` |
| `mem0/configs/llms/azure.py` | Added `reasoning_effort` to `AzureOpenAIConfig` |
| `mem0/llms/base.py` | Pass `reasoning_effort` in `_get_supported_params()` for reasoning models |
| `mem0/llms/azure_openai_structured.py` | Pass `reasoning_effort` when set |
| `tests/llms/test_openai.py` | 3 new tests for reasoning_effort behavior |
| `tests/llms/test_azure_openai.py` | 3 new tests for reasoning_effort behavior |

## Usage

```python
from mem0 import Memory

config = {
    "llm": {
        "provider": "azure_openai",
        "config": {
            "model": "o3-mini",
            "reasoning_effort": "low",
            "azure_kwargs": {
                "api_key": "...",
                "azure_deployment": "...",
                "azure_endpoint": "...",
                "api_version": "..."
            }
        }
    }
}

m = Memory.from_config(config)
```

## Test plan

- [x] All existing tests pass (25/25)
- [x] New tests verify reasoning_effort is passed for reasoning models (o1, o3-mini, gpt-5)
- [x] New tests verify reasoning_effort is NOT passed when not configured
- [x] New tests verify reasoning_effort is ignored for non-reasoning models