### PR TITLE
fix: handle chatty LLM responses in JSON parsing

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -27,7 +27,6 @@ from mem0.memory.telemetry import MEM0_TELEMETRY, capture_event
 from mem0.memory.utils import (
     ensure_json_instruction,
     extract_json,
-    extract_json_from_chatty_response,
     get_fact_retrieval_messages,
     normalize_facts,
     parse_messages,
@@ -516,15 +515,15 @@ class Memory(MemoryBase):
         )
 
         try:
-            response = remove_code_blocks(response)
-            if not response.strip():
+            cleaned_response = remove_code_blocks(response)
+            if not cleaned_response.strip():
                 new_retrieved_facts = []
             else:
                 try:
                     # First try direct JSON parsing
-                    new_retrieved_facts = json.loads(response, strict=False)["facts"]
+                    new_retrieved_facts = json.loads(cleaned_response, strict=False)["facts"]
                 except json.JSONDecodeError:
-                    # Try extracting JSON from response using built-in function
+                    # Try extracting JSON from response (handles chatty LLM output)
                     extracted_json = extract_json(response)
                     new_retrieved_facts = json.loads(extracted_json, strict=False)["facts"]
                 new_retrieved_facts = normalize_facts(new_retrieved_facts)
@@ -592,7 +591,7 @@ class Memory(MemoryBase):
                     try:
                         new_memories_with_actions = json.loads(remove_code_blocks(response), strict=False)
                     except json.JSONDecodeError:
-                        extracted_json = extract_json_from_chatty_response(response)
+                        extracted_json = extract_json(response)
                         new_memories_with_actions = json.loads(extracted_json, strict=False)
             except Exception as e:
                 logger.error(f"Invalid JSON response: {e}")
@@ -1580,15 +1579,15 @@ class AsyncMemory(MemoryBase):
             response_format={"type": "json_object"},
         )
         try:
-            response = remove_code_blocks(response)
-            if not response.strip():
+            cleaned_response = remove_code_blocks(response)
+            if not cleaned_response.strip():
                 new_retrieved_facts = []
             else:
                 try:
                     # First try direct JSON parsing
-                    new_retrieved_facts = json.loads(response, strict=False)["facts"]
+                    new_retrieved_facts = json.loads(cleaned_response, strict=False)["facts"]
                 except json.JSONDecodeError:
-                    # Try extracting JSON from response using built-in function
+                    # Try extracting JSON from response (handles chatty LLM output)
                     extracted_json = extract_json(response)
                     new_retrieved_facts = json.loads(extracted_json, strict=False)["facts"]
                 new_retrieved_facts = normalize_facts(new_retrieved_facts)
@@ -1659,7 +1658,7 @@ class AsyncMemory(MemoryBase):
                     try:
                         new_memories_with_actions = json.loads(remove_code_blocks(response), strict=False)
                     except json.JSONDecodeError:
-                        extracted_json = extract_json_from_chatty_response(response)
+                        extracted_json = extract_json(response)
                         new_memories_with_actions = json.loads(extracted_json, strict=False)
             except Exception as e:
                 logger.error(f"Invalid JSON response: {e}")

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -124,36 +124,21 @@ def remove_code_blocks(content: str) -> str:
 def extract_json(text):
     """
     Extracts JSON content from a string, removing enclosing triple backticks and optional 'json' tag if present.
-    If no code block is found, returns the text as-is.
+    If no code block is found, attempts to locate JSON by finding the first '{' and last '}'.
+    If that also fails, returns the text as-is.
     """
     text = text.strip()
     match = re.search(r"```(?:json)?\s*(.*?)\s*```", text, re.DOTALL)
     if match:
         json_str = match.group(1)
     else:
-        json_str = text  # assume it's raw JSON
+        start_idx = text.find("{")
+        end_idx = text.rfind("}")
+        if start_idx != -1 and end_idx != -1 and end_idx > start_idx:
+            json_str = text[start_idx : end_idx + 1]
+        else:
+            json_str = text
     return json_str
-
-
-def extract_json_from_chatty_response(text):
-    """
-    Extracts JSON content from an LLM response that may contain conversational
-    text around the actual JSON payload.
-
-    Tries three strategies in order:
-    1. Find JSON inside triple-backtick code blocks
-    2. Locate JSON by finding the first '{' and last '}'
-    3. Return the text as-is
-    """
-    text = text.strip()
-    match = re.search(r"```(?:json)?\s*(.*?)\s*```", text, re.DOTALL)
-    if match:
-        return match.group(1)
-    start_idx = text.find("{")
-    end_idx = text.rfind("}")
-    if start_idx != -1 and end_idx != -1 and end_idx > start_idx:
-        return text[start_idx : end_idx + 1]
-    return text
 
 
 def get_image_description(image_obj, llm, vision_details):

