### PR TITLE
fix(upstash_vector): pass namespace as top-level arg to query_many, not inside each query dict

### DIFF
--- a/mem0/vector_stores/upstash_vector.py
+++ b/mem0/vector_stores/upstash_vector.py
@@ -132,11 +132,10 @@ class UpstashVector(VectorStoreBase):
                     "top_k": limit,
                     "filter": filters_str or "",
                     "include_metadata": True,
-                    "namespace": self.collection_name,
                 }
                 for v in vectors
             ]
-            responses = self.client.query_many(queries=queries)
+            responses = self.client.query_many(queries=queries, namespace=self.collection_name)
             # flatten
             response = [res for res_list in responses for res in res_list]
 

--- a/tests/vector_stores/test_upstash_vector.py
+++ b/tests/vector_stores/test_upstash_vector.py
@@ -69,11 +69,11 @@ def test_search_vectors(upstash_instance, mock_index):
             {
                 "vector": vectors[0],
                 "top_k": 2,
-                "namespace": "ns",
                 "include_metadata": True,
                 "filter": 'age = 30 AND name = "John"',
             }
-        ]
+        ],
+        namespace="ns",
     )
 
     assert len(results) == 2
@@ -311,11 +311,11 @@ def test_search_vectors_empty_filters(upstash_instance):
             {
                 "vector": vectors[0],
                 "top_k": 1,
-                "namespace": "ns",
                 "include_metadata": True,
                 "filter": "",
             }
-        ]
+        ],
+        namespace="ns",
     )
 
     assert len(results) == 1
@@ -350,3 +350,35 @@ def test_insert_vectors_no_ids(upstash_instance):
         ],
         namespace="ns",
     )
+
+
+def test_search_vectors_namespace_not_in_query_dicts(upstash_instance):
+    """namespace must be passed as a top-level arg to query_many, not inside each QueryRequest dict.
+
+    The new upstash_vector client's query_many() signature is:
+        query_many(*, queries: List[QueryRequest], namespace: str = DEFAULT_NAMESPACE, ...)
+    Embedding namespace inside each query dict caused TypeError on single-query
+    calls (duplicate keyword) and wrong-namespace results on multi-query calls.
+    (issue #4207)
+    """
+    mock_result = [
+        QueryResult(id="id1", score=0.9, vector=None, metadata={"k": "v1"}, data=None),
+        QueryResult(id="id2", score=0.8, vector=None, metadata={"k": "v2"}, data=None),
+    ]
+    upstash_instance.client.query_many.return_value = [mock_result, mock_result]
+
+    vectors = [[0.1, 0.2], [0.3, 0.4]]
+    upstash_instance.search(query="test", vectors=vectors, limit=2)
+
+    call_kwargs = upstash_instance.client.query_many.call_args
+    # namespace must be a top-level keyword argument
+    assert call_kwargs.kwargs.get("namespace") == "ns" or (
+        len(call_kwargs.args) > 1 and call_kwargs.args[1] == "ns"
+    ), "namespace must be passed as a top-level argument to query_many"
+
+    # namespace must NOT appear inside individual query dicts
+    for q in call_kwargs.kwargs.get("queries", []):
+        assert "namespace" not in q, (
+            "namespace must not be embedded inside per-query dicts; "
+            "it belongs as a top-level argument to query_many()"
+        )


### PR DESCRIPTION
## Summary

`UpstashVector.search` with `enable_embeddings=False` was broken for single-vector queries with the current `upstash_vector` client SDK, and silently returned results from the wrong namespace for multi-vector queries.

## Root Cause

The new `upstash_vector` SDK's `query_many()` signature is:

```python
query_many(*, queries: List[QueryRequest], namespace: str = DEFAULT_NAMESPACE, ...)
```

`namespace` is a **top-level** keyword argument, and `QueryRequest` objects must NOT contain a `"namespace"` key.

The previous code embedded namespace inside each query dict:

```python
# Before (buggy)
queries = [
    {"vector": v, "top_k": limit, "filter": ..., "include_metadata": True, "namespace": self.collection_name},
    ...
]
responses = self.client.query_many(queries=queries)  # namespace missing at top level
```

This caused two failures (#4207):

1. **Single vector**: `query_many` special-cases `len(queries)==1` and calls `self.query(**query, namespace=namespace)`. Since the query dict already had `namespace`, this raised:
   ```
   TypeError: query() got multiple values for keyword argument 'namespace'
   ```
2. **Multiple vectors**: `namespace` inside the dict was silently ignored, returning results from the wrong (default) namespace.

## Fix

Remove `"namespace"` from the per-query dicts and pass it at the top level:

```python
# After (fixed)
queries = [
    {"vector": v, "top_k": limit, "filter": ..., "include_metadata": True},
    ...
]
responses = self.client.query_many(queries=queries, namespace=self.collection_name)
```

## Tests

- Updated `test_search_vectors` and `test_search_vectors_empty_filters` to assert the correct call signature.
- Added `test_search_vectors_namespace_not_in_query_dicts` as an explicit regression guard that verifies `namespace` is a top-level argument and is absent from per-query dicts.

Fixes #4207
