### PR TITLE
fix: wrap vector and payload in lists in langchain vector store update

### DIFF
--- a/mem0/vector_stores/langchain.py
+++ b/mem0/vector_stores/langchain.py
@@ -115,7 +115,7 @@ class Langchain(VectorStoreBase):
         Update a vector and its payload.
         """
         self.delete(vector_id)
-        self.insert(vector, payload, [vector_id])
+        self.insert([vector], [payload], [vector_id])
 
     def get(self, vector_id):
         """


### PR DESCRIPTION
## Summary
Fixes type mismatch in the langchain vector store adapter's `update()` method. The method was passing bare `vector` and `payload` arguments to `insert()`, but `insert()` expects `List[List[float]]` and `List[Dict]`.

Fixes #3767

## Changes
- Wrapped `vector` and `payload` in single-element lists in the `update` method call to `insert`

## Test plan
- [ ] `update()` calls `insert()` with correctly typed parameters
- [ ] Vector store update operations work with the langchain adapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)