### PR TITLE
docs: adapt companion cookbook to Mem0 OSS (Qdrant + Ollama)

### DIFF
--- a/docs/cookbooks/essentials/building-ai-companion.mdx
+++ b/docs/cookbooks/essentials/building-ai-companion.mdx
@@ -10,6 +10,12 @@ Problem: LLMs are stateless. GPT doesn't remember conversations. You could stuff
 
 The solution: Mem0. It extracts and stores what matters from conversations, then retrieves it when needed. Your companion remembers user preferences, past events, and history.
 
+Here we use **Mem0 open source** (`Memory`): vectors in **Qdrant**, chat and embeddings via **Ollama**. The optional **OpenAI** Python SDK calls Ollama’s **OpenAI-compatible** `/v1` API for Ray’s replies.
+
+<Note>
+**Setup:** `pip install mem0ai qdrant-client openai ollama` · Qdrant on `localhost:6333` · pull a chat model (e.g. `llama3.1:latest`) and `nomic-embed-text:latest` · use `embedding_model_dims` **768** for that embedder.
+</Note>
+
 In this cookbook we'll build a **fitness companion** that:
 
 - Remembers user goals across sessions
@@ -27,30 +33,63 @@ Max wants to train for a marathon. He starts chatting with Ray, an AI running co
 
 ```python
 from openai import OpenAI
-from mem0 import MemoryClient
+from mem0 import Memory
 
-openai_client = OpenAI(api_key="your-openai-key")
-mem0_client = MemoryClient(api_key="your-mem0-key")
+OLLAMA_URL = "http://localhost:11434"
+CHAT_MODEL = "llama3.1:latest"
+
+memory = Memory.from_config({
+    "vector_store": {
+        "provider": "qdrant",
+        "config": {
+            "collection_name": "fitness_companion",
+            "host": "localhost",
+            "port": 6333,
+            "embedding_model_dims": 768,
+        },
+    },
+    "llm": {
+        "provider": "ollama",
+        "config": {
+            "model": CHAT_MODEL,
+            "temperature": 0,
+            "max_tokens": 2000,
+            "ollama_base_url": OLLAMA_URL,
+        },
+    },
+    "embedder": {
+        "provider": "ollama",
+        "config": {
+            "model": "nomic-embed-text:latest",
+            "ollama_base_url": OLLAMA_URL,
+        },
+    },
+})
+
+ollama_chat = OpenAI(base_url=f"{OLLAMA_URL}/v1", api_key="ollama")
 
 def chat(user_input, user_id):
     # Retrieve relevant memories
-    memories = mem0_client.search(user_input, user_id=user_id, limit=5)
-    context = "\\n".join(m["memory"] for m in memories["results"])
+    memories = memory.search(user_input, user_id=user_id, limit=5)
+    context = "\n".join(m["memory"] for m in memories["results"])
 
-    # Call LLM with memory context
-    response = openai_client.chat.completions.create(
-        model="gpt-4o-mini",
+    # Call LLM with memory context (Ollama via OpenAI-compatible API)
+    response = ollama_chat.chat.completions.create(
+        model=CHAT_MODEL,
         messages=[
-            {"role": "system", "content": f"You're Ray, a running coach. Memories:\\n{context}"},
-            {"role": "user", "content": user_input}
-        ]
+            {"role": "system", "content": f"You're Ray, a running coach. Memories:\n{context}"},
+            {"role": "user", "content": user_input},
+        ],
     ).choices[0].message.content
 
     # Store the exchange
-    mem0_client.add([
-        {"role": "user", "content": user_input},
-        {"role": "assistant", "content": response}
-    ], user_id=user_id)
+    memory.add(
+        [
+            {"role": "user", "content": user_input},
+            {"role": "assistant", "content": response},
+        ],
+        user_id=user_id,
+    )
 
     return response
 
@@ -89,51 +128,40 @@ Max mentions his knee hurts. That's different from his marathon goal - one is te
 
 **Categories vs Metadata:**
 
-- **Categories**: AI-assigned by Mem0 based on content (you can't force them)
-- **Metadata**: Manually set by you for forced tagging
+- **Categories**: Model them with a stable field in **`metadata`** on every `add`—here we use **`memory_bucket`** (`goals`, `constraints`, `preferences`).
+- **Metadata**: Manually set by you for forced tagging.
 
-Define custom categories at the project level. Mem0 will automatically tag memories with relevant categories based on content:
+Define that vocabulary once in your code and pass the right `memory_bucket` on each memory:
 
 ```python
-mem0_client.project.update(custom_categories=[
-    {"goals": "Race targets and training objectives"},
-    {"constraints": "Injuries, limitations, recovery needs"},
-    {"preferences": "Training style, surfaces, schedules"}
-])
+# Add goal
+memory.add(
+    [{"role": "user", "content": "Sub-4 marathon is my A-race"}],
+    user_id="max",
+    metadata={"memory_bucket": "goals"},
+)
+
+# Add constraint
+memory.add(
+    [{"role": "user", "content": "My right knee flares up on downhills"}],
+    user_id="max",
+    metadata={"memory_bucket": "constraints"},
+)
 
 ```
 
 <Note>
-**Categories vs Metadata:** Categories are AI-assigned by Mem0 based on content semantics. You define the palette, Mem0 picks which ones apply. If you need guaranteed tagging, use `metadata` instead.
+**Categories vs Metadata:** You assign category-like labels in `metadata` on each `add`. If you need guaranteed tags for filtering, set those keys yourself.
 </Note>
 
-Now when you add memories, Mem0 automatically assigns the appropriate categories:
+**Important:** Filters only see what you put on `add`. Add `memory_bucket` and any extra keys you plan to filter on:
 
 ```python
-# Add goal - Mem0 automatically tags it as "goals"
-mem0_client.add(
-    [{"role": "user", "content": "Sub-4 marathon is my A-race"}],
-    user_id="max"
-)
-
-# Add constraint - Mem0 automatically tags it as "constraints"
-mem0_client.add(
-    [{"role": "user", "content": "My right knee flares up on downhills"}],
-    user_id="max"
-)
-
-```
-
-Mem0 reads the content and intelligently picks which categories apply. You define the palette, it handles the tagging.
-
-**Important:** You cannot force specific categories. Mem0's platform decides which categories are relevant based on content. If you need to force-tag something, use `metadata` instead:
-
-```python
-# Force tag using metadata (not categories)
-mem0_client.add(
+# Force tag using metadata
+memory.add(
     [{"role": "user", "content": "Some workout note"}],
     user_id="max",
-    metadata={"workout_type": "speed", "forced_tag": "custom_label"}
+    metadata={"memory_bucket": "goals", "workout_type": "speed", "forced_tag": "custom_label"},
 )
 
 ```
@@ -143,14 +171,10 @@ mem0_client.add(
 Retrieve just constraints for workout planning:
 
 ```python
-constraints = mem0_client.search(
+constraints = memory.search(
     query="injury concerns",
-    filters={
-        "AND": [
-            {"user_id": "max"},
-            {"categories": {"in": ["constraints"]}}
-        ]
-    },
+    user_id="max",
+    filters={"memory_bucket": {"in": ["constraints"]}},
     threshold=0.0  # optional: widen recall for short phrases
 )
 print([m["memory"] for m in constraints["results"]])
@@ -169,7 +193,7 @@ Ray can plan workouts that avoid aggravating Max's knee, without pulling in race
 Run the basic loop for a week and check what's stored:
 
 ```python
-memories = mem0_client.get_all(filters={"AND": [{"user_id": "max"}]})
+memories = memory.get_all(user_id="max")
 print([m["memory"] for m in memories["results"]])
 # Output: ["Max wants to run marathon under 4 hours", "hey", "lol ok", "cool thanks", "gtg bye"]
 
@@ -183,10 +207,12 @@ Noise. Greetings and filler clutter the memory.
 
 ### Custom Instructions
 
-Tell Mem0 what matters:
+Tell Mem0 what matters. With `Memory`, put the extraction rules in **`custom_fact_extraction_prompt`** on the config dict (same object you pass to `Memory.from_config`). Ask for JSON with a top-level **`"facts"`** list at the end of the prompt.
+
+Start from the config you built in the basic loop, then add:
 
 ```python
-mem0_client.project.update(custom_instructions="""
+MEMORY_CONFIG["custom_fact_extraction_prompt"] = """
 Extract from running coach conversations:
 - Training goals and race targets
 - Physical constraints or injuries
@@ -197,7 +223,10 @@ Exclude:
 - Greetings and filler
 - Casual chatter
 - Hypotheticals unless planning related
-""")
+
+Return JSON with key "facts" as a list of strings (use [] if nothing to store).
+"""
+memory = Memory.from_config(MEMORY_CONFIG)
 
 ```
 
@@ -207,7 +236,7 @@ Now chat again:
 chat("hey how's it going", user_id="max")
 chat("I prefer trail running over roads", user_id="max")
 
-memories = mem0_client.get_all(filters={"AND": [{"user_id": "max"}]})
+memories = memory.get_all(user_id="max")
 print([m["memory"] for m in memories["results"]])
 # Output: ["Max wants to run marathon under 4 hours", "Max prefers trail running over roads"]
 
@@ -221,20 +250,19 @@ Only meaningful facts. Filler gets dropped automatically.
 
 ---
 
----
-
 ## Agent Memory for Personality
 
 ### Why Agents Need Memory Too
 
 Max prefers direct feedback, not motivational fluff. Ray needs to remember how to communicate - that's agent memory, separate from user memory.
 
-Store agent personality:
+Store agent personality (`infer=False` stores the line verbatim):
 
 ```python
-mem0_client.add(
-    [{"role": "system", "content": "Max wants direct, data-driven feedback. Skip motivational language."}],
-    agent_id="ray_coach"
+memory.add(
+    "Max wants direct, data-driven feedback. Skip motivational language.",
+    agent_id="ray_coach",
+    infer=False,
 )
 
 ```
@@ -243,14 +271,18 @@ Retrieve agent style alongside user memories:
 
 ```python
 # Get coach personality
-agent_memories = mem0_client.search("coaching style", agent_id="ray_coach")
+agent_memories = memory.search("coaching style", agent_id="ray_coach")
 # Output: ["Max wants direct, data-driven feedback. Skip motivational language."]
 
 # Store conversations with agent_id
-mem0_client.add([
-    {"role": "user", "content": "How'd my run look today?"},
-    {"role": "assistant", "content": "Pace was 8:15/mile. Heart rate 152, zone 2."}
-], user_id="max", agent_id="ray_coach")
+memory.add(
+    [
+        {"role": "user", "content": "How'd my run look today?"},
+        {"role": "assistant", "content": "Pace was 8:15/mile. Heart rate 152, zone 2."},
+    ],
+    user_id="max",
+    agent_id="ray_coach",
+)
 
 ```
 
@@ -270,10 +302,13 @@ Don't send every single message to Mem0. Keep recent context in memory, let Mem0
 
 ```python
 # Store only meaningful exchanges in Mem0
-mem0_client.add([
-    {"role": "user", "content": "I want to run a marathon"},
-    {"role": "assistant", "content": "Let's build a training plan"}
-], user_id="max")
+memory.add(
+    [
+        {"role": "user", "content": "I want to run a marathon"},
+        {"role": "assistant", "content": "Let's build a training plan"},
+    ],
+    user_id="max",
+)
 
 # Skip storing filler
 # "hey" → don't store
@@ -293,20 +328,22 @@ Last 10 messages in your app's buffer. Important facts in Mem0. Faster, cheaper,
 
 Max tweaks his ankle. It'll heal in two weeks - the memory should expire too.
 
+Store **`expires_on`** in **`metadata`** and prune or hide the memory in your app after that date (same outcome as a time-bound fact).
+
 ```python
 from datetime import datetime, timedelta
 
 expiration = (datetime.now() + timedelta(days=14)).strftime("%Y-%m-%d")
 
-mem0_client.add(
+memory.add(
     [{"role": "user", "content": "Rolled my left ankle, needs rest"}],
     user_id="max",
-    expiration_date=expiration
+    metadata={"memory_bucket": "constraints", "expires_on": expiration},
 )
 
 ```
 
-In 14 days, this memory disappears automatically. Ray stops asking about the ankle.
+Once you prune past `expires_on`, Ray stops asking about the ankle.
 
 ---
 
@@ -315,37 +352,64 @@ In 14 days, this memory disappears automatically. Ray stops asking about the ank
 Here's the Mem0 setup combining everything:
 
 ```python
-from mem0 import MemoryClient
+from mem0 import Memory
 from datetime import datetime, timedelta
 
-mem0_client = MemoryClient(api_key="your-mem0-key")
-
-# Configure memory filtering and categories
-mem0_client.project.update(
-    custom_instructions="""
+MEMORY_CONFIG = {
+    "vector_store": {
+        "provider": "qdrant",
+        "config": {
+            "collection_name": "fitness_companion",
+            "host": "localhost",
+            "port": 6333,
+            "embedding_model_dims": 768,
+        },
+    },
+    "llm": {
+        "provider": "ollama",
+        "config": {
+            "model": "llama3.1:latest",
+            "temperature": 0,
+            "max_tokens": 2000,
+            "ollama_base_url": "http://localhost:11434",
+        },
+    },
+    "embedder": {
+        "provider": "ollama",
+        "config": {
+            "model": "nomic-embed-text:latest",
+            "ollama_base_url": "http://localhost:11434",
+        },
+    },
+    "custom_fact_extraction_prompt": """
     Extract: goals, constraints, preferences, progress
     Exclude: greetings, filler, casual chat
+    Return JSON with key "facts" as a list of strings.
     """,
-    custom_categories=[
-        {"name": "goals", "description": "Training targets"},
-        {"name": "constraints", "description": "Injuries and limitations"},
-        {"name": "preferences", "description": "Training style"}
-    ]
-)
+}
+
+memory = Memory.from_config(MEMORY_CONFIG)
 
 ```
 
 **Week 1 - Store goals and preferences:**
 
 ```python
-mem0_client.add([
-    {"role": "user", "content": "I want to run a sub-4 marathon"},
-    {"role": "assistant", "content": "Got it. Let's build a training plan."}
-], user_id="max", agent_id="ray", categories=["goals"])
+memory.add(
+    [
+        {"role": "user", "content": "I want to run a sub-4 marathon"},
+        {"role": "assistant", "content": "Got it. Let's build a training plan."},
+    ],
+    user_id="max",
+    agent_id="ray",
+    metadata={"memory_bucket": "goals"},
+)
 
-mem0_client.add([
-    {"role": "user", "content": "I prefer trail running over roads"}
-], user_id="max", categories=["preferences"])
+memory.add(
+    [{"role": "user", "content": "I prefer trail running over roads"}],
+    user_id="max",
+    metadata={"memory_bucket": "preferences"},
+)
 
 ```
 
@@ -353,11 +417,10 @@ mem0_client.add([
 
 ```python
 expiration = (datetime.now() + timedelta(days=14)).strftime("%Y-%m-%d")
-mem0_client.add(
+memory.add(
     [{"role": "user", "content": "Rolled ankle, need light workouts"}],
     user_id="max",
-    categories=["constraints"],
-    expiration_date=expiration
+    metadata={"memory_bucket": "constraints", "expires_on": expiration},
 )
 
 ```
@@ -365,8 +428,8 @@ mem0_client.add(
 **Retrieve for context:**
 
 ```python
-memories = mem0_client.search("training plan", user_id="max", limit=5)
-# Gets: marathon goal, trail preference, ankle injury (if still valid)
+memories = memory.search("training plan", user_id="max", limit=5)
+# Gets: marathon goal, trail preference, ankle injury (if still valid / not pruned)
 
 ```
 
@@ -381,14 +444,14 @@ Ray remembers goals, preferences, and personality. Handles temporary injuries. W
 Training for Boston is different from training for New York. Separate the memory threads:
 
 ```python
-mem0_client.add(messages, user_id="max", run_id="boston-2025")
-mem0_client.add(messages, user_id="max", run_id="nyc-2025")
+memory.add(messages, user_id="max", run_id="boston-2025")
+memory.add(messages, user_id="max", run_id="nyc-2025")
 
 # Retrieve only Boston memories
-boston_memories = mem0_client.search(
+boston_memories = memory.search(
     "training plan",
     user_id="max",
-    run_id="boston-2025"
+    run_id="boston-2025",
 )
 
 ```
@@ -406,7 +469,7 @@ old_logs = [
 ]
 
 for log in old_logs:
-    mem0_client.add(log, user_id="max")
+    memory.add(log, user_id="max")
 
 ```
 
@@ -416,11 +479,11 @@ Max changes his goal from sub-4 to sub-3:45:
 
 ```python
 # Find the old memory
-memories = mem0_client.get_all(filters={"AND": [{"user_id": "max"}]})
+memories = memory.get_all(user_id="max")
 goal_memory = [m for m in memories["results"] if "sub-4" in m["memory"]][0]
 
 # Update it
-mem0_client.update(goal_memory["id"], "Max wants to run sub-3:45 marathon")
+memory.update(goal_memory["id"], "Max wants to run sub-3:45 marathon")
 
 ```
 
@@ -431,8 +494,8 @@ Update instead of creating duplicates.
 Max works with Ray for running and Jordan for strength training:
 
 ```python
-chat("easy run today", user_id="max", agent_id="ray")
-chat("leg day workout", user_id="max", agent_id="jordan")
+memory.add([{"role": "user", "content": "easy run today"}], user_id="max", agent_id="ray")
+memory.add([{"role": "user", "content": "leg day workout"}], user_id="max", agent_id="jordan")
 
 ```
 
@@ -443,10 +506,10 @@ Each coach maintains separate personality memory while sharing user context.
 Prioritize recent training over old data:
 
 ```python
-recent = mem0_client.search(
+recent = memory.search(
     "training progress",
     user_id="max",
-    filters={"created_at": {"gte": "2025-10-01"}}
+    filters={"created_at": {"gte": "2025-10-01"}},
 )
 
 ```
@@ -456,17 +519,17 @@ recent = mem0_client.search(
 Tag workouts by type:
 
 ```python
-mem0_client.add(
+memory.add(
     [{"role": "user", "content": "10x400m intervals"}],
     user_id="max",
-    metadata={"workout_type": "speed", "intensity": "high"}
+    metadata={"workout_type": "speed", "intensity": "high"},
 )
 
-# Later, find all speed workouts
-speed_sessions = mem0_client.search(
+# Later, find all speed workouts (filter keys match payload fields from metadata on add)
+speed_sessions = memory.search(
     "speed work",
     user_id="max",
-    filters={"metadata": {"workout_type": "speed"}}
+    filters={"workout_type": "speed"},
 )
 
 ```
@@ -476,10 +539,10 @@ speed_sessions = mem0_client.search(
 Delete irrelevant memories:
 
 ```python
-mem0_client.delete(memory_id="mem_xyz")
+memory.delete(memory_id="mem_xyz")
 
 # Or clear an entire run_id
-mem0_client.delete_all(user_id="max", run_id="old-training-cycle")
+memory.delete_all(user_id="max", run_id="old-training-cycle")
 
 ```
 
@@ -515,7 +578,7 @@ Before launching:
 - Define 2-3 categories (goals, constraints, preferences)
 - Add expiration strategy for time-bound facts
 - Implement error handling for API calls
-- Monitor memory quality in Mem0 dashboard
+- Monitor memory quality (Mem0 dashboard or `get_all` / Qdrant when local)
 - Clear test data from production project
 
 ---


### PR DESCRIPTION
## Description
Updates the **Build a Companion with Mem0** essentials cookbook (`docs/cookbooks/essentials/building-ai-companion.mdx`) so it documents **Mem0 OSS** end-to-end: `Memory.from_config`With **Qdrant** and **Ollama** (LLM + embeddings), OpenAI-compatible chat against Ollama’s `/v1` API, and OSS memory APIs (`search`, `add`, `get_all`, `update`, `delete`, `delete_all`). 

Replaces hosted-only patterns with **`metadata` + `memory_bucket`** (goals / constraints / preferences), correct **`filters`** for the local vector store (including top-level fields from `metadata`), custom fact extraction, and expiry via metadata / app-side pruning—while keeping the same story arc as the original post.

## Type of Change
- [x] Documentation update

## Breaking Changes
N/A
## Test Coverage

- [x] I tested manually (describe below)

**Manual / E2E (local):** Ran through the cookbook flow locally with **Qdrant** (e.g. Docker) and **Ollama** running: config load, memory add/search with `user_id` / `memory_bucket`, filtered retrieval, updates/deletes, and chat + memory-augmented replies against the Ollama OpenAI-compatible endpoint—confirming the doc’s steps and code snippets behave as written for OSS.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [x] I have updated documentation if needed