--- a/tests/test_chatty_llm_parsing.py
+++ b/tests/test_chatty_llm_parsing.py
@@ -1,21 +1,21 @@
 """Tests for chatty LLM JSON parsing robustness.
 
-Validates that extract_json_from_chatty_response and the full fallback chain
-correctly handle responses from local LLMs (LM Studio, Ollama) that wrap JSON
-in conversational text, markdown code blocks, or both.
+Validates that extract_json and the full fallback chain correctly handle
+responses from local LLMs (LM Studio, Ollama) that wrap JSON in
+conversational text, markdown code blocks, or both.
 """
 
 import json
 
 import pytest
 
-from mem0.memory.utils import extract_json, extract_json_from_chatty_response, remove_code_blocks
+from mem0.memory.utils import extract_json, remove_code_blocks
 
 
-# --- Test extract_json (unchanged, for regression) ---
+# --- Test extract_json ---
 
 class TestExtractJson:
-    """Regression tests for extract_json — must stay unchanged."""
+    """Tests for extract_json utility."""
 
     def test_pure_json(self):
         text = '{"memory": [{"id": "0", "text": "likes basketball", "event": "ADD"}]}'
@@ -46,52 +46,17 @@ I hope this helps!"""
         parsed = json.loads(result)
         assert parsed["memory"][0]["text"] == "likes basketball"
 
-    def test_no_code_block_returns_as_is(self):
-        """Without code blocks, extract_json returns text as-is (no {/} heuristic)."""
-        text = 'Here is the result: {"memory": []}'
-        result = extract_json(text)
-        assert result == text  # returned as-is, NOT extracted
-
-
-# --- Test extract_json_from_chatty_response (new function) ---
-
-class TestExtractJsonFromChattyResponse:
-    """Tests for the new chatty-response-aware JSON extractor."""
-
-    def test_pure_json(self):
-        text = '{"memory": [{"id": "0", "text": "likes basketball", "event": "ADD"}]}'
-        result = extract_json_from_chatty_response(text)
-        parsed = json.loads(result)
-        assert parsed["memory"][0]["text"] == "likes basketball"
-
-    def test_json_in_markdown_code_block(self):
-        text = '```json\n{"memory": [{"id": "0", "text": "likes basketball", "event": "ADD"}]}\n```'
-        result = extract_json_from_chatty_response(text)
-        parsed = json.loads(result)
-        assert parsed["memory"][0]["text"] == "likes basketball"
-
-    def test_chatty_with_markdown(self):
-        """LLM wraps JSON in conversational text AND markdown."""
-        text = """Here is the extracted memory:
-```json
-{"memory": [{"id": "0", "text": "likes basketball", "event": "ADD"}]}
-```
-I hope this helps!"""
-        result = extract_json_from_chatty_response(text)
-        parsed = json.loads(result)
-        assert parsed["memory"][0]["text"] == "likes basketball"
-
     def test_chatty_without_markdown(self):
-        """LLM wraps JSON in conversational text without markdown."""
+        """extract_json finds JSON by {/} boundaries when no code block is present."""
         text = """Here is the memory update you requested:
 {"memory": [{"id": "0", "text": "likes gaming", "event": "ADD"}]}
 That's the result."""
-        result = extract_json_from_chatty_response(text)
+        result = extract_json(text)
         parsed = json.loads(result)
         assert parsed["memory"][0]["text"] == "likes gaming"
 
     def test_chatty_multiline_json_without_markdown(self):
