### PR TITLE
feat(ts-sdk): add DeepSeek LLM provider

### DIFF
--- a/mem0-ts/src/oss/src/index.ts
+++ b/mem0-ts/src/oss/src/index.ts
@@ -18,6 +18,7 @@ export * from "./llms/ollama";
 export * from "./llms/lmstudio";
 export * from "./llms/mistral";
 export * from "./llms/langchain";
+export * from "./llms/deepseek";
 export * from "./vector_stores/base";
 export * from "./vector_stores/memory";
 export * from "./vector_stores/qdrant";

--- a/mem0-ts/src/oss/src/llms/deepseek.ts
+++ b/mem0-ts/src/oss/src/llms/deepseek.ts
@@ -1,0 +1,76 @@
+import OpenAI from "openai";
+import { LLM, LLMResponse } from "./base";
+import { LLMConfig, Message } from "../types";
+
+const DEEPSEEK_BASE_URL = "https://api.deepseek.com/v1";
+
+export class DeepSeekLLM implements LLM {
+  private client: OpenAI;
+  private model: string;
+
+  constructor(config: LLMConfig) {
+    const apiKey = config.apiKey || process.env.DEEPSEEK_API_KEY;
+    if (!apiKey) {
+      throw new Error(
+        "DeepSeek API key is required. Provide it via config.apiKey or the DEEPSEEK_API_KEY environment variable.",
+      );
+    }
+    this.client = new OpenAI({
+      apiKey,
+      baseURL: config.baseURL || DEEPSEEK_BASE_URL,
+    });
+    this.model = config.model || "deepseek-chat";
+  }
+
+  async generateResponse(
+    messages: Message[],
+    responseFormat?: { type: string },
+    tools?: any[],
+  ): Promise<string | LLMResponse> {
+    const completion = await this.client.chat.completions.create({
+      model: this.model,
+      messages: messages.map((msg) => ({
+        role: msg.role as "system" | "user" | "assistant",
+        content:
+          typeof msg.content === "string"
+            ? msg.content
+            : JSON.stringify(msg.content),
+      })),
+      response_format: responseFormat as { type: "text" | "json_object" },
+      ...(tools && { tools, tool_choice: "auto" }),
+    });
+
+    const response = completion.choices[0].message;
+
+    if (response.tool_calls) {
+      return {
+        content: response.content || "",
+        role: response.role,
+        toolCalls: response.tool_calls.map((call) => ({
+          name: call.function.name,
+          arguments: call.function.arguments,
+        })),
+      };
+    }
+
+    return response.content || "";
+  }
+
+  async generateChat(messages: Message[]): Promise<LLMResponse> {
+    const completion = await this.client.chat.completions.create({
+      model: this.model,
+      messages: messages.map((msg) => ({
+        role: msg.role as "system" | "user" | "assistant",
+        content:
+          typeof msg.content === "string"
+            ? msg.content
+            : JSON.stringify(msg.content),
+      })),
+    });
+    const message = completion.choices[0].message;
+    return {
+      content: message.content || "",
+      role: message.role,
+    };
+  }
+}

--- a/mem0-ts/src/oss/src/utils/factory.ts
+++ b/mem0-ts/src/oss/src/utils/factory.ts
@@ -31,6 +31,7 @@ import { GoogleLLM } from "../llms/google";
 import { AzureOpenAILLM } from "../llms/azure";
 import { AzureOpenAIEmbedder } from "../embeddings/azure";
 import { LangchainLLM } from "../llms/langchain";
+import { DeepSeekLLM } from "../llms/deepseek";
 import { LangchainEmbedder } from "../embeddings/langchain";
 import { LangchainVectorStore } from "../vector_stores/langchain";
 import { AzureAISearch } from "../vector_stores/azure_ai_search";
@@ -82,6 +83,8 @@ export class LLMFactory {
         return new MistralLLM(config);
       case "langchain":
         return new LangchainLLM(config);
+      case "deepseek":
+        return new DeepSeekLLM(config);
       default:
         throw new Error(`Unsupported LLM provider: ${provider}`);
     }

