### PR TITLE
fix(oss): Forward all LLM config keys through ConfigManager.mergeConfig()

### DIFF
--- a/mem0-ts/src/oss/src/config/manager.ts
+++ b/mem0-ts/src/oss/src/config/manager.ts
@@ -113,6 +113,7 @@ export class ConfigManager {
             defaultConf.baseURL;
 
           return {
+            ...userConf,
             baseURL: llmBaseURL,
             url: userConf?.url,
             apiKey:

--- a/mem0-ts/src/oss/src/types/index.ts
+++ b/mem0-ts/src/oss/src/types/index.ts
@@ -139,13 +139,15 @@ export const MemoryConfigSchema = z.object({
   }),
   llm: z.object({
     provider: z.string(),
-    config: z.object({
-      apiKey: z.string().optional(),
-      model: z.union([z.string(), z.any()]).optional(),
-      modelProperties: z.record(z.string(), z.any()).optional(),
-      baseURL: z.string().optional(),
-      url: z.string().optional(),
-    }),
+    config: z
+      .object({
+        apiKey: z.string().optional(),
+        model: z.union([z.string(), z.any()]).optional(),
+        modelProperties: z.record(z.string(), z.any()).optional(),
+        baseURL: z.string().optional(),
+        url: z.string().optional(),
+      })
+      .passthrough(),
   }),
   historyDbPath: z.string().optional(),
   customPrompt: z.string().optional(),

--- a/mem0-ts/src/oss/tests/config-manager.test.ts
+++ b/mem0-ts/src/oss/tests/config-manager.test.ts
@@ -347,6 +347,52 @@ describe("ConfigManager", () => {
       expect(cfg.vectorStore.config.port).toBe(6333);
     });
   });
+
+  describe("mergeConfig - LLM config passthrough", () => {
+    const baseEmbedder = {
+      provider: "openai",
+      config: { apiKey: "test-key" },
+    };
+    const baseVectorStore = {
+      provider: "memory",
+      config: { collectionName: "test" },
+    };
+
+    it("should preserve maxTokens and temperature in LLM config", () => {
+      const config = ConfigManager.mergeConfig({
+        embedder: baseEmbedder,
+        vectorStore: baseVectorStore,
+        llm: {
+          provider: "anthropic",
+          config: {
+            apiKey: "sk-ant-test",
+            model: "claude-sonnet-4-20250514",
+            maxTokens: 8192,
+            temperature: 0.1,
+          },
+        },
+      });
+
+      expect(config.llm.config.maxTokens).toBe(8192);
+      expect(config.llm.config.temperature).toBe(0.1);
+      expect(config.llm.config.model).toBe("claude-sonnet-4-20250514");
+      expect(config.llm.config.apiKey).toBe("sk-ant-test");
+    });
+
+    it("should not include extra keys when none are provided", () => {
+      const config = ConfigManager.mergeConfig({
+        embedder: baseEmbedder,
+        vectorStore: baseVectorStore,
+        llm: {
+          provider: "openai",
+          config: { apiKey: "sk-test" },
+        },
+      });
+
+      expect(config.llm.config.maxTokens).toBeUndefined();
+      expect(config.llm.config.temperature).toBeUndefined();
+    });
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Description

`ConfigManager.mergeConfig()` explicitly constructs the LLM config object by copying only `baseURL`, `apiKey`, `model`, and `modelProperties` from user-provided config. All other keys are silently dropped. This means LLM configuration parameters like `maxTokens` and `temperature` never reach any LLM provider constructor, even when the provider class supports them.

This is the same bug class as #4268 (embedder `baseURL` dropped by ConfigManager). Credit to nasacontrol-hq who identified both root causes in PR #4068 (closed, not merged): the Zod schema stripping undeclared keys AND ConfigManager's explicit allowlist.

**Two barriers, both fixed:**

1. **Zod schema stripping:** `MemoryConfigSchema` uses default Zod object behavior for `llm.config`, which strips undeclared keys during `parse()`. Added `.passthrough()` to preserve user-provided keys through validation. This matches the pattern already used by `vectorStore.config` in the same schema.

2. **ConfigManager allowlist:** `mergeConfig()` constructs a new object with only the known keys. Added `...userConf` spread before the explicit fields so all user-provided keys survive, with computed fields (apiKey fallback, model resolution) overriding after the spread.

We discovered the Zod barrier independently during testing: the spread fix alone wasn't enough because `MemoryConfigSchema.parse()` stripped unknown keys before they reached `mergeConfig()`. Searching existing issues confirmed nasacontrol-hq had already identified this.

**Alternative approach:** If the spread is too broad, the minimal fix is to explicitly add `maxTokens`, `temperature`, and `url` to the return object. We went with spread to avoid needing a `mergeConfig()` update every time a new provider adds a config parameter.

Related: #4061, #4268

Fixes the LLM config path only. The embedder merge path (#4268) has the same issue and could receive the same treatment in a follow-up.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Two new unit tests added to `config-manager.test.ts`:

1. Verifies `maxTokens` and `temperature` survive the full path through `MemoryConfigSchema.parse()` and `mergeConfig()`
2. Verifies no extra keys leak into the LLM config when none are provided (regression guard)

The ConfigManager spread has been running in production for 4 days on a self-hosted Qdrant + Anthropic deployment (~7,600 memories) via a local dist patch. The Zod `.passthrough()` fix was discovered and added during unit test development for this PR.

- [x] Unit Test

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

Full suite: 472/473 pass. The 1 failure (`memory.crud.test.ts` "preserves createdAt and sets updatedAt") is pre-existing and reproduces on `main`.

## Maintainer Checklist

- [ ] Made sure Checks passed

---

**Note:** First PR here. Happy to adjust anything.