### PR TITLE
fix: support Azure OpenAI in OpenMemory categorization

### DIFF
--- a/openmemory/api/app/utils/categorization.py
+++ b/openmemory/api/app/utils/categorization.py
@@ -1,14 +1,29 @@
 import logging
+import os
 from typing import List
 
 from app.utils.prompts import MEMORY_CATEGORIZATION_PROMPT
 from dotenv import load_dotenv
-from openai import OpenAI
+from openai import AzureOpenAI, OpenAI
 from pydantic import BaseModel
 from tenacity import retry, stop_after_attempt, wait_exponential
 
 load_dotenv()
-openai_client = OpenAI()
+
+
+def _create_openai_client():
+    """Create the appropriate OpenAI client based on available env vars."""
+    if os.environ.get("AZURE_OPENAI_API_KEY") and os.environ.get("AZURE_OPENAI_ENDPOINT"):
+        return AzureOpenAI(
+            api_key=os.environ["AZURE_OPENAI_API_KEY"],
+            azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
+            api_version=os.environ.get("OPENAI_API_VERSION", "2024-12-01-preview"),
+        )
+    return OpenAI()
+
+
+openai_client = _create_openai_client()
+categorization_model = os.environ.get("CATEGORIZATION_MODEL", "gpt-4o-mini")
 
 
 class MemoryCategories(BaseModel):
@@ -25,7 +40,7 @@ def get_categories_for_memory(memory: str) -> List[str]:
 
         # Let OpenAI handle the pydantic parsing directly
         completion = openai_client.beta.chat.completions.parse(
-            model="gpt-4o-mini",
+            model=categorization_model,
             messages=messages,
             response_format=MemoryCategories,
             temperature=0


### PR DESCRIPTION
## Problem

The memory categorization module in OpenMemory hardcodes `openai_client = OpenAI()`. When deploying with Azure OpenAI credentials (`AZURE_OPENAI_API_KEY` + `AZURE_OPENAI_ENDPOINT`), this raises `AuthenticationError` because the standard `OpenAI()` client ignores Azure-specific env vars.

This means categorization silently fails for any Azure OpenAI deployment, even though the core mem0 library supports Azure OpenAI.

## Fix

- Auto-detect Azure OpenAI: if `AZURE_OPENAI_API_KEY` and `AZURE_OPENAI_ENDPOINT` are set, use `AzureOpenAI()` client; otherwise fall back to `OpenAI()`
- Make the categorization model configurable via `CATEGORIZATION_MODEL` env var (default: `gpt-4o-mini`, unchanged for existing users)

## Changes

- `openmemory/api/app/utils/categorization.py`: Added `_create_openai_client()` factory function + `CATEGORIZATION_MODEL` env var (18 lines added, 3 removed)

## Testing

- Verified with Azure OpenAI (`gpt-4o` deployment) -- categorization works correctly
- Verified with standard OpenAI -- falls back to `OpenAI()` as before
- No behavior change for existing users