### PR TITLE
fix(server): add missing psycopg-pool dependency

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -4,3 +4,4 @@ pydantic==2.10.4
 mem0ai>=0.1.48
 python-dotenv==1.0.1
 psycopg>=3.2.8
+psycopg-pool>=3.2.6,<4.0.0


### PR DESCRIPTION
## Description

Adds missing psycopg-pool dependency to server/requirements.txt to fix the ImportError when configuring Rest API Server using docker compose.

The pgvector.py module imports psycopg_pool.ConnectionPool at module load time, but this dependency was missing from the server requirements file even though psycopg itself was listed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit Test - All 50 tests in tests/vector_stores/test_pgvector.py pass locally.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

Fixes #3753