### PR TITLE
fix: make qdrant and posthog optional dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,13 +84,23 @@ Get up and running in minutes with automatic updates, analytics, and enterprise 
 
 ### Self-Hosted (Open Source)
 
-Install the sdk via pip:
+Install the SDK via pip:
 
 ```bash
 pip install mem0ai
 ```
 
-Install sdk via npm:
+Install optional extras as needed:
+
+```bash
+# Qdrant provider support
+pip install "mem0ai[qdrant]"
+
+# PostHog telemetry support
+pip install "mem0ai[telemetry]"
+```
+
+Install SDK via npm:
 ```bash
 npm install mem0ai
 ```

--- a/docs/open-source/configuration.mdx
+++ b/docs/open-source/configuration.mdx
@@ -27,9 +27,18 @@ icon: "sliders"
 pip install mem0ai
 ```
 </Step>
-<Step title="Add provider SDKs (example: Qdrant + OpenAI)">
+<Step title="Install optional extras (examples)">
 ```bash
-pip install qdrant-client openai
+# Qdrant provider support
+pip install "mem0ai[qdrant]"
+
+# PostHog telemetry support
+pip install "mem0ai[telemetry]"
+```
+</Step>
+<Step title="Add provider SDKs (example: OpenAI)">
+```bash
+pip install openai
 ```
 </Step>
 </Steps>

--- a/mem0/configs/vector_stores/qdrant.py
+++ b/mem0/configs/vector_stores/qdrant.py
@@ -2,10 +2,16 @@ from typing import Any, ClassVar, Dict, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-
-class QdrantConfig(BaseModel):
+try:
     from qdrant_client import QdrantClient
 
+    _QDRANT_IMPORT_ERROR = None
+except ImportError as e:
+    QdrantClient = Any
+    _QDRANT_IMPORT_ERROR = e
+
+
+class QdrantConfig(BaseModel):
     QdrantClient: ClassVar[type] = QdrantClient
 
     collection_name: str = Field("mem0", description="Name of the collection")
@@ -21,6 +27,12 @@ class QdrantConfig(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def check_host_port_or_path(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        if _QDRANT_IMPORT_ERROR is not None:
+            raise ImportError(
+                "The 'qdrant-client' library is required for the qdrant provider. "
+                'Install it with `pip install "mem0ai[qdrant]"`.'
+            ) from _QDRANT_IMPORT_ERROR
+
         host, port, path, url, api_key = (
             values.get("host"),
             values.get("port"),

--- a/mem0/memory/telemetry.py
+++ b/mem0/memory/telemetry.py
@@ -3,14 +3,21 @@ import os
 import platform
 import sys
 
-from posthog import Posthog
-
 import mem0
 from mem0.memory.setup import get_or_create_user_id
+
+try:
+    from posthog import Posthog
+
+    POSTHOG_AVAILABLE = True
+except ImportError:
+    Posthog = None
+    POSTHOG_AVAILABLE = False
 
 MEM0_TELEMETRY = os.environ.get("MEM0_TELEMETRY", "True")
 PROJECT_API_KEY = "phc_hgJkUVJFYtmaJqrvf6CYN67TIQ8yhXAkWzUn9AMU4yX"
 HOST = "https://us.i.posthog.com"
+_POSTHOG_WARNING_EMITTED = False
 
 if isinstance(MEM0_TELEMETRY, str):
     MEM0_TELEMETRY = MEM0_TELEMETRY.lower() in ("true", "1", "yes")
@@ -24,9 +31,21 @@ logging.getLogger("urllib3").setLevel(logging.CRITICAL + 1)
 
 class AnonymousTelemetry:
     def __init__(self, vector_store=None):
+        global _POSTHOG_WARNING_EMITTED
+
         if not MEM0_TELEMETRY:
             self.posthog = None
             self.user_id = None
+            return
+
+        if not POSTHOG_AVAILABLE:
+            self.posthog = None
+            self.user_id = None
+            if not _POSTHOG_WARNING_EMITTED:
+                logging.getLogger(__name__).warning(
+                    "PostHog is not installed. Telemetry is disabled. Install with `pip install \"mem0ai[telemetry]\"`."
+                )
+                _POSTHOG_WARNING_EMITTED = True
             return
 
         self.posthog = Posthog(project_api_key=PROJECT_API_KEY, host=HOST)

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -194,7 +194,15 @@ class VectorStoreFactory:
         if class_type:
             if not isinstance(config, dict):
                 config = config.model_dump()
