### PR TITLE
fix: support Bedrock Claude 4.x and inference profile model IDs

### DIFF
--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -4,6 +4,7 @@ from typing import Dict, Optional, Union
 from mem0.configs.embeddings.base import BaseEmbedderConfig
 from mem0.configs.llms.anthropic import AnthropicConfig
 from mem0.configs.llms.azure import AzureOpenAIConfig
+from mem0.configs.llms.aws_bedrock import AWSBedrockConfig
 from mem0.configs.llms.base import BaseLlmConfig
 from mem0.configs.llms.deepseek import DeepSeekConfig
 from mem0.configs.llms.lmstudio import LMStudioConfig
@@ -37,7 +38,7 @@ class LlmFactory:
         "openai": ("mem0.llms.openai.OpenAILLM", OpenAIConfig),
         "groq": ("mem0.llms.groq.GroqLLM", BaseLlmConfig),
         "together": ("mem0.llms.together.TogetherLLM", BaseLlmConfig),
-        "aws_bedrock": ("mem0.llms.aws_bedrock.AWSBedrockLLM", BaseLlmConfig),
+        "aws_bedrock": ("mem0.llms.aws_bedrock.AWSBedrockLLM", AWSBedrockConfig),
         "litellm": ("mem0.llms.litellm.LiteLLM", BaseLlmConfig),
         "azure_openai": ("mem0.llms.azure_openai.AzureOpenAILLM", AzureOpenAIConfig),
         "openai_structured": ("mem0.llms.openai_structured.OpenAIStructuredLLM", OpenAIConfig),


### PR DESCRIPTION
## Summary

Three fixes to support AWS Bedrock Claude 4.x models (Sonnet 4.5, Opus 4, Sonnet 4.6) that use cross-region inference profiles.

## Changes

### 1. Use `AWSBedrockConfig` in `LlmFactory` (`mem0/utils/factory.py`)

The `aws_bedrock` provider was mapped to `BaseLlmConfig`, which doesn't accept AWS-specific parameters like `aws_region`. Changed to use `AWSBedrockConfig` which properly handles these parameters.

### 2. Handle inference profile IDs in `extract_provider` (`mem0/llms/aws_bedrock.py`)

Claude 4.x models use inference profile IDs with region prefixes: `us.anthropic.claude-sonnet-4-5-20250929-v1:0`

The old `extract_provider` returned `"us"` instead of `"anthropic"`, causing the wrong code path (generic `invoke_model` instead of Converse API). Fixed to detect `us/eu/global/ap` prefixes and return the actual provider.

### 3. Don't send both `temperature` and `topP` (`mem0/llms/aws_bedrock.py`)

Claude 4.x models reject simultaneous `temperature` + `topP` in the Converse API:
```
ValidationException: temperature and top_p cannot both be specified
```

Fixed `inferenceConfig` construction in `_generate_standard` and `_generate_with_tools` to only include one parameter based on explicit configuration.

## Testing

Tested with `us.anthropic.claude-sonnet-4-5-20250929-v1:0` on Bedrock:
- `Memory.from_config()` initializes correctly with `aws_region`
- `memory.add()` with `infer=True` extracts facts via Converse API
- `memory.search()` returns semantically relevant results

```python
config = {
    "llm": {
        "provider": "aws_bedrock",
        "config": {
            "model": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
            "aws_region": "us-east-1",
            "temperature": 0.1,
            "max_tokens": 2000,
        }
    },
    ...
}
m = Memory.from_config(config)
result = m.add("My name is Tom. I am a backend engineer in Beijing.", user_id="test")
# {'results': [{'memory': 'Name is Tom', 'event': 'ADD'}, ...]}
```

Fixes #4138, #4136