### PR TITLE
fix: use root LLM config as fallback for graph store instead of hardcoded OpenAI default

### DIFF
--- a/mem0-ts/src/oss/src/config/defaults.ts
+++ b/mem0-ts/src/oss/src/config/defaults.ts
@@ -34,12 +34,6 @@ export const DEFAULT_MEMORY_CONFIG: MemoryConfig = {
       username: process.env.NEO4J_USERNAME || "neo4j",
       password: process.env.NEO4J_PASSWORD || "password",
     },
-    llm: {
-      provider: "openai",
-      config: {
-        model: "gpt-4-turbo-preview",
-      },
-    },
   },
   historyStore: {
     provider: "sqlite",

--- a/mem0-ts/src/oss/src/memory/graph_memory.ts
+++ b/mem0-ts/src/oss/src/memory/graph_memory.ts
@@ -80,18 +80,18 @@ export class MemoryGraph {
     );
 
     this.llmProvider = "openai";
+    let llmConfig = this.config.llm.config;
+
     if (this.config.llm?.provider) {
       this.llmProvider = this.config.llm.provider;
     }
     if (this.config.graphStore?.llm?.provider) {
       this.llmProvider = this.config.graphStore.llm.provider;
+      llmConfig = this.config.graphStore.llm.config ?? llmConfig;
     }
 
-    this.llm = LLMFactory.create(this.llmProvider, this.config.llm.config);
-    this.structuredLlm = LLMFactory.create(
-      this.llmProvider,
-      this.config.llm.config,
-    );
+    this.llm = LLMFactory.create(this.llmProvider, llmConfig);
+    this.structuredLlm = LLMFactory.create(this.llmProvider, llmConfig);
     this.threshold = 0.7;
   }
 

