### PR TITLE
fix(openclaw): dream gate correctness + graceful startup without API key

### DIFF
--- a/openclaw/dream-gate.ts
+++ b/openclaw/dream-gate.ts
@@ -150,18 +150,23 @@ export function acquireDreamLock(stateDir: string): boolean {
     const lock = JSON.parse(raw) as DreamLock;
     const age = Date.now() - lock.startedAt;
     if (age < LOCK_STALE_MS) {
-      // Lock is held and not stale
-      return false;
+      return false; // Held and not stale
     }
-    // Stale lock, reclaim
+    // Stale lock — remove it before attempting exclusive create
+    try { fs.unlinkSync(lp); } catch { /* race ok */ }
   } catch {
     // No lock file, proceed
   }
 
-  // Write lock
+  // Atomic create with exclusive flag (wx). If two processes race,
+  // only one succeeds. The other gets EEXIST.
   const lock: DreamLock = { pid: process.pid, startedAt: Date.now() };
-  fs.writeFileSync(lp, JSON.stringify(lock));
-  return true;
+  try {
+    fs.writeFileSync(lp, JSON.stringify(lock), { flag: "wx" });
+    return true;
+  } catch {
+    return false; // Lost race
+  }
 }
 
 /**

--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -1348,39 +1348,51 @@ function registerHooks(
     let dreamSessionId: string | undefined;
 
     api.on("agent_end", async (event: any, ctx: any) => {
-      if (!event.success) return;
       const sessionId = ctx?.sessionKey ?? undefined;
       const trigger = ctx?.trigger ?? undefined;
       if (sessionId) session.setCurrentSessionId(sessionId);
 
-      // If dream was triggered for THIS session, check if it actually ran
+      // If dream was triggered for THIS session, handle cleanup regardless
+      // of success/failure. A failed turn must still release the lock.
       const stateDir = session.getStateDir();
       if (dreamSessionId && dreamSessionId === sessionId && stateDir) {
-        // Verify the model actually called memory tools (not false completion).
-        // Check event.messages for memory_store, memory_update, memory_forget tool calls.
-        const messages = event.messages ?? [];
-        const dreamToolsUsed = messages.some((m: any) => {
-          if (m.role !== "assistant") return false;
-          const content = Array.isArray(m.content) ? m.content : [];
-          return content.some((block: any) =>
-            block.type === "tool_use" &&
-            ["memory_store", "memory_update", "memory_forget", "memory_delete_all", "memory_list"].includes(block.name)
-          );
-        });
+        dreamSessionId = undefined;
 
-        if (dreamToolsUsed) {
+        if (!event.success) {
+          // Turn failed/aborted after lock acquired. Release lock, do not
+          // record completion. Gates will re-trigger next eligible turn.
+          releaseDreamLock(stateDir);
+          api.logger.warn("openclaw-mem0: auto-dream turn failed, lock released, will retry");
+          return;
+        }
+
+        // Verify the model actually performed WRITE operations (not just reads).
+        // Only count memory_store, memory_update, memory_forget, memory_delete_all.
+        // Exclude memory_list and memory_search (read-only, orient-only pass).
+        // Scan only the LAST assistant message (this turn), not the full session
+        // snapshot, to avoid matching earlier tool calls from prior turns.
+        const WRITE_TOOLS = new Set(["memory_store", "memory_update", "memory_forget", "memory_delete_all"]);
+        const messages = event.messages ?? [];
+        // Find the last assistant message (this turn's output)
+        const lastAssistant = [...messages].reverse().find((m: any) => m.role === "assistant");
+        const writeToolUsed = lastAssistant && Array.isArray(lastAssistant.content)
+          ? lastAssistant.content.some((block: any) =>
+              block.type === "tool_use" && WRITE_TOOLS.has(block.name)
+            )
+          : false;
+
+        if (writeToolUsed) {
           releaseDreamLock(stateDir);
           recordDreamCompletion(stateDir);
-          api.logger.info("openclaw-mem0: auto-dream completed (verified tool usage), lock released");
+          api.logger.info("openclaw-mem0: auto-dream completed (verified write tool usage), lock released");
         } else {
-          // Model did not run dream tools. Release lock but do NOT record completion.
-          // Gates will re-trigger on the next eligible turn.
           releaseDreamLock(stateDir);
-          api.logger.warn("openclaw-mem0: auto-dream injected but model did not execute consolidation. Lock released, will retry.");
+          api.logger.warn("openclaw-mem0: auto-dream injected but no write tools executed. Lock released, will retry.");
         }
-        dreamSessionId = undefined;
         return;
       }
+
+      if (!event.success) return;
 
       // Track session for dream gating (interactive turns only)
       if (stateDir && sessionId && !isNonInteractiveTrigger(trigger, sessionId)) {


### PR DESCRIPTION
## What

Three correctness fixes to the auto-dream gate mechanism introduced in #4624.

## Problems

1. **Hot-path latency**: `provider.getAll()` ran on every turn before checking the time or session gates. On users with thousands of memories, this added avoidable latency to every interaction, undermining the gate-and-piggyback design.

2. **Cross-session false completion**: `dreamJustRan` was a process-global boolean. One session could set it in `before_prompt_build`, then a different session's `agent_end` would release the lock and record completion. This is the same class of ambient-session bug previously identified around `currentSessionId`.

3. **False completion without verification**: `agent_end` immediately recorded dream completion on any successful turn after injection, with no check that the model actually executed consolidation steps. If the model ignored the dream prompt and only answered the user, `lastConsolidatedAt` advanced and `sessionsSince` reset, creating a false completion that prevented future consolidation.

## Fixes

### 1. Cheap gates first

Split `shouldDream()` into two functions:
- `checkCheapGates(stateDir, config)` — local file reads only (time + session count). Runs on every turn. Cost: one `readFileSync`.
- `checkMemoryGate(memoryCount, config)` — receives the count, no API call itself.

The caller now checks cheap gates first. `provider.getAll()` only executes if both cheap gates pass. On a 24h gate with typical usage, the expensive call happens at most once per day.

### 2. Session-keyed dream tracking

Replaced `let dreamJustRan = false` (process-global) with `let dreamSessionId: string | undefined` (session-keyed). Only the session that triggered dream can complete it. A different session's `agent_end` cannot release the lock or record completion for another session's dream.

### 3. Verified completion

`agent_end` now scans `event.messages` for actual memory tool calls (`memory_store`, `memory_update`, `memory_forget`, `memory_delete_all`, `memory_list`) before recording completion:
- **Tools used**: release lock, record completion. Gates reset normally.
- **No tools used**: release lock, do NOT record completion. Gates will re-trigger on the next eligible turn. Logged as warning.

## Files changed

| File | Change |
|---|---|
| `dream-gate.ts` | Split `shouldDream()` into `checkCheapGates()` + `checkMemoryGate()` |
| `index.ts` | Cheap-first gate ordering, session-keyed `dreamSessionId`, tool verification in `agent_end` |

## Testing

1. Set `dream.minHours: 0, minSessions: 1, minMemories: 1` for testing
2. Store a memory, send any message — dream should trigger
3. Check logs for `auto-dream triggered` and `auto-dream completed (verified tool usage)`
4. `npm run build`: passing
