### PR TITLE
fix: handle vector=None in Qdrant adapter update() to prevent validation error

### DIFF
--- a/mem0/vector_stores/qdrant.py
+++ b/mem0/vector_stores/qdrant.py
@@ -204,8 +204,18 @@ class Qdrant(VectorStoreBase):
             vector (list, optional): Updated vector. Defaults to None.
             payload (dict, optional): Updated payload. Defaults to None.
         """
-        point = PointStruct(id=vector_id, vector=vector, payload=payload)
-        self.client.upsert(collection_name=self.collection_name, points=[point])
+        if vector is None:
+            # Only update payload without touching the vector.
+            # Passing vector=None to PointStruct causes a Pydantic validation
+            # error, and would corrupt the stored embedding.
+            self.client.set_payload(
+                collection_name=self.collection_name,
+                payload=payload,
+                points=[vector_id],
+            )
+        else:
+            point = PointStruct(id=vector_id, vector=vector, payload=payload)
+            self.client.upsert(collection_name=self.collection_name, points=[point])
 
     def get(self, vector_id: int) -> dict:
         """


### PR DESCRIPTION
## Description

Fixes Pydantic validation error in the Qdrant vector store adapter when `update()` is called with `vector=None`, as reported in #3780.

### Problem

When `Memory._add_to_vector_store()` encounters an unchanged memory (NONE event), it calls:

```python
self.vector_store.update(
    vector_id=memory_id,
    vector=None,
    payload=updated_metadata,
)
```

Qdrant's `PointStruct` requires a valid vector, causing:

```
6 validation errors for PointStruct
vector.list[float]
  Input should be a valid list [type=list_type, input_value=None]
```

### Solution

When `vector is None`, use Qdrant's `set_payload()` API to update only the metadata without touching the stored embedding:

```python
if vector is None:
    self.client.set_payload(
        collection_name=self.collection_name,
        payload=payload,
        points=[vector_id],
    )
else:
    point = PointStruct(id=vector_id, vector=vector, payload=payload)
    self.client.upsert(...)
```

This is the same class of bug as #4336 (Valkey adapter), where `vector=None` corrupts or crashes the update.

### Changes

| File | Change |
|------|--------|
| `mem0/vector_stores/qdrant.py` | Use `set_payload()` when vector is None |

Fixes #3780