-        """LLM wraps multi-line JSON in conversational text without markdown."""
+        """extract_json finds multi-line JSON by {/} boundaries."""
         text = """Here is the memory update:
 {
   "memory": [
@@ -103,26 +68,26 @@ That's the result."""
   ]
 }
 """
-        result = extract_json_from_chatty_response(text)
+        result = extract_json(text)
         parsed = json.loads(result)
         assert parsed["memory"][0]["text"] == "User likes gaming"
 
     def test_no_json_at_all(self):
         """No JSON in the text — should return as-is."""
         text = "I don't have any memory updates."
-        result = extract_json_from_chatty_response(text)
+        result = extract_json(text)
         assert result == text
 
     def test_whitespace_padding(self):
         text = '  \n  {"memory": []}  \n  '
-        result = extract_json_from_chatty_response(text)
+        result = extract_json(text)
         parsed = json.loads(result)
         assert parsed == {"memory": []}
 
     def test_nested_json_objects(self):
         """JSON with nested objects should find outermost braces."""
         text = 'Sure! {"memory": [{"id": "0", "text": "test", "event": "ADD"}]} Done.'
-        result = extract_json_from_chatty_response(text)
+        result = extract_json(text)
         parsed = json.loads(result)
         assert parsed["memory"][0]["id"] == "0"
 
@@ -159,7 +124,7 @@ class TestRemoveCodeBlocks:
         This is a known limitation of remove_code_blocks: it matches the code
         block regex first, and only strips think tags from the result. When
         think tags come before the code block, the regex fails entirely.
-        The fallback chain (extract_json_from_chatty_response) handles this.
+        The fallback chain (extract_json) handles this case.
         """
         text = '<think>reasoning here</think>\n```json\n{"memory": []}\n```'
         result = remove_code_blocks(text)
@@ -167,12 +132,12 @@ class TestRemoveCodeBlocks:
             json.loads(result)
 
 
-# --- Test the full fallback chain (remove_code_blocks -> extract_json_from_chatty_response) ---
+# --- Test the full fallback chain (remove_code_blocks -> extract_json) ---
 
 class TestFallbackChain:
     """Tests the actual fallback pattern used in _add_to_vector_store:
     try json.loads(remove_code_blocks(response))
-    except JSONDecodeError: json.loads(extract_json_from_chatty_response(response))
+    except JSONDecodeError: json.loads(extract_json(response))
     """
 
     def _parse_with_fallback(self, response):
@@ -180,7 +145,7 @@ class TestFallbackChain:
         try:
             return json.loads(remove_code_blocks(response), strict=False)
         except json.JSONDecodeError:
-            extracted = extract_json_from_chatty_response(response)
+            extracted = extract_json(response)
             return json.loads(extracted, strict=False)
 
     def test_clean_json(self):


### PR DESCRIPTION
## Linked Issue

Closes #3788

## Description

Local LLMs (LM Studio, Ollama) often wrap JSON output in conversational text (e.g., "Here is the memory extraction: {...} I hope this helps!"). This caused empty results because `json.loads` failed on the chatty text and the error was silently swallowed.

Three changes:

1. **Enhanced `extract_json()`** to locate JSON by first `{` / last `}` boundaries when no code block is found. This is safe for all existing callers — clean JSON, code-block-wrapped JSON, and arrays all produce identical results since the heuristic only activates when there's no code block AND the text contains `{`/`}`.

2. **Added `JSONDecodeError` fallback to memory action parsing** in both sync and async `_add_to_vector_store` paths. This was completely missing — when the LLM returned chatty text, `json.loads(remove_code_blocks(response))` failed and the outer `except Exception` silently set `new_memories_with_actions = {}`.

3. **Fixed fact retrieval paths** to pass the original `response` to `extract_json()` instead of the already-processed output of `remove_code_blocks()`. Previously `response = remove_code_blocks(response)` mutated the variable, so the fallback received degraded input.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

### Tests Added

New test file `tests/test_chatty_llm_parsing.py` with 21 tests across three test classes:

**`TestExtractJson`** (9 tests) — validates `extract_json()` handles:
- Pure JSON, markdown code blocks, plain code blocks
- Chatty text with embedded markdown code blocks
- Chatty text without code blocks (new `{`/`}` heuristic)
- Multi-line JSON in chatty text, nested objects, whitespace, no-JSON-at-all

**`TestRemoveCodeBlocks`** (4 tests) — regression tests confirming:
- Clean code block stripping works
- Chatty text without code blocks is NOT parsed (verifying fallback is needed)
- `<think>` tag handling edge cases

**`TestFallbackChain`** (8 tests) — validates the full `remove_code_blocks → extract_json` pattern as used in `main.py`:
- Clean JSON, markdown-wrapped, chatty+markdown, chatty without markdown
- `<think>` tags with JSON, LM Studio-style responses
- Completely invalid responses (verifies error propagation)
- Facts extraction responses (both LLM call paths)

All 58 tests pass (21 new + 25 existing memory + 12 LLM provider tests).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed