### PR TITLE
feat: support llm, rerank, and embedding modules using models provided by the alibaba bailian platform

### DIFF
--- a/mem0/configs/llms/bailian.py
+++ b/mem0/configs/llms/bailian.py
@@ -1,0 +1,79 @@
+from typing import Any, Callable, List, Optional
+
+from mem0.configs.llms.base import BaseLlmConfig
+
+
+class BailianConfig(BaseLlmConfig):
+    """
+    Configuration class for OpenAI and OpenRouter-specific parameters.
+    Inherits from BaseLlmConfig and adds OpenAI-specific settings.
+    """
+
+    def __init__(
+        self,
+        # Base parameters
+        model: Optional[str] = None,
+        temperature: float = 0.1,
+        api_key: Optional[str] = None,
+        max_tokens: int = 2000,
+        top_p: float = 0.1,
+        top_k: int = 1,
+        enable_vision: bool = False,
+        vision_details: Optional[str] = "auto",
+        http_client_proxies: Optional[dict] = None,
+        # OpenAI-specific parameters
+        openai_base_url: Optional[str] = None,
+        models: Optional[List[str]] = None,
+        route: Optional[str] = "fallback",
+        openrouter_base_url: Optional[str] = None,
+        site_url: Optional[str] = None,
+        app_name: Optional[str] = None,
+        store: bool = False,
+        # Response monitoring callback
+        response_callback: Optional[Callable[[Any, dict, dict], None]] = None,
+    ):
+        """
+        Initialize OpenAI configuration.
+
+        Args:
+            model: OpenAI model to use, defaults to None
+            temperature: Controls randomness, defaults to 0.1
+            api_key: OpenAI API key, defaults to None
+            max_tokens: Maximum tokens to generate, defaults to 2000
+            top_p: Nucleus sampling parameter, defaults to 0.1
+            top_k: Top-k sampling parameter, defaults to 1
+            enable_vision: Enable vision capabilities, defaults to False
+            vision_details: Vision detail level, defaults to "auto"
+            http_client_proxies: HTTP client proxy settings, defaults to None
+            openai_base_url: OpenAI API base URL, defaults to None
+            models: List of models for OpenRouter, defaults to None
+            route: OpenRouter route strategy, defaults to "fallback"
+            openrouter_base_url: OpenRouter base URL, defaults to None
+            site_url: Site URL for OpenRouter, defaults to None
+            app_name: Application name for OpenRouter, defaults to None
+            response_callback: Optional callback for monitoring LLM responses.
+        """
+        # Initialize base parameters
+        super().__init__(
+            model=model,
+            temperature=temperature,
+            api_key=api_key,
+            max_tokens=max_tokens,
+            top_p=top_p,
+            top_k=top_k,
+            enable_vision=enable_vision,
+            vision_details=vision_details,
+            http_client_proxies=http_client_proxies,
+        )
+
+        # OpenAI-specific parameters
+        self.openai_base_url = openai_base_url
+        self.models = models
+        self.route = route
+        self.openrouter_base_url = openrouter_base_url
+        self.site_url = site_url
+        self.app_name = app_name
+        self.store = store
+
+        # Response monitoring
+        self.response_callback = response_callback

--- a/mem0/configs/rerankers/bailian.py
+++ b/mem0/configs/rerankers/bailian.py
@@ -1,0 +1,30 @@
+from typing import Optional
+from pydantic import Field
+
+from mem0.configs.rerankers.base import BaseRerankerConfig
+
+
+class BailianRerankerConfig(BaseRerankerConfig):
+    """
+    Configuration for DashScope reranker.
+
+    Attributes:
+        model (str): Model to use for reranking. Defaults to "qwen3-rerank".
+        api_key (str): Dashscope API key. If not provided, will try to read DASHSCOPE_API_KEY from  environment variable.
+        return_documents (boolean): Number of top documents to return after reranking.
+        api_url (str): DashScope API URL. Defaults to "".
+        top_k (int): Number of top documents to return after reranking.
+    """
+
+    model: str = Field(
+        default="qwen3-rerank",
+        description="Model to use for reranking. Available models: qwen3-rerank, gte-rerank-v2",
+    )
+    api_key: Optional[str] = Field(default=None, description="DashScope API key")
+    api_url: Optional[str] = Field(default=None, description="reranker API URL")
+    return_documents: Optional[bool] = Field(
+        default=True, description="return documents(Only for gte-rerank-v2)"
+    )
+    top_k: Optional[int] = Field(
+        default=100, description="Number of top documents to return after reranking"
+    )

--- a/mem0/embeddings/bailian.py
+++ b/mem0/embeddings/bailian.py
@@ -1,0 +1,84 @@
+import os
+import warnings
+from typing import Literal, Optional, List
+
+from openai import OpenAI
+
+from mem0.configs.embeddings.base import BaseEmbedderConfig
+from mem0.embeddings.base import EmbeddingBase
+
+
+class BaiLianEmbedding(EmbeddingBase):
+    def __init__(self, config: Optional[BaseEmbedderConfig] = None):
+        super().__init__(config)
+
+        self.config.model = self.config.model or os.getenv("EMBEDDER_CONFIG_MODEL","text-embedding-v4")
+        self.config.embedding_dims = self.config.embedding_dims or int(os.getenv("EMBEDDER_CONFIG_DIMS","1536"))
+
+        api_key = (self.config.api_key
+                   or os.getenv("DASHSCOPE_API_KEY")
+                   or os.getenv("EMBEDDER_API_KEY"))
+        base_url = (
+            self.config.openai_base_url
+            or os.getenv("DASHSCOPE_BASE_URL")
+            or os.getenv("EMBEDDER_BASE_URL")
+            or "https://dashscope.aliyuncs.com/compatible-mode/v1"
+        )
+        self.client = OpenAI(api_key=api_key, base_url=base_url)
+
+    def embed(self, text, memory_action: Optional[Literal["add", "search", "update"]] = None):
+        """
+        Get the embedding for the given text using BaiLian.
+
+        Args:
+            text (str): The text to embed.
+            memory_action (optional): The type of embedding to use. Must be one of "add", "search", or "update". Defaults to None.
+        Returns:
+            list: The embedding vector.
+        """
+        text = text.replace("\n", " ")
+        return (
+            self.client.embeddings.create(input=[text], model=self.config.model, dimensions=self.config.embedding_dims, encoding_format = "float")
+            .data[0]
+            .embedding
+        )
+    
+    def batch_embed(self, texts: List[str], memory_action: Optional[Literal["add", "search", "update"]] = None):
+        """
+        Batch embed multiple texts for better performance.
+        API limit: Maximum 10 texts per batch. Automatically splits into multiple batches if needed.
+        
+        Args:
+            texts (List[str]): List of texts to embed.
+            memory_action (optional): The type of embedding to use. Must be one of "add", "search", or "update". Defaults to None.
+        
+        Returns:
+            List[list]: List of embedding vectors.
+        """
+        if not texts:
+            return []
+        
+        # Clean texts
+        cleaned_texts = [text.replace("\n", " ") for text in texts]
+        
+        # Batch size limit: 10 texts per API call
+        batch_size = 10
+        all_embeddings = []
+        
+        # Process in batches
+        for i in range(0, len(cleaned_texts), batch_size):
+            batch = cleaned_texts[i:i + batch_size]
+            
+            # Batch API call
+            response = self.client.embeddings.create(
+                input=batch,
+                model=self.config.model,
+                dimensions=self.config.embedding_dims,
+                encoding_format="float"
+            )
+            
+            # Collect embeddings from this batch
+            batch_embeddings = [item.embedding for item in response.data]
+            all_embeddings.extend(batch_embeddings)
+        
+        return all_embeddings

--- a/mem0/embeddings/bailian.py
+++ b/mem0/embeddings/bailian.py
@@ -1,0 +1,84 @@
+import os
+import warnings
+from typing import Literal, Optional
+
+from openai import OpenAI
+
+from mem0.configs.embeddings.base import BaseEmbedderConfig
+from mem0.embeddings.base import EmbeddingBase
+
+
+class BaiLianEmbedding(EmbeddingBase):
+    def __init__(self, config: Optional[BaseEmbedderConfig] = None):
+        super().__init__(config)
+
+        self.config.model = self.config.model or os.getenv("EMBEDDER_CONFIG_MODEL","text-embedding-v4")
+        self.config.embedding_dims = self.config.embedding_dims or int(os.getenv("EMBEDDER_CONFIG_DIMS","1536"))
+
+        api_key = (self.config.api_key
+                   or os.getenv("DASHSCOPE_API_KEY")
+                   or os.getenv("EMBEDDER_API_KEY"))
+        base_url = (
+            self.config.openai_base_url
+            or os.getenv("DASHSCOPE_BASE_URL")
+            or os.getenv("EMBEDDER_BASE_URL")
+            or "https://dashscope.aliyuncs.com/compatible-mode/v1"
+        )
+        self.client = OpenAI(api_key=api_key, base_url=base_url)
+
+    def embed(self, text, memory_action: Optional[Literal["add", "search", "update"]] = None):
+        """
+        Get the embedding for the given text using BaiLian.
+
+        Args:
+            text (str): The text to embed.
+            memory_action (optional): The type of embedding to use. Must be one of "add", "search", or "update". Defaults to None.
+        Returns:
+            list: The embedding vector.
+        """
+        text = text.replace("\n", " ")
+        return (
+            self.client.embeddings.create(input=[text], model=self.config.model, dimensions=self.config.embedding_dims, encoding_format = "float")
+            .data[0]
+            .embedding
+        )
+    
+    def embed_batch(self, texts, memory_action="add"):
+        """
+        Batch embed multiple texts for better performance.
+        API limit: Maximum 10 texts per batch. Automatically splits into multiple batches if needed.
+
+        Args:
+            texts (List[str]): List of texts to embed.
+            memory_action (optional): The type of embedding to use. Must be one of "add", "search", or "update". Defaults to "add".
+
+        Returns:
+            List[list]: List of embedding vectors.
+        """
+        if not texts:
+            return []
+        
+        # Clean texts
+        cleaned_texts = [text.replace("\n", " ") for text in texts]
+        
+        # Batch size limit: 10 texts per API call
+        batch_size = 10
+        all_embeddings = []
+        
+        # Process in batches
+        for i in range(0, len(cleaned_texts), batch_size):
+            batch = cleaned_texts[i:i + batch_size]
+            
+            # Batch API call
+            response = self.client.embeddings.create(
+                input=batch,
+                model=self.config.model,
+                dimensions=self.config.embedding_dims,
+                encoding_format="float"
+            )
+            
+            # Collect embeddings from this batch
+            batch_embeddings = [item.embedding for item in response.data]
+            all_embeddings.extend(batch_embeddings)
+        
+        return all_embeddings

--- a/mem0/embeddings/configs.py
+++ b/mem0/embeddings/configs.py
@@ -25,6 +25,7 @@ class EmbedderConfig(BaseModel):
             "langchain",
             "aws_bedrock",
             "fastembed",
+            "bailian",
         ]:
             return v
         else:

--- a/mem0/llms/bailian.py
+++ b/mem0/llms/bailian.py
@@ -1,0 +1,137 @@
+import json
+import logging
+import os
+from typing import Dict, List, Optional
+
+from openai import OpenAI
+
+from mem0.configs.llms.base import BaseLlmConfig
+from mem0.configs.llms.bailian import BailianConfig
+from mem0.llms.base import LLMBase
+from mem0.memory.utils import extract_json
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class BaiLianLLM(LLMBase):
+    def __init__(self, config: Optional[BaseLlmConfig] = None):
+        # Convert to BailianConfig if needed
+        if config is None:
+            config = BaseLlmConfig()
+        elif isinstance(config, dict):
+            config = BaseLlmConfig(**config)
+        elif isinstance(config, BailianConfig):
+            config = config
+        elif isinstance(config, BaseLlmConfig) and not isinstance(config, BailianConfig):
+            # Convert BaseLlmConfig to BailianConfig
+            # Handle base_url parameter if it exists
+            base_url = getattr(config, 'base_url', None)
+            config = BailianConfig(
+                model=config.model,
+                temperature=config.temperature,
+                api_key=config.api_key,
+                max_tokens=config.max_tokens,
+                top_p=config.top_p,
+                top_k=config.top_k,
+                enable_vision=config.enable_vision,
+                vision_details=config.vision_details,
+                http_client_proxies=config.http_client,
+                base_url=base_url
+            )
+
+        super().__init__(config)
+
+        if not self.config.model:
+            self.config.model = os.getenv("LLM_CONFIG_MODEL") or "qwen-plus"
+
+        api_key = (self.config.api_key
+                   or os.getenv("DASHSCOPE_API_KEY")
+                   or os.getenv("LLM_API_KEY"))
+        base_url = (getattr(self.config, 'openai_base_url', None)
+                    or os.getenv("DASHSCOPE_BASE_URL")
+                    or os.getenv("LLM_BASE_URL")
+                    or "https://dashscope.aliyuncs.com/compatible-mode/v1")
+
+        self.client = OpenAI(api_key=api_key, base_url=base_url)
+
+    def _parse_response(self, response, tools):
+        """
+        Process the response based on whether tools are used or not.
+
+        Args:
+            response: The raw response from API.
+            tools: The list of tools provided in the request.
+
+        Returns:
+            str or dict: The processed response.
+        """
+        if tools:
+            processed_response = {
+                "content": response.choices[0].message.content,
+                "tool_calls": [],
+            }
+
+            if response.choices[0].message.tool_calls:
+                for tool_call in response.choices[0].message.tool_calls:
+                    processed_response["tool_calls"].append(
+                        {
+                            "name": tool_call.function.name,
+                            "arguments": json.loads(
+                                extract_json(tool_call.function.arguments)
+                            ),
+                        }
+                    )
+
+            return processed_response
+        else:
+            return response.choices[0].message.content
+
+    def generate_response(
+        self,
+        messages: List[Dict[str, str]],
+        response_format=None,
+        tools: Optional[List[Dict]] = None,
+        tool_choice: str = "auto",
+        **kwargs,
+    ):
+        """
+        Generate a JSON response based on the given messages using OpenAI.
+
+        Args:
+            messages (list): List of message dicts containing 'role' and 'content'.
+            response_format (str or object, optional): Format of the response. Defaults to "text".
+            tools (list, optional): List of tools that the model can call. Defaults to None.
+            tool_choice (str, optional): Tool choice method. Defaults to "auto".
+            **kwargs: Additional OpenAI-specific parameters.
+
+        Returns:
+            json: The generated response.
+        """
+        params = self._get_supported_params(messages=messages, **kwargs)
+
+        params.update(
+            {
+                "model": self.config.model,
+                "messages": messages,
+            }
+        )
+
+        if response_format:
+            params["response_format"] = response_format
+        if (
+            tools
+        ):  # TODO: Remove tools if no issues found with new memory addition logic
+            params["tools"] = tools
+            params["tool_choice"] = tool_choice
+        response = self.client.chat.completions.create(**params)
+
+        logger.debug("params: \n-------------------")
+        logger.debug(params["messages"])
+        logger.debug("\n-------------------\n")
+        parsed_response = self._parse_response(response, tools)
+        logger.debug("parsed_response: \n-------------------")
+        logger.debug(parsed_response)
+        logger.debug("\n-------------------\n")
+        return parsed_response

--- a/mem0/llms/configs.py
+++ b/mem0/llms/configs.py
@@ -29,6 +29,7 @@ class LlmConfig(BaseModel):
             "lmstudio",
             "vllm",
             "langchain",
+            "bailian",
         ):
             return v
         else:

--- a/mem0/reranker/bailian_reranker.py
+++ b/mem0/reranker/bailian_reranker.py
@@ -1,0 +1,164 @@
+import os
+from typing import List, Dict, Any
+import os
+import requests
+from mem0.reranker.base import BaseReranker
+
+
+class bailian_reranker(BaseReranker):
+    """Dashscope-based reranker implementation."""
+
+    def __init__(self, config):
+        """
+        Initialize dashscope reranker.
+
+        Args:
+            config: DashscopeRerankerConfig object with configuration parameters
+        """
+
+        self.config = config
+        self.api_key = (
+            config.api_key
+            or os.getenv("DASHSCOPE_API_KEY")
+            or os.getenv("RERANKER_API_KEY")
+        )
+        if not self.api_key:
+            raise ValueError(
+                "Dashscope API key is required. Set DASHSCOPE_API_KEY environment variable or pass api_key in config."
+            )
+
+        self.url = (
+            config.api_url
+            or os.getenv("DASHSCOPE_RERANKER_URL")
+            or os.getenv("RERANKER_BASE_URL")
+            or "https://dashscope.aliyuncs.com/compatible-api/v1/reranks"
+        )
+        self.model = (
+            config.model or os.getenv("RERANKER_CONFIG_MODEL") or "qwen3-rerank"
+        )
+        if self.model not in ["qwen3-rerank", "gte-rerank-v2"]:
+            raise ValueError(
+                "Invalid model name. Supported models are 'qwen3-rerank' and 'gte-rerank-v2'."
+            )
+        self.return_documents = config.return_documents or True
+
+    def rerank(
+        self, query: str, documents: List[Dict[str, Any]], top_k: int = None
+    ) -> List[Dict[str, Any]]:
+        """
+        Rerank documents using Dashscope's rerank API.
+
+        Args:
+            query: The search query
+            documents: List of documents to rerank
+            top_k: Number of top documents to return
+
+        Returns:
+            List of reranked documents with rerank_score
+        """
+        if not documents:
+            return documents
+
+        # Extract text content for reranking
+        doc_texts = []
+        for doc in documents:
+            if "memory" in doc:
+                doc_texts.append(doc["memory"])
+            elif "text" in doc:
+                doc_texts.append(doc["text"])
+            elif "content" in doc:
+                doc_texts.append(doc["content"])
+            else:
+                doc_texts.append(str(doc))
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+        # prepare data
+        data = {}
+        if self.model == "qwen3-rerank":
+            data = {
+                "model": self.model,
+                "documents": doc_texts,
+                "query": query,
+                "top_n": top_k or self.config.top_k or len(documents),
+                "instruct": "Given a search query, retrieve relevant passages that answer the query.",
+            }
+        elif self.model == "gte-rerank-v2":
+            data = {
+                "model": self.model,
+                "input": {"query": query, "documents": doc_texts},
+                "parameters": {
+                    "return_documents": self.return_documents,
+                    "top_n": top_k or self.config.top_k or len(documents),
+                },
+            }
+        else:
+            raise ValueError(
+                "Invalid model name. Supported models are 'qwen3-rerank' and 'gte-rerank-v2'."
+            )
+
+        try:
+            # Call Bailian rerank API
+            response = requests.post(self.url, headers=headers, json=data)
+
+            # Check if request was successful
+            response.raise_for_status()
+
+            # Parse the response according to the actual structure
+            response_data = response.json()
+
+            if self.model == "qwen3-rerank":
+                results = response_data.get("results", [])
+            else:
+                results = response_data.get("output", {}).get("results", [])
+
+            # Create reranked results
+            reranked_docs = []
+            for result in results:
+                index = result.get("index", 0)
+                relevance_score = result.get("relevance_score", 0.0)
+                document_text = result.get("document", {}).get("text", "")
+
+                # Get the original document using the index
+                if 0 <= index < len(documents):
+                    original_doc = documents[index].copy()
+                else:
+                    # Fallback: find document by matching text content
+                    original_doc = None
+                    for i, doc in enumerate(documents):
+                        doc_content = (
+                            doc.get("memory")
+                            or doc.get("text")
+                            or doc.get("content")
+                            or str(doc)
+                        )
+                        if doc_content == document_text:
+                            original_doc = documents[i].copy()
+                            break
+
+                    if original_doc is None:
+                        continue  # Skip if we can't match the document
+
+                original_doc["rerank_score"] = relevance_score
+                reranked_docs.append(original_doc)
+
+            # Sort by relevance score in descending order
+            reranked_docs.sort(key=lambda x: x["rerank_score"], reverse=True)
+
+            # Apply top_k limit
+            if top_k:
+                reranked_docs = reranked_docs[:top_k]
+            elif self.config.top_k:
+                reranked_docs = reranked_docs[: self.config.top_k]
+
+            return reranked_docs
+
+        except Exception as e:
+            print(f"Error during reranking: {e}")
+            # Fallback to original order if reranking fails
+            for doc in documents:
+                doc["rerank_score"] = 0.0
+            return documents[:top_k] if top_k else documents

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -15,12 +15,14 @@ from mem0.configs.llms.ollama import OllamaConfig
 from mem0.configs.llms.openai import OpenAIConfig
 from mem0.configs.llms.vllm import VllmConfig
 from mem0.configs.llms.xai import XAIConfig
+from mem0.configs.llms.bailian import BailianConfig
 from mem0.configs.rerankers.base import BaseRerankerConfig
 from mem0.configs.rerankers.cohere import CohereRerankerConfig
 from mem0.configs.rerankers.huggingface import HuggingFaceRerankerConfig
 from mem0.configs.rerankers.llm import LLMRerankerConfig
 from mem0.configs.rerankers.sentence_transformer import SentenceTransformerRerankerConfig
 from mem0.configs.rerankers.zero_entropy import ZeroEntropyRerankerConfig
+from mem0.configs.rerankers.bailian import BailianRerankerConfig
 from mem0.embeddings.mock import MockEmbeddings
 
 
@@ -56,6 +58,7 @@ class LlmFactory:
         "lmstudio": ("mem0.llms.lmstudio.LMStudioLLM", LMStudioConfig),
         "vllm": ("mem0.llms.vllm.VllmLLM", VllmConfig),
         "langchain": ("mem0.llms.langchain.LangchainLLM", BaseLlmConfig),
+        "bailian": ("mem0.llms.bailian.BaiLianLLM", BailianConfig),
     }
 
     @classmethod
@@ -160,6 +163,7 @@ class EmbedderFactory:
         "langchain": "mem0.embeddings.langchain.LangchainEmbedding",
         "aws_bedrock": "mem0.embeddings.aws_bedrock.AWSBedrockEmbedding",
         "fastembed": "mem0.embeddings.fastembed.FastEmbedEmbedding",
+        "bailian": "mem0.embeddings.bailian.BaiLianEmbedding",
     }
 
     @classmethod
@@ -236,6 +240,7 @@ class RerankerFactory:
         "zero_entropy": ("mem0.reranker.zero_entropy_reranker.ZeroEntropyReranker", ZeroEntropyRerankerConfig),
         "llm_reranker": ("mem0.reranker.llm_reranker.LLMReranker", LLMRerankerConfig),
         "huggingface": ("mem0.reranker.huggingface_reranker.HuggingFaceReranker", HuggingFaceRerankerConfig),
+        "bailian": ("mem0.reranker.bailian_reranker.bailian_reranker", BailianRerankerConfig),
     }
 
     @classmethod

--- a/tests/test_bailian_models.py
+++ b/tests/test_bailian_models.py
@@ -1,0 +1,529 @@
+"""
+Bailian Platform Model Integration Tests
+
+Tests for LLM, Embedding, and Reranker components using Bailian platform models.
+Configuration is passed via environment variables.
+
+Environment Variables:
+    BAILIAN_API_KEY       (required) Bailian (Dashscope) API key
+    BAILIAN_LLM_MODEL     (optional) LLM model name, default: qwen3-max
+    BAILIAN_EMBEDDER_MODEL(optional) Embedding model name, default: text-embedding-v4
+    BAILIAN_EMBEDDER_DIMS (optional) Embedding dimensions, default: 1536
+    BAILIAN_RERANKER_MODEL(optional) Reranker model name, default: qwen3-rerank
+    BAILIAN_QDRANT_HOST   (optional) Qdrant host, default: localhost
+    BAILIAN_QDRANT_PORT   (optional) Qdrant port, default: 6333
+    BAILIAN_QDRANT_COLLECTION (optional) Qdrant collection name, default: test_bailian
+
+Usage:
+    BAILIAN_API_KEY=sk-xxx \
+    BAILIAN_LLM_MODEL=qwen3-max \
+    BAILIAN_EMBEDDER_MODEL=text-embedding-v4 \
+    BAILIAN_EMBEDDER_DIMS=1536 \
+    BAILIAN_RERANKER_MODEL=qwen3-rerank \
+        pytest tests/test_bailian_models.py -v
+"""
+
+import json
+import math
+import os
+
+import pytest
+
+from mem0.configs.embeddings.base import BaseEmbedderConfig
+from mem0.configs.llms.bailian import BailianConfig
+from mem0.configs.rerankers.bailian import BailianRerankerConfig
+from mem0.embeddings.bailian import BaiLianEmbedding
+from mem0.llms.bailian import BaiLianLLM
+from mem0.reranker.bailian_reranker import bailian_reranker
+
+# ===========================================================================
+# Configuration from environment variables
+# ===========================================================================
+BAILIAN_CONFIG = {
+    "api_key": os.environ.get("BAILIAN_API_KEY", ""),
+    "llm_model": os.environ.get("BAILIAN_LLM_MODEL", "qwen3-max"),
+    "llm_base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    "embedder_model": os.environ.get("BAILIAN_EMBEDDER_MODEL", "text-embedding-v4"),
+    "embedder_dims": int(os.environ.get("BAILIAN_EMBEDDER_DIMS", "1536")),
+    "reranker_model": os.environ.get("BAILIAN_RERANKER_MODEL", "qwen3-rerank"),
+    "reranker_base_url": "https://dashscope.aliyuncs.com/compatible-api/v1/reranks",
+    "reranker_top_k": 3,
+    "qdrant_host": os.environ.get("BAILIAN_QDRANT_HOST", "localhost"),
+    "qdrant_port": int(os.environ.get("BAILIAN_QDRANT_PORT", "6333")),
+    "qdrant_collection": os.environ.get("BAILIAN_QDRANT_COLLECTION", "test_bailian"),
+}
+
+SKIP_REASON = "Bailian API key not provided (set BAILIAN_API_KEY env var)"
+
+
+def _cosine_similarity(vec_a, vec_b):
+    """Compute cosine similarity between two vectors."""
+    dot = sum(a * b for a, b in zip(vec_a, vec_b))
+    norm_a = math.sqrt(sum(a * a for a in vec_a))
+    norm_b = math.sqrt(sum(b * b for b in vec_b))
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+# ===========================================================================
+# LLM Tests
+# ===========================================================================
+class TestBaiLianLLM:
+    """Tests for BaiLian LLM via Dashscope."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        api_key = BAILIAN_CONFIG["api_key"]
+        if not api_key:
+            pytest.skip(SKIP_REASON)
+        config = BailianConfig(
+            model=BAILIAN_CONFIG["llm_model"],
+            api_key=api_key,
+            openai_base_url=BAILIAN_CONFIG["llm_base_url"],
+            temperature=0.1,
+            max_tokens=1000,
+        )
+        self.llm = BaiLianLLM(config)
+
+    def test_bailian_llm_generate_response(self):
+        """Test basic text generation capability."""
+        messages = [
+            {"role": "user", "content": "What is 2 + 3? Answer with just the number."}
+        ]
+        response = self.llm.generate_response(messages=messages)
+
+        assert response is not None
+        assert isinstance(response, str)
+        assert len(response.strip()) > 0
+        assert "5" in response
+
+    def test_bailian_llm_json_response(self):
+        """Test JSON format response generation."""
+        messages = [
+            {
+                "role": "system",
+                "content": "You are a helpful assistant that responds in JSON format.",
+            },
+            {
+                "role": "user",
+                "content": 'Return a JSON object with key "name" set to "Alice" and key "age" set to 30.',
+            },
+        ]
+        response = self.llm.generate_response(
+            messages=messages,
+            response_format={"type": "json_object"},
+        )
+
+        assert response is not None
+        assert isinstance(response, str)
+
+        parsed = json.loads(response)
+        assert "name" in parsed
+        assert parsed["name"] == "Alice"
+        assert "age" in parsed
+        assert parsed["age"] == 30
+
+    def test_bailian_llm_fact_extraction(self):
+        """Test fact extraction scenario similar to mem0 usage."""
+        fact_extraction_prompt = (
+            "You are a Personal Information Organizer. "
+            "Extract relevant facts from the conversation and return them "
+            'in JSON format with a "facts" key containing a list of strings.\n\n'
+            "Example:\n"
+            'Input: Hi, my name is John. I am a software engineer.\n'
+            'Output: {"facts": ["Name is John", "Is a Software engineer"]}'
+        )
+        messages = [
+            {"role": "system", "content": fact_extraction_prompt},
+            {
+                "role": "user",
+                "content": (
+                    "Input:\n"
+                    "My name is Alice, I live in Xihu District, Hangzhou. "
+                    "I like drinking Latte, and I dislike Americano coffee."
+                ),
+            },
+        ]
+        response = self.llm.generate_response(
+            messages=messages,
+            response_format={"type": "json_object"},
+        )
+
+        assert response is not None
+        parsed = json.loads(response)
+        assert "facts" in parsed
+        assert isinstance(parsed["facts"], list)
+        assert len(parsed["facts"]) >= 2
+
+        # Verify key facts are extracted
+        facts_text = " ".join(parsed["facts"]).lower()
+        assert "alice" in facts_text
+        assert "hangzhou" in facts_text or "xihu" in facts_text
+
+
+# ===========================================================================
+# Embedding Tests
+# ===========================================================================
+class TestBaiLianEmbedding:
+    """Tests for BaiLian Embedding."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        api_key = BAILIAN_CONFIG["api_key"]
+        if not api_key:
+            pytest.skip(SKIP_REASON)
+        self.expected_dims = BAILIAN_CONFIG["embedder_dims"]
+        config = BaseEmbedderConfig(
+            model=BAILIAN_CONFIG["embedder_model"],
+            api_key=api_key,
+            embedding_dims=self.expected_dims,
+        )
+        self.embedder = BaiLianEmbedding(config)
+
+    def test_bailian_embedding_single(self):
+        """Test single text embedding returns correct dimensions."""
+        text = "My name is Alice and I live in Hangzhou."
+        embedding = self.embedder.embed(text)
+
+        assert embedding is not None
+        assert isinstance(embedding, list)
+        assert len(embedding) == self.expected_dims
+        # Verify all elements are floats
+        assert all(isinstance(v, float) for v in embedding)
+
+    def test_bailian_embedding_batch(self):
+        """Test batch embedding returns consistent dimensions."""
+        texts = [
+            "Alice likes drinking Latte.",
+            "Bob prefers green tea.",
+            "Charlie enjoys black coffee.",
+        ]
+        embeddings = self.embedder.batch_embed(texts)
+
+        assert embeddings is not None
+        assert isinstance(embeddings, list)
+        assert len(embeddings) == len(texts)
+        for emb in embeddings:
+            assert len(emb) == self.expected_dims
+
+    def test_bailian_embedding_similarity(self):
+        """Test semantic similarity: similar texts should have higher cosine similarity."""
+        text_a = "I like drinking coffee in the morning."
+        text_b = "I enjoy having coffee when I wake up."
+        text_c = "The stock market crashed yesterday."
+
+        emb_a = self.embedder.embed(text_a)
+        emb_b = self.embedder.embed(text_b)
+        emb_c = self.embedder.embed(text_c)
+
+        sim_ab = _cosine_similarity(emb_a, emb_b)
+        sim_ac = _cosine_similarity(emb_a, emb_c)
+
+        # Similar texts should have higher similarity
+        assert sim_ab > sim_ac, (
+            f"Expected similar texts to have higher similarity: "
+            f"sim(a,b)={sim_ab:.4f} should be > sim(a,c)={sim_ac:.4f}"
+        )
+        # Similar texts should have reasonably high similarity
+        assert sim_ab > 0.7, f"Expected sim(a,b) > 0.7, got {sim_ab:.4f}"
+
+
+# ===========================================================================
+# Reranker Tests
+# ===========================================================================
+class TestBaiLianReranker:
+    """Tests for BaiLian Reranker."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        api_key = BAILIAN_CONFIG["api_key"]
+        if not api_key:
+            pytest.skip(SKIP_REASON)
+        config = BailianRerankerConfig(
+            model=BAILIAN_CONFIG["reranker_model"],
+            api_key=api_key,
+            api_url=BAILIAN_CONFIG["reranker_base_url"],
+            top_k=BAILIAN_CONFIG["reranker_top_k"],
+            return_documents=True,
+        )
+        self.reranker = bailian_reranker(config)
+
+    def test_bailian_reranker_basic(self):
+        """Test basic reranking returns results with rerank_score."""
+        query = "What coffee does Alice like?"
+        documents = [
+            {"memory": "Alice likes drinking Latte."},
+            {"memory": "Bob prefers Americano coffee."},
+            {"memory": "Alice lives in Hangzhou."},
+            {"memory": "Charlie enjoys green tea."},
+        ]
+
+        results = self.reranker.rerank(query=query, documents=documents)
+
+        assert results is not None
+        assert isinstance(results, list)
+        assert len(results) > 0
+        # Every result should have a rerank_score
+        for doc in results:
+            assert "rerank_score" in doc, f"Missing rerank_score in: {doc}"
+            assert isinstance(doc["rerank_score"], (int, float))
+
+    def test_bailian_reranker_relevance_order(self):
+        """Test that more relevant documents rank higher than irrelevant ones."""
+        query = "What coffee does Alice like?"
+        documents = [
+            {"memory": "Charlie enjoys green tea."},
+            {"memory": "Alice likes drinking Latte."},
+            {"memory": "The weather in Hangzhou is nice."},
+            {"memory": "Bob prefers Americano coffee."},
+        ]
+
+        results = self.reranker.rerank(query=query, documents=documents)
+
+        assert len(results) > 0
+
+        # Build a score lookup by memory text
+        score_map = {doc["memory"]: doc["rerank_score"] for doc in results}
+
+        # The relevant document about Alice's coffee should score higher
+        # than the clearly irrelevant weather document
+        alice_score = score_map.get("Alice likes drinking Latte.", 0)
+        weather_score = score_map.get("The weather in Hangzhou is nice.", 0)
+        assert alice_score > weather_score, (
+            f"Expected Alice's coffee doc to score higher than weather doc: "
+            f"alice={alice_score:.4f} vs weather={weather_score:.4f}"
+        )
+
+        # Scores should be in descending order
+        scores = [doc["rerank_score"] for doc in results]
+        for i in range(len(scores) - 1):
+            assert scores[i] >= scores[i + 1], (
+                f"Scores not in descending order at index {i}: "
+                f"{scores[i]} < {scores[i + 1]}"
+            )
+
+    def test_bailian_reranker_top_k(self):
+        """Test that top_k parameter limits the number of results."""
+        query = "What does Alice like?"
+        documents = [
+            {"memory": "Alice likes drinking Latte."},
+            {"memory": "Alice lives in Hangzhou."},
+            {"memory": "Alice dislikes Americano coffee."},
+            {"memory": "Bob prefers green tea."},
+            {"memory": "Charlie enjoys black coffee."},
+        ]
+
+        top_k = 2
+        results = self.reranker.rerank(query=query, documents=documents, top_k=top_k)
+
+        assert results is not None
+        assert len(results) <= top_k, (
+            f"Expected at most {top_k} results, got {len(results)}"
+        )
+
+
+# ===========================================================================
+# Memory.from_config Integration Tests
+# ===========================================================================
+class TestMemoryFromConfig:
+    """End-to-end tests using Memory.from_config with Bailian models and Qdrant vector store."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        api_key = BAILIAN_CONFIG["api_key"]
+        if not api_key:
+            pytest.skip(SKIP_REASON)
+
+        from mem0 import Memory
+
+        config = {
+            "version": "v1.1",
+            "llm": {
+                "provider": "bailian",
+                "config": {
+                    "api_key": api_key,
+                    "model": BAILIAN_CONFIG["llm_model"],
+                    "enable_vision": False,
+                },
+            },
+            "embedder": {
+                "provider": "bailian",
+                "config": {
+                    "api_key": api_key,
+                    "model": BAILIAN_CONFIG["embedder_model"],
+                    "embedding_dims": BAILIAN_CONFIG["embedder_dims"],
+                },
+            },
+            "vector_store": {
+                "provider": "qdrant",
+                "config": {
+                    "collection_name": BAILIAN_CONFIG["qdrant_collection"],
+                    "host": BAILIAN_CONFIG["qdrant_host"],
+                    "port": BAILIAN_CONFIG["qdrant_port"],
+                },
+            },
+        }
+        self.memory = Memory.from_config(config)
+        self.user_id = "test_bailian_user"
+
+        # Clean up before each test
+        try:
+            self.memory.delete_all(user_id=self.user_id)
+        except Exception:
+            pass
+
+    def teardown_method(self):
+        """Clean up after each test."""
+        try:
+            self.memory.delete_all(user_id=self.user_id)
+        except Exception:
+            pass
+
+    def test_memory_add_and_get_all(self):
+        """Test adding memories and retrieving them."""
+        messages = [
+            {
+                "role": "user",
+                "content": "My name is Alice, I live in Xihu District, Hangzhou.",
+            }
+        ]
+        result = self.memory.add(messages=messages, user_id=self.user_id)
+
+        assert result is not None
+        assert "results" in result
+
+        # Retrieve all memories
+        all_memories = self.memory.get_all(user_id=self.user_id)
+        assert all_memories is not None
+        assert "results" in all_memories
+        assert len(all_memories["results"]) > 0
+
+    def test_memory_search(self):
+        """Test adding memories and searching for them."""
+        messages = [
+            {
+                "role": "user",
+                "content": (
+                    "I like drinking Latte coffee. "
+                    "I dislike Americano. "
+                    "My favorite programming language is Python."
+                ),
+            }
+        ]
+        self.memory.add(messages=messages, user_id=self.user_id)
+
+        # Search for coffee preference
+        search_result = self.memory.search(
+            query="What coffee does the user like?",
+            user_id=self.user_id,
+        )
+
+        assert search_result is not None
+        assert "results" in search_result
+        assert len(search_result["results"]) > 0
+
+        # The top result should be related to coffee/Latte
+        top_memory = search_result["results"][0]["memory"].lower()
+        assert "latte" in top_memory or "coffee" in top_memory, (
+            f"Expected top search result to mention Latte or coffee, got: {top_memory}"
+        )
+
+    def test_memory_update_and_delete(self):
+        """Test updating and deleting a memory."""
+        messages = [
+            {"role": "user", "content": "My favorite color is blue."}
+        ]
+        add_result = self.memory.add(messages=messages, user_id=self.user_id)
+
+        assert "results" in add_result
+        assert len(add_result["results"]) > 0
+
+        # Get the memory ID
+        memory_id = add_result["results"][0].get("id")
+        assert memory_id is not None
+
+        # Update the memory
+        update_result = self.memory.update(
+            memory_id=memory_id, data="My favorite color is green."
+        )
+        assert update_result is not None
+
+        # Verify the update
+        updated_memory = self.memory.get(memory_id)
+        assert "green" in updated_memory["memory"].lower()
+
+        # Delete the memory
+        delete_result = self.memory.delete(memory_id=memory_id)
+        assert delete_result is not None
+
+    def test_memory_from_config_with_reranker(self):
+        """Test Memory.from_config with reranker enabled."""
+        from mem0 import Memory
+
+        config = {
+            "version": "v1.1",
+            "llm": {
+                "provider": "bailian",
+                "config": {
+                    "api_key": BAILIAN_CONFIG["api_key"],
+                    "model": BAILIAN_CONFIG["llm_model"],
+                    "enable_vision": False,
+                },
+            },
+            "embedder": {
+                "provider": "bailian",
+                "config": {
+                    "api_key": BAILIAN_CONFIG["api_key"],
+                    "model": BAILIAN_CONFIG["embedder_model"],
+                    "embedding_dims": BAILIAN_CONFIG["embedder_dims"],
+                },
+            },
+            "vector_store": {
+                "provider": "qdrant",
+                "config": {
+                    "collection_name": BAILIAN_CONFIG["qdrant_collection"] + "_reranker",
+                    "host": BAILIAN_CONFIG["qdrant_host"],
+                    "port": BAILIAN_CONFIG["qdrant_port"],
+                },
+            },
+            "reranker": {
+                "provider": "bailian",
+                "config": {
+                    "api_key": BAILIAN_CONFIG["api_key"],
+                    "model": BAILIAN_CONFIG["reranker_model"],
+                    "return_documents": True,
+                    "top_k": BAILIAN_CONFIG["reranker_top_k"],
+                },
+            },
+        }
+        memory = Memory.from_config(config)
+        user_id = "test_reranker_user"
+
+        try:
+            # Add multiple memories
+            memory.add(
+                messages=[{"role": "user", "content": "I love playing basketball on weekends."}],
+                user_id=user_id,
+            )
+            memory.add(
+                messages=[{"role": "user", "content": "My favorite food is sushi."}],
+                user_id=user_id,
+            )
+
+            # Search with reranker
+            result = memory.search(query="What sport does the user play?", user_id=user_id)
+
+            assert result is not None
+            assert "results" in result
+            assert len(result["results"]) > 0
+
+            top_memory = result["results"][0]["memory"].lower()
+            assert "basketball" in top_memory or "sport" in top_memory, (
+                f"Expected top result to mention basketball, got: {top_memory}"
+            )
+        finally:
+            try:
+                memory.delete_all(user_id=user_id)
+            except Exception:
+                pass

