### PR TITLE
fix: explicitly set encoding_format=float for OpenAI embeddings

### DIFF
--- a/mem0/embeddings/openai.py
+++ b/mem0/embeddings/openai.py
@@ -43,7 +43,12 @@ class OpenAIEmbedding(EmbeddingBase):
         """
         text = text.replace("\n", " ")
         return (
-            self.client.embeddings.create(input=[text], model=self.config.model, dimensions=self.config.embedding_dims)
+            self.client.embeddings.create(
+                input=[text],
+                model=self.config.model,
+                dimensions=self.config.embedding_dims,
+                encoding_format="float",
+            )
             .data[0]
             .embedding
         )


### PR DESCRIPTION
## Summary
- Explicitly sets `encoding_format="float"` in the OpenAI embeddings `embed()` call
- The OpenAI Python SDK v1.0+ defaults to `encoding_format="base64"` when not specified, which breaks OpenAI-compatible proxies (OpenRouter, LiteLLM, vLLM, Ollama) that don't support base64
- This caused intermittent `ValueError: No embedding data received` errors for users with custom `openai_base_url`

## Test plan
- [ ] Verify embeddings work against the official OpenAI API
- [ ] Verify embeddings work against an OpenAI-compatible proxy (e.g., OpenRouter)
- [ ] Verify no regression in embedding quality/dimensions

Fixes #4057

🤖 Generated with [Claude Code](https://claude.com/claude-code)