### PR TITLE
fix: use native AsyncOpenAI in AsyncMemory instead of asyncio.to_thread

### DIFF
--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -1,3 +1,4 @@
+import asyncio
 from abc import ABC, abstractmethod
 from typing import Dict, List, Optional, Union
 
@@ -116,6 +117,27 @@ class LLMBase(ABC):
             str or dict: The generated response.
         """
         pass
+
+    async def agenerate_response(
+        self, messages: List[Dict[str, str]], tools: Optional[List[Dict]] = None, tool_choice: str = "auto", **kwargs
+    ):
+        """
+        Async version of generate_response. By default, wraps the sync method
+        via asyncio.to_thread. Subclasses with native async clients (e.g. OpenAI)
+        should override this for true async behavior.
+
+        Args:
+            messages (list): List of message dicts containing 'role' and 'content'.
+            tools (list, optional): List of tools that the model can call. Defaults to None.
+            tool_choice (str, optional): Tool choice method. Defaults to "auto".
+            **kwargs: Additional provider-specific parameters.
+
+        Returns:
+            str or dict: The generated response.
+        """
+        return await asyncio.to_thread(
+            self.generate_response, messages=messages, tools=tools, tool_choice=tool_choice, **kwargs
+        )
 
     def _get_common_params(self, **kwargs) -> Dict:
         """

--- a/mem0/llms/openai.py
+++ b/mem0/llms/openai.py
@@ -3,7 +3,7 @@ import logging
 import os
 from typing import Dict, List, Optional, Union
 
-from openai import OpenAI
+from openai import AsyncOpenAI, OpenAI
 
 from mem0.configs.llms.base import BaseLlmConfig
 from mem0.configs.llms.openai import OpenAIConfig
@@ -45,11 +45,18 @@ class OpenAILLM(LLMBase):
                 or os.getenv("OPENROUTER_API_BASE")
                 or "https://openrouter.ai/api/v1",
             )
+            self.async_client = AsyncOpenAI(
+                api_key=os.environ.get("OPENROUTER_API_KEY"),
+                base_url=self.config.openrouter_base_url
+                or os.getenv("OPENROUTER_API_BASE")
+                or "https://openrouter.ai/api/v1",
+            )
         else:
             api_key = self.config.api_key or os.getenv("OPENAI_API_KEY")
             base_url = self.config.openai_base_url or os.getenv("OPENAI_BASE_URL") or "https://api.openai.com/v1"
 
             self.client = OpenAI(api_key=api_key, base_url=base_url)
