### PR TITLE
fix: correct typo and add tool role support

### DIFF
--- a/mem0/graphs/utils.py
+++ b/mem0/graphs/utils.py
@@ -66,7 +66,7 @@ Guidelines:
 2. Deletion Criteria: Delete a relationship only if it meets at least one of these conditions:
    - Outdated or Inaccurate: The new information is more recent or accurate.
    - Contradictory: The new information conflicts with or negates the existing information.
-3. DO NOT DELETE if their is a possibility of same type of relationship but different destination nodes.
+3. DO NOT DELETE if there is a possibility of same type of relationship but different destination nodes.
 4. Comprehensive Analysis:
    - Thoroughly examine each existing relationship against the new information and delete as necessary.
    - Multiple deletions may be required based on the new information.
@@ -76,7 +76,7 @@ Guidelines:
 6. Temporal Awareness: Prioritize recency when timestamps are available.
 7. Necessity Principle: Only DELETE relationships that must be deleted and are contradictory/outdated to the new information to maintain an accurate and coherent memory graph.
 
-Note: DO NOT DELETE if their is a possibility of same type of relationship but different destination nodes. 
+Note: DO NOT DELETE if there is a possibility of same type of relationship but different destination nodes. 
 
 For example: 
 Existing Memory: alice -- loves_to_eat -- pizza

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -63,6 +63,8 @@ def parse_messages(messages):
             response += f"user: {msg['content']}\n"
         if msg["role"] == "assistant":
             response += f"assistant: {msg['content']}\n"
+        if msg["role"] == "tool":
+            response += f"tool: {msg['content']}\n"
     return response
 
 

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -10,11 +10,11 @@ from mem0.configs.prompts import (
 
 def get_fact_retrieval_messages(message, is_agent_memory=False):
     """Get fact retrieval messages based on the memory type.
-    
+
     Args:
         message: The message content to extract facts from
         is_agent_memory: If True, use agent memory extraction prompt, else use user memory extraction prompt
-        
+
     Returns:
         tuple: (system_prompt, user_prompt)
     """
@@ -48,8 +48,7 @@ def ensure_json_instruction(system_prompt, user_prompt):
     combined = (system_prompt + user_prompt).lower()
     if "json" not in combined:
         system_prompt += (
-            "\n\nYou must return your response in valid JSON format "
-            "with a 'facts' key containing an array of strings."
+            "\n\nYou must return your response in valid JSON format with a 'facts' key containing an array of strings."
         )
     return system_prompt, user_prompt
 
@@ -91,9 +90,8 @@ def remove_code_blocks(content: str) -> str:
     """
     pattern = r"^```[a-zA-Z0-9]*\n([\s\S]*?)\n```$"
     match = re.match(pattern, content.strip())
-    match_res=match.group(1).strip() if match else content.strip()
+    match_res = match.group(1).strip() if match else content.strip()
     return re.sub(r"<think>.*?</think>", "", match_res, flags=re.DOTALL).strip()
-
 
 
 def extract_json(text):
@@ -232,4 +230,3 @@ def sanitize_relationship_for_cypher(relationship) -> str:
         sanitized = sanitized.replace(old, new)
 
     return re.sub(r"_+", "_", sanitized).strip("_")
-


### PR DESCRIPTION
## Summary

This PR fixes issue #4325:

### Fix 1: Typo in graphs/utils.py
- Changed "their is" to "there is" (2 occurrences)

### Fix 2: Add tool role support in parse_messages
- Added handling for "tool" role in messages in memory/utils.py
- Previously only system, user, and assistant roles were handled

## Changes
```diff
-3. DO NOT DELETE if their is a possibility
+3. DO NOT DELETE if there is a possibility

+if msg["role"] == "tool":
+    response += f"tool: {msg['content']}\n"
```

## Testing
- Verified tool role is correctly parsed and formatted
- Confirmed typo fixes in graphs/utils.py