### PR TITLE
Added GaussDB support for improved cloud database flexibility

### DIFF
--- a/docs/components/vectordbs/dbs/gaussdb.mdx
+++ b/docs/components/vectordbs/dbs/gaussdb.mdx
@@ -1,0 +1,123 @@
+---
+title: GaussDB
+description: "Use Huawei Cloud GaussDB as a vector store in Mem0 for PostgreSQL-compatible vector similarity search with built-in vector types."
+---
+
+[GaussDB](https://www.huaweicloud.com/product/gaussdb.html) is Huawei Cloud's enterprise-grade distributed relational database, fully compatible with PostgreSQL. It features built-in vector data types (`floatvector`, `boolvector`) — no extensions required — making it ideal for AI applications deployed on Huawei Cloud.
+
+### Usage
+
+```python
+import os
+from mem0 import Memory
+
+os.environ["OPENAI_API_KEY"] = "sk-xx"
+
+config = {
+    "vector_store": {
+        "provider": "gaussdb",
+        "config": {
+            "host": "127.0.0.1",
+            "port": 5432,
+            "user": "test",
+            "password": "123",
+            "dbname": "mem0_db",
+        }
+    }
+}
+
+m = Memory.from_config(config)
+messages = [
+    {"role": "user", "content": "I'm planning to watch a movie tonight. Any recommendations?"},
+    {"role": "assistant", "content": "How about thriller movies? They can be quite engaging."},
+    {"role": "user", "content": "I'm not a big fan of thriller movies but I love sci-fi movies."},
+    {"role": "assistant", "content": "Got it! I'll avoid thriller recommendations and suggest sci-fi movies in the future."}
+]
+m.add(messages, user_id="alice", metadata={"category": "movies"})
+```
+
+#### Using HNSW Index
+
+For faster approximate nearest neighbor search with sufficient memory:
+
+```python
+config = {
+    "vector_store": {
+        "provider": "gaussdb",
+        "config": {
+            "host": "127.0.0.1",
+            "port": 5432,
+            "user": "test",
+            "password": "123",
+            "dbname": "mem0_db",
+            "hnsw": True,
+        }
+    }
+}
+```
+
+#### Using DiskANN Index
+
+For large-scale datasets with disk-friendly approximate nearest neighbor search:
+
+```python
+config = {
+    "vector_store": {
+        "provider": "gaussdb",
+        "config": {
+            "host": "127.0.0.1",
+            "port": 5432,
+            "user": "test",
+            "password": "123",
+            "dbname": "mem0_db",
+            "diskann": True,
+        }
+    }
+}
+```
+
+#### Using Connection String with SSL
+
+```python
+config = {
+    "vector_store": {
+        "provider": "gaussdb",
+        "config": {
+            "connection_string": "host=127.0.0.1 port=5432 user=test password=123 dbname=mem0_db",
+            "sslmode": "require",
+        }
+    }
+}
+```
+
+<Note>
+GaussDB has built-in vector types and does not require `CREATE EXTENSION vector` (unlike PostgreSQL with pgvector). The `gaussdb` Python driver and `gaussdb-pool` package are required: `pip install gaussdb gaussdb-pool`.
+</Note>
+
+### Config
+
+Here are the parameters available for configuring GaussDB:
+
+| Parameter | Description | Default Value |
+| --- | --- | --- |
+| `host` | GaussDB server host | `None` |
+| `port` | GaussDB server port | `5432` |
+| `user` | Database user | `None` |
+| `password` | Database password | `None` |
+| `dbname` | Database name | `None` |
+| `collection_name` | Table name used as collection | `mem0` |
+| `embedding_model_dims` | Dimensions of the embedding model | `1536` |
+| `diskann` | Whether to use DiskANN index for ANN search | `False` |
+| `hnsw` | Whether to use HNSW index for ANN search | `False` |
+| `sslmode` | SSL mode for connection (e.g., 'disable', 'require', 'verify-full') | `None` |
+| `minconn` | Minimum number of connections in the pool | `1` |
+| `maxconn` | Maximum number of connections in the pool | `5` |
+| `connection_string` | Full DSN connection string (overrides individual parameters) | `None` |
+| `connection_pool` | Pre-configured connection pool object | `None` |
+
+**Note**: When both `diskann` and `hnsw` are enabled, only DiskANN index is created.
+
+**Note**: The connection parameters have the following priority:
+1. `connection_pool` (highest priority)
+2. `connection_string`
+3. Individual connection parameters (`host`, `port`, `user`, `password`, `dbname`, `sslmode`)

--- a/docs/components/vectordbs/overview.mdx
+++ b/docs/components/vectordbs/overview.mdx
@@ -34,6 +34,7 @@ See the list of supported vector databases below.
   <Card title="Amazon S3 Vectors" href="/components/vectordbs/dbs/s3_vectors"></Card>
   <Card title="Databricks" href="/components/vectordbs/dbs/databricks"></Card>
   <Card title="Turbopuffer" href="/components/vectordbs/dbs/turbopuffer"></Card>
+  <Card title="GaussDB" href="/components/vectordbs/dbs/gaussdb"></Card>
 </CardGroup>
 
 ## Usage

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -235,7 +235,8 @@
                               "components/vectordbs/dbs/s3_vectors",
                               "components/vectordbs/dbs/databricks",
                               "components/vectordbs/dbs/neptune_analytics",
-                              "components/vectordbs/dbs/turbopuffer"
+                              "components/vectordbs/dbs/turbopuffer",
+                              "components/vectordbs/dbs/gaussdb"
                             ]
                           }
                         ]

