### PR TITLE
fix(ts-oss): register pgvector in VectorStoreFactory (#3367)

### DIFF
--- a/docs/components/vectordbs/dbs/pgvector.mdx
+++ b/docs/components/vectordbs/dbs/pgvector.mdx
@@ -48,7 +48,7 @@ const config = {
       password: '123',
       host: '127.0.0.1',
       port: 5432,
-      dbname: 'vector_store', // Optional, defaults to 'postgres'
+      dbname: 'vector_store', // Optional; TypeScript OSS defaults to `vector_store` when omitted
       diskann: false, // Optional, requires pgvectorscale extension
       hnsw: false, // Optional, for HNSW indexing
     },
@@ -84,6 +84,8 @@ Here are the parameters available for configuring pgvector:
 | `sslmode` | SSL mode for PostgreSQL connection (e.g., 'require', 'prefer', 'disable') | `None` |
 | `connection_string` | PostgreSQL connection string (overrides individual connection parameters) | `None` |
 | `connection_pool` | psycopg2 connection pool object (overrides connection string and individual parameters) | `None` |
+
+**Note (TypeScript OSS):** If you omit `dbname`, the TypeScript client uses the database name `vector_store`. Python defaults to `postgres` for `dbname`, as in the table above.
 
 **Note**: The connection parameters have the following priority:
 1. `connection_pool` (highest priority)

--- a/mem0-ts/src/oss/src/index.ts
+++ b/mem0-ts/src/oss/src/index.ts
@@ -26,4 +26,5 @@ export * from "./vector_stores/supabase";
 export * from "./vector_stores/langchain";
 export * from "./vector_stores/vectorize";
 export * from "./vector_stores/azure_ai_search";
+export * from "./vector_stores/pgvector";
 export * from "./utils/factory";

--- a/mem0-ts/src/oss/src/utils/factory.ts
+++ b/mem0-ts/src/oss/src/utils/factory.ts
@@ -34,6 +34,7 @@ import { LangchainLLM } from "../llms/langchain";
 import { LangchainEmbedder } from "../embeddings/langchain";
 import { LangchainVectorStore } from "../vector_stores/langchain";
 import { AzureAISearch } from "../vector_stores/azure_ai_search";
+import { PGVector } from "../vector_stores/pgvector";
 
 export class EmbedderFactory {
   static create(provider: string, config: EmbeddingConfig): Embedder {
@@ -104,6 +105,8 @@ export class VectorStoreFactory {
         return new VectorizeDB(config as any);
       case "azure-ai-search":
         return new AzureAISearch(config as any);
+      case "pgvector":
+        return new PGVector(config as any);
       default:
         throw new Error(`Unsupported vector store provider: ${provider}`);
     }

--- a/mem0-ts/src/oss/src/vector_stores/pgvector.ts
+++ b/mem0-ts/src/oss/src/vector_stores/pgvector.ts
@@ -1,4 +1,4 @@
-import { Client, Pool } from "pg";
+import { Client } from "pg";
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
 
@@ -35,6 +35,7 @@ export class PGVector implements VectorStore {
       host: config.host,
       port: config.port,
     });
+    this.initialize().catch(console.error);
   }
 
   async initialize(): Promise<void> {

--- a/mem0-ts/src/oss/tests/factory.unit.test.ts
+++ b/mem0-ts/src/oss/tests/factory.unit.test.ts
@@ -118,6 +118,11 @@ jest.mock("../src/vector_stores/azure_ai_search", () => ({
     .fn()
     .mockImplementation((config) => ({ type: "azure-ai-search", config })),
 }));
+jest.mock("../src/vector_stores/pgvector", () => ({
+  PGVector: jest
+    .fn()
+    .mockImplementation((config) => ({ type: "pgvector", config })),
+}));
 jest.mock("../src/storage/SupabaseHistoryManager", () => ({
   SupabaseHistoryManager: jest
     .fn()
@@ -236,6 +241,7 @@ describe("VectorStoreFactory", () => {
     ["langchain"],
     ["vectorize"],
     ["azure-ai-search"],
+    ["pgvector"],
   ])("creates vector store for provider '%s'", (provider) => {
     expect(() =>
       VectorStoreFactory.create(provider, dummyVSConfig),


### PR DESCRIPTION
## Linked Issue
Closes #3367

## Description
Wires **`pgvector`** into TypeScript OSS **`VectorStoreFactory`** (it was implemented but not registered). Also exports **`PGVector`** from `mem0ai/oss`, triggers **`initialize()`** from the constructor like other stores, and updates **factory unit tests** with a pgvector mock.

**Docs:** `pgvector.mdx` - TS snippet comment + note that **omitting `dbname`** defaults to **`vector_store`** in TS OSS vs **`postgres`** in Python. So the same has been mentioned

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Breaking Changes
N/A
## Test Coverage

- [x] I added/updated unit tests

- `cd mem0-ts/src/oss && npx tsc --noEmit`
- `cd mem0-ts && npx jest src/oss/tests/factory.unit.test.ts` → **37 passed** (includes `pgvector` in `VectorStoreFactory`).

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed