### PR TITLE
fix(oss): make pgvector pg import compatible with ESM

### DIFF
--- a/mem0-ts/src/oss/src/vector_stores/pgvector.ts
+++ b/mem0-ts/src/oss/src/vector_stores/pgvector.ts
@@ -1,4 +1,6 @@
-import { Client } from "pg";
+import type { Client as ClientType } from "pg";
+import pkg from "pg";
+const { Client } = pkg;
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
 
@@ -14,7 +16,7 @@ interface PGVectorConfig extends VectorStoreConfig {
 }
 
 export class PGVector implements VectorStore {
-  private client: Client;
+  private client: ClientType;
   private collectionName: string;
   private useDiskann: boolean;
   private useHnsw: boolean;


### PR DESCRIPTION
### Fix: pgvector `pg` import compatibility with Node ESM

#### Problem
In the OSS bundle, the pgvector vector store imports `pg` like this:

```ts
import { Client } from "pg";
```

But `pg` is a **CommonJS** module. Under **Node ESM**, it does not provide named exports, so module evaluation fails with:

```text
SyntaxError: Named export 'Client' not found. The requested module 'pg' is a CommonJS module
```

This breaks downstream integrations (e.g. OpenClaw Mem0 plugin) because the OSS bundle throws during import, causing memory **capture** and **recall** to fail.

#### Solution
Switch to a CJS-safe ESM import style:

```ts
import type { Client as ClientType } from "pg";
import pkg from "pg";
const { Client } = pkg;

private client: ClientType;
```

#### Testing
- Node: v22.22.0
- `pnpm test` in `mem0-ts/` ✅

Closes: #4543
