### PR TITLE
fix: complete PUT /api/v1/config endpoint to persist changes

### DIFF
--- a/openmemory/api/app/routers/config.py
+++ b/openmemory/api/app/routers/config.py
@@ -152,9 +152,14 @@ async def update_configuration(config: ConfigSchema, db: Session = Depends(get_d
             updated_config["openmemory"] = {}
         updated_config["openmemory"].update(config.openmemory.dict(exclude_none=True))
     
-    # Update mem0 settings
-    updated_config["mem0"] = config.mem0.dict(exclude_none=True)
-    
+    # Update mem0 settings if provided
+    if config.mem0 is not None:
+        updated_config["mem0"] = config.mem0.dict(exclude_none=True)
+
+    save_config_to_db(db, updated_config)
+    reset_memory_client()
+    return updated_config
+
 
 @router.patch("/", response_model=ConfigSchema)
 async def patch_configuration(config_update: ConfigSchema, db: Session = Depends(get_db)):


### PR DESCRIPTION
## Summary
- Added missing `save_config_to_db()` call so configuration changes are actually persisted to the database
- Added missing `reset_memory_client()` call to refresh the memory client with updated config
- Added missing `return updated_config` statement so the endpoint returns the updated configuration
- Added `None` check for `config.mem0` to prevent `AttributeError` when only `openmemory` settings are provided

## Problem
The `PUT /api/v1/config` endpoint reads and updates the config in memory but never saves it back to the database. This means all configuration changes via this endpoint are silently discarded. Compare with the `PATCH /` and `POST /reset` endpoints which both correctly call `save_config_to_db()` and `reset_memory_client()`.

Additionally, `config.mem0.dict()` was called without checking if `config.mem0` is `None`, which would raise an `AttributeError` when a user only provides `openmemory` settings in the request body.

## Test plan
- [ ] Call `PUT /api/v1/config` with updated settings, then `GET /api/v1/config` to verify changes persisted
- [ ] Call `PUT /api/v1/config` with only `openmemory` settings (no `mem0` key) to verify no error
- [ ] Verify the response body matches the updated configuration

Fixes #4193

🤖 Generated with [Claude Code](https://claude.com/claude-code)