### PR TITLE
fix: OpenAI embedder in TS SDK now respects url config

### DIFF
--- a/mem0-ts/src/oss/src/embeddings/openai.ts
+++ b/mem0-ts/src/oss/src/embeddings/openai.ts
@@ -8,7 +8,7 @@ export class OpenAIEmbedder implements Embedder {
   private embeddingDims?: number;
 
   constructor(config: EmbeddingConfig) {
-    this.openai = new OpenAI({ apiKey: config.apiKey });
+    this.openai = new OpenAI({ apiKey: config.apiKey, baseURL: config.url });
     this.model = config.model || "text-embedding-3-small";
     this.embeddingDims = config.embeddingDims || 1536;
   }


### PR DESCRIPTION
## Summary
- Passes `config.url` as `baseURL` to the OpenAI client constructor in the TypeScript SDK's OpenAIEmbedder
- Previously, the url config was completely ignored, making it impossible to use OpenAI-compatible endpoints

## Test plan
- [ ] Configure OpenAI embedder with a custom `url` and verify requests go to the custom endpoint
- [ ] Verify default OpenAI endpoint still works when no url is configured

Fixes #4048

🤖 Generated with [Claude Code](https://claude.com/claude-code)