### PR TITLE
fix: wrap vector and payload in lists in Langchain adapter update()

### DIFF
--- a/mem0/vector_stores/langchain.py
+++ b/mem0/vector_stores/langchain.py
@@ -115,7 +115,7 @@ class Langchain(VectorStoreBase):
         Update a vector and its payload.
         """
         self.delete(vector_id)
-        self.insert(vector, payload, [vector_id])
+        self.insert([vector], [payload], [vector_id])
 
     def get(self, vector_id):
         """

--- a/tests/vector_stores/test_langchain_vector_store.py
+++ b/tests/vector_stores/test_langchain_vector_store.py
@@ -224,3 +224,29 @@ def test_list_with_exception(langchain_instance):
 
     # Verify that an empty list is returned when an exception occurs
     assert results == []
+
+
+def test_update_wraps_params_in_lists(langchain_instance):
+    """Test that update() wraps vector and payload in lists before calling insert().
+
+    Regression test for https://github.com/mem0ai/mem0/issues/3767
+    The insert() method expects List[List[float]] for vectors and List[Dict]
+    for payloads, but update() was passing unwrapped single values.
+    """
+    vector = [0.1, 0.2, 0.3]
+    payload = {"data": "updated text", "name": "vector1"}
+    vector_id = "id1"
+
+    # Mock delete and add_embeddings
+    langchain_instance.client.delete = Mock()
+    langchain_instance.client.add_embeddings = Mock()
+
+    langchain_instance.update(vector_id=vector_id, vector=vector, payload=payload)
+
+    # Verify delete was called with the correct ID
+    langchain_instance.client.delete.assert_called_once_with(ids=[vector_id])
+
+    # Verify insert received list-wrapped parameters
+    langchain_instance.client.add_embeddings.assert_called_once_with(
+        embeddings=[vector], metadatas=[payload], ids=[vector_id]
+    )


### PR DESCRIPTION
## Description

Fixes type mismatch in the Langchain vector store adapter's `update()` method as reported in #3767.

### Problem

The `update()` method passes unwrapped `vector` and `payload` values to `insert()`:

```python
# Before (broken)
def update(self, vector_id, vector=None, payload=None):
    self.delete(vector_id)
    self.insert(vector, payload, [vector_id])  # vector and payload not wrapped
```

But `insert()` expects:
- `vectors: List[List[float]]` — a list of vectors
- `payloads: Optional[List[Dict]]` — a list of payloads

This causes runtime errors when updating vectors through the Langchain adapter.

### Fix

```python
# After (fixed)
def update(self, vector_id, vector=None, payload=None):
    self.delete(vector_id)
    self.insert([vector], [payload], [vector_id])  # properly wrapped in lists
```

### Changes

| File | Change |
|------|--------|
| `mem0/vector_stores/langchain.py` | Wrap `vector` and `payload` in lists in `update()` |
| `tests/vector_stores/test_langchain_vector_store.py` | Add regression test |

Fixes #3767