### PR TITLE
fix: robust fact extraction with surrogate sanitization and retry

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -29,6 +29,7 @@ from mem0.memory.utils import (
     extract_json,
     get_fact_retrieval_messages,
     normalize_facts,
+    parse_facts_from_response,
     parse_messages,
     parse_vision_messages,
     process_telemetry_filters,
@@ -515,22 +516,14 @@ class Memory(MemoryBase):
             response_format={"type": "json_object"},
         )
 
-        try:
-            cleaned_response = remove_code_blocks(response)
-            if not cleaned_response.strip():
-                new_retrieved_facts = []
-            else:
-                try:
-                    # First try direct JSON parsing
-                    new_retrieved_facts = json.loads(cleaned_response, strict=False)["facts"]
-                except json.JSONDecodeError:
-                    # Try extracting JSON from response (handles chatty LLM output)
-                    extracted_json = extract_json(response)
-                    new_retrieved_facts = json.loads(extracted_json, strict=False)["facts"]
-                new_retrieved_facts = normalize_facts(new_retrieved_facts)
-        except Exception as e:
-            logger.error(f"Error in new_retrieved_facts: {e}")
-            new_retrieved_facts = []
+        new_retrieved_facts = parse_facts_from_response(
+            response,
+            max_retries=2,
+            llm=self.llm,
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            response_format={"type": "json_object"},
+        )
 
         if not new_retrieved_facts:
             logger.debug("No new facts retrieved from input. Skipping memory update LLM call.")
@@ -1612,22 +1605,14 @@ class AsyncMemory(MemoryBase):
             messages=[{"role": "system", "content": system_prompt}, {"role": "user", "content": user_prompt}],
             response_format={"type": "json_object"},
         )
-        try:
-            cleaned_response = remove_code_blocks(response)
-            if not cleaned_response.strip():
-                new_retrieved_facts = []
-            else:
-                try:
-                    # First try direct JSON parsing
-                    new_retrieved_facts = json.loads(cleaned_response, strict=False)["facts"]
-                except json.JSONDecodeError:
-                    # Try extracting JSON from response (handles chatty LLM output)
-                    extracted_json = extract_json(response)
-                    new_retrieved_facts = json.loads(extracted_json, strict=False)["facts"]
-                new_retrieved_facts = normalize_facts(new_retrieved_facts)
-        except Exception as e:
-            logger.error(f"Error in new_retrieved_facts: {e}")
-            new_retrieved_facts = []
+        new_retrieved_facts = parse_facts_from_response(
+            response,
+            max_retries=2,
+            llm=self.llm,
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            response_format={"type": "json_object"},
+        )
 
         if not new_retrieved_facts:
             logger.debug("No new facts retrieved from input. Skipping memory update LLM call.")

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -1,7 +1,8 @@
 import hashlib
