### PR TITLE
feat: add reasoning_effort parameter support for reasoning models

### DIFF
--- a/mem0/configs/llms/azure.py
+++ b/mem0/configs/llms/azure.py
@@ -22,6 +22,7 @@ class AzureOpenAIConfig(BaseLlmConfig):
         enable_vision: bool = False,
         vision_details: Optional[str] = "auto",
         http_client_proxies: Optional[dict] = None,
+        reasoning_effort: Optional[str] = None,
         # Azure OpenAI-specific parameters
         azure_kwargs: Optional[Dict[str, Any]] = None,
     ):
@@ -51,6 +52,7 @@ class AzureOpenAIConfig(BaseLlmConfig):
             enable_vision=enable_vision,
             vision_details=vision_details,
             http_client_proxies=http_client_proxies,
+            reasoning_effort=reasoning_effort,
         )
 
         # Azure OpenAI-specific parameters

--- a/mem0/configs/llms/base.py
+++ b/mem0/configs/llms/base.py
@@ -24,6 +24,7 @@ class BaseLlmConfig(ABC):
         enable_vision: bool = False,
         vision_details: Optional[str] = "auto",
         http_client_proxies: Optional[Union[Dict, str]] = None,
+        reasoning_effort: Optional[str] = None,
     ):
         """
         Initialize a base configuration class instance for the LLM.
@@ -50,6 +51,9 @@ class BaseLlmConfig(ABC):
                 Options: "low", "high", "auto". Defaults to "auto"
             http_client_proxies: Proxy settings for HTTP client.
                 Can be a dict or string. Defaults to None
+            reasoning_effort: Effort level for reasoning models (e.g., o1, o3, gpt-5).
+                Options: "low", "medium", "high". Only applicable to reasoning models.
+                Defaults to None (uses the model's default)
         """
         self.model = model
         self.temperature = temperature
@@ -60,3 +64,4 @@ class BaseLlmConfig(ABC):
         self.enable_vision = enable_vision
         self.vision_details = vision_details
         self.http_client = httpx.Client(proxies=http_client_proxies) if http_client_proxies else None
+        self.reasoning_effort = reasoning_effort

--- a/mem0/configs/llms/openai.py
+++ b/mem0/configs/llms/openai.py
@@ -21,6 +21,7 @@ class OpenAIConfig(BaseLlmConfig):
         enable_vision: bool = False,
         vision_details: Optional[str] = "auto",
         http_client_proxies: Optional[dict] = None,
+        reasoning_effort: Optional[str] = None,
         # OpenAI-specific parameters
         openai_base_url: Optional[str] = None,
         models: Optional[List[str]] = None,
@@ -64,6 +65,7 @@ class OpenAIConfig(BaseLlmConfig):
             enable_vision=enable_vision,
             vision_details=vision_details,
             http_client_proxies=http_client_proxies,
+            reasoning_effort=reasoning_effort,
         )
 
         # OpenAI-specific parameters

--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -88,6 +88,11 @@ class LLMBase(ABC):
                 supported_params["tools"] = kwargs["tools"]
             if "tool_choice" in kwargs:
                 supported_params["tool_choice"] = kwargs["tool_choice"]
+            
+            # Add reasoning_effort for reasoning models if configured
+            reasoning_effort = getattr(self.config, 'reasoning_effort', None)
+            if reasoning_effort:
+                supported_params["reasoning_effort"] = reasoning_effort
                 
             return supported_params
         else:

