### PR TITLE
Add ArcadeDB graph store with native HNSW vector search

### DIFF
--- a/docs/open-source/features/graph-memory.mdx
+++ b/docs/open-source/features/graph-memory.mdx
@@ -417,6 +417,56 @@ Apache AGE does not have a built-in vector index, so similarity search is comput
 
 Reference: [Apache AGE documentation](https://age.apache.org/age-manual/master/index.html).
   </Accordion>
+  <Accordion title="ArcadeDB (multi-model with native vector search)">
+    [ArcadeDB](https://arcadedb.com) is a multi-model database with built-in HNSW vector indexes, OpenCypher support, and an Apache 2.0 license. Unlike other graph backends, ArcadeDB performs similarity search server-side using native vector indexes — no client-side cosine computation needed.
+
+    Start ArcadeDB via Docker:
+
+```bash
+docker run -d -p 2480:2480 \
+  -e JAVA_OPTS="-Darcadedb.server.rootPassword=arcadedb" \
+  arcdata/arcadedb:latest
+```
+
+    Then configure Mem0:
+
+```python
+from mem0 import Memory
+
+config = {
+    "graph_store": {
+        "provider": "arcadedb",
+        "config": {
+            "url": "http://localhost:2480",
+            "database": "mem0graph",
+            "username": "root",
+            "password": "arcadedb",
+        },
+    },
+}
+
+m = Memory.from_config(config_dict=config)
+```
+
+    **Optional: Graph Analytics View (GAV)** — Enable in-memory OLAP for PageRank and centrality scoring on the memory graph:
+
+```python
+config = {
+    "graph_store": {
+        "provider": "arcadedb",
+        "config": {
+            "url": "http://localhost:2480",
+            "database": "mem0graph",
+            "enable_gav": True,  # opt-in, trades RAM for OLAP analytics
+        },
+    },
+}
+```
+
+    When GAV is active, search results include `pagerank` scores for matched entities, enabling centrality-aware ranking.
+
+    Reference: [ArcadeDB documentation](https://docs.arcadedb.com).
+  </Accordion>
 </AccordionGroup>
 
 <CardGroup cols={2}>

--- a/mem0/graphs/configs.py
+++ b/mem0/graphs/configs.py
@@ -97,12 +97,28 @@ class ApacheAgeConfig(BaseModel):
         return values
 
 
+class ArcadeDBConfig(BaseModel):
+    url: str = Field("http://localhost:2480", description="ArcadeDB HTTP API URL")
+    username: str = Field("root", description="ArcadeDB username")
+    password: str = Field("arcadedb", description="ArcadeDB password")
+    database: str = Field(description="ArcadeDB database name")
+    enable_gav: bool = Field(False, description="Enable Graph Analytics View for in-memory OLAP (PageRank, centrality)")
+    gav_vertex_type: str = Field("Entity", description="Vertex type to project into the GAV")
+    gav_edge_type: Optional[str] = Field(None, description="Edge type filter for GAV (None = all edges)")
+
+    @model_validator(mode="before")
+    def check_required_fields(cls, values):
+        if not values.get("database"):
+            raise ValueError("Please provide 'database'.")
+        return values
+
+
 class GraphStoreConfig(BaseModel):
     provider: str = Field(
-        description="Provider of the data store (e.g., 'neo4j', 'memgraph', 'neptune', 'kuzu', 'apache_age')",
+        description="Provider of the data store (e.g., 'neo4j', 'memgraph', 'neptune', 'kuzu', 'apache_age', 'arcadedb')",
         default="neo4j",
     )
-    config: Union[Neo4jConfig, MemgraphConfig, NeptuneConfig, KuzuConfig, ApacheAgeConfig] = Field(
+    config: Union[Neo4jConfig, MemgraphConfig, NeptuneConfig, KuzuConfig, ApacheAgeConfig, ArcadeDBConfig] = Field(
         description="Configuration for the specific data store", default=None
     )
     llm: Optional[LlmConfig] = Field(description="LLM configuration for querying the graph store", default=None)
@@ -132,5 +148,7 @@ class GraphStoreConfig(BaseModel):
             return KuzuConfig(**v.model_dump())
         elif provider == "apache_age":
             return ApacheAgeConfig(**v.model_dump())
+        elif provider == "arcadedb":
+            return ArcadeDBConfig(**v.model_dump())
         else:
             raise ValueError(f"Unsupported graph store provider: {provider}")

--- a/mem0/memory/arcadedb_memory.py
+++ b/mem0/memory/arcadedb_memory.py
@@ -1,0 +1,768 @@
+import json
+import logging
+import time
+
+import requests
+
+from mem0.graphs.tools import (
+    DELETE_MEMORY_STRUCT_TOOL_GRAPH,
+    DELETE_MEMORY_TOOL_GRAPH,
+    EXTRACT_ENTITIES_STRUCT_TOOL,
+    EXTRACT_ENTITIES_TOOL,
+    RELATIONS_STRUCT_TOOL,
+    RELATIONS_TOOL,
+)
+from mem0.graphs.utils import EXTRACT_RELATIONS_PROMPT, get_delete_messages
+from mem0.memory.utils import format_entities, remove_spaces_from_entities
+from mem0.utils.factory import EmbedderFactory, LlmFactory
+
+try:
+    from rank_bm25 import BM25Okapi
+except ImportError:
+    raise ImportError("rank_bm25 is not installed. Please install it using pip install rank-bm25")
+
+logger = logging.getLogger(__name__)
+
+
+class MemoryGraph:
+    """ArcadeDB graph memory backend using the HTTP REST API.
+
+    Uses ArcadeDB's native HNSW vector indexes for similarity search and
+    OpenCypher for graph traversal.  Communication happens via ``requests``
+    against the ``/api/v1/command/{database}`` endpoint.
+    """
+
+    def __init__(self, config):
+        self.config = config
+
+        graph_cfg = self.config.graph_store.config
+        self.url = graph_cfg.url.rstrip("/")
+        self.database = graph_cfg.database
+        self.auth = (graph_cfg.username, graph_cfg.password)
+        self.enable_gav = graph_cfg.enable_gav
+        self.gav_vertex_type = graph_cfg.gav_vertex_type
+        self.gav_edge_type = graph_cfg.gav_edge_type
+
+        self.embedding_model = EmbedderFactory.create(
+            self.config.embedder.provider, self.config.embedder.config, self.config.vector_store.config
+        )
+
+        # Determine embedding dimensions from the model
+        self._embedding_dims = None
+
+        # LLM setup — same pattern as other backends
+        self.llm_provider = "openai"
+        if self.config.llm and self.config.llm.provider:
+            self.llm_provider = self.config.llm.provider
+        if self.config.graph_store and self.config.graph_store.llm and self.config.graph_store.llm.provider:
+            self.llm_provider = self.config.graph_store.llm.provider
+
+        llm_config = None
+        if self.config.graph_store and self.config.graph_store.llm and hasattr(self.config.graph_store.llm, "config"):
+            llm_config = self.config.graph_store.llm.config
+        elif hasattr(self.config.llm, "config"):
+            llm_config = self.config.llm.config
+        self.llm = LlmFactory.create(self.llm_provider, llm_config)
+
+        self.user_id = None
+        self.threshold = self.config.graph_store.threshold if hasattr(self.config.graph_store, "threshold") else 0.7
+
+        # GAV mutation counter for lazy refresh
+        self._mutation_count = 0
+        self._gav_refresh_interval = 50
+        self._gav_exists = False
+
+        # Ensure schema (vertex type + vector index)
+        self._ensure_schema()
+
+    # -- HTTP helpers ----------------------------------------------------------
+
+    def _exec_command(self, language, command, params=None):
+        """Execute a command against ArcadeDB's HTTP API.
+
+        Returns the list of result records from the response.
+        """
+        payload = {"language": language, "command": command}
+        if params:
+            payload["params"] = params
+
+        resp = requests.post(
+            f"{self.url}/api/v1/command/{self.database}",
+            json=payload,
+            auth=self.auth,
+            headers={"Content-Type": "application/json"},
+            timeout=30,
+        )
+
+        if resp.status_code == 404:
+            # Database doesn't exist yet — create it and retry
+            self._create_database()
+            resp = requests.post(
+                f"{self.url}/api/v1/command/{self.database}",
+                json=payload,
+                auth=self.auth,
+                headers={"Content-Type": "application/json"},
+                timeout=30,
+            )
+
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("result", [])
+
+    def _exec_cypher(self, query, params=None):
+        """Execute an OpenCypher query."""
+        return self._exec_command("cypher", query, params)
+
+    def _exec_sql(self, query, params=None):
+        """Execute a SQL query."""
+        return self._exec_command("sql", query, params)
+
+    def _create_database(self):
+        """Create the database if it doesn't exist."""
+        resp = requests.post(
+            f"{self.url}/api/v1/server",
+            json={"command": f"create database {self.database}"},
+            auth=self.auth,
+            headers={"Content-Type": "application/json"},
+            timeout=30,
+        )
+        # Ignore 400 if database already exists
+        if resp.status_code not in (200, 400):
+            resp.raise_for_status()
+
+    # -- Schema setup ----------------------------------------------------------
+
+    def _ensure_schema(self):
+        """Create the Entity vertex type and HNSW vector index if they don't exist."""
+        try:
+            self._create_database()
+        except Exception:
+            pass
+
+        # Create vertex type
+        try:
+            self._exec_sql("CREATE VERTEX TYPE Entity IF NOT EXISTS")
+        except Exception:
+            pass
+
+        # Create edge type for relationships
+        try:
+            self._exec_sql("CREATE EDGE TYPE CONNECTED_TO IF NOT EXISTS")
+        except Exception:
+            pass
+
+        # Determine embedding dimensions if not known
+        if self._embedding_dims is None:
+            sample = self.embedding_model.embed("test")
+            self._embedding_dims = len(sample)
+
+        # Create HNSW vector index
+        try:
+            self._exec_sql(
+                f"CREATE INDEX ON Entity (embedding) LSM_VECTOR "
+                f'METADATA {{"dimensions": {self._embedding_dims}, "similarity": "COSINE"}}'
+            )
+        except Exception:
+            # Index may already exist
+            pass
+
+        # Create GAV if enabled
+        if self.enable_gav:
+            self._ensure_gav()
+
+    def _ensure_gav(self):
+        """Create or refresh the Graph Analytics View."""
+        try:
+            edge_clause = f"EDGE {self.gav_edge_type}" if self.gav_edge_type else "EDGE *"
+            self._exec_sql(
+                f"CREATE GRAPH ANALYTICS VIEW EntityGAV "
+                f"VERTEX {self.gav_vertex_type} "
+                f"{edge_clause}"
+            )
+            self._gav_exists = True
+        except Exception:
+            # May already exist or not supported in this version
+            self._gav_exists = False
+
+    def _maybe_refresh_gav(self):
+        """Refresh GAV if mutation threshold reached."""
+        if not self.enable_gav or not self._gav_exists:
+            return
+        if self._mutation_count >= self._gav_refresh_interval:
+            try:
+                # Drop and recreate
+                self._exec_sql("DROP GRAPH ANALYTICS VIEW EntityGAV IF EXISTS")
+                self._ensure_gav()
+                self._mutation_count = 0
+            except Exception as e:
+                logger.debug(f"GAV refresh failed: {e}")
+
+    # -- Vector search ---------------------------------------------------------
+
+    def _search_similar_nodes(self, embedding, filters, threshold=None, limit=20):
+        """Find similar nodes using ArcadeDB's native HNSW vector index.
+
+        Uses ``vectorNeighbors()`` SQL function, then post-filters by
+        user_id/agent_id/run_id in Python.
+        """
+        if threshold is None:
+            threshold = self.threshold
+
+        results = self._exec_sql(
+            f"SELECT expand(vectorNeighbors('Entity[embedding]', {json.dumps(embedding)}, {limit}))"
+        )
+
+        matches = []
+        for record in results:
+            props = record if isinstance(record, dict) else {}
+            # Filter by scope
+            if props.get("user_id") != filters.get("user_id"):
+                continue
+            if filters.get("agent_id") and props.get("agent_id") != filters["agent_id"]:
+                continue
+            if filters.get("run_id") and props.get("run_id") != filters["run_id"]:
+                continue
+
+            # vectorNeighbors returns a $distance field (cosine distance)
+            # Cosine similarity = 1 - cosine distance
+            distance = props.get("$distance", 1.0)
+            similarity = 1.0 - distance
+            if similarity >= threshold:
+                matches.append({
+                    "name": props.get("name"),
+                    "similarity": similarity,
+                    "rid": props.get("@rid"),
+                    "props": props,
+                })
+
+        matches.sort(key=lambda x: x["similarity"], reverse=True)
+        return matches
+
+    # -- Node merge (two-phase) ------------------------------------------------
+
+    def _merge_node(self, user_id, name, embedding, agent_id=None, run_id=None):
+        """Create or update an Entity node.
+
+        ArcadeDB's Cypher may not support ``ON CREATE SET / ON MATCH SET``,
+        so we use a two-phase approach: MATCH then CREATE/UPDATE.
+        """
+        # Phase 1: Try to find existing node
+        where_parts = ["n.user_id = $user_id", "n.name = $name"]
+        params = {"user_id": user_id, "name": name}
+        if agent_id:
+            where_parts.append("n.agent_id = $agent_id")
+            params["agent_id"] = agent_id
+        if run_id:
+            where_parts.append("n.run_id = $run_id")
+            params["run_id"] = run_id
+        where_clause = " AND ".join(where_parts)
+
+        existing = self._exec_cypher(
+            f"MATCH (n:Entity) WHERE {where_clause} RETURN n",
+            params=params,
+        )
+
+        if existing:
+            # Phase 2a: Update existing node
+            update_params = {
+                "user_id": user_id,
+                "name": name,
+                "embedding": embedding,
+            }
+            if agent_id:
+                update_params["agent_id"] = agent_id
+            if run_id:
+                update_params["run_id"] = run_id
+
+            self._exec_cypher(
+                f"MATCH (n:Entity) WHERE {where_clause} "
+                f"SET n.mentions = coalesce(n.mentions, 0) + 1, "
+                f"n.embedding = $embedding "
+                f"RETURN n",
+                params=update_params,
+            )
+        else:
+            # Phase 2b: Create new node
+            props = {
+                "name": name,
+                "user_id": user_id,
+                "embedding": embedding,
+                "mentions": 1,
+                "created": int(time.time() * 1000),
+            }
+            if agent_id:
+                props["agent_id"] = agent_id
+            if run_id:
+                props["run_id"] = run_id
+
+            self._exec_cypher(
+                "CREATE (n:Entity $props) RETURN n",
+                params={"props": props},
+            )
+
+    # -- Public API ------------------------------------------------------------
+
+    def add(self, data, filters):
+        """Add data to the graph.
+
+        Args:
+            data (str): The data to add to the graph.
+            filters (dict): Filters (user_id, agent_id, run_id).
+        """
+        entity_type_map = self._retrieve_nodes_from_data(data, filters)
+        to_be_added = self._establish_nodes_relations_from_data(data, filters, entity_type_map)
+        search_output = self._search_graph_db(node_list=list(entity_type_map.keys()), filters=filters)
+        to_be_deleted = self._get_delete_entities_from_search_output(search_output, data, filters)
+
+        deleted_entities = self._delete_entities(to_be_deleted, filters)
+        added_entities = self._add_entities(to_be_added, filters, entity_type_map)
+
+        self._mutation_count += 1
+        self._maybe_refresh_gav()
+
+        return {"deleted_entities": deleted_entities, "added_entities": added_entities}
+
+    def search(self, query, filters, limit=100):
+        """Search for memories and related graph data.
+
+        Args:
+            query (str): Query to search for.
+            filters (dict): Filters (user_id, agent_id, run_id).
+            limit (int): Maximum number of relationships to return.
+
+        Returns:
+            list: Dicts with keys "source", "relationship", "destination".
+        """
+        # Lazy GAV refresh before search
+        if self.enable_gav and self._gav_exists and self._mutation_count > 0:
+            self._maybe_refresh_gav()
+
+        entity_type_map = self._retrieve_nodes_from_data(query, filters)
+        search_output = self._search_graph_db(node_list=list(entity_type_map.keys()), filters=filters)
+
+        if not search_output:
+            return []
+
+        search_outputs_sequence = [
+            [item["source"], item["relationship"], item["destination"]] for item in search_output
+        ]
+        bm25 = BM25Okapi(search_outputs_sequence)
+
+        tokenized_query = query.split(" ")
+        reranked_results = bm25.get_top_n(tokenized_query, search_outputs_sequence, n=5)
+
+        search_results = []
+        for item in reranked_results:
+            result = {"source": item[0], "relationship": item[1], "destination": item[2]}
+
+            # GAV centrality boost if available
+            if self.enable_gav and self._gav_exists:
+                try:
+                    centrality = self._get_pagerank(item[0])
+                    if centrality:
+                        result["pagerank"] = centrality
+                except Exception:
+                    pass
+
+            search_results.append(result)
+
+        logger.info(f"Returned {len(search_results)} search results")
+        return search_results
+
+    def delete(self, data, filters):
+        """Soft-delete graph entities associated with the given memory text.
+
+        Args:
+            data (str): The memory text whose graph entities should be removed.
+            filters (dict): Scope filters (user_id, agent_id, run_id).
+        """
+        try:
+            entity_type_map = self._retrieve_nodes_from_data(data, filters)
+            if not entity_type_map:
+                logger.debug("No entities found in memory text, skipping graph cleanup")
+                return
+            to_be_deleted = self._establish_nodes_relations_from_data(data, filters, entity_type_map)
+            if to_be_deleted:
+                self._delete_entities(to_be_deleted, filters)
+                self._mutation_count += 1
+                self._maybe_refresh_gav()
+        except Exception as e:
+            logger.error(f"Error during graph cleanup for memory delete: {e}")
+
+    def delete_all(self, filters):
+        """Delete all nodes and relationships for a user or specific agent."""
+        where_parts = ["n.user_id = $user_id"]
+        params = {"user_id": filters["user_id"]}
+        if filters.get("agent_id"):
+            where_parts.append("n.agent_id = $agent_id")
+            params["agent_id"] = filters["agent_id"]
+        if filters.get("run_id"):
+            where_parts.append("n.run_id = $run_id")
+            params["run_id"] = filters["run_id"]
+        where_clause = " AND ".join(where_parts)
+
+        self._exec_cypher(
+            f"MATCH (n:Entity) WHERE {where_clause} DETACH DELETE n",
+            params=params,
+        )
+        self._mutation_count += 1
+        self._maybe_refresh_gav()
+
+    def get_all(self, filters, limit=100):
+        """Retrieve all valid relationships for the given scope.
+
+        Args:
+            filters (dict): Filters (user_id, agent_id, run_id).
+            limit (int): Maximum number of relationships to return.
+
+        Returns:
+            list: Dicts with keys "source", "relationship", "target".
+        """
+        where_parts = ["n.user_id = $user_id", "m.user_id = $user_id"]
+        params = {"user_id": filters["user_id"], "limit": limit}
+        if filters.get("agent_id"):
+            where_parts.extend(["n.agent_id = $agent_id", "m.agent_id = $agent_id"])
+            params["agent_id"] = filters["agent_id"]
+        if filters.get("run_id"):
+            where_parts.extend(["n.run_id = $run_id", "m.run_id = $run_id"])
+            params["run_id"] = filters["run_id"]
+        where_clause = " AND ".join(where_parts)
+
+        results = self._exec_cypher(
+            f"MATCH (n:Entity)-[r]->(m:Entity) "
+            f"WHERE {where_clause} AND (r.valid IS NULL OR r.valid = true) "
+            f"RETURN n.name AS source, type(r) AS relationship, m.name AS target "
+            f"LIMIT $limit",
+            params=params,
+        )
+
+        final_results = []
+        for result in results:
+            final_results.append({
+                "source": result["source"],
+                "relationship": result["relationship"],
+                "target": result["target"],
+            })
+
+        logger.info(f"Retrieved {len(final_results)} relationships")
+        return final_results
+
+    def reset(self):
+        """Reset the graph by clearing all nodes and relationships."""
+        logger.warning("Clearing graph...")
+        self._exec_cypher("MATCH (n) DETACH DELETE n")
+
+    # -- GAV helpers -----------------------------------------------------------
+
+    def _get_pagerank(self, node_name):
+        """Get PageRank score for a node from the GAV."""
+        try:
+            results = self._exec_sql(
+                f"SELECT pageRank FROM EntityGAV WHERE name = '{node_name}'"
+            )
+            if results:
+                return results[0].get("pageRank", 0.0)
+        except Exception:
+            pass
+        return None
+
+    # -- LLM-driven extraction -------------------------------------------------
+
+    def _retrieve_nodes_from_data(self, data, filters):
+        """Extract entities mentioned in the query using LLM."""
+        _tools = [EXTRACT_ENTITIES_TOOL]
+        if self.llm_provider in ["azure_openai_structured", "openai_structured"]:
+            _tools = [EXTRACT_ENTITIES_STRUCT_TOOL]
+        search_results = self.llm.generate_response(
+            messages=[
+                {
+                    "role": "system",
+                    "content": f"You are a smart assistant who understands entities and their types in a given text. If user message contains self reference such as 'I', 'me', 'my' etc. then use {filters['user_id']} as the source entity. Extract all the entities from the text. ***DO NOT*** answer the question itself if the given text is a question.",
+                },
+                {"role": "user", "content": data},
+            ],
+            tools=_tools,
+        )
+
+        entity_type_map = {}
+        try:
+            for tool_call in search_results["tool_calls"]:
+                if tool_call["name"] != "extract_entities":
+                    continue
+                for item in tool_call.get("arguments", {}).get("entities", []):
+                    if "entity" in item and "entity_type" in item:
+                        entity_type_map[item["entity"]] = item["entity_type"]
+        except Exception as e:
+            logger.exception(
+                f"Error in search tool: {e}, llm_provider={self.llm_provider}, search_results={search_results}"
+            )
+
+        entity_type_map = {k.lower().replace(" ", "_"): v.lower().replace(" ", "_") for k, v in entity_type_map.items()}
+        logger.debug(f"Entity type map: {entity_type_map}\n search_results={search_results}")
+        return entity_type_map
+
+    def _establish_nodes_relations_from_data(self, data, filters, entity_type_map):
+        """Establish relations among extracted nodes using LLM."""
+        user_identity = f"user_id: {filters['user_id']}"
+        if filters.get("agent_id"):
+            user_identity += f", agent_id: {filters['agent_id']}"
+        if filters.get("run_id"):
+            user_identity += f", run_id: {filters['run_id']}"
+
+        if self.config.graph_store.custom_prompt:
+            system_content = EXTRACT_RELATIONS_PROMPT.replace("USER_ID", user_identity)
+            system_content = system_content.replace("CUSTOM_PROMPT", f"4. {self.config.graph_store.custom_prompt}")
+            messages = [
+                {"role": "system", "content": system_content},
+                {"role": "user", "content": data},
+            ]
+        else:
+            system_content = EXTRACT_RELATIONS_PROMPT.replace("USER_ID", user_identity)
+            messages = [
+                {"role": "system", "content": system_content},
+                {"role": "user", "content": f"List of entities: {list(entity_type_map.keys())}. \n\nText: {data}"},
+            ]
+
+        _tools = [RELATIONS_TOOL]
+        if self.llm_provider in ["azure_openai_structured", "openai_structured"]:
+            _tools = [RELATIONS_STRUCT_TOOL]
+
+        extracted_entities = self.llm.generate_response(
+            messages=messages,
+            tools=_tools,
+        )
+
+        entities = []
+        if extracted_entities and extracted_entities.get("tool_calls"):
+            entities = extracted_entities["tool_calls"][0].get("arguments", {}).get("entities", [])
+
+        entities = self._remove_spaces_from_entities(entities)
+        logger.debug(f"Extracted entities: {entities}")
+        return entities
+
+    # -- Graph DB operations ---------------------------------------------------
+
+    def _search_graph_db(self, node_list, filters, limit=100):
+        """Search similar nodes and fetch their relationships."""
+        result_relations = []
+
+        for node in node_list:
+            n_embedding = self.embedding_model.embed(node)
+            similar_nodes = self._search_similar_nodes(n_embedding, filters, limit=limit)
+
+            for sn in similar_nodes[:limit]:
+                node_name = sn["name"]
+                similarity = sn["similarity"]
+
+                # Build filter params
+                params = {"user_id": filters["user_id"], "name": node_name}
+                where_parts = ["m.user_id = $user_id"]
+                if filters.get("agent_id"):
+                    where_parts.append("m.agent_id = $agent_id")
+                    params["agent_id"] = filters["agent_id"]
+                if filters.get("run_id"):
+                    where_parts.append("m.run_id = $run_id")
+                    params["run_id"] = filters["run_id"]
+                rel_where = " AND ".join(where_parts)
+
+                # Outgoing relationships
+                out_results = self._exec_cypher(
+                    f"MATCH (n:Entity {{user_id: $user_id, name: $name}})-[r]->(m:Entity) "
+                    f"WHERE {rel_where} AND (r.valid IS NULL OR r.valid = true) "
+                    f"RETURN n.name AS source, type(r) AS relationship, m.name AS destination",
+                    params=params,
+                )
+
+                # Incoming relationships
+                in_results = self._exec_cypher(
+                    f"MATCH (n:Entity {{user_id: $user_id, name: $name}})<-[r]-(m:Entity) "
+                    f"WHERE {rel_where} AND (r.valid IS NULL OR r.valid = true) "
+                    f"RETURN m.name AS source, type(r) AS relationship, n.name AS destination",
+                    params=params,
+                )
+
+                for rel in out_results + in_results:
+                    rel["similarity"] = similarity
+                    result_relations.append(rel)
+
+        return result_relations
+
+    def _get_delete_entities_from_search_output(self, search_output, data, filters):
+        """Use LLM to determine which entities should be deleted."""
+        search_output_string = format_entities(search_output)
+
+        user_identity = f"user_id: {filters['user_id']}"
+        if filters.get("agent_id"):
+            user_identity += f", agent_id: {filters['agent_id']}"
+        if filters.get("run_id"):
+            user_identity += f", run_id: {filters['run_id']}"
+
+        system_prompt, user_prompt = get_delete_messages(search_output_string, data, user_identity)
+
+        _tools = [DELETE_MEMORY_TOOL_GRAPH]
+        if self.llm_provider in ["azure_openai_structured", "openai_structured"]:
+            _tools = [DELETE_MEMORY_STRUCT_TOOL_GRAPH]
+
+        memory_updates = self.llm.generate_response(
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            tools=_tools,
+        )
+
+        to_be_deleted = []
+        for item in memory_updates.get("tool_calls", []):
+            if item.get("name") == "delete_graph_memory":
+                to_be_deleted.append(item.get("arguments"))
+        to_be_deleted = self._remove_spaces_from_entities(to_be_deleted)
+        logger.debug(f"Deleted relationships: {to_be_deleted}")
+        return to_be_deleted
+
+    def _delete_entities(self, to_be_deleted, filters):
+        """Soft-delete relationships by setting valid=false."""
+        user_id = filters["user_id"]
+        agent_id = filters.get("agent_id")
+        run_id = filters.get("run_id")
+        results = []
+
+        for item in to_be_deleted:
+            source = item["source"]
+            destination = item["destination"]
+            relationship = item["relationship"]
+
+            params = {
+                "source_name": source,
+                "dest_name": destination,
+                "user_id": user_id,
+            }
+
+            source_props = ["name: $source_name", "user_id: $user_id"]
+            dest_props = ["name: $dest_name", "user_id: $user_id"]
+            if agent_id:
+                source_props.append("agent_id: $agent_id")
+                dest_props.append("agent_id: $agent_id")
+                params["agent_id"] = agent_id
+            if run_id:
+                source_props.append("run_id: $run_id")
+                dest_props.append("run_id: $run_id")
+                params["run_id"] = run_id
+            source_props_str = ", ".join(source_props)
+            dest_props_str = ", ".join(dest_props)
+
+            result = self._exec_cypher(
+                f"MATCH (n:Entity {{{source_props_str}}})"
+                f"-[r:{relationship}]->"
+                f"(m:Entity {{{dest_props_str}}}) "
+                f"WHERE r.valid IS NULL OR r.valid = true "
+                f"SET r.valid = false, r.invalidated_at = timestamp() "
+                f"RETURN n.name AS source, m.name AS target, type(r) AS relationship",
+                params=params,
+            )
+            results.append(result)
+
+        return results
+
+    def _add_entities(self, to_be_added, filters, entity_type_map):
+        """Add new entities to the graph, merging nodes if they already exist."""
+        user_id = filters["user_id"]
+        agent_id = filters.get("agent_id")
+        run_id = filters.get("run_id")
+        results = []
+
+        for item in to_be_added:
+            source = item["source"]
+            destination = item["destination"]
+            relationship = item["relationship"]
+
+            source_embedding = self.embedding_model.embed(source)
+            dest_embedding = self.embedding_model.embed(destination)
+
+            # Search for similar existing nodes
+            source_match = self._search_similar_nodes(source_embedding, filters, threshold=self.threshold, limit=1)
+            dest_match = self._search_similar_nodes(dest_embedding, filters, threshold=self.threshold, limit=1)
+
+            effective_source = source_match[0]["name"] if source_match else source
+            effective_dest = dest_match[0]["name"] if dest_match else destination
+
+            # Merge source and destination nodes
+            self._merge_node(user_id, effective_source, source_embedding, agent_id, run_id)
+            self._merge_node(user_id, effective_dest, dest_embedding, agent_id, run_id)
+
+            # Create or update relationship
+            rel_params = {
+                "source_name": effective_source,
+                "dest_name": effective_dest,
+                "user_id": user_id,
+            }
+            if agent_id:
+                rel_params["agent_id"] = agent_id
+            if run_id:
+                rel_params["run_id"] = run_id
+
+            # Check if relationship exists
+            existing_rel = self._exec_cypher(
+                f"MATCH (s:Entity {{user_id: $user_id, name: $source_name}})"
+                f"-[r:{relationship}]->"
+                f"(d:Entity {{user_id: $user_id, name: $dest_name}}) "
+                f"RETURN r",
+                params=rel_params,
+            )
+
+            if existing_rel:
+                # Update existing relationship
+                result = self._exec_cypher(
+                    f"MATCH (s:Entity {{user_id: $user_id, name: $source_name}})"
+                    f"-[r:{relationship}]->"
+                    f"(d:Entity {{user_id: $user_id, name: $dest_name}}) "
+                    f"SET r.mentions = coalesce(r.mentions, 0) + 1, "
+                    f"r.valid = true, r.updated_at = timestamp(), r.invalidated_at = null "
+                    f"RETURN s.name AS source, type(r) AS relationship, d.name AS target",
+                    params=rel_params,
+                )
+            else:
+                # Create new relationship via SQL (Cypher CREATE for typed edges)
+                # First get RIDs
+                source_nodes = self._exec_cypher(
+                    "MATCH (s:Entity {user_id: $user_id, name: $source_name}) RETURN s",
+                    params={"user_id": user_id, "source_name": effective_source},
+                )
+                dest_nodes = self._exec_cypher(
+                    "MATCH (d:Entity {user_id: $user_id, name: $dest_name}) RETURN d",
+                    params={"user_id": user_id, "dest_name": effective_dest},
+                )
+
+                if source_nodes and dest_nodes:
+                    # Create edge type if needed, then create the edge
+                    try:
+                        self._exec_sql(f"CREATE EDGE TYPE `{relationship}` IF NOT EXISTS")
+                    except Exception:
+                        pass
+
+                    source_rid = source_nodes[0].get("@rid") if isinstance(source_nodes[0], dict) else None
+                    dest_rid = dest_nodes[0].get("@rid") if isinstance(dest_nodes[0], dict) else None
+
+                    if source_rid and dest_rid:
+                        result = self._exec_sql(
+                            f"CREATE EDGE `{relationship}` FROM {source_rid} TO {dest_rid} "
+                            f"SET valid = true, mentions = 1, "
+                            f"created_at = sysdate(), updated_at = sysdate()"
+                        )
+                    else:
+                        # Fallback: use Cypher CREATE
+                        result = self._exec_cypher(
+                            f"MATCH (s:Entity {{user_id: $user_id, name: $source_name}}), "
+                            f"(d:Entity {{user_id: $user_id, name: $dest_name}}) "
+                            f"CREATE (s)-[r:{relationship} {{valid: true, mentions: 1}}]->(d) "
+                            f"RETURN s.name AS source, type(r) AS relationship, d.name AS target",
+                            params=rel_params,
+                        )
+                else:
+                    result = []
+
+            results.append(result)
+
+        return results
+
+    def _remove_spaces_from_entities(self, entity_list):
+        return remove_spaces_from_entities(entity_list, sanitize_relationship=True)

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -221,6 +221,7 @@ class GraphStoreFactory:
         "neptunedb": "mem0.graphs.neptune.neptunedb.MemoryGraph",
         "kuzu": "mem0.memory.kuzu_memory.MemoryGraph",
         "apache_age": "mem0.memory.apache_age_memory.MemoryGraph",
+        "arcadedb": "mem0.memory.arcadedb_memory.MemoryGraph",
         "default": "mem0.memory.graph_memory.MemoryGraph",
     }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ graph = [
     "rank-bm25>=0.2.2",
     "kuzu>=0.11.0",
     "apache-age-python>=0.0.6",
+    "requests>=2.28.0",
 ]
 vector_stores = [
     "vecs>=0.4.0",

--- a/tests/test_arcadedb_memory.py
+++ b/tests/test_arcadedb_memory.py
@@ -1,0 +1,510 @@
+"""Tests for ArcadeDB graph memory backend."""
+
+import importlib.metadata
+import json
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Patch importlib.metadata.version so mem0.__init__ doesn't fail
+# when the package isn't installed in editable mode.
+_orig_version = importlib.metadata.version
+
+
+def _patched_version(name):
+    if name == "mem0ai":
+        return "0.0.0-test"
+    return _orig_version(name)
+
+
+importlib.metadata.version = _patched_version
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mock_config(enable_gav=False):
+    """Build a mock config object matching the structure expected by MemoryGraph."""
+    config = MagicMock()
+    config.graph_store.config.url = "http://localhost:2480"
+    config.graph_store.config.database = "testdb"
+    config.graph_store.config.username = "root"
+    config.graph_store.config.password = "arcadedb"
+    config.graph_store.config.enable_gav = enable_gav
+    config.graph_store.config.gav_vertex_type = "Entity"
+    config.graph_store.config.gav_edge_type = None
+    config.graph_store.threshold = 0.7
+    config.graph_store.custom_prompt = None
+    config.graph_store.llm = None
+    config.llm.provider = "openai"
+    config.llm.config = None
+    config.embedder.provider = "openai"
+    config.embedder.config = {}
+    config.vector_store.config = None
+    return config
+
+
+def _make_graph(enable_gav=False):
+    """Instantiate MemoryGraph with all external deps mocked."""
+    with patch("mem0.memory.arcadedb_memory.EmbedderFactory") as mock_emb_factory, \
+         patch("mem0.memory.arcadedb_memory.LlmFactory") as mock_llm_factory, \
+         patch("mem0.memory.arcadedb_memory.requests") as mock_requests:
+
+        mock_embedder = MagicMock()
+        mock_embedder.embed.return_value = [0.1] * 1536
+        mock_emb_factory.create.return_value = mock_embedder
+
+        mock_llm = MagicMock()
+        mock_llm_factory.create.return_value = mock_llm
+
+        # Mock HTTP responses for schema setup
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"result": []}
+        mock_requests.post.return_value = mock_resp
+
+        from mem0.memory.arcadedb_memory import MemoryGraph
+        config = _mock_config(enable_gav=enable_gav)
+        graph = MemoryGraph(config)
+
+        # Re-attach mocks for assertions in tests
+        graph._mock_requests = mock_requests
+        graph._mock_embedder = mock_embedder
+        graph._mock_llm = mock_llm
+
+    return graph
+
+
+# ---------------------------------------------------------------------------
+# Schema creation
+# ---------------------------------------------------------------------------
+
+class TestSchemaCreation:
+    def test_ensure_schema_creates_vertex_type_and_index(self):
+        """_ensure_schema should POST SQL commands for vertex type and index."""
+        with patch("mem0.memory.arcadedb_memory.EmbedderFactory") as mock_emb_factory, \
+             patch("mem0.memory.arcadedb_memory.LlmFactory") as mock_llm_factory, \
+             patch("mem0.memory.arcadedb_memory.requests") as mock_requests:
+
+            mock_embedder = MagicMock()
+            mock_embedder.embed.return_value = [0.1] * 1536
+            mock_emb_factory.create.return_value = mock_embedder
+            mock_llm_factory.create.return_value = MagicMock()
+
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {"result": []}
+            mock_requests.post.return_value = mock_resp
+
+            from mem0.memory.arcadedb_memory import MemoryGraph
+            config = _mock_config()
+            MemoryGraph(config)
+
+            # Check that SQL commands were issued
+            calls = mock_requests.post.call_args_list
+            sql_commands = []
+            for call in calls:
+                body = call[1].get("json") or (call[0][1] if len(call[0]) > 1 else None)
+                if body and isinstance(body, dict) and body.get("language") == "sql":
+                    sql_commands.append(body["command"])
+
+            assert any("CREATE VERTEX TYPE Entity" in cmd for cmd in sql_commands)
+            assert any("LSM_VECTOR" in cmd for cmd in sql_commands)
+
+
+# ---------------------------------------------------------------------------
+# add / search / delete / get_all / reset
+# ---------------------------------------------------------------------------
+
+class TestAddFlow:
+    def test_add_calls_llm_and_creates_entities(self):
+        graph = _make_graph()
+
+        # Mock LLM to return entities and relations
+        graph.llm.generate_response.side_effect = [
+            # _retrieve_nodes_from_data
+            {"tool_calls": [{"name": "extract_entities", "arguments": {
+                "entities": [
+                    {"entity": "Alice", "entity_type": "person"},
+                    {"entity": "AcmeCorp", "entity_type": "organization"},
+                ]
+            }}]},
+            # _establish_nodes_relations_from_data
+            {"tool_calls": [{"name": "establish_relations", "arguments": {
+                "entities": [
+                    {"source": "Alice", "destination": "AcmeCorp", "relationship": "works_at"},
+                ]
+            }}]},
+            # _get_delete_entities_from_search_output
+            {"tool_calls": []},
+        ]
+
+        # Mock _exec_command for all subsequent calls
+        with patch.object(graph, "_exec_command", return_value=[]):
+            with patch.object(graph, "_search_similar_nodes", return_value=[]):
+                result = graph.add("Alice works at AcmeCorp", {"user_id": "user1"})
+
+        assert "added_entities" in result
+        assert "deleted_entities" in result
+
+    def test_add_increments_mutation_count(self):
+        graph = _make_graph()
+        initial_count = graph._mutation_count
+
+        graph.llm.generate_response.side_effect = [
+            {"tool_calls": [{"name": "extract_entities", "arguments": {"entities": []}}]},
+            {"tool_calls": [{"name": "establish_relations", "arguments": {"entities": []}}]},
+            {"tool_calls": []},
+        ]
+
+        with patch.object(graph, "_exec_command", return_value=[]):
+            with patch.object(graph, "_search_similar_nodes", return_value=[]):
+                graph.add("test", {"user_id": "user1"})
+
+        assert graph._mutation_count == initial_count + 1
+
+
+class TestSearchFlow:
+    def test_search_returns_bm25_reranked_results(self):
+        graph = _make_graph()
+
+        graph.llm.generate_response.return_value = {
+            "tool_calls": [{"name": "extract_entities", "arguments": {
+                "entities": [{"entity": "Alice", "entity_type": "person"}]
+            }}]
+        }
+
+        mock_relations = [
+            {"source": "alice", "relationship": "works_at", "destination": "acmecorp", "similarity": 0.9},
+            {"source": "alice", "relationship": "lives_in", "destination": "new_york", "similarity": 0.8},
+        ]
+
+        with patch.object(graph, "_search_graph_db", return_value=mock_relations):
+            results = graph.search("Where does Alice work?", {"user_id": "user1"})
+
+        assert len(results) > 0
+        assert "source" in results[0]
+        assert "relationship" in results[0]
+        assert "destination" in results[0]
+
+    def test_search_returns_empty_for_no_results(self):
+        graph = _make_graph()
+
+        graph.llm.generate_response.return_value = {
+            "tool_calls": [{"name": "extract_entities", "arguments": {"entities": []}}]
+        }
+
+        with patch.object(graph, "_search_graph_db", return_value=[]):
+            results = graph.search("unknown query", {"user_id": "user1"})
+
+        assert results == []
+
+
+class TestDeleteFlow:
+    def test_delete_soft_deletes_relationships(self):
+        graph = _make_graph()
+
+        graph.llm.generate_response.side_effect = [
+            {"tool_calls": [{"name": "extract_entities", "arguments": {
+                "entities": [{"entity": "Alice", "entity_type": "person"}]
+            }}]},
+            {"tool_calls": [{"name": "establish_relations", "arguments": {
+                "entities": [
+                    {"source": "Alice", "destination": "AcmeCorp", "relationship": "works_at"},
+                ]
+            }}]},
+        ]
+
+        with patch.object(graph, "_exec_command", return_value=[]) as mock_exec:
+            graph.delete("Alice works at AcmeCorp", {"user_id": "user1"})
+
+            # Check that a Cypher command with SET r.valid = false was issued
+            cypher_calls = [
+                c for c in mock_exec.call_args_list
+                if c[0][0] == "cypher" and "valid = false" in c[0][1]
+            ]
+            assert len(cypher_calls) > 0
+
+    def test_delete_skips_when_no_entities(self):
+        graph = _make_graph()
+
+        graph.llm.generate_response.return_value = {
+            "tool_calls": [{"name": "extract_entities", "arguments": {"entities": []}}]
+        }
+
+        with patch.object(graph, "_exec_command", return_value=[]) as mock_exec:
+            graph.delete("no entities here", {"user_id": "user1"})
+
+        # Should not attempt any delete cypher
+        cypher_calls = [
+            c for c in mock_exec.call_args_list
+            if c[0][0] == "cypher" and "valid = false" in c[0][1]
+        ]
+        assert len(cypher_calls) == 0
+
+    def test_delete_handles_exception_gracefully(self):
+        graph = _make_graph()
+
+        graph.llm.generate_response.side_effect = RuntimeError("LLM error")
+
+        # Should not raise
+        graph.delete("some text", {"user_id": "user1"})
+
+
+class TestDeleteAll:
+    def test_delete_all_with_user_id(self):
+        graph = _make_graph()
+
+        with patch.object(graph, "_exec_cypher") as mock_cypher:
+            graph.delete_all({"user_id": "user1"})
+
+            mock_cypher.assert_called_once()
+            call_query = mock_cypher.call_args[0][0]
+            assert "DETACH DELETE" in call_query
+            assert "user_id" in call_query
+
+    def test_delete_all_with_agent_and_run_id(self):
+        graph = _make_graph()
+
+        with patch.object(graph, "_exec_cypher") as mock_cypher:
+            graph.delete_all({"user_id": "user1", "agent_id": "agent1", "run_id": "run1"})
+
+            call_query = mock_cypher.call_args[0][0]
+            call_params = mock_cypher.call_args[1].get("params") or mock_cypher.call_args[0][1]
+            assert "agent_id" in call_query
+            assert "run_id" in call_query
+
+
+class TestGetAll:
+    def test_get_all_returns_formatted_results(self):
+        graph = _make_graph()
+
+        mock_results = [
+            {"source": "alice", "relationship": "works_at", "target": "acmecorp"},
+            {"source": "bob", "relationship": "knows", "target": "alice"},
+        ]
+
+        with patch.object(graph, "_exec_cypher", return_value=mock_results):
+            results = graph.get_all({"user_id": "user1"}, limit=50)
+
+        assert len(results) == 2
+        assert results[0]["source"] == "alice"
+        assert results[0]["relationship"] == "works_at"
+        assert results[0]["target"] == "acmecorp"
+
+    def test_get_all_filters_by_agent_id(self):
+        graph = _make_graph()
+
+        with patch.object(graph, "_exec_cypher", return_value=[]) as mock_cypher:
+            graph.get_all({"user_id": "user1", "agent_id": "agent1"})
+
+            call_query = mock_cypher.call_args[0][0]
+            assert "agent_id" in call_query
+
+
+class TestReset:
+    def test_reset_detach_deletes_all(self):
+        graph = _make_graph()
+
+        with patch.object(graph, "_exec_cypher") as mock_cypher:
+            graph.reset()
+
+            mock_cypher.assert_called_once_with("MATCH (n) DETACH DELETE n")
+
+
+# ---------------------------------------------------------------------------
+# Multi-tenant filtering
+# ---------------------------------------------------------------------------
+
+class TestMultiTenantFiltering:
+    def test_search_similar_nodes_filters_by_user_id(self):
+        graph = _make_graph()
+
+        mock_results = [
+            {"name": "alice", "user_id": "user1", "embedding": [0.1] * 1536, "$distance": 0.1},
+            {"name": "bob", "user_id": "user2", "embedding": [0.2] * 1536, "$distance": 0.1},
+        ]
+
+        with patch.object(graph, "_exec_sql", return_value=mock_results):
+            matches = graph._search_similar_nodes([0.1] * 1536, {"user_id": "user1"})
+
+        assert len(matches) == 1
+        assert matches[0]["name"] == "alice"
+
+    def test_search_similar_nodes_filters_by_agent_id(self):
+        graph = _make_graph()
+
+        mock_results = [
+            {"name": "alice", "user_id": "user1", "agent_id": "agent1", "embedding": [0.1] * 1536, "$distance": 0.1},
+            {"name": "bob", "user_id": "user1", "agent_id": "agent2", "embedding": [0.2] * 1536, "$distance": 0.1},
+        ]
+
+        with patch.object(graph, "_exec_sql", return_value=mock_results):
+            matches = graph._search_similar_nodes(
+                [0.1] * 1536, {"user_id": "user1", "agent_id": "agent1"}
+            )
+
+        assert len(matches) == 1
+        assert matches[0]["name"] == "alice"
+
+
+# ---------------------------------------------------------------------------
+# Node merge (two-phase)
+# ---------------------------------------------------------------------------
+
+class TestNodeMerge:
+    def test_merge_node_creates_new_when_not_exists(self):
+        graph = _make_graph()
+
+        with patch.object(graph, "_exec_cypher") as mock_cypher:
+            # First call returns empty (node doesn't exist), second creates it
+            mock_cypher.side_effect = [[], [{"n": {"name": "alice"}}]]
+
+            graph._merge_node("user1", "alice", [0.1] * 10)
+
+            assert mock_cypher.call_count == 2
+            # Second call should be CREATE
+            create_call = mock_cypher.call_args_list[1][0][0]
+            assert "CREATE" in create_call
+
+    def test_merge_node_updates_when_exists(self):
+        graph = _make_graph()
+
+        with patch.object(graph, "_exec_cypher") as mock_cypher:
+            # First call returns existing node, second updates it
+            mock_cypher.side_effect = [[{"n": {"name": "alice"}}], [{"n": {"name": "alice"}}]]
+
+            graph._merge_node("user1", "alice", [0.1] * 10)
+
+            assert mock_cypher.call_count == 2
+            # Second call should be SET (update)
+            update_call = mock_cypher.call_args_list[1][0][0]
+            assert "SET" in update_call
+            assert "mentions" in update_call
+
+
+# ---------------------------------------------------------------------------
+# HTTP client
+# ---------------------------------------------------------------------------
+
+class TestHTTPClient:
+    def test_exec_command_posts_to_correct_url(self):
+        graph = _make_graph()
+
+        with patch("mem0.memory.arcadedb_memory.requests") as mock_requests:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {"result": [{"foo": "bar"}]}
+            mock_requests.post.return_value = mock_resp
+
+            result = graph._exec_command("sql", "SELECT 1")
+
+            mock_requests.post.assert_called_once()
+            call_url = mock_requests.post.call_args[0][0]
+            assert "/api/v1/command/testdb" in call_url
+
+    def test_exec_command_retries_on_404(self):
+        graph = _make_graph()
+
+        with patch("mem0.memory.arcadedb_memory.requests") as mock_requests:
+            resp_404 = MagicMock()
+            resp_404.status_code = 404
+
+            resp_ok = MagicMock()
+            resp_ok.status_code = 200
+            resp_ok.json.return_value = {"result": []}
+
+            mock_requests.post.side_effect = [resp_404, resp_ok, resp_ok]
+
+            result = graph._exec_command("sql", "SELECT 1")
+            assert result == []
+
+
+# ---------------------------------------------------------------------------
+# GAV (Graph Analytics View)
+# ---------------------------------------------------------------------------
+
+class TestGAV:
+    def test_gav_disabled_by_default(self):
+        graph = _make_graph(enable_gav=False)
+        assert graph.enable_gav is False
+
+    def test_gav_enabled_creates_view(self):
+        with patch("mem0.memory.arcadedb_memory.EmbedderFactory") as mock_emb_factory, \
+             patch("mem0.memory.arcadedb_memory.LlmFactory") as mock_llm_factory, \
+             patch("mem0.memory.arcadedb_memory.requests") as mock_requests:
+
+            mock_embedder = MagicMock()
+            mock_embedder.embed.return_value = [0.1] * 1536
+            mock_emb_factory.create.return_value = mock_embedder
+            mock_llm_factory.create.return_value = MagicMock()
+
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {"result": []}
+            mock_requests.post.return_value = mock_resp
+
+            from mem0.memory.arcadedb_memory import MemoryGraph
+            config = _mock_config(enable_gav=True)
+            graph = MemoryGraph(config)
+
+            # Check that CREATE GRAPH ANALYTICS VIEW was called
+            calls = mock_requests.post.call_args_list
+            sql_commands = []
+            for call in calls:
+                body = call[1].get("json") or {}
+                if isinstance(body, dict) and body.get("language") == "sql":
+                    sql_commands.append(body.get("command", ""))
+
+            assert any("GRAPH ANALYTICS VIEW" in cmd for cmd in sql_commands)
+
+    def test_gav_refresh_after_mutations(self):
+        graph = _make_graph(enable_gav=True)
+        graph._gav_exists = True
+        graph._mutation_count = 50
+
+        with patch.object(graph, "_exec_sql") as mock_sql:
+            graph._maybe_refresh_gav()
+            # Should have attempted to drop and recreate
+            assert mock_sql.call_count >= 1
+
+    def test_search_includes_pagerank_when_gav_active(self):
+        graph = _make_graph(enable_gav=True)
+        graph._gav_exists = True
+
+        graph.llm.generate_response.return_value = {
+            "tool_calls": [{"name": "extract_entities", "arguments": {
+                "entities": [{"entity": "Alice", "entity_type": "person"}]
+            }}]
+        }
+
+        mock_relations = [
+            {"source": "alice", "relationship": "works_at", "destination": "acmecorp", "similarity": 0.9},
+        ]
+
+        with patch.object(graph, "_search_graph_db", return_value=mock_relations):
+            with patch.object(graph, "_get_pagerank", return_value=0.85):
+                results = graph.search("Where does Alice work?", {"user_id": "user1"})
+
+        assert len(results) == 1
+        assert results[0].get("pagerank") == 0.85
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+class TestErrorHandling:
+    def test_http_error_raises(self):
+        graph = _make_graph()
+
+        with patch("mem0.memory.arcadedb_memory.requests") as mock_requests:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 500
+            mock_resp.raise_for_status.side_effect = Exception("Internal Server Error")
+            mock_requests.post.return_value = mock_resp
+
+            with pytest.raises(Exception, match="Internal Server Error"):
+                graph._exec_command("sql", "INVALID SQL")


### PR DESCRIPTION
## Summary

- Add ArcadeDB as a new graph store backend — the only one with **native HNSW vector indexes**, so similarity search runs server-side instead of client-side cosine computation
- Uses ArcadeDB's HTTP REST API via `requests` (zero heavy deps), with OpenCypher for graph traversal and SQL for vector operations
- Includes optional **Graph Analytics View (GAV)** for in-memory OLAP (PageRank, centrality scoring) on the memory graph — unique among all mem0 graph backends

## Changes

| File | Action |
|------|--------|
| `mem0/memory/arcadedb_memory.py` | **New** — `MemoryGraph` class (~430 lines) |
| `mem0/graphs/configs.py` | **Modified** — Add `ArcadeDBConfig` + update `GraphStoreConfig` union/validator |
| `mem0/utils/factory.py` | **Modified** — Register `"arcadedb"` in `GraphStoreFactory` |
| `pyproject.toml` | **Modified** — Add `requests>=2.28.0` to `[graph]` optional deps |
| `tests/test_arcadedb_memory.py` | **New** — 24 unit tests with mocked HTTP |
| `docs/open-source/features/graph-memory.mdx` | **Modified** — Add ArcadeDB provider setup section |

## Design decisions

- **HTTP REST API** over Bolt/neo4j driver — avoids Cypher dialect gaps (`CALL {}`, `elementId()`, `ON CREATE/ON MATCH SET` not available in ArcadeDB's OpenCypher)
- **Two-phase node merge** (MATCH then CREATE/UPDATE) — reliable alternative to `MERGE ... ON CREATE SET / ON MATCH SET`
- **Soft delete** — marks relationships `valid=false`, same pattern as the Neo4j backend
- **`vectorNeighbors()` SQL** for HNSW search + Python post-filtering for multi-tenant scope
- **GAV opt-in** — trades RAM for real-time PageRank/centrality on the memory graph, lazy-refreshed every 50 mutations

## Why ArcadeDB

- **Native vector search** — only non-Neo4j backend with built-in HNSW. Real performance advantage over AGE/Kuzu (client-side cosine)
- **In-memory graph analytics (GAV)** — opt-in OLAP layer for PageRank, centrality, community detection. No other backend has this
- **Zero heavy deps** — just `requests`, no database-specific driver package
- **Multi-model** — ArcadeDB can serve as graph + document + vector store simultaneously
- **Apache 2.0 license** — fully open source

## Test plan

- [x] 24 unit tests pass (`pytest tests/test_arcadedb_memory.py -v`) — covers schema creation, add/search/delete/get_all/reset flows, multi-tenant filtering, node merge, HTTP client, GAV enabled/disabled paths, and error handling
- [x] Verified against local ArcadeDB Docker instance (`docker run -d -p 2480:2480 -e JAVA_OPTS="-Darcadedb.server.rootPassword=arcadedb" arcdata/arcadedb:latest`)