### PR TITLE
fix(openclaw): preserve OSS historyDbPath and create sqlite parent dir

### DIFF
--- a/openclaw/index.test.ts
+++ b/openclaw/index.test.ts
@@ -5,11 +5,15 @@
  * malformed input, and the resolveUserId priority chain.
  */
 import { describe, it, expect } from "vitest";
+import { mkdtemp, rm, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import {
   extractAgentId,
   effectiveUserId,
   agentUserId,
   resolveUserId,
+  resolveOssHistoryConfig,
 } from "./index.ts";
 
 // ---------------------------------------------------------------------------
@@ -161,5 +165,46 @@ describe("multi-agent isolation", () => {
   it("main session shares the base namespace (no isolation)", () => {
     const mainId = effectiveUserId(base, "agent:main:uuid-m");
     expect(mainId).toBe(base);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OSS history sqlite config helper
+// ---------------------------------------------------------------------------
+
+describe("resolveOssHistoryConfig", () => {
+  it("creates the parent directory and returns both history fields", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "openclaw-mem0-"));
+    try {
+      const dbPath = join(tmp, "nested", "history.db");
+      const result = await resolveOssHistoryConfig(dbPath);
+      expect(result.historyDbPath).toBe(dbPath);
+      expect(result.historyStore).toEqual({
+        provider: "sqlite",
+        config: { historyDbPath: dbPath },
+      });
+      const parent = await stat(join(tmp, "nested"));
+      expect(parent.isDirectory()).toBe(true);
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("applies resolvePath before creating directories and wiring historyStore", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "openclaw-mem0-"));
+    try {
+      const result = await resolveOssHistoryConfig("history.db", (p) =>
+        join(tmp, "resolved", p),
+      );
+      expect(result.historyDbPath).toBe(join(tmp, "resolved", "history.db"));
+      expect(result.historyStore).toEqual({
+        provider: "sqlite",
+        config: { historyDbPath: join(tmp, "resolved", "history.db") },
+      });
+      const parent = await stat(join(tmp, "resolved"));
+      expect(parent.isDirectory()).toBe(true);
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -16,6 +16,8 @@
  * - Dual mode: platform or open-source (self-hosted)
  */
 
+import { mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
 import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 
@@ -240,10 +242,13 @@ class OSSProvider implements Mem0Provider {
     if (this.ossConfig?.llm) config.llm = this.ossConfig.llm;
 
     if (this.ossConfig?.historyDbPath) {
-      const dbPath = this.resolvePath
-        ? this.resolvePath(this.ossConfig.historyDbPath)
-        : this.ossConfig.historyDbPath;
-      config.historyDbPath = dbPath;
+      Object.assign(
+        config,
+        await resolveOssHistoryConfig(
+          this.ossConfig.historyDbPath,
+          this.resolvePath,
+        ),
+      );
     }
 
     if (this.customPrompt) config.customPrompt = this.customPrompt;
@@ -603,6 +608,24 @@ function createProvider(
 // ============================================================================
 // Helpers
 // ============================================================================
+
+export async function resolveOssHistoryConfig(
+  historyDbPath: string,
+  resolvePath?: (p: string) => string,
+): Promise<{
+  historyDbPath: string;
+  historyStore: { provider: "sqlite"; config: { historyDbPath: string } };
+}> {
+  const resolvedPath = resolvePath ? resolvePath(historyDbPath) : historyDbPath;
+  await mkdir(dirname(resolvedPath), { recursive: true });
+  return {
+    historyDbPath: resolvedPath,
+    historyStore: {
+      provider: "sqlite",
+      config: { historyDbPath: resolvedPath },
+    },
+  };
+}
 
 /** Convert Record<string, string> categories to the array format mem0ai expects */
 function categoriesToArray(


### PR DESCRIPTION
### Summary

This fixes OSS mode initialization for the OpenClaw Mem0 plugin when `oss.historyDbPath` is configured.

In current versions, the plugin only passes the top-level `historyDbPath` field through to `mem0ai/oss`. However, some `mem0ai` OSS versions still normalize history config through `historyStore`, which means the configured path may be ignored and SQLite falls back to the default relative `memory.db`.

This causes memory tools such as `memory_search` / `memory_list` / `memory_get` to fail in service-style environments with:

```text
SqliteError: unable to open database file
```

### Root cause

There are two issues interacting here:

1. The plugin only sets:

```ts
config.historyDbPath = dbPath
```

but does not explicitly populate:

```ts
config.historyStore = {
  provider: "sqlite",
  config: { historyDbPath: dbPath }
}
```

2. The parent directory for the configured SQLite history DB may not exist yet.

As a result, in some OSS setups the effective history SQLite path is not reliably honored, and initialization can fail.

### What this PR changes

- adds a small helper to resolve OSS history DB config
- creates the parent directory for `historyDbPath` before initializing Mem0 OSS
- wires both:
  - top-level `historyDbPath`
  - explicit `historyStore.config.historyDbPath`

So the configured path survives config normalization in affected `mem0ai` OSS versions.

### Why this approach

This is intentionally a minimal plugin-side compatibility fix.

It does **not** change behavior for users who do not set `oss.historyDbPath`, and it avoids waiting for every downstream environment to pick up an upstream `mem0ai` fix before the OpenClaw plugin works reliably.

### Tests

Added regression coverage for:

1. creating the parent directory for the configured history DB path
2. applying `resolvePath(...)` before wiring the final `historyStore.config.historyDbPath`

### Validation

Locally validated with the OpenClaw Mem0 plugin in OSS mode:

- `memory_search` ✅
- `memory_list` ✅
- `openclaw mem0 search` ✅

### Notes

This patch is especially relevant for daemon / service / plugin runtime environments where:
- `process.cwd()` is not stable
- relative SQLite paths are fragile
- parent directories may not exist yet

### Related upstream context

This appears related to recent OSS SQLite path handling issues in `mem0ai`, where `historyDbPath` and SQLite file path resolution may not always be preserved as expected across config normalization paths.
