### PR TITLE
fix(vector_stores): wrap vector and payload in lists in LangChain update method

### DIFF
--- a/mem0/vector_stores/langchain.py
+++ b/mem0/vector_stores/langchain.py
@@ -115,7 +115,11 @@ class Langchain(VectorStoreBase):
         Update a vector and its payload.
         """
         self.delete(vector_id)
-        self.insert(vector, payload, [vector_id])
+        self.insert(
+            [vector] if vector is not None else [],
+            [payload] if payload is not None else None,
+            [vector_id],
+        )
 
     def get(self, vector_id):
         """


### PR DESCRIPTION
## Problem

The `update()` method in `mem0/vector_stores/langchain.py` passes scalar `vector` and `payload` values directly to `insert()`, which expects `List[List[float]]` and `Optional[List[Dict]]` respectively. This causes a `TypeError` when the insert method iterates over these parameters.

## Fix

Wrap `vector` and `payload` in lists before passing them to `insert()`:

```python
# Before
self.insert(vector, payload, [vector_id])

# After  
self.insert(
    [vector] if vector is not None else [],
    [payload] if payload is not None else None,
    [vector_id],
)
```

Fixes #3767