### PR TITLE
fix(openclaw): clear recall timeout to stop phantom timeout warnings (#4763)

### DIFF
--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -736,22 +736,34 @@ function registerHooks(
         };
       };
 
+      // Sentinel to distinguish a real timeout from a legitimate `undefined`
+      // return from `recallWork` (e.g. when no memories match). This avoids
+      // mis-logging a timeout when the work completed successfully with no
+      // results.
+      const TIMEOUT_SENTINEL = Symbol("openclaw-mem0.recall.timeout");
+      let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
       try {
-        const timeout = new Promise<undefined>((resolve) => {
-          setTimeout(() => resolve(undefined), RECALL_TIMEOUT_MS);
+        const timeout = new Promise<typeof TIMEOUT_SENTINEL>((resolve) => {
+          timeoutHandle = setTimeout(
+            () => resolve(TIMEOUT_SENTINEL),
+            RECALL_TIMEOUT_MS,
+          );
         });
-        const result = await Promise.race([
-          recallWork(),
-          timeout.then(() => {
-            api.logger.warn(
-              `openclaw-mem0: recall timed out after ${RECALL_TIMEOUT_MS}ms, skipping`,
-            );
-            return undefined;
-          }),
-        ]);
+        const result = await Promise.race([recallWork(), timeout]);
+        if (result === TIMEOUT_SENTINEL) {
+          api.logger.warn(
+            `openclaw-mem0: recall timed out after ${RECALL_TIMEOUT_MS}ms, skipping`,
+          );
+          return undefined;
+        }
         return result;
       } catch (err) {
         api.logger.warn(`openclaw-mem0: recall failed: ${String(err)}`);
+      } finally {
+        // Cancel the pending timer so a successful recall does not leave a
+        // phantom `setTimeout` callback that would fire RECALL_TIMEOUT_MS
+        // later and log a spurious "recall timed out" warning. See #4763.
+        if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
       }
     });
   }


### PR DESCRIPTION
## Summary

Fixes #4763. The `before_prompt_build` recall handler in `openclaw/index.ts` raced `recallWork()` against a `setTimeout`-backed timeout promise, but the timer was never cancelled when `recallWork` won the race. The scheduled callback still fired `RECALL_TIMEOUT_MS` later and ran `timeout.then(() => logger.warn(...))`, producing a misleading

```
openclaw-mem0: recall timed out after 8000ms, skipping
```

warning in the log long after a successful recall had already injected memories into the agent prompt.

In production this produced roughly one phantom warning per recall, which made it impossible to tell real timeouts from false positives and suggested a (non-existent) ~50% failure rate on the recall path.

## Fix

* Keep a reference to the `setTimeout` handle and `clearTimeout` it in a `finally` block. A successful recall (or a thrown error in `recallWork`) now cancels the pending timer so the `.then` callback never runs.
* Use an explicit `Symbol` sentinel on the timeout branch. Previously both "recall finished with no matching memories" and "timeout won the race" resolved to `undefined`, so the warning could not be gated on that value alone.
* Log the warning and return `undefined` only when the sentinel actually wins the race, preserving the exact user-visible behaviour of real timeouts.

## Test plan

Verified on a live OpenClaw gateway (`@mem0/openclaw-mem0@1.0.5`, OSS mode with Qdrant + Ollama):

- [x] Successful recall with matches: `injecting N memories into context` fires once, no phantom warning at handler-start + 8s.
- [x] Successful recall with **no** matches: handler returns silently, no `injecting` log, no phantom warning.
- [x] Forced real timeout (paused the embedder): `recall timed out after 8000ms, skipping` fires exactly once, handler returns `undefined`. Same behaviour as before the fix.
- [x] Thrown error inside `recallWork`: `finally` still runs, timer is cleared, no phantom warning, `recall failed: ...` is logged as before.
- [x] `node --check` on the transpiled bundle; TypeScript type-checks cleanly against the sentinel `Symbol` + `ReturnType<typeof setTimeout>`.

## Notes

* Kept the fix scoped to the single recall handler. The surrounding `recallWork` logic, `auto-capture` path, and the rest of `registerHooks` are untouched.
* Did not change `RECALL_TIMEOUT_MS` or expose it as config — intentionally a minimal fix. Happy to follow up with a separate PR making the timeout configurable if that's desired.
* Commit message references the issue; let me know if you'd like the PR title or commit split differently.
