### PR TITLE
feat: add reasoning_effort parameter support for Azure OpenAI and OpenAI configs

### DIFF
--- a/mem0/configs/llms/azure.py
+++ b/mem0/configs/llms/azure.py
@@ -24,6 +24,7 @@ class AzureOpenAIConfig(BaseLlmConfig):
         http_client_proxies: Optional[dict] = None,
         # Azure OpenAI-specific parameters
         azure_kwargs: Optional[Dict[str, Any]] = None,
+        reasoning_effort: Optional[str] = None,
     ):
         """
         Initialize Azure OpenAI configuration.
@@ -39,6 +40,7 @@ class AzureOpenAIConfig(BaseLlmConfig):
             vision_details: Vision detail level, defaults to "auto"
             http_client_proxies: HTTP client proxy settings, defaults to None
             azure_kwargs: Azure-specific configuration, defaults to None
+            reasoning_effort: Reasoning effort for reasoning models (e.g. "low", "medium", "high"), defaults to None
         """
         # Initialize base parameters
         super().__init__(
@@ -55,3 +57,4 @@ class AzureOpenAIConfig(BaseLlmConfig):
 
         # Azure OpenAI-specific parameters
         self.azure_kwargs = AzureConfig(**(azure_kwargs or {}))
+        self.reasoning_effort = reasoning_effort

--- a/mem0/configs/llms/openai.py
+++ b/mem0/configs/llms/openai.py
@@ -31,6 +31,7 @@ class OpenAIConfig(BaseLlmConfig):
         store: bool = False,
         # Response monitoring callback
         response_callback: Optional[Callable[[Any, dict, dict], None]] = None,
+        reasoning_effort: Optional[str] = None,
     ):
         """
         Initialize OpenAI configuration.
@@ -52,6 +53,7 @@ class OpenAIConfig(BaseLlmConfig):
             site_url: Site URL for OpenRouter, defaults to None
             app_name: Application name for OpenRouter, defaults to None
             response_callback: Optional callback for monitoring LLM responses.
+            reasoning_effort: Reasoning effort for reasoning models (e.g. "low", "medium", "high"), defaults to None
         """
         # Initialize base parameters
         super().__init__(
@@ -77,3 +79,6 @@ class OpenAIConfig(BaseLlmConfig):
 
         # Response monitoring
         self.response_callback = response_callback
+
+        # Reasoning effort for reasoning models
+        self.reasoning_effort = reasoning_effort

--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -88,6 +88,10 @@ class LLMBase(ABC):
                 supported_params["tools"] = kwargs["tools"]
             if "tool_choice" in kwargs:
                 supported_params["tool_choice"] = kwargs["tool_choice"]
+            
+            reasoning_effort = getattr(self.config, 'reasoning_effort', None)
+            if reasoning_effort:
+                supported_params["reasoning_effort"] = reasoning_effort
                 
             return supported_params
         else:


### PR DESCRIPTION
## Summary

Closes #3651

The base class `_is_reasoning_model()` detects reasoning models (o1, o3, gpt-5) but `reasoning_effort` was not wired through to the API call. This adds support for the parameter in both `AzureOpenAIConfig` and `OpenAIConfig`.

## Changes

- **`mem0/configs/llms/azure.py`**: Added `reasoning_effort: Optional[str] = None` parameter to `AzureOpenAIConfig` (valid: "low", "medium", "high")
- **`mem0/configs/llms/openai.py`**: Same `reasoning_effort` parameter added to `OpenAIConfig` for consistency
- **`mem0/llms/base.py`**: In `_get_supported_params()` reasoning model branch, reads `reasoning_effort` from config and includes it in supported params when set

## How it works

When a reasoning model is detected, `_get_supported_params()` now passes `reasoning_effort` through to the API call, allowing users to control compute allocation for models like o1 and o3.