### PR TITLE
feat: improve local LLM stability with robust JSON parsing and memory…

### DIFF
--- a/docs/components/llms/models/ollama.mdx
+++ b/docs/components/llms/models/ollama.mdx
@@ -60,6 +60,21 @@ await memory.add(messages, { userId: "alice", metadata: { category: "movies" } }
 ```
 </CodeGroup>
 
+## Local Model Optimizations
+
+Mem0 includes specific optimizations for running with local LLMs (like Llama 3.1 via Ollama):
+
+- **Robust JSON Parsing**: Mem0 automatically handles noisy model outputs, including preamble text and markdown code blocks, ensuring stable memory extraction even when local models don't strictly follow JSON-only formatting.
+- **Memory Granularity**: Use `entry_mode="chunk"` for large documents to extract semantic segments instead of atomic facts, which significantly improves context retention for smaller local models.
+
+```python
+config = {
+    "llm": {"provider": "ollama", "config": {"model": "llama3.1"}},
+    "entry_mode": "chunk" # Preserves larger semantic chunks
+}
+m = Memory.from_config(config)
+```
+
 ## Config
 
 All available parameters for the `ollama` config are present in [Master List of All Params in Config](../config).

--- a/docs/core-concepts/memory-operations/add.mdx
+++ b/docs/core-concepts/memory-operations/add.mdx
@@ -22,6 +22,7 @@ Adding memory is how Mem0 captures useful details from a conversation so your ag
 - **Infer** – Controls whether Mem0 extracts structured memories (`infer=True`, default) or stores raw messages.
 - **Metadata** – Optional filters (e.g., `{"category": "movie_recommendations"}`) that improve retrieval later.
 - **User / Session identifiers** – `user_id`, `session_id`, or `run_id` that scope the memory for future searches.
+- **Entry Mode** – Controls memory granularity. Use `"fact"` (default) for atomic extraction or `"chunk"` for preserving larger semantic segments.
 
 ## How does it work?
 
@@ -114,6 +115,9 @@ messages = [
 
 # Store inferred memories (default behavior)
 result = m.add(messages, user_id="alice", metadata={"category": "movie_recommendations"})
+
+# Store using semantic chunks (ideal for long documents)
+result = m.add(messages, user_id="alice", entry_mode="chunk")
 
 # Optionally store raw messages without inference
 result = m.add(messages, user_id="alice", metadata={"category": "movie_recommendations"}, infer=False)

--- a/mem0/__init__.py
+++ b/mem0/__init__.py
@@ -1,6 +1,9 @@
 import importlib.metadata
 
-__version__ = importlib.metadata.version("mem0ai")
+try:
+    __version__ = importlib.metadata.version("mem0ai")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "unknown"
 
 from mem0.client.main import AsyncMemoryClient, MemoryClient  # noqa
 from mem0.memory.main import AsyncMemory, Memory  # noqa

--- a/mem0/configs/base.py
+++ b/mem0/configs/base.py
@@ -64,6 +64,10 @@ class MemoryConfig(BaseModel):
         description="Custom prompt for the update memory",
         default=None,
     )
+    entry_mode: str = Field(
+        description="Threshold for the memory extraction (fact or chunk)",
+        default="fact",
+    )
 
 
 class AzureConfig(BaseModel):

--- a/mem0/configs/prompts.py
+++ b/mem0/configs/prompts.py
@@ -457,3 +457,27 @@ def get_update_memory_messages(retrieved_old_memory_dict, response_content, cust
 
     Do not return anything except the JSON format.
     """
+
+
+CHUNK_EXTRACTION_PROMPT = f"""You are a Document Information Splitter, specialized in breaking down long documents into meaningful, semantic chunks (paragraphs or sections). 
+Your primary role is to extract distinct segments of information that preserve the context and flow of the original text, rather than extracting isolated atomic facts.
+
+Guidelines for Chunking:
+1. Preserve Context: Each chunk should be self-contained enough to be understood on its own but large enough to include supporting details.
+2. Maintain Semantic Integrity: Break the text at natural boundaries like paragraph ends, topic shifts, or section headers.
+3. Don't Over-Summarize: Unlike fact extraction, keep the original phrasing and detail of the segment as much as possible.
+4. Avoid "Tiny" Entries: Each chunk should ideally be 2-5 sentences long, representing a complete thought or piece of context.
+
+Example:
+Input: "The project started in 2021. We initially focused on the backend architecture using Python and FastAPI. By 2022, we expanded to include a React-based frontend and moved to a microservices layout."
+Output: {{"facts": ["The project started in 2021 with an initial focus on backend architecture using Python and FastAPI.", "By 2022, the project expanded to include a React-based frontend and moved to a microservices architecture."]}}
+
+Return the chunks in a JSON format with a key as "facts" containing a list of strings, each string being a semantic chunk.
+
+Remember the following:
+- Today's date is {datetime.now().strftime("%Y-%m-%d")}.
+- Return only the JSON. Do not include any preamble.
+- Detect the language of the input and record the chunks in the same language.
+
+Following is the document text. Extract the relevant semantic chunks:
+"""

--- a/mem0/llms/ollama.py
+++ b/mem0/llms/ollama.py
@@ -116,14 +116,11 @@ class OllamaLLM(LLMBase):
             "messages": messages,
         }
 
-        # Handle JSON response format by using Ollama's native format parameter
-        if response_format and response_format.get("type") == "json_object":
-            params["format"] = "json"
-            # Also add JSON format instruction to the last message as a fallback
-            if messages and messages[-1]["role"] == "user":
-                messages[-1]["content"] += "\n\nPlease respond with valid JSON only."
-            else:
-                messages.append({"role": "user", "content": "Please respond with valid JSON only."})
+        # NOTE: We avoid using Ollama's native "format": "json" because it often 
+        # causes models to wrap JSON in markdown blocks even when told not to, 
+        # which can break parsing. We rely on our robust extract_json utility instead.
+        # if response_format and response_format.get("type") == "json_object":
+        #     params["format"] = "json"
 
         # Add options for Ollama (temperature, num_predict, top_p)
         options = {

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -18,6 +18,7 @@ from mem0.configs.enums import MemoryType
 from mem0.configs.prompts import (
     PROCEDURAL_MEMORY_SYSTEM_PROMPT,
     get_update_memory_messages,
+    CHUNK_EXTRACTION_PROMPT,
 )
 from mem0.exceptions import ValidationError as Mem0ValidationError
 from mem0.memory.base import MemoryBase
@@ -361,6 +362,7 @@ class Memory(MemoryBase):
         infer: bool = True,
         memory_type: Optional[str] = None,
         prompt: Optional[str] = None,
+        entry_mode: Optional[str] = None,
     ):
         """
         Create a new memory.
@@ -439,7 +441,7 @@ class Memory(MemoryBase):
             messages = parse_vision_messages(messages)
 
         with concurrent.futures.ThreadPoolExecutor() as executor:
-            future1 = executor.submit(self._add_to_vector_store, messages, processed_metadata, effective_filters, infer)
+            future1 = executor.submit(self._add_to_vector_store, messages, processed_metadata, effective_filters, infer, entry_mode)
             future2 = executor.submit(self._add_to_graph, messages, effective_filters)
 
             concurrent.futures.wait([future1, future2])
@@ -455,7 +457,7 @@ class Memory(MemoryBase):
 
         return {"results": vector_store_result}
 
-    def _add_to_vector_store(self, messages, metadata, filters, infer):
+    def _add_to_vector_store(self, messages, metadata, filters, infer, entry_mode=None):
         if not infer:
             returned_memories = []
             for message_dict in messages:
@@ -497,6 +499,9 @@ class Memory(MemoryBase):
 
         if self.config.custom_fact_extraction_prompt:
             system_prompt = self.config.custom_fact_extraction_prompt
+            user_prompt = f"Input:\n{parsed_messages}"
+        elif (entry_mode or self.config.entry_mode) == "chunk":
+            system_prompt = CHUNK_EXTRACTION_PROMPT
             user_prompt = f"Input:\n{parsed_messages}"
         else:
             # Determine if this should use agent memory extraction based on agent_id presence
@@ -1591,6 +1596,9 @@ class AsyncMemory(MemoryBase):
         parsed_messages = parse_messages(messages)
         if self.config.custom_fact_extraction_prompt:
             system_prompt = self.config.custom_fact_extraction_prompt
+            user_prompt = f"Input:\n{parsed_messages}"
+        elif (entry_mode or self.config.entry_mode) == "chunk":
+            system_prompt = CHUNK_EXTRACTION_PROMPT
             user_prompt = f"Input:\n{parsed_messages}"
         else:
             # Determine if this should use agent memory extraction based on agent_id presence

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -108,16 +108,23 @@ def normalize_facts(raw_facts):
 def remove_code_blocks(content: str) -> str:
     """
     Removes enclosing code block markers ```[language] and ``` from a given string.
+    Also removes <think> tags.
 
     Remarks:
-    - The function uses a regex pattern to match code blocks that may start with ``` followed by an optional language tag (letters or numbers) and end with ```.
+    - The function uses a regex pattern to find code blocks that may start with ``` followed by an optional language tag (letters or numbers) and end with ```.
     - If a code block is detected, it returns only the inner content, stripping out the markers.
-    - If no code block markers are found, the original content is returned as-is.
+    - If no code block markers are found, it still removes <think> tags.
     """
-    pattern = r"^```[a-zA-Z0-9]*\n([\s\S]*?)\n```$"
-    match = re.match(pattern, content.strip())
-    match_res=match.group(1).strip() if match else content.strip()
-    return re.sub(r"<think>.*?</think>", "", match_res, flags=re.DOTALL).strip()
+    # Remove <think> tags first
+    content = re.sub(r"<think>.*?</think>", "", content, flags=re.DOTALL).strip()
+    
+    # Match code blocks anywhere in the string
+    pattern = r"```[a-zA-Z0-9]*\n?([\s\S]*?)\n?```"
+    match = re.search(pattern, content)
+    if match:
+        return match.group(1).strip()
+    
+    return content.strip()
 
 
 
@@ -128,17 +135,19 @@ def extract_json(text):
     If that also fails, returns the text as-is.
     """
     text = text.strip()
+    
+    # Try finding code blocks first
     match = re.search(r"```(?:json)?\s*(.*?)\s*```", text, re.DOTALL)
     if match:
-        json_str = match.group(1)
-    else:
-        start_idx = text.find("{")
-        end_idx = text.rfind("}")
-        if start_idx != -1 and end_idx != -1 and end_idx > start_idx:
-            json_str = text[start_idx : end_idx + 1]
-        else:
-            json_str = text
-    return json_str
+        return match.group(1).strip()
+
+    # If no code blocks, look for the first '{' and last '}'
+    start_idx = text.find("{")
+    end_idx = text.rfind("}")
+    if start_idx != -1 and end_idx != -1 and end_idx > start_idx:
+        return text[start_idx : end_idx + 1].strip()
+
+    return text
 
 
 def get_image_description(image_obj, llm, vision_details):
@@ -264,4 +273,3 @@ def sanitize_relationship_for_cypher(relationship) -> str:
         sanitized = sanitized.replace(old, new)
 
     return re.sub(r"_+", "_", sanitized).strip("_")
-

--- a/tests/memory/test_granularity.py
+++ b/tests/memory/test_granularity.py
@@ -1,0 +1,56 @@
+import os
+os.environ["OPENAI_API_KEY"] = "sk-" + "a"*48
+
+from unittest.mock import MagicMock, patch
+from mem0.configs.base import MemoryConfig
+from mem0.configs.prompts import CHUNK_EXTRACTION_PROMPT
+
+# Mock factories before importing Memory to avoid API key requirements
+with patch('mem0.utils.factory.EmbedderFactory.create'), \
+     patch('mem0.utils.factory.VectorStoreFactory.create'), \
+     patch('mem0.utils.factory.LlmFactory.create'), \
+     patch('mem0.utils.factory.RerankerFactory.create'), \
+     patch('mem0.memory.main.SQLiteManager'), \
+     patch('mem0.memory.main.capture_event'):
+    from mem0.memory.main import Memory
+
+def test_entry_mode_selection():
+    config = MemoryConfig()
+    
+    with patch('mem0.memory.main.VectorStoreFactory.create'):
+        mem = Memory(config)
+    
+    mem.llm = MagicMock()
+    mem.llm.generate_response.return_value = '{"facts": ["fact1"]}'
+    mem.embedding_model = MagicMock()
+    mem.vector_store = MagicMock()
+    
+    # 1. Test DEFAULT (fact)
+    mem.add("Test", user_id="test")
+    call_args = mem.llm.generate_response.call_args_list[0]
+    messages = call_args[1].get('messages') or call_args[0][0]
+    system_prompt = messages[0]['content']
+    assert "fact" in system_prompt.lower()
+    assert "chunk" not in system_prompt.lower()
+
+    # 2. Test CHUNK mode via config
+    mem.llm.reset_mock()
+    mem.config.entry_mode = "chunk"
+    mem.add("Test", user_id="test")
+    call_args = mem.llm.generate_response.call_args_list[0]
+    messages = call_args[1].get('messages') or call_args[0][0]
+    system_prompt = messages[0]['content']
+    assert "Document Information Splitter" in system_prompt
+
+    # 3. Test CHUNK mode via override
+    mem.llm.reset_mock()
+    mem.config.entry_mode = "fact"
+    mem.add("Test", user_id="test", entry_mode="chunk")
+    call_args = mem.llm.generate_response.call_args_list[0]
+    messages = call_args[1].get('messages') or call_args[0][0]
+    system_prompt = messages[0]['content']
+    assert "Document Information Splitter" in system_prompt
+
+if __name__ == "__main__":
+    test_entry_mode_selection()
+    print("Test Granularity: OK")

--- a/tests/memory/test_utils.py
+++ b/tests/memory/test_utils.py
@@ -1,0 +1,35 @@
+import re
+from mem0.memory.utils import extract_json, remove_code_blocks
+
+def test_remove_code_blocks():
+    # Test thinking tags
+    assert remove_code_blocks("<think>abc</think>\ncontent") == "content"
+    
+    # Test code block extraction (nested or with preamble)
+    assert remove_code_blocks("Here is code: ```python\nprint(1)\n```") == "print(1)"
+    
+    # Test no code block
+    assert remove_code_blocks("plain text") == "plain text"
+
+def test_extract_json_robustness():
+    # Scenario: Raw JSON
+    raw = '{"facts": ["fact1"]}'
+    assert extract_json(raw) == raw
+    
+    # Scenario: JSON in Markdown
+    markdown = '```json\n{"facts": ["fact1"]}\n```'
+    assert extract_json(markdown) == '{"facts": ["fact1"]}'
+    
+    # Scenario: JSON with Preamble and Postamble
+    noisy = 'Text before\n{"facts": ["fact1"]}\nText after'
+    assert extract_json(noisy) == '{"facts": ["fact1"]}'
+    
+    # Scenario: Markdown JSON with Preamble
+    noisy_markdown = 'Sure! ```json\n{"facts": ["fact1"]}\n``` done.'
+    assert extract_json(noisy_markdown) == '{"facts": ["fact1"]}'
+
+if __name__ == "__main__":
+    # Manual execution if needed
+    test_remove_code_blocks()
+    test_extract_json_robustness()
+    print("Test Utils: OK")


### PR DESCRIPTION
## Linked Issue

Closes #<!-- issue number -->

## Description

- Improves local LLM stability for memory extraction, especially with Ollama-hosted models that often return noisy or non-strict JSON output.
- Makes JSON parsing more robust by extracting structured content from markdown code blocks, preamble text, and other imperfect local-model responses instead of assuming a clean raw JSON payload.
- Adds support for memory granularity via `entry_mode`, allowing `"fact"` mode for atomic memories and `"chunk"` mode for larger semantic segments that preserve more document context.
- Improves package import resilience by avoiding a hard failure when `mem0ai` package metadata is unavailable in local/dev environments.
- Updates Ollama and memory-operation docs to explain local-model optimizations and when to use chunk-based extraction.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Manual verification:
- rebased the branch onto the latest `main`
- verified conflict resolution in `mem0/memory/utils.py`
- checked the new `extract_json()` behavior for:
  - fenced ```json code blocks
  - responses with leading/trailing text around JSON
  - raw JSON responses
- reviewed the new `entry_mode="chunk"` flow in `mem0/memory/main.py` and prompt/config wiring
- reviewed documentation updates for Ollama and memory add operations

Added/updated tests:
- `tests/memory/test_granularity.py`
- `tests/memory/test_utils.py`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [x] I have updated documentation if needed
