### PR TITLE
fix(server): extract data string from payload in update_memory endpoint

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -133,6 +133,8 @@ class SearchRequest(BaseModel):
     limit: Optional[int] = Field(None, description="Maximum number of results to return.")
     threshold: Optional[float] = Field(None, description="Minimum similarity score for results.")
 
+class MemoryUpdate(BaseModel):
+    data: str = Field(..., description="New content to update the memory with.")
 
 @app.post("/configure", summary="Configure Mem0")
 def set_config(config: Dict[str, Any], _api_key: Optional[str] = Depends(verify_api_key)):
@@ -197,24 +199,20 @@ def search_memories(search_req: SearchRequest, _api_key: Optional[str] = Depends
         logging.exception("Error in search_memories:")
         raise HTTPException(status_code=500, detail=str(e))
 
-
 @app.put("/memories/{memory_id}", summary="Update a memory")
-def update_memory(memory_id: str, updated_memory: Dict[str, Any], _api_key: Optional[str] = Depends(verify_api_key)):
-    """Update an existing memory with new content.
-    
-    Args:
-        memory_id (str): ID of the memory to update
-        updated_memory (str): New content to update the memory with
-        
-    Returns:
-        dict: Success message indicating the memory was updated
+def update_memory(
+    memory_id: str, 
+    update_data: MemoryUpdate,  # 使用模型替代 Dict
+    _api_key: Optional[str] = Depends(verify_api_key)
+):
+    """
+    Update an existing memory with new content.
     """
     try:
-        return MEMORY_INSTANCE.update(memory_id=memory_id, data=updated_memory)
+        return MEMORY_INSTANCE.update(memory_id=memory_id, data=update_data.data)
     except Exception as e:
         logging.exception("Error in update_memory:")
         raise HTTPException(status_code=500, detail=str(e))
-
 
 @app.get("/memories/{memory_id}/history", summary="Get memory history")
 def memory_history(memory_id: str, _api_key: Optional[str] = Depends(verify_api_key)):


### PR DESCRIPTION
## Description

The `update_memory` endpoint in `server/main.py` was previously passing a `Dict` payload directly to `MEMORY_INSTANCE.update`. However, the underlying SDK expects a `str` for the `data` parameter. 

This PR introduces a `MemoryUpdate` Pydantic model to explicitly handle the input schema and ensures that only the string content is passed to the memory instance, preventing `AttributeError` during runtime.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

**Manual Test:**
Verified using a Python script to call the `PUT /memories/{memory_id}` endpoint.
- **Before:** Received `500 Internal Server Error` due to `dict` having no attribute `replace`.
- **After:** Received `200 OK` and the memory was successfully updated in both the vector store and graph store (Neo4j).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed