### PR TITLE
feat: add ModelsLab LLM provider

### DIFF
--- a/mem0/configs/llms/modelslab.py
+++ b/mem0/configs/llms/modelslab.py
@@ -1,0 +1,40 @@
+from typing import Optional
+
+from mem0.configs.llms.base import BaseLlmConfig
+
+
+class ModelsLabConfig(BaseLlmConfig):
+    """
+    Configuration class for ModelsLab-specific parameters.
+    Inherits from BaseLlmConfig and adds ModelsLab settings.
+
+    ModelsLab provides an OpenAI-compatible uncensored chat API.
+    API key: https://modelslab.com/account/api-key
+    Docs: https://docs.modelslab.com
+    """
+
+    def __init__(
+        self,
+        model: Optional[str] = None,
+        temperature: float = 0.1,
+        api_key: Optional[str] = None,
+        max_tokens: int = 2000,
+        top_p: float = 1.0,
+        top_k: int = 1,
+        enable_vision: bool = False,
+        vision_details: Optional[str] = "auto",
+        http_client_proxies: Optional[dict] = None,
+        modelslab_base_url: Optional[str] = None,
+    ):
+        super().__init__(
+            model=model,
+            temperature=temperature,
+            api_key=api_key,
+            max_tokens=max_tokens,
+            top_p=top_p,
+            top_k=top_k,
+            enable_vision=enable_vision,
+            vision_details=vision_details,
+            http_client_proxies=http_client_proxies,
+        )
+        self.modelslab_base_url = modelslab_base_url or "https://modelslab.com/api/uncensored-chat/v1"

--- a/mem0/llms/configs.py
+++ b/mem0/llms/configs.py
@@ -26,6 +26,7 @@ class LlmConfig(BaseModel):
             "xai",
             "sarvam",
             "lmstudio",
+            "modelslab",
             "vllm",
             "langchain",
         ):

--- a/mem0/llms/modelslab.py
+++ b/mem0/llms/modelslab.py
@@ -1,0 +1,120 @@
+import json
+import os
+from typing import Dict, List, Optional, Union
+
+from openai import OpenAI
+
+from mem0.configs.llms.base import BaseLlmConfig
+from mem0.configs.llms.modelslab import ModelsLabConfig
+from mem0.llms.base import LLMBase
+from mem0.memory.utils import extract_json
+
+
+class ModelsLabLLM(LLMBase):
+    """LLM provider for ModelsLab's OpenAI-compatible uncensored chat API.
+
+    Usage::
+
+        from mem0 import Memory
+
+        config = {
+            "llm": {
+                "provider": "modelslab",
+                "config": {
+                    "model": "meta-llama/Meta-Llama-3-8B-Instruct",
+                    "api_key": "your-modelslab-api-key",
+                    "temperature": 0.1,
+                    "max_tokens": 2000,
+                }
+            }
+        }
+        m = Memory.from_config(config)
+
+    Docs: https://docs.modelslab.com
+    API key: https://modelslab.com/account/api-key
+    """
+
+    def __init__(self, config: Optional[Union[BaseLlmConfig, ModelsLabConfig, Dict]] = None):
+        if config is None:
+            config = ModelsLabConfig()
+        elif isinstance(config, dict):
+            config = ModelsLabConfig(**config)
+        elif isinstance(config, BaseLlmConfig) and not isinstance(config, ModelsLabConfig):
+            config = ModelsLabConfig(
+                model=config.model,
+                temperature=config.temperature,
+                api_key=config.api_key,
+                max_tokens=config.max_tokens,
+                top_p=config.top_p,
+                top_k=config.top_k,
+                enable_vision=config.enable_vision,
+                vision_details=config.vision_details,
+                http_client_proxies=config.http_client,
+            )
+
+        super().__init__(config)
+
+        self.config.model = self.config.model or "meta-llama/Meta-Llama-3-8B-Instruct"
+        self.config.api_key = (
+            self.config.api_key
+            or os.environ.get("MODELSLAB_API_KEY")
+        )
+
+        self.client = OpenAI(
+            base_url=self.config.modelslab_base_url,
+            api_key=self.config.api_key,
+        )
+
+    def _parse_response(self, response, tools):
+        if tools:
+            processed_response = {
+                "content": response.choices[0].message.content,
+                "tool_calls": [],
+            }
+            if response.choices[0].message.tool_calls:
+                for tool_call in response.choices[0].message.tool_calls:
+                    processed_response["tool_calls"].append(
+                        {
+                            "name": tool_call.function.name,
+                            "arguments": json.loads(extract_json(tool_call.function.arguments)),
+                        }
+                    )
+            return processed_response
+        return response.choices[0].message.content
+
+    def generate_response(
+        self,
+        messages: List[Dict[str, str]],
+        response_format=None,
+        tools: Optional[List[Dict]] = None,
+        tool_choice: str = "auto",
+        **kwargs,
+    ):
+        """Generate a response using ModelsLab's uncensored chat API.
+
+        Args:
+            messages: List of message dicts with 'role' and 'content' keys.
+            response_format: Response format (e.g., JSON mode).
+            tools: List of tool definitions for function calling.
+            tool_choice: How to select tools ("auto", "none", or specific).
+
+        Returns:
+            str or dict: The generated response content.
+        """
+        params = self._get_supported_params(messages=messages, **kwargs)
+        params.update(
+            {
+                "model": self.config.model,
+                "messages": messages,
+                "temperature": self.config.temperature,
+                "max_tokens": self.config.max_tokens,
+            }
+        )
+        if response_format:
+            params["response_format"] = response_format
+        if tools:
+            params["tools"] = tools
+            params["tool_choice"] = tool_choice
+
+        response = self.client.chat.completions.create(**params)
+        return self._parse_response(response, tools)

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -7,6 +7,7 @@ from mem0.configs.llms.azure import AzureOpenAIConfig
 from mem0.configs.llms.base import BaseLlmConfig
 from mem0.configs.llms.deepseek import DeepSeekConfig
 from mem0.configs.llms.lmstudio import LMStudioConfig
