### PR TITLE
fix(ts-sdk): resolve sqlite db paths in OSS mode

### DIFF
--- a/mem0-ts/src/oss/src/config/manager.ts
+++ b/mem0-ts/src/oss/src/config/manager.ts
@@ -95,16 +95,33 @@ export class ConfigManager {
         })(),
       },
       historyDbPath:
-        userConfig.historyDbPath || DEFAULT_MEMORY_CONFIG.historyDbPath,
+        userConfig.historyDbPath ||
+        userConfig.historyStore?.config?.historyDbPath ||
+        DEFAULT_MEMORY_CONFIG.historyStore.config.historyDbPath,
       customPrompt: userConfig.customPrompt,
       graphStore: {
         ...DEFAULT_MEMORY_CONFIG.graphStore,
         ...userConfig.graphStore,
       },
-      historyStore: {
-        ...DEFAULT_MEMORY_CONFIG.historyStore,
-        ...userConfig.historyStore,
-      },
+      historyStore: (() => {
+        const defaultHistoryStore = DEFAULT_MEMORY_CONFIG.historyStore;
+        const historyProvider =
+          userConfig.historyStore?.provider || defaultHistoryStore.provider;
+
+        return {
+          ...defaultHistoryStore,
+          ...userConfig.historyStore,
+          provider: historyProvider,
+          config: {
+            ...defaultHistoryStore.config,
+            ...userConfig.historyStore?.config,
+            ...(historyProvider.toLowerCase() === "sqlite" &&
+            userConfig.historyDbPath
+              ? { historyDbPath: userConfig.historyDbPath }
+              : {}),
+          },
+        };
+      })(),
       disableHistory:
         userConfig.disableHistory || DEFAULT_MEMORY_CONFIG.disableHistory,
       enableGraph: userConfig.enableGraph || DEFAULT_MEMORY_CONFIG.enableGraph,

--- a/mem0-ts/src/oss/src/storage/SQLiteManager.ts
+++ b/mem0-ts/src/oss/src/storage/SQLiteManager.ts
@@ -1,5 +1,6 @@
 import Database from "better-sqlite3";
 import { HistoryManager } from "./base";
