### PR TITLE
feat(azure): Add reasoning_effort parameter support for reasoning models

### DIFF
--- a/mem0/configs/llms/azure.py
+++ b/mem0/configs/llms/azure.py
@@ -24,6 +24,8 @@ class AzureOpenAIConfig(BaseLlmConfig):
         http_client_proxies: Optional[dict] = None,
         # Azure OpenAI-specific parameters
         azure_kwargs: Optional[Dict[str, Any]] = None,
+        # Reasoning models parameters
+        reasoning_effort: Optional[str] = None,
     ):
         """
         Initialize Azure OpenAI configuration.
@@ -39,6 +41,8 @@ class AzureOpenAIConfig(BaseLlmConfig):
             vision_details: Vision detail level, defaults to "auto"
             http_client_proxies: HTTP client proxy settings, defaults to None
             azure_kwargs: Azure-specific configuration, defaults to None
+            reasoning_effort: Reasoning effort for reasoning models (o1, o3, gpt-5).
+                Options: "low", "medium", "high". Defaults to None
         """
         # Initialize base parameters
         super().__init__(
@@ -55,3 +59,6 @@ class AzureOpenAIConfig(BaseLlmConfig):
 
         # Azure OpenAI-specific parameters
         self.azure_kwargs = AzureConfig(**(azure_kwargs or {}))
+
+        # Reasoning effort for reasoning models (o1, o3, gpt-5)
+        self.reasoning_effort = reasoning_effort

--- a/mem0/llms/azure_openai.py
+++ b/mem0/llms/azure_openai.py
@@ -65,6 +65,7 @@ class AzureOpenAILLM(LLMBase):
             api_key=api_key,
             http_client=self.config.http_client,
             default_headers=default_headers,
+            reasoning_effort=self.config.reasoning_effort,
         )
 
     def _parse_response(self, response, tools):


### PR DESCRIPTION
## Summary

Add support for `reasoning_effort` parameter in AzureOpenAIConfig for reasoning models (o1, o3, gpt-5).

## Changes

1. Add `reasoning_effort` parameter to `AzureOpenAIConfig` class
2. Pass `reasoning_effort` to AzureOpenAI client

## Fixes

Fixes #3651