--- a/tests/test_bailian_models.py
+++ b/tests/test_bailian_models.py
@@ -1,0 +1,589 @@
+"""
+Bailian Platform Model Integration Tests
+
+Tests for LLM, Embedding, and Reranker components using Bailian platform models.
+Configuration is passed via environment variables.
+
+Environment Variables:
+    BAILIAN_API_KEY       (required) Bailian (Dashscope) API key
+    BAILIAN_LLM_MODEL     (optional) LLM model name, default: qwen3-max
+    BAILIAN_EMBEDDER_MODEL(optional) Embedding model name, default: text-embedding-v4
+    BAILIAN_EMBEDDER_DIMS (optional) Embedding dimensions, default: 1536
+    BAILIAN_RERANKER_MODEL(optional) Reranker model name, default: qwen3-rerank
+    BAILIAN_QDRANT_HOST   (optional) Qdrant host, default: localhost
+    BAILIAN_QDRANT_PORT   (optional) Qdrant port, default: 6333
+    BAILIAN_QDRANT_COLLECTION (optional) Qdrant collection name, default: test_bailian
+
+Usage:
+    BAILIAN_API_KEY=sk-xxx \
+    BAILIAN_LLM_MODEL=qwen3-max \
+    BAILIAN_EMBEDDER_MODEL=text-embedding-v4 \
+    BAILIAN_EMBEDDER_DIMS=1536 \
+    BAILIAN_RERANKER_MODEL=qwen3-rerank \
+        pytest tests/test_bailian_models.py -v
+"""
+
+import json
+import math
+import os
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mem0.configs.embeddings.base import BaseEmbedderConfig
+from mem0.configs.llms.bailian import BailianConfig
+from mem0.configs.rerankers.bailian import BailianRerankerConfig
+from mem0.embeddings.bailian import BaiLianEmbedding
+from mem0.llms.bailian import BaiLianLLM
+from mem0.reranker.bailian_reranker import bailian_reranker
+
+# ===========================================================================
+# Configuration from environment variables
+# ===========================================================================
+BAILIAN_CONFIG = {
+    "api_key": os.environ.get("BAILIAN_API_KEY", ""),
+    "llm_model": os.environ.get("BAILIAN_LLM_MODEL", "qwen3-max"),
+    "llm_base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    "embedder_model": os.environ.get("BAILIAN_EMBEDDER_MODEL", "text-embedding-v4"),
+    "embedder_dims": int(os.environ.get("BAILIAN_EMBEDDER_DIMS", "1536")),
+    "reranker_model": os.environ.get("BAILIAN_RERANKER_MODEL", "qwen3-rerank"),
+    "reranker_base_url": "https://dashscope.aliyuncs.com/compatible-api/v1/reranks",
+    "reranker_top_k": 3,
+    "qdrant_host": os.environ.get("BAILIAN_QDRANT_HOST", "localhost"),
+    "qdrant_port": int(os.environ.get("BAILIAN_QDRANT_PORT", "6333")),
+    "qdrant_collection": os.environ.get("BAILIAN_QDRANT_COLLECTION", "test_bailian"),
+}
+
+SKIP_REASON = "Bailian API key not provided (set BAILIAN_API_KEY env var)"
+
+
+def _cosine_similarity(vec_a, vec_b):
+    """Compute cosine similarity between two vectors."""
+    dot = sum(a * b for a, b in zip(vec_a, vec_b))
+    norm_a = math.sqrt(sum(a * a for a in vec_a))
+    norm_b = math.sqrt(sum(b * b for b in vec_b))
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+# ===========================================================================
+# LLM Tests
+# ===========================================================================
+class TestBaiLianLLM:
+    """Tests for BaiLian LLM via Dashscope."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        api_key = BAILIAN_CONFIG["api_key"]
+        if not api_key:
+            pytest.skip(SKIP_REASON)
+        config = BailianConfig(
+            model=BAILIAN_CONFIG["llm_model"],
+            api_key=api_key,
+            openai_base_url=BAILIAN_CONFIG["llm_base_url"],
+            temperature=0.1,
+            max_tokens=1000,
+        )
+        self.llm = BaiLianLLM(config)
+
+    def test_bailian_llm_generate_response(self):
+        """Test basic text generation capability."""
+        messages = [
+            {"role": "user", "content": "What is 2 + 3? Answer with just the number."}
+        ]
+        response = self.llm.generate_response(messages=messages)
+
+        assert response is not None
+        assert isinstance(response, str)
+        assert len(response.strip()) > 0
+        assert "5" in response
+
+    def test_bailian_llm_json_response(self):
+        """Test JSON format response generation."""
+        messages = [
+            {
+                "role": "system",
+                "content": "You are a helpful assistant that responds in JSON format.",
+            },
+            {
+                "role": "user",
+                "content": 'Return a JSON object with key "name" set to "Alice" and key "age" set to 30.',
+            },
+        ]
+        response = self.llm.generate_response(
+            messages=messages,
+            response_format={"type": "json_object"},
+        )
+
+        assert response is not None
+        assert isinstance(response, str)
+
+        parsed = json.loads(response)
+        assert "name" in parsed
+        assert parsed["name"] == "Alice"
+        assert "age" in parsed
+        assert parsed["age"] == 30
+
+    def test_bailian_llm_fact_extraction(self):
+        """Test fact extraction scenario similar to mem0 usage."""
+        fact_extraction_prompt = (
+            "You are a Personal Information Organizer. "
+            "Extract relevant facts from the conversation and return them "
+            'in JSON format with a "facts" key containing a list of strings.\n\n'
+            "Example:\n"
+            'Input: Hi, my name is John. I am a software engineer.\n'
+            'Output: {"facts": ["Name is John", "Is a Software engineer"]}'
+        )
+        messages = [
+            {"role": "system", "content": fact_extraction_prompt},
+            {
+                "role": "user",
+                "content": (
+                    "Input:\n"
+                    "My name is Alice, I live in Xihu District, Hangzhou. "
+                    "I like drinking Latte, and I dislike Americano coffee."
+                ),
+            },
+        ]
+        response = self.llm.generate_response(
+            messages=messages,
+            response_format={"type": "json_object"},
+        )
+
+        assert response is not None
+        parsed = json.loads(response)
+        assert "facts" in parsed
+        assert isinstance(parsed["facts"], list)
+        assert len(parsed["facts"]) >= 2
+
+        # Verify key facts are extracted
+        facts_text = " ".join(parsed["facts"]).lower()
+        assert "alice" in facts_text
+        assert "hangzhou" in facts_text or "xihu" in facts_text
+
+
+# ===========================================================================
+# Embedding Tests
+# ===========================================================================
+class TestBaiLianEmbedding:
+    """Tests for BaiLian Embedding."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        api_key = BAILIAN_CONFIG["api_key"]
+        if not api_key:
+            pytest.skip(SKIP_REASON)
+        self.expected_dims = BAILIAN_CONFIG["embedder_dims"]
+        config = BaseEmbedderConfig(
+            model=BAILIAN_CONFIG["embedder_model"],
+            api_key=api_key,
+            embedding_dims=self.expected_dims,
+        )
+        self.embedder = BaiLianEmbedding(config)
+
+    def test_bailian_embedding_single(self):
+        """Test single text embedding returns correct dimensions."""
+        text = "My name is Alice and I live in Hangzhou."
+        embedding = self.embedder.embed(text)
+
+        assert embedding is not None
+        assert isinstance(embedding, list)
+        assert len(embedding) == self.expected_dims
+        # Verify all elements are floats
+        assert all(isinstance(v, float) for v in embedding)
+
+    def test_bailian_embedding_batch(self):
+        """Test batch embedding returns consistent dimensions."""
+        texts = [
+            "Alice likes drinking Latte.",
+            "Bob prefers green tea.",
+            "Charlie enjoys black coffee.",
+        ]
+        embeddings = self.embedder.embed_batch(texts)
+
+        assert embeddings is not None
+        assert isinstance(embeddings, list)
+        assert len(embeddings) == len(texts)
+        for emb in embeddings:
+            assert len(emb) == self.expected_dims
+
+    def test_bailian_embedding_similarity(self):
+        """Test semantic similarity: similar texts should have higher cosine similarity."""
+        text_a = "I like drinking coffee in the morning."
+        text_b = "I enjoy having coffee when I wake up."
+        text_c = "The stock market crashed yesterday."
+
+        emb_a = self.embedder.embed(text_a)
+        emb_b = self.embedder.embed(text_b)
+        emb_c = self.embedder.embed(text_c)
+
+        sim_ab = _cosine_similarity(emb_a, emb_b)
+        sim_ac = _cosine_similarity(emb_a, emb_c)
+
+        # Similar texts should have higher similarity
+        assert sim_ab > sim_ac, (
+            f"Expected similar texts to have higher similarity: "
+            f"sim(a,b)={sim_ab:.4f} should be > sim(a,c)={sim_ac:.4f}"
+        )
+        # Similar texts should have reasonably high similarity
+        assert sim_ab > 0.7, f"Expected sim(a,b) > 0.7, got {sim_ab:.4f}"
+
+
+# ===========================================================================
+# Embedding Batch Splitting Tests (mocked, no API key required)
+# ===========================================================================
+class TestBaiLianEmbeddingBatching:
+    """Mocked regression tests for native batch splitting of embed_batch."""
+
+    def _make_embedder(self):
+        config = BaseEmbedderConfig(
+            model="text-embedding-v4",
+            api_key="test-key",
+            embedding_dims=1024,
+        )
+        return BaiLianEmbedding(config)
+
+    def test_embed_batch_splits_batches_of_10(self):
+        """11 inputs must be sent to the API as batches of sizes [10, 1]
+        (DashScope rejects more than 10 inputs per request)."""
+        with patch("mem0.embeddings.bailian.OpenAI") as mock_openai:
+            mock_client = Mock()
+            mock_openai.return_value = mock_client
+
+            def fake_create(**kwargs):
+                response = Mock()
+                response.data = [Mock(embedding=[0.1] * 1024) for _ in kwargs["input"]]
+                return response
+
+            mock_client.embeddings.create.side_effect = fake_create
+
+            embedder = self._make_embedder()
+            texts = [f"text {i}" for i in range(11)]
+            embeddings = embedder.embed_batch(texts)
+
+            assert len(embeddings) == 11
+            batch_sizes = [
+                len(call.kwargs["input"]) for call in mock_client.embeddings.create.call_args_list
+            ]
+            assert batch_sizes == [10, 1]
+
+    def test_embed_batch_overrides_base_contract(self):
+        """embed_batch must use the native batching implementation, not the
+        base class sequential fallback (one embed() call per text)."""
+        with patch("mem0.embeddings.bailian.OpenAI") as mock_openai:
+            mock_client = Mock()
+            mock_openai.return_value = mock_client
+
+            def fake_create(**kwargs):
+                response = Mock()
+                response.data = [Mock(embedding=[0.1] * 1024) for _ in kwargs["input"]]
+                return response
+
+            mock_client.embeddings.create.side_effect = fake_create
+
+            embedder = self._make_embedder()
+            embedder.embed_batch([f"text {i}" for i in range(11)])
+
+            # Native batching: 2 API calls; sequential fallback would make 11.
+            assert mock_client.embeddings.create.call_count == 2
+
+
+# ===========================================================================
+# Reranker Tests
+# ===========================================================================
+class TestBaiLianReranker:
+    """Tests for BaiLian Reranker."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        api_key = BAILIAN_CONFIG["api_key"]
+        if not api_key:
+            pytest.skip(SKIP_REASON)
+        config = BailianRerankerConfig(
+            model=BAILIAN_CONFIG["reranker_model"],
+            api_key=api_key,
+            api_url=BAILIAN_CONFIG["reranker_base_url"],
+            top_k=BAILIAN_CONFIG["reranker_top_k"],
+            return_documents=True,
+        )
+        self.reranker = bailian_reranker(config)
+
+    def test_bailian_reranker_basic(self):
+        """Test basic reranking returns results with rerank_score."""
+        query = "What coffee does Alice like?"
+        documents = [
+            {"memory": "Alice likes drinking Latte."},
+            {"memory": "Bob prefers Americano coffee."},
+            {"memory": "Alice lives in Hangzhou."},
+            {"memory": "Charlie enjoys green tea."},
+        ]
+
+        results = self.reranker.rerank(query=query, documents=documents)
+
+        assert results is not None
+        assert isinstance(results, list)
+        assert len(results) > 0
+        # Every result should have a rerank_score
+        for doc in results:
+            assert "rerank_score" in doc, f"Missing rerank_score in: {doc}"
+            assert isinstance(doc["rerank_score"], (int, float))
+
+    def test_bailian_reranker_relevance_order(self):
+        """Test that more relevant documents rank higher than irrelevant ones."""
+        query = "What coffee does Alice like?"
+        documents = [
+            {"memory": "Charlie enjoys green tea."},
+            {"memory": "Alice likes drinking Latte."},
+            {"memory": "The weather in Hangzhou is nice."},
+            {"memory": "Bob prefers Americano coffee."},
+        ]
+
+        results = self.reranker.rerank(query=query, documents=documents)
+
+        assert len(results) > 0
+
+        # Build a score lookup by memory text
+        score_map = {doc["memory"]: doc["rerank_score"] for doc in results}
+
+        # The relevant document about Alice's coffee should score higher
+        # than the clearly irrelevant weather document
+        alice_score = score_map.get("Alice likes drinking Latte.", 0)
+        weather_score = score_map.get("The weather in Hangzhou is nice.", 0)
+        assert alice_score > weather_score, (
+            f"Expected Alice's coffee doc to score higher than weather doc: "
+            f"alice={alice_score:.4f} vs weather={weather_score:.4f}"
+        )
+
+        # Scores should be in descending order
+        scores = [doc["rerank_score"] for doc in results]
+        for i in range(len(scores) - 1):
+            assert scores[i] >= scores[i + 1], (
+                f"Scores not in descending order at index {i}: "
+                f"{scores[i]} < {scores[i + 1]}"
+            )
+
+    def test_bailian_reranker_top_k(self):
+        """Test that top_k parameter limits the number of results."""
+        query = "What does Alice like?"
+        documents = [
+            {"memory": "Alice likes drinking Latte."},
+            {"memory": "Alice lives in Hangzhou."},
+            {"memory": "Alice dislikes Americano coffee."},
+            {"memory": "Bob prefers green tea."},
+            {"memory": "Charlie enjoys black coffee."},
+        ]
+
+        top_k = 2
+        results = self.reranker.rerank(query=query, documents=documents, top_k=top_k)
+
+        assert results is not None
+        assert len(results) <= top_k, (
+            f"Expected at most {top_k} results, got {len(results)}"
+        )
+
+
+# ===========================================================================
+# Memory.from_config Integration Tests
+# ===========================================================================
+class TestMemoryFromConfig:
+    """End-to-end tests using Memory.from_config with Bailian models and Qdrant vector store."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        api_key = BAILIAN_CONFIG["api_key"]
+        if not api_key:
+            pytest.skip(SKIP_REASON)
+
+        from mem0 import Memory
+
+        config = {
+            "version": "v1.1",
+            "llm": {
+                "provider": "bailian",
+                "config": {
+                    "api_key": api_key,
+                    "model": BAILIAN_CONFIG["llm_model"],
+                    "enable_vision": False,
+                },
+            },
+            "embedder": {
+                "provider": "bailian",
+                "config": {
+                    "api_key": api_key,
+                    "model": BAILIAN_CONFIG["embedder_model"],
+                    "embedding_dims": BAILIAN_CONFIG["embedder_dims"],
+                },
+            },
+            "vector_store": {
+                "provider": "qdrant",
+                "config": {
+                    "collection_name": BAILIAN_CONFIG["qdrant_collection"],
+                    "host": BAILIAN_CONFIG["qdrant_host"],
+                    "port": BAILIAN_CONFIG["qdrant_port"],
+                },
+            },
+        }
+        self.memory = Memory.from_config(config)
+        self.user_id = "test_bailian_user"
+
+        # Clean up before each test
+        try:
+            self.memory.delete_all(user_id=self.user_id)
+        except Exception:
+            pass
+
+    def teardown_method(self):
+        """Clean up after each test."""
+        try:
+            self.memory.delete_all(user_id=self.user_id)
+        except Exception:
+            pass
+
+    def test_memory_add_and_get_all(self):
+        """Test adding memories and retrieving them."""
+        messages = [
+            {
+                "role": "user",
+                "content": "My name is Alice, I live in Xihu District, Hangzhou.",
+            }
+        ]
+        result = self.memory.add(messages=messages, user_id=self.user_id)
+
+        assert result is not None
+        assert "results" in result
+
+        # Retrieve all memories
+        all_memories = self.memory.get_all(user_id=self.user_id)
+        assert all_memories is not None
+        assert "results" in all_memories
+        assert len(all_memories["results"]) > 0
+
+    def test_memory_search(self):
+        """Test adding memories and searching for them."""
+        messages = [
+            {
+                "role": "user",
+                "content": (
+                    "I like drinking Latte coffee. "
+                    "I dislike Americano. "
+                    "My favorite programming language is Python."
+                ),
+            }
+        ]
+        self.memory.add(messages=messages, user_id=self.user_id)
+
+        # Search for coffee preference
+        search_result = self.memory.search(
+            query="What coffee does the user like?",
+            user_id=self.user_id,
+        )
+
+        assert search_result is not None
+        assert "results" in search_result
+        assert len(search_result["results"]) > 0
+
+        # The top result should be related to coffee/Latte
+        top_memory = search_result["results"][0]["memory"].lower()
+        assert "latte" in top_memory or "coffee" in top_memory, (
+            f"Expected top search result to mention Latte or coffee, got: {top_memory}"
+        )
+
+    def test_memory_update_and_delete(self):
+        """Test updating and deleting a memory."""
+        messages = [
+            {"role": "user", "content": "My favorite color is blue."}
+        ]
+        add_result = self.memory.add(messages=messages, user_id=self.user_id)
+
+        assert "results" in add_result
+        assert len(add_result["results"]) > 0
+
+        # Get the memory ID
+        memory_id = add_result["results"][0].get("id")
+        assert memory_id is not None
+
+        # Update the memory
+        update_result = self.memory.update(
+            memory_id=memory_id, data="My favorite color is green."
+        )
+        assert update_result is not None
+
+        # Verify the update
+        updated_memory = self.memory.get(memory_id)
+        assert "green" in updated_memory["memory"].lower()
+
+        # Delete the memory
+        delete_result = self.memory.delete(memory_id=memory_id)
+        assert delete_result is not None
+
+    def test_memory_from_config_with_reranker(self):
+        """Test Memory.from_config with reranker enabled."""
+        from mem0 import Memory
+
+        config = {
+            "version": "v1.1",
+            "llm": {
+                "provider": "bailian",
+                "config": {
+                    "api_key": BAILIAN_CONFIG["api_key"],
+                    "model": BAILIAN_CONFIG["llm_model"],
+                    "enable_vision": False,
+                },
+            },
+            "embedder": {
+                "provider": "bailian",
+                "config": {
+                    "api_key": BAILIAN_CONFIG["api_key"],
+                    "model": BAILIAN_CONFIG["embedder_model"],
+                    "embedding_dims": BAILIAN_CONFIG["embedder_dims"],
+                },
+            },
+            "vector_store": {
+                "provider": "qdrant",
+                "config": {
+                    "collection_name": BAILIAN_CONFIG["qdrant_collection"] + "_reranker",
+                    "host": BAILIAN_CONFIG["qdrant_host"],
+                    "port": BAILIAN_CONFIG["qdrant_port"],
+                },
+            },
+            "reranker": {
+                "provider": "bailian",
+                "config": {
+                    "api_key": BAILIAN_CONFIG["api_key"],
+                    "model": BAILIAN_CONFIG["reranker_model"],
+                    "return_documents": True,
+                    "top_k": BAILIAN_CONFIG["reranker_top_k"],
+                },
+            },
+        }
+        memory = Memory.from_config(config)
+        user_id = "test_reranker_user"
+
+        try:
+            # Add multiple memories
+            memory.add(
+                messages=[{"role": "user", "content": "I love playing basketball on weekends."}],
+                user_id=user_id,
+            )
+            memory.add(
+                messages=[{"role": "user", "content": "My favorite food is sushi."}],
+                user_id=user_id,
+            )
+
+            # Search with reranker
+            result = memory.search(query="What sport does the user play?", user_id=user_id)
+
+            assert result is not None
+            assert "results" in result
+            assert len(result["results"]) > 0
+
+            top_memory = result["results"][0]["memory"].lower()
+            assert "basketball" in top_memory or "sport" in top_memory, (
+                f"Expected top result to mention basketball, got: {top_memory}"
+            )
+        finally:
+            try:
+                memory.delete_all(user_id=user_id)
+            except Exception:
+                pass


### PR DESCRIPTION
feat: support llm, rerank, and embedding modules using models provided by the alibaba bailian platform (#4651)

## Linked Issue

Closes #4651 

## Description

Mem0 currently supports OpenAI, Azure OpenAI, and several other LLM/Embedding providers out of the box, but lacks native support for Alibaba Cloud's Bailian platform — one of the most widely used AI model platforms in China. Users deploying mem0 in Chinese cloud environments need to use Bailian-hosted models (e.g., Qwen series, DeepSeek series) for LLM inference, text embedding, and document reranking. Without built-in Bailian provider support, users must write custom adapter code or resort to fragile workarounds to integrate these models.

This feature adds first-class Bailian provider support across all three model components:

LLM: Text generation and structured JSON output (e.g., qwen3-max, deepseek-v3.2)
Embedder: Text embedding via Dashscope's OpenAI-compatible API (e.g., text-embedding-v4)
Reranker: Document reranking via Dashscope's rerank API (e.g., qwen3-rerank)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe what breaks and the migration path. Delete this section if not applicable. -->

N/A

## Test Coverage

- [x] I added/updated unit tests
- [x] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

<!-- Describe how you tested this, or link to CI results. -->

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
