### PR TITLE
fix: OllamaLLM reads url from correct config level

### DIFF
--- a/mem0-ts/src/oss/src/config/manager.ts
+++ b/mem0-ts/src/oss/src/config/manager.ts
@@ -81,7 +81,8 @@ export class ConfigManager {
           }
 
           return {
-            baseURL: userConf?.baseURL || defaultConf.baseURL,
+            baseURL: userConf?.baseURL || userConf?.url || defaultConf.baseURL,
+            url: userConf?.url,
             apiKey:
               userConf?.apiKey !== undefined
                 ? userConf.apiKey

--- a/mem0-ts/src/oss/src/llms/ollama.ts
+++ b/mem0-ts/src/oss/src/llms/ollama.ts
@@ -11,7 +11,7 @@ export class OllamaLLM implements LLM {
 
   constructor(config: LLMConfig) {
     this.ollama = new Ollama({
-      host: config.config?.url || "http://localhost:11434",
+      host: config.url || config.baseURL || config.config?.url || "http://localhost:11434",
     });
     this.model = config.model || "llama3.1:8b";
     this.ensureModelExists().catch((err) => {


### PR DESCRIPTION
## Summary
- Fixes OllamaLLM constructor accessing `config.config?.url` (double-nested) when LLMFactory passes the flat inner config object — `url` was always `undefined`, falling back to `localhost:11434`
- OllamaLLM now reads `config.url || config.baseURL` with proper fallback chain
- ConfigManager.mergeConfig now preserves `url` in the LLM config (matching embedder config which already preserved it)

## Test plan
- [ ] Configure Ollama LLM with a remote `url` (e.g., `http://10.0.0.100:11434`) and verify it connects to the remote server instead of localhost
- [ ] Verify localhost fallback still works when no url is configured

Fixes #4059

🤖 Generated with [Claude Code](https://claude.com/claude-code)