### PR TITLE
feat: advanced filter support for `get_all()` 

### DIFF
--- a/docs/open-source/features/metadata-filtering.mdx
+++ b/docs/open-source/features/metadata-filtering.mdx
@@ -39,6 +39,43 @@ Enhanced metadata filtering in Mem0 1.0.0 lets you run complex queries across me
   </Accordion>
 </AccordionGroup>
 
+### Supported methods
+
+Enhanced metadata filters work with both `search()` and `get_all()`:
+
+```python
+from mem0 import Memory
+
+m = Memory()
+
+# search() — semantic search with filters
+results = m.search(
+    "What are my preferences?",
+    user_id="alice",
+    filters={
+        "AND": [
+            {"category": "preferences"},
+            {"priority": {"gte": 5}}
+        ]
+    }
+)
+
+# get_all() — retrieve all matching memories without semantic search
+results = m.get_all(
+    user_id="alice",
+    filters={
+        "AND": [
+            {"created_at": {"gte": "2024-06-01T00:00:00"}},
+            {"created_at": {"lt": "2024-07-01T00:00:00"}}
+        ]
+    }
+)
+```
+
+<Info icon="check">
+  Use `search()` when you have a query and want relevance-ranked results. Use `get_all()` when you want everything matching your filters — no embedding, no ranking, just filtered retrieval.
+</Info>
+
 ### Metadata selectors
 
 Start with key-value filters when you need direct matches on metadata fields.


### PR DESCRIPTION
## Description

`search()` already supports advanced metadata filters like `gt`, `gte`, `lt`, `lte`,  and logical operators like `AND`, `OR`, `NOT`) but `get_all()` did not. This meant users couldn't filter memories by date ranges or other advanced criteria when using `get_all()`.

The filter processing logic (`_has_advanced_operators()` and `_process_metadata_filters()`) already existed, it just wasn't wired into `get_all()`. This PR adds the same processing to both sync and async `get_all()` methods, updates their docstrings, and documents the new capability in the OSS metadata filtering docs.

Fixes #4125

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [x] Unit Test

Added `test_get_all_with_advanced_filters` in `tests/test_memory.py` which verifies that advanced operators (`AND`, `gte`, `lte`) are processed before being passed to the vector store. All 12 tests in `test_memory.py` pass.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #4125
- [ ] Made sure Checks passed