+            self.async_client = AsyncOpenAI(api_key=api_key, base_url=base_url)
 
     def _parse_response(self, response, tools):
         """
@@ -143,6 +150,71 @@ class OpenAILLM(LLMBase):
                 self.config.response_callback(self, response, params)
             except Exception as e:
                 # Log error but don't propagate
+                logging.error(f"Error due to callback: {e}")
+                pass
+        return parsed_response
+
+    async def agenerate_response(
+        self,
+        messages: List[Dict[str, str]],
+        response_format=None,
+        tools: Optional[List[Dict]] = None,
+        tool_choice: str = "auto",
+        **kwargs,
+    ):
+        """
+        Async version of generate_response using native AsyncOpenAI client.
+
+        Args:
+            messages (list): List of message dicts containing 'role' and 'content'.
+            response_format (str or object, optional): Format of the response. Defaults to "text".
+            tools (list, optional): List of tools that the model can call. Defaults to None.
+            tool_choice (str, optional): Tool choice method. Defaults to "auto".
+            **kwargs: Additional OpenAI-specific parameters.
+
+        Returns:
+            str or dict: The generated response.
+        """
+        params = self._get_supported_params(messages=messages, **kwargs)
+
+        params.update({
+            "model": self.config.model,
+            "messages": messages,
+        })
+
+        if os.getenv("OPENROUTER_API_KEY"):
+            openrouter_params = {}
+            if self.config.models:
+                openrouter_params["models"] = self.config.models
+                openrouter_params["route"] = self.config.route
+                params.pop("model")
+
+            if self.config.site_url and self.config.app_name:
+                extra_headers = {
+                    "HTTP-Referer": self.config.site_url,
+                    "X-Title": self.config.app_name,
+                }
+                openrouter_params["extra_headers"] = extra_headers
+
+            params.update(**openrouter_params)
+
+        else:
+            openai_specific_generation_params = ["store"]
+            for param in openai_specific_generation_params:
+                if hasattr(self.config, param):
+                    params[param] = getattr(self.config, param)
+
+        if response_format:
+            params["response_format"] = response_format
+        if tools:
+            params["tools"] = tools
+            params["tool_choice"] = tool_choice
+        response = await self.async_client.chat.completions.create(**params)
+        parsed_response = self._parse_response(response, tools)
+        if self.config.response_callback:
+            try:
+                self.config.response_callback(self, response, params)
+            except Exception as e:
                 logging.error(f"Error due to callback: {e}")
                 pass
         return parsed_response

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1636,8 +1636,7 @@ class AsyncMemory(MemoryBase):
         # Ensure 'json' appears in prompts for json_object response format compatibility
         system_prompt, user_prompt = ensure_json_instruction(system_prompt, user_prompt)
 
-        response = await asyncio.to_thread(
-            self.llm.generate_response,
+        response = await self.llm.agenerate_response(
             messages=[{"role": "system", "content": system_prompt}, {"role": "user", "content": user_prompt}],
             response_format={"type": "json_object"},
         )
@@ -1705,8 +1704,7 @@ class AsyncMemory(MemoryBase):
                 retrieved_old_memory, new_retrieved_facts, self.config.custom_update_memory_prompt
             )
             try:
-                response = await asyncio.to_thread(
-                    self.llm.generate_response,
+                response = await self.llm.agenerate_response(
                     messages=[{"role": "user", "content": function_calling_prompt}],
                     response_format={"type": "json_object"},
                 )
@@ -2426,7 +2424,7 @@ class AsyncMemory(MemoryBase):
                 response = await asyncio.to_thread(llm.invoke, input=parsed_messages)
                 procedural_memory = response.content
             else:
-                procedural_memory = await asyncio.to_thread(self.llm.generate_response, messages=parsed_messages)
+                procedural_memory = await self.llm.agenerate_response(messages=parsed_messages)
                 procedural_memory = remove_code_blocks(procedural_memory)
         
         except Exception as e:

--- a/tests/llms/test_base_async.py
+++ b/tests/llms/test_base_async.py
@@ -1,0 +1,33 @@
+import asyncio
+from typing import Dict, List, Optional
+from unittest.mock import patch
+
+import pytest
+
+from mem0.llms.base import LLMBase
+
+
+class DummyLLM(LLMBase):
+    """A concrete LLM subclass for testing the base class fallback."""
+
+    def generate_response(
+        self, messages: List[Dict[str, str]], tools: Optional[List[Dict]] = None, tool_choice: str = "auto", **kwargs
+    ):
+        return "sync response"
+
+
+@pytest.mark.asyncio
+async def test_base_agenerate_response_fallback():
+    """Test that the base class agenerate_response falls back to asyncio.to_thread."""
+    llm = DummyLLM(config={"model": "test-model"})
+
+    with patch("mem0.llms.base.asyncio.to_thread", return_value="sync response") as mock_to_thread:
+        mock_to_thread.return_value = "sync response"
+        # Make to_thread a coroutine
+        async def fake_to_thread(fn, **kwargs):
+            return fn(**kwargs)
+
+        with patch("mem0.llms.base.asyncio.to_thread", side_effect=fake_to_thread):
+            result = await llm.agenerate_response(messages=[{"role": "user", "content": "hi"}])
+
+    assert result == "sync response"

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -9,9 +9,11 @@ from mem0.llms.openai import OpenAILLM
 
 @pytest.fixture
 def mock_openai_client():
-    with patch("mem0.llms.openai.OpenAI") as mock_openai:
+    with patch("mem0.llms.openai.OpenAI") as mock_openai, \
+         patch("mem0.llms.openai.AsyncOpenAI") as mock_async_openai:
         mock_client = Mock()
         mock_openai.return_value = mock_client
+        mock_async_openai.return_value = Mock()
         yield mock_client
 
 

--- a/tests/llms/test_openai_async.py
+++ b/tests/llms/test_openai_async.py
@@ -1,0 +1,138 @@
+import asyncio
+import os
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from mem0.configs.llms.openai import OpenAIConfig
+from mem0.llms.openai import OpenAILLM
+
+
+@pytest.fixture
+def mock_openai_clients():
+    with patch("mem0.llms.openai.OpenAI") as mock_openai, \
+         patch("mem0.llms.openai.AsyncOpenAI") as mock_async_openai:
+        mock_client = Mock()
+        mock_openai.return_value = mock_client
+        mock_async_client = Mock()
+        mock_async_openai.return_value = mock_async_client
+        yield mock_client, mock_async_client
+
+
+@pytest.mark.asyncio
+async def test_agenerate_response_without_tools(mock_openai_clients):
+    _, mock_async_client = mock_openai_clients
+    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = OpenAILLM(config)
+
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello, how are you?"},
+    ]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="I'm doing well, thank you for asking!"))]
+    mock_async_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+    response = await llm.agenerate_response(messages)
+
+    mock_async_client.chat.completions.create.assert_called_once_with(
+        model="gpt-4.1-nano-2025-04-14", messages=messages, temperature=0.7, max_tokens=100, top_p=1.0, store=False
+    )
+    assert response == "I'm doing well, thank you for asking!"
+
+
+@pytest.mark.asyncio
+async def test_agenerate_response_with_tools(mock_openai_clients):
+    _, mock_async_client = mock_openai_clients
+    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = OpenAILLM(config)
+
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Add a new memory: Today is a sunny day."},
+    ]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "add_memory",
+                "description": "Add a memory",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"data": {"type": "string", "description": "Data to add to memory"}},
+                    "required": ["data"],
+                },
+            },
+        }
+    ]
+
+    mock_response = Mock()
+    mock_message = Mock()
+    mock_message.content = "I've added the memory for you."
+    mock_tool_call = Mock()
+    mock_tool_call.function.name = "add_memory"
+    mock_tool_call.function.arguments = '{"data": "Today is a sunny day."}'
+    mock_message.tool_calls = [mock_tool_call]
+    mock_response.choices = [Mock(message=mock_message)]
+    mock_async_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+    response = await llm.agenerate_response(messages, tools=tools)
+
+    mock_async_client.chat.completions.create.assert_called_once_with(
+        model="gpt-4.1-nano-2025-04-14", messages=messages, temperature=0.7, max_tokens=100, top_p=1.0,
+        tools=tools, tool_choice="auto", store=False
+    )
+    assert response["content"] == "I've added the memory for you."
+    assert len(response["tool_calls"]) == 1
+    assert response["tool_calls"][0]["name"] == "add_memory"
+    assert response["tool_calls"][0]["arguments"] == {"data": "Today is a sunny day."}
+
+
+@pytest.mark.asyncio
+async def test_agenerate_response_with_response_format(mock_openai_clients):
+    _, mock_async_client = mock_openai_clients
+    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = OpenAILLM(config)
+
+    messages = [{"role": "user", "content": "Return JSON"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content='{"key": "value"}'))]
+    mock_async_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+    response = await llm.agenerate_response(messages, response_format={"type": "json_object"})
+
+    call_kwargs = mock_async_client.chat.completions.create.call_args[1]
+    assert call_kwargs["response_format"] == {"type": "json_object"}
+    assert response == '{"key": "value"}'
+
+
+@pytest.mark.asyncio
+async def test_agenerate_uses_async_client_not_sync(mock_openai_clients):
+    """Verify that agenerate_response uses async_client, not the sync client."""
+    mock_sync_client, mock_async_client = mock_openai_clients
+    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = OpenAILLM(config)
+
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Hi"))]
+    mock_async_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+    await llm.agenerate_response(messages)
+
+    # Async client should be called
+    mock_async_client.chat.completions.create.assert_called_once()
+    # Sync client should NOT be called
+    mock_sync_client.chat.completions.create.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_client_initialized(mock_openai_clients):
+    """Verify that both sync and async clients are initialized."""
+    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", api_key="test-key")
+    llm = OpenAILLM(config)
+    assert hasattr(llm, 'client')
+    assert hasattr(llm, 'async_client')


### PR DESCRIPTION
## Summary

- Add `agenerate_response()` async method to `LLMBase` with `asyncio.to_thread` fallback for providers that don't have native async clients
- Implement `agenerate_response()` in `OpenAILLM` using the `AsyncOpenAI` client for true async I/O
- Update `AsyncMemory` to call `llm.agenerate_response()` directly instead of wrapping sync calls with `asyncio.to_thread`

## Motivation

`AsyncMemory` was wrapping synchronous `OpenAI` client calls via `asyncio.to_thread(self.llm.generate_response, ...)`, which runs the LLM call in a thread pool rather than using true async I/O. The `openai` Python library provides `AsyncOpenAI` specifically for this purpose.

## Changes

| File | Change |
|------|--------|
| `mem0/llms/base.py` | Added `agenerate_response()` with `asyncio.to_thread` fallback |
| `mem0/llms/openai.py` | Added `AsyncOpenAI` client + native `agenerate_response()` |
| `mem0/memory/main.py` | Replaced 3 `asyncio.to_thread(self.llm.generate_response, ...)` calls with `self.llm.agenerate_response(...)` |
| `tests/llms/test_openai.py` | Updated fixture to also mock `AsyncOpenAI` |
| `tests/llms/test_openai_async.py` | New tests for async OpenAI LLM |
| `tests/llms/test_base_async.py` | New test for base class fallback |

## Backward compatibility

- `generate_response()` is unchanged — all sync usage works exactly as before
- Non-OpenAI providers automatically get `asyncio.to_thread` fallback via `LLMBase.agenerate_response()`, so `AsyncMemory` continues to work with all providers
- Other `asyncio.to_thread` calls in `AsyncMemory` (for embeddings, vector store, graph, etc.) are left untouched — this PR focuses only on LLM calls

## Test plan

- [x] All 11 existing `test_openai.py` tests pass
- [x] 5 new async OpenAI tests pass (with/without tools, response format, client isolation)
- [x] 1 new base class fallback test passes

Closes #3781

🤖 Generated with [Claude Code](https://claude.com/claude-code)