### PR TITLE
fix: normalize timestamp handling to UTC and preserve compatibility for existing memories

### DIFF
--- a/mem0/graphs/neptune/neptunedb.py
+++ b/mem0/graphs/neptune/neptunedb.py
@@ -1,7 +1,6 @@
 import logging
 import uuid
-from datetime import datetime
-import pytz
+from datetime import datetime, timezone
 
 from .base import NeptuneBase
 
@@ -114,7 +113,7 @@ class MemoryGraph(NeptuneBase):
             "name": destination,
             "type": destination_type,
             "user_id": user_id,
-            "created_at": datetime.now(pytz.timezone("US/Pacific")).isoformat(),
+            "created_at": datetime.now(timezone.utc).isoformat(),
         }
         self.vector_store.insert(
             vectors=[dest_embedding],
@@ -189,7 +188,7 @@ class MemoryGraph(NeptuneBase):
             "name": source,
             "type": source_type,
             "user_id": user_id,
-            "created_at": datetime.now(pytz.timezone("US/Pacific")).isoformat(),
+            "created_at": datetime.now(timezone.utc).isoformat(),
         }
         self.vector_store.insert(
             vectors=[source_embedding],
@@ -316,14 +315,14 @@ class MemoryGraph(NeptuneBase):
             "name": source,
             "type": source_type,
             "user_id": user_id,
-            "created_at": datetime.now(pytz.timezone("US/Pacific")).isoformat(),
+            "created_at": datetime.now(timezone.utc).isoformat(),
         }
         destination_id = str(uuid.uuid4())
         destination_payload = {
             "name": destination,
             "type": destination_type,
             "user_id": user_id,
-            "created_at": datetime.now(pytz.timezone("US/Pacific")).isoformat(),
+            "created_at": datetime.now(timezone.utc).isoformat(),
         }
         self.vector_store.insert(
             vectors=[source_embedding, dest_embedding],

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -8,10 +8,9 @@ import os
 import uuid
 import warnings
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
-import pytz
 from pydantic import ValidationError
 
 from mem0.configs.base import MemoryConfig, MemoryItem
@@ -49,6 +48,22 @@ warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*swigva
 
 # Initialize logger early for util functions
 logger = logging.getLogger(__name__)
+
+
+def _normalize_iso_timestamp_to_utc(timestamp: Optional[str]) -> Optional[str]:
+    """Normalize timezone-aware ISO timestamps to UTC without rewriting naive values."""
+    if not timestamp:
+        return timestamp
+
+    try:
+        parsed = datetime.fromisoformat(timestamp)
+    except ValueError:
+        return timestamp
+
+    if parsed.tzinfo is None:
+        return timestamp
+
+    return parsed.astimezone(timezone.utc).isoformat()
 
 
 def _safe_deepcopy_config(config):
@@ -580,7 +595,10 @@ class Memory(MemoryBase):
                                 updated_metadata["agent_id"] = metadata["agent_id"]
                             if metadata.get("run_id"):
                                 updated_metadata["run_id"] = metadata["run_id"]
-                            updated_metadata["updated_at"] = datetime.now(pytz.timezone("US/Pacific")).isoformat()
+                            updated_metadata["created_at"] = _normalize_iso_timestamp_to_utc(
+                                updated_metadata.get("created_at")
+                            )
+                            updated_metadata["updated_at"] = datetime.now(timezone.utc).isoformat()
 
                             self.vector_store.update(
                                 vector_id=memory_id,
@@ -643,8 +661,8 @@ class Memory(MemoryBase):
             id=memory.id,
             memory=memory.payload.get("data", ""),
             hash=memory.payload.get("hash"),
-            created_at=memory.payload.get("created_at"),
-            updated_at=memory.payload.get("updated_at"),
+            created_at=_normalize_iso_timestamp_to_utc(memory.payload.get("created_at")),
+            updated_at=_normalize_iso_timestamp_to_utc(memory.payload.get("updated_at")),
         ).model_dump()
 
         for key in promoted_payload_keys:
@@ -746,8 +764,8 @@ class Memory(MemoryBase):
                 id=mem.id,
                 memory=mem.payload.get("data", ""),
                 hash=mem.payload.get("hash"),
-                created_at=mem.payload.get("created_at"),
-                updated_at=mem.payload.get("updated_at"),
+                created_at=_normalize_iso_timestamp_to_utc(mem.payload.get("created_at")),
+                updated_at=_normalize_iso_timestamp_to_utc(mem.payload.get("updated_at")),
             ).model_dump(exclude={"score"})
 
             for key in promoted_payload_keys:
