### PR TITLE
fix: replace sqlite3 with better-sqlite3 to fix native binding resolution

### DIFF
--- a/mem0-ts/package.json
+++ b/mem0-ts/package.json
@@ -108,14 +108,13 @@
     "@supabase/supabase-js": "^2.49.1",
     "@types/jest": "29.5.14",
     "@types/pg": "8.11.0",
-    "@types/sqlite3": "3.1.11",
     "cloudflare": "^4.2.0",
     "groq-sdk": "0.3.0",
     "neo4j-driver": "^5.28.1",
     "ollama": "^0.5.14",
     "pg": "8.11.3",
     "redis": "^4.6.13",
-    "sqlite3": "5.1.7"
+    "better-sqlite3": "^11.9.1"
   },
   "engines": {
     "node": ">=18"
@@ -127,7 +126,7 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild",
-      "sqlite3"
+      "better-sqlite3"
     ]
   }
 }


### PR DESCRIPTION
## Summary

Replace `sqlite3` with `better-sqlite3` to fix the native binding resolution issue that occurs when the @mem0/openclaw-mem0 plugin is loaded through jiti (JIT TypeScript/ESM loader).

## Problem

The `sqlite3` package uses the `bindings` module to locate its native `.node` addon at runtime by walking up from `__dirname` of the caller. When OpenClaw loads the mem0 plugin through jiti, the caller `__dirname` resolves to jiti's own location inside the pnpm store (`/app/node_modules/.pnpm/jiti@2.6.1/node_modules/jiti/`), but the actual `node_sqlite3.node` binary lives in the plugin's extension directory (`/home/node/.openclaw/extensions/openclaw-mem0/node_modules/sqlite3/build/Release/node_sqlite3.node`). The bindings module never searches there.

This causes the error:
```
Error: Could not locate the bindings file. Tried:
 → /app/node_modules/.pnpm/jiti@2.6.1/node_modules/jiti/build/node_sqlite3.node
 → ...
```

## Solution

Replace `sqlite3` with `better-sqlite3` which:
- Ships prebuilt binaries via `prebuild-install` (no compile step needed)
- Uses a different native loading mechanism that doesn't rely on the `bindings` module's path walking
- Is synchronous (simpler API, often faster for the write-ahead-log pattern mem0 uses)
- Has broader platform coverage out of the box (x64, ARM64, musl/glibc)

## Changes

### SQLiteManager.ts
- Rewritten to use `better-sqlite3`'s synchronous API
- Removed async wrapper methods (`run`, `all`) since better-sqlite3 is sync
- Simplified `init()` - no longer needs async error handling
- `addHistory`, `getHistory`, `reset` now use prepared statements

### package.json
- **peerDependencies**: `sqlite3: 5.1.7` → `better-sqlite3: ^11.9.1`
- **pnpm.onlyBuiltDependencies**: `sqlite3` → `better-sqlite3`
- Removed `@types/sqlite3` from peerDependencies (better-sqlite3 ships its own types)

## Migration

Users will need to:
1. `npm uninstall sqlite3` or `pnpm remove sqlite3`
2. `npm install better-sqlite3` or `pnpm add better-sqlite3`

## Testing

- [ ] Test with OpenClaw plugin loading
- [ ] Test on x86_64 Linux
- [ ] Test on ARM64 (if available)
- [ ] Verify all SQLiteManager methods work correctly

## Fixes

- Fixes #4107 - sqlite3 native binding resolution fails due to jiti path mismatch
- Fixes #4050 - Same root cause on ARM64

## Related

- https://github.com/WiseLibs/better-sqlite3
- https://github.com/mem0ai/mem0/issues/4107
- https://github.com/mem0ai/mem0/issues/4050
