### PR TITLE
fix: add missing limit, threshold, infer params to REST API

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -76,6 +76,7 @@ class MemoryCreate(BaseModel):
     agent_id: Optional[str] = None
     run_id: Optional[str] = None
     metadata: Optional[Dict[str, Any]] = None
+    infer: Optional[bool] = None
 
 
 class SearchRequest(BaseModel):
@@ -84,6 +85,8 @@ class SearchRequest(BaseModel):
     run_id: Optional[str] = None
     agent_id: Optional[str] = None
     filters: Optional[Dict[str, Any]] = None
+    limit: Optional[int] = None
+    threshold: Optional[float] = None
 
 
 @app.post("/configure", summary="Configure Mem0")


### PR DESCRIPTION
## Summary
- Adds `limit` and `threshold` fields to `SearchRequest` Pydantic model
- Adds `infer` field to `MemoryCreate` Pydantic model
- These params were silently dropped by Pydantic v2's default `extra='ignore'` behavior, making them impossible to use via the REST API
- No handler changes needed — existing `model_dump()` + `**params` pattern forwards these automatically

## Test plan
- [ ] `POST /search` with `limit=5` returns at most 5 results
- [ ] `POST /search` with `threshold=0.8` filters low-relevance results
- [ ] `POST /memories` with `infer=false` stores without LLM processing

Fixes #3976

🤖 Generated with [Claude Code](https://claude.com/claude-code)