### PR TITLE
fix(openclaw): improve credential detection in extraction instructions

### DIFF
--- a/openclaw/config.ts
+++ b/openclaw/config.ts
@@ -111,7 +111,9 @@ LANGUAGE:
 - If the user speaks Spanish, store the memory in Spanish; do not translate
 
 Exclude (NEVER store):
-- Passwords, API keys, tokens, secrets, or any credentials — even if shared in conversation. Instead store: "Tavily API key was configured and saved to .env (as of 2026-02-20)"
+- Passwords, API keys, tokens, secrets, or any credentials — even when embedded in configuration blocks, setup logs, or tool output. This includes strings starting with sk-, m0-, ak_, ghp_, bot tokens (digits followed by colon and alphanumeric string), bearer tokens, webhook URLs containing tokens, pairing codes, and any long alphanumeric strings that appear in config/env contexts. Never include the actual secret value in a memory. Instead, record that the credential was configured:
+  WRONG: "User's API key is sk-abc123..." or "Bot token is 12345:AABcd..."
+  RIGHT: "API key was configured for the service (as of YYYY-MM-DD)" or "Telegram bot token was set up"
 - One-time commands or instructions ("stop the script", "continue where you left off")
 - Acknowledgments or emotional reactions ("ok", "sounds good", "you're right", "sir")
 - Transient UI/navigation states ("user is in the admin panel", "relay is attached")


### PR DESCRIPTION
## Summary

Improve the credential exclude rule in OpenClaw plugin's custom extraction instructions to prevent the LLM from storing API keys, bot tokens, and other secrets embedded in configuration blocks and tool output.

## Problem

The previous rule was too generic: `"Passwords, API keys, tokens, secrets, or any credentials — even if shared in conversation."` The extraction LLM failed to recognize credentials when they appeared inside config blocks, setup logs, or tool output. In testing, 29% of memories (4 out of 14) contained leaked credentials including API keys, bot tokens, dashboard tokens, and pairing codes.

## Fix

Replace the generic rule with concrete guidance:
- **Specific patterns**: `sk-`, `m0-`, `ak_`, `ghp_`, bot tokens (digits:alphanumeric), bearer tokens, webhook URLs with tokens, pairing codes
- **WRONG/RIGHT examples**: Show the LLM exactly what to extract instead of the raw secret

## Test plan

- [ ] Verify extraction LLM stops storing raw credential values
- [ ] Verify the LLM still records that credentials were configured (without the actual values)
- [ ] Test with config blocks containing bot tokens, API keys, and webhook URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)