### PR TITLE
fix: strip markdown fences in removeCodeBlocks instead of deleting content

### DIFF
--- a/mem0-ts/src/oss/src/prompts/index.ts
+++ b/mem0-ts/src/oss/src/prompts/index.ts
@@ -278,5 +278,5 @@ export function parseMessages(messages: string[]): string {
 }
 
 export function removeCodeBlocks(text: string): string {
-  return text.replace(/```[^`]*```/g, "");
+  return text.replace(/```(?:\w+)?\n?([\s\S]*?)```/g, "$1").trim();
 }


### PR DESCRIPTION
## Summary

Fixes #4108

The `removeCodeBlocks()` function in the TypeScript SDK fails to properly handle markdown code blocks returned by Claude. The existing regex `/```[^`]*```/g` has two bugs:

1. **`[^`]*` cannot match newlines**, so multi-line code blocks (the common case) are never matched at all
2. **The replacement deletes the entire match** instead of preserving the inner content — so even if it did match, the JSON inside would be lost

Claude frequently returns JSON wrapped in markdown fences despite prompt instructions not to, causing `JSON.parse()` to fail at [memory/index.ts:313](https://github.com/mem0ai/mem0/blob/main/mem0-ts/src/oss/src/memory/index.ts#L313) and [memory/index.ts:367](https://github.com/mem0ai/mem0/blob/main/mem0-ts/src/oss/src/memory/index.ts#L367).

## Fix

Updated the regex from:
```typescript
text.replace(/```[^`]*```/g, "")
```
to:
```typescript
text.replace(/```(?:\w+)?\n?([\s\S]*?)```/g, "$1").trim()
```

This correctly:
- Matches an optional language identifier (e.g., `json`)
- Uses `[\s\S]*?` to match content across newlines
- Captures and preserves the inner content via `$1`
- Trims any surrounding whitespace

## Test plan

- [ ] Verify `removeCodeBlocks('```json\n{"facts":["test"]}\n```')` returns `{"facts":["test"]}`
- [ ] Verify `removeCodeBlocks('{"facts":[]}')` returns `{"facts":[]}` (no-op when no fences)
- [ ] Verify multi-block input strips all fences while preserving content
- [ ] Run existing TS SDK test suite