### PR TITLE
fix: handle empty/None LLM responses gracefully in fact extraction

### DIFF
--- a/mem0/llms/gemini.py
+++ b/mem0/llms/gemini.py
@@ -63,7 +63,7 @@ class GeminiLLM(LLMBase):
                 for part in response.candidates[0].content.parts:
                     if hasattr(part, "text") and part.text:
                         return part.text
-            return ""
+            return None
 
     def _reformat_messages(self, messages: List[Dict[str, str]]):
         """

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -515,18 +515,22 @@ class Memory(MemoryBase):
         )
 
         try:
-            response = remove_code_blocks(response)
-            if not response.strip():
+            if not response:
+                logger.warning("Empty response from LLM during fact extraction, skipping.")
                 new_retrieved_facts = []
             else:
-                try:
-                    # First try direct JSON parsing
-                    new_retrieved_facts = json.loads(response, strict=False)["facts"]
-                except json.JSONDecodeError:
-                    # Try extracting JSON from response using built-in function
-                    extracted_json = extract_json(response)
-                    new_retrieved_facts = json.loads(extracted_json, strict=False)["facts"]
-                new_retrieved_facts = normalize_facts(new_retrieved_facts)
+                response = remove_code_blocks(response)
+                if not response.strip():
+                    new_retrieved_facts = []
+                else:
+                    try:
+                        # First try direct JSON parsing
+                        new_retrieved_facts = json.loads(response, strict=False)["facts"]
+                    except json.JSONDecodeError:
+                        # Try extracting JSON from response using built-in function
+                        extracted_json = extract_json(response)
+                        new_retrieved_facts = json.loads(extracted_json, strict=False)["facts"]
+                    new_retrieved_facts = normalize_facts(new_retrieved_facts)
         except Exception as e:
             logger.error(f"Error in new_retrieved_facts: {e}")
             new_retrieved_facts = []
@@ -1547,18 +1551,22 @@ class AsyncMemory(MemoryBase):
             response_format={"type": "json_object"},
         )
         try:
-            response = remove_code_blocks(response)
-            if not response.strip():
+            if not response:
+                logger.warning("Empty response from LLM during fact extraction, skipping.")
                 new_retrieved_facts = []
             else:
-                try:
-                    # First try direct JSON parsing
-                    new_retrieved_facts = json.loads(response, strict=False)["facts"]
-                except json.JSONDecodeError:
-                    # Try extracting JSON from response using built-in function
-                    extracted_json = extract_json(response)
-                    new_retrieved_facts = json.loads(extracted_json, strict=False)["facts"]
-                new_retrieved_facts = normalize_facts(new_retrieved_facts)
+                response = remove_code_blocks(response)
+                if not response.strip():
+                    new_retrieved_facts = []
+                else:
+                    try:
+                        # First try direct JSON parsing
+                        new_retrieved_facts = json.loads(response, strict=False)["facts"]
+                    except json.JSONDecodeError:
+                        # Try extracting JSON from response using built-in function
+                        extracted_json = extract_json(response)
+                        new_retrieved_facts = json.loads(extracted_json, strict=False)["facts"]
+                    new_retrieved_facts = normalize_facts(new_retrieved_facts)
         except Exception as e:
             logger.error(f"Error in new_retrieved_facts: {e}")
             new_retrieved_facts = []


### PR DESCRIPTION
## Description

Fixes crashes when LLM providers (particularly Gemini) return empty or None responses during memory fact extraction.

### Problem

Multiple users reported intermittent errors with Gemini (#3410, 19 comments):

```
Invalid JSON response: Expecting value: line 1 column 1 (char 0)
```

and:

```
AttributeError: 'NoneType' object has no attribute 'strip'
```

**Root cause**: `GeminiLLM._parse_response()` returns `""` (empty string) when Gemini produces no content parts. But when the response is truly empty or `None`, calling `remove_code_blocks()` and `.strip()` on it causes errors.

### Solution

1. **`gemini.py`**: Return `None` instead of `""` when no content parts are available — this correctly signals "no response" rather than "empty text response"

2. **`main.py` (sync + async)**: Add early `None` check before processing the response:
   ```python
   if not response:
       logger.warning("Empty response from LLM during fact extraction, skipping.")
       new_retrieved_facts = []
   else:
       response = remove_code_blocks(response)
       ...
   ```

### Changes

| File | Change |
|------|--------|
| `mem0/llms/gemini.py` | Return `None` instead of `""` for empty responses |
| `mem0/memory/main.py` | Add `None` guard in sync and async `_add_to_vector_store` |

Relates to #3410