### PR TITLE
fix(bedrock): avoid sending both temperature and top_p in Converse API

### DIFF
--- a/mem0/configs/llms/aws_bedrock.py
+++ b/mem0/configs/llms/aws_bedrock.py
@@ -16,7 +16,7 @@ class AWSBedrockConfig(BaseLlmConfig):
         model: Optional[str] = None,
         temperature: float = 0.1,
         max_tokens: int = 2000,
-        top_p: float = 0.9,
+        top_p: Optional[float] = None,
         top_k: int = 1,
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
@@ -33,7 +33,9 @@ class AWSBedrockConfig(BaseLlmConfig):
             model: Bedrock model identifier (e.g., "amazon.nova-3-mini-20241119-v1:0")
             temperature: Controls randomness (0.0 to 2.0)
             max_tokens: Maximum tokens to generate
-            top_p: Nucleus sampling parameter (0.0 to 1.0)
+            top_p: Nucleus sampling parameter (0.0 to 1.0). Default None (omitted).
+                   Note: Some models (e.g. Claude Haiku 4.5) do not allow both
+                   temperature and top_p to be specified simultaneously.
             top_k: Top-k sampling parameter (1 to 40)
             aws_access_key_id: AWS access key (optional, uses env vars if not provided)
             aws_secret_access_key: AWS secret key (optional, uses env vars if not provided)
@@ -78,9 +80,13 @@ class AWSBedrockConfig(BaseLlmConfig):
         base_config = {
             "temperature": self.temperature,
             "max_tokens": self.max_tokens,
-            "top_p": self.top_p,
             "top_k": self.top_k,
         }
+
+        # Only include top_p if explicitly set (some models like Claude Haiku 4.5
+        # reject requests that specify both temperature and top_p)
+        if self.top_p is not None:
+            base_config["top_p"] = self.top_p
 
         # Add custom model kwargs
         base_config.update(self.model_kwargs)

--- a/mem0/llms/aws_bedrock.py
+++ b/mem0/llms/aws_bedrock.py
@@ -498,14 +498,17 @@ class AWSBedrockLLM(LLMBase):
                 tool_config = {"tools": converse_tools}
 
         # Prepare converse parameters
+        inference_config = {
+            "maxTokens": self.model_config.get("max_tokens", 2000),
+            "temperature": self.model_config.get("temperature", 0.1),
+        }
+        if "top_p" in self.model_config:
+            inference_config["topP"] = self.model_config["top_p"]
+
         converse_params = {
             "modelId": self.config.model,
             "messages": formatted_messages,
-            "inferenceConfig": {
-                "maxTokens": self.model_config.get("max_tokens", 2000),
-                "temperature": self.model_config.get("temperature", 0.1),
-                "topP": self.model_config.get("top_p", 0.9),
-            }
+            "inferenceConfig": inference_config,
         }
 
         # Add system message if present (for Anthropic)
@@ -528,14 +531,17 @@ class AWSBedrockLLM(LLMBase):
             formatted_messages, system_message = self._format_messages_anthropic(messages)
 
             # Prepare converse parameters
+            inference_config = {
+                "maxTokens": self.model_config.get("max_tokens", 2000),
+                "temperature": self.model_config.get("temperature", 0.1),
+            }
+            if "top_p" in self.model_config:
+                inference_config["topP"] = self.model_config["top_p"]
+
             converse_params = {
                 "modelId": self.config.model,
                 "messages": formatted_messages,
-                "inferenceConfig": {
-                    "maxTokens": self.model_config.get("max_tokens", 2000),
-                    "temperature": self.model_config.get("temperature", 0.1),
-                    "topP": self.model_config.get("top_p", 0.9),
-                }
+                "inferenceConfig": inference_config,
             }
 
             # Add system message if present
@@ -564,14 +570,17 @@ class AWSBedrockLLM(LLMBase):
             }
             
             # Use converse API for Nova models
+            nova_inference_config = {
+                "maxTokens": input_body["max_tokens"],
+                "temperature": input_body["temperature"],
+            }
+            if "top_p" in input_body:
+                nova_inference_config["topP"] = input_body["top_p"]
+
             response = self.client.converse(
                 modelId=self.config.model,
                 messages=input_body["messages"],
-                inferenceConfig={
-                    "maxTokens": input_body["max_tokens"],
-                    "temperature": input_body["temperature"],
-                    "topP": input_body["top_p"],
-                }
+                inferenceConfig=nova_inference_config,
             )
             
             return self._parse_response(response)


### PR DESCRIPTION
## Problem

Some AWS Bedrock models (e.g. **Claude Haiku 4.5** `claude-haiku-4-5-20251001-v1:0`) reject Converse API requests that specify both `temperature` and `top_p` simultaneously:

```
botocore.errorfactory.ValidationException: An error occurred (ValidationException)
when calling the Converse operation: The model returned the following errors:
`temperature` and `top_p` cannot both be specified for this model. Please use only one.
```

Currently, `AWSBedrockConfig` always sets `top_p=0.9` by default, and all Converse API call sites unconditionally include `topP` in `inferenceConfig`. This makes it impossible to use these newer models with mem0.

## Solution

**Config layer (`AWSBedrockConfig`):**
- Change `top_p` default from `0.9` to `None`
- `get_model_config()` only includes `top_p` when explicitly set by the user

**LLM layer (`AWSBedrockLLM`):**
- All 3 Converse API call paths now conditionally include `topP` only when `top_p` is present in `model_config`:
  - `_generate_with_tools()` (tool-enabled models)
  - `_generate_standard()` (Anthropic path)
  - `_generate_standard()` (Nova path)

## Backward Compatibility

- Users who **explicitly set** `top_p` in config will still have it sent to the API (no behavior change)
- Users who **don't set** `top_p` (the common case) will no longer hit the conflict error on newer models
- Legacy InvokeModel paths (non-Converse) are not affected

## Testing

Tested with Claude Haiku 4.5 (`us.anthropic.claude-haiku-4-5-20251001-v1:0`) on AWS Bedrock:
- Without this fix: ❌ `ValidationException: temperature and top_p cannot both be specified`
- With this fix: ✅ Works correctly with default config (only temperature sent)
- With explicit `top_p=0.9`: ✅ Works on models that support both params

## Changes

| File | Change |
|------|--------|
| `mem0/configs/llms/aws_bedrock.py` | `top_p` default `0.9` → `None`; filter from `get_model_config()` when None |
| `mem0/llms/aws_bedrock.py` | Conditional `topP` in all 3 Converse API `inferenceConfig` blocks |