### PR TITLE
fix: only send store when explicitly configured

### DIFF
--- a/mem0/configs/llms/openai.py
+++ b/mem0/configs/llms/openai.py
@@ -29,7 +29,7 @@ class OpenAIConfig(BaseLlmConfig):
         openrouter_base_url: Optional[str] = None,
         site_url: Optional[str] = None,
         app_name: Optional[str] = None,
-        store: bool = False,
+        store: Optional[bool] = None,
         # Response monitoring callback
         response_callback: Optional[Callable[[Any, dict, dict], None]] = None,
     ):
@@ -53,6 +53,7 @@ class OpenAIConfig(BaseLlmConfig):
             openrouter_base_url: OpenRouter base URL, defaults to None
             site_url: Site URL for OpenRouter, defaults to None
             app_name: Application name for OpenRouter, defaults to None
+            store: Whether to persist OpenAI responses when the backend supports it, defaults to None
             response_callback: Optional callback for monitoring LLM responses.
         """
         # Initialize base parameters

--- a/mem0/llms/openai.py
+++ b/mem0/llms/openai.py
@@ -126,10 +126,8 @@ class OpenAILLM(LLMBase):
             params.update(**openrouter_params)
         
         else:
-            openai_specific_generation_params = ["store"]
-            for param in openai_specific_generation_params:
-                if hasattr(self.config, param):
-                    params[param] = getattr(self.config, param)
+            if self.config.store is not None:
+                params["store"] = self.config.store
             
         if response_format:
             params["response_format"] = response_format

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -55,7 +55,7 @@ def test_generate_response_without_tools(mock_openai_client):
     response = llm.generate_response(messages)
 
     mock_openai_client.chat.completions.create.assert_called_once_with(
-        model="gpt-4.1-nano-2025-04-14", messages=messages, temperature=0.7, max_tokens=100, top_p=1.0, store=False
+        model="gpt-4.1-nano-2025-04-14", messages=messages, temperature=0.7, max_tokens=100, top_p=1.0
     )
     assert response == "I'm doing well, thank you for asking!"
 
@@ -97,7 +97,7 @@ def test_generate_response_with_tools(mock_openai_client):
     response = llm.generate_response(messages, tools=tools)
 
     mock_openai_client.chat.completions.create.assert_called_once_with(
-        model="gpt-4.1-nano-2025-04-14", messages=messages, temperature=0.7, max_tokens=100, top_p=1.0, tools=tools, tool_choice="auto", store=False
+        model="gpt-4.1-nano-2025-04-14", messages=messages, temperature=0.7, max_tokens=100, top_p=1.0, tools=tools, tool_choice="auto"
     )
 
     assert response["content"] == "I've added the memory for you."
@@ -168,6 +168,22 @@ def test_callback_exception_handling(mock_openai_client):
     
     # Verify callback was called (even though it raised an exception)
     assert llm.config.response_callback is faulty_callback
+
+
+def test_generate_response_includes_store_when_explicitly_configured(mock_openai_client):
+    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", store=False)
+    llm = OpenAILLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Response"))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    call_kwargs = mock_openai_client.chat.completions.create.call_args[1]
+    assert call_kwargs["store"] is False
+
 
 
 def test_reasoning_model_with_reasoning_effort(mock_openai_client):


### PR DESCRIPTION
## Summary
- make `OpenAIConfig.store` opt-in by defaulting it to `None`
- only forward `store` to the OpenAI client when users explicitly configure it
- update OpenAI LLM tests to cover the new default behavior and the explicit `store=False` path

## Testing
- `python3 -m pytest tests/llms/test_openai.py -q`

## Why
OpenAI-compatible backends like Gemini reject the OpenAI-only `store` field. Before this change, mem0 always injected `store=False` because the config field always existed, even when users never asked for it.

Closes #4709.
