### PR TITLE
fix: strip /v1 suffix from ollama_base_url to prevent incorrect endpoint construction

### DIFF
--- a/mem0/embeddings/ollama.py
+++ b/mem0/embeddings/ollama.py
@@ -28,7 +28,16 @@ class OllamaEmbedding(EmbeddingBase):
         self.config.model = self.config.model or "nomic-embed-text"
         self.config.embedding_dims = self.config.embedding_dims or 512
 
-        self.client = Client(host=self.config.ollama_base_url)
+        # Strip /v1 suffix if present — some users mistakenly set ollama_base_url
+        # to http://host:11434/v1 (OpenAI-style). The Ollama client appends its
+        # own path, so /v1 would result in incorrect endpoints like /v1/api/embed.
+        base_url = self.config.ollama_base_url
+        if base_url:
+            base_url = base_url.rstrip("/")
+            if base_url.endswith("/v1"):
+                base_url = base_url[:-3]
+
+        self.client = Client(host=base_url)
         self._ensure_model_exists()
 
     @staticmethod


### PR DESCRIPTION
Linked Issue
Closes #4736
Description
When ollama_base_url is set to http://host:11434/v1 (a common mistake since most other providers like OpenAI use /v1), the Ollama Python client prepends that path to every API call, resulting in incorrect endpoints like /v1/api/embed instead of the correct /api/embed. This causes TypeError: fetch failed on every embedding call.
This fix strips the /v1 suffix from ollama_base_url before passing it to the Ollama Client, so the correct endpoint is always constructed regardless of how the user configured the base URL.
Type of Change

 Bug fix (non-breaking change that fixes an issue)
 New feature (non-breaking change that adds functionality)
 Breaking change (fix or feature that would cause existing functionality to change)
 Refactor (no functional changes)
 Documentation update

Breaking Changes
N/A
Test Coverage

 I added/updated unit tests
 I added/updated integration tests
 I tested manually (describe below)
 No tests needed (explain why)

Reproduced the incorrect endpoint construction by setting ollama_base_url to http://localhost:11434/v1 and verified the fix correctly strips the /v1 suffix before passing to the Ollama client.
Checklist

 My code follows the project's style guidelines
 I have performed a self-review of my code
 I have added tests that prove my fix/feature works
 New and existing tests pass locally
 I have updated documentation if needed