### PR TITLE
fix(ts): pass baseURL to OpenAI client in OpenAIEmbedder

### DIFF
--- a/mem0-ts/src/oss/src/embeddings/openai.ts
+++ b/mem0-ts/src/oss/src/embeddings/openai.ts
@@ -8,7 +8,7 @@ export class OpenAIEmbedder implements Embedder {
   private embeddingDims?: number;
 
   constructor(config: EmbeddingConfig) {
-    this.openai = new OpenAI({ apiKey: config.apiKey });
+    this.openai = new OpenAI({ apiKey: config.apiKey, baseURL: config.url });
     this.model = config.model || "text-embedding-3-small";
     this.embeddingDims = config.embeddingDims || 1536;
   }


### PR DESCRIPTION
## Summary

- Fixes #4191
- The `OpenAIEmbedder` constructor only passed `apiKey` to the OpenAI client, silently ignoring the `url` config property
- Users of OpenAI-compatible endpoints (NVIDIA, Ollama, local servers, etc.) were forced to set `process.env.OPENAI_BASE_URL` as a workaround
- This forwards `config.url` as the OpenAI client's `baseURL` option, consistent with how `OllamaEmbedder` uses `config.url` and how `OpenAILLM` passes its own `baseURL`

## Test plan

- [ ] Configure mem0 with a custom `url` in the embedder config and verify embeddings are fetched from the correct endpoint