### PR TITLE
fix: handle truncated code blocks in removeCodeBlocks

### DIFF
--- a/mem0-ts/src/oss/src/prompts/index.ts
+++ b/mem0-ts/src/oss/src/prompts/index.ts
@@ -282,5 +282,8 @@ export function removeCodeBlocks(text: string): string {
   // The old regex /```[^`]*```/g replaced the entire block (including
   // its content) with an empty string, so when an LLM returned JSON
   // wrapped in ```json ... ``` the actual payload was discarded.
-  return text.replace(/```(?:\w+)?\n?([\s\S]*?)```/g, "$1").trim();
+  let result = text.replace(/```(?:\w+)?\n?([\s\S]*?)```/g, "$1").trim();
+  // Handle truncated responses where closing ``` never arrives
+  result = result.replace(/^```(?:\w+)?\n?/, "").replace(/\n?```$/, "").trim();
+  return result;
 }

--- a/mem0-ts/src/oss/tests/remove-code-blocks.test.ts
+++ b/mem0-ts/src/oss/tests/remove-code-blocks.test.ts
@@ -27,4 +27,20 @@ describe("removeCodeBlocks", () => {
     expect(removeCodeBlocks(input)).toContain('"facts"');
     expect(removeCodeBlocks(input)).not.toContain("```");
   });
+
+  it("handles truncated code blocks (missing closing fence)", () => {
+    // This simulates a truncated LLM response where the closing ``` never arrives
+    const input = '```json\n{"facts": ["hello"]}';
+    expect(removeCodeBlocks(input)).toBe('{"facts": ["hello"]}');
+  });
+
+  it("handles truncated code block with language spec", () => {
+    const input = '```json\n{"key": "value"';
+    expect(removeCodeBlocks(input)).toBe('{"key": "value"}');
+  });
+
+  it("handles truncated code block at end of response", () => {
+    const input = '{"result": true}\n```';
+    expect(removeCodeBlocks(input)).toBe('{"result": true}');
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #4401 - `removeCodeBlocks` fails to strip markdown fences from truncated LLM responses.

## Problem

The regex `/```(?:\w+)?\n?([\s\S]*?)```/g` requires both opening and closing backtick fences to match. When LLM responses are truncated (no closing fence arrives), the raw text starting with \`\`\`json\`\`\` is passed directly to `JSON.parse`, causing crashes.

## Solution

Add a second pass to strip any remaining leading/trailing fence markers:

```typescript
let result = text.replace(/```(?:\w+)?\n?([\s\S]*?)```/g, "$1").trim();
// Handle truncated responses where closing ``` never arrives
result = result.replace(/^```(?:\w+)?\n?/, "").replace(/\n?```$/, "").trim();
```

## Testing

Added test cases for:
- Truncated code blocks (missing closing fence)
- Truncated code block with language spec
- Truncated code block at end of response

## Files Changed

- `mem0-ts/src/oss/src/prompts/index.ts` - Added truncation handling
- `mem0-ts/src/oss/tests/remove-code-blocks.test.ts` - Added test cases