### PR TITLE
ci: add concurrency with cancel-in-progress to all CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: ci
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/cli-node-ci.yml
+++ b/.github/workflows/cli-node-ci.yml
@@ -1,5 +1,9 @@
 name: CLI Node CI
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/cli-python-ci.yml
+++ b/.github/workflows/cli-python-ci.yml
@@ -1,5 +1,9 @@
 name: CLI Python CI
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/openclaw-checks.yml
+++ b/.github/workflows/openclaw-checks.yml
@@ -1,5 +1,9 @@
 name: openclaw checks
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/ts-sdk-ci.yml
+++ b/.github/workflows/ts-sdk-ci.yml
@@ -1,5 +1,9 @@
 name: TypeScript SDK CI
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary

- Adds `concurrency` with `cancel-in-progress: true` to all 5 CI workflows
- Superseded PR runs are automatically cancelled, saving runner minutes
- Push-to-main runs are not affected (each gets a unique concurrency group)

## Problem

None of the CI workflows (`ci`, `CLI Node CI`, `CLI Python CI`, `openclaw checks`, `TypeScript SDK CI`) define a `concurrency` group. When multiple commits are pushed to a PR branch in quick succession, every push triggers a full CI run. Earlier runs continue to completion even though their results are irrelevant — the PR will show the latest run's status regardless.

This wastes GitHub Actions runner minutes on every PR that receives rapid pushes (force-pushes after review feedback, quick iteration, etc.).

## Fix

Added a `concurrency` block to each workflow:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
  cancel-in-progress: true
```

The group key uses `github.head_ref` for PR-triggered runs (so all runs for the same PR branch share a group) and falls back to `github.run_id` for push-to-main runs (so each main branch run gets its own unique group and is never cancelled).

## Verification

1. Push two commits quickly to a PR branch — first run should be cancelled, only the second completes
2. Push to `main` — run should complete normally (not cancelled)

---

> [!NOTE]
> Created by [Mendral](https://mendral.com). Tag @mendral-agent with feedback or questions.