### PR TITLE
fix: preserve original actor_id during UPDATE operations

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1248,10 +1248,12 @@ class Memory(MemoryBase):
             new_metadata["agent_id"] = existing_memory.payload["agent_id"]
         if "run_id" not in new_metadata and "run_id" in existing_memory.payload:
             new_metadata["run_id"] = existing_memory.payload["run_id"]
-        if "actor_id" not in new_metadata and "actor_id" in existing_memory.payload:
-            new_metadata["actor_id"] = existing_memory.payload["actor_id"]
         if "role" not in new_metadata and "role" in existing_memory.payload:
             new_metadata["role"] = existing_memory.payload["role"]
+
+        # Always preserve actor_id as memory owner (not last updater)
+        if "actor_id" in existing_memory.payload:
+            new_metadata["actor_id"] = existing_memory.payload["actor_id"]
 
         if data in existing_embeddings:
             embeddings = existing_embeddings[data]
@@ -2343,11 +2345,12 @@ class AsyncMemory(MemoryBase):
             new_metadata["agent_id"] = existing_memory.payload["agent_id"]
         if "run_id" not in new_metadata and "run_id" in existing_memory.payload:
             new_metadata["run_id"] = existing_memory.payload["run_id"]
-
-        if "actor_id" not in new_metadata and "actor_id" in existing_memory.payload:
-            new_metadata["actor_id"] = existing_memory.payload["actor_id"]
         if "role" not in new_metadata and "role" in existing_memory.payload:
             new_metadata["role"] = existing_memory.payload["role"]
+
+        # Always preserve actor_id as memory owner (not last updater)
+        if "actor_id" in existing_memory.payload:
+            new_metadata["actor_id"] = existing_memory.payload["actor_id"]
 
         if data in existing_embeddings:
             embeddings = existing_embeddings[data]

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -438,3 +438,94 @@ async def test_async_update_nonexistent_memory_raises_error(mock_sqlite, mock_ll
         await memory._update_memory("non-existent-id", "new data", {"new data": [0.1, 0.2]})
 
     mock_vector_store.update.assert_not_called()
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.main.SQLiteManager')
+def test_update_memory_preserves_actor_id(mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
+    """
+    Test that updating a memory preserves the original actor_id.
+    
+    Ensures multi-actor scenarios maintain memory ownership tracking
+    even when different actors trigger UPDATE operations.
+    """
+    mock_embedder = MagicMock()
+    mock_embedder.embed.return_value = [0.1, 0.2, 0.3]
+    mock_embedder_factory.return_value = mock_embedder
+    
+    mock_vector_store = MagicMock()
+    mock_vector_factory.return_value = mock_vector_store
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+    config = MemoryConfig()
+    memory = MemoryClass(config)
+
+    existing_memory = MagicMock()
+    existing_memory.payload = {
+        "data": "I am player #1",
+        "created_at": "2024-01-01T00:00:00+00:00",
+        "actor_id": "Alice",
+        "user_id": "team",
+    }
+    mock_vector_store.get.return_value = existing_memory
+
+    memory._update_memory(
+        memory_id="mem-123",
+        data="Player #1 is a good person",
+        existing_embeddings={},
+        metadata={"actor_id": "Bob", "user_id": "team"}
+    )
+
+    call_kwargs = mock_vector_store.update.call_args.kwargs
+    assert call_kwargs["metadata"]["actor_id"] == "Alice"
+    assert call_kwargs["metadata"]["data"] == "Player #1 is a good person"
+
+
+@pytest.mark.asyncio
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.main.SQLiteManager')
+async def test_async_update_memory_preserves_actor_id(mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
+    """
+    Test that async updating a memory preserves the original actor_id.
+    
+    Ensures async UPDATE operations maintain memory ownership tracking
+    in multi-actor shared workspace scenarios.
+    """
+    mock_embedder = MagicMock()
+    mock_embedder.embed.return_value = [0.1, 0.2, 0.3]
+    mock_embedder_factory.return_value = mock_embedder
+    
+    mock_vector_store = MagicMock()
+    mock_vector_factory.return_value = mock_vector_store
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import AsyncMemory
+    config = MemoryConfig()
+    memory = AsyncMemory(config)
+
+    existing_memory = MagicMock()
+    existing_memory.payload = {
+        "data": "I am player #1",
+        "created_at": "2024-01-01T00:00:00+00:00",
+        "actor_id": "Alice",
+        "user_id": "team",
+    }
+    mock_vector_store.get.return_value = existing_memory
+
+    await memory._update_memory(
+        memory_id="mem-123",
+        data="Player #1 is a good person",
+        existing_embeddings={},
+        metadata={"actor_id": "Bob", "user_id": "team"}
+    )
+
+    call_kwargs = mock_vector_store.update.call_args.kwargs
+    assert call_kwargs["metadata"]["actor_id"] == "Alice"
+    assert call_kwargs["metadata"]["data"] == "Player #1 is a good person"


### PR DESCRIPTION
- Treat actor_id as memory owner (immutable) not last updater
- Remove ineffective condition check in both sync and async versions
- Add comprehensive test coverage for multi-actor scenarios
- Maintain consistency with other session identifiers

Fixes #4490

## Description

This PR fixes issue #4490 where `actor_id` metadata gets overwritten during memory UPDATE operations in multi-actor scenarios.

**Problem**: When using shared `user_id` with `metadata={"actor_id": ...}` to distinguish different actors, if a different actor triggers an UPDATE event, the original `actor_id` is overwritten.

**Root Cause**: In `_update_memory()` method, the condition check:
```python
if "actor_id" not in new_metadata and "actor_id" in existing_memory.payload:
    new_metadata["actor_id"] = existing_memory.payload["actor_id"]
```
is ineffective because `new_metadata` always contains the current actor's ID.

**Solution**: 
- Treat `actor_id` as memory owner (immutable) instead of last updater
- Remove ineffective condition check in `_update_memory()` method (both sync and async)
- Force preservation of original `actor_id` from existing memory payload:
```python
if "actor_id" in existing_memory.payload:
    new_metadata["actor_id"] = existing_memory.payload["actor_id"]
```

**Impact**:
- ✅ Fixes memory ownership tracking
- ✅ Restores ability to query by original creator
- ✅ Maintains role-level memory isolation in shared user_id scenarios
- ✅ Consistent with other session identifiers (user_id, agent_id)

Fixes #4490

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Tested using monkey patch method with the following scenario:

- **Environment**: Mem0 v1.0.7, Python 3.13, Qdrant (local)
- **Test Scenario**: 
  1. Alice creates a memory with `actor_id="Alice"`
  2. Bob updates Alice's memory (triggers UPDATE event)
  
**Results**:
- **Before fix**: `actor_id` becomes "Bob", Alice's memory cannot be queried by `metadata={"actor_id": "Alice"}`
- **After fix**: `actor_id` remains "Alice", query works correctly ✓

**Test Code**:
```python
# Alice creates memory
m.add("I love pizza", user_id="shared_user", metadata={"actor_id": "Alice"})

# Bob updates it
m.add("I love pasta", user_id="shared_user", metadata={"actor_id": "Bob"})

# Query Alice's memories
results = m.search("food", user_id="shared_user", filters={"actor_id": "Alice"})
# Before: [] (empty, actor_id was overwritten)
# After: [pizza memory] (correct, actor_id preserved)
```

- [x] Unit Test (comprehensive test coverage added for multi-actor scenarios)
- [x] Test Script (manual verification with monkey patch)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #4490
- [ ] Made sure Checks passed
