### PR TITLE
fix: prevent embedding corruption in Valkey update() when vector is None

### DIFF
--- a/mem0/vector_stores/valkey.py
+++ b/mem0/vector_stores/valkey.py
@@ -491,8 +491,13 @@ class ValkeyDB(VectorStoreBase):
                 "hash": payload.get("hash", f"hash_{vector_id}"),  # Use a default hash if not provided
                 "memory": payload.get("data", f"data_{vector_id}"),  # Use a default data if not provided
                 "created_at": int(datetime.fromisoformat(payload["created_at"]).timestamp()),
-                "embedding": np.array(vector, dtype=np.float32).tobytes(),
             }
+
+            # Only update embedding if a new vector is provided.
+            # When vector is None (e.g. metadata-only updates), preserve the existing embedding.
+            if vector is not None:
+                hash_data["embedding"] = np.array(vector, dtype=np.float32).tobytes()
+
 
             # Add updated_at if available
             if "updated_at" in payload:


### PR DESCRIPTION
Fixes #4336

When `Memory._add_to_vector_store()` determines a memory is unchanged (NONE event), it calls `vector_store.update()` to update only session metadata while preserving the existing embedding.The Valkey implementation unconditionally serializes the vector with `np.array(vector, dtype=np.float32).tobytes()`. 

When vector is None, this produces a 4-byte scalar instead of the expected embedding size (e.g. 4096 bytes for 1024-dim models), overwriting the correct embedding. The affected memory becomes permanently unsearchable via vector similarity.

**Fix**: Remove the embedding from the `hash_data` dict and only add it when `vector is not None`. HSET with a mapping that omits embedding simply leaves the existing value in the hash untouched. This is consistent with how other vector databases within Mem0 handle it (`if vector is not None: item["values"] = vector`). 

No behavior change for callers that pass a real vector (e.g. the `_update_memory` path).