### PR TITLE
fix: replace .single() with .maybeSingle() in SupabaseDB.get() to handle missing rows

### DIFF
--- a/mem0-ts/src/oss/src/vector_stores/supabase.ts
+++ b/mem0-ts/src/oss/src/vector_stores/supabase.ts
@@ -267,7 +267,7 @@ See the SQL migration instructions in the code comments.`,
         .from(this.tableName)
         .select("*")
         .eq("id", vectorId)
-        .single();
+        .maybeSingle();
 
       if (error) throw error;
       if (!data) return null;


### PR DESCRIPTION
Fixes #4596

## Problem
`SupabaseDB.get(vectorId)` used `.single()` which throws `PGRST116` when no row exists. A missing row is not an error — it's a valid not-found case.

## Fix
Replace `.single()` with `.maybeSingle()` on line 270 of `supabase.ts`. This returns `null` instead of throwing when no row is found, which is already handled correctly by the `if (!data) return null` check.