### PR TITLE
fix(openclaw): pass historyDbPath to historyStore config

### DIFF
--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -238,6 +238,17 @@ class OSSProvider implements Mem0Provider {
         ? this.resolvePath(this.ossConfig.historyDbPath)
         : this.ossConfig.historyDbPath;
       config.historyDbPath = dbPath;
+      // mem0ai's HistoryManagerFactory reads from historyStore.config.historyDbPath,
+      // not the top-level historyDbPath. Set both to ensure SQLite history works.
+      if (!this.ossConfig.historyStore) {
+        config.historyStore = {
+          provider: "sqlite",
+          config: { historyDbPath: dbPath },
+        };
+      }
+    }
+    if (this.ossConfig?.historyStore) {
+      config.historyStore = this.ossConfig.historyStore;
     }
 
     if (this.customPrompt) config.customPrompt = this.customPrompt;


### PR DESCRIPTION
## Bug

When configuring `historyDbPath` in the OpenClaw plugin config (`openclaw.json`), the SQLite history database is never written to — the file stays at 0 bytes with no tables.

## Root Cause

The plugin sets `config.historyDbPath` (top-level), but mem0ai's `HistoryManagerFactory` reads from `config.historyStore.config.historyDbPath`. The top-level value is stored in the merged config but never reaches the `SQLiteManager`, which falls back to the default path.

## Fix

When `historyDbPath` is set and no explicit `historyStore` is configured, automatically populate `config.historyStore` with the sqlite provider pointing to the resolved path. Also passes through any explicit `historyStore` config if provided.

## Testing

Before fix: `mem0-history.db` stays at 0 bytes, `sqlite3 mem0-history.db '.tables'` returns nothing.

After fix: `mem0-history.db` grows to 12KB+ on first operation, `memory_history` table is created, and all add/update/delete operations are recorded.

Tested with:
- Open-source mode
- Qdrant v1.13.0 vector store  
- Ollama nomic-embed-text embedder (768 dims)
- xAI grok as LLM provider (via OpenAI-compatible config)