### PR TITLE
fix(s3vectors): handle vector=None in update() to prevent boto3 validation error

### DIFF
--- a/mem0/vector_stores/s3_vectors.py
+++ b/mem0/vector_stores/s3_vectors.py
@@ -122,7 +122,37 @@ class S3Vectors(VectorStoreBase):
         )
 
     def update(self, vector_id, vector=None, payload=None):
-        # S3 Vectors uses put_vectors for updates (overwrite)
+        # S3 Vectors uses put_vectors for updates (overwrite).
+        # When vector=None (e.g. metadata-only update triggered by event=NONE),
+        # fetch the existing vector data first to avoid passing None to boto3
+        # which causes a parameter validation error:
+        #   "Invalid type for parameter vectors[0].data.float32, value: None"
+        if vector is None:
+            existing = self.get(vector_id)
+            if existing is None:
+                logger.warning(f"update called with vector=None but {vector_id} not found; skipping")
+                return
+            try:
+                response = self.client.get_vectors(
+                    vectorBucketName=self.vector_bucket_name,
+                    indexName=self.collection_name,
+                    keys=[vector_id],
+                    returnData=True,
+                    returnMetadata=True,
+                )
+                vectors = response.get("vectors", [])
+                if not vectors:
+                    logger.warning(f"update: no vector data found for {vector_id}; skipping")
+                    return
+                vector = vectors[0].get("data", {}).get("float32")
+                if vector is None:
+                    logger.warning(f"update: float32 data is None for {vector_id}; skipping")
+                    return
+                if payload is None:
+                    payload = existing.payload
+            except Exception as e:
+                logger.error(f"update: failed to fetch existing vector for {vector_id}: {e}")
+                return
         self.insert(vectors=[vector], payloads=[payload], ids=[vector_id])
 
     def get(self, vector_id) -> Optional[OutputData]:


### PR DESCRIPTION
## Problem

When mem0's LLM decides a memory doesn't need updating (`event=NONE`), it still calls `vector_store.update(vector_id, vector=None, payload=updated_metadata)` to refresh session identifiers (`agent_id`/`run_id`).

The S3Vectors `update()` implementation blindly passes `vector=None` to `insert()`, which constructs `{"data": {"float32": None}}` and fails boto3 parameter validation:

```
ERROR mem0.memory.main: Error processing memory action: {'event': 'NONE'},
Error: Parameter validation failed:
Invalid type for parameter vectors[0].data.float32, value: None, 
type: <class 'NoneType'>, valid types: <class 'list'>, <class 'tuple'>
```

This error is logged as `ERROR` on every `event=NONE` occurrence, polluting logs and causing confusion — the memory operation actually succeeds, but the metadata update silently fails.

## Root Cause

In `memory/main.py`, the `event=NONE` branch:

```python
elif event_type == "NONE":
    if memory_id and (metadata.get("agent_id") or metadata.get("run_id")):
        ...
        self.vector_store.update(
            vector_id=memory_id,
            vector=None,  # Keep same embeddings
            payload=updated_metadata,
        )
```

The OpenSearch adapter handles `vector=None` correctly (`if vector is not None: doc["vector_field"] = vector`), but S3Vectors does not.

## Fix

When `vector=None`, fetch the existing float32 data via `get_vectors(returnData=True)` before calling `insert()`. If retrieval fails, skip with a warning instead of crashing.

## Testing

Reproduced locally with S3Vectors backend — confirmed zero errors after fix when repeatedly writing the same memory content (triggering `event=NONE`).

Related to the same pattern as the OpenSearch adapter fix in the existing codebase.