### PR TITLE
fix: skip embedding update when vector is None in Valkey adapter

### DIFF
--- a/mem0/vector_stores/valkey.py
+++ b/mem0/vector_stores/valkey.py
@@ -491,8 +491,12 @@ class ValkeyDB(VectorStoreBase):
                 "hash": payload.get("hash", f"hash_{vector_id}"),  # Use a default hash if not provided
                 "memory": payload.get("data", f"data_{vector_id}"),  # Use a default data if not provided
                 "created_at": int(datetime.fromisoformat(payload["created_at"]).timestamp()),
-                "embedding": np.array(vector, dtype=np.float32).tobytes(),
             }
+
+            # Only update embedding if a new vector is provided;
+            # passing None would corrupt the stored embedding (np.array(None) → 4-byte scalar)
+            if vector is not None:
+                hash_data["embedding"] = np.array(vector, dtype=np.float32).tobytes()
 
             # Add updated_at if available
             if "updated_at" in payload:


### PR DESCRIPTION
## Description

Fixes data corruption bug in the Valkey vector store adapter reported in #4336.

### Problem

When `Memory._add_to_vector_store()` encounters an unchanged memory (NONE action), it calls:

```python
self.vector_store.update(
    vector_id=memory_id,
    vector=None,          # no new vector
    payload=updated_metadata,
)
```

In `valkey.py`, the `update()` method **unconditionally** serializes the vector:

```python
"embedding": np.array(vector, dtype=np.float32).tobytes()
```

When `vector` is `None`, `np.array(None, dtype=np.float32)` produces a **4-byte scalar**, which overwrites the correct embedding (e.g., 4096 bytes for 1024-dim). The memory text remains intact, but it becomes **permanently unsearchable** via vector similarity.

### Solution

Only write the `embedding` field when a new vector is actually provided:

```python
if vector is not None:
    hash_data["embedding"] = np.array(vector, dtype=np.float32).tobytes()
```

### Changes

| File | Change |
|------|--------|
| `mem0/vector_stores/valkey.py` | Skip embedding serialization when `vector is None` |

Fixes #4336