### PR TITLE
fix(core): add retry and surrogate pair cleanup for fact extraction

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import uuid
 import warnings
 from copy import deepcopy
@@ -507,30 +508,32 @@ class Memory(MemoryBase):
         # Ensure 'json' appears in prompts for json_object response format compatibility
         system_prompt, user_prompt = ensure_json_instruction(system_prompt, user_prompt)
 
-        response = self.llm.generate_response(
-            messages=[
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": user_prompt},
-            ],
-            response_format={"type": "json_object"},
-        )
-
-        try:
-            response = remove_code_blocks(response)
-            if not response.strip():
-                new_retrieved_facts = []
-            else:
+        new_retrieved_facts = []
+        _fact_messages = [{"role": "system", "content": system_prompt}, {"role": "user", "content": user_prompt}]
+        for _attempt in range(3):
+            try:
+                response = self.llm.generate_response(
+                    messages=_fact_messages,
+                    response_format={"type": "json_object"},
+                )
+                response = remove_code_blocks(response)
+                # Clean invalid surrogate pair escapes (common with Qwen3 and other non-OpenAI LLMs)
+                response = re.sub(r'\\u[dD][89a-fA-F][0-9a-fA-F]{2}', '', response)
+                if not response.strip():
+                    new_retrieved_facts = []
+                    break
                 try:
-                    # First try direct JSON parsing
                     new_retrieved_facts = json.loads(response, strict=False)["facts"]
                 except json.JSONDecodeError:
-                    # Try extracting JSON from response using built-in function
                     extracted_json = extract_json(response)
                     new_retrieved_facts = json.loads(extracted_json, strict=False)["facts"]
                 new_retrieved_facts = normalize_facts(new_retrieved_facts)
-        except Exception as e:
-            logger.error(f"Error in new_retrieved_facts: {e}")
-            new_retrieved_facts = []
+                break  # Success
+            except Exception as e:
+                logger.warning(f"Fact extraction attempt {_attempt + 1}/3 failed: {e}")
+                if _attempt == 2:
+                    logger.error("Fact extraction failed after 3 attempts, skipping")
+                    new_retrieved_facts = []
 
         if not new_retrieved_facts:
             logger.debug("No new facts retrieved from input. Skipping memory update LLM call.")
@@ -1584,27 +1587,33 @@ class AsyncMemory(MemoryBase):
         # Ensure 'json' appears in prompts for json_object response format compatibility
         system_prompt, user_prompt = ensure_json_instruction(system_prompt, user_prompt)
 
-        response = await asyncio.to_thread(
-            self.llm.generate_response,
-            messages=[{"role": "system", "content": system_prompt}, {"role": "user", "content": user_prompt}],
-            response_format={"type": "json_object"},
-        )
-        try:
-            response = remove_code_blocks(response)
-            if not response.strip():
-                new_retrieved_facts = []
-            else:
+        new_retrieved_facts = []
+        _fact_messages = [{"role": "system", "content": system_prompt}, {"role": "user", "content": user_prompt}]
+        for _attempt in range(3):
+            try:
+                response = await asyncio.to_thread(
+                    self.llm.generate_response,
+                    messages=_fact_messages,
+                    response_format={"type": "json_object"},
+                )
+                response = remove_code_blocks(response)
+                # Clean invalid surrogate pair escapes (common with Qwen3 and other non-OpenAI LLMs)
+                response = re.sub(r'\\u[dD][89a-fA-F][0-9a-fA-F]{2}', '', response)
+                if not response.strip():
+                    new_retrieved_facts = []
+                    break
                 try:
-                    # First try direct JSON parsing
                     new_retrieved_facts = json.loads(response, strict=False)["facts"]
                 except json.JSONDecodeError:
-                    # Try extracting JSON from response using built-in function
                     extracted_json = extract_json(response)
                     new_retrieved_facts = json.loads(extracted_json, strict=False)["facts"]
                 new_retrieved_facts = normalize_facts(new_retrieved_facts)
-        except Exception as e:
-            logger.error(f"Error in new_retrieved_facts: {e}")
-            new_retrieved_facts = []
+                break  # Success
+            except Exception as e:
+                logger.warning(f"Fact extraction attempt {_attempt + 1}/3 failed: {e}")
+                if _attempt == 2:
+                    logger.error("Fact extraction failed after 3 attempts, skipping")
+                    new_retrieved_facts = []
 
         if not new_retrieved_facts:
             logger.debug("No new facts retrieved from input. Skipping memory update LLM call.")


### PR DESCRIPTION
## Linked Issue

Closes #4540

## Description

Non-OpenAI LLMs (e.g. Qwen3 via Cerebras, Ollama models) occasionally produce malformed JSON responses during fact extraction, causing all extracted facts to be silently discarded. This PR adds:

1. **Retry up to 3 times** — Transient LLM JSON issues usually resolve on retry. Currently there is no retry; a single parse failure loses all facts.

2. **Surrogate pair cleanup** — Qwen3 and similar models processing multilingual content occasionally produce UTF-16 surrogate pair escapes (`\uD800`-`\uDFFF`) that cause `JSONDecodeError` even with `strict=False`, and `UnicodeEncodeError` during subsequent embedding.

Both `Memory` (sync) and `AsyncMemory` are updated symmetrically.

### Before

```python
# Single try/except — one failure = all facts lost
response = self.llm.generate_response(...)
try:
    new_retrieved_facts = json.loads(response, strict=False)["facts"]
except Exception as e:
    logger.error(f"Error in new_retrieved_facts: {e}")
    new_retrieved_facts = []
```

### After

```python
# Retry up to 3 times with surrogate cleanup
for _attempt in range(3):
    try:
        response = self.llm.generate_response(...)
        response = remove_code_blocks(response)
        response = re.sub(r'\\u[dD][89a-fA-F][0-9a-fA-F]{2}', '', response)
        new_retrieved_facts = json.loads(response, strict=False)["facts"]
        new_retrieved_facts = normalize_facts(new_retrieved_facts)
        break
    except Exception as e:
        logger.warning(f"Fact extraction attempt {_attempt + 1}/3 failed: {e}")
        if _attempt == 2:
            logger.error("Fact extraction failed after 3 attempts, skipping")
            new_retrieved_facts = []
```

### Production evidence

Self-hosted deployment with Cerebras Qwen3-235B (572 memories, 2+ weeks):
- Before fix: intermittent `Invalid \uXXXX escape` errors, facts silently lost
- After fix: surrogate errors eliminated, transient failures recovered by retry

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A — backward compatible. On first-attempt success, behavior is identical to current code.

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

**Manual testing:**
- Production deployment running 2+ weeks with Cerebras Qwen3-235B
- Surrogate pair errors no longer occur after regex cleanup
- Transient JSON parse failures recovered on 2nd attempt in production logs
- Verified both sync Memory and async AsyncMemory paths

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed