### PR TITLE
fix: removeCodeBlocks regex preserves content inside code fences

### DIFF
--- a/mem0-ts/src/oss/src/prompts/index.ts
+++ b/mem0-ts/src/oss/src/prompts/index.ts
@@ -278,5 +278,5 @@ export function parseMessages(messages: string[]): string {
 }
 
 export function removeCodeBlocks(text: string): string {
-  return text.replace(/```[^`]*```/g, "");
+  return text.replace(/```(?:\w*\n)?([\s\S]*?)```/g, "$1").trim();
 }


### PR DESCRIPTION
## Summary
- Fixes the `removeCodeBlocks` regex that was destroying all JSON content from LLM responses instead of just stripping markdown code fences
- The old regex `/```[^`]*```/g` matched and removed everything between fences, causing `JSON.parse` to fail with `SyntaxError: Unexpected end of JSON input`
- New regex `/```(?:\w*\n)?([\s\S]*?)```/g` correctly strips only fence delimiters while preserving content inside

## Test plan
- [ ] Verify `removeCodeBlocks('```json\n{"facts": ["test"]}\n```')` returns `{"facts": ["test"]}`
- [ ] Verify plain JSON without fences passes through unchanged
- [ ] Verify multi-line content with backticks inside is handled correctly

Fixes #4036
Closes #4141
Closes #4108

🤖 Generated with [Claude Code](https://claude.com/claude-code)