### PR TITLE
fix: handle control characters in LLM JSON responses

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -452,11 +452,11 @@ class Memory(MemoryBase):
             else:
                 try:
                     # First try direct JSON parsing
-                    new_retrieved_facts = json.loads(response)["facts"]
+                    new_retrieved_facts = json.loads(response, strict=False)["facts"]
                 except json.JSONDecodeError:
                     # Try extracting JSON from response using built-in function
                     extracted_json = extract_json(response)
-                    new_retrieved_facts = json.loads(extracted_json)["facts"]
+                    new_retrieved_facts = json.loads(extracted_json, strict=False)["facts"]
                 new_retrieved_facts = normalize_facts(new_retrieved_facts)
         except Exception as e:
             logger.error(f"Error in new_retrieved_facts: {e}")
@@ -520,7 +520,7 @@ class Memory(MemoryBase):
                     new_memories_with_actions = {}
                 else:
                     response = remove_code_blocks(response)
-                    new_memories_with_actions = json.loads(response)
+                    new_memories_with_actions = json.loads(response, strict=False)
             except Exception as e:
                 logger.error(f"Invalid JSON response: {e}")
                 new_memories_with_actions = {}
@@ -1481,11 +1481,11 @@ class AsyncMemory(MemoryBase):
             else:
                 try:
                     # First try direct JSON parsing
-                    new_retrieved_facts = json.loads(response)["facts"]
+                    new_retrieved_facts = json.loads(response, strict=False)["facts"]
                 except json.JSONDecodeError:
                     # Try extracting JSON from response using built-in function
                     extracted_json = extract_json(response)
-                    new_retrieved_facts = json.loads(extracted_json)["facts"]
+                    new_retrieved_facts = json.loads(extracted_json, strict=False)["facts"]
                 new_retrieved_facts = normalize_facts(new_retrieved_facts)
         except Exception as e:
             logger.error(f"Error in new_retrieved_facts: {e}")
@@ -1552,7 +1552,7 @@ class AsyncMemory(MemoryBase):
                     new_memories_with_actions = {}
                 else:
                     response = remove_code_blocks(response)
-                    new_memories_with_actions = json.loads(response)
+                    new_memories_with_actions = json.loads(response, strict=False)
             except Exception as e:
                 logger.error(f"Invalid JSON response: {e}")
                 new_memories_with_actions = {}


### PR DESCRIPTION
## Description

- Uses `strict=False` in all `json.loads()` calls that parse LLM responses in `mem0/memory/main.py`.
- This allows control characters (newlines, tabs, etc.) inside JSON string values, which LLMs occasionally produce.
- Applied to both sync (`Memory`) and async (`AsyncMemory`) code paths, covering `new_memories_with_actions` and `new_retrieved_facts` parsing.

Fixes #2194

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Verified the fix handles the exact scenario from the issue:

```python
import json

# Reproduces issue #2194 - literal newline in JSON string value
bad_json = '{"memory": [{"id": "0", "text": "app\n                         store", "event": "NONE"}]}'

# Before fix: raises JSONDecodeError: Invalid control character
json.loads(bad_json)  # FAILS

# After fix: parses successfully
json.loads(bad_json, strict=False)  # SUCCESS: {'memory': [{'id': '0', 'text': 'app\n                         store', 'event': 'NONE'}]}
```

- `strict=False` only relaxes control character handling — all other JSON validation remains unchanged.
- No behavior change for valid JSON responses (which is the common case).
- Fallback `extract_json()` paths also updated to ensure consistent handling.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Maintainer Checklist

- [x] closes #2194
- [ ] Made sure Checks passed