### PR TITLE
docs(openclaw): align searchThreshold default with plugin code

### DIFF
--- a/docs/integrations/openclaw.mdx
+++ b/docs/integrations/openclaw.mdx
@@ -123,7 +123,7 @@ openclaw mem0 stats
 | `autoRecall` | `boolean` | `true` | Inject memories before each turn |
 | `autoCapture` | `boolean` | `true` | Store facts after each turn |
 | `topK` | `number` | `5` | Max memories per recall |
-| `searchThreshold` | `number` | `0.3` | Min similarity (0–1) |
+| `searchThreshold` | `number` | `0.5` | Min similarity (0–1) |
 
 ### Platform Mode Options
 

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -120,7 +120,7 @@ openclaw mem0 stats
 | `autoRecall` | `boolean` | `true` | Inject memories before each turn |
 | `autoCapture` | `boolean` | `true` | Store facts after each turn |
 | `topK` | `number` | `5` | Max memories per recall |
-| `searchThreshold` | `number` | `0.3` | Min similarity (0–1) |
+| `searchThreshold` | `number` | `0.5` | Min similarity (0–1) |
 
 ### Platform mode
 


### PR DESCRIPTION
## Summary
- update OpenClaw integration docs to show `searchThreshold` default as `0.5`
- update plugin README to show the same default

## Why
The plugin code defaults `searchThreshold` to `0.5`, but docs currently show `0.3`. This PR aligns docs with actual behavior to avoid confusion during tuning.

## Changes
- `docs/integrations/openclaw.mdx`
- `openclaw/README.md`