### PR TITLE
fix: map aws_bedrock to AWSBedrockConfig in LlmFactory

### DIFF
--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -4,6 +4,7 @@ from typing import Dict, Optional, Union
 from mem0.configs.embeddings.base import BaseEmbedderConfig
 from mem0.configs.llms.anthropic import AnthropicConfig
 from mem0.configs.llms.azure import AzureOpenAIConfig
+from mem0.configs.llms.aws_bedrock import AWSBedrockConfig
 from mem0.configs.llms.base import BaseLlmConfig
 from mem0.configs.llms.deepseek import DeepSeekConfig
 from mem0.configs.llms.lmstudio import LMStudioConfig
@@ -37,7 +38,7 @@ class LlmFactory:
         "openai": ("mem0.llms.openai.OpenAILLM", OpenAIConfig),
         "groq": ("mem0.llms.groq.GroqLLM", BaseLlmConfig),
         "together": ("mem0.llms.together.TogetherLLM", BaseLlmConfig),
-        "aws_bedrock": ("mem0.llms.aws_bedrock.AWSBedrockLLM", BaseLlmConfig),
+        "aws_bedrock": ("mem0.llms.aws_bedrock.AWSBedrockLLM", AWSBedrockConfig),
         "litellm": ("mem0.llms.litellm.LiteLLM", BaseLlmConfig),
         "azure_openai": ("mem0.llms.azure_openai.AzureOpenAILLM", AzureOpenAIConfig),
         "openai_structured": ("mem0.llms.openai_structured.OpenAIStructuredLLM", OpenAIConfig),


### PR DESCRIPTION
## Summary
- Fixes `LlmFactory.provider_to_class` mapping for `aws_bedrock` from `BaseLlmConfig` to `AWSBedrockConfig`
- This was causing `TypeError: BaseLlmConfig.__init__() got an unexpected keyword argument 'aws_region'` when configuring AWS-specific parameters
- Other providers (openai, anthropic, azure_openai) already correctly use their specific config classes

## Test plan
- [ ] Verify `Memory.from_config()` with `aws_bedrock` provider and `aws_region` parameter no longer raises TypeError
- [ ] Verify AWS credentials are properly forwarded to the Bedrock client

Fixes #4136

🤖 Generated with [Claude Code](https://claude.com/claude-code)