### PR TITLE
feat(server): add /health endpoint for container orchestration

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -219,6 +219,17 @@ def reset_memory():
         raise HTTPException(status_code=500, detail=str(e))
 
 
+@app.get("/health", summary="Health check", tags=["System"])
+def health_check():
+    """Health check endpoint for container orchestration (Docker, Kubernetes).
+
+    Returns 200 if the server is running and the memory instance is initialized.
+    """
+    if MEMORY_INSTANCE is None:
+        raise HTTPException(status_code=503, detail="Memory instance not initialized")
+    return {"status": "ok"}
+
+
 @app.get("/", summary="Redirect to the OpenAPI documentation", include_in_schema=False)
 def home():
     """Redirect to the OpenAPI documentation."""


### PR DESCRIPTION
Adds a `/health` endpoint for Docker healthcheck and Kubernetes liveness/readiness probes. Returns 200 when Memory is initialized, 503 otherwise.

Usage in docker-compose:
```yaml
healthcheck:
  test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
  interval: 30s
  timeout: 10s
  retries: 3
```