### PR TITLE
[fix] groq model

### DIFF
--- a/mem0/llms/groq.py
+++ b/mem0/llms/groq.py
@@ -17,7 +17,7 @@ class GroqLLM(LLMBase):
         super().__init__(config)
 
         if not self.config.model:
-            self.config.model = "llama3-70b-8192"
+            self.config.model = "llama-3.3-70b-versatile"
 
         api_key = self.config.api_key or os.getenv("GROQ_API_KEY")
         self.client = Groq(api_key=api_key)


### PR DESCRIPTION
The default Groq model llama3-70b-8192 is deprecated and causes a 400 error when using mem0 with the Groq provider. 
so change "llama3-70b-8192" this to "llama-3.3-70b-versatile" model.
 
## Linked Issue 

Closes #4694

 ## Description 

The default Groq model llama3-70b-8192 has been deprecated and results in a 400 error when using mem0 with the Groq provider. This PR updates the default model to llama-3.3-70b-versatile, which is currently supported and resolves the issue. Additionally, this ensures that users can use the Groq provider out-of-the-box without encountering model deprecation errors. 

## Type of Change

 - [x] Bug fix (non-breaking change that fixes an issue) 
 - [ ] New feature (non-breaking change that adds functionality) 
 - [ ] Breaking change (fix or feature that would cause existing functionality to change) 
 - [x] Refactor (no functional changes) 
 - [ ] Documentation update 
 
 
## Breaking Changes 

N/A

## Test Coverage

- [ ] I added/updated unit tests 
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [x] No tests needed (This change only updates a default configuration value and does not modify logic or behavior.) 

Manual Testing: 

Reproduced the issue using the Groq provider with default config (resulted in 400 error). Updated the model to llama-3.3-70b-versatile. Verified that requests now complete successfully without errors. 


## Checklist 

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code 
- [ ] I have added tests that prove my fix/feature works 
- [x] New and existing tests pass locally 
- [ ] I have updated documentation if needed 



## Sample code

```python

from dotenv import load_dotenv
import os
from mem0 import Memory

load_dotenv()


config = {
    "vector_store": {  # vector db
        "provider": "qdrant",
        "config": {
            "collection_name": "user_personal",
            "host": "localhost",
            "port": 6333,
            "embedding_model_dims": 384
        }
    },
    "llm": {            #LLM
        "provider": "groq",
        "config": {
            "api_key" : os.getenv("GROQ_API_KEY")
        }
    },
    "embedder": {       # embedding model
        "provider": "huggingface",
        "config": {
            "model": "multi-qa-MiniLM-L6-cos-v1",
            "embedding_dims": 384
        }
    }
}

# client
m = Memory.from_config(config)

messages = [
    {"role": "user", "content": "I'm planning to watch a movie tonight. Any recommendations?"},
    {"role": "assistant", "content": "How about thriller movies? They can be quite engaging."},
    {"role": "user", "content": "I'm not a big fan of thriller movies but I love sci-fi movies."},
    {"role": "assistant", "content": "Got it! I'll avoid thriller recommendations and suggest sci-fi movies in the future."}
]
m.add(messages, user_id="alice", metadata={"category": "movies"})


```

I tried this one and works fine with use "llama-3.3-70b-versatile" model.