### PR TITLE
fix: reuse shared ThreadPoolExecutor in add/get_all/search to prevent thread leak

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1,5 +1,6 @@
 import asyncio
 import concurrent
+import concurrent.futures
 import gc
 import hashlib
 import json
@@ -303,6 +304,7 @@ class Memory(MemoryBase):
                 self.config.vector_store.provider, telemetry_config
             )
         capture_event("mem0.init", self, {"sync_type": "sync"})
+        self._executor = concurrent.futures.ThreadPoolExecutor()
 
     @classmethod
     def from_config(cls, config_dict: Dict[str, Any]):
@@ -438,14 +440,13 @@ class Memory(MemoryBase):
         else:
             messages = parse_vision_messages(messages)
 
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            future1 = executor.submit(self._add_to_vector_store, messages, processed_metadata, effective_filters, infer)
-            future2 = executor.submit(self._add_to_graph, messages, effective_filters)
+        future1 = self._executor.submit(self._add_to_vector_store, messages, processed_metadata, effective_filters, infer)
+        future2 = self._executor.submit(self._add_to_graph, messages, effective_filters)
 
-            concurrent.futures.wait([future1, future2])
+        concurrent.futures.wait([future1, future2])
 
-            vector_store_result = future1.result()
-            graph_result = future2.result()
+        vector_store_result = future1.result()
+        graph_result = future2.result()
 
         if self.enable_graph:
             return {
@@ -782,18 +783,17 @@ class Memory(MemoryBase):
             "mem0.get_all", self, {"limit": limit, "keys": keys, "encoded_ids": encoded_ids, "sync_type": "sync"}
         )
 
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            future_memories = executor.submit(self._get_all_from_vector_store, effective_filters, limit)
-            future_graph_entities = (
-                executor.submit(self.graph.get_all, effective_filters, limit) if self.enable_graph else None
-            )
+        future_memories = self._executor.submit(self._get_all_from_vector_store, effective_filters, limit)
+        future_graph_entities = (
+            self._executor.submit(self.graph.get_all, effective_filters, limit) if self.enable_graph else None
+        )
 
-            concurrent.futures.wait(
-                [future_memories, future_graph_entities] if future_graph_entities else [future_memories]
-            )
+        concurrent.futures.wait(
+            [future_memories, future_graph_entities] if future_graph_entities else [future_memories]
+        )
 
-            all_memories_result = future_memories.result()
-            graph_entities_result = future_graph_entities.result() if future_graph_entities else None
+        all_memories_result = future_memories.result()
+        graph_entities_result = future_graph_entities.result() if future_graph_entities else None
 
         if self.enable_graph:
             return {"results": all_memories_result, "relations": graph_entities_result}
@@ -921,18 +921,17 @@ class Memory(MemoryBase):
             },
         )
 
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            future_memories = executor.submit(self._search_vector_store, query, effective_filters, limit, threshold)
-            future_graph_entities = (
-                executor.submit(self.graph.search, query, effective_filters, limit) if self.enable_graph else None
-            )
+        future_memories = self._executor.submit(self._search_vector_store, query, effective_filters, limit, threshold)
+        future_graph_entities = (
+            self._executor.submit(self.graph.search, query, effective_filters, limit) if self.enable_graph else None
+        )
 
-            concurrent.futures.wait(
-                [future_memories, future_graph_entities] if future_graph_entities else [future_memories]
-            )
+        concurrent.futures.wait(
+            [future_memories, future_graph_entities] if future_graph_entities else [future_memories]
+        )
 
-            original_memories = future_memories.result()
-            graph_entities = future_graph_entities.result() if future_graph_entities else None
+        original_memories = future_memories.result()
+        graph_entities = future_graph_entities.result() if future_graph_entities else None
 
         # Apply reranking if enabled and reranker is available
         if rerank and self.reranker and original_memories:

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -304,7 +304,21 @@ class Memory(MemoryBase):
                 self.config.vector_store.provider, telemetry_config
             )
         capture_event("mem0.init", self, {"sync_type": "sync"})
-        self._executor = concurrent.futures.ThreadPoolExecutor()
+        self._executor = concurrent.futures.ThreadPoolExecutor(max_workers=4)
+
+    def close(self):
+        """Shut down the shared thread pool executor."""
+        self._executor.shutdown(wait=False)
+
+    def __del__(self):
+        self.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False
 
     @classmethod
     def from_config(cls, config_dict: Dict[str, Any]):

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -310,16 +310,6 @@ class Memory(MemoryBase):
         """Shut down the shared thread pool executor."""
         self._executor.shutdown(wait=False)
 
-    def __del__(self):
-        self.close()
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.close()
-        return False
-
     @classmethod
     def from_config(cls, config_dict: Dict[str, Any]):
         try:


### PR DESCRIPTION
Fixes #4586

## Problem
`add()`, `get_all()`, and `search()` each created a new `ThreadPoolExecutor` per call. Under sustained traffic this causes thread accumulation — ~1 thread/min at 50 req/s, leading to 800+ idle threads and OOM kills after hours.

## Fix
Replace the three per-call executors with a single `self._executor` initialized once in `__init__` and reused across all calls.

## Testing
- Existing tests pass (`tests/configs/`, `tests/memory/test_main.py`, `tests/memory/test_memory_utils.py`, `tests/memory/test_storage.py`)