### PR TITLE
feat(typescript-sdk): add config validation for OpenAI LLM and Embedder

### DIFF
--- a/mem0-ts/src/oss/src/embeddings/openai.ts
+++ b/mem0-ts/src/oss/src/embeddings/openai.ts
@@ -2,12 +2,29 @@ import OpenAI from "openai";
 import { Embedder } from "./base";
 import { EmbeddingConfig } from "../types";
 
+function validateOpenAIEmbedderConfig(config: EmbeddingConfig): void {
+  if (!config.apiKey) {
+    const hasWrongApiKey = "openaiApiKey" in config;
+    const errorMsg = "OpenAI Embedder config validation failed: 'apiKey' is required." +
+      (hasWrongApiKey ? " Did you mean 'apiKey' (not 'openaiApiKey')?" : "");
+    throw new Error(errorMsg);
+  }
+
+  if ("openaiApiKey" in config) {
+    console.warn("Warning: 'openaiApiKey' is not a valid config key. Use 'apiKey' instead.");
+  }
+  if ("baseUrl" in config) {
+    console.warn("Warning: 'baseUrl' is not a valid config key. Use 'baseURL' instead.");
+  }
+}
+
 export class OpenAIEmbedder implements Embedder {
   private openai: OpenAI;
   private model: string;
   private embeddingDims?: number;
 
   constructor(config: EmbeddingConfig) {
+    validateOpenAIEmbedderConfig(config);
     this.openai = new OpenAI({
       apiKey: config.apiKey,
       baseURL: config.baseURL || config.url,

--- a/mem0-ts/src/oss/src/llms/openai.ts
+++ b/mem0-ts/src/oss/src/llms/openai.ts
@@ -2,11 +2,31 @@ import OpenAI from "openai";
 import { LLM, LLMResponse } from "./base";
 import { LLMConfig, Message } from "../types";
 
+function validateOpenAIConfig(config: LLMConfig): void {
+  if (!config.apiKey) {
+    const hasWrongApiKey = "openaiApiKey" in config;
+    const errorMsg = "OpenAI LLM config validation failed: 'apiKey' is required." +
+      (hasWrongApiKey ? " Did you mean 'apiKey' (not 'openaiApiKey')?" : "");
+    throw new Error(errorMsg);
+  }
+
+  if ("openaiApiKey" in config) {
+    console.warn("Warning: 'openaiApiKey' is not a valid config key. Use 'apiKey' instead.");
+  }
+  if ("baseUrl" in config) {
+    console.warn("Warning: 'baseUrl' is not a valid config key. Use 'baseURL' instead.");
+  }
+  if ("url" in config && !config.baseURL) {
+    console.warn("Warning: 'url' is not a valid config key. Use 'baseURL' instead.");
+  }
+}
+
 export class OpenAILLM implements LLM {
   private openai: OpenAI;
   private model: string;
 
   constructor(config: LLMConfig) {
+    validateOpenAIConfig(config);
     this.openai = new OpenAI({
       apiKey: config.apiKey,
       baseURL: config.baseURL,

--- a/mem0-ts/src/oss/tests/openai-config-validation.test.ts
+++ b/mem0-ts/src/oss/tests/openai-config-validation.test.ts
@@ -1,0 +1,111 @@
+/// <reference types="jest" />
+import { OpenAILLM } from "../src/llms/openai";
+import { OpenAIEmbedder } from "../src/embeddings/openai";
+import { LLMConfig, EmbeddingConfig } from "../src/types";
+
+describe("OpenAILLM Config Validation", () => {
+  const originalConsoleWarn = console.warn;
+
+  beforeEach(() => {
+    console.warn = jest.fn();
+  });
+
+  afterEach(() => {
+    console.warn = originalConsoleWarn;
+  });
+
+  it("should throw error when apiKey is missing", () => {
+    expect(() => {
+      new OpenAILLM({} as LLMConfig);
+    }).toThrow("OpenAI LLM config validation failed: 'apiKey' is required.");
+  });
+
+  it("should throw error with helpful message when openaiApiKey is used instead of apiKey", () => {
+    expect(() => {
+      new OpenAILLM({ openaiApiKey: "test-key" } as unknown as LLMConfig);
+    }).toThrow(
+      "OpenAI LLM config validation failed: 'apiKey' is required. Did you mean 'apiKey' (not 'openaiApiKey')?"
+    );
+  });
+
+  it("should warn when openaiApiKey is provided alongside apiKey", () => {
+    new OpenAILLM({ apiKey: "test-key", openaiApiKey: "wrong-key" } as unknown as LLMConfig);
+    expect(console.warn).toHaveBeenCalledWith(
+      "Warning: 'openaiApiKey' is not a valid config key. Use 'apiKey' instead."
+    );
+  });
+
+  it("should warn when baseUrl is provided", () => {
+    new OpenAILLM({ apiKey: "test-key", baseUrl: "https://example.com" } as unknown as LLMConfig);
+    expect(console.warn).toHaveBeenCalledWith(
+      "Warning: 'baseUrl' is not a valid config key. Use 'baseURL' instead."
+    );
+  });
+
+  it("should warn when url is provided without baseURL", () => {
+    new OpenAILLM({ apiKey: "test-key", url: "https://example.com" } as unknown as LLMConfig);
+    expect(console.warn).toHaveBeenCalledWith(
+      "Warning: 'url' is not a valid config key. Use 'baseURL' instead."
+    );
+  });
+
+  it("should succeed with valid apiKey", () => {
+    const llm = new OpenAILLM({ apiKey: "test-key" } as LLMConfig);
+    expect(llm).toBeDefined();
+  });
+
+  it("should succeed with valid apiKey and baseURL", () => {
+    const llm = new OpenAILLM({ apiKey: "test-key", baseURL: "https://api.openai.com/v1" } as LLMConfig);
+    expect(llm).toBeDefined();
+  });
+});
+
+describe("OpenAIEmbedder Config Validation", () => {
+  const originalConsoleWarn = console.warn;
+
+  beforeEach(() => {
+    console.warn = jest.fn();
+  });
+
+  afterEach(() => {
+    console.warn = originalConsoleWarn;
+  });
+
+  it("should throw error when apiKey is missing", () => {
+    expect(() => {
+      new OpenAIEmbedder({} as EmbeddingConfig);
+    }).toThrow("OpenAI Embedder config validation failed: 'apiKey' is required.");
+  });
+
+  it("should throw error with helpful message when openaiApiKey is used instead of apiKey", () => {
+    expect(() => {
+      new OpenAIEmbedder({ openaiApiKey: "test-key" } as unknown as EmbeddingConfig);
+    }).toThrow(
+      "OpenAI Embedder config validation failed: 'apiKey' is required. Did you mean 'apiKey' (not 'openaiApiKey')?"
+    );
+  });
+
+  it("should warn when openaiApiKey is provided alongside apiKey", () => {
+    new OpenAIEmbedder({ apiKey: "test-key", openaiApiKey: "wrong-key" } as unknown as EmbeddingConfig);
+    expect(console.warn).toHaveBeenCalledWith(
+      "Warning: 'openaiApiKey' is not a valid config key. Use 'apiKey' instead."
+    );
+  });
+
+  it("should warn when baseUrl is provided", () => {
+    new OpenAIEmbedder({ apiKey: "test-key", baseUrl: "https://example.com" } as unknown as EmbeddingConfig);
+    expect(console.warn).toHaveBeenCalledWith(
+      "Warning: 'baseUrl' is not a valid config key. Use 'baseURL' instead."
+    );
+  });
+
+  it("should succeed with valid apiKey", () => {
+    const embedder = new OpenAIEmbedder({ apiKey: "test-key" } as EmbeddingConfig);
+    expect(embedder).toBeDefined();
+  });
+
+  it("should succeed with valid apiKey and baseURL", () => {
+    const embedder = new OpenAIEmbedder({ apiKey: "test-key", baseURL: "https://api.openai.com/v1" } as EmbeddingConfig);
+    expect(embedder).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Add validation to catch wrong config keys (openaiApiKey, baseUrl, url) that should be (apiKey, baseURL) in TypeScript SDK
- This prevents silent failures and 401 errors when users use Python SDK-style config keys
- Validate apiKey is present and throw clear error if missing
- Warn if openaiApiKey, baseUrl, or url detected instead of correct keys
- Add unit tests for all validation scenarios

## Related Issue
Fixes #4299