--- a/mem0/configs/vector_stores/gaussdb.py
+++ b/mem0/configs/vector_stores/gaussdb.py
@@ -1,0 +1,48 @@
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class GaussDBConfig(BaseModel):
+    """Configuration for GaussDB vector database."""
+
+    host: Optional[str] = Field(None, description="GaussDB server host")
+    port: int = Field(5432, description="GaussDB server port")
+    user: Optional[str] = Field(None, description="Database user")
+    password: Optional[str] = Field(None, description="Database password")
+    dbname: Optional[str] = Field(None, description="Database name")
+    collection_name: str = Field("mem0", description="Table name used as collection")
+    embedding_model_dims: int = Field(1536, description="Dimensions of the embedding model")
+    diskann: bool = Field(False, description="Create DiskANN index for ANN search")
+    hnsw: bool = Field(False, description="Create HNSW index for ANN search")
+    sslmode: Optional[str] = Field(None, description="SSL mode: disable/require/verify-full")
+    minconn: int = Field(1, description="Minimum number of connections in the pool")
+    maxconn: int = Field(5, description="Maximum number of connections in the pool")
+    connection_string: Optional[str] = Field(None, description="Full DSN, overrides individual params")
+    connection_pool: Optional[Any] = Field(None, description="Pre-configured connection pool object")
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_auth(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        if values.get("connection_pool") or values.get("connection_string"):
+            return values
+        for field in ("host", "user", "dbname", "password"):
+            if not values.get(field):
+                raise ValueError(
+                    f"'{field}' is required when connection_pool and connection_string are not provided"
+                )
+        return values
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_extra_fields(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        allowed_fields = set(cls.model_fields.keys())
+        extra_fields = set(values.keys()) - allowed_fields
+        if extra_fields:
+            raise ValueError(
+                f"Extra fields not allowed: {', '.join(extra_fields)}. "
+                f"Allowed fields: {', '.join(allowed_fields)}"
+            )
+        return values

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -173,6 +173,7 @@ class VectorStoreFactory:
         "upstash_vector": "mem0.vector_stores.upstash_vector.UpstashVector",
         "azure_ai_search": "mem0.vector_stores.azure_ai_search.AzureAISearch",
         "azure_mysql": "mem0.vector_stores.azure_mysql.AzureMySQL",
+        "gaussdb": "mem0.vector_stores.gaussdb.GaussDB",
         "pinecone": "mem0.vector_stores.pinecone.PineconeDB",
         "mongodb": "mem0.vector_stores.mongodb.MongoDB",
         "redis": "mem0.vector_stores.redis.RedisDB",

--- a/mem0/vector_stores/configs.py
+++ b/mem0/vector_stores/configs.py
@@ -23,6 +23,7 @@ class VectorStoreConfig(BaseModel):
         "upstash_vector": "UpstashVectorConfig",
         "azure_ai_search": "AzureAISearchConfig",
         "azure_mysql": "AzureMySQLConfig",
+        "gaussdb": "GaussDBConfig",
         "redis": "RedisDBConfig",
         "valkey": "ValkeyConfig",
         "databricks": "DatabricksConfig",

--- a/mem0/vector_stores/gaussdb.py
+++ b/mem0/vector_stores/gaussdb.py
@@ -1,0 +1,366 @@
+import json
+import logging
+from contextlib import contextmanager
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
+
+try:
+    import gaussdb  # noqa: F401
+    from gaussdb_pool import ConnectionPool
+    from gaussdb.rows import dict_row
+    from gaussdb.types.json import Jsonb
+    GAUSSDB_AVAILABLE = True
+except ImportError:
+    GAUSSDB_AVAILABLE = False
+    ConnectionPool = None
+    dict_row = None
+    Jsonb = None
+
+from mem0.vector_stores.base import VectorStoreBase
+
+logger = logging.getLogger(__name__)
+
+
+class OutputData(BaseModel):
+    id: Optional[str]
+    score: Optional[float]
+    payload: Optional[dict]
+
+
+class GaussDB(VectorStoreBase):
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        user: str,
+        password: Optional[str],
+        dbname: str,
+        collection_name: str,
+        embedding_model_dims: int,
+        diskann: bool = False,
+        hnsw: bool = False,
+        sslmode: Optional[str] = None,
+        minconn: int = 1,
+        maxconn: int = 5,
+        connection_string: Optional[str] = None,
+        connection_pool: Optional[Any] = None,
+    ):
+        """
+        Initialize the GaussDB vector store.
+
+        Args:
+            host (str): GaussDB server host.
+            port (int): GaussDB server port.
+            user (str): Database user.
+            password (str, optional): Database password.
+            dbname (str): Database name.
+            collection_name (str): Table name used as collection.
+            embedding_model_dims (int): Dimension of the embedding vector.
+            diskann (bool): Use DiskANN index for faster search.
+            hnsw (bool): Use HNSW index for faster search.
+            sslmode (str, optional): SSL mode (e.g., 'disable', 'require', 'verify-full').
+            minconn (int): Minimum number of connections in the pool.
+            maxconn (int): Maximum number of connections in the pool.
+            connection_string (str, optional): Full DSN connection string (overrides individual parameters).
+            connection_pool (Any, optional): Pre-configured connection pool object.
+        """
+        if not GAUSSDB_AVAILABLE:
+            raise ImportError(
+                "GaussDB vector store requires the gaussdb package. "
+                "Install with: pip install gaussdb gaussdb-pool"
+            )
+
+        self.collection_name = collection_name
+        self.embedding_model_dims = embedding_model_dims
+        self.use_diskann = diskann
+        self.hnsw = hnsw
+
+        if connection_pool is not None:
+            self.connection_pool = connection_pool
+        else:
+            conninfo = connection_string or (
+                f"host={host} port={port} user={user} "
+                f"password={password} dbname={dbname}"
+            )
+            if sslmode:
+                conninfo = f"{conninfo} sslmode={sslmode}"
+            self.connection_pool = ConnectionPool(
+                conninfo, min_size=minconn, max_size=maxconn, open=True
+            )
+            logger.info("GaussDB connection pool created")
+
+        if collection_name not in self.list_cols():
+            self.create_col(collection_name, embedding_model_dims)
+
+    @contextmanager
+    def _get_cursor(self, commit: bool = False):
+        """
+        Unified context manager to get a cursor from the connection pool.
+        Auto-commits or rolls back based on exception, and returns the connection to the pool.
+        """
+        with self.connection_pool.connection() as conn:
+            with conn.cursor(row_factory=dict_row) as cur:
+                try:
+                    yield cur
+                    if commit:
+                        conn.commit()
+                except Exception as exc:
+                    conn.rollback()
+                    logger.error(f"Database error: {exc}", exc_info=True)
+                    raise
+
+    def create_col(self, name: str = None, vector_size: int = None, distance: str = "cosine"):
+        """
+        Create a new collection (table in GaussDB).
+        Will also initialize vector search index (DiskANN or HNSW) if specified.
+        """
+        table = name or self.collection_name
+        dims = vector_size or self.embedding_model_dims
+        with self._get_cursor(commit=True) as cur:
+            cur.execute(f"""
+                CREATE TABLE IF NOT EXISTS {table} (
+                    id      UUID PRIMARY KEY,
+                    vector  vector({dims}),
+                    payload JSONB
+                )
+            """)
+            if self.use_diskann:
+                cur.execute(f"""
+                    CREATE INDEX IF NOT EXISTS {table}_diskann_idx
+                    ON {table} USING diskann (vector vector_cosine_ops)
+                """)
+            elif self.hnsw:
+                cur.execute(f"""
+                    CREATE INDEX IF NOT EXISTS {table}_hnsw_idx
+                    ON {table} USING hnsw (vector vector_cosine_ops)
+                """)
+        logger.info(f"Created collection '{table}' (dims={dims}, diskann={self.use_diskann}, hnsw={self.hnsw})")
+
+    def insert(
+        self,
+        vectors: List[List[float]],
+        payloads: Optional[List[Dict]] = None,
+        ids: Optional[List[str]] = None,
+    ):
+        """
+        Insert vectors into the collection. Uses executemany for batch insertion
+        with ON DUPLICATE KEY UPDATE for upsert semantics.
+
+        Args:
+            vectors (List[List[float]]): List of embedding vectors.
+            payloads (List[Dict], optional): List of metadata payloads.
+            ids (List[str], optional): List of vector IDs. Auto-generated UUIDs if not provided.
+        """
+        if payloads is None:
+            payloads = [{}] * len(vectors)
+        if ids is None:
+            import uuid
+            ids = [str(uuid.uuid4()) for _ in range(len(vectors))]
+
+        data = [(vid, str(vec), Jsonb(pl)) for vid, vec, pl in zip(ids, vectors, payloads)]
+        with self._get_cursor(commit=True) as cur:
+            cur.executemany(
+                f"INSERT INTO {self.collection_name} (id, vector, payload) "
+                f"VALUES (%s, %s, %s) "
+                f"ON DUPLICATE KEY UPDATE vector = VALUES(vector), payload = VALUES(payload)",
+                data,
+            )
+
+    def search(
+        self,
+        query: str,
+        vectors: List[float],
+        limit: int = 5,
+        filters: Optional[Dict] = None,
+    ) -> List[OutputData]:
+        """
+        Search for similar vectors using cosine distance.
+
+        Args:
+            query (str): Query string (unused, kept for interface compatibility).
+            vectors (List[float]): Query vector.
+            limit (int): Number of results to return. Defaults to 5.
+            filters (Dict, optional): JSONB payload filters to apply.
+
+        Returns:
+            List[OutputData]: Search results sorted by distance.
+        """
+        conditions, params = [], []
+        if filters:
+            for k, v in filters.items():
+                conditions.append("payload->>%s = %s")
+                params.extend([k, str(v)])
+        where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
+
+        with self._get_cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT id, vector <=> %s::vector AS distance, payload
+                FROM {self.collection_name}
+                {where}
+                ORDER BY distance
+                LIMIT %s
+                """,
+                [str(vectors)] + params + [limit],
+            )
+            results = cur.fetchall()
+
+        return [
+            OutputData(
+                id=str(r["id"]),
+                score=float(r["distance"]),
+                payload=json.loads(r["payload"]) if isinstance(r["payload"], str) else r["payload"],
+            )
+            for r in results
+        ]
+
+    def delete(self, vector_id: str):
+        """
+        Delete a vector by ID.
+
+        Args:
+            vector_id (str): ID of the vector to delete.
+        """
+        with self._get_cursor(commit=True) as cur:
+            cur.execute(f"DELETE FROM {self.collection_name} WHERE id = %s", (vector_id,))
+
+    def update(
+        self,
+        vector_id: str,
+        vector: Optional[List[float]] = None,
+        payload: Optional[Dict] = None,
+    ):
+        """
+        Update a vector and/or its payload.
+
+        Args:
+            vector_id (str): ID of the vector to update.
+            vector (List[float], optional): Updated vector.
+            payload (Dict, optional): Updated payload.
+        """
+        with self._get_cursor(commit=True) as cur:
+            if vector is not None:
+                cur.execute(
+                    f"UPDATE {self.collection_name} SET vector = %s::vector WHERE id = %s",
+                    (str(vector), vector_id),
+                )
+            if payload is not None:
+                cur.execute(
+                    f"UPDATE {self.collection_name} SET payload = %s WHERE id = %s",
+                    (Jsonb(payload), vector_id),
+                )
+
+    def get(self, vector_id: str) -> Optional[OutputData]:
+        """
+        Retrieve a vector by ID.
+
+        Args:
+            vector_id (str): ID of the vector to retrieve.
+
+        Returns:
+            OutputData: Retrieved vector, or None if not found.
+        """
+        with self._get_cursor() as cur:
+            cur.execute(
+                f"SELECT id, payload FROM {self.collection_name} WHERE id = %s",
+                (vector_id,),
+            )
+            r = cur.fetchone()
+        if not r:
+            return None
+        return OutputData(
+            id=str(r["id"]),
+            score=None,
+            payload=json.loads(r["payload"]) if isinstance(r["payload"], str) else r["payload"],
+        )
+
+    def list_cols(self) -> List[str]:
+        """
+        List all collections (tables) in the public schema.
+
+        Returns:
+            List[str]: List of collection names.
+        """
+        with self._get_cursor() as cur:
+            cur.execute(
+                "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'"
+            )
+            return [row["table_name"] for row in cur.fetchall()]
+
+    def delete_col(self):
+        """Delete the current collection."""
+        with self._get_cursor(commit=True) as cur:
+            cur.execute(f"DROP TABLE IF EXISTS {self.collection_name}")
+        logger.info(f"Deleted collection '{self.collection_name}'")
+
+    def col_info(self) -> Dict[str, Any]:
+        """
+        Get information about the current collection.
+
+        Returns:
+            Dict[str, Any]: Collection info with name, count, and size. Empty dict if not found.
+        """
+        with self._get_cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT table_name,
+                       (SELECT COUNT(*) FROM {self.collection_name}) AS row_count,
+                       pg_size_pretty(pg_total_relation_size('{self.collection_name}')) AS total_size
+                FROM information_schema.tables
+                WHERE table_schema = 'public' AND table_name = %s
+                """,
+                (self.collection_name,),
+            )
+            r = cur.fetchone()
+        return (
+            {"name": r["table_name"], "count": r["row_count"], "size": r["total_size"]}
+            if r
+            else {}
+        )
+
+    def list(self, filters: Optional[Dict] = None, limit: int = 100) -> List[List[OutputData]]:
+        """
+        List all vectors in the collection.
+
+        Args:
+            filters (Dict, optional): JSONB payload filters to apply.
+            limit (int): Maximum number of vectors to return. Defaults to 100.
+
+        Returns:
+            List[List[OutputData]]: List of vectors.
+        """
+        conditions, params = [], []
+        if filters:
+            for k, v in filters.items():
+                conditions.append("payload->>%s = %s")
+                params.extend([k, str(v)])
+        where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
+        with self._get_cursor() as cur:
+            cur.execute(
+                f"SELECT id, payload FROM {self.collection_name} {where} LIMIT %s",
+                (*params, limit),
+            )
+            results = cur.fetchall()
+        return [[
+            OutputData(
+                id=str(r["id"]),
+                score=None,
+                payload=json.loads(r["payload"]) if isinstance(r["payload"], str) else r["payload"],
+            )
+            for r in results
+        ]]
+
+    def reset(self):
+        """Reset the collection by deleting and recreating it."""
+        logger.warning(f"Resetting collection {self.collection_name}...")
+        self.delete_col()
+        self.create_col(name=self.collection_name, vector_size=self.embedding_model_dims)
+
+    def __del__(self):
+        """Close the database connection pool when the object is deleted."""
+        try:
+            if hasattr(self, "connection_pool") and self.connection_pool:
+                self.connection_pool.close()
+        except Exception:
+            pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ vector_stores = [
     "pymongo>=4.13.2",
     "pymochow>=2.2.9",
     "pymysql>=1.1.0",
+    "gaussdb[pool]>=1.0.0",
     "dbutils>=3.0.3",
     "valkey>=6.0.0",
     "databricks-sdk>=0.63.0",

--- a/tests/vector_stores/test_gaussdb.py
+++ b/tests/vector_stores/test_gaussdb.py
@@ -1,0 +1,499 @@
+import json
+import uuid
+import pytest
+from unittest.mock import Mock, patch
+
+from mem0.vector_stores.gaussdb import GaussDB, OutputData
+
+
+@pytest.fixture(autouse=True)
+def mock_jsonb():
+    """Mock Jsonb as a passthrough so tests work without the gaussdb driver."""
+    with patch("mem0.vector_stores.gaussdb.Jsonb", side_effect=lambda x: x):
+        yield
+
+
+@pytest.fixture
+def mock_connection_pool():
+    pool = Mock()
+    conn = Mock()
+    cursor = Mock()
+
+    cursor.fetchall = Mock(return_value=[])
+    cursor.fetchone = Mock(return_value=None)
+    cursor.execute = Mock()
+    cursor.__enter__ = Mock(return_value=cursor)
+    cursor.__exit__ = Mock(return_value=False)
+
+    conn.cursor = Mock(return_value=cursor)
+    conn.commit = Mock()
+    conn.rollback = Mock()
+    conn.__enter__ = Mock(return_value=conn)
+    conn.__exit__ = Mock(return_value=False)
+
+    pool.connection = Mock(return_value=conn)
+    pool.close = Mock()
+
+    return pool, conn, cursor
+
+
+@pytest.fixture
+def gaussdb_instance(mock_connection_pool):
+    pool, conn, cursor = mock_connection_pool
+    with patch("mem0.vector_stores.gaussdb.GAUSSDB_AVAILABLE", True), \
+         patch("mem0.vector_stores.gaussdb.ConnectionPool") as MockPool:
+        MockPool.return_value = pool
+        instance = GaussDB(
+            host="localhost",
+            port=5432,
+            user="test",
+            password="test",
+            dbname="testdb",
+            collection_name="test_col",
+            embedding_model_dims=4,
+        )
+        instance.connection_pool = pool
+        return instance
+
+
+def test_init_creates_pool(mock_connection_pool):
+    pool, conn, cursor = mock_connection_pool
+    with patch("mem0.vector_stores.gaussdb.GAUSSDB_AVAILABLE", True), \
+         patch("mem0.vector_stores.gaussdb.ConnectionPool") as MockPool:
+        MockPool.return_value = pool
+        GaussDB(
+            host="localhost", port=5432, user="test", password="test",
+            dbname="testdb", collection_name="test_col", embedding_model_dims=4,
+        )
+        call_kwargs = MockPool.call_args
+        conninfo = call_kwargs[0][0]
+        assert "localhost" in conninfo
+        assert "5432" in conninfo
+        assert "test" in conninfo
+        assert "testdb" in conninfo
+
+
+def test_init_with_connection_pool(mock_connection_pool):
+    pool, conn, cursor = mock_connection_pool
+    with patch("mem0.vector_stores.gaussdb.GAUSSDB_AVAILABLE", True), \
+         patch("mem0.vector_stores.gaussdb.ConnectionPool") as MockPool:
+        GaussDB(
+            host="localhost", port=5432, user="test", password="test",
+            dbname="testdb", collection_name="test_col", embedding_model_dims=4,
+            connection_pool=pool,
+        )
+        MockPool.assert_not_called()
+
+
+def test_init_creates_collection_if_not_exists(mock_connection_pool):
+    pool, conn, cursor = mock_connection_pool
+    cursor.fetchall.return_value = []
+    with patch("mem0.vector_stores.gaussdb.GAUSSDB_AVAILABLE", True), \
+         patch("mem0.vector_stores.gaussdb.ConnectionPool") as MockPool:
+        MockPool.return_value = pool
+        GaussDB(
+            host="localhost", port=5432, user="test", password="test",
+            dbname="testdb", collection_name="test_col", embedding_model_dims=4,
+        )
+    sql_calls = " ".join(str(c) for c in cursor.execute.call_args_list)
+    assert "CREATE TABLE" in sql_calls
+
+
+def test_init_skips_create_if_exists(mock_connection_pool):
+    pool, conn, cursor = mock_connection_pool
+    cursor.fetchall.return_value = [{"table_name": "test_col"}]
+    with patch("mem0.vector_stores.gaussdb.GAUSSDB_AVAILABLE", True), \
+         patch("mem0.vector_stores.gaussdb.ConnectionPool") as MockPool:
+        MockPool.return_value = pool
+        cursor.execute.reset_mock()
+        GaussDB(
+            host="localhost", port=5432, user="test", password="test",
+            dbname="testdb", collection_name="test_col", embedding_model_dims=4,
+        )
+    sql_calls = " ".join(str(c) for c in cursor.execute.call_args_list)
+    assert "CREATE TABLE" not in sql_calls
+
+
+def test_create_col_without_hnsw(gaussdb_instance, mock_connection_pool):
+    pool, conn, cursor = mock_connection_pool
+    cursor.execute.reset_mock()
+    gaussdb_instance.create_col(name="new_col", vector_size=4)
+    sql_calls = " ".join(str(c) for c in cursor.execute.call_args_list)
+    assert "CREATE TABLE" in sql_calls
+    assert "CREATE INDEX" not in sql_calls
+
+
+def test_create_col_with_hnsw(mock_connection_pool):
+    pool, conn, cursor = mock_connection_pool
+    cursor.fetchall.return_value = [{"table_name": "test_col"}]
+    with patch("mem0.vector_stores.gaussdb.GAUSSDB_AVAILABLE", True), \
+         patch("mem0.vector_stores.gaussdb.ConnectionPool") as MockPool:
+        MockPool.return_value = pool
+        instance = GaussDB(
+            host="localhost", port=5432, user="test", password="test",
+            dbname="testdb", collection_name="test_col", embedding_model_dims=4,
+            hnsw=True,
+        )
+        instance.connection_pool = pool
+    cursor.execute.reset_mock()
+    instance.create_col(name="new_col", vector_size=4)
+    sql_calls = " ".join(str(c) for c in cursor.execute.call_args_list)
+    assert "hnsw" in sql_calls.lower()
+
+
+def test_create_col_with_diskann(mock_connection_pool):
+    pool, conn, cursor = mock_connection_pool
+    cursor.fetchall.return_value = [{"table_name": "test_col"}]
+    with patch("mem0.vector_stores.gaussdb.GAUSSDB_AVAILABLE", True), \
+         patch("mem0.vector_stores.gaussdb.ConnectionPool") as MockPool:
+        MockPool.return_value = pool
+        instance = GaussDB(
+            host="localhost", port=5432, user="test", password="test",
+            dbname="testdb", collection_name="test_col", embedding_model_dims=4,
+            diskann=True,
+        )
+        instance.connection_pool = pool
+    cursor.execute.reset_mock()
+    instance.create_col(name="new_col", vector_size=4)
+    sql_calls = " ".join(str(c) for c in cursor.execute.call_args_list)
+    assert "diskann" in sql_calls.lower()
+    assert "hnsw" not in sql_calls.lower()
+
+
+def test_create_col_diskann_takes_priority_over_hnsw(mock_connection_pool):
+    pool, conn, cursor = mock_connection_pool
+    cursor.fetchall.return_value = [{"table_name": "test_col"}]
+    with patch("mem0.vector_stores.gaussdb.GAUSSDB_AVAILABLE", True), \
+         patch("mem0.vector_stores.gaussdb.ConnectionPool") as MockPool:
+        MockPool.return_value = pool
+        instance = GaussDB(
+            host="localhost", port=5432, user="test", password="test",
+            dbname="testdb", collection_name="test_col", embedding_model_dims=4,
+            diskann=True, hnsw=True,
+        )
+        instance.connection_pool = pool
+    cursor.execute.reset_mock()
+    instance.create_col(name="new_col", vector_size=4)
+    sql_calls = " ".join(str(c) for c in cursor.execute.call_args_list)
+    assert "diskann" in sql_calls.lower()
+    assert "hnsw" not in sql_calls.lower()
+
+
+def test_insert_uses_executemany(gaussdb_instance, mock_connection_pool):
+    pool, conn, cursor = mock_connection_pool
+    cursor.executemany = Mock()
+    gaussdb_instance.insert(
+        vectors=[[0.1, 0.2, 0.3, 0.4], [0.5, 0.6, 0.7, 0.8]],
+        payloads=[{"text": "a"}, {"text": "b"}],
+        ids=[str(uuid.uuid4()), str(uuid.uuid4())],
+    )
+    assert cursor.executemany.call_count == 1
+    data = cursor.executemany.call_args[0][1]
+    assert len(data) == 2
+
+
+def test_insert_uses_on_duplicate_key_update(gaussdb_instance, mock_connection_pool):
+    pool, conn, cursor = mock_connection_pool
+    cursor.executemany = Mock()
+    gaussdb_instance.insert(vectors=[[0.1, 0.2, 0.3, 0.4]], ids=[str(uuid.uuid4())])
+    sql = cursor.executemany.call_args[0][0]
+    assert "ON DUPLICATE KEY UPDATE" in sql
+    assert "ON CONFLICT" not in sql
+
+
+def test_insert_generates_ids_if_none(gaussdb_instance, mock_connection_pool):
+    pool, conn, cursor = mock_connection_pool
+    cursor.executemany = Mock()
+    gaussdb_instance.insert(vectors=[[0.1, 0.2, 0.3, 0.4]])
+    assert cursor.executemany.call_count == 1
+    data = cursor.executemany.call_args[0][1]
+    assert data[0][0] is not None  # auto-generated id
+
+
+def test_search_uses_cosine_operator(gaussdb_instance, mock_connection_pool):
+    pool, conn, cursor = mock_connection_pool
+    test_uuid = str(uuid.uuid4())
+    cursor.fetchall.return_value = [
+        {"id": test_uuid, "distance": 0.1, "payload": json.dumps({"text": "hello"})}
+    ]
+    results = gaussdb_instance.search(query="test", vectors=[0.1, 0.2, 0.3, 0.4])
+    sql = cursor.execute.call_args[0][0]
+    assert "<=>" in sql
+    assert isinstance(results, list)
+    assert isinstance(results[0], OutputData)
+
+
+def test_search_with_filters(gaussdb_instance, mock_connection_pool):
+    pool, conn, cursor = mock_connection_pool
+    cursor.fetchall.return_value = []
+    gaussdb_instance.search(query="test", vectors=[0.1, 0.2, 0.3, 0.4], filters={"user_id": "alice"})
+    sql = cursor.execute.call_args[0][0]
+    assert "payload->>" in sql
+
+
+def test_search_returns_correct_score(gaussdb_instance, mock_connection_pool):
+    pool, conn, cursor = mock_connection_pool
+    cursor.fetchall.return_value = [
+        {"id": str(uuid.uuid4()), "distance": 0.42, "payload": {"text": "hello"}}
+    ]
+    results = gaussdb_instance.search(query="test", vectors=[0.1, 0.2, 0.3, 0.4])
+    assert results[0].score == pytest.approx(0.42)
+
+
+def test_delete_executes_correct_sql(gaussdb_instance, mock_connection_pool):
+    pool, conn, cursor = mock_connection_pool
+    cursor.execute.reset_mock()
+    test_uuid = str(uuid.uuid4())
+    gaussdb_instance.delete(test_uuid)
+    sql = cursor.execute.call_args[0][0]
+    assert "DELETE FROM" in sql
+    assert cursor.execute.call_args[0][1] == (test_uuid,)
+
+
+def test_update_vector_only(gaussdb_instance, mock_connection_pool):
+    pool, conn, cursor = mock_connection_pool
+    cursor.execute.reset_mock()
+    gaussdb_instance.update(str(uuid.uuid4()), vector=[0.1, 0.2, 0.3, 0.4])
+    assert cursor.execute.call_count == 1
+    sql = cursor.execute.call_args[0][0]
+    assert "vector" in sql
+    assert "::vector" in sql
+
+
+def test_update_payload_only(gaussdb_instance, mock_connection_pool):
+    pool, conn, cursor = mock_connection_pool
+    cursor.execute.reset_mock()
+    gaussdb_instance.update(str(uuid.uuid4()), payload={"text": "updated"})
+    assert cursor.execute.call_count == 1
+    sql = cursor.execute.call_args[0][0]
+    assert "payload" in sql
+    assert "vector" not in sql
+
+
+def test_get_returns_output_data(gaussdb_instance, mock_connection_pool):
+    pool, conn, cursor = mock_connection_pool
+    test_uuid = str(uuid.uuid4())
+    cursor.fetchone.return_value = {"id": test_uuid, "payload": json.dumps({"text": "hello"})}
+    result = gaussdb_instance.get(test_uuid)
+    assert isinstance(result, OutputData)
+    assert result.id == test_uuid
+    assert result.score is None
+
+
+def test_get_returns_none_if_not_found(gaussdb_instance, mock_connection_pool):
+    pool, conn, cursor = mock_connection_pool
+    cursor.fetchone.return_value = None
+    result = gaussdb_instance.get(str(uuid.uuid4()))
+    assert result is None
+
+
+def test_list_cols_queries_information_schema(gaussdb_instance, mock_connection_pool):
+    pool, conn, cursor = mock_connection_pool
+    cursor.fetchall.return_value = [{"table_name": "test_col"}]
+    cols = gaussdb_instance.list_cols()
+    sql = cursor.execute.call_args[0][0]
+    assert "information_schema" in sql
+    assert "public" in sql
+    assert cols == ["test_col"]
+
+
+def test_delete_col_drops_table(gaussdb_instance, mock_connection_pool):
+    pool, conn, cursor = mock_connection_pool
+    cursor.execute.reset_mock()
+    gaussdb_instance.delete_col()
+    sql = cursor.execute.call_args[0][0]
+    assert "DROP TABLE IF EXISTS" in sql
+    assert "test_col" in sql
+
+
+def test_col_info_returns_dict(gaussdb_instance, mock_connection_pool):
+    pool, conn, cursor = mock_connection_pool
+    cursor.fetchone.return_value = {"table_name": "test_col", "row_count": 10, "total_size": "16 kB"}
+    info = gaussdb_instance.col_info()
+    assert info["name"] == "test_col"
+    assert info["count"] == 10
+    assert "size" in info
+
+
+def test_col_info_returns_empty_if_not_found(gaussdb_instance, mock_connection_pool):
+    pool, conn, cursor = mock_connection_pool
+    cursor.fetchone.return_value = None
+    info = gaussdb_instance.col_info()
+    assert info == {}
+
+
+def test_list_with_filters(gaussdb_instance, mock_connection_pool):
+    pool, conn, cursor = mock_connection_pool
+    cursor.fetchall.return_value = []
+    gaussdb_instance.list(filters={"user_id": "alice"})
+    sql = cursor.execute.call_args[0][0]
+    assert "payload->>" in sql
+
+
+def test_reset_deletes_and_recreates(gaussdb_instance, mock_connection_pool):
+    pool, conn, cursor = mock_connection_pool
+    cursor.execute.reset_mock()
+    gaussdb_instance.reset()
+    sql_calls = " ".join(str(c) for c in cursor.execute.call_args_list)
+    assert "DROP TABLE" in sql_calls
+    assert "CREATE TABLE" in sql_calls
+
+
+def test_del_closes_pool(gaussdb_instance, mock_connection_pool):
+    pool, conn, cursor = mock_connection_pool
+    gaussdb_instance.__del__()
+    pool.close.assert_called_once()
+
+
+def test_output_data_model():
+    test_uuid = str(uuid.uuid4())
+    data = OutputData(id=test_uuid, score=0.95, payload={"text": "hello"})
+    assert data.id == test_uuid
+    assert data.score == 0.95
+    assert data.payload == {"text": "hello"}
+
+    empty = OutputData(id=None, score=None, payload=None)
+    assert empty.id is None
+
+
+def test_search_returns_multiple_results_with_correct_fields(gaussdb_instance, mock_connection_pool):
+    """Test search returns multiple results with correct id, score, payload."""
+    pool, conn, cursor = mock_connection_pool
+    uid1, uid2 = str(uuid.uuid4()), str(uuid.uuid4())
+    cursor.fetchall.return_value = [
+        {"id": uid1, "distance": 0.1, "payload": {"user_id": "alice", "text": "hello"}},
+        {"id": uid2, "distance": 0.2, "payload": {"user_id": "alice", "text": "world"}},
+    ]
+    results = gaussdb_instance.search(query="test", vectors=[0.1, 0.2, 0.3, 0.4], limit=2)
+    assert len(results) == 2
+    assert results[0].id == uid1
+    assert results[0].score == pytest.approx(0.1)
+    assert results[0].payload["text"] == "hello"
+    assert results[1].id == uid2
+    assert results[1].score == pytest.approx(0.2)
+    assert results[1].payload["text"] == "world"
+
+
+def test_search_with_multiple_filters(gaussdb_instance, mock_connection_pool):
+    """Test search with multiple filters verifies WHERE clause and payload content."""
+    pool, conn, cursor = mock_connection_pool
+    uid = str(uuid.uuid4())
+    cursor.fetchall.return_value = [
+        {"id": uid, "distance": 0.1, "payload": {"user_id": "alice", "agent_id": "agent1", "run_id": "run1"}},
+    ]
+    filters = {"user_id": "alice", "agent_id": "agent1", "run_id": "run1"}
+    results = gaussdb_instance.search(query="test", vectors=[0.1, 0.2, 0.3, 0.4], filters=filters)
+    sql = cursor.execute.call_args[0][0]
+    assert "WHERE" in sql
+    assert sql.count("payload->>") == 3
+    assert len(results) == 1
+    assert results[0].payload["user_id"] == "alice"
+    assert results[0].payload["agent_id"] == "agent1"
+    assert results[0].payload["run_id"] == "run1"
+
+
+def test_search_without_filters_has_no_where(gaussdb_instance, mock_connection_pool):
+    """Test search without filters does not include WHERE clause."""
+    pool, conn, cursor = mock_connection_pool
+    cursor.fetchall.return_value = []
+    gaussdb_instance.search(query="test", vectors=[0.1, 0.2, 0.3, 0.4])
+    sql = cursor.execute.call_args[0][0]
+    assert "WHERE" not in sql
+
+
+def test_list_without_filters_has_no_where(gaussdb_instance, mock_connection_pool):
+    """Test list without filters does not include WHERE clause."""
+    pool, conn, cursor = mock_connection_pool
+    cursor.fetchall.return_value = []
+    gaussdb_instance.list()
+    sql = cursor.execute.call_args[0][0]
+    assert "WHERE" not in sql
+
+
+def test_update_both_vector_and_payload(gaussdb_instance, mock_connection_pool):
+    """Test updating both vector and payload in a single call."""
+    pool, conn, cursor = mock_connection_pool
+    cursor.execute.reset_mock()
+    gaussdb_instance.update(str(uuid.uuid4()), vector=[0.1, 0.2, 0.3, 0.4], payload={"text": "updated"})
+    assert cursor.execute.call_count == 2
+    sql_calls = [str(c) for c in cursor.execute.call_args_list]
+    assert any("vector" in s and "::vector" in s for s in sql_calls)
+    assert any("payload" in s for s in sql_calls)
+
+
+def test_update_payload_uses_jsonb(gaussdb_instance, mock_connection_pool):
+    """Test that update uses Jsonb wrapper for payload serialization."""
+    pool, conn, cursor = mock_connection_pool
+    cursor.execute.reset_mock()
+    test_payload = {"text": "data", "number": 42}
+    with patch("mem0.vector_stores.gaussdb.Jsonb") as mock_jsonb_cls:
+        mock_jsonb_cls.return_value = "jsonb_wrapped"
+        gaussdb_instance.update(str(uuid.uuid4()), payload=test_payload)
+        mock_jsonb_cls.assert_called_once_with(test_payload)
+
+
+def test_insert_payload_uses_jsonb(gaussdb_instance, mock_connection_pool):
+    """Test that insert uses Jsonb wrapper for payload serialization."""
+    pool, conn, cursor = mock_connection_pool
+    cursor.executemany = Mock()
+    test_payload = {"text": "hello"}
+    with patch("mem0.vector_stores.gaussdb.Jsonb") as mock_jsonb_cls:
+        mock_jsonb_cls.return_value = "jsonb_wrapped"
+        gaussdb_instance.insert(
+            vectors=[[0.1, 0.2, 0.3, 0.4]],
+            payloads=[test_payload],
+            ids=[str(uuid.uuid4())],
+        )
+        mock_jsonb_cls.assert_called_once_with(test_payload)
+
+
+def test_transaction_rollback_on_error(gaussdb_instance, mock_connection_pool):
+    """Test that transaction is rolled back when an operation raises an error."""
+    pool, conn, cursor = mock_connection_pool
+    cursor.execute.side_effect = Exception("Database error")
+    with pytest.raises(Exception, match="Database error"):
+        gaussdb_instance.delete(str(uuid.uuid4()))
+    conn.rollback.assert_called()
+
+
+def test_transaction_commit_on_success(gaussdb_instance, mock_connection_pool):
+    """Test that transaction is committed on successful operation."""
+    pool, conn, cursor = mock_connection_pool
+    cursor.execute.reset_mock()
+    gaussdb_instance.delete(str(uuid.uuid4()))
+    conn.commit.assert_called()
+
+
+def test_init_with_connection_string_and_sslmode(mock_connection_pool):
+    """Test initialization with connection_string and sslmode."""
+    pool, conn, cursor = mock_connection_pool
+    with patch("mem0.vector_stores.gaussdb.GAUSSDB_AVAILABLE", True), \
+         patch("mem0.vector_stores.gaussdb.ConnectionPool") as MockPool:
+        MockPool.return_value = pool
+        GaussDB(
+            host="localhost", port=5432, user="test", password="test",
+            dbname="testdb", collection_name="test_col", embedding_model_dims=4,
+            connection_string="host=myhost port=5432 user=u password=p dbname=d",
+            sslmode="require",
+        )
+        conninfo = MockPool.call_args[0][0]
+        assert "myhost" in conninfo
+        assert "sslmode=require" in conninfo
+
+
+def test_config_requires_password_without_dsn():
+    from mem0.configs.vector_stores.gaussdb import GaussDBConfig
+    with pytest.raises(ValueError):
+        GaussDBConfig(host="h", user="u", dbname="d")
+
+
+def test_config_accepts_connection_string():
+    from mem0.configs.vector_stores.gaussdb import GaussDBConfig
+    cfg = GaussDBConfig(connection_string="host=h user=u dbname=d password=p")
+    assert cfg.connection_string is not None
+
+
+def test_config_rejects_extra_fields():
+    from mem0.configs.vector_stores.gaussdb import GaussDBConfig
+    with pytest.raises(ValueError, match="Extra fields"):
+        GaussDBConfig(host="h", user="u", dbname="d", password="p", unknown_field="x")


### PR DESCRIPTION
## Description

Add support for GaussDB as vector database and also update the docs.

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## How Has This Been Tested?

- [x] Unit Test (40 test cases, mock-based, no driver required)
- [x] Test Script (please provide)
```python
import os
from mem0 import Memory

os.environ["OPENAI_API_KEY"] = "sk-xx"

config = {
    "vector_store": {
        "provider": "gaussdb",
        "config": {
            "host": "127.0.0.1",
            "port": 5432,
            "user": "test",
            "password": "123",
            "dbname": "mem0_db",
        }
    }
}

m = Memory.from_config(config)
m.add("visiting to paris", user_id="test")
```

## Changes

| File | Change |
|------|--------|
| `mem0/vector_stores/gaussdb.py` | New — GaussDB vector store implementation |
| `mem0/configs/vector_stores/gaussdb.py` | New — GaussDBConfig with Pydantic validation |
| `mem0/vector_stores/configs.py` | Modified — register `"gaussdb": "GaussDBConfig"` |
| `mem0/utils/factory.py` | Modified — register `"gaussdb": "mem0.vector_stores.gaussdb.GaussDB"` |
| `pyproject.toml` | Modified — add `gaussdb[pool]>=1.0.0` dependency |
| `tests/vector_stores/test_gaussdb.py` | New — 40 unit tests |
| `docs/components/vectordbs/dbs/gaussdb.mdx` | New — documentation page with usage examples and config reference |
| `docs/components/vectordbs/overview.mdx` | Modified — add GaussDB card |
| `docs/docs.json` | Modified — add GaussDB to navigation |

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
