### PR TITLE
Add Jina v5 embeddings provider

### DIFF
--- a/docs/components/embedders/models/jina.mdx
+++ b/docs/components/embedders/models/jina.mdx
@@ -1,0 +1,50 @@
+---
+title: Jina AI
+---
+
+To use Jina AI embedding models, set the `JINA_API_KEY` environment variable. You can obtain the API key from [jina.ai](https://jina.ai).
+
+### Usage
+
+```python Python
+import os
+from mem0 import Memory
+
+os.environ["JINA_API_KEY"] = "your_api_key"
+
+config = {
+    "embedder": {
+        "provider": "jina",
+        "config": {
+            "model": "jina-embeddings-v5-text-nano"
+        }
+    }
+}
+
+m = Memory.from_config(config)
+messages = [
+    {"role": "user", "content": "I'm planning to watch a movie tonight. Any recommendations?"},
+    {"role": "assistant", "content": "How about thriller movies? They can be quite engaging."},
+    {"role": "user", "content": "I'm not a big fan of thriller movies but I love sci-fi movies."},
+    {"role": "assistant", "content": "Got it! I'll avoid thriller recommendations and suggest sci-fi movies in the future."}
+]
+m.add(messages, user_id="john")
+```
+
+### Config
+
+Here are the parameters available for configuring the Jina AI embedder:
+
+| Parameter | Description | Default Value |
+| --- | --- | --- |
+| `model` | The name of the embedding model to use | `jina-embeddings-v5-text-nano` |
+| `embedding_dims` | Dimensions of the embedding model | `768` |
+| `api_key` | The Jina AI API key | `None` |
+| `model_kwargs` | Additional model parameters (e.g. `{"task": "retrieval.passage"}`) | `{}` |
+
+### Available Models
+
+| Model | Parameters | Dimensions | Max Tokens |
+| --- | --- | --- | --- |
+| `jina-embeddings-v5-text-nano` | 239M | 768 | 8192 |
+| `jina-embeddings-v5-text-small` | 677M | 1024 | 32768 |

--- a/docs/components/embedders/overview.mdx
+++ b/docs/components/embedders/overview.mdx
@@ -23,6 +23,7 @@ See the list of supported embedders below.
   <Card title="LM Studio" href="/components/embedders/models/lmstudio"></Card>
   <Card title="Langchain" href="/components/embedders/models/langchain"></Card>
   <Card title="AWS Bedrock" href="/components/embedders/models/aws_bedrock"></Card>
+  <Card title="Jina AI" href="/components/embedders/models/jina"></Card>
 </CardGroup>
 
 ## Usage

--- a/embedchain/embedchain/embedder/jina.py
+++ b/embedchain/embedchain/embedder/jina.py
@@ -1,0 +1,148 @@
+import os
+from typing import Optional
+
+try:
+    from chromadb.api.types import Documents, EmbeddingFunction, Embeddings
+except RuntimeError:
+    from embedchain.utils.misc import use_pysqlite3
+
+    use_pysqlite3()
+    from chromadb.api.types import Documents, EmbeddingFunction, Embeddings
+
+from embedchain.config import BaseEmbedderConfig
+from embedchain.embedder.base import BaseEmbedder
+from embedchain.models import VectorDimensions
+
+
+class JinaEmbeddingFunction(EmbeddingFunction):
+    """
+    Jina AI Embedding Function for ChromaDB.
+    
+    Supports both API and local modes:
+    - API: jina-embeddings-v5-text-nano (768d), jina-embeddings-v5-text-small (1024d)
+    - Local: jinaai/jina-embeddings-v5-text-nano, jinaai/jina-embeddings-v5-text-small
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model_name: str = "jina-embeddings-v5-text-nano",
+        task: str = "retrieval.passage",
+        use_local: bool = False,
+        model_kwargs: Optional[dict] = None,
+    ):
+        self._model_name = model_name
+        self._task = task
+        self._use_local = use_local
+        
+        if use_local:
+            # Local mode using HuggingFace transformers
+            try:
+                from langchain_community.embeddings import HuggingFaceEmbeddings
+            except ImportError:
+                raise ValueError(
+                    "The langchain-community package is not installed. Please install it with `pip install langchain-community`"
+                )
+            
+            # Map short names to full HuggingFace model IDs
+            if not model_name.startswith("jinaai/"):
+                hf_model_map = {
+                    "jina-embeddings-v5-text-nano": "jinaai/jina-embeddings-v5-text-nano",
+                    "jina-embeddings-v5-text-small": "jinaai/jina-embeddings-v5-text-small",
+                }
+                hf_model_name = hf_model_map.get(model_name, model_name)
+            else:
+                hf_model_name = model_name
+            
+            self._embeddings = HuggingFaceEmbeddings(
+                model_name=hf_model_name,
+                model_kwargs=model_kwargs or {},
+            )
+        else:
+            # API mode
+            if api_key is None:
+                raise ValueError("api_key is required for API mode")
+            
+            try:
+                from openai import OpenAI
+            except ImportError:
+                raise ValueError(
+                    "The openai python package is not installed. Please install it with `pip install openai`"
+                )
+            
+            self._client = OpenAI(api_key=api_key, base_url="https://api.jina.ai/v1")
+
+    def __call__(self, input: Documents) -> Embeddings:
+        if self._use_local:
+            return self._embeddings.embed_documents(input)
+        else:
+            response = self._client.embeddings.create(
+                input=input,
+                model=self._model_name,
+                extra_body={"task": self._task},
+            )
+            return [item.embedding for item in response.data]
+
+
+class JinaEmbedder(BaseEmbedder):
+    """
+    Jina AI Embedder for mem0.
+    
+    Supports both API and local deployment:
+    
+    API mode (default):
+        from embedchain.config import BaseEmbedderConfig
+        config = BaseEmbedderConfig(
+            model="jina-embeddings-v5-text-nano",
+            api_key="your-jina-api-key"
+        )
+        embedder = JinaEmbedder(config=config)
+    
+    Local mode (HuggingFace models):
+        config = BaseEmbedderConfig(
+            model="jinaai/jina-embeddings-v5-text-nano",
+            model_kwargs={"use_local": True}
+        )
+        embedder = JinaEmbedder(config=config)
+    """
+    
+    def __init__(self, config: Optional[BaseEmbedderConfig] = None):
+        super().__init__(config=config)
+
+        if self.config.model is None:
+            self.config.model = "jina-embeddings-v5-text-nano"
+
+        # Check if local mode is requested
+        use_local = self.config.model_kwargs.get("use_local", False)
+        
+        if not use_local:
+            # API mode - require API key
+            api_key = self.config.api_key or os.environ.get("JINA_API_KEY")
+            if api_key is None:
+                raise ValueError("JINA_API_KEY environment variable not provided. For local mode, set model_kwargs={'use_local': True}")
+        else:
+            api_key = None
+
+        # Default task to retrieval.passage, can be overridden via model_kwargs
+        task = self.config.model_kwargs.get("task", "retrieval.passage")
+
+        embedding_fn = JinaEmbeddingFunction(
+            api_key=api_key,
+            model_name=self.config.model,
+            task=task,
+            use_local=use_local,
+            model_kwargs=self.config.model_kwargs,
+        )
+        self.set_embedding_fn(embedding_fn=embedding_fn)
+
+        # Set vector dimension based on model
+        if self.config.vector_dimension:
+            vector_dimension = self.config.vector_dimension
+        elif "nano" in self.config.model:
+            vector_dimension = VectorDimensions.JINA_NANO.value
+        elif "small" in self.config.model:
+            vector_dimension = VectorDimensions.JINA_SMALL.value
+        else:
+            vector_dimension = VectorDimensions.JINA_NANO.value
+
+        self.set_vector_dimension(vector_dimension=vector_dimension)

--- a/embedchain/embedchain/models/vector_dimensions.py
+++ b/embedchain/embedchain/models/vector_dimensions.py
@@ -14,3 +14,5 @@ class VectorDimensions(Enum):
     OLLAMA = 384
     AMAZON_TITAN_V1 = 1536
     AMAZON_TITAN_V2 = 1024
+    JINA_NANO = 768
+    JINA_SMALL = 1024

--- a/embedchain/tests/embedder/test_jina_embedder.py
+++ b/embedchain/tests/embedder/test_jina_embedder.py
@@ -1,0 +1,125 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from embedchain.config import BaseEmbedderConfig
+from embedchain.embedder.jina import JinaEmbedder
+from embedchain.models import VectorDimensions
+
+
+def test_jina_embedder_with_default_model(monkeypatch):
+    monkeypatch.setenv("JINA_API_KEY", "test_api_key")
+    config = BaseEmbedderConfig()
+    
+    with patch('embedchain.embedder.jina.JinaEmbeddingFunction') as mock_embedding_fn:
+        embedder = JinaEmbedder(config=config)
+        assert embedder.config.model == "jina-embeddings-v5-text-nano"
+        assert embedder.vector_dimension == VectorDimensions.JINA_NANO.value
+        mock_embedding_fn.assert_called_once_with(
+            api_key="test_api_key",
+            model_name="jina-embeddings-v5-text-nano",
+            task="retrieval.passage",
+            use_local=False,
+            model_kwargs={},
+        )
+
+
+def test_jina_embedder_with_custom_model(monkeypatch):
+    monkeypatch.setenv("JINA_API_KEY", "test_api_key")
+    config = BaseEmbedderConfig(model="jina-embeddings-v5-text-small")
+    
+    with patch('embedchain.embedder.jina.JinaEmbeddingFunction') as mock_embedding_fn:
+        embedder = JinaEmbedder(config=config)
+        assert embedder.config.model == "jina-embeddings-v5-text-small"
+        assert embedder.vector_dimension == VectorDimensions.JINA_SMALL.value
+        mock_embedding_fn.assert_called_once_with(
+            api_key="test_api_key",
+            model_name="jina-embeddings-v5-text-small",
+            task="retrieval.passage",
+            use_local=False,
+            model_kwargs={},
+        )
+
+
+def test_jina_embedder_with_custom_task(monkeypatch):
+    monkeypatch.setenv("JINA_API_KEY", "test_api_key")
+    config = BaseEmbedderConfig(
+        model="jina-embeddings-v5-text-nano",
+        model_kwargs={"task": "retrieval.query"}
+    )
+    
+    with patch('embedchain.embedder.jina.JinaEmbeddingFunction') as mock_embedding_fn:
+        embedder = JinaEmbedder(config=config)
+        mock_embedding_fn.assert_called_once_with(
+            api_key="test_api_key",
+            model_name="jina-embeddings-v5-text-nano",
+            task="retrieval.query",
+            use_local=False,
+            model_kwargs={"task": "retrieval.query"},
+        )
+
+
+def test_jina_embedder_without_api_key():
+    config = BaseEmbedderConfig()
+    
+    with patch('embedchain.embedder.jina.JinaEmbeddingFunction'):
+        with pytest.raises(ValueError, match="JINA_API_KEY"):
+            JinaEmbedder(config=config)
+
+
+def test_jina_embedder_local_mode_nano():
+    config = BaseEmbedderConfig(
+        model="jinaai/jina-embeddings-v5-text-nano",
+        model_kwargs={"use_local": True}
+    )
+    
+    with patch('embedchain.embedder.jina.JinaEmbeddingFunction') as mock_embedding_fn:
+        embedder = JinaEmbedder(config=config)
+        assert embedder.config.model == "jinaai/jina-embeddings-v5-text-nano"
+        assert embedder.vector_dimension == VectorDimensions.JINA_NANO.value
+        mock_embedding_fn.assert_called_once_with(
+            api_key=None,
+            model_name="jinaai/jina-embeddings-v5-text-nano",
+            task="retrieval.passage",
+            use_local=True,
+            model_kwargs={"use_local": True},
+        )
+
+
+def test_jina_embedder_local_mode_small():
+    config = BaseEmbedderConfig(
+        model="jinaai/jina-embeddings-v5-text-small",
+        model_kwargs={"use_local": True}
+    )
+    
+    with patch('embedchain.embedder.jina.JinaEmbeddingFunction') as mock_embedding_fn:
+        embedder = JinaEmbedder(config=config)
+        assert embedder.config.model == "jinaai/jina-embeddings-v5-text-small"
+        assert embedder.vector_dimension == VectorDimensions.JINA_SMALL.value
+        mock_embedding_fn.assert_called_once_with(
+            api_key=None,
+            model_name="jinaai/jina-embeddings-v5-text-small",
+            task="retrieval.passage",
+            use_local=True,
+            model_kwargs={"use_local": True},
+        )
+
+
+def test_jina_embedder_local_mode_short_name():
+    """Test local mode with short model name (auto-converted to HF format)"""
+    config = BaseEmbedderConfig(
+        model="jina-embeddings-v5-text-nano",
+        model_kwargs={"use_local": True}
+    )
+    
+    with patch('embedchain.embedder.jina.JinaEmbeddingFunction') as mock_embedding_fn:
+        embedder = JinaEmbedder(config=config)
+        assert embedder.config.model == "jina-embeddings-v5-text-nano"
+        assert embedder.vector_dimension == VectorDimensions.JINA_NANO.value
+        mock_embedding_fn.assert_called_once_with(
+            api_key=None,
+            model_name="jina-embeddings-v5-text-nano",
+            task="retrieval.passage",
+            use_local=True,
+            model_kwargs={"use_local": True},
+        )


### PR DESCRIPTION
## Summary

Add [Jina AI](https://jina.ai) as a supported embedding provider for mem0, supporting **both API and local deployment modes**.

**jina-embeddings-v5-text-nano** (239M params) is the top-ranked embedding model under 500M parameters on [MTEB](https://huggingface.co/spaces/mteb/leaderboard):
- MTEB English v2: **71.0** avg
- MMTEB multilingual: **65.5** avg
- Half the size of comparable models with superior performance across retrieval, STS, and reranking tasks

<img src="https://jina-ai-gmbh.ghost.io/content/images/2026/02/IMG_1153.JPG" width="800" alt="MMTEB Multilingual Benchmark">

*MMTEB scores vs model size. jina-v5-text models (red) outperform models 2-16x their size. ([source](https://jina.ai/blog/jina-embeddings-v5-text))*

<img src="https://jina-ai-gmbh.ghost.io/content/images/2026/02/IMG_1154.JPG" width="800" alt="MTEB English Benchmark">

*MTEB English v2 scores. v5-text-nano (239M) achieves 71.0, matching models with 2x+ parameters. ([source](https://jina.ai/blog/jina-embeddings-v5-text))*

| Model | Params | Dim | Max Tokens | MTEB-EN | MMTEB |
|-------|--------|-----|------------|---------|-------|
| jina-embeddings-v5-text-nano | 239M | 768 | 8192 | 71.0 | 65.5 |
| jina-embeddings-v5-text-small | 677M | 1024 | 32768 | 71.7 | 67.0 |

Both models are **open-weight** (Apache 2.0) and support Matryoshka dimension reduction, task-specific embeddings, and local deployment via HuggingFace transformers.

Paper: [arXiv:2602.15547](https://arxiv.org/abs/2602.15547) | [Blog](https://jina.ai/blog/jina-embeddings-v5-text) | [HuggingFace](https://huggingface.co/jinaai)

## Features

- **API mode**: Jina AI hosted API at `https://api.jina.ai/v1` (OpenAI-compatible)
- **Local mode**: Open-weight models via HuggingFace transformers. Run locally with sentence-transformers and point to `jinaai/jina-embeddings-v5-text-nano` or `jinaai/jina-embeddings-v5-text-small`
- Task-specific embeddings via `task` parameter (`retrieval.passage`, `retrieval.query`, `text-matching`, etc.)
- Auto-conversion of short model names to full HuggingFace model IDs in local mode
- Vector dimension auto-detection based on model name

## Changes

- New `JinaEmbedder` and `JinaEmbeddingFunction` in `embedchain/embedchain/embedder/jina.py`
- Register Jina vector dimensions in `embedchain/embedchain/models/vector_dimensions.py`
- Comprehensive unit tests with coverage for both API and local modes
- Support for both nano (768d) and small (1024d) models

## Usage

### API Mode (default)

```python
from embedchain import App
from embedchain.config import BaseEmbedderConfig

config = BaseEmbedderConfig(
    provider="jina",
    model="jina-embeddings-v5-text-nano",
    api_key="your-jina-api-key"
)
app = App(config={"embedder": config})
```

### Local Mode (self-hosted)

```python
from embedchain import App
from embedchain.config import BaseEmbedderConfig

config = BaseEmbedderConfig(
    provider="jina",
    model="jinaai/jina-embeddings-v5-text-nano",
    model_kwargs={"use_local": True}
)
app = App(config={"embedder": config})
```

### Task-Specific Embeddings

```python
# For document indexing
doc_config = BaseEmbedderConfig(
    provider="jina",
    model="jina-embeddings-v5-text-nano",
    api_key="your-jina-api-key",
    model_kwargs={"task": "retrieval.passage"}
)

# For queries
query_config = BaseEmbedderConfig(
    provider="jina",
    model="jina-embeddings-v5-text-nano",
    api_key="your-jina-api-key",
    model_kwargs={"task": "retrieval.query"}
)
```
