### PR TITLE
fix(docs): use filters param for search in LiveKit integration

### DIFF
--- a/docs/integrations/livekit.mdx
+++ b/docs/integrations/livekit.mdx
@@ -114,7 +114,7 @@ class MemoryEnabledAgent(Agent):
             logger.info("About to await mem0_client.search for RAG context")
             search_results = await mem0_client.search(
                 new_message.text_content,
-                user_id=RAG_USER_ID,
+                filters={"user_id": RAG_USER_ID},
             )
             logger.info(f"mem0_client.search returned: {search_results}")
             if search_results and search_results.get('results', []):


### PR DESCRIPTION
## Description

The LiveKit integration docs use `user_id=RAG_USER_ID` as a direct kwarg in the `search()` call. However, the v2 search API (`/v2/memories/search/`) requires `user_id` inside the `filters` object it's a required field per the `MemorySearchInputV2` schema in openapi.json.  

With the current code, `user_id` gets placed at the top level of the payload where the API ignores it, so search silently returns empty results. Users following this guide get a voice agent with no memory recall.

Changed to `filters={"user_id": RAG_USER_ID}` which matches the v2 API contract and the official code samples.

Fixes #3832

## Type of change

- [x] Documentation update

## How Has This Been Tested?

- [x] Verified the `MemorySearchInputV2` schema in openapi.json requires `filters` as a top-level field with `user_id` nested inside
- [x] Traced the SDK code path in `mem0/client/main.py:252-277` — confirmed `user_id=` kwarg lands at payload top level, not inside `filters`
- [x] Confirmed the `add()` call using `user_id=` directly is correct (v1 endpoint accepts it at top level)

## Checklist:

 - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have checked my code and corrected any misspellings
