### PR TITLE
fix(ollama): deep-copy messages to prevent in-place mutation

### DIFF
--- a/mem0/llms/ollama.py
+++ b/mem0/llms/ollama.py
@@ -1,3 +1,4 @@
+import copy
 import json
 from typing import Dict, List, Optional, Union
 
@@ -119,7 +120,10 @@ class OllamaLLM(LLMBase):
         # Handle JSON response format by using Ollama's native format parameter
         if response_format and response_format.get("type") == "json_object":
             params["format"] = "json"
-            # Also add JSON format instruction to the last message as a fallback
+            # Add JSON format instruction to the last message as a fallback.
+            # Work on a copy to avoid mutating the caller's messages list.
+            messages = copy.deepcopy(messages)
+            params["messages"] = messages
             if messages and messages[-1]["role"] == "user":
                 messages[-1]["content"] += "\n\nPlease respond with valid JSON only."
             else:

--- a/tests/llms/test_ollama.py
+++ b/tests/llms/test_ollama.py
@@ -140,3 +140,23 @@ def test_parse_response_with_tools_object_style(mock_ollama_client):
     result = llm._parse_response(mock_response, tools)
 
     assert result["tool_calls"] == [{"name": "extract", "arguments": {"entities": ["Alice"]}}]
+
+
+def test_generate_response_json_format_does_not_mutate_messages(mock_ollama_client):
+    """Requesting JSON response_format must not modify the caller's messages list."""
+    config = OllamaConfig(model="llama3.1:70b", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = OllamaLLM(config)
+    messages = [
+        {"role": "user", "content": "Give me a list of colors"},
+    ]
+    original_content = messages[0]["content"]
+    original_length = len(messages)
+
+    mock_response = {"message": {"content": '{"colors": ["red"]}'}}
+    mock_ollama_client.chat.return_value = mock_response
+
+    llm.generate_response(messages, response_format={"type": "json_object"})
+
+    # Caller's messages must be untouched
+    assert len(messages) == original_length
+    assert messages[0]["content"] == original_content

--- a/tests/llms/test_ollama.py
+++ b/tests/llms/test_ollama.py
@@ -160,3 +160,9 @@ def test_generate_response_json_format_does_not_mutate_messages(mock_ollama_clie
     # Caller's messages must be untouched
     assert len(messages) == original_length
     assert messages[0]["content"] == original_content
+
+    # Verify behavior is preserved — Ollama still receives the JSON instruction
+    call_kwargs = mock_ollama_client.chat.call_args[1]
+    sent_messages = call_kwargs["messages"]
+    assert "json" in call_kwargs.get("format", "")
+    assert "Please respond with valid JSON only." in sent_messages[-1]["content"]


### PR DESCRIPTION
## Linked Issue

Related to data integrity concerns in the Ollama LLM provider.

## Description

`OllamaLLM.generate_response()` mutated the caller's messages list in-place when `response_format={"type": "json_object"}` was requested. It appended JSON instruction text to `messages[-1]["content"]` and could append a new message to the list. Any code reusing the messages list after the call would see corrupted data.

## Root Cause

```python
# Before — mutates caller's list
if messages and messages[-1]["role"] == "user":
    messages[-1]["content"] += "\n\nPlease respond with valid JSON only."
```

## Fix

Deep-copy messages before modification and rebind `params["messages"]` to the copy:

```python
messages = copy.deepcopy(messages)
params["messages"] = messages
```

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test Coverage

- [x] I added/updated unit tests

Added `test_generate_response_json_format_does_not_mutate_messages` which verifies:
1. Caller's messages list length is unchanged after the call
2. Caller's message content is unchanged
3. Ollama client still receives the `format=json` param
4. Ollama client still receives the JSON instruction in the copied messages

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed