### PR TITLE
fix: preserve original actor_id during memory update

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1289,7 +1289,7 @@ class Memory(MemoryBase):
             new_metadata["agent_id"] = existing_memory.payload["agent_id"]
         if "run_id" not in new_metadata and "run_id" in existing_memory.payload:
             new_metadata["run_id"] = existing_memory.payload["run_id"]
-        if "actor_id" not in new_metadata and "actor_id" in existing_memory.payload:
+        if "actor_id" in existing_memory.payload:
             new_metadata["actor_id"] = existing_memory.payload["actor_id"]
         if "role" not in new_metadata and "role" in existing_memory.payload:
             new_metadata["role"] = existing_memory.payload["role"]
@@ -2440,7 +2440,7 @@ class AsyncMemory(MemoryBase):
         if "run_id" not in new_metadata and "run_id" in existing_memory.payload:
             new_metadata["run_id"] = existing_memory.payload["run_id"]
 
-        if "actor_id" not in new_metadata and "actor_id" in existing_memory.payload:
+        if "actor_id" in existing_memory.payload:
             new_metadata["actor_id"] = existing_memory.payload["actor_id"]
         if "role" not in new_metadata and "role" in existing_memory.payload:
             new_metadata["role"] = existing_memory.payload["role"]

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -581,6 +581,52 @@ class TestMetadataNotMutated:
         )
 
 
+def test_update_preserves_actor_id_when_different_actor_updates(mocker):
+    """actor_id must be preserved from the original memory even when the
+    updating caller passes a different actor_id in metadata (issue #4490)."""
+    memory = _build_memory_instance(mocker, Memory)
+    memory.vector_store.get.return_value = MagicMock(
+        payload={
+            "data": "I am player #1",
+            "user_id": "team",
+            "actor_id": "Alice",
+            "created_at": "2026-01-01T00:00:00+00:00",
+        }
+    )
+
+    memory._update_memory(
+        "mem-id", "Player #1 is a good person",
+        {"Player #1 is a good person": [0.1, 0.2, 0.3]},
+        metadata={"user_id": "team", "actor_id": "Bob"},
+    )
+
+    stored = memory.vector_store.update.call_args.kwargs["payload"]
+    assert stored["actor_id"] == "Alice"
+
+
+@pytest.mark.asyncio
+async def test_async_update_preserves_actor_id_when_different_actor_updates(mocker):
+    """Async variant: actor_id must be preserved from the original memory (issue #4490)."""
+    memory = _build_memory_instance(mocker, AsyncMemory)
+    memory.vector_store.get.return_value = MagicMock(
+        payload={
+            "data": "I am player #1",
+            "user_id": "team",
+            "actor_id": "Alice",
+            "created_at": "2026-01-01T00:00:00+00:00",
+        }
+    )
+
+    await memory._update_memory(
+        "mem-id", "Player #1 is a good person",
+        {"Player #1 is a good person": [0.1, 0.2, 0.3]},
+        metadata={"user_id": "team", "actor_id": "Bob"},
+    )
+
+    stored = memory.vector_store.update.call_args.kwargs["payload"]
+    assert stored["actor_id"] == "Alice"
+
+
 def test_normalize_iso_timestamp_to_utc_preserves_naive_values():
     assert _normalize_iso_timestamp_to_utc("2026-03-18T00:00:00") == "2026-03-18T00:00:00"
 


### PR DESCRIPTION
Linked Issue 

  Closes #4490                                                                                                                                                                                       
   
  Description                                                                                                                                                                                        
                                                            
  actor_id metadata gets overwritten during memory UPDATE operations when a different actor triggers the update. The preservation condition "actor_id" not in new_metadata in _update_memory() never 
  triggers because new_metadata always contains the caller's actor_id (passed through from _build_filters_and_metadata() via deepcopy(metadata)).
                                                                                                                                                                                                     
  This breaks actor-level memory isolation in multi-actor scenarios (shared user_id with per-actor actor_id). After a different actor triggers an UPDATE, querying by the original creator's actor_id
   returns empty results.
                                                                                                                                                                                                     
  Fix: Remove the "actor_id" not in new_metadata guard so actor_id is always preserved from the existing memory. This treats actor_id as memory ownership rather than last-updater. The history table
   already tracks all contributors via db.add_history().
                                                                                                                                                                                                     
  Applied to both sync and async _update_memory() code paths.

  Type of Change                                                                                                                                                                                     
   
  - Bug fix (non-breaking change that fixes an issue)                                                                                                                                                
  - New feature (non-breaking change that adds functionality)
  - Breaking change (fix or feature that would cause existing functionality to change)
  - Refactor (no functional changes)
  - Documentation update                                                                                                                                                                             
   
  Breaking Changes                                                                                                                                                                                   
                                                            
  N/A

  Test Coverage

  - I added/updated unit tests
  - I added/updated integration tests
  - I tested manually (describe below)
  - No tests needed (explain why)
                                                                                                                                                                                                     
  Added two tests covering both sync and async paths: test_update_preserves_actor_id_when_different_actor_updates and test_async_update_preserves_actor_id_when_different_actor_updates. All 36 tests
   pass locally.                                                                                                                                                                                     
                                                                                                                                                                                                     
  Checklist                                                 

  - My code follows the project's style guidelines                                                                                                                                                   
  - I have performed a self-review of my code
  - I have added tests that prove my fix/feature works                                                                                                                                               
  - New and existing tests pass locally                     
  - I have updated documentation if needed
                                                                 