### PR TITLE
fix(embeddings): auto-detect LM Studio embedding dims instead of hardcoded 1536

### DIFF
--- a/mem0/embeddings/lmstudio.py
+++ b/mem0/embeddings/lmstudio.py
@@ -11,10 +11,28 @@ class LMStudioEmbedding(EmbeddingBase):
         super().__init__(config)
 
         self.config.model = self.config.model or "nomic-ai/nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.f16.gguf"
-        self.config.embedding_dims = self.config.embedding_dims or 1536
         self.config.api_key = self.config.api_key or "lm-studio"
 
         self.client = OpenAI(base_url=self.config.lmstudio_base_url, api_key=self.config.api_key)
+
+        if not self.config.embedding_dims:
+            self.config.embedding_dims = self._detect_embedding_dims()
+
+    def _detect_embedding_dims(self) -> int:
+        """
+        Auto-detect the embedding dimensions by making a test embed call.
+
+        LM Studio can serve any locally loaded model, so the output dimensions
+        depend entirely on which model the user has loaded. The previous hardcoded
+        fallback of 1536 only matches OpenAI text-embedding-3-small/ada-002 and
+        causes dimension mismatch errors with any other model (e.g. nomic-embed-text
+        at 768, bge-large at 1024, etc.).
+        """
+        try:
+            response = self.client.embeddings.create(input=["test"], model=self.config.model)
+            return len(response.data[0].embedding)
+        except Exception:
+            return 1536
 
     def embed(self, text, memory_action: Optional[Literal["add", "search", "update"]] = None):
         """


### PR DESCRIPTION
## Problem

`LMStudioEmbedding` hardcoded `embedding_dims = 1536` as a fallback. LM Studio is a local model server that can serve **any** model, so the actual output dimensions depend entirely on what model the user has loaded:

| Model | Actual dims |
|-------|------------|
| `nomic-embed-text` | 768 |
| `bge-large-en-v1.5` | 1024 |
| `e5-large-v2` | 1024 |
| `text-embedding-ada-002` | 1536 |

When using anything other than an OpenAI-compatible 1536-dim model, Qdrant (and other dimension-sensitive vector stores) would create collections with the wrong size, leading to dimension mismatch errors at insert time.

## Root Cause

`mem0/embeddings/lmstudio.py` line 14:
```python
self.config.embedding_dims = self.config.embedding_dims or 1536
```

## Fix

Added `_detect_embedding_dims()` that makes a lightweight probe call to `client.embeddings.create()` at init time and measures the actual output vector length. The probe only runs when `embedding_dims` is not explicitly set by the user.

- User-supplied `embedding_dims` is always respected (probe is skipped)
- Falls back to `1536` only if the probe itself fails (e.g. LM Studio not running)
- No new dependencies
