### PR TITLE
docs: update deprecated Google embedding model example

### DIFF
--- a/docs/components/embedders/models/google_AI.mdx
+++ b/docs/components/embedders/models/google_AI.mdx
@@ -5,6 +5,8 @@ description: "Configure Google AI as an embedding provider in Mem0 using Gemini 
 
 To use Google AI embedding models, set the `GOOGLE_API_KEY` environment variables. You can obtain the Gemini API key from [here](https://aistudio.google.com/app/apikey).
 
+> **Note:** Google deprecated `models/text-embedding-004` in January 2026. The examples below use `gemini-embedding-001`, which is the current recommended model.
+
 ### Usage
 
 <CodeGroup>
@@ -19,7 +21,7 @@ config = {
     "embedder": {
         "provider": "gemini",
         "config": {
-            "model": "models/text-embedding-004",
+            "model": "gemini-embedding-001",
         }
     }
 }
@@ -66,7 +68,7 @@ Here are the parameters available for configuring Gemini embedder:
 <Tab title="Python">
 | Parameter        | Description                          | Default Value           |
 | ---------------- | ------------------------------------ | ----------------------- |
-| `model`          | The name of the embedding model to use| `models/text-embedding-004` |
+| `model`          | The name of the embedding model to use| `gemini-embedding-001` |
 | `embedding_dims` | Dimensions of the embedding model     | `1536`                  |
 | `api_key`        | The Google API key                   | `None`                  |
 </Tab>


### PR DESCRIPTION
## Summary
- update the Google AI embedder docs to recommend `gemini-embedding-001`
- note the deprecation of `models/text-embedding-004`

Closes #3942
