### PR TITLE
fix(openclaw): use absolute sqlite history path in OSS mode

### DIFF
--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -238,6 +238,14 @@ class OSSProvider implements Mem0Provider {
         ? this.resolvePath(this.ossConfig.historyDbPath)
         : this.ossConfig.historyDbPath;
       config.historyDbPath = dbPath;
+      // mem0 OSS resolves history through historyStore; keep it aligned
+      // so we don't fall back to default relative "memory.db".
+      config.historyStore = {
+        provider: "sqlite",
+        config: {
+          historyDbPath: dbPath,
+        },
+      };
     }
 
     if (this.customPrompt) config.customPrompt = this.customPrompt;


### PR DESCRIPTION
## Summary
When `oss.historyDbPath` is configured in `@mem0/openclaw-mem0`, we set `config.historyDbPath` but not `config.historyStore.config.historyDbPath`.

In mem0 OSS config merge, `historyStore` defaults can still point to relative `memory.db`, which can trigger `SQLITE_CANTOPEN` in OpenClaw hook execution depending on process CWD.

This change keeps `historyStore` aligned with the resolved `historyDbPath`.

## Changes
- In `openclaw/index.ts` OSS provider init:
  - when `oss.historyDbPath` is present, also set:
    - `config.historyStore.provider = "sqlite"`
    - `config.historyStore.config.historyDbPath = resolved dbPath`

## Why this fixes it
mem0 OSS history manager is constructed from `historyStore` config. If that path remains default relative `memory.db`, sqlite open can fail in runtime environments where CWD differs from expected plugin state dir.

By forcing the resolved absolute path in `historyStore`, sqlite opens consistently and avoids hook-time `SQLITE_CANTOPEN` crashes.
