### PR TITLE
fix: prevent hallucinated memories on empty messages payload

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -429,6 +429,15 @@ class Memory(MemoryBase):
                 suggestion="Convert your input to a string, dictionary, or list of dictionaries."
             )
 
+        # Guard: return early when messages list is empty or contains no meaningful content.
+        # This prevents the LLM from hallucinating memories when called with an empty payload.
+        has_content = any(
+            isinstance(m, dict) and m.get("content") and str(m["content"]).strip()
+            for m in messages
+        )
+        if not messages or not has_content:
+            return {"results": []}
+
         if agent_id is not None and memory_type == MemoryType.PROCEDURAL.value:
             results = self._create_procedural_memory(messages, metadata=processed_metadata, prompt=prompt)
             return results
@@ -1517,6 +1526,15 @@ class AsyncMemory(MemoryBase):
                 details={"provided_type": type(messages).__name__, "valid_types": ["str", "dict", "list[dict]"]},
                 suggestion="Convert your input to a string, dictionary, or list of dictionaries."
             )
+
+        # Guard: return early when messages list is empty or contains no meaningful content.
+        # This prevents the LLM from hallucinating memories when called with an empty payload.
+        has_content = any(
+            isinstance(m, dict) and m.get("content") and str(m["content"]).strip()
+            for m in messages
+        )
+        if not messages or not has_content:
+            return {"results": []}
 
         if agent_id is not None and memory_type == MemoryType.PROCEDURAL.value:
             results = await self._create_procedural_memory(


### PR DESCRIPTION
## Summary
- Add input validation in `Memory.add()` (both sync and async) to return early when messages is empty or contains no meaningful content
- Prevents the LLM from generating hallucinated memories from empty input
- Guard applies regardless of whether `run_id` or other parameters are provided

## Problem
When `Memory.add()` receives an empty messages list with a valid `run_id`, it still sends a request to the LLM, which generates and persists ghost memories. See #4099.

## Test plan
- [ ] `Memory.add(messages=[], run_id="abc")` returns `{"results": []}`, no memories created
- [ ] `Memory.add(messages=[{"role": "user", "content": ""}], run_id="abc")` returns empty result
- [ ] `Memory.add(messages=[{"role": "user", "content": "Hello"}], run_id="abc")` still works normally
- [ ] Async `Memory.add()` with empty messages also returns early

Fixes #4099