### PR TITLE
feat: add close() method and context manager to Memory and AsyncMemory

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1357,6 +1357,63 @@ class Memory(MemoryBase):
             )
         capture_event("mem0.reset", self, {"sync_type": "sync"})
 
+    def close(self):
+        """Gracefully release all resources held by this Memory instance.
+
+        Closes the SQLite history database, vector store client connections,
+        telemetry vector store, and graph store driver (if configured).
+        Safe to call multiple times. After calling close(), this instance
+        should not be used.
+        """
+        # Close SQLite history database
+        if hasattr(self, "db") and self.db is not None:
+            try:
+                self.db.close()
+            except Exception:
+                logger.debug("Failed to close history database", exc_info=True)
+
+        # Close the main vector store client
+        if hasattr(self, "vector_store") and hasattr(self.vector_store, "client"):
+            client = self.vector_store.client
+            if hasattr(client, "close"):
+                try:
+                    client.close()
+                except Exception:
+                    logger.debug("Failed to close vector store client", exc_info=True)
+
+        # Close the telemetry vector store client
+        if hasattr(self, "_telemetry_vector_store") and hasattr(self._telemetry_vector_store, "client"):
+            client = self._telemetry_vector_store.client
+            if hasattr(client, "close"):
+                try:
+                    client.close()
+                except Exception:
+                    logger.debug("Failed to close telemetry vector store client", exc_info=True)
+
+        # Close graph store driver if present
+        if hasattr(self, "graph") and self.graph is not None:
+            if hasattr(self.graph, "_driver") and hasattr(self.graph._driver, "close"):
+                try:
+                    self.graph._driver.close()
+                except Exception:
+                    logger.debug("Failed to close graph store driver", exc_info=True)
+
+    def __enter__(self):
+        """Enable use as a context manager."""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Close resources when exiting context manager."""
+        self.close()
+        return False
+
+    def __del__(self):
+        """Attempt cleanup on garbage collection."""
+        try:
+            self.close()
+        except Exception:
+            pass
+
     def chat(self, query):
         raise NotImplementedError("Chat function not implemented yet.")
 
@@ -2499,6 +2556,56 @@ class AsyncMemory(MemoryBase):
             self.config.vector_store.provider, self.config.vector_store.config
         )
         capture_event("mem0.reset", self, {"sync_type": "async"})
+
+    async def close(self):
+        """Gracefully release all resources held by this AsyncMemory instance.
+
+        Closes the SQLite history database, vector store client connections,
+        telemetry vector store, and graph store driver (if configured).
+        Safe to call multiple times. After calling close(), this instance
+        should not be used.
+        """
+        # Close SQLite history database
+        if hasattr(self, "db") and self.db is not None:
+            try:
+                await asyncio.to_thread(self.db.close)
+            except Exception:
+                logger.debug("Failed to close history database", exc_info=True)
+
+        # Close the main vector store client
+        if hasattr(self, "vector_store") and hasattr(self.vector_store, "client"):
+            client = self.vector_store.client
+            if hasattr(client, "close"):
+                try:
+                    await asyncio.to_thread(client.close)
+                except Exception:
+                    logger.debug("Failed to close vector store client", exc_info=True)
+
+        # Close the telemetry vector store client
+        if hasattr(self, "_telemetry_vector_store") and hasattr(self._telemetry_vector_store, "client"):
+            client = self._telemetry_vector_store.client
+            if hasattr(client, "close"):
+                try:
+                    await asyncio.to_thread(client.close)
+                except Exception:
+                    logger.debug("Failed to close telemetry vector store client", exc_info=True)
+
+        # Close graph store driver if present
+        if hasattr(self, "graph") and self.graph is not None:
+            if hasattr(self.graph, "_driver") and hasattr(self.graph._driver, "close"):
+                try:
+                    await asyncio.to_thread(self.graph._driver.close)
+                except Exception:
+                    logger.debug("Failed to close graph store driver", exc_info=True)
+
+    async def __aenter__(self):
+        """Enable use as an async context manager."""
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Close resources when exiting async context manager."""
+        await self.close()
+        return False
 
     async def chat(self, query):
         raise NotImplementedError("Chat function not implemented yet.")

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -572,3 +572,89 @@ def test_update_infer_true_caches_embedding_on_llm_rewrite(mock_sqlite, mock_llm
     # It should NOT be called a 3rd time inside _update_memory
     assert embedder.embed.call_count == 2
     mock_vector_store.update.assert_called_once()
+
+
+# ── close() / context-manager tests ──────────────────────────────────────
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+def test_close_releases_resources(mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
+    """Test that close() calls close on db and vector store client."""
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_store = MagicMock()
+    mock_vector_client = MagicMock()
+    mock_vector_store.client = mock_vector_client
+    mock_vector_factory.return_value = mock_vector_store
+    mock_llm_factory.return_value = MagicMock()
+    mock_db = MagicMock()
+    mock_sqlite.return_value = mock_db
+
+    from mem0.memory.main import Memory as MemoryClass
+    config = MemoryConfig()
+    memory = MemoryClass(config)
+
+    memory.close()
+
+    # SQLiteManager.close() should have been called
+    mock_db.close.assert_called_once()
+    # Vector store client.close() should have been called
+    mock_vector_client.close.assert_called()
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+def test_close_is_idempotent(mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
+    """Test that calling close() twice does not raise errors."""
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_store = MagicMock()
+    mock_vector_store.client = MagicMock()
+    mock_vector_factory.return_value = mock_vector_store
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+    config = MemoryConfig()
+    memory = MemoryClass(config)
+
+    # Calling close twice should not raise
+    memory.close()
+    memory.close()
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+def test_context_manager(mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
+    """Test that Memory can be used as a context manager."""
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_store = MagicMock()
+    mock_vector_client = MagicMock()
+    mock_vector_store.client = mock_vector_client
+    mock_vector_factory.return_value = mock_vector_store
+    mock_llm_factory.return_value = MagicMock()
+    mock_db = MagicMock()
+    mock_sqlite.return_value = mock_db
+
+    from mem0.memory.main import Memory as MemoryClass
+    config = MemoryConfig()
+
+    with MemoryClass(config) as memory:
+        assert memory is not None
+
+    # After exiting context, resources should be closed
+    mock_db.close.assert_called_once()
+    mock_vector_client.close.assert_called()
+
+
+def test_close_on_partial_init():
+    """Test that close() is safe to call when __init__ failed partway through."""
+    with patch.object(Memory, "__init__", return_value=None):
+        memory = Memory()
+        # Simulate partial init — no attributes set
+        memory.close()  # Should not raise


### PR DESCRIPTION
Addresses #4098 — Memory class had no way to gracefully release resources (SQLite connections, vector store clients, graph store drivers), causing ImportError warnings on Python shutdown.

Changes:

- Add close() to Memory: releases SQLite DB, vector store client, telemetry vector store client, and graph store driver

- Add __enter__/__exit__ to Memory for 'with' statement support

- Add __del__ to Memory for GC safety

- Add async close() to AsyncMemory with asyncio.to_thread

- Add __aenter__/__aexit__ to AsyncMemory for 'async with' support

- All close calls are wrapped in try/except for robustness

- close() is safe to call multiple times (idempotent)

- Add 4 new tests: resource release, idempotent close, context manager, partial init safety

## Linked Issue

Closes #<!-- issue number -->

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe what breaks and the migration path. Delete this section if not applicable. -->

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

<!-- Describe how you tested this, or link to CI results. -->

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] I have updated documentation if needed
