### PR TITLE
feat(llm): Add reasoning_effort parameter to AzureOpenAIConfig

### DIFF
--- a/mem0/configs/llms/azure.py
+++ b/mem0/configs/llms/azure.py
@@ -24,6 +24,8 @@ class AzureOpenAIConfig(BaseLlmConfig):
         http_client_proxies: Optional[dict] = None,
         # Azure OpenAI-specific parameters
         azure_kwargs: Optional[Dict[str, Any]] = None,
+        # Reasoning effort parameter for reasoning models
+        reasoning_effort: Optional[str] = None,
     ):
         """
         Initialize Azure OpenAI configuration.
@@ -39,6 +41,7 @@ class AzureOpenAIConfig(BaseLlmConfig):
             vision_details: Vision detail level, defaults to "auto"
             http_client_proxies: HTTP client proxy settings, defaults to None
             azure_kwargs: Azure-specific configuration, defaults to None
+            reasoning_effort: Reasoning effort level ("low", "medium", "high") for reasoning models, defaults to None
         """
         # Initialize base parameters
         super().__init__(
@@ -55,3 +58,4 @@ class AzureOpenAIConfig(BaseLlmConfig):
 
         # Azure OpenAI-specific parameters
         self.azure_kwargs = AzureConfig(**(azure_kwargs or {}))
+        self.reasoning_effort = reasoning_effort

--- a/mem0/llms/azure_openai.py
+++ b/mem0/llms/azure_openai.py
@@ -137,5 +137,9 @@ class AzureOpenAILLM(LLMBase):
             params["tools"] = tools
             params["tool_choice"] = tool_choice
 
+        # Add reasoning_effort if configured
+        if hasattr(self.config, 'reasoning_effort') and self.config.reasoning_effort:
+            params["reasoning_effort"] = self.config.reasoning_effort
+
         response = self.client.chat.completions.create(**params)
         return self._parse_response(response, tools)


### PR DESCRIPTION
## Summary

Adds support for the  parameter in AzureOpenAIConfig, allowing users to specify reasoning effort levels ("low", "medium", "high") for reasoning models.

## Changes

- Added  parameter to  class
- Passes  to Azure OpenAI client when generating responses
- Supports OpenAI SDK's reasoning_effort parameter for reasoning models

## Fix

Fixes #3651 - Users can now use:

```python
config = AzureOpenAIConfig(
    model="o1-preview",
    reasoning_effort="low"
)
```

Without receiving: `TypeError: AzureOpenAIConfig.__init__() got an unexpected keyword argument 'reasoning_effort'`