### PR TITLE
feat(opensearch): make KNN engine configurable via knn_engine parameter

### DIFF
--- a/mem0/configs/vector_stores/opensearch.py
+++ b/mem0/configs/vector_stores/opensearch.py
@@ -11,6 +11,7 @@ class OpenSearchConfig(BaseModel):
     password: Optional[str] = Field(None, description="Password for authentication")
     api_key: Optional[str] = Field(None, description="API key for authentication (if applicable)")
     embedding_model_dims: int = Field(1536, description="Dimension of the embedding vector")
+    knn_engine: str = Field("nmslib", description="KNN engine to use (nmslib, faiss, lucene). OpenSearch Serverless requires 'faiss' or 'lucene'.")
     verify_certs: bool = Field(False, description="Verify SSL certificates (default False for OpenSearch)")
     use_ssl: bool = Field(False, description="Use SSL for connection (default False for OpenSearch)")
     http_auth: Optional[object] = Field(None, description="HTTP authentication method / AWS SigV4")

--- a/mem0/vector_stores/opensearch.py
+++ b/mem0/vector_stores/opensearch.py
@@ -39,6 +39,7 @@ class OpenSearchDB(VectorStoreBase):
 
         self.collection_name = config.collection_name
         self.embedding_model_dims = config.embedding_model_dims
+        self.knn_engine = config.knn_engine
         self.create_col(self.collection_name, self.embedding_model_dims)
 
     def create_index(self) -> None:
@@ -53,7 +54,7 @@ class OpenSearchDB(VectorStoreBase):
                     "vector_field": {
                         "type": "knn_vector",
                         "dimension": self.embedding_model_dims,
-                        "method": {"engine": "nmslib", "name": "hnsw", "space_type": "cosinesimil"},
+                        "method": {"engine": self.knn_engine, "name": "hnsw", "space_type": "cosinesimil"},
                     },
                     "metadata": {"type": "object", "properties": {"user_id": {"type": "keyword"}}},
                 }
@@ -75,7 +76,7 @@ class OpenSearchDB(VectorStoreBase):
                     "vector_field": {
                         "type": "knn_vector",
                         "dimension": vector_size,
-                        "method": {"engine": "nmslib", "name": "hnsw", "space_type": "cosinesimil"},
+                        "method": {"engine": self.knn_engine, "name": "hnsw", "space_type": "cosinesimil"},
                     },
                     "payload": {"type": "object"},
                     "id": {"type": "keyword"},


### PR DESCRIPTION
Relates to #3739.

The KNN engine is hardcoded to `nmslib`, which is not available on OpenSearch Serverless. Adds a `knn_engine` config parameter (default: `nmslib`) so users can switch to `faiss` or `lucene` for Serverless compatibility.

```python
config = {"vector_store": {"provider": "opensearch", "config": {"knn_engine": "faiss"}}}
```