### PR TITLE
feat(openclaw): per-sender userId for multi-user deployments (fixes #4288)

### DIFF
--- a/docs/integrations/openclaw.mdx
+++ b/docs/integrations/openclaw.mdx
@@ -37,7 +37,7 @@ Pick any stable, unique identifier for the user. Common choices:
 
 All memories are scoped to this `userId` — different values create separate memory namespaces. If you don't set it, it defaults to `"default"`, which means all users share the same memory space.
 
-<Tip>In a multi-user application, set `userId` dynamically per user (e.g. from your auth system) rather than hardcoding a single value.</Tip>
+<Tip>In a multi-user application, set `userId` dynamically per user (e.g. from your auth system) rather than hardcoding a single value. For multi-user DM bots (e.g. Telegram, Discord DMs), use `userIdScope: "per-sender"` so each sender gets isolated memory automatically.</Tip>
 
 ### Platform Mode (Mem0 Cloud)
 
@@ -134,6 +134,7 @@ openclaw mem0 stats
 |-----|------|---------|-------------|
 | `mode` | `"platform"` \| `"open-source"` | `"platform"` | Which backend to use |
 | `userId` | `string` | `"default"` | Scope memories per user |
+| `userIdScope` | `"static"` \| `"per-sender"` | `"static"` | `"per-sender"` isolates memory per sender (for multi-user DM bots) |
 | `autoRecall` | `boolean` | `true` | Inject memories before each turn |
 | `autoCapture` | `boolean` | `true` | Store facts after each turn |
 | `topK` | `number` | `5` | Max memories per recall |

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -50,6 +50,16 @@ memory_search({ query: "user's tech stack", agentId: "researcher" })
 
 Resolution priority: explicit `agentId` > explicit `userId` > session-derived > configured default.
 
+### Per-sender memory isolation (multi-user deployments)
+
+When multiple human users (senders) talk to the same bot via DMs (e.g. `dmScope: per-channel-peer`), set `userIdScope: "per-sender"` so each sender gets their own memory namespace. Otherwise all senders share the configured `userId`.
+
+**How it works:**
+
+- With `userIdScope: "static"` (default): one `userId` for all senders 
+- With `userIdScope: "per-sender"`: effective userId is derived from `ctx.senderId` when available- each sender gets isolated memory (`baseUserId:sender:senderId`, or combined with per-agent).
+- When `senderId` is missing, falls back to static/per-agent behavior.
+
 ## Setup
 
 ```bash
@@ -68,7 +78,7 @@ Pick any stable, unique identifier for the user. Common choices:
 
 All memories are scoped to this `userId` — different values create separate memory namespaces. If you don't set it, it defaults to `"default"`, which means all users share the same memory space.
 
-> **Tip:** In a multi-user application, set `userId` dynamically per user (e.g. from your auth system) rather than hardcoding a single value.
+> **Tip:** In a multi-user application, set `userId` dynamically per user (e.g. from your auth system) rather than hardcoding a single value. For multi-user DM bots, use `userIdScope: "per-sender"`.
 
 ### Platform (Mem0 Cloud)
 
@@ -157,6 +167,7 @@ openclaw mem0 stats --agent researcher
 |-----|------|---------|---|
 | `mode` | `"platform"` \| `"open-source"` | `"platform"` | Which backend to use |
 | `userId` | `string` | `"default"` | Any unique identifier you choose for the user (e.g. `"alice"`, `"user_123"`). All memories are scoped to this value. Not found in any dashboard — you define it yourself. |
+| `userIdScope` | `"static"` \| `"per-sender"` | `"static"` | One userId for all senders, or isolate per sender. Use `"per-sender"` for multi-user DM bots. |
 | `autoRecall` | `boolean` | `true` | Inject memories before each turn |
 | `autoCapture` | `boolean` | `true` | Store facts after each turn |
 | `topK` | `number` | `5` | Max memories per recall |

--- a/openclaw/index.test.ts
+++ b/openclaw/index.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect } from "vitest";
 import {
   extractAgentId,
   effectiveUserId,
+  effectiveUserIdForRequest,
   agentUserId,
   resolveUserId,
 } from "./index.ts";
@@ -84,6 +85,54 @@ describe("effectiveUserId", () => {
 });
 
 // ---------------------------------------------------------------------------
+// effectiveUserIdForRequest
+// ---------------------------------------------------------------------------
+describe("effectiveUserIdForRequest", () => {
+  const base = "alice";
+
+  it("returns same as effectiveUserId when userIdScope is static", () => {
+    expect(
+      effectiveUserIdForRequest(base, "static", undefined, undefined),
+    ).toBe("alice");
+    expect(
+      effectiveUserIdForRequest(base, "static", "agent:researcher:uuid", undefined),
+    ).toBe("alice:agent:researcher");
+  });
+
+  it("returns per-sender namespace when userIdScope is per-sender and senderId present", () => {
+    expect(
+      effectiveUserIdForRequest(base, "per-sender", undefined, "user-123"),
+    ).toBe("alice:sender:user-123");
+  });
+
+  it("combines agent and sender when both present (per-sender)", () => {
+    expect(
+      effectiveUserIdForRequest(
+        base,
+        "per-sender",
+        "agent:researcher:uuid",
+        "user-456",
+      ),
+    ).toBe("alice:agent:researcher:sender:user-456");
+  });
+
+  it("falls back to effectiveUserId when per-sender but senderId absent", () => {
+    expect(
+      effectiveUserIdForRequest(base, "per-sender", undefined, undefined),
+    ).toBe("alice");
+    expect(
+      effectiveUserIdForRequest(base, "per-sender", "agent:beta:uuid", undefined),
+    ).toBe("alice:agent:beta");
+  });
+
+  it("falls back to effectiveUserId when per-sender but senderId empty string", () => {
+    expect(
+      effectiveUserIdForRequest(base, "per-sender", undefined, ""),
+    ).toBe("alice");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // agentUserId
 // ---------------------------------------------------------------------------
 describe("agentUserId", () => {
@@ -135,6 +184,24 @@ describe("resolveUserId", () => {
 
   it("ignores empty-string userId (falsy)", () => {
     expect(resolveUserId(base, { userId: "" })).toBe("alice");
+  });
+
+  it("uses per-sender namespace when userIdScope per-sender and senderId present", () => {
+    expect(
+      resolveUserId(base, {}, undefined, "per-sender", "telegram-789"),
+    ).toBe("alice:sender:telegram-789");
+  });
+
+  it("combines agent and sender when agentId + per-sender + senderId", () => {
+    expect(
+      resolveUserId(
+        base,
+        { agentId: "researcher" },
+        "agent:researcher:uuid",
+        "per-sender",
+        "user-99",
+      ),
+    ).toBe("alice:agent:researcher:sender:user-99");
   });
 });
 

--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -12,6 +12,8 @@
  * - Auto-capture: stores key facts scoped to the current session after each agent turn
  * - Per-agent isolation: multi-agent setups write/read from separate userId namespaces
  *   automatically via sessionKey routing (zero breaking changes for single-agent setups)
+ * - Per-sender isolation: with userIdScope "per-sender", each sender gets isolated memory
+ *   (requires ctx.senderId from OpenClaw; use for multi-user DM bots)
  * - CLI: openclaw mem0 search, openclaw mem0 stats
  * - Dual mode: platform or open-source (self-hosted)
  */
@@ -44,6 +46,7 @@ type Mem0Config = {
   };
   // Shared
   userId: string;
+  userIdScope: "static" | "per-sender";
   autoCapture: boolean;
   autoRecall: boolean;
   searchThreshold: number;
@@ -498,6 +501,7 @@ const ALLOWED_KEYS = [
   "mode",
   "apiKey",
   "userId",
+  "userIdScope",
   "orgId",
   "projectId",
   "autoCapture",
@@ -550,12 +554,16 @@ const mem0ConfigSchema = {
       ) as unknown as Mem0Config["oss"];
     }
 
+    const userIdScope: "static" | "per-sender" =
+      cfg.userIdScope === "per-sender" ? "per-sender" : "static";
+
     return {
       mode,
       apiKey:
         typeof cfg.apiKey === "string" ? resolveEnvVars(cfg.apiKey) : undefined,
       userId:
         typeof cfg.userId === "string" && cfg.userId ? cfg.userId : "default",
+      userIdScope,
       orgId: typeof cfg.orgId === "string" ? cfg.orgId : undefined,
       projectId: typeof cfg.projectId === "string" ? cfg.projectId : undefined,
       autoCapture: cfg.autoCapture !== false,
@@ -637,6 +645,25 @@ export function effectiveUserId(baseUserId: string, sessionKey?: string): string
   return agentId ? `${baseUserId}:agent:${agentId}` : baseUserId;
 }
 
+/**
+ * Derive the effective user_id with optional per-sender scoping.
+ * When userIdScope is "per-sender" and senderId is present, namespaces by sender.
+ * Otherwise delegates to effectiveUserId (per-agent or base).
+ */
+export function effectiveUserIdForRequest(
+  baseUserId: string,
+  userIdScope: "static" | "per-sender",
+  sessionKey?: string,
+  senderId?: string,
+): string {
+  if (userIdScope === "per-sender" && senderId) {
+    const agentPart = extractAgentId(sessionKey);
+    const prefix = agentPart ? `${baseUserId}:agent:${agentPart}` : baseUserId;
+    return `${prefix}:sender:${senderId}`;
+  }
+  return effectiveUserId(baseUserId, sessionKey);
+}
+
 /** Build a user_id for an explicit agentId (e.g. from tool params). */
 export function agentUserId(baseUserId: string, agentId: string): string {
   return `${baseUserId}:agent:${agentId}`;
@@ -644,15 +671,29 @@ export function agentUserId(baseUserId: string, agentId: string): string {
 
 /**
  * Resolve user_id with priority: explicit agentId > explicit userId > session-derived > configured.
+ * When userIdScope is "per-sender" and senderId is present, namespacing includes sender.
  */
 export function resolveUserId(
   baseUserId: string,
   opts: { agentId?: string; userId?: string },
   currentSessionId?: string,
+  userIdScope?: "static" | "per-sender",
+  senderId?: string,
 ): string {
-  if (opts.agentId) return agentUserId(baseUserId, opts.agentId);
+  if (opts.agentId) {
+    const agentUid = agentUserId(baseUserId, opts.agentId);
+    if (userIdScope === "per-sender" && senderId) {
+      return `${agentUid}:sender:${senderId}`;
+    }
+    return agentUid;
+  }
   if (opts.userId) return opts.userId;
-  return effectiveUserId(baseUserId, currentSessionId);
+  return effectiveUserIdForRequest(
+    baseUserId,
+    userIdScope ?? "static",
+    currentSessionId,
+    senderId,
+  );
 }
 
 // ============================================================================
@@ -671,26 +712,43 @@ const memoryPlugin = {
     const cfg = mem0ConfigSchema.parse(api.pluginConfig);
     const provider = createProvider(cfg, api);
 
-    // Track current session ID for tool-level session scoping
+    // Track current session ID and sender ID for tool-level scoping
     let currentSessionId: string | undefined;
+    let currentSenderId: string | undefined;
 
     // ========================================================================
-    // Per-agent isolation helpers (thin wrappers around exported functions)
+    // Per-agent / per-sender isolation helpers (thin wrappers around exported functions)
     // ========================================================================
-    const _effectiveUserId = (sessionKey?: string) =>
-      effectiveUserId(cfg.userId, sessionKey);
+    const _effectiveUserId = (sessionKey?: string, senderId?: string) =>
+      effectiveUserIdForRequest(
+        cfg.userId,
+        cfg.userIdScope,
+        sessionKey,
+        senderId,
+      );
     const _agentUserId = (id: string) => agentUserId(cfg.userId, id);
     const _resolveUserId = (opts: { agentId?: string; userId?: string }) =>
-      resolveUserId(cfg.userId, opts, currentSessionId);
+      resolveUserId(
+        cfg.userId,
+        opts,
+        currentSessionId,
+        cfg.userIdScope,
+        currentSenderId,
+      );
 
     api.logger.info(
-      `openclaw-mem0: registered (mode: ${cfg.mode}, user: ${cfg.userId}, graph: ${cfg.enableGraph}, autoRecall: ${cfg.autoRecall}, autoCapture: ${cfg.autoCapture})`,
+      `openclaw-mem0: registered (mode: ${cfg.mode}, user: ${cfg.userId}, userIdScope: ${cfg.userIdScope}, graph: ${cfg.enableGraph}, autoRecall: ${cfg.autoRecall}, autoCapture: ${cfg.autoCapture})`,
     );
 
     // Helper: build add options
-    function buildAddOptions(userIdOverride?: string, runId?: string, sessionKey?: string): AddOptions {
+    function buildAddOptions(
+      userIdOverride?: string,
+      runId?: string,
+      sessionKey?: string,
+      senderId?: string,
+    ): AddOptions {
       const opts: AddOptions = {
-        user_id: userIdOverride || _effectiveUserId(sessionKey),
+        user_id: userIdOverride || _effectiveUserId(sessionKey, senderId),
         source: "OPENCLAW",
       };
       if (runId) opts.run_id = runId;
@@ -709,9 +767,10 @@ const memoryPlugin = {
       limit?: number,
       runId?: string,
       sessionKey?: string,
+      senderId?: string,
     ): SearchOptions {
       const opts: SearchOptions = {
-        user_id: userIdOverride || _effectiveUserId(sessionKey),
+        user_id: userIdOverride || _effectiveUserId(sessionKey, senderId),
         top_k: limit ?? cfg.topK,
         limit: limit ?? cfg.topK,
         threshold: cfg.searchThreshold,
@@ -1243,7 +1302,9 @@ const memoryPlugin = {
             try {
               const limit = parseInt(opts.limit, 10);
               const scope = opts.scope as "session" | "long-term" | "all";
-              const uid = opts.agent ? _agentUserId(opts.agent) : _effectiveUserId(currentSessionId);
+              const uid = opts.agent
+                ? _agentUserId(opts.agent)
+                : _effectiveUserId(currentSessionId, currentSenderId);
 
               let allResults: MemoryItem[] = [];
 
@@ -1338,15 +1399,23 @@ const memoryPlugin = {
       api.on("before_agent_start", async (event, ctx) => {
         if (!event.prompt || event.prompt.length < 5) return;
 
-        // Track session ID
+        // Track session ID and sender ID for per-sender scoping
         const sessionId = (ctx as any)?.sessionKey ?? undefined;
+        const senderId = (ctx as any)?.senderId ?? undefined;
         if (sessionId) currentSessionId = sessionId;
+        if (senderId !== undefined) currentSenderId = senderId;
 
         try {
-          // Search long-term memories (user-scoped, isolated per agent)
+          // Search long-term memories (user-scoped, isolated per agent/sender)
           const longTermResults = await provider.search(
             event.prompt,
-            buildSearchOptions(undefined, undefined, undefined, sessionId),
+            buildSearchOptions(
+              undefined,
+              undefined,
+              undefined,
+              sessionId,
+              senderId,
+            ),
           );
 
           // Search session memories (session-scoped) if we have a session ID
@@ -1354,7 +1423,13 @@ const memoryPlugin = {
           if (currentSessionId) {
             sessionResults = await provider.search(
               event.prompt,
-              buildSearchOptions(undefined, undefined, currentSessionId, sessionId),
+              buildSearchOptions(
+                undefined,
+                undefined,
+                currentSessionId,
+                sessionId,
+                senderId,
+              ),
             );
           }
 
@@ -1405,9 +1480,11 @@ const memoryPlugin = {
           return;
         }
 
-        // Track session ID
+        // Track session ID and sender ID for per-sender scoping
         const sessionId = (ctx as any)?.sessionKey ?? undefined;
+        const senderId = (ctx as any)?.senderId ?? undefined;
         if (sessionId) currentSessionId = sessionId;
+        if (senderId !== undefined) currentSenderId = senderId;
 
         try {
           // Extract messages, limiting to last 10
@@ -1459,7 +1536,12 @@ const memoryPlugin = {
 
           if (formattedMessages.length === 0) return;
 
-          const addOpts = buildAddOptions(undefined, currentSessionId, sessionId);
+          const addOpts = buildAddOptions(
+            undefined,
+            currentSessionId,
+            sessionId,
+            senderId,
+          );
           const result = await provider.add(
             formattedMessages,
             addOpts,

--- a/openclaw/openclaw.plugin.json
+++ b/openclaw/openclaw.plugin.json
@@ -17,6 +17,10 @@
       "placeholder": "default",
       "help": "User ID for scoping memories"
     },
+    "userIdScope": {
+      "label": "User ID Scope",
+      "help": "\"static\" (one userId for all) or \"per-sender\" (each sender gets isolated memory namespace). Use per-sender for multi-user DM bots."
+    },
     "orgId": {
       "label": "Organization ID",
       "placeholder": "org-...",
@@ -87,6 +91,10 @@
       },
       "userId": {
         "type": "string"
+      },
+      "userIdScope": {
+        "type": "string",
+        "enum": ["static", "per-sender"]
       },
       "orgId": {
         "type": "string"


### PR DESCRIPTION
## Description

Adds `userIdScope` config option (`"static"` | `"per-sender"`) so multi-user OpenClaw deployments (e.g. `dmScope: per-channel-peer`) can isolate memory per sender. With `per-sender`, effective userId is derived from `ctx.senderId` when available, each sender gets their own namespace (`baseUserId:sender:senderId`). Default remains `static` for backward compatibility.

**Motivation:** When many users (e.g. employees, customers) talk to the same bot via DMs, they currently share one memory namespace. This change lets each sender have isolated memory.

**Dependencies:** OpenClaw must pass `senderId` in the plugin hook context (OpenClaw 2026.3+). When `senderId` is missing, behavior falls back to static/per-agent.

Fixes #4288

## Type of change
- [x] New feature (non-breaking change which adds functionality)
## How Has This Been Tested?
- [x] Unit Test
Added unit tests in `openclaw/index.test.ts` for `effectiveUserIdForRequest` and `resolveUserId` with per-sender behavior. Run: `cd openclaw && npm test` - all 31 tests pass.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
## Maintainer Checklist
- [ ] closes #4288
- [ ] Made sure Checks passed