### PR TITLE
fix: consistent created_at format between search and get_all

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1082,7 +1082,9 @@ class Memory(MemoryBase):
         metadata = metadata or {}
         metadata["data"] = data
         metadata["hash"] = hashlib.md5(data.encode()).hexdigest()
-        metadata["created_at"] = datetime.now(pytz.timezone("US/Pacific")).isoformat()
+        if "created_at" not in metadata:
+            metadata["created_at"] = datetime.now(pytz.timezone("US/Pacific")).isoformat()
+        metadata["updated_at"] = metadata["created_at"]
 
         self.vector_store.insert(
             vectors=[embeddings],
@@ -2144,7 +2146,9 @@ class AsyncMemory(MemoryBase):
         metadata = metadata or {}
         metadata["data"] = data
         metadata["hash"] = hashlib.md5(data.encode()).hexdigest()
-        metadata["created_at"] = datetime.now(pytz.timezone("US/Pacific")).isoformat()
+        if "created_at" not in metadata:
+            metadata["created_at"] = datetime.now(pytz.timezone("US/Pacific")).isoformat()
+        metadata["updated_at"] = metadata["created_at"]
 
         await asyncio.to_thread(
             self.vector_store.insert,


### PR DESCRIPTION
## Summary

Fixes #3720

The `created_at` value returned by `search` could differ from `get_all` for the same memory. Two root causes were identified in `_create_memory` (both sync `Memory` and async `AsyncMemory` classes):

1. **`created_at` was always overwritten with current time** — even when the caller (e.g. the platform API honoring a user-provided `timestamp`) had already set `created_at` in the metadata dict. This caused newly-created memories to lose the intended timestamp, while updated memories (via `_update_memory`) correctly preserved it from the existing payload.

2. **`updated_at` was never set on creation** — only `_update_memory` populated `updated_at`. This meant freshly created memories had `created_at` but a missing `updated_at`, which could surface as `None` in results and cause inconsistencies depending on the vector store backend.

### Changes

- Preserve any pre-existing `created_at` in metadata instead of unconditionally overwriting it with `datetime.now()`
- Initialize `updated_at` to the same value as `created_at` on memory creation, so both fields are always present in the vector store payload

### Test plan

- [x] Verified existing tests still pass (pre-existing env-level failures unrelated to this change)
- [ ] Manual test: call `add()` with metadata containing a custom `created_at`, then verify `search()` and `get_all()` return the same `created_at` value
- [ ] Manual test: call `add()` without custom `created_at`, verify both `created_at` and `updated_at` are set to the same auto-generated timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)