### PR TITLE
fix(ts): forward baseURL to OpenAI embedder

### DIFF
--- a/mem0-ts/src/oss/src/embeddings/openai.ts
+++ b/mem0-ts/src/oss/src/embeddings/openai.ts
@@ -8,7 +8,7 @@ export class OpenAIEmbedder implements Embedder {
   private embeddingDims?: number;
 
   constructor(config: EmbeddingConfig) {
-    this.openai = new OpenAI({ apiKey: config.apiKey });
+    this.openai = new OpenAI({ apiKey: config.apiKey, baseURL: config.baseURL });
     this.model = config.model || "text-embedding-3-small";
     this.embeddingDims = config.embeddingDims || 1536;
   }

--- a/mem0-ts/src/oss/src/types/index.ts
+++ b/mem0-ts/src/oss/src/types/index.ts
@@ -14,6 +14,7 @@ export interface Message {
 
 export interface EmbeddingConfig {
   apiKey?: string;
+  baseURL?: string;
   model?: string | any;
   url?: string;
   embeddingDims?: number;


### PR DESCRIPTION
## Summary

The `OpenAIEmbedder` constructor only passes `apiKey` to the OpenAI client, ignoring `baseURL`. This is inconsistent with `OpenAILLM` which already forwards `baseURL`, and with the Zod config schema which already validates `baseURL` on the embedder config.

Without this fix, users hosting OpenAI-compatible embedding servers (e.g. llama.cpp, vLLM, TEI) cannot set the endpoint through config and must rely on the `OPENAI_BASE_URL` environment variable. This causes conflicts when the same env var is also needed for model API calls to a different endpoint.

## Changes

- Add `baseURL` to the `EmbeddingConfig` TypeScript interface (matches existing Zod schema)
- Forward `baseURL` from config to the OpenAI client constructor in `OpenAIEmbedder` (matches `OpenAILLM` behavior)

Both changes are backwards-compatible — `baseURL` is optional and `undefined` preserves existing behavior (falls back to env var, then default).