### PR TITLE
feat: add MiniMax as a supported LLM provider (M2.7 default)

### DIFF
--- a/LLM.md
+++ b/LLM.md
@@ -273,7 +273,7 @@ config = MemoryConfig(
 
 ### Supported Providers
 
-#### LLM Providers (19 supported)
+#### LLM Providers (20 supported)
 - **openai** - OpenAI GPT models (default)
 - **anthropic** - Claude models
 - **gemini** - Google Gemini
@@ -289,6 +289,7 @@ config = MemoryConfig(
 - **lmstudio** - LM Studio local server
 - **vllm** - vLLM inference server
 - **langchain** - LangChain integration
+- **minimax** - MiniMax models
 - **openai_structured** - OpenAI with structured output
 - **azure_openai_structured** - Azure OpenAI with structured output
 

--- a/docs/components/llms/models/minimax.mdx
+++ b/docs/components/llms/models/minimax.mdx
@@ -17,7 +17,7 @@ config = {
     "llm": {
         "provider": "minimax",
         "config": {
-            "model": "MiniMax-M1",  # default model
+            "model": "MiniMax-M2.7",  # default model
             "temperature": 0.2,
             "max_tokens": 2000,
             "top_p": 1.0
@@ -42,7 +42,7 @@ config = {
     "llm": {
         "provider": "minimax",
         "config": {
-            "model": "MiniMax-M1",
+            "model": "MiniMax-M2.7",
             "minimax_base_url": "https://your-custom-endpoint.com",
             "api_key": "your-api-key"  # alternatively to using environment variable
         }

--- a/docs/components/llms/models/minimax.mdx
+++ b/docs/components/llms/models/minimax.mdx
@@ -1,0 +1,55 @@
+---
+title: MiniMax
+---
+
+To use MiniMax LLM models, you have to set the `MINIMAX_API_KEY` environment variable. You can also optionally set `MINIMAX_API_BASE` if you need to use a different API endpoint (defaults to "https://api.minimax.io/v1").
+
+## Usage
+
+```python
+import os
+from mem0 import Memory
+
+os.environ["MINIMAX_API_KEY"] = "your-api-key"
+os.environ["OPENAI_API_KEY"] = "your-api-key" # for embedder model
+
+config = {
+    "llm": {
+        "provider": "minimax",
+        "config": {
+            "model": "MiniMax-M1",  # default model
+            "temperature": 0.2,
+            "max_tokens": 2000,
+            "top_p": 1.0
+        }
+    }
+}
+
+m = Memory.from_config(config)
+messages = [
+    {"role": "user", "content": "I'm planning to watch a movie tonight. Any recommendations?"},
+    {"role": "assistant", "content": "How about thriller movies? They can be quite engaging."},
+    {"role": "user", "content": "I'm not a big fan of thriller movies but I love sci-fi movies."},
+    {"role": "assistant", "content": "Got it! I'll avoid thriller recommendations and suggest sci-fi movies in the future."}
+]
+m.add(messages, user_id="alice", metadata={"category": "movies"})
+```
+
+You can also configure the API base URL in the config:
+
+```python
+config = {
+    "llm": {
+        "provider": "minimax",
+        "config": {
+            "model": "MiniMax-M1",
+            "minimax_base_url": "https://your-custom-endpoint.com",
+            "api_key": "your-api-key"  # alternatively to using environment variable
+        }
+    }
+}
+```
+
+## Config
+
+All available parameters for the `minimax` config are present in [Master List of All Params in Config](../config).

--- a/docs/components/llms/overview.mdx
+++ b/docs/components/llms/overview.mdx
@@ -34,6 +34,7 @@ See the list of supported LLMs below.
   <Card title="Sarvam AI" href="/components/llms/models/sarvam" />
   <Card title="LM Studio" href="/components/llms/models/lmstudio" />
   <Card title="Langchain" href="/components/llms/models/langchain" />
+  <Card title="MiniMax" href="/components/llms/models/minimax" />
 </CardGroup>
 
 ## Structured vs Unstructured Outputs

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -17,530 +17,531 @@
   "navigation": {
     "anchors": [
       {
-            "anchor": "Documentation",
-            "icon": "book-open",
-            "tabs": [
+        "anchor": "Documentation",
+        "icon": "book-open",
+        "tabs": [
+          {
+            "tab": "Welcome",
+            "groups": [
               {
-                "tab": "Welcome",
-                "groups": [
+                "group": "Start Here",
+                "icon": "home",
+                "pages": [
+                  "introduction"
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "Mem0 Platform",
+            "groups": [
+              {
+                "group": "Getting Started",
+                "icon": "rocket",
+                "pages": [
+                  "platform/overview",
+                  "platform/mem0-mcp",
+                  "platform/platform-vs-oss",
+                  "platform/quickstart"
+                ]
+              },
+              {
+                "group": "Core Concepts",
+                "icon": "brain",
+                "pages": [
+                  "core-concepts/memory-types",
+                  "core-concepts/memory-operations/add",
+                  "core-concepts/memory-operations/search",
+                  "core-concepts/memory-operations/update",
+                  "core-concepts/memory-operations/delete"
+                ]
+              },
+              {
+                "group": "Platform Features",
+                "icon": "star",
+                "pages": [
+                  "platform/features/platform-overview",
                   {
-                    "group": "Start Here",
-                    "icon": "home",
+                    "group": "Essential Features",
+                    "icon": "circle-check",
                     "pages": [
-                      "introduction"
+                      "platform/features/v2-memory-filters",
+                      "platform/features/entity-scoped-memory",
+                      "platform/features/async-client",
+                      "platform/features/async-mode-default-change",
+                      "platform/features/multimodal-support",
+                      "platform/features/custom-categories"
+                    ]
+                  },
+                  {
+                    "group": "Advanced Features",
+                    "icon": "bolt",
+                    "pages": [
+                      "platform/features/graph-memory",
+                      "platform/features/graph-threshold",
+                      "platform/features/advanced-retrieval",
+                      "platform/advanced-memory-operations",
+                      "platform/features/criteria-retrieval",
+                      "platform/features/contextual-add",
+                      "platform/features/custom-instructions"
+                    ]
+                  },
+                  {
+                    "group": "Data Management",
+                    "icon": "database",
+                    "pages": [
+                      "platform/features/direct-import",
+                      "platform/features/memory-export",
+                      "platform/features/timestamp",
+                      "platform/features/expiration-date"
+                    ]
+                  },
+                  {
+                    "group": "Integration Features",
+                    "icon": "plug",
+                    "pages": [
+                      "platform/features/webhooks",
+                      "platform/features/feedback-mechanism",
+                      "platform/features/group-chat",
+                      "platform/features/mcp-integration"
                     ]
                   }
                 ]
               },
               {
-                "tab": "Mem0 Platform",
-                "groups": [
+                "group": "Support & Troubleshooting",
+                "icon": "life-buoy",
+                "pages": [
+                  "platform/faqs"
+                ]
+              },
+              {
+                "group": "Migration Guide",
+                "icon": "arrow-right",
+                "pages": [
+                  "migration/oss-to-platform",
+                  "migration/v0-to-v1",
+                  "migration/breaking-changes",
+                  "migration/api-changes"
+                ]
+              },
+              {
+                "group": "Contribute",
+                "icon": "clipboard-list",
+                "pages": [
+                  "platform/contribute"
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "Open Source",
+            "groups": [
+              {
+                "group": "Getting Started",
+                "icon": "rocket",
+                "pages": [
+                  "open-source/overview",
+                  "open-source/python-quickstart",
+                  "open-source/node-quickstart"
+                ]
+              },
+              {
+                "group": "Self-Hosting Features",
+                "icon": "server",
+                "pages": [
+                  "open-source/features/overview",
+                  "open-source/features/graph-memory",
+                  "open-source/features/metadata-filtering",
+                  "open-source/features/reranker-search",
+                  "open-source/features/async-memory",
+                  "open-source/features/multimodal-support",
+                  "open-source/features/custom-fact-extraction-prompt",
+                  "open-source/features/custom-update-memory-prompt",
+                  "open-source/features/rest-api",
+                  "open-source/features/openai_compatibility"
+                ]
+              },
+              {
+                "group": "Configuration",
+                "icon": "sliders",
+                "pages": [
+                  "open-source/configuration",
                   {
-                    "group": "Getting Started",
-                    "icon": "rocket",
+                    "group": "LLMs",
+                    "icon": "message-bot",
                     "pages": [
-                      "platform/overview",
-                      "platform/mem0-mcp",
-                      "platform/platform-vs-oss",
-                      "platform/quickstart"
-                    ]
-                  },
-                  {
-                    "group": "Core Concepts",
-                    "icon": "brain",
-                    "pages": [
-                      "core-concepts/memory-types",
-                      "core-concepts/memory-operations/add",
-                      "core-concepts/memory-operations/search",
-                      "core-concepts/memory-operations/update",
-                      "core-concepts/memory-operations/delete"
-                    ]
-                  },
-                  {
-                    "group": "Platform Features",
-                    "icon": "star",
-                    "pages": [
-                      "platform/features/platform-overview",
+                      "components/llms/overview",
+                      "components/llms/config",
                       {
-                        "group": "Essential Features",
-                        "icon": "circle-check",
+                        "group": "Supported LLMs",
+                        "icon": "list",
                         "pages": [
-                          "platform/features/v2-memory-filters",
-                          "platform/features/entity-scoped-memory",
-                          "platform/features/async-client",
-                          "platform/features/async-mode-default-change",
-                          "platform/features/multimodal-support",
-                          "platform/features/custom-categories"
-                        ]
-                      },
-                      {
-                        "group": "Advanced Features",
-                        "icon": "bolt",
-                        "pages": [
-                          "platform/features/graph-memory",
-                          "platform/features/graph-threshold",
-                          "platform/features/advanced-retrieval",
-                          "platform/advanced-memory-operations",
-                          "platform/features/criteria-retrieval",
-                          "platform/features/contextual-add",
-                          "platform/features/custom-instructions"
-                        ]
-                      },
-                      {
-                        "group": "Data Management",
-                        "icon": "database",
-                        "pages": [
-                          "platform/features/direct-import",
-                          "platform/features/memory-export",
-                          "platform/features/timestamp",
-                          "platform/features/expiration-date"
-                        ]
-                      },
-                      {
-                        "group": "Integration Features",
-                        "icon": "plug",
-                        "pages": [
-                          "platform/features/webhooks",
-                          "platform/features/feedback-mechanism",
-                          "platform/features/group-chat",
-                          "platform/features/mcp-integration"
+                          "components/llms/models/openai",
+                          "components/llms/models/anthropic",
+                          "components/llms/models/azure_openai",
+                          "components/llms/models/ollama",
+                          "components/llms/models/together",
+                          "components/llms/models/groq",
+                          "components/llms/models/litellm",
+                          "components/llms/models/mistral_AI",
+                          "components/llms/models/google_AI",
+                          "components/llms/models/aws_bedrock",
+                          "components/llms/models/deepseek",
+                          "components/llms/models/xAI",
+                          "components/llms/models/sarvam",
+                          "components/llms/models/lmstudio",
+                          "components/llms/models/langchain",
+                          "components/llms/models/vllm",
+                          "components/llms/models/minimax"
                         ]
                       }
                     ]
                   },
                   {
-                    "group": "Support & Troubleshooting",
-                    "icon": "life-buoy",
+                    "group": "Vector Databases",
+                    "icon": "hard-drive",
                     "pages": [
-                      "platform/faqs"
-                    ]
-                  },
-                  {
-                    "group": "Migration Guide",
-                    "icon": "arrow-right",
-                    "pages": [
-                      "migration/oss-to-platform",
-                      "migration/v0-to-v1",
-                      "migration/breaking-changes",
-                      "migration/api-changes"
-                    ]
-                  },
-                  {
-                    "group": "Contribute",
-                    "icon": "clipboard-list",
-                    "pages": [
-                      "platform/contribute"
-                    ]
-                  }
-                ]
-              },
-              {
-                "tab": "Open Source",
-                "groups": [
-                  {
-                    "group": "Getting Started",
-                    "icon": "rocket",
-                    "pages": [
-                      "open-source/overview",
-                      "open-source/python-quickstart",
-                      "open-source/node-quickstart"
-                    ]
-                  },
-                  {
-                    "group": "Self-Hosting Features",
-                    "icon": "server",
-                    "pages": [
-                      "open-source/features/overview",
-                      "open-source/features/graph-memory",
-                      "open-source/features/metadata-filtering",
-                      "open-source/features/reranker-search",
-                      "open-source/features/async-memory",
-                      "open-source/features/multimodal-support",
-                      "open-source/features/custom-fact-extraction-prompt",
-                      "open-source/features/custom-update-memory-prompt",
-                      "open-source/features/rest-api",
-                      "open-source/features/openai_compatibility"
-                    ]
-                  },
-                  {
-                    "group": "Configuration",
-                    "icon": "sliders",
-                    "pages": [
-                      "open-source/configuration",
+                      "components/vectordbs/overview",
+                      "components/vectordbs/config",
                       {
-                        "group": "LLMs",
-                        "icon": "message-bot",
+                        "group": "Supported Vector Databases",
+                        "icon": "list",
                         "pages": [
-                          "components/llms/overview",
-                          "components/llms/config",
-                          {
-                            "group": "Supported LLMs",
-                            "icon": "list",
-                            "pages": [
-                              "components/llms/models/openai",
-                              "components/llms/models/anthropic",
-                              "components/llms/models/azure_openai",
-                              "components/llms/models/ollama",
-                              "components/llms/models/together",
-                              "components/llms/models/groq",
-                              "components/llms/models/litellm",
-                              "components/llms/models/mistral_AI",
-                              "components/llms/models/google_AI",
-                              "components/llms/models/aws_bedrock",
-                              "components/llms/models/deepseek",
-                              "components/llms/models/xAI",
-                              "components/llms/models/sarvam",
-                              "components/llms/models/lmstudio",
-                              "components/llms/models/langchain",
-                              "components/llms/models/vllm"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "Vector Databases",
-                        "icon": "hard-drive",
-                        "pages": [
-                          "components/vectordbs/overview",
-                          "components/vectordbs/config",
-                          {
-                            "group": "Supported Vector Databases",
-                            "icon": "list",
-                            "pages": [
-                              "components/vectordbs/dbs/qdrant",
-                              "components/vectordbs/dbs/chroma",
-                              "components/vectordbs/dbs/pgvector",
-                              "components/vectordbs/dbs/milvus",
-                              "components/vectordbs/dbs/pinecone",
-                              "components/vectordbs/dbs/mongodb",
-                              "components/vectordbs/dbs/azure",
-                              "components/vectordbs/dbs/azure_mysql",
-                              "components/vectordbs/dbs/redis",
-                              "components/vectordbs/dbs/valkey",
-                              "components/vectordbs/dbs/elasticsearch",
-                              "components/vectordbs/dbs/opensearch",
-                              "components/vectordbs/dbs/supabase",
-                              "components/vectordbs/dbs/upstash-vector",
-                              "components/vectordbs/dbs/vectorize",
-                              "components/vectordbs/dbs/vertex_ai",
-                              "components/vectordbs/dbs/weaviate",
-                              "components/vectordbs/dbs/faiss",
-                              "components/vectordbs/dbs/langchain",
-                              "components/vectordbs/dbs/baidu",
-                              "components/vectordbs/dbs/cassandra",
-                              "components/vectordbs/dbs/s3_vectors",
-                              "components/vectordbs/dbs/databricks",
-                              "components/vectordbs/dbs/neptune_analytics"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "Embedding Models",
-                        "icon": "cube",
-                        "pages": [
-                          "components/embedders/overview",
-                          "components/embedders/config",
-                          {
-                            "group": "Supported Embedding Models",
-                            "icon": "list",
-                            "pages": [
-                              "components/embedders/models/openai",
-                              "components/embedders/models/azure_openai",
-                              "components/embedders/models/ollama",
-                              "components/embedders/models/huggingface",
-                              "components/embedders/models/vertexai",
-                              "components/embedders/models/google_AI",
-                              "components/embedders/models/lmstudio",
-                              "components/embedders/models/together",
-                              "components/embedders/models/langchain",
-                              "components/embedders/models/aws_bedrock"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "Rerankers",
-                        "icon": "ranking-star",
-                        "pages": [
-                          "components/rerankers/overview",
-                          "components/rerankers/config",
-                          "components/rerankers/optimization",
-                          "components/rerankers/custom-prompts",
-                          {
-                            "group": "Supported Rerankers",
-                            "icon": "list",
-                            "pages": [
-                              "components/rerankers/models/cohere",
-                              "components/rerankers/models/sentence_transformer",
-                              "components/rerankers/models/huggingface",
-                              "components/rerankers/models/llm_reranker",
-                              "components/rerankers/models/zero_entropy"
-                            ]
-                          }
+                          "components/vectordbs/dbs/qdrant",
+                          "components/vectordbs/dbs/chroma",
+                          "components/vectordbs/dbs/pgvector",
+                          "components/vectordbs/dbs/milvus",
+                          "components/vectordbs/dbs/pinecone",
+                          "components/vectordbs/dbs/mongodb",
+                          "components/vectordbs/dbs/azure",
+                          "components/vectordbs/dbs/azure_mysql",
+                          "components/vectordbs/dbs/redis",
+                          "components/vectordbs/dbs/valkey",
+                          "components/vectordbs/dbs/elasticsearch",
+                          "components/vectordbs/dbs/opensearch",
+                          "components/vectordbs/dbs/supabase",
+                          "components/vectordbs/dbs/upstash-vector",
+                          "components/vectordbs/dbs/vectorize",
+                          "components/vectordbs/dbs/vertex_ai",
+                          "components/vectordbs/dbs/weaviate",
+                          "components/vectordbs/dbs/faiss",
+                          "components/vectordbs/dbs/langchain",
+                          "components/vectordbs/dbs/baidu",
+                          "components/vectordbs/dbs/cassandra",
+                          "components/vectordbs/dbs/s3_vectors",
+                          "components/vectordbs/dbs/databricks",
+                          "components/vectordbs/dbs/neptune_analytics"
                         ]
                       }
                     ]
                   },
                   {
-                    "group": "Community & Support",
-                    "icon": "users",
+                    "group": "Embedding Models",
+                    "icon": "cube",
                     "pages": [
-                      "contributing/development",
-                      "contributing/documentation"
+                      "components/embedders/overview",
+                      "components/embedders/config",
+                      {
+                        "group": "Supported Embedding Models",
+                        "icon": "list",
+                        "pages": [
+                          "components/embedders/models/openai",
+                          "components/embedders/models/azure_openai",
+                          "components/embedders/models/ollama",
+                          "components/embedders/models/huggingface",
+                          "components/embedders/models/vertexai",
+                          "components/embedders/models/google_AI",
+                          "components/embedders/models/lmstudio",
+                          "components/embedders/models/together",
+                          "components/embedders/models/langchain",
+                          "components/embedders/models/aws_bedrock"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Rerankers",
+                    "icon": "ranking-star",
+                    "pages": [
+                      "components/rerankers/overview",
+                      "components/rerankers/config",
+                      "components/rerankers/optimization",
+                      "components/rerankers/custom-prompts",
+                      {
+                        "group": "Supported Rerankers",
+                        "icon": "list",
+                        "pages": [
+                          "components/rerankers/models/cohere",
+                          "components/rerankers/models/sentence_transformer",
+                          "components/rerankers/models/huggingface",
+                          "components/rerankers/models/llm_reranker",
+                          "components/rerankers/models/zero_entropy"
+                        ]
+                      }
                     ]
                   }
                 ]
               },
               {
-                "tab": "OpenMemory",
-                "groups": [
-                  {
-                    "group": "Overview & Quickstart",
-                    "icon": "square-terminal",
-                    "pages": [
-                      "openmemory/overview",
-                      "openmemory/quickstart",
-                      "openmemory/integrations"
-                    ]
-                  }
+                "group": "Community & Support",
+                "icon": "users",
+                "pages": [
+                  "contributing/development",
+                  "contributing/documentation"
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "OpenMemory",
+            "groups": [
+              {
+                "group": "Overview & Quickstart",
+                "icon": "square-terminal",
+                "pages": [
+                  "openmemory/overview",
+                  "openmemory/quickstart",
+                  "openmemory/integrations"
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "Cookbooks",
+            "groups": [
+              {
+                "group": "Getting Started",
+                "icon": "lightbulb",
+                "pages": [
+                  "cookbooks/overview"
                 ]
               },
               {
-                "tab": "Cookbooks",
-                "groups": [
-                  {
-                    "group": "Getting Started",
-                    "icon": "lightbulb",
-                    "pages": [
-                      "cookbooks/overview"
-                    ]
-                  },
-                  {
-                    "group": "Essentials",
-                    "icon": "flag",
-                    "pages": [
-                      "cookbooks/essentials/building-ai-companion",
-                      "cookbooks/essentials/entity-partitioning-playbook",
-                      "cookbooks/essentials/controlling-memory-ingestion",
-                      "cookbooks/essentials/memory-expiration-short-and-long-term",
-                      "cookbooks/essentials/tagging-and-organizing-memories",
-                      "cookbooks/essentials/exporting-memories",
-                      "cookbooks/essentials/choosing-memory-architecture-vector-vs-graph"
-                    ]
-                  },
-                  {
-                    "group": "Companion Playbooks",
-                    "icon": "users",
-                    "pages": [
-                      "cookbooks/companions/quickstart-demo",
-                      "cookbooks/companions/nodejs-companion",
-                      "cookbooks/companions/ai-tutor",
-                      "cookbooks/companions/travel-assistant",
-                      "cookbooks/companions/youtube-research",
-                      "cookbooks/companions/voice-companion-openai",
-                      "cookbooks/companions/local-companion-ollama"
-                    ]
-                  },
-                  {
-                    "group": "Ops & Automations",
-                    "icon": "briefcase",
-                    "pages": [
-                      "cookbooks/operations/support-inbox",
-                      "cookbooks/operations/email-automation",
-                      "cookbooks/operations/content-writing",
-                      "cookbooks/operations/deep-research",
-                      "cookbooks/operations/team-task-agent"
-                    ]
-                  },
-                  {
-                    "group": "Integrations & Platforms",
-                    "icon": "plug",
-                    "pages": [
-                      "cookbooks/integrations/agents-sdk-tool",
-                      "cookbooks/integrations/openai-tool-calls",
-                      "cookbooks/integrations/mastra-agent",
-                      "cookbooks/integrations/healthcare-google-adk",
-                      "cookbooks/integrations/aws-bedrock",
-                      "cookbooks/integrations/neptune-analytics",
-                      "cookbooks/integrations/tavily-search"
-                    ]
-                  },
-                  {
-                    "group": "Frameworks & Multimodal",
-                    "icon": "layers",
-                    "pages": [
-                      "cookbooks/frameworks/llamaindex-react",
-                      "cookbooks/frameworks/llamaindex-multiagent",
-                      "cookbooks/frameworks/multimodal-retrieval",
-                      "cookbooks/frameworks/eliza-os-character",
-                      "cookbooks/frameworks/chrome-extension",
-                      "cookbooks/frameworks/gemini-3-with-mem0-mcp"
-                    ]
-                  }
+                "group": "Essentials",
+                "icon": "flag",
+                "pages": [
+                  "cookbooks/essentials/building-ai-companion",
+                  "cookbooks/essentials/entity-partitioning-playbook",
+                  "cookbooks/essentials/controlling-memory-ingestion",
+                  "cookbooks/essentials/memory-expiration-short-and-long-term",
+                  "cookbooks/essentials/tagging-and-organizing-memories",
+                  "cookbooks/essentials/exporting-memories",
+                  "cookbooks/essentials/choosing-memory-architecture-vector-vs-graph"
                 ]
               },
               {
-                "tab": "Integrations",
-                "groups": [
-                  {
-                    "group": "Overview",
-                    "icon": "plug",
-                    "pages": [
-                      "integrations"
-                    ]
-                  },
-                  {
-                    "group": "Agent Frameworks",
-                    "icon": "robot",
-                    "pages": [
-                      "integrations/langchain",
-                      "integrations/langgraph",
-                      "integrations/llama-index",
-                      "integrations/crewai",
-                      "integrations/autogen",
-                      "integrations/agno",
-                      "integrations/camel-ai",
-                      "integrations/openclaw",
-                      "integrations/openai-agents-sdk",
-                      "integrations/google-ai-adk",
-                      "integrations/mastra",
-                      "integrations/vercel-ai-sdk"
-                    ]
-                  },
-                  {
-                    "group": "Voice & Real-time",
-                    "icon": "microphone",
-                    "pages": [
-                      "integrations/livekit",
-                      "integrations/pipecat",
-                      "integrations/elevenlabs"
-                    ]
-                  },
-                  {
-                    "group": "Cloud & Infrastructure",
-                    "icon": "cloud",
-                    "pages": [
-                      "integrations/aws-bedrock"
-                    ]
-                  },
-                  {
-                    "group": "Developer Tools",
-                    "icon": "wrench",
-                    "pages": [
-                      "integrations/dify",
-                      "integrations/flowise",
-                      "integrations/langchain-tools",
-                      "integrations/agentops",
-                      "integrations/keywords",
-                      "integrations/raycast"
-                    ]
-                  }
+                "group": "Companion Playbooks",
+                "icon": "users",
+                "pages": [
+                  "cookbooks/companions/quickstart-demo",
+                  "cookbooks/companions/nodejs-companion",
+                  "cookbooks/companions/ai-tutor",
+                  "cookbooks/companions/travel-assistant",
+                  "cookbooks/companions/youtube-research",
+                  "cookbooks/companions/voice-companion-openai",
+                  "cookbooks/companions/local-companion-ollama"
                 ]
               },
               {
-                "tab": "API Reference",
-                "groups": [
-                  {
-                    "group": "Getting Started",
-                    "icon": "rocket",
-                    "pages": [
-                      "api-reference",
-                      "api-reference/organizations-projects"
-                    ]
-                  },
-                  {
-                    "group": "Core Memory Operations",
-                    "icon": "microchip",
-                    "pages": [
-                      "api-reference/memory/add-memories",
-                      "api-reference/memory/get-memories",
-                      "api-reference/memory/search-memories",
-                      "api-reference/memory/update-memory",
-                      "api-reference/memory/delete-memory"
-                    ]
-                  },
-                  {
-                    "group": "Memory APIs",
-                    "icon": "sparkles",
-                    "pages": [
-                      "api-reference/memory/create-memory-export",
-                      "api-reference/memory/feedback",
-                      "api-reference/memory/get-memory",
-                      "api-reference/memory/history-memory",
-                      "api-reference/memory/get-memory-export",
-                      "api-reference/memory/batch-update",
-                      "api-reference/memory/batch-delete",
-                      "api-reference/memory/delete-memories"
-                    ]
-                  },
-                  {
-                    "group": "Events APIs",
-                    "icon": "clock",
-                    "pages": [
-                      "api-reference/events/get-events",
-                      "api-reference/events/get-event"
-                    ]
-                  },
-                  {
-                    "group": "Entities APIs",
-                    "icon": "users",
-                    "pages": [
-                      "api-reference/entities/get-users",
-                      "api-reference/entities/delete-user"
-                    ]
-                  },
-                  {
-                    "group": "Organizations APIs",
-                    "icon": "building",
-                    "pages": [
-                      "api-reference/organization/create-org",
-                      "api-reference/organization/get-orgs",
-                      "api-reference/organization/get-org",
-                      "api-reference/organization/get-org-members",
-                      "api-reference/organization/add-org-member",
-                      "api-reference/organization/delete-org"
-                    ]
-                  },
-                  {
-                    "group": "Project APIs",
-                    "icon": "folder",
-                    "pages": [
-                      "api-reference/project/create-project",
-                      "api-reference/project/get-projects",
-                      "api-reference/project/get-project",
-                      "api-reference/project/get-project-members",
-                      "api-reference/project/add-project-member",
-                      "api-reference/project/delete-project"
-                    ]
-                  },
-                  {
-                    "group": "Webhook APIs",
-                    "icon": "webhook",
-                    "pages": [
-                      "api-reference/webhook/create-webhook",
-                      "api-reference/webhook/get-webhook",
-                      "api-reference/webhook/update-webhook",
-                      "api-reference/webhook/delete-webhook"
-                    ]
-                  }
+                "group": "Ops & Automations",
+                "icon": "briefcase",
+                "pages": [
+                  "cookbooks/operations/support-inbox",
+                  "cookbooks/operations/email-automation",
+                  "cookbooks/operations/content-writing",
+                  "cookbooks/operations/deep-research",
+                  "cookbooks/operations/team-task-agent"
                 ]
               },
               {
-                "tab": "Release Notes",
-                "groups": [
-                  {
-                    "group": "Changelog",
-                    "icon": "rocket",
-                    "pages": [
-                      "changelog"
-                    ]
-                  }
+                "group": "Integrations & Platforms",
+                "icon": "plug",
+                "pages": [
+                  "cookbooks/integrations/agents-sdk-tool",
+                  "cookbooks/integrations/openai-tool-calls",
+                  "cookbooks/integrations/mastra-agent",
+                  "cookbooks/integrations/healthcare-google-adk",
+                  "cookbooks/integrations/aws-bedrock",
+                  "cookbooks/integrations/neptune-analytics",
+                  "cookbooks/integrations/tavily-search"
+                ]
+              },
+              {
+                "group": "Frameworks & Multimodal",
+                "icon": "layers",
+                "pages": [
+                  "cookbooks/frameworks/llamaindex-react",
+                  "cookbooks/frameworks/llamaindex-multiagent",
+                  "cookbooks/frameworks/multimodal-retrieval",
+                  "cookbooks/frameworks/eliza-os-character",
+                  "cookbooks/frameworks/chrome-extension",
+                  "cookbooks/frameworks/gemini-3-with-mem0-mcp"
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "Integrations",
+            "groups": [
+              {
+                "group": "Overview",
+                "icon": "plug",
+                "pages": [
+                  "integrations"
+                ]
+              },
+              {
+                "group": "Agent Frameworks",
+                "icon": "robot",
+                "pages": [
+                  "integrations/langchain",
+                  "integrations/langgraph",
+                  "integrations/llama-index",
+                  "integrations/crewai",
+                  "integrations/autogen",
+                  "integrations/agno",
+                  "integrations/camel-ai",
+                  "integrations/openclaw",
+                  "integrations/openai-agents-sdk",
+                  "integrations/google-ai-adk",
+                  "integrations/mastra",
+                  "integrations/vercel-ai-sdk"
+                ]
+              },
+              {
+                "group": "Voice & Real-time",
+                "icon": "microphone",
+                "pages": [
+                  "integrations/livekit",
+                  "integrations/pipecat",
+                  "integrations/elevenlabs"
+                ]
+              },
+              {
+                "group": "Cloud & Infrastructure",
+                "icon": "cloud",
+                "pages": [
+                  "integrations/aws-bedrock"
+                ]
+              },
+              {
+                "group": "Developer Tools",
+                "icon": "wrench",
+                "pages": [
+                  "integrations/dify",
+                  "integrations/flowise",
+                  "integrations/langchain-tools",
+                  "integrations/agentops",
+                  "integrations/keywords",
+                  "integrations/raycast"
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "API Reference",
+            "groups": [
+              {
+                "group": "Getting Started",
+                "icon": "rocket",
+                "pages": [
+                  "api-reference",
+                  "api-reference/organizations-projects"
+                ]
+              },
+              {
+                "group": "Core Memory Operations",
+                "icon": "microchip",
+                "pages": [
+                  "api-reference/memory/add-memories",
+                  "api-reference/memory/get-memories",
+                  "api-reference/memory/search-memories",
+                  "api-reference/memory/update-memory",
+                  "api-reference/memory/delete-memory"
+                ]
+              },
+              {
+                "group": "Memory APIs",
+                "icon": "sparkles",
+                "pages": [
+                  "api-reference/memory/create-memory-export",
+                  "api-reference/memory/feedback",
+                  "api-reference/memory/get-memory",
+                  "api-reference/memory/history-memory",
+                  "api-reference/memory/get-memory-export",
+                  "api-reference/memory/batch-update",
+                  "api-reference/memory/batch-delete",
+                  "api-reference/memory/delete-memories"
+                ]
+              },
+              {
+                "group": "Events APIs",
+                "icon": "clock",
+                "pages": [
+                  "api-reference/events/get-events",
+                  "api-reference/events/get-event"
+                ]
+              },
+              {
+                "group": "Entities APIs",
+                "icon": "users",
+                "pages": [
+                  "api-reference/entities/get-users",
+                  "api-reference/entities/delete-user"
+                ]
+              },
+              {
+                "group": "Organizations APIs",
+                "icon": "building",
+                "pages": [
+                  "api-reference/organization/create-org",
+                  "api-reference/organization/get-orgs",
+                  "api-reference/organization/get-org",
+                  "api-reference/organization/get-org-members",
+                  "api-reference/organization/add-org-member",
+                  "api-reference/organization/delete-org"
+                ]
+              },
+              {
+                "group": "Project APIs",
+                "icon": "folder",
+                "pages": [
+                  "api-reference/project/create-project",
+                  "api-reference/project/get-projects",
+                  "api-reference/project/get-project",
+                  "api-reference/project/get-project-members",
+                  "api-reference/project/add-project-member",
+                  "api-reference/project/delete-project"
+                ]
+              },
+              {
+                "group": "Webhook APIs",
+                "icon": "webhook",
+                "pages": [
+                  "api-reference/webhook/create-webhook",
+                  "api-reference/webhook/get-webhook",
+                  "api-reference/webhook/update-webhook",
+                  "api-reference/webhook/delete-webhook"
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "Release Notes",
+            "groups": [
+              {
+                "group": "Changelog",
+                "icon": "rocket",
+                "pages": [
+                  "changelog"
                 ]
               }
             ]
           }
         ]
+      }
+    ]
   },
   "background": {
     "color": {

--- a/mem0/configs/llms/minimax.py
+++ b/mem0/configs/llms/minimax.py
@@ -1,0 +1,56 @@
+from typing import Optional
+
+from mem0.configs.llms.base import BaseLlmConfig
+
+
+class MiniMaxConfig(BaseLlmConfig):
+    """
+    Configuration class for MiniMax-specific parameters.
+    Inherits from BaseLlmConfig and adds MiniMax-specific settings.
+    """
+
+    def __init__(
+        self,
+        # Base parameters
+        model: Optional[str] = None,
+        temperature: float = 0.1,
+        api_key: Optional[str] = None,
+        max_tokens: int = 2000,
+        top_p: float = 0.1,
+        top_k: int = 1,
+        enable_vision: bool = False,
+        vision_details: Optional[str] = "auto",
+        http_client_proxies: Optional[dict] = None,
+        # MiniMax-specific parameters
+        minimax_base_url: Optional[str] = None,
+    ):
+        """
+        Initialize MiniMax configuration.
+
+        Args:
+            model: MiniMax model to use, defaults to None
+            temperature: Controls randomness, defaults to 0.1
+            api_key: MiniMax API key, defaults to None
+            max_tokens: Maximum tokens to generate, defaults to 2000
+            top_p: Nucleus sampling parameter, defaults to 0.1
+            top_k: Top-k sampling parameter, defaults to 1
+            enable_vision: Enable vision capabilities, defaults to False
+            vision_details: Vision detail level, defaults to "auto"
+            http_client_proxies: HTTP client proxy settings, defaults to None
+            minimax_base_url: MiniMax API base URL, defaults to None
+        """
+        # Initialize base parameters
+        super().__init__(
+            model=model,
+            temperature=temperature,
+            api_key=api_key,
+            max_tokens=max_tokens,
+            top_p=top_p,
+            top_k=top_k,
+            enable_vision=enable_vision,
+            vision_details=vision_details,
+            http_client_proxies=http_client_proxies,
+        )
+
+        # MiniMax-specific parameters
+        self.minimax_base_url = minimax_base_url

--- a/mem0/llms/configs.py
+++ b/mem0/llms/configs.py
@@ -28,6 +28,7 @@ class LlmConfig(BaseModel):
             "lmstudio",
             "vllm",
             "langchain",
+            "minimax",
         ):
             return v
         else:

--- a/mem0/llms/minimax.py
+++ b/mem0/llms/minimax.py
@@ -34,7 +34,7 @@ class MiniMaxLLM(LLMBase):
         super().__init__(config)
 
         if not self.config.model:
-            self.config.model = "MiniMax-M1"
+            self.config.model = "MiniMax-M2.7"
 
         api_key = self.config.api_key or os.getenv("MINIMAX_API_KEY")
         base_url = self.config.minimax_base_url or os.getenv("MINIMAX_API_BASE") or "https://api.minimax.io/v1"

--- a/mem0/llms/minimax.py
+++ b/mem0/llms/minimax.py
@@ -1,0 +1,107 @@
+import json
+import os
+from typing import Dict, List, Optional, Union
+
+from openai import OpenAI
+
+from mem0.configs.llms.base import BaseLlmConfig
+from mem0.configs.llms.minimax import MiniMaxConfig
+from mem0.llms.base import LLMBase
+from mem0.memory.utils import extract_json
+
+
+class MiniMaxLLM(LLMBase):
+    def __init__(self, config: Optional[Union[BaseLlmConfig, MiniMaxConfig, Dict]] = None):
+        # Convert to MiniMaxConfig if needed
+        if config is None:
+            config = MiniMaxConfig()
+        elif isinstance(config, dict):
+            config = MiniMaxConfig(**config)
+        elif isinstance(config, BaseLlmConfig) and not isinstance(config, MiniMaxConfig):
+            # Convert BaseLlmConfig to MiniMaxConfig
+            config = MiniMaxConfig(
+                model=config.model,
+                temperature=config.temperature,
+                api_key=config.api_key,
+                max_tokens=config.max_tokens,
+                top_p=config.top_p,
+                top_k=config.top_k,
+                enable_vision=config.enable_vision,
+                vision_details=config.vision_details,
+                http_client_proxies=config.http_client,
+            )
+
+        super().__init__(config)
+
+        if not self.config.model:
+            self.config.model = "MiniMax-M1"
+
+        api_key = self.config.api_key or os.getenv("MINIMAX_API_KEY")
+        base_url = self.config.minimax_base_url or os.getenv("MINIMAX_API_BASE") or "https://api.minimax.io/v1"
+        self.client = OpenAI(api_key=api_key, base_url=base_url)
+
+    def _parse_response(self, response, tools):
+        """
+        Process the response based on whether tools are used or not.
+
+        Args:
+            response: The raw response from API.
+            tools: The list of tools provided in the request.
+
+        Returns:
+            str or dict: The processed response.
+        """
+        if tools:
+            processed_response = {
+                "content": response.choices[0].message.content,
+                "tool_calls": [],
+            }
+
+            if response.choices[0].message.tool_calls:
+                for tool_call in response.choices[0].message.tool_calls:
+                    processed_response["tool_calls"].append(
+                        {
+                            "name": tool_call.function.name,
+                            "arguments": json.loads(extract_json(tool_call.function.arguments)),
+                        }
+                    )
+
+            return processed_response
+        else:
+            return response.choices[0].message.content
+
+    def generate_response(
+        self,
+        messages: List[Dict[str, str]],
+        response_format=None,
+        tools: Optional[List[Dict]] = None,
+        tool_choice: str = "auto",
+        **kwargs,
+    ):
+        """
+        Generate a response based on the given messages using MiniMax.
+
+        Args:
+            messages (list): List of message dicts containing 'role' and 'content'.
+            response_format (str or object, optional): Format of the response. Defaults to "text".
+            tools (list, optional): List of tools that the model can call. Defaults to None.
+            tool_choice (str, optional): Tool choice method. Defaults to "auto".
+            **kwargs: Additional MiniMax-specific parameters.
+
+        Returns:
+            str: The generated response.
+        """
+        params = self._get_supported_params(messages=messages, **kwargs)
+        params.update(
+            {
+                "model": self.config.model,
+                "messages": messages,
+            }
+        )
+
+        if tools:
+            params["tools"] = tools
+            params["tool_choice"] = tool_choice
+
+        response = self.client.chat.completions.create(**params)
+        return self._parse_response(response, tools)

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -7,6 +7,7 @@ from mem0.configs.llms.azure import AzureOpenAIConfig
 from mem0.configs.llms.base import BaseLlmConfig
 from mem0.configs.llms.deepseek import DeepSeekConfig
 from mem0.configs.llms.lmstudio import LMStudioConfig
+from mem0.configs.llms.minimax import MiniMaxConfig
 from mem0.configs.llms.ollama import OllamaConfig
 from mem0.configs.llms.openai import OpenAIConfig
 from mem0.configs.llms.vllm import VllmConfig
@@ -50,6 +51,7 @@ class LlmFactory:
         "lmstudio": ("mem0.llms.lmstudio.LMStudioLLM", LMStudioConfig),
         "vllm": ("mem0.llms.vllm.VllmLLM", VllmConfig),
         "langchain": ("mem0.llms.langchain.LangchainLLM", BaseLlmConfig),
+        "minimax": ("mem0.llms.minimax.MiniMaxLLM", MiniMaxConfig),
     }
 
     @classmethod

--- a/tests/llms/test_minimax.py
+++ b/tests/llms/test_minimax.py
@@ -1,0 +1,118 @@
+import os
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mem0.configs.llms.base import BaseLlmConfig
+from mem0.configs.llms.minimax import MiniMaxConfig
+from mem0.llms.minimax import MiniMaxLLM
+
+
+@pytest.fixture
+def mock_minimax_client():
+    with patch("mem0.llms.minimax.OpenAI") as mock_openai:
+        mock_client = Mock()
+        mock_openai.return_value = mock_client
+        yield mock_client
+
+
+def test_minimax_llm_base_url():
+    # case1: default config with MiniMax official base url
+    config = BaseLlmConfig(model="MiniMax-M1", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key")
+    llm = MiniMaxLLM(config)
+    assert str(llm.client.base_url).rstrip("/") == "https://api.minimax.io/v1"
+
+    # case2: with env variable MINIMAX_API_BASE
+    provider_base_url = "https://api.provider.com/v1/"
+    os.environ["MINIMAX_API_BASE"] = provider_base_url
+    config = MiniMaxConfig(model="MiniMax-M1", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key")
+    llm = MiniMaxLLM(config)
+    assert str(llm.client.base_url) == provider_base_url
+
+    # case3: with config.minimax_base_url
+    config_base_url = "https://api.config.com/v1/"
+    config = MiniMaxConfig(
+        model="MiniMax-M1",
+        temperature=0.7,
+        max_tokens=100,
+        top_p=1.0,
+        api_key="api_key",
+        minimax_base_url=config_base_url,
+    )
+    llm = MiniMaxLLM(config)
+    assert str(llm.client.base_url) == config_base_url
+
+    # cleanup
+    del os.environ["MINIMAX_API_BASE"]
+
+
+def test_generate_response_without_tools(mock_minimax_client):
+    config = BaseLlmConfig(model="MiniMax-M1", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = MiniMaxLLM(config)
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello, how are you?"},
+    ]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="I'm doing well, thank you for asking!"))]
+    mock_minimax_client.chat.completions.create.return_value = mock_response
+
+    response = llm.generate_response(messages)
+
+    mock_minimax_client.chat.completions.create.assert_called_once_with(
+        model="MiniMax-M1", messages=messages, temperature=0.7, max_tokens=100, top_p=1.0
+    )
+    assert response == "I'm doing well, thank you for asking!"
+
+
+def test_generate_response_with_tools(mock_minimax_client):
+    config = BaseLlmConfig(model="MiniMax-M1", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = MiniMaxLLM(config)
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Add a new memory: Today is a sunny day."},
+    ]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "add_memory",
+                "description": "Add a memory",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"data": {"type": "string", "description": "Data to add to memory"}},
+                    "required": ["data"],
+                },
+            },
+        }
+    ]
+
+    mock_response = Mock()
+    mock_message = Mock()
+    mock_message.content = "I've added the memory for you."
+
+    mock_tool_call = Mock()
+    mock_tool_call.function.name = "add_memory"
+    mock_tool_call.function.arguments = '{"data": "Today is a sunny day."}'
+
+    mock_message.tool_calls = [mock_tool_call]
+    mock_response.choices = [Mock(message=mock_message)]
+    mock_minimax_client.chat.completions.create.return_value = mock_response
+
+    response = llm.generate_response(messages, tools=tools)
+
+    mock_minimax_client.chat.completions.create.assert_called_once_with(
+        model="MiniMax-M1",
+        messages=messages,
+        temperature=0.7,
+        max_tokens=100,
+        top_p=1.0,
+        tools=tools,
+        tool_choice="auto",
+    )
+
+    assert response["content"] == "I've added the memory for you."
+    assert len(response["tool_calls"]) == 1
+    assert response["tool_calls"][0]["name"] == "add_memory"
+    assert response["tool_calls"][0]["arguments"] == {"data": "Today is a sunny day."}

--- a/tests/llms/test_minimax.py
+++ b/tests/llms/test_minimax.py
@@ -18,21 +18,21 @@ def mock_minimax_client():
 
 def test_minimax_llm_base_url():
     # case1: default config with MiniMax official base url
-    config = BaseLlmConfig(model="MiniMax-M1", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key")
+    config = BaseLlmConfig(model="MiniMax-M2.7", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key")
     llm = MiniMaxLLM(config)
     assert str(llm.client.base_url).rstrip("/") == "https://api.minimax.io/v1"
 
     # case2: with env variable MINIMAX_API_BASE
     provider_base_url = "https://api.provider.com/v1/"
     os.environ["MINIMAX_API_BASE"] = provider_base_url
-    config = MiniMaxConfig(model="MiniMax-M1", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key")
+    config = MiniMaxConfig(model="MiniMax-M2.7", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key")
     llm = MiniMaxLLM(config)
     assert str(llm.client.base_url) == provider_base_url
 
     # case3: with config.minimax_base_url
     config_base_url = "https://api.config.com/v1/"
     config = MiniMaxConfig(
-        model="MiniMax-M1",
+        model="MiniMax-M2.7",
         temperature=0.7,
         max_tokens=100,
         top_p=1.0,
@@ -46,8 +46,15 @@ def test_minimax_llm_base_url():
     del os.environ["MINIMAX_API_BASE"]
 
 
+def test_minimax_default_model(mock_minimax_client):
+    """Test that MiniMax-M2.7 is used as default when no model is specified."""
+    config = MiniMaxConfig(temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key")
+    llm = MiniMaxLLM(config)
+    assert llm.config.model == "MiniMax-M2.7"
+
+
 def test_generate_response_without_tools(mock_minimax_client):
-    config = BaseLlmConfig(model="MiniMax-M1", temperature=0.7, max_tokens=100, top_p=1.0)
+    config = BaseLlmConfig(model="MiniMax-M2.7", temperature=0.7, max_tokens=100, top_p=1.0)
     llm = MiniMaxLLM(config)
     messages = [
         {"role": "system", "content": "You are a helpful assistant."},
@@ -61,13 +68,13 @@ def test_generate_response_without_tools(mock_minimax_client):
     response = llm.generate_response(messages)
 
     mock_minimax_client.chat.completions.create.assert_called_once_with(
-        model="MiniMax-M1", messages=messages, temperature=0.7, max_tokens=100, top_p=1.0
+        model="MiniMax-M2.7", messages=messages, temperature=0.7, max_tokens=100, top_p=1.0
     )
     assert response == "I'm doing well, thank you for asking!"
 
 
 def test_generate_response_with_tools(mock_minimax_client):
-    config = BaseLlmConfig(model="MiniMax-M1", temperature=0.7, max_tokens=100, top_p=1.0)
+    config = BaseLlmConfig(model="MiniMax-M2.7", temperature=0.7, max_tokens=100, top_p=1.0)
     llm = MiniMaxLLM(config)
     messages = [
         {"role": "system", "content": "You are a helpful assistant."},
@@ -103,7 +110,7 @@ def test_generate_response_with_tools(mock_minimax_client):
     response = llm.generate_response(messages, tools=tools)
 
     mock_minimax_client.chat.completions.create.assert_called_once_with(
-        model="MiniMax-M1",
+        model="MiniMax-M2.7",
         messages=messages,
         temperature=0.7,
         max_tokens=100,


### PR DESCRIPTION
## Summary
- Add MiniMax as a supported LLM provider using OpenAI-compatible API
- Default model set to **MiniMax-M2.7** (latest flagship model with enhanced reasoning and coding)
- Support custom API base URL via config or `MINIMAX_API_BASE` environment variable

## Changes
- `mem0/llms/minimax.py`: MiniMaxLLM class using OpenAI SDK with MiniMax-M2.7 default
- `mem0/configs/llms/minimax.py`: MiniMaxConfig with minimax_base_url support
- `mem0/llms/configs.py`: Register minimax as valid provider
- `mem0/utils/factory.py`: Add MiniMax to LlmFactory
- `tests/llms/test_minimax.py`: Unit tests for base URL, default model, tool calling
- `docs/components/llms/models/minimax.mdx`: Usage documentation

## Why
MiniMax-M2.7 is the latest flagship model with enhanced reasoning and coding capabilities, available via OpenAI-compatible API at `https://api.minimax.io/v1`.

## Testing
- Unit tests covering base URL resolution, response parsing, and tool calling
- Default model verification test for MiniMax-M2.7