### PR TITLE
fix: narrower sensitive field matching + None guards + langchain type fix

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -69,9 +69,11 @@ def _safe_deepcopy_config(config):
         else:
             clone_dict = {k: v for k, v in config.__dict__.items()}
         
-        sensitive_tokens = ("auth", "credential", "password", "token", "secret", "key", "connection_class")
+        sensitive_exact_fields = {"password", "api_key", "secret_key", "access_token", "credentials", "connection_class"}
+        sensitive_tokens = ("credential", "secret", "_token")
         for field_name in list(clone_dict.keys()):
-            if any(token in field_name.lower() for token in sensitive_tokens):
+            lower_name = field_name.lower()
+            if lower_name in sensitive_exact_fields or any(token in lower_name for token in sensitive_tokens):
                 clone_dict[field_name] = None
         
         try:
@@ -1148,6 +1150,9 @@ class Memory(MemoryBase):
             logger.error(f"Error getting memory with ID {memory_id} during update.")
             raise ValueError(f"Error getting memory with ID {memory_id}. Please provide a valid 'memory_id'")
 
+        if existing_memory is None:
+            raise ValueError(f"Memory with ID {memory_id} not found. Please provide a valid 'memory_id'")
+
         prev_value = existing_memory.payload.get("data")
 
         new_metadata = deepcopy(metadata) if metadata is not None else {}
@@ -1196,6 +1201,9 @@ class Memory(MemoryBase):
     def _delete_memory(self, memory_id):
         logger.info(f"Deleting memory with {memory_id=}")
         existing_memory = self.vector_store.get(vector_id=memory_id)
+        if existing_memory is None:
+            logger.warning(f"Memory with ID {memory_id} not found, skipping delete")
+            return memory_id
         prev_value = existing_memory.payload.get("data", "")
         self.vector_store.delete(vector_id=memory_id)
         self.db.add_history(
@@ -2228,6 +2236,9 @@ class AsyncMemory(MemoryBase):
             logger.error(f"Error getting memory with ID {memory_id} during update.")
             raise ValueError(f"Error getting memory with ID {memory_id}. Please provide a valid 'memory_id'")
 
+        if existing_memory is None:
+            raise ValueError(f"Memory with ID {memory_id} not found. Please provide a valid 'memory_id'")
+
         prev_value = existing_memory.payload.get("data")
 
         new_metadata = deepcopy(metadata) if metadata is not None else {}
@@ -2279,6 +2290,9 @@ class AsyncMemory(MemoryBase):
     async def _delete_memory(self, memory_id):
         logger.info(f"Deleting memory with {memory_id=}")
         existing_memory = await asyncio.to_thread(self.vector_store.get, vector_id=memory_id)
+        if existing_memory is None:
+            logger.warning(f"Memory with ID {memory_id} not found, skipping delete")
+            return memory_id
         prev_value = existing_memory.payload.get("data", "")
 
         await asyncio.to_thread(self.vector_store.delete, vector_id=memory_id)

--- a/mem0/vector_stores/langchain.py
+++ b/mem0/vector_stores/langchain.py
@@ -115,7 +115,7 @@ class Langchain(VectorStoreBase):
         Update a vector and its payload.
         """
         self.delete(vector_id)
-        self.insert(vector, payload, [vector_id])
+        self.insert([vector] if vector is not None else [], [payload] if payload is not None else None, [vector_id])
 
     def get(self, vector_id):
         """

--- a/tests/vector_stores/test_opensearch.py
+++ b/tests/vector_stores/test_opensearch.py
@@ -300,8 +300,10 @@ def test_safe_deepcopy_config_handles_opensearch_auth(mock_sqlite, mock_llm_fact
     
     safe_config = _safe_deepcopy_config(config_with_auth)
     
-    assert safe_config.http_auth is None
-    assert safe_config.auth is None
+    # http_auth and auth should be preserved — they're runtime-required fields, not secrets
+    assert safe_config.http_auth is not None
+    assert safe_config.auth is not None
+    # credentials should still be sanitized — it matches sensitive token "credential"
     assert safe_config.credentials is None
     assert safe_config.connection_class is None
     


### PR DESCRIPTION
## Summary

- **`_safe_deepcopy_config` strips `http_auth` (#3580):** The sensitive field filter used broad substring matching — `"auth"` matched `http_auth`, removing it from OpenSearch configs. Replaced with exact field names (`password`, `api_key`, `secret_key`, `access_token`, `credentials`, `connection_class`) and narrower tokens (`credential`, `secret`, `_token`). `http_auth` and `auth` are now preserved.

- **`_update_memory` / `_delete_memory` AttributeError on missing ID:** `vector_store.get()` returns `None` when ID doesn't exist, but the code immediately accesses `.payload` without checking. Added `None` guard with clear error message (update) or early return (delete). Applied to both sync and async versions.

- **Langchain `update()` type mismatch (#3767):** `update()` passed a single vector (`List[float]`) to `insert()`, which expects `List[List[float]]`. Wrapped in `[vector]` / `[payload]`.

## Test plan

- [x] All 12 OpenSearch tests pass (`pytest tests/vector_stores/test_opensearch.py`)
- [ ] Verify `_safe_deepcopy_config` preserves `http_auth` with AWS auth objects
- [ ] Verify `_update_memory("nonexistent_id")` raises `ValueError` instead of `AttributeError`
- [ ] Verify `_delete_memory("nonexistent_id")` returns gracefully instead of crashing
- [ ] Verify langchain `update()` correctly wraps vector/payload in lists

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)