### PR TITLE
fix: preserve http_auth in _safe_deepcopy_config for OpenSearch (#3580)

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -70,11 +70,16 @@ def _safe_deepcopy_config(config):
         else:
             clone_dict = {k: v for k, v in config.__dict__.items()}
         
-        sensitive_tokens = ("auth", "credential", "password", "token", "secret", "key", "connection_class")
+        # Strip sensitive values (passwords, tokens, etc.) but preserve runtime auth objects
+        # (http_auth, auth, connection_class) required for OpenSearch/AWS and similar clients
+        sensitive_tokens = ("credential", "password", "token", "secret", "key")
+        preserve_runtime_auth = ("http_auth", "auth", "connection_class")
         for field_name in list(clone_dict.keys()):
+            if field_name.lower() in preserve_runtime_auth:
+                continue
             if any(token in field_name.lower() for token in sensitive_tokens):
                 clone_dict[field_name] = None
-        
+
         try:
             return config_class(**clone_dict)
         except Exception as reconstruction_error:

--- a/tests/vector_stores/test_opensearch.py
+++ b/tests/vector_stores/test_opensearch.py
@@ -300,10 +300,12 @@ def test_safe_deepcopy_config_handles_opensearch_auth(mock_sqlite, mock_llm_fact
     
     safe_config = _safe_deepcopy_config(config_with_auth)
     
-    assert safe_config.http_auth is None
-    assert safe_config.auth is None
+    # Runtime auth objects preserved for OpenSearch/AWS clients (fixes #3580)
+    assert safe_config.http_auth is not None
+    assert safe_config.auth is not None
+    assert safe_config.connection_class is not None
+    # Credentials (secrets) still stripped for telemetry safety
     assert safe_config.credentials is None
-    assert safe_config.connection_class is None
     
     assert safe_config.collection_name == "opensearch_test"
     assert safe_config.host == "localhost"


### PR DESCRIPTION
## Summary
Fixes #3580

`_safe_deepcopy_config()` sanitizer was overly broad — it removed any field name containing "auth", which unintentionally nulled `http_auth`, a required runtime field for OpenSearch and AWS-signed clients.

## Root Cause
The `sensitive_tokens` tuple included "auth" and "connection_class", causing `http_auth` to match and be set to `None`. The telemetry vector store (created with the sanitized config) then failed to connect to OpenSearch with 403/signature errors.

## Solution
- Preserve runtime auth objects: `http_auth`, `auth`, `connection_class`
- Continue stripping genuinely sensitive data: `credential`, `password`, `token`, `secret`, `key`

## Changes
- `mem0/memory/main.py`: Add `preserve_runtime_auth` check before stripping; narrow `sensitive_tokens`
- `tests/vector_stores/test_opensearch.py`: Update test to assert auth objects are preserved

Made with [Cursor](https://cursor.com)