### PR TITLE
fix(llms): remove dead validation + add reasoning model compat to OpenAIStructuredLLM

### DIFF
--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -35,11 +35,6 @@ class LLMBase(ABC):
         if not hasattr(self.config, "model"):
             raise ValueError("Configuration must have a 'model' attribute")
 
-        if not hasattr(self.config, "api_key") and not hasattr(self.config, "api_key"):
-            # Check if API key is available via environment variable
-            # This will be handled by individual providers
-            pass
-
     def _is_reasoning_model(self, model: str) -> bool:
         """
         Check if the model is a reasoning model or GPT-5 series that doesn't support certain parameters.

--- a/mem0/llms/openai_structured.py
+++ b/mem0/llms/openai_structured.py
@@ -36,17 +36,15 @@ class OpenAIStructuredLLM(LLMBase):
         Returns:
             str: The generated response.
         """
-        params = {
-            "model": self.config.model,
-            "messages": messages,
-            "temperature": self.config.temperature,
-        }
-
-        if response_format:
-            params["response_format"] = response_format
-        if tools:
-            params["tools"] = tools
-            params["tool_choice"] = tool_choice
+        params = self._get_supported_params(
+            messages=messages,
+            temperature=self.config.temperature,
+            response_format=response_format,
+            tools=tools,
+            tool_choice=tool_choice if tools else None,
+        )
+        # model must always be present regardless of reasoning model filtering
+        params["model"] = self.config.model
 
         response = self.client.beta.chat.completions.parse(**params)
         return response.choices[0].message.content

--- a/mem0/llms/openai_structured.py
+++ b/mem0/llms/openai_structured.py
@@ -36,15 +36,22 @@ class OpenAIStructuredLLM(LLMBase):
         Returns:
             str: The generated response.
         """
+        optional = {}
+        if response_format:
+            optional["response_format"] = response_format
+        if tools:
+            optional["tools"] = tools
+            optional["tool_choice"] = tool_choice
+
         params = self._get_supported_params(
             messages=messages,
             temperature=self.config.temperature,
-            response_format=response_format,
-            tools=tools,
-            tool_choice=tool_choice if tools else None,
+            **optional,
         )
         # model must always be present regardless of reasoning model filtering
         params["model"] = self.config.model
+        # Strip any remaining None values to avoid sending them to the API
+        params = {k: v for k, v in params.items() if v is not None}
 
         response = self.client.beta.chat.completions.parse(**params)
         return response.choices[0].message.content

--- a/tests/llms/test_openai_structured.py
+++ b/tests/llms/test_openai_structured.py
@@ -1,0 +1,49 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mem0.configs.llms.base import BaseLlmConfig
+from mem0.llms.openai_structured import OpenAIStructuredLLM
+
+
+@pytest.fixture
+def mock_openai_client():
+    with patch("mem0.llms.openai_structured.OpenAI") as mock_openai:
+        mock_client = Mock()
+        mock_openai.return_value = mock_client
+        yield mock_client
+
+
+def test_reasoning_model_strips_temperature(mock_openai_client):
+    """Reasoning models (o3) should not receive temperature param."""
+    config = BaseLlmConfig(model="o3", api_key="test")
+    llm = OpenAIStructuredLLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Response"))]
+    mock_openai_client.beta.chat.completions.parse.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    call_kwargs = mock_openai_client.beta.chat.completions.parse.call_args[1]
+    assert "temperature" not in call_kwargs
+    assert call_kwargs["model"] == "o3"
+    assert call_kwargs["messages"] == messages
+
+
+def test_regular_model_includes_temperature(mock_openai_client):
+    """Regular models should receive temperature param."""
+    config = BaseLlmConfig(model="gpt-4o-2024-08-06", temperature=0.5, api_key="test")
+    llm = OpenAIStructuredLLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Response"))]
+    mock_openai_client.beta.chat.completions.parse.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    call_kwargs = mock_openai_client.beta.chat.completions.parse.call_args[1]
+    assert call_kwargs["temperature"] == 0.5
+    assert call_kwargs["model"] == "gpt-4o-2024-08-06"


### PR DESCRIPTION
## Linked Issue

Addresses LLM provider code quality and reasoning model compatibility.

## Description

Two fixes in the LLM provider layer:

### 1. Dead code removal in `base.py`

`_validate_config()` had a duplicate condition that checked the same attribute twice:

```python
if not hasattr(self.config, "api_key") and not hasattr(self.config, "api_key"):
    pass
```

This was dead code — removed entirely.

### 2. Reasoning model compatibility in `openai_structured.py`

`OpenAIStructuredLLM` passed `temperature` directly to the API without filtering. Reasoning models (o1, o3) don't support `temperature` and reject the request. All other providers use `_get_supported_params()` which strips unsupported params for reasoning models — now `OpenAIStructuredLLM` follows the same pattern.

Also strips `None` values from params to avoid sending unset optional fields to the API.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test Coverage

- [x] I added/updated unit tests

Added `tests/llms/test_openai_structured.py` with:
- `test_reasoning_model_strips_temperature` — verifies o3 does NOT receive temperature
- `test_regular_model_includes_temperature` — verifies gpt-4o does receive temperature

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed