### PR TITLE
fix: wrap vector and payload in lists in Langchain update method

### DIFF
--- a/mem0/vector_stores/langchain.py
+++ b/mem0/vector_stores/langchain.py
@@ -115,7 +115,7 @@ class Langchain(VectorStoreBase):
         Update a vector and its payload.
         """
         self.delete(vector_id)
-        self.insert(vector, payload, [vector_id])
+        self.insert([vector], [payload], [vector_id])
 
     def get(self, vector_id):
         """


### PR DESCRIPTION
## Summary
- Fixes type mismatch in `Langchain.update()` where `vector` and `payload` were passed directly to `self.insert()` without being wrapped in lists
- `insert()` expects `vectors: List[List[float]]` and `payloads: List[Dict]`, but `update()` was passing single values instead

## Changes
In `mem0/vector_stores/langchain.py`, changed:
```python
self.insert(vector, payload, [vector_id])
```
to:
```python
self.insert([vector], [payload], [vector_id])
```

Fixes #3767