### PR TITLE
fix(openai): make store opt-in so it stops leaking to non-OpenAI backends

### DIFF
--- a/mem0/configs/llms/openai.py
+++ b/mem0/configs/llms/openai.py
@@ -29,7 +29,7 @@ class OpenAIConfig(BaseLlmConfig):
         openrouter_base_url: Optional[str] = None,
         site_url: Optional[str] = None,
         app_name: Optional[str] = None,
-        store: bool = False,
+        store: Optional[bool] = None,
         # Response monitoring callback
         response_callback: Optional[Callable[[Any, dict, dict], None]] = None,
     ):
@@ -53,6 +53,11 @@ class OpenAIConfig(BaseLlmConfig):
             openrouter_base_url: OpenRouter base URL, defaults to None
             site_url: Site URL for OpenRouter, defaults to None
             app_name: Application name for OpenRouter, defaults to None
+            store: Whether to store the conversation on OpenAI's server. Opt-in;
+                defaults to None (not sent). Set to True or False only if you
+                want the value forwarded to the OpenAI API. Leaving it None
+                avoids leaking the field into OpenAI-compatible backends that
+                reject unknown fields (Gemini, Groq, vLLM, etc.).
             response_callback: Optional callback for monitoring LLM responses.
         """
         # Initialize base parameters

--- a/mem0/llms/openai.py
+++ b/mem0/llms/openai.py
@@ -126,11 +126,12 @@ class OpenAILLM(LLMBase):
             params.update(**openrouter_params)
         
         else:
-            openai_specific_generation_params = ["store"]
-            for param in openai_specific_generation_params:
-                if hasattr(self.config, param):
-                    params[param] = getattr(self.config, param)
-            
+            # Only send OpenAI-specific parameters when the user has explicitly
+            # configured them. OpenAI-compatible backends (Gemini, Groq, vLLM, etc.)
+            # reject unknown fields, so `store` must be opt-in, not opt-out.
+            if self.config.store is not None:
+                params["store"] = self.config.store
+
         if response_format:
             params["response_format"] = response_format
         if tools:  # TODO: Remove tools if no issues found with new memory addition logic

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -55,7 +55,7 @@ def test_generate_response_without_tools(mock_openai_client):
     response = llm.generate_response(messages)
 
     mock_openai_client.chat.completions.create.assert_called_once_with(
-        model="gpt-4.1-nano-2025-04-14", messages=messages, temperature=0.7, max_tokens=100, top_p=1.0, store=False
+        model="gpt-4.1-nano-2025-04-14", messages=messages, temperature=0.7, max_tokens=100, top_p=1.0
     )
     assert response == "I'm doing well, thank you for asking!"
 
@@ -97,7 +97,7 @@ def test_generate_response_with_tools(mock_openai_client):
     response = llm.generate_response(messages, tools=tools)
 
     mock_openai_client.chat.completions.create.assert_called_once_with(
-        model="gpt-4.1-nano-2025-04-14", messages=messages, temperature=0.7, max_tokens=100, top_p=1.0, tools=tools, tool_choice="auto", store=False
+        model="gpt-4.1-nano-2025-04-14", messages=messages, temperature=0.7, max_tokens=100, top_p=1.0, tools=tools, tool_choice="auto"
     )
 
     assert response["content"] == "I've added the memory for you."
@@ -229,6 +229,60 @@ def test_reasoning_effort_config_values():
 
     config = OpenAIConfig(model="o3")
     assert config.reasoning_effort is None
+
+
+def test_store_not_sent_by_default(mock_openai_client):
+    """`store` must NOT be injected into requests when the user has not
+    explicitly configured it. Regression test for issue #4709, where
+    `store=False` was unconditionally sent and rejected by OpenAI-compatible
+    backends such as Google Gemini."""
+    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", temperature=0.1)
+    assert config.store is None  # new opt-in default
+    llm = OpenAILLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Response"))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    call_kwargs = mock_openai_client.chat.completions.create.call_args.kwargs
+    assert "store" not in call_kwargs
+
+
+def test_store_sent_when_explicitly_true(mock_openai_client):
+    """When the user explicitly sets `store=True`, the field must be forwarded."""
+    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", store=True)
+    llm = OpenAILLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Response"))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    call_kwargs = mock_openai_client.chat.completions.create.call_args.kwargs
+    assert call_kwargs["store"] is True
+
+
+def test_store_sent_when_explicitly_false(mock_openai_client):
+    """When the user explicitly sets `store=False`, the field must still be
+    forwarded — explicit opt-out is a valid configuration for users who rely on
+    it for OpenAI's zero-data-retention behavior."""
+    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", store=False)
+    llm = OpenAILLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Response"))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    call_kwargs = mock_openai_client.chat.completions.create.call_args.kwargs
+    assert call_kwargs["store"] is False
 
 
 def test_callback_with_tools(mock_openai_client):


### PR DESCRIPTION
## Linked Issue

Closes #4709

## Description

`OpenAIConfig.store` defaulted to `False`, which meant `hasattr(self.config, "store")` in `mem0/llms/openai.py` was always `True`. As a result, `store=False` was unconditionally injected into every `client.chat.completions.create(...)` call on the non-OpenRouter code path — including when the user pointed `openai_base_url` at an OpenAI-compatible backend like Google Gemini. Gemini (and other strict compat endpoints) reject unknown fields and the call fails.

@kaiisfree traced the root cause in the issue thread and recommended making `store` opt-in. This PR implements that:

- `mem0/configs/llms/openai.py`: `store: bool = False` → `store: Optional[bool] = None`. Docstring updated to explain the new semantics.
- `mem0/llms/openai.py`: replaces the `openai_specific_generation_params` / `hasattr` loop with an explicit `if self.config.store is not None: params["store"] = self.config.store` guard, with a comment explaining why it must be opt-in.
- `tests/llms/test_openai.py`: the two existing tests (`test_generate_response_without_tools`, `test_generate_response_with_tools`) no longer expect `store=False` in the forwarded kwargs, because `store` is no longer sent by default.

Users who deliberately set `store=True` or `store=False` still have their value forwarded to the API — only the default has changed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

Behavioral change for users who were implicitly relying on the old default: previously every request included `store=False`; now nothing is sent unless `store` is explicitly configured. For direct OpenAI usage this matches OpenAI's documented default behavior, so the observable result should be unchanged. Users who want to guarantee `store=False` reaches OpenAI can set it explicitly on their `OpenAIConfig`.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added three regression tests in `tests/llms/test_openai.py`:

- `test_store_not_sent_by_default` — asserts `"store"` is absent from the forwarded kwargs when `OpenAIConfig` is constructed without a `store` value. This is the regression guard for #4709.
- `test_store_sent_when_explicitly_true` — asserts `store=True` is forwarded when explicitly configured.
- `test_store_sent_when_explicitly_false` — asserts `store=False` is still forwarded when the user explicitly opts out, since explicit opt-out is a valid configuration for users who rely on OpenAI's zero-data-retention behavior.

Ran `pytest tests/llms/test_openai.py` in a clean venv (mem0 installed via `pip install -e .`): 14 passed in 1.10s. Ran the broader `tests/llms/` collection (skipping modules missing optional deps on this host): 103 passed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
