### PR TITLE
fix: mark Cursor Marketplace plugin as unavailable, redirect to MCP options

### DIFF
--- a/docs/integrations/cursor.mdx
+++ b/docs/integrations/cursor.mdx
@@ -69,6 +69,10 @@ Add the following to your `.cursor/mcp.json`:
 
 ### Option D — Cursor Marketplace (Full Plugin)
 
+<Warning>
+  The Mem0 plugin is not currently available in the Cursor Marketplace. Use Options A, B, or C above for a working MCP installation.
+</Warning>
+
 Install from the [Cursor Marketplace](https://cursor.com/marketplace) for the complete experience including lifecycle hooks, the Mem0 SDK skill, and automatic memory capture.
 
 <Info icon="check">
@@ -136,7 +140,7 @@ You: The /orders endpoint is also slow, same pattern as before.
 - **"Connection failed"** — Verify `MEM0_API_KEY` is set: `echo $MEM0_API_KEY`
 - **Duplicate tools** — If you had a previous MCP config for `mem0`, remove it before installing the plugin
 - **No tools appearing** — Go to Cursor Settings > MCP and verify the `mem0` server shows as connected
-- **Hooks not running** — Hooks require the Marketplace install (Option D). Deeplink/manual installs only provide MCP tools.
+- **Hooks not running** — Hooks require the Marketplace install (Option D), which is temporarily unavailable. Use Options A, B, or C for MCP tools in the meantime.
 
 <CardGroup cols={2}>
   <Card title="Mem0 MCP Setup" icon="puzzle-piece" href="/platform/mem0-mcp">


### PR DESCRIPTION
…ptions (#4755)

## Linked Issue
Closes #4755

## Description
The Mem0 plugin is not currently available in the Cursor Marketplace despite being documented as Option D in the Cursor integration guide. Users following the docs hit a dead end with no working alternative guidance provided.

Added a Warning block under Option D directing users to Options A, B, or C for a working MCP installation. Updated the troubleshooting note for "Hooks not running" to reflect that Option D is temporarily unavailable.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes
N/A

## Test Coverage
- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [x] No tests needed (explain why)

Documentation-only change. Verified manually by confirming the Cursor Marketplace returns no results when searching for "mem0".

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [x] I have updated documentation if needed