### PR TITLE
fix(embeddings): set FastEmbed embedding_dims from model metadata at init

### DIFF
--- a/mem0/embeddings/fastembed.py
+++ b/mem0/embeddings/fastembed.py
@@ -13,7 +13,10 @@ class FastEmbedEmbedding(EmbeddingBase):
         super().__init__(config)
 
         self.config.model = self.config.model or "thenlper/gte-large"
-        self.dense_model = TextEmbedding(model_name = self.config.model)
+        self.dense_model = TextEmbedding(model_name=self.config.model)
+
+        if not self.config.embedding_dims:
+            self.config.embedding_dims = self.dense_model.embedding_size
 
     def embed(self, text, memory_action: Optional[Literal["add", "search", "update"]] = None):
         """


### PR DESCRIPTION
## Problem

`FastEmbedEmbedding` never populated `embedding_dims`, leaving it as `None`. Dimension-sensitive vector stores (Qdrant, Milvus, pgvector, etc.) fall back to their own hardcoded defaults (typically 1536) when `embedding_dims` is not set. This causes dimension mismatch errors since actual FastEmbed models output different sizes:

| Model | Actual dims |
|-------|------------|
| `thenlper/gte-large` | 1024 |
| `BAAI/bge-small-en-v1.5` | 384 |
| `BAAI/bge-base-en-v1.5` | 768 |
| `BAAI/bge-large-en-v1.5` | 1024 |

## Root Cause

`mem0/embeddings/fastembed.py` never set `self.config.embedding_dims`, so it remained `None` after init.

## Fix

Read `embedding_size` from the already-loaded `TextEmbedding` model via `self.dense_model.embedding_size`. This is a property backed by the model's metadata descriptor — no probe call, no network request, no additional cost. The information is already available the moment `TextEmbedding(model_name=...)` returns.

- User-supplied `embedding_dims` is always respected
- Zero overhead — reads from in-memory model metadata
- No new dependencies
