### PR TITLE
fix: accept default /tmp/chroma path in ChromaDbConfig validator

### DIFF
--- a/mem0/configs/vector_stores/chroma.py
+++ b/mem0/configs/vector_stores/chroma.py
@@ -32,8 +32,8 @@ class ChromaDbConfig(BaseModel):
             values.pop("path", None)
             return values
         
-        # Check if local/server configuration is provided (excluding default tmp path for cloud config)
-        local_config = bool(path and path != "/tmp/chroma") or bool(host and port)
+        # Check if local/server configuration is provided
+        local_config = bool(path) or bool(host and port)
         
         if not cloud_config and not local_config:
             raise ValueError("Either ChromaDB Cloud configuration (api_key, tenant) or local configuration (path or host/port) must be provided.")

--- a/tests/vector_stores/test_chroma.py
+++ b/tests/vector_stores/test_chroma.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from mem0.vector_stores.chroma import ChromaDB
+from mem0.configs.vector_stores.chroma import ChromaDbConfig
 
 
 @pytest.fixture
@@ -249,3 +250,15 @@ def test_generate_where_clause_non_string_values():
     # ChromaDB accepts non-string values in filters
     expected = {"$and": [{"user_id": {"$eq": "alice"}}, {"count": {"$eq": 5}}, {"active": {"$eq": True}}]}
     assert result == expected
+
+
+def test_chroma_config_accepts_default_tmp_path():
+    """Test that ChromaDbConfig accepts the default /tmp/chroma path."""
+    config = ChromaDbConfig(path="/tmp/chroma")
+    assert config.path == "/tmp/chroma"
+
+
+def test_chroma_config_rejects_no_config():
+    """Test that ChromaDbConfig rejects when no connection config is provided."""
+    with pytest.raises(ValueError):
+        ChromaDbConfig()


### PR DESCRIPTION
## Description

When using the `chroma` vector store provider without explicitly setting a `path`, `VectorStoreConfig` auto-generates `path="/tmp/chroma"`. However, `ChromaDbConfig.check_connection_config` explicitly excluded `/tmp/chroma` from being considered a valid local configuration path, causing a `ValueError`.

The fix removes the `/tmp/chroma` exclusion from the `local_config` check so the auto-generated default path is accepted. The cloud config path-stripping logic (which removes the auto-generated path when cloud credentials are provided) is unaffected.

Fixes #3881

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit Test

Added two tests:
- `test_chroma_config_accepts_default_tmp_path`: verifies `ChromaDbConfig(path="/tmp/chroma")` succeeds
- `test_chroma_config_rejects_no_config`: verifies `ChromaDbConfig()` with no arguments still raises `ValueError`

All 17 chroma tests pass.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes