### PR TITLE
fix: use AWSBedrockConfig for aws_bedrock provider in LlmFactory

### DIFF
--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -4,6 +4,7 @@ from typing import Dict, Optional, Union
 from mem0.configs.embeddings.base import BaseEmbedderConfig
 from mem0.configs.llms.anthropic import AnthropicConfig
 from mem0.configs.llms.azure import AzureOpenAIConfig
+from mem0.configs.llms.aws_bedrock import AWSBedrockConfig
 from mem0.configs.llms.base import BaseLlmConfig
 from mem0.configs.llms.deepseek import DeepSeekConfig
 from mem0.configs.llms.lmstudio import LMStudioConfig
@@ -37,7 +38,7 @@ class LlmFactory:
         "openai": ("mem0.llms.openai.OpenAILLM", OpenAIConfig),
         "groq": ("mem0.llms.groq.GroqLLM", BaseLlmConfig),
         "together": ("mem0.llms.together.TogetherLLM", BaseLlmConfig),
-        "aws_bedrock": ("mem0.llms.aws_bedrock.AWSBedrockLLM", BaseLlmConfig),
+        "aws_bedrock": ("mem0.llms.aws_bedrock.AWSBedrockLLM", AWSBedrockConfig),
         "litellm": ("mem0.llms.litellm.LiteLLM", BaseLlmConfig),
         "azure_openai": ("mem0.llms.azure_openai.AzureOpenAILLM", AzureOpenAIConfig),
         "openai_structured": ("mem0.llms.openai_structured.OpenAIStructuredLLM", OpenAIConfig),


### PR DESCRIPTION
## Problem

`LlmFactory.provider_to_class` maps `aws_bedrock` to `BaseLlmConfig`, which doesn't accept AWS-specific parameters (`aws_region`, `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`, `aws_profile`).

This causes a `TypeError` when users configure the AWS Bedrock LLM provider with region:

```python
config = {
    "llm": {
        "provider": "aws_bedrock",
        "config": {
            "model": "anthropic.claude-3-haiku-20240307-v1:0",
            "aws_region": "us-east-1",  # TypeError!
        }
    },
    ...
}
Memory.from_config(config)
# TypeError: BaseLlmConfig.__init__() got an unexpected keyword argument 'aws_region'
```

## Fix

Import and use `AWSBedrockConfig` (which already exists in `mem0/configs/llms/aws_bedrock.py`) instead of `BaseLlmConfig` for the `aws_bedrock` provider mapping.

This is consistent with how other providers are mapped — `openai` uses `OpenAIConfig`, `anthropic` uses `AnthropicConfig`, `azure_openai` uses `AzureOpenAIConfig`, etc.

## Changes

- `mem0/utils/factory.py`: Import `AWSBedrockConfig` and use it in `provider_to_class` mapping

Fixes #4136