### PR TITLE
fix(openmemory): load API defaults from default_config.json

### DIFF
--- a/openmemory/api/app/routers/config.py
+++ b/openmemory/api/app/routers/config.py
@@ -1,4 +1,6 @@
 from typing import Any, Dict, Optional
+import json
+from pathlib import Path
 
 from app.database import get_db
 from app.models import Config as ConfigModel
@@ -47,11 +49,9 @@ class ConfigSchema(BaseModel):
     mem0: Optional[Mem0Config] = None
 
 def get_default_configuration():
-    """Get the default configuration with sensible defaults for LLM and embedder."""
-    return {
-        "openmemory": {
-            "custom_instructions": None
-        },
+    """Get default config from default_config.json with a safe fallback."""
+    fallback = {
+        "openmemory": {"custom_instructions": None},
         "mem0": {
             "llm": {
                 "provider": "openai",
@@ -59,19 +59,38 @@ def get_default_configuration():
                     "model": "gpt-4o-mini",
                     "temperature": 0.1,
                     "max_tokens": 2000,
-                    "api_key": "env:OPENAI_API_KEY"
-                }
+                    "api_key": "env:OPENAI_API_KEY",
+                },
             },
             "embedder": {
                 "provider": "openai",
                 "config": {
                     "model": "text-embedding-3-small",
-                    "api_key": "env:OPENAI_API_KEY"
-                }
+                    "api_key": "env:OPENAI_API_KEY",
+                },
             },
-            "vector_store": None
-        }
+            "vector_store": None,
+        },
     }
+
+    config_path = Path(__file__).resolve().parents[2] / "default_config.json"
+    try:
+        file_config = json.loads(config_path.read_text(encoding="utf-8"))
+        merged = {
+            "openmemory": file_config.get("openmemory", fallback["openmemory"]),
+            "mem0": file_config.get("mem0", fallback["mem0"]),
+        }
+    except Exception:
+        merged = fallback
+
+    # Ensure required sections always exist
+    merged.setdefault("openmemory", fallback["openmemory"])
+    merged.setdefault("mem0", {})
+    merged["mem0"].setdefault("llm", fallback["mem0"]["llm"])
+    merged["mem0"].setdefault("embedder", fallback["mem0"]["embedder"])
+    merged["mem0"].setdefault("vector_store", fallback["mem0"]["vector_store"])
+
+    return merged
 
 def get_config_from_db(db: Session, key: str = "main"):
     """Get configuration from database."""

--- a/openmemory/api/tests/test_default_configuration.py
+++ b/openmemory/api/tests/test_default_configuration.py
@@ -1,0 +1,41 @@
+import json
+from pathlib import Path
+
+from app.routers import config as config_router
+
+
+def test_get_default_configuration_reads_file(tmp_path, monkeypatch):
+    # Build a fake module file path so parents[2]/default_config.json resolves into tmp_path
+    fake_module = tmp_path / "api" / "app" / "routers" / "config.py"
+    fake_module.parent.mkdir(parents=True)
+    fake_module.write_text("# fake", encoding="utf-8")
+
+    defaults_path = tmp_path / "api" / "default_config.json"
+    defaults_path.parent.mkdir(parents=True, exist_ok=True)
+    defaults_path.write_text(
+        json.dumps(
+            {
+                "openmemory": {"custom_instructions": "from-file"},
+                "mem0": {
+                    "llm": {"provider": "openai", "config": {"model": "gpt-4o-mini"}},
+                    "embedder": {"provider": "openai", "config": {"model": "text-embedding-3-small"}},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(config_router, "__file__", str(fake_module))
+
+    cfg = config_router.get_default_configuration()
+    assert cfg["openmemory"]["custom_instructions"] == "from-file"
+    assert cfg["mem0"]["llm"]["provider"] == "openai"
+    assert "vector_store" in cfg["mem0"]
+
+
+def test_get_default_configuration_fallback_when_file_unavailable(monkeypatch):
+    monkeypatch.setattr(Path, "read_text", lambda *args, **kwargs: (_ for _ in ()).throw(FileNotFoundError()))
+    cfg = config_router.get_default_configuration()
+    assert cfg["mem0"]["llm"]["provider"] == "openai"
+    assert cfg["mem0"]["embedder"]["provider"] == "openai"
+    assert "vector_store" in cfg["mem0"]


### PR DESCRIPTION
## Summary
- update `get_default_configuration()` to load defaults from `openmemory/api/default_config.json`
- keep robust fallback to existing OpenAI defaults when file is missing/invalid
- ensure required sections always exist: `openmemory.custom_instructions`, `mem0.llm`, `mem0.embedder`, `mem0.vector_store`
- add tests for file-read and fallback behaviors

## Why
This aligns API defaults with `default_config.json` while preserving backwards-compatible startup behavior.

## Validation
- `OPENAI_API_KEY=dummy PYTHONPATH=openmemory/api python3 -m pytest openmemory/api/tests/test_default_configuration.py -q`
- Result: `2 passed`

Fixes #4192
