### PR TITLE
fix(docs): eliminate ~222 SEO redirect chains on docs.mem0.ai

### DIFF
--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -10,7 +10,7 @@ description: "REST APIs for memory management, search, and entity operations"
 Mem0 provides a comprehensive REST API for integrating advanced memory capabilities into your applications. Create, search, update, and manage memories across users, agents, and custom entities with simple HTTP requests.
 
 <Info>
-**Quick start:** Get your API key from the [Mem0 Dashboard](https://app.mem0.ai/dashboard/api-keys) and make your first memory operation in minutes.
+**Quick start:** Get your API key from the <a href="https://app.mem0.ai/dashboard/api-keys" rel="nofollow">Mem0 Dashboard</a> and make your first memory operation in minutes.
 </Info>
 
 ---
@@ -87,7 +87,7 @@ All API requests require authentication using Token-based authentication. Includ
 Authorization: Token <your-api-key>
 ```
 
-Get your API key from the [Mem0 Dashboard](https://app.mem0.ai/dashboard/api-keys).
+Get your API key from the <a href="https://app.mem0.ai/dashboard/api-keys" rel="nofollow">Mem0 Dashboard</a>.
 
 <Warning>
 **Keep your API key secure.** Never expose it in client-side code or public repositories. Use environment variables and server-side requests only.

--- a/docs/cookbooks/companions/quickstart-demo.mdx
+++ b/docs/cookbooks/companions/quickstart-demo.mdx
@@ -45,7 +45,7 @@ Before you begin, follow these steps to set up the demo application:
    OPENAI_API_KEY=your_openai_api_key
    MEM0_API_KEY=your_mem0_api_key
    ```
-   You can obtain your `MEM0_API_KEY` by signing up at [Mem0 API Dashboard](https://app.mem0.ai/dashboard/api-keys).
+   You can obtain your `MEM0_API_KEY` by signing up at <a href="https://app.mem0.ai/dashboard/api-keys" rel="nofollow">Mem0 API Dashboard</a>.
 
 5. Start the development server:
    ```bash

--- a/docs/cookbooks/essentials/controlling-memory-ingestion.mdx
+++ b/docs/cookbooks/essentials/controlling-memory-ingestion.mdx
@@ -38,7 +38,7 @@ client = MemoryClient(api_key="your-api-key")
 ```
 
 <Note>
-Replace `your-api-key` with your actual Mem0 API key from the [dashboard](https://app.mem0.ai). Without proper API authentication, memory operations will fail.
+Replace `your-api-key` with your actual Mem0 API key from the <a href="https://app.mem0.ai" rel="nofollow">dashboard</a>. Without proper API authentication, memory operations will fail.
 </Note>
 
 ---

--- a/docs/cookbooks/essentials/entity-partitioning-playbook.mdx
+++ b/docs/cookbooks/essentials/entity-partitioning-playbook.mdx
@@ -17,7 +17,7 @@ from mem0 import MemoryClient
 client = MemoryClient(api_key="m0-...")
 ```
 
-Grab an API key from the <Link href="https://app.mem0.ai/">Mem0 dashboard</Link> to get started.
+Grab an API key from the <a href="https://app.mem0.ai/" rel="nofollow">Mem0 dashboard</a> to get started.
 
 ## Store and Retrieve Scoped Memories
 

--- a/docs/cookbooks/essentials/exporting-memories.mdx
+++ b/docs/cookbooks/essentials/exporting-memories.mdx
@@ -20,7 +20,7 @@ client = MemoryClient(api_key="your-api-key")
 ```
 
 <Note>
-Your API key needs export permissions to download memory data. Check your project settings on the [dashboard](https://app.mem0.ai) if export operations fail with authentication errors.
+Your API key needs export permissions to download memory data. Check your project settings on the <a href="https://app.mem0.ai" rel="nofollow">dashboard</a> if export operations fail with authentication errors.
 </Note>
 
 Let's add some sample memories to work with:

--- a/docs/cookbooks/frameworks/gemini-3-with-mem0-mcp.mdx
+++ b/docs/cookbooks/frameworks/gemini-3-with-mem0-mcp.mdx
@@ -55,7 +55,7 @@ GEMINI_API_KEY=your-gemini-api-key-here
 ```
 
 <Note>
-Ensure you have your Mem0 API key from the [Mem0 Dashboard](https://app.mem0.ai) and your Gemini API key from the [Google AI Studio](https://ai.studio/app/api-keys).
+Ensure you have your Mem0 API key from the <a href="https://app.mem0.ai" rel="nofollow">Mem0 Dashboard</a> and your Gemini API key from the [Google AI Studio](https://ai.studio/app/api-keys).
 </Note>
 
 ## Gemini Memory Agent

--- a/docs/cookbooks/frameworks/llamaindex-multiagent.mdx
+++ b/docs/cookbooks/frameworks/llamaindex-multiagent.mdx
@@ -41,7 +41,7 @@ Set up your environment variables:
 - `MEM0_API_KEY`: Your Mem0 Platform API key
 - `OPENAI_API_KEY`: Your OpenAI API key
 
-You can obtain your Mem0 Platform API key from the [Mem0 Platform](https://app.mem0.ai).
+You can obtain your Mem0 Platform API key from the <a href="https://app.mem0.ai" rel="nofollow">Mem0 Platform</a>.
 
 ## Complete Implementation
 
@@ -357,7 +357,7 @@ Based on our previous session, I remember we covered Vision Language Models and 
 ## Help & Resources
 
 - [LlamaIndex Agent Workflows](https://docs.llamaindex.ai/en/stable/use_cases/agents/)
-- [Mem0 Platform](https://app.mem0.ai/)
+- <a href="https://app.mem0.ai/" rel="nofollow">Mem0 Platform</a>
 
 ---
 

--- a/docs/cookbooks/frameworks/llamaindex-react.mdx
+++ b/docs/cookbooks/frameworks/llamaindex-react.mdx
@@ -25,7 +25,7 @@ os.environ["OPENAI_API_KEY"] = "<your-openai-api-key>"
 llm = OpenAI(model="gpt-4.1-nano-2025-04-14")
 ```
 
-Initialize the Mem0 client. You can find your API key [here](https://app.mem0.ai/dashboard/api-keys). Read about Mem0 [Open Source](https://docs.mem0.ai/open-source/overview).
+Initialize the Mem0 client. You can find your API key <a href="https://app.mem0.ai/dashboard/api-keys" rel="nofollow">here</a>. Read about Mem0 [Open Source](https://docs.mem0.ai/open-source/overview).
 ```python
 os.environ["MEM0_API_KEY"] = "<your-mem0-api-key>"
 

--- a/docs/cookbooks/frameworks/mirofish-swarm-memory.mdx
+++ b/docs/cookbooks/frameworks/mirofish-swarm-memory.mdx
@@ -754,7 +754,7 @@ Exact output varies as Mem0 automatically extracts and deduplicates entities. Th
 - [MiroFish GitHub](https://github.com/666ghj/MiroFish) — Source code and setup guide
 - [MiroFish Documentation](https://deepwiki.com/666ghj/MiroFish) — Full framework docs
 - [Mem0 Graph Memory](/open-source/features/graph-memory) — Graph Memory documentation
-- [Mem0 Documentation](https://docs.mem0.ai/) — Full API reference
+- [Mem0 Documentation](https://docs.mem0.ai/introduction) — Full API reference
 
 <CardGroup cols={2}>
   <Card title="Graph Memory" icon="network-wired" href="/open-source/features/graph-memory">

--- a/docs/cookbooks/integrations/agents-sdk-tool.mdx
+++ b/docs/cookbooks/integrations/agents-sdk-tool.mdx
@@ -222,8 +222,8 @@ context = Mem0Context(user_id="user123")
 
 ## Resources
 
-- [Mem0 Documentation](https://docs.mem0.ai)
-- [Mem0 Dashboard](https://app.mem0.ai/dashboard)
+- [Mem0 Documentation](https://docs.mem0.ai/introduction)
+- <a href="https://app.mem0.ai/dashboard" rel="nofollow">Mem0 Dashboard</a>
 - [API Reference](https://docs.mem0.ai/api-reference)
 
 ---

--- a/docs/cookbooks/integrations/openai-tool-calls.mdx
+++ b/docs/cookbooks/integrations/openai-tool-calls.mdx
@@ -23,7 +23,7 @@ MEM0_API_KEY=your_mem0_api_key
 OPENAI_API_KEY=your_openai_api_key
 ```
 
-Get your Mem0 API key from the [Mem0 Dashboard](https://app.mem0.ai/dashboard/api-keys).
+Get your Mem0 API key from the <a href="https://app.mem0.ai/dashboard/api-keys" rel="nofollow">Mem0 Dashboard</a>.
 
 ### Configuration
 
@@ -308,8 +308,8 @@ run().catch(console.error);
 
 ## Resources
 
-- [Mem0 Documentation](https://docs.mem0.ai)
-- [Mem0 Dashboard](https://app.mem0.ai/dashboard)
+- [Mem0 Documentation](https://docs.mem0.ai/introduction)
+- <a href="https://app.mem0.ai/dashboard" rel="nofollow">Mem0 Dashboard</a>
 - [API Reference](https://docs.mem0.ai/api-reference)
 - [OpenAI Documentation](https://platform.openai.com/docs)
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -12,7 +12,7 @@
   "logo": {
     "light": "/logo/light.svg",
     "dark": "/logo/dark.svg",
-    "href": "https://app.mem0.ai/"
+    "href": "https://mem0.ai"
   },
   "navigation": {
     "anchors": [

--- a/docs/integrations/agentops.mdx
+++ b/docs/integrations/agentops.mdx
@@ -24,7 +24,7 @@ pip install mem0ai agentops python-dotenv
 2. Valid API keys:
    - [AgentOps API Key](https://app.agentops.ai/dashboard/api-keys)
    - OpenAI API Key (for LLM operations)
-   - [Mem0 API Key](https://app.mem0.ai/dashboard/api-keys) (optional, for cloud operations)
+   - <a href="https://app.mem0.ai/dashboard/api-keys" rel="nofollow">Mem0 API Key</a> (optional, for cloud operations)
 
 ## Basic Integration Example
 

--- a/docs/integrations/agno.mdx
+++ b/docs/integrations/agno.mdx
@@ -23,7 +23,7 @@ pip install agno mem0ai python-dotenv
 ```
 
 2. Valid API keys:
-   - [Mem0 API Key](https://app.mem0.ai/dashboard/api-keys)
+   - <a href="https://app.mem0.ai/dashboard/api-keys" rel="nofollow">Mem0 API Key</a>
    - OpenAI API Key (for the agent model)
 
 ## Quick Integration (Using `Mem0Tools`)

--- a/docs/integrations/autogen.mdx
+++ b/docs/integrations/autogen.mdx
@@ -19,7 +19,7 @@ pip install autogen mem0ai openai python-dotenv
 
 First, we'll import the necessary libraries and set up our configurations.
 
-<Note>Remember to get the Mem0 API key from [Mem0 Platform](https://app.mem0.ai).</Note>
+<Note>Remember to get the Mem0 API key from <a href="https://app.mem0.ai" rel="nofollow">Mem0 Platform</a>.</Note>
 
 ```python
 import os

--- a/docs/integrations/chatdev.mdx
+++ b/docs/integrations/chatdev.mdx
@@ -18,7 +18,7 @@ In this guide, you'll:
 - **Python 3.12+**
 - **[uv](https://docs.astral.sh/uv/)** — Python package manager
 - **Node.js 18+** and **npm** — only needed if using the web console
-- A **Mem0 API key** from [app.mem0.ai](https://app.mem0.ai)
+- A **Mem0 API key** from <a href="https://app.mem0.ai" rel="nofollow">app.mem0.ai</a>
 - An **OpenAI API key** (or another LLM provider supported by ChatDev)
 
 ## Setup and Configuration
@@ -39,7 +39,7 @@ cd frontend && npm install && cd ..
 
 Set up your environment variables in a `.env` file:
 
-<Note>Get your Mem0 API key from [Mem0 Platform](https://app.mem0.ai).</Note>
+<Note>Get your Mem0 API key from <a href="https://app.mem0.ai" rel="nofollow">Mem0 Platform</a>.</Note>
 
 ```bash
 MEM0_API_KEY=your-mem0-api-key
@@ -194,7 +194,7 @@ This means retrieval returns memories from **both** the user's scope and the age
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `api_key` | Yes | Mem0 API key from [app.mem0.ai](https://app.mem0.ai) |
+| `api_key` | Yes | Mem0 API key from <a href="https://app.mem0.ai" rel="nofollow">app.mem0.ai</a> |
 | `user_id` | No | Scope memories to a specific user |
 | `agent_id` | No | Scope memories to a specific agent |
 
@@ -216,9 +216,9 @@ This means retrieval returns memories from **both** the user's scope and the age
 
 - **No memories returned on first run** — This is expected. Memories are stored *after* the agent responds, so the first interaction has no prior context. Memories appear starting from the second interaction onward.
 - **`mem0ai` not installed** — If you see `ImportError: mem0ai is required for Mem0Memory`, run `uv add mem0ai` or `pip install mem0ai` to add the dependency.
-- **Invalid API key** — A wrong or expired `MEM0_API_KEY` will log errors like `Mem0 search failed` or `Mem0 add failed` but won't crash the agent. Check your key at [app.mem0.ai](https://app.mem0.ai).
+- **Invalid API key** — A wrong or expired `MEM0_API_KEY` will log errors like `Mem0 search failed` or `Mem0 add failed` but won't crash the agent. Check your key at <a href="https://app.mem0.ai" rel="nofollow">app.mem0.ai</a>.
 - **Pipeline headers in memories** — ChatDev automatically strips internal pipeline headers (e.g., `=== INPUT FROM TASK (user) ===`) before sending text to Mem0, so your memories stay clean.
-- **Clearing test memories** — To delete memories created during testing, use the Mem0 dashboard at [app.mem0.ai](https://app.mem0.ai) or the Python SDK: `MemoryClient().delete_all(user_id="your-test-user")`.
+- **Clearing test memories** — To delete memories created during testing, use the Mem0 dashboard at <a href="https://app.mem0.ai" rel="nofollow">app.mem0.ai</a> or the Python SDK: `MemoryClient().delete_all(user_id="your-test-user")`.
 
 ## Key Features
 

--- a/docs/integrations/claude-code.mdx
+++ b/docs/integrations/claude-code.mdx
@@ -17,8 +17,8 @@ Add persistent memory to [**Claude Code**](https://docs.anthropic.com/en/docs/cl
 Before setting up Mem0 with Claude Code, ensure you have:
 
 1. A Mem0 Platform account and API key:
-   - [Sign up at app.mem0.ai](https://app.mem0.ai)
-   - [Get your API key](https://app.mem0.ai/dashboard/api-keys) (starts with `m0-`)
+   - <a href="https://app.mem0.ai" rel="nofollow">Sign up at app.mem0.ai</a>
+   - <a href="https://app.mem0.ai/dashboard/api-keys" rel="nofollow">Get your API key</a> (starts with `m0-`)
 
 2. Claude Code CLI or Claude Cowork desktop app installed
 

--- a/docs/integrations/codex.mdx
+++ b/docs/integrations/codex.mdx
@@ -17,8 +17,8 @@ Add persistent memory to [**OpenAI Codex**](https://openai.com/index/codex/) wit
 Before setting up Mem0 with Codex, ensure you have:
 
 1. A Mem0 Platform account and API key:
-   - [Sign up at app.mem0.ai](https://app.mem0.ai)
-   - [Get your API key](https://app.mem0.ai/dashboard/api-keys) (starts with `m0-`)
+   - <a href="https://app.mem0.ai" rel="nofollow">Sign up at app.mem0.ai</a>
+   - <a href="https://app.mem0.ai/dashboard/api-keys" rel="nofollow">Get your API key</a> (starts with `m0-`)
 
 2. OpenAI Codex access
 

--- a/docs/integrations/crewai.mdx
+++ b/docs/integrations/crewai.mdx
@@ -22,7 +22,7 @@ pip install crewai crewai-tools mem0ai
 
 Import required modules and set up configurations:
 
-<Note>Remember to get your API keys from [Mem0 Platform](https://app.mem0.ai), [OpenAI](https://platform.openai.com) and [Serper Dev](https://serper.dev) for search capabilities.</Note>
+<Note>Remember to get your API keys from <a href="https://app.mem0.ai" rel="nofollow">Mem0 Platform</a>, [OpenAI](https://platform.openai.com) and [Serper Dev](https://serper.dev) for search capabilities.</Note>
 
 ```python
 import os

--- a/docs/integrations/cursor.mdx
+++ b/docs/integrations/cursor.mdx
@@ -17,8 +17,8 @@ Add persistent memory to [**Cursor**](https://cursor.com) with the Mem0 plugin. 
 Before setting up Mem0 with Cursor, ensure you have:
 
 1. A Mem0 Platform account and API key:
-   - [Sign up at app.mem0.ai](https://app.mem0.ai)
-   - [Get your API key](https://app.mem0.ai/dashboard/api-keys) (starts with `m0-`)
+   - <a href="https://app.mem0.ai" rel="nofollow">Sign up at app.mem0.ai</a>
+   - <a href="https://app.mem0.ai/dashboard/api-keys" rel="nofollow">Get your API key</a> (starts with `m0-`)
 
 2. Cursor installed ([cursor.com](https://cursor.com))
 

--- a/docs/integrations/flowise.mdx
+++ b/docs/integrations/flowise.mdx
@@ -38,7 +38,7 @@ npx flowise start
 
 ### 2. Obtain Your Mem0 API Key
 
-1. Navigate to the [Mem0 API Key dashboard](https://app.mem0.ai/dashboard/api-keys).
+1. Navigate to the <a href="https://app.mem0.ai/dashboard/api-keys" rel="nofollow">Mem0 API Key dashboard</a>.
 2. Generate or copy your existing Mem0 API Key.
 
 ![Mem0 API Key](https://raw.githubusercontent.com/FlowiseAI/FlowiseDocs/main/en/.gitbook/assets/mem0/api-key.png)
@@ -70,7 +70,7 @@ Test your memory configuration:
 
 1. Save your Flowise configuration
 2. Run a test chat and store some information
-3. Verify the stored memories in the [Mem0 Dashboard](https://app.mem0.ai/dashboard/requests)
+3. Verify the stored memories in the <a href="https://app.mem0.ai/dashboard/requests" rel="nofollow">Mem0 Dashboard</a>
 
 ![Flowise Test Chat](https://raw.githubusercontent.com/FlowiseAI/FlowiseDocs/main/en/.gitbook/assets/mem0/flowise-chat-1.png)
 
@@ -103,7 +103,7 @@ Available settings include:
 
 ### Platform Configuration
 
-Additional settings available in [Mem0 Project Settings](https://app.mem0.ai/dashboard/project-settings):
+Additional settings available in <a href="https://app.mem0.ai/dashboard/project-settings" rel="nofollow">Mem0 Project Settings</a>:
 
 1. **Custom Instructions**: Define memory extraction rules
 2. **Expiration Date**: Set automatic memory cleanup periods

--- a/docs/integrations/google-ai-adk.mdx
+++ b/docs/integrations/google-ai-adk.mdx
@@ -22,7 +22,7 @@ pip install google-adk mem0ai python-dotenv
 ```
 
 2. Valid API keys:
-   - [Mem0 API Key](https://app.mem0.ai/dashboard/api-keys)
+   - <a href="https://app.mem0.ai/dashboard/api-keys" rel="nofollow">Mem0 API Key</a>
    - Google AI Studio API Key
 
 ## Basic Integration Example

--- a/docs/integrations/hermes.mdx
+++ b/docs/integrations/hermes.mdx
@@ -52,7 +52,7 @@ hermes memory setup
 
 Select **mem0** as the provider and enter your Mem0 API key when prompted. The wizard writes your config to `~/.hermes/mem0.json`.
 
-<Note>Get your API key from [app.mem0.ai](https://app.mem0.ai).</Note>
+<Note>Get your API key from <a href="https://app.mem0.ai" rel="nofollow">app.mem0.ai</a>.</Note>
 
 ### Option 2: Manual Configuration
 

--- a/docs/integrations/keywords.mdx
+++ b/docs/integrations/keywords.mdx
@@ -16,7 +16,7 @@ Combining Mem0 with Keywords AI allows you to:
 4. Optimize token usage and reduce costs
 
 <Note>
-You can get your Mem0 API key, user_id, and org_id from the [Mem0 dashboard](https://app.mem0.ai/). These are required for proper integration.
+You can get your Mem0 API key, user_id, and org_id from the <a href="https://app.mem0.ai/" rel="nofollow">Mem0 dashboard</a>. These are required for proper integration.
 </Note>
 
 ## Setup and Configuration

--- a/docs/integrations/langchain.mdx
+++ b/docs/integrations/langchain.mdx
@@ -22,7 +22,7 @@ pip install langchain langchain_openai mem0ai python-dotenv
 
 Import required modules and set up configurations:
 
-<Note>Remember to get the Mem0 API key from [Mem0 Platform](https://app.mem0.ai).</Note>
+<Note>Remember to get the Mem0 API key from <a href="https://app.mem0.ai" rel="nofollow">Mem0 Platform</a>.</Note>
 
 ```python
 import os

--- a/docs/integrations/langgraph.mdx
+++ b/docs/integrations/langgraph.mdx
@@ -23,7 +23,7 @@ pip install langgraph langchain-openai mem0ai python-dotenv
 
 Import required modules and set up configurations:
 
-<Note>Remember to get the Mem0 API key from [Mem0 Platform](https://app.mem0.ai).</Note>
+<Note>Remember to get the Mem0 API key from <a href="https://app.mem0.ai" rel="nofollow">Mem0 Platform</a>.</Note>
 
 ```python
 from typing import Annotated, TypedDict, List

--- a/docs/integrations/llama-index.mdx
+++ b/docs/integrations/llama-index.mdx
@@ -22,7 +22,7 @@ pip install llama-index-core llama-index-memory-mem0 python-dotenv
 Set your Mem0 Platform API key as an environment variable. You can replace `<your-mem0-api-key>` with your actual API key:
 
 <Note type="info">
-  You can obtain your Mem0 Platform API key from the [Mem0 Platform](https://app.mem0.ai/login).
+  You can obtain your Mem0 Platform API key from the <a href="https://app.mem0.ai/login" rel="nofollow">Mem0 Platform</a>.
 </Note>
 
 ```python

--- a/docs/integrations/mastra.mdx
+++ b/docs/integrations/mastra.mdx
@@ -23,7 +23,7 @@ npm install @mastra/core @mastra/mem0 @ai-sdk/openai zod
 
 Set up your environment variables:
 
-<Note>Remember to get the Mem0 API key from [Mem0 Platform](https://app.mem0.ai).</Note>
+<Note>Remember to get the Mem0 API key from <a href="https://app.mem0.ai" rel="nofollow">Mem0 Platform</a>.</Note>
 
 ```bash
 MEM0_API_KEY=your-mem0-api-key

--- a/docs/integrations/openai-agents-sdk.mdx
+++ b/docs/integrations/openai-agents-sdk.mdx
@@ -22,7 +22,7 @@ pip install openai-agents mem0ai
 ```
 
 2. Valid API keys:
-   - [Mem0 API Key](https://app.mem0.ai/dashboard/api-keys)
+   - <a href="https://app.mem0.ai/dashboard/api-keys" rel="nofollow">Mem0 API Key</a>
    - [OpenAI API Key](https://platform.openai.com/api-keys)
 
 ## Basic Integration Example

--- a/docs/integrations/openclaw.mdx
+++ b/docs/integrations/openclaw.mdx
@@ -42,7 +42,7 @@ All memories are scoped to this `userId` — different values create separate me
 
 ### Platform Mode (Mem0 Cloud)
 
-<Note>Get your API key from [app.mem0.ai](https://app.mem0.ai).</Note>
+<Note>Get your API key from <a href="https://app.mem0.ai" rel="nofollow">app.mem0.ai</a>.</Note>
 
 Add to your `openclaw.json`:
 

--- a/docs/integrations/raycast.mdx
+++ b/docs/integrations/raycast.mdx
@@ -9,7 +9,7 @@ Mem0 is a self-improving memory layer for LLM applications, enabling personalize
 
 **Get your API Key**: You'll need a Mem0 API key to use this extension:
 
-a. Sign up at [app.mem0.ai](https://app.mem0.ai)
+a. Sign up at <a href="https://app.mem0.ai" rel="nofollow">app.mem0.ai</a>
 
 b. Navigate to your API Keys page
 

--- a/docs/integrations/vercel-ai-sdk.mdx
+++ b/docs/integrations/vercel-ai-sdk.mdx
@@ -29,7 +29,7 @@ npm install @mem0/vercel-ai-provider
 
 ### Setting Up Mem0
 
-1. Get your **Mem0 API Key** from the [Mem0 Dashboard](https://app.mem0.ai/dashboard/api-keys).
+1. Get your **Mem0 API Key** from the <a href="https://app.mem0.ai/dashboard/api-keys" rel="nofollow">Mem0 Dashboard</a>.
 
 2. Initialize the Mem0 Client in your application:
 

--- a/docs/migration/oss-to-platform.mdx
+++ b/docs/migration/oss-to-platform.mdx
@@ -28,7 +28,7 @@ Move your Mem0 implementation to managed infrastructure with enterprise features
 
 ## Plan
 
-1. **Sign up**: Create an account on [Mem0 Platform](https://app.mem0.ai).
+1. **Sign up**: Create an account on <a href="https://app.mem0.ai" rel="nofollow">Mem0 Platform</a>.
 2. **Get API Key**: Navigate to **Settings > API Keys** and generate a new key.
 3. **Review Usage**: Identify where you instantiate `Memory` and where you call `search` or `get_all`.
 
@@ -368,7 +368,7 @@ If you encounter issues, you can revert immediately by switching your import bac
 
 ## Next Steps
 
-- [Platform Dashboard](https://app.mem0.ai) - Monitor usage and manage settings.
+- <a href="https://app.mem0.ai" rel="nofollow">Platform Dashboard</a> - Monitor usage and manage settings.
 - [Webhooks Setup](/platform/features/webhooks) - Configure real-time event notifications.
 - [Organizations & Projects](/api-reference/organizations-projects) - Set up multi-tenancy for your team.
 

--- a/docs/platform/mem0-mcp.mdx
+++ b/docs/platform/mem0-mcp.mdx
@@ -7,8 +7,8 @@ estimatedTime: "~2 minutes"
 
 <Info>
   **Prerequisites**
-  - Mem0 Platform account ([Sign up here](https://app.mem0.ai))
-  - API key ([Get one from dashboard](https://app.mem0.ai/settings/api-keys))
+  - Mem0 Platform account (<a href="https://app.mem0.ai" rel="nofollow">Sign up here</a>)
+  - API key (<a href="https://app.mem0.ai/settings/api-keys" rel="nofollow">Get one from dashboard</a>)
   - Node.js 14+ (for npx)
   - An MCP-compatible client (Claude, Claude Code, Cursor, Windsurf, VS Code, OpenCode)
 </Info>
@@ -163,7 +163,7 @@ Agent: Updated your project status successfully.
 ```
 
 <Info icon="check">
-  If you get "Connection failed", ensure you have a valid API key from [Mem0 Dashboard](https://app.mem0.ai/settings/api-keys).
+  If you get "Connection failed", ensure you have a valid API key from <a href="https://app.mem0.ai/settings/api-keys" rel="nofollow">Mem0 Dashboard</a>.
 </Info>
 
 ---
@@ -171,7 +171,7 @@ Agent: Updated your project status successfully.
 ## Quick Recovery
 
 - **"Connection refused"** → Check your internet connection and ensure the MCP client is correctly configured
-- **"Invalid API key"** → Get a new key from [Mem0 Dashboard](https://app.mem0.ai/settings/api-keys)
+- **"Invalid API key"** → Get a new key from <a href="https://app.mem0.ai/settings/api-keys" rel="nofollow">Mem0 Dashboard</a>
 - **"npx command not found"** → Install Node.js from [nodejs.org](https://nodejs.org)
 
 ---

--- a/docs/platform/overview.mdx
+++ b/docs/platform/overview.mdx
@@ -64,7 +64,7 @@ Mem0 is the memory engine that keeps conversations contextual so users never rep
   <Card title="Connect Integrations" icon="plug" href="/integrations">
     LangChain, CrewAI, Vercel AI SDK.
   </Card>
-  <Card title="Monitor in the Dashboard" icon="presentation" href="https://app.mem0.ai">
+  <Card title="Monitor in the Dashboard" icon="presentation" href="https://app.mem0.ai/login">
     Track activity and manage workspaces.
   </Card>
 </CardGroup>

--- a/docs/platform/platform-vs-oss.mdx
+++ b/docs/platform/platform-vs-oss.mdx
@@ -150,7 +150,7 @@ Mem0 offers two powerful ways to add memory to your AI applications. Choose base
   <Card
     title="Try Platform Free"
     icon="rocket"
-    href="https://app.mem0.ai"
+    href="https://app.mem0.ai/login"
   >
     Sign up and test the Platform with our free tier. No credit card required.
   </Card>

--- a/docs/platform/quickstart.mdx
+++ b/docs/platform/quickstart.mdx
@@ -9,8 +9,8 @@ Get started with Mem0 Platform's hosted API in under 5 minutes. This guide shows
 
 ## Prerequisites
 
-- Mem0 Platform account ([Sign up here](https://app.mem0.ai))
-- API key ([Get one from dashboard](https://app.mem0.ai/dashboard/settings?tab=api-keys&subtab=configuration))
+- Mem0 Platform account (<a href="https://app.mem0.ai" rel="nofollow">Sign up here</a>)
+- API key (<a href="https://app.mem0.ai/dashboard/settings?tab=api-keys&subtab=configuration" rel="nofollow">Get one from dashboard</a>)
 - Python 3.10+, Node.js 14+, or cURL
 
 ## Installation

--- a/docs/vibecoding.mdx
+++ b/docs/vibecoding.mdx
@@ -12,7 +12,7 @@ We follow the llms.txt standard:
 - [llms.txt](https://docs.mem0.ai/llms.txt)
 
 <CardGroup cols={2}>
-  <Card title="Get an API Key" icon="key" href="https://app.mem0.ai">
+  <Card title="Get an API Key" icon="key" href="https://app.mem0.ai/login">
     Sign up for Mem0 Platform and start building
   </Card>
   <Card title="Quickstart" icon="rocket" href="/platform/quickstart">
@@ -34,7 +34,7 @@ Works with Claude Code, Cursor, Windsurf, and any assistant that supports skills
 
 Connect Claude, Claude Code, Cursor, Windsurf, VS Code, OpenCode, or any MCP-compatible client to Mem0.
 
-Get your API key from [app.mem0.ai](https://app.mem0.ai), then add Mem0 MCP with a single command:
+Get your API key from <a href="https://app.mem0.ai" rel="nofollow">app.mem0.ai</a>, then add Mem0 MCP with a single command:
 
 ```bash
 npx mcp-add \


### PR DESCRIPTION
## Description

  An SEO audit found ~375 redirect chains across mem0.ai properties. ~222 of those originate from the Mintlify docs site (docs.mem0.ai) and are fixed in this PR:

  1. **Logo href fix (~200 chains):** The clickable logo on every docs page pointed to `app.mem0.ai/` which 307-redirected to `/login` for unauthenticated crawlers. Changed to `mem0.ai` which
  returns 200 directly.

  2. **Nofollow on auth-gated links (~19 chains):** All inline `app.mem0.ai/dashboard/*`, `app.mem0.ai/settings/*` links in 33 MDX files now have `rel="nofollow"` so crawlers skip them. Links still
   work for users.

  3. **Docs root link fix (3 chains):** Three MDX files linked to `docs.mem0.ai/` (root) which 308-redirected to `/introduction`. Changed to link directly to `/introduction`.

  **Remaining ~150 chains** originate from the Framer marketing site (mem0.ai, blog) and need to be fixed there:
  - Framer "Docs" navbar link should point to `docs.mem0.ai/introduction` not `docs.mem0.ai/` (~95 chains)
  - Blog CTA buttons to `app.mem0.ai/get-api-key` need nofollow (~8 chains)
  - Blog links using `www.mem0.ai` should use `mem0.ai` (~6 chains)

  ## Type of Change

  - [ ] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Refactor (no functional changes)
  - [x] Documentation update

  ## Breaking Changes

  N/A

  ## Test Coverage

  - [ ] I added/updated unit tests
  - [ ] I added/updated integration tests
  - [x] I tested manually (describe below)
  - [ ] No tests needed (explain why)

  Verified on local Mintlify dev server (`localhost:3000`):
  - Logo now links to `mem0.ai` (not `app.mem0.ai/`)
  - All `app.mem0.ai` hrefs in rendered HTML have `rel="nofollow"` or point to `/login`
  - Zero remaining markdown-style `[text](https://app.mem0.ai/...)` links in MDX files
  - `<a>` tags with nofollow render correctly inside Mintlify components (`<Note>`, `<Info>`, `<Card>`, markdown tables)
  - `docs.json` validates as valid JSON

  ## Checklist

  - [x] My code follows the project's style guidelines
  - [x] I have performed a self-review of my code
  - [ ] I have added tests that prove my fix/feature works
  - [x] New and existing tests pass locally
  - [x] I have updated documentation if needed