--- a/mem0-ts/src/oss/tests/deepseek-llm.test.ts
+++ b/mem0-ts/src/oss/tests/deepseek-llm.test.ts
@@ -1,0 +1,161 @@
+import { DeepSeekLLM } from "../src/llms/deepseek";
+
+// Mock the openai module
+jest.mock("openai", () => {
+  const mockCreate = jest.fn();
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => ({
+      chat: {
+        completions: {
+          create: mockCreate,
+        },
+      },
+    })),
+    mockCreate,
+  };
+});
+
+// Helper to get mockCreate from the mocked module
+function getMockCreate() {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const OpenAI = require("openai");
+  return OpenAI.mockCreate;
+}
+
+describe("DeepSeekLLM", () => {
+  const apiKey = "test-deepseek-key";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("should initialize with provided API key and default model", () => {
+      const llm = new DeepSeekLLM({ apiKey });
+      expect(llm).toBeInstanceOf(DeepSeekLLM);
+    });
+
+    it("should use DEEPSEEK_API_KEY env var if no apiKey in config", () => {
+      process.env.DEEPSEEK_API_KEY = "env-api-key";
+      const llm = new DeepSeekLLM({});
+      expect(llm).toBeInstanceOf(DeepSeekLLM);
+      delete process.env.DEEPSEEK_API_KEY;
+    });
+
+    it("should throw if no API key is provided", () => {
+      delete process.env.DEEPSEEK_API_KEY;
+      expect(() => new DeepSeekLLM({})).toThrow("DeepSeek API key is required");
+    });
+
+    it("should accept a custom baseURL", () => {
+      const llm = new DeepSeekLLM({
+        apiKey,
+        baseURL: "https://custom.deepseek.example.com/v1",
+      });
+      expect(llm).toBeInstanceOf(DeepSeekLLM);
+    });
+  });
+
+  describe("generateResponse", () => {
+    it("should return text content for a plain response", async () => {
+      const mockCreate = getMockCreate();
+      mockCreate.mockResolvedValueOnce({
+        choices: [
+          {
+            message: {
+              role: "assistant",
+              content: "Hello from DeepSeek!",
+              tool_calls: null,
+            },
+          },
+        ],
+      });
+
+      const llm = new DeepSeekLLM({ apiKey });
+      const result = await llm.generateResponse([
+        { role: "user", content: "Hi" },
+      ]);
+      expect(result).toBe("Hello from DeepSeek!");
+    });
+
+    it("should return LLMResponse with toolCalls when tool_calls present", async () => {
+      const mockCreate = getMockCreate();
+      mockCreate.mockResolvedValueOnce({
+        choices: [
+          {
+            message: {
+              role: "assistant",
+              content: null,
+              tool_calls: [
+                {
+                  function: {
+                    name: "add_memory",
+                    arguments: '{"memory": "test"}',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      const llm = new DeepSeekLLM({ apiKey });
+      const result = await llm.generateResponse(
+        [{ role: "user", content: "Remember this" }],
+        undefined,
+        [{ type: "function", function: { name: "add_memory" } }],
+      );
+      expect(result).toEqual({
+        content: "",
+        role: "assistant",
+        toolCalls: [{ name: "add_memory", arguments: '{"memory": "test"}' }],
+      });
+    });
+
+    it("should pass responseFormat to the API", async () => {
+      const mockCreate = getMockCreate();
+      mockCreate.mockResolvedValueOnce({
+        choices: [
+          {
+            message: {
+              role: "assistant",
+              content: '{"key":"val"}',
+              tool_calls: null,
+            },
+          },
+        ],
+      });
+
+      const llm = new DeepSeekLLM({ apiKey, model: "deepseek-reasoner" });
+      await llm.generateResponse([{ role: "user", content: "Return JSON" }], {
+        type: "json_object",
+      });
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ response_format: { type: "json_object" } }),
+      );
+    });
+  });
+
+  describe("generateChat", () => {
+    it("should return LLMResponse with content and role", async () => {
+      const mockCreate = getMockCreate();
+      mockCreate.mockResolvedValueOnce({
+        choices: [
+          {
+            message: {
+              role: "assistant",
+              content: "Chat reply",
+            },
+          },
+        ],
+      });
+
+      const llm = new DeepSeekLLM({ apiKey });
+      const result = await llm.generateChat([
+        { role: "user", content: "Chat message" },
+      ]);
+      expect(result).toEqual({ content: "Chat reply", role: "assistant" });
+    });
+  });
+});

--- a/mem0-ts/src/oss/tests/factory.unit.test.ts
+++ b/mem0-ts/src/oss/tests/factory.unit.test.ts
@@ -82,6 +82,11 @@ jest.mock("../src/llms/langchain", () => ({
     .fn()
     .mockImplementation((config) => ({ type: "langchain-llm", config })),
 }));
+jest.mock("../src/llms/deepseek", () => ({
+  DeepSeekLLM: jest
+    .fn()
+    .mockImplementation((config) => ({ type: "deepseek-llm", config })),
+}));
 jest.mock("../src/llms/lmstudio", () => ({
   LMStudioLLM: jest
     .fn()
@@ -200,6 +205,7 @@ describe("LLMFactory", () => {
     ["mistral"],
     ["langchain"],
     ["lmstudio"],
+    ["deepseek"],
   ])("creates LLM for provider '%s'", (provider) => {
     expect(() => LLMFactory.create(provider, dummyLLMConfig)).not.toThrow();
   });


### PR DESCRIPTION
## Summary

Closes #4606

The Python SDK ships a full DeepSeek LLM provider (`mem0/llms/deepseek.py`) but the TypeScript SDK had no equivalent, leaving Node.js users unable to use DeepSeek models with mem0.

## Changes

- **`mem0-ts/src/oss/src/llms/deepseek.ts`** — New `DeepSeekLLM` class implementing the `LLM` interface using the `openai` SDK (already a dep) pointed at DeepSeek's OpenAI-compatible endpoint (`https://api.deepseek.com/v1`)
  - Default model: `deepseek-chat` (mirrors Python SDK default)
  - Full `generateResponse` support: plain text, `responseFormat`, and `tool_calls`
  - `generateChat` for standard multi-turn chat
  - API key from `config.apiKey` or `DEEPSEEK_API_KEY` env var
  - `baseURL` configurable for alternative endpoints

- **`factory.ts`** — Registers `DeepSeekLLM` under the `"deepseek"` provider string in `LLMFactory`

- **`index.ts`** — Exports `DeepSeekLLM` from the public API

- **`tests/deepseek-llm.test.ts`** — Unit tests covering constructor (apiKey sources, missing key error, custom baseURL), `generateResponse` (plain text, tool calls, responseFormat), and `generateChat`

- **`tests/factory.unit.test.ts`** — Adds `DeepSeekLLM` mock and `"deepseek"` to the LLMFactory `test.each` matrix

## No new dependencies

Uses the `openai` package already in `package.json` — DeepSeek exposes an OpenAI-compatible REST API.
