### PR TITLE
fix(ts-sdk): infer vector store dimension from embedder config

### DIFF
--- a/mem0-ts/src/oss/src/config/manager.ts
+++ b/mem0-ts/src/oss/src/config/manager.ts
@@ -43,13 +43,22 @@ export class ConfigManager {
           const defaultConf = DEFAULT_MEMORY_CONFIG.vectorStore.config;
           const userConf = userConfig.vectorStore?.config;
 
+          // Infer vector dimension from the embedder config when the user
+          // has not explicitly set it on the vector store.  This prevents
+          // dimension mismatches when using non-OpenAI embedders (e.g.
+          // Ollama nomic-embed-text produces 768-dim vectors while the
+          // default was hardcoded to 1536).
+          const embeddingDims = userConfig.embedder?.config?.embeddingDims;
+          const inferredDimension =
+            userConf?.dimension || embeddingDims || defaultConf.dimension;
+
           // Prioritize user-provided client instance
           if (userConf?.client && typeof userConf.client === "object") {
             return {
               client: userConf.client,
               // Include other fields from userConf if necessary, or omit defaults
               collectionName: userConf.collectionName, // Can be undefined
-              dimension: userConf.dimension || defaultConf.dimension, // Merge dimension
+              dimension: inferredDimension,
               ...userConf, // Include any other passthrough fields from user
             };
           } else {
@@ -57,7 +66,7 @@ export class ConfigManager {
             return {
               collectionName:
                 userConf?.collectionName || defaultConf.collectionName,
-              dimension: userConf?.dimension || defaultConf.dimension,
+              dimension: inferredDimension,
               // Ensure client is not carried over from defaults if not provided by user
               client: undefined,
               // Include other passthrough fields from userConf even if no client

--- a/mem0-ts/src/oss/tests/config-manager.test.ts
+++ b/mem0-ts/src/oss/tests/config-manager.test.ts
@@ -1,0 +1,112 @@
+/// <reference types="jest" />
+import { ConfigManager } from "../src/config/manager";
+
+describe("ConfigManager", () => {
+  describe("mergeConfig", () => {
+    it("should use default dimension (1536) when no embedder dims or vector store dimension provided", () => {
+      const config = ConfigManager.mergeConfig({
+        embedder: {
+          provider: "openai",
+          config: {
+            apiKey: "test-key",
+          },
+        },
+        vectorStore: {
+          provider: "memory",
+          config: {
+            collectionName: "test",
+          },
+        },
+        llm: {
+          provider: "openai",
+          config: {
+            apiKey: "test-key",
+          },
+        },
+      });
+
+      expect(config.vectorStore.config.dimension).toBe(1536);
+    });
+
+    it("should infer vector store dimension from embedder embeddingDims", () => {
+      const config = ConfigManager.mergeConfig({
+        embedder: {
+          provider: "ollama",
+          config: {
+            model: "nomic-embed-text",
+            embeddingDims: 768,
+          },
+        },
+        vectorStore: {
+          provider: "qdrant",
+          config: {
+            collectionName: "test",
+          },
+        },
+        llm: {
+          provider: "openai",
+          config: {
+            apiKey: "test-key",
+          },
+        },
+      });
+
+      expect(config.vectorStore.config.dimension).toBe(768);
+    });
+
+    it("should prefer explicit vector store dimension over embedder dims", () => {
+      const config = ConfigManager.mergeConfig({
+        embedder: {
+          provider: "ollama",
+          config: {
+            model: "nomic-embed-text",
+            embeddingDims: 768,
+          },
+        },
+        vectorStore: {
+          provider: "qdrant",
+          config: {
+            collectionName: "test",
+            dimension: 1024,
+          },
+        },
+        llm: {
+          provider: "openai",
+          config: {
+            apiKey: "test-key",
+          },
+        },
+      });
+
+      expect(config.vectorStore.config.dimension).toBe(1024);
+    });
+
+    it("should infer dimension when using a custom client instance", () => {
+      const mockClient = { someMethod: () => {} };
+      const config = ConfigManager.mergeConfig({
+        embedder: {
+          provider: "ollama",
+          config: {
+            model: "nomic-embed-text",
+            embeddingDims: 768,
+          },
+        },
+        vectorStore: {
+          provider: "qdrant",
+          config: {
+            collectionName: "test",
+            client: mockClient,
+          },
+        },
+        llm: {
+          provider: "openai",
+          config: {
+            apiKey: "test-key",
+          },
+        },
+      });
+
+      expect(config.vectorStore.config.dimension).toBe(768);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #4212

When using non-OpenAI embedders (e.g. Ollama `nomic-embed-text` with 768 dims), the Qdrant collection was always created with 1536 dimensions because the vector store config defaulted to the OpenAI dimension without considering the embedder's actual output size. This caused every `add()` and `search()` call to fail with a dimension mismatch error from Qdrant.

This PR updates `ConfigManager.mergeConfig()` to automatically infer the vector store dimension from the embedder's `embeddingDims` config when the user has not explicitly set it on the vector store. The priority order is:

1. Explicit `vectorStore.config.dimension` (user override — always wins)
2. `embedder.config.embeddingDims` (inferred from embedder)
3. Default `1536` (backward compatible fallback)

This fix benefits **all** vector store providers (Qdrant, Memory, Vectorize, etc.) since the dimension is resolved at the config layer.

## Test Plan
- Added `config-manager.test.ts` with 4 test cases covering:
  - Default dimension (1536) when no embedder dims specified
  - Dimension inferred from `embeddingDims` (e.g. 768 for Ollama)
  - Explicit vector store dimension takes priority over embedder dims
  - Dimension inference works with custom client instances
- All existing tests pass (`factory.test.ts`)