### PR TITLE
fix: LLM config manager falls back to userConf.url for baseURL (#4715)

### DIFF
--- a/mem0-ts/src/oss/src/config/manager.ts
+++ b/mem0-ts/src/oss/src/config/manager.ts
@@ -110,6 +110,7 @@ export class ConfigManager {
             ((userConf as Record<string, unknown>)?.lmstudio_base_url as
               | string
               | undefined) ??
+            userConf?.url ??
             defaultConf.baseURL;
 
           return {

--- a/mem0-ts/src/oss/tests/config-manager.test.ts
+++ b/mem0-ts/src/oss/tests/config-manager.test.ts
@@ -127,6 +127,20 @@ describe("ConfigManager", () => {
       expect(config.llm.config.url).toBe("http://fallback:11434");
     });
 
+    it("should use url as baseURL fallback when no baseURL provided (issue #4715)", () => {
+      const config = ConfigManager.mergeConfig({
+        embedder: baseEmbedder,
+        vectorStore: baseVectorStore,
+        llm: {
+          provider: "ollama",
+          config: { model: "llama3.1:8b", url: "http://my-ollama-host:11434" },
+        },
+      });
+
+      expect(config.llm.config.baseURL).toBe("http://my-ollama-host:11434");
+      expect(config.llm.config.url).toBe("http://my-ollama-host:11434");
+    });
+
     it("should use default baseURL when no url or baseURL provided", () => {
       const config = ConfigManager.mergeConfig({
         embedder: baseEmbedder,


### PR DESCRIPTION
## Summary

Fixes #4715

The LLM config's `baseURL` resolution in `ConfigManager.mergeConfig()` skipped `userConf?.url` in its fallback chain, unlike the embedder config which correctly includes it. This caused Ollama and other custom LLM providers configured with `url` to silently connect to `api.openai.com` instead of the configured host.

## Fix

Added `userConf?.url` to the LLM `baseURL` fallback chain (matching embedder behavior):

```typescript
// Before (broken):
const llmBaseURL = userConf?.baseURL ?? lmstudio_base_url ?? defaultConf.baseURL;

// After (fixed):
const llmBaseURL = userConf?.baseURL ?? lmstudio_base_url ?? userConf?.url ?? defaultConf.baseURL;
```

## Test

- Added test: `"should use url as baseURL fallback when no baseURL provided (issue #4715)"`
- All 27 existing tests continue to pass