### PR TITLE
fix(memory): fix inconsistent return type, deadlock, race condition, and dead core

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -237,7 +237,7 @@ class Memory(MemoryBase):
     @classmethod
     def from_config(cls, config_dict: Dict[str, Any]):
         try:
-            config = cls._process_config(config_dict)
+            cls._process_config(config_dict)
             config = MemoryConfig(**config_dict)
         except ValidationError as e:
             logger.error(f"Configuration validation error: {e}")
@@ -253,11 +253,7 @@ class Memory(MemoryBase):
                 config_dict["vector_store"]["config"]["embedding_model_dims"] = config_dict["embedder"]["config"][
                     "embedding_dims"
                 ]
-        try:
-            return config_dict
-        except ValidationError as e:
-            logger.error(f"Configuration validation error: {e}")
-            raise
+        return config_dict
 
     def _should_use_agent_memory_extraction(self, messages, metadata):
         """Determine whether to use agent memory extraction based on the logic:
@@ -605,7 +601,7 @@ class Memory(MemoryBase):
         added_entities = []
         if self.enable_graph:
             if filters.get("user_id") is None:
-                filters["user_id"] = "user"
+                filters = {**filters, "user_id": "user"}
 
             data = "\n".join([msg["content"] for msg in messages if "content" in msg and msg["role"] != "system"])
             added_entities = self.graph.add(data, filters)
@@ -1289,7 +1285,7 @@ class AsyncMemory(MemoryBase):
     @classmethod
     async def from_config(cls, config_dict: Dict[str, Any]):
         try:
-            config = cls._process_config(config_dict)
+            cls._process_config(config_dict)
             config = MemoryConfig(**config_dict)
         except ValidationError as e:
             logger.error(f"Configuration validation error: {e}")
@@ -1305,11 +1301,7 @@ class AsyncMemory(MemoryBase):
                 config_dict["vector_store"]["config"]["embedding_model_dims"] = config_dict["embedder"]["config"][
                     "embedding_dims"
                 ]
-        try:
-            return config_dict
-        except ValidationError as e:
-            logger.error(f"Configuration validation error: {e}")
-            raise
+        return config_dict
 
     def _should_use_agent_memory_extraction(self, messages, metadata):
         """Determine whether to use agent memory extraction based on the logic:
@@ -1651,7 +1643,7 @@ class AsyncMemory(MemoryBase):
         added_entities = []
         if self.enable_graph:
             if filters.get("user_id") is None:
-                filters["user_id"] = "user"
+                filters = {**filters, "user_id": "user"}
 
             data = "\n".join([msg["content"] for msg in messages if "content" in msg and msg["role"] != "system"])
             added_entities = await asyncio.to_thread(self.graph.add, data, filters)

--- a/mem0/memory/storage.py
+++ b/mem0/memory/storage.py
@@ -11,7 +11,7 @@ class SQLiteManager:
     def __init__(self, db_path: str = ":memory:"):
         self.db_path = db_path
         self.connection = sqlite3.connect(self.db_path, check_same_thread=False)
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
         self._migrate_history_table()
         self._create_history_table()
 

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -168,7 +168,7 @@ def process_telemetry_filters(filters):
     Process the telemetry filters
     """
     if filters is None:
-        return {}
+        return [], {}
 
     encoded_ids = {}
     if "user_id" in filters:


### PR DESCRIPTION
## Description

Fix four bugs in the `mem0/memory/` module:

1. **`process_telemetry_filters` inconsistent return type** (`utils.py`): When `filters` is `None`, the function returned `{}` (dict) while all other paths return a `(list, dict)` tuple. Callers unpack as `keys, encoded_ids = process_telemetry_filters(filters)`, which raises `ValueError` on `None` input. Fixed to return `[], {}`.

2. **SQLiteManager deadlock** (`storage.py`): `reset()` acquires `self._lock` then calls `_create_history_table()` which also tries to acquire `self._lock`. Since `threading.Lock` is not reentrant, this causes a deadlock. Changed to `threading.RLock()`.

3. **`_add_to_graph` race condition** (`main.py`): `_add_to_graph` mutates the shared `filters` dict (`filters["user_id"] = "user"`) while executing concurrently with `_add_to_vector_store` in a `ThreadPoolExecutor`. Fixed by creating a copy with `{**filters, "user_id": "user"}`. Applied to both sync and async versions.

4. **Dead code in `_process_config`** (`main.py`): `try: return config_dict except ValidationError` can never raise `ValidationError`. Removed the unreachable try/except. Also fixed `from_config` where `_process_config`'s return value was assigned but immediately overwritten.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit Test — existing tests pass; changes are minimal and safe.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes