### PR TITLE
fix: extract JSON from markdown code blocks instead of removing them

### DIFF
--- a/mem0-ts/src/oss/src/prompts/index.ts
+++ b/mem0-ts/src/oss/src/prompts/index.ts
@@ -278,5 +278,11 @@ export function parseMessages(messages: string[]): string {
 }
 
 export function removeCodeBlocks(text: string): string {
-  return text.replace(/```[^`]*```/g, "");
+  // Extract content from markdown code blocks (e.g. ```json\n{...}\n```)
+  // rather than removing them entirely, since the JSON we need is inside.
+  const match = text.match(/```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/);
+  if (match) {
+    return match[1].trim();
+  }
+  return text;
 }


### PR DESCRIPTION
## Problem

`removeCodeBlocks()` in `prompts/index.ts` uses a regex that strips markdown code blocks **entirely**, discarding the JSON content inside:

```typescript
// Before: removes the whole block, including the JSON
text.replace(/```[^`]*```/g, "");
```

When Claude wraps its JSON response in markdown fences (\`\`\`json ... \`\`\`), the function removes the JSON too, and `JSON.parse()` then fails on an empty string:

```
Failed to parse facts from LLM response: SyntaxError: Unexpected end of JSON input
```

## Fix

Extract the content **inside** the first code block instead of removing the block:

```typescript
const match = text.match(/```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/);
if (match) {
  return match[1].trim();
}
return text;
```

Fixes #4108