### PR TITLE
fix(vector_stores): wrap vector and payload in lists in Langchain update method

### DIFF
--- a/mem0/vector_stores/langchain.py
+++ b/mem0/vector_stores/langchain.py
@@ -115,7 +115,11 @@ class Langchain(VectorStoreBase):
         Update a vector and its payload.
         """
         self.delete(vector_id)
-        self.insert(vector, payload, [vector_id])
+        self.insert(
+            [vector] if vector is not None else [],
+            [payload] if payload is not None else None,
+            [vector_id],
+        )
 
     def get(self, vector_id):
         """


### PR DESCRIPTION
## Problem

The `update()` method in `mem0/vector_stores/langchain.py` passes `vector` and `payload` directly to `insert()`, but `insert()` expects `List[List[float]]` and `Optional[List[Dict]]` respectively. This causes a type mismatch and runtime errors when calling `update()`.



## Solution

Wrap `vector` and `payload` in lists before passing them to `insert()`, matching the expected type signatures.

## Testing

- Verified syntax with Python AST parser
- Fix aligns the call signature with the `insert()` method's declared types

Closes #3767