### PR TITLE
fix(vector_stores): normalize distance-to-similarity for threshold filtering

### DIFF
--- a/mem0/vector_stores/chroma.py
+++ b/mem0/vector_stores/chroma.py
@@ -99,7 +99,8 @@ class ChromaDB(VectorStoreBase):
         for i in range(max_length):
             entry = OutputData(
                 id=ids[i] if isinstance(ids, list) and ids and i < len(ids) else None,
-                score=(distances[i] if isinstance(distances, list) and distances and i < len(distances) else None),
+                # Chroma returns L2 distance (lower = better): convert to similarity (higher = better)
+                score=(1.0 / (1.0 + distances[i]) if isinstance(distances, list) and distances and i < len(distances) and distances[i] is not None else None),
                 payload=(metadatas[i] if isinstance(metadatas, list) and metadatas and i < len(metadatas) else None),
             )
             result.append(entry)

--- a/mem0/vector_stores/pgvector.py
+++ b/mem0/vector_stores/pgvector.py
@@ -241,7 +241,8 @@ class PGVector(VectorStoreBase):
             )
 
             results = cur.fetchall()
-        return [OutputData(id=str(r[0]), score=float(r[1]), payload=r[2]) for r in results]
+        # `<=>` returns cosine distance (range [0, 2]): convert to similarity (higher = better)
+        return [OutputData(id=str(r[0]), score=max(0.0, 1.0 - float(r[1])), payload=r[2]) for r in results]
 
     def delete(self, vector_id: str) -> None:
         """

--- a/mem0/vector_stores/redis.py
+++ b/mem0/vector_stores/redis.py
@@ -158,7 +158,8 @@ class RedisDB(VectorStoreBase):
         return [
             MemoryResult(
                 id=result["memory_id"],
-                score=float(result["vector_distance"]),
+                # Redis cosine distance (range [0, 2]): convert to similarity (higher = better)
+                score=max(0.0, 1.0 - float(result["vector_distance"])),
                 payload={
                     "hash": result["hash"],
                     "data": result["memory"],

--- a/mem0/vector_stores/s3_vectors.py
+++ b/mem0/vector_stores/s3_vectors.py
@@ -80,7 +80,8 @@ class S3Vectors(VectorStoreBase):
                 except json.JSONDecodeError:
                     logger.warning(f"Failed to parse metadata for key {v.get('key')}")
                     payload = {}
-            results.append(OutputData(id=v.get("key"), score=v.get("distance"), payload=payload))
+            # s3_vectors uses cosine distance (range [0, 2]): convert to similarity (higher = better)
+            results.append(OutputData(id=v.get("key"), score=max(0.0, 1.0 - float(v.get("distance") or 0)), payload=payload))
         return results
 
     def insert(self, vectors, payloads=None, ids=None):

--- a/mem0/vector_stores/supabase.py
+++ b/mem0/vector_stores/supabase.py
@@ -135,7 +135,8 @@ class Supabase(VectorStoreBase):
             data=vectors, limit=limit, filters=filters, include_metadata=True, include_value=True
         )
 
-        return [OutputData(id=str(result[0]), score=float(result[1]), payload=result[2]) for result in results]
+        # Supabase returns cosine distance (range [0, 2]): convert to similarity (higher = better)
+        return [OutputData(id=str(result[0]), score=max(0.0, 1.0 - float(result[1])), payload=result[2]) for result in results]
 
     def delete(self, vector_id: str):
         """

--- a/mem0/vector_stores/valkey.py
+++ b/mem0/vector_stores/valkey.py
@@ -378,8 +378,9 @@ class ValkeyDB(VectorStoreBase):
         """
         memory_results = []
         for doc in results.docs:
-            # Extract the score
-            score = float(doc.vector_score) if hasattr(doc, "vector_score") else None
+            # Valkey/Redis cosine distance (range [0, 2]): convert to similarity (higher = better)
+            raw = float(doc.vector_score) if hasattr(doc, "vector_score") else None
+            score = max(0.0, 1.0 - raw) if raw is not None else None
 
             # Create the payload
             payload = {


### PR DESCRIPTION
## Summary

Fix for issue #4453: threshold filtering is inverted for distance-based vector stores.

### Problem

Many vector store backends return raw **distance** values (lower = better), but the threshold check in  assumes **similarity scores** (higher = better). This causes:

- Good matches (low distance) → filtered OUT ❌
- Bad matches (high distance) → kept ❌

### Fix

Normalize all distance-based stores to return **similarity** (higher = better, range [0, 1]):

| Store | Conversion | Formula |
|-------|-----------|---------|
| pgvector | cosine distance (0-2) |  |
| chroma | L2 distance (0-∞) |  |
| redis | cosine distance (0-2) |  |
| valkey | cosine distance (0-2) |  |
| supabase | cosine distance (0-2) |  |
| s3_vectors | cosine distance (0-2) |  |

### Precedent

Weaviate already does this correctly at :


### Files Changed

- 
- 
- 
- 
- 
- 

### Testing

This is a semantic change — existing tests should still pass as they verify result ordering, not absolute threshold values.

Closes #4453