### PR TITLE
fix: only reset vector store collection when no filters are provided

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1050,7 +1050,8 @@ class Memory(MemoryBase):
         memories = self.vector_store.list(filters=filters)[0]
         for memory in memories:
             self._delete_memory(memory.id)
-        self.vector_store.reset()
+        if not filters:
+            self.vector_store.reset()
 
         logger.info(f"Deleted {len(memories)} memories")
 


### PR DESCRIPTION
## Problem

`delete_all()` calls `vector_store.reset()` unconditionally after deleting individual filtered memories. `reset()` drops and recreates the **entire** collection, destroying ALL memories across all users — even when filters are provided (e.g. `user_id='alice'`).

This means calling `m.delete_all(user_id='alice')` deletes Alice's memories individually, then **drops the entire collection**, wiping Bob's, Charlie's, and everyone else's memories too.

Fixes #3785

## Fix

Only call `reset()` when no filters are given (true "delete everything" intent). When filters are present, the individual `_delete_memory()` calls already handle the filtered deletion correctly.

## Changes

- `mem0/memory/main.py`: Guard `self.vector_store.reset()` with `if not filters:`