### PR TITLE
fix(bedrock): fix set literal typo in AI21 response parsing default

### DIFF
--- a/mem0/llms/aws_bedrock.py
+++ b/mem0/llms/aws_bedrock.py
@@ -409,7 +409,7 @@ class AWSBedrockLLM(LLMBase):
             elif self.provider == "cohere":
                 return response_json.get("generations", [{"text": ""}])[0].get("text", "")
             elif self.provider == "ai21":
-                return response_json.get("completions", [{"data", {"text": ""}}])[0].get("data", {}).get("text", "")
+                return response_json.get("completions", [{"data": {"text": ""}}])[0].get("data", {}).get("text", "")
             else:
                 # Generic parsing - try common response fields
                 for field in ["content", "text", "completion", "generation"]:

--- a/tests/llms/test_aws_bedrock.py
+++ b/tests/llms/test_aws_bedrock.py
@@ -436,7 +436,6 @@ class TestParseResponseLegacy:
 
     def _make_invoke_response(self, body_dict: dict):
         """Build a mock InvokeModel response with a readable body stream."""
-        import io
         body_bytes = json.dumps(body_dict).encode()
         mock_body = MagicMock()
         mock_body.read.return_value = body_bytes

--- a/tests/llms/test_aws_bedrock.py
+++ b/tests/llms/test_aws_bedrock.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -424,3 +425,63 @@ class TestMiniMaxProvider:
             assert msg["role"] != "system"
         # user message must be present
         assert kwargs["messages"][0]["role"] == "user"
+
+
+# ---------------------------------------------------------------------------
+# _parse_response — legacy InvokeModel response parsing
+# ---------------------------------------------------------------------------
+
+class TestParseResponseLegacy:
+    """Tests for the InvokeModel (non-Converse) response parsing path."""
+
+    def _make_invoke_response(self, body_dict: dict):
+        """Build a mock InvokeModel response with a readable body stream."""
+        import io
+        body_bytes = json.dumps(body_dict).encode()
+        mock_body = MagicMock()
+        mock_body.read.return_value = body_bytes
+        return {"body": mock_body}
+
+    def test_ai21_completions_normal(self, mock_boto3):
+        """AI21 response with a normal completions array is parsed correctly."""
+        llm = _make_llm("ai21.j2-mid-v1", mock_boto3)
+        response = self._make_invoke_response({
+            "completions": [{"data": {"text": "Hello from AI21"}}]
+        })
+        result = llm._parse_response(response)
+        assert result == "Hello from AI21"
+
+    def test_ai21_completions_missing_key_uses_fallback(self, mock_boto3):
+        """When 'completions' key is absent, the fallback default must not
+        crash.  Before the fix this raised TypeError because the default was
+        ``[{"data", {"text": ""}}]`` (a set literal) instead of
+        ``[{"data": {"text": ""}}]`` (a dict literal)."""
+        llm = _make_llm("ai21.j2-mid-v1", mock_boto3)
+        response = self._make_invoke_response({"id": "some-id"})
+        # Must NOT raise TypeError: unhashable type: 'dict'
+        result = llm._parse_response(response)
+        assert result == ""
+
+    def test_anthropic_content_normal(self, mock_boto3):
+        llm = _make_llm("anthropic.claude-3-5-sonnet-20240620-v1:0", mock_boto3)
+        response = self._make_invoke_response({
+            "content": [{"text": "Hello from Anthropic"}]
+        })
+        result = llm._parse_response(response)
+        assert result == "Hello from Anthropic"
+
+    def test_mistral_outputs_normal(self, mock_boto3):
+        llm = _make_llm("mistral.mistral-7b-instruct-v0:2", mock_boto3)
+        response = self._make_invoke_response({
+            "outputs": [{"text": "Hello from Mistral"}]
+        })
+        result = llm._parse_response(response)
+        assert result == "Hello from Mistral"
+
+    def test_cohere_generations_normal(self, mock_boto3):
+        llm = _make_llm("cohere.command-text-v14", mock_boto3)
+        response = self._make_invoke_response({
+            "generations": [{"text": "Hello from Cohere"}]
+        })
+        result = llm._parse_response(response)
+        assert result == "Hello from Cohere"


### PR DESCRIPTION
Was setting up mem0 with AI21 Jamba models on AWS Bedrock and noticed every response from the InvokeModel path silently returns `"Error parsing response"` instead of the actual model output.

Traced it to line 412 in `mem0/llms/aws_bedrock.py` — the fallback default for the AI21 completions parser uses a comma instead of a colon:

```python
# Before (broken — creates a set literal, always raises TypeError):
response_json.get("completions", [{"data", {"text": ""}}])[0].get(...)

# After (correct — creates a dict literal, matching the sibling lines):
response_json.get("completions", [{"data": {"text": ""}}])[0].get(...)
```

The comma makes `{"data", {"text": ""}}` a Python set literal containing a string and a dict. Since dicts are unhashable, this always raises `TypeError: cannot use 'dict' as a set element (unhashable type: 'dict')`, which gets silently caught by the outer `except Exception` at line 425 and returns `"Error parsing response"`.

The sibling lines for Anthropic (393), Mistral (408), and Cohere (410) all use the correct colon syntax.

**Reproduction:**
```python
>>> response_json = {}
>>> response_json.get("completions", [{"data", {"text": ""}}])[0]
TypeError: cannot use 'dict' as a set element (unhashable type: 'dict')
```

**Tests added:** 5 new tests in `TestParseResponseLegacy` covering the InvokeModel response parsing path for AI21, Anthropic, Mistral, and Cohere — including the specific regression case where AI21's `completions` key is absent and the fallback must work.