+import json
 import logging
 import re
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from mem0.configs.prompts import (
     AGENT_MEMORY_EXTRACTION_PROMPT,
@@ -104,6 +105,116 @@ def normalize_facts(raw_facts):
         if fact:
             normalized.append(fact)
     return normalized
+
+
+def sanitize_json_string(text: str) -> str:
+    """Remove invalid UTF-16 surrogate pair escapes from a JSON string.
+
+    Non-OpenAI LLMs (e.g. Qwen3 via Cerebras, Ollama models) occasionally
+    produce lone surrogate escapes (\\uD800-\\uDFFF) in their JSON output.
+    These are invalid in JSON per RFC 8259 and cause ``json.JSONDecodeError``
+    even with ``strict=False``.
+
+    This function replaces:
+    - Valid surrogate *pairs* (high + low) with the Unicode replacement char
+    - Lone high/low surrogates with the Unicode replacement char
+    """
+    # Replace surrogate pairs first (high followed by low surrogate)
+    text = re.sub(
+        r"\\u[dD][89aAbB][0-9a-fA-F]{2}\\u[dD][c-fC-F][0-9a-fA-F]{2}",
+        "\ufffd",
+        text,
+    )
+    # Replace any remaining lone surrogates
+    text = re.sub(
+        r"\\u[dD][89a-fA-F][0-9a-fA-F]{2}",
+        "\ufffd",
+        text,
+    )
+    return text
+
+
+def parse_facts_from_response(
+    response: str,
+    *,
+    max_retries: int = 0,
+    llm=None,
+    system_prompt: str = "",
+    user_prompt: str = "",
+    response_format: Optional[Dict] = None,
+) -> list:
+    """Parse fact-extraction JSON from an LLM response with sanitization and retry.
+
+    Handles common failure modes from non-OpenAI LLMs:
+    1. Invalid UTF-16 surrogate escapes — cleaned before parsing
+    2. Chatty output wrapping JSON in markdown or prose — extracted via ``extract_json``
+    3. Transient malformed JSON — retried by re-calling the LLM up to ``max_retries`` times
+
+    Args:
+        response: The raw LLM response string.
+        max_retries: Number of times to retry the LLM call on parse failure (default 0).
+        llm: The LLM instance to call for retries. Required if ``max_retries > 0``.
+        system_prompt: System prompt for retry calls.
+        user_prompt: User prompt for retry calls.
+        response_format: Response format dict for retry calls.
+
+    Returns:
+        A list of normalized fact strings. Empty list if all attempts fail.
+    """
+    attempts = 1 + max_retries
+    last_error = None
+
+    for attempt in range(attempts):
+        if attempt > 0:
+            if llm is None:
+                logger.warning("Cannot retry fact extraction: no LLM provided")
+                break
+            logger.warning(
+                "Retrying fact extraction (attempt %d/%d) after error: %s",
+                attempt + 1, attempts, last_error,
+            )
+            try:
+                response = llm.generate_response(
+                    messages=[
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": user_prompt},
+                    ],
+                    response_format=response_format or {"type": "json_object"},
+                )
+            except Exception as e:
+                logger.warning("LLM retry call failed: %s", e)
+                last_error = e
+                continue
+
+        try:
+            cleaned = remove_code_blocks(response)
+            if not cleaned.strip():
+                return []
+
+            # Sanitize invalid surrogate escapes before JSON parsing
+            cleaned = sanitize_json_string(cleaned)
+
+            try:
+                facts = json.loads(cleaned, strict=False)["facts"]
+            except (json.JSONDecodeError, KeyError):
+                # Try extracting JSON from chatty output
+                extracted = extract_json(response)
+                extracted = sanitize_json_string(extracted)
+                facts = json.loads(extracted, strict=False)["facts"]
+
+            return normalize_facts(facts)
+
+        except Exception as e:
+            last_error = e
+            if attempt < attempts - 1:
+                logger.warning(
+                    "Fact extraction parse failed (attempt %d/%d): %s",
+                    attempt + 1, attempts, e,
+                )
+            else:
+                logger.error("Fact extraction failed after %d attempt(s): %s", attempts, e)
+
+    return []
 
 
 def remove_code_blocks(content: str) -> str:

--- a/tests/memory/test_fact_extraction_parsing.py
+++ b/tests/memory/test_fact_extraction_parsing.py
@@ -1,0 +1,208 @@
+"""Tests for robust fact extraction JSON parsing.
+
+Covers:
+- sanitize_json_string: invalid UTF-16 surrogate escape handling
+- parse_facts_from_response: end-to-end parsing with sanitization and retry
+"""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from mem0.memory.utils import parse_facts_from_response, sanitize_json_string
+
+
+# ---------------------------------------------------------------------------
+# sanitize_json_string
+# ---------------------------------------------------------------------------
+
+class TestSanitizeJsonString:
+    def test_lone_high_surrogate_replaced(self):
+        """Lone high surrogate (\\uD800-\\uDBFF) should be replaced."""
+        text = r'{"facts": ["User likes \uD83D pizza"]}'
+        result = sanitize_json_string(text)
+        assert r"\uD83D" not in result
+        assert "\ufffd" in result
+
+    def test_lone_low_surrogate_replaced(self):
+        """Lone low surrogate (\\uDC00-\\uDFFF) should be replaced."""
+        text = r'{"facts": ["Test \uDE00 value"]}'
+        result = sanitize_json_string(text)
+        assert r"\uDE00" not in result
+        assert "\ufffd" in result
+
+    def test_surrogate_pair_replaced(self):
+        """A full surrogate pair (high + low) should be replaced as one unit."""
+        # \uD83D\uDE00 is the surrogate pair for 😀
+        text = r'{"facts": ["emoji \uD83D\uDE00 here"]}'
+        result = sanitize_json_string(text)
+        assert r"\uD83D" not in result
+        assert r"\uDE00" not in result
+        # Should produce exactly one replacement char for the pair
+        assert result.count("\ufffd") == 1
+
+    def test_valid_unicode_escapes_preserved(self):
+        """Normal unicode escapes (non-surrogate) should be left intact."""
+        text = r'{"facts": ["User speaks \u4e2d\u6587"]}'
+        result = sanitize_json_string(text)
+        assert result == text  # No change
+
+    def test_no_escapes_passthrough(self):
+        """Plain strings without any unicode escapes pass through unchanged."""
+        text = '{"facts": ["User likes Python"]}'
+        result = sanitize_json_string(text)
+        assert result == text
+
+    def test_multiple_surrogates_all_replaced(self):
+        """Multiple lone surrogates in the same string are all handled."""
+        text = r'{"facts": ["\uD800 and \uDBFF and \uDC00"]}'
+        result = sanitize_json_string(text)
+        assert r"\uD800" not in result
+        assert r"\uDBFF" not in result
+        assert r"\uDC00" not in result
+
+    def test_sanitized_output_is_valid_json(self):
+        """After sanitization, the string should be parseable as JSON."""
+        text = r'{"facts": ["User said \uD83D hello"]}'
+        result = sanitize_json_string(text)
+        parsed = json.loads(result)
+        assert "facts" in parsed
+        assert len(parsed["facts"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# parse_facts_from_response
+# ---------------------------------------------------------------------------
+
+class TestParseFactsFromResponse:
+    def test_valid_json_parsed(self):
+        """Standard valid JSON response is parsed correctly."""
+        response = '{"facts": ["User likes Python", "Lives in Tokyo"]}'
+        facts = parse_facts_from_response(response)
+        assert facts == ["User likes Python", "Lives in Tokyo"]
+
+    def test_empty_response_returns_empty(self):
+        """Empty or whitespace-only response returns empty list."""
+        assert parse_facts_from_response("") == []
+        assert parse_facts_from_response("   ") == []
+
+    def test_empty_facts_array(self):
+        """Response with empty facts array returns empty list."""
+        assert parse_facts_from_response('{"facts": []}') == []
+
+    def test_code_block_wrapped_json(self):
+        """JSON wrapped in markdown code blocks is handled."""
+        response = '```json\n{"facts": ["User prefers Vim"]}\n```'
+        facts = parse_facts_from_response(response)
+        assert facts == ["User prefers Vim"]
+
+    def test_surrogate_escapes_sanitized_before_parse(self):
+        r"""Invalid surrogate escapes (\uD800-\uDFFF) are cleaned before parsing."""
+        # This would cause json.JSONDecodeError without sanitization
+        response = r'{"facts": ["User name is \uD83D test"]}'
+        facts = parse_facts_from_response(response)
+        assert len(facts) == 1
+        assert "\ufffd" in facts[0]  # Replacement char
+
+    def test_chatty_output_with_json_extracted(self):
+        """LLM response with prose around JSON is handled via extract_json fallback."""
+        response = (
+            "Here are the facts I extracted:\n\n"
+            '```json\n{"facts": ["Prefers dark mode"]}\n```\n\n'
+            "Let me know if you need more."
+        )
+        facts = parse_facts_from_response(response)
+        assert facts == ["Prefers dark mode"]
+
+    def test_dict_facts_normalized(self):
+        """Facts returned as objects (common with smaller LLMs) are normalized."""
+        response = '{"facts": [{"fact": "Uses VS Code"}, {"text": "Knows Rust"}]}'
+        facts = parse_facts_from_response(response)
+        assert facts == ["Uses VS Code", "Knows Rust"]
+
+    def test_no_retry_by_default(self):
+        """With max_retries=0 (default), a bad response fails immediately."""
+        response = "this is not json at all"
+        facts = parse_facts_from_response(response)
+        assert facts == []
+
+    def test_retry_succeeds_on_second_attempt(self):
+        """When first response is bad, retry with LLM produces valid result."""
+        bad_response = "totally broken json {"
+        good_response = '{"facts": ["Recovered fact"]}'
+
+        mock_llm = MagicMock()
+        mock_llm.generate_response.return_value = good_response
+
+        facts = parse_facts_from_response(
+            bad_response,
+            max_retries=1,
+            llm=mock_llm,
+            system_prompt="sys",
+            user_prompt="usr",
+        )
+        assert facts == ["Recovered fact"]
+        mock_llm.generate_response.assert_called_once()
+
+    def test_retry_all_attempts_fail(self):
+        """When all retry attempts also produce bad JSON, returns empty list."""
+        bad_response = "broken"
+
+        mock_llm = MagicMock()
+        mock_llm.generate_response.return_value = "still broken"
+
+        facts = parse_facts_from_response(
+            bad_response,
+            max_retries=2,
+            llm=mock_llm,
+            system_prompt="sys",
+            user_prompt="usr",
+        )
+        assert facts == []
+        assert mock_llm.generate_response.call_count == 2
+
+    def test_retry_not_attempted_without_llm(self):
+        """If max_retries > 0 but no LLM provided, retries are skipped gracefully."""
+        facts = parse_facts_from_response(
+            "bad json",
+            max_retries=3,
+            llm=None,
+        )
+        assert facts == []
+
+    def test_retry_llm_call_itself_fails(self):
+        """If the LLM call during retry raises, we continue to next attempt."""
+        mock_llm = MagicMock()
+        mock_llm.generate_response.side_effect = [
+            RuntimeError("API timeout"),
+            '{"facts": ["Finally worked"]}',
+        ]
+
+        facts = parse_facts_from_response(
+            "initial bad",
+            max_retries=2,
+            llm=mock_llm,
+            system_prompt="sys",
+            user_prompt="usr",
+        )
+        assert facts == ["Finally worked"]
+        assert mock_llm.generate_response.call_count == 2
+
+    def test_production_surrogate_scenario(self):
+        """Realistic scenario from Cerebras Qwen3-235B producing invalid surrogates."""
+        # Simulates the exact error pattern from the issue report
+        response = (
+            r'{"facts": ["用户的名字是\uD835\uDC00张三", '
+            r'"User prefers \uD83D dark mode", '
+            r'"Lives in Beijing"]}'
+        )
+        facts = parse_facts_from_response(response)
+        assert len(facts) == 3
+        assert "Lives in Beijing" in facts
+
+    def test_think_tags_stripped(self):
+        """<think> tags from reasoning models are stripped before parsing."""
+        response = '<think>Let me analyze...</think>{"facts": ["User likes cats"]}'
+        facts = parse_facts_from_response(response)
+        assert facts == ["User likes cats"]


### PR DESCRIPTION
## Summary

Closes #4540

Non-OpenAI LLMs (e.g. Qwen3 via Cerebras, Ollama models) occasionally produce invalid UTF-16 surrogate pair escapes (`\uD800`-`\uDFFF`) in their JSON output. The current code silently discards **all** extracted facts on any parse error — with no retry and minimal logging. This means conversations are permanently lost from the memory store without any user-visible signal.

## Root Cause

Two issues in `_add_to_vector_store` (both `Memory` and `AsyncMemory`):

1. **Invalid surrogate escapes**: Non-OpenAI LLMs processing multilingual content occasionally emit lone or paired UTF-16 surrogate escapes that are invalid in JSON per RFC 8259. `json.loads()` raises `JSONDecodeError` even with `strict=False`.
2. **No retry on transient failures**: The single `try/except` catches any exception and silently sets `new_retrieved_facts = []`. LLM JSON failures are often transient (the same input succeeds on retry), but there's no retry mechanism.

## Changes

### New utilities in `mem0/memory/utils.py`:

- **`sanitize_json_string()`** — Removes invalid UTF-16 surrogate pair escapes before JSON parsing. Handles both lone surrogates (`\uD800`-`\uDFFF`) and full surrogate pairs (high+low). Replaces with Unicode replacement character (`\uFFFD`).

- **`parse_facts_from_response()`** — Consolidated fact-extraction parser that:
  - Sanitizes surrogate escapes before every parse attempt
  - Falls back to `extract_json()` for chatty LLM output (existing behavior preserved)
  - Retries via LLM re-call up to `max_retries` times for transient failures
  - Logs each failed attempt as warning, final failure as error
  - Returns normalized facts list (empty list on complete failure)

### Updated in `mem0/memory/main.py`:

- Replaced inline `try/except` parsing blocks in both `Memory._add_to_vector_store()` and `AsyncMemory._add_to_vector_store()` with `parse_facts_from_response()`
- Configured with `max_retries=2` (3 total attempts), matching the issue reporter's recommendation

## Tests

21 new tests in `tests/memory/test_fact_extraction_parsing.py`:

**`sanitize_json_string`** (7 tests):
- Lone high/low surrogates replaced
- Full surrogate pairs replaced as single unit
- Valid unicode escapes preserved
- Plain strings pass through unchanged
- Multiple surrogates all handled
- Sanitized output is valid JSON

**`parse_facts_from_response`** (14 tests):
- Valid JSON, empty input, empty facts array
- Code block wrapped JSON
- Surrogate escapes sanitized before parse
- Chatty output with prose around JSON
- Dict-format facts normalized (`{"fact": ...}`)
- No retry by default (`max_retries=0`)
- Retry succeeds on second attempt
- All retry attempts fail → empty list
- Retry without LLM → graceful skip
- LLM call itself fails during retry → continues to next attempt
- Production scenario (Cerebras Qwen3 surrogate pattern)
- `<think>` tags stripped

All 21 new tests pass. All 29 existing related tests (`test_memory_utils.py` + `test_chatty_llm_parsing.py`) continue to pass.