### PR TITLE
fix: merge payload fields in MongoDB update instead of replacing

### DIFF
--- a/mem0/vector_stores/mongodb.py
+++ b/mem0/vector_stores/mongodb.py
@@ -198,7 +198,8 @@ class MongoDB(VectorStoreBase):
         if vector is not None:
             update_fields["embedding"] = vector
         if payload is not None:
-            update_fields["payload"] = payload
+            for key, value in payload.items():
+                update_fields[f"payload.{key}"] = value
 
         if update_fields:
             try:


### PR DESCRIPTION
## Summary
- Fixes the MongoDB vector store `update()` method which replaced the entire `payload` document on update, causing all existing metadata to be lost
- Now uses MongoDB dot-notation (`payload.key`) with `$set` to merge individual payload fields, preserving existing metadata that isn't being updated
- Before: `{"$set": {"payload": new_payload}}` (full replacement)
- After: `{"$set": {"payload.data": ..., "payload.hash": ...}}` (field-level merge)

## Test plan
- [ ] Update a memory's content and verify metadata fields (bucket_id, category, etc.) are preserved
- [ ] Verify new payload fields are correctly added
- [ ] Verify updated payload fields are correctly changed

Fixes #3966

🤖 Generated with [Claude Code](https://claude.com/claude-code)