### PR TITLE
feat(azure): add reasoning_effort parameter for reasoning models

### DIFF
--- a/mem0/configs/llms/azure.py
+++ b/mem0/configs/llms/azure.py
@@ -24,6 +24,8 @@ class AzureOpenAIConfig(BaseLlmConfig):
         http_client_proxies: Optional[dict] = None,
         # Azure OpenAI-specific parameters
         azure_kwargs: Optional[Dict[str, Any]] = None,
+        # Reasoning model parameters
+        reasoning_effort: Optional[str] = None,
     ):
         """
         Initialize Azure OpenAI configuration.
@@ -39,6 +41,7 @@ class AzureOpenAIConfig(BaseLlmConfig):
             vision_details: Vision detail level, defaults to "auto"
             http_client_proxies: HTTP client proxy settings, defaults to None
             azure_kwargs: Azure-specific configuration, defaults to None
+            reasoning_effort: Reasoning effort level for reasoning models ("low", "medium", "high"), defaults to None
         """
         # Initialize base parameters
         super().__init__(
@@ -55,3 +58,6 @@ class AzureOpenAIConfig(BaseLlmConfig):
 
         # Azure OpenAI-specific parameters
         self.azure_kwargs = AzureConfig(**(azure_kwargs or {}))
+
+        # Reasoning model parameters
+        self.reasoning_effort = reasoning_effort

--- a/mem0/llms/azure_openai.py
+++ b/mem0/llms/azure_openai.py
@@ -126,12 +126,16 @@ class AzureOpenAILLM(LLMBase):
         messages[-1]["content"] = user_prompt
 
         params = self._get_supported_params(messages=messages, **kwargs)
-        
+
         # Add model and messages
         params.update({
             "model": self.config.model,
             "messages": messages,
         })
+
+        # Add reasoning_effort for reasoning models if configured
+        if hasattr(self.config, 'reasoning_effort') and self.config.reasoning_effort:
+            params["reasoning_effort"] = self.config.reasoning_effort
 
         if tools:
             params["tools"] = tools


### PR DESCRIPTION
## Description

Add support for the `reasoning_effort` parameter in `AzureOpenAIConfig` to enable testing and comparison of different reasoning effort levels ("low", "medium", "high") supported by the latest OpenAI SDK for reasoning models (o1, o3, gpt-5 series).

## Changes

- Add `reasoning_effort` parameter to `AzureOpenAIConfig` class
- Pass `reasoning_effort` to Azure OpenAI API when configured

## Usage Example

```python
from mem0 import Memory

config = {
    "llm": {
        "provider": "azure_openai",
        "config": {
            "model": "o3-mini",
            "reasoning_effort": "low"  # or "medium", "high"
        }
    }
}

memory = Memory.from_config(config)
```

## Related Issue

Fixes #3651

## Type of Change

- [x] New feature (non-breaking change which adds functionality)