### PR TITLE
fix(openclaw): add SQLite resilience for OSS mode initialization

### DIFF
--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -549,7 +549,7 @@ function assertAllowedKeys(
   throw new Error(`${label} has unknown keys: ${unknown.join(", ")}`);
 }
 
-const mem0ConfigSchema = {
+export const mem0ConfigSchema = {
   parse(value: unknown): Mem0Config {
     if (!value || typeof value !== "object" || Array.isArray(value)) {
       throw new Error("openclaw-mem0 config required");
@@ -615,7 +615,7 @@ const mem0ConfigSchema = {
 // Provider Factory
 // ============================================================================
 
-function createProvider(
+export function createProvider(
   cfg: Mem0Config,
   api: OpenClawPluginApi,
 ): Mem0Provider {

--- a/openclaw/sqlite-resilience.test.ts
+++ b/openclaw/sqlite-resilience.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Tests for SQLite resilience fixes:
+ * 1. disableHistory config passthrough
+ * 2. initPromise poisoning fix (retry after failure)
+ * 3. Graceful SQLite fallback in OSSProvider
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mem0ConfigSchema, createProvider } from "./index.ts";
+
+// ---------------------------------------------------------------------------
+// 1. Config: disableHistory passthrough
+// ---------------------------------------------------------------------------
+describe("mem0ConfigSchema — disableHistory", () => {
+  const baseConfig = {
+    mode: "open-source",
+    oss: {
+      embedder: { provider: "openai", config: { apiKey: "sk-test" } },
+    },
+  };
+
+  it("preserves oss.disableHistory: true through config parsing", () => {
+    const cfg = mem0ConfigSchema.parse({
+      ...baseConfig,
+      oss: { ...baseConfig.oss, disableHistory: true },
+    });
+    expect(cfg.oss?.disableHistory).toBe(true);
+  });
+
+  it("preserves oss.disableHistory: false through config parsing", () => {
+    const cfg = mem0ConfigSchema.parse({
+      ...baseConfig,
+      oss: { ...baseConfig.oss, disableHistory: false },
+    });
+    expect(cfg.oss?.disableHistory).toBe(false);
+  });
+
+  it("omits disableHistory when not provided", () => {
+    const cfg = mem0ConfigSchema.parse(baseConfig);
+    expect(cfg.oss?.disableHistory).toBeUndefined();
+  });
+
+  it("does not reject unknown keys inside oss object", () => {
+    // oss sub-object is passed through resolveEnvVarsDeep, not key-checked
+    expect(() =>
+      mem0ConfigSchema.parse({
+        ...baseConfig,
+        oss: { ...baseConfig.oss, disableHistory: true },
+      }),
+    ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. OSSProvider: disableHistory flows to Memory constructor
+// ---------------------------------------------------------------------------
+describe("OSSProvider — disableHistory passthrough to Memory", () => {
+  let capturedConfig: Record<string, unknown> | undefined;
+  let memoryCallCount: number;
+
+  beforeEach(() => {
+    capturedConfig = undefined;
+    memoryCallCount = 0;
+
+    vi.doMock("mem0ai/oss", () => ({
+      Memory: class MockMemory {
+        constructor(config: Record<string, unknown>) {
+          memoryCallCount++;
+          capturedConfig = { ...config };
+        }
+        async add() { return { results: [] }; }
+        async search() { return { results: [] }; }
+        async get() { return {}; }
+        async getAll() { return []; }
+        async delete() { }
+      },
+    }));
+  });
+
+  it("passes disableHistory: true to Memory when configured", async () => {
+    const { createProvider } = await import("./index.ts");
+    const cfg = mem0ConfigSchema.parse({
+      mode: "open-source",
+      oss: { disableHistory: true },
+    });
+    const api = { resolvePath: (p: string) => p } as any;
+    const provider = createProvider(cfg, api);
+
+    // Trigger lazy init by calling search
+    try {
+      await provider.search("test", { user_id: "u1" });
+    } catch { /* provider may fail on mock, that's ok */ }
+
+    expect(capturedConfig).toBeDefined();
+    expect(capturedConfig!.disableHistory).toBe(true);
+  });
+
+  it("does not set disableHistory when not configured", async () => {
+    const { createProvider } = await import("./index.ts");
+    const cfg = mem0ConfigSchema.parse({
+      mode: "open-source",
+      oss: {},
+    });
+    const api = { resolvePath: (p: string) => p } as any;
+    const provider = createProvider(cfg, api);
+
+    try {
+      await provider.search("test", { user_id: "u1" });
+    } catch { }
+
+    expect(capturedConfig).toBeDefined();
+    expect(capturedConfig!.disableHistory).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. OSSProvider: initPromise is cleared on failure (allows retry)
+// ---------------------------------------------------------------------------
+describe("OSSProvider — initPromise retry after failure", () => {
+  let callCount: number;
+
+  beforeEach(() => {
+    callCount = 0;
+
+    vi.doMock("mem0ai/oss", () => ({
+      Memory: class MockMemory {
+        constructor() {
+          callCount++;
+          if (callCount === 1) {
+            throw new Error("SQLITE_CANTOPEN: simulated binding failure");
+          }
+          // Second+ call succeeds
+        }
+        async search() { return { results: [] }; }
+        async get() { return {}; }
+        async getAll() { return []; }
+        async add() { return { results: [] }; }
+        async delete() { }
+      },
+    }));
+  });
+
+  it("retries initialization after a transient failure", async () => {
+    const { createProvider } = await import("./index.ts");
+    const cfg = mem0ConfigSchema.parse({
+      mode: "open-source",
+      oss: { disableHistory: true },
+    });
+    const api = { resolvePath: (p: string) => p } as any;
+    const provider = createProvider(cfg, api);
+
+    // First call: _init throws, but initPromise is cleared so retry is possible
+    await expect(
+      provider.search("test", { user_id: "u1" }),
+    ).rejects.toThrow("SQLITE_CANTOPEN");
+
+    // Second call: should retry _init (not return cached rejection)
+    // callCount === 1 threw, so callCount === 2 should succeed
+    const results = await provider.search("test", { user_id: "u1" });
+    expect(results).toBeDefined();
+    expect(callCount).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. OSSProvider: graceful fallback disables history on init failure
+// ---------------------------------------------------------------------------
+describe("OSSProvider — graceful SQLite fallback", () => {
+  let capturedConfigs: Record<string, unknown>[];
+
+  beforeEach(() => {
+    capturedConfigs = [];
+
+    vi.doMock("mem0ai/oss", () => ({
+      Memory: class MockMemory {
+        constructor(config: Record<string, unknown>) {
+          capturedConfigs.push({ ...config });
+          if (!config.disableHistory) {
+            throw new Error("Could not locate the bindings file");
+          }
+          // Succeeds when disableHistory is true
+        }
+        async search() { return { results: [] }; }
+        async get() { return {}; }
+        async getAll() { return []; }
+        async add() { return { results: [] }; }
+        async delete() { }
+      },
+    }));
+  });
+
+  it("retries with disableHistory: true when initial construction fails", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { createProvider } = await import("./index.ts");
+    const cfg = mem0ConfigSchema.parse({
+      mode: "open-source",
+      oss: {},
+    });
+    const api = { resolvePath: (p: string) => p } as any;
+    const provider = createProvider(cfg, api);
+
+    // Should succeed — first attempt fails, fallback with disableHistory succeeds
+    const results = await provider.search("test", { user_id: "u1" });
+    expect(results).toBeDefined();
+
+    // Memory constructor was called twice
+    expect(capturedConfigs).toHaveLength(2);
+    expect(capturedConfigs[0].disableHistory).toBeFalsy();
+    expect(capturedConfigs[1].disableHistory).toBe(true);
+
+    // Warning was logged
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[mem0] Memory initialization failed"),
+      expect.stringContaining("bindings file"),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("does not retry when disableHistory is already true", async () => {
+    vi.doMock("mem0ai/oss", () => ({
+      Memory: class MockMemory {
+        constructor(config: Record<string, unknown>) {
+          // Fail even with disableHistory (e.g. vector store issue)
+          throw new Error("vector store connection refused");
+        }
+      },
+    }));
+
+    const { createProvider } = await import("./index.ts");
+    const cfg = mem0ConfigSchema.parse({
+      mode: "open-source",
+      oss: { disableHistory: true },
+    });
+    const api = { resolvePath: (p: string) => p } as any;
+    const provider = createProvider(cfg, api);
+
+    // Should throw — no fallback possible when disableHistory was already set
+    await expect(
+      provider.search("test", { user_id: "u1" }),
+    ).rejects.toThrow("vector store connection refused");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. PlatformProvider — initPromise retry after failure
+// ---------------------------------------------------------------------------
+describe("PlatformProvider — initPromise retry after failure", () => {
+  let callCount: number;
+
+  beforeEach(() => {
+    callCount = 0;
+
+    vi.doMock("mem0ai", () => ({
+      default: class MockMemoryClient {
+        constructor() {
+          callCount++;
+          if (callCount === 1) {
+            throw new Error("Network timeout");
+          }
+        }
+        async search() { return []; }
+        async get() { return {}; }
+        async getAll() { return []; }
+        async add() { return { results: [] }; }
+        async delete() { }
+      },
+    }));
+  });
+
+  it("retries initialization after a transient failure", async () => {
+    const { createProvider } = await import("./index.ts");
+    const cfg = mem0ConfigSchema.parse({
+      mode: "platform",
+      apiKey: "test-api-key",
+    });
+    const api = { resolvePath: (p: string) => p } as any;
+    const provider = createProvider(cfg, api);
+
+    // First call fails
+    await expect(
+      provider.search("test", { user_id: "u1" }),
+    ).rejects.toThrow("Network timeout");
+
+    // Second call should retry (not return cached rejection)
+    const results = await provider.search("test", { user_id: "u1" });
+    expect(results).toBeDefined();
+    expect(callCount).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

- **Fix `initPromise` poisoning** in both `PlatformProvider` and `OSSProvider` — a failed `_init()` permanently cached the rejected promise, making the provider broken with no retry possible. Now clears the promise on failure so subsequent calls retry.
- **Add `disableHistory` passthrough** — exposes `oss.disableHistory` in the plugin config so users can explicitly opt out of SQLite history storage (the underlying `mem0ai/oss` SDK already supports this via `DummyHistoryManager`).
- **Graceful SQLite fallback** — wraps `new Memory(config)` in a try-catch; if construction fails and history wasn't already disabled, automatically retries with `disableHistory: true` and logs a warning. This auto-recovers from native binding failures (jiti resolver regression in OpenClaw 2026.3.x) without losing core memory functionality.

Addresses the class of failures reported in openclaw/openclaw#31676, openclaw/openclaw#36377, and #4172.

### Configuration

Users hitting SQLite binding issues can now explicitly disable history:
```json
{
  "mode": "open-source",
  "oss": {
    "disableHistory": true,
    "vectorStore": { "provider": "qdrant", "config": {} }
  }
}
```

Or rely on the automatic fallback (no config change needed).

## Tests

10 new tests added in `openclaw/sqlite-resilience.test.ts` (all passing):

### Config passthrough (4 tests)
- `disableHistory: true` survives `resolveEnvVarsDeep` config parsing
- `disableHistory: false` is preserved, not coerced
- Field is `undefined` when omitted from config
- `oss` sub-object accepts `disableHistory` without unknown-key rejection

### OSSProvider passthrough (2 tests)
- `disableHistory: true` reaches the `Memory` constructor when configured
- `disableHistory` is absent from `Memory` config when user doesn't set it

### initPromise retry (2 tests)
- **OSSProvider**: after a transient failure (e.g. `SQLITE_CANTOPEN`), `initPromise` is cleared and the next call retries successfully instead of returning the cached rejection
- **PlatformProvider**: same fix verified — network timeout on first init allows retry on second call

### Graceful SQLite fallback (2 tests)
- When `Memory()` throws a binding error, automatically retries with `disableHistory: true` and logs a `console.warn`; provider becomes functional
- When `disableHistory` is already `true` and init still fails (e.g. vector store issue), throws immediately — no infinite retry loop

## Test plan

- [x] All 24 existing unit tests pass
- [x] All 10 new resilience tests pass (34 total)
