### PR TITLE
fix: add robust JSON repair for malformed LLM output

### DIFF
--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -127,8 +127,16 @@ def extract_json(text):
     Extracts JSON content from a string, removing enclosing triple backticks and optional 'json' tag if present.
     If no code block is found, attempts to locate JSON by finding the first '{' and last '}'.
     If that also fails, returns the text as-is.
+
+    Also applies best-effort repairs for common LLM JSON malformations:
+    - Strips <think>...</think> reasoning tags
+    - Removes trailing commas before } and ]
+    - Attempts to close unterminated JSON by appending missing brackets/braces
     """
     text = text.strip()
+    # Strip <think> tags that some reasoning models emit
+    text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL).strip()
+
     match = re.search(r"```(?:json)?\s*(.*?)\s*```", text, re.DOTALL)
     if match:
         json_str = match.group(1)
@@ -139,6 +147,63 @@ def extract_json(text):
             json_str = text[start_idx : end_idx + 1]
         else:
             json_str = text
+
+    json_str = _repair_json(json_str)
+    return json_str
+
+
+def _repair_json(json_str: str) -> str:
+    """Apply best-effort repairs to common JSON malformations from LLMs.
+
+    Fixes:
+    - Trailing commas before } and ] (e.g. ``[1, 2,]``)
+    - Unterminated JSON missing closing brackets/braces
+    """
+    # Remove trailing commas before closing brackets/braces
+    json_str = re.sub(r",\s*([}\]])", r"\1", json_str)
+
+    # Attempt to close unterminated JSON
+    try:
+        json_module = __import__("json")
+        json_module.loads(json_str)
+        return json_str
+    except (json_module.JSONDecodeError, ValueError):
+        pass
+
+    # Count unmatched brackets/braces (ignoring those inside strings)
+    open_braces = 0
+    open_brackets = 0
+    in_string = False
+    escape = False
+    for ch in json_str:
+        if escape:
+            escape = False
+            continue
+        if ch == "\\":
+            escape = True
+            continue
+        if ch == '"' and not escape:
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
+        if ch == "{":
+            open_braces += 1
+        elif ch == "}":
+            open_braces -= 1
+        elif ch == "[":
+            open_brackets += 1
+        elif ch == "]":
+            open_brackets -= 1
+
+    # Append missing closers
+    if open_brackets > 0 or open_braces > 0:
+        # Close in reverse order of typical nesting (brackets before braces)
+        json_str += "]" * max(0, open_brackets)
+        json_str += "}" * max(0, open_braces)
+        # Clean up any trailing commas introduced before our new closers
+        json_str = re.sub(r",\s*([}\]])", r"\1", json_str)
+
     return json_str
 
 

--- a/tests/test_chatty_llm_parsing.py
+++ b/tests/test_chatty_llm_parsing.py
@@ -91,6 +91,66 @@ That's the result."""
         parsed = json.loads(result)
         assert parsed["memory"][0]["id"] == "0"
 
+    def test_trailing_comma_in_array(self):
+        """Trailing commas in arrays should be repaired."""
+        text = '{"facts": ["Name is Alex", "Likes pizza",]}'
+        result = extract_json(text)
+        parsed = json.loads(result)
+        assert parsed["facts"] == ["Name is Alex", "Likes pizza"]
+
+    def test_trailing_comma_in_object(self):
+        """Trailing commas in objects should be repaired."""
+        text = '{"id": "0", "text": "test", "event": "ADD",}'
+        result = extract_json(text)
+        parsed = json.loads(result)
+        assert parsed["event"] == "ADD"
+
+    def test_unterminated_json_missing_closing_brace(self):
+        """Unterminated JSON with missing closing brace should be repaired."""
+        text = '{"facts": ["Name is Alex", "Likes pizza"]'
+        result = extract_json(text)
+        parsed = json.loads(result)
+        assert parsed["facts"] == ["Name is Alex", "Likes pizza"]
+
+    def test_unterminated_json_missing_bracket_and_brace(self):
+        """Unterminated JSON with missing bracket and brace should be repaired."""
+        text = '{"facts": ["Name is Alex", "Likes pizza"'
+        result = extract_json(text)
+        parsed = json.loads(result)
+        assert parsed["facts"] == ["Name is Alex", "Likes pizza"]
+
+    def test_think_tags_stripped(self):
+        """<think> tags should be stripped before extracting JSON."""
+        text = '<think>Let me analyze this</think>{"facts": ["Name is Alex"]}'
+        result = extract_json(text)
+        parsed = json.loads(result)
+        assert parsed["facts"] == ["Name is Alex"]
+
+    def test_think_tags_with_chatty_text(self):
+        """<think> tags combined with chatty text should be handled."""
+        text = '<think>Processing...</think>\nHere are the facts:\n{"facts": ["Name is Alex"]}\nDone.'
+        result = extract_json(text)
+        parsed = json.loads(result)
+        assert parsed["facts"] == ["Name is Alex"]
+
+    def test_trailing_comma_and_unterminated(self):
+        """Combined trailing comma and unterminated JSON should be repaired."""
+        text = '{"facts": ["Name is Alex",  '
+        result = extract_json(text)
+        parsed = json.loads(result)
+        assert parsed["facts"] == ["Name is Alex"]
+
+    def test_gemini_style_reasoning_leak(self):
+        """Simulate Gemini leaking reasoning tokens before JSON output."""
+        text = """I'll extract the facts from this conversation.
+
+{"facts": ["User's name is Alex", "User likes basketball"]}
+
+These are the key facts."""
+        result = extract_json(text)
+        parsed = json.loads(result)
+        assert len(parsed["facts"]) == 2
+
 
 # --- Test remove_code_blocks ---
 


### PR DESCRIPTION
## Summary
- LLMs (especially Gemini models) sometimes produce malformed JSON by leaking reasoning tokens, adding trailing commas, or truncating output before closing brackets.
- Enhanced `extract_json()` with:
  - Stripping `<think>...</think>` reasoning tags before extraction
  - Removing trailing commas before `}` and `]` (common LLM error)
  - Auto-closing unterminated JSON by counting unmatched brackets/braces

Closes #3918

## Test plan
- [x] Added 8 new tests for: trailing commas, unterminated JSON, think tags, Gemini-style reasoning leaks
- [x] All 29 JSON parsing tests pass (including existing ones)
- [x] Verified the full fallback chain still works correctly