### PR TITLE
perf(storage): enable SQLite WAL mode for better concurrency

### DIFF
--- a/mem0/memory/storage.py
+++ b/mem0/memory/storage.py
@@ -11,6 +11,10 @@ class SQLiteManager:
     def __init__(self, db_path: str = ":memory:"):
         self.db_path = db_path
         self.connection = sqlite3.connect(self.db_path, check_same_thread=False)
+        # Enable WAL mode for better concurrent read/write performance.
+        # WAL allows readers and writers to operate simultaneously without blocking.
+        if db_path != ":memory:":
+            self.connection.execute("PRAGMA journal_mode=WAL")
         self._lock = threading.Lock()
         self._migrate_history_table()
         self._create_history_table()


### PR DESCRIPTION
SQLite default journal mode blocks concurrent reads during writes. WAL allows readers and writers to operate simultaneously, improving performance in multi-threaded environments.

Only enabled for file-based databases (not `:memory:`).