### PR TITLE
fix(ts-sdk): OllamaLLM ignores url config, always falls back to local…

### DIFF
--- a/mem0-ts/src/oss/src/llms/ollama.ts
+++ b/mem0-ts/src/oss/src/llms/ollama.ts
@@ -11,7 +11,7 @@ export class OllamaLLM implements LLM {
 
   constructor(config: LLMConfig) {
     this.ollama = new Ollama({
-      host: config.config?.url || "http://localhost:11434",
+      host: config.url || config.config?.url || "http://localhost:11434",
     });
     this.model = config.model || "llama3.1:8b";
     this.ensureModelExists().catch((err) => {

--- a/mem0-ts/src/oss/src/types/index.ts
+++ b/mem0-ts/src/oss/src/types/index.ts
@@ -44,6 +44,7 @@ export interface LLMConfig {
   config?: Record<string, any>;
   apiKey?: string;
   model?: string | any;
+  url?: string;
   modelProperties?: Record<string, any>;
 }
 


### PR DESCRIPTION
## Problem

The `OllamaLLM` constructor reads `config.config?.url` to get the Ollama host URL. However, when the `Memory` class instantiates the LLM via `LLMFactory.create(provider, this.config.llm.config)`, it passes the inner config object directly — meaning `config.url` holds the URL while `config.config` is `undefined`.

This causes `OllamaLLM` to always fall back to `http://localhost:11434`, making it impossible to use a remote Ollama instance (e.g. Docker, another network host, `host.docker.internal`).
The `OllamaEmbedder` correctly reads `config.url` — only the LLM class is broken.

## Fix

- Check `config.url` first (consistent with `OllamaEmbedder`), fall back to `config.config?.url` for backward compat
- Add `url?: string` to `LLMConfig` type (already on `EmbeddingConfig`)

## Testing

Verified with `openclaw-mem0` plugin + self-hosted Ollama on remote Docker host:
- Before: `TypeError: fetch failed` → `ECONNREFUSED 127.0.0.1:11434`
- After: memories stored and retrieved successfully

Fixes #4104