### PR TITLE
fix: make AsyncMemory.from_config a regular classmethod

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1283,7 +1283,7 @@ class AsyncMemory(MemoryBase):
         capture_event("mem0.init", self, {"sync_type": "async"})
 
     @classmethod
-    async def from_config(cls, config_dict: Dict[str, Any]):
+    def from_config(cls, config_dict: Dict[str, Any]):
         try:
             config = cls._process_config(config_dict)
             config = MemoryConfig(**config_dict)


### PR DESCRIPTION
## Description

`AsyncMemory.from_config()` is declared as `async` but contains no async operations — it only validates config and calls `cls(config)`. This forces users to use `await` even in synchronous initialization contexts (e.g. FastAPI module-level setup).

Remove the `async` keyword so it can be called as a regular classmethod.

Fixes #2755

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Test Script (please provide)

```python
from mem0.memory.main import AsyncMemory
import inspect
assert not inspect.iscoroutinefunction(AsyncMemory.from_config)
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes