### PR TITLE
fix(openclaw): document camelCase Qdrant config keys and add authenticated remote example

### DIFF
--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -73,7 +73,25 @@ Sensible defaults out of the box. To customize the embedder, vector store, or LL
   "userId": "your-user-id",
   "oss": {
     "embedder": { "provider": "openai", "config": { "model": "text-embedding-3-small" } },
-    "vectorStore": { "provider": "qdrant", "config": { "host": "localhost", "port": 6333 } },
+    "vectorStore": {
+      "provider": "qdrant",
+      "config": {
+        "url": "http://localhost:6333",
+        "collectionName": "my-memories",
+        "dimension": 1536
+      }
+    },
+    // Remote Qdrant with API key — note: all keys must be camelCase
+    // "vectorStore": {
+    //   "provider": "qdrant",
+    //   "config": {
+    //     "url": "https://your-qdrant-host:6333",
+    //     "apiKey": "your-qdrant-api-key",
+    //     "collectionName": "my-memories",
+    //     "dimension": 1536,
+    //     "checkCompatibility": false
+    //   }
+    // },
     "llm": { "provider": "openai", "config": { "model": "gpt-4o" } }
   }
 }
@@ -143,7 +161,7 @@ Works with zero extra config. The `oss` block lets you swap out any component:
 | `oss.embedder.provider` | `string` | `"openai"` | Embedding provider (`"openai"`, `"ollama"`, etc.) |
 | `oss.embedder.config` | `object` | — | Provider config: `apiKey`, `model`, `baseURL` |
 | `oss.vectorStore.provider` | `string` | `"memory"` | Vector store (`"memory"`, `"qdrant"`, `"chroma"`, etc.) |
-| `oss.vectorStore.config` | `object` | — | Provider config: `host`, `port`, `collectionName`, `dimension` |
+| `oss.vectorStore.config` | `object` | — | Provider config (all keys **camelCase**): `url`, `host`, `port`, `apiKey` (for authenticated remote instances), `collectionName`, `dimension`, `checkCompatibility` |
 | `oss.llm.provider` | `string` | `"openai"` | LLM provider (`"openai"`, `"anthropic"`, `"ollama"`, etc.) |
 | `oss.llm.config` | `object` | — | Provider config: `apiKey`, `model`, `baseURL`, `temperature` |
 | `oss.historyDbPath` | `string` | — | SQLite path for memory edit history |


### PR DESCRIPTION
## Problem

When users configure a remote Qdrant instance with API key authentication in the `openclaw-mem0` plugin, they get `401 Unauthorized` errors — even when Qdrant is reachable and the key is correct.

**Root cause:** The plugin's internal Qdrant class (from `mem0ai`) reads config keys in **camelCase** (`apiKey`, `collectionName`, `dimension`), but the README example only showed `host`/`port` with no mention of what keys to use for authenticated remote instances. Users familiar with the Mem0 Python SDK or Qdrant's own docs naturally try `api_key`, `collection_name`, `embedding_model_dims` — which are **silently ignored**, so the API key never reaches the Qdrant client.

## Fix

- Updated the OSS config example to use correct camelCase Qdrant keys (`url`, `collectionName`, `dimension`)
- Added a commented example showing how to connect to a **remote authenticated Qdrant** instance with `apiKey`
- Clarified in the options table that all `oss.vectorStore.config` keys must be camelCase
- Added `checkCompatibility: false` note for deployments where client/server versions differ

## Testing

Verified locally against Qdrant v1.17.0 with `mem0ai` v1.1 — search returns `SUCCESS` after applying camelCase config keys.

---

> Discovered and debugged by **Ariel Tolome** while setting up a self-hosted Qdrant backend for OpenClaw.