### PR TITLE
fix(ts): include url fallback in LLM config baseURL resolution

### DIFF
--- a/mem0-ts/src/oss/src/config/manager.ts
+++ b/mem0-ts/src/oss/src/config/manager.ts
@@ -110,6 +110,7 @@ export class ConfigManager {
             ((userConf as Record<string, unknown>)?.lmstudio_base_url as
               | string
               | undefined) ??
+            userConf?.url ??
             defaultConf.baseURL;
 
           return {


### PR DESCRIPTION
## Linked Issue

Closes #4715

## Description
The LLM config manager's `baseURL` resolution chain does not fall back to `userConf.url`, unlike the embedder config which does. When a user configures a non-OpenAI LLM provider (e.g. Ollama) with `url` in the config, the config manager skips it and falls back to `defaultConf.baseURL` (`https://api.openai.com/v1`), causing all LLM requests to silently hit OpenAI instead of the configured host.

This is a one-line fix adding `userConf?.url ??` to the LLM `baseURL` resolution chain in `mem0-ts/src/oss/src/config/manager.ts`, matching the existing embedder behavior.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Tested on a multi-tenant OpenClaw deployment (5 instances) running mem0ai 2.3.0 with Ollama LLM (`provider: "ollama"`, `url: "http://host.docker.internal:11434"`) inside Docker containers.   
## Before fix:
`OllamaLLM` received `baseURL: "https://api.openai.com/v1"` from the config manager. Memory capture failed with `TypeError: fetch failed` (container can't reach api.openai.com) or `404 Not Found` (Ollama client hitting OpenAI endpoints).

## After fix:
`OllamaLLM` correctly connects to the configured Ollama host. Memory recall and capture both succeed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed