### PR TITLE
fix: use CrossEncoder for cross-encoder reranker models

### DIFF
--- a/mem0/reranker/sentence_transformer_reranker.py
+++ b/mem0/reranker/sentence_transformer_reranker.py
@@ -6,7 +6,7 @@ from mem0.configs.rerankers.base import BaseRerankerConfig
 from mem0.configs.rerankers.sentence_transformer import SentenceTransformerRerankerConfig
 
 try:
-    from sentence_transformers import SentenceTransformer
+    from sentence_transformers import SentenceTransformer, CrossEncoder
     SENTENCE_TRANSFORMERS_AVAILABLE = True
 except ImportError:
     SENTENCE_TRANSFORMERS_AVAILABLE = False
@@ -41,8 +41,26 @@ class SentenceTransformerReranker(BaseReranker):
             )
 
         self.config = config
-        self.model = SentenceTransformer(self.config.model, device=self.config.device)
+        self._is_cross_encoder = self._detect_cross_encoder(self.config.model)
+        if self._is_cross_encoder:
+            self.model = CrossEncoder(self.config.model, device=self.config.device)
+        else:
+            self.model = SentenceTransformer(self.config.model, device=self.config.device)
         
+    @staticmethod
+    def _detect_cross_encoder(model_name: str) -> bool:
+        """Detect if a model is a cross-encoder based on its name.
+
+        Cross-encoder models require the ``CrossEncoder`` class from
+        sentence-transformers.  Using ``SentenceTransformer`` with these
+        models silently falls back to mean pooling and produces all-zero
+        relevance scores.
+        """
+        if not model_name:
+            return False
+        name_lower = model_name.lower()
+        return "cross-encoder" in name_lower or "reranker" in name_lower
+
     def rerank(self, query: str, documents: List[Dict[str, Any]], top_k: int = None) -> List[Dict[str, Any]]:
         """
         Rerank documents using sentence transformer cross-encoder.

--- a/tests/rerankers/test_sentence_transformer_reranker.py
+++ b/tests/rerankers/test_sentence_transformer_reranker.py
@@ -1,0 +1,148 @@
+import pytest
+import numpy as np
+from unittest.mock import patch, MagicMock
+
+from mem0.reranker.sentence_transformer_reranker import SentenceTransformerReranker
+
+
+@pytest.fixture
+def mock_cross_encoder():
+    with patch("mem0.reranker.sentence_transformer_reranker.CrossEncoder") as mock_cls:
+        mock_model = MagicMock()
+        mock_cls.return_value = mock_model
+        yield mock_cls, mock_model
+
+
+@pytest.fixture
+def mock_sentence_transformer():
+    with patch("mem0.reranker.sentence_transformer_reranker.SentenceTransformer") as mock_cls:
+        mock_model = MagicMock()
+        mock_cls.return_value = mock_model
+        yield mock_cls, mock_model
+
+
+class TestDetectCrossEncoder:
+    def test_cross_encoder_prefix(self):
+        assert SentenceTransformerReranker._detect_cross_encoder("cross-encoder/ms-marco-MiniLM-L-6-v2") is True
+
+    def test_reranker_in_name(self):
+        assert SentenceTransformerReranker._detect_cross_encoder("BAAI/bge-reranker-base") is True
+
+    def test_regular_model(self):
+        assert SentenceTransformerReranker._detect_cross_encoder("all-MiniLM-L6-v2") is False
+
+    def test_empty_string(self):
+        assert SentenceTransformerReranker._detect_cross_encoder("") is False
+
+    def test_none(self):
+        assert SentenceTransformerReranker._detect_cross_encoder(None) is False
+
+    def test_case_insensitive(self):
+        assert SentenceTransformerReranker._detect_cross_encoder("Cross-Encoder/ms-marco-MiniLM-L-6-v2") is True
+
+
+class TestInit:
+    def test_cross_encoder_model_uses_cross_encoder_class(self, mock_cross_encoder):
+        mock_cls, _ = mock_cross_encoder
+        reranker = SentenceTransformerReranker({
+            "model": "cross-encoder/ms-marco-MiniLM-L-6-v2",
+        })
+        mock_cls.assert_called_once_with("cross-encoder/ms-marco-MiniLM-L-6-v2", device=None)
+        assert reranker._is_cross_encoder is True
+
+    def test_bi_encoder_model_uses_sentence_transformer_class(self, mock_sentence_transformer):
+        mock_cls, _ = mock_sentence_transformer
+        reranker = SentenceTransformerReranker({
+            "model": "all-MiniLM-L6-v2",
+        })
+        mock_cls.assert_called_once_with("all-MiniLM-L6-v2", device=None)
+        assert reranker._is_cross_encoder is False
+
+    def test_default_model_is_cross_encoder(self, mock_cross_encoder):
+        mock_cls, _ = mock_cross_encoder
+        reranker = SentenceTransformerReranker({})
+        mock_cls.assert_called_once()
+        assert reranker._is_cross_encoder is True
+
+
+class TestRerank:
+    def test_empty_documents(self, mock_cross_encoder):
+        reranker = SentenceTransformerReranker({
+            "model": "cross-encoder/ms-marco-MiniLM-L-6-v2",
+        })
+        result = reranker.rerank("query", [])
+        assert result == []
+
+    def test_documents_sorted_by_score_descending(self, mock_cross_encoder):
+        _, mock_model = mock_cross_encoder
+        mock_model.predict.return_value = np.array([0.3, 0.9, 0.6])
+
+        reranker = SentenceTransformerReranker({
+            "model": "cross-encoder/ms-marco-MiniLM-L-6-v2",
+        })
+        docs = [
+            {"memory": "low relevance"},
+            {"memory": "high relevance"},
+            {"memory": "mid relevance"},
+        ]
+
+        result = reranker.rerank("test query", docs)
+
+        assert len(result) == 3
+        assert result[0]["memory"] == "high relevance"
+        assert result[0]["rerank_score"] == pytest.approx(0.9)
+        assert result[1]["memory"] == "mid relevance"
+        assert result[2]["memory"] == "low relevance"
+
+    def test_top_k_limits_results(self, mock_cross_encoder):
+        _, mock_model = mock_cross_encoder
+        mock_model.predict.return_value = np.array([0.3, 0.9, 0.6])
+
+        reranker = SentenceTransformerReranker({
+            "model": "cross-encoder/ms-marco-MiniLM-L-6-v2",
+        })
+        docs = [
+            {"memory": "low"},
+            {"memory": "high"},
+            {"memory": "mid"},
+        ]
+
+        result = reranker.rerank("test query", docs, top_k=2)
+        assert len(result) == 2
+        assert result[0]["memory"] == "high"
+
+    def test_extracts_text_from_different_keys(self, mock_cross_encoder):
+        _, mock_model = mock_cross_encoder
+        mock_model.predict.return_value = np.array([0.8, 0.5, 0.3])
+
+        reranker = SentenceTransformerReranker({
+            "model": "cross-encoder/ms-marco-MiniLM-L-6-v2",
+        })
+        docs = [
+            {"memory": "from memory key"},
+            {"text": "from text key"},
+            {"content": "from content key"},
+        ]
+
+        reranker.rerank("query", docs)
+
+        pairs = mock_model.predict.call_args[0][0]
+        assert pairs[0] == ["query", "from memory key"]
+        assert pairs[1] == ["query", "from text key"]
+        assert pairs[2] == ["query", "from content key"]
+
+    def test_fallback_on_predict_failure(self, mock_cross_encoder):
+        _, mock_model = mock_cross_encoder
+        mock_model.predict.side_effect = RuntimeError("model error")
+
+        reranker = SentenceTransformerReranker({
+            "model": "cross-encoder/ms-marco-MiniLM-L-6-v2",
+        })
+        docs = [
+            {"memory": "doc1"},
+            {"memory": "doc2"},
+        ]
+
+        result = reranker.rerank("query", docs)
+        assert len(result) == 2
+        assert all(doc["rerank_score"] == 0.0 for doc in result)


### PR DESCRIPTION
## Summary
- Fixes #4033 — `SentenceTransformerReranker` silently produced all-zero scores with cross-encoder models
- Root cause: cross-encoder models were loaded via `SentenceTransformer()` instead of `CrossEncoder()`, causing silent fallback to mean pooling and zero scores
- Added detection logic for cross-encoder model names and conditional initialization with the correct class

## Changes
- `mem0/reranker/sentence_transformer_reranker.py` — added `CrossEncoder` import, `_detect_cross_encoder()` method, conditional init
- `tests/rerankers/test_sentence_transformer_reranker.py` — 14 new unit tests

## Test plan
- [x] All 45 reranker tests pass (31 existing + 14 new)
- [x] Cross-encoder models now produce meaningful rerank scores
- [x] Sentence-transformer models continue to work unchanged