### PR TITLE
fix(pgvector): make initialize() idempotent so double-init stops crashing

### DIFF
--- a/mem0-ts/src/oss/src/vector_stores/pgvector.ts
+++ b/mem0-ts/src/oss/src/vector_stores/pgvector.ts
@@ -22,6 +22,7 @@ export class PGVector implements VectorStore {
   private useHnsw: boolean;
   private readonly dbName: string;
   private config: PGVectorConfig;
+  private _initPromise?: Promise<void>;
 
   constructor(config: PGVectorConfig) {
     this.collectionName = config.collectionName || "memories";
@@ -41,6 +42,26 @@ export class PGVector implements VectorStore {
   }
 
   async initialize(): Promise<void> {
+    // Idempotent: multiple calls (constructor fire-and-forget + explicit
+    // Memory._autoInitialize await) must share a single in-flight promise.
+    // Without this, the second call hits `this.client.connect()` on an
+    // already-connected `pg.Client` and throws "Client has already been
+    // connected. You cannot reuse a client." See #4727.
+    //
+    // On rejection the cached promise is cleared so that callers which are
+    // allowed to retry (e.g. Memory._ensureInitialized after a transient
+    // postgres failure) get a fresh init attempt instead of re-throwing
+    // the original error forever.
+    if (!this._initPromise) {
+      this._initPromise = this._doInitialize().catch((error) => {
+        this._initPromise = undefined;
+        throw error;
+      });
+    }
+    return this._initPromise;
+  }
+
+  private async _doInitialize(): Promise<void> {
     try {
       await this.client.connect();
 

--- a/mem0-ts/src/oss/tests/pgvector-init.test.ts
+++ b/mem0-ts/src/oss/tests/pgvector-init.test.ts
@@ -1,0 +1,151 @@
+/**
+ * PGVector initialization idempotency tests.
+ *
+ * Regression guard for #4727 — `PGVector` is constructed with a fire-and-forget
+ * `initialize()` call, then `Memory._autoInitialize()` explicitly awaits
+ * `initialize()` a second time. The second call used to run `this.client.connect()`
+ * on an already-connected `pg.Client` and throw:
+ *
+ *   Error: Client has already been connected. You cannot reuse a client.
+ *
+ * These tests mock the `pg.Client` to prove that:
+ *   1. Multiple concurrent `initialize()` calls share a single in-flight promise.
+ *   2. Each `pg.Client` instance only has `connect()` invoked once.
+ *   3. The existing behavior of creating the target database and swapping
+ *      clients is preserved.
+ */
+/// <reference types="jest" />
+
+// Track every client instance the code under test creates so we can assert
+// on their lifecycle without needing a real postgres.
+interface FakeClient {
+  connect: jest.Mock;
+  end: jest.Mock;
+  query: jest.Mock;
+  database: string;
+}
+
+const createdClients: FakeClient[] = [];
+
+jest.mock("pg", () => {
+  return {
+    __esModule: true,
+    default: {
+      Client: jest.fn().mockImplementation((cfg: { database: string }) => {
+        // State lives in the closure so the mock does not depend on
+        // `this` binding through `jest.fn().mockImplementation(...)`.
+        let connected = false;
+        const instance: FakeClient = {
+          database: cfg.database,
+          connect: jest.fn().mockImplementation(async () => {
+            if (connected) {
+              throw new Error(
+                "Client has already been connected. You cannot reuse a client.",
+              );
+            }
+            connected = true;
+          }),
+          end: jest.fn().mockImplementation(async () => {
+            connected = false;
+          }),
+          query: jest.fn().mockImplementation(async (sql: string) => {
+            // Minimal fake results so `_doInitialize` reaches the end.
+            if (/FROM pg_database/.test(sql)) {
+              return { rows: [{ "?column?": 1 }] }; // database already exists
+            }
+            if (/information_schema\.tables/.test(sql)) {
+              return { rows: [] }; // collection does not exist yet
+            }
+            return { rows: [] };
+          }),
+        };
+        createdClients.push(instance);
+        return instance;
+      }),
+    },
+  };
+});
+
+import { PGVector } from "../src/vector_stores/pgvector";
+
+function baseConfig() {
+  return {
+    collectionName: "test_collection",
+    dbname: "vector_store",
+    user: "test",
+    password: "test",
+    host: "localhost",
+    port: 5432,
+    embeddingModelDims: 1024,
+  };
+}
+
+beforeEach(() => {
+  createdClients.length = 0;
+  // Silence the `console.error` from the constructor's fire-and-forget
+  // promise so the test output stays clean.
+  jest.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  (console.error as jest.Mock).mockRestore?.();
+});
+
+describe("PGVector initialization idempotency (#4727)", () => {
+  test("multiple initialize() calls share a single in-flight promise", async () => {
+    const store = new PGVector(baseConfig());
+
+    // Mimic Memory._autoInitialize() explicitly awaiting initialize()
+    // on top of the constructor's fire-and-forget call.
+    await Promise.all([
+      store.initialize(),
+      store.initialize(),
+      store.initialize(),
+    ]);
+
+    // PGVector swaps the client: first instance talks to `postgres`,
+    // second talks to the target `vector_store` database.
+    expect(createdClients.length).toBe(2);
+
+    // Neither client should have `connect()` called more than once —
+    // that is the exact precondition the pg driver rejects.
+    for (const client of createdClients) {
+      expect(client.connect).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  test("subsequent initialize() after completion returns cached promise without reconnect", async () => {
+    const store = new PGVector(baseConfig());
+
+    await store.initialize();
+    const clientsAfterFirst = createdClients.length;
+
+    // A later, fully-sequential call (e.g. Memory retrying after a
+    // transient error) must not trigger a fresh connect cycle.
+    await store.initialize();
+
+    expect(createdClients.length).toBe(clientsAfterFirst);
+    for (const client of createdClients) {
+      expect(client.connect).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  test("initialize() never throws the 'already been connected' error", async () => {
+    const store = new PGVector(baseConfig());
+
+    // If the bug from #4727 regresses, one of these awaits will reject
+    // with the exact error string below.
+    await expect(
+      Promise.all([store.initialize(), store.initialize()]),
+    ).resolves.not.toThrow();
+
+    for (const client of createdClients) {
+      const connectErrors = client.connect.mock.results
+        .filter((r) => r.type === "throw")
+        .map((r) => (r.value as Error).message);
+      expect(connectErrors).not.toContain(
+        "Client has already been connected. You cannot reuse a client.",
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Linked Issue

Closes #4727

## Description

`PGVector` was calling `initialize()` twice on startup and the second call crashed on an already-connected `pg.Client`:

```
Error: Client has already been connected. You cannot reuse a client.
    at Client._connect (.../pg/lib/client.js:94:19)
    at PGVector.initialize (.../mem0ai/dist/oss/index.mjs:3688:25)
    at _Memory._autoInitialize (.../mem0ai/dist/oss/index.mjs:4952:28)
    at _Memory._ensureInitialized (.../mem0ai/dist/oss/index.mjs:4961:5)
```

The double call comes from two places that are both correct on their own:

1. `PGVector`'s constructor fires `this.initialize().catch(console.error)` as a fire-and-forget (`mem0-ts/src/oss/src/vector_stores/pgvector.ts:40`).
2. `Memory._autoInitialize` then explicitly awaits `this.vectorStore.initialize()` (`mem0-ts/src/oss/src/memory/index.ts:125`). The comment right above it says this is required for stores like Qdrant that kick off init asynchronously in their constructor.

The race means two separate init runs can interleave on the same `pg.Client` instance, and the pg driver rejects the second `.connect()` call with the error above. In OpenClaw + pgvector OSS-mode deployments, this blocks `_Memory.getAll`, `search`, and `add` — every memory operation on startup.

**Fix:** apply the idempotent `_initPromise` pattern that `Qdrant` already uses at `qdrant.ts:342`. The first caller runs `_doInitialize()`; every subsequent caller awaits the same cached promise instead of kicking off a second run. The cached promise is cleared on rejection so that `Memory._ensureInitialized` can still recover from a transient postgres failure (bad credentials, network blip) without being permanently stuck on the first error.

The body of `initialize()` was renamed to `_doInitialize()` — no other behavior changed, the database-swap flow (connect to `postgres` → create target DB if needed → disconnect → reconnect against target DB → create extension + memory_migrations + collection) is untouched.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A. Users who only ever called `initialize()` once (directly or via `Memory`) see identical behavior. Users who were tripping the double-init crash now get a single successful init.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added `mem0-ts/src/oss/tests/pgvector-init.test.ts` with three regression tests that mock the `pg.Client` and prove double-init is now safe:

- `multiple initialize() calls share a single in-flight promise` — three racing `Promise.all([initialize(), initialize(), initialize()])` calls, asserts both the bootstrap `postgres` client and the target-database client each have `connect()` called exactly once.
- `subsequent initialize() after completion returns cached promise without reconnect` — simulates `Memory._autoInitialize` awaiting `initialize()` after the constructor's fire-and-forget has already completed, asserts no new clients are constructed and no additional `connect()` calls happen.
- `initialize() never throws the 'already been connected' error` — explicit guard against the exact error string from the bug report.

The mock rejects double-`connect()` with the same `"Client has already been connected. You cannot reuse a client."` message the real pg driver uses, so the tests fail against the original code for exactly the right reason. Verified by reverting `pgvector.ts` to `main` and re-running — all three tests fail with the bug's error string. After restoring the fix, all three pass.

Ran the full `mem0-ts` OSS test suite:

```
pnpm --filter mem0ai test  →  Test Suites: 23 passed, 23 total; Tests: 341 passed, 341 total
prettier --check src/oss/src/vector_stores/pgvector.ts src/oss/tests/pgvector-init.test.ts  →  All matched files use Prettier code style!
```

No regressions in any other vector store, memory, or embedder test.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
