### PR TITLE
fix: add json-repair fallback for malformed LLM JSON responses

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -7,6 +7,12 @@ import logging
 import os
 import uuid
 import warnings
+
+try:
+    import json_repair
+    _JSON_REPAIR_AVAILABLE = True
+except ImportError:
+    _JSON_REPAIR_AVAILABLE = False
 from copy import deepcopy
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Union
@@ -521,12 +527,36 @@ class Memory(MemoryBase):
                 new_retrieved_facts = []
             else:
                 try:
-                    # First try direct JSON parsing
+                    # Level 1: direct JSON parsing
                     new_retrieved_facts = json.loads(response, strict=False)["facts"]
                 except json.JSONDecodeError:
-                    # Try extracting JSON from response using built-in function
-                    extracted_json = extract_json(response)
-                    new_retrieved_facts = json.loads(extracted_json, strict=False)["facts"]
+                    try:
+                        # Level 2: extract JSON substring from response
+                        extracted_json = extract_json(response)
+                        new_retrieved_facts = json.loads(extracted_json, strict=False)["facts"]
+                        warnings.warn(
+                            "JSON extraction fallback (level 2) triggered for fact retrieval. "
+                            "The LLM returned malformed JSON that required post-processing.",
+                            stacklevel=2,
+                        )
+                    except Exception:
+                        if _JSON_REPAIR_AVAILABLE:
+                            # Level 3: repair malformed JSON (handles Gemini and other models
+                            # that produce slightly invalid JSON)
+                            repaired = json_repair.loads(response)
+                            if isinstance(repaired, dict) and "facts" in repaired:
+                                new_retrieved_facts = repaired["facts"]
+                            elif isinstance(repaired, list):
+                                new_retrieved_facts = repaired
+                            else:
+                                new_retrieved_facts = []
+                            warnings.warn(
+                                "JSON repair fallback (level 3) triggered for fact retrieval. "
+                                "The LLM returned malformed JSON that required json_repair.",
+                                stacklevel=2,
+                            )
+                        else:
+                            raise
                 new_retrieved_facts = normalize_facts(new_retrieved_facts)
         except Exception as e:
             logger.error(f"Error in new_retrieved_facts: {e}")
@@ -1595,12 +1625,36 @@ class AsyncMemory(MemoryBase):
                 new_retrieved_facts = []
             else:
                 try:
-                    # First try direct JSON parsing
+                    # Level 1: direct JSON parsing
                     new_retrieved_facts = json.loads(response, strict=False)["facts"]
                 except json.JSONDecodeError:
-                    # Try extracting JSON from response using built-in function
-                    extracted_json = extract_json(response)
-                    new_retrieved_facts = json.loads(extracted_json, strict=False)["facts"]
+                    try:
+                        # Level 2: extract JSON substring from response
+                        extracted_json = extract_json(response)
+                        new_retrieved_facts = json.loads(extracted_json, strict=False)["facts"]
+                        warnings.warn(
+                            "JSON extraction fallback (level 2) triggered for fact retrieval. "
+                            "The LLM returned malformed JSON that required post-processing.",
+                            stacklevel=2,
+                        )
+                    except Exception:
+                        if _JSON_REPAIR_AVAILABLE:
+                            # Level 3: repair malformed JSON (handles Gemini and other models
+                            # that produce slightly invalid JSON)
+                            repaired = json_repair.loads(response)
+                            if isinstance(repaired, dict) and "facts" in repaired:
+                                new_retrieved_facts = repaired["facts"]
+                            elif isinstance(repaired, list):
+                                new_retrieved_facts = repaired
+                            else:
+                                new_retrieved_facts = []
+                            warnings.warn(
+                                "JSON repair fallback (level 3) triggered for fact retrieval. "
+                                "The LLM returned malformed JSON that required json_repair.",
+                                stacklevel=2,
+                            )
+                        else:
+                            raise
                 new_retrieved_facts = normalize_facts(new_retrieved_facts)
         except Exception as e:
             logger.error(f"Error in new_retrieved_facts: {e}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "pytz>=2024.1",
     "sqlalchemy>=2.0.31",
     "protobuf>=5.29.6,<7.0.0",
+    "json-repair>=0.30.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Problem

Fixes #3918

Gemini and certain other LLMs occasionally return JSON that is technically malformed (trailing commas, unquoted keys, single-quoted strings, truncated output, etc.) even when `response_format={"type": "json_object"}` is requested. The existing two-level fallback — `json.loads` → `extract_json` — is insufficient to recover from these cases, causing `memory extraction` to silently return an empty list and lose all facts from the conversation turn.

## Solution

Introduce a **three-level fallback** for the fact-retrieval JSON parsing in both the **sync** (`_add_to_vector_store`) and **async** (`_add_to_vector_store_async`) code paths:

| Level | Strategy | Notes |
|-------|----------|-------|
| 1 | `json.loads(response, strict=False)` | Fast path, unchanged |
| 2 | `extract_json(response)` + `json.loads` | Existing fallback |
| 3 | `json_repair.loads(response)` | **New** — handles Gemini-style quirks |

- Levels 2 and 3 emit a `warnings.warn` so the caller is informed without flooding logs.
- `json_repair` is imported with a `try/except` guard; the library is optional at import time and level 3 is only reached when it is present.
- `json-repair>=0.30.0` is added to the core `dependencies` in `pyproject.toml`.

## Testing

```python
import json_repair

# Simulate Gemini-style output with trailing comma
bad_json = '{"facts": ["user likes hiking", "user is vegetarian",]}'
result = json_repair.loads(bad_json)
assert result["facts"] == ["user likes hiking", "user is vegetarian"]
```

## Checklist

- [x] Both sync and async paths updated identically
- [x] Graceful degradation when `json_repair` is not installed
- [x] Warning logged at levels 2 and 3 for observability
- [x] `json-repair` added to `pyproject.toml` core dependencies
- [x] Syntax verified (`ast.parse`)