### PR TITLE
fix(vllm): forward response_format to OpenAI-compatible API

### DIFF
--- a/mem0/llms/vllm.py
+++ b/mem0/llms/vllm.py
@@ -99,6 +99,8 @@ class VllmLLM(LLMBase):
             }
         )
 
+        if response_format:
+            params["response_format"] = response_format
         if tools:
             params["tools"] = tools
             params["tool_choice"] = tool_choice

--- a/tests/llms/test_vllm.py
+++ b/tests/llms/test_vllm.py
@@ -88,6 +88,50 @@ def test_generate_response_with_tools(mock_vllm_client):
 
 
 
+def test_generate_response_with_response_format(mock_vllm_client):
+    config = BaseLlmConfig(model="Qwen/Qwen2.5-32B-Instruct", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = VllmLLM(config)
+    messages = [
+        {"role": "system", "content": "You are a memory extraction assistant."},
+        {"role": "user", "content": "I like hiking on weekends."},
+    ]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content='{"facts": ["User likes hiking on weekends"]}'))]
+    mock_vllm_client.chat.completions.create.return_value = mock_response
+
+    response = llm.generate_response(messages, response_format={"type": "json_object"})
+
+    mock_vllm_client.chat.completions.create.assert_called_once_with(
+        model="Qwen/Qwen2.5-32B-Instruct",
+        messages=messages,
+        temperature=0.7,
+        max_tokens=100,
+        top_p=1.0,
+        response_format={"type": "json_object"},
+    )
+    assert response == '{"facts": ["User likes hiking on weekends"]}'
+
+
+def test_generate_response_without_response_format(mock_vllm_client):
+    config = BaseLlmConfig(model="Qwen/Qwen2.5-32B-Instruct", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = VllmLLM(config)
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Tell me a joke."},
+    ]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Why did the chicken cross the road?"))]
+    mock_vllm_client.chat.completions.create.return_value = mock_response
+
+    response = llm.generate_response(messages)
+
+    call_kwargs = mock_vllm_client.chat.completions.create.call_args[1]
+    assert "response_format" not in call_kwargs
+    assert response == "Why did the chicken cross the road?"
+
+
 def create_mocked_memory():
     """Create a fully mocked Memory instance for testing."""
     with patch('mem0.utils.factory.LlmFactory.create') as mock_llm_factory, \


### PR DESCRIPTION
## Summary
- The `vllm` LLM provider accepted `response_format` as a parameter in `generate_response()` but never forwarded it into the actual API request params
- This caused JSON parsing failures (`Invalid JSON response: Expecting value`) during memory extraction/update because the model returned free-form text instead of constrained JSON
- Fix: add `response_format` to params, matching the pattern used by `openai.py`, `groq.py`, `deepseek.py`, and all other OpenAI-compatible providers

Closes #4607

## Changes
- **`mem0/llms/vllm.py`** — Added 2 lines to forward `response_format` into request params
- **`tests/llms/test_vllm.py`** — Added 2 new tests:
  - `test_generate_response_with_response_format` — verifies `response_format` is passed to the API
  - `test_generate_response_without_response_format` — verifies it's omitted when not provided

## Test plan
- [x] All 4 vllm tests pass (2 existing + 2 new)
- [x] Fix is identical to the pattern in `openai.py` line 134-135