### PR TITLE
fix: strip markdown code blocks from Claude JSON responses

### DIFF
--- a/mem0-ts/src/oss/src/prompts/index.ts
+++ b/mem0-ts/src/oss/src/prompts/index.ts
@@ -278,5 +278,5 @@ export function parseMessages(messages: string[]): string {
 }
 
 export function removeCodeBlocks(text: string): string {
-  return text.replace(/```[^`]*```/g, "");
+  return text.replace(/```(?:\w+)?\n?([\s\S]*?)```/g, "$1").trim();
 }


### PR DESCRIPTION
## Summary
- Fixes the `removeCodeBlocks()` helper in the TypeScript SDK which was **deleting** the entire code block (including the JSON content inside) instead of **extracting** it
- When Claude wraps JSON output in ` ```json ... ``` `, the old regex replaced everything with an empty string, causing `JSON.parse()` to throw `SyntaxError: Unexpected end of JSON input`
- The new regex extracts the content inside code blocks and handles the optional language identifier (e.g., `json`)

Fixes #4108

## Changes
- `mem0-ts/src/oss/src/prompts/index.ts`: Changed `removeCodeBlocks()` regex from `/```[^`]*```/g` (which deleted content) to `` /```(?:\w+)?\n?([\s\S]*?)```/g `` (which extracts content)

## Test plan
- [ ] Verify JSON responses wrapped in ` ```json\n{...}\n``` ` code blocks are parsed correctly
- [ ] Verify raw JSON responses (without code blocks) still work
- [ ] Verify responses with multiple code blocks are handled

🤖 Generated with [Claude Code](https://claude.com/claude-code)