### PR TITLE
fix: avoid sending both temperature and topP to AWS Bedrock Converse API (#3891)

### DIFF
--- a/mem0/configs/llms/aws_bedrock.py
+++ b/mem0/configs/llms/aws_bedrock.py
@@ -16,7 +16,7 @@ class AWSBedrockConfig(BaseLlmConfig):
         model: Optional[str] = None,
         temperature: float = 0.1,
         max_tokens: int = 2000,
-        top_p: float = 0.9,
+        top_p: Optional[float] = None,
         top_k: int = 1,
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
@@ -33,7 +33,8 @@ class AWSBedrockConfig(BaseLlmConfig):
             model: Bedrock model identifier (e.g., "amazon.nova-3-mini-20241119-v1:0")
             temperature: Controls randomness (0.0 to 2.0)
             max_tokens: Maximum tokens to generate
-            top_p: Nucleus sampling parameter (0.0 to 1.0)
+            top_p: Nucleus sampling parameter (0.0 to 1.0). Defaults to None to avoid
+                conflicts with models that reject both temperature and topP (e.g. Claude 4.5+)
             top_k: Top-k sampling parameter (1 to 40)
             aws_access_key_id: AWS access key (optional, uses env vars if not provided)
             aws_secret_access_key: AWS secret key (optional, uses env vars if not provided)
@@ -78,9 +79,13 @@ class AWSBedrockConfig(BaseLlmConfig):
         base_config = {
             "temperature": self.temperature,
             "max_tokens": self.max_tokens,
-            "top_p": self.top_p,
             "top_k": self.top_k,
         }
+
+        # Only include top_p if explicitly set to avoid conflicts with
+        # models that reject both temperature and topP (e.g. Claude Sonnet 4.5+)
+        if self.top_p is not None:
+            base_config["top_p"] = self.top_p
 
         # Add custom model kwargs
         base_config.update(self.model_kwargs)

--- a/mem0/llms/aws_bedrock.py
+++ b/mem0/llms/aws_bedrock.py
@@ -116,6 +116,21 @@ class AWSBedrockLLM(LLMBase):
             logger.warning(f"Could not verify model availability: {e}")
             self.available_models = []
 
+    def _build_inference_config(self, max_tokens=None):
+        """Build inferenceConfig for the Converse API, omitting topP when not set.
+
+        Claude Sonnet 4.5+ models reject requests that include both temperature
+        and topP simultaneously. By only including topP when explicitly configured,
+        we avoid this conflict while remaining backward-compatible.
+        """
+        config = {
+            "maxTokens": max_tokens or self.model_config.get("max_tokens", 2000),
+            "temperature": self.model_config.get("temperature", 0.1),
+        }
+        if "top_p" in self.model_config:
+            config["topP"] = self.model_config["top_p"]
+        return config
+
     def _initialize_provider_settings(self):
         """Initialize provider-specific settings and capabilities."""
         # Determine capabilities based on provider and model
@@ -501,11 +516,7 @@ class AWSBedrockLLM(LLMBase):
         converse_params = {
             "modelId": self.config.model,
             "messages": formatted_messages,
-            "inferenceConfig": {
-                "maxTokens": self.model_config.get("max_tokens", 2000),
-                "temperature": self.model_config.get("temperature", 0.1),
-                "topP": self.model_config.get("top_p", 0.9),
-            }
+            "inferenceConfig": self._build_inference_config(),
         }
 
         # Add system message if present (for Anthropic)
@@ -531,11 +542,7 @@ class AWSBedrockLLM(LLMBase):
             converse_params = {
                 "modelId": self.config.model,
                 "messages": formatted_messages,
-                "inferenceConfig": {
-                    "maxTokens": self.model_config.get("max_tokens", 2000),
-                    "temperature": self.model_config.get("temperature", 0.1),
-                    "topP": self.model_config.get("top_p", 0.9),
-                }
+                "inferenceConfig": self._build_inference_config(),
             }
 
             # Add system message if present
@@ -556,22 +563,11 @@ class AWSBedrockLLM(LLMBase):
         elif self.provider == "amazon" and "nova" in self.config.model.lower():
             # Nova models use converse API even without tools
             formatted_messages = self._format_messages_amazon(messages)
-            input_body = {
-                "messages": formatted_messages,
-                "max_tokens": self.model_config.get("max_tokens", 5000),
-                "temperature": self.model_config.get("temperature", 0.1),
-                "top_p": self.model_config.get("top_p", 0.9),
-            }
-            
             # Use converse API for Nova models
             response = self.client.converse(
                 modelId=self.config.model,
-                messages=input_body["messages"],
-                inferenceConfig={
-                    "maxTokens": input_body["max_tokens"],
-                    "temperature": input_body["temperature"],
-                    "topP": input_body["top_p"],
-                }
+                messages=formatted_messages,
+                inferenceConfig=self._build_inference_config(max_tokens=self.model_config.get("max_tokens", 5000)),
             )
             
             return self._parse_response(response)

--- a/tests/llms/test_aws_bedrock.py
+++ b/tests/llms/test_aws_bedrock.py
@@ -1,0 +1,117 @@
+"""Tests for AWS Bedrock LLM — temperature/topP conflict fix.
+
+Covers:
+- inferenceConfig omits topP when top_p is not set (default None)
+- inferenceConfig includes topP when top_p is explicitly set
+- AWSBedrockConfig defaults top_p to None
+- get_model_config excludes top_p when None
+- Backward compatibility: explicit top_p still works
+
+Regression test for #3891: Claude Sonnet 4.5+ rejects requests with both
+temperature and topP specified simultaneously.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from mem0.configs.llms.aws_bedrock import AWSBedrockConfig
+
+
+# ===========================================================================
+# AWSBedrockConfig — top_p defaults and model config
+# ===========================================================================
+
+class TestAWSBedrockConfigTopP:
+    """Test that AWSBedrockConfig handles top_p correctly."""
+
+    def test_default_top_p_is_none(self):
+        """top_p should default to None to avoid conflicts with Claude 4.5+."""
+        config = AWSBedrockConfig()
+        assert config.top_p is None
+
+    def test_explicit_top_p_is_preserved(self):
+        """When user explicitly sets top_p, it should be preserved."""
+        config = AWSBedrockConfig(top_p=0.9)
+        assert config.top_p == 0.9
+
+    def test_get_model_config_excludes_top_p_when_none(self):
+        """get_model_config should not include top_p when it is None."""
+        config = AWSBedrockConfig()
+        model_config = config.get_model_config()
+        assert "top_p" not in model_config
+
+    def test_get_model_config_includes_top_p_when_set(self):
+        """get_model_config should include top_p when explicitly set."""
+        config = AWSBedrockConfig(top_p=0.95)
+        model_config = config.get_model_config()
+        assert model_config["top_p"] == 0.95
+
+    def test_temperature_always_included(self):
+        """temperature should always be in model config."""
+        config = AWSBedrockConfig(temperature=0.5)
+        model_config = config.get_model_config()
+        assert model_config["temperature"] == 0.5
+
+
+# ===========================================================================
+# AWSBedrockLLM — _build_inference_config
+# ===========================================================================
+
+class TestBuildInferenceConfig:
+    """Test the _build_inference_config helper method."""
+
+    @patch("mem0.llms.aws_bedrock.boto3")
+    def test_inference_config_without_top_p(self, mock_boto3):
+        """When top_p is None, inferenceConfig should not include topP."""
+        mock_boto3.client.return_value = MagicMock()
+
+        from mem0.llms.aws_bedrock import AWSBedrockLLM
+
+        config = AWSBedrockConfig(
+            model="anthropic.claude-sonnet-4-5-20250514-v1:0",
+            temperature=0.1,
+        )
+
+        with patch.object(AWSBedrockLLM, '_test_connection'):
+            llm = AWSBedrockLLM(config)
+
+        inference_config = llm._build_inference_config()
+        assert "temperature" in inference_config
+        assert "maxTokens" in inference_config
+        assert "topP" not in inference_config
+
+    @patch("mem0.llms.aws_bedrock.boto3")
+    def test_inference_config_with_top_p(self, mock_boto3):
+        """When top_p is explicitly set, inferenceConfig should include topP."""
+        mock_boto3.client.return_value = MagicMock()
+
+        from mem0.llms.aws_bedrock import AWSBedrockLLM
+
+        config = AWSBedrockConfig(
+            model="anthropic.claude-3-5-sonnet-20240620-v1:0",
+            temperature=0.1,
+            top_p=0.9,
+        )
+
+        with patch.object(AWSBedrockLLM, '_test_connection'):
+            llm = AWSBedrockLLM(config)
+
+        inference_config = llm._build_inference_config()
+        assert inference_config["topP"] == 0.9
+        assert inference_config["temperature"] == 0.1
+
+    @patch("mem0.llms.aws_bedrock.boto3")
+    def test_inference_config_custom_max_tokens(self, mock_boto3):
+        """max_tokens override should be respected."""
+        mock_boto3.client.return_value = MagicMock()
+
+        from mem0.llms.aws_bedrock import AWSBedrockLLM
+
+        config = AWSBedrockConfig(
+            model="anthropic.claude-3-5-sonnet-20240620-v1:0",
+        )
+
+        with patch.object(AWSBedrockLLM, '_test_connection'):
+            llm = AWSBedrockLLM(config)
+
+        inference_config = llm._build_inference_config(max_tokens=5000)
+        assert inference_config["maxTokens"] == 5000


### PR DESCRIPTION
  ## Description

  Claude Sonnet 4.5 and Haiku 4.5 models on AWS Bedrock reject requests that include both `temperature` and `topP` simultaneously, raising a `ValidationException`. Per [AWS docs](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages-request-response.html):

  > "Claude Sonnet 4.5 and Claude Haiku 4.5 support specifying either the temperature or top_p parameter, but not both."

  The previous code always sent both parameters because `AWSBedrockConfig` defaulted `top_p=0.9`.

  ### Fix
  - Changed `top_p` default from `0.9` to `None` in `AWSBedrockConfig`
  - Added `_build_inference_config()` helper that only includes `topP` when explicitly set
  - Replaced 3 hardcoded `inferenceConfig` blocks with calls to the helper
  - `get_model_config()` now excludes `top_p` when `None`

  ### Backward compatibility
  - Users who don't set `top_p` → only `temperature` sent → works with Claude 4.5+
  - Users who explicitly set `top_p=0.9` → both sent → works with older models
  - `topP` is optional in the Converse API — omitting it uses the model's default

  ### Changes
  - `mem0/configs/llms/aws_bedrock.py` — `top_p` default `None`, conditional `get_model_config()`
  - `mem0/llms/aws_bedrock.py` — `_build_inference_config()` helper, DRY across 3 call sites
  - `tests/llms/test_aws_bedrock.py` — 8 new tests

  Fixes #3891

  ## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

  ## How Has This Been Tested?

  - [x] Unit Test

  8 tests covering:
  - Config defaults (`top_p=None`)
  - `get_model_config()` excludes/includes `top_p` correctly
  - `_build_inference_config()` omits/includes `topP` correctly
  - Custom `max_tokens` override

  Run with: `pytest tests/llms/test_aws_bedrock.py -v`

  ## Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes
  - [x] I have checked my code and corrected any misspellings

  ## Maintainer Checklist

  - [ ] closes #3891
