### PR TITLE
fix(ts): register PGVector in VectorStoreFactory switch

### DIFF
--- a/mem0-ts/src/oss/src/utils/factory.ts
+++ b/mem0-ts/src/oss/src/utils/factory.ts
@@ -32,6 +32,7 @@ import { LangchainLLM } from "../llms/langchain";
 import { LangchainEmbedder } from "../embeddings/langchain";
 import { LangchainVectorStore } from "../vector_stores/langchain";
 import { AzureAISearch } from "../vector_stores/azure_ai_search";
+import { PGVector } from "../vector_stores/pgvector";
 
 export class EmbedderFactory {
   static create(provider: string, config: EmbeddingConfig): Embedder {
@@ -98,6 +99,8 @@ export class VectorStoreFactory {
         return new VectorizeDB(config as any);
       case "azure-ai-search":
         return new AzureAISearch(config as any);
+      case "pgvector":
+        return new PGVector(config as any);
       default:
         throw new Error(`Unsupported vector store provider: ${provider}`);
     }


### PR DESCRIPTION
## Problem

The `PGVector` class exists at `mem0-ts/src/oss/src/vector_stores/pgvector.ts` and is documented as a supported provider (with TypeScript examples in the docs), but it was never added to the `VectorStoreFactory` switch statement.

This means any user configuring `provider: 'pgvector'` in TypeScript gets:
```
Error: Unsupported vector store provider: pgvector
```

## Fix

Two lines in `factory.ts`:
1. Add import for `PGVector`
2. Add `case "pgvector"` to `VectorStoreFactory.create()`

## Testing

Verified locally against PostgreSQL 18 with pgvector extension — initialization, insert, and vector similarity search all work correctly with the registered provider.

## Notes

The Python SDK already supports pgvector. This brings the TypeScript SDK to parity with the docs and Python SDK.