### PR TITLE
chore(docs): adding skills.sh installation command in the readme.

### DIFF
--- a/skills/mem0/README.md
+++ b/skills/mem0/README.md
@@ -13,6 +13,12 @@ When installed, Claude can:
 
 ## Installation
 
+### CLI (Claude Code, OpenCode, OpenClaw, or any tool that supports skills)
+
+```bash
+npx skills add https://github.com/mem0ai/mem0 --skill mem0
+```
+
 ### Claude.ai
 
 1. Download this `skills/mem0` folder as a ZIP


### PR DESCRIPTION
 Description
                                                                                                                                                                                                     
  The skills/mem0/README.md was missing the npx skills add installation command, which is the primary way users install agent skills via CLI tools like Claude Code, OpenCode, and OpenClaw.

  Added the CLI installation section with the correct command.

  Fixes #4344

  Type of change

  - Documentation update

  How Has This Been Tested?

  - Verified the command npx skills add https://github.com/mem0ai/mem0 --skill mem0 works correctly

  Checklist:

  - My code follows the style guidelines of this project
  - I have performed a self-review of my own code
  - I have made corresponding changes to the documentation
  - My changes generate no new warnings

  Maintainer Checklist

  - closes #4344
  - Made sure Checks passed