### PR TITLE
fix: extract text from dict in update_memory to prevent TypeError in embed()

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1085,6 +1085,11 @@ class Memory(MemoryBase):
         """
         capture_event("mem0.update", self, {"memory_id": memory_id, "sync_type": "sync"})
 
+        if isinstance(data, dict):
+            data = data.get("data") or str(data)
+        if not isinstance(data, str):
+            data = str(data)
+
         existing_embeddings = {data: self.embedding_model.embed(data, "update")}
 
         self._update_memory(memory_id, data, existing_embeddings)
@@ -2148,6 +2153,11 @@ class AsyncMemory(MemoryBase):
             {'message': 'Memory updated successfully!'}
         """
         capture_event("mem0.update", self, {"memory_id": memory_id, "sync_type": "async"})
+
+        if isinstance(data, dict):
+            data = data.get("data") or str(data)
+        if not isinstance(data, str):
+            data = str(data)
 
         embeddings = await asyncio.to_thread(self.embedding_model.embed, data, "update")
         existing_embeddings = {data: embeddings}

--- a/server/main.py
+++ b/server/main.py
@@ -152,16 +152,17 @@ def search_memories(search_req: SearchRequest):
 @app.put("/memories/{memory_id}", summary="Update a memory")
 def update_memory(memory_id: str, updated_memory: Dict[str, Any]):
     """Update an existing memory with new content.
-    
+
     Args:
         memory_id (str): ID of the memory to update
-        updated_memory (str): New content to update the memory with
-        
+        updated_memory (Dict[str, Any]): Request body containing the new memory content
+
     Returns:
         dict: Success message indicating the memory was updated
     """
     try:
-        return MEMORY_INSTANCE.update(memory_id=memory_id, data=updated_memory)
+        data = updated_memory.get("data", "") if isinstance(updated_memory, dict) else updated_memory
+        return MEMORY_INSTANCE.update(memory_id=memory_id, data=data)
     except Exception as e:
         logging.exception("Error in update_memory:")
         raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
## Description

Fixes `TypeError` when `update_memory` API endpoint receives a dict payload, as reported in #3235.

### Problem

`PUT /memories/{memory_id}` receives `Dict[str, Any]` (e.g. `{"data": "new text"}`), which is passed directly to `Memory.update(data=...)`. The `update()` method calls `self.embedding_model.embed(data)`, which expects a string. When `data` is a dict, `embed()` internally calls `data.replace()`, raising:

```
TypeError: 'dict' object has no attribute 'replace'
```

### Solution

**Defense in depth** — fix at both the API layer and the core layer:

1. **`server/main.py`**: Extract `data` field from dict before passing to `Memory.update()`
2. **`mem0/memory/main.py`** (sync + async `update()`): Add type normalization — if `data` is a dict, extract `.get("data")`; if still not a string, convert with `str()`
3. Fixed docstring to match actual type annotation (`Dict[str, Any]` not `str`)

### Changes

| File | Change |
|------|--------|
| `server/main.py` | Extract text from dict, fix docstring |
| `mem0/memory/main.py` | Type guard in sync `update()` |
| `mem0/memory/main.py` | Type guard in async `update()` |

Fixes #3235