### PR TITLE
fix(opensearch): gracefully handle missing indices.refresh() for Serverless compatibility

### DIFF
--- a/mem0/vector_stores/opensearch.py
+++ b/mem0/vector_stores/opensearch.py
@@ -122,8 +122,13 @@ class OpenSearchDB(VectorStoreBase):
             }
             try:
                 self.client.index(index=self.collection_name, body=body)
-                # Force refresh to make documents immediately searchable for tests
-                self.client.indices.refresh(index=self.collection_name)
+                # Force refresh to make documents immediately searchable.
+                # Wrapped in try/except because OpenSearch Serverless does not
+                # support the indices.refresh() API (returns 404).
+                try:
+                    self.client.indices.refresh(index=self.collection_name)
+                except Exception:
+                    pass
                 
                 results.append(OutputData(
                     id=id_,


### PR DESCRIPTION
Fixes #3739. OpenSearch Serverless does not support `indices.refresh()`, causing `NotFoundError(404)` on every vector insertion since v1.0.0. Wraps the refresh call in try/except.