### PR TITLE
feat: support reasoning_effort in AzureOpenAIConfig

### DIFF
--- a/mem0/configs/llms/azure.py
+++ b/mem0/configs/llms/azure.py
@@ -19,6 +19,7 @@ class AzureOpenAIConfig(BaseLlmConfig):
         max_tokens: int = 2000,
         top_p: float = 0.1,
         top_k: int = 1,
+        reasoning_effort: Optional[str] = None,
         enable_vision: bool = False,
         vision_details: Optional[str] = "auto",
         http_client_proxies: Optional[dict] = None,
@@ -35,6 +36,7 @@ class AzureOpenAIConfig(BaseLlmConfig):
             max_tokens: Maximum tokens to generate, defaults to 2000
             top_p: Nucleus sampling parameter, defaults to 0.1
             top_k: Top-k sampling parameter, defaults to 1
+            reasoning_effort: Reasoning effort level for reasoning-capable models, defaults to None
             enable_vision: Enable vision capabilities, defaults to False
             vision_details: Vision detail level, defaults to "auto"
             http_client_proxies: HTTP client proxy settings, defaults to None
@@ -48,6 +50,7 @@ class AzureOpenAIConfig(BaseLlmConfig):
             max_tokens=max_tokens,
             top_p=top_p,
             top_k=top_k,
+            reasoning_effort=reasoning_effort,
             enable_vision=enable_vision,
             vision_details=vision_details,
             http_client_proxies=http_client_proxies,

--- a/mem0/configs/llms/base.py
+++ b/mem0/configs/llms/base.py
@@ -21,6 +21,7 @@ class BaseLlmConfig(ABC):
         max_tokens: int = 2000,
         top_p: float = 0.1,
         top_k: int = 1,
+        reasoning_effort: Optional[str] = None,
         enable_vision: bool = False,
         vision_details: Optional[str] = "auto",
         http_client_proxies: Optional[Union[Dict, str]] = None,
@@ -44,6 +45,8 @@ class BaseLlmConfig(ABC):
             top_k: Top-k sampling parameter. Limits the number of tokens considered for each step.
                 Higher values make word selection more diverse.
                 Range: 1 to 40. Defaults to 1
+            reasoning_effort: Reasoning effort level for reasoning-capable models.
+                Typical values: "low", "medium", "high". Defaults to None
             enable_vision: Whether to enable vision capabilities for the model.
                 Only applicable to vision-enabled models. Defaults to False
             vision_details: Level of detail for vision processing.
@@ -57,6 +60,7 @@ class BaseLlmConfig(ABC):
         self.max_tokens = max_tokens
         self.top_p = top_p
         self.top_k = top_k
+        self.reasoning_effort = reasoning_effort
         self.enable_vision = enable_vision
         self.vision_details = vision_details
         self.http_client = httpx.Client(proxies=http_client_proxies) if http_client_proxies else None

--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -88,7 +88,11 @@ class LLMBase(ABC):
                 supported_params["tools"] = kwargs["tools"]
             if "tool_choice" in kwargs:
                 supported_params["tool_choice"] = kwargs["tool_choice"]
-                
+
+            reasoning_effort = kwargs.get("reasoning_effort", getattr(self.config, "reasoning_effort", None))
+            if reasoning_effort is not None:
+                supported_params["reasoning_effort"] = reasoning_effort
+
             return supported_params
         else:
             # For regular models, include all common parameters

--- a/tests/llms/test_azure_openai.py
+++ b/tests/llms/test_azure_openai.py
@@ -39,6 +39,27 @@ def test_generate_response_without_tools(mock_openai_client):
     assert response == "I'm doing well, thank you for asking!"
 
 
+def test_generate_response_reasoning_model_includes_reasoning_effort(mock_openai_client):
+    config = AzureOpenAIConfig(model="o3", reasoning_effort="low")
+    llm = AzureOpenAILLM(config)
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello, how are you?"},
+    ]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="ok"))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    mock_openai_client.chat.completions.create.assert_called_once_with(
+        model="o3",
+        messages=messages,
+        reasoning_effort="low",
+    )
+
+
 def test_generate_response_with_tools(mock_openai_client):
     config = AzureOpenAIConfig(model=MODEL, temperature=TEMPERATURE, max_tokens=MAX_TOKENS, top_p=TOP_P)
     llm = AzureOpenAILLM(config)


### PR DESCRIPTION
## Summary\n- add `reasoning_effort` to `BaseLlmConfig` and wire it through `AzureOpenAIConfig`\n- forward `reasoning_effort` for reasoning models in the Azure/OpenAI LLM call path\n- add a focused unit test to ensure Azure reasoning-model calls include `reasoning_effort`\n\n## Validation\n- `pytest -q tests/llms/test_azure_openai.py -q`\n\nFixes #3651