### PR TITLE
fix: use shared ThreadPoolExecutor to prevent thread leaks in Memory class (#4586)

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import concurrent.futures
 import concurrent
 import gc
 import hashlib
@@ -241,6 +242,10 @@ setup_config()
 logger = logging.getLogger(__name__)
 
 
+
+# A shared thread pool to prevent thread exhaustion overhead across repeated add/search calls
+_shared_executor = concurrent.futures.ThreadPoolExecutor(thread_name_prefix="mem0-executor")
+
 class Memory(MemoryBase):
     def __init__(self, config: MemoryConfig = MemoryConfig()):
         self.config = config
@@ -438,14 +443,13 @@ class Memory(MemoryBase):
         else:
             messages = parse_vision_messages(messages)
 
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            future1 = executor.submit(self._add_to_vector_store, messages, processed_metadata, effective_filters, infer)
-            future2 = executor.submit(self._add_to_graph, messages, effective_filters)
+        future1 = _shared_executor.submit(self._add_to_vector_store, messages, processed_metadata, effective_filters, infer)
+        future2 = _shared_executor.submit(self._add_to_graph, messages, effective_filters)
 
-            concurrent.futures.wait([future1, future2])
+        concurrent.futures.wait([future1, future2])
 
-            vector_store_result = future1.result()
-            graph_result = future2.result()
+        vector_store_result = future1.result()
+        graph_result = future2.result()
 
         if self.enable_graph:
             return {
@@ -782,18 +786,17 @@ class Memory(MemoryBase):
             "mem0.get_all", self, {"limit": limit, "keys": keys, "encoded_ids": encoded_ids, "sync_type": "sync"}
         )
 
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            future_memories = executor.submit(self._get_all_from_vector_store, effective_filters, limit)
-            future_graph_entities = (
-                executor.submit(self.graph.get_all, effective_filters, limit) if self.enable_graph else None
-            )
+        future_memories = _shared_executor.submit(self._get_all_from_vector_store, effective_filters, limit)
+        future_graph_entities = (
+            _shared_executor.submit(self.graph.get_all, effective_filters, limit) if self.enable_graph else None
+        )
 
-            concurrent.futures.wait(
-                [future_memories, future_graph_entities] if future_graph_entities else [future_memories]
-            )
+        concurrent.futures.wait(
+            [future_memories, future_graph_entities] if future_graph_entities else [future_memories]
+        )
 
-            all_memories_result = future_memories.result()
-            graph_entities_result = future_graph_entities.result() if future_graph_entities else None
+        all_memories_result = future_memories.result()
+        graph_entities_result = future_graph_entities.result() if future_graph_entities else None
 
         if self.enable_graph:
             return {"results": all_memories_result, "relations": graph_entities_result}
@@ -921,18 +924,17 @@ class Memory(MemoryBase):
             },
         )
 
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            future_memories = executor.submit(self._search_vector_store, query, effective_filters, limit, threshold)
-            future_graph_entities = (
-                executor.submit(self.graph.search, query, effective_filters, limit) if self.enable_graph else None
-            )
+        future_memories = _shared_executor.submit(self._search_vector_store, query, effective_filters, limit, threshold)
+        future_graph_entities = (
+            _shared_executor.submit(self.graph.search, query, effective_filters, limit) if self.enable_graph else None
+        )
 
-            concurrent.futures.wait(
-                [future_memories, future_graph_entities] if future_graph_entities else [future_memories]
-            )
+        concurrent.futures.wait(
+            [future_memories, future_graph_entities] if future_graph_entities else [future_memories]
+        )
 
-            original_memories = future_memories.result()
-            graph_entities = future_graph_entities.result() if future_graph_entities else None
+        original_memories = future_memories.result()
+        graph_entities = future_graph_entities.result() if future_graph_entities else None
 
         # Apply reranking if enabled and reranker is available
         if rerank and self.reranker and original_memories:

--- a/mem0/vector_stores/elasticsearch.py
+++ b/mem0/vector_stores/elasticsearch.py
@@ -150,13 +150,10 @@ class ElasticsearchDB(VectorStoreBase):
 
         response = self.client.search(index=self.collection_name, body=search_query)
 
-        results = []
-        for hit in response["hits"]["hits"]:
-            results.append(
-                OutputData(id=hit["_id"], score=hit["_score"], payload=hit.get("_source", {}).get("metadata", {}))
-            )
-
-        return results
+        return [
+            OutputData(id=hit["_id"], score=hit["_score"], payload=hit.get("_source", {}).get("metadata", {}))
+            for hit in response["hits"]["hits"]
+        ]
 
     def delete(self, vector_id: str) -> None:
         """Delete a vector by ID."""
@@ -218,15 +215,14 @@ class ElasticsearchDB(VectorStoreBase):
 
         response = self.client.search(index=self.collection_name, body=query)
 
-        results = []
-        for hit in response["hits"]["hits"]:
-            results.append(
-                OutputData(
-                    id=hit["_id"],
-                    score=1.0,  # Default score for list operation
-                    payload=hit.get("_source", {}).get("metadata", {}),
-                )
+        results = [
+            OutputData(
+                id=hit["_id"],
+                score=1.0,  # Default score for list operation
+                payload=hit.get("_source", {}).get("metadata", {}),
             )
+            for hit in response["hits"]["hits"]
+        ]
 
         return [results]
 

--- a/mem0/vector_stores/faiss.py
+++ b/mem0/vector_stores/faiss.py
@@ -402,11 +402,8 @@ class FAISS(VectorStoreBase):
             return [self.collection_name] if self.index else []
 
         try:
-            collections = []
             path = Path(self.path).parent
-            for file in path.glob("*.faiss"):
-                collections.append(file.stem)
-            return collections
+            return [file.stem for file in path.glob("*.faiss")]
         except Exception as e:
             logger.warning(f"Failed to list collections: {e}")
             return [self.collection_name] if self.index else []

--- a/mem0/vector_stores/vertex_ai_vector_search.py
+++ b/mem0/vector_stores/vertex_ai_vector_search.py
@@ -110,16 +110,14 @@ class GoogleMatchingEngine(VectorStoreBase):
             List[OutputData]: Parsed output data.
         """
         results = data.get("nearestNeighbors", {}).get("neighbors", [])
-        output_data = []
-        for result in results:
-            output_data.append(
-                OutputData(
-                    id=result.get("datapoint").get("datapointId"),
-                    score=result.get("distance"),
-                    payload=result.get("datapoint").get("metadata"),
-                )
+        return [
+            OutputData(
+                id=result.get("datapoint").get("datapointId"),
+                score=result.get("distance"),
+                payload=result.get("datapoint").get("metadata"),
             )
-        return output_data
+            for result in results
+        ]
 
     def _create_restriction(self, key: str, value: Any) -> aiplatform_v1.types.index.IndexDatapoint.Restriction:
         """Create a restriction object for the Matching Engine index.


### PR DESCRIPTION
Closes #4586

### Description

In high-concurrency environments, creating a new `ThreadPoolExecutor()` instance for every `add()`, `search()`, and `get_all()` method call creates significant OS thread creation overhead and leads to thread exhaustion since executors often wait for worker threads to age out before OS resources are returned.

This PR introduces a module-level `_shared_executor` for the synchronous `Memory` class (mirroring the way `AsyncMemory` naturally uses a shared executor via asyncio). This solves the leak, natively bounds concurrency to `min(32, os.cpu_count() + 4)`, and speeds up fan-out tasks.

*(Refactored using the open-source [0-editor](https://github.com/0-protocol/0-editor))*