### PR TITLE
feat(oss): Check existing MD5 hash before inserting duplicate memories

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -687,6 +687,24 @@ export class Memory {
     existingEmbeddings: Record<string, number[]>,
     metadata: Record<string, any>,
   ): Promise<string> {
+    const dataHash = createHash("md5").update(data).digest("hex");
+
+    // Check if an exact duplicate exists (same text, same user scope)
+    if (this.vectorStore.findByPayload) {
+      try {
+        const hashFilters: Record<string, any> = { hash: dataHash };
+        if (metadata.userId) hashFilters.userId = metadata.userId;
+        if (metadata.agentId) hashFilters.agentId = metadata.agentId;
+
+        const existing = await this.vectorStore.findByPayload(hashFilters, 1);
+        if (existing.length > 0) {
+          return existing[0].id;
+        }
+      } catch {
+        // Hash check failed; proceed with insert (fail-open)
+      }
+    }
+
     const memoryId = uuidv4();
     const embedding =
       existingEmbeddings[data] || (await this.embedder.embed(data));
@@ -694,7 +712,7 @@ export class Memory {
     const memoryMetadata = {
       ...metadata,
       data,
-      hash: createHash("md5").update(data).digest("hex"),
+      hash: dataHash,
       createdAt: new Date().toISOString(),
     };
 

--- a/mem0-ts/src/oss/src/vector_stores/base.ts
+++ b/mem0-ts/src/oss/src/vector_stores/base.ts
@@ -23,6 +23,10 @@ export interface VectorStore {
     filters?: SearchFilters,
     limit?: number,
   ): Promise<[VectorStoreResult[], number]>;
+  findByPayload?(
+    filters: Record<string, any>,
+    limit?: number,
+  ): Promise<VectorStoreResult[]>;
   getUserId(): Promise<string>;
   setUserId(userId: string): Promise<void>;
   initialize(): Promise<void>;

--- a/mem0-ts/src/oss/src/vector_stores/qdrant.ts
+++ b/mem0-ts/src/oss/src/vector_stores/qdrant.ts
@@ -199,6 +199,28 @@ export class Qdrant implements VectorStore {
     return [results, response.points.length];
   }
 
+  async findByPayload(
+    filters: Record<string, any>,
+    limit: number = 1,
+  ): Promise<VectorStoreResult[]> {
+    const conditions = Object.entries(filters).map(([key, value]) => ({
+      key,
+      match: { value },
+    }));
+
+    const response = await this.client.scroll(this.collectionName, {
+      filter: { must: conditions },
+      limit,
+      with_payload: true,
+      with_vectors: false,
+    });
+
+    return response.points.map((point) => ({
+      id: String(point.id),
+      payload: (point.payload as Record<string, any>) || {},
+    }));
+  }
+
   private generateUUID(): string {
     return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(
       /[xy]/g,

--- a/mem0-ts/src/oss/tests/hash-dedup.test.ts
+++ b/mem0-ts/src/oss/tests/hash-dedup.test.ts
@@ -1,0 +1,201 @@
+/// <reference types="jest" />
+
+import { createHash } from "crypto";
+
+// ─────────────────────────────────────────────────────────────────────────
+// Qdrant.findByPayload() - filter construction
+// ─────────────────────────────────────────────────────────────────────────
+
+jest.mock("@qdrant/js-client-rest", () => ({
+  QdrantClient: jest.fn().mockImplementation(() => ({
+    search: jest.fn().mockResolvedValue([]),
+    createCollection: jest.fn().mockResolvedValue(undefined),
+    scroll: jest.fn().mockResolvedValue({ points: [] }),
+    getCollection: jest.fn().mockResolvedValue({
+      config: { params: { vectors: { size: 4, distance: "Cosine" } } },
+    }),
+  })),
+}));
+
+import { Qdrant } from "../src/vector_stores/qdrant";
+
+describe("Qdrant.findByPayload()", () => {
+  let store: Qdrant;
+  let mockClient: any;
+
+  beforeEach(() => {
+    mockClient = {
+      search: jest.fn().mockResolvedValue([]),
+      createCollection: jest.fn().mockResolvedValue(undefined),
+      scroll: jest.fn().mockResolvedValue({ points: [] }),
+      getCollection: jest.fn().mockResolvedValue({
+        config: { params: { vectors: { size: 4, distance: "Cosine" } } },
+      }),
+    };
+
+    store = new Qdrant({
+      client: mockClient,
+      collectionName: "test",
+      embeddingModelDims: 4,
+      dimension: 4,
+    });
+  });
+
+  it("builds correct must conditions from filters object", async () => {
+    await store.findByPayload({ hash: "abc123", userId: "u1" }, 1);
+
+    expect(mockClient.scroll).toHaveBeenCalledWith("test", {
+      filter: {
+        must: [
+          { key: "hash", match: { value: "abc123" } },
+          { key: "userId", match: { value: "u1" } },
+        ],
+      },
+      limit: 1,
+      with_payload: true,
+      with_vectors: false,
+    });
+  });
+
+  it("returns mapped results from scroll response", async () => {
+    mockClient.scroll.mockResolvedValueOnce({
+      points: [
+        { id: "point-1", payload: { data: "test fact", hash: "abc" } },
+      ],
+    });
+
+    const results = await store.findByPayload({ hash: "abc" });
+
+    expect(results).toEqual([
+      { id: "point-1", payload: { data: "test fact", hash: "abc" } },
+    ]);
+  });
+
+  it("returns empty array when no matches", async () => {
+    const results = await store.findByPayload({ hash: "nonexistent" });
+    expect(results).toEqual([]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Memory.createMemory() - hash dedup via add(infer: false)
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("Memory.createMemory() - hash dedup", () => {
+  let MemoryClass: any;
+  let mockVStore: any;
+  let mockEmbedder: any;
+  let mockHistory: any;
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    mockEmbedder = {
+      embed: jest.fn().mockResolvedValue([0.1, 0.2, 0.3, 0.4]),
+      embedBatch: jest.fn().mockResolvedValue([[0.1, 0.2, 0.3, 0.4]]),
+    };
+    mockHistory = {
+      addHistory: jest.fn().mockResolvedValue(undefined),
+      getHistory: jest.fn().mockResolvedValue([]),
+      reset: jest.fn().mockResolvedValue(undefined),
+    };
+    mockVStore = {
+      insert: jest.fn().mockResolvedValue(undefined),
+      search: jest.fn().mockResolvedValue([]),
+      get: jest.fn().mockResolvedValue(null),
+      update: jest.fn().mockResolvedValue(undefined),
+      delete: jest.fn().mockResolvedValue(undefined),
+      deleteCol: jest.fn().mockResolvedValue(undefined),
+      list: jest.fn().mockResolvedValue([[], 0]),
+      getUserId: jest.fn().mockResolvedValue("test-user-id"),
+      setUserId: jest.fn().mockResolvedValue(undefined),
+      initialize: jest.fn().mockResolvedValue(undefined),
+      findByPayload: jest.fn().mockResolvedValue([]),
+    };
+
+    jest.doMock("../src/utils/factory", () => ({
+      EmbedderFactory: { create: jest.fn().mockReturnValue(mockEmbedder) },
+      VectorStoreFactory: { create: jest.fn().mockReturnValue(mockVStore) },
+      LLMFactory: {
+        create: jest.fn().mockReturnValue({
+          generateResponse: jest.fn().mockResolvedValue('{"facts":[]}'),
+        }),
+      },
+      HistoryManagerFactory: { create: jest.fn().mockReturnValue(mockHistory) },
+    }));
+    jest.doMock("../src/utils/telemetry", () => ({
+      captureClientEvent: jest.fn().mockResolvedValue(undefined),
+    }));
+
+    MemoryClass = require("../src/memory").Memory;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  function createMemory() {
+    return new MemoryClass({
+      embedder: { provider: "openai", config: { apiKey: "test-key" } },
+      vectorStore: {
+        provider: "memory",
+        config: { collectionName: "test", dimension: 4 },
+      },
+      llm: { provider: "openai", config: { apiKey: "test-key" } },
+      disableHistory: true,
+    });
+  }
+
+  it("skips insert and returns existing ID when hash match found", async () => {
+    const factText = "User prefers dark mode";
+    const expectedHash = createHash("md5").update(factText).digest("hex");
+
+    mockVStore.findByPayload.mockResolvedValueOnce([
+      { id: "existing-id", payload: { data: factText, hash: expectedHash } },
+    ]);
+
+    const mem = createMemory();
+    const result = await mem.add(factText, { userId: "u1", infer: false });
+
+    // findByPayload was called with the hash and userId
+    expect(mockVStore.findByPayload).toHaveBeenCalledWith(
+      expect.objectContaining({ hash: expectedHash, userId: "u1" }),
+      1,
+    );
+
+    // insert was NOT called (dedup kicked in)
+    expect(mockVStore.insert).not.toHaveBeenCalled();
+
+    // returned the existing ID
+    expect(result.results[0].id).toBe("existing-id");
+  });
+
+  it("proceeds with insert when no hash match found", async () => {
+    mockVStore.findByPayload.mockResolvedValueOnce([]);
+
+    const mem = createMemory();
+    await mem.add("Brand new fact", { userId: "u1", infer: false });
+
+    // findByPayload was called
+    expect(mockVStore.findByPayload).toHaveBeenCalled();
+
+    // insert was called (no dedup match)
+    expect(mockVStore.insert).toHaveBeenCalled();
+  });
+
+  it("proceeds with insert when findByPayload throws (fail-open)", async () => {
+    mockVStore.findByPayload.mockRejectedValueOnce(
+      new Error("Qdrant connection failed"),
+    );
+
+    const mem = createMemory();
+    await mem.add("Some fact", { userId: "u1", infer: false });
+
+    // findByPayload was called and threw
+    expect(mockVStore.findByPayload).toHaveBeenCalled();
+
+    // insert was still called (fail-open)
+    expect(mockVStore.insert).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description

`createMemory()` computes an MD5 hash of the fact text and stores it in the Qdrant payload, but never checks whether a memory with the same hash already exists before inserting. The LLM dedup pipeline (`getUpdateMemoryMessages`) is the only defense against exact duplicates, and when it incorrectly chooses ADD for a known fact, identical memories accumulate silently.

In our production deployment (10,114 points over 30 days), this resulted in 2,155 exact-text duplicates (21% of the collection), including 668 copies of a single fact from an extraction model that was later replaced.

This PR adds a hash-based pre-insert check in `createMemory()` using the existing `hash` payload field, scoped by `userId`/`agentId` to prevent cross-user dedup. Three source files changed, one test file added.

**Design choices:**
- **Uses the `VectorStore` interface** (new optional `findByPayload` method) instead of Qdrant-specific casts. Any store that implements it gets dedup for free.
- **Optional method.** Stores that don't implement `findByPayload` skip the check entirely. No breakage.
- **Scoped by userId/agentId.** Two different users can have the same fact.
- **Fail-open.** If the hash check throws, insertion proceeds normally. Worst case is a duplicate, which is the current behavior.

**Payload field names:** The filter uses `userId`/`agentId` as stored in the Qdrant payload by the TypeScript SDK. Implementors using the Python SDK (which stores `user_id`/`agent_id`) should verify field names match.

**Performance:** For Qdrant, creating a keyword payload index on `hash` makes the scroll query effectively O(1). Without the index, Qdrant does a sequential scan (still fast below ~100K points but the index is recommended).

**Scope:** This PR addresses exact-text duplicates only. Near-duplicates (e.g. "User likes cryptography" vs "User is knowledgeable about cryptography") require cosine-similarity checks at insert time. We have a working cosine gate locally that reuses the embedding already computed for insert (zero extra cost), but it adds more code surface and is better suited for a follow-up.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Six new unit tests added to `hash-dedup.test.ts` in two groups:

**Qdrant.findByPayload() (3 tests):**
1. Builds correct `must` filter conditions from the filters object
2. Maps Qdrant scroll results to `VectorStoreResult` format
3. Returns empty array when no matches found

**Memory.createMemory() dedup (3 tests):**
4. Skips insert and returns existing ID when hash match found
5. Proceeds with normal insert when no hash match
6. Proceeds with normal insert when `findByPayload` throws (fail-open)

Also running in production for 4 days on a self-hosted Qdrant deployment with ~7,600 points. The hash gate catches exact duplicates that the LLM pipeline misses.

- [x] Unit Test

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

Full suite: 442/443 pass. The 1 failure (`memory.crud.test.ts` "preserves createdAt and sets updatedAt") is pre-existing and reproduces on `main`.

## Maintainer Checklist

- [ ] Made sure Checks passed