### PR TITLE
fix: handle empty/invalid LLM response in fact extraction

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -507,17 +507,23 @@ class Memory(MemoryBase):
         # Ensure 'json' appears in prompts for json_object response format compatibility
         system_prompt, user_prompt = ensure_json_instruction(system_prompt, user_prompt)
 
-        response = self.llm.generate_response(
-            messages=[
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": user_prompt},
-            ],
-            response_format={"type": "json_object"},
-        )
+        try:
+            response = self.llm.generate_response(
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+                response_format={"type": "json_object"},
+            )
+        except Exception as e:
+            logger.error(f"Error in fact extraction response: {e}")
+            response = ""
 
         try:
-            cleaned_response = remove_code_blocks(response)
-            if not cleaned_response.strip():
+            if not response or not response.strip():
+                logger.warning("Empty response from LLM for fact extraction")
+                new_retrieved_facts = []
+            elif not (cleaned_response := remove_code_blocks(response)).strip():
                 new_retrieved_facts = []
             else:
                 try:
@@ -1601,14 +1607,21 @@ class AsyncMemory(MemoryBase):
         # Ensure 'json' appears in prompts for json_object response format compatibility
         system_prompt, user_prompt = ensure_json_instruction(system_prompt, user_prompt)
 
-        response = await asyncio.to_thread(
-            self.llm.generate_response,
-            messages=[{"role": "system", "content": system_prompt}, {"role": "user", "content": user_prompt}],
-            response_format={"type": "json_object"},
-        )
         try:
-            cleaned_response = remove_code_blocks(response)
-            if not cleaned_response.strip():
+            response = await asyncio.to_thread(
+                self.llm.generate_response,
+                messages=[{"role": "system", "content": system_prompt}, {"role": "user", "content": user_prompt}],
+                response_format={"type": "json_object"},
+            )
+        except Exception as e:
+            logger.error(f"Error in fact extraction response: {e}")
+            response = ""
+
+        try:
+            if not response or not response.strip():
+                logger.warning("Empty response from LLM for fact extraction")
+                new_retrieved_facts = []
+            elif not (cleaned_response := remove_code_blocks(response)).strip():
                 new_retrieved_facts = []
             else:
                 try:

--- a/tests/test_empty_response_handling.py
+++ b/tests/test_empty_response_handling.py
@@ -1,0 +1,86 @@
+"""Tests for empty/invalid LLM response handling in fact extraction.
+
+When LLMs like Groq compound models return non-JSON or empty responses
+for the fact extraction call, _add_to_vector_store should handle it
+gracefully instead of crashing.
+"""
+
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from mem0 import Memory
+
+
+@pytest.fixture
+def memory_instance():
+    with patch("mem0.memory.main.MemoryBase.__init__", return_value=None), \
+         patch("mem0.memory.main.capture_event"):
+        m = Memory.__new__(Memory)
+        m.config = MagicMock()
+        m.config.custom_fact_extraction_prompt = None
+        m.config.custom_update_memory_prompt = None
+        m.config.version = "v1.0"
+        m.api_version = "v1.0"
+        m.llm = MagicMock()
+        m.embedding_model = MagicMock()
+        m.vector_store = MagicMock()
+        m.db = MagicMock()
+        m.enable_graph = False
+        yield m
+
+
+class TestFactExtractionErrorHandling:
+    """Verify _add_to_vector_store handles bad LLM responses for fact extraction."""
+
+    def test_none_response_returns_empty(self, memory_instance):
+        """None from generate_response should not crash."""
+        memory_instance.llm.generate_response.return_value = None
+        memory_instance._should_use_agent_memory_extraction = Mock(return_value=False)
+
+        result = memory_instance._add_to_vector_store(
+            messages=[{"role": "user", "content": "Hello"}],
+            metadata={"user_id": "test"},
+            filters={"user_id": "test"},
+            infer=True,
+        )
+        assert result == []
+
+    def test_empty_string_response_returns_empty(self, memory_instance):
+        """Empty string from generate_response should not crash."""
+        memory_instance.llm.generate_response.return_value = ""
+        memory_instance._should_use_agent_memory_extraction = Mock(return_value=False)
+
+        result = memory_instance._add_to_vector_store(
+            messages=[{"role": "user", "content": "Hello"}],
+            metadata={"user_id": "test"},
+            filters={"user_id": "test"},
+            infer=True,
+        )
+        assert result == []
+
+    def test_non_json_response_returns_empty(self, memory_instance):
+        """Plain text (non-JSON) response should not crash."""
+        memory_instance.llm.generate_response.return_value = "I cannot help with that request."
+        memory_instance._should_use_agent_memory_extraction = Mock(return_value=False)
+
+        result = memory_instance._add_to_vector_store(
+            messages=[{"role": "user", "content": "Hello"}],
+            metadata={"user_id": "test"},
+            filters={"user_id": "test"},
+            infer=True,
+        )
+        assert result == []
+
+    def test_generate_response_exception_returns_empty(self, memory_instance):
+        """If generate_response raises, should not crash."""
+        memory_instance.llm.generate_response.side_effect = Exception("API error: unsupported parameter")
+        memory_instance._should_use_agent_memory_extraction = Mock(return_value=False)
+
+        result = memory_instance._add_to_vector_store(
+            messages=[{"role": "user", "content": "Hello"}],
+            metadata={"user_id": "test"},
+            filters={"user_id": "test"},
+            infer=True,
+        )
+        assert result == []


### PR DESCRIPTION
## Linked Issue

Closes #4054

## Description

Groq compound models (and potentially other LLM providers) can return non-JSON or empty responses when `response_format={"type": "json_object"}` is passed. The second `generate_response()` call in `_add_to_vector_store()` (memory actions) already handles this with try/except and None checks, but the first call (fact extraction) didn't, causing crashes.

This applies the same defensive pattern to the first `generate_response()` call in both sync and async paths:

1. Wrap `generate_response()` in try/except so API errors (like Groq rejecting the `response_format` param) don't crash the whole flow
2. Check for None/empty response before calling `remove_code_blocks()`, which would throw `AttributeError` on None input

The fix mirrors what's already done at line 578-585 (sync) and line 1672-1680 (async) for the second LLM call.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added `tests/test_empty_response_handling.py` with 4 tests:
- None response from LLM returns `[]` without crashing
- Empty string response returns `[]` without crashing
- Non-JSON text response (e.g. "I cannot help with that") returns `[]`
- `generate_response()` raising an exception returns `[]`

All 4 pass locally.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed