### PR TITLE
fix(proxy): fix mutable default arg, invalid kwarg, and silent exception

### DIFF
--- a/mem0/proxy/main.py
+++ b/mem0/proxy/main.py
@@ -52,7 +52,7 @@ class Completions:
     def create(
         self,
         model: str,
-        messages: List = [],
+        messages: Optional[List] = None,
         # Mem0 arguments
         user_id: Optional[str] = None,
         agent_id: Optional[str] = None,
@@ -92,6 +92,9 @@ class Completions:
         api_key: Optional[str] = None,
         model_list: Optional[list] = None,  # pass in a list of api_base,keys, etc.
     ):
+        if messages is None:
+            messages = []
+
         if not any([user_id, agent_id, run_id]):
             raise ValueError("One of user_id, agent_id, run_id must be provided")
 
@@ -151,15 +154,17 @@ class Completions:
 
     def _async_add_to_memory(self, messages, user_id, agent_id, run_id, metadata, filters):
         def add_task():
-            logger.debug("Adding to memory asynchronously")
-            self.mem0_client.add(
-                messages=messages,
-                user_id=user_id,
-                agent_id=agent_id,
-                run_id=run_id,
-                metadata=metadata,
-                filters=filters,
-            )
+            try:
+                logger.debug("Adding to memory asynchronously")
+                self.mem0_client.add(
+                    messages=messages,
+                    user_id=user_id,
+                    agent_id=agent_id,
+                    run_id=run_id,
+                    metadata=metadata,
+                )
+            except Exception:
+                logger.exception("Failed to add memory asynchronously")
 
         threading.Thread(target=add_task, daemon=True).start()
 


### PR DESCRIPTION
## Description

Fix three bugs in `mem0/proxy/main.py`:

1. **Mutable default argument**: `messages: List = []` shares a single list across all calls. Changed to `Optional[List] = None` with `if messages is None: messages = []` in the function body.

2. **Invalid `filters` keyword argument**: `_async_add_to_memory` passes `filters=filters` to `Memory.add()`, but `Memory.add()` does not accept a `filters` parameter. This causes `TypeError` in local (non-API) mode. Since the error occurs in a daemon thread with no error handling, it is silently swallowed and memories are never saved. Removed the invalid kwarg.

3. **Silent exception in daemon thread**: `_async_add_to_memory` runs in a daemon thread with no try/except. Any exception (including the TypeError above) is silently lost. Added error handling with `logger.exception()`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit Test — existing tests pass; the invalid kwarg fix corrects a runtime TypeError.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes