### PR TITLE
docs: add Claude Code setup instructions for OpenMemory

### DIFF
--- a/docs/openmemory/integrations.mdx
+++ b/docs/openmemory/integrations.mdx
@@ -46,6 +46,7 @@ Replace `<client-name>` with the desired client name and `<user-id>` with the va
 | Witsy       | `npx install-mcp http://localhost:8765/mcp/witsy/sse/<user-id> --client witsy` |
 | Enconvo     | `npx install-mcp http://localhost:8765/mcp/enconvo/sse/<user-id> --client enconvo` |
 | Augment     | `npx install-mcp http://localhost:8765/mcp/augment/sse/<user-id> --client augment` |
+| Claude Code | `claude mcp add -s user -t sse OpenMemory http://localhost:8765/mcp/openmemory/sse/<user-id>` |
 
 ### What This Does
 

--- a/docs/openmemory/quickstart.mdx
+++ b/docs/openmemory/quickstart.mdx
@@ -182,6 +182,11 @@ You can configure the MCP client using the following command (replace `username`
 npx @openmemory/install local "http://localhost:8765/mcp/cursor/sse/username" --client cursor
 ```
 
+**For Claude Code (CLI):**
+```bash
+claude mcp add -s user -t sse OpenMemory "http://localhost:8765/mcp/openmemory/sse/username"
+```
+
 The OpenMemory dashboard will be available at http://localhost:3000. From here, you can view and manage your memories and check connection status with your MCP clients.
 
 Once set up, OpenMemory runs locally on your machine, ensuring all your AI memories remain private and secure while being accessible across any compatible MCP client.


### PR DESCRIPTION
## Description

Add Claude Code (CLI) setup instructions to the OpenMemory integration docs. Claude Code uses its own native `claude mcp add` command rather than `npx @openmemory/install` (which only supports GUI-based MCP clients like Claude Desktop, Cursor, etc.).

Changes:
- Added Claude Code row to the supported clients table in `docs/openmemory/integrations.mdx`
- Added Claude Code example to the local setup section in `docs/openmemory/quickstart.mdx`

Fixes #2912

## Type of change

- [x] Documentation update

## How Has This Been Tested?

- [x] Verified `claude mcp add -s user -t sse` is the correct syntax for adding SSE MCP servers in Claude Code
- [x] Confirmed `@openmemory/install` does not support Claude Code as a client (only Claude Desktop)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #2912
- [ ] Made sure Checks passed