### PR TITLE
fix(openclaw): prevent extraction of standalone timestamps as memories

### DIFF
--- a/openclaw/config.ts
+++ b/openclaw/config.ts
@@ -117,6 +117,7 @@ Exclude (NEVER store):
 - Transient UI/navigation states ("user is in the admin panel", "relay is attached")
 - Ephemeral process status ("download at 50%", "daemon not running", "still syncing")
 - Cron heartbeat outputs, NO_REPLY responses, compaction flush directives
+- The current date/time as a standalone fact — timestamps are conversation context, not durable knowledge. "User indicates current time is 3:25 PM" is NEVER worth storing. However, DO use timestamps to anchor other facts: "User installed Ollama on 2026-03-21" is correct.
 - System routing metadata (message IDs, sender IDs, channel routing info)
 - Generic small talk with no informational content
 - Raw code snippets (capture the intent/decision, not the code itself)


### PR DESCRIPTION
## Summary

- Add explicit exclude rule to OpenClaw plugin's custom extraction instructions to prevent the LLM from storing standalone timestamps as durable memories
- Timestamps anchoring real facts (e.g., "User installed Ollama on 2026-03-21") are still preserved

## Problem

OpenClaw injects the current time into every message as context for the agent. The extraction LLM sees this and stores "User indicates current time is 3:25 PM" as a permanent memory. This happens every 10-30 minutes for active users.

**Prod data evidence:**
- noah48: 10K+ timestamp memories ("User indicates current time is X UTC" stored every 15-30 min)
- shuiyell: memory store dominated by timestamp entries
- Pattern: `memory_id: 75162ece`, `447e817b`, `5b0dec36`, `e7397d95` (all timestamp-only memories)

## Fix

One-line addition to the `Exclude (NEVER store)` section of `DEFAULT_CUSTOM_INSTRUCTIONS` in `config.ts`:

```
- The current date/time as a standalone fact — timestamps are conversation context,
  not durable knowledge. "User indicates current time is 3:25 PM" is NEVER worth
  storing. However, DO use timestamps to anchor other facts: "User installed Ollama
  on 2026-03-21" is correct.
```

Since the plugin sends `custom_instructions` in 99.7% of ADD requests, this applies to virtually all OpenClaw traffic without requiring any platform changes.

## Test plan

- [ ] Verify extraction LLM stops creating "User indicates current time is..." memories
- [ ] Verify time-anchored facts like "User installed X on YYYY-MM-DD" are still extracted correctly
- [ ] Monitor noah48 / shuiyell memory stores for reduction in timestamp entries after rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)