### PR TITLE
fix(ollama): store config for modelProperties passthrough and handle pull failures

### DIFF
--- a/mem0-ts/src/oss/src/embeddings/ollama.ts
+++ b/mem0-ts/src/oss/src/embeddings/ollama.ts
@@ -49,7 +49,14 @@ export class OllamaEmbedder implements Embedder {
     const local_models = await this.ollama.list();
     if (!local_models.models.find((m: any) => m.name === this.model)) {
       logger.info(`Pulling model ${this.model}...`);
-      await this.ollama.pull({ model: this.model });
+      try {
+        await this.ollama.pull({ model: this.model });
+      } catch (err) {
+        logger.warn(
+          `Failed to pull model ${this.model}: ${err}. ` +
+            `If the model is already available, this error can be safely ignored.`,
+        );
+      }
     }
     this.initialized = true;
     return true;

--- a/mem0-ts/src/oss/src/llms/ollama.ts
+++ b/mem0-ts/src/oss/src/llms/ollama.ts
@@ -6,10 +6,12 @@ import { logger } from "../utils/logger";
 export class OllamaLLM implements LLM {
   private ollama: Ollama;
   private model: string;
+  private config: LLMConfig;
   // Using this variable to avoid calling the Ollama server multiple times
   private initialized: boolean = false;
 
   constructor(config: LLMConfig) {
+    this.config = config;
     this.ollama = new Ollama({
       host: config.url || config.baseURL || "http://localhost:11434",
     });
@@ -30,6 +32,7 @@ export class OllamaLLM implements LLM {
       logger.error(`Error ensuring model exists: ${err}`);
     }
 
+    const modelProps = this.config?.modelProperties ?? {};
     const completion = await this.ollama.chat({
       model: this.model,
       messages: messages.map((msg) => {
@@ -44,6 +47,7 @@ export class OllamaLLM implements LLM {
       }),
       ...(responseFormat?.type === "json_object" && { format: "json" }),
       ...(tools && { tools, tool_choice: "auto" }),
+      ...modelProps,
     });
 
     const response = completion.message;
@@ -96,7 +100,14 @@ export class OllamaLLM implements LLM {
     const local_models = await this.ollama.list();
     if (!local_models.models.find((m: any) => m.name === this.model)) {
       logger.info(`Pulling model ${this.model}...`);
-      await this.ollama.pull({ model: this.model });
+      try {
+        await this.ollama.pull({ model: this.model });
+      } catch (err) {
+        logger.warn(
+          `Failed to pull model ${this.model}: ${err}. ` +
+            `If the model is already available, this error can be safely ignored.`,
+        );
+      }
     }
     this.initialized = true;
     return true;


### PR DESCRIPTION
## Summary

Two fixes for the Ollama provider in `mem0-ts`:

- **OllamaLLM does not pass `modelProperties` to `ollama.chat()`** — The constructor never stored the `config` object, so properties like `think: false` (needed for reasoning models such as Qwen3) were silently dropped. This fix stores `config` and spreads `modelProperties` into the chat call options.

- **`ensureModelExists()` crashes when `ollama.pull()` fails** — On environments where the Ollama data directory is not writable (e.g. system-installed Ollama running as a separate user), `pull()` throws a permission error that propagates up and blocks all LLM/embedding calls. This fix wraps `pull()` in a try/catch with a warning log, allowing operation to continue when the model is already available locally.

## Changed files

- `mem0-ts/src/oss/src/llms/ollama.ts` — Store `this.config`, spread `modelProperties` into `ollama.chat()`, wrap `pull()` in try/catch
- `mem0-ts/src/oss/src/embeddings/ollama.ts` — Wrap `pull()` in try/catch

## How to reproduce

### Bug 1 (modelProperties not passed):
```typescript
const config = {
  llm: {
    provider: "ollama",
    config: {
      model: "qwen3:30b",
      baseURL: "http://localhost:11434",
      modelProperties: { think: false }  // this was silently ignored
    }
  }
};
const mem = new Memory(config);
// mem.llm.config was undefined → modelProperties never reached ollama.chat()
```

### Bug 2 (pull crash):
```bash
# When Ollama is installed system-wide (e.g. via apt/systemd)
# and the data dir /usr/share/ollama/.ollama/models/ is owned by root,
# ollama.pull() throws "permission denied" even though the model exists locally.
```

## Test plan

- [x] Verified `modelProperties.think: false` is passed to `ollama.chat()` with Qwen3 models
- [x] Verified `ensureModelExists()` logs a warning but continues when `pull()` fails with permission denied
- [x] Verified normal flow still works when model needs to be pulled and pull succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)