@@ -978,8 +996,8 @@ class Memory(MemoryBase):
                 id=mem.id,
                 memory=mem.payload.get("data", ""),
                 hash=mem.payload.get("hash"),
-                created_at=mem.payload.get("created_at"),
-                updated_at=mem.payload.get("updated_at"),
+                created_at=_normalize_iso_timestamp_to_utc(mem.payload.get("created_at")),
+                updated_at=_normalize_iso_timestamp_to_utc(mem.payload.get("updated_at")),
                 score=mem.score,
             ).model_dump()
 
@@ -1088,7 +1106,7 @@ class Memory(MemoryBase):
         metadata = metadata or {}
         metadata["data"] = data
         metadata["hash"] = hashlib.md5(data.encode()).hexdigest()
-        metadata["created_at"] = datetime.now(pytz.timezone("US/Pacific")).isoformat()
+        metadata["created_at"] = datetime.now(timezone.utc).isoformat()
 
         self.vector_store.insert(
             vectors=[embeddings],
@@ -1160,8 +1178,8 @@ class Memory(MemoryBase):
 
         new_metadata["data"] = data
         new_metadata["hash"] = hashlib.md5(data.encode()).hexdigest()
-        new_metadata["created_at"] = existing_memory.payload.get("created_at")
-        new_metadata["updated_at"] = datetime.now(pytz.timezone("US/Pacific")).isoformat()
+        new_metadata["created_at"] = _normalize_iso_timestamp_to_utc(existing_memory.payload.get("created_at"))
+        new_metadata["updated_at"] = datetime.now(timezone.utc).isoformat()
 
         # Preserve session identifiers from existing memory only if not provided in new metadata
         if "user_id" not in new_metadata and "user_id" in existing_memory.payload:
@@ -1604,7 +1622,10 @@ class AsyncMemory(MemoryBase):
                                     updated_metadata["agent_id"] = meta["agent_id"]
                                 if meta.get("run_id"):
                                     updated_metadata["run_id"] = meta["run_id"]
-                                updated_metadata["updated_at"] = datetime.now(pytz.timezone("US/Pacific")).isoformat()
+                                updated_metadata["created_at"] = _normalize_iso_timestamp_to_utc(
+                                    updated_metadata.get("created_at")
+                                )
+                                updated_metadata["updated_at"] = datetime.now(timezone.utc).isoformat()
 
                                 await asyncio.to_thread(
                                     self.vector_store.update,
@@ -1690,8 +1711,8 @@ class AsyncMemory(MemoryBase):
             id=memory.id,
             memory=memory.payload.get("data", ""),
             hash=memory.payload.get("hash"),
-            created_at=memory.payload.get("created_at"),
-            updated_at=memory.payload.get("updated_at"),
+            created_at=_normalize_iso_timestamp_to_utc(memory.payload.get("created_at")),
+            updated_at=_normalize_iso_timestamp_to_utc(memory.payload.get("updated_at")),
         ).model_dump()
 
         for key in promoted_payload_keys:
@@ -1798,8 +1819,8 @@ class AsyncMemory(MemoryBase):
                 id=mem.id,
                 memory=mem.payload.get("data", ""),
                 hash=mem.payload.get("hash"),
-                created_at=mem.payload.get("created_at"),
-                updated_at=mem.payload.get("updated_at"),
+                created_at=_normalize_iso_timestamp_to_utc(mem.payload.get("created_at")),
+                updated_at=_normalize_iso_timestamp_to_utc(mem.payload.get("updated_at")),
             ).model_dump(exclude={"score"})
 
             for key in promoted_payload_keys:
