### PR TITLE
chore(openclaw): bump version to 0.3.0

### DIFF
--- a/openclaw/CHANGELOG.md
+++ b/openclaw/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the `@mem0/openclaw-mem0` plugin will be documented in this file.
 
+## [0.3.0] - 2026-03-10
+
+### Fixed
+- Updated `mem0ai` dependency which includes the sqlite3 to better-sqlite3 migration for native binding resolution (#4270)
+
 ## [0.2.0] - 2026-03-09
 
 ### Added

--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mem0/openclaw-mem0",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "description": "Mem0 memory backend for OpenClaw — platform or self-hosted open-source",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
- Bumps `@mem0/openclaw-mem0` plugin version from `0.2.0` to `0.3.0`
- Updates CHANGELOG with the upstream `mem0ai` dependency fix (sqlite3 → better-sqlite3 for native binding resolution, #4270)
