### PR TITLE
fix: only pass dimensions to OpenAI embeddings API when explicitly configured

### DIFF
--- a/tests/embeddings/test_openai_embeddings.py
+++ b/tests/embeddings/test_openai_embeddings.py
@@ -24,7 +24,7 @@ def test_embed_default_model(mock_openai_client):
     result = embedder.embed("Hello world")
 
     mock_openai_client.embeddings.create.assert_called_once_with(
-        input=["Hello world"], model="text-embedding-3-small", dimensions=1536
+        input=["Hello world"], model="text-embedding-3-small"
     )
     assert result == [0.1, 0.2, 0.3]
 
@@ -54,7 +54,7 @@ def test_embed_removes_newlines(mock_openai_client):
     result = embedder.embed("Hello\nworld")
 
     mock_openai_client.embeddings.create.assert_called_once_with(
-        input=["Hello world"], model="text-embedding-3-small", dimensions=1536
+        input=["Hello world"], model="text-embedding-3-small"
     )
     assert result == [0.7, 0.8, 0.9]
 
@@ -69,7 +69,7 @@ def test_embed_without_api_key_env_var(mock_openai_client):
     result = embedder.embed("Testing API key")
 
     mock_openai_client.embeddings.create.assert_called_once_with(
-        input=["Testing API key"], model="text-embedding-3-small", dimensions=1536
+        input=["Testing API key"], model="text-embedding-3-small"
     )
     assert result == [1.0, 1.1, 1.2]
 
@@ -85,6 +85,6 @@ def test_embed_uses_environment_api_key(mock_openai_client, monkeypatch):
     result = embedder.embed("Environment key test")
 
     mock_openai_client.embeddings.create.assert_called_once_with(
-        input=["Environment key test"], model="text-embedding-3-small", dimensions=1536
+        input=["Environment key test"], model="text-embedding-3-small"
     )
     assert result == [1.3, 1.4, 1.5]


### PR DESCRIPTION
## Summary

Fixes #4153

`OpenAIEmbedding` always passes the `dimensions` parameter to `client.embeddings.create()`, even when the user has not explicitly configured `embedding_dims`. This causes a 400 error on OpenAI-compatible backends (e.g. vLLM serving non-matryoshka models like Qwen3-Embedding-0.6B) that reject the `dimensions` parameter.

## Root Cause

In `__init__`, `embedding_dims` is always defaulted to 1536:
```python
self.config.embedding_dims = self.config.embedding_dims or 1536
```
Then `embed()` unconditionally passes it:
```python
self.client.embeddings.create(input=[text], model=self.config.model, dimensions=self.config.embedding_dims)
```

## Fix

Track whether the user explicitly provided `embedding_dims` **before** applying the default:
```python
self._pass_dimensions = self.config.embedding_dims is not None
self.config.embedding_dims = self.config.embedding_dims or 1536
```

Only include `dimensions` in the API call when the user explicitly configured it:
```python
kwargs = {"input": [text], "model": self.config.model}
if self._pass_dimensions:
    kwargs["dimensions"] = self.config.embedding_dims
return self.client.embeddings.create(**kwargs).data[0].embedding
```

## Backward Compatibility

- **Users who set `embedding_dims`**: behavior unchanged, `dimensions` is sent
- **Users who don't set `embedding_dims`**: `dimensions` is no longer sent, fixing non-matryoshka backends
- **`self.config.embedding_dims`** still defaults to 1536 for vector store index creation