### PR TITLE
fix(mem0-ts): respect baseURL in OpenAIEmbedder config

### DIFF
--- a/mem0-ts/src/oss/src/embeddings/openai.ts
+++ b/mem0-ts/src/oss/src/embeddings/openai.ts
@@ -8,7 +8,10 @@ export class OpenAIEmbedder implements Embedder {
   private embeddingDims?: number;
 
   constructor(config: EmbeddingConfig) {
-    this.openai = new OpenAI({ apiKey: config.apiKey });
+    this.openai = new OpenAI({
+      apiKey: config.apiKey,
+      baseURL: config.baseURL,
+    });
     this.model = config.model || "text-embedding-3-small";
     this.embeddingDims = config.embeddingDims || 1536;
   }

--- a/mem0-ts/src/oss/src/types/index.ts
+++ b/mem0-ts/src/oss/src/types/index.ts
@@ -16,6 +16,7 @@ export interface EmbeddingConfig {
   apiKey?: string;
   model?: string | any;
   url?: string;
+  baseURL?: string;
   embeddingDims?: number;
   modelProperties?: Record<string, any>;
 }

--- a/mem0-ts/src/oss/tests/openai-embedder.test.ts
+++ b/mem0-ts/src/oss/tests/openai-embedder.test.ts
@@ -1,0 +1,45 @@
+/// <reference types="jest" />
+import OpenAI from "openai";
+import { OpenAIEmbedder } from "../src/embeddings/openai";
+
+jest.mock("openai", () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => ({
+      embeddings: {
+        create: jest.fn(),
+      },
+    })),
+  };
+});
+
+describe("OpenAIEmbedder", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("passes baseURL to OpenAI client when provided", () => {
+    new OpenAIEmbedder({
+      apiKey: "test-key",
+      baseURL: "https://integrate.api.nvidia.com/v1",
+      model: "text-embedding-3-small",
+    });
+
+    expect(OpenAI).toHaveBeenCalledWith({
+      apiKey: "test-key",
+      baseURL: "https://integrate.api.nvidia.com/v1",
+    });
+  });
+
+  it("still initializes when baseURL is omitted", () => {
+    new OpenAIEmbedder({
+      apiKey: "test-key",
+      model: "text-embedding-3-small",
+    });
+
+    expect(OpenAI).toHaveBeenCalledWith({
+      apiKey: "test-key",
+      baseURL: undefined,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- forward `config.baseURL` into the OpenAI client constructor in `OpenAIEmbedder`
- add unit tests to verify behavior when `baseURL` is provided or omitted
- add `baseURL?: string` to `EmbeddingConfig` typing for consistency

## Why
`OpenAIEmbedder` previously ignored `baseURL`, which made OpenAI-compatible endpoint usage (e.g. custom/proxy endpoints) inconsistent.

## Validation
- `npx jest tests/openai-embedder.test.ts --runInBand --config '{"transform":{"^.+\\.tsx?$":"ts-jest"}}'`

Fixes #4191
