### PR TITLE
ci: fix pip caching in ci.yml by using setup-python built-in cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       - name: Clean up disk space
         run: |
           df -h
@@ -57,12 +58,6 @@ jobs:
           df -h
       - name: Install Hatch
         run: pip install hatch
-      - name: Load cached venv
-        id: cached-hatch-dependencies
-        uses: actions/cache@v3
-        with:
-          path: .venv
-          key: venv-mem0-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
       - name: Install GEOS Libraries
         run: sudo apt-get update && sudo apt-get install -y libgeos-dev
       - name: Install dependencies
@@ -70,7 +65,6 @@ jobs:
           pip install --upgrade pip
           pip install -e ".[test,graph,vector_stores,llms,extras]"
           pip install ruff
-        if: steps.cached-hatch-dependencies.outputs.cache-hit != 'true'
       - name: Run Linting
         run: make lint
       - name: Run tests and generate coverage report
@@ -89,17 +83,11 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       - name: Install Hatch
         run: pip install hatch
-      - name: Load cached venv
-        id: cached-hatch-dependencies
-        uses: actions/cache@v3
-        with:
-          path: .venv
-          key: venv-embedchain-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
       - name: Install dependencies
         run: cd embedchain && make install_all
-        if: steps.cached-hatch-dependencies.outputs.cache-hit != 'true'
       - name: Run Formatting
         run: |
           mkdir -p embedchain/.ruff_cache && chmod -R 777 embedchain/.ruff_cache


### PR DESCRIPTION
## Summary

- Replaces broken `actions/cache` steps with `setup-python`'s built-in `cache: 'pip'`
- Removes stale cache-hit guards that caused dependency installs to be skipped incorrectly
- Affects both `build_mem0` and `build_embedchain` jobs

## Problem

Both CI jobs in `ci.yml` cache `.venv` (via `actions/cache@v3`) but install dependencies into the system Python with `pip install`, not into a virtualenv. The cache path and the install target are mismatched, so the cache provides zero benefit — every run re-downloads and installs all dependencies from scratch.

Worse, the `build_mem0` job guards its `Install dependencies` step with `if: steps.cached-hatch-dependencies.outputs.cache-hit != 'true'`. If the cache step ever reports a false hit (stale `.venv` directory exists), the entire dependency install is skipped, which can cause test failures from missing packages.

The same pattern exists in `build_embedchain` (cache at lines 96-100, guard at line 102).

## Fix

- Added `cache: 'pip'` to `actions/setup-python` in both jobs. This uses setup-python's built-in pip download cache, which caches the correct thing (pip's download cache directory) and works regardless of whether you use venvs or system installs.
- Removed the `actions/cache@v3` steps that cached `.venv` (never useful).
- Removed the `if: steps.cached-hatch-dependencies.outputs.cache-hit != 'true'` guard on dependency install steps so dependencies are always installed (pip is fast on cache hit — it just verifies packages are already installed).

## Verification

1. Run the CI workflow and check the `Set up Python` step for "Cache hit" or "Cache miss" messages from setup-python's built-in caching
2. On a second run with the same pyproject.toml, confirm pip cache is hit and install completes faster
3. Verify all tests still pass (no missing dependencies)

---

> [!NOTE]
> Created by [Mendral](https://mendral.com). Tag @mendral-agent with feedback or questions.