### PR TITLE
fix(docs): correct Deploy with Docker Compose card link

### DIFF
--- a/docs/open-source/configuration.mdx
+++ b/docs/open-source/configuration.mdx
@@ -168,6 +168,6 @@ memory = Memory.from_config_file("config.yaml")
     title="Deploy with Docker Compose"
     description="Follow the end-to-end OSS deployment walkthrough."
     icon="server"
-    href="/cookbooks/companions/local-companion-ollama"
+    href="/open-source/features/rest-api"
   />
 </CardGroup>

--- a/docs/open-source/overview.mdx
+++ b/docs/open-source/overview.mdx
@@ -46,7 +46,7 @@ Mem0 Open Source delivers the same adaptive memory engine as the platform, but p
 </CardGroup>
 
 <CardGroup cols={2}>
-  <Card title="Deploy with Docker Compose" icon="server" href="/cookbooks/companions/local-companion-ollama">
+  <Card title="Deploy with Docker Compose" icon="server" href="/open-source/features/rest-api">
     Reference deployment with REST endpoints.
   </Card>
   <Card title="Use the REST API" icon="code" href="/open-source/features/rest-api">


### PR DESCRIPTION
## Description

The "Deploy with Docker Compose" card on the Configuration and Overview pages linked to `/cookbooks/companions/local-companion-ollama`, which is an Ollama provider cookbook with no Docker Compose content. Updated both pages to link to `/open-source/features/rest-api`, which contains the actual Docker Compose deployment instructions.  

Fixes #4285

## Type of change

Please delete options that are not relevant.

- [x] Documentation update