@@ -2039,8 +2060,8 @@ class AsyncMemory(MemoryBase):
                 id=mem.id,
                 memory=mem.payload.get("data", ""),
                 hash=mem.payload.get("hash"),
-                created_at=mem.payload.get("created_at"),
-                updated_at=mem.payload.get("updated_at"),
+                created_at=_normalize_iso_timestamp_to_utc(mem.payload.get("created_at")),
+                updated_at=_normalize_iso_timestamp_to_utc(mem.payload.get("updated_at")),
                 score=mem.score,
             ).model_dump()
 
@@ -2154,7 +2175,7 @@ class AsyncMemory(MemoryBase):
         metadata = metadata or {}
         metadata["data"] = data
         metadata["hash"] = hashlib.md5(data.encode()).hexdigest()
-        metadata["created_at"] = datetime.now(pytz.timezone("US/Pacific")).isoformat()
+        metadata["created_at"] = datetime.now(timezone.utc).isoformat()
 
         await asyncio.to_thread(
             self.vector_store.insert,
@@ -2244,8 +2265,8 @@ class AsyncMemory(MemoryBase):
 
         new_metadata["data"] = data
         new_metadata["hash"] = hashlib.md5(data.encode()).hexdigest()
-        new_metadata["created_at"] = existing_memory.payload.get("created_at")
-        new_metadata["updated_at"] = datetime.now(pytz.timezone("US/Pacific")).isoformat()
+        new_metadata["created_at"] = _normalize_iso_timestamp_to_utc(existing_memory.payload.get("created_at"))
+        new_metadata["updated_at"] = datetime.now(timezone.utc).isoformat()
 
         # Preserve session identifiers from existing memory only if not provided in new metadata
         if "user_id" not in new_metadata and "user_id" in existing_memory.payload:

--- a/mem0/vector_stores/redis.py
+++ b/mem0/vector_stores/redis.py
@@ -1,10 +1,9 @@
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import reduce
 
 import numpy as np
-import pytz
 import redis
 from redis.commands.search.query import Query
 from redisvl.index import SearchIndex
@@ -163,14 +162,14 @@ class RedisDB(VectorStoreBase):
                 payload={
                     "hash": result["hash"],
                     "data": result["memory"],
-                    "created_at": datetime.fromtimestamp(
-                        int(result["created_at"]), tz=pytz.timezone("US/Pacific")
-                    ).isoformat(timespec="microseconds"),
+                    "created_at": datetime.fromtimestamp(int(result["created_at"]), tz=timezone.utc).isoformat(
+                        timespec="microseconds"
+                    ),
                     **(
                         {
-                            "updated_at": datetime.fromtimestamp(
-                                int(result["updated_at"]), tz=pytz.timezone("US/Pacific")
-                            ).isoformat(timespec="microseconds")
+                            "updated_at": datetime.fromtimestamp(int(result["updated_at"]), tz=timezone.utc).isoformat(
+                                timespec="microseconds"
+                            )
                         }
                         if "updated_at" in result
                         else {}
@@ -207,14 +206,12 @@ class RedisDB(VectorStoreBase):
         payload = {
             "hash": result["hash"],
             "data": result["memory"],
-            "created_at": datetime.fromtimestamp(int(result["created_at"]), tz=pytz.timezone("US/Pacific")).isoformat(
-                timespec="microseconds"
-            ),
+            "created_at": datetime.fromtimestamp(int(result["created_at"]), tz=timezone.utc).isoformat(timespec="microseconds"),
             **(
                 {
-                    "updated_at": datetime.fromtimestamp(
-                        int(result["updated_at"]), tz=pytz.timezone("US/Pacific")
-                    ).isoformat(timespec="microseconds")
+                    "updated_at": datetime.fromtimestamp(int(result["updated_at"]), tz=timezone.utc).isoformat(
+                        timespec="microseconds"
+                    )
                 }
                 if "updated_at" in result
                 else {}
@@ -270,14 +267,14 @@ class RedisDB(VectorStoreBase):
                     payload={
                         "hash": result["hash"],
                         "data": result["memory"],
-                        "created_at": datetime.fromtimestamp(
-                            int(result["created_at"]), tz=pytz.timezone("US/Pacific")
-                        ).isoformat(timespec="microseconds"),
+                        "created_at": datetime.fromtimestamp(int(result["created_at"]), tz=timezone.utc).isoformat(
+                            timespec="microseconds"
+                        ),
                         **(
                             {
-                                "updated_at": datetime.fromtimestamp(
-                                    int(result["updated_at"]), tz=pytz.timezone("US/Pacific")
-                                ).isoformat(timespec="microseconds")
+                                "updated_at": datetime.fromtimestamp(int(result["updated_at"]), tz=timezone.utc).isoformat(
+                                    timespec="microseconds"
+                                )
                             }
                             if result.__dict__.get("updated_at")
                             else {}

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -1,9 +1,10 @@
 import logging
+from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 import pytest
 
-from mem0.memory.main import AsyncMemory, Memory
+from mem0.memory.main import AsyncMemory, Memory, _normalize_iso_timestamp_to_utc
 
 
 def _setup_mocks(mocker):
@@ -21,9 +22,28 @@ def _setup_mocks(mocker):
     mock_llm = mocker.MagicMock()
     mocker.patch("mem0.utils.factory.LlmFactory.create", mock_llm)
 
-    mocker.patch("mem0.memory.storage.SQLiteManager", mocker.MagicMock())
+    mocker.patch("mem0.memory.main.SQLiteManager", mocker.MagicMock())
+    mocker.patch("mem0.memory.main.MEM0_TELEMETRY", False)
 
     return mock_llm, mock_vector_store
+
+
+def _build_memory_instance(mocker, memory_cls):
+    _setup_mocks(mocker)
+    memory = memory_cls()
+    memory.config = mocker.MagicMock()
+    memory.config.custom_fact_extraction_prompt = None
+    memory.config.custom_update_memory_prompt = None
+    memory.api_version = "v1.1"
+    memory.vector_store = mocker.MagicMock()
+    memory.db = mocker.MagicMock()
+    return memory
+
+
+def _assert_utc_timestamp(timestamp: str):
+    parsed = datetime.fromisoformat(timestamp)
+    assert parsed.tzinfo == timezone.utc
+    assert parsed.utcoffset().total_seconds() == 0
 
 
 class TestAddToVectorStoreErrors:
@@ -127,3 +147,53 @@ class TestAsyncAddToVectorStoreErrors:
         assert result == []
         assert "Empty response from LLM, no memories to extract" in caplog.text
         assert mock_capture_event.call_count == 1
+
+
+def test_create_memory_uses_utc_timestamps(mocker):
+    memory = _build_memory_instance(mocker, Memory)
+
+    memory._create_memory("new memory", {"new memory": [0.1, 0.2, 0.3]}, metadata={})
+
+    payload = memory.vector_store.insert.call_args.kwargs["payloads"][0]
+    _assert_utc_timestamp(payload["created_at"])
+
+
+def test_update_memory_uses_utc_timestamps(mocker):
+    memory = _build_memory_instance(mocker, Memory)
+    memory.vector_store.get.return_value = MagicMock(
+        payload={"data": "old memory", "created_at": "2026-03-17T17:00:00-07:00"}
+    )
+
+    memory._update_memory("memory-id", "new memory", {"new memory": [0.1, 0.2, 0.3]}, metadata={})
+
+    payload = memory.vector_store.update.call_args.kwargs["payload"]
+    assert payload["created_at"] == "2026-03-18T00:00:00+00:00"
+    _assert_utc_timestamp(payload["updated_at"])
+
+
+@pytest.mark.asyncio
+async def test_async_create_memory_uses_utc_timestamps(mocker):
+    memory = _build_memory_instance(mocker, AsyncMemory)
+
+    await memory._create_memory("new memory", {"new memory": [0.1, 0.2, 0.3]}, metadata={})
+
+    payload = memory.vector_store.insert.call_args.kwargs["payloads"][0]
+    _assert_utc_timestamp(payload["created_at"])
+
+
+@pytest.mark.asyncio
+async def test_async_update_memory_uses_utc_timestamps(mocker):
+    memory = _build_memory_instance(mocker, AsyncMemory)
+    memory.vector_store.get.return_value = MagicMock(
+        payload={"data": "old memory", "created_at": "2026-03-17T17:00:00-07:00"}
+    )
+
+    await memory._update_memory("memory-id", "new memory", {"new memory": [0.1, 0.2, 0.3]}, metadata={})
+
+    payload = memory.vector_store.update.call_args.kwargs["payload"]
+    assert payload["created_at"] == "2026-03-18T00:00:00+00:00"
+    _assert_utc_timestamp(payload["updated_at"])
+
+
+def test_normalize_iso_timestamp_to_utc_preserves_naive_values():
+    assert _normalize_iso_timestamp_to_utc("2026-03-18T00:00:00") == "2026-03-18T00:00:00"

--- a/tests/memory/test_neptune_memory.py
+++ b/tests/memory/test_neptune_memory.py
@@ -1,4 +1,5 @@
 import unittest
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 import pytest
 from mem0.graphs.neptune.neptunedb import MemoryGraph
@@ -288,6 +289,25 @@ class TestNeptuneMemory(unittest.TestCase):
 
         # Check the result
         self.assertEqual(result, mock_query_result)
+
+    def test_add_new_entities_payloads_use_utc_timestamps(self):
+        """Test that Neptune vector-store payloads use UTC timestamps."""
+        self.memory_graph._add_new_entities_cypher(
+            source="alice",
+            source_embedding=[0.1, 0.2],
+            source_type="person",
+            destination="bob",
+            dest_embedding=[0.3, 0.4],
+            destination_type="person",
+            relationship="KNOWS",
+            user_id=self.user_id,
+        )
+
+        _, kwargs = self.mock_vector_store.insert.call_args
+        for payload in kwargs["payloads"]:
+            parsed = datetime.fromisoformat(payload["created_at"])
+            self.assertEqual(parsed.tzinfo, timezone.utc)
+            self.assertEqual(parsed.utcoffset().total_seconds(), 0)
 
     def test_search_graph_db(self):
         """Test the _search_graph_db method."""

--- a/tests/vector_stores/test_redis.py
+++ b/tests/vector_stores/test_redis.py
@@ -1,0 +1,91 @@
+import json
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("redis")
+pytest.importorskip("redisvl")
+
+from mem0.vector_stores.redis import RedisDB
+
+
+class MockRedisResult(dict):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.__dict__.update(kwargs)
+
+
+@pytest.fixture
+def mock_search_index():
+    return MagicMock()
+
+
+@pytest.fixture
+def redis_db(mock_search_index):
+    with patch("mem0.vector_stores.redis.redis.Redis.from_url", return_value=MagicMock()), patch(
+        "mem0.vector_stores.redis.SearchIndex.from_dict", return_value=mock_search_index
+    ):
+        return RedisDB(
+            redis_url="redis://localhost:6379",
+            collection_name="test_collection",
+            embedding_model_dims=3,
+        )
+
+
+def test_search_formats_timestamps_in_utc(redis_db, mock_search_index):
+    mock_search_index.query.return_value = [
+        {
+            "memory_id": "memory-id",
+            "vector_distance": "0.1",
+            "hash": "hash",
+            "memory": "hello",
+            "metadata": json.dumps({"topic": "test"}),
+            "created_at": "0",
+            "updated_at": "1",
+            "user_id": "user-1",
+        }
+    ]
+
+    result = redis_db.search("hello", [0.1, 0.2, 0.3], filters={"user_id": "user-1"})[0]
+
+    assert result.payload["created_at"] == "1970-01-01T00:00:00.000000+00:00"
+    assert result.payload["updated_at"] == "1970-01-01T00:00:01.000000+00:00"
+
+
+def test_get_formats_timestamps_in_utc(redis_db, mock_search_index):
+    mock_search_index.fetch.return_value = {
+        "memory_id": "memory-id",
+        "hash": "hash",
+        "memory": "hello",
+        "metadata": json.dumps({"topic": "test"}),
+        "created_at": "0",
+        "updated_at": "1",
+    }
+
+    result = redis_db.get("memory-id")
+
+    assert result.payload["created_at"] == "1970-01-01T00:00:00.000000+00:00"
+    assert result.payload["updated_at"] == "1970-01-01T00:00:01.000000+00:00"
+
+
+def test_list_formats_timestamps_in_utc(redis_db, mock_search_index):
+    mock_search_index.search.return_value = MagicMock(
+        docs=[
+            MockRedisResult(
+                memory_id="memory-id",
+                hash="hash",
+                memory="hello",
+                metadata=json.dumps({"topic": "test"}),
+                created_at="0",
+                updated_at="1",
+                user_id="user-1",
+            )
+        ]
+    )
+
+    result = redis_db.list(filters={"user_id": "user-1"})[0][0]
+
+    assert result.payload["created_at"] == "1970-01-01T00:00:00.000000+00:00"
+    assert result.payload["updated_at"] == "1970-01-01T00:00:01.000000+00:00"
+    assert datetime.fromisoformat(result.payload["created_at"]).tzinfo == timezone.utc


### PR DESCRIPTION
## Description

This PR fixes hardcoded `US/Pacific` timestamps for memory metadata and related read paths by switching affected code to UTC.

Before this change, new `created_at` / `updated_at` values could be written with `-07:00` / `-08:00` offsets, which caused incorrect date boundaries and broken filtering behavior for users outside Pacific time. This was especially problematic near UTC midnight.

This PR updates:

- `mem0/memory/main.py`
- `mem0/vector_stores/redis.py`
- `mem0/graphs/neptune/neptunedb.py`

## What Changed

- Replaced hardcoded `US/Pacific` writes with `datetime.now(timezone.utc).isoformat()`
- Replaced Redis timestamp rendering from `US/Pacific` to `timezone.utc`
- Updated Neptune graph payload creation to use UTC timestamps
- Added compatibility normalization for existing timezone-aware ISO timestamps in memory read/update paths

## Production Safety / Existing Data

This PR is intentionally backwards-safe for existing memories:

- Existing timezone-aware ISO timestamps are not reinterpreted as a different moment in time
- When existing memories are updated or returned through memory read/search/list paths, timezone-aware timestamps are normalized to UTC using their stored offset
- Naive timestamps are left unchanged to avoid making unsafe assumptions about historical data

That means old prod memories should not be corrupted by this change.

Important nuance:

- For Redis-backed data, stored values are already numeric timestamps underneath, so this mostly fixes incorrect timezone presentation
- For existing string-based stores, this PR improves compatibility, but a separate backfill would still be the safest way to fully normalize all historical records to UTC

## Why This Approach

This PR avoids a risky in-place migration of old timestamps while still fixing new writes immediately.

It gives us:

- Correct UTC timestamps for all new writes
- Correct UTC rendering for affected read paths
- Safe normalization of old offset-aware values without changing their meaning

## Follow-Up Recommendation

For a complete production migration story, a separate follow-up can add:

- canonical numeric timestamp fields for filtering
- a batched backfill for historical string timestamps
- a final cutover so filtering no longer depends on mixed ISO string formats

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested locally in a `.venv` with:

```bash
.venv/bin/python -m pytest tests/memory/test_main.py tests/memory/test_neptune_memory.py tests/vector_stores/test_redis.py
```

Added regression coverage for:

- sync memory UTC timestamp creation/update
- async memory UTC timestamp creation/update
- normalization of old offset-aware timestamps to UTC
- Neptune payload timestamps
- Redis search/get/list UTC rendering

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] New and existing relevant tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #4402
- [ ] Made sure Checks passed
