### PR TITLE
fix(cd): restrict PyPI publish to main SDK tags only

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -38,7 +38,7 @@ jobs:
       #     packages_dir: dist/
 
       - name: Publish distribution 📦 to PyPI
-        if: startsWith(github.ref, 'refs/tags')
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages_dir: dist/


### PR DESCRIPTION
## Summary
- Fix the main `cd.yml` workflow to only publish `mem0ai` on SDK-specific tags (`v*`), preventing accidental publishes on CLI or other package tags

## Details
- Changed the publish step condition from `startsWith(github.ref, 'refs/tags')` to `startsWith(github.ref, 'refs/tags/v')`
- Previously, any release tag (e.g. `cli-v0.2.0b1`, `ts-sdk-v2.5.0`) would match and attempt to publish the main SDK to PyPI
- Now only tags like `v1.0.9` trigger the publish step

## Test Plan
- [ ] Create a release with tag `cli-v0.2.0b1` and verify `cd.yml` does **not** publish to PyPI
- [ ] Create a release with tag `v1.0.10` and verify `cd.yml` **does** publish to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)