### PR TITLE
fix(vercel-ai-sdk): fix chat model type and graph mode memory injection

### DIFF
--- a/vercel-ai-sdk/src/mem0-generic-language-model.ts
+++ b/vercel-ai-sdk/src/mem0-generic-language-model.ts
@@ -89,13 +89,13 @@ export class Mem0GenericLanguageModel implements LanguageModelV2 {
       content: memoriesPrompt
     };
 
+    if (isGraphEnabled) {
+      memories = memories?.results;
+    }
+
     // Add the system prompt to the beginning of the messages if there are memories
     if (memories?.length > 0) {
       messagesPrompts.unshift(systemPrompt);
-    }
-
-    if (isGraphEnabled) {
-      memories = memories?.results;
     }
 
     return { memories, messagesPrompts };

--- a/vercel-ai-sdk/src/mem0-provider.ts
+++ b/vercel-ai-sdk/src/mem0-provider.ts
@@ -113,7 +113,7 @@ export function createMem0(
         mem0ApiKey: options.mem0ApiKey,
         apiKey: options.apiKey,
         mem0Config: options.mem0Config,
-        modelType: "completion",
+        modelType: "chat",
       },
       options.config
     );


### PR DESCRIPTION
## Description

Fix two bugs in the Vercel AI SDK integration (`vercel-ai-sdk/`):

1. **Copy-paste bug in `createChatModel`** (`mem0-provider.ts`): `createChatModel` passes `modelType: "completion"` instead of `"chat"`, copied from `createCompletionModel`. This means `provider.chat(model)` incorrectly creates a completion model.

2. **Graph mode memories never injected** (`mem0-generic-language-model.ts`): When `enable_graph` is true, `getMemories()` returns `{results: [...], relations: [...]}` (an object, not an array). The check `memories?.length > 0` returns `undefined > 0 = false` on an object, so the system prompt with memories is never injected. Fixed by extracting `memories.results` before checking length.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit Test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes