### PR TITLE
Add type hints and docstrings to VectorStoreBase and EmbeddingBase

### DIFF
--- a/mem0/embeddings/base.py
+++ b/mem0/embeddings/base.py
@@ -18,14 +18,15 @@ class EmbeddingBase(ABC):
             self.config = config
 
     @abstractmethod
-    def embed(self, text, memory_action: Optional[Literal["add", "search", "update"]]):
+    def embed(self, text: str, memory_action: Optional[Literal["add", "search", "update"]] = None) -> list:
         """
         Get the embedding for the given text.
 
         Args:
-            text (str): The text to embed.
-            memory_action (optional): The type of embedding to use. Must be one of "add", "search", or "update". Defaults to None.
+            text: The text to embed.
+            memory_action: The type of embedding to use. Must be one of "add", "search", or "update". Defaults to None.
+
         Returns:
-            list: The embedding vector.
+            The embedding vector as a list of floats.
         """
         pass

--- a/mem0/vector_stores/base.py
+++ b/mem0/vector_stores/base.py
@@ -1,58 +1,134 @@
 from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional, Union
 
 
 class VectorStoreBase(ABC):
     @abstractmethod
-    def create_col(self, name, vector_size, distance):
-        """Create a new collection."""
+    def create_col(self, name: str, vector_size: int, distance: str) -> None:
+        """Create a new collection.
+
+        Args:
+            name: Name of the collection to create.
+            vector_size: Dimensionality of the vectors to be stored.
+            distance: Distance metric to use (e.g., "cosine", "euclidean").
+        """
         pass
 
     @abstractmethod
-    def insert(self, vectors, payloads=None, ids=None):
-        """Insert vectors into a collection."""
+    def insert(
+        self,
+        vectors: List[List[float]],
+        payloads: Optional[List[Dict[str, Any]]] = None,
+        ids: Optional[List[Union[str, int]]] = None,
+    ) -> None:
+        """Insert vectors into a collection.
+
+        Args:
+            vectors: List of embedding vectors to insert.
+            payloads: Optional metadata payloads associated with each vector.
+            ids: Optional identifiers for each vector.
+        """
         pass
 
     @abstractmethod
-    def search(self, query, vectors, limit=5, filters=None):
-        """Search for similar vectors."""
+    def search(
+        self,
+        query: str,
+        vectors: List[float],
+        limit: int = 5,
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> List[Dict[str, Any]]:
+        """Search for similar vectors.
+
+        Args:
+            query: The query string.
+            vectors: The query embedding vector.
+            limit: Maximum number of results to return.
+            filters: Optional filters to apply to the search.
+
+        Returns:
+            List of search results with scores and payloads.
+        """
         pass
 
     @abstractmethod
-    def delete(self, vector_id):
-        """Delete a vector by ID."""
+    def delete(self, vector_id: Union[str, int]) -> None:
+        """Delete a vector by ID.
+
+        Args:
+            vector_id: The identifier of the vector to delete.
+        """
         pass
 
     @abstractmethod
-    def update(self, vector_id, vector=None, payload=None):
-        """Update a vector and its payload."""
+    def update(
+        self,
+        vector_id: Union[str, int],
+        vector: Optional[List[float]] = None,
+        payload: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Update a vector and its payload.
+
+        Args:
+            vector_id: The identifier of the vector to update.
+            vector: Optional new embedding vector.
+            payload: Optional new metadata payload.
+        """
         pass
 
     @abstractmethod
-    def get(self, vector_id):
-        """Retrieve a vector by ID."""
+    def get(self, vector_id: Union[str, int]) -> Optional[Dict[str, Any]]:
+        """Retrieve a vector by ID.
+
+        Args:
+            vector_id: The identifier of the vector to retrieve.
+
+        Returns:
+            Dictionary containing the vector data and payload, or None if not found.
+        """
         pass
 
     @abstractmethod
-    def list_cols(self):
-        """List all collections."""
+    def list_cols(self) -> List[str]:
+        """List all collections.
+
+        Returns:
+            List of collection names.
+        """
         pass
 
     @abstractmethod
-    def delete_col(self):
+    def delete_col(self) -> None:
         """Delete a collection."""
         pass
 
     @abstractmethod
-    def col_info(self):
-        """Get information about a collection."""
+    def col_info(self) -> Dict[str, Any]:
+        """Get information about a collection.
+
+        Returns:
+            Dictionary containing collection metadata such as vector count and configuration.
+        """
         pass
 
     @abstractmethod
-    def list(self, filters=None, limit=None):
-        """List all memories."""
+    def list(
+        self,
+        filters: Optional[Dict[str, Any]] = None,
+        limit: Optional[int] = None,
+    ) -> List[Dict[str, Any]]:
+        """List all memories.
+
+        Args:
+            filters: Optional filters to narrow results.
+            limit: Optional maximum number of results.
+
+        Returns:
+            List of stored memory entries.
+        """
         pass
 
     @abstractmethod
-    def reset(self):
-        """Reset by delete the collection and recreate it."""
+    def reset(self) -> None:
+        """Reset by deleting the collection and recreating it."""
         pass


### PR DESCRIPTION
## Summary

- Add comprehensive type annotations to all 11 abstract methods in `VectorStoreBase`
- Add detailed parameter and return type docstrings following Google style
- Add missing default value for `memory_action` parameter in `EmbeddingBase.embed()`
- Fix typo in `reset()` docstring ("delete" -> "deleting")

## Motivation

The `VectorStoreBase` abstract class had no type hints on any of its method signatures, while concrete implementations (e.g., `Qdrant`, `Chroma`) already use typed parameters. This creates a gap where:

- IDEs cannot provide autocompletion when coding against the base class
- Static type checkers (`mypy`, `pyright`) cannot verify implementations match the contract
- New contributors implementing custom vector stores have to read concrete implementations to understand expected types

## Changes

**`mem0/vector_stores/base.py`:**
- Added `typing` imports (`Any`, `Dict`, `List`, `Optional`, `Union`)
- Annotated all parameters and return types across 11 abstract methods
- Added Google-style docstrings with Args/Returns sections

**`mem0/embeddings/base.py`:**
- Added return type `-> list` to `embed()` method
- Added default `= None` for `memory_action` parameter (matching all implementations)
- Cleaned up docstring formatting

## Test plan

- [ ] Verify existing tests pass (no behavioral changes, only annotations)
- [ ] Confirm type annotations match concrete implementations (Qdrant, Chroma, Pinecone, etc.)