### PR TITLE
refactor: update OpenClaw plugin config, hook logic, and documentation

### DIFF
--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -149,9 +149,6 @@ openclaw mem0 dream --dry-run
 | Key | Type | Default | Description |
 | --- | ---- | ------- | ----------- |
 | `apiKey` | `string` | — | **Required.** Mem0 API key (supports `${MEM0_API_KEY}`) |
-| `orgId` | `string` | — | Organization ID |
-| `projectId` | `string` | — | Project ID |
-| `enableGraph` | `boolean` | `false` | Entity graph for relationship tracking |
 | `customInstructions` | `string` | *(built-in)* | Custom extraction rules |
 | `customCategories` | `object` | *(12 defaults)* | Category name to description map |
 
@@ -169,7 +166,6 @@ All fields optional. Defaults: `text-embedding-3-small` embeddings, local SQLite
 | `oss.llm.provider` | `string` | `"openai"` | LLM provider |
 | `oss.llm.config` | `object` | — | Provider config (`apiKey`, `model`, `baseURL`) |
 | `oss.historyDbPath` | `string` | — | SQLite path for edit history |
-| `oss.disableHistory` | `boolean` | `false` | Skip history DB |
 
 ## License
 

--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -367,16 +367,11 @@ function registerHooks(
       }
 
       const promptLower = event.prompt.toLowerCase();
-      const isChannelSystemEvent = /^system(?:\s*\(untrusted\))?:\s*\[/i.test(
-        event.prompt,
-      );
       const isSystemPrompt =
-        !isChannelSystemEvent &&
-        (promptLower.includes("a new session was started") ||
-          promptLower.includes("session startup sequence") ||
-          promptLower.includes("/new or /reset") ||
-          promptLower.startsWith("system:") ||
-          promptLower.startsWith("run your session"));
+        promptLower.includes("a new session was started") ||
+        promptLower.includes("session startup sequence") ||
+        promptLower.includes("/new or /reset") ||
+        promptLower.startsWith("run your session");
       if (isSystemPrompt) {
         api.logger.info(
           "openclaw-mem0: skills-mode skipping recall for system/bootstrap prompt",
@@ -618,16 +613,11 @@ function registerHooks(
       }
 
       const promptLower = event.prompt.toLowerCase();
-      const isChannelSystemEvent = /^system(?:\s*\(untrusted\))?:\s*\[/i.test(
-        event.prompt,
-      );
       const isSystemPrompt =
-        !isChannelSystemEvent &&
-        (promptLower.includes("a new session was started") ||
-          promptLower.includes("session startup sequence") ||
-          promptLower.includes("/new or /reset") ||
-          promptLower.startsWith("system:") ||
-          promptLower.startsWith("run your session"));
+        promptLower.includes("a new session was started") ||
+        promptLower.includes("session startup sequence") ||
+        promptLower.includes("/new or /reset") ||
+        promptLower.startsWith("run your session");
       if (isSystemPrompt) {
         api.logger.info(
           "openclaw-mem0: skipping recall for system/bootstrap prompt",
@@ -806,7 +796,8 @@ function registerHooks(
           return false;
         return msg.content.some(
           (block: any) =>
-            block?.type === "tool_use" && MEMORY_MUTATE_TOOLS.has(block.name),
+            (block?.type === "tool_use" || block?.type === "toolCall") &&
+            MEMORY_MUTATE_TOOLS.has(block.name),
         );
       });
       if (agentUsedMemoryTool) {

--- a/openclaw/openclaw.plugin.json
+++ b/openclaw/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-mem0",
   "name": "Memory (Mem0)",
-  "description": "Mem0 memory backend for OpenClaw — platform or self-hosted open-source",
+  "description": "Mem0 memory backend for OpenClaw — platform or self-hosted open-source. Injects recalled memories into agent context (auto-recall) and extracts facts after each turn (auto-capture). Both configurable via autoRecall/autoCapture settings.",
   "version": "1.0.5",
   "kind": "memory",
   "skills": ["skills"],
@@ -13,9 +13,23 @@
   },
   "providerAuthEnvVars": {
     "mem0": ["MEM0_API_KEY"],
-    "mem0-oss-openai": ["OPENAI_API_KEY"],
-    "mem0-oss-anthropic": ["ANTHROPIC_API_KEY"]
+    "openclaw-mem0-oss": ["OPENAI_API_KEY"]
   },
+  "providerAuthChoices": [
+    {
+      "provider": "mem0",
+      "method": "api-key",
+      "choiceId": "mem0-api-key",
+      "choiceLabel": "Mem0 API key",
+      "choiceHint": "Required for platform mode. Get your key at https://app.mem0.ai/dashboard/api-keys",
+      "groupId": "mem0",
+      "groupLabel": "Mem0",
+      "optionKey": "apiKey",
+      "cliFlag": "--mem0-api-key",
+      "cliOption": "--mem0-api-key <key>",
+      "cliDescription": "Mem0 platform API key"
+    }
+  ],
   "uiHints": {
     "mode": {
       "label": "Mode",
@@ -31,16 +45,6 @@
       "label": "Default User ID",
       "placeholder": "default",
       "help": "User ID for scoping memories"
-    },
-    "orgId": {
-      "label": "Organization ID",
-      "placeholder": "org-...",
-      "advanced": true
-    },
-    "projectId": {
-      "label": "Project ID",
-      "placeholder": "proj-...",
-      "advanced": true
     },
     "autoCapture": {
       "label": "Auto-Capture",
@@ -64,10 +68,6 @@
       "label": "Custom Prompt (Open-Source)",
       "advanced": true,
       "help": "Custom prompt for open-source mode memory extraction."
-    },
-    "enableGraph": {
-      "label": "Enable Graph Memory",
-      "help": "Enable Mem0 graph memory for entity relationships (platform mode only)"
     },
     "searchThreshold": {
       "label": "Search Threshold",
@@ -110,12 +110,6 @@
       "userEmail": {
         "type": "string"
       },
-      "orgId": {
-        "type": "string"
-      },
-      "projectId": {
-        "type": "string"
-      },
       "autoCapture": {
         "type": "boolean"
       },
@@ -133,9 +127,6 @@
       },
       "customPrompt": {
         "type": "string"
-      },
-      "enableGraph": {
-        "type": "boolean"
       },
       "searchThreshold": {
         "type": "number"
@@ -192,7 +183,6 @@
             "properties": {
               "enabled": { "type": "boolean" },
               "importanceThreshold": { "type": "number" },
-              "enableGraph": { "type": "boolean" },
               "credentialPatterns": { "type": "array", "items": { "type": "string" } }
             }
           },

--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -42,8 +42,8 @@
       "./dist/index.js"
     ],
     "compat": {
-      "pluginApi": ">=2026.3.28 <=2026.4.2",
-      "minGatewayVersion": "2026.3.28"
+      "pluginApi": ">=2026.3.28",
+      "minGatewayVersion": ">=2026.3.28"
     },
     "build": {
       "openclawVersion": "2026.4.1",

--- a/openclaw/skills/memory-triage/SKILL.md
+++ b/openclaw/skills/memory-triage/SKILL.md
@@ -1,14 +1,13 @@
 ---
 name: memory-triage
 description: >
-  ALWAYS USE THIS SKILL. Persistent long-term memory protocol powered by mem0.
-  After EVERY response, evaluate the conversation for durable facts worth storing
-  via memory_add. Handles identity, preferences, decisions, configurations, rules,
-  projects, and relationships. Use memory_add (NOT workspace files) for all user facts.
-  Read this skill at the start of every session.
+  Persistent long-term memory protocol powered by mem0.
+  Evaluate conversations for durable facts worth storing via memory_add.
+  Handles identity, preferences, decisions, configurations, rules,
+  projects, and relationships. Loaded by the openclaw-mem0 plugin when skills mode is active.
 user-invocable: false
 metadata:
-  {"openclaw": {"always": true, "emoji": "🧠", "requires": {"env": ["MEM0_API_KEY"], "bins": []}}}
+  {"openclaw": {"always": false, "emoji": "🧠", "requires": {"env": ["MEM0_API_KEY"], "bins": []}}}
 ---
 
 # Memory Protocol


### PR DESCRIPTION
Bug Fixes:
  - Fix duplicate memory adds — auto-capture guard now detects OpenClaw's toolCall block type (was only checking Anthropic's tool_use format), so auto-capture skips when agent already called
  memory_add                                                                                                                                                                                  
  - Fix Feishu/channel recall skip — removed overly broad startsWith("system:") bootstrap check that matched channel system events; now only matches 4 specific bootstrap phrases
  - Fix init interactive choice bug (readline prefill concatenation)                                                                                                             
                                              
  Removed:                                    
  - orgId, projectId, enableGraph from manifest configSchema, uiHints, and README
  - ANTHROPIC_API_KEY from providerAuthEnvVars (never used in OSS mode)                                                                                                                              
  - oss.disableHistory from README (internal fallback, not user-configurable)                                                                                                                        
                                                                                                                                                                                                     
  Added:                                                                                                                                                                                             
  - providerAuthChoices declaring MEM0_API_KEY for ClawHub scanner compliance
  - Plugin description now explicitly declares auto-recall/auto-capture behavior                                                                                                                     
                                                                                                                                                                                                     
  Manifest & Compatibility:                                                                                                                                                                          
  - pluginApi range changed from >=2026.3.28 <=2026.4.2 to >=2026.3.28 (no upper bound)                                                                                                              
  - minGatewayVersion updated to >=2026.3.28 format                                    
                                                                                                                                                                                                     
  Skills:                                                                                                                                                                                            
  - memory-triage: set always: false, updated description                                                                                                                                            
  - memory-triage version bumped to 1.0.5                                                                                                                                                            
  - Docs changelog updated with v1.0.5 entry           