### PR TITLE
Add client side filtering for S3 List Method

### DIFF
--- a/mem0/vector_stores/s3_vectors.py
+++ b/mem0/vector_stores/s3_vectors.py
@@ -150,25 +150,33 @@ class S3Vectors(VectorStoreBase):
         return response.get("index", {})
 
     def list(self, filters=None, limit=None):
-        # Note: list_vectors does not support metadata filtering.
-        if filters:
-            logger.warning("S3 Vectors `list` does not support metadata filtering. Ignoring filters.")
-
         params = {
             "vectorBucketName": self.vector_bucket_name,
             "indexName": self.collection_name,
             "returnData": False,
             "returnMetadata": True,
         }
-        if limit:
-            params["maxResults"] = limit
 
         paginator = self.client.get_paginator("list_vectors")
         pages = paginator.paginate(**params)
         all_vectors = []
         for page in pages:
             all_vectors.extend(page.get("vectors", []))
-        return [self._parse_output(all_vectors)]
+
+        results = self._parse_output(all_vectors)
+
+        # Filters are not by S3 for this method, so we filter client side
+        if filters:
+            filtered = []
+            for r in results:
+                if all(r.payload.get(key) == value for key, value in filters.items()):
+                    filtered.append(r)
+            results = filtered
+
+        if limit:
+            results = results[:limit]
+
+        return [results]
 
     def reset(self):
         logger.warning(f"Resetting index {self.collection_name}...")

--- a/tests/vector_stores/test_s3_vectors.py
+++ b/tests/vector_stores/test_s3_vectors.py
@@ -1,7 +1,7 @@
-from mem0.configs.vector_stores.s3_vectors import S3VectorsConfig
 import pytest
 from botocore.exceptions import ClientError
 
+from mem0.configs.vector_stores.s3_vectors import S3VectorsConfig
 from mem0.memory.main import Memory
 from mem0.vector_stores.s3_vectors import S3Vectors
 
@@ -195,6 +195,52 @@ def test_delete(mock_boto_client):
     mock_boto_client.delete_vectors.assert_called_once_with(
         vectorBucketName=BUCKET_NAME, indexName=INDEX_NAME, keys=["id1"]
     )
+
+
+def test_list_with_filters(mock_boto_client):
+    """Test that list applies client-side filtering when filters are provided."""
+    mock_paginator = mock_boto_client.get_paginator.return_value
+    mock_paginator.paginate.return_value = [
+        {
+            "vectors": [
+                {"key": "id1", "metadata": {"user_id": "user1", "data": "memory one"}},
+                {"key": "id2", "metadata": {"user_id": "user2", "data": "memory two"}},
+                {"key": "id3", "metadata": {"user_id": "user1", "data": "memory three"}},
+            ]
+        }
+    ]
+
+    store = S3Vectors(
+        vector_bucket_name=BUCKET_NAME,
+        collection_name=INDEX_NAME,
+        embedding_model_dims=EMBEDDING_DIMS,
+    )
+    results = store.list(filters={"user_id": "user1"})
+
+    assert len(results[0]) == 2
+    assert all(r.payload["user_id"] == "user1" for r in results[0])
+
+
+def test_list(mock_boto_client):
+    """Test that list returns all vectors when no filters are provided."""
+    mock_paginator = mock_boto_client.get_paginator.return_value
+    mock_paginator.paginate.return_value = [
+        {
+            "vectors": [
+                {"key": "id1", "metadata": {"user_id": "user1", "data": "memory one"}},
+                {"key": "id2", "metadata": {"user_id": "user2", "data": "memory two"}},
+            ]
+        }
+    ]
+
+    store = S3Vectors(
+        vector_bucket_name=BUCKET_NAME,
+        collection_name=INDEX_NAME,
+        embedding_model_dims=EMBEDDING_DIMS,
+    )
+    results = store.list()
+
+    assert len(results[0]) == 2
 
 
 def test_reset(mock_boto_client):


### PR DESCRIPTION
## Linked Issue

Closes [3887](https://github.com/mem0ai/mem0/issues/3887)

## Description

 Filtering is not supported on the server side for the List method for S3 Buckets. This PR seeks to amend this by adding client side filtering to produce the same effect.

API Documentation for List Method: [Link](https://docs.aws.amazon.com/AmazonS3/latest/API/API_S3VectorBuckets_ListVectors.html)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe what breaks and the migration path. Delete this section if not applicable. -->

N/A

## Test Coverage

- [X] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

I added a unit test that verifies the returned results are filtered when filters are present. Additionally, I added a test that verifies the returned results are unmodified when filters are empty.

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [X] I have added tests that prove my fix/feature works
- [X] New and existing tests pass locally
- [X] I have updated documentation if needed
