### PR TITLE
chore: fix failing CI lint errors

### DIFF
--- a/cli/python/src/mem0_cli/commands/init_cmd.py
+++ b/cli/python/src/mem0_cli/commands/init_cmd.py
@@ -103,14 +103,13 @@ def run_init(*, api_key: str | None = None, user_id: str | None = None) -> None:
         return
 
     # Non-TTY without full flags -> error
-    if not sys.stdin.isatty():
-        if not api_key or not user_id:
-            print_error(
-                err_console,
-                "Non-interactive terminal detected and required flags missing.",
-                hint="Run: mem0 init --api-key <key> --user-id <id>",
-            )
-            raise typer.Exit(1)
+    if not sys.stdin.isatty() and (not api_key or not user_id):
+        print_error(
+            err_console,
+            "Non-interactive terminal detected and required flags missing.",
+            hint="Run: mem0 init --api-key <key> --user-id <id>",
+        )
+        raise typer.Exit(1)
 
     print_banner(console)
     console.print()

--- a/cli/python/src/mem0_cli/commands/utils.py
+++ b/cli/python/src/mem0_cli/commands/utils.py
@@ -22,7 +22,6 @@ from mem0_cli.branding import (
     print_success,
     timed_status,
 )
-from mem0_cli.config import load_config
 
 console = Console()
 err_console = Console(stderr=True)

--- a/cli/python/tests/test_commands.py
+++ b/cli/python/tests/test_commands.py
@@ -16,7 +16,15 @@ from mem0_cli.commands.config_cmd import (
     cmd_config_show,
 )
 from mem0_cli.commands.entities import cmd_entities_delete, cmd_entities_list
-from mem0_cli.commands.memory import cmd_add, cmd_delete, cmd_delete_all, cmd_get, cmd_list, cmd_search, cmd_update
+from mem0_cli.commands.memory import (
+    cmd_add,
+    cmd_delete,
+    cmd_delete_all,
+    cmd_get,
+    cmd_list,
+    cmd_search,
+    cmd_update,
+)
 from mem0_cli.commands.utils import (
     cmd_import,
     cmd_status,
@@ -586,7 +594,7 @@ class TestDeleteAllCommand:
         mock_backend.delete.assert_not_called()
 
     def test_delete_all_project_wide(self, mock_backend):
-        console, buf = _make_console()
+        console, _buf = _make_console()
         err_console, _err_buf = _make_err_console()
         with (
             patch("mem0_cli.commands.memory.console", console),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,3 +163,10 @@ test = [
 [tool.ruff]
 line-length = 120
 exclude = ["embedchain/", "openmemory/"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["mem0", "mem0_cli"]
+
+[tool.isort]
+profile = "black"
+known_first_party = ["mem0", "mem0_cli"]


### PR DESCRIPTION
Closes CI lint failures on main

  Description

  Fix 4 lint errors breaking CI and resolve a ruff/isort import ordering conflict by adding known-first-party config for both tools.

  - SIM102: Combine nested if in init_cmd.py
  - F401: Remove unused load_config import in utils.py
  - I001: Fix import sorting in test_commands.py
  - RUF059: Prefix unused buf with _ in test_commands.py
  - Add [tool.ruff.lint.isort] and [tool.isort] known-first-party config to pyproject.toml

