### PR TITLE
fix: handle None content and empty candidates in GeminiLLM parsing

### DIFF
--- a/mem0/llms/gemini.py
+++ b/mem0/llms/gemini.py
@@ -32,22 +32,25 @@ class GeminiLLM(LLMBase):
         Returns:
             str or dict: The processed response.
         """
+        # Get parts safely — content can be None when Gemini blocks the response
+        candidate = response.candidates[0] if response.candidates else None
+        parts = candidate.content.parts if candidate and candidate.content else None
+
         if tools:
             processed_response = {
                 "content": None,
                 "tool_calls": [],
             }
 
-            # Extract content from the first candidate
-            if response.candidates and response.candidates[0].content.parts:
-                for part in response.candidates[0].content.parts:
+            if parts:
+                # Extract content from the first candidate
+                for part in parts:
                     if hasattr(part, "text") and part.text:
                         processed_response["content"] = part.text
                         break
 
-            # Extract function calls
-            if response.candidates and response.candidates[0].content.parts:
-                for part in response.candidates[0].content.parts:
+                # Extract function calls
+                for part in parts:
                     if hasattr(part, "function_call") and part.function_call:
                         fn = part.function_call
                         processed_response["tool_calls"].append(
@@ -59,8 +62,8 @@ class GeminiLLM(LLMBase):
 
             return processed_response
         else:
-            if response.candidates and response.candidates[0].content.parts:
-                for part in response.candidates[0].content.parts:
+            if parts:
+                for part in parts:
                     if hasattr(part, "text") and part.text:
                         return part.text
             return ""

--- a/tests/llms/test_gemini.py
+++ b/tests/llms/test_gemini.py
@@ -117,3 +117,73 @@ def test_generate_response_with_tools(mock_gemini_client: Mock):
     assert len(response["tool_calls"]) == 1
     assert response["tool_calls"][0]["name"] == "add_memory"
     assert response["tool_calls"][0]["arguments"] == {"data": "Today is a sunny day."}
+
+
+def test_parse_response_none_content_no_tools(mock_gemini_client: Mock):
+    """Gemini can return content=None when response is blocked by safety filters."""
+    config = BaseLlmConfig(model="gemini-2.0-flash", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = GeminiLLM(config)
+
+    mock_candidate = Mock(content=None)
+    mock_response = Mock(candidates=[mock_candidate])
+
+    result = llm._parse_response(mock_response, tools=None)
+    assert result == ""
+
+
+def test_parse_response_none_content_with_tools(mock_gemini_client: Mock):
+    """Gemini can return content=None when response is blocked by safety filters (tools path)."""
+    config = BaseLlmConfig(model="gemini-2.0-flash", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = GeminiLLM(config)
+
+    mock_candidate = Mock(content=None)
+    mock_response = Mock(candidates=[mock_candidate])
+
+    result = llm._parse_response(mock_response, tools=[{"function": {"name": "test"}}])
+    assert result == {"content": None, "tool_calls": []}
+
+
+def test_parse_response_empty_candidates(mock_gemini_client: Mock):
+    """Gemini can return an empty candidates list."""
+    config = BaseLlmConfig(model="gemini-2.0-flash", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = GeminiLLM(config)
+
+    mock_response = Mock(candidates=[])
+    result = llm._parse_response(mock_response, tools=None)
+    assert result == ""
+
+
+def test_parse_response_none_candidates(mock_gemini_client: Mock):
+    """Gemini can return candidates=None."""
+    config = BaseLlmConfig(model="gemini-2.0-flash", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = GeminiLLM(config)
+
+    mock_response = Mock(candidates=None)
+    result = llm._parse_response(mock_response, tools=None)
+    assert result == ""
+
+
+def test_parse_response_empty_parts_no_tools(mock_gemini_client: Mock):
+    """Gemini can return content with an empty parts list."""
+    config = BaseLlmConfig(model="gemini-2.0-flash", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = GeminiLLM(config)
+
+    mock_content = Mock(parts=[])
+    mock_candidate = Mock(content=mock_content)
+    mock_response = Mock(candidates=[mock_candidate])
+
+    result = llm._parse_response(mock_response, tools=None)
+    assert result == ""
+
+
+def test_parse_response_empty_parts_with_tools(mock_gemini_client: Mock):
+    """Gemini can return content with an empty parts list (tools path)."""
+    config = BaseLlmConfig(model="gemini-2.0-flash", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = GeminiLLM(config)
+
+    mock_content = Mock(parts=[])
+    mock_candidate = Mock(content=mock_content)
+    mock_response = Mock(candidates=[mock_candidate])
+
+    result = llm._parse_response(mock_response, tools=[{"function": {"name": "test"}}])
+    assert result == {"content": None, "tool_calls": []}


### PR DESCRIPTION
Description

  Fixes AttributeError: 'NoneType' object has no attribute 'parts' crash in GeminiLLM._parse_response() when Gemini returns a response where content is None (e.g., safety filter blocks, rate
  limiting, thinking-only responses).

  The existing null check in _parse_response() guarded against empty candidates but not against content itself being None. When Gemini blocks a response, response.candidates[0].content is None, so
  accessing .parts on it crashes. This affected all three access points in the method (both the tools and no-tools code paths).

  The fix extracts candidate and parts into guarded local variables at the top of the method, replacing three repeated unsafe access chains with a single safe extraction. Returns "" (not None) to
  preserve the string-return contract shared by all other LLM providers.

  Fixes #3410

  Type of change

  - Bug fix (non-breaking change which fixes an issue)

  How Has This Been Tested?

  - Unit Test

  Added 6 new edge case tests to tests/llms/test_gemini.py:
  - test_parse_response_none_content_no_tools — content=None without tools
  - test_parse_response_none_content_with_tools — content=None with tools
  - test_parse_response_empty_candidates — empty candidates list
  - test_parse_response_none_candidates — None candidates
  - test_parse_response_empty_parts_no_tools — empty parts list without tools
  - test_parse_response_empty_parts_with_tools — empty parts list with tools

  Run: hatch run dev_py_3_12:pytest tests/llms/test_gemini.py -v — all 8 tests pass (2 existing + 6 new).
  Full suite: hatch run dev_py_3_12:pytest tests/ -v — 768 passed, 0 failures.

  Checklist:

  - My code follows the style guidelines of this project
  - I have performed a self-review of my own code
  - I have commented my code, particularly in hard-to-understand areas
  - I have made corresponding changes to the documentation
  - My changes generate no new warnings
  - I have added tests that prove my fix is effective or that my feature works
  - New and existing unit tests pass locally with my changes
  - Any dependent changes have been merged and published in downstream modules
  - I have checked my code and corrected any misspellings

  Maintainer Checklist

  - closes #3410
  - Made sure Checks passed
