### PR TITLE
Fix Ollama host fallback for OSS

### DIFF
--- a/mem0-ts/src/oss/src/embeddings/ollama.ts
+++ b/mem0-ts/src/oss/src/embeddings/ollama.ts
@@ -12,7 +12,13 @@ export class OllamaEmbedder implements Embedder {
 
   constructor(config: EmbeddingConfig) {
     this.ollama = new Ollama({
-      host: config.url || "http://localhost:11434",
+      host:
+        config.url ||
+        // allow OpenAI-style baseURL/baseUrl or env fallback
+        (config as any).baseURL ||
+        (config as any).baseUrl ||
+        process.env.OLLAMA_HOST ||
+        "http://localhost:11434",
     });
     this.model = config.model || "nomic-embed-text:latest";
     this.embeddingDims = config.embeddingDims || 768;

--- a/mem0-ts/src/oss/src/llms/ollama.ts
+++ b/mem0-ts/src/oss/src/llms/ollama.ts
@@ -11,7 +11,12 @@ export class OllamaLLM implements LLM {
 
   constructor(config: LLMConfig) {
     this.ollama = new Ollama({
-      host: config.config?.url || "http://localhost:11434",
+      host:
+        config.config?.url ||
+        (config.config as any)?.baseURL ||
+        (config.config as any)?.baseUrl ||
+        process.env.OLLAMA_HOST ||
+        "http://localhost:11434",
     });
     this.model = config.model || "llama3.1:8b";
     this.ensureModelExists().catch((err) => {


### PR DESCRIPTION
## Summary\n- Allow Ollama OSS embedder/LLM to honor baseURL/baseUrl or OLLAMA_HOST\n- Avoid localhost fallback when running remote Ollama\n\n## Context\nMem0 OSS defaults to localhost, which breaks remote Ollama setups (OpenClaw + remote Ollama at 10.1.1.100:31028). This change makes Ollama host resolution more robust.\n\n## Files\n- mem0-ts/src/oss/src/embeddings/ollama.ts\n- mem0-ts/src/oss/src/llms/ollama.ts