### PR TITLE
fix: honor historyDbPath config in Node SDK OSS mode

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -77,6 +77,11 @@ export class Memory {
         },
       };
 
+      // If user provided historyDbPath, ensure it overrides the historyStore default
+      if (this.config.historyDbPath && this.config.historyStore?.config) {
+        this.config.historyStore.config.historyDbPath = this.config.historyDbPath;
+      }
+
       this.db =
         this.config.historyStore && !this.config.disableHistory
           ? HistoryManagerFactory.create(


### PR DESCRIPTION
## Summary
- Fixes `historyDbPath` being silently ignored in the Node SDK OSS mode
- `ConfigManager.mergeConfig()` always populates `historyStore` with defaults, so the branch that reads `historyDbPath` was dead code
- Now `historyDbPath` overrides `historyStore.config.historyDbPath` before the history manager is created
- This prevents `SQLITE_CANTOPEN` errors when `process.cwd()` is not writable (common in daemon/service contexts)

## Test plan
- [ ] Configure `historyDbPath: "/tmp/custom-history.db"` and verify the DB file is created at that path
- [ ] Verify default behavior still works when `historyDbPath` is not set
- [ ] Verify `disableHistory: true` still skips history entirely

Fixes #4096
Closes #4080
Closes #4074

🤖 Generated with [Claude Code](https://claude.com/claude-code)