### PR TITLE
feat(oss): lazy-load optional providers and add comprehensive PR gate

### DIFF
--- a/mem0-ts/README.md
+++ b/mem0-ts/README.md
@@ -13,6 +13,52 @@ For the open-source version, you can install the Mem0 package using npm:
 npm i mem0ai
 ```
 
+### Optional Provider Dependencies
+
+`mem0ai/oss` now lazy-loads optional provider SDKs. You only need to install
+the packages for providers you actually configure.
+
+Common optional installs:
+
+```bash
+# SQLite-based memory/history stores
+pnpm add better-sqlite3
+
+# Vector stores
+pnpm add @qdrant/js-client-rest redis @supabase/supabase-js pg cloudflare @cloudflare/workers-types
+
+# LLM/embedding providers
+pnpm add @anthropic-ai/sdk @google/genai groq-sdk ollama @mistralai/mistralai
+
+# Graph and Azure providers
+pnpm add neo4j-driver @azure/identity @azure/search-documents
+
+# LangChain providers
+pnpm add @langchain/core
+```
+
+If a provider package is missing, mem0 throws a provider-specific install hint
+only when that provider is selected.
+
+### PR-Gate Verification for Optional Dependency Lazy-Loading
+
+Run this sequence before opening a PR for optional-dependency lazy-loading work:
+
+```bash
+pnpm run test:optional-deps:lazy
+pnpm run test:optional-deps:utils
+pnpm test -- src/oss/src/tests/sqlite-path-resolution.test.ts
+pnpm test -- src/oss/src/tests/sqlite-backward-compat.test.ts
+pnpm run build
+pnpm run test:optional-deps:smoke
+```
+
+Or run the complete gate in one command:
+
+```bash
+pnpm run test:optional-deps:gate
+```
+
 ## 2. API Key Setup
 
 For the cloud offering, sign in to [Mem0 Platform](https://app.mem0.ai/dashboard/api-keys) to obtain your API Key.

--- a/mem0-ts/package.json
+++ b/mem0-ts/package.json
@@ -42,6 +42,10 @@
     "test:integration": "jest --config jest.integration.config.js --forceExit",
     "test:ts": "jest --config jest.config.js",
     "test:watch": "jest --config jest.config.js --watch",
+    "test:optional-deps:lazy": "jest --runInBand src/oss/src/tests/optional-deps-lazy-loading.test.ts",
+    "test:optional-deps:utils": "jest --runInBand src/oss/src/tests/optional-deps-utils.test.ts",
+    "test:optional-deps:smoke": "node scripts/optional-deps-pack-smoke.cjs",
+    "test:optional-deps:gate": "pnpm run test:optional-deps:lazy && pnpm run test:optional-deps:utils && pnpm test -- src/oss/src/tests/sqlite-path-resolution.test.ts && pnpm test -- src/oss/src/tests/sqlite-backward-compat.test.ts && pnpm run build && pnpm run test:optional-deps:smoke",
     "format": "npm run clean && prettier --write .",
     "format:check": "npm run clean && prettier --check ."
   },

--- a/mem0-ts/scripts/optional-deps-pack-smoke.cjs
+++ b/mem0-ts/scripts/optional-deps-pack-smoke.cjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+function run(command, cwd) {
+  const result = spawnSync(command, {
+    shell: true,
+    cwd,
+    encoding: "utf8",
+    env: process.env,
+  });
+
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+
+  if (result.status !== 0) {
+    throw new Error(
+      `Command failed (exit ${result.status}): ${command}\n` +
+        `stdout:\n${result.stdout || ""}\n` +
+        `stderr:\n${result.stderr || ""}`,
+    );
+  }
+}
+
+function runNode(code, cwd) {
+  const result = spawnSync(process.execPath, ["-e", code], {
+    cwd,
+    encoding: "utf8",
+    env: process.env,
+  });
+
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+
+  if (result.status !== 0) {
+    throw new Error(
+      `Node smoke check failed (exit ${result.status})\n` +
+        `stdout:\n${result.stdout || ""}\n` +
+        `stderr:\n${result.stderr || ""}`,
+    );
+  }
+}
+
+function writeJson(filePath, value) {
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2) + "\n", "utf8");
+}
+
+async function main() {
+  const repoRoot = path.resolve(__dirname, "..");
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "mem0-pack-smoke-"));
+  const packDir = path.join(tmpRoot, "pack");
+  const fixtureDir = path.join(tmpRoot, "fixture");
+
+  fs.mkdirSync(packDir, { recursive: true });
+  fs.mkdirSync(fixtureDir, { recursive: true });
+
+  try {
+    console.log("[smoke] packing mem0-ts tarball");
+    run(`pnpm pack --pack-destination "${packDir}"`, repoRoot);
+
+    const tarballs = fs
+      .readdirSync(packDir)
+      .filter((name) => name.endsWith(".tgz"));
+    if (tarballs.length === 0) {
+      throw new Error(`No tarball produced in ${packDir}`);
+    }
+    const tarballPath = path.join(packDir, tarballs[0]);
+
+    console.log("[smoke] creating clean fixture project");
+    writeJson(path.join(fixtureDir, "package.json"), {
+      name: "mem0-optional-deps-smoke",
+      version: "1.0.0",
+      private: true,
+    });
+    fs.writeFileSync(
+      path.join(fixtureDir, ".npmrc"),
+      "auto-install-peers=false\nstrict-peer-dependencies=false\n",
+      "utf8",
+    );
+
+    console.log("[smoke] installing packed tarball without optional peers");
+    run(
+      `pnpm add --config.auto-install-peers=false "${tarballPath}"`,
+      fixtureDir,
+    );
+
+    console.log(
+      "[smoke] verify optional sqlite peer is absent in clean fixture",
+    );
+    runNode(
+      `
+try {
+  require.resolve("better-sqlite3");
+  console.error("better-sqlite3 should not be installed in this smoke fixture");
+  process.exit(1);
+} catch (error) {
+  if (!error || error.code !== "MODULE_NOT_FOUND") {
+    console.error(error);
+    process.exit(1);
+  }
+}
+      `,
+      fixtureDir,
+    );
+
+    console.log("[smoke] verify require('mem0ai/oss') works");
+    runNode(`require("mem0ai/oss");`, fixtureDir);
+
+    console.log(
+      "[smoke] verify sqlite provider fails with explicit install hint when optional dep is missing",
+    );
+    runNode(
+      `
+const { HistoryManagerFactory } = require("mem0ai/oss");
+try {
+  HistoryManagerFactory.create("sqlite", {
+    provider: "sqlite",
+    config: { historyDbPath: ":memory:" },
+  });
+  console.error("Expected sqlite provider creation to fail without better-sqlite3");
+  process.exit(1);
+} catch (error) {
+  const message = String((error && error.message) || error);
+  if (!message.includes("Install optional dependency 'better-sqlite3'")) {
+    console.error("Unexpected error message:", message);
+    process.exit(1);
+  }
+}
+      `,
+      fixtureDir,
+    );
+
+    console.log(
+      "[smoke] verify disableHistory + non-sqlite vector store path succeeds",
+    );
+    runNode(
+      `
+const { Memory } = require("mem0ai/oss");
+(async () => {
+  const memory = new Memory({
+    disableHistory: true,
+    embedder: {
+      provider: "openai",
+      config: { apiKey: "test-key", model: "text-embedding-3-small" },
+    },
+    llm: {
+      provider: "openai",
+      config: { apiKey: "test-key", model: "gpt-4.1-nano-2025-04-14" },
+    },
+    vectorStore: {
+      provider: "langchain",
+      config: {
+        dimension: 3,
+        client: {
+          addVectors: async () => undefined,
+          similaritySearchVectorWithScore: async () => [],
+        },
+      },
+    },
+  });
+  await memory._ensureInitialized();
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+      `,
+      fixtureDir,
+    );
+
+    console.log("[smoke] optional dependency pack smoke checks passed");
+  } finally {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/mem0-ts/src/oss/src/embeddings/google.ts
+++ b/mem0-ts/src/oss/src/embeddings/google.ts
@@ -1,13 +1,18 @@
-import { GoogleGenAI } from "@google/genai";
 import { Embedder } from "./base";
 import { EmbeddingConfig } from "../types";
+import { loadOptionalDependency } from "../utils/optional-deps";
 
 export class GoogleEmbedder implements Embedder {
-  private google: GoogleGenAI;
+  private google: any;
   private model: string;
   private embeddingDims?: number;
 
   constructor(config: EmbeddingConfig) {
+    const GoogleGenAI = loadOptionalDependency<any>(
+      "@google/genai",
+      "Google embedding provider",
+      "GoogleGenAI",
+    );
     this.google = new GoogleGenAI({
       apiKey: config.apiKey || process.env.GOOGLE_API_KEY,
     });
@@ -30,6 +35,6 @@ export class GoogleEmbedder implements Embedder {
       contents: texts,
       config: { outputDimensionality: this.embeddingDims },
     });
-    return response.embeddings!.map((item) => item.values!);
+    return response.embeddings!.map((item: any) => item.values!);
   }
 }

--- a/mem0-ts/src/oss/src/embeddings/langchain.ts
+++ b/mem0-ts/src/oss/src/embeddings/langchain.ts
@@ -1,4 +1,4 @@
-import { Embeddings } from "@langchain/core/embeddings";
+import type { Embeddings } from "@langchain/core/embeddings";
 import { Embedder } from "./base";
 import { EmbeddingConfig } from "../types";
 

--- a/mem0-ts/src/oss/src/embeddings/ollama.ts
+++ b/mem0-ts/src/oss/src/embeddings/ollama.ts
@@ -1,16 +1,21 @@
-import { Ollama } from "ollama";
 import { Embedder } from "./base";
 import { EmbeddingConfig } from "../types";
 import { logger } from "../utils/logger";
+import { loadOptionalDependency } from "../utils/optional-deps";
 
 export class OllamaEmbedder implements Embedder {
-  private ollama: Ollama;
+  private ollama: any;
   private model: string;
   private embeddingDims?: number;
   // Using this variable to avoid calling the Ollama server multiple times
   private initialized: boolean = false;
 
   constructor(config: EmbeddingConfig) {
+    const Ollama = loadOptionalDependency<any>(
+      "ollama",
+      "Ollama embedding provider",
+      "Ollama",
+    );
     this.ollama = new Ollama({
       host: config.url || config.baseURL || "http://localhost:11434",
     });

--- a/mem0-ts/src/oss/src/llms/anthropic.ts
+++ b/mem0-ts/src/oss/src/llms/anthropic.ts
@@ -1,9 +1,9 @@
-import Anthropic from "@anthropic-ai/sdk";
 import { LLM, LLMResponse } from "./base";
 import { LLMConfig, Message } from "../types";
+import { loadOptionalDependency } from "../utils/optional-deps";
 
 export class AnthropicLLM implements LLM {
-  private client: Anthropic;
+  private client: any;
   private model: string;
 
   constructor(config: LLMConfig) {
@@ -11,6 +11,10 @@ export class AnthropicLLM implements LLM {
     if (!apiKey) {
       throw new Error("Anthropic API key is required");
     }
+    const Anthropic = loadOptionalDependency<any>(
+      "@anthropic-ai/sdk",
+      "Anthropic LLM provider",
+    );
     this.client = new Anthropic({ apiKey });
     this.model = config.model || "claude-3-sonnet-20240229";
   }

--- a/mem0-ts/src/oss/src/llms/google.ts
+++ b/mem0-ts/src/oss/src/llms/google.ts
@@ -1,12 +1,17 @@
-import { GoogleGenAI } from "@google/genai";
 import { LLM, LLMResponse } from "./base";
 import { LLMConfig, Message } from "../types";
+import { loadOptionalDependency } from "../utils/optional-deps";
 
 export class GoogleLLM implements LLM {
-  private google: GoogleGenAI;
+  private google: any;
   private model: string;
 
   constructor(config: LLMConfig) {
+    const GoogleGenAI = loadOptionalDependency<any>(
+      "@google/genai",
+      "Google LLM provider",
+      "GoogleGenAI",
+    );
     this.google = new GoogleGenAI({ apiKey: config.apiKey });
     this.model = config.model || "gemini-2.0-flash";
   }
@@ -53,7 +58,7 @@ export class GoogleLLM implements LLM {
       return {
         content: completion.text || "",
         role: "assistant",
-        toolCalls: completion.functionCalls.map((call) => ({
+        toolCalls: completion.functionCalls.map((call: any) => ({
           name: call.name!,
           arguments: JSON.stringify(call.args),
         })),

--- a/mem0-ts/src/oss/src/llms/groq.ts
+++ b/mem0-ts/src/oss/src/llms/groq.ts
@@ -1,9 +1,9 @@
-import { Groq } from "groq-sdk";
 import { LLM, LLMResponse } from "./base";
 import { LLMConfig, Message } from "../types";
+import { loadOptionalDependency } from "../utils/optional-deps";
 
 export class GroqLLM implements LLM {
-  private client: Groq;
+  private client: any;
   private model: string;
 
   constructor(config: LLMConfig) {
@@ -11,6 +11,11 @@ export class GroqLLM implements LLM {
     if (!apiKey) {
       throw new Error("Groq API key is required");
     }
+    const Groq = loadOptionalDependency<any>(
+      "groq-sdk",
+      "Groq LLM provider",
+      "Groq",
+    );
     this.client = new Groq({ apiKey });
     this.model = config.model || "llama3-70b-8192";
   }

--- a/mem0-ts/src/oss/src/llms/langchain.ts
+++ b/mem0-ts/src/oss/src/llms/langchain.ts
@@ -1,10 +1,4 @@
-import { BaseLanguageModel } from "@langchain/core/language_models/base";
-import {
-  AIMessage,
-  HumanMessage,
-  SystemMessage,
-  BaseMessage,
-} from "@langchain/core/messages";
+import type { BaseLanguageModel } from "@langchain/core/language_models/base";
 import { z } from "zod";
 import { LLM, LLMResponse } from "./base";
 import { LLMConfig, Message } from "../types/index";
@@ -16,8 +10,25 @@ import {
   GraphRelationsArgsSchema,
   GraphSimpleRelationshipArgsSchema, // Used for delete tool
 } from "../graphs/tools";
+import { loadOptionalDependency } from "../utils/optional-deps";
 
-const convertToLangchainMessages = (messages: Message[]): BaseMessage[] => {
+const convertToLangchainMessages = (messages: Message[]): any[] => {
+  const SystemMessage = loadOptionalDependency<any>(
+    "@langchain/core/messages",
+    "LangChain LLM provider",
+    "SystemMessage",
+  );
+  const HumanMessage = loadOptionalDependency<any>(
+    "@langchain/core/messages",
+    "LangChain LLM provider",
+    "HumanMessage",
+  );
+  const AIMessage = loadOptionalDependency<any>(
+    "@langchain/core/messages",
+    "LangChain LLM provider",
+    "AIMessage",
+  );
+
   return messages.map((msg) => {
     const content =
       typeof msg.content === "string"
@@ -232,7 +243,7 @@ export class LangchainLLM implements LLM {
       if (response && typeof response.content === "string") {
         return {
           content: response.content,
-          role: (response as BaseMessage).lc_id ? "assistant" : "assistant",
+          role: "assistant",
         };
       } else {
         console.warn(

--- a/mem0-ts/src/oss/src/llms/mistral.ts
+++ b/mem0-ts/src/oss/src/llms/mistral.ts
@@ -1,15 +1,20 @@
-import { Mistral } from "@mistralai/mistralai";
 import { LLM, LLMResponse } from "./base";
 import { LLMConfig, Message } from "../types";
+import { loadOptionalDependency } from "../utils/optional-deps";
 
 export class MistralLLM implements LLM {
-  private client: Mistral;
+  private client: any;
   private model: string;
 
   constructor(config: LLMConfig) {
     if (!config.apiKey) {
       throw new Error("Mistral API key is required");
     }
+    const Mistral = loadOptionalDependency<any>(
+      "@mistralai/mistralai",
+      "Mistral LLM provider",
+      "Mistral",
+    );
     this.client = new Mistral({
       apiKey: config.apiKey,
     });
@@ -68,7 +73,7 @@ export class MistralLLM implements LLM {
       return {
         content: this.contentToString(message.content),
         role: message.role || "assistant",
-        toolCalls: message.toolCalls.map((call) => ({
+        toolCalls: message.toolCalls.map((call: any) => ({
           name: call.function.name,
           arguments:
             typeof call.function.arguments === "string"

--- a/mem0-ts/src/oss/src/llms/ollama.ts
+++ b/mem0-ts/src/oss/src/llms/ollama.ts
@@ -1,15 +1,20 @@
-import { Ollama } from "ollama";
 import { LLM, LLMResponse } from "./base";
 import { LLMConfig, Message } from "../types";
 import { logger } from "../utils/logger";
+import { loadOptionalDependency } from "../utils/optional-deps";
 
 export class OllamaLLM implements LLM {
-  private ollama: Ollama;
+  private ollama: any;
   private model: string;
   // Using this variable to avoid calling the Ollama server multiple times
   private initialized: boolean = false;
 
   constructor(config: LLMConfig) {
+    const Ollama = loadOptionalDependency<any>(
+      "ollama",
+      "Ollama LLM provider",
+      "Ollama",
+    );
     this.ollama = new Ollama({
       host: config.url || config.baseURL || "http://localhost:11434",
     });
@@ -52,7 +57,7 @@ export class OllamaLLM implements LLM {
       return {
         content: response.content || "",
         role: response.role,
-        toolCalls: response.tool_calls.map((call) => ({
+        toolCalls: response.tool_calls.map((call: any) => ({
           name: call.function.name,
           arguments: JSON.stringify(call.function.arguments),
         })),

--- a/mem0-ts/src/oss/src/memory/graph_memory.ts
+++ b/mem0-ts/src/oss/src/memory/graph_memory.ts
@@ -1,4 +1,4 @@
-import neo4j, { Driver } from "neo4j-driver";
+import type { Driver } from "neo4j-driver";
 import { BM25 } from "../utils/bm25";
 import { GraphStoreConfig } from "../graphs/configs";
 import { MemoryConfig } from "../types";
@@ -12,6 +12,7 @@ import {
 } from "../graphs/tools";
 import { EXTRACT_RELATIONS_PROMPT, getDeleteMessages } from "../graphs/utils";
 import { logger } from "../utils/logger";
+import { loadOptionalDependency } from "../utils/optional-deps";
 
 interface SearchOutput {
   source: string;
@@ -65,6 +66,11 @@ export class MemoryGraph {
     ) {
       throw new Error("Neo4j configuration is incomplete");
     }
+
+    const neo4j = loadOptionalDependency<any>(
+      "neo4j-driver",
+      "Neo4j graph memory provider",
+    );
 
     this.graph = neo4j.driver(
       config.graphStore.config.url,

--- a/mem0-ts/src/oss/src/storage/SQLiteManager.ts
+++ b/mem0-ts/src/oss/src/storage/SQLiteManager.ts
@@ -1,14 +1,18 @@
-import Database from "better-sqlite3";
 import { HistoryManager } from "./base";
 import { ensureSQLiteDirectory } from "../utils/sqlite";
+import { loadOptionalDependency } from "../utils/optional-deps";
 
 export class SQLiteManager implements HistoryManager {
-  private db: Database.Database;
-  private stmtInsert!: Database.Statement;
-  private stmtSelect!: Database.Statement;
+  private db: any;
+  private stmtInsert!: any;
+  private stmtSelect!: any;
 
   constructor(dbPath: string) {
     ensureSQLiteDirectory(dbPath);
+    const Database = loadOptionalDependency<any>(
+      "better-sqlite3",
+      "sqlite history store",
+    );
     this.db = new Database(dbPath);
     this.init();
   }

--- a/mem0-ts/src/oss/src/storage/SupabaseHistoryManager.ts
+++ b/mem0-ts/src/oss/src/storage/SupabaseHistoryManager.ts
@@ -1,6 +1,7 @@
-import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import { v4 as uuidv4 } from "uuid";
 import { HistoryManager } from "./base";
+import { loadOptionalDependency } from "../utils/optional-deps";
 
 interface HistoryEntry {
   id: string;
@@ -25,6 +26,11 @@ export class SupabaseHistoryManager implements HistoryManager {
 
   constructor(config: SupabaseHistoryConfig) {
     this.tableName = config.tableName || "memory_history";
+    const createClient = loadOptionalDependency<any>(
+      "@supabase/supabase-js",
+      "Supabase history store",
+      "createClient",
+    );
     this.supabase = createClient(config.supabaseUrl, config.supabaseKey);
     this.initializeSupabase().catch(console.error);
   }

--- a/mem0-ts/src/oss/src/tests/optional-deps-lazy-loading.test.ts
+++ b/mem0-ts/src/oss/src/tests/optional-deps-lazy-loading.test.ts
@@ -1,0 +1,322 @@
+const OPTIONAL_MODULES = [
+  "better-sqlite3",
+  "@anthropic-ai/sdk",
+  "@google/genai",
+  "groq-sdk",
+  "ollama",
+  "@mistralai/mistralai",
+  "@qdrant/js-client-rest",
+  "redis",
+  "@supabase/supabase-js",
+  "pg",
+  "cloudflare",
+  "@azure/identity",
+  "@azure/search-documents",
+  "neo4j-driver",
+];
+
+const OPENAI_LLM_CONFIG = {
+  apiKey: "test-key",
+  model: "gpt-4.1-nano-2025-04-14",
+};
+
+async function withMissingModules<T>(
+  modules: string[],
+  fn: () => T | Promise<T>,
+): Promise<T> {
+  jest.resetModules();
+  for (const moduleName of modules) {
+    jest.doMock(
+      moduleName,
+      () => {
+        const err = new Error(`Cannot find module '${moduleName}'`) as Error & {
+          code?: string;
+        };
+        err.code = "MODULE_NOT_FOUND";
+        throw err;
+      },
+      { virtual: true },
+    );
+  }
+
+  try {
+    return await fn();
+  } finally {
+    for (const moduleName of modules) {
+      jest.dontMock(moduleName);
+    }
+    jest.resetModules();
+  }
+}
+
+function assertUnrelatedProviderStillWorks(): void {
+  const { LLMFactory } = require("../utils/factory");
+  expect(() => LLMFactory.create("openai", OPENAI_LLM_CONFIG)).not.toThrow();
+}
+
+type ProviderCase = {
+  name: string;
+  packageName: string;
+  selectProvider: () => void;
+};
+
+const providerCases: ProviderCase[] = [
+  {
+    name: "sqlite history provider",
+    packageName: "better-sqlite3",
+    selectProvider: () => {
+      const { HistoryManagerFactory } = require("../utils/factory");
+      HistoryManagerFactory.create("sqlite", {
+        provider: "sqlite",
+        config: { historyDbPath: ":memory:" },
+      });
+    },
+  },
+  {
+    name: "memory vector store provider",
+    packageName: "better-sqlite3",
+    selectProvider: () => {
+      const { VectorStoreFactory } = require("../utils/factory");
+      VectorStoreFactory.create("memory", { dimension: 3 });
+    },
+  },
+  {
+    name: "qdrant vector store provider",
+    packageName: "@qdrant/js-client-rest",
+    selectProvider: () => {
+      const { VectorStoreFactory } = require("../utils/factory");
+      VectorStoreFactory.create("qdrant", {
+        collectionName: "memories",
+        dimension: 3,
+        path: "/tmp/mem0-qdrant",
+      });
+    },
+  },
+  {
+    name: "redis vector store provider",
+    packageName: "redis",
+    selectProvider: () => {
+      const { VectorStoreFactory } = require("../utils/factory");
+      VectorStoreFactory.create("redis", {
+        collectionName: "memories",
+        redisUrl: "redis://127.0.0.1:6379",
+        embeddingModelDims: 3,
+      });
+    },
+  },
+  {
+    name: "supabase vector store provider",
+    packageName: "@supabase/supabase-js",
+    selectProvider: () => {
+      const { VectorStoreFactory } = require("../utils/factory");
+      VectorStoreFactory.create("supabase", {
+        tableName: "memories",
+        supabaseUrl: "https://example.supabase.co",
+        supabaseKey: "test-key",
+      });
+    },
+  },
+  {
+    name: "pgvector provider",
+    packageName: "pg",
+    selectProvider: () => {
+      const { PGVector } = require("../vector_stores/pgvector");
+      new PGVector({
+        collectionName: "memories",
+        user: "postgres",
+        password: "postgres",
+        host: "127.0.0.1",
+        port: 5432,
+        embeddingModelDims: 3,
+      });
+    },
+  },
+  {
+    name: "cloudflare vectorize provider",
+    packageName: "cloudflare",
+    selectProvider: () => {
+      const { VectorStoreFactory } = require("../utils/factory");
+      VectorStoreFactory.create("vectorize", {
+        apiKey: "test-token",
+        accountId: "account-id",
+        indexName: "index-name",
+        dimension: 3,
+      });
+    },
+  },
+  {
+    name: "azure ai search provider (search-documents package)",
+    packageName: "@azure/search-documents",
+    selectProvider: () => {
+      const { VectorStoreFactory } = require("../utils/factory");
+      VectorStoreFactory.create("azure-ai-search", {
+        serviceName: "test-service",
+        collectionName: "test-index",
+        embeddingModelDims: 3,
+        apiKey: "test-api-key",
+      });
+    },
+  },
+  {
+    name: "azure ai search provider (identity package)",
+    packageName: "@azure/identity",
+    selectProvider: () => {
+      const { VectorStoreFactory } = require("../utils/factory");
+      VectorStoreFactory.create("azure-ai-search", {
+        serviceName: "test-service",
+        collectionName: "test-index",
+        embeddingModelDims: 3,
+        apiKey: "test-api-key",
+      });
+    },
+  },
+  {
+    name: "neo4j graph provider",
+    packageName: "neo4j-driver",
+    selectProvider: () => {
+      const { MemoryGraph } = require("../memory/graph_memory");
+      new MemoryGraph({
+        embedder: {
+          provider: "openai",
+          config: { apiKey: "test-key", model: "text-embedding-3-small" },
+        },
+        llm: {
+          provider: "openai",
+          config: OPENAI_LLM_CONFIG,
+        },
+        vectorStore: {
+          provider: "memory",
+          config: { dimension: 3 },
+        },
+        enableGraph: true,
+        graphStore: {
+          provider: "neo4j",
+          config: {
+            url: "neo4j://localhost:7687",
+            username: "neo4j",
+            password: "password",
+          },
+        },
+      });
+    },
+  },
+  {
+    name: "anthropic llm provider",
+    packageName: "@anthropic-ai/sdk",
+    selectProvider: () => {
+      const { LLMFactory } = require("../utils/factory");
+      LLMFactory.create("anthropic", {
+        apiKey: "test-key",
+        model: "claude-3-sonnet-20240229",
+      });
+    },
+  },
+  {
+    name: "google llm provider",
+    packageName: "@google/genai",
+    selectProvider: () => {
+      const { LLMFactory } = require("../utils/factory");
+      LLMFactory.create("google", {
+        apiKey: "test-key",
+        model: "gemini-2.0-flash",
+      });
+    },
+  },
+  {
+    name: "groq llm provider",
+    packageName: "groq-sdk",
+    selectProvider: () => {
+      const { LLMFactory } = require("../utils/factory");
+      LLMFactory.create("groq", {
+        apiKey: "test-key",
+        model: "llama3-70b-8192",
+      });
+    },
+  },
+  {
+    name: "ollama llm provider",
+    packageName: "ollama",
+    selectProvider: () => {
+      const { LLMFactory } = require("../utils/factory");
+      LLMFactory.create("ollama", {
+        model: "llama3.1:8b",
+        url: "http://localhost:11434",
+      });
+    },
+  },
+  {
+    name: "mistral llm provider",
+    packageName: "@mistralai/mistralai",
+    selectProvider: () => {
+      const { LLMFactory } = require("../utils/factory");
+      LLMFactory.create("mistral", {
+        apiKey: "test-key",
+        model: "mistral-tiny-latest",
+      });
+    },
+  },
+];
+
+describe("optional dependency lazy-loading", () => {
+  it("does not load optional dependencies when importing OSS entrypoint", async () => {
+    await expect(
+      withMissingModules(OPTIONAL_MODULES, () => {
+        jest.isolateModules(() => {
+          require("../index");
+        });
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it.each(providerCases)(
+    "throws install hint only when selected provider is used: $name",
+    async ({ packageName, selectProvider }) => {
+      await expect(
+        withMissingModules([packageName], () => {
+          jest.isolateModules(() => {
+            require("../index");
+            assertUnrelatedProviderStillWorks();
+            expect(() => selectProvider()).toThrow(
+              `Install optional dependency '${packageName}'`,
+            );
+          });
+        }),
+      ).resolves.toBeUndefined();
+    },
+  );
+
+  it("does not fail for disableHistory=true with non-sqlite vector store", async () => {
+    await withMissingModules(["better-sqlite3"], async () => {
+      let MemoryCtor: any;
+      jest.isolateModules(() => {
+        ({ Memory: MemoryCtor } = require("../memory"));
+      });
+
+      const memory = new MemoryCtor({
+        disableHistory: true,
+        embedder: {
+          provider: "openai",
+          config: { apiKey: "test-key", model: "text-embedding-3-small" },
+        },
+        llm: {
+          provider: "openai",
+          config: { apiKey: "test-key", model: "gpt-4.1-nano-2025-04-14" },
+        },
+        vectorStore: {
+          provider: "langchain",
+          config: {
+            dimension: 3,
+            client: {
+              addVectors: async () => undefined,
+              similaritySearchVectorWithScore: async () => [],
+            },
+          },
+        },
+      });
+
+      await expect(
+        (memory as any)._ensureInitialized(),
+      ).resolves.toBeUndefined();
+    });
+  });
+});

--- a/mem0-ts/src/oss/src/tests/optional-deps-utils.test.ts
+++ b/mem0-ts/src/oss/src/tests/optional-deps-utils.test.ts
@@ -1,0 +1,145 @@
+function loadOptionalDepsModuleWithMockedRequire(
+  mockedRequire: (name: string) => any,
+): typeof import("../utils/optional-deps") {
+  jest.resetModules();
+  jest.doMock("module", () => {
+    const actual = jest.requireActual("module");
+    return {
+      ...actual,
+      createRequire: () => mockedRequire,
+    };
+  });
+
+  let loadedModule: typeof import("../utils/optional-deps");
+  jest.isolateModules(() => {
+    loadedModule = require("../utils/optional-deps");
+  });
+
+  jest.dontMock("module");
+  jest.resetModules();
+  return loadedModule!;
+}
+
+function missingModuleError(moduleName: string): Error & { code: string } {
+  const error = new Error(`Cannot find module '${moduleName}'`) as Error & {
+    code: string;
+  };
+  error.code = "MODULE_NOT_FOUND";
+  return error;
+}
+
+describe("optional dependency loader utility", () => {
+  it("resolves default export", () => {
+    const { loadOptionalDependency } = loadOptionalDepsModuleWithMockedRequire(
+      (name) => {
+        if (name === "test-default-package") {
+          return { default: "DEFAULT_VALUE" };
+        }
+        throw missingModuleError(name);
+      },
+    );
+
+    expect(loadOptionalDependency("test-default-package", "test usage")).toBe(
+      "DEFAULT_VALUE",
+    );
+  });
+
+  it("resolves named export from top-level module object", () => {
+    const { loadOptionalDependency } = loadOptionalDepsModuleWithMockedRequire(
+      (name) => {
+        if (name === "test-named-package") {
+          return { createClient: "NAMED_VALUE" };
+        }
+        throw missingModuleError(name);
+      },
+    );
+
+    expect(
+      loadOptionalDependency(
+        "test-named-package",
+        "test usage",
+        "createClient",
+      ),
+    ).toBe("NAMED_VALUE");
+  });
+
+  it("resolves named export from nested default object", () => {
+    const { loadOptionalDependency } = loadOptionalDepsModuleWithMockedRequire(
+      (name) => {
+        if (name === "test-nested-default-package") {
+          return {
+            default: { SearchClient: "SEARCH_CLIENT_CTOR" },
+          };
+        }
+        throw missingModuleError(name);
+      },
+    );
+
+    expect(
+      loadOptionalDependency(
+        "test-nested-default-package",
+        "test usage",
+        "SearchClient",
+      ),
+    ).toBe("SEARCH_CLIENT_CTOR");
+  });
+
+  it("maps MODULE_NOT_FOUND to friendly install hint for known package", () => {
+    const { loadOptionalDependency } = loadOptionalDepsModuleWithMockedRequire(
+      (name) => {
+        throw missingModuleError(name);
+      },
+    );
+
+    expect(() =>
+      loadOptionalDependency("better-sqlite3", "sqlite history store"),
+    ).toThrow(
+      "Install optional dependency 'better-sqlite3' to use sqlite history store. Try: pnpm add better-sqlite3",
+    );
+  });
+
+  it("falls back to generic install hint for unknown package", () => {
+    const { loadOptionalDependency } = loadOptionalDepsModuleWithMockedRequire(
+      (name) => {
+        throw missingModuleError(name);
+      },
+    );
+
+    expect(() =>
+      loadOptionalDependency("unknown-optional-package", "custom provider"),
+    ).toThrow("Try: pnpm add unknown-optional-package");
+  });
+
+  it("preserves non-MODULE_NOT_FOUND errors", () => {
+    const { loadOptionalDependency } = loadOptionalDepsModuleWithMockedRequire(
+      () => {
+        throw new Error("unexpected runtime failure");
+      },
+    );
+
+    expect(() =>
+      loadOptionalDependency("better-sqlite3", "sqlite history store"),
+    ).toThrow("unexpected runtime failure");
+  });
+
+  it("throws clear error when expected export is missing", () => {
+    const { loadOptionalDependency } = loadOptionalDepsModuleWithMockedRequire(
+      (name) => {
+        if (name === "missing-export-package") {
+          return { default: { OtherExport: 1 } };
+        }
+        throw missingModuleError(name);
+      },
+    );
+
+    expect(() =>
+      loadOptionalDependency(
+        "missing-export-package",
+        "custom provider",
+        "ExpectedExport",
+      ),
+    ).toThrow(
+      "Optional dependency 'missing-export-package' does not expose expected export 'ExpectedExport'",
+    );
+  });
+});

--- a/mem0-ts/src/oss/src/utils/optional-deps.ts
+++ b/mem0-ts/src/oss/src/utils/optional-deps.ts
@@ -1,0 +1,85 @@
+import path from "path";
+import { createRequire } from "module";
+
+const OPTIONAL_DEP_INSTALL_HINTS: Record<string, string> = {
+  "better-sqlite3": "pnpm add better-sqlite3",
+  "@anthropic-ai/sdk": "pnpm add @anthropic-ai/sdk",
+  "@google/genai": "pnpm add @google/genai",
+  "groq-sdk": "pnpm add groq-sdk",
+  ollama: "pnpm add ollama",
+  "@mistralai/mistralai": "pnpm add @mistralai/mistralai",
+  "@qdrant/js-client-rest": "pnpm add @qdrant/js-client-rest",
+  redis: "pnpm add redis",
+  "@supabase/supabase-js": "pnpm add @supabase/supabase-js",
+  pg: "pnpm add pg",
+  cloudflare: "pnpm add cloudflare @cloudflare/workers-types",
+  "@azure/identity": "pnpm add @azure/identity @azure/search-documents",
+  "@azure/search-documents": "pnpm add @azure/search-documents @azure/identity",
+  "neo4j-driver": "pnpm add neo4j-driver",
+  "@langchain/core": "pnpm add @langchain/core",
+};
+
+const runtimeRequire = createRequire(
+  typeof __filename !== "undefined"
+    ? __filename
+    : path.join(process.cwd(), "__mem0_runtime_require__.js"),
+);
+
+function isMissingModuleError(error: unknown, packageName: string): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const code = (error as Error & { code?: string }).code;
+  if (code !== "MODULE_NOT_FOUND") {
+    return false;
+  }
+
+  const message = error.message || "";
+  return (
+    message.includes(`'${packageName}'`) ||
+    message.includes(`"${packageName}"`) ||
+    message.includes(`Cannot find package '${packageName}'`)
+  );
+}
+
+function toOptionalDependencyError(
+  packageName: string,
+  usageContext: string,
+): Error {
+  const installHint =
+    OPTIONAL_DEP_INSTALL_HINTS[packageName] || `pnpm add ${packageName}`;
+
+  return new Error(
+    `Install optional dependency '${packageName}' to use ${usageContext}. ` +
+      `Try: ${installHint}`,
+  );
+}
+
+export function loadOptionalDependency<T = any>(
+  packageName: string,
+  usageContext: string,
+  exportName?: string,
+): T {
+  try {
+    const loaded = runtimeRequire(packageName) as any;
+    const resolved = exportName
+      ? (loaded?.[exportName] ?? loaded?.default?.[exportName])
+      : (loaded?.default ?? loaded);
+
+    if (resolved === undefined) {
+      throw new Error(
+        `Optional dependency '${packageName}' does not expose expected export '${exportName || "default"}'`,
+      );
+    }
+
+    return resolved as T;
+  } catch (error) {
+    if (isMissingModuleError(error, packageName)) {
+      throw toOptionalDependencyError(packageName, usageContext);
+    }
+    throw error;
+  }
+}
+
+export const optionalDependencyInstallHints = OPTIONAL_DEP_INSTALL_HINTS;

--- a/mem0-ts/src/oss/src/vector_stores/azure_ai_search.ts
+++ b/mem0-ts/src/oss/src/vector_stores/azure_ai_search.ts
@@ -1,21 +1,20 @@
 import {
-  SearchClient,
-  SearchIndexClient,
-  AzureKeyCredential,
-  SearchIndex,
-  SearchField,
-  SearchFieldDataType,
-  SimpleField,
-  VectorSearch,
-  VectorSearchProfile,
-  HnswAlgorithmConfiguration,
-  ScalarQuantizationCompression,
-  BinaryQuantizationCompression,
-  VectorizedQuery,
+  type SearchClient,
+  type SearchIndexClient,
+  type SearchIndex,
+  type SearchField,
+  type SearchFieldDataType,
+  type SimpleField,
+  type VectorSearch,
+  type VectorSearchProfile,
+  type HnswAlgorithmConfiguration,
+  type ScalarQuantizationCompression,
+  type BinaryQuantizationCompression,
+  type VectorizedQuery,
 } from "@azure/search-documents";
-import { DefaultAzureCredential } from "@azure/identity";
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
+import { loadOptionalDependency } from "../utils/optional-deps";
 
 /**
  * Configuration interface for Azure AI Search vector store
@@ -94,21 +93,41 @@ export class AzureAISearch implements VectorStore {
     this.apiKey = config.apiKey;
 
     const serviceEndpoint = `https://${this.serviceName}.search.windows.net`;
+    const SearchClientCtor = loadOptionalDependency<any>(
+      "@azure/search-documents",
+      "Azure AI Search vector store provider",
+      "SearchClient",
+    );
+    const SearchIndexClientCtor = loadOptionalDependency<any>(
+      "@azure/search-documents",
+      "Azure AI Search vector store provider",
+      "SearchIndexClient",
+    );
+    const AzureKeyCredentialCtor = loadOptionalDependency<any>(
+      "@azure/search-documents",
+      "Azure AI Search vector store provider",
+      "AzureKeyCredential",
+    );
+    const DefaultAzureCredentialCtor = loadOptionalDependency<any>(
+      "@azure/identity",
+      "Azure AI Search vector store provider",
+      "DefaultAzureCredential",
+    );
 
     // Determine authentication: API key or DefaultAzureCredential
     const credential =
       this.apiKey && this.apiKey !== "" && this.apiKey !== "your-api-key"
-        ? new AzureKeyCredential(this.apiKey)
-        : new DefaultAzureCredential();
+        ? new AzureKeyCredentialCtor(this.apiKey)
+        : new DefaultAzureCredentialCtor();
 
     // Initialize clients
-    this.searchClient = new SearchClient(
+    this.searchClient = new SearchClientCtor(
       serviceEndpoint,
       this.indexName,
       credential,
     );
 
-    this.indexClient = new SearchIndexClient(serviceEndpoint, credential);
+    this.indexClient = new SearchIndexClientCtor(serviceEndpoint, credential);
 
     // Initialize the index
     this.initialize().catch(console.error);

--- a/mem0-ts/src/oss/src/vector_stores/langchain.ts
+++ b/mem0-ts/src/oss/src/vector_stores/langchain.ts
@@ -1,7 +1,7 @@
-import { VectorStore as LangchainVectorStoreInterface } from "@langchain/core/vectorstores";
-import { Document } from "@langchain/core/documents";
+import type { VectorStore as LangchainVectorStoreInterface } from "@langchain/core/vectorstores";
 import { VectorStore } from "./base"; // mem0's VectorStore interface
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
+import { loadOptionalDependency } from "../utils/optional-deps";
 
 // Config specifically for the Langchain wrapper
 interface LangchainStoreConfig extends VectorStoreConfig {
@@ -75,6 +75,12 @@ export class LangchainVectorStore implements VectorStore {
         }
       });
     }
+
+    const Document = loadOptionalDependency<any>(
+      "@langchain/core/documents",
+      "LangChain vector store provider",
+      "Document",
+    );
 
     // Convert payloads to Langchain Document metadata format
     const documents = payloads.map((payload, i) => {

--- a/mem0-ts/src/oss/src/vector_stores/memory.ts
+++ b/mem0-ts/src/oss/src/vector_stores/memory.ts
@@ -1,12 +1,12 @@
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
-import Database from "better-sqlite3";
 import fs from "fs";
 import path from "path";
 import {
   ensureSQLiteDirectory,
   getDefaultVectorStoreDbPath,
 } from "../utils/sqlite";
+import { loadOptionalDependency } from "../utils/optional-deps";
 
 interface MemoryVector {
   id: string;
@@ -15,7 +15,7 @@ interface MemoryVector {
 }
 
 export class MemoryVectorStore implements VectorStore {
-  private db: Database.Database;
+  private db: any;
   private dimension: number;
   private dbPath: string;
 
@@ -34,6 +34,10 @@ export class MemoryVectorStore implements VectorStore {
     }
 
     ensureSQLiteDirectory(this.dbPath);
+    const Database = loadOptionalDependency<any>(
+      "better-sqlite3",
+      "the in-memory sqlite vector store",
+    );
     this.db = new Database(this.dbPath);
     this.init();
   }

--- a/mem0-ts/src/oss/src/vector_stores/pgvector.ts
+++ b/mem0-ts/src/oss/src/vector_stores/pgvector.ts
@@ -1,6 +1,6 @@
-import { Client, Pool } from "pg";
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
+import { loadOptionalDependency } from "../utils/optional-deps";
 
 interface PGVectorConfig extends VectorStoreConfig {
   dbname?: string;
@@ -14,7 +14,8 @@ interface PGVectorConfig extends VectorStoreConfig {
 }
 
 export class PGVector implements VectorStore {
-  private client: Client;
+  private client: any;
+  private ClientCtor: any;
   private collectionName: string;
   private useDiskann: boolean;
   private useHnsw: boolean;
@@ -22,13 +23,18 @@ export class PGVector implements VectorStore {
   private config: PGVectorConfig;
 
   constructor(config: PGVectorConfig) {
+    this.ClientCtor = loadOptionalDependency<any>(
+      "pg",
+      "Postgres pgvector provider",
+      "Client",
+    );
     this.collectionName = config.collectionName || "memories";
     this.useDiskann = config.diskann || false;
     this.useHnsw = config.hnsw || false;
     this.dbName = config.dbname || "vector_store";
     this.config = config;
 
-    this.client = new Client({
+    this.client = new this.ClientCtor({
       database: "postgres", // Initially connect to default postgres database
       user: config.user,
       password: config.password,
@@ -51,7 +57,7 @@ export class PGVector implements VectorStore {
       await this.client.end();
 
       // Connect to the target database
-      this.client = new Client({
+      this.client = new this.ClientCtor({
         database: this.dbName,
         user: this.config.user,
         password: this.config.password,
@@ -192,7 +198,7 @@ export class PGVector implements VectorStore {
 
     const result = await this.client.query(searchQuery, filterValues);
 
-    return result.rows.map((row) => ({
+    return result.rows.map((row: any) => ({
       id: row.id,
       payload: row.payload,
       score: row.distance,
@@ -246,7 +252,7 @@ export class PGVector implements VectorStore {
       FROM information_schema.tables
       WHERE table_schema = 'public'
     `);
-    return result.rows.map((row) => row.table_name);
+    return result.rows.map((row: any) => row.table_name);
   }
 
   async list(
@@ -290,7 +296,7 @@ export class PGVector implements VectorStore {
       this.client.query(countQuery, filterValues.slice(0, -1)), // Remove limit parameter for count query
     ]);
 
-    const results = listResult.rows.map((row) => ({
+    const results = listResult.rows.map((row: any) => ({
       id: row.id,
       payload: row.payload,
     }));

--- a/mem0-ts/src/oss/src/vector_stores/qdrant.ts
+++ b/mem0-ts/src/oss/src/vector_stores/qdrant.ts
@@ -1,10 +1,10 @@
-import { QdrantClient } from "@qdrant/js-client-rest";
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
 import * as fs from "fs";
+import { loadOptionalDependency } from "../utils/optional-deps";
 
 interface QdrantConfig extends VectorStoreConfig {
-  client?: QdrantClient;
+  client?: any;
   host?: string;
   port?: number;
   path?: string;
@@ -29,7 +29,7 @@ interface QdrantCondition {
 }
 
 export class Qdrant implements VectorStore {
-  private client: QdrantClient;
+  private client: any;
   private readonly collectionName: string;
   private dimension: number;
   private _initPromise?: Promise<void>;
@@ -38,6 +38,11 @@ export class Qdrant implements VectorStore {
     if (config.client) {
       this.client = config.client;
     } else {
+      const QdrantClient = loadOptionalDependency<any>(
+        "@qdrant/js-client-rest",
+        "Qdrant vector store provider",
+        "QdrantClient",
+      );
       const params: Record<string, any> = {};
       if (config.apiKey) {
         params.apiKey = config.apiKey;
@@ -128,7 +133,7 @@ export class Qdrant implements VectorStore {
       limit,
     });
 
-    return results.map((hit) => ({
+    return results.map((hit: any) => ({
       id: String(hit.id),
       payload: (hit.payload as Record<string, any>) || {},
       score: hit.score,
@@ -191,7 +196,7 @@ export class Qdrant implements VectorStore {
       scrollRequest,
     );
 
-    const results = response.points.map((point) => ({
+    const results = response.points.map((point: any) => ({
       id: String(point.id),
       payload: (point.payload as Record<string, any>) || {},
     }));

--- a/mem0-ts/src/oss/src/vector_stores/redis.ts
+++ b/mem0-ts/src/oss/src/vector_stores/redis.ts
@@ -1,4 +1,3 @@
-import { createClient } from "redis";
 import type {
   RedisClientType,
   RedisDefaultModules,
@@ -8,6 +7,7 @@ import type {
 } from "redis";
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
+import { loadOptionalDependency } from "../utils/optional-deps";
 
 interface RedisConfig extends VectorStoreConfig {
   redisUrl: string;
@@ -142,6 +142,11 @@ export class RedisDB implements VectorStore {
   private _initPromise?: Promise<void>;
 
   constructor(config: RedisConfig) {
+    const createClient = loadOptionalDependency<any>(
+      "redis",
+      "Redis vector store provider",
+      "createClient",
+    );
     this.indexName = config.collectionName;
     this.indexPrefix = `mem0:${config.collectionName}`;
 
@@ -169,7 +174,7 @@ export class RedisDB implements VectorStore {
       username: config.username,
       password: config.password,
       socket: {
-        reconnectStrategy: (retries) => {
+        reconnectStrategy: (retries: number) => {
           if (retries > 10) {
             console.error("Max reconnection attempts reached");
             return new Error("Max reconnection attempts reached");

--- a/mem0-ts/src/oss/src/vector_stores/supabase.ts
+++ b/mem0-ts/src/oss/src/vector_stores/supabase.ts
@@ -1,6 +1,7 @@
-import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
+import { loadOptionalDependency } from "../utils/optional-deps";
 
 interface VectorData {
   id: string;
@@ -89,6 +90,11 @@ export class SupabaseDB implements VectorStore {
   private _initPromise?: Promise<void>;
 
   constructor(config: SupabaseConfig) {
+    const createClient = loadOptionalDependency<any>(
+      "@supabase/supabase-js",
+      "Supabase vector store provider",
+      "createClient",
+    );
     this.client = createClient(config.supabaseUrl, config.supabaseKey);
     this.tableName = config.tableName;
     this.embeddingColumnName = config.embeddingColumnName || "embedding";

--- a/mem0-ts/src/oss/src/vector_stores/vectorize.ts
+++ b/mem0-ts/src/oss/src/vector_stores/vectorize.ts
@@ -1,7 +1,7 @@
-import Cloudflare from "cloudflare";
-import type { Vectorize, VectorizeVector } from "@cloudflare/workers-types";
+import type { VectorizeVector } from "@cloudflare/workers-types";
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
+import { loadOptionalDependency } from "../utils/optional-deps";
 
 interface VectorizeConfig extends VectorStoreConfig {
   apiKey?: string;
@@ -16,13 +16,17 @@ interface CloudflareVector {
 }
 
 export class VectorizeDB implements VectorStore {
-  private client: Cloudflare | null = null;
+  private client: any = null;
   private dimensions: number;
   private indexName: string;
   private accountId: string;
   private _initPromise?: Promise<void>;
 
   constructor(config: VectorizeConfig) {
+    const Cloudflare = loadOptionalDependency<any>(
+      "cloudflare",
+      "Cloudflare Vectorize provider",
+    );
     this.client = new Cloudflare({ apiToken: config.apiKey });
     this.dimensions = config.dimension || 1536;
     this.indexName = config.indexName;
@@ -92,7 +96,7 @@ export class VectorizeDB implements VectorStore {
       );
 
       return (
-        (result?.matches?.map((match) => ({
+        (result?.matches?.map((match: any) => ({
           id: match.id,
           payload: match.metadata,
           score: match.score,
@@ -212,7 +216,7 @@ export class VectorizeDB implements VectorStore {
       );
 
       const matches =
-        (result?.matches?.map((match) => ({
+        (result?.matches?.map((match: any) => ({
           id: match.id,
           payload: match.metadata,
           score: match.score,


### PR DESCRIPTION
## Summary
- add a centralized optional dependency loader for OSS providers with consistent install hints (`Install optional dependency '<pkg>'`)
- switch optional provider SDK usage to runtime lazy loading across sqlite/history, vector stores, graph, and LLM/embedding adapters
- add a comprehensive regression gate for optional dependency behavior:
  - provider-matrix lazy-loading test coverage
  - loader utility unit tests
  - packed-artifact smoke harness (`pnpm pack` + clean install checks)
- add repeatable gate scripts and README verification docs for PR validation

## Why
Issue #3291 requires `mem0ai/oss` to avoid hard-failing on optional provider packages unless that provider is actually selected.

## What changed
- new optional dependency utility: `mem0-ts/src/oss/src/utils/optional-deps.ts`
- provider updates to use lazy loading for optional SDKs (sqlite, qdrant, redis, supabase, pgvector, cloudflare vectorize, azure ai search, neo4j, anthropic, google, groq, ollama, mistral, langchain)
- new tests:
  - `mem0-ts/src/oss/src/tests/optional-deps-lazy-loading.test.ts`
  - `mem0-ts/src/oss/src/tests/optional-deps-utils.test.ts`
- new publish-artifact smoke script:
  - `mem0-ts/scripts/optional-deps-pack-smoke.cjs`
- new npm scripts:
  - `test:optional-deps:lazy`
  - `test:optional-deps:utils`
  - `test:optional-deps:smoke`
  - `test:optional-deps:gate`
- README updates for optional dependency install guidance + PR-gate command sequence

## Tests Run
Executed on the branch for this PR:

```bash
pnpm run test:optional-deps:gate
```

The gate command runs and passed all of the following:

```bash
pnpm run test:optional-deps:lazy
pnpm run test:optional-deps:utils
pnpm test -- src/oss/src/tests/sqlite-path-resolution.test.ts
pnpm test -- src/oss/src/tests/sqlite-backward-compat.test.ts
pnpm run build
pnpm run test:optional-deps:smoke
```

Results summary:
- lazy-loading matrix: 17 passed
- optional-deps utility tests: 7 passed
- sqlite path-resolution: 19 passed
- sqlite backward-compat: 22 passed
- build: passed
- tarball smoke harness: passed (including clean install without optional peers)

Fixes #3291
