### PR TITLE
fix(ts): extract content from code blocks instead of deleting it

### DIFF
--- a/mem0-ts/src/oss/src/prompts/index.ts
+++ b/mem0-ts/src/oss/src/prompts/index.ts
@@ -278,5 +278,9 @@ export function parseMessages(messages: string[]): string {
 }
 
 export function removeCodeBlocks(text: string): string {
-  return text.replace(/```[^`]*```/g, "");
+  // Extract content inside code fences instead of deleting it.
+  // The old regex /```[^`]*```/g replaced the entire block (including
+  // its content) with an empty string, so when an LLM returned JSON
+  // wrapped in ```json ... ``` the actual payload was discarded.
+  return text.replace(/```(?:\w+)?\n?([\s\S]*?)```/g, "$1").trim();
 }

--- a/mem0-ts/src/oss/tests/remove-code-blocks.test.ts
+++ b/mem0-ts/src/oss/tests/remove-code-blocks.test.ts
@@ -1,0 +1,29 @@
+import { removeCodeBlocks } from "../src/prompts";
+
+describe("removeCodeBlocks", () => {
+  it("extracts JSON from ```json code fence", () => {
+    const input = '```json\n{"facts": ["hello"]}\n```';
+    expect(removeCodeBlocks(input)).toBe('{"facts": ["hello"]}');
+  });
+
+  it("extracts content from bare ``` code fence", () => {
+    const input = '```\n{"key": "value"}\n```';
+    expect(removeCodeBlocks(input)).toBe('{"key": "value"}');
+  });
+
+  it("returns plain text unchanged", () => {
+    const input = '{"facts": ["hello"]}';
+    expect(removeCodeBlocks(input)).toBe('{"facts": ["hello"]}');
+  });
+
+  it("handles multiple code blocks", () => {
+    const input = '```json\n{"a":1}\n```\nsome text\n```json\n{"b":2}\n```';
+    expect(removeCodeBlocks(input)).toBe('{"a":1}\n\nsome text\n{"b":2}');
+  });
+
+  it("handles Claude-style response with surrounding text", () => {
+    const input = 'Here is the JSON:\n```json\n{"facts": ["user likes TypeScript"]}\n```';
+    expect(removeCodeBlocks(input)).toContain('"facts"');
+    expect(removeCodeBlocks(input)).not.toContain("```");
+  });
+});


### PR DESCRIPTION
## Problem

Fixes #4108 — `removeCodeBlocks` deletes entire code blocks (including their JSON payload) instead of extracting the content inside them.

The regex `/ ```[^`]*``` /g` matches everything between the opening and closing fence markers and replaces **all of it** with an empty string. When Claude returns:

```
```json
{"facts": ["user likes TypeScript"]}
```
```

the function returns `""` and `JSON.parse` throws `SyntaxError: Unexpected end of JSON input`.

## Fix

Replace the regex with a capturing group that **extracts** the content inside code fences while stripping only the fence markers:

```ts
// Before (deletes content)
text.replace(/```[^`]*```/g, "")

// After (extracts content)
text.replace(/```(?:\w+)?\n?([\s\S]*?)```/g, "$1").trim()
```

## Tests

Added `remove-code-blocks.test.ts` covering:
- JSON in ` ```json ` fence
- Bare ` ``` ` fence
- Plain text passthrough (no fences)
- Multiple code blocks
- Claude-style response with surrounding text