### PR TITLE
feat(openclaw): add disableHistory passthrough for OSS mode

### DIFF
--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -248,7 +248,9 @@ class OSSProvider implements Mem0Provider {
     }
 
     if (this.customPrompt) config.customPrompt = this.customPrompt;
-    if (this.ossConfig?.disableHistory) config.disableHistory = true;
+    if (this.ossConfig && "disableHistory" in this.ossConfig) {
+      config.disableHistory = this.ossConfig.disableHistory;
+    }
 
     this.memory = new Memory(config);
   }


### PR DESCRIPTION
## Summary

Adds `disableHistory` config option to the OSS mode configuration, allowing multi-agent OpenClaw setups to bypass SQLite history storage and avoid race conditions.

## Problem

In multi-agent OpenClaw deployments, multiple agents initialize simultaneously at gateway startup. Each agent triggers `new Memory()` which attempts to open the same SQLite history database file. This causes `SQLITE_CANTOPEN` errors due to file locking race conditions:

```
SqliteError: unable to open database file
```

The underlying `mem0ai` SDK already supports `disableHistory: true` which uses a `DummyHistoryManager` instead of SQLite, but the OpenClaw plugin doesn't pass this config through.

## Solution

Add 2 lines to enable the `disableHistory` passthrough:

1. Add `disableHistory?: boolean` to the OSSConfig interface
2. Pass through in `_init()`: `if (this.ossConfig?.disableHistory) config.disableHistory = true;`

## Usage

```json
{
  "plugins": {
    "entries": {
      "openclaw-mem0": {
        "config": {
          "mode": "open-source",
          "oss": {
            "disableHistory": true,
            "vectorStore": { "provider": "qdrant", "config": { } }
          }
        }
      }
    }
  }
}
```

## Impact

- No breaking changes for existing configurations
- Opt-in fix for multi-agent setups experiencing SQLite race conditions
- The history database is only used for deduplication tracking; all actual memories are stored in Qdrant/vector store and are unaffected

## Testing

Verified in production multi-agent OpenClaw setup (9 agents) - eliminates all `SQLITE_CANTOPEN` errors at startup.

Fixes #4172