### PR TITLE
fix: wrap vector and payload in lists when calling insert from update

### DIFF
--- a/mem0/vector_stores/langchain.py
+++ b/mem0/vector_stores/langchain.py
@@ -115,7 +115,7 @@ class Langchain(VectorStoreBase):
         Update a vector and its payload.
         """
         self.delete(vector_id)
-        self.insert(vector, payload, [vector_id])
+        self.insert([vector], [payload] if payload is not None else None, [vector_id])
 
     def get(self, vector_id):
         """


### PR DESCRIPTION
## Problem

The `update` method in `mem0/vector_stores/langchain.py` passes single `vector` and `payload` values directly to `insert()`, which expects `List[List[float]]` and `List[Dict]`:

```python
# Current (broken):
self.insert(vector, payload, [vector_id])

# insert signature:
def insert(self, vectors: List[List[float]], payloads: Optional[List[Dict]] = None, ids: Optional[List[str]] = None):
```

This type mismatch causes `insert` to iterate over the inner elements of the vector (individual floats) and payload (individual dict keys) instead of treating them as single items.

## Fix

Wrap `vector` and `payload` in lists:

```python
self.insert([vector], [payload] if payload is not None else None, [vector_id])
```

Fixes #3767