--- a/tests/llms/test_reasoning_effort.py
+++ b/tests/llms/test_reasoning_effort.py
@@ -1,0 +1,150 @@
+"""Tests for reasoning_effort parameter support in LLM configurations."""
+
+import pytest
+from unittest.mock import Mock, patch
+
+from mem0.configs.llms.base import BaseLlmConfig
+from mem0.configs.llms.openai import OpenAIConfig
+from mem0.configs.llms.azure import AzureOpenAIConfig
+from mem0.llms.openai import OpenAILLM
+from mem0.llms.azure_openai import AzureOpenAILLM
+
+
+class TestReasoningEffortConfig:
+    """Test reasoning_effort parameter in config classes."""
+
+    def test_base_config_default_reasoning_effort_is_none(self):
+        """reasoning_effort should default to None."""
+        config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", api_key="test-key")
+        assert config.reasoning_effort is None
+
+    def test_base_config_accepts_reasoning_effort(self):
+        """Config should accept reasoning_effort parameter."""
+        config = OpenAIConfig(
+            model="o3",
+            api_key="test-key",
+            reasoning_effort="low",
+        )
+        assert config.reasoning_effort == "low"
+
+    def test_openai_config_reasoning_effort(self):
+        """OpenAIConfig should pass reasoning_effort to base."""
+        for effort in ["low", "medium", "high"]:
+            config = OpenAIConfig(
+                model="o3-mini",
+                api_key="test-key",
+                reasoning_effort=effort,
+            )
+            assert config.reasoning_effort == effort
+
+    def test_azure_config_reasoning_effort(self):
+        """AzureOpenAIConfig should pass reasoning_effort to base."""
+        config = AzureOpenAIConfig(
+            model="o3",
+            api_key="test-key",
+            reasoning_effort="high",
+            azure_kwargs={
+                "azure_deployment": "test-deployment",
+                "azure_endpoint": "https://test.openai.azure.com/",
+            },
+        )
+        assert config.reasoning_effort == "high"
+
+
+class TestReasoningModelDetection:
+    """Test _is_reasoning_model detection."""
+
+    @patch("mem0.llms.openai.OpenAI")
+    def test_reasoning_models_detected(self, mock_openai):
+        """Known reasoning models should be detected."""
+        mock_openai.return_value = Mock()
+        reasoning_models = ["o1", "o1-preview", "o3-mini", "o3", "gpt-5", "gpt-5o", "gpt-5o-mini"]
+        for model_name in reasoning_models:
+            config = OpenAIConfig(model=model_name, api_key="test-key")
+            llm = OpenAILLM(config)
+            assert llm._is_reasoning_model(model_name), f"{model_name} should be detected as reasoning model"
+
+    @patch("mem0.llms.openai.OpenAI")
+    def test_regular_models_not_detected(self, mock_openai):
+        """Regular models should not be detected as reasoning models."""
+        mock_openai.return_value = Mock()
+        regular_models = ["gpt-4.1-nano-2025-04-14", "gpt-4.1-2025-04-14", "gpt-4.1-mini-2025-07-18"]
+        for model_name in regular_models:
+            config = OpenAIConfig(model=model_name, api_key="test-key")
+            llm = OpenAILLM(config)
+            assert not llm._is_reasoning_model(model_name), f"{model_name} should NOT be detected as reasoning model"
+
+
+class TestReasoningEffortInParams:
+    """Test that reasoning_effort is correctly passed to API calls."""
+
+    @patch("mem0.llms.openai.OpenAI")
+    def test_reasoning_effort_included_for_reasoning_model(self, mock_openai):
+        """reasoning_effort should be included in params for reasoning models."""
+        mock_openai.return_value = Mock()
+        config = OpenAIConfig(
+            model="o3",
+            api_key="test-key",
+            reasoning_effort="low",
+        )
+        llm = OpenAILLM(config)
+        params = llm._get_supported_params(messages=[{"role": "user", "content": "test"}])
+        assert "reasoning_effort" in params
+        assert params["reasoning_effort"] == "low"
+
+    @patch("mem0.llms.openai.OpenAI")
+    def test_reasoning_effort_not_included_when_none(self, mock_openai):
+        """reasoning_effort should not be in params when not configured."""
+        mock_openai.return_value = Mock()
+        config = OpenAIConfig(
+            model="o3",
+            api_key="test-key",
+        )
+        llm = OpenAILLM(config)
+        params = llm._get_supported_params(messages=[{"role": "user", "content": "test"}])
+        assert "reasoning_effort" not in params
+
+    @patch("mem0.llms.openai.OpenAI")
+    def test_reasoning_effort_not_included_for_regular_model(self, mock_openai):
+        """reasoning_effort should not affect regular model params."""
+        mock_openai.return_value = Mock()
+        config = OpenAIConfig(
+            model="gpt-4.1-nano-2025-04-14",
+            api_key="test-key",
+            reasoning_effort="low",
+        )
+        llm = OpenAILLM(config)
+        params = llm._get_supported_params(messages=[{"role": "user", "content": "test"}])
+        # Regular models go through _get_common_params, not the reasoning path
+        assert "temperature" in params
+
+    @patch("mem0.llms.openai.OpenAI")
+    def test_temperature_excluded_for_reasoning_model(self, mock_openai):
+        """temperature should NOT be in params for reasoning models."""
+        mock_openai.return_value = Mock()
+        config = OpenAIConfig(
+            model="o3",
+            api_key="test-key",
+            reasoning_effort="medium",
+        )
+        llm = OpenAILLM(config)
+        params = llm._get_supported_params(messages=[{"role": "user", "content": "test"}])
+        assert "temperature" not in params
+        assert "top_p" not in params
+        assert "max_tokens" not in params
+
+
+class TestDictConfig:
+    """Test reasoning_effort works when config is passed as dict."""
+
+    @patch("mem0.llms.openai.OpenAI")
+    def test_dict_config_with_reasoning_effort(self, mock_openai):
+        """Should work when config is provided as a dict."""
+        mock_openai.return_value = Mock()
+        config_dict = {
+            "model": "o3-mini",
+            "api_key": "test-key",
+            "reasoning_effort": "high",
+        }
+        llm = OpenAILLM(config=config_dict)
+        assert llm.config.reasoning_effort == "high"


### PR DESCRIPTION
## Description

This PR adds support for the `reasoning_effort` parameter for reasoning models (o1, o3, gpt-5 series) as requested in #3651.

### Problem

When using reasoning models like o1, o3 or gpt-5 with `reasoning_effort` in the config, a `TypeError` is raised:
```
TypeError: AzureOpenAIConfig.__init__() got an unexpected keyword argument 'reasoning_effort'
```

### Solution

- Added `reasoning_effort` parameter to `BaseLlmConfig` with proper documentation
- Propagated the parameter through `OpenAIConfig` and `AzureOpenAIConfig`
- Included `reasoning_effort` in `_get_supported_params()` for reasoning models only
- The parameter is excluded for non-reasoning models (no behavioral change)

### Changes

| File | Change |
|------|--------|
| `mem0/configs/llms/base.py` | Add `reasoning_effort` param, docs, attribute |
| `mem0/configs/llms/openai.py` | Propagate `reasoning_effort` to base |
| `mem0/configs/llms/azure.py` | Propagate `reasoning_effort` to base |
| `mem0/llms/base.py` | Include `reasoning_effort` in `_get_supported_params` for reasoning models |
| `tests/llms/test_reasoning_effort.py` | 8 test cases covering config, detection, params |

### Usage

```python
from mem0 import Memory

config = {
    "llm": {
        "provider": "openai",
        "config": {
            "model": "o3-mini",
            "reasoning_effort": "low",
        }
    }
}
m = Memory.from_config(config)
```

Closes #3651