### PR TITLE
fix: make check_same_thread conditional on SQLite in OpenMemory

### DIFF
--- a/openmemory/api/app/database.py
+++ b/openmemory/api/app/database.py
@@ -12,9 +12,12 @@ if not DATABASE_URL:
     raise RuntimeError("DATABASE_URL is not set in environment")
 
 # SQLAlchemy engine & session
+connect_args = {}
+if DATABASE_URL.startswith("sqlite"):
+    connect_args["check_same_thread"] = False
 engine = create_engine(
     DATABASE_URL,
-    connect_args={"check_same_thread": False}  # Needed for SQLite
+    connect_args=connect_args
 )
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 


### PR DESCRIPTION
## Problem

`check_same_thread=False` is a SQLite-specific `connect_arg` in SQLAlchemy. When `DATABASE_URL` points to PostgreSQL (via psycopg2), passing this argument raises an error. Since the OpenMemory docs recommend PostgreSQL for production, this breaks the recommended setup.

## Fix

Only pass `check_same_thread=False` when `DATABASE_URL` starts with `sqlite`. For all other databases, pass empty `connect_args`.

## Changes

- `openmemory/api/app/database.py`: Conditional `connect_args` based on database type (4 lines changed)

## Testing

- Verified with PostgreSQL (pgvector) -- engine creates successfully
- Verified with default SQLite -- `check_same_thread=False` still applied
- No behavior change for existing SQLite users