### PR TITLE
fix(mem0-ts): fix role check, cosine similarity, LLM role mapping, and search limit

### DIFF
--- a/mem0-ts/src/oss/src/llms/google.ts
+++ b/mem0-ts/src/oss/src/llms/google.ts
@@ -26,7 +26,7 @@ export class GoogleLLM implements LLM {
                 : JSON.stringify(msg.content),
           },
         ],
-        role: msg.role === "system" ? "model" : "user",
+        role: msg.role === "system" || msg.role === "assistant" ? "model" : "user",
       })),
 
       model: this.model,

--- a/mem0-ts/src/oss/src/memory/graph_memory.ts
+++ b/mem0-ts/src/oss/src/memory/graph_memory.ts
@@ -155,7 +155,7 @@ export class MemoryGraph {
 
     const bm25 = new BM25(searchOutputsSequence);
     const tokenizedQuery = query.split(" ");
-    const rerankedResults = bm25.search(tokenizedQuery).slice(0, 5);
+    const rerankedResults = bm25.search(tokenizedQuery).slice(0, limit);
 
     const searchResults = rerankedResults.map((item) => ({
       source: item[0],

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -275,7 +275,7 @@ export class Memory {
     if (!infer) {
       const returnedMemories: MemoryItem[] = [];
       for (const message of messages) {
-        if (message.content === "system") {
+        if (message.role === "system") {
           continue;
         }
         const memoryId = await this.createMemory(

--- a/mem0-ts/src/oss/src/vector_stores/memory.ts
+++ b/mem0-ts/src/oss/src/vector_stores/memory.ts
@@ -64,7 +64,9 @@ export class MemoryVectorStore implements VectorStore {
       normA += a[i] * a[i];
       normB += b[i] * b[i];
     }
-    return dotProduct / (Math.sqrt(normA) * Math.sqrt(normB));
+    const denominator = Math.sqrt(normA) * Math.sqrt(normB);
+    if (denominator === 0) return 0;
+    return dotProduct / denominator;
   }
 
   private filterVector(vector: MemoryVector, filters?: SearchFilters): boolean {


### PR DESCRIPTION
## Description

Fix four bugs in the TypeScript SDK (`mem0-ts/`):

1. **Wrong field check in `addToVectorStore`** (`memory/index.ts`): Checks `message.content === "system"` instead of `message.role === "system"`. This means system messages are stored as memories, and any message with content literally being "system" is incorrectly skipped.

2. **Divide by zero in `cosineSimilarity`** (`vector_stores/memory.ts`): Zero vectors cause `NaN` from division by zero, which pollutes search result sorting. Added a guard to return 0 when the denominator is zero.

3. **Google LLM role mapping** (`llms/google.ts`): Maps "assistant" role to "user" instead of "model". The Gemini API uses "model" for assistant responses. This breaks multi-turn conversation context.

4. **Unused `limit` parameter in `graph_memory.search`** (`memory/graph_memory.ts`): The `limit` parameter (default 100) is declared but never used; results are hardcoded to `.slice(0, 5)`. Changed to use the `limit` parameter.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit Test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes