### PR TITLE
fix: keep sync vector-store calls on caller thread

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -362,6 +362,16 @@ class Memory(MemoryBase):
         if executor is not None:
             executor.shutdown(wait=True)
 
+    def close(self):
+        self._shutdown_sync_executor()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+        return False
+
     def _get_qdrant_local_status(self) -> Optional[bool]:
         if self.config.vector_store.provider != "qdrant":
             return None
@@ -392,20 +402,20 @@ class Memory(MemoryBase):
 
         return qdrant_local_status
 
-    def _run_sync_vector_and_graph(self, vector_store_call, graph_call=None):
+    def _run_sync_vector_and_graph(self, vector_fn, graph_fn=None):
         """Run sync vector-store work with optional graph work using safe dispatch."""
-        if graph_call is None:
-            return vector_store_call(), None
+        if graph_fn is None:
+            return vector_fn(), None
 
         executor = self._get_sync_executor()
         if self._should_run_vector_store_on_caller_thread():
-            future_graph = executor.submit(graph_call)
-            vector_result = vector_store_call()
+            future_graph = executor.submit(graph_fn)
+            vector_result = vector_fn()
             graph_result = future_graph.result()
             return vector_result, graph_result
 
-        future_vector = executor.submit(vector_store_call)
-        future_graph = executor.submit(graph_call)
+        future_vector = executor.submit(vector_fn)
+        future_graph = executor.submit(graph_fn)
         concurrent.futures.wait([future_vector, future_graph])
         vector_result = future_vector.result()
         graph_result = future_graph.result()
@@ -504,14 +514,14 @@ class Memory(MemoryBase):
         def vector_store_call():
             return self._add_to_vector_store(messages, processed_metadata, vector_filters, infer)
 
-        graph_call = None
+        graph_fn = None
         if self.enable_graph:
             graph_filters = deepcopy(effective_filters)
 
-            def graph_call():
+            def graph_fn():
                 return self._add_to_graph(messages, graph_filters)
 
-        vector_store_result, graph_result = self._run_sync_vector_and_graph(vector_store_call, graph_call)
+        vector_store_result, graph_result = self._run_sync_vector_and_graph(vector_store_call, graph_fn)
 
         if self.enable_graph:
             return {
@@ -840,15 +850,15 @@ class Memory(MemoryBase):
         def vector_store_call():
             return self._get_all_from_vector_store(vector_filters, limit)
 
-        graph_call = None
+        graph_fn = None
         if self.enable_graph:
             graph_filters = deepcopy(effective_filters)
 
-            def graph_call():
+            def graph_fn():
                 return self.graph.get_all(graph_filters, limit)
 
         all_memories_result, graph_entities_result = self._run_sync_vector_and_graph(
-            vector_store_call, graph_call
+            vector_store_call, graph_fn
         )
 
         if self.enable_graph:
@@ -982,14 +992,14 @@ class Memory(MemoryBase):
         def vector_store_call():
             return self._search_vector_store(query, vector_filters, limit, threshold)
 
-        graph_call = None
+        graph_fn = None
         if self.enable_graph:
             graph_filters = deepcopy(effective_filters)
 
-            def graph_call():
+            def graph_fn():
                 return self.graph.search(query, graph_filters, limit)
 
-        original_memories, graph_entities = self._run_sync_vector_and_graph(vector_store_call, graph_call)
+        original_memories, graph_entities = self._run_sync_vector_and_graph(vector_store_call, graph_fn)
 
         # Apply reranking if enabled and reranker is available
         if rerank and self.reranker and original_memories:
@@ -1359,7 +1369,7 @@ class Memory(MemoryBase):
 
     def __del__(self):
         try:
-            self._shutdown_sync_executor()
+            self.close()
         except Exception:
             pass
 
@@ -1371,7 +1381,7 @@ class Memory(MemoryBase):
             Recreates the vector store with a new client
         """
         logger.warning("Resetting all memories")
-        self._shutdown_sync_executor()
+        self.close()
 
         if hasattr(self.db, "connection") and self.db.connection:
             self.db.connection.execute("DROP TABLE IF EXISTS history")

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -276,6 +276,7 @@ class Memory(MemoryBase):
             self.enable_graph = True
         else:
             self.graph = None
+        self._sync_executor = None
         if MEM0_TELEMETRY:
             # Create telemetry config manually to avoid deepcopy issues with thread locks
             telemetry_config_dict = {}
@@ -350,6 +351,26 @@ class Memory(MemoryBase):
         # Use agent memory extraction if agent_id is present and there are assistant messages
         return has_agent_id and has_assistant_messages
 
+    def _get_sync_executor(self):
+        if self._sync_executor is None:
+            self._sync_executor = concurrent.futures.ThreadPoolExecutor(max_workers=2)
+        return self._sync_executor
+
+    def _shutdown_sync_executor(self):
+        executor = getattr(self, "_sync_executor", None)
+        self._sync_executor = None
+        if executor is not None:
+            executor.shutdown(wait=True)
+
+    def _get_qdrant_local_status(self) -> Optional[bool]:
+        if self.config.vector_store.provider != "qdrant":
+            return None
+
+        is_local = getattr(self.vector_store, "is_local", None)
+        if isinstance(is_local, bool):
+            return is_local
+        return None
+
     def _should_run_vector_store_on_caller_thread(self) -> bool:
         """Return True when sync vector-store work should avoid worker threads.
 
@@ -359,29 +380,35 @@ class Memory(MemoryBase):
         if not self.enable_graph:
             return True
 
-        if self.config.vector_store.provider != "qdrant":
+        qdrant_local_status = self._get_qdrant_local_status()
+        if qdrant_local_status is None:
+            if self.config.vector_store.provider == "qdrant":
+                logger.warning(
+                    "Qdrant local status is unavailable. "
+                    "Running sync vector-store work on the caller thread for safety."
+                )
+                return True
             return False
 
-        return bool(getattr(self.vector_store, "is_local", False))
+        return qdrant_local_status
 
     def _run_sync_vector_and_graph(self, vector_store_call, graph_call=None):
         """Run sync vector-store work with optional graph work using safe dispatch."""
         if graph_call is None:
             return vector_store_call(), None
 
+        executor = self._get_sync_executor()
         if self._should_run_vector_store_on_caller_thread():
-            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-                future_graph = executor.submit(graph_call)
-                vector_result = vector_store_call()
-                graph_result = future_graph.result()
+            future_graph = executor.submit(graph_call)
+            vector_result = vector_store_call()
+            graph_result = future_graph.result()
             return vector_result, graph_result
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
-            future_vector = executor.submit(vector_store_call)
-            future_graph = executor.submit(graph_call)
-            concurrent.futures.wait([future_vector, future_graph])
-            vector_result = future_vector.result()
-            graph_result = future_graph.result()
+        future_vector = executor.submit(vector_store_call)
+        future_graph = executor.submit(graph_call)
+        concurrent.futures.wait([future_vector, future_graph])
+        vector_result = future_vector.result()
+        graph_result = future_graph.result()
         return vector_result, graph_result
 
     def add(
@@ -472,13 +499,17 @@ class Memory(MemoryBase):
         else:
             messages = parse_vision_messages(messages)
 
+        vector_filters = deepcopy(effective_filters)
+
         def vector_store_call():
-            return self._add_to_vector_store(messages, processed_metadata, effective_filters, infer)
+            return self._add_to_vector_store(messages, processed_metadata, vector_filters, infer)
 
         graph_call = None
         if self.enable_graph:
+            graph_filters = deepcopy(effective_filters)
+
             def graph_call():
-                return self._add_to_graph(messages, deepcopy(effective_filters))
+                return self._add_to_graph(messages, graph_filters)
 
         vector_store_result, graph_result = self._run_sync_vector_and_graph(vector_store_call, graph_call)
 
@@ -804,13 +835,17 @@ class Memory(MemoryBase):
             "mem0.get_all", self, {"limit": limit, "keys": keys, "encoded_ids": encoded_ids, "sync_type": "sync"}
         )
 
+        vector_filters = deepcopy(effective_filters)
+
         def vector_store_call():
-            return self._get_all_from_vector_store(effective_filters, limit)
+            return self._get_all_from_vector_store(vector_filters, limit)
 
         graph_call = None
         if self.enable_graph:
+            graph_filters = deepcopy(effective_filters)
+
             def graph_call():
-                return self.graph.get_all(deepcopy(effective_filters), limit)
+                return self.graph.get_all(graph_filters, limit)
 
         all_memories_result, graph_entities_result = self._run_sync_vector_and_graph(
             vector_store_call, graph_call
@@ -942,13 +977,17 @@ class Memory(MemoryBase):
             },
         )
 
+        vector_filters = deepcopy(effective_filters)
+
         def vector_store_call():
-            return self._search_vector_store(query, effective_filters, limit, threshold)
+            return self._search_vector_store(query, vector_filters, limit, threshold)
 
         graph_call = None
         if self.enable_graph:
+            graph_filters = deepcopy(effective_filters)
+
             def graph_call():
-                return self.graph.search(query, deepcopy(effective_filters), limit)
+                return self.graph.search(query, graph_filters, limit)
 
         original_memories, graph_entities = self._run_sync_vector_and_graph(vector_store_call, graph_call)
 
@@ -1318,6 +1357,12 @@ class Memory(MemoryBase):
         )
         return memory_id
 
+    def __del__(self):
+        try:
+            self._shutdown_sync_executor()
+        except Exception:
+            pass
+
     def reset(self):
         """
         Reset the memory store by:
@@ -1326,6 +1371,7 @@ class Memory(MemoryBase):
             Recreates the vector store with a new client
         """
         logger.warning("Resetting all memories")
+        self._shutdown_sync_executor()
 
         if hasattr(self.db, "connection") and self.db.connection:
             self.db.connection.execute("DROP TABLE IF EXISTS history")

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -350,6 +350,40 @@ class Memory(MemoryBase):
         # Use agent memory extraction if agent_id is present and there are assistant messages
         return has_agent_id and has_assistant_messages
 
+    def _should_run_vector_store_on_caller_thread(self) -> bool:
+        """Return True when sync vector-store work should avoid worker threads.
+
+        Running sync vector-store operations on the caller thread avoids thread-affinity
+        problems for local backends such as QdrantLocal.
+        """
+        if not self.enable_graph:
+            return True
+
+        if self.config.vector_store.provider != "qdrant":
+            return False
+
+        return bool(getattr(self.vector_store, "is_local", False))
+
+    def _run_sync_vector_and_graph(self, vector_store_call, graph_call=None):
+        """Run sync vector-store work with optional graph work using safe dispatch."""
+        if graph_call is None:
+            return vector_store_call(), None
+
+        if self._should_run_vector_store_on_caller_thread():
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+                future_graph = executor.submit(graph_call)
+                vector_result = vector_store_call()
+                graph_result = future_graph.result()
+            return vector_result, graph_result
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+            future_vector = executor.submit(vector_store_call)
+            future_graph = executor.submit(graph_call)
+            concurrent.futures.wait([future_vector, future_graph])
+            vector_result = future_vector.result()
+            graph_result = future_graph.result()
+        return vector_result, graph_result
+
     def add(
         self,
         messages,
@@ -438,14 +472,15 @@ class Memory(MemoryBase):
         else:
             messages = parse_vision_messages(messages)
 
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            future1 = executor.submit(self._add_to_vector_store, messages, processed_metadata, effective_filters, infer)
-            future2 = executor.submit(self._add_to_graph, messages, effective_filters)
+        def vector_store_call():
+            return self._add_to_vector_store(messages, processed_metadata, effective_filters, infer)
 
-            concurrent.futures.wait([future1, future2])
+        graph_call = None
+        if self.enable_graph:
+            def graph_call():
+                return self._add_to_graph(messages, deepcopy(effective_filters))
 
-            vector_store_result = future1.result()
-            graph_result = future2.result()
+        vector_store_result, graph_result = self._run_sync_vector_and_graph(vector_store_call, graph_call)
 
         if self.enable_graph:
             return {
@@ -769,18 +804,17 @@ class Memory(MemoryBase):
             "mem0.get_all", self, {"limit": limit, "keys": keys, "encoded_ids": encoded_ids, "sync_type": "sync"}
         )
 
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            future_memories = executor.submit(self._get_all_from_vector_store, effective_filters, limit)
-            future_graph_entities = (
-                executor.submit(self.graph.get_all, effective_filters, limit) if self.enable_graph else None
-            )
+        def vector_store_call():
+            return self._get_all_from_vector_store(effective_filters, limit)
 
-            concurrent.futures.wait(
-                [future_memories, future_graph_entities] if future_graph_entities else [future_memories]
-            )
+        graph_call = None
+        if self.enable_graph:
+            def graph_call():
+                return self.graph.get_all(deepcopy(effective_filters), limit)
 
-            all_memories_result = future_memories.result()
-            graph_entities_result = future_graph_entities.result() if future_graph_entities else None
+        all_memories_result, graph_entities_result = self._run_sync_vector_and_graph(
+            vector_store_call, graph_call
+        )
 
         if self.enable_graph:
             return {"results": all_memories_result, "relations": graph_entities_result}
@@ -908,18 +942,15 @@ class Memory(MemoryBase):
             },
         )
 
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            future_memories = executor.submit(self._search_vector_store, query, effective_filters, limit, threshold)
-            future_graph_entities = (
-                executor.submit(self.graph.search, query, effective_filters, limit) if self.enable_graph else None
-            )
+        def vector_store_call():
+            return self._search_vector_store(query, effective_filters, limit, threshold)
 
-            concurrent.futures.wait(
-                [future_memories, future_graph_entities] if future_graph_entities else [future_memories]
-            )
+        graph_call = None
+        if self.enable_graph:
+            def graph_call():
+                return self.graph.search(query, deepcopy(effective_filters), limit)
 
-            original_memories = future_memories.result()
-            graph_entities = future_graph_entities.result() if future_graph_entities else None
+        original_memories, graph_entities = self._run_sync_vector_and_graph(vector_store_call, graph_call)
 
         # Apply reranking if enabled and reranker is available
         if rerank and self.reranker and original_memories:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,5 +1,6 @@
 import json
 import threading
+from copy import deepcopy
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -172,6 +173,792 @@ def test_search_runs_vector_store_on_caller_thread_when_graph_disabled(
 
     assert result == {"results": []}
     memory._search_vector_store.assert_called_once()
+
+
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.storage.SQLiteManager")
+def test_add_runs_vector_store_on_caller_thread_for_graph_enabled_local_qdrant(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+
+    config = MemoryConfig()
+    memory = MemoryClass(config)
+    memory.enable_graph = True
+    memory.config.vector_store.provider = "qdrant"
+    memory.vector_store.is_local = True
+
+    caller_thread_id = threading.get_ident()
+
+    def thread_bound_add(*_args, **_kwargs):
+        assert threading.get_ident() == caller_thread_id, "_add_to_vector_store ran on a worker thread"
+        return []
+
+    memory._add_to_vector_store = MagicMock(side_effect=thread_bound_add)
+    memory._add_to_graph = MagicMock(return_value=[])
+
+    result = memory.add(messages=[{"role": "user", "content": "hello"}], user_id="test-user", infer=False)
+
+    assert result == {"results": [], "relations": []}
+    memory._add_to_vector_store.assert_called_once()
+    memory._add_to_graph.assert_called_once()
+    memory._shutdown_sync_executor()
+
+
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.storage.SQLiteManager")
+def test_get_all_runs_vector_store_on_caller_thread_for_graph_enabled_local_qdrant(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+
+    config = MemoryConfig()
+    memory = MemoryClass(config)
+    memory.enable_graph = True
+    memory.config.vector_store.provider = "qdrant"
+    memory.vector_store.is_local = True
+    memory.graph = MagicMock()
+    memory.graph.get_all = MagicMock(return_value=[])
+
+    caller_thread_id = threading.get_ident()
+
+    def thread_bound_get_all(*_args, **_kwargs):
+        assert threading.get_ident() == caller_thread_id, "_get_all_from_vector_store ran on a worker thread"
+        return []
+
+    memory._get_all_from_vector_store = MagicMock(side_effect=thread_bound_get_all)
+
+    result = memory.get_all(user_id="test-user", limit=10)
+
+    assert result == {"results": [], "relations": []}
+    memory._get_all_from_vector_store.assert_called_once()
+    memory.graph.get_all.assert_called_once()
+    memory._shutdown_sync_executor()
+
+
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.storage.SQLiteManager")
+def test_search_runs_vector_store_on_caller_thread_for_graph_enabled_local_qdrant(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+
+    config = MemoryConfig()
+    memory = MemoryClass(config)
+    memory.enable_graph = True
+    memory.config.vector_store.provider = "qdrant"
+    memory.vector_store.is_local = True
+    memory.reranker = None
+    memory.graph = MagicMock()
+    memory.graph.search = MagicMock(return_value=[])
+
+    caller_thread_id = threading.get_ident()
+
+    def thread_bound_search(*_args, **_kwargs):
+        assert threading.get_ident() == caller_thread_id, "_search_vector_store ran on a worker thread"
+        return []
+
+    memory._search_vector_store = MagicMock(side_effect=thread_bound_search)
+
+    result = memory.search(query="hello", user_id="test-user", limit=5)
+
+    assert result == {"results": [], "relations": []}
+    memory._search_vector_store.assert_called_once()
+    memory.graph.search.assert_called_once()
+    memory._shutdown_sync_executor()
+
+
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.storage.SQLiteManager")
+def test_search_falls_back_to_caller_thread_when_qdrant_local_status_unknown(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory, caplog
+):
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+
+    class DummyVectorStore:
+        pass
+
+    config = MemoryConfig()
+    memory = MemoryClass(config)
+    memory.enable_graph = True
+    memory.config.vector_store.provider = "qdrant"
+    memory.vector_store = DummyVectorStore()
+    memory.reranker = None
+    memory.graph = MagicMock()
+    memory.graph.search = MagicMock(return_value=[])
+
+    caller_thread_id = threading.get_ident()
+
+    def thread_bound_search(*_args, **_kwargs):
+        assert threading.get_ident() == caller_thread_id, "_search_vector_store ran on a worker thread"
+        return []
+
+    memory._search_vector_store = MagicMock(side_effect=thread_bound_search)
+
+    with caplog.at_level("WARNING", logger="mem0.memory.main"):
+        result = memory.search(query="hello", user_id="test-user", limit=5)
+
+    assert result == {"results": [], "relations": []}
+    assert any("local status is unavailable" in record.message for record in caplog.records)
+    memory._shutdown_sync_executor()
+
+
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.storage.SQLiteManager")
+def test_add_uses_distinct_filter_dicts_for_vector_and_graph(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+
+    config = MemoryConfig()
+    memory = MemoryClass(config)
+    memory.enable_graph = True
+    memory.config.vector_store.provider = "qdrant"
+    memory.vector_store.is_local = True
+
+    nested_filters = {"user_id": "test-user", "nested": {"topics": ["python"]}}
+    seen = {}
+    marker_set = threading.Event()
+
+    def vector_side_effect(_messages, _metadata, filters, _infer):
+        seen["vector_filter_id"] = id(filters)
+        filters["nested"]["topics"].append("vector")
+        marker_set.set()
+        return []
+
+    def graph_side_effect(_messages, filters):
+        marker_set.wait(timeout=1)
+        seen["graph_filter_id"] = id(filters)
+        seen["graph_nested_topics"] = filters["nested"]["topics"]
+        return []
+
+    memory._add_to_vector_store = MagicMock(side_effect=vector_side_effect)
+    memory._add_to_graph = MagicMock(side_effect=graph_side_effect)
+
+    with patch(
+        "mem0.memory.main._build_filters_and_metadata",
+        return_value=({"user_id": "test-user"}, deepcopy(nested_filters)),
+    ):
+        result = memory.add(messages=[{"role": "user", "content": "hello"}], user_id="test-user", infer=False)
+
+    assert result == {"results": [], "relations": []}
+    assert seen["vector_filter_id"] != seen["graph_filter_id"]
+    assert seen["graph_nested_topics"] == ["python"]
+    memory._shutdown_sync_executor()
+
+
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.storage.SQLiteManager")
+def test_get_all_uses_distinct_filter_dicts_for_vector_and_graph(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+
+    config = MemoryConfig()
+    memory = MemoryClass(config)
+    memory.enable_graph = True
+    memory.config.vector_store.provider = "qdrant"
+    memory.vector_store.is_local = True
+    memory.graph = MagicMock()
+
+    nested_filters = {"user_id": "test-user", "nested": {"topics": ["python"]}}
+    seen = {}
+    marker_set = threading.Event()
+
+    def vector_side_effect(filters, _limit):
+        seen["vector_filter_id"] = id(filters)
+        filters["nested"]["topics"].append("vector")
+        marker_set.set()
+        return []
+
+    def graph_side_effect(filters, _limit):
+        marker_set.wait(timeout=1)
+        seen["graph_filter_id"] = id(filters)
+        seen["graph_nested_topics"] = filters["nested"]["topics"]
+        return []
+
+    memory._get_all_from_vector_store = MagicMock(side_effect=vector_side_effect)
+    memory.graph.get_all = MagicMock(side_effect=graph_side_effect)
+
+    with patch(
+        "mem0.memory.main._build_filters_and_metadata",
+        return_value=({}, deepcopy(nested_filters)),
+    ):
+        result = memory.get_all(user_id="test-user", limit=10)
+
+    assert result == {"results": [], "relations": []}
+    assert seen["vector_filter_id"] != seen["graph_filter_id"]
+    assert seen["graph_nested_topics"] == ["python"]
+    memory._shutdown_sync_executor()
+
+
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.storage.SQLiteManager")
+def test_search_uses_distinct_filter_dicts_for_vector_and_graph(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+
+    config = MemoryConfig()
+    memory = MemoryClass(config)
+    memory.enable_graph = True
+    memory.config.vector_store.provider = "qdrant"
+    memory.vector_store.is_local = True
+    memory.reranker = None
+    memory.graph = MagicMock()
+
+    nested_filters = {"user_id": "test-user", "nested": {"topics": ["python"]}}
+    seen = {}
+    marker_set = threading.Event()
+
+    def vector_side_effect(_query, filters, _limit, _threshold):
+        seen["vector_filter_id"] = id(filters)
+        filters["nested"]["topics"].append("vector")
+        marker_set.set()
+        return []
+
+    def graph_side_effect(_query, filters, _limit):
+        marker_set.wait(timeout=1)
+        seen["graph_filter_id"] = id(filters)
+        seen["graph_nested_topics"] = filters["nested"]["topics"]
+        return []
+
+    memory._search_vector_store = MagicMock(side_effect=vector_side_effect)
+    memory.graph.search = MagicMock(side_effect=graph_side_effect)
+
+    with patch(
+        "mem0.memory.main._build_filters_and_metadata",
+        return_value=({}, deepcopy(nested_filters)),
+    ):
+        result = memory.search(query="hello", user_id="test-user", limit=5)
+
+    assert result == {"results": [], "relations": []}
+    assert seen["vector_filter_id"] != seen["graph_filter_id"]
+    assert seen["graph_nested_topics"] == ["python"]
+    memory._shutdown_sync_executor()
+
+
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.storage.SQLiteManager")
+def test_sync_executor_is_reused_across_repeated_sync_calls(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+
+    config = MemoryConfig()
+    memory = MemoryClass(config)
+    memory.enable_graph = True
+    memory.config.vector_store.provider = "chroma"
+    memory.reranker = None
+    memory.graph = MagicMock()
+    memory.graph.search = MagicMock(return_value=[])
+    memory._search_vector_store = MagicMock(return_value=[])
+
+    memory.search(query="hello", user_id="test-user", limit=5)
+    first_executor = memory._sync_executor
+
+    memory.search(query="hello", user_id="test-user", limit=5)
+
+    assert first_executor is not None
+    assert memory._sync_executor is first_executor
+    memory._shutdown_sync_executor()
+
+
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.storage.SQLiteManager")
+def test_reset_shuts_down_sync_executor_and_clears_cached_instance(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+
+    config = MemoryConfig()
+    memory = MemoryClass(config)
+    fake_executor = MagicMock()
+    memory._sync_executor = fake_executor
+
+    memory.reset()
+
+    fake_executor.shutdown.assert_called_once_with(wait=True)
+    assert memory._sync_executor is None
+
+
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.storage.SQLiteManager")
+def test_add_runs_vector_store_on_worker_thread_for_graph_enabled_remote_qdrant(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+
+    config = MemoryConfig()
+    memory = MemoryClass(config)
+    memory.enable_graph = True
+    memory.config.vector_store.provider = "qdrant"
+    memory.vector_store.is_local = False
+
+    caller_thread_id = threading.get_ident()
+    seen = {}
+
+    def vector_side_effect(*_args, **_kwargs):
+        seen["vector_thread_id"] = threading.get_ident()
+        return []
+
+    memory._add_to_vector_store = MagicMock(side_effect=vector_side_effect)
+    memory._add_to_graph = MagicMock(return_value=[])
+
+    result = memory.add(messages=[{"role": "user", "content": "hello"}], user_id="test-user", infer=False)
+
+    assert result == {"results": [], "relations": []}
+    assert seen["vector_thread_id"] != caller_thread_id
+    memory._shutdown_sync_executor()
+
+
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.storage.SQLiteManager")
+def test_search_runs_vector_store_on_worker_thread_for_graph_enabled_non_qdrant_without_warning(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory, caplog
+):
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+
+    class DummyVectorStore:
+        pass
+
+    config = MemoryConfig()
+    memory = MemoryClass(config)
+    memory.enable_graph = True
+    memory.config.vector_store.provider = "chroma"
+    memory.vector_store = DummyVectorStore()
+    memory.reranker = None
+    memory.graph = MagicMock()
+    memory.graph.search = MagicMock(return_value=[])
+
+    caller_thread_id = threading.get_ident()
+    seen = {}
+
+    def thread_bound_search(*_args, **_kwargs):
+        seen["vector_thread_id"] = threading.get_ident()
+        return []
+
+    memory._search_vector_store = MagicMock(side_effect=thread_bound_search)
+
+    with caplog.at_level("WARNING", logger="mem0.memory.main"):
+        result = memory.search(query="hello", user_id="test-user", limit=5)
+
+    assert result == {"results": [], "relations": []}
+    assert seen["vector_thread_id"] != caller_thread_id
+    assert not any("local status is unavailable" in record.message for record in caplog.records)
+    memory._shutdown_sync_executor()
+
+
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.storage.SQLiteManager")
+def test_get_sync_executor_lazy_singleton_per_instance(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+
+    memory = MemoryClass(MemoryConfig())
+    assert memory._sync_executor is None
+
+    executor1 = memory._get_sync_executor()
+    executor2 = memory._get_sync_executor()
+
+    assert executor1 is executor2
+    memory._shutdown_sync_executor()
+
+
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.storage.SQLiteManager")
+def test_shutdown_sync_executor_is_idempotent(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+
+    memory = MemoryClass(MemoryConfig())
+    fake_executor = MagicMock()
+    memory._sync_executor = fake_executor
+
+    memory._shutdown_sync_executor()
+    memory._shutdown_sync_executor()
+
+    fake_executor.shutdown.assert_called_once_with(wait=True)
+    assert memory._sync_executor is None
+
+
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.storage.SQLiteManager")
+def test_reset_with_no_cached_executor_is_noop_for_shutdown(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+
+    memory = MemoryClass(MemoryConfig())
+    memory._sync_executor = None
+
+    memory.reset()
+
+    assert memory._sync_executor is None
+
+
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.storage.SQLiteManager")
+def test_del_swallows_sync_executor_shutdown_errors(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+
+    memory = MemoryClass(MemoryConfig())
+    memory._shutdown_sync_executor = MagicMock(side_effect=RuntimeError("boom"))
+
+    memory.__del__()
+
+    memory._shutdown_sync_executor.assert_called_once()
+
+
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.storage.SQLiteManager")
+def test_add_nested_filters_are_isolated_for_non_qdrant_parallel_branch(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+
+    nested_filters = {"user_id": "test-user", "nested": {"topics": ["python"]}}
+    memory = MemoryClass(MemoryConfig())
+    memory.enable_graph = True
+    memory.config.vector_store.provider = "chroma"
+
+    seen = {}
+    marker_set = threading.Event()
+
+    def vector_side_effect(_messages, _metadata, filters, _infer):
+        seen["vector_filter_id"] = id(filters)
+        filters["nested"]["topics"].append("vector")
+        marker_set.set()
+        return []
+
+    def graph_side_effect(_messages, filters):
+        marker_set.wait(timeout=1)
+        seen["graph_filter_id"] = id(filters)
+        seen["graph_nested_topics"] = filters["nested"]["topics"]
+        return []
+
+    memory._add_to_vector_store = MagicMock(side_effect=vector_side_effect)
+    memory._add_to_graph = MagicMock(side_effect=graph_side_effect)
+
+    with patch(
+        "mem0.memory.main._build_filters_and_metadata",
+        return_value=({"user_id": "test-user"}, deepcopy(nested_filters)),
+    ):
+        result = memory.add(messages=[{"role": "user", "content": "hello"}], user_id="test-user", infer=False)
+
+    assert result == {"results": [], "relations": []}
+    assert seen["vector_filter_id"] != seen["graph_filter_id"]
+    assert seen["graph_nested_topics"] == ["python"]
+    memory._shutdown_sync_executor()
+
+
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.storage.SQLiteManager")
+def test_get_all_nested_filters_are_isolated_for_non_qdrant_parallel_branch(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+
+    nested_filters = {"user_id": "test-user", "nested": {"topics": ["python"]}}
+    memory = MemoryClass(MemoryConfig())
+    memory.enable_graph = True
+    memory.config.vector_store.provider = "chroma"
+    memory.graph = MagicMock()
+
+    seen = {}
+    marker_set = threading.Event()
+
+    def vector_side_effect(filters, _limit):
+        seen["vector_filter_id"] = id(filters)
+        filters["nested"]["topics"].append("vector")
+        marker_set.set()
+        return []
+
+    def graph_side_effect(filters, _limit):
+        marker_set.wait(timeout=1)
+        seen["graph_filter_id"] = id(filters)
+        seen["graph_nested_topics"] = filters["nested"]["topics"]
+        return []
+
+    memory._get_all_from_vector_store = MagicMock(side_effect=vector_side_effect)
+    memory.graph.get_all = MagicMock(side_effect=graph_side_effect)
+
+    with patch(
+        "mem0.memory.main._build_filters_and_metadata",
+        return_value=({}, deepcopy(nested_filters)),
+    ):
+        result = memory.get_all(user_id="test-user", limit=10)
+
+    assert result == {"results": [], "relations": []}
+    assert seen["vector_filter_id"] != seen["graph_filter_id"]
+    assert seen["graph_nested_topics"] == ["python"]
+    memory._shutdown_sync_executor()
+
+
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.storage.SQLiteManager")
+def test_search_nested_filters_are_isolated_for_non_qdrant_parallel_branch(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+
+    nested_filters = {"user_id": "test-user", "nested": {"topics": ["python"]}}
+    memory = MemoryClass(MemoryConfig())
+    memory.enable_graph = True
+    memory.config.vector_store.provider = "chroma"
+    memory.reranker = None
+    memory.graph = MagicMock()
+
+    seen = {}
+    marker_set = threading.Event()
+
+    def vector_side_effect(_query, filters, _limit, _threshold):
+        seen["vector_filter_id"] = id(filters)
+        filters["nested"]["topics"].append("vector")
+        marker_set.set()
+        return []
+
+    def graph_side_effect(_query, filters, _limit):
+        marker_set.wait(timeout=1)
+        seen["graph_filter_id"] = id(filters)
+        seen["graph_nested_topics"] = filters["nested"]["topics"]
+        return []
+
+    memory._search_vector_store = MagicMock(side_effect=vector_side_effect)
+    memory.graph.search = MagicMock(side_effect=graph_side_effect)
+
+    with patch(
+        "mem0.memory.main._build_filters_and_metadata",
+        return_value=({}, deepcopy(nested_filters)),
+    ):
+        result = memory.search(query="hello", user_id="test-user", limit=5)
+
+    assert result == {"results": [], "relations": []}
+    assert seen["vector_filter_id"] != seen["graph_filter_id"]
+    assert seen["graph_nested_topics"] == ["python"]
+    memory._shutdown_sync_executor()
+
+
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.storage.SQLiteManager")
+def test_run_sync_vector_and_graph_raises_when_vector_callable_fails(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+
+    memory = MemoryClass(MemoryConfig())
+    memory.enable_graph = True
+    memory.config.vector_store.provider = "chroma"
+
+    def vector_fail():
+        raise RuntimeError("vector failed")
+
+    def graph_ok():
+        return []
+
+    try:
+        with pytest.raises(RuntimeError, match="vector failed"):
+            memory._run_sync_vector_and_graph(vector_fail, graph_ok)
+    finally:
+        memory._shutdown_sync_executor()
+
+
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.storage.SQLiteManager")
+def test_run_sync_vector_and_graph_raises_when_graph_callable_fails(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+
+    memory = MemoryClass(MemoryConfig())
+    memory.enable_graph = True
+    memory.config.vector_store.provider = "chroma"
+
+    def vector_ok():
+        return []
+
+    def graph_fail():
+        raise RuntimeError("graph failed")
+
+    try:
+        with pytest.raises(RuntimeError, match="graph failed"):
+            memory._run_sync_vector_and_graph(vector_ok, graph_fail)
+    finally:
+        memory._shutdown_sync_executor()
+
+
+@pytest.mark.parametrize("iteration", range(50))
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.storage.SQLiteManager")
+def test_repeatability_parallel_search_branch(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory, iteration
+):
+    del iteration
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+
+    memory = MemoryClass(MemoryConfig())
+    memory.enable_graph = True
+    memory.config.vector_store.provider = "chroma"
+    memory.reranker = None
+    memory.graph = MagicMock()
+    memory.graph.search = MagicMock(return_value=[])
+    memory._search_vector_store = MagicMock(return_value=[])
+
+    result = memory.search(query="hello", user_id="test-user", limit=5)
+
+    assert result == {"results": [], "relations": []}
+    memory._shutdown_sync_executor()
 
 
 @patch('mem0.utils.factory.EmbedderFactory.create')

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,4 +1,5 @@
 import json
+import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -75,6 +76,102 @@ def test_list_memories(memory_client):
     memories = memory_client.get_all(user_id="test_user")
     assert data1 in memories
     assert data2 in memories
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+def test_add_runs_vector_store_on_caller_thread_when_graph_disabled(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+    config = MemoryConfig()
+    memory = MemoryClass(config)
+    memory.enable_graph = False
+
+    caller_thread_id = threading.get_ident()
+
+    def thread_bound_add(*_args, **_kwargs):
+        assert threading.get_ident() == caller_thread_id, "_add_to_vector_store ran on a worker thread"
+        return []
+
+    memory._add_to_vector_store = MagicMock(side_effect=thread_bound_add)
+    memory._add_to_graph = MagicMock(return_value=[])
+
+    result = memory.add(messages=[{"role": "user", "content": "hello"}], user_id="test-user", infer=False)
+
+    assert result == {"results": []}
+    memory._add_to_vector_store.assert_called_once()
+    memory._add_to_graph.assert_not_called()
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+def test_get_all_runs_vector_store_on_caller_thread_when_graph_disabled(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+    config = MemoryConfig()
+    memory = MemoryClass(config)
+    memory.enable_graph = False
+
+    caller_thread_id = threading.get_ident()
+
+    def thread_bound_get_all(*_args, **_kwargs):
+        assert threading.get_ident() == caller_thread_id, "_get_all_from_vector_store ran on a worker thread"
+        return []
+
+    memory._get_all_from_vector_store = MagicMock(side_effect=thread_bound_get_all)
+
+    result = memory.get_all(user_id="test-user", limit=10)
+
+    assert result == {"results": []}
+    memory._get_all_from_vector_store.assert_called_once()
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+def test_search_runs_vector_store_on_caller_thread_when_graph_disabled(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+    config = MemoryConfig()
+    memory = MemoryClass(config)
+    memory.enable_graph = False
+    memory.reranker = None
+
+    caller_thread_id = threading.get_ident()
+
+    def thread_bound_search(*_args, **_kwargs):
+        assert threading.get_ident() == caller_thread_id, "_search_vector_store ran on a worker thread"
+        return []
+
+    memory._search_vector_store = MagicMock(side_effect=thread_bound_search)
+
+    result = memory.search(query="hello", user_id="test-user", limit=5)
+
+    assert result == {"results": []}
+    memory._search_vector_store.assert_called_once()
 
 
 @patch('mem0.utils.factory.EmbedderFactory.create')

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -572,13 +572,18 @@ def test_add_runs_vector_store_on_worker_thread_for_graph_enabled_remote_qdrant(
         seen["vector_thread_id"] = threading.get_ident()
         return []
 
+    def graph_side_effect(*_args, **_kwargs):
+        seen["graph_thread_id"] = threading.get_ident()
+        return []
+
     memory._add_to_vector_store = MagicMock(side_effect=vector_side_effect)
-    memory._add_to_graph = MagicMock(return_value=[])
+    memory._add_to_graph = MagicMock(side_effect=graph_side_effect)
 
     result = memory.add(messages=[{"role": "user", "content": "hello"}], user_id="test-user", infer=False)
 
     assert result == {"results": [], "relations": []}
     assert seen["vector_thread_id"] != caller_thread_id
+    assert seen["graph_thread_id"] != caller_thread_id
     memory._shutdown_sync_executor()
 
 
@@ -701,7 +706,32 @@ def test_reset_with_no_cached_executor_is_noop_for_shutdown(
 @patch("mem0.utils.factory.VectorStoreFactory.create")
 @patch("mem0.utils.factory.LlmFactory.create")
 @patch("mem0.memory.storage.SQLiteManager")
-def test_del_swallows_sync_executor_shutdown_errors(
+def test_context_manager_closes_sync_executor_on_exit(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+
+    fake_executor = MagicMock()
+    with patch("mem0.memory.main.concurrent.futures.ThreadPoolExecutor", return_value=fake_executor):
+        with MemoryClass(MemoryConfig()) as memory:
+            executor = memory._get_sync_executor()
+            assert executor is fake_executor
+            assert memory._sync_executor is fake_executor
+
+        fake_executor.shutdown.assert_called_once_with(wait=True)
+        assert memory._sync_executor is None
+
+
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.storage.SQLiteManager")
+def test_del_swallows_close_errors(
     mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
 ):
     mock_embedder_factory.return_value = MagicMock()
@@ -712,11 +742,11 @@ def test_del_swallows_sync_executor_shutdown_errors(
     from mem0.memory.main import Memory as MemoryClass
 
     memory = MemoryClass(MemoryConfig())
-    memory._shutdown_sync_executor = MagicMock(side_effect=RuntimeError("boom"))
+    memory.close = MagicMock(side_effect=RuntimeError("boom"))
 
     memory.__del__()
 
-    memory._shutdown_sync_executor.assert_called_once()
+    memory.close.assert_called_once()
 
 
 @patch("mem0.utils.factory.EmbedderFactory.create")

--- a/tests/vector_stores/test_qdrant.py
+++ b/tests/vector_stores/test_qdrant.py
@@ -1,6 +1,6 @@
 import unittest
 import uuid
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from qdrant_client import QdrantClient
 from qdrant_client.models import (
@@ -24,6 +24,52 @@ class TestQdrant(unittest.TestCase):
             path="test_path",
             on_disk=True,
         )
+
+    def test_is_local_false_when_client_is_provided(self):
+        self.assertFalse(self.qdrant.is_local)
+
+    def test_is_local_true_for_path_initialization(self):
+        client = MagicMock(spec=QdrantClient)
+        client.get_collections.return_value = MagicMock(collections=[])
+
+        with patch("mem0.vector_stores.qdrant.QdrantClient", return_value=client):
+            qdrant = Qdrant(
+                collection_name="test_collection",
+                embedding_model_dims=128,
+                path="test_path",
+                on_disk=True,
+            )
+
+        self.assertTrue(qdrant.is_local)
+
+    def test_is_local_false_for_remote_url_initialization(self):
+        client = MagicMock(spec=QdrantClient)
+        client.get_collections.return_value = MagicMock(collections=[])
+
+        with patch("mem0.vector_stores.qdrant.QdrantClient", return_value=client):
+            qdrant = Qdrant(
+                collection_name="test_collection",
+                embedding_model_dims=128,
+                url="http://localhost:6333",
+                on_disk=True,
+            )
+
+        self.assertFalse(qdrant.is_local)
+
+    def test_is_local_false_for_remote_host_port_initialization(self):
+        client = MagicMock(spec=QdrantClient)
+        client.get_collections.return_value = MagicMock(collections=[])
+
+        with patch("mem0.vector_stores.qdrant.QdrantClient", return_value=client):
+            qdrant = Qdrant(
+                collection_name="test_collection",
+                embedding_model_dims=128,
+                host="localhost",
+                port=6333,
+                on_disk=True,
+            )
+
+        self.assertFalse(qdrant.is_local)
 
     def test_create_col(self):
         self.client_mock.get_collections.return_value = MagicMock(collections=[])


### PR DESCRIPTION
## Summary
- Keep sync vector-store work on the caller thread when graph is disabled.
- Keep vector-store work on the caller thread for local qdrant when graph is enabled.
- Centralize sync dispatch in Memory with a thread-safety gate helper.
- Add regression tests for add, get_all, and search thread affinity when graph is disabled.

## Why
- Local qdrant paths can be thread-affine and may fail when sync vector-store calls run in worker threads.

## Verification
- uv run --extra dev ruff check mem0/memory/main.py tests/test_memory.py
- uv run --extra test pytest tests/test_memory.py -k "thread or qdrant or vector_store" -q
- uv run --extra test pytest tests/test_memory.py -q

Fixes #1989
