### PR TITLE
fix: use tempfile.gettempdir() for cross-platform vector store default path

### DIFF
--- a/mem0/vector_stores/configs.py
+++ b/mem0/vector_stores/configs.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 from typing import Dict, Optional
 
 from pydantic import BaseModel, Field, model_validator
@@ -60,7 +62,7 @@ class VectorStoreConfig(BaseModel):
 
         # also check if path in allowed kays for pydantic model, and whether config extra fields are allowed
         if "path" not in config and "path" in config_class.__annotations__:
-            config["path"] = f"/tmp/{provider}"
+            config["path"] = os.path.join(tempfile.gettempdir(), provider)
 
         self.config = config_class(**config)
         return self


### PR DESCRIPTION
## Description

Fixes vector store initialization failures on Windows, macOS LaunchAgents, and restricted Linux environments, as reported in #4279.

### Problem

The default vector store path is hardcoded to `/tmp/{provider}` in `mem0/vector_stores/configs.py`:

```python
config["path"] = f"/tmp/{provider}"
```

This fails on:
- **Windows**: `/tmp` doesn't exist
- **macOS LaunchAgents**: Limited permissions, `/tmp` cleared on reboot
- **Linux systemd**: Private `/tmp` namespaces, `noexec` restrictions
- **Docker**: Ephemeral unless volume-mounted

### Solution

Use `tempfile.gettempdir()` which returns the platform-appropriate temp directory:

```python
import os
import tempfile

config["path"] = os.path.join(tempfile.gettempdir(), provider)
```

This resolves to:
- Linux/macOS: `/tmp` (or `$TMPDIR` if set)
- Windows: `%TEMP%` (typically `C:\\Users\\...\\AppData\\Local\\Temp`)

### Changes

| File | Change |
|------|--------|
| `mem0/vector_stores/configs.py` | Replace hardcoded `/tmp/` with `tempfile.gettempdir()` |

Fixes #4279