### PR TITLE
fix: respect Docker Compose env vars for LLM/embedder config

### DIFF
--- a/openmemory/api/.env.example
+++ b/openmemory/api/.env.example
@@ -1,2 +1,13 @@
 OPENAI_API_KEY=sk-xxx
 USER=user
+
+# Optional: override default LLM/embedder provider (default: openai)
+# LLM_PROVIDER=ollama
+# LLM_MODEL=llama3.1:latest
+# LLM_API_KEY=
+# LLM_TEMPERATURE=0.1
+# LLM_MAX_TOKENS=2000
+# EMBEDDER_PROVIDER=ollama
+# EMBEDDER_MODEL=nomic-embed-text
+# EMBEDDER_API_KEY=
+# OLLAMA_BASE_URL=http://host.docker.internal:11434

--- a/openmemory/api/app/routers/config.py
+++ b/openmemory/api/app/routers/config.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any, Dict, Optional
 
 from app.database import get_db
@@ -47,27 +48,55 @@ class ConfigSchema(BaseModel):
     mem0: Optional[Mem0Config] = None
 
 def get_default_configuration():
-    """Get the default configuration with sensible defaults for LLM and embedder."""
+    """Get the default configuration with sensible defaults for LLM and embedder.
+
+    Environment variables override the hardcoded defaults so that Docker Compose
+    users can configure the provider/model via ``.env`` or ``environment:``
+    without touching the database:
+
+    - ``LLM_PROVIDER``      – LLM provider name (default: ``openai``)
+    - ``LLM_MODEL``         – LLM model name (default: ``gpt-4o-mini``)
+    - ``LLM_API_KEY``       – API key for the LLM (default: ``env:OPENAI_API_KEY``)
+    - ``LLM_TEMPERATURE``   – Temperature (default: ``0.1``)
+    - ``LLM_MAX_TOKENS``    – Max tokens (default: ``2000``)
+    - ``EMBEDDER_PROVIDER``  – Embedder provider name (default: ``openai``)
+    - ``EMBEDDER_MODEL``     – Embedder model name (default: ``text-embedding-3-small``)
+    - ``EMBEDDER_API_KEY``   – API key for the embedder (default: ``env:OPENAI_API_KEY``)
+    - ``OLLAMA_BASE_URL``    – Base URL for Ollama, applied to both LLM and embedder
+                               when their provider is ``ollama``
+    """
+    llm_provider = os.environ.get("LLM_PROVIDER", "openai")
+    embedder_provider = os.environ.get("EMBEDDER_PROVIDER", "openai")
+    ollama_base_url = os.environ.get("OLLAMA_BASE_URL")
+
+    llm_config: Dict[str, Any] = {
+        "model": os.environ.get("LLM_MODEL", "gpt-4o-mini"),
+        "temperature": float(os.environ.get("LLM_TEMPERATURE", "0.1")),
+        "max_tokens": int(os.environ.get("LLM_MAX_TOKENS", "2000")),
+        "api_key": os.environ.get("LLM_API_KEY", "env:OPENAI_API_KEY"),
+    }
+    if llm_provider == "ollama" and ollama_base_url:
+        llm_config["ollama_base_url"] = ollama_base_url
+
+    embedder_config: Dict[str, Any] = {
+        "model": os.environ.get("EMBEDDER_MODEL", "text-embedding-3-small"),
+        "api_key": os.environ.get("EMBEDDER_API_KEY", "env:OPENAI_API_KEY"),
+    }
+    if embedder_provider == "ollama" and ollama_base_url:
+        embedder_config["ollama_base_url"] = ollama_base_url
+
     return {
         "openmemory": {
             "custom_instructions": None
         },
         "mem0": {
             "llm": {
-                "provider": "openai",
-                "config": {
-                    "model": "gpt-4o-mini",
-                    "temperature": 0.1,
-                    "max_tokens": 2000,
-                    "api_key": "env:OPENAI_API_KEY"
-                }
+                "provider": llm_provider,
+                "config": llm_config,
             },
             "embedder": {
-                "provider": "openai",
-                "config": {
-                    "model": "text-embedding-3-small",
-                    "api_key": "env:OPENAI_API_KEY"
-                }
+                "provider": embedder_provider,
+                "config": embedder_config,
             },
             "vector_store": None
         }

--- a/openmemory/docker-compose.yml
+++ b/openmemory/docker-compose.yml
@@ -11,6 +11,15 @@ services:
     environment:
       - USER
       - API_KEY
+      - LLM_PROVIDER
+      - LLM_MODEL
+      - LLM_API_KEY
+      - LLM_TEMPERATURE
+      - LLM_MAX_TOKENS
+      - EMBEDDER_PROVIDER
+      - EMBEDDER_MODEL
+      - EMBEDDER_API_KEY
+      - OLLAMA_BASE_URL
     env_file:
       - api/.env
     depends_on:


### PR DESCRIPTION
## Summary
- `get_default_configuration()` now reads environment variables (`LLM_PROVIDER`, `LLM_MODEL`, `EMBEDDER_PROVIDER`, `EMBEDDER_MODEL`, `OLLAMA_BASE_URL`, etc.) to build the initial configuration
- Updated `docker-compose.yml` to pass these variables through to the container
- Updated `.env.example` to document available environment variables

## Problem
Docker Compose users setting `LLM_PROVIDER=ollama` or `OLLAMA_BASE_URL=http://host.docker.internal:11434` in their `.env` file found these values were completely ignored. The initial configuration stored in the SQLite database was always hardcoded to OpenAI defaults, making it impossible to configure non-OpenAI providers without using the API or UI after startup.

## Supported Environment Variables

| Variable | Default | Description |
|---|---|---|
| `LLM_PROVIDER` | `openai` | LLM provider (openai, ollama, anthropic, etc.) |
| `LLM_MODEL` | `gpt-4o-mini` | LLM model name |
| `LLM_API_KEY` | `env:OPENAI_API_KEY` | API key for the LLM provider |
| `LLM_TEMPERATURE` | `0.1` | Temperature setting |
| `LLM_MAX_TOKENS` | `2000` | Maximum tokens to generate |
| `EMBEDDER_PROVIDER` | `openai` | Embedder provider |
| `EMBEDDER_MODEL` | `text-embedding-3-small` | Embedder model name |
| `EMBEDDER_API_KEY` | `env:OPENAI_API_KEY` | API key for the embedder |
| `OLLAMA_BASE_URL` | _(none)_ | Base URL for Ollama (auto-applied when provider is ollama) |

## Test plan
- [ ] Set `LLM_PROVIDER=ollama`, `LLM_MODEL=llama3.1:latest`, `OLLAMA_BASE_URL=http://host.docker.internal:11434` in `.env`, start fresh (delete openmemory.db), verify `GET /api/v1/config` returns Ollama config
- [ ] Without any env vars set, verify OpenAI defaults are still used
- [ ] Verify `POST /api/v1/config/reset` rebuilds config from current env vars

Fixes #4194

🤖 Generated with [Claude Code](https://claude.com/claude-code)