### PR TITLE
fix: remove npm self-upgrade from CD workflows

### DIFF
--- a/.github/workflows/cli-node-cd.yml
+++ b/.github/workflows/cli-node-cd.yml
@@ -30,9 +30,6 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: cli/node/pnpm-lock.yaml
 
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/openclaw-cd.yml
+++ b/.github/workflows/openclaw-cd.yml
@@ -30,9 +30,6 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: openclaw/pnpm-lock.yaml
 
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/ts-sdk-cd.yml
+++ b/.github/workflows/ts-sdk-cd.yml
@@ -30,9 +30,6 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: mem0-ts/pnpm-lock.yaml
 
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/vercel-ai-cd.yml
+++ b/.github/workflows/vercel-ai-cd.yml
@@ -30,9 +30,6 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: vercel-ai-sdk/pnpm-lock.yaml
 
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Linked Issue

N/A — CI failure observed during release pipeline runs.

## Description

Removes the `npm install -g npm@latest` step from all 4 CD workflows (`ts-sdk-cd`, `cli-node-cd`, `vercel-ai-cd`, `openclaw-cd`).

This step causes an intermittent `MODULE_NOT_FOUND: Cannot find module 'promise-retry'` crash because npm deletes its own `node_modules` mid-install when upgrading itself globally. Node.js 22 already ships with npm 10.x which has full support for `--provenance` and OIDC trusted publishing, so the upgrade is unnecessary.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Verified that Node 22's bundled npm (`npm --version` → 10.9+) supports `--provenance` and OIDC publishing natively. The removed step was the sole cause of the `MODULE_NOT_FOUND` CI failures.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed