### PR TITLE
fix: handle missing IDs in temp_uuid_mapping to prevent KeyError on LLM hallucinated IDs

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -615,25 +615,39 @@ class Memory(MemoryBase):
                         )
                         returned_memories.append({"id": memory_id, "memory": action_text, "event": event_type})
                     elif event_type == "UPDATE":
+                        memory_id = temp_uuid_mapping.get(resp.get("id"))
+                        if not memory_id:
+                            logger.warning(
+                                f"Skipping UPDATE: memory ID '{resp.get('id')}' not found in mapping "
+                                "(possible LLM hallucination)"
+                            )
+                            continue
                         self._update_memory(
-                            memory_id=temp_uuid_mapping[resp.get("id")],
+                            memory_id=memory_id,
                             data=action_text,
                             existing_embeddings=new_message_embeddings,
                             metadata=deepcopy(metadata),
                         )
                         returned_memories.append(
                             {
-                                "id": temp_uuid_mapping[resp.get("id")],
+                                "id": memory_id,
                                 "memory": action_text,
                                 "event": event_type,
                                 "previous_memory": resp.get("old_memory"),
                             }
                         )
                     elif event_type == "DELETE":
-                        self._delete_memory(memory_id=temp_uuid_mapping[resp.get("id")])
+                        memory_id = temp_uuid_mapping.get(resp.get("id"))
+                        if not memory_id:
+                            logger.warning(
+                                f"Skipping DELETE: memory ID '{resp.get('id')}' not found in mapping "
+                                "(possible LLM hallucination)"
+                            )
+                            continue
+                        self._delete_memory(memory_id=memory_id)
                         returned_memories.append(
                             {
-                                "id": temp_uuid_mapping[resp.get("id")],
+                                "id": memory_id,
                                 "memory": action_text,
                                 "event": event_type,
                             }
@@ -663,7 +677,7 @@ class Memory(MemoryBase):
                         else:
                             logger.info("NOOP for Memory.")
                 except Exception as e:
-                    logger.error(f"Error processing memory action: {resp}, Error: {e}")
+                    logger.error(f"Error processing memory action: {resp}, {type(e).__name__}: {e}")
         except Exception as e:
             logger.error(f"Error iterating new_memories_with_actions: {e}")
 
@@ -1652,18 +1666,32 @@ class AsyncMemory(MemoryBase):
                         )
                         memory_tasks.append((task, resp, "ADD", None))
                     elif event_type == "UPDATE":
+                        memory_id = temp_uuid_mapping.get(resp.get("id"))
+                        if not memory_id:
+                            logger.warning(
+                                f"Skipping UPDATE: memory ID '{resp.get('id')}' not found in mapping "
+                                "(possible LLM hallucination)"
+                            )
+                            continue
                         task = asyncio.create_task(
                             self._update_memory(
-                                memory_id=temp_uuid_mapping[resp["id"]],
+                                memory_id=memory_id,
                                 data=action_text,
                                 existing_embeddings=new_message_embeddings,
                                 metadata=deepcopy(metadata),
                             )
                         )
-                        memory_tasks.append((task, resp, "UPDATE", temp_uuid_mapping[resp["id"]]))
+                        memory_tasks.append((task, resp, "UPDATE", memory_id))
                     elif event_type == "DELETE":
-                        task = asyncio.create_task(self._delete_memory(memory_id=temp_uuid_mapping[resp.get("id")]))
-                        memory_tasks.append((task, resp, "DELETE", temp_uuid_mapping[resp.get("id")]))
+                        memory_id = temp_uuid_mapping.get(resp.get("id"))
+                        if not memory_id:
+                            logger.warning(
+                                f"Skipping DELETE: memory ID '{resp.get('id')}' not found in mapping "
+                                "(possible LLM hallucination)"
+                            )
+                            continue
+                        task = asyncio.create_task(self._delete_memory(memory_id=memory_id))
+                        memory_tasks.append((task, resp, "DELETE", memory_id))
                     elif event_type == "NONE":
                         # Even if content doesn't need updating, update session IDs if provided
                         memory_id = temp_uuid_mapping.get(resp.get("id"))
@@ -1694,7 +1722,7 @@ class AsyncMemory(MemoryBase):
                         else:
                             logger.info("NOOP for Memory (async).")
                 except Exception as e:
-                    logger.error(f"Error processing memory action (async): {resp}, Error: {e}")
+                    logger.error(f"Error processing memory action (async): {resp}, {type(e).__name__}: {e}")
 
             for task, resp, event_type, mem_id in memory_tasks:
                 try:

--- a/tests/test_temp_uuid_mapping.py
+++ b/tests/test_temp_uuid_mapping.py
@@ -1,0 +1,72 @@
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from mem0.memory.main import AsyncMemory, Memory
+
+
+def _build_memory(mocker, memory_cls):
+    mock_embedder = mocker.MagicMock()
+    mock_embedder.return_value.embed.return_value = [0.1, 0.2, 0.3]
+    mocker.patch("mem0.utils.factory.EmbedderFactory.create", mock_embedder)
+
+    mock_vector_store = mocker.MagicMock()
+    mocker.patch(
+        "mem0.utils.factory.VectorStoreFactory.create", side_effect=[mock_vector_store.return_value, mocker.MagicMock()]
+    )
+    mocker.patch("mem0.utils.factory.LlmFactory.create", mocker.MagicMock())
+    mocker.patch("mem0.memory.storage.SQLiteManager", mocker.MagicMock())
+    mocker.patch("mem0.memory.main.capture_event", mocker.MagicMock())
+
+    memory = memory_cls()
+    memory.config = mocker.MagicMock()
+    memory.config.custom_fact_extraction_prompt = None
+    memory.config.custom_update_memory_prompt = None
+    memory.api_version = "v1.1"
+    return memory
+
+
+@pytest.mark.parametrize("event_type", ["UPDATE", "DELETE"])
+def test_sync_skips_missing_temp_uuid_mapping_ids(mocker, caplog, event_type):
+    memory = _build_memory(mocker, Memory)
+    memory.llm.generate_response.side_effect = [
+        '{"facts": ["new fact"]}',
+        f'{{"memory": [{{"id": "12", "text": "changed memory", "event": "{event_type}"}}]}}',
+    ]
+    memory.vector_store.search.return_value = [SimpleNamespace(id="real-memory-id", payload={"data": "stored memory"})]
+    memory._update_memory = mocker.MagicMock()
+    memory._delete_memory = mocker.MagicMock()
+
+    with caplog.at_level(logging.WARNING):
+        result = memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "test"}], metadata={}, filters={}, infer=True
+        )
+
+    assert result == []
+    assert f"Skipping {event_type}: memory ID '12' not found in mapping" in caplog.text
+    memory._update_memory.assert_not_called()
+    memory._delete_memory.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("event_type", ["UPDATE", "DELETE"])
+async def test_async_skips_missing_temp_uuid_mapping_ids(mocker, caplog, event_type):
+    memory = _build_memory(mocker, AsyncMemory)
+    memory.llm.generate_response.side_effect = [
+        '{"facts": ["new fact"]}',
+        f'{{"memory": [{{"id": "12", "text": "changed memory", "event": "{event_type}"}}]}}',
+    ]
+    memory.vector_store.search.return_value = [SimpleNamespace(id="real-memory-id", payload={"data": "stored memory"})]
+    memory._update_memory = mocker.AsyncMock()
+    memory._delete_memory = mocker.AsyncMock()
+
+    with caplog.at_level(logging.WARNING):
+        result = await memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "test"}], metadata={}, effective_filters={}, infer=True
+        )
+
+    assert result == []
+    assert f"Skipping {event_type}: memory ID '12' not found in mapping" in caplog.text
+    memory._update_memory.assert_not_awaited()
+    memory._delete_memory.assert_not_awaited()


### PR DESCRIPTION
## Description

Fixes recurring production `KeyError` in `temp_uuid_mapping` during UPDATE/DELETE operations, as reported in #3931.

### Problem

When the LLM returns memory actions with IDs that don't exist in `temp_uuid_mapping` (hallucinated IDs), direct dict access `temp_uuid_mapping[resp["id"]]` raises `KeyError`. This has been **recurring in production since January 2026** across multiple users.

The error message is also cryptic — `KeyError('12')` is logged as just `'12'`, making debugging difficult.

### Production occurrences (from issue comments)

```
Error processing memory action (async): {'id': '12', 'text': '...'}, Error: '12'
Error processing memory action (async): {'id': '9',  'text': '...'}, Error: '9'
Error processing memory action (async): {'id': '7',  'text': '...'}, Error: '7'
Error processing memory action (async): {'id': '16', 'text': '...'}, Error: '16'
```

### Solution

1. **Use `dict.get()` instead of `[]`** for UPDATE and DELETE branches in both sync and async `_add_to_vector_store()`
2. **Skip with warning** when ID is not found, instead of crashing
3. **Include exception type** in error logs: `Error: '12'` → `KeyError: '12'`

### Changes

| File | Change |
|------|--------|
| `mem0/memory/main.py` | Safe `.get()` lookup + skip for sync UPDATE/DELETE |
| `mem0/memory/main.py` | Safe `.get()` lookup + skip for async UPDATE/DELETE |
| `mem0/memory/main.py` | Better error logging with `type(e).__name__` |
| `tests/test_temp_uuid_mapping.py` | Tests for sync/async × UPDATE/DELETE with missing IDs |

Fixes #3931