### PR TITLE
fix(qdrant): use DatetimeRange for ISO datetime string range filters

### DIFF
--- a/mem0/vector_stores/qdrant.py
+++ b/mem0/vector_stores/qdrant.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from qdrant_client import QdrantClient
 from qdrant_client.models import (
+    DatetimeRange,
     Distance,
     FieldCondition,
     Filter,
@@ -177,6 +178,10 @@ class Qdrant(VectorStoreBase):
                     f"Use AND to combine them as separate conditions."
                 )
             range_kwargs = {op: value[op] for op in range_ops if op in value}
+            sample_value = next(iter(range_kwargs.values()))
+            if isinstance(sample_value, str):
+                # String values are datetime strings (ISO format) — use DatetimeRange
+                return FieldCondition(key=key, datetime_range=DatetimeRange(**range_kwargs))
             return FieldCondition(key=key, range=Range(**range_kwargs))
         elif "eq" in value:
             return FieldCondition(key=key, match=MatchValue(value=value["eq"]))

--- a/tests/vector_stores/test_qdrant.py
+++ b/tests/vector_stores/test_qdrant.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 from qdrant_client import QdrantClient
 from qdrant_client.models import (
+    DatetimeRange,
     Distance,
     FieldCondition,
     Filter,
@@ -814,3 +815,48 @@ class TestQdrantEnhancedFilters(unittest.TestCase):
         self.assertIsNotNone(result.must_not)
         # Deduplicated: NOT wins, $not is skipped — exactly 1 entry
         self.assertEqual(len(result.must_not), 1)
+
+    def test_datetime_range_uses_datetime_range_model(self):
+        """ISO datetime strings should use DatetimeRange, not numeric Range.
+
+        Regression test for issue #4591: datetime range queries silently
+        returned 0 results because Range (numeric) was used instead of
+        DatetimeRange for ISO datetime string values.
+        """
+
+        cond = self.qdrant._build_field_condition(
+            "created_at",
+            {"gte": "2024-01-01T00:00:00Z", "lt": "2024-02-01T00:00:00Z"},
+        )
+        self.assertIsInstance(cond, FieldCondition)
+        self.assertIsNone(cond.range)
+        self.assertIsNotNone(cond.datetime_range)
+        self.assertIsInstance(cond.datetime_range, DatetimeRange)
+        self.assertEqual(cond.datetime_range.gte, "2024-01-01T00:00:00Z")
+        self.assertEqual(cond.datetime_range.lt, "2024-02-01T00:00:00Z")
+
+    def test_numeric_range_still_uses_range(self):
+        """Numeric values should continue to use Range, not DatetimeRange."""
+        cond = self.qdrant._build_field_condition("priority", {"gte": 5, "lte": 10})
+        self.assertIsInstance(cond, FieldCondition)
+        self.assertIsNotNone(cond.range)
+        self.assertIsNone(cond.datetime_range)
+        self.assertEqual(cond.range.gte, 5)
+        self.assertEqual(cond.range.lte, 10)
+
+    def test_create_filter_datetime_range(self):
+        """Datetime range filter through _create_filter should use DatetimeRange."""
+
+        result = self.qdrant._create_filter({
+            "user_id": "alice",
+            "created_at": {"gte": "2024-01-01T00:00:00Z", "lt": "2024-06-01T00:00:00Z"},
+        })
+        self.assertIsInstance(result, Filter)
+        self.assertEqual(len(result.must), 2)
+
+        datetime_cond = [c for c in result.must if c.key == "created_at"][0]
+        self.assertIsInstance(datetime_cond.datetime_range, DatetimeRange)
+        self.assertEqual(datetime_cond.datetime_range.gte, "2024-01-01T00:00:00Z")
+
+        numeric_cond = [c for c in result.must if c.key == "user_id"][0]
+        self.assertIsInstance(numeric_cond.match, MatchValue)


### PR DESCRIPTION
## What
Fixes Qdrant vector store adapter to use `DatetimeRange` instead of numeric `Range` when range filter values are datetime strings.

## Why
`_build_field_condition` always used `Range` (numeric) for range filters, even when values are ISO datetime strings. This caused datetime range queries to silently return 0 results — including the exact examples from the [official docs](https://docs.mem0.ai/open-source/features/metadata-filtering) (time-based filtering).

See: #4591

## How
In `_build_field_condition`, the range branch now inspects the first value:
- **String** → `DatetimeRange` via `FieldCondition(datetime_range=...)`
- **Number** → `Range` via `FieldCondition(range=...)` (unchanged)

## Testing
- `test_datetime_range_uses_datetime_range_model` — ISO strings produce DatetimeRange
- `test_numeric_range_still_uses_range` — numbers still use Range
- `test_create_filter_datetime_range` — end-to-end filter with mixed datetime + equality
- `ruff check` passes

## Checklist
- [x] Tests added
- [x] Linter passes
- [x] No breaking change for numeric range filters

Closes #4591