### PR TITLE
fix(proxy): remove auto pip install of litellm at import time

### DIFF
--- a/mem0/proxy/main.py
+++ b/mem0/proxy/main.py
@@ -1,6 +1,4 @@
 import logging
-import subprocess
-import sys
 import threading
 from typing import List, Optional, Union
 
@@ -11,12 +9,10 @@ import mem0
 try:
     import litellm
 except ImportError:
-    try:
-        subprocess.check_call([sys.executable, "-m", "pip", "install", "litellm"])
-        import litellm
-    except subprocess.CalledProcessError:
-        print("Failed to install 'litellm'. Please install it manually using 'pip install litellm'.")
-        sys.exit(1)
+    raise ImportError(
+        "The 'litellm' library is required for Mem0 proxy. "
+        "Please install it using: pip install litellm"
+    )
 
 from mem0 import Memory, MemoryClient
 from mem0.configs.prompts import MEMORY_ANSWER_PROMPT


### PR DESCRIPTION
The proxy module runs `subprocess.check_call` to `pip install litellm` when the import fails. This is:
- **Security risk**: arbitrary code execution during import
- **Breaks in containers**: read-only filesystems, CI pipelines
- **Surprising behavior**: libraries should not auto-install dependencies

Replaced with a clear `ImportError` message. Also removes unused `subprocess` and `sys` imports.