--- a/mem0-ts/src/oss/tests/config-manager.test.ts
+++ b/mem0-ts/src/oss/tests/config-manager.test.ts
@@ -350,6 +350,78 @@ describe("ConfigManager", () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────
+// Graph store LLM config propagation (issue #3425)
+// ─────────────────────────────────────────────────────────────────────────
+describe("mergeConfig - graph store LLM config (issue #3425)", () => {
+  const baseEmbedder = {
+    provider: "openai",
+    config: { apiKey: "test-key" },
+  };
+  const baseVectorStore = {
+    provider: "memory",
+    config: { collectionName: "test" },
+  };
+  const graphStoreNeo4j = {
+    provider: "neo4j",
+    config: {
+      url: "neo4j://localhost:7687",
+      username: "neo4j",
+      password: "password",
+    },
+  };
+
+  it("should NOT have a default graphStore.llm — root llm should be the fallback", () => {
+    const config = ConfigManager.mergeConfig({
+      embedder: baseEmbedder,
+      vectorStore: baseVectorStore,
+      llm: {
+        provider: "anthropic",
+        config: { model: "claude-sonnet-4-20250514" },
+      },
+      graphStore: graphStoreNeo4j,
+    });
+
+    // graphStore should NOT have its own llm after merge
+    expect(config.graphStore?.llm).toBeUndefined();
+    // root llm should be anthropic
+    expect(config.llm.provider).toBe("anthropic");
+    expect(config.llm.config.model).toBe("claude-sonnet-4-20250514");
+  });
+
+  it("should preserve explicit graphStore.llm when user provides it", () => {
+    const config = ConfigManager.mergeConfig({
+      embedder: baseEmbedder,
+      vectorStore: baseVectorStore,
+      llm: {
+        provider: "anthropic",
+        config: { model: "claude-sonnet-4-20250514" },
+      },
+      graphStore: {
+        ...graphStoreNeo4j,
+        llm: { provider: "openai", config: { model: "gpt-4o" } },
+      },
+    });
+
+    // graphStore should have its own llm
+    expect(config.graphStore?.llm?.provider).toBe("openai");
+    expect(config.graphStore?.llm?.config).toEqual({ model: "gpt-4o" });
+    // root llm should still be anthropic
+    expect(config.llm.provider).toBe("anthropic");
+  });
+
+  it("should not have graphStore.llm when user does not provide one", () => {
+    const config = ConfigManager.mergeConfig({
+      embedder: baseEmbedder,
+      vectorStore: baseVectorStore,
+      llm: { provider: "openai", config: { model: "gpt-4o" } },
+    });
+
+    // Default graphStore should not have llm
+    expect(config.graphStore?.llm).toBeUndefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
 // Memory class – LM Studio end-to-end flow (mocked factories)
 // ─────────────────────────────────────────────────────────────────────────
 describe("Memory – LM Studio end-to-end flow", () => {

--- a/mem0-ts/src/oss/tests/graph-memory-parsing.test.ts
+++ b/mem0-ts/src/oss/tests/graph-memory-parsing.test.ts
@@ -511,6 +511,137 @@ describe("Prompt construction — all json_object sites include 'json'", () => {
 // 5. Edge cases – malformed entity fields in _removeSpacesFromEntities
 // ═══════════════════════════════════════════════════════════════════════════
 
+// ═══════════════════════════════════════════════════════════════════════════
+// 5a. LLM config propagation — graph store uses correct provider & config
+//     Regression test for https://github.com/mem0ai/mem0/issues/3425
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("LLM config propagation to graph store (issue #3425)", () => {
+  const { LLMFactory } = require("../src/utils/factory");
+
+  beforeEach(() => {
+    (LLMFactory.create as jest.Mock).mockClear();
+  });
+
+  it("uses root llm config when no graphStore.llm is provided", () => {
+    const config = {
+      graphStore: {
+        config: {
+          url: "bolt://localhost:7687",
+          username: "neo4j",
+          password: "test",
+        },
+      },
+      embedder: { provider: "openai", config: {} },
+      llm: {
+        provider: "anthropic",
+        config: { model: "claude-sonnet-4-20250514", apiKey: "sk-ant-test" },
+      },
+    } as any;
+
+    new MemoryGraph(config);
+
+    expect(LLMFactory.create).toHaveBeenCalledWith("anthropic", {
+      model: "claude-sonnet-4-20250514",
+      apiKey: "sk-ant-test",
+    });
+    // Both llm and structuredLlm should use the same config
+    expect(LLMFactory.create).toHaveBeenCalledTimes(2);
+    expect(LLMFactory.create).toHaveBeenNthCalledWith(1, "anthropic", {
+      model: "claude-sonnet-4-20250514",
+      apiKey: "sk-ant-test",
+    });
+    expect(LLMFactory.create).toHaveBeenNthCalledWith(2, "anthropic", {
+      model: "claude-sonnet-4-20250514",
+      apiKey: "sk-ant-test",
+    });
+  });
+
+  it("uses graphStore.llm config when provided, overriding root llm", () => {
+    const config = {
+      graphStore: {
+        config: {
+          url: "bolt://localhost:7687",
+          username: "neo4j",
+          password: "test",
+        },
+        llm: {
+          provider: "openai",
+          config: { model: "gpt-4o", apiKey: "sk-openai-test" },
+        },
+      },
+      embedder: { provider: "openai", config: {} },
+      llm: {
+        provider: "anthropic",
+        config: { model: "claude-sonnet-4-20250514", apiKey: "sk-ant-test" },
+      },
+    } as any;
+
+    new MemoryGraph(config);
+
+    // Should use graphStore.llm, NOT root llm
+    expect(LLMFactory.create).toHaveBeenNthCalledWith(1, "openai", {
+      model: "gpt-4o",
+      apiKey: "sk-openai-test",
+    });
+    expect(LLMFactory.create).toHaveBeenNthCalledWith(2, "openai", {
+      model: "gpt-4o",
+      apiKey: "sk-openai-test",
+    });
+  });
+
+  it("falls back to root llm config when graphStore.llm.config is undefined", () => {
+    // Note: in practice, Zod schema requires config when graphStore.llm is
+    // present. This tests the defensive fallback in MemoryGraph itself.
+    const config = {
+      graphStore: {
+        config: {
+          url: "bolt://localhost:7687",
+          username: "neo4j",
+          password: "test",
+        },
+        llm: {
+          provider: "openai",
+          // config explicitly undefined
+          config: undefined,
+        },
+      },
+      embedder: { provider: "openai", config: {} },
+      llm: {
+        provider: "anthropic",
+        config: { model: "claude-sonnet-4-20250514" },
+      },
+    } as any;
+
+    new MemoryGraph(config);
+
+    // Provider from graphStore.llm, but config falls back to root llm.config
+    expect(LLMFactory.create).toHaveBeenNthCalledWith(1, "openai", {
+      model: "claude-sonnet-4-20250514",
+    });
+  });
+
+  it("defaults to openai when neither root nor graphStore llm provider is set", () => {
+    const config = {
+      graphStore: {
+        config: {
+          url: "bolt://localhost:7687",
+          username: "neo4j",
+          password: "test",
+        },
+      },
+      embedder: { provider: "openai", config: {} },
+      llm: { config: { model: "gpt-4" } },
+    } as any;
+
+    new MemoryGraph(config);
+
+    expect(LLMFactory.create).toHaveBeenNthCalledWith(1, "openai", {
+      model: "gpt-4",
+    });
+  });
+});
+
 describe("_removeSpacesFromEntities (via _establishNodesRelationsFromData)", () => {
   it("normalises spaces and case in entity source/relationship/destination", async () => {
     mockGenerateResponse.mockResolvedValueOnce({


### PR DESCRIPTION
## Description

If the user provides a root-level `llm` config (e.g. Anthropic), the graph store ignores it and uses the hardcoded default OpenAI config instead. The user-provided LLM config only works for the graph store if it is redundantly specified under `graphStore.llm`.

**Root cause (two problems in `graph_memory.ts`):**

1. **Default config override** — `defaults.ts` hardcoded `graphStore.llm` to `openai/gpt-4-turbo-preview`. Since `ConfigManager.mergeConfig` shallow-spreads defaults first, this always overrode the user's root `llm.provider`.

2. **Provider/config mismatch** — The constructor resolved the LLM *provider* with correct precedence (`graphStore.llm` → root `llm` → `"openai"`), but always passed `this.config.llm.config` (root config) to `LLMFactory.create`, ignoring `graphStore.llm.config` entirely.

**Fix:**
- Remove the hardcoded default `graphStore.llm` from `defaults.ts` so the root `llm` naturally becomes the fallback.
- Make the config resolution in `graph_memory.ts` follow the same precedence as the provider resolution: use `graphStore.llm.config` when present, fall back to root `llm.config`.

Fixes https://github.com/mem0ai/mem0/issues/3425

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added 7 new tests across two test files:

**`graph-memory-parsing.test.ts`** — 4 unit tests for `MemoryGraph` constructor (mocked LLMFactory):
- [x] Root `llm` config propagates when no `graphStore.llm` is set
- [x] `graphStore.llm` overrides root `llm` (both provider and config)
- [x] Defensive fallback to root config when `graphStore.llm.config` is undefined
- [x] Defaults to `"openai"` when no provider is set anywhere

**`config-manager.test.ts`** — 3 end-to-end tests through `ConfigManager.mergeConfig`:
- [x] No default `graphStore.llm` exists after merge (root `llm` is the fallback)
- [x] Explicit `graphStore.llm` is preserved when user provides it
- [x] No `graphStore.llm` when user doesn't provide one

**Full test suite results (511 tests across 33 suites — all pass):**
- [x] `graph-memory-parsing.test.ts` — 31 passed
- [x] `config-manager.test.ts` — 26 passed
- [x] `graph-prompts.test.ts` — 21 passed
- [x] `memory.init.test.ts` — 5 passed
- [x] `memory.add.test.ts` — 10 passed
- [x] `memory.crud.test.ts` — 22 passed
- [x] 15 other unit test files — 301 passed
- [x] 7 client test files — 95 passed
- [x] Build (with prettier check) passes

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [x] closes #3425
- [x] Made sure Checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)