### PR TITLE
fix(openclaw): graceful startup without API key

### DIFF
--- a/openclaw/config.ts
+++ b/openclaw/config.ts
@@ -196,14 +196,9 @@ export const mem0ConfigSchema = {
     const mode: Mem0Mode =
       cfg.mode === "oss" || cfg.mode === "open-source" ? "open-source" : "platform";
 
-    // Platform mode requires apiKey
-    if (mode === "platform") {
-      if (typeof cfg.apiKey !== "string" || !cfg.apiKey) {
-        throw new Error(
-          "apiKey is required for platform mode (set mode: \"open-source\" for self-hosted)",
-        );
-      }
-    }
+    // Platform mode requires apiKey — but don't throw on missing config.
+    // The plugin should register successfully and log a setup message.
+    const needsSetup = mode === "platform" && (typeof cfg.apiKey !== "string" || !cfg.apiKey);
 
     // Resolve env vars in oss config
     let ossConfig: Mem0Config["oss"];
@@ -241,6 +236,7 @@ export const mem0ConfigSchema = {
       searchThreshold:
         typeof cfg.searchThreshold === "number" ? cfg.searchThreshold : 0.5,
       topK: typeof cfg.topK === "number" ? cfg.topK : 5,
+      needsSetup,
       oss: ossConfig,
       skills:
         cfg.skills && typeof cfg.skills === "object" && !Array.isArray(cfg.skills)

--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -94,6 +94,23 @@ const memoryPlugin = {
 
   register(api: OpenClawPluginApi) {
     const cfg = mem0ConfigSchema.parse(api.pluginConfig);
+
+    if (cfg.needsSetup) {
+      api.logger.warn(
+        "openclaw-mem0: API key not configured. Memory features are disabled.\n" +
+        "  To set up, run:\n" +
+        '  openclaw config set plugins.entries.openclaw-mem0.config.apiKey "m0-your-key"\n' +
+        "  openclaw gateway restart\n" +
+        "  Get your key at: https://app.mem0.ai/dashboard/api-keys"
+      );
+      api.registerService({
+        id: "openclaw-mem0",
+        start: () => { api.logger.info("openclaw-mem0: waiting for API key configuration"); },
+        stop: () => {},
+      });
+      return;
+    }
+
     const provider = createProvider(cfg, api);
 
     // Track current session ID for tool-level session scoping.

--- a/openclaw/types.ts
+++ b/openclaw/types.ts
@@ -28,6 +28,8 @@ export type Mem0Config = {
   autoRecall: boolean;
   searchThreshold: number;
   topK: number;
+  // Setup state
+  needsSetup?: boolean;
   // Agentic harness skills
   skills?: SkillsConfig;
 };


### PR DESCRIPTION
## What

Plugin no longer crashes during `register()` when API key is missing. Registers successfully, logs setup instructions with the exact command to run, and disables memory features until configured.

## Why

When a user runs `openclaw plugins install @mem0/openclaw-mem0` without configuring an API key first, the plugin throws during registration. The gateway logs an error and the plugin fails to load. Users see a cryptic error instead of actionable setup instructions.

## Fix

- `config.ts`: replaced `throw new Error()` with a `needsSetup` flag on the config object
- `types.ts`: added `needsSetup?: boolean` to `Mem0Config`  
- `index.ts`: early return in `register()` when `needsSetup` is true. Logs:
  ```
  openclaw-mem0: API key not configured. Memory features are disabled.
    To set up, run:
    openclaw config set plugins.entries.openclaw-mem0.config.apiKey "m0-your-key"
    openclaw gateway restart
    Get your key at: https://app.mem0.ai/dashboard/api-keys
  ```

## Before/After

**Before**: `openclaw plugins install` -> `register()` throws -> gateway error log
**After**: `openclaw plugins install` -> registers ok -> clear setup message -> user configures -> restart -> working