### PR TITLE
fix: cast vector_distance to float in Redis search

### DIFF
--- a/mem0/vector_stores/redis.py
+++ b/mem0/vector_stores/redis.py
@@ -159,7 +159,7 @@ class RedisDB(VectorStoreBase):
         return [
             MemoryResult(
                 id=result["memory_id"],
-                score=result["vector_distance"],
+                score=float(result["vector_distance"]),
                 payload={
                     "hash": result["hash"],
                     "data": result["memory"],


### PR DESCRIPTION
## Summary

Fixes #4294 - Redis vector_distance returned as string causes threshold search to fail

## Problem

When using Redis as the vector store and passing a `threshold` parameter to `memory.search()`, mem0 throws a TypeError because `vector_distance` is returned as a string by redisvl instead of a float.

## Root Cause

redisvl returns `vector_distance` as a string, causing TypeError when comparing with float threshold values:
```
>= not supported between instances of str and float
```

## Solution

Cast `vector_distance` to float before assigning to the score field:
```python
score=float(result["vector_distance"]),
```

## Testing

This fix ensures that the score value is always a float, allowing proper comparison with threshold values in search operations.