### PR TITLE
fix qdrant memory count in openclaw

### DIFF
--- a/openclaw/cli/commands.ts
+++ b/openclaw/cli/commands.ts
@@ -36,6 +36,7 @@ import type {
   MemoryItem,
   SearchOptions,
 } from "../types.ts";
+import { buildQdrantCountRequest, countMemories } from "../providers.ts";
 import { loadDreamPrompt } from "../skill-loader.ts";
 import { readText } from "../fs-safe.ts";
 import type { PluginAuthConfig } from "./config-file.ts";
@@ -1387,13 +1388,27 @@ export function registerCliCommands(
         .action(async (opts: { dryRun?: boolean }) => {
           try {
             const uid = cfg.userId;
+            const qdrantExactCountAvailable =
+              buildQdrantCountRequest(cfg, uid) !== null;
+            const count = qdrantExactCountAvailable
+              ? await countMemories(provider, cfg, {
+                  userId: uid,
+                  source: "OPENCLAW",
+                })
+              : null;
             const memories = await provider.getAll({
               user_id: uid,
               source: "OPENCLAW",
+              ...(typeof count === "number" ? { page_size: count } : {}),
             });
-            const count = Array.isArray(memories) ? memories.length : 0;
+            const effectiveCount =
+              typeof count === "number"
+                ? count
+                : Array.isArray(memories)
+                  ? memories.length
+                  : 0;
 
-            if (count === 0) {
+            if (effectiveCount === 0) {
               console.log("No memories to consolidate.");
               return;
             }
@@ -1412,7 +1427,7 @@ export function registerCliCommands(
             )) {
               process.stderr.write(`  ${cat}: ${num}\n`);
             }
-            process.stderr.write(`  TOTAL: ${count}\n\n`);
+            process.stderr.write(`  TOTAL: ${effectiveCount}\n\n`);
 
             if (opts.dryRun) {
               process.stderr.write("Dry run — no changes made.\n");
@@ -1444,7 +1459,7 @@ export function registerCliCommands(
               dreamPrompt,
               "</dream-protocol>",
               "",
-              `<all-memories count="${count}" user="${uid}">`,
+              `<all-memories count="${effectiveCount}" user="${uid}">`,
               memoryDump,
               "</all-memories>",
               "",

--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -25,7 +25,11 @@ import type {
   AddOptions,
   SearchOptions,
 } from "./types.ts";
-import { createProvider, providerToBackend } from "./providers.ts";
+import {
+  createProvider,
+  providerToBackend,
+  countMemories,
+} from "./providers.ts";
 import { mem0ConfigSchema } from "./config.ts";
 import type { FileConfig } from "./config.ts";
 import { filterMessagesForExtraction } from "./filtering.ts";
@@ -454,11 +458,10 @@ function registerHooks(
           );
           if (cheapResult.proceed) {
             // Cheap gates passed. Now do the expensive memory count check.
-            const memories = await provider.getAll({
-              user_id: userId,
+            const memCount = await countMemories(provider, cfg, {
+              userId,
               source: "OPENCLAW",
             });
-            const memCount = Array.isArray(memories) ? memories.length : 0;
             const memResult = checkMemoryGate(
               memCount,
               cfg.skills?.dream ?? {},

--- a/openclaw/providers.ts
+++ b/openclaw/providers.ts
@@ -17,6 +17,12 @@ import type {
 // Result Normalizers
 // ============================================================================
 
+interface QdrantCountRequest {
+  url: string;
+  headers: Record<string, string>;
+  body: string;
+}
+
 function normalizeMemoryItem(raw: any): MemoryItem {
   return {
     id: raw.id ?? raw.memory_id ?? "",
@@ -69,6 +75,111 @@ function normalizeAddResult(raw: any): AddResult {
     };
   }
   return { results: [] };
+}
+
+function readStringConfigValue(
+  config: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = config?.[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readPortConfigValue(
+  config: Record<string, unknown> | undefined,
+  key: string,
+): number | undefined {
+  const value = config?.[key];
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return Math.floor(value);
+  }
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return undefined;
+}
+
+export function buildQdrantCountRequest(
+  cfg: Mem0Config,
+  userId: string,
+): QdrantCountRequest | null {
+  if (cfg.mode !== "open-source") return null;
+  if (cfg.oss?.vectorStore?.provider !== "qdrant") return null;
+
+  const vectorConfig =
+    cfg.oss.vectorStore.config as Record<string, unknown> | undefined;
+  const collectionName = readStringConfigValue(vectorConfig, "collectionName");
+  if (!collectionName) return null;
+
+  const explicitUrl = readStringConfigValue(vectorConfig, "url");
+  const apiKey = readStringConfigValue(vectorConfig, "apiKey");
+  const baseUrl = (() => {
+    if (explicitUrl) return explicitUrl.replace(/\/+$/, "");
+    const host = readStringConfigValue(vectorConfig, "host") ?? "127.0.0.1";
+    const port = readPortConfigValue(vectorConfig, "port") ?? 6333;
+    const protocol = vectorConfig?.https === true ? "https" : "http";
+    return `${protocol}://${host}:${port}`;
+  })();
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (apiKey) headers["api-key"] = apiKey;
+
+  return {
+    url: `${baseUrl}/collections/${encodeURIComponent(collectionName)}/points/count`,
+    headers,
+    body: JSON.stringify({
+      exact: true,
+      filter: {
+        must: [{ key: "userId", match: { value: userId } }],
+      },
+    }),
+  };
+}
+
+async function countMemoriesWithQdrant(
+  cfg: Mem0Config,
+  userId: string,
+): Promise<number | null> {
+  const request = buildQdrantCountRequest(cfg, userId);
+  if (!request) return null;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5000);
+  try {
+    const response = await fetch(request.url, {
+      method: "POST",
+      headers: request.headers,
+      body: request.body,
+      signal: controller.signal,
+    });
+    if (!response.ok) return null;
+    const payload = await response.json();
+    return typeof payload?.result?.count === "number"
+      ? payload.result.count
+      : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function countMemories(
+  provider: Mem0Provider,
+  cfg: Mem0Config,
+  options: { userId: string; source?: string },
+): Promise<number> {
+  const exactCount = await countMemoriesWithQdrant(cfg, options.userId);
+  if (typeof exactCount === "number") return exactCount;
+
+  const memories = await provider.getAll({
+    user_id: options.userId,
+    ...(options.source ? { source: options.source } : {}),
+  });
+  return Array.isArray(memories) ? memories.length : 0;
 }
 
 // ============================================================================
@@ -400,6 +511,7 @@ class OSSProvider implements Mem0Provider {
     // OSS SDK uses camelCase: userId/runId, not user_id/run_id
     const getAllOpts: Record<string, unknown> = { userId: options.user_id };
     if (options.run_id) getAllOpts.runId = options.run_id;
+    if (options.page_size != null) getAllOpts.limit = options.page_size;
     if (options.source) getAllOpts.source = options.source;
     const results = await this.memory.getAll(getAllOpts);
     if (Array.isArray(results)) return results.map(normalizeMemoryItem);

--- a/openclaw/sqlite-resilience.test.ts
+++ b/openclaw/sqlite-resilience.test.ts
@@ -58,6 +58,7 @@ describe("OSSProvider — disableHistory passthrough to Memory", () => {
   let memoryCallCount: number;
 
   beforeEach(() => {
+    vi.resetModules();
     capturedConfig = undefined;
     memoryCallCount = 0;
 
@@ -129,6 +130,7 @@ describe("OSSProvider — initPromise retry after failure", () => {
   let callCount: number;
 
   beforeEach(() => {
+    vi.resetModules();
     callCount = 0;
 
     vi.doMock("mem0ai/oss", () => ({
@@ -186,6 +188,7 @@ describe("OSSProvider — graceful SQLite fallback", () => {
   let capturedConfigs: Record<string, unknown>[];
 
   beforeEach(() => {
+    vi.resetModules();
     capturedConfigs = [];
 
     vi.doMock("mem0ai/oss", () => ({
@@ -273,6 +276,7 @@ describe("PlatformProvider — initPromise retry after failure", () => {
   let callCount: number;
 
   beforeEach(() => {
+    vi.resetModules();
     callCount = 0;
 
     vi.doMock("mem0ai", () => ({

--- a/openclaw/tests/cli-commands.test.ts
+++ b/openclaw/tests/cli-commands.test.ts
@@ -168,7 +168,7 @@ function createMockBackend() {
   };
 }
 
-function createMockCfg() {
+function createMockCfg(overrides: Record<string, unknown> = {}) {
   return {
     mode: "platform" as const,
     userId: "testuser",
@@ -182,6 +182,7 @@ function createMockCfg() {
     customInstructions: "",
     customCategories: {},
     skills: {},
+    ...overrides,
   };
 }
 
@@ -189,10 +190,10 @@ function createMockCfg() {
  * Register CLI commands using mocked deps, and return the captured
  * mem0 command tree plus all mock objects for assertions.
  */
-function setup() {
+function setup(cfgOverrides: Record<string, unknown> = {}) {
   const provider = createMockProvider();
   const backend = createMockBackend();
-  const cfg = createMockCfg();
+  const cfg = createMockCfg(cfgOverrides);
   const effectiveUserId = vi.fn().mockReturnValue("testuser");
   const agentUserId = vi.fn((id: string) => `testuser:agent:${id}`);
   const buildSearchOptions = vi.fn().mockReturnValue({
@@ -275,6 +276,7 @@ describe("registerCliCommands", () => {
     consoleSpy.error.mockRestore();
     consoleSpy.warn.mockRestore();
     stderrSpy.mockRestore();
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
@@ -1182,6 +1184,49 @@ describe("registerCliCommands", () => {
       expect(stdoutOutput).toContain("dream prompt");
       expect(stdoutOutput).toContain("<all-memories");
       expect(stdoutOutput).toContain("User is an engineer");
+
+      stdoutSpy.mockRestore();
+    });
+
+    it("uses qdrant exact count to request the full memory inventory", async () => {
+      const { mem0, provider } = setup({
+        mode: "open-source",
+        oss: {
+          vectorStore: {
+            provider: "qdrant",
+            config: {
+              host: "127.0.0.1",
+              port: 6333,
+              collectionName: "openclaw_mem0",
+            },
+          },
+        },
+      });
+      provider.getAll.mockResolvedValueOnce([
+        {
+          id: "m1",
+          memory: "User is an engineer",
+          categories: ["identity"],
+          metadata: { category: "identity", importance: 0.9 },
+          created_at: "2026-01-01",
+        },
+      ]);
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ result: { count: 337 } }),
+      }));
+      const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+      const dreamCmd = findCommand(mem0, "dream")!;
+
+      await dreamCmd._action!({});
+
+      expect(provider.getAll).toHaveBeenCalledWith({
+        user_id: "testuser",
+        source: "OPENCLAW",
+        page_size: 337,
+      });
+      const stdoutOutput = stdoutSpy.mock.calls.map((c) => c[0]).join("");
+      expect(stdoutOutput).toContain('<all-memories count="337" user="testuser">');
 
       stdoutSpy.mockRestore();
     });

--- a/openclaw/tests/providers.test.ts
+++ b/openclaw/tests/providers.test.ts
@@ -4,9 +4,13 @@
  * Verifies that the Backend wrapper correctly delegates to the
  * underlying Mem0Provider methods with proper argument mapping.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-import { providerToBackend } from "../providers.ts";
+import {
+  buildQdrantCountRequest,
+  countMemories,
+  providerToBackend,
+} from "../providers.ts";
 
 // ---------------------------------------------------------------------------
 // Mock provider factory
@@ -33,8 +37,113 @@ function createMockProvider() {
 
 const DEFAULT_USER = "test-user";
 
+function createOssQdrantConfig() {
+  return {
+    mode: "open-source" as const,
+    userId: DEFAULT_USER,
+    topK: 5,
+    enableGraph: false,
+    autoCapture: true,
+    autoRecall: true,
+    searchThreshold: 0.5,
+    customInstructions: "",
+    customCategories: {},
+    oss: {
+      vectorStore: {
+        provider: "qdrant",
+        config: {
+          host: "127.0.0.1",
+          port: 6333,
+          collectionName: "openclaw_mem0",
+        },
+      },
+    },
+  };
+}
+
 beforeEach(() => {
   vi.resetAllMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// ---------------------------------------------------------------------------
+// exact count helpers
+// ---------------------------------------------------------------------------
+
+describe("buildQdrantCountRequest", () => {
+  it("builds a qdrant count request for OSS mode", () => {
+    const request = buildQdrantCountRequest(
+      createOssQdrantConfig() as any,
+      "test-user:agent:researcher",
+    );
+
+    expect(request).not.toBeNull();
+    expect(request?.url).toBe(
+      "http://127.0.0.1:6333/collections/openclaw_mem0/points/count",
+    );
+    expect(request?.headers).toEqual({
+      "Content-Type": "application/json",
+    });
+    expect(JSON.parse(request?.body ?? "{}")).toEqual({
+      exact: true,
+      filter: {
+        must: [
+          {
+            key: "userId",
+            match: { value: "test-user:agent:researcher" },
+          },
+        ],
+      },
+    });
+  });
+});
+
+describe("countMemories", () => {
+  it("uses qdrant exact count when available", async () => {
+    const provider = createMockProvider();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ result: { count: 337 } }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const count = await countMemories(provider as any, createOssQdrantConfig() as any, {
+      userId: DEFAULT_USER,
+      source: "OPENCLAW",
+    });
+
+    expect(count).toBe(337);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:6333/collections/openclaw_mem0/points/count",
+      expect.objectContaining({
+        method: "POST",
+      }),
+    );
+    expect(provider.getAll).not.toHaveBeenCalled();
+  });
+
+  it("falls back to provider.getAll when exact count is unavailable", async () => {
+    const provider = createMockProvider();
+    provider.getAll.mockResolvedValueOnce([
+      { id: "m1", memory: "one" },
+      { id: "m2", memory: "two" },
+    ]);
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+
+    const count = await countMemories(provider as any, createOssQdrantConfig() as any, {
+      userId: DEFAULT_USER,
+      source: "OPENCLAW",
+    });
+
+    expect(count).toBe(2);
+    expect(provider.getAll).toHaveBeenCalledWith({
+      user_id: DEFAULT_USER,
+      source: "OPENCLAW",
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- fix incorrect memory counts in OpenClaw mem0 when using OSS + Qdrant
- pass `page_size` through to the OSS SDK `limit` parameter so full inventories can be fetched when the true total is known
- stabilize `sqlite-resilience.test.ts` by resetting modules between suites

## Root cause
The OSS SDK's `getAll()` defaults to `limit = 100`. OpenClaw mem0 was using `getAll().length` as if it were the total memory count, which under-reported counts for users with more than 100 memories and caused dream/inventory flows to operate on truncated data.

## What changed
- add a Qdrant exact-count helper and prefer it when OSS is configured with Qdrant
- fall back to the existing `getAll()` length behavior for other backends
- thread exact counts into dream gating and dream inventory generation
- map OSS `page_size` to SDK `limit`
- add regression coverage for the Qdrant count path and the full inventory path
- reset modules in `sqlite-resilience.test.ts` to avoid cross-suite mock leakage

## Validation
- `npx vitest run tests/providers.test.ts tests/cli-commands.test.ts`
- `npm test`