### PR TITLE
OSS Node SDK: honor historyDbPath for default sqlite history store

### DIFF
--- a/mem0-ts/src/oss/src/config/manager.ts
+++ b/mem0-ts/src/oss/src/config/manager.ts
@@ -101,10 +101,24 @@ export class ConfigManager {
         ...DEFAULT_MEMORY_CONFIG.graphStore,
         ...userConfig.graphStore,
       },
-      historyStore: {
-        ...DEFAULT_MEMORY_CONFIG.historyStore,
-        ...userConfig.historyStore,
-      },
+      historyStore: (() => {
+        const historyStore = {
+          ...DEFAULT_MEMORY_CONFIG.historyStore,
+          ...userConfig.historyStore,
+        };
+
+        // Ensure top-level historyDbPath is respected even when the default
+        // sqlite historyStore is present.
+        if (
+          userConfig.historyDbPath &&
+          historyStore?.provider === "sqlite" &&
+          historyStore.config
+        ) {
+          historyStore.config.historyDbPath = userConfig.historyDbPath;
+        }
+
+        return historyStore;
+      })(),
       disableHistory:
         userConfig.disableHistory || DEFAULT_MEMORY_CONFIG.disableHistory,
       enableGraph: userConfig.enableGraph || DEFAULT_MEMORY_CONFIG.enableGraph,

--- a/mem0-ts/src/oss/tests/config.manager.test.ts
+++ b/mem0-ts/src/oss/tests/config.manager.test.ts
@@ -1,0 +1,19 @@
+/// <reference types="jest" />
+
+import { ConfigManager } from "../src/config/manager";
+
+describe("ConfigManager.mergeConfig", () => {
+  it("propagates historyDbPath into the default sqlite historyStore", () => {
+    const merged = ConfigManager.mergeConfig({
+      historyDbPath: "/tmp/custom-history.db",
+      // Intentionally omit historyStore to verify the default historyStore
+      // uses the configured top-level historyDbPath.
+    });
+
+    expect(merged.historyDbPath).toBe("/tmp/custom-history.db");
+    expect(merged.historyStore?.provider).toBe("sqlite");
+    expect(merged.historyStore?.config?.historyDbPath).toBe(
+      "/tmp/custom-history.db",
+    );
+  });
+});


### PR DESCRIPTION
Fixes #4096\n\nWhen users set top-level historyDbPath (without providing historyStore), the merged config always included the default sqlite historyStore with historyDbPath="memory.db". That caused Memory to open the history DB in process.cwd().\n\nThis change propagates userConfig.historyDbPath into the default sqlite historyStore config, and adds a unit test to prevent regressions.