### PR TITLE
fix(opensearch): preserve http_auth in _safe_deepcopy_config

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -52,14 +52,37 @@ logger = logging.getLogger(__name__)
 
 
 def _safe_deepcopy_config(config):
-    """Safely deepcopy config, falling back to JSON serialization for non-serializable objects."""
+    """Safely deepcopy config, falling back to JSON serialization for non-serializable objects.
+
+    Auth-related fields (e.g. http_auth, aws_auth, connection_class) are preserved even when
+    they contain non-picklable objects such as AWS RequestSigner instances. Without this
+    preservation the fallback path would silently drop these fields and break authentication
+    (see https://github.com/mem0ai/mem0/issues/3580).
+    """
+    # Fields that may hold non-picklable auth objects – saved and restored explicitly
+    # so they survive both a failed deepcopy and the JSON-serialisation fallback path.
+    AUTH_FIELDS = {"http_auth", "aws_auth", "connection_class"}
+
+    # Save original auth field values (if present on the config object)
+    if hasattr(config, "__dict__"):
+        saved_auth = {k: getattr(config, k) for k in AUTH_FIELDS if getattr(config, k, None) is not None}
+    else:
+        saved_auth = {}
+
     try:
-        return deepcopy(config)
+        result = deepcopy(config)
+        # Restore auth fields in case deepcopy dropped or mangled them
+        for k, v in saved_auth.items():
+            try:
+                object.__setattr__(result, k, v)
+            except (AttributeError, TypeError):
+                pass
+        return result
     except Exception as e:
         logger.debug(f"Deepcopy failed, using JSON serialization: {e}")
-        
+
         config_class = type(config)
-        
+
         if hasattr(config, "model_dump"):
             try:
                 clone_dict = config.model_dump(mode="json")
@@ -70,12 +93,18 @@ def _safe_deepcopy_config(config):
             clone_dict = asdict(config)
         else:
             clone_dict = {k: v for k, v in config.__dict__.items()}
-        
-        sensitive_tokens = ("auth", "credential", "password", "token", "secret", "key", "connection_class")
+
+        sensitive_tokens = ("credential", "password", "token", "secret", "key")
         for field_name in list(clone_dict.keys()):
+            # Do NOT nullify auth fields – needed for OpenSearch / AWS authentication
+            if field_name in AUTH_FIELDS:
+                continue
             if any(token in field_name.lower() for token in sensitive_tokens):
                 clone_dict[field_name] = None
-        
+
+        # Restore non-serialisable auth objects from the original config
+        clone_dict.update(saved_auth)
+
         try:
             return config_class(**clone_dict)
         except Exception as reconstruction_error:


### PR DESCRIPTION
Fixes #3580

## Problem

`_safe_deepcopy_config()` has a fallback path that is triggered when `deepcopy` fails (e.g. when `http_auth` contains a non-picklable AWS `RequestSigner` object). In this fallback path the function nullifies all fields whose names match sensitive tokens — including **`http_auth`**, **`aws_auth`**, and **`connection_class`** — via the `"auth"` substring match.

This silently drops the AWS authentication credentials, causing subsequent OpenSearch requests to fail with `403 Forbidden`.

## Root cause

```python
# Before – "auth" matches http_auth and aws_auth → set to None
sensitive_tokens = ("auth", "credential", ...)
for field_name in list(clone_dict.keys()):
    if any(token in field_name.lower() for token in sensitive_tokens):
        clone_dict[field_name] = None  # ← breaks http_auth!
```

## Fix

1. Introduce an explicit `AUTH_FIELDS` set (`http_auth`, `aws_auth`, `connection_class`).
2. Save their values **before** deepcopy / fallback serialisation.
3. Skip nullification for fields in `AUTH_FIELDS`.
4. Restore saved values **after** the copy so they are always present in the returned config.

```python
AUTH_FIELDS = {"http_auth", "aws_auth", "connection_class"}
saved_auth = {k: getattr(config, k) for k in AUTH_FIELDS if getattr(config, k, None) is not None}
# ... copy logic ...
clone_dict.update(saved_auth)  # restore
```

## Testing

Reproducible with any AWS OpenSearch setup that passes an `AWSV4SignerAuth` (or similar non-picklable object) as `http_auth`. After this fix the auth object survives the config copy and requests succeed.