### PR TITLE
chore: bump protobuf dependency to 5.29.6 and extend upper bound to 7.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "posthog>=3.5.0",
     "pytz>=2024.1",
     "sqlalchemy>=2.0.31",
-    "protobuf>=5.29.0,<6.0.0",
+    "protobuf>=5.29.6,<7.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Description

  Bumps protobuf minimum from 5.29.0 to 5.29.6 and extends upper bound to <7.0.0 to resolve CVE-2026-0994 (CVSS 8.2 HIGH DoS via recursion depth bypass in json_format.ParseDict()).

  - |  >=5.29.6 ensures the patched version is installed (5.x fix)
  - <7.0.0 allows protobuf 6.x (patched in 6.33.5), aligning with all transitive dependency upper bounds
  - mem0 has zero direct protobuf imports it's purely a transitive dependency via qdrant-client and Google Cloud libs

  Fixes #3963, #4322


  Type of change

  - Bug fix (non-breaking change which fixes an issue)

  How Has This Been Tested?

  - Verified all transitive dependencies are compatible with >=5.29.6,<7.0.0:
    - qdrant-client 1.17.1: protobuf>=3.20.0
    - opentelemetry-proto 1.40.0: protobuf>=5.0,<7.0
    - google-cloud-aiplatform 1.141.0: protobuf>=3.20.2,<7.0.0
    - google-api-core 2.30.0: protobuf>=4.25.8,<7.0.0
    - openai, litellm, google-genai: no protobuf constraint

  Checklist:

  - My code follows the style guidelines of this project
  - I have performed a self-review of my own code
  - My changes generate no new warnings

  Maintainer Checklist

  - closes #3963, #4322
