### PR TITLE
feat: add boto3 timeout configuration for AWS Bedrock client

### DIFF
--- a/mem0/configs/llms/aws_bedrock.py
+++ b/mem0/configs/llms/aws_bedrock.py
@@ -23,6 +23,8 @@ class AWSBedrockConfig(BaseLlmConfig):
         aws_region: str = "",
         aws_session_token: Optional[str] = None,
         aws_profile: Optional[str] = None,
+        read_timeout: Optional[int] = None,
+        connect_timeout: Optional[int] = None,
         model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs,
     ):
@@ -40,6 +42,8 @@ class AWSBedrockConfig(BaseLlmConfig):
             aws_region: AWS region for Bedrock service
             aws_session_token: AWS session token for temporary credentials
             aws_profile: AWS profile name for credentials
+            read_timeout: boto3 read timeout in seconds (default: botocore default)
+            connect_timeout: boto3 connect timeout in seconds (default: botocore default)
             model_kwargs: Additional model-specific parameters
             **kwargs: Additional arguments passed to base class
         """
@@ -57,6 +61,8 @@ class AWSBedrockConfig(BaseLlmConfig):
         self.aws_region = aws_region or os.getenv("AWS_REGION", "us-west-2")
         self.aws_session_token = aws_session_token
         self.aws_profile = aws_profile
+        self.read_timeout = read_timeout
+        self.connect_timeout = connect_timeout
         self.model_kwargs = model_kwargs or {}
 
     @property

--- a/mem0/llms/aws_bedrock.py
+++ b/mem0/llms/aws_bedrock.py
@@ -78,6 +78,17 @@ class AWSBedrockLLM(LLMBase):
         try:
             aws_config = self.config.get_aws_config()
 
+            # Apply timeout configuration if specified
+            if self.config.read_timeout is not None or self.config.connect_timeout is not None:
+                from botocore.config import Config as BotoConfig
+
+                timeout_kwargs = {}
+                if self.config.read_timeout is not None:
+                    timeout_kwargs["read_timeout"] = self.config.read_timeout
+                if self.config.connect_timeout is not None:
+                    timeout_kwargs["connect_timeout"] = self.config.connect_timeout
+                aws_config["config"] = BotoConfig(**timeout_kwargs)
+
             # Create Bedrock runtime client
             self.client = boto3.client("bedrock-runtime", **aws_config)
 

--- a/tests/llms/test_aws_bedrock.py
+++ b/tests/llms/test_aws_bedrock.py
@@ -1,0 +1,49 @@
+from unittest.mock import MagicMock, patch
+
+from mem0.configs.llms.aws_bedrock import AWSBedrockConfig
+
+
+class TestAWSBedrockTimeout:
+    """Test boto3 timeout configuration for AWS Bedrock."""
+
+    def test_default_timeouts_are_none(self):
+        config = AWSBedrockConfig()
+        assert config.read_timeout is None
+        assert config.connect_timeout is None
+
+    def test_custom_timeouts(self):
+        config = AWSBedrockConfig(read_timeout=300, connect_timeout=10)
+        assert config.read_timeout == 300
+        assert config.connect_timeout == 10
+
+    @patch("mem0.llms.aws_bedrock.boto3")
+    def test_timeout_passed_to_boto3_client(self, mock_boto3):
+        mock_boto3.client.return_value = MagicMock()
+        from mem0.llms.aws_bedrock import AWSBedrockLLM
+
+        config = AWSBedrockConfig(read_timeout=600, connect_timeout=30)
+
+        with patch.object(AWSBedrockLLM, "_test_connection"):
+            with patch.object(AWSBedrockLLM, "_initialize_provider_settings"):
+                llm = AWSBedrockLLM(config)
+
+        call_kwargs = mock_boto3.client.call_args
+        boto_config = call_kwargs.kwargs.get("config") or call_kwargs[1].get("config")
+        assert boto_config is not None
+        assert boto_config.read_timeout == 600
+        assert boto_config.connect_timeout == 30
+
+    @patch("mem0.llms.aws_bedrock.boto3")
+    def test_no_timeout_no_boto_config(self, mock_boto3):
+        mock_boto3.client.return_value = MagicMock()
+        from mem0.llms.aws_bedrock import AWSBedrockLLM
+
+        config = AWSBedrockConfig()
+
+        with patch.object(AWSBedrockLLM, "_test_connection"):
+            with patch.object(AWSBedrockLLM, "_initialize_provider_settings"):
+                llm = AWSBedrockLLM(config)
+
+        call_kwargs = mock_boto3.client.call_args
+        boto_config = call_kwargs.kwargs.get("config") or call_kwargs[1].get("config")
+        assert boto_config is None


### PR DESCRIPTION
## Description

Add `read_timeout` and `connect_timeout` parameters to `AWSBedrockConfig`. When specified, a `botocore.config.Config` object is passed to the boto3 client, overriding the default 60-second read timeout which is too short for large memory extraction operations.

### Usage

```python
config = {
    "llm": {
        "provider": "aws_bedrock",
        "config": {
            "model": "us.anthropic.claude-sonnet-4-20250514-v1:0",
            "read_timeout": 300,
            "connect_timeout": 10,
        }
    }
}
```

Both parameters default to `None` (uses botocore defaults), so this is fully backward-compatible.

Fixes #3825

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Unit tests

```bash
pytest tests/llms/test_aws_bedrock.py -v
```

4 tests covering: default config, custom timeouts, boto3 client receives Config object, no Config when timeouts not set.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings