### PR TITLE
fix(ts-sdk): externalize all peerDependencies in tsup config

### DIFF
--- a/mem0-ts/src/oss/tests/tsup-externals.test.ts
+++ b/mem0-ts/src/oss/tests/tsup-externals.test.ts
@@ -1,0 +1,51 @@
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Drift-prevention test: ensures every peerDependency in package.json
+ * is listed in tsup.config.ts's external array so tsup never bundles
+ * optional provider SDKs into the dist output.
+ */
+describe("tsup.config.ts externals", () => {
+  let peerDeps: string[];
+  let directDeps: string[];
+  let externalDeps: string[];
+
+  beforeAll(() => {
+    const pkgPath = path.resolve(__dirname, "../../../package.json");
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
+    // Filter out @types/* packages — they are type-only and not bundled at runtime
+    peerDeps = Object.keys(pkg.peerDependencies || {}).filter(
+      (dep) => !dep.startsWith("@types/"),
+    );
+    directDeps = Object.keys(pkg.dependencies || {});
+
+    const tsupConfigPath = path.resolve(__dirname, "../../../tsup.config.ts");
+    const tsupContent = fs.readFileSync(tsupConfigPath, "utf-8");
+
+    // Extract strings from the external array (supports double, single, and backtick quotes)
+    const externalMatch = tsupContent.match(
+      /const external\s*=\s*\[([\s\S]*?)\];/,
+    );
+    if (!externalMatch) {
+      throw new Error("Could not find external array in tsup.config.ts");
+    }
+    const matches = externalMatch[1].match(/["'`]([^"'`]+)["'`]/g);
+    externalDeps = (matches || []).map((m) => m.replace(/["'`]/g, ""));
+  });
+
+  it("should have every peerDependency in the external array", () => {
+    const missing = peerDeps.filter((dep) => !externalDeps.includes(dep));
+    expect(missing).toEqual([]);
+  });
+
+  it("should not have stale entries that are not in package.json", () => {
+    const allDeps = [...peerDeps, ...directDeps];
+    const stale = externalDeps.filter((dep) => !allDeps.includes(dep));
+    expect(stale).toEqual([]);
+  });
+
+  it("should have peerDependencies defined in package.json", () => {
+    expect(peerDeps.length).toBeGreaterThan(0);
+  });
+});

--- a/mem0-ts/tsup.config.ts
+++ b/mem0-ts/tsup.config.ts
@@ -10,6 +10,16 @@ const external = [
   "better-sqlite3",
   "@qdrant/js-client-rest",
   "redis",
+  "ollama",
+  "@google/genai",
+  "@mistralai/mistralai",
+  "neo4j-driver",
+  "@supabase/supabase-js",
+  "@azure/search-documents",
+  "@azure/identity",
+  "cloudflare",
+  "@cloudflare/workers-types",
+  "@langchain/core",
 ];
 
 export default defineConfig([


### PR DESCRIPTION
## Description

The TypeScript SDK (`mem0ai/oss`) crashes at load time with `Cannot find module 'ollama'` when users don't have the `ollama` package installed, even when using a completely different provider (e.g., Gemini, OpenAI). This happens because `ollama` and 9 other peerDependencies were missing from `tsup.config.ts`'s `external` array, causing tsup to bundle them inline instead of treating them as external requires.

This PR adds all missing peerDependencies to the `external` array and includes a drift-prevention test that will fail if a new peerDep is added to `package.json` without being externalized in `tsup.config.ts`.

Fixes #3857

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Verified `npm run build` passes and bundle compiles cleanly
- Inspected `dist/oss/index.js` to confirm `require("ollama")` is a simple external require (2 lines), not the entire inlined package
- Confirmed all other newly externalized deps (`@google/genai`, `@mistralai/mistralai`, `@supabase/supabase-js`, etc.) are also externalized correctly
- Drift-prevention test validates every runtime peerDependency is present in the external array
- Reverse staleness test validates no orphaned entries exist in the external array

- [x] Unit Test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [x] closes #3857
- [ ] Made sure Checks passed