### PR TITLE
fix: move namespace from query dicts to query_many() argument in UpstashVector

### DIFF
--- a/mem0/vector_stores/upstash_vector.py
+++ b/mem0/vector_stores/upstash_vector.py
@@ -132,11 +132,10 @@ class UpstashVector(VectorStoreBase):
                     "top_k": limit,
                     "filter": filters_str or "",
                     "include_metadata": True,
-                    "namespace": self.collection_name,
                 }
                 for v in vectors
             ]
-            responses = self.client.query_many(queries=queries)
+            responses = self.client.query_many(queries=queries, namespace=self.collection_name)
             # flatten
             response = [res for res_list in responses for res in res_list]
 


### PR DESCRIPTION
## Description

Fixes broken search in UpstashVector when `enable_embeddings=False`, as reported in #4207.

### Problem

In `upstash_vector.py`, the `search()` method passes `namespace` inside each query dict for `query_many()`:

```python
queries = [
    {
        "vector": v,
        "namespace": self.collection_name,  # ❌ Wrong place
        ...
    }
]
responses = self.client.query_many(queries=queries)
```

The `upstash_vector` client's `query_many()` expects `namespace` as a **top-level argument**, not inside individual query dicts. This causes the namespace to be ignored, returning results from the wrong namespace or raising errors.

### Solution

Move `namespace` from inside query dicts to the `query_many()` call:

```python
queries = [
    {
        "vector": v,
        # namespace removed from here
        ...
    }
]
responses = self.client.query_many(queries=queries, namespace=self.collection_name)  # ✅
```

### Changes

| File | Change |
|------|--------|
| `mem0/vector_stores/upstash_vector.py` | Move namespace to `query_many()` argument |

Fixes #4207