### PR TITLE
fix(qdrant): handle 401/403 in ensureCollection for scoped JWTs

### DIFF
--- a/mem0-ts/src/oss/src/vector_stores/qdrant.ts
+++ b/mem0-ts/src/oss/src/vector_stores/qdrant.ts
@@ -282,7 +282,7 @@ export class Qdrant implements VectorStore {
         },
       });
     } catch (error: any) {
-      if (error?.status === 409) {
+      if (error?.status === 409 || error?.status === 401 || error?.status === 403) {
         // Collection already exists — verify configuration for the main collection
         if (name === this.collectionName) {
           try {


### PR DESCRIPTION
## Description

`ensureCollection` calls `createCollection` and only catches `409 Conflict` to handle the "already exists" case. When Qdrant is configured with a collection-scoped JWT, `createCollection` returns `401`/`403` because creating collections requires global access. These status codes were not caught, causing every write operation to throw.

This is a regression introduced by #4297 which changed `ensureCollection` to an atomic create-and-catch-409 pattern. The fix correctly handled the 409 race condition but did not account for 401/403 responses from scoped JWTs.

Fixes #4355

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Verified by live debugging against the compiled `dist/oss/index.mjs` in a running container configured with Qdrant collection-scoped JWTs. Before the fix every `mem.add()` call threw `403 Forbidden: Global access is required`. After the fix the call succeeds — `getCollection` runs with the scoped token and confirms the collection exists.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Maintainer Checklist

- [ ] closes #4355
- [ ] Made sure Checks passed
