### PR TITLE
fix: normalize delete_all vector store list results across providers

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -790,21 +790,24 @@ class Memory(MemoryBase):
 
         return {"results": all_memories_result}
 
-    def _get_all_from_vector_store(self, filters, limit):
-        memories_result = self.vector_store.list(filters=filters, limit=limit)
+    def _unwrap_list_results(self, memories_result):
+        """Normalize vector_store.list() outputs across providers.
 
-        # Handle different vector store return formats by inspecting first element
+        Providers may return:
+        - [mem1, mem2]
+        - [[mem1, mem2]]
+        - ([mem1, mem2], count)
+        """
         if isinstance(memories_result, (tuple, list)) and len(memories_result) > 0:
             first_element = memories_result[0]
-
-            # If first element is a container, unwrap one level
             if isinstance(first_element, (list, tuple)):
-                actual_memories = first_element
-            else:
-                # First element is a memory object, structure is already flat
-                actual_memories = memories_result
-        else:
-            actual_memories = memories_result
+                return first_element
+            return memories_result
+        return memories_result
+
+    def _get_all_from_vector_store(self, filters, limit):
+        memories_result = self.vector_store.list(filters=filters, limit=limit)
+        actual_memories = self._unwrap_list_results(memories_result)
 
         promoted_payload_keys = [
             "user_id",
@@ -1149,7 +1152,7 @@ class Memory(MemoryBase):
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "sync"})
         # delete matching vector memories individually (do NOT reset the collection)
-        memories = self.vector_store.list(filters=filters)[0]
+        memories = self._unwrap_list_results(self.vector_store.list(filters=filters))
         for memory in memories:
             self._delete_memory(memory.id)
 
@@ -1874,21 +1877,24 @@ class AsyncMemory(MemoryBase):
 
         return results_dict
 
-    async def _get_all_from_vector_store(self, filters, limit):
-        memories_result = await asyncio.to_thread(self.vector_store.list, filters=filters, limit=limit)
+    def _unwrap_list_results(self, memories_result):
+        """Normalize vector_store.list() outputs across providers.
 
-        # Handle different vector store return formats by inspecting first element
+        Providers may return:
+        - [mem1, mem2]
+        - [[mem1, mem2]]
+        - ([mem1, mem2], count)
+        """
         if isinstance(memories_result, (tuple, list)) and len(memories_result) > 0:
             first_element = memories_result[0]
-
-            # If first element is a container, unwrap one level
             if isinstance(first_element, (list, tuple)):
-                actual_memories = first_element
-            else:
-                # First element is a memory object, structure is already flat
-                actual_memories = memories_result
-        else:
-            actual_memories = memories_result
+                return first_element
+            return memories_result
+        return memories_result
+
+    async def _get_all_from_vector_store(self, filters, limit):
+        memories_result = await asyncio.to_thread(self.vector_store.list, filters=filters, limit=limit)
+        actual_memories = self._unwrap_list_results(memories_result)
 
         promoted_payload_keys = [
             "user_id",
@@ -2242,15 +2248,15 @@ class AsyncMemory(MemoryBase):
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "async"})
-        memories = await asyncio.to_thread(self.vector_store.list, filters=filters)
+        memories = self._unwrap_list_results(await asyncio.to_thread(self.vector_store.list, filters=filters))
 
         delete_tasks = []
-        for memory in memories[0]:
+        for memory in memories:
             delete_tasks.append(self._delete_memory(memory.id))
 
         await asyncio.gather(*delete_tasks)
 
-        logger.info(f"Deleted {len(memories[0])} memories")
+        logger.info(f"Deleted {len(memories)} memories")
 
         if self.enable_graph:
             await asyncio.to_thread(self.graph.delete_all, filters)

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -188,6 +188,21 @@ async def test_async_update_memory_uses_utc_timestamps(mocker):
     _assert_utc_timestamp(payload["updated_at"])
 
 
+@pytest.mark.asyncio
+async def test_async_delete_all_handles_flat_list_from_vector_store(mocker):
+    memory = _build_memory_instance(mocker, AsyncMemory)
+    memory.enable_graph = False
+    memory.vector_store.list.return_value = [MagicMock(id="1"), MagicMock(id="2")]
+    memory._delete_memory = mocker.AsyncMock()
+
+    result = await memory.delete_all(user_id="test_user")
+
+    assert result == {"message": "Memories deleted successfully!"}
+    assert memory._delete_memory.await_count == 2
+    memory._delete_memory.assert_any_await("1")
+    memory._delete_memory.assert_any_await("2")
+
+
 def test_normalize_iso_timestamp_to_utc_preserves_naive_values():
     assert _normalize_iso_timestamp_to_utc("2026-03-18T00:00:00") == "2026-03-18T00:00:00"
 

--- a/tests/test_delete_all_list_formats.py
+++ b/tests/test_delete_all_list_formats.py
@@ -1,0 +1,72 @@
+from unittest.mock import MagicMock, patch
+
+from mem0.configs.base import MemoryConfig
+from mem0.memory.main import Memory
+
+
+class MockVectorMemory:
+    def __init__(self, memory_id: str):
+        self.id = memory_id
+        self.payload = {"data": f"memory-{memory_id}"}
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.memory.main.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+def test_delete_all_handles_flat_list_from_vector_store(
+    mock_sqlite,
+    mock_llm_factory,
+    mock_vector_factory,
+    mock_embedder_factory,
+):
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_store = MagicMock()
+    mock_vector_factory.return_value = mock_vector_store
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    config = MemoryConfig()
+    memory = Memory(config)
+    memory.enable_graph = False
+    memory._delete_memory = MagicMock()
+
+    mock_vector_store.list.return_value = [MockVectorMemory("1"), MockVectorMemory("2")]
+
+    result = memory.delete_all(user_id="user-1")
+
+    assert result == {"message": "Memories deleted successfully!"}
+    assert memory._delete_memory.call_count == 2
+    memory._delete_memory.assert_any_call("1")
+    memory._delete_memory.assert_any_call("2")
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.memory.main.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+def test_delete_all_handles_tuple_from_vector_store(
+    mock_sqlite,
+    mock_llm_factory,
+    mock_vector_factory,
+    mock_embedder_factory,
+):
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_store = MagicMock()
+    mock_vector_factory.return_value = mock_vector_store
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    config = MemoryConfig()
+    memory = Memory(config)
+    memory.enable_graph = False
+    memory._delete_memory = MagicMock()
+
+    mock_vector_store.list.return_value = ([MockVectorMemory("1"), MockVectorMemory("2")], 2)
+
+    result = memory.delete_all(user_id="user-1")
+
+    assert result == {"message": "Memories deleted successfully!"}
+    assert memory._delete_memory.call_count == 2
+    memory._delete_memory.assert_any_call("1")
+    memory._delete_memory.assert_any_call("2")


### PR DESCRIPTION
### Summary
This PR fixes `delete_all()` / `AsyncMemory.delete_all()` so they correctly handle different `vector_store.list()` return formats across providers.

Before this change, `delete_all()` assumed the result always needed `[0]` indexing. That works for providers returning tuple/nested formats, but breaks for providers that already return a flat list of memory objects.

### Problem
`get_all()` already contains compatibility logic for multiple `list()` result shapes, but `delete_all()` was still using older assumptions:

- sync path:
  - `self.vector_store.list(filters=filters)[0]`
- async path:
  - iterating over `memories[0]`

This causes incorrect behavior for providers that return:

```python
[mem1, mem2]
```

instead of:

```python
[[mem1, mem2]]
# or
([mem1, mem2], count)
```

In those cases, `delete_all()` can treat the first memory object as the whole result container.

### Fix
Added a shared normalization helper in both `Memory` and `AsyncMemory` to support:

- flat list: `[mem1, mem2]`
- nested list: `[[mem1, mem2]]`
- tuple with count: `([mem1, mem2], count)`

Updated these code paths to use the normalized result:

- `Memory._get_all_from_vector_store()`
- `Memory.delete_all()`
- `AsyncMemory._get_all_from_vector_store()`
- `AsyncMemory.delete_all()`

### Tests
Added/updated targeted tests covering delete_all compatibility:

- flat list handling
- tuple result handling
- async delete_all flat list handling

### Validation
Ran targeted tests with the project venv:

```bash
.venv/bin/python -m pytest -q tests/test_delete_all_list_formats.py tests/memory/test_main.py -k 'delete_all_handles_flat_list_from_vector_store or delete_all_handles_tuple_from_vector_store or get_all_handles'
```

Result:

```bash
3 passed, 12 deselected
```

### Notes
There is an existing unrelated issue in the current test suite around a broken patch target in `tests/test_main.py`, so this PR keeps the scope focused on the `delete_all()` list-format compatibility bug and validates it with targeted tests.
