### PR TITLE
fix: merge multiple filter operators for same key

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -977,11 +977,11 @@ class Memory(MemoryBase):
                 }
                 
                 if operator in operator_map:
-                    result[key] = {operator_map[operator]: value}
+                    result.setdefault(key, {})[operator_map[operator]] = value
                 else:
                     raise ValueError(f"Unsupported metadata filter operator: {operator}")
             return result
-        
+
         for key, value in metadata_filters.items():
             if key == "AND":
                 # Logical AND: combine multiple conditions
@@ -2095,7 +2095,7 @@ class AsyncMemory(MemoryBase):
                 }
 
                 if operator in operator_map:
-                    result[key] = {operator_map[operator]: value}
+                    result.setdefault(key, {})[operator_map[operator]] = value
                 else:
                     raise ValueError(f"Unsupported metadata filter operator: {operator}")
             return result

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -713,3 +713,47 @@ async def test_async_delete_memory_history_has_timestamps(mock_sqlite, mock_llm_
     assert call_kwargs["created_at"] == "2024-01-01T00:00:00+00:00"
     assert call_kwargs["updated_at"] is not None
     datetime.fromisoformat(call_kwargs["updated_at"])  # verify valid ISO timestamp
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+class TestProcessMetadataFiltersMerge:
+    """Regression tests for issue #3952: multiple operators on the same key must be merged."""
+
+    def _make_memory(self, mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
+        mock_embedder_factory.return_value = MagicMock()
+        mock_vector_factory.return_value = MagicMock()
+        mock_llm_factory.return_value = MagicMock()
+        mock_sqlite.return_value = MagicMock()
+        from mem0.memory.main import Memory as MemoryClass
+        return MemoryClass(MemoryConfig())
+
+    def test_multiple_operators_same_key_merged(self, mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
+        """Filters like created_at: {gte: X, lte: Y} must preserve both operators."""
+        memory = self._make_memory(mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory)
+        result = memory._process_metadata_filters({
+            "created_at": {"gte": 1000, "lte": 2000}
+        })
+        assert result == {"created_at": {"gte": 1000, "lte": 2000}}
+
+    def test_single_operator_still_works(self, mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
+        """Single operator filters must continue to work."""
+        memory = self._make_memory(mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory)
+        result = memory._process_metadata_filters({
+            "created_at": {"gte": 1000}
+        })
+        assert result == {"created_at": {"gte": 1000}}
+
+    def test_multiple_keys_with_multiple_operators(self, mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
+        """Multiple keys each with multiple operators."""
+        memory = self._make_memory(mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory)
+        result = memory._process_metadata_filters({
+            "created_at": {"gte": 1000, "lte": 2000},
+            "score": {"gt": 0.5, "lt": 0.9},
+        })
+        assert result == {
+            "created_at": {"gte": 1000, "lte": 2000},
+            "score": {"gt": 0.5, "lt": 0.9},
+        }


### PR DESCRIPTION
## Description

Fixes a bug where metadata filters with multiple operators on the same key silently drop all but the last operator. For example, a date range filter like `{"created_at": {"gte": 1000, "lte": 2000}}` would lose the `gte` condition and only apply `lte`.

**Root cause:** In `_process_metadata_filters` → `process_condition`, the loop over operators overwrites `result[key]` with a new dict on each iteration instead of merging into the existing one:
```python
# Before (buggy): overwrites on each iteration
result[key] = {operator_map[operator]: value}

# After (fixed): merges into existing dict
result.setdefault(key, {})[operator_map[operator]] = value
```

The bug exists in both the sync `Memory` class and the async `AsyncMemory` class — this PR fixes both.

**Note:** PR #3953 attempted this fix but was closed due to unsigned CLA and only addressed one of the two locations.

Fixes #3952

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Added 3 new unit tests in `tests/test_memory.py` under `TestProcessMetadataFiltersMerge`:

1. **`test_multiple_operators_same_key_merged`** — Core regression test: verifies `{"created_at": {"gte": 1000, "lte": 2000}}` produces a filter with both operators preserved.
2. **`test_single_operator_still_works`** — Ensures single-operator filters (the common case) are unaffected by the change.
3. **`test_multiple_keys_with_multiple_operators`** — Verifies multiple keys each with multiple operators all merge correctly.

All 31 tests in `test_memory.py` pass:
```
$ python -m pytest tests/test_memory.py -v
============================== 31 passed in 0.49s ===============================
```

- [x] Unit Test
- [ ] Test Script (please provide)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Maintainer Checklist

- [x] closes #3952
- [ ] Made sure Checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)