### PR TITLE
feat(server): add CORS middleware support with configurable origins

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional
 
 from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, RedirectResponse
 from pydantic import BaseModel, Field
 
@@ -62,6 +63,16 @@ app = FastAPI(
     title="Mem0 REST APIs",
     description="A REST API for managing and searching memories for your AI Agents and Apps.",
     version="1.0.0",
+)
+
+# CORS configuration via environment variables
+CORS_ORIGINS = os.environ.get("CORS_ORIGINS", "*").split(",")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=CORS_ORIGINS,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
 


### PR DESCRIPTION
## Description

Adds CORS middleware to the REST API server, enabling browser-based frontends to interact with mem0.

### Problem

The server has no CORS configuration, so any browser-based app calling the API gets blocked by the browser's same-origin policy.

### Solution

Add `CORSMiddleware` with origins configurable via `CORS_ORIGINS` environment variable:

```bash
# Default: allow all origins (development)
CORS_ORIGINS=*

# Production: restrict to specific domains
CORS_ORIGINS=https://app.example.com,https://admin.example.com
```

### Changes

| File | Change |
|------|--------|
| `server/main.py` | Add CORSMiddleware with env-based config |