### PR TITLE
fix: add vector=None safety guard to all vector store update() methods

### DIFF
--- a/mem0/vector_stores/azure_ai_search.py
+++ b/mem0/vector_stores/azure_ai_search.py
@@ -270,7 +270,7 @@ class AzureAISearch(VectorStoreBase):
             payload (Dict, optional): Updated payload.
         """
         document = {"id": vector_id}
-        if vector:
+        if vector is not None:
             document["vector"] = vector
         if payload:
             json_payload = json.dumps(payload)

--- a/mem0/vector_stores/baidu.py
+++ b/mem0/vector_stores/baidu.py
@@ -245,7 +245,12 @@ class BaiduDB(VectorStoreBase):
             vector (List[float], optional): Updated vector.
             payload (Dict, optional): Updated payload.
         """
-        row = Row(id=vector_id, vector=vector, metadata=payload)
+        row_kwargs = {"id": vector_id}
+        if vector is not None:
+            row_kwargs["vector"] = vector
+        if payload is not None:
+            row_kwargs["metadata"] = payload
+        row = Row(**row_kwargs)
         self._table.upsert(rows=[row])
 
     def get(self, vector_id):

--- a/mem0/vector_stores/chroma.py
+++ b/mem0/vector_stores/chroma.py
@@ -183,7 +183,12 @@ class ChromaDB(VectorStoreBase):
             vector (Optional[List[float]], optional): Updated vector. Defaults to None.
             payload (Optional[Dict], optional): Updated payload. Defaults to None.
         """
-        self.collection.update(ids=vector_id, embeddings=vector, metadatas=payload)
+        update_kwargs = {"ids": vector_id}
+        if vector is not None:
+            update_kwargs["embeddings"] = vector
+        if payload is not None:
+            update_kwargs["metadatas"] = payload
+        self.collection.update(**update_kwargs)
 
     def get(self, vector_id: str) -> OutputData:
         """

--- a/mem0/vector_stores/langchain.py
+++ b/mem0/vector_stores/langchain.py
@@ -114,8 +114,11 @@ class Langchain(VectorStoreBase):
         """
         Update a vector and its payload.
         """
+        if vector is None:
+            logger.warning("Skipping LangChain vector update for ID %s because vector is None", vector_id)
+            return
         self.delete(vector_id)
-        self.insert(vector, payload, [vector_id])
+        self.insert([vector], [payload] if payload is not None else None, [vector_id])
 
     def get(self, vector_id):
         """

--- a/mem0/vector_stores/milvus.py
+++ b/mem0/vector_stores/milvus.py
@@ -181,7 +181,11 @@ class MilvusDB(VectorStoreBase):
             vector (List[float], optional): Updated vector.
             payload (Dict, optional): Updated payload.
         """
-        schema = {"id": vector_id, "vectors": vector, "metadata": payload}
+        schema = {"id": vector_id}
+        if vector is not None:
+            schema["vectors"] = vector
+        if payload is not None:
+            schema["metadata"] = payload
         self.client.upsert(collection_name=self.collection_name, data=schema)
 
     def get(self, vector_id):

--- a/mem0/vector_stores/qdrant.py
+++ b/mem0/vector_stores/qdrant.py
@@ -204,6 +204,14 @@ class Qdrant(VectorStoreBase):
             vector (list, optional): Updated vector. Defaults to None.
             payload (dict, optional): Updated payload. Defaults to None.
         """
+        if vector is None:
+            if payload is not None:
+                self.client.set_payload(
+                    collection_name=self.collection_name,
+                    payload=payload,
+                    points=[vector_id],
+                )
+            return
         point = PointStruct(id=vector_id, vector=vector, payload=payload)
         self.client.upsert(collection_name=self.collection_name, points=[point])
 

--- a/mem0/vector_stores/s3_vectors.py
+++ b/mem0/vector_stores/s3_vectors.py
@@ -123,6 +123,20 @@ class S3Vectors(VectorStoreBase):
 
     def update(self, vector_id, vector=None, payload=None):
         # S3 Vectors uses put_vectors for updates (overwrite)
+        if vector is None:
+            response = self.client.get_vectors(
+                vectorBucketName=self.vector_bucket_name,
+                indexName=self.collection_name,
+                keys=[vector_id],
+                returnData=True,
+                returnMetadata=True,
+            )
+            existing_vectors = response.get("vectors", [])
+            if not existing_vectors:
+                logger.warning(f"Skipping S3 Vectors update for missing vector ID '{vector_id}'.")
+                return
+            existing_vector = existing_vectors[0].get("data", {}).get("float32")
+            vector = existing_vector
         self.insert(vectors=[vector], payloads=[payload], ids=[vector_id])
 
     def get(self, vector_id) -> Optional[OutputData]:

--- a/mem0/vector_stores/upstash_vector.py
+++ b/mem0/vector_stores/upstash_vector.py
@@ -175,12 +175,16 @@ class UpstashVector(VectorStoreBase):
             vector (list, optional): Updated vector. Defaults to None.
             payload (dict, optional): Updated payload. Defaults to None.
         """
+        update_kwargs = {
+            "id": str(vector_id),
+            "data": payload.get("data") if payload else None,
+            "metadata": payload,
+            "namespace": self.collection_name,
+        }
+        if vector is not None:
+            update_kwargs["vector"] = vector
         self.client.update(
-            id=str(vector_id),
-            vector=vector,
-            data=payload.get("data") if payload else None,
-            metadata=payload,
-            namespace=self.collection_name,
+            **update_kwargs,
         )
 
     def get(self, vector_id: int) -> Optional[OutputData]:

--- a/mem0/vector_stores/vertex_ai_vector_search.py
+++ b/mem0/vector_stores/vertex_ai_vector_search.py
@@ -340,6 +340,10 @@ class GoogleMatchingEngine(VectorStoreBase):
         if vector is None and payload is None:
             raise ValueError("Either vector or payload must be provided for update")
 
+        if vector is None:
+            logger.warning("Skipping Vertex AI vector update for vector_id %s because vector is None", vector_id)
+            return False
+
         # First check if the vector exists
         try:
             existing = self.get(vector_id)


### PR DESCRIPTION
## Description

Comprehensive fix for `vector=None` handling across all vector store adapters. Redis and Valkey were fixed in #4362, but **9 other adapters** were still vulnerable to crashes or data corruption.

### Problem

When `Memory._add_to_vector_store()` encounters an unchanged memory (NONE action), it calls `update(vector=None)`. Many adapters pass `None` directly to their backend APIs, causing:
- Pydantic validation errors (Qdrant)
- `np.array(None)` corruption (Valkey/Redis — already fixed)
- Unnecessary delete+insert cycles with None data (Langchain)
- Silent data overwrites with empty vectors (Milvus, Chroma, Baidu)

### Solution

Each adapter gets backend-appropriate handling:

| Adapter | Fix |
|---------|-----|
| `azure_ai_search` | Use `is not None` instead of truthiness |
| `baidu` | Conditionally build Row kwargs |
| `chroma` | Conditionally pass embeddings/metadatas |
| `langchain` | Skip delete+insert when vector is None |
| `milvus` | Conditionally build upsert schema |
| `qdrant` | Use `set_payload()` for metadata-only updates |
| `s3_vectors` | Fetch existing vector before overwrite |
| `upstash_vector` | Conditionally include vector in update kwargs |
| `vertex_ai_vector_search` | Skip when vector is None |

### Changes

9 files modified in `mem0/vector_stores/`

Relates to #4336, #3780