### PR TITLE
feat(reranker): add concurrent LLM scoring via max_workers config

### DIFF
--- a/mem0/configs/rerankers/llm.py
+++ b/mem0/configs/rerankers/llm.py
@@ -43,6 +43,14 @@ class LLMRerankerConfig(BaseRerankerConfig):
         default=100,
         description="Maximum tokens for LLM response"
     )
+    max_workers: int = Field(
+        default=1,
+        description=(
+            "Number of parallel workers for concurrent LLM scoring. "
+            "Set > 1 to score multiple documents simultaneously and reduce "
+            "latency proportionally. Defaults to 1 (sequential)."
+        ),
+    )
     scoring_prompt: Optional[str] = Field(
         default=None,
         description="Custom prompt template for scoring documents"

--- a/mem0/reranker/llm_reranker.py
+++ b/mem0/reranker/llm_reranker.py
@@ -1,4 +1,5 @@
 import re
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Dict, List, Union
 
 from mem0.configs.rerankers.base import BaseRerankerConfig
@@ -60,7 +61,7 @@ class LLMReranker(BaseReranker):
 
         # Default scoring prompt
         self.scoring_prompt = getattr(self.config, 'scoring_prompt', None) or self._get_default_prompt()
-        
+
     def _get_default_prompt(self) -> str:
         """Get the default scoring prompt template."""
         return """You are a relevance scoring assistant. Given a query and a document, you need to score how relevant the document is to the query.
@@ -82,72 +83,91 @@ Provide only a single numerical score between 0.0 and 1.0. Do not include any ex
         # Look for decimal numbers between 0.0 and 1.0
         pattern = r'\b([01](?:\.\d+)?)\b'
         matches = re.findall(pattern, response_text)
-        
+
         if matches:
             score = float(matches[0])
             return min(max(score, 0.0), 1.0)  # Clamp between 0.0 and 1.0
-        
+
         # Fallback: return 0.5 if no valid score found
         return 0.5
-    
+
+    def _score_document(self, query: str, doc: Dict[str, Any]) -> Dict[str, Any]:
+        """Score a single document against the query.
+
+        Returns the document dict (copy) with a ``rerank_score`` field added.
+        Falls back to 0.5 on any LLM error so the pipeline never hard-fails.
+        """
+        if 'memory' in doc:
+            doc_text = doc['memory']
+        elif 'text' in doc:
+            doc_text = doc['text']
+        elif 'content' in doc:
+            doc_text = doc['content']
+        else:
+            doc_text = str(doc)
+
+        try:
+            prompt = self.scoring_prompt.format(query=query, document=doc_text)
+            response = self.llm.generate_response(
+                messages=[{"role": "user", "content": prompt}]
+            )
+            score = self._extract_score(response)
+        except Exception:
+            score = 0.5
+
+        scored_doc = doc.copy()
+        scored_doc['rerank_score'] = score
+        return scored_doc
+
     def rerank(self, query: str, documents: List[Dict[str, Any]], top_k: int = None) -> List[Dict[str, Any]]:
         """
         Rerank documents using LLM scoring.
-        
+
+        Documents are scored in parallel when ``max_workers > 1``, reducing
+        latency proportionally to the number of workers.
+
         Args:
-            query: The search query
-            documents: List of documents to rerank
-            top_k: Number of top documents to return
-            
+            query: The search query.
+            documents: List of documents to rerank, each with a 'memory',
+                'text', or 'content' field.
+            top_k: Number of top documents to return. Falls back to
+                ``config.top_k`` when not provided.
+
         Returns:
-            List of reranked documents with rerank_score
+            List of reranked documents sorted by ``rerank_score`` descending,
+            with the score added to each document dict.
         """
         if not documents:
             return documents
-        
-        scored_docs = []
-        
-        for doc in documents:
-            # Extract text content
-            if 'memory' in doc:
-                doc_text = doc['memory']
-            elif 'text' in doc:
-                doc_text = doc['text']  
-            elif 'content' in doc:
-                doc_text = doc['content']
-            else:
-                doc_text = str(doc)
-            
-            try:
-                # Generate scoring prompt
-                prompt = self.scoring_prompt.format(query=query, document=doc_text)
-                
-                # Get LLM response
-                response = self.llm.generate_response(
-                    messages=[{"role": "user", "content": prompt}]
-                )
-                
-                # Extract score from response
-                score = self._extract_score(response)
-                
-                # Create scored document
-                scored_doc = doc.copy()
-                scored_doc['rerank_score'] = score
-                scored_docs.append(scored_doc)
 
-            except Exception:
-                # Fallback: assign neutral score if scoring fails
-                scored_doc = doc.copy()
-                scored_doc['rerank_score'] = 0.5
-                scored_docs.append(scored_doc)
-        
-        # Sort by relevance score in descending order
+        max_workers = min(self.config.max_workers, len(documents))
+
+        if max_workers > 1:
+            # Parallel scoring — submit all documents concurrently
+            scored_docs: List[Dict[str, Any]] = [None] * len(documents)
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                future_to_idx = {
+                    executor.submit(self._score_document, query, doc): idx
+                    for idx, doc in enumerate(documents)
+                }
+                for future in as_completed(future_to_idx):
+                    idx = future_to_idx[future]
+                    try:
+                        scored_docs[idx] = future.result()
+                    except Exception:
+                        fallback = documents[idx].copy()
+                        fallback['rerank_score'] = 0.5
+                        scored_docs[idx] = fallback
+        else:
+            # Sequential scoring (default, max_workers=1)
+            scored_docs = [self._score_document(query, doc) for doc in documents]
+
+        # Sort by relevance score descending
         scored_docs.sort(key=lambda x: x['rerank_score'], reverse=True)
-        
+
         # Apply top_k limit
-        if top_k:
-            scored_docs = scored_docs[:top_k]
-        elif self.config.top_k:
-            scored_docs = scored_docs[:self.config.top_k]
-            
+        effective_top_k = top_k or self.config.top_k
+        if effective_top_k:
+            scored_docs = scored_docs[:effective_top_k]
+
         return scored_docs

--- a/tests/rerankers/test_llm_reranker_concurrent.py
+++ b/tests/rerankers/test_llm_reranker_concurrent.py
@@ -1,0 +1,181 @@
+"""Tests for LLMReranker concurrent scoring (max_workers > 1).
+
+Covers:
+- max_workers=1 default (sequential, existing behaviour unchanged)
+- max_workers>1 parallel path (all docs scored, order preserved by score)
+- max_workers capped at len(documents) to avoid creating excess threads
+- Concurrent path still applies top_k correctly
+- Individual worker failure falls back to 0.5 without crashing the batch
+- Original documents are never mutated
+- Config field accepted and validated
+"""
+
+from concurrent.futures import Future
+from unittest.mock import MagicMock, patch
+
+from mem0.configs.rerankers.llm import LLMRerankerConfig
+from mem0.reranker.llm_reranker import LLMReranker
+
+
+# ---------------------------------------------------------------------------
+# Config tests
+# ---------------------------------------------------------------------------
+
+class TestMaxWorkersConfig:
+    def test_default_max_workers_is_1(self):
+        config = LLMRerankerConfig()
+        assert config.max_workers == 1
+
+    def test_custom_max_workers_accepted(self):
+        config = LLMRerankerConfig(max_workers=4)
+        assert config.max_workers == 4
+
+    def test_max_workers_passed_through_dict_config(self, mock_llm):
+        reranker = LLMReranker({"provider": "openai", "max_workers": 8})
+        assert reranker.config.max_workers == 8
+
+
+# ---------------------------------------------------------------------------
+# Sequential path (max_workers=1, default)
+# ---------------------------------------------------------------------------
+
+class TestSequentialRerank:
+    """Ensures the default sequential path is unchanged."""
+
+    def test_sequential_scores_all_docs(self, mock_llm):
+        _, mock_llm_instance = mock_llm
+        mock_llm_instance.generate_response.side_effect = ["0.9", "0.2", "0.6"]
+
+        reranker = LLMReranker({"provider": "openai"})  # max_workers defaults to 1
+        docs = [{"memory": "a"}, {"memory": "b"}, {"memory": "c"}]
+        result = reranker.rerank("query", docs)
+
+        assert len(result) == 3
+        assert result[0]["rerank_score"] == 0.9
+        assert result[1]["rerank_score"] == 0.6
+        assert result[2]["rerank_score"] == 0.2
+
+    def test_sequential_calls_llm_n_times(self, mock_llm):
+        _, mock_llm_instance = mock_llm
+        mock_llm_instance.generate_response.return_value = "0.5"
+
+        reranker = LLMReranker({"provider": "openai"})
+        docs = [{"memory": f"doc{i}"} for i in range(5)]
+        reranker.rerank("query", docs)
+
+        assert mock_llm_instance.generate_response.call_count == 5
+
+
+# ---------------------------------------------------------------------------
+# Concurrent path (max_workers > 1)
+# ---------------------------------------------------------------------------
+
+class TestConcurrentRerank:
+    def test_concurrent_returns_all_docs(self, mock_llm):
+        _, mock_llm_instance = mock_llm
+        mock_llm_instance.generate_response.return_value = "0.7"
+
+        reranker = LLMReranker({"provider": "openai", "max_workers": 4})
+        docs = [{"memory": f"doc{i}"} for i in range(6)]
+        result = reranker.rerank("query", docs)
+
+        assert len(result) == 6
+
+    def test_concurrent_sorted_by_score_descending(self, mock_llm):
+        _, mock_llm_instance = mock_llm
+        # Scores returned in arbitrary order (simulates concurrent completion)
+        mock_llm_instance.generate_response.side_effect = ["0.3", "0.9", "0.1", "0.7"]
+
+        reranker = LLMReranker({"provider": "openai", "max_workers": 4})
+        docs = [{"memory": f"doc{i}"} for i in range(4)]
+        result = reranker.rerank("query", docs)
+
+        scores = [r["rerank_score"] for r in result]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_concurrent_top_k_applied(self, mock_llm):
+        _, mock_llm_instance = mock_llm
+        mock_llm_instance.generate_response.side_effect = ["0.9", "0.5", "0.1", "0.7"]
+
+        reranker = LLMReranker({"provider": "openai", "max_workers": 4})
+        docs = [{"memory": f"doc{i}"} for i in range(4)]
+        result = reranker.rerank("query", docs, top_k=2)
+
+        assert len(result) == 2
+        assert result[0]["rerank_score"] >= result[1]["rerank_score"]
+
+    def test_max_workers_capped_at_num_documents(self, mock_llm):
+        """ThreadPoolExecutor should be created with at most len(docs) workers."""
+        _, mock_llm_instance = mock_llm
+        mock_llm_instance.generate_response.return_value = "0.5"
+
+        reranker = LLMReranker({"provider": "openai", "max_workers": 100})
+        docs = [{"memory": "only two docs"}, {"memory": "doc2"}]
+
+        with patch("mem0.reranker.llm_reranker.ThreadPoolExecutor") as mock_executor_cls:
+            mock_executor_cls.return_value.__enter__ = MagicMock(return_value=MagicMock(
+                submit=MagicMock(side_effect=lambda fn, *a, **kw: _make_future(fn(*a, **kw)))
+            ))
+            mock_executor_cls.return_value.__exit__ = MagicMock(return_value=False)
+            reranker.rerank("query", docs)
+            # Should be capped at 2 (len(docs)), not 100
+            mock_executor_cls.assert_called_once_with(max_workers=2)
+
+    def test_concurrent_worker_failure_falls_back_to_0_5(self, mock_llm):
+        """A single worker raising an exception should not crash the whole batch."""
+        _, mock_llm_instance = mock_llm
+        # First call raises, second succeeds
+        mock_llm_instance.generate_response.side_effect = [
+            RuntimeError("API timeout"), "0.8"
+        ]
+
+        reranker = LLMReranker({"provider": "openai", "max_workers": 2})
+        docs = [{"memory": "bad doc"}, {"memory": "good doc"}]
+        result = reranker.rerank("query", docs)
+
+        assert len(result) == 2
+        scores = {r["memory"]: r["rerank_score"] for r in result}
+        assert scores["bad doc"] == 0.5
+        assert scores["good doc"] == 0.8
+
+    def test_concurrent_does_not_mutate_originals(self, mock_llm):
+        _, mock_llm_instance = mock_llm
+        mock_llm_instance.generate_response.return_value = "0.8"
+
+        reranker = LLMReranker({"provider": "openai", "max_workers": 3})
+        originals = [{"memory": f"doc{i}", "id": str(i)} for i in range(3)]
+        reranker.rerank("query", originals)
+
+        for doc in originals:
+            assert "rerank_score" not in doc
+
+
+# ---------------------------------------------------------------------------
+# Edge cases common to both paths
+# ---------------------------------------------------------------------------
+
+class TestRerankEdgeCases:
+    def test_empty_documents_returns_empty(self, mock_llm):
+        reranker = LLMReranker({"provider": "openai", "max_workers": 4})
+        assert reranker.rerank("query", []) == []
+
+    def test_single_document_concurrent(self, mock_llm):
+        _, mock_llm_instance = mock_llm
+        mock_llm_instance.generate_response.return_value = "0.6"
+
+        reranker = LLMReranker({"provider": "openai", "max_workers": 4})
+        result = reranker.rerank("query", [{"memory": "solo doc"}])
+
+        assert len(result) == 1
+        assert result[0]["rerank_score"] == 0.6
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+def _make_future(result):
+    """Create a resolved Future for mocking ThreadPoolExecutor.submit."""
+    f = Future()
+    f.set_result(result)
+    return f


### PR DESCRIPTION
## Summary

Closes #4303

The `LLMReranker` scored documents sequentially — one LLM round-trip per document. For N documents this meant N × latency, making reranking a bottleneck in high-recall pipelines.

This PR adds a `max_workers` config parameter that enables concurrent scoring via `ThreadPoolExecutor`, reducing latency proportionally.

## Changes

### `mem0/configs/rerankers/llm.py`
- New `max_workers: int = 1` field. Defaults to `1` — **fully backward compatible**, existing behaviour is unchanged.

### `mem0/reranker/llm_reranker.py`
- Extracted `_score_document()` helper that scores one document and returns a copy with `rerank_score` added — used by both paths.
- `rerank()`: when `max_workers > 1`, submits all documents to a `ThreadPoolExecutor` concurrently. Workers are capped at `min(max_workers, len(documents))` to avoid excess threads.
- Per-worker failures fall back to score `0.5` — a single flaky LLM call never aborts the batch.

### `tests/rerankers/test_llm_reranker_concurrent.py` (new)
Full test coverage for the concurrent path:
- Config field default and custom values
- Sequential path still works as before
- Concurrent path: all docs scored, sorted descending, `top_k` applied
- `max_workers` capped at `len(documents)`
- Per-worker failure falls back to `0.5` gracefully
- Original documents not mutated

## Usage

```python
config = {
    "reranker": {
        "provider": "llm",
        "config": {
            "provider": "openai",
            "model": "gpt-4o-mini",
            "max_workers": 8,  # score 8 docs in parallel
        }
    }
}
m = Memory.from_config(config)
results = m.search("query", user_id="u1")  # ~8x faster reranking
```

## Performance

With `max_workers=N` and N documents, wall-clock reranking time drops from `N × llm_latency` to approximately `llm_latency` (bounded by the slowest single call). No change for `max_workers=1`.