+import { ensureSQLiteDirectory } from "../utils/sqlite";
 
 export class SQLiteManager implements HistoryManager {
   private db: Database.Database;
@@ -7,6 +8,7 @@ export class SQLiteManager implements HistoryManager {
   private stmtSelect!: Database.Statement;
 
   constructor(dbPath: string) {
+    ensureSQLiteDirectory(dbPath);
     this.db = new Database(dbPath);
     this.init();
   }

--- a/mem0-ts/src/oss/src/tests/sqlite-path-resolution.test.ts
+++ b/mem0-ts/src/oss/src/tests/sqlite-path-resolution.test.ts
@@ -1,0 +1,104 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { ConfigManager } from "../config/manager";
+import { SQLiteManager } from "../storage/SQLiteManager";
+import { HistoryManagerFactory } from "../utils/factory";
+import { MemoryVectorStore } from "../vector_stores/memory";
+
+function normalize(vector: number[]): number[] {
+  const norm = Math.sqrt(vector.reduce((sum, value) => sum + value * value, 0));
+  return vector.map((value) => value / norm);
+}
+
+describe("SQLite path resolution", () => {
+  const originalCwd = process.cwd();
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    jest.restoreAllMocks();
+  });
+
+  it("propagates top-level historyDbPath into the sqlite history store config", async () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "mem0-history-path-"),
+    );
+    const historyDbPath = path.join(tempDir, "nested", "history.db");
+    let manager: SQLiteManager | undefined;
+
+    try {
+      const mergedConfig = ConfigManager.mergeConfig({ historyDbPath });
+
+      expect(mergedConfig.historyDbPath).toBe(historyDbPath);
+      expect(mergedConfig.historyStore?.provider).toBe("sqlite");
+      expect(mergedConfig.historyStore?.config.historyDbPath).toBe(
+        historyDbPath,
+      );
+
+      manager = HistoryManagerFactory.create(
+        mergedConfig.historyStore!.provider,
+        mergedConfig.historyStore!,
+      ) as SQLiteManager;
+      await manager.addHistory("memory-1", null, "remember me", "ADD");
+
+      expect(fs.existsSync(historyDbPath)).toBe(true);
+    } finally {
+      manager?.close();
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("defaults the memory vector store dbPath to ~/.mem0/vector_store.db", async () => {
+    const fakeHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), "mem0-home-"));
+    const tempCwd = fs.mkdtempSync(path.join(os.tmpdir(), "mem0-cwd-"));
+    const expectedDbPath = path.join(fakeHomeDir, ".mem0", "vector_store.db");
+
+    try {
+      jest.spyOn(os, "homedir").mockReturnValue(fakeHomeDir);
+      process.chdir(tempCwd);
+
+      const store = new MemoryVectorStore({ dimension: 4 });
+      await store.insert(
+        [normalize([1, 0, 0, 0])],
+        ["vector-1"],
+        [{ data: "hello" }],
+      );
+
+      expect(fs.existsSync(expectedDbPath)).toBe(true);
+      expect(fs.existsSync(path.join(tempCwd, "vector_store.db"))).toBe(false);
+    } finally {
+      fs.rmSync(fakeHomeDir, { recursive: true, force: true });
+      fs.rmSync(tempCwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not depend on a writable current working directory for the default vector store db", async () => {
+    const fakeHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), "mem0-home-"));
+    const readOnlyCwd = fs.mkdtempSync(
+      path.join(os.tmpdir(), "mem0-readonly-cwd-"),
+    );
+    const expectedDbPath = path.join(fakeHomeDir, ".mem0", "vector_store.db");
+
+    try {
+      fs.chmodSync(readOnlyCwd, 0o555);
+      jest.spyOn(os, "homedir").mockReturnValue(fakeHomeDir);
+      process.chdir(readOnlyCwd);
+
+      const store = new MemoryVectorStore({ dimension: 4 });
+      await store.insert(
+        [normalize([0, 1, 0, 0])],
+        ["vector-2"],
+        [{ data: "hello again" }],
+      );
+
+      expect(fs.existsSync(expectedDbPath)).toBe(true);
+      expect(fs.existsSync(path.join(readOnlyCwd, "vector_store.db"))).toBe(
+        false,
+      );
+    } finally {
+      fs.chmodSync(readOnlyCwd, 0o755);
+      fs.rmSync(fakeHomeDir, { recursive: true, force: true });
+      fs.rmSync(readOnlyCwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/mem0-ts/src/oss/src/types/index.ts
+++ b/mem0-ts/src/oss/src/types/index.ts
@@ -23,6 +23,7 @@ export interface EmbeddingConfig {
 export interface VectorStoreConfig {
   collectionName?: string;
   dimension?: number;
+  dbPath?: string;
   client?: any;
   instance?: any;
   [key: string]: any;
@@ -129,6 +130,7 @@ export const MemoryConfigSchema = z.object({
       .object({
         collectionName: z.string().optional(),
         dimension: z.number().optional(),
+        dbPath: z.string().optional(),
         client: z.any().optional(),
       })
       .passthrough(),

--- a/mem0-ts/src/oss/src/utils/sqlite.ts
+++ b/mem0-ts/src/oss/src/utils/sqlite.ts
@@ -1,0 +1,15 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+export function getDefaultVectorStoreDbPath(): string {
+  return path.join(os.homedir(), ".mem0", "vector_store.db");
+}
+
+export function ensureSQLiteDirectory(dbPath: string): void {
+  if (!dbPath || dbPath === ":memory:" || dbPath.startsWith("file:")) {
+    return;
+  }
+
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+}

--- a/mem0-ts/src/oss/src/vector_stores/memory.ts
+++ b/mem0-ts/src/oss/src/vector_stores/memory.ts
@@ -1,7 +1,10 @@
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
 import Database from "better-sqlite3";
-import path from "path";
+import {
+  ensureSQLiteDirectory,
+  getDefaultVectorStoreDbPath,
+} from "../utils/sqlite";
 
 interface MemoryVector {
   id: string;
@@ -16,10 +19,8 @@ export class MemoryVectorStore implements VectorStore {
 
   constructor(config: VectorStoreConfig) {
     this.dimension = config.dimension || 1536; // Default OpenAI dimension
-    this.dbPath = path.join(process.cwd(), "vector_store.db");
-    if (config.dbPath) {
-      this.dbPath = config.dbPath;
-    }
+    this.dbPath = config.dbPath || getDefaultVectorStoreDbPath();
+    ensureSQLiteDirectory(this.dbPath);
     this.db = new Database(this.dbPath);
     this.init();
   }


### PR DESCRIPTION
## Description

Fixes two OSS SQLite path bugs in the TypeScript SDK:

- propagate top-level `historyDbPath` into `historyStore.config.historyDbPath` when the history provider is `sqlite`
- make the memory vector store SQLite path configurable via `vectorStore.config.dbPath`
- default the vector store database to `~/.mem0/vector_store.db` instead of resolving from `process.cwd()`
- create parent directories for file-backed SQLite databases before opening them
- add regression tests covering both fixes, including a non-writable CWD case

Fixes #4290

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Unit Test
- [ ] Test Script (please provide)

Commands run locally:

```bash
cd mem0-ts
npx prettier --check src/oss/src/config/manager.ts src/oss/src/storage/SQLiteManager.ts src/oss/src/tests/sqlite-path-resolution.test.ts src/oss/src/types/index.ts src/oss/src/utils/sqlite.ts src/oss/src/vector_stores/memory.ts
npm test -- --runInBand src/oss/src/tests/better-sqlite3-migration.test.ts src/oss/src/tests/sqlite-path-resolution.test.ts
npm run build
```

Additional note: `npm test -- --runInBand` for the entire `mem0-ts` package still hits pre-existing failures in unrelated integration-style tests (`src/client/tests/memoryClient.test.ts`, `src/oss/tests/memory.test.ts`) that require external services / outdated call signatures. This PR does not modify those areas.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [x] closes #4290
- [ ] Made sure Checks passed
