### PR TITLE
  feat(oss): pass graphStore config through to Mem0 Memory constructor

### DIFF
--- a/openclaw/providers.ts
+++ b/openclaw/providers.ts
@@ -194,6 +194,7 @@ class OSSProvider implements Mem0Provider {
     if (this.ossConfig?.vectorStore)
       config.vectorStore = this.ossConfig.vectorStore;
     if (this.ossConfig?.llm) config.llm = this.ossConfig.llm;
+    if (this.ossConfig?.graphStore) config.graphStore = this.ossConfig.graphStore;
 
     if (this.ossConfig?.historyDbPath) {
       const dbPath = this.resolvePath

--- a/openclaw/sqlite-resilience.test.ts
+++ b/openclaw/sqlite-resilience.test.ts
@@ -1,8 +1,11 @@
 /**
  * Tests for SQLite resilience fixes:
  * 1. disableHistory config passthrough
- * 2. initPromise poisoning fix (retry after failure)
- * 3. Graceful SQLite fallback in OSSProvider
+ * 2. disableHistory flows to Memory constructor
+ * 3. graphStore config passthrough
+ * 4. initPromise poisoning fix (retry after failure)
+ * 5. Graceful SQLite fallback in OSSProvider
+ * 6. PlatformProvider initPromise retry
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mem0ConfigSchema, createProvider } from "./index.ts";
@@ -113,7 +116,69 @@ describe("OSSProvider — disableHistory passthrough to Memory", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 3. OSSProvider: initPromise is cleared on failure (allows retry)
+// 3. OSSProvider: graphStore config flows to Memory constructor
+// ---------------------------------------------------------------------------
+describe("OSSProvider — graphStore passthrough to Memory", () => {
+  let capturedConfig: Record<string, unknown> | undefined;
+
+  beforeEach(() => {
+    capturedConfig = undefined;
+
+    vi.doMock("mem0ai/oss", () => ({
+      Memory: class MockMemory {
+        constructor(config: Record<string, unknown>) {
+          capturedConfig = { ...config };
+        }
+        async add() { return { results: [] }; }
+        async search() { return { results: [] }; }
+        async get() { return {}; }
+        async getAll() { return []; }
+        async delete() { }
+      },
+    }));
+  });
+
+  it("passes graphStore to Memory when configured", async () => {
+    const graphStore = {
+      provider: "neo4j",
+      config: { url: "bolt://localhost:7687", username: "neo4j", password: "test" },
+    };
+    const { createProvider } = await import("./index.ts");
+    const cfg = mem0ConfigSchema.parse({
+      mode: "open-source",
+      oss: { graphStore },
+    });
+    const api = { resolvePath: (p: string) => p } as any;
+    const provider = createProvider(cfg, api);
+
+    try {
+      await provider.search("test", { user_id: "u1" });
+    } catch { /* provider may fail on mock, that's ok */ }
+
+    expect(capturedConfig).toBeDefined();
+    expect(capturedConfig!.graphStore).toEqual(graphStore);
+  });
+
+  it("does not set graphStore when not configured", async () => {
+    const { createProvider } = await import("./index.ts");
+    const cfg = mem0ConfigSchema.parse({
+      mode: "open-source",
+      oss: {},
+    });
+    const api = { resolvePath: (p: string) => p } as any;
+    const provider = createProvider(cfg, api);
+
+    try {
+      await provider.search("test", { user_id: "u1" });
+    } catch { }
+
+    expect(capturedConfig).toBeDefined();
+    expect(capturedConfig!.graphStore).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. OSSProvider: initPromise is cleared on failure (allows retry)
 // ---------------------------------------------------------------------------
 describe("OSSProvider — initPromise retry after failure", () => {
   let callCount: number;
@@ -162,7 +227,7 @@ describe("OSSProvider — initPromise retry after failure", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 4. OSSProvider: graceful fallback disables history on init failure
+// 5. OSSProvider: graceful fallback disables history on init failure
 // ---------------------------------------------------------------------------
 describe("OSSProvider — graceful SQLite fallback", () => {
   let capturedConfigs: Record<string, unknown>[];
@@ -241,7 +306,7 @@ describe("OSSProvider — graceful SQLite fallback", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 5. PlatformProvider — initPromise retry after failure
+// 6. PlatformProvider — initPromise retry after failure
 // ---------------------------------------------------------------------------
 describe("PlatformProvider — initPromise retry after failure", () => {
   let callCount: number;

--- a/openclaw/types.ts
+++ b/openclaw/types.ts
@@ -19,6 +19,7 @@ export type Mem0Config = {
     embedder?: { provider: string; config: Record<string, unknown> };
     vectorStore?: { provider: string; config: Record<string, unknown> };
     llm?: { provider: string; config: Record<string, unknown> };
+    graphStore?: { provider: string; config: Record<string, unknown>; llm?: { provider: string; config: Record<string, unknown> }; customPrompt?: string };
     historyDbPath?: string;
     disableHistory?: boolean;
   };


### PR DESCRIPTION
## Description

OSSProvider._init() forwards embedder, vectorStore, llm, and historyDbPath to the Mem0 Memory constructor but
  silently drops graphStore. Mem0's Node.js SDK already supports graphStore natively, so this one-line addition
  enables graph backends open-source mode.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [ ] Unit Test
- [ ] Test Script (please provide)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [x] closes #4070
- [ ] Made sure Checks passed
