### PR TITLE
Fix Upstash query_many namespace and vector shape compatibility

### DIFF
--- a/mem0/vector_stores/upstash_vector.py
+++ b/mem0/vector_stores/upstash_vector.py
@@ -126,17 +126,18 @@ class UpstashVector(VectorStoreBase):
                 namespace=self.collection_name,
             )
         else:
+            if vectors and not isinstance(vectors[0], list):
+                vectors = [vectors]
             queries = [
                 {
                     "vector": v,
                     "top_k": limit,
                     "filter": filters_str or "",
                     "include_metadata": True,
-                    "namespace": self.collection_name,
                 }
                 for v in vectors
             ]
-            responses = self.client.query_many(queries=queries)
+            responses = self.client.query_many(queries=queries, namespace=self.collection_name)
             # flatten
             response = [res for res_list in responses for res in res_list]
 


### PR DESCRIPTION
## Summary

Fix integration issues between `mem0`'s `UpstashVector` backend and the latest `upstash_vector` client:

- Correct how `namespace` is passed to `query_many`.
- Make the `vectors` argument shape compatible with `upstash_vector`'s expectations.

## Context

The current implementation of `UpstashVector.search` is incompatible with the newer `upstash_vector` API:

1. `query_many` now expects `namespace` as a top-level argument, and `QueryRequest` items should not contain a `namespace` field.
2. In addition, `search` may receive a single query vector (e.g. a flat list of floats) instead of a list of vectors, which does not match the shape that `query_many` expects.

These issues are described in #4207 .

## Changes

1. **Fix query_many namespace usage**

   In `mem0/vector_stores/upstash_vector.py`, for the non-embedding branch of `search`:

   - Remove `"namespace": self.collection_name` from each query dict.
   - Pass `namespace=self.collection_name` directly to `self.client.query_many(...)`.

   This aligns with the current `upstash_vector` implementation and avoids:

   - `TypeError: upstash_vector.core.index_operations.IndexOperations.query() got multiple values for keyword argument 'namespace'` when `len(queries) == 1`.
   - Empty results when `len(queries) > 1` because the per-query `namespace` field is ignored.

2. **Normalize vectors shape**

   Still in `search`, normalize the `vectors` argument:

   - If `vectors` is a single vector (e.g. a flat list of floats) instead of a list of vectors, wrap it into a list so that `query_many` always receives a `List[List[float]]`.

   This makes `mem0` more robust to how callers provide the query vectors and ensures compatibility with `upstash_vector`'s `query_many` expectations.

## Test Plan

- Configure `UpstashVector` with `enable_embeddings=False` and a non-default `collection_name`.
- Insert some vectors into the Upstash index under that namespace.
- Call `search` with:
  - A single query vector (`vectors` is one flat list).
  - Multiple query vectors (`vectors` is a list of lists).
- Verify that:
  - No `TypeError` is raised when there is only one query.
  - Results are returned from the correct namespace for both single and multiple query vectors.