### PR TITLE
fix: sanitize hyphens in Neo4j Cypher relationship names

### DIFF
--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -197,6 +197,7 @@ def sanitize_relationship_for_cypher(relationship) -> str:
         "}": "_rbrace_",
         "<": "_langle_",
         ">": "_rangle_",
+        "-": "_",
     }
 
     # Apply replacements and clean up

--- a/tests/memory/test_neo4j_cypher_syntax.py
+++ b/tests/memory/test_neo4j_cypher_syntax.py
@@ -1,6 +1,32 @@
 import os
 from unittest.mock import Mock, patch
 
+from mem0.memory.utils import sanitize_relationship_for_cypher
+
+
+class TestSanitizeRelationshipForCypher:
+    """Test that relationship names are properly sanitized for Neo4j Cypher queries."""
+
+    def test_hyphen_replaced_with_underscore(self):
+        """Hyphens in relationship names cause Neo4j CypherSyntaxError and must be replaced."""
+        assert sanitize_relationship_for_cypher("manages_via_low-cost_models") == "manages_via_low_cost_models"
+
+    def test_multiple_hyphens(self):
+        assert sanitize_relationship_for_cypher("co-owns-with") == "co_owns_with"
+
+    def test_no_special_chars_unchanged(self):
+        assert sanitize_relationship_for_cypher("works_at") == "works_at"
+
+    def test_spaces_not_handled_here(self):
+        """Spaces are replaced upstream before this function is called."""
+        # sanitize only handles special chars, spaces are handled by the caller
+        result = sanitize_relationship_for_cypher("has relationship")
+        assert result == "has relationship"
+
+    def test_existing_chars_still_sanitized(self):
+        assert "_slash_" in sanitize_relationship_for_cypher("read/write")
+        assert "_at_" in sanitize_relationship_for_cypher("user@company")
+
 
 class TestNeo4jCypherSyntaxFix:
     """Test that Neo4j Cypher syntax fixes work correctly"""


### PR DESCRIPTION
## Problem

When an LLM extracts relationship names containing hyphens (e.g. `manages_via_low-cost_models`), Neo4j throws a `CypherSyntaxError` because `-` is not a valid character in unquoted Cypher identifiers:

```
neo4j.exceptions.CypherSyntaxError: Invalid input '-': expected a parameter, '&', '*', ':', 'WHERE', ']', '{' or '|'
"MERGE (source)-[r:manages_via_low-cost_models]->(destination)"
```

## Root Cause

`sanitize_relationship_for_cypher()` in `mem0/memory/utils.py` handles many special characters (`/`, `@`, `!`, etc.) but does **not** handle `-` (hyphen/minus).

## Fix

Add `"-": "_"` to the character mapping in `sanitize_relationship_for_cypher()`, consistent with how other special characters are already handled.

**Before:** `manages_via_low-cost_models` → CypherSyntaxError  
**After:** `manages_via_low-cost_models` → `manages_via_low_cost_models` ✅

## Changes

- `mem0/memory/utils.py`: Add hyphen to sanitization char_map (1 line)
- `tests/memory/test_neo4j_cypher_syntax.py`: Add 5 test cases for the sanitization function

## Testing

All 5 new tests pass:
```
tests/memory/test_neo4j_cypher_syntax.py::TestSanitizeRelationshipForCypher::test_hyphen_replaced_with_underscore PASSED
tests/memory/test_neo4j_cypher_syntax.py::TestSanitizeRelationshipForCypher::test_multiple_hyphens PASSED
tests/memory/test_neo4j_cypher_syntax.py::TestSanitizeRelationshipForCypher::test_no_special_chars_unchanged PASSED
tests/memory/test_neo4j_cypher_syntax.py::TestSanitizeRelationshipForCypher::test_spaces_not_handled_here PASSED
tests/memory/test_neo4j_cypher_syntax.py::TestSanitizeRelationshipForCypher::test_existing_chars_still_sanitized PASSED
```