### PR TITLE
fix(memory): preserve OpenSearch auth objects in _safe_deepcopy_config

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -69,9 +69,15 @@ def _safe_deepcopy_config(config):
         else:
             clone_dict = {k: v for k, v in config.__dict__.items()}
         
-        sensitive_tokens = ("auth", "credential", "password", "token", "secret", "key", "connection_class")
+        # Keep runtime authentication objects required by OpenSearch clients,
+        # while still redacting truly sensitive scalar secrets for telemetry safety.
+        sensitive_tokens = ("credential", "password", "token", "secret", "key")
+        preserve_fields = {"http_auth", "auth", "connection_class"}
         for field_name in list(clone_dict.keys()):
-            if any(token in field_name.lower() for token in sensitive_tokens):
+            lowered = field_name.lower()
+            if lowered in preserve_fields:
+                continue
+            if any(token in lowered for token in sensitive_tokens):
                 clone_dict[field_name] = None
         
         try:

--- a/tests/vector_stores/test_opensearch.py
+++ b/tests/vector_stores/test_opensearch.py
@@ -300,10 +300,10 @@ def test_safe_deepcopy_config_handles_opensearch_auth(mock_sqlite, mock_llm_fact
     
     safe_config = _safe_deepcopy_config(config_with_auth)
     
-    assert safe_config.http_auth is None
-    assert safe_config.auth is None
+    assert safe_config.http_auth is not None
+    assert safe_config.auth is not None
     assert safe_config.credentials is None
-    assert safe_config.connection_class is None
+    assert safe_config.connection_class is not None
     
     assert safe_config.collection_name == "opensearch_test"
     assert safe_config.host == "localhost"


### PR DESCRIPTION
## Summary
This PR fixes issue #3580 by preventing `_safe_deepcopy_config` from stripping runtime OpenSearch auth objects that are required for client initialization.

## What changed
- In `mem0/memory/main.py`:
  - Preserve runtime fields: `http_auth`, `auth`, `connection_class`
  - Continue redacting sensitive scalar fields: `credential`, `password`, `token`, `secret`, `key`
- In `tests/vector_stores/test_opensearch.py`:
  - Updated assertions to verify preserved runtime auth objects
  - Kept assertion that credentials are still redacted

## Why
Current telemetry-safe cloning can over-redact OpenSearch config fields and break runtime behavior for auth-backed clients. This change keeps required runtime objects while preserving redaction of secrets.

## Testing
- `pytest -q tests/vector_stores/test_opensearch.py`
- Result: 12 passed

## Checklist
- [x] Focused change with minimal surface area
- [x] Added/updated targeted tests
- [x] No breaking API changes
