### PR TITLE
chore: bump openclaw plugin version to 0.1.3

### DIFF
--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mem0/openclaw-mem0",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "description": "Mem0 memory backend for OpenClaw — platform or self-hosted open-source",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
- Bumped openclaw plugin version from 0.1.2 to 0.1.3

## Changes
- Updated version field in `openclaw/package.json`

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Chore (maintenance tasks, version bumps, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

🤖 Generated with [Claude Code](https://claude.com/claude-code)