### PR TITLE
fix(openclaw): make autoCapture non-blocking, add timeout to autoRecall

### DIFF
--- a/openclaw/config.ts
+++ b/openclaw/config.ts
@@ -171,6 +171,7 @@ const ALLOWED_KEYS = [
   "searchThreshold",
   "topK",
   "oss",
+  "recallTimeoutMs",
 ];
 
 function assertAllowedKeys(
@@ -240,6 +241,7 @@ export const mem0ConfigSchema = {
       searchThreshold:
         typeof cfg.searchThreshold === "number" ? cfg.searchThreshold : 0.5,
       topK: typeof cfg.topK === "number" ? cfg.topK : 5,
+      recallTimeoutMs: typeof cfg.recallTimeoutMs === "number" ? cfg.recallTimeoutMs : 5000,
       oss: ossConfig,
     };
   },

--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -822,6 +822,37 @@ function registerCli(
 // Lifecycle Hook Registration
 // ============================================================================
 
+function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  label: string,
+  logger: { warn: (msg: string) => void },
+): Promise<T | undefined> {
+  let settled = false;
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<undefined>((resolve) => {
+    timer = setTimeout(() => {
+      settled = true;
+      logger.warn(`openclaw-mem0: ${label} timed out after ${ms}ms, skipping`);
+      resolve(undefined);
+    }, ms);
+  });
+  return Promise.race([
+    promise.then(
+      (v) => { clearTimeout(timer); settled = true; return v; },
+      (err) => { clearTimeout(timer); settled = true; throw err; },
+    ),
+    timeout,
+  ]).then((result) => {
+    // If the timeout won the race, swallow any late resolution/rejection
+    // from the original promise to avoid unhandled rejections.
+    if (settled && result === undefined) {
+      promise.catch(() => {});
+    }
+    return result;
+  });
+}
+
 function registerHooks(
   api: OpenClawPluginApi,
   provider: Mem0Provider,
@@ -863,10 +894,18 @@ function registerHooks(
         const recallTopK = Math.max((cfg.topK ?? 5) * 2, 10);
 
         // Search long-term memories (user-scoped; subagents read from parent namespace)
-        let longTermResults = await provider.search(
-          event.prompt,
-          buildSearchOptions(undefined, recallTopK, undefined, recallSessionKey),
+        const recallTimeoutMs = cfg.recallTimeoutMs ?? 5000;
+        const rawResults = await withTimeout(
+          provider.search(
+            event.prompt,
+            buildSearchOptions(undefined, recallTopK, undefined, recallSessionKey),
+          ),
+          recallTimeoutMs,
+          "recall search",
+          api.logger,
         );
+        if (!rawResults) return; // timed out
+        let longTermResults = rawResults;
 
         // Client-side threshold filter for auto-recall — use a stricter
         // threshold (0.6) than explicit tool searches (0.5) to avoid
@@ -894,10 +933,15 @@ function registerHooks(
         if (event.prompt.length < 100 || isNewSession) {
           const broadOpts = buildSearchOptions(undefined, 5, undefined, recallSessionKey);
           broadOpts.threshold = 0.5;
-          const broadResults = await provider.search(
-            "recent decisions, preferences, active projects, and configuration",
-            broadOpts,
-          );
+          const broadResults = await withTimeout(
+            provider.search(
+              "recent decisions, preferences, active projects, and configuration",
+              broadOpts,
+            ),
+            recallTimeoutMs,
+            "broad recall search",
+            api.logger,
+          ) ?? [];
           const existingIds = new Set(longTermResults.map((r) => r.id));
           for (const r of broadResults) {
             if (!existingIds.has(r.id)) {
@@ -912,10 +956,15 @@ function registerHooks(
         // Search session memories (session-scoped) if we have a session ID
         let sessionResults: MemoryItem[] = [];
         if (sessionId) {
-          sessionResults = await provider.search(
-            event.prompt,
-            buildSearchOptions(undefined, undefined, sessionId, recallSessionKey),
-          );
+          sessionResults = await withTimeout(
+            provider.search(
+              event.prompt,
+              buildSearchOptions(undefined, undefined, sessionId, recallSessionKey),
+            ),
+            recallTimeoutMs,
+            "session recall search",
+            api.logger,
+          ) ?? [];
           sessionResults = sessionResults.filter(
             (r) => (r.score ?? 0) >= cfg.searchThreshold,
           );
@@ -991,6 +1040,10 @@ function registerHooks(
       // Update shared state for tools (best-effort — tools don't have ctx)
       if (sessionId) session.setCurrentSessionId(sessionId);
 
+      // Fire-and-forget: capture does not produce a return value that the
+      // host framework needs, so run the heavy LLM work in a detached
+      // promise to avoid blocking the event loop.
+      void (async () => {
       try {
         // Patterns indicating an assistant message contains a summary of
         // completed work — these are high-value for extraction and should
@@ -1123,6 +1176,7 @@ function registerHooks(
       } catch (err) {
         api.logger.warn(`openclaw-mem0: capture failed: ${String(err)}`);
       }
+      })();
     });
   }
 }

--- a/openclaw/types.ts
+++ b/openclaw/types.ts
@@ -28,6 +28,7 @@ export type Mem0Config = {
   autoRecall: boolean;
   searchThreshold: number;
   topK: number;
+  recallTimeoutMs: number;
 };
 
 export interface AddOptions {


### PR DESCRIPTION
Fixes #4634

## Problem

The `autoCapture` and `autoRecall` hooks in the OpenClaw plugin block the Node.js event loop when the backing LLM is slow (cold Ollama starts, network latency). In event-driven hosts like Discord bots, this causes 30-40s lag spikes for all concurrent users.

## Changes

**autoCapture (agent_end):** Wrapped the message processing and `provider.add()` call in a detached promise. The handler returns immediately since the host framework doesn't need a return value from capture. Errors are still logged.

**autoRecall (before_agent_start):** Can't fully fire-and-forget since the agent needs the returned context. Instead, all `provider.search()` calls are wrapped in a timeout (configurable via `recallTimeoutMs`, default 5000ms). If any search exceeds the timeout, it's skipped gracefully — the agent starts without memories rather than freezing everything.

**Config:** Added optional `recallTimeoutMs` field to `Mem0Config`. No config changes required for existing users.

## Files changed

- `openclaw/index.ts` — `withTimeout` helper, fire-and-forget wrapper on capture, timeout on recall searches
- `openclaw/types.ts` — `recallTimeoutMs` field on `Mem0Config`
- `openclaw/config.ts` — parsing and default for `recallTimeoutMs`

## Notes

- The timeout does not cancel in-flight LLM calls (JS limitations) — the promise continues running but its result is discarded. Late rejections are swallowed to prevent `UnhandledPromiseRejection`.
- On cold Ollama starts, the first interaction will likely skip recall. Subsequent interactions hit warm models and complete within the timeout.