### PR TITLE
fix(configs): migrate CassandraConfig and AzureMySQLConfig to pydantic v2 ConfigDict

### DIFF
--- a/mem0/configs/vector_stores/azure_mysql.py
+++ b/mem0/configs/vector_stores/azure_mysql.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class AzureMySQLConfig(BaseModel):
@@ -80,5 +80,4 @@ class AzureMySQLConfig(BaseModel):
 
         return values
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/mem0/configs/vector_stores/cassandra.py
+++ b/mem0/configs/vector_stores/cassandra.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class CassandraConfig(BaseModel):
@@ -72,6 +72,5 @@ class CassandraConfig(BaseModel):
 
         return values
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 


### PR DESCRIPTION
## Summary

`CassandraConfig` and `AzureMySQLConfig` were the only two vector store config classes still using the pydantic v1 inner `class Config:` pattern. Every other config in `mem0/configs/vector_stores/` (qdrant, chroma, milvus, pinecone, redis, weaviate, etc.) already uses the pydantic v2 `model_config = ConfigDict(...)` style.

## Changes

- `mem0/configs/vector_stores/cassandra.py`: replace `class Config: arbitrary_types_allowed = True` with `model_config = ConfigDict(arbitrary_types_allowed=True)`, add `ConfigDict` to imports
- `mem0/configs/vector_stores/azure_mysql.py`: same change

## Why

Pydantic v2 emits a deprecation warning when the inner `class Config:` pattern is used. This aligns these two files with the rest of the codebase and removes the inconsistency.

## No behaviour change

`arbitrary_types_allowed = True` and `ConfigDict(arbitrary_types_allowed=True)` are functionally identical — this is purely a consistency and forward-compatibility fix.