-            vector_store_instance = load_class(class_type)
+            try:
+                vector_store_instance = load_class(class_type)
+            except ModuleNotFoundError as e:
+                if provider_name == "qdrant" and "qdrant_client" in str(e):
+                    raise ImportError(
+                        "The 'qdrant-client' library is required for the qdrant provider. "
+                        'Install it with `pip install "mem0ai[qdrant]"`.'
+                    ) from e
+                raise
             return vector_store_instance(**config)
         else:
             raise ValueError(f"Unsupported VectorStore provider: {provider_name}")

--- a/mem0/vector_stores/qdrant.py
+++ b/mem0/vector_stores/qdrant.py
@@ -1,18 +1,26 @@
 import logging
 import os
 import shutil
+from typing import Any
 
-from qdrant_client import QdrantClient
-from qdrant_client.models import (
-    Distance,
-    FieldCondition,
-    Filter,
-    MatchValue,
-    PointIdsList,
-    PointStruct,
-    Range,
-    VectorParams,
-)
+try:
+    from qdrant_client import QdrantClient
+    from qdrant_client.models import (
+        Distance,
+        FieldCondition,
+        Filter,
+        MatchValue,
+        PointIdsList,
+        PointStruct,
+        Range,
+        VectorParams,
+    )
+
+    _QDRANT_IMPORT_ERROR = None
+except ImportError as e:
+    QdrantClient = Any
+    Distance = FieldCondition = Filter = MatchValue = PointIdsList = PointStruct = Range = VectorParams = Any
+    _QDRANT_IMPORT_ERROR = e
 
 from mem0.vector_stores.base import VectorStoreBase
 
@@ -24,7 +32,7 @@ class Qdrant(VectorStoreBase):
         self,
         collection_name: str,
         embedding_model_dims: int,
-        client: QdrantClient = None,
+        client: Any = None,
         host: str = None,
         port: int = None,
         path: str = None,
