### PR TITLE
fix: wrap vector and payload in lists in Langchain update() (#3767)

### DIFF
--- a/mem0/vector_stores/langchain.py
+++ b/mem0/vector_stores/langchain.py
@@ -115,7 +115,7 @@ class Langchain(VectorStoreBase):
         Update a vector and its payload.
         """
         self.delete(vector_id)
-        self.insert(vector, payload, [vector_id])
+        self.insert([vector] if vector is not None else [], [payload] if payload is not None else None, [vector_id])
 
     def get(self, vector_id):
         """

--- a/tests/vector_stores/test_langchain_vector_store.py
+++ b/tests/vector_stores/test_langchain_vector_store.py
@@ -224,3 +224,20 @@ def test_list_with_exception(langchain_instance):
 
     # Verify that an empty list is returned when an exception occurs
     assert results == []
+
+
+def test_update_wraps_vector_and_payload_in_lists(langchain_instance):
+    """Test that update correctly wraps vector and payload in lists when calling insert."""
+    langchain_instance.client.delete = Mock()
+    langchain_instance.client.add_embeddings = Mock()
+
+    vector = [0.1, 0.2, 0.3]
+    payload = {"data": "updated text", "name": "updated"}
+    vector_id = "id1"
+
+    langchain_instance.update(vector_id=vector_id, vector=vector, payload=payload)
+
+    langchain_instance.client.delete.assert_called_once_with(ids=[vector_id])
+    langchain_instance.client.add_embeddings.assert_called_once_with(
+        embeddings=[vector], metadatas=[payload], ids=[vector_id]
+    )


### PR DESCRIPTION
## Summary
Fixes #3767 — Type mismatch in Langchain Vector Store Adapter's update method.

## Root Cause
The `update()` method passed single `vector` and `payload` values directly to `insert()`, which expects `List[List[float]]` for vectors and `Optional[List[Dict]]` for payloads. This caused a type mismatch and incorrect behavior when updating vectors.

## Changes
- Wrap `vector` in `[vector]` when calling `insert()` (or `[]` if None)
- Wrap `payload` in `[payload]` when calling `insert()` (or `None` if None)
- Added test `test_update_wraps_vector_and_payload_in_lists` to verify correct behavior

## Testing
- All existing langchain vector store tests pass
- New test verifies update correctly passes lists to insert

Made with [Cursor](https://cursor.com)