### PR TITLE
fix(client): prevent feedback telemetry TypeError

### DIFF
--- a/mem0/client/main.py
+++ b/mem0/client/main.py
@@ -876,7 +876,7 @@ class MemoryClient:
 
         response = self.client.post("/v1/feedback/", json=data)
         response.raise_for_status()
-        capture_client_event("client.feedback", self, data, {"sync_type": "sync"})
+        capture_client_event("client.feedback", self, {**data, "sync_type": "sync"})
         return response.json()
 
     def _prepare_payload(self, messages: List[Dict[str, str]], kwargs: Dict[str, Any]) -> Dict[str, Any]:
@@ -1749,5 +1749,5 @@ class AsyncMemoryClient:
 
         response = await self.async_client.post("/v1/feedback/", json=data)
         response.raise_for_status()
-        capture_client_event("client.feedback", self, data, {"sync_type": "async"})
+        capture_client_event("client.feedback", self, {**data, "sync_type": "async"})
         return response.json()

--- a/tests/test_client_feedback.py
+++ b/tests/test_client_feedback.py
@@ -1,0 +1,59 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mem0.client.main import AsyncMemoryClient, MemoryClient
+
+
+def _build_memory_client(response_payload=None):
+    client = MemoryClient.__new__(MemoryClient)
+    client.user_email = "user@example.com"
+    client.client = MagicMock()
+    response = client.client.post.return_value
+    response.json.return_value = response_payload or {"message": "Feedback recorded"}
+    response.raise_for_status.return_value = None
+    return client
+
+
+def test_memory_client_feedback_uses_single_telemetry_payload():
+    client = _build_memory_client()
+
+    with patch("mem0.client.main.capture_client_event") as mock_capture:
+        result = client.feedback("mem_1", feedback="positive", feedback_reason="accurate")
+
+    assert result == {"message": "Feedback recorded"}
+    client.client.post.assert_called_once_with(
+        "/v1/feedback/",
+        json={"memory_id": "mem_1", "feedback": "POSITIVE", "feedback_reason": "accurate"},
+    )
+    mock_capture.assert_called_once_with(
+        "client.feedback",
+        client,
+        {"memory_id": "mem_1", "feedback": "POSITIVE", "feedback_reason": "accurate", "sync_type": "sync"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_memory_client_feedback_uses_single_telemetry_payload():
+    client = AsyncMemoryClient.__new__(AsyncMemoryClient)
+    client.user_email = "user@example.com"
+    client.async_client = MagicMock()
+
+    response = MagicMock()
+    response.json.return_value = {"message": "Feedback recorded"}
+    response.raise_for_status.return_value = None
+    client.async_client.post = AsyncMock(return_value=response)
+
+    with patch("mem0.client.main.capture_client_event") as mock_capture:
+        result = await client.feedback("mem_1", feedback="negative", feedback_reason="outdated")
+
+    assert result == {"message": "Feedback recorded"}
+    client.async_client.post.assert_awaited_once_with(
+        "/v1/feedback/",
+        json={"memory_id": "mem_1", "feedback": "NEGATIVE", "feedback_reason": "outdated"},
+    )
+    mock_capture.assert_called_once_with(
+        "client.feedback",
+        client,
+        {"memory_id": "mem_1", "feedback": "NEGATIVE", "feedback_reason": "outdated", "sync_type": "async"},
+    )


### PR DESCRIPTION
## Linked Issue

Closes #4794

## Description

`MemoryClient.feedback()` and `AsyncMemoryClient.feedback()` were passing feedback data and sync metadata as separate positional arguments to `capture_client_event()`. That helper accepts a single optional metadata payload, so successful feedback calls could raise a local `TypeError` after the API response completed.

This merges the feedback fields and sync mode into one telemetry payload for both sync and async clients.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Validated locally:

```bash
.venv/bin/python -m pytest -q tests/test_client_feedback.py
.venv/bin/python -m pytest -q tests/test_telemetry.py tests/test_telemetry_sampling.py
.venv/bin/python -m ruff check mem0/client/main.py tests/test_client_feedback.py
.venv/bin/python -m ruff format --check mem0/client/main.py tests/test_client_feedback.py
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
