### PR TITLE
feat(sdk): add multilingual param to project update

### DIFF
--- a/docs/api-reference/organizations-projects.mdx
+++ b/docs/api-reference/organizations-projects.mdx
@@ -102,7 +102,7 @@ client.project.update(
 client.project.update(enable_graph=True)
 
 # Use the input language for memory storage and retrieval
-client.project.update(use_input_language=True)
+client.project.update(multilingual=True)
 
 # Update multiple settings at once
 client.project.update(
@@ -112,7 +112,7 @@ client.project.update(
         {"work_context": "Professional context and work-related information"}
     ],
     enable_graph=True,
-    use_input_language=True
+    multilingual=True
 )
 ```
 

--- a/docs/api-reference/organizations-projects.mdx
+++ b/docs/api-reference/organizations-projects.mdx
@@ -82,7 +82,7 @@ new_project = client.project.create(
 
 ### Update Project Settings
 
-Modify project configuration including custom instructions, categories, and graph settings:
+Modify project configuration including custom instructions, categories, graph settings, and language preferences:
 
 ```python
 # Update project with custom categories
@@ -101,6 +101,9 @@ client.project.update(
 # Enable graph memory for the project
 client.project.update(enable_graph=True)
 
+# Use the input language for memory storage and retrieval
+client.project.update(use_input_language=True)
+
 # Update multiple settings at once
 client.project.update(
     custom_instructions="...",
@@ -108,7 +111,8 @@ client.project.update(
         {"personal_info": "User personal information and preferences"},
         {"work_context": "Professional context and work-related information"}
     ],
-    enable_graph=True
+    enable_graph=True,
+    use_input_language=True
 )
 ```
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3634,6 +3634,10 @@
 											"type": "object"
 										},
 										"description": "List of custom categories to be used for memory categorization."
+									},
+									"use_input_language": {
+										"type": "boolean",
+										"description": "Whether to use the input language for memory storage and retrieval."
 									}
 								}
 							}

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3635,7 +3635,7 @@
 										},
 										"description": "List of custom categories to be used for memory categorization."
 									},
-									"use_input_language": {
+									"multilingual": {
 										"type": "boolean",
 										"description": "Whether to use the input language for memory storage and retrieval."
 									}

--- a/mem0-ts/src/client/mem0.types.ts
+++ b/mem0-ts/src/client/mem0.types.ts
@@ -167,6 +167,7 @@ export interface PromptUpdatePayload {
   exclusion_prompt?: string;
   memory_depth?: string | null;
   usecase_setting?: string | number;
+  use_input_language?: boolean;
   [key: string]: any;
 }
 

--- a/mem0-ts/src/client/mem0.types.ts
+++ b/mem0-ts/src/client/mem0.types.ts
@@ -167,7 +167,7 @@ export interface PromptUpdatePayload {
   exclusion_prompt?: string;
   memory_depth?: string | null;
   usecase_setting?: string | number;
-  use_input_language?: boolean;
+  multilingual?: boolean;
   [key: string]: any;
 }
 

--- a/mem0/client/main.py
+++ b/mem0/client/main.py
@@ -676,6 +676,7 @@ class MemoryClient:
         exclusion_prompt: Optional[str] = None,
         memory_depth: Optional[str] = None,
         usecase_setting: Optional[str] = None,
+        use_input_language: Optional[bool] = None,
     ) -> Dict[str, Any]:
         """Update the project settings.
 
@@ -689,6 +690,7 @@ class MemoryClient:
             exclusion_prompt: Exclusion prompt for the project
             memory_depth: Memory depth for the project
             usecase_setting: Usecase setting for the project
+            use_input_language: Whether to use the input language for memory storage and retrieval
 
         Returns:
             Dictionary containing the API response.
@@ -718,6 +720,7 @@ class MemoryClient:
             and exclusion_prompt is None
             and memory_depth is None
             and usecase_setting is None
+            and use_input_language is None
         ):
             raise ValueError(
                 "Currently we only support updating custom_instructions or "
@@ -736,6 +739,7 @@ class MemoryClient:
                 "exclusion_prompt": exclusion_prompt,
                 "memory_depth": memory_depth,
                 "usecase_setting": usecase_setting,
+                "use_input_language": use_input_language,
             }
         )
         response = self.client.patch(
@@ -756,6 +760,7 @@ class MemoryClient:
                 "exclusion_prompt": exclusion_prompt,
                 "memory_depth": memory_depth,
                 "usecase_setting": usecase_setting,
+                "use_input_language": use_input_language,
                 "sync_type": "sync",
             },
         )
@@ -1554,6 +1559,7 @@ class AsyncMemoryClient:
         retrieval_criteria: Optional[List[Dict[str, Any]]] = None,
         enable_graph: Optional[bool] = None,
         version: Optional[str] = None,
+        use_input_language: Optional[bool] = None,
     ) -> Dict[str, Any]:
         """Update the project settings.
 
@@ -1563,6 +1569,7 @@ class AsyncMemoryClient:
             retrieval_criteria: New retrieval criteria for the project
             enable_graph: Enable or disable the graph for the project
             version: Version of the project
+            use_input_language: Whether to use the input language for memory storage and retrieval
 
         Returns:
             Dictionary containing the API response.
@@ -1588,6 +1595,7 @@ class AsyncMemoryClient:
             and retrieval_criteria is None
             and enable_graph is None
             and version is None
+            and use_input_language is None
         ):
             raise ValueError(
                 "Currently we only support updating custom_instructions or custom_categories or retrieval_criteria, so you must provide at least one of them"
@@ -1600,6 +1608,7 @@ class AsyncMemoryClient:
                 "retrieval_criteria": retrieval_criteria,
                 "enable_graph": enable_graph,
                 "version": version,
+                "use_input_language": use_input_language,
             }
         )
         response = await self.async_client.patch(
@@ -1616,6 +1625,7 @@ class AsyncMemoryClient:
                 "retrieval_criteria": retrieval_criteria,
                 "enable_graph": enable_graph,
                 "version": version,
+                "use_input_language": use_input_language,
                 "sync_type": "async",
             },
         )

--- a/mem0/client/main.py
+++ b/mem0/client/main.py
@@ -676,7 +676,7 @@ class MemoryClient:
         exclusion_prompt: Optional[str] = None,
         memory_depth: Optional[str] = None,
         usecase_setting: Optional[str] = None,
-        use_input_language: Optional[bool] = None,
+        multilingual: Optional[bool] = None,
     ) -> Dict[str, Any]:
         """Update the project settings.
 
@@ -690,7 +690,7 @@ class MemoryClient:
             exclusion_prompt: Exclusion prompt for the project
             memory_depth: Memory depth for the project
             usecase_setting: Usecase setting for the project
-            use_input_language: Whether to use the input language for memory storage and retrieval
+            multilingual: Whether to use the input language for memory storage and retrieval
 
         Returns:
             Dictionary containing the API response.
@@ -720,7 +720,7 @@ class MemoryClient:
             and exclusion_prompt is None
             and memory_depth is None
             and usecase_setting is None
-            and use_input_language is None
+            and multilingual is None
         ):
             raise ValueError(
                 "Currently we only support updating custom_instructions or "
@@ -739,7 +739,7 @@ class MemoryClient:
                 "exclusion_prompt": exclusion_prompt,
                 "memory_depth": memory_depth,
                 "usecase_setting": usecase_setting,
-                "use_input_language": use_input_language,
+                "multilingual": multilingual,
             }
         )
         response = self.client.patch(
@@ -760,7 +760,7 @@ class MemoryClient:
                 "exclusion_prompt": exclusion_prompt,
                 "memory_depth": memory_depth,
                 "usecase_setting": usecase_setting,
-                "use_input_language": use_input_language,
+                "multilingual": multilingual,
                 "sync_type": "sync",
             },
         )
@@ -1559,7 +1559,7 @@ class AsyncMemoryClient:
         retrieval_criteria: Optional[List[Dict[str, Any]]] = None,
         enable_graph: Optional[bool] = None,
         version: Optional[str] = None,
-        use_input_language: Optional[bool] = None,
+        multilingual: Optional[bool] = None,
     ) -> Dict[str, Any]:
         """Update the project settings.
 
@@ -1569,7 +1569,7 @@ class AsyncMemoryClient:
             retrieval_criteria: New retrieval criteria for the project
             enable_graph: Enable or disable the graph for the project
             version: Version of the project
-            use_input_language: Whether to use the input language for memory storage and retrieval
+            multilingual: Whether to use the input language for memory storage and retrieval
 
         Returns:
             Dictionary containing the API response.
@@ -1595,7 +1595,7 @@ class AsyncMemoryClient:
             and retrieval_criteria is None
             and enable_graph is None
             and version is None
-            and use_input_language is None
+            and multilingual is None
         ):
             raise ValueError(
                 "Currently we only support updating custom_instructions or custom_categories or retrieval_criteria, so you must provide at least one of them"
@@ -1608,7 +1608,7 @@ class AsyncMemoryClient:
                 "retrieval_criteria": retrieval_criteria,
                 "enable_graph": enable_graph,
                 "version": version,
-                "use_input_language": use_input_language,
+                "multilingual": multilingual,
             }
         )
         response = await self.async_client.patch(
@@ -1625,7 +1625,7 @@ class AsyncMemoryClient:
                 "retrieval_criteria": retrieval_criteria,
                 "enable_graph": enable_graph,
                 "version": version,
-                "use_input_language": use_input_language,
+                "multilingual": multilingual,
                 "sync_type": "async",
             },
         )

--- a/mem0/client/project.py
+++ b/mem0/client/project.py
@@ -399,6 +399,7 @@ class Project(BaseProject):
         custom_categories: Optional[List[str]] = None,
         retrieval_criteria: Optional[List[Dict[str, Any]]] = None,
         enable_graph: Optional[bool] = None,
+        use_input_language: Optional[bool] = None,
     ) -> Dict[str, Any]:
         """
         Update project settings.
@@ -408,6 +409,7 @@ class Project(BaseProject):
             custom_categories: New categories for the project
             retrieval_criteria: New retrieval criteria for the project
             enable_graph: Enable or disable the graph for the project
+            use_input_language: Whether to use the input language for memory storage and retrieval
 
         Returns:
             Dictionary containing the API response.
@@ -424,11 +426,12 @@ class Project(BaseProject):
             and custom_categories is None
             and retrieval_criteria is None
             and enable_graph is None
+            and use_input_language is None
         ):
             raise ValueError(
                 "At least one parameter must be provided for update: "
                 "custom_instructions, custom_categories, retrieval_criteria, "
-                "enable_graph"
+                "enable_graph, use_input_language"
             )
 
         payload = self._prepare_params(
@@ -437,6 +440,7 @@ class Project(BaseProject):
                 "custom_categories": custom_categories,
                 "retrieval_criteria": retrieval_criteria,
                 "enable_graph": enable_graph,
+                "use_input_language": use_input_language,
             }
         )
         response = self._client.patch(
@@ -452,6 +456,7 @@ class Project(BaseProject):
                 "custom_categories": custom_categories,
                 "retrieval_criteria": retrieval_criteria,
                 "enable_graph": enable_graph,
+                "use_input_language": use_input_language,
                 "sync_type": "sync",
             },
         )
@@ -716,6 +721,7 @@ class AsyncProject(BaseProject):
         custom_categories: Optional[List[str]] = None,
         retrieval_criteria: Optional[List[Dict[str, Any]]] = None,
         enable_graph: Optional[bool] = None,
+        use_input_language: Optional[bool] = None,
     ) -> Dict[str, Any]:
         """
         Update project settings.
@@ -725,6 +731,7 @@ class AsyncProject(BaseProject):
             custom_categories: New categories for the project
             retrieval_criteria: New retrieval criteria for the project
             enable_graph: Enable or disable the graph for the project
+            use_input_language: Whether to use the input language for memory storage and retrieval
 
         Returns:
             Dictionary containing the API response.
@@ -741,11 +748,12 @@ class AsyncProject(BaseProject):
             and custom_categories is None
             and retrieval_criteria is None
             and enable_graph is None
+            and use_input_language is None
         ):
             raise ValueError(
                 "At least one parameter must be provided for update: "
                 "custom_instructions, custom_categories, retrieval_criteria, "
-                "enable_graph"
+                "enable_graph, use_input_language"
             )
 
         payload = self._prepare_params(
@@ -754,6 +762,7 @@ class AsyncProject(BaseProject):
                 "custom_categories": custom_categories,
                 "retrieval_criteria": retrieval_criteria,
                 "enable_graph": enable_graph,
+                "use_input_language": use_input_language,
             }
         )
         response = await self._client.patch(
@@ -769,6 +778,7 @@ class AsyncProject(BaseProject):
                 "custom_categories": custom_categories,
                 "retrieval_criteria": retrieval_criteria,
                 "enable_graph": enable_graph,
+                "use_input_language": use_input_language,
                 "sync_type": "async",
             },
         )

--- a/mem0/client/project.py
+++ b/mem0/client/project.py
@@ -399,7 +399,7 @@ class Project(BaseProject):
         custom_categories: Optional[List[str]] = None,
         retrieval_criteria: Optional[List[Dict[str, Any]]] = None,
         enable_graph: Optional[bool] = None,
-        use_input_language: Optional[bool] = None,
+        multilingual: Optional[bool] = None,
     ) -> Dict[str, Any]:
         """
         Update project settings.
@@ -409,7 +409,7 @@ class Project(BaseProject):
             custom_categories: New categories for the project
             retrieval_criteria: New retrieval criteria for the project
             enable_graph: Enable or disable the graph for the project
-            use_input_language: Whether to use the input language for memory storage and retrieval
+            multilingual: Whether to use the input language for memory storage and retrieval
 
         Returns:
             Dictionary containing the API response.
@@ -426,12 +426,12 @@ class Project(BaseProject):
             and custom_categories is None
             and retrieval_criteria is None
             and enable_graph is None
-            and use_input_language is None
+            and multilingual is None
         ):
             raise ValueError(
                 "At least one parameter must be provided for update: "
                 "custom_instructions, custom_categories, retrieval_criteria, "
-                "enable_graph, use_input_language"
+                "enable_graph, multilingual"
             )
 
         payload = self._prepare_params(
@@ -440,7 +440,7 @@ class Project(BaseProject):
                 "custom_categories": custom_categories,
                 "retrieval_criteria": retrieval_criteria,
                 "enable_graph": enable_graph,
-                "use_input_language": use_input_language,
+                "multilingual": multilingual,
             }
         )
         response = self._client.patch(
@@ -456,7 +456,7 @@ class Project(BaseProject):
                 "custom_categories": custom_categories,
                 "retrieval_criteria": retrieval_criteria,
                 "enable_graph": enable_graph,
-                "use_input_language": use_input_language,
+                "multilingual": multilingual,
                 "sync_type": "sync",
             },
         )
@@ -721,7 +721,7 @@ class AsyncProject(BaseProject):
         custom_categories: Optional[List[str]] = None,
         retrieval_criteria: Optional[List[Dict[str, Any]]] = None,
         enable_graph: Optional[bool] = None,
-        use_input_language: Optional[bool] = None,
+        multilingual: Optional[bool] = None,
     ) -> Dict[str, Any]:
         """
         Update project settings.
@@ -731,7 +731,7 @@ class AsyncProject(BaseProject):
             custom_categories: New categories for the project
             retrieval_criteria: New retrieval criteria for the project
             enable_graph: Enable or disable the graph for the project
-            use_input_language: Whether to use the input language for memory storage and retrieval
+            multilingual: Whether to use the input language for memory storage and retrieval
 
         Returns:
             Dictionary containing the API response.
@@ -748,12 +748,12 @@ class AsyncProject(BaseProject):
             and custom_categories is None
             and retrieval_criteria is None
             and enable_graph is None
-            and use_input_language is None
+            and multilingual is None
         ):
             raise ValueError(
                 "At least one parameter must be provided for update: "
                 "custom_instructions, custom_categories, retrieval_criteria, "
-                "enable_graph, use_input_language"
+                "enable_graph, multilingual"
             )
 
         payload = self._prepare_params(
@@ -762,7 +762,7 @@ class AsyncProject(BaseProject):
                 "custom_categories": custom_categories,
                 "retrieval_criteria": retrieval_criteria,
                 "enable_graph": enable_graph,
-                "use_input_language": use_input_language,
+                "multilingual": multilingual,
             }
         )
         response = await self._client.patch(
@@ -778,7 +778,7 @@ class AsyncProject(BaseProject):
                 "custom_categories": custom_categories,
                 "retrieval_criteria": retrieval_criteria,
                 "enable_graph": enable_graph,
-                "use_input_language": use_input_language,
+                "multilingual": multilingual,
                 "sync_type": "async",
             },
         )


### PR DESCRIPTION
## Summary
- Add `multilingual` as an accepted `Optional[bool]` parameter to `project.update()` (sync + async) and the deprecated `update_project()` methods (sync + async)
- Add `multilingual` to the TypeScript `PromptUpdatePayload` type
- Update OpenAPI spec to document the field on the PATCH project endpoint
- Update API reference docs with usage examples

The backend API already accepts this field — this change exposes it in the SDKs so users can enable multilingual memory storage and retrieval via `client.project.update(multilingual=True)`.

## Test plan
- [x] `ruff` lint passes on changed Python files
- [ ] CI runs `make test` on Python 3.10-3.12
- [ ] Verify `client.project.update(multilingual=True)` sends the field in the PATCH payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)