### PR TITLE
feat(oss): Forward score threshold from Memory.search() to Qdrant

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -499,6 +499,7 @@ export class Memory {
       queryEmbedding,
       limit,
       filters,
+      config.threshold,
     );
 
     // Search graph store if available

--- a/mem0-ts/src/oss/src/memory/memory.types.ts
+++ b/mem0-ts/src/oss/src/memory/memory.types.ts
@@ -16,6 +16,7 @@ export interface AddMemoryOptions extends Entity {
 export interface SearchMemoryOptions extends Entity {
   limit?: number;
   filters?: SearchFilters;
+  threshold?: number;
 }
 
 export interface GetAllMemoryOptions extends Entity {

--- a/mem0-ts/src/oss/src/vector_stores/base.ts
+++ b/mem0-ts/src/oss/src/vector_stores/base.ts
@@ -10,6 +10,7 @@ export interface VectorStore {
     query: number[],
     limit?: number,
     filters?: SearchFilters,
+    scoreThreshold?: number,
   ): Promise<VectorStoreResult[]>;
   get(vectorId: string): Promise<VectorStoreResult | null>;
   update(

--- a/mem0-ts/src/oss/src/vector_stores/qdrant.ts
+++ b/mem0-ts/src/oss/src/vector_stores/qdrant.ts
@@ -120,13 +120,18 @@ export class Qdrant implements VectorStore {
     query: number[],
     limit: number = 5,
     filters?: SearchFilters,
+    scoreThreshold?: number,
   ): Promise<VectorStoreResult[]> {
     const queryFilter = this.createFilter(filters);
-    const results = await this.client.search(this.collectionName, {
+    const searchParams: Record<string, any> = {
       vector: query,
       filter: queryFilter,
       limit,
-    });
+    };
+    if (scoreThreshold != null) {
+      searchParams.score_threshold = scoreThreshold;
+    }
+    const results = await this.client.search(this.collectionName, searchParams);
 
     return results.map((hit) => ({
       id: String(hit.id),

--- a/mem0-ts/src/oss/tests/search-threshold.test.ts
+++ b/mem0-ts/src/oss/tests/search-threshold.test.ts
@@ -1,0 +1,180 @@
+/// <reference types="jest" />
+
+// ─────────────────────────────────────────────────────────────────────────
+// Qdrant - scoreThreshold forwarding
+// ─────────────────────────────────────────────────────────────────────────
+
+jest.mock("@qdrant/js-client-rest", () => ({
+  QdrantClient: jest.fn().mockImplementation(() => ({
+    search: jest.fn().mockResolvedValue([]),
+    createCollection: jest.fn().mockResolvedValue(undefined),
+    scroll: jest.fn().mockResolvedValue({ points: [] }),
+    getCollection: jest.fn().mockResolvedValue({
+      config: { params: { vectors: { size: 4, distance: "Cosine" } } },
+    }),
+  })),
+}));
+
+import { Qdrant } from "../src/vector_stores/qdrant";
+
+describe("Qdrant - scoreThreshold", () => {
+  let store: Qdrant;
+  let mockClient: any;
+
+  beforeEach(() => {
+    mockClient = {
+      search: jest.fn().mockResolvedValue([
+        { id: "id1", payload: { data: "test" }, score: 0.9 },
+      ]),
+      createCollection: jest.fn().mockResolvedValue(undefined),
+      scroll: jest.fn().mockResolvedValue({ points: [] }),
+      getCollection: jest.fn().mockResolvedValue({
+        config: { params: { vectors: { size: 4, distance: "Cosine" } } },
+      }),
+    };
+
+    store = new Qdrant({
+      client: mockClient,
+      collectionName: "test",
+      embeddingModelDims: 4,
+      dimension: 4,
+    });
+  });
+
+  it("passes score_threshold to Qdrant client when scoreThreshold is provided", async () => {
+    await store.search([1, 0, 0, 0], 5, undefined, 0.7);
+
+    expect(mockClient.search).toHaveBeenCalledWith(
+      "test",
+      expect.objectContaining({ score_threshold: 0.7 }),
+    );
+  });
+
+  it("omits score_threshold when scoreThreshold is not provided", async () => {
+    await store.search([1, 0, 0, 0], 5);
+
+    const searchParams = mockClient.search.mock.calls[0][1];
+    expect(searchParams).not.toHaveProperty("score_threshold");
+  });
+
+  it("omits score_threshold when scoreThreshold is undefined", async () => {
+    await store.search([1, 0, 0, 0], 5, undefined, undefined);
+
+    const searchParams = mockClient.search.mock.calls[0][1];
+    expect(searchParams).not.toHaveProperty("score_threshold");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Memory.search() - threshold forwarding
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("Memory.search() - threshold forwarding", () => {
+  let MemoryClass: any;
+  let mockVStore: any;
+  let mockEmbedder: any;
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    mockEmbedder = {
+      embed: jest.fn().mockResolvedValue([0.1, 0.2, 0.3, 0.4]),
+      embedBatch: jest.fn().mockResolvedValue([[0.1, 0.2, 0.3, 0.4]]),
+    };
+    mockVStore = {
+      insert: jest.fn().mockResolvedValue(undefined),
+      search: jest.fn().mockResolvedValue([
+        {
+          id: "mem-1",
+          payload: {
+            data: "User likes hiking",
+            userId: "u1",
+            hash: "abc",
+            createdAt: "2026-01-01",
+          },
+          score: 0.9,
+        },
+      ]),
+      get: jest.fn().mockResolvedValue(null),
+      update: jest.fn().mockResolvedValue(undefined),
+      delete: jest.fn().mockResolvedValue(undefined),
+      deleteCol: jest.fn().mockResolvedValue(undefined),
+      list: jest.fn().mockResolvedValue([[], 0]),
+      getUserId: jest.fn().mockResolvedValue("test-user-id"),
+      setUserId: jest.fn().mockResolvedValue(undefined),
+      initialize: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const mockLlm = {
+      generateResponse: jest.fn().mockResolvedValue('{"facts":[]}'),
+    };
+
+    jest.doMock("../src/utils/factory", () => ({
+      EmbedderFactory: { create: jest.fn().mockReturnValue(mockEmbedder) },
+      VectorStoreFactory: { create: jest.fn().mockReturnValue(mockVStore) },
+      LLMFactory: { create: jest.fn().mockReturnValue(mockLlm) },
+      HistoryManagerFactory: {
+        create: jest.fn().mockReturnValue({
+          addHistory: jest.fn().mockResolvedValue(undefined),
+          getHistory: jest.fn().mockResolvedValue([]),
+          reset: jest.fn().mockResolvedValue(undefined),
+        }),
+      },
+    }));
+    jest.doMock("../src/utils/telemetry", () => ({
+      captureClientEvent: jest.fn().mockResolvedValue(undefined),
+    }));
+
+    MemoryClass = require("../src/memory").Memory;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  it("forwards threshold to vectorStore.search() as 4th argument", async () => {
+    const mem = new MemoryClass({
+      embedder: { provider: "openai", config: { apiKey: "test-key" } },
+      vectorStore: {
+        provider: "memory",
+        config: { collectionName: "test", dimension: 4 },
+      },
+      llm: { provider: "openai", config: { apiKey: "test-key" } },
+      disableHistory: true,
+    });
+
+    await mem.search("what does the user like", {
+      userId: "u1",
+      threshold: 0.7,
+    });
+
+    expect(mockVStore.search).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.any(Number),
+      expect.objectContaining({ userId: "u1" }),
+      0.7,
+    );
+  });
+
+  it("passes undefined threshold when not provided", async () => {
+    const mem = new MemoryClass({
+      embedder: { provider: "openai", config: { apiKey: "test-key" } },
+      vectorStore: {
+        provider: "memory",
+        config: { collectionName: "test", dimension: 4 },
+      },
+      llm: { provider: "openai", config: { apiKey: "test-key" } },
+      disableHistory: true,
+    });
+
+    await mem.search("what does the user like", { userId: "u1" });
+
+    expect(mockVStore.search).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.any(Number),
+      expect.objectContaining({ userId: "u1" }),
+      undefined,
+    );
+  });
+});


### PR DESCRIPTION
## Description

`Memory.search()` accepts configuration options but never forwards a similarity threshold to the underlying vector store. Qdrant supports `score_threshold` natively, but the TypeScript SDK has no path to pass it through. This PR adds optional threshold forwarding from `Memory.search()` through the `VectorStore` interface to the Qdrant implementation.

The Python SDK already supports this parameter (`threshold` in `Memory.search()`). This brings the TypeScript SDK to parity.

Four source files changed, one test file added.

**Note on #4115 / #4106:** The recent fix for "OpenClaw Extension OSS Mode lacks threshold restrictions" added client-side post-filtering in the OpenClaw plugin's `OSSProvider`. That's a useful fallback, but it retrieves all results from Qdrant and discards low-scoring ones after the fact. This PR adds server-side filtering, where Qdrant itself excludes low-relevance results before they leave the database. The two are complementary.

**Interface change:** All `VectorStore` implementations need the updated `search()` signature (add `scoreThreshold?: number` as the 4th parameter). Implementations that don't support native threshold filtering can accept and ignore it. If maintainers prefer, an options object could replace positional params to avoid further signature growth.

Related: #4108, #4106, #3283

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Five new unit tests added to `search-threshold.test.ts` in two groups:

**Qdrant (3 tests):**
1. `score_threshold` is passed to the Qdrant client when `scoreThreshold` is provided
2. `score_threshold` is omitted when `scoreThreshold` is not provided
3. `score_threshold` is omitted when `scoreThreshold` is explicitly `undefined`

**Memory.search() (2 tests):**
4. `config.threshold` is forwarded as the 4th argument to `vectorStore.search()`
5. 4th argument is `undefined` when threshold is not provided

Also running in production for 4 days on a self-hosted Qdrant (v1.13.0) with `threshold: 0.6`. Similarity scores are well-calibrated: real matches return 0.87-0.91, noise sits at 0.3-0.5. A threshold of 0.6 cleanly separates the two.

- [x] Unit Test

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

Full suite: 475/476 pass. The 1 failure (`memory.crud.test.ts` "preserves createdAt and sets updatedAt") is pre-existing and reproduces on `main`.

## Maintainer Checklist

- [ ] Made sure Checks passed