### PR TITLE
fix: use OS-appropriate data directory instead of /tmp for vector stores

### DIFF
--- a/mem0/vector_stores/configs.py
+++ b/mem0/vector_stores/configs.py
@@ -1,6 +1,35 @@
+import os
+import sys
+from pathlib import Path
 from typing import Dict, Optional
 
 from pydantic import BaseModel, Field, model_validator
+
+
+def _default_data_dir(provider: str) -> str:
+    """Return an OS-appropriate data directory for the given vector store provider.
+
+    Respects MEM0_DATA_DIR environment variable if set. Otherwise:
+    - Linux: $XDG_DATA_HOME/mem0/{provider} or ~/.local/share/mem0/{provider}
+    - macOS: ~/Library/Application Support/mem0/{provider}
+    - Windows: %LOCALAPPDATA%/mem0/{provider} or %APPDATA%/mem0/{provider}
+    """
+    env_dir = os.environ.get("MEM0_DATA_DIR")
+    if env_dir:
+        return str(Path(env_dir) / provider)
+
+    if sys.platform == "win32":
+        base = os.environ.get("LOCALAPPDATA") or os.environ.get("APPDATA", "")
+        if base:
+            return str(Path(base) / "mem0" / provider)
+        return str(Path.home() / "mem0" / provider)
+    elif sys.platform == "darwin":
+        return str(Path.home() / "Library" / "Application Support" / "mem0" / provider)
+    else:
+        xdg = os.environ.get("XDG_DATA_HOME", "")
+        if xdg:
+            return str(Path(xdg) / "mem0" / provider)
+        return str(Path.home() / ".local" / "share" / "mem0" / provider)
 
 
 class VectorStoreConfig(BaseModel):
@@ -61,7 +90,7 @@ class VectorStoreConfig(BaseModel):
 
         # also check if path in allowed kays for pydantic model, and whether config extra fields are allowed
         if "path" not in config and "path" in config_class.__annotations__:
-            config["path"] = f"/tmp/{provider}"
+            config["path"] = _default_data_dir(provider)
 
         self.config = config_class(**config)
         return self

--- a/tests/vector_stores/test_default_data_dir.py
+++ b/tests/vector_stores/test_default_data_dir.py
@@ -1,0 +1,67 @@
+"""Tests for OS-appropriate default data directory (issue #4279)."""
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+from mem0.vector_stores.configs import _default_data_dir
+
+
+class TestDefaultDataDir(unittest.TestCase):
+    """Verify _default_data_dir returns OS-appropriate paths."""
+
+    def test_mem0_data_dir_env_override(self):
+        """MEM0_DATA_DIR env var should override platform defaults."""
+        with patch.dict(os.environ, {"MEM0_DATA_DIR": "/custom/data"}):
+            result = _default_data_dir("qdrant")
+            self.assertEqual(result, "/custom/data/qdrant")
+
+    def test_mem0_data_dir_env_different_provider(self):
+        """MEM0_DATA_DIR should work with any provider name."""
+        with patch.dict(os.environ, {"MEM0_DATA_DIR": "/data"}, clear=False):
+            result = _default_data_dir("chroma")
+            self.assertEqual(result, "/data/chroma")
+
+    @patch("sys.platform", "linux")
+    def test_linux_xdg_data_home(self):
+        """Linux with XDG_DATA_HOME set should use it."""
+        env = {"XDG_DATA_HOME": "/home/user/.data"}
+        with patch.dict(os.environ, env, clear=False):
+            os.environ.pop("MEM0_DATA_DIR", None)
+            result = _default_data_dir("qdrant")
+            self.assertEqual(result, "/home/user/.data/mem0/qdrant")
+
+    @patch("sys.platform", "linux")
+    def test_linux_default_without_xdg(self):
+        """Linux without XDG_DATA_HOME should use ~/.local/share/mem0."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MEM0_DATA_DIR", None)
+            os.environ.pop("XDG_DATA_HOME", None)
+            result = _default_data_dir("qdrant")
+            self.assertIn(".local/share/mem0/qdrant", result)
+
+    @patch("sys.platform", "darwin")
+    def test_macos_default(self):
+        """macOS should use ~/Library/Application Support/mem0."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MEM0_DATA_DIR", None)
+            result = _default_data_dir("chroma")
+            self.assertIn("Library/Application Support/mem0/chroma", result)
+
+    @patch("sys.platform", "win32")
+    def test_windows_localappdata(self):
+        """Windows with LOCALAPPDATA should use it."""
+        env = {"LOCALAPPDATA": "C:\\Users\\user\\AppData\\Local"}
+        with patch.dict(os.environ, env, clear=False):
+            os.environ.pop("MEM0_DATA_DIR", None)
+            result = _default_data_dir("qdrant")
+            self.assertIn("mem0", result)
+            self.assertIn("qdrant", result)
+
+    def test_no_tmp_in_default_path(self):
+        """Default path should never be /tmp (the whole point of issue #4279)."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MEM0_DATA_DIR", None)
+            result = _default_data_dir("qdrant")
+            self.assertNotIn("/tmp/", result)

--- a/tests/vector_stores/test_default_data_dir.py
+++ b/tests/vector_stores/test_default_data_dir.py
@@ -1,7 +1,6 @@
 """Tests for OS-appropriate default data directory (issue #4279)."""
 
 import os
-import sys
 import unittest
 from unittest.mock import patch
 


### PR DESCRIPTION
## Summary
- Defaulting vector store paths to `/tmp/{provider}` causes data loss on reboot, permission errors in restricted environments (LaunchAgent, systemd, containers), and fails on Windows.
- Replace with OS-appropriate directories:
  - Linux: `$XDG_DATA_HOME/mem0/{provider}` (default `~/.local/share/mem0/`)
  - macOS: `~/Library/Application Support/mem0/{provider}`
  - Windows: `%LOCALAPPDATA%/mem0/{provider}`
- Users can override via `MEM0_DATA_DIR` environment variable.

Closes #4279

## Test plan
- [x] Added 7 tests covering Linux (XDG), macOS, Windows, env var override, and no-/tmp assertion
- [x] All 279 tests pass across the full suite