### PR TITLE
fix: prevent duplicate embedding API calls in mem0.add when infer=False

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -407,7 +407,7 @@ class Memory(MemoryBase):
 
                 msg_content = message_dict["content"]
                 msg_embeddings = self.embedding_model.embed(msg_content, "add")
-                mem_id = self._create_memory(msg_content, msg_embeddings, per_msg_meta)
+                mem_id = self._create_memory(msg_content, {msg_content: msg_embeddings}, per_msg_meta)
 
                 returned_memories.append(
                     {
@@ -1437,7 +1437,7 @@ class AsyncMemory(MemoryBase):
 
                 msg_content = message_dict["content"]
                 msg_embeddings = await asyncio.to_thread(self.embedding_model.embed, msg_content, "add")
-                mem_id = await self._create_memory(msg_content, msg_embeddings, per_msg_meta)
+                mem_id = await self._create_memory(msg_content, {msg_content: msg_embeddings}, per_msg_meta)
 
                 returned_memories.append(
                     {


### PR DESCRIPTION
## Summary

Fixes #3723

When calling `mem0.add()` with `infer=False`, the embedding API is called **twice** for each message. This happens because `_add_to_vector_store` passes the raw embedding vector (a list of floats) directly to `_create_memory` as the `existing_embeddings` parameter, but `_create_memory` expects a **dict** mapping `{data_string: embedding_vector}`.

The lookup `if data in existing_embeddings` checks whether a string key exists in what is actually a list of floats, which always evaluates to `False`, causing `_create_memory` to generate the embedding a second time.

### Root cause

In `_add_to_vector_store` (both sync `Memory` and `AsyncMemory`), the non-infer path:

```python
msg_embeddings = self.embedding_model.embed(msg_content, "add")       # 1st call
mem_id = self._create_memory(msg_content, msg_embeddings, per_msg_meta)
```

Inside `_create_memory`:
```python
if data in existing_embeddings:   # str in list[float] -> always False
    embeddings = existing_embeddings[data]
else:
    embeddings = self.embedding_model.embed(data, memory_action="add") # 2nd call (duplicate!)
```

### Fix

Wrap the embeddings in a dict to match the expected format, consistent with how the `infer=True` code path already does it:

```python
mem_id = self._create_memory(msg_content, {msg_content: msg_embeddings}, per_msg_meta)
```

This ensures `_create_memory` finds the pre-computed embedding in the dict and skips the redundant API call.

## Test plan

- [x] Existing tests pass (`tests/memory/test_main.py` -- 4/4 passed)
- [ ] Manual verification: `mem0.add('foo', user_id='default')` with `infer=False` should produce only one embedding API call instead of two