+from mem0.configs.llms.modelslab import ModelsLabConfig
 from mem0.configs.llms.ollama import OllamaConfig
 from mem0.configs.llms.openai import OpenAIConfig
 from mem0.configs.llms.vllm import VllmConfig
@@ -48,6 +49,7 @@ class LlmFactory:
         "xai": ("mem0.llms.xai.XAILLM", BaseLlmConfig),
         "sarvam": ("mem0.llms.sarvam.SarvamLLM", BaseLlmConfig),
         "lmstudio": ("mem0.llms.lmstudio.LMStudioLLM", LMStudioConfig),
+        "modelslab": ("mem0.llms.modelslab.ModelsLabLLM", ModelsLabConfig),
         "vllm": ("mem0.llms.vllm.VllmLLM", VllmConfig),
         "langchain": ("mem0.llms.langchain.LangchainLLM", BaseLlmConfig),
     }


### PR DESCRIPTION
## Summary

Adds **ModelsLab** as an OpenAI-compatible LLM provider, following the LMStudio provider pattern.

[ModelsLab](https://modelslab.com) provides an uncensored chat API at `/api/uncensored-chat/v1` that is fully compatible with the OpenAI SDK.

## Usage

```python
from mem0 import Memory

config = {
    'llm': {
        'provider': 'modelslab',
        'config': {
            'model': 'meta-llama/Meta-Llama-3-8B-Instruct',
            'api_key': 'your-modelslab-api-key',  # or MODELSLAB_API_KEY env var
            'temperature': 0.1,
            'max_tokens': 2000,
        }
    }
}
m = Memory.from_config(config)
```

## Files Changed (4 files)

| File | Change |
|------|--------|
| `mem0/configs/llms/modelslab.py` | `ModelsLabConfig` (extends `BaseLlmConfig`) |
| `mem0/llms/modelslab.py` | `ModelsLabLLM` (extends `LLMBase`, uses OpenAI SDK) |
| `mem0/llms/configs.py` | Add `'modelslab'` to valid providers list |
| `mem0/utils/factory.py` | Register provider in LLM factory |

## API Details

- **Endpoint**: `https://modelslab.com/api/uncensored-chat/v1`
- **Auth**: Standard Bearer token (OpenAI SDK compatible)
- **Env var**: `MODELSLAB_API_KEY`
- **Models**: Any model available on ModelsLab (e.g., Meta-Llama-3, Mixtral, etc.)
- **Docs**: https://docs.modelslab.com