### PR TITLE
fix: use platform-appropriate user data dir instead of /tmp for vector store default path

### DIFF
--- a/mem0/vector_stores/configs.py
+++ b/mem0/vector_stores/configs.py
@@ -1,3 +1,6 @@
+import os
+
+from pathlib import Path
 from typing import Dict, Optional
 
 from pydantic import BaseModel, Field, model_validator
@@ -60,7 +63,18 @@ class VectorStoreConfig(BaseModel):
 
         # also check if path in allowed kays for pydantic model, and whether config extra fields are allowed
         if "path" not in config and "path" in config_class.__annotations__:
-            config["path"] = f"/tmp/{provider}"
+            # Use a platform-appropriate user data directory instead of /tmp, which is
+            # ephemeral on many systems and may be unwritable in service/restricted environments.
+            # Preference order: XDG_DATA_HOME (Linux) → APPDATA (Windows) → ~/.local/share
+            xdg = os.environ.get("XDG_DATA_HOME")
+            app_data = os.environ.get("APPDATA")
+            if xdg:
+                base = Path(xdg)
+            elif app_data:
+                base = Path(app_data)
+            else:
+                base = Path.home() / ".local" / "share"
+            config["path"] = str(base / "mem0" / provider)
 
         self.config = config_class(**config)
         return self


### PR DESCRIPTION
## Problem

The default vector store path is hardcoded to `/tmp/{provider}` in `mem0/vector_stores/configs.py`. This causes initialization failures or silent data loss in common deployment scenarios (closes #4279):

| Environment | Problem |
|---|---|
| macOS LaunchAgent | `/tmp` cleared on reboot → data loss; restricted permissions |
| Linux systemd | `/tmp` may have `noexec`, private namespaces, or restrictive ACLs |
| Windows | `/tmp` doesn't exist → `FileNotFoundError` |
| Docker (no volume) | `/tmp` is ephemeral → data lost on container restart |

## Fix

Use a cross-platform user data directory following established conventions:

```python
# Linux/macOS: $XDG_DATA_HOME/mem0/{provider}  (falls back to ~/.local/share/mem0/{provider})
# Windows:     %APPDATA%/mem0/{provider}
```

This follows the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/) on Linux, the standard `%APPDATA%` path on Windows, and a sensible fallback of `~/.local/share` elsewhere.

## Backward compatibility

Users who relied on the `/tmp/{provider}` default will need to migrate their data once. Users who already set an explicit `path` in config are unaffected (the new logic only applies when no path is provided).

Closes #4279