@@ -46,6 +54,12 @@ class Qdrant(VectorStoreBase):
             api_key (str, optional): API key for Qdrant server. Defaults to None.
             on_disk (bool, optional): Enables persistent storage. Defaults to False.
         """
+        if _QDRANT_IMPORT_ERROR is not None:
+            raise ImportError(
+                "The 'qdrant-client' library is required for the qdrant provider. "
+                'Install it with `pip install "mem0ai[qdrant]"`.'
+            ) from _QDRANT_IMPORT_ERROR
+
         if client:
             self.client = client
             self.is_local = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,16 +14,20 @@ license = "Apache-2.0"
 license-files = ["LICENSE"]
 requires-python = ">=3.9,<4.0"
 dependencies = [
-    "qdrant-client>=1.9.1",
     "pydantic>=2.7.3",
     "openai>=1.90.0",
-    "posthog>=3.5.0",
     "pytz>=2024.1",
     "sqlalchemy>=2.0.31",
     "protobuf>=5.29.6,<7.0.0",
 ]
 
 [project.optional-dependencies]
+qdrant = [
+    "qdrant-client>=1.9.1",
+]
+telemetry = [
+    "posthog>=3.5.0",
+]
 graph = [
     "langchain-neo4j>=0.4.0",
     "langchain-aws>=0.2.23",
@@ -33,6 +37,7 @@ graph = [
     "kuzu>=0.11.0",
 ]
 vector_stores = [
+    "qdrant-client>=1.9.1",
     "vecs>=0.4.0",
     "chromadb>=0.4.24",
     "cassandra-driver>=3.29.0",
@@ -109,6 +114,8 @@ only-include = ["mem0"]
 python = "3.9"
 features = [
   "test",
+  "qdrant",
+  "telemetry",
   "graph",
   "vector_stores",
   "llms",
@@ -119,6 +126,8 @@ features = [
 python = "3.10"
 features = [
   "test",
+  "qdrant",
+  "telemetry",
   "graph",
   "vector_stores",
   "llms",
@@ -129,6 +138,8 @@ features = [
 python = "3.11"
 features = [
   "test",
+  "qdrant",
+  "telemetry",
   "graph",
   "vector_stores",
   "llms",
@@ -139,6 +150,8 @@ features = [
 python = "3.12"
 features = [
   "test",
+  "qdrant",
+  "telemetry",
   "graph",
   "vector_stores",
   "llms",

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -1,0 +1,63 @@
+import builtins
+import importlib
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from mem0.utils.factory import VectorStoreFactory
+
+
+def test_vector_store_factory_qdrant_missing_dependency_has_install_hint():
+    config = {"collection_name": "test_collection", "embedding_model_dims": 1536}
+
+    with patch(
+        "mem0.utils.factory.importlib.import_module",
+        side_effect=ModuleNotFoundError("No module named 'qdrant_client'"),
+    ):
+        with pytest.raises(ImportError, match=r"mem0ai\[qdrant\]"):
+            VectorStoreFactory.create("qdrant", config)
+
+
+def test_vector_store_factory_non_qdrant_provider_does_not_require_qdrant():
+    class FakeChromaStore:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    def fake_import(name, *args, **kwargs):
+        if name == "mem0.vector_stores.qdrant":
+            raise ModuleNotFoundError("No module named 'qdrant_client'")
+        if name == "mem0.vector_stores.chroma":
+            class _Module:
+                ChromaDB = FakeChromaStore
+
+            return _Module()
+        return importlib.import_module(name, *args, **kwargs)
+
+    config = {"collection_name": "test_collection"}
+    with patch.dict(VectorStoreFactory.provider_to_class, {"chroma": "mem0.vector_stores.chroma.ChromaDB"}, clear=False):
+        with patch("mem0.utils.factory.importlib.import_module", side_effect=fake_import):
+            instance = VectorStoreFactory.create("chroma", config)
+
+    assert isinstance(instance, FakeChromaStore)
+    assert instance.kwargs == config
+
+
+def test_telemetry_module_imports_without_posthog_and_degrades_gracefully(monkeypatch):
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "posthog":
+            raise ImportError("No module named 'posthog'")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    sys.modules.pop("mem0.memory.telemetry", None)
+
+    telemetry_module = importlib.import_module("mem0.memory.telemetry")
+    monkeypatch.setattr(telemetry_module, "MEM0_TELEMETRY", True)
+
+    telemetry_instance = telemetry_module.AnonymousTelemetry()
+
+    assert telemetry_instance.posthog is None
+    assert telemetry_instance.user_id is None


### PR DESCRIPTION
## Summary
- Move `qdrant-client` and `posthog` out of base dependencies into optional extras.
- Add graceful runtime fallback when `posthog` is missing (telemetry no-op + warning).
- Add actionable qdrant import guidance (`pip install "mem0ai[qdrant]"`).
- Update OSS install docs for base install vs extras.

## Changes
- `pyproject.toml`
  - remove `qdrant-client`, `posthog` from base deps
  - add extras: `qdrant`, `telemetry`
  - include `qdrant-client` in `vector_stores` extra
  - add `qdrant` + `telemetry` features to hatch dev envs
- `mem0/memory/telemetry.py`
  - guarded posthog import and no-op fallback when unavailable
- `mem0/vector_stores/qdrant.py`
- `mem0/configs/vector_stores/qdrant.py`
- `mem0/utils/factory.py`
  - helpful ImportError messaging for missing qdrant dependency
- docs
  - README and OSS configuration install guidance updated
- tests
  - add `tests/test_optional_dependencies.py`

## Verification
- `uv run --extra test pytest tests/test_optional_dependencies.py -q`
- `uv run --extra test pytest tests/test_telemetry.py -q`
- `uv run --extra test --extra qdrant pytest tests/vector_stores/test_qdrant.py -q`
- `uv run python -c "import mem0; print(mem0.__version__)"`

Fixes #4209
