### PR TITLE
fix: load default configuration from default_config.json

### DIFF
--- a/openmemory/api/app/routers/config.py
+++ b/openmemory/api/app/routers/config.py
@@ -1,3 +1,5 @@
+import json
+import os
 from typing import Any, Dict, Optional
 
 from app.database import get_db
@@ -6,6 +8,11 @@ from app.utils.memory import reset_memory_client
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
+
+_DEFAULT_CONFIG_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "default_config.json",
+)
 
 router = APIRouter(prefix="/api/v1/config", tags=["config"])
 
@@ -46,32 +53,51 @@ class ConfigSchema(BaseModel):
     openmemory: Optional[OpenMemoryConfig] = None
     mem0: Optional[Mem0Config] = None
 
-def get_default_configuration():
-    """Get the default configuration with sensible defaults for LLM and embedder."""
-    return {
-        "openmemory": {
-            "custom_instructions": None
+_HARDCODED_DEFAULTS = {
+    "openmemory": {
+        "custom_instructions": None
+    },
+    "mem0": {
+        "llm": {
+            "provider": "openai",
+            "config": {
+                "model": "gpt-4o-mini",
+                "temperature": 0.1,
+                "max_tokens": 2000,
+                "api_key": "env:OPENAI_API_KEY"
+            }
         },
-        "mem0": {
-            "llm": {
-                "provider": "openai",
-                "config": {
-                    "model": "gpt-4o-mini",
-                    "temperature": 0.1,
-                    "max_tokens": 2000,
-                    "api_key": "env:OPENAI_API_KEY"
-                }
-            },
-            "embedder": {
-                "provider": "openai",
-                "config": {
-                    "model": "text-embedding-3-small",
-                    "api_key": "env:OPENAI_API_KEY"
-                }
-            },
-            "vector_store": None
-        }
+        "embedder": {
+            "provider": "openai",
+            "config": {
+                "model": "text-embedding-3-small",
+                "api_key": "env:OPENAI_API_KEY"
+            }
+        },
+        "vector_store": None
     }
+}
+
+
+def get_default_configuration():
+    """Get the default configuration.
+
+    Loads from ``default_config.json`` when the file exists and is valid JSON,
+    falling back to hardcoded defaults otherwise.  The ``openmemory`` section
+    is always ensured to be present so that the rest of the codebase can rely
+    on it.
+    """
+    try:
+        with open(_DEFAULT_CONFIG_PATH, "r") as f:
+            config = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return _HARDCODED_DEFAULTS.copy()
+
+    # Ensure the openmemory section always exists
+    config.setdefault("openmemory", {"custom_instructions": None})
+    # Ensure the mem0 section always exists
+    config.setdefault("mem0", _HARDCODED_DEFAULTS["mem0"])
+    return config
 
 def get_config_from_db(db: Session, key: str = "main"):
     """Get configuration from database."""


### PR DESCRIPTION
## Summary
- Modified `get_default_configuration()` to read from `default_config.json` instead of hardcoding OpenAI defaults
- Falls back to hardcoded defaults if the file is missing or contains invalid JSON
- Ensures `openmemory` and `mem0` sections are always present in the returned config

## Problem
`get_default_configuration()` in `config.py` had all default values hardcoded inline, completely ignoring the `default_config.json` file that exists in `openmemory/api/`. Users who customized `default_config.json` (e.g., to use Ollama instead of OpenAI) found their changes had no effect because the file was never read.

## Test plan
- [ ] Modify `default_config.json` to use a non-OpenAI provider, restart server, verify `GET /api/v1/config` returns the file-based defaults
- [ ] Delete `default_config.json`, restart server, verify hardcoded OpenAI defaults are returned
- [ ] Call `POST /api/v1/config/reset` to verify reset uses file-based defaults

Fixes #4192

🤖 Generated with [Claude Code](https://claude.com/claude-code)