### PR TITLE
fix: remove destructive vector_store.reset() from delete_all()

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -37,8 +37,8 @@ from mem0.utils.factory import (
     EmbedderFactory,
     GraphStoreFactory,
     LlmFactory,
-    VectorStoreFactory,
     RerankerFactory,
+    VectorStoreFactory,
 )
 
 # Suppress SWIG deprecation warnings globally
@@ -1046,11 +1046,10 @@ class Memory(MemoryBase):
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "sync"})
-        # delete all vector memories and reset the collections
+        # delete matching vector memories individually (do NOT reset the collection)
         memories = self.vector_store.list(filters=filters)[0]
         for memory in memories:
             self._delete_memory(memory.id)
-        self.vector_store.reset()
 
         logger.info(f"Deleted {len(memories)} memories")
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -196,12 +196,15 @@ def test_delete_all(memory_instance, version, enable_graph):
     memory_instance.enable_graph = enable_graph
     mock_memories = [Mock(id="1"), Mock(id="2")]
     memory_instance.vector_store.list = Mock(return_value=(mock_memories, None))
+    memory_instance.vector_store.reset = Mock()
     memory_instance._delete_memory = Mock()
     memory_instance.graph.delete_all = Mock()
 
     result = memory_instance.delete_all(user_id="test_user")
 
     assert memory_instance._delete_memory.call_count == 2
+    # Ensure the collection is NOT dropped — only matched memories should be removed
+    memory_instance.vector_store.reset.assert_not_called()
 
     if enable_graph:
         memory_instance.graph.delete_all.assert_called_once_with({"user_id": "test_user"})


### PR DESCRIPTION
Description   

  delete_all(user_id=...) is meant to delete only memories matching the provided filters. However, after deleting individual memories it called self.vector_store.reset(), which drops the entire    
  collection/table — destroying ALL memories regardless of the filter.
                                                                                                                                                                                                     
  The async version of delete_all() already omits this call, confirming it was unintentional in the sync path.

  Fixes #3785

  Type of change

  - Bug fix (non-breaking change which fixes an issue)

  How Has This Been Tested?

  - Unit Test

  Added regression assertion vector_store.reset.assert_not_called() to the existing test_delete_all test. Both parametrizations (v1.0/v1.1) pass.

  Checklist:

  - My code follows the style guidelines of this project
  - I have performed a self-review of my own code
  - My changes generate no new warnings
  - I have added tests that prove my fix is effective or that my feature works
  - New and existing unit tests pass locally with my changes

  Maintainer Checklist

  - closes #3785
  - Made sure Checks passed