### PR TITLE
fix(langchain): wrap scalar args in lists when calling insert() from update()

### DIFF
--- a/mem0/vector_stores/langchain.py
+++ b/mem0/vector_stores/langchain.py
@@ -115,7 +115,11 @@ class Langchain(VectorStoreBase):
         Update a vector and its payload.
         """
         self.delete(vector_id)
-        self.insert(vector, payload, [vector_id])
+        self.insert(
+            [vector] if vector is not None else [],
+            [payload] if payload is not None else None,
+            [vector_id],
+        )
 
     def get(self, vector_id):
         """


### PR DESCRIPTION
The `update()` method passes scalar values to `insert()` which expects lists, causing a `TypeError`. This fix wraps the arguments in lists.

Closes #3767