### PR TITLE
fix: extract data string from update_memory request body

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -201,16 +201,25 @@ def search_memories(search_req: SearchRequest, _api_key: Optional[str] = Depends
 @app.put("/memories/{memory_id}", summary="Update a memory")
 def update_memory(memory_id: str, updated_memory: Dict[str, Any], _api_key: Optional[str] = Depends(verify_api_key)):
     """Update an existing memory with new content.
-    
+
     Args:
         memory_id (str): ID of the memory to update
-        updated_memory (str): New content to update the memory with
-        
+        updated_memory (dict): Request body containing 'data' (str) with the new memory content,
+            and optionally 'metadata' (dict) for additional metadata updates.
+
     Returns:
         dict: Success message indicating the memory was updated
     """
     try:
-        return MEMORY_INSTANCE.update(memory_id=memory_id, data=updated_memory)
+        data = updated_memory.get("data")
+        if data is None:
+            raise HTTPException(status_code=400, detail="Request body must contain a 'data' field with the new memory content")
+        if not isinstance(data, str):
+            raise HTTPException(status_code=400, detail="'data' field must be a string")
+        metadata = updated_memory.get("metadata")
+        return MEMORY_INSTANCE.update(memory_id=memory_id, data=data, metadata=metadata)
+    except HTTPException:
+        raise
     except Exception as e:
         logging.exception("Error in update_memory:")
         raise HTTPException(status_code=500, detail=str(e))

--- a/tests/test_server_params.py
+++ b/tests/test_server_params.py
@@ -505,3 +505,42 @@ class TestCallSignatureMatch:
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert kwargs["query"] == "food"
+
+
+# ===========================================================================
+# UpdateMemory: data extraction from dict body (issue #3933)
+# ===========================================================================
+
+class TestUpdateMemory:
+    """Verify that update_memory correctly extracts data string from dict body."""
+
+    def test_update_with_data_field(self, client, mock_memory):
+        """PUT /memories/{id} with {'data': 'new content'} should forward the string."""
+        resp = client.put("/memories/mem-1", json={"data": "Likes tennis on weekends"})
+        assert resp.status_code == 200
+        _, kwargs = mock_memory.update.call_args
+        assert kwargs["memory_id"] == "mem-1"
+        assert kwargs["data"] == "Likes tennis on weekends"
+
+    def test_update_with_data_and_metadata(self, client, mock_memory):
+        """PUT /memories/{id} with data and metadata should forward both."""
+        resp = client.put("/memories/mem-1", json={
+            "data": "Likes tennis",
+            "metadata": {"category": "sports"},
+        })
+        assert resp.status_code == 200
+        _, kwargs = mock_memory.update.call_args
+        assert kwargs["data"] == "Likes tennis"
+        assert kwargs["metadata"] == {"category": "sports"}
+
+    def test_update_missing_data_field_returns_400(self, client, mock_memory):
+        """PUT /memories/{id} without 'data' field should return 400."""
+        resp = client.put("/memories/mem-1", json={"content": "wrong field name"})
+        assert resp.status_code == 400
+        assert "data" in resp.json()["detail"].lower()
+
+    def test_update_with_non_string_data_returns_400(self, client, mock_memory):
+        """PUT /memories/{id} with non-string data should return 400."""
+        resp = client.put("/memories/mem-1", json={"data": {"nested": "dict"}})
+        assert resp.status_code == 400
+        assert "string" in resp.json()["detail"].lower()


### PR DESCRIPTION
## Summary
- The `PUT /memories/{id}` endpoint received the request body as a dict and passed it directly to `Memory.update()`, which expects a string for the `data` parameter.
- This caused `"'dict' object has no attribute 'replace'"` errors when the embedding model tried to process the dict.
- Now extracts the `data` string field from the request body dict and optionally forwards the `metadata` field. Returns 400 if `data` is missing or not a string.

Closes #3933

## Test plan
- [x] Added 4 new tests: valid update, update with metadata, missing data field (400), non-string data (400)
- [x] All 117 server tests pass (including auth tests)