### PR TITLE
fix(embedchain): fix silent filter drops and document-metadata misalignment

### DIFF
--- a/embedchain/embedchain/embedchain.py
+++ b/embedchain/embedchain/embedchain.py
@@ -400,9 +400,18 @@ class EmbedChain(JSONSerializable):
         chunks_before_addition = self.db.count()
 
         # Filter out empty documents and ensure they meet the API requirements
-        valid_documents = [doc for doc in documents if doc and isinstance(doc, str)]
-
-        documents = valid_documents
+        filtered = [
+            (doc, meta, id_)
+            for doc, meta, id_ in zip(documents, metadatas, ids)
+            if doc and isinstance(doc, str)
+        ]
+        if filtered:
+            documents, metadatas, ids = zip(*filtered)
+            documents = list(documents)
+            metadatas = list(metadatas)
+            ids = list(ids)
+        else:
+            documents, metadatas, ids = [], [], []
 
         # Chunk documents into batches of 2048 and handle each batch
         # helps wigth large loads of embeddings  that hit OpenAI limits

--- a/embedchain/embedchain/vectordb/chroma.py
+++ b/embedchain/embedchain/vectordb/chroma.py
@@ -87,8 +87,7 @@ class ChromaDB(BaseVectorDB):
             return where
         where_filters = []
         for k, v in where.items():
-            if isinstance(v, str):
-                where_filters.append({k: v})
+            where_filters.append({k: v})
         return {"$and": where_filters}
 
     def _get_or_create_collection(self, name: str) -> Collection:


### PR DESCRIPTION
## Summary

- **ChromaDB `_generate_where_clause` silently drops non-string filter values**: When a `where` dict contains multiple keys, the method only keeps entries where the value is a `str`, silently discarding `int`, `float`, and `bool` values. This causes incorrect query/filter results when metadata contains numeric or boolean fields. ChromaDB natively supports these types in `$and` filters.

- **`EmbedChain._load_and_embed` document-metadata-id misalignment**: When empty or non-string documents are filtered out (lines 402-405), only the `documents` list is filtered. The corresponding `metadatas` and `ids` lists are not filtered, causing misaligned data to be passed to `self.db.add()`. This can result in wrong metadata being associated with wrong documents in the vector database.

## Test plan

- [ ] Verify `_generate_where_clause({"app_id": "test", "score": 0.5})` returns `{"$and": [{"app_id": "test"}, {"score": 0.5}]}` instead of `{"$and": [{"app_id": "test"}]}`
- [ ] Verify that when documents contain empty strings, the filtered documents/metadatas/ids remain correctly aligned
- [ ] Run existing test suite: `cd embedchain && make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
