### PR TITLE
Customize OpenMemory for local DashScope deployment

### DIFF
--- a/openmemory/.gitignore
+++ b/openmemory/.gitignore
@@ -1,4 +1,5 @@
 *.db
+*.db-journal
 .env*
 !.env.example
 !.env.dev

--- a/openmemory/Makefile
+++ b/openmemory/Makefile
@@ -1,5 +1,6 @@
 .PHONY: help up down logs shell migrate test test-clean env ui-install ui-start ui-dev ui-build ui-dev-start
 
+OPENMEMORY_UI_PORT=53000
 NEXT_PUBLIC_USER_ID=$(USER)
 NEXT_PUBLIC_API_URL=http://localhost:8765
 
@@ -49,4 +50,4 @@ downgrade:
 	docker compose exec api alembic downgrade -1
 
 ui-dev:
-	cd ui && NEXT_PUBLIC_USER_ID=$(USER) NEXT_PUBLIC_API_URL=$(NEXT_PUBLIC_API_URL) pnpm install && pnpm dev
+	cd ui && PORT=$(OPENMEMORY_UI_PORT) NEXT_PUBLIC_USER_ID=$(USER) NEXT_PUBLIC_API_URL=$(NEXT_PUBLIC_API_URL) pnpm install && pnpm dev

--- a/openmemory/README.md
+++ b/openmemory/README.md
@@ -84,16 +84,16 @@ make up  # runs openmemory mcp server and ui
 
 After running these commands, you will have:
 - OpenMemory MCP server running at: http://localhost:8765 (API documentation available at http://localhost:8765/docs)
-- OpenMemory UI running at: http://localhost:3000
+- OpenMemory UI running at: http://localhost:53000
 
-#### UI not working on `localhost:3000`?
+#### UI not working on `localhost:53000`?
 
