### PR TITLE
fix: add 'json' keyword to update memory prompt for Groq compatibility

### DIFF
--- a/mem0-ts/src/oss/src/prompts/index.ts
+++ b/mem0-ts/src/oss/src/prompts/index.ts
@@ -96,7 +96,7 @@ export function getUpdateMemoryMessages(
   retrievedOldMemory: Array<{ id: string; text: string }>,
   newRetrievedFacts: string[],
 ): string {
-  return `You are a smart memory manager which controls the memory of a system.
+  return `You are a smart memory manager which controls the memory of a system. You must return a JSON object with a "memory" key.
   You can perform four operations: (1) add into the memory, (2) update the memory, (3) delete from the memory, and (4) no change.
   
   Based on the above four operations, the memory will change.

--- a/mem0/configs/prompts.py
+++ b/mem0/configs/prompts.py
@@ -172,7 +172,7 @@ Remember the following:
 Following is a conversation between the user and the assistant. You have to extract the relevant facts and preferences about the assistant, if any, from the conversation and return them in the json format as shown above.
 """
 
-DEFAULT_UPDATE_MEMORY_PROMPT = """You are a smart memory manager which controls the memory of a system.
+DEFAULT_UPDATE_MEMORY_PROMPT = """You are a smart memory manager which controls the memory of a system. You must return a JSON object with a "memory" key.
 You can perform four operations: (1) add into the memory, (2) update the memory, (3) delete from the memory, and (4) no change.
 
 Based on the above four operations, the memory will change.


### PR DESCRIPTION
## Problem

Closes #3559
Closes #3008

Groq's API requires the word `json` to appear in the messages array when using `response_format: { type: 'json_object' }`. The `getUpdateMemoryMessages` prompt (and `DEFAULT_UPDATE_MEMORY_PROMPT` in Python) does not contain the word `json` explicitly — it only uses JSON structure examples as data — causing every memory update call to fail with:

```
400 Bad Request: 'messages' must contain the word 'json' in some form,
to use 'response_format' of type 'json_object'.
```

This affects any Groq model used as the mem0 LLM (`llama-3.1-8b-instant`, `llama-3.3-70b`, `meta-llama/llama-4-scout-17b-16e-instruct`, etc.).

## Fix

Append `"You must return a JSON object with a 'memory' key."` to the opening line of the update memory prompt in both:

- `mem0-ts/src/oss/src/prompts/index.ts` (`getUpdateMemoryMessages`)
- `mem0/configs/prompts.py` (`DEFAULT_UPDATE_MEMORY_PROMPT`)

This satisfies Groq's requirement while being accurate (the prompt already expects a JSON response with a `memory` key) and is a no-op for all other providers (OpenAI, Anthropic, Ollama, etc.).

## Testing

Verified with `llama-3.1-8b-instant` on Groq — memory captures and updates now succeed without errors.