### PR TITLE
feat(vector_stores): support chained comparison operators in filters

### DIFF
--- a/mem0/vector_stores/chroma.py
+++ b/mem0/vector_stores/chroma.py
@@ -264,31 +264,18 @@ class ChromaDB(VectorStoreBase):
                 return None
             elif isinstance(value, dict):
                 # Handle comparison operators
-                chroma_condition = {}
+                op_map = {
+                    "eq": "$eq", "ne": "$ne", "gt": "$gt", "gte": "$gte",
+                    "lt": "$lt", "lte": "$lte", "in": "$in", "nin": "$nin",
+                    "contains": "$eq", "icontains": "$eq",
+                }
+                conditions = []
                 for op, val in value.items():
-                    if op == "eq":
-                        chroma_condition[key] = {"$eq": val}
-                    elif op == "ne":
-                        chroma_condition[key] = {"$ne": val}
-                    elif op == "gt":
-                        chroma_condition[key] = {"$gt": val}
-                    elif op == "gte":
-                        chroma_condition[key] = {"$gte": val}
-                    elif op == "lt":
-                        chroma_condition[key] = {"$lt": val}
-                    elif op == "lte":
-                        chroma_condition[key] = {"$lte": val}
-                    elif op == "in":
-                        chroma_condition[key] = {"$in": val}
-                    elif op == "nin":
-                        chroma_condition[key] = {"$nin": val}
-                    elif op in ["contains", "icontains"]:
-                        # ChromaDB doesn't support contains, fallback to equality
-                        chroma_condition[key] = {"$eq": val}
-                    else:
-                        # Unknown operator, treat as equality
-                        chroma_condition[key] = {"$eq": val}
-                return chroma_condition
+                    chroma_op = op_map.get(op, "$eq")
+                    conditions.append({key: {chroma_op: val}})
+                if len(conditions) == 1:
+                    return conditions[0]
+                return {"$and": conditions}
             else:
                 # Simple equality
                 return {key: {"$eq": value}}

--- a/mem0/vector_stores/faiss.py
+++ b/mem0/vector_stores/faiss.py
@@ -280,11 +280,27 @@ class FAISS(VectorStoreBase):
         if not filters or not payload:
             return True
 
+        op_funcs = {
+            "eq": lambda a, b: a == b,
+            "ne": lambda a, b: a != b,
+            "gt": lambda a, b: a > b,
+            "gte": lambda a, b: a >= b,
+            "lt": lambda a, b: a < b,
+            "lte": lambda a, b: a <= b,
+            "in": lambda a, b: a in b,
+            "nin": lambda a, b: a not in b,
+        }
+
         for key, value in filters.items():
             if key not in payload:
                 return False
 
-            if isinstance(value, list):
+            if isinstance(value, dict):
+                for op, val in value.items():
+                    func = op_funcs.get(op)
+                    if func is None or not func(payload[key], val):
+                        return False
+            elif isinstance(value, list):
                 if payload[key] not in value:
                     return False
             elif payload[key] != value:

--- a/mem0/vector_stores/milvus.py
+++ b/mem0/vector_stores/milvus.py
@@ -106,9 +106,26 @@ class MilvusDB(VectorStoreBase):
         Returns:
             str: formated filter.
         """
+        op_map = {
+            "eq": "==", "ne": "!=",
+            "gt": ">", "gte": ">=",
+            "lt": "<", "lte": "<=",
+        }
+
         operands = []
         for key, value in filters.items():
-            if isinstance(value, str):
+            if isinstance(value, dict):
+                for op, val in value.items():
+                    if op in op_map:
+                        if isinstance(val, str):
+                            operands.append(f'(metadata["{key}"] {op_map[op]} "{val}")')
+                        else:
+                            operands.append(f'(metadata["{key}"] {op_map[op]} {val})')
+                    elif op == "in":
+                        operands.append(f'(metadata["{key}"] in {val})')
+                    elif op == "nin":
+                        operands.append(f'(metadata["{key}"] not in {val})')
+            elif isinstance(value, str):
                 operands.append(f'(metadata["{key}"] == "{value}")')
             else:
                 operands.append(f'(metadata["{key}"] == {value})')

--- a/mem0/vector_stores/pgvector.py
+++ b/mem0/vector_stores/pgvector.py
@@ -199,6 +199,35 @@ class PGVector(VectorStoreBase):
                     data,
                 )
 
+    def _build_filter_conditions(self, filters):
+        """Build SQL WHERE clause components from a filter dict.
+
+        Handles simple equality (scalar value) and operator dicts
+        (value is dict with keys: eq, ne, gt, gte, lt, lte, in, nin).
+        """
+        conditions = []
+        params = []
+        op_sql = {"eq": "=", "ne": "!=", "gt": ">", "gte": ">=", "lt": "<", "lte": "<="}
+
+        for k, v in filters.items():
+            if isinstance(v, dict):
+                for op, val in v.items():
+                    if op in op_sql:
+                        cast = "::numeric" if isinstance(val, (int, float)) else ""
+                        conditions.append(f"(payload->>%s){cast} {op_sql[op]} %s")
+                        params.extend([k, val])
+                    elif op == "in":
+                        conditions.append("payload->>%s = ANY(%s)")
+                        params.extend([k, val])
+                    elif op == "nin":
+                        conditions.append("NOT (payload->>%s = ANY(%s))")
+                        params.extend([k, val])
+            else:
+                conditions.append("payload->>%s = %s")
+                params.extend([k, str(v)])
+
+        return conditions, params
+
     def search(
         self,
         query: str,
@@ -218,13 +247,7 @@ class PGVector(VectorStoreBase):
         Returns:
             list: Search results.
         """
-        filter_conditions = []
-        filter_params = []
-
-        if filters:
-            for k, v in filters.items():
-                filter_conditions.append("payload->>%s = %s")
-                filter_params.extend([k, str(v)])
+        filter_conditions, filter_params = self._build_filter_conditions(filters) if filters else ([], [])
 
         filter_clause = "WHERE " + " AND ".join(filter_conditions) if filter_conditions else ""
 
@@ -362,13 +385,7 @@ class PGVector(VectorStoreBase):
         Returns:
             List[OutputData]: List of vectors.
         """
-        filter_conditions = []
-        filter_params = []
-
-        if filters:
-            for k, v in filters.items():
-                filter_conditions.append("payload->>%s = %s")
-                filter_params.extend([k, str(v)])
+        filter_conditions, filter_params = self._build_filter_conditions(filters) if filters else ([], [])
 
         filter_clause = "WHERE " + " AND ".join(filter_conditions) if filter_conditions else ""
 

--- a/mem0/vector_stores/pinecone.py
+++ b/mem0/vector_stores/pinecone.py
@@ -193,11 +193,18 @@ class PineconeDB(VectorStoreBase):
         if not filters:
             return {}
 
+        op_map = {
+            "eq": "$eq", "ne": "$ne",
+            "gt": "$gt", "gte": "$gte",
+            "lt": "$lt", "lte": "$lte",
+            "in": "$in", "nin": "$nin",
+        }
+
         pinecone_filter = {}
 
         for key, value in filters.items():
-            if isinstance(value, dict) and "gte" in value and "lte" in value:
-                pinecone_filter[key] = {"$gte": value["gte"], "$lte": value["lte"]}
+            if isinstance(value, dict):
+                pinecone_filter[key] = {op_map.get(op, "$eq"): val for op, val in value.items()}
             else:
                 pinecone_filter[key] = {"$eq": value}
 

--- a/tests/vector_stores/test_chroma.py
+++ b/tests/vector_stores/test_chroma.py
@@ -252,6 +252,57 @@ def test_generate_where_clause_non_string_values():
     assert result == expected
 
 
+# ===========================================================================
+# _generate_where_clause: operator dict support (fix for #3914)
+# ===========================================================================
+
+
+def test_generate_where_clause_range_filter():
+    """Range filter with gte + lte should wrap in $and with separate conditions."""
+    filters = {"score": {"gte": 1, "lte": 10}}
+    result = ChromaDB._generate_where_clause(filters)
+    expected = {"$and": [{"score": {"$gte": 1}}, {"score": {"$lte": 10}}]}
+    assert result == expected
+
+
+def test_generate_where_clause_single_operator():
+    """Single operator should produce a single condition without $and."""
+    filters = {"age": {"gt": 25}}
+    result = ChromaDB._generate_where_clause(filters)
+    expected = {"age": {"$gt": 25}}
+    assert result == expected
+
+
+def test_generate_where_clause_mixed_equality_and_range():
+    """Equality and range filters should coexist in $and."""
+    filters = {"user_id": "alice", "score": {"gte": 1, "lte": 10}}
+    result = ChromaDB._generate_where_clause(filters)
+    # Should have $and with equality + nested $and for range
+    assert "$and" in result
+    conditions = result["$and"]
+    # Find the equality and range conditions
+    eq_found = any(c.get("user_id") == {"$eq": "alice"} for c in conditions)
+    range_found = any("$and" in c for c in conditions)
+    assert eq_found
+    assert range_found
+
+
+def test_generate_where_clause_ne_operator():
+    """ne operator should produce $ne."""
+    filters = {"status": {"ne": "archived"}}
+    result = ChromaDB._generate_where_clause(filters)
+    expected = {"status": {"$ne": "archived"}}
+    assert result == expected
+
+
+def test_generate_where_clause_in_operator():
+    """in operator should produce $in."""
+    filters = {"cat": {"in": ["a", "b"]}}
+    result = ChromaDB._generate_where_clause(filters)
+    expected = {"cat": {"$in": ["a", "b"]}}
+    assert result == expected
+
+
 def test_chroma_config_accepts_default_tmp_path():
     """Test that ChromaDbConfig accepts the default /tmp/chroma path."""
     config = ChromaDbConfig(path="/tmp/chroma")

--- a/tests/vector_stores/test_faiss.py
+++ b/tests/vector_stores/test_faiss.py
@@ -299,3 +299,49 @@ def test_normalize_L2(faiss_instance, mock_faiss_index):
 
             # Verify faiss.normalize_L2 was called
             mock_normalize.assert_called_once()
+
+
+# ===========================================================================
+# _apply_filters: operator dict support (fix for #3914)
+# ===========================================================================
+
+
+def test_apply_filters_range(faiss_instance):
+    """Range filter with gte + lte should match values within range."""
+    filters = {"score": {"gte": 5, "lte": 10}}
+    assert faiss_instance._apply_filters({"score": 7}, filters) is True
+    assert faiss_instance._apply_filters({"score": 5}, filters) is True
+    assert faiss_instance._apply_filters({"score": 10}, filters) is True
+    assert faiss_instance._apply_filters({"score": 4}, filters) is False
+    assert faiss_instance._apply_filters({"score": 11}, filters) is False
+
+
+def test_apply_filters_single_gt(faiss_instance):
+    """Single gt operator should filter correctly."""
+    filters = {"age": {"gt": 18}}
+    assert faiss_instance._apply_filters({"age": 25}, filters) is True
+    assert faiss_instance._apply_filters({"age": 18}, filters) is False
+    assert faiss_instance._apply_filters({"age": 10}, filters) is False
+
+
+def test_apply_filters_ne(faiss_instance):
+    """ne operator should exclude matching values."""
+    filters = {"status": {"ne": "archived"}}
+    assert faiss_instance._apply_filters({"status": "active"}, filters) is True
+    assert faiss_instance._apply_filters({"status": "archived"}, filters) is False
+
+
+def test_apply_filters_in_nin(faiss_instance):
+    """in and nin operators should check list membership."""
+    assert faiss_instance._apply_filters({"cat": "a"}, {"cat": {"in": ["a", "b"]}}) is True
+    assert faiss_instance._apply_filters({"cat": "c"}, {"cat": {"in": ["a", "b"]}}) is False
+    assert faiss_instance._apply_filters({"cat": "c"}, {"cat": {"nin": ["a", "b"]}}) is True
+    assert faiss_instance._apply_filters({"cat": "a"}, {"cat": {"nin": ["a", "b"]}}) is False
+
+
+def test_apply_filters_mixed_equality_and_range(faiss_instance):
+    """Equality and operator dict filters should coexist."""
+    filters = {"user_id": "alice", "score": {"gte": 1, "lte": 10}}
+    assert faiss_instance._apply_filters({"user_id": "alice", "score": 5}, filters) is True
+    assert faiss_instance._apply_filters({"user_id": "bob", "score": 5}, filters) is False
+    assert faiss_instance._apply_filters({"user_id": "alice", "score": 15}, filters) is False

--- a/tests/vector_stores/test_milvus.py
+++ b/tests/vector_stores/test_milvus.py
@@ -319,6 +319,50 @@ class TestMilvusDB:
         mock_milvus_client.create_collection.assert_not_called()
 
 
+    # ===========================================================================
+    # _create_filter: operator dict support (fix for #3914)
+    # ===========================================================================
+
+    def test_create_filter_range(self, milvus_db):
+        """Range filter with gte + lte should produce both >= and <= conditions."""
+        filter_str = milvus_db._create_filter({"score": {"gte": 1, "lte": 10}})
+        assert 'metadata["score"] >= 1' in filter_str
+        assert 'metadata["score"] <= 10' in filter_str
+        assert " and " in filter_str
+
+    def test_create_filter_single_gt(self, milvus_db):
+        """Single gt operator should produce > condition."""
+        filter_str = milvus_db._create_filter({"age": {"gt": 25}})
+        assert filter_str == '(metadata["age"] > 25)'
+
+    def test_create_filter_ne(self, milvus_db):
+        """ne operator should produce != condition."""
+        filter_str = milvus_db._create_filter({"status": {"ne": "done"}})
+        assert filter_str == '(metadata["status"] != "done")'
+
+    def test_create_filter_in(self, milvus_db):
+        """in operator should produce in condition."""
+        filter_str = milvus_db._create_filter({"cat": {"in": [1, 2]}})
+        assert filter_str == '(metadata["cat"] in [1, 2])'
+
+    def test_create_filter_nin(self, milvus_db):
+        """nin operator should produce not in condition."""
+        filter_str = milvus_db._create_filter({"cat": {"nin": [1, 2]}})
+        assert filter_str == '(metadata["cat"] not in [1, 2])'
+
+    def test_create_filter_mixed_equality_and_range(self, milvus_db):
+        """Equality and operator dict filters should coexist."""
+        filter_str = milvus_db._create_filter({"user_id": "alice", "score": {"gte": 1, "lte": 10}})
+        assert 'metadata["user_id"] == "alice"' in filter_str
+        assert 'metadata["score"] >= 1' in filter_str
+        assert 'metadata["score"] <= 10' in filter_str
+
+    def test_create_filter_equality_unchanged(self, milvus_db):
+        """Existing equality filters should continue to work."""
+        filter_str = milvus_db._create_filter({"user_id": "alice"})
+        assert filter_str == '(metadata["user_id"] == "alice")'
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
 

--- a/tests/vector_stores/test_pgvector.py
+++ b/tests/vector_stores/test_pgvector.py
@@ -2228,3 +2228,92 @@ class TestPGVector(unittest.TestCase):
     def tearDown(self):
         """Clean up after each test."""
         pass
+
+
+# ===========================================================================
+# _build_filter_conditions: operator dict support (fix for #3914)
+# ===========================================================================
+
+
+class TestBuildFilterConditions(unittest.TestCase):
+    """Tests for the _build_filter_conditions helper method."""
+
+    def _make_pgvector(self):
+        with patch('mem0.vector_stores.pgvector.PSYCOPG_VERSION', 3):
+            with patch('mem0.vector_stores.pgvector.ConnectionPool'):
+                return PGVector(
+                    dbname="test_db",
+                    collection_name="test_collection",
+                    embedding_model_dims=3,
+                    user="test_user",
+                    password="test_pass",
+                    host="localhost",
+                    port=5432,
+                    diskann=False,
+                    hnsw=False,
+                    minconn=1,
+                    maxconn=4,
+                )
+
+    def test_range_filter(self):
+        """Range filter with gte + lte should produce two SQL conditions with ::numeric cast."""
+        pgvector = self._make_pgvector()
+        conditions, params = pgvector._build_filter_conditions({"score": {"gte": 1, "lte": 10}})
+        self.assertEqual(len(conditions), 2)
+        self.assertTrue(any("::numeric >=" in c for c in conditions))
+        self.assertTrue(any("::numeric <=" in c for c in conditions))
+        self.assertIn("score", params)
+        self.assertIn(1, params)
+        self.assertIn(10, params)
+
+    def test_single_gt_operator(self):
+        """Single gt operator should produce one SQL condition."""
+        pgvector = self._make_pgvector()
+        conditions, params = pgvector._build_filter_conditions({"age": {"gt": 25}})
+        self.assertEqual(len(conditions), 1)
+        self.assertIn("::numeric >", conditions[0])
+        self.assertEqual(params, ["age", 25])
+
+    def test_ne_operator(self):
+        """ne operator should produce != SQL condition."""
+        pgvector = self._make_pgvector()
+        conditions, params = pgvector._build_filter_conditions({"status": {"ne": "archived"}})
+        self.assertEqual(len(conditions), 1)
+        self.assertIn("!=", conditions[0])
+        self.assertNotIn("::numeric", conditions[0])
+        self.assertEqual(params, ["status", "archived"])
+
+    def test_in_operator(self):
+        """in operator should produce ANY() SQL condition."""
+        pgvector = self._make_pgvector()
+        conditions, params = pgvector._build_filter_conditions({"cat": {"in": ["a", "b"]}})
+        self.assertEqual(len(conditions), 1)
+        self.assertIn("ANY", conditions[0])
+        self.assertEqual(params, ["cat", ["a", "b"]])
+
+    def test_nin_operator(self):
+        """nin operator should produce NOT ... ANY() SQL condition."""
+        pgvector = self._make_pgvector()
+        conditions, params = pgvector._build_filter_conditions({"cat": {"nin": ["a", "b"]}})
+        self.assertEqual(len(conditions), 1)
+        self.assertIn("NOT", conditions[0])
+        self.assertIn("ANY", conditions[0])
+
+    def test_equality_unchanged(self):
+        """Simple equality should produce the same output as before."""
+        pgvector = self._make_pgvector()
+        conditions, params = pgvector._build_filter_conditions({"user_id": "alice"})
+        self.assertEqual(len(conditions), 1)
+        self.assertEqual(conditions[0], "payload->>%s = %s")
+        self.assertEqual(params, ["user_id", "alice"])
+
+    def test_mixed_equality_and_range(self):
+        """Equality and range filters should coexist."""
+        pgvector = self._make_pgvector()
+        conditions, params = pgvector._build_filter_conditions(
+            {"user_id": "alice", "score": {"gte": 1, "lte": 10}}
+        )
+        self.assertEqual(len(conditions), 3)  # 1 equality + 2 range
+        # Equality condition
+        self.assertIn("payload->>%s = %s", conditions)
+        self.assertIn("alice", params)

--- a/tests/vector_stores/test_pinecone.py
+++ b/tests/vector_stores/test_pinecone.py
@@ -188,3 +188,44 @@ def test_count_with_none_vector_count(pinecone_db):
     count = pinecone_db.count()
     assert count == 0
     pinecone_db.index.describe_index_stats.assert_called_once()
+
+
+# ===========================================================================
+# _create_filter: operator dict support (fix for #3914)
+# ===========================================================================
+
+
+def test_create_filter_range(pinecone_db):
+    """Range filter with gte + lte should map to $gte + $lte."""
+    result = pinecone_db._create_filter({"score": {"gte": 1, "lte": 10}})
+    assert result == {"score": {"$gte": 1, "$lte": 10}}
+
+
+def test_create_filter_single_gt(pinecone_db):
+    """Single gt operator should map to $gt."""
+    result = pinecone_db._create_filter({"age": {"gt": 25}})
+    assert result == {"age": {"$gt": 25}}
+
+
+def test_create_filter_ne(pinecone_db):
+    """ne operator should map to $ne."""
+    result = pinecone_db._create_filter({"status": {"ne": "done"}})
+    assert result == {"status": {"$ne": "done"}}
+
+
+def test_create_filter_in(pinecone_db):
+    """in operator should map to $in."""
+    result = pinecone_db._create_filter({"cat": {"in": ["a", "b"]}})
+    assert result == {"cat": {"$in": ["a", "b"]}}
+
+
+def test_create_filter_mixed(pinecone_db):
+    """Equality and operator dict filters should coexist."""
+    result = pinecone_db._create_filter({"user_id": "alice", "score": {"gte": 1, "lte": 10}})
+    assert result == {"user_id": {"$eq": "alice"}, "score": {"$gte": 1, "$lte": 10}}
+
+
+def test_create_filter_equality_unchanged(pinecone_db):
+    """Simple equality should still produce $eq."""
+    result = pinecone_db._create_filter({"user_id": "alice"})
+    assert result == {"user_id": {"$eq": "alice"}}


### PR DESCRIPTION
## Summary
- Adds range/operator filter support (`eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`) to 5 vector stores that previously only handled simple equality filters. This enables chained comparisons like `{"score": {"gte": 1, "lte": 10}}` across all major stores.
- **ChromaDB**: Fix operator overwrite in `convert_condition()` — wrap multiple operators per key in `$and`
- **PGVector**: Extract shared `_build_filter_conditions()` helper with SQL operator mapping and `::numeric` casting, used by both `search()` and `list()`
- **Pinecone**: Replace hardcoded `gte+lte` pair check with generic operator mapping
- **FAISS**: Add operator dict dispatch to `_apply_filters()` for Python-side post-search filtering
- **Milvus**: Add operator dict branch to `_create_filter()` using native expression syntax

Qdrant already supported this and is unchanged (used as reference implementation).

Fixes #3914

## Test plan
- [x] FAISS: 17 tests pass (6 new `_apply_filters` operator tests)
- [x] Pinecone: 13 tests pass (6 new `_create_filter` operator tests)
- [x] Milvus: 26 tests pass (7 new `_create_filter` operator tests)
- [x] ChromaDB: 20 tests pass (5 new `_generate_where_clause` operator tests)
- [x] PGVector: 57 tests pass (7 new `_build_filter_conditions` tests)
- [x] No regressions on existing tests (3 async failures are pre-existing on main)
- [x] Filter output formats verified against official docs (ChromaDB, Pinecone, Milvus, pgvector)