### PR TITLE
docs: fix OSS REST API endpoint discrepancies

### DIFF
--- a/docs/open-source/features/rest-api.mdx
+++ b/docs/open-source/features/rest-api.mdx
@@ -14,6 +14,10 @@ The Mem0 REST API server exposes every OSS memory operation over HTTP. Run it al
 </Info>
 
 <Warning>
+  **OSS vs Platform API paths:** The self-hosted OSS server does **not** use the `/v1/` prefix. For example, the endpoint is `POST /memories`, not `POST /v1/memories/`. The [API Reference](/api-reference) documents the hosted platform at `api.mem0.ai` which uses `/v1/` paths — those do not apply to the OSS server.
+</Warning>
+
+<Warning>
   Enable API key authentication (see below) and HTTPS before exposing the server to anything beyond your internal network.
 </Warning>
 
@@ -147,18 +151,42 @@ curl -X POST http://localhost:8000/memories \
 </Info>
 
 ```bash
-curl "http://localhost:8000/memories/search?user_id=alice&query=vegetable"
+curl -X POST http://localhost:8000/search \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "vegetable",
+    "user_id": "alice"
+  }'
 ```
 
 ### Explore with OpenAPI docs
 
-1. Navigate to `http://localhost:8000/docs`.  
-2. Pick an endpoint (e.g., `POST /memories/search`).  
+1. Navigate to `http://localhost:8000/docs`.
+2. Pick an endpoint (e.g., `POST /search`).  
 3. Fill in parameters and click **Execute** to try requests in-browser.
 
 <Tip>
   Export the generated `curl` snippets from the OpenAPI UI to bootstrap integration tests.
 </Tip>
+
+---
+
+## Endpoint reference
+
+The OSS REST server exposes the following endpoints. None use the `/v1/` prefix.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/configure` | Set memory configuration |
+| `POST` | `/memories` | Create memories |
+| `GET` | `/memories` | Get all memories (filter by `user_id`, `agent_id`, or `run_id`) |
+| `GET` | `/memories/{memory_id}` | Get a specific memory |
+| `PUT` | `/memories/{memory_id}` | Update a memory |
+| `DELETE` | `/memories/{memory_id}` | Delete a specific memory |
+| `DELETE` | `/memories` | Delete all memories for an identifier |
+| `GET` | `/memories/{memory_id}/history` | Get memory history |
+| `POST` | `/search` | Search memories |
+| `POST` | `/reset` | Reset all memories |
 
 ---
 


### PR DESCRIPTION
Fixes #4445
Related to #2680

## Summary

Fixes the documentation discrepancy reported in #4445 (also related to #2680) where users deploying the self-hosted OSS server encounter incorrect API endpoint paths in the docs.

### Problems found

1. **Missing clarification between OSS and Platform APIs:** The [API Reference](https://docs.mem0.ai/api-reference) documents the hosted platform at `api.mem0.ai` which uses `/v1/` prefixed paths (e.g., `POST /v1/memories/`). The OSS server in `server/main.py` does **not** use the `/v1/` prefix (e.g., `POST /memories`). There was no callout explaining this distinction, leading users to try `/v1/` paths on their self-hosted server and get 404s.

2. **Incorrect search endpoint in examples:** The search example showed `GET /memories/search?user_id=alice&query=vegetable`, but the actual implementation is `POST /search` with a JSON body. Both the path and HTTP method were wrong.

3. **No endpoint reference table:** OSS users had no authoritative list of available endpoints and had to read the source code or navigate to `/docs` on a running server.

### Solution

- Added a warning callout at the top of the OSS REST API docs clearly distinguishing OSS paths (no `/v1/`) from platform paths
- Fixed the search curl example to use `POST /search` with a JSON request body, matching the `SearchRequest` model in `server/main.py`
- Fixed the OpenAPI docs reference from `POST /memories/search` to `POST /search`
- Added a complete endpoint reference table listing all 10 API endpoints with correct methods and paths, verified against `server/main.py`

## Test plan

- [x] Verify all 10 endpoints in the reference table match the routes defined in `server/main.py`
- [x] Confirm the search curl example matches the `SearchRequest` Pydantic model and `POST /search` route
- [x] Check the docs use valid Mintlify syntax (warning callout, markdown table) consistent with sibling docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)