### PR TITLE
fix(ts-sdk): include url fallback in LLM config resolution

### DIFF
--- a/mem0-ts/src/oss/src/config/manager.ts
+++ b/mem0-ts/src/oss/src/config/manager.ts
@@ -110,6 +110,7 @@ export class ConfigManager {
             ((userConf as Record<string, unknown>)?.lmstudio_base_url as
               | string
               | undefined) ??
+            userConf?.url ??
             defaultConf.baseURL;
 
           return {


### PR DESCRIPTION
## Summary

Fixes #4715 — LLM config manager ignores `url` field, causing Ollama/custom LLM providers to connect to `api.openai.com` instead.

## Root Cause

The LLM config `baseURL` resolution chain in `manager.ts` (L108–113) was:
```
userConf?.baseURL ?? lmstudio_base_url ?? defaultConf.baseURL
```

Missing `userConf?.url` fallback that the embedder config (L24–29) already includes:
```
userConf?.baseURL ?? lmstudio_base_url ?? userConf?.url
```

## Fix

One-line change: add `userConf?.url ??` before `defaultConf.baseURL` in the LLM config fallback chain, making it consistent with the embedder config.

## Before → After

| Config | Before | After |
|--------|--------|-------|
| `{ provider: "ollama", config: { url: "http://host:11434" } }` | → `https://api.openai.com/v1` ❌ | → `http://host:11434` ✅ |