### PR TITLE
fix: use npx npm@latest for OIDC trusted publishing

### DIFF
--- a/.github/workflows/cli-node-cd.yml
+++ b/.github/workflows/cli-node-cd.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           if [ "${{ github.event.release.prerelease }}" = "true" ]; then
             PREID=$(node -p "require('./package.json').version.split('-')[1].split('.')[0]")
-            npm publish --provenance --access public --tag "$PREID"
+            npx npm@latest publish --provenance --access public --tag "$PREID"
           else
-            npm publish --provenance --access public
+            npx npm@latest publish --provenance --access public
           fi

--- a/.github/workflows/openclaw-cd.yml
+++ b/.github/workflows/openclaw-cd.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           if [ "${{ github.event.release.prerelease }}" = "true" ]; then
             PREID=$(node -p "require('./package.json').version.split('-')[1].split('.')[0]")
-            npm publish --provenance --access public --tag "$PREID"
+            npx npm@latest publish --provenance --access public --tag "$PREID"
           else
-            npm publish --provenance --access public
+            npx npm@latest publish --provenance --access public
           fi

--- a/.github/workflows/ts-sdk-cd.yml
+++ b/.github/workflows/ts-sdk-cd.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           if [ "${{ github.event.release.prerelease }}" = "true" ]; then
             PREID=$(node -p "require('./package.json').version.split('-')[1].split('.')[0]")
-            npm publish --provenance --access public --tag "$PREID"
+            npx npm@latest publish --provenance --access public --tag "$PREID"
           else
-            npm publish --provenance --access public
+            npx npm@latest publish --provenance --access public
           fi

--- a/.github/workflows/vercel-ai-cd.yml
+++ b/.github/workflows/vercel-ai-cd.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           if [ "${{ github.event.release.prerelease }}" = "true" ]; then
             PREID=$(node -p "require('./package.json').version.split('-')[1].split('.')[0]")
-            npm publish --provenance --access public --tag "$PREID"
+            npx npm@latest publish --provenance --access public --tag "$PREID"
           else
-            npm publish --provenance --access public
+            npx npm@latest publish --provenance --access public
           fi


### PR DESCRIPTION
## Linked Issue

Closes #<!-- follow-up to PR #4723 -->

## Description

Replaces `npm publish` with `npx npm@latest publish` in all 4 CD workflows (`ts-sdk-cd`, `cli-node-cd`, `vercel-ai-cd`, `openclaw-cd`).

After removing the broken `npm install -g npm@latest` step in #4723, the bundled npm in Node 22 fails OIDC trusted publishing with `E404 Not Found`. The bundled npm reads the empty `NODE_AUTH_TOKEN` placeholder from `actions/setup-node`'s `.npmrc` and sends it as a bearer token instead of falling back to OIDC authentication. Using `npx npm@latest` runs the latest npm transiently — no global install corruption, and proper OIDC tokenless publishing support.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Verified that `npx npm@latest publish --provenance --access public` correctly uses OIDC authentication when `NODE_AUTH_TOKEN` is unset, while the bundled `npm publish` falls back to the empty token and returns E404.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed