### PR TITLE
fix: skip malformed entities in _remove_spaces_from_entities

### DIFF
--- a/mem0/memory/graph_memory.py
+++ b/mem0/memory/graph_memory.py
@@ -607,12 +607,16 @@ class MemoryGraph:
         return results
 
     def _remove_spaces_from_entities(self, entity_list):
+        cleaned = []
         for item in entity_list:
+            if not item or not all(key in item for key in ("source", "relationship", "destination")):
+                continue
             item["source"] = item["source"].lower().replace(" ", "_")
             # Use the sanitization function for relationships to handle special characters
             item["relationship"] = sanitize_relationship_for_cypher(item["relationship"].lower().replace(" ", "_"))
             item["destination"] = item["destination"].lower().replace(" ", "_")
-        return entity_list
+            cleaned.append(item)
+        return cleaned
 
     def _search_source_node(self, source_embedding, filters, threshold=0.9):
         # Build WHERE conditions


### PR DESCRIPTION
## Description

When the LLM returns empty dicts (`{}`) or dicts missing required keys (`source`, `relationship`, `destination`) in the entity deletion list, `_remove_spaces_from_entities` crashes with a `KeyError`. This happens when the LLM determines no entities need to be deleted but still returns `[{}]` instead of `[]`.

This PR filters out invalid entries before processing — items that are empty or missing any of the three required keys are silently skipped.

Fixes #3907

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests

```bash
pytest tests/memory/test_neo4j_cypher_syntax.py::TestRemoveSpacesFromEntities -v
```

4 new tests covering: empty dicts, incomplete dicts, all-empty list, and normal entities.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings