### PR TITLE
fix(reranker): support nested llm config in LLMReranker for non-OpenAI providers

### DIFF
--- a/mem0/configs/rerankers/llm.py
+++ b/mem0/configs/rerankers/llm.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Dict, Optional
 from pydantic import Field
 
 from mem0.configs.rerankers.base import BaseRerankerConfig
@@ -7,7 +7,7 @@ from mem0.configs.rerankers.base import BaseRerankerConfig
 class LLMRerankerConfig(BaseRerankerConfig):
     """
     Configuration for LLM-based reranker.
-    
+
     Attributes:
         model (str): LLM model to use for reranking. Defaults to "gpt-4o-mini".
         api_key (str): API key for the LLM provider.
@@ -16,8 +16,21 @@ class LLMRerankerConfig(BaseRerankerConfig):
         temperature (float): Temperature for LLM generation. Defaults to 0.0 for deterministic scoring.
         max_tokens (int): Maximum tokens for LLM response. Defaults to 100.
         scoring_prompt (str): Custom prompt template for scoring documents.
+        llm (dict): Optional nested LLM configuration dict with ``provider`` and ``config``
+            keys.  When provided, ``provider`` and all fields inside ``config`` (e.g.
+            ``ollama_base_url``, ``model``) take precedence over the top-level fields.
+
+            Example::
+
+                {
+                    "provider": "ollama",
+                    "config": {
+                        "model": "dengcao/Qwen3-Reranker-0.6B:F16",
+                        "ollama_base_url": "http://localhost:11434"
+                    }
+                }
     """
-    
+
     model: str = Field(
         default="gpt-4o-mini",
         description="LLM model to use for reranking"
@@ -45,4 +58,11 @@ class LLMRerankerConfig(BaseRerankerConfig):
     scoring_prompt: Optional[str] = Field(
         default=None,
         description="Custom prompt template for scoring documents"
+    )
+    llm: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description=(
+            "Nested LLM configuration with 'provider' and 'config' keys. "
+            "Overrides top-level provider/model/api_key when provided."
+        ),
     )

--- a/mem0/reranker/llm_reranker.py
+++ b/mem0/reranker/llm_reranker.py
@@ -33,19 +33,33 @@ class LLMReranker(BaseReranker):
 
         self.config = config
 
-        # Create LLM configuration for the factory
-        llm_config = {
-            "model": self.config.model,
-            "temperature": self.config.temperature,
-            "max_tokens": self.config.max_tokens,
-        }
-
-        # Add API key if provided
-        if self.config.api_key:
-            llm_config["api_key"] = self.config.api_key
+        # If a nested ``llm`` dict was provided (e.g. when using non-OpenAI
+        # providers like Ollama that require provider-specific fields such as
+        # ``ollama_base_url``), use it directly to configure the LLM factory.
+        # The nested dict must contain at least a ``provider`` key; an optional
+        # ``config`` sub-dict is merged in as the LLM config.
+        if self.config.llm:
+            nested = self.config.llm
+            llm_provider = nested.get("provider", self.config.provider)
+            llm_config: dict = dict(nested.get("config") or {})
+            # Ensure temperature / max_tokens defaults are present unless
+            # the caller already supplied them in the nested config.
+            llm_config.setdefault("temperature", self.config.temperature)
+            llm_config.setdefault("max_tokens", self.config.max_tokens)
+        else:
+            llm_provider = self.config.provider
+            # Create LLM configuration for the factory
+            llm_config = {
+                "model": self.config.model,
+                "temperature": self.config.temperature,
+                "max_tokens": self.config.max_tokens,
+            }
+            # Add API key if provided
+            if self.config.api_key:
+                llm_config["api_key"] = self.config.api_key
 
         # Initialize LLM using the factory
-        self.llm = LlmFactory.create(self.config.provider, llm_config)
+        self.llm = LlmFactory.create(llm_provider, llm_config)
 
         # Default scoring prompt
         self.scoring_prompt = getattr(self.config, 'scoring_prompt', None) or self._get_default_prompt()


### PR DESCRIPTION
## Summary

Fixes #3768

When the `llm_reranker` is configured with a non-OpenAI provider such as Ollama, the provider-specific fields (e.g. `ollama_base_url`) could not be passed because `LLMRerankerConfig` only exposed top-level `model`/`api_key` fields and `LLMReranker.__init__` built a fixed `llm_config` dict that omitted them.

Users who tried:
```yaml
reranker:
  provider: llm_reranker
  config:
    llm:
      provider: ollama
      config:
        model: dengcao/Qwen3-Reranker-0.6B:F16
        ollama_base_url: http://localhost:11434
```
got the Ollama provider ignoring the base URL, causing all requests to fall back to the global LLM provider (OpenAI) and fail with an auth error.

## Changes

1. **`mem0/configs/rerankers/llm.py`** — Added an optional `llm: Dict[str, Any]` field to `LLMRerankerConfig` that mirrors the standard mem0 LLM config shape (`{provider, config: {...}}`).

2. **`mem0/reranker/llm_reranker.py`** — In `LLMReranker.__init__`, detect the nested `llm` dict and pass its inner `config` dict (including `ollama_base_url`, `model`, etc.) directly to `LlmFactory.create()`, using the nested provider name. When no nested `llm` dict is present the existing behaviour is unchanged.