### PR TITLE
fix(memory): prevent double embedding API call in Memory.add for simple text messages

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -407,7 +407,7 @@ class Memory(MemoryBase):
 
                 msg_content = message_dict["content"]
                 msg_embeddings = self.embedding_model.embed(msg_content, "add")
-                mem_id = self._create_memory(msg_content, msg_embeddings, per_msg_meta)
+                mem_id = self._create_memory(msg_content, {msg_content: msg_embeddings}, per_msg_meta)
 
                 returned_memories.append(
                     {


### PR DESCRIPTION
## Problem

Fixes #3723

When `Memory.add()` is called with a simple text message (non-conversation `is_simple_text_message` path), the embedding API is called **twice** for the same content, doubling API costs and latency.

### Root Cause

`_create_memory(data, existing_embeddings)` expects `existing_embeddings` to be a **dict** mapping `text → embedding vector`, so it can look up pre-computed embeddings:

```python
def _create_memory(self, data, existing_embeddings, metadata=None):
    if data in existing_embeddings:        # dict lookup
        embeddings = existing_embeddings[data]
    else:
        embeddings = self.embedding_model.embed(data, memory_action="add")  # 2nd call!
```

In the simple text path, the **raw embedding list** was passed instead of a `{text: embedding}` dict:

```python
msg_embeddings = self.embedding_model.embed(msg_content, "add")   # 1st call
mem_id = self._create_memory(msg_content, msg_embeddings, ...)    # ← raw list!
```

Inside `_create_memory`, `msg_content in msg_embeddings` is always `False` (a string can never be found in a list of floats), so `embed()` fires a **second time**.

## Solution

Wrap the pre-computed embedding in the expected `{text: embedding}` dict format:

```python
mem_id = self._create_memory(msg_content, {msg_content: msg_embeddings}, per_msg_meta)
```

The dict lookup now succeeds and the redundant API call is avoided.

## Testing

- Verified with FAISS vector store: `Memory.add("foo", user_id="default")` now triggers exactly one embedding API call
- The structured memory path (via `new_message_embeddings`) was already correct