### PR TITLE
fix: Pass embeddingDims to OpenAI embeddings API

### DIFF
--- a/mem0-ts/src/oss/src/embeddings/openai.ts
+++ b/mem0-ts/src/oss/src/embeddings/openai.ts
@@ -20,6 +20,7 @@ export class OpenAIEmbedder implements Embedder {
     const response = await this.openai.embeddings.create({
       model: this.model,
       input: text,
+      dimensions: this.embeddingDims,
     });
     return response.data[0].embedding;
   }
@@ -28,7 +29,7 @@ export class OpenAIEmbedder implements Embedder {
     const response = await this.openai.embeddings.create({
       model: this.model,
       input: texts,
+      dimensions: this.embeddingDims,
     });
     return response.data.map((item) => item.embedding);
   }
-}


### PR DESCRIPTION
Fixes #4615

The OpenAIEmbedder class stores embeddingDims from config but never passes it to the OpenAI embeddings.create() call. This causes dimension mismatch errors when using embedding models with configurable dimensions.

Added `dimensions: this.embeddingDims` parameter to both `embed()` and `embedBatch()` methods.

## Linked Issue

Closes #<!-- issue number -->

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe what breaks and the migration path. Delete this section if not applicable. -->

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

<!-- Describe how you tested this, or link to CI results. -->

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] I have updated documentation if needed
