### PR TITLE
fix: _safe_deepcopy_config no longer strips http_auth from OpenSearch configs

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -69,9 +69,15 @@ def _safe_deepcopy_config(config):
         else:
             clone_dict = {k: v for k, v in config.__dict__.items()}
         
-        sensitive_tokens = ("auth", "credential", "password", "token", "secret", "key", "connection_class")
+        sensitive_tokens = ("credential", "password", "token", "secret", "key", "connection_class")
+        # Match exact field names for "auth" variants to avoid stripping
+        # transport-level fields like http_auth that are not secrets.
+        sensitive_exact = ("auth",)
         for field_name in list(clone_dict.keys()):
-            if any(token in field_name.lower() for token in sensitive_tokens):
+            lower_name = field_name.lower()
+            if any(token in lower_name for token in sensitive_tokens):
+                clone_dict[field_name] = None
+            elif lower_name in sensitive_exact:
                 clone_dict[field_name] = None
         
         try:


### PR DESCRIPTION
## Summary

Fixes #3580

`_safe_deepcopy_config()` uses substring matching to sanitize sensitive fields for telemetry. The token `"auth"` matches `http_auth`, which is a transport-level field required by OpenSearch's `AWSV4SignerAuth`. This causes 403 authentication errors.

## Root Cause

```python
sensitive_tokens = ("auth", ...)
# 'auth' in 'http_auth'.lower() == True → field set to None
```

## Fix

Moved `"auth"` from substring matching to exact-match comparison:

- **Substring match** (unchanged): `credential`, `password`, `token`, `secret`, `key`, `connection_class`
- **Exact match** (new): `auth` — only matches the field name `auth` exactly, not `http_auth`

| Field | Before | After |
|---|---|---|
| `auth` | ✅ Stripped | ✅ Stripped |
| `http_auth` | ❌ Stripped | ✅ Preserved |
| `auth_token` | ✅ Stripped | ✅ Stripped (via `token` substring) |
| `api_key` | ✅ Stripped | ✅ Stripped |