### PR TITLE
fix(mem0-ts): normalize snake_case config keys to camelCase in Memory constructor

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -7,6 +7,7 @@ import {
   Message,
   SearchFilters,
   SearchResult,
+  normalizeMemoryConfig,
 } from "../types";
 import {
   EmbedderFactory,
@@ -51,6 +52,8 @@ export class Memory {
   telemetryId: string;
 
   constructor(config: Partial<MemoryConfig> = {}) {
+    // Normalize snake_case keys to camelCase for backward compatibility
+    config = normalizeMemoryConfig(config);
     // Merge and validate config
     this.config = ConfigManager.mergeConfig(config);
 

--- a/mem0-ts/src/oss/src/types/index.ts
+++ b/mem0-ts/src/oss/src/types/index.ts
@@ -170,3 +170,46 @@ export const MemoryConfigSchema = z.object({
     .optional(),
   disableHistory: z.boolean().optional(),
 });
+
+/**
+ * Normalizes snake_case config keys to camelCase for backward compatibility.
+ * Some integrations (e.g. OpenClaw wizard) write snake_case keys, but mem0ai-ts
+ * expects camelCase throughout. This helper transparently converts common aliases.
+ */
+export function normalizeMemoryConfig(config: any): any {
+  if (!config || typeof config !== 'object') return config;
+
+  const normalized = { ...config };
+
+  // Normalize embedder config
+  if (normalized.embedder?.config) {
+    const ec = { ...normalized.embedder.config };
+    if ('api_key' in ec && !('apiKey' in ec))          { ec.apiKey        = ec.api_key;        delete ec.api_key; }
+    if ('embedding_dims' in ec && !('embeddingDims' in ec)) { ec.embeddingDims = ec.embedding_dims; delete ec.embedding_dims; }
+    normalized.embedder = { ...normalized.embedder, config: ec };
+  }
+
+  // Normalize llm config
+  if (normalized.llm?.config) {
+    const lc = { ...normalized.llm.config };
+    if ('api_key' in lc && !('apiKey' in lc)) { lc.apiKey = lc.api_key; delete lc.api_key; }
+    normalized.llm = { ...normalized.llm, config: lc };
+  }
+
+  // Normalize vectorStore config
+  if (normalized.vectorStore?.config) {
+    const vc = { ...normalized.vectorStore.config };
+    if ('api_key' in vc && !('apiKey' in vc))                       { vc.apiKey         = vc.api_key;              delete vc.api_key; }
+    if ('collection_name' in vc && !('collectionName' in vc))       { vc.collectionName  = vc.collection_name;      delete vc.collection_name; }
+    if ('embedding_model_dims' in vc && !('dimension' in vc))       { vc.dimension       = vc.embedding_model_dims; delete vc.embedding_model_dims; }
+    // Force HTTP when host+port provided (avoids SSL errors on plain HTTP Qdrant)
+    if ('host' in vc && !('url' in vc)) {
+      vc.url = `http://${vc.host}:${vc.port || 6333}`;
+      delete vc.host;
+      delete vc.port;
+    }
+    normalized.vectorStore = { ...normalized.vectorStore, config: vc };
+  }
+
+  return normalized;
+}


### PR DESCRIPTION
## Problem

`mem0ai` (JS/TS package) exclusively uses camelCase config keys (`apiKey`, `collectionName`, `embeddingDims`), but many integration wizards and config generators write snake_case (`api_key`, `collection_name`, `embedding_dims`) — which is the Python/shell convention.

This causes **silent failures** with no obvious error:
- `api_key` is ignored → OpenAI gets no auth header → `401 Unauthorized`
- `collection_name` is ignored → wrong/missing Qdrant collection
- `host` + `port` for Qdrant → JS client defaults to HTTPS → SSL handshake failure on plain HTTP deployments

## Fix

Added `normalizeMemoryConfig()` to `types/index.ts` that converts common snake_case aliases to camelCase, and called it automatically at the top of the `Memory` constructor.

**Conversions handled:**
| Snake_case (input) | camelCase (expected) | Scope |
|---|---|---|
| `api_key` | `apiKey` | embedder, llm, vectorStore |
| `embedding_dims` | `embeddingDims` | embedder |
| `collection_name` | `collectionName` | vectorStore |
| `embedding_model_dims` | `dimension` | vectorStore |
| `host` + `port` | `url` (http://) | vectorStore |

## Changes

- `mem0-ts/src/oss/src/types/index.ts` — adds exported `normalizeMemoryConfig()` helper
- `mem0-ts/src/oss/src/memory/index.ts` — calls normalization before `ConfigManager.mergeConfig()`

## Backward Compatibility

- Fully backward compatible — camelCase keys are passed through unchanged
- Only converts keys if the camelCase equivalent is not already set (no overwrite)