### PR TITLE
fix: make OpenSearch filter dynamic instead of hardcoded fields

### DIFF
--- a/mem0/vector_stores/opensearch.py
+++ b/mem0/vector_stores/opensearch.py
@@ -157,9 +157,8 @@ class OpenSearchDB(VectorStoreBase):
         # Prepare filter conditions if applicable
         filter_clauses = []
         if filters:
-            for key in ["user_id", "run_id", "agent_id"]:
-                value = filters.get(key)
-                if value:
+            for key, value in filters.items():
+                if value is not None:
                     filter_clauses.append({"term": {f"payload.{key}.keyword": value}})
 
         # Combine knn with filters if needed


### PR DESCRIPTION
## Description

Previously, the search method only applied filters for a hardcoded set of fields (user_id, run_id, agent_id), causing any other field passed in the filters parameter to be silently ignored.

This PR replaces the static field iteration with a dynamic one that iterates directly over the provided filters dict, so any key passed by the caller is correctly applied as a filter clause in the final OpenSearch query.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Added unit tests to verify that any field passed in filters is correctly applied to the OpenSearch query. Tests cover: dynamic filter fields, None value exclusion, and plain knn query when no filters are provided.

- [x] Unit Test
- [ ] Test Script (please provide)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
