### PR TITLE
fix(redis): cast vector_distance to float to prevent TypeError on threshold search

### DIFF
--- a/mem0/vector_stores/redis.py
+++ b/mem0/vector_stores/redis.py
@@ -159,7 +159,7 @@ class RedisDB(VectorStoreBase):
         return [
             MemoryResult(
                 id=result["memory_id"],
-                score=result["vector_distance"],
+                score=float(result["vector_distance"]),
                 payload={
                     "hash": result["hash"],
                     "data": result["memory"],


### PR DESCRIPTION
## Problem

`redisvl` returns `vector_distance` as a **string**, not a float. When `memory.search()` is called with a `threshold` parameter, mem0 compares the score to the threshold:

```python
score=result["vector_distance"]  # str, e.g. '0.123456'
```

This causes (closes #4294):
```
TypeError: '>=' not supported between instances of 'str' and 'float'
```

## Fix

Wrap the `vector_distance` value in `float()` before assigning it to `score`:

```python
score=float(result["vector_distance"])  # ✅
```

One-line change, no behaviour change for valid distances.