### PR TITLE
chore: remove the integration/mirofish path from docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -402,7 +402,6 @@
                       "integrations/autogen",
                       "integrations/agno",
                       "integrations/camel-ai",
-                      "integrations/mirofish",
                       "integrations/openclaw",
                       "integrations/openai-agents-sdk",
                       "integrations/google-ai-adk",


### PR DESCRIPTION
doc fix