### PR TITLE
fix: resolve duplicate embedding API call in mem0.add when infer=False (Issue #3723)

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -407,7 +407,7 @@ class Memory(MemoryBase):
 
                 msg_content = message_dict["content"]
                 msg_embeddings = self.embedding_model.embed(msg_content, "add")
-                mem_id = self._create_memory(msg_content, msg_embeddings, per_msg_meta)
+                mem_id = self._create_memory(msg_content, {msg_content: msg_embeddings}, per_msg_meta)
 
                 returned_memories.append(
                     {
@@ -1437,7 +1437,7 @@ class AsyncMemory(MemoryBase):
 
                 msg_content = message_dict["content"]
                 msg_embeddings = await asyncio.to_thread(self.embedding_model.embed, msg_content, "add")
-                mem_id = await self._create_memory(msg_content, msg_embeddings, per_msg_meta)
+                mem_id = await self._create_memory(msg_content, {msg_content: msg_embeddings}, per_msg_meta)
 
                 returned_memories.append(
                     {


### PR DESCRIPTION
## Summary

This PR fixes Issue #3723 where `mem0.add` was calling the embedding API twice when adding a simple memory.

## Root Cause

When `infer=False`, the code was passing the embedding vector directly to `_create_memory()` instead of a dictionary:

```python
msg_embeddings = self.embedding_model.embed(msg_content, "add")
mem_id = self._create_memory(msg_content, msg_embeddings, per_msg_meta)  # msg_embeddings is a vector, not a dict!
```

However, `_create_memory()` expects `existing_embeddings` to be a dictionary and checks:
```python
if data in existing_embeddings:  # This fails because existing_embeddings is a vector, not a dict
    embeddings = existing_embeddings[data]
else:
    embeddings = self.embedding_model.embed(data, memory_action="add")  # Called again unnecessarily!
```

## Fix

Wrap the embedding vector in a dictionary with the message content as the key:

```python
mem_id = self._create_memory(msg_content, {msg_content: msg_embeddings}, per_msg_meta)
```

This fix was applied to both `Memory` and `AsyncMemory` classes in `mem0/memory/main.py`.

## Files Changed

- `mem0/memory/main.py`: Fixed two lines (sync and async versions)

---

Fixes #3723