### PR TITLE
feat: make update memory search limit configurable

### DIFF
--- a/mem0/configs/base.py
+++ b/mem0/configs/base.py
@@ -64,6 +64,11 @@ class MemoryConfig(BaseModel):
         description="Custom prompt for the update memory",
         default=None,
     )
+    update_memory_search_limit: int = Field(
+        description="Maximum number of existing memories to retrieve per extracted fact during the memory update step. "
+        "Higher values improve deduplication accuracy at the cost of more tokens in the update prompt.",
+        default=5,
+    )
 
 
 class AzureConfig(BaseModel):

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -247,6 +247,7 @@ class Memory(MemoryBase):
 
         self.custom_fact_extraction_prompt = self.config.custom_fact_extraction_prompt
         self.custom_update_memory_prompt = self.config.custom_update_memory_prompt
+        self.update_memory_search_limit = self.config.update_memory_search_limit
         self.embedding_model = EmbedderFactory.create(
             self.config.embedder.provider,
             self.config.embedder.config,
@@ -569,7 +570,7 @@ class Memory(MemoryBase):
             existing_memories = self.vector_store.search(
                 query=new_mem,
                 vectors=messages_embeddings,
-                limit=5,
+                limit=self.update_memory_search_limit,
                 filters=search_filters,
             )
             for mem in existing_memories:
@@ -1680,7 +1681,7 @@ class AsyncMemory(MemoryBase):
                 self.vector_store.search,
                 query=new_mem_content,
                 vectors=embeddings,
-                limit=5,
+                limit=self.update_memory_search_limit,
                 filters=search_filters,
             )
             return [{"id": mem.id, "text": mem.payload.get("data", "")} for mem in existing_mems]


### PR DESCRIPTION
## Linked Issue

(No issue)

## Description

The `Memory.add()` method searches existing memories to decide whether to ADD, UPDATE, or DELETE. The number of candidates retrieved per extracted fact is hardcoded to `limit=5` in both the sync and async code paths (`mem0/memory/main.py`).

For stores with many memories (e.g., hundreds of operational facts about different entities with similar structure), 5 candidates is often insufficient. The vector search may return semantically similar but *wrong* memories, causing the update prompt to ADD duplicates instead of UPDATE the correct existing memory.

This PR adds an `update_memory_search_limit` option to `MemoryConfig` (default: 5, preserving backward compatibility) and threads it through both code paths.

### Example

```python
config = {
    "update_memory_search_limit": 20,  # was hardcoded to 5
    # ... other config ...
}
memory = Memory.from_config(config)
```

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Tested with a Qdrant vector store containing 72 operational memories. With `limit=5`, a short status update like "ticket 118397 is fixed" could not find the correct existing memory in candidates, leading to duplicate ADDs. With `limit=20`, the correct memories were retrieved as candidates. The config option is correctly read from `MemoryConfig`, stored as `self.update_memory_search_limit`, and used in both sync (`_add_to_vector_store`) and async (`_aadd_to_vector_store`) paths.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
