### PR TITLE
Fixes #4490: Preserve original `actor_id` during memory UPDATE operat…

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1248,8 +1248,14 @@ class Memory(MemoryBase):
             new_metadata["agent_id"] = existing_memory.payload["agent_id"]
         if "run_id" not in new_metadata and "run_id" in existing_memory.payload:
             new_metadata["run_id"] = existing_memory.payload["run_id"]
-        if "actor_id" not in new_metadata and "actor_id" in existing_memory.payload:
+
+        # ===== Fixes #4490 START =====
+        # Original code: if "actor_id" not in new_metadata and "actor_id" in existing_memory.payload:
+        # Fixed: unconditionally preserve original actor_id (if exists)
+        if "actor_id" in existing_memory.payload:
             new_metadata["actor_id"] = existing_memory.payload["actor_id"]
+        # ===== Fixes #4490 END =====
+
         if "role" not in new_metadata and "role" in existing_memory.payload:
             new_metadata["role"] = existing_memory.payload["role"]
 
@@ -2344,8 +2350,13 @@ class AsyncMemory(MemoryBase):
         if "run_id" not in new_metadata and "run_id" in existing_memory.payload:
             new_metadata["run_id"] = existing_memory.payload["run_id"]
 
-        if "actor_id" not in new_metadata and "actor_id" in existing_memory.payload:
+        # ===== Fixes #4490 START =====
+        # Original code: if "actor_id" not in new_metadata and "actor_id" in existing_memory.payload:
+        # Fixed: unconditionally preserve original actor_id (if exists)
+        if "actor_id" in existing_memory.payload:
             new_metadata["actor_id"] = existing_memory.payload["actor_id"]
+        # ===== Fixes #4490 END =====
+
         if "role" not in new_metadata and "role" in existing_memory.payload:
             new_metadata["role"] = existing_memory.payload["role"]
 


### PR DESCRIPTION
# Fix: Preserve original `actor_id` during memory UPDATE operations

Fixes #4490

## Description

This PR fixes a bug where `actor_id` metadata gets overwritten during UPDATE operations, breaking actor-level memory isolation in multi-actor scenarios.

**Changes**:
- Modified `_update_memory()` in `mem0/memory/main.py` (both sync and async versions)
- Changed conditional preservation to unconditional preservation of original `actor_id`

I've tested this fix locally using a monkey patch approach and it resolves the issue. However, I would greatly appreciate maintainer review to ensure it aligns with the project's design goals.

---

## Problem Statement

**Quick summary**: When using `metadata={"actor_id": ...}` with shared `user_id` in multi-actor scenarios, the `actor_id` field gets overwritten when a different actor triggers an UPDATE event:

```python
# Actor A creates memory
m.add([{"role": "user", "content": "I am player #1"}], 
      user_id="team", metadata={"actor_id": "Alice"})
# ✓ Memory created with actor_id="Alice"

# Actor B updates A's memory  
m.add([{"role": "user", "content": "Player #1 is a good person"}],
      user_id="team", metadata={"actor_id": "Bob"})
# ❌ Memory updated but actor_id becomes "Bob"

# Query fails
m.search(query="", filters={"actor_id": "Alice"})  # Returns empty!
```

**Impact**:
1. Cannot query by original creator after UPDATE
2. Memory ownership tracking lost
3. Actor isolation fails in shared `user_id` scenarios

For full details, see issue #4490.

---

## Changes Made

### Code Changes

**File**: `mem0/memory/main.py`

**Functions Modified**: 
- `_update_memory()` (sync version)
- `async _update_memory()` (async version)

**Before**:
```python
if "actor_id" not in new_metadata and "actor_id" in existing_memory.payload:
    new_metadata["actor_id"] = existing_memory.payload["actor_id"]
```

**After**:
```python
if "actor_id" in existing_memory.payload:
    new_metadata["actor_id"] = existing_memory.payload["actor_id"]
```

**Rationale**: The condition `"actor_id" not in new_metadata` always evaluates to `False` because `new_metadata` contains the current actor's ID (passed via metadata). Removing this condition makes `actor_id` preservation work as intended.

This change treats `actor_id` as **"memory owner"** (immutable) rather than **"last updater"**. The history table already tracks all contributors via `db.add_history()`, so update history is preserved.

### Design Consistency

This fix aligns with how other session identifiers are preserved:

```python
# Existing code already preserves these (when not in new_metadata):
if "user_id" not in new_metadata and "user_id" in existing_memory.payload:
    new_metadata["user_id"] = existing_memory.payload["user_id"]
if "agent_id" not in new_metadata and "agent_id" in existing_memory.payload:
    new_metadata["agent_id"] = existing_memory.payload["agent_id"]
if "run_id" not in new_metadata and "run_id" in existing_memory.payload:
    new_metadata["run_id"] = existing_memory.payload["run_id"]
```

The fix makes `actor_id` follow the same preservation pattern, but removes the always-false condition.

---

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

---

## How Has This Been Tested?

- [x] Test Script (provided below)

### Test Methodology

I validated this fix using a **monkey patch approach** that applies the proposed change to the existing codebase without modifying source files. This allowed me to test the behavior before submitting the PR.

### Before Fix (Bug Demonstration)

**Test scenario**: Alice creates a memory, Bob updates it with different `actor_id`

**Result**:
```
=== State AFTER Bob's UPDATE ===
  Event: UPDATE
  This actor_id: 'Bob'  ← Overwritten!

ISOLATION TEST:
  Query Alice's memories: 0 found
  ❌ BUG: Alice's memory lost!
```

### After Fix (Monkey Patch Validation)

**Applied patch**:
```python
from mem0.memory.main import Memory as MemoryClass

def _patched_update_memory(self, memory_id, data, existing_embeddings, metadata=None):
    # ... (identical to original except actor_id handling)
    
    # ===== FIX =====
    if "actor_id" in existing_memory.payload:
        new_metadata["actor_id"] = existing_memory.payload["actor_id"]
    # ===============
    
    # ... (rest unchanged)

MemoryClass._update_memory = _patched_update_memory
```

**Result**:
```
=== State AFTER Bob's UPDATE ===
  Event: UPDATE
  This actor_id: 'Alice'  ← Preserved!

ISOLATION TEST:
  Query Alice's memories: 1 found
  ✅ SUCCESS: Alice's memory preserved!
```

### Key Verification Points

✅ UPDATE event correctly triggered (not ADD)  
✅ Memory content correctly updated  
✅ `actor_id` preserved as original creator  
✅ Query filtering by `actor_id` works correctly  
✅ No side effects on other metadata fields

**Test Environment**:
- Mem0 version: v1.0.7
- Python: 3.13
- Vector Store: Qdrant (local)
- OS: macOS

---

## Backward Compatibility

To the best of my understanding, this change should **not** introduce breaking changes:
- Existing code continues to work without modification
- API signature remains unchanged
- Only affects behavior in multi-actor UPDATE scenarios
- History table continues to track all contributors

However, I may be missing some edge cases, so maintainer review would be greatly appreciated!

### Behavior Change Details

**Before this fix:**
When calling `add()` with a different `actor_id` that triggers an UPDATE event, the `actor_id` would be overwritten to the new actor.

**After this fix:**
The original `actor_id` (memory creator) is preserved during UPDATE operations.

**Scenarios NOT affected:**
- ✅ Calling `update()` method directly (already preserves `actor_id` correctly)
- ✅ Updating memories without `actor_id` field (behavior unchanged)
- ✅ Adding new memories (no UPDATE event triggered)

**If you were relying on UPDATE to change `actor_id`:**
You should use this pattern instead:
```python
# Delete the old memory
m.delete(memory_id)

# Add a new memory with new actor
m.add(..., metadata={"actor_id": "new_actor"})
```

This change aligns with the semantic meaning of `actor_id` as the **memory creator** (immutable), not the **last updater** (tracked in history table).

---

## Alternative Approaches Considered

I also thought about these alternatives, but decided against them (open to feedback though!):

1. **Track both `created_by` and `updated_by`**
   - Would require more complex schema changes
   - Less backward-compatible
   - Might not be necessary since history table already tracks updates

2. **Make preservation configurable**
   - Would add API complexity
   - I couldn't think of a clear use case for wanting `actor_id` to change
   - Seems to go against the semantic meaning of "actor"

If either of these approaches seems better, I'm happy to revise the PR!

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (in PR description)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works *(awaiting maintainer guidance on test location/structure)*
- [ ] New and existing unit tests pass locally with my changes *(no existing tests for this specific behavior)*
- [x] Any dependent changes have been merged and published in downstream modules (N/A)
- [x] I have checked my code and corrected any misspellings

---

## Final Notes

Thank you so much for taking the time to review this PR! I really appreciate the excellent work you've done on this library. 🙏

I'm still relatively new to this codebase, so I apologize if I've missed anything important or if there's a better approach I should have taken. I'm very open to feedback and happy to:
- Make any adjustments to the code
- Add more comprehensive tests (please guide me on where they should go)
- Revise the approach entirely if there's a better solution
- Answer any questions about my testing methodology

Please feel free to reject or request changes if this doesn't fit with the project's direction. I mainly wanted to contribute back to a library that's been so helpful for my work!

Thanks again! 🙇

---

## Maintainer Checklist

- [ ] closes #4490
- [ ] Made sure Checks passed