-If the UI does not start properly on [http://localhost:3000](http://localhost:3000), try running it manually:
+If the UI does not start properly on [http://localhost:53000](http://localhost:53000), try running it manually:
 
 ```bash
 cd ui
 pnpm install
-pnpm dev
+PORT=53000 pnpm dev
 ```
 
 ### MCP Client Setup

--- a/openmemory/api/app/mcp_server.py
+++ b/openmemory/api/app/mcp_server.py
@@ -15,6 +15,7 @@ Key features:
 - Environment variable parsing for API keys
 """
 
+import asyncio
 import contextvars
 import datetime
 import json
@@ -57,6 +58,305 @@ mcp_router = APIRouter(prefix="/mcp")
 # Initialize SSE transport
 sse = SseServerTransport("/mcp/messages/")
 
+
+async def _run_tool_in_thread(tool_name: str, uid: str, client_name: str, fn, *args):
+    return await asyncio.to_thread(fn, uid, client_name, *args)
+
+
+def _add_memories_sync(uid: str, client_name: str, text: str) -> str:
+    memory_client = get_memory_client_safe()
+    if not memory_client:
+        return "Error: Memory system is currently unavailable. Please try again later."
+
+    try:
+        db = SessionLocal()
+        try:
+            user, app = get_user_and_app(db, user_id=uid, app_id=client_name)
+
+            if not app.is_active:
+                return f"Error: App {app.name} is currently paused on OpenMemory. Cannot create new memories."
+
+            response = memory_client.add(
+                text,
+                user_id=uid,
+                metadata={
+                    "source_app": "openmemory",
+                    "mcp_client": client_name,
+                },
+            )
+
+            if isinstance(response, dict) and "results" in response:
+                for result in response["results"]:
+                    memory_id = uuid.UUID(result["id"])
+                    memory = db.query(Memory).filter(Memory.id == memory_id).first()
+
+                    if result["event"] == "ADD":
+                        if not memory:
+                            memory = Memory(
+                                id=memory_id,
+                                user_id=user.id,
+                                app_id=app.id,
+                                content=result["memory"],
+                                state=MemoryState.active,
+                            )
+                            db.add(memory)
+                        else:
+                            memory.state = MemoryState.active
+                            memory.content = result["memory"]
+
+                        history = MemoryStatusHistory(
+                            memory_id=memory_id,
+                            changed_by=user.id,
+                            old_state=MemoryState.deleted if memory else None,
+                            new_state=MemoryState.active,
+                        )
+                        db.add(history)
+
+                    elif result["event"] == "DELETE" and memory:
+                        memory.state = MemoryState.deleted
+                        memory.deleted_at = datetime.datetime.now(datetime.UTC)
+                        history = MemoryStatusHistory(
+                            memory_id=memory_id,
+                            changed_by=user.id,
+                            old_state=MemoryState.active,
+                            new_state=MemoryState.deleted,
+                        )
+                        db.add(history)
+
+                db.commit()
+
+            return json.dumps(response)
+        finally:
+            db.close()
+    except Exception as e:
+        logging.exception("Error adding to memory: %s", e)
+        return f"Error adding to memory: {e}"
+
+
+def _search_memory_sync(uid: str, client_name: str, query: str) -> str:
+    memory_client = get_memory_client_safe()
+    if not memory_client:
+        return "Error: Memory system is currently unavailable. Please try again later."
+
+    try:
+        db = SessionLocal()
+        try:
+            user, app = get_user_and_app(db, user_id=uid, app_id=client_name)
+
+            user_memories = db.query(Memory).filter(Memory.user_id == user.id).all()
+            accessible_memory_ids = [memory.id for memory in user_memories if check_memory_access_permissions(db, memory, app.id)]
+
+            embeddings = memory_client.embedding_model.embed(query, "search")
+            hits = memory_client.vector_store.search(
+                query=query,
+                vectors=embeddings,
+                limit=10,
+                filters={"user_id": uid},
+            )
+
+            allowed = set(str(mid) for mid in accessible_memory_ids) if accessible_memory_ids else None
+
+            results = []
+            for hit in hits:
+                memory_id, score, payload = hit.id, hit.score, hit.payload
+                if (allowed and memory_id is None) or (allowed and memory_id not in allowed):
+                    continue
+
+                results.append(
+                    {
+                        "id": memory_id,
+                        "memory": payload.get("data"),
+                        "hash": payload.get("hash"),
+                        "created_at": payload.get("created_at"),
+                        "updated_at": payload.get("updated_at"),
+                        "score": score,
+                    }
+                )
+
+            for result in results:
+                if result.get("id"):
+                    db.add(
+                        MemoryAccessLog(
+                            memory_id=uuid.UUID(result["id"]),
+                            app_id=app.id,
+                            access_type="search",
+                            metadata_={
+                                "query": query,
+                                "score": result.get("score"),
+                                "hash": result.get("hash"),
+                            },
+                        )
+                    )
+            db.commit()
+
+            return json.dumps({"results": results}, indent=2)
+        finally:
+            db.close()
+    except Exception as e:
+        logging.exception("Error searching memory: %s", e)
+        return f"Error searching memory: {e}"
+
+
+def _list_memories_sync(uid: str, client_name: str) -> str:
+    memory_client = get_memory_client_safe()
+    if not memory_client:
+        return "Error: Memory system is currently unavailable. Please try again later."
+
+    try:
+        db = SessionLocal()
+        try:
+            user, app = get_user_and_app(db, user_id=uid, app_id=client_name)
+
+            memories = memory_client.get_all(user_id=uid)
+            filtered_memories = []
+
+            user_memories = db.query(Memory).filter(Memory.user_id == user.id).all()
+            accessible_memory_ids = [memory.id for memory in user_memories if check_memory_access_permissions(db, memory, app.id)]
+
+            if isinstance(memories, dict) and "results" in memories:
+                for memory_data in memories["results"]:
+                    if "id" in memory_data:
+                        memory_id = uuid.UUID(memory_data["id"])
+                        if memory_id in accessible_memory_ids:
+                            db.add(
+                                MemoryAccessLog(
+                                    memory_id=memory_id,
+                                    app_id=app.id,
+                                    access_type="list",
+                                    metadata_={"hash": memory_data.get("hash")},
+                                )
+                            )
+                            filtered_memories.append(memory_data)
+                db.commit()
+            else:
+                for memory in memories:
+                    memory_id = uuid.UUID(memory["id"])
+                    memory_obj = db.query(Memory).filter(Memory.id == memory_id).first()
+                    if memory_obj and check_memory_access_permissions(db, memory_obj, app.id):
+                        db.add(
+                            MemoryAccessLog(
+                                memory_id=memory_id,
+                                app_id=app.id,
+                                access_type="list",
+                                metadata_={"hash": memory.get("hash")},
+                            )
+                        )
+                        filtered_memories.append(memory)
+                db.commit()
+
+            return json.dumps(filtered_memories, indent=2)
+        finally:
+            db.close()
+    except Exception as e:
+        logging.exception("Error getting memories: %s", e)
+        return f"Error getting memories: {e}"
+
+
+def _delete_memories_sync(uid: str, client_name: str, memory_ids: list[str]) -> str:
+    memory_client = get_memory_client_safe()
+    if not memory_client:
+        return "Error: Memory system is currently unavailable. Please try again later."
+
+    try:
+        db = SessionLocal()
+        try:
+            user, app = get_user_and_app(db, user_id=uid, app_id=client_name)
+
+            requested_ids = [uuid.UUID(memory_id) for memory_id in memory_ids]
+            user_memories = db.query(Memory).filter(Memory.user_id == user.id).all()
+            accessible_memory_ids = [memory.id for memory in user_memories if check_memory_access_permissions(db, memory, app.id)]
+            ids_to_delete = [memory_id for memory_id in requested_ids if memory_id in accessible_memory_ids]
+
+            if not ids_to_delete:
+                return "Error: No accessible memories found with provided IDs"
+
+            for memory_id in ids_to_delete:
+                try:
+                    memory_client.delete(str(memory_id))
+                except Exception as delete_error:
+                    logging.warning("Failed to delete memory %s from vector store: %s", memory_id, delete_error)
+
+            now = datetime.datetime.now(datetime.UTC)
+            for memory_id in ids_to_delete:
+                memory = db.query(Memory).filter(Memory.id == memory_id).first()
+                if memory:
+                    memory.state = MemoryState.deleted
+                    memory.deleted_at = now
+                    db.add(
+                        MemoryStatusHistory(
+                            memory_id=memory_id,
+                            changed_by=user.id,
+                            old_state=MemoryState.active,
+                            new_state=MemoryState.deleted,
+                        )
+                    )
+                    db.add(
+                        MemoryAccessLog(
+                            memory_id=memory_id,
+                            app_id=app.id,
+                            access_type="delete",
+                            metadata_={"operation": "delete_by_id"},
+                        )
+                    )
+
+            db.commit()
+            return f"Successfully deleted {len(ids_to_delete)} memories"
+        finally:
+            db.close()
+    except Exception as e:
+        logging.exception("Error deleting memories: %s", e)
+        return f"Error deleting memories: {e}"
+
+
+def _delete_all_memories_sync(uid: str, client_name: str) -> str:
+    memory_client = get_memory_client_safe()
+    if not memory_client:
+        return "Error: Memory system is currently unavailable. Please try again later."
+
+    try:
+        db = SessionLocal()
+        try:
+            user, app = get_user_and_app(db, user_id=uid, app_id=client_name)
+
+            user_memories = db.query(Memory).filter(Memory.user_id == user.id).all()
+            accessible_memory_ids = [memory.id for memory in user_memories if check_memory_access_permissions(db, memory, app.id)]
+
+            for memory_id in accessible_memory_ids:
+                try:
+                    memory_client.delete(str(memory_id))
+                except Exception as delete_error:
+                    logging.warning("Failed to delete memory %s from vector store: %s", memory_id, delete_error)
+
+            now = datetime.datetime.now(datetime.UTC)
+            for memory_id in accessible_memory_ids:
+                memory = db.query(Memory).filter(Memory.id == memory_id).first()
+                memory.state = MemoryState.deleted
+                memory.deleted_at = now
+                db.add(
+                    MemoryStatusHistory(
+                        memory_id=memory_id,
+                        changed_by=user.id,
+                        old_state=MemoryState.active,
+                        new_state=MemoryState.deleted,
+                    )
+                )
+                db.add(
+                    MemoryAccessLog(
+                        memory_id=memory_id,
+                        app_id=app.id,
+                        access_type="delete_all",
+                        metadata_={"operation": "bulk_delete"},
+                    )
+                )
+
+            db.commit()
+            return "Successfully deleted all memories"
+        finally:
+            db.close()
+    except Exception as e:
+        logging.exception("Error deleting memories: %s", e)
+        return f"Error deleting memories: {e}"
+
 @mcp.tool(description="Add a new memory. This method is called everytime the user informs anything about themselves, their preferences, or anything that has any relevant information which can be useful in the future conversation. This can also be called when the user asks you to remember something.")
 async def add_memories(text: str) -> str:
     uid = user_id_var.get(None)
@@ -66,79 +366,7 @@ async def add_memories(text: str) -> str:
         return "Error: user_id not provided"
     if not client_name:
         return "Error: client_name not provided"
-
-    # Get memory client safely
-    memory_client = get_memory_client_safe()
-    if not memory_client:
-        return "Error: Memory system is currently unavailable. Please try again later."
-
-    try:
-        db = SessionLocal()
-        try:
-            # Get or create user and app
-            user, app = get_user_and_app(db, user_id=uid, app_id=client_name)
-
-            # Check if app is active
-            if not app.is_active:
-                return f"Error: App {app.name} is currently paused on OpenMemory. Cannot create new memories."
-
-            response = memory_client.add(text,
-                                         user_id=uid,
-                                         metadata={
-                                            "source_app": "openmemory",
-                                            "mcp_client": client_name,
-                                        })
-
-            # Process the response and update database
-            if isinstance(response, dict) and 'results' in response:
-                for result in response['results']:
-                    memory_id = uuid.UUID(result['id'])
-                    memory = db.query(Memory).filter(Memory.id == memory_id).first()
-
-                    if result['event'] == 'ADD':
-                        if not memory:
-                            memory = Memory(
-                                id=memory_id,
-                                user_id=user.id,
-                                app_id=app.id,
-                                content=result['memory'],
-                                state=MemoryState.active
-                            )
-                            db.add(memory)
-                        else:
-                            memory.state = MemoryState.active
-                            memory.content = result['memory']
-
-                        # Create history entry
-                        history = MemoryStatusHistory(
-                            memory_id=memory_id,
-                            changed_by=user.id,
-                            old_state=MemoryState.deleted if memory else None,
-                            new_state=MemoryState.active
-                        )
-                        db.add(history)
-
-                    elif result['event'] == 'DELETE':
-                        if memory:
-                            memory.state = MemoryState.deleted
-                            memory.deleted_at = datetime.datetime.now(datetime.UTC)
-                            # Create history entry
-                            history = MemoryStatusHistory(
-                                memory_id=memory_id,
-                                changed_by=user.id,
-                                old_state=MemoryState.active,
-                                new_state=MemoryState.deleted
-                            )
-                            db.add(history)
-
-                db.commit()
-
-            return json.dumps(response)
-        finally:
-            db.close()
-    except Exception as e:
-        logging.exception(f"Error adding to memory: {e}")
-        return f"Error adding to memory: {e}"
+    return await _run_tool_in_thread("add_memories", uid, client_name, _add_memories_sync, text)
 
 
 @mcp.tool(description="Search through stored memories. This method is called EVERYTIME the user asks anything.")
@@ -150,73 +378,7 @@ async def search_memory(query: str) -> str:
     if not client_name:
         return "Error: client_name not provided"
 
-    # Get memory client safely
-    memory_client = get_memory_client_safe()
-    if not memory_client:
-        return "Error: Memory system is currently unavailable. Please try again later."
-
-    try:
-        db = SessionLocal()
-        try:
-            # Get or create user and app
-            user, app = get_user_and_app(db, user_id=uid, app_id=client_name)
-
-            # Get accessible memory IDs based on ACL
-            user_memories = db.query(Memory).filter(Memory.user_id == user.id).all()
-            accessible_memory_ids = [memory.id for memory in user_memories if check_memory_access_permissions(db, memory, app.id)]
-
-            filters = {
-                "user_id": uid
-            }
-
-            embeddings = memory_client.embedding_model.embed(query, "search")
-
-            hits = memory_client.vector_store.search(
-                query=query, 
-                vectors=embeddings, 
-                limit=10, 
-                filters=filters,
-            )
-
-            allowed = set(str(mid) for mid in accessible_memory_ids) if accessible_memory_ids else None
-
-            results = []
-            for h in hits:
-                # All vector db search functions return OutputData class
-                id, score, payload = h.id, h.score, h.payload
-                if allowed and h.id is None or h.id not in allowed: 
-                    continue
-                
-                results.append({
-                    "id": id, 
-                    "memory": payload.get("data"), 
-                    "hash": payload.get("hash"),
-                    "created_at": payload.get("created_at"), 
-                    "updated_at": payload.get("updated_at"), 
-                    "score": score,
-                })
-
-            for r in results: 
-                if r.get("id"): 
-                    access_log = MemoryAccessLog(
-                        memory_id=uuid.UUID(r["id"]),
-                        app_id=app.id,
-                        access_type="search",
-                        metadata_={
-                            "query": query,
-                            "score": r.get("score"),
-                            "hash": r.get("hash"),
-                        },
-                    )
-                    db.add(access_log)
-            db.commit()
-
-            return json.dumps({"results": results}, indent=2)
-        finally:
-            db.close()
-    except Exception as e:
-        logging.exception(e)
-        return f"Error searching memory: {e}"
+    return await _run_tool_in_thread("search_memory", uid, client_name, _search_memory_sync, query)
 
 
 @mcp.tool(description="List all memories in the user's memory")
@@ -228,64 +390,7 @@ async def list_memories() -> str:
     if not client_name:
         return "Error: client_name not provided"
 
-    # Get memory client safely
-    memory_client = get_memory_client_safe()
-    if not memory_client:
-        return "Error: Memory system is currently unavailable. Please try again later."
-
-    try:
-        db = SessionLocal()
-        try:
-            # Get or create user and app
-            user, app = get_user_and_app(db, user_id=uid, app_id=client_name)
-
-            # Get all memories
-            memories = memory_client.get_all(user_id=uid)
-            filtered_memories = []
-
-            # Filter memories based on permissions
-            user_memories = db.query(Memory).filter(Memory.user_id == user.id).all()
-            accessible_memory_ids = [memory.id for memory in user_memories if check_memory_access_permissions(db, memory, app.id)]
-            if isinstance(memories, dict) and 'results' in memories:
-                for memory_data in memories['results']:
-                    if 'id' in memory_data:
-                        memory_id = uuid.UUID(memory_data['id'])
-                        if memory_id in accessible_memory_ids:
-                            # Create access log entry
-                            access_log = MemoryAccessLog(
-                                memory_id=memory_id,
-                                app_id=app.id,
-                                access_type="list",
-                                metadata_={
-                                    "hash": memory_data.get('hash')
-                                }
-                            )
-                            db.add(access_log)
-                            filtered_memories.append(memory_data)
-                db.commit()
-            else:
-                for memory in memories:
-                    memory_id = uuid.UUID(memory['id'])
-                    memory_obj = db.query(Memory).filter(Memory.id == memory_id).first()
-                    if memory_obj and check_memory_access_permissions(db, memory_obj, app.id):
-                        # Create access log entry
-                        access_log = MemoryAccessLog(
-                            memory_id=memory_id,
-                            app_id=app.id,
-                            access_type="list",
-                            metadata_={
-                                "hash": memory.get('hash')
-                            }
-                        )
-                        db.add(access_log)
-                        filtered_memories.append(memory)
-                db.commit()
-            return json.dumps(filtered_memories, indent=2)
-        finally:
-            db.close()
-    except Exception as e:
-        logging.exception(f"Error getting memories: {e}")
-        return f"Error getting memories: {e}"
+    return await _run_tool_in_thread("list_memories", uid, client_name, _list_memories_sync)
 
 
 @mcp.tool(description="Delete specific memories by their IDs")
@@ -297,69 +402,7 @@ async def delete_memories(memory_ids: list[str]) -> str:
     if not client_name:
         return "Error: client_name not provided"
 
-    # Get memory client safely
-    memory_client = get_memory_client_safe()
-    if not memory_client:
-        return "Error: Memory system is currently unavailable. Please try again later."
-
-    try:
-        db = SessionLocal()
-        try:
-            # Get or create user and app
-            user, app = get_user_and_app(db, user_id=uid, app_id=client_name)
-
-            # Convert string IDs to UUIDs and filter accessible ones
-            requested_ids = [uuid.UUID(mid) for mid in memory_ids]
-            user_memories = db.query(Memory).filter(Memory.user_id == user.id).all()
-            accessible_memory_ids = [memory.id for memory in user_memories if check_memory_access_permissions(db, memory, app.id)]
-
-            # Only delete memories that are both requested and accessible
-            ids_to_delete = [mid for mid in requested_ids if mid in accessible_memory_ids]
-
-            if not ids_to_delete:
-                return "Error: No accessible memories found with provided IDs"
-
-            # Delete from vector store
-            for memory_id in ids_to_delete:
-                try:
-                    memory_client.delete(str(memory_id))
-                except Exception as delete_error:
-                    logging.warning(f"Failed to delete memory {memory_id} from vector store: {delete_error}")
-
-            # Update each memory's state and create history entries
-            now = datetime.datetime.now(datetime.UTC)
-            for memory_id in ids_to_delete:
-                memory = db.query(Memory).filter(Memory.id == memory_id).first()
-                if memory:
-                    # Update memory state
-                    memory.state = MemoryState.deleted
-                    memory.deleted_at = now
-
-                    # Create history entry
-                    history = MemoryStatusHistory(
-                        memory_id=memory_id,
-                        changed_by=user.id,
-                        old_state=MemoryState.active,
-                        new_state=MemoryState.deleted
-                    )
-                    db.add(history)
-
-                    # Create access log entry
-                    access_log = MemoryAccessLog(
-                        memory_id=memory_id,
-                        app_id=app.id,
-                        access_type="delete",
-                        metadata_={"operation": "delete_by_id"}
-                    )
-                    db.add(access_log)
-
-            db.commit()
-            return f"Successfully deleted {len(ids_to_delete)} memories"
-        finally:
-            db.close()
-    except Exception as e:
-        logging.exception(f"Error deleting memories: {e}")
-        return f"Error deleting memories: {e}"
+    return await _run_tool_in_thread("delete_memories", uid, client_name, _delete_memories_sync, memory_ids)
 
 
 @mcp.tool(description="Delete all memories in the user's memory")
@@ -371,60 +414,7 @@ async def delete_all_memories() -> str:
     if not client_name:
         return "Error: client_name not provided"
 
-    # Get memory client safely
-    memory_client = get_memory_client_safe()
-    if not memory_client:
-        return "Error: Memory system is currently unavailable. Please try again later."
-
-    try:
-        db = SessionLocal()
-        try:
-            # Get or create user and app
-            user, app = get_user_and_app(db, user_id=uid, app_id=client_name)
-
-            user_memories = db.query(Memory).filter(Memory.user_id == user.id).all()
-            accessible_memory_ids = [memory.id for memory in user_memories if check_memory_access_permissions(db, memory, app.id)]
-
-            # delete the accessible memories only
-            for memory_id in accessible_memory_ids:
-                try:
-                    memory_client.delete(str(memory_id))
-                except Exception as delete_error:
-                    logging.warning(f"Failed to delete memory {memory_id} from vector store: {delete_error}")
-
-            # Update each memory's state and create history entries
-            now = datetime.datetime.now(datetime.UTC)
-            for memory_id in accessible_memory_ids:
-                memory = db.query(Memory).filter(Memory.id == memory_id).first()
-                # Update memory state
-                memory.state = MemoryState.deleted
-                memory.deleted_at = now
-
-                # Create history entry
-                history = MemoryStatusHistory(
-                    memory_id=memory_id,
-                    changed_by=user.id,
-                    old_state=MemoryState.active,
-                    new_state=MemoryState.deleted
-                )
-                db.add(history)
-
-                # Create access log entry
-                access_log = MemoryAccessLog(
-                    memory_id=memory_id,
-                    app_id=app.id,
-                    access_type="delete_all",
-                    metadata_={"operation": "bulk_delete"}
-                )
-                db.add(access_log)
-
-            db.commit()
-            return "Successfully deleted all memories"
-        finally:
-            db.close()
-    except Exception as e:
-        logging.exception(f"Error deleting memories: {e}")
-        return f"Error deleting memories: {e}"
+    return await _run_tool_in_thread("delete_all_memories", uid, client_name, _delete_all_memories_sync)
 
 
 @mcp_router.get("/{client_name}/sse/{user_id}")

--- a/openmemory/api/app/routers/config.py
+++ b/openmemory/api/app/routers/config.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any, Dict, Optional
 
 from app.database import get_db
@@ -9,45 +10,58 @@ from sqlalchemy.orm import Session
 
 router = APIRouter(prefix="/api/v1/config", tags=["config"])
 
+
 class LLMConfig(BaseModel):
     model: str = Field(..., description="LLM model name")
-    temperature: float = Field(..., description="Temperature setting for the model")
-    max_tokens: int = Field(..., description="Maximum tokens to generate")
-    api_key: Optional[str] = Field(None, description="API key or 'env:API_KEY' to use environment variable")
-    ollama_base_url: Optional[str] = Field(None, description="Base URL for Ollama server (e.g., http://host.docker.internal:11434)")
+    temperature: Optional[float] = Field(None, description="Temperature for generation")
+    max_tokens: Optional[int] = Field(None, description="Max tokens for generation")
+    api_key: Optional[str] = Field(None, description="API key")
+    ollama_base_url: Optional[str] = Field(None, description="Ollama base URL")
+    openai_base_url: Optional[str] = Field(None, description="OpenAI-compatible base URL")
+
 
 class LLMProvider(BaseModel):
     provider: str = Field(..., description="LLM provider name")
     config: LLMConfig
 
+
 class EmbedderConfig(BaseModel):
-    model: str = Field(..., description="Embedder model name")
-    api_key: Optional[str] = Field(None, description="API key or 'env:API_KEY' to use environment variable")
-    ollama_base_url: Optional[str] = Field(None, description="Base URL for Ollama server (e.g., http://host.docker.internal:11434)")
+    model: str = Field(..., description="Embedding model name")
+    api_key: Optional[str] = Field(None, description="API key")
+    ollama_base_url: Optional[str] = Field(None, description="Ollama base URL")
+    openai_base_url: Optional[str] = Field(None, description="OpenAI-compatible base URL")
+    embedding_dims: Optional[int] = Field(None, description="Embedding dimensions")
+
 
 class EmbedderProvider(BaseModel):
     provider: str = Field(..., description="Embedder provider name")
     config: EmbedderConfig
+
 
 class VectorStoreProvider(BaseModel):
     provider: str = Field(..., description="Vector store provider name")
     # Below config can vary widely based on the vector store used. Refer https://docs.mem0.ai/components/vectordbs/config
     config: Dict[str, Any] = Field(..., description="Vector store-specific configuration")
 
+
 class OpenMemoryConfig(BaseModel):
-    custom_instructions: Optional[str] = Field(None, description="Custom instructions for memory management and fact extraction")
+    custom_instructions: Optional[str] = Field(
+        None, description="Custom instructions for memory management and fact extraction"
+    )
+
 
 class Mem0Config(BaseModel):
     llm: Optional[LLMProvider] = None
     embedder: Optional[EmbedderProvider] = None
     vector_store: Optional[VectorStoreProvider] = None
 
+
 class ConfigSchema(BaseModel):
     openmemory: Optional[OpenMemoryConfig] = None
     mem0: Optional[Mem0Config] = None
 
+
 def get_default_configuration():
-    """Get the default configuration with sensible defaults for LLM and embedder."""
     return {
         "openmemory": {
             "custom_instructions": None
@@ -56,22 +70,33 @@ def get_default_configuration():
             "llm": {
                 "provider": "openai",
                 "config": {
-                    "model": "gpt-4o-mini",
+                    "model": os.getenv("OPENMEMORY_LLM_MODEL", "qwen3-max"),
                     "temperature": 0.1,
-                    "max_tokens": 2000,
-                    "api_key": "env:OPENAI_API_KEY"
+                    "api_key": "env:OPENAI_API_KEY",
+                    "openai_base_url": "env:OPENAI_BASE_URL"
                 }
             },
             "embedder": {
                 "provider": "openai",
                 "config": {
-                    "model": "text-embedding-3-small",
-                    "api_key": "env:OPENAI_API_KEY"
+                    "model": os.getenv("OPENMEMORY_EMBED_MODEL", "text-embedding-v4"),
+                    "api_key": "env:OPENAI_API_KEY",
+                    "openai_base_url": "env:OPENAI_BASE_URL",
+                    "embedding_dims": int(os.getenv("OPENMEMORY_EMBED_DIMS", "2048"))
                 }
             },
-            "vector_store": None
+            "vector_store": {
+                "provider": "qdrant",
+                "config": {
+                    "collection_name": "openmemory",
+                    "host": "mem0_store",
+                    "port": 6333,
+                    "embedding_model_dims": int(os.getenv("OPENMEMORY_EMBED_DIMS", "2048"))
+                }
+            }
         }
     }
+
 
 def get_config_from_db(db: Session, key: str = "main"):
     """Get configuration from database."""
@@ -117,6 +142,7 @@ def get_config_from_db(db: Session, key: str = "main"):
     
     return config_value
 
+
 def save_config_to_db(db: Session, config: Dict[str, Any], key: str = "main"):
     """Save configuration to database."""
     db_config = db.query(ConfigModel).filter(ConfigModel.key == key).first()
@@ -132,29 +158,30 @@ def save_config_to_db(db: Session, config: Dict[str, Any], key: str = "main"):
     db.refresh(db_config)
     return db_config.value
 
+
 @router.get("/", response_model=ConfigSchema)
 async def get_configuration(db: Session = Depends(get_db)):
     """Get the current configuration."""
     config = get_config_from_db(db)
     return config
 
+
 @router.put("/", response_model=ConfigSchema)
 async def update_configuration(config: ConfigSchema, db: Session = Depends(get_db)):
     """Update the configuration."""
     current_config = get_config_from_db(db)
-    
-    # Convert to dict for processing
     updated_config = current_config.copy()
-    
-    # Update openmemory settings if provided
+
     if config.openmemory is not None:
-        if "openmemory" not in updated_config:
-            updated_config["openmemory"] = {}
-        updated_config["openmemory"].update(config.openmemory.dict(exclude_none=True))
-    
-    # Update mem0 settings
-    updated_config["mem0"] = config.mem0.dict(exclude_none=True)
-    
+        updated_config["openmemory"] = config.openmemory.dict(exclude_none=True)
+
+    if config.mem0 is not None:
+        updated_config["mem0"] = config.mem0.dict(exclude_none=True)
+
+    save_config_to_db(db, updated_config)
+    reset_memory_client()
+    return updated_config
+
 
 @router.patch("/", response_model=ConfigSchema)
 async def patch_configuration(config_update: ConfigSchema, db: Session = Depends(get_db)):
@@ -194,12 +221,14 @@ async def reset_configuration(db: Session = Depends(get_db)):
             detail=f"Failed to reset configuration: {str(e)}"
         )
 
+
 @router.get("/mem0/llm", response_model=LLMProvider)
 async def get_llm_configuration(db: Session = Depends(get_db)):
     """Get only the LLM configuration."""
     config = get_config_from_db(db)
     llm_config = config.get("mem0", {}).get("llm", {})
     return llm_config
+
 
 @router.put("/mem0/llm", response_model=LLMProvider)
 async def update_llm_configuration(llm_config: LLMProvider, db: Session = Depends(get_db)):
@@ -218,12 +247,14 @@ async def update_llm_configuration(llm_config: LLMProvider, db: Session = Depend
     reset_memory_client()
     return current_config["mem0"]["llm"]
 
+
 @router.get("/mem0/embedder", response_model=EmbedderProvider)
 async def get_embedder_configuration(db: Session = Depends(get_db)):
     """Get only the Embedder configuration."""
     config = get_config_from_db(db)
     embedder_config = config.get("mem0", {}).get("embedder", {})
     return embedder_config
+
 
 @router.put("/mem0/embedder", response_model=EmbedderProvider)
 async def update_embedder_configuration(embedder_config: EmbedderProvider, db: Session = Depends(get_db)):
@@ -242,12 +273,14 @@ async def update_embedder_configuration(embedder_config: EmbedderProvider, db: S
     reset_memory_client()
     return current_config["mem0"]["embedder"]
 
+
 @router.get("/mem0/vector_store", response_model=Optional[VectorStoreProvider])
 async def get_vector_store_configuration(db: Session = Depends(get_db)):
     """Get only the Vector Store configuration."""
     config = get_config_from_db(db)
     vector_store_config = config.get("mem0", {}).get("vector_store", None)
     return vector_store_config
+
 
 @router.put("/mem0/vector_store", response_model=VectorStoreProvider)
 async def update_vector_store_configuration(vector_store_config: VectorStoreProvider, db: Session = Depends(get_db)):
@@ -266,12 +299,14 @@ async def update_vector_store_configuration(vector_store_config: VectorStoreProv
     reset_memory_client()
     return current_config["mem0"]["vector_store"]
 
+
 @router.get("/openmemory", response_model=OpenMemoryConfig)
 async def get_openmemory_configuration(db: Session = Depends(get_db)):
     """Get only the OpenMemory configuration."""
     config = get_config_from_db(db)
     openmemory_config = config.get("openmemory", {})
     return openmemory_config
+
 
 @router.put("/openmemory", response_model=OpenMemoryConfig)
 async def update_openmemory_configuration(openmemory_config: OpenMemoryConfig, db: Session = Depends(get_db)):

--- a/openmemory/api/app/utils/categorization.py
+++ b/openmemory/api/app/utils/categorization.py
@@ -1,43 +1,47 @@
+import json
 import logging
+import os
 from typing import List
 
 from app.utils.prompts import MEMORY_CATEGORIZATION_PROMPT
 from dotenv import load_dotenv
 from openai import OpenAI
-from pydantic import BaseModel
 from tenacity import retry, stop_after_attempt, wait_exponential
 
 load_dotenv()
-openai_client = OpenAI()
+openai_client = OpenAI(
+    api_key=os.getenv("OPENAI_API_KEY"),
+    base_url=os.getenv("OPENAI_BASE_URL"),
+)
 
-
-class MemoryCategories(BaseModel):
-    categories: List[str]
+CATEGORY_MODEL = os.getenv("OPENMEMORY_CATEGORIZATION_MODEL") or os.getenv("OPENMEMORY_LLM_MODEL", "qwen3-max")
 
 
 @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=4, max=15))
 def get_categories_for_memory(memory: str) -> List[str]:
+    completion = None
     try:
         messages = [
             {"role": "system", "content": MEMORY_CATEGORIZATION_PROMPT},
+            {"role": "system", "content": 'Respond with JSON only using this schema: {"categories": ["..."]}.'},
             {"role": "user", "content": memory}
         ]
 
-        # Let OpenAI handle the pydantic parsing directly
-        completion = openai_client.beta.chat.completions.parse(
-            model="gpt-4o-mini",
+        completion = openai_client.chat.completions.create(
+            model=CATEGORY_MODEL,
             messages=messages,
-            response_format=MemoryCategories,
+            response_format={"type": "json_object"},
             temperature=0
         )
 
-        parsed: MemoryCategories = completion.choices[0].message.parsed
-        return [cat.strip().lower() for cat in parsed.categories]
+        payload = json.loads(completion.choices[0].message.content or "{}")
+        categories = payload.get("categories", [])
+        if not isinstance(categories, list):
+            return []
+        return [str(cat).strip().lower() for cat in categories if str(cat).strip()]
 
     except Exception as e:
         logging.error(f"[ERROR] Failed to get categories: {e}")
-        try:
+        if completion is not None:
             logging.debug(f"[DEBUG] Raw response: {completion.choices[0].message.content}")
-        except Exception as debug_e:
-            logging.debug(f"[DEBUG] Could not extract raw response: {debug_e}")
         raise

--- a/openmemory/api/app/utils/memory.py
+++ b/openmemory/api/app/utils/memory.py
@@ -135,6 +135,10 @@ def reset_memory_client():
 
 def get_default_memory_config():
     """Get default memory client configuration with sensible defaults."""
+    default_embed_dims = int(os.environ.get("OPENMEMORY_EMBED_DIMS", "2048"))
+    default_llm_model = os.environ.get("OPENMEMORY_LLM_MODEL", "qwen3-max")
+    default_embed_model = os.environ.get("OPENMEMORY_EMBED_MODEL", "text-embedding-v4")
+
     # Detect vector store based on environment variables
     vector_store_config = {
         "collection_name": "openmemory",
@@ -152,7 +156,8 @@ def get_default_memory_config():
         vector_store_provider = "qdrant"
         vector_store_config.update({
             "host": os.environ.get('QDRANT_HOST'),
-            "port": int(os.environ.get('QDRANT_PORT'))
+            "port": int(os.environ.get('QDRANT_PORT')),
+            "embedding_model_dims": default_embed_dims
         })
     elif os.environ.get('WEAVIATE_CLUSTER_URL') or (os.environ.get('WEAVIATE_HOST') and os.environ.get('WEAVIATE_PORT')):
         vector_store_provider = "weaviate"
@@ -193,7 +198,7 @@ def get_default_memory_config():
             "url": milvus_url,
             "token": os.environ.get('MILVUS_TOKEN', ''),  # Always include, empty string for local setup
             "db_name": os.environ.get('MILVUS_DB_NAME', ''),
-            "embedding_model_dims": 1536,
+            "embedding_model_dims": default_embed_dims,
             "metric_type": "COSINE"  # Using COSINE for better semantic similarity
         }
     elif os.environ.get('ELASTICSEARCH_HOST') and os.environ.get('ELASTICSEARCH_PORT'):
@@ -211,7 +216,7 @@ def get_default_memory_config():
             "password": os.environ.get('ELASTICSEARCH_PASSWORD', 'changeme'),
             "verify_certs": False,
             "use_ssl": False,
-            "embedding_model_dims": 1536
+            "embedding_model_dims": default_embed_dims
         })
     elif os.environ.get('OPENSEARCH_HOST') and os.environ.get('OPENSEARCH_PORT'):
         vector_store_provider = "opensearch"
@@ -224,7 +229,7 @@ def get_default_memory_config():
         vector_store_config = {
             "collection_name": "openmemory",
             "path": os.environ.get('FAISS_PATH'),
-            "embedding_model_dims": 1536,
+            "embedding_model_dims": default_embed_dims,
             "distance_strategy": "cosine"
         }
     else:
@@ -232,6 +237,7 @@ def get_default_memory_config():
         vector_store_provider = "qdrant"
         vector_store_config.update({
             "port": 6333,
+            "embedding_model_dims": default_embed_dims,
         })
     
     print(f"Auto-detected vector store: {vector_store_provider} with config: {vector_store_config}")
@@ -244,17 +250,19 @@ def get_default_memory_config():
         "llm": {
             "provider": "openai",
             "config": {
-                "model": "gpt-4o-mini",
+                "model": default_llm_model,
                 "temperature": 0.1,
-                "max_tokens": 2000,
-                "api_key": "env:OPENAI_API_KEY"
+                "api_key": "env:OPENAI_API_KEY",
+                "openai_base_url": "env:OPENAI_BASE_URL"
             }
         },
         "embedder": {
             "provider": "openai",
             "config": {
-                "model": "text-embedding-3-small",
-                "api_key": "env:OPENAI_API_KEY"
+                "model": default_embed_model,
+                "api_key": "env:OPENAI_API_KEY",
+                "openai_base_url": "env:OPENAI_BASE_URL",
+                "embedding_dims": default_embed_dims
             }
         },
         "version": "v1.1"

--- a/openmemory/api/config.json
+++ b/openmemory/api/config.json
@@ -1,19 +1,33 @@
 {
+    "openmemory": {
+        "custom_instructions": null
+    },
     "mem0": {
         "llm": {
             "provider": "openai",
             "config": {
-                "model": "gpt-4o-mini",
+                "model": "qwen3-max",
                 "temperature": 0.1,
-                "max_tokens": 2000,
-                "api_key": "env:API_KEY"
+                "api_key": "env:OPENAI_API_KEY",
+                "openai_base_url": "env:OPENAI_BASE_URL"
             }
         },
         "embedder": {
             "provider": "openai",
             "config": {
-                "model": "text-embedding-3-small",
-                "api_key": "env:API_KEY"
+                "model": "text-embedding-v4",
+                "api_key": "env:OPENAI_API_KEY",
+                "openai_base_url": "env:OPENAI_BASE_URL",
+                "embedding_dims": 2048
+            }
+        },
+        "vector_store": {
+            "provider": "qdrant",
+            "config": {
+                "collection_name": "openmemory",
+                "host": "mem0_store",
+                "port": 6333,
+                "embedding_model_dims": 2048
             }
         }
     }

--- a/openmemory/api/default_config.json
+++ b/openmemory/api/default_config.json
@@ -1,20 +1,34 @@
 {
+    "openmemory": {
+        "custom_instructions": null
+    },
     "mem0": {
         "llm": {
             "provider": "openai",
             "config": {
-                "model": "gpt-4o-mini",
+                "model": "qwen3-max",
                 "temperature": 0.1,
-                "max_tokens": 2000,
-                "api_key": "env:OPENAI_API_KEY"
+                "api_key": "env:OPENAI_API_KEY",
+                "openai_base_url": "env:OPENAI_BASE_URL"
             }
         },
         "embedder": {
             "provider": "openai",
             "config": {
-                "model": "text-embedding-3-small",
-                "api_key": "env:OPENAI_API_KEY"
+                "model": "text-embedding-v4",
+                "api_key": "env:OPENAI_API_KEY",
+                "openai_base_url": "env:OPENAI_BASE_URL",
+                "embedding_dims": 2048
+            }
+        },
+        "vector_store": {
+            "provider": "qdrant",
+            "config": {
+                "collection_name": "openmemory",
+                "host": "mem0_store",
+                "port": 6333,
+                "embedding_model_dims": 2048
             }
         }
     }
-} 
+}

--- a/openmemory/docker-compose.yml
+++ b/openmemory/docker-compose.yml
@@ -1,10 +1,10 @@
 services:
   mem0_store:
-    image: qdrant/qdrant
+    image: docker.m.daocloud.io/qdrant/qdrant:latest
     ports:
       - "6333:6333"
     volumes:
-      - mem0_storage:/mem0/storage
+      - mem0_storage:/qdrant/storage
   openmemory-mcp:
     image: mem0/openmemory-mcp
     build: api/
@@ -20,14 +20,14 @@ services:
     volumes:
       - ./api:/usr/src/openmemory
     command: >
-      sh -c "uvicorn main:app --host 0.0.0.0 --port 8765 --reload --workers 4"
+      sh -c "uvicorn main:app --host 0.0.0.0 --port 8765"
   openmemory-ui:
     build:
       context: ui/
       dockerfile: Dockerfile
     image: mem0/openmemory-ui:latest
     ports:
-      - "3000:3000"
+      - "53000:53000"
     environment:
       - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
       - NEXT_PUBLIC_USER_ID=${USER}

--- a/openmemory/run.sh
+++ b/openmemory/run.sh
@@ -33,9 +33,9 @@ if [ $(docker ps -aq -f name=mem0_ui) ]; then
   docker rm -f mem0_ui
 fi
 
-# Find an available port starting from 3000
+# Find an available port starting from 53000
 echo "🔍 Looking for available port for frontend..."
-for port in {3000..3010}; do
+for port in {53000..53010}; do
   if ! lsof -i:$port >/dev/null 2>&1; then
     FRONTEND_PORT=$port
     break
@@ -43,7 +43,7 @@ for port in {3000..3010}; do
 done
 
 if [ -z "$FRONTEND_PORT" ]; then
-  echo "❌ Could not find an available port between 3000 and 3010"
+  echo "❌ Could not find an available port between 53000 and 53010"
   exit 1
 fi
 
@@ -377,7 +377,7 @@ fi
 echo "🚀 Starting frontend on port $FRONTEND_PORT..."
 docker run -d \
   --name mem0_ui \
-  -p ${FRONTEND_PORT}:3000 \
+  -p ${FRONTEND_PORT}:53000 \
   -e NEXT_PUBLIC_API_URL="$NEXT_PUBLIC_API_URL" \
   -e NEXT_PUBLIC_USER_ID="$USER" \
   mem0/openmemory-ui:latest

--- a/openmemory/ui/Dockerfile
+++ b/openmemory/ui/Dockerfile
@@ -1,12 +1,18 @@
 # syntax=docker.io/docker/dockerfile:1
 
 # Base stage for common setup
-FROM node:18-alpine AS base
+FROM swr.cn-north-4.myhuaweicloud.com/ddn-k8s/docker.io/library/node:18-alpine AS base
+
+ARG ALPINE_MIRROR=https://mirrors.aliyun.com/alpine
+ARG NPM_REGISTRY=https://registry.npmmirror.com
+ARG PNPM_VERSION=10.5.2
+
+ENV npm_config_registry=${NPM_REGISTRY}
 
 # Install dependencies for pnpm
-RUN apk add --no-cache libc6-compat curl && \
-    corepack enable && \
-    corepack prepare pnpm@latest --activate
+RUN sed -i "s|https://dl-cdn.alpinelinux.org/alpine|${ALPINE_MIRROR}|g" /etc/apk/repositories && \
+    apk add --no-cache libc6-compat curl && \
+    npm install -g pnpm@${PNPM_VERSION}
 
 WORKDIR /app
 
@@ -25,7 +31,7 @@ COPY . .
 
 RUN cp next.config.dev.mjs next.config.mjs
 RUN cp .env.example .env
-RUN pnpm build
+RUN NODE_OPTIONS=--max-old-space-size=1024 NEXT_TELEMETRY_DISABLED=1 pnpm build
 
 FROM base AS runner
 WORKDIR /app
@@ -44,8 +50,8 @@ RUN chmod +x /home/nextjs/entrypoint.sh
 
 USER nextjs
 
-EXPOSE 3000
-ENV PORT=3000
+EXPOSE 53000
+ENV PORT=53000
 ENV HOSTNAME="0.0.0.0"
 
 ENTRYPOINT ["/home/nextjs/entrypoint.sh"]


### PR DESCRIPTION
## Summary
- switch OpenMemory defaults to DashScope-compatible Qwen models and expose the missing config fields for base URL and embedding dimensions
- keep the local self-hosted setup stable by running the API as a single-process uvicorn service with the customized UI/Qdrant container settings
- update local OpenMemory docs and runtime defaults to match the Colima-based deployment flow and current ports

## Validation
- python3 -m py_compile openmemory/api/app/mcp_server.py openmemory/api/app/routers/config.py openmemory/api/app/utils/categorization.py openmemory/api/app/utils/memory.py
- python3 -m json.tool openmemory/api/config.json
- python3 -m json.tool openmemory/api/default_config.json
- docker compose config

## Notes
- this branch contains the project-specific local deployment customizations we validated in a Colima environment
- the standalone deployment note file kept outside this repository was not included in this PR