### PR TITLE
fix: cast vector_distance to float in Redis search

### DIFF
--- a/mem0/vector_stores/redis.py
+++ b/mem0/vector_stores/redis.py
@@ -159,7 +159,7 @@ class RedisDB(VectorStoreBase):
         return [
             MemoryResult(
                 id=result["memory_id"],
-                score=result["vector_distance"],
+                score=float(result["vector_distance"]),
                 payload={
                     "hash": result["hash"],
                     "data": result["memory"],


### PR DESCRIPTION
## Summary
- Fixes #4294 — Redis `vector_distance` returned as string causes threshold search to fail
- Casts `vector_distance` to `float` before assigning to the score field in `RedisDB.search()`

## Test plan
- [x] Verify `memory.search()` with Redis vector store and a `threshold` parameter no longer raises `TypeError`
- [x] Confirm search results return correct float scores
