### PR TITLE
fix(graph): skip unnecessary LLM calls when search output or entity map is empty

### DIFF
--- a/mem0/graphs/neptune/base.py
+++ b/mem0/graphs/neptune/base.py
@@ -64,6 +64,9 @@ class NeptuneBase(ABC):
             filters (dict): A dictionary containing filters to be applied during the addition.
         """
         entity_type_map = self._retrieve_nodes_from_data(data, filters)
+        if not entity_type_map:
+            return {"deleted_entities": [], "added_entities": []}
+
         to_be_added = self._establish_nodes_relations_from_data(data, filters, entity_type_map)
         search_output = self._search_graph_db(node_list=list(entity_type_map.keys()), filters=filters)
         to_be_deleted = self._get_delete_entities_from_search_output(search_output, data, filters)
@@ -157,6 +160,8 @@ class NeptuneBase(ABC):
         """
         Get the entities to be deleted from the search output.
         """
+        if not search_output:
+            return []
 
         search_output_string = format_entities(search_output)
         system_prompt, user_prompt = get_delete_messages(search_output_string, data, filters["user_id"])

--- a/mem0/memory/graph_memory.py
+++ b/mem0/memory/graph_memory.py
@@ -82,6 +82,9 @@ class MemoryGraph:
             filters (dict): A dictionary containing filters to be applied during the addition.
         """
         entity_type_map = self._retrieve_nodes_from_data(data, filters)
+        if not entity_type_map:
+            return {"deleted_entities": [], "added_entities": []}
+
         to_be_added = self._establish_nodes_relations_from_data(data, filters, entity_type_map)
         search_output = self._search_graph_db(node_list=list(entity_type_map.keys()), filters=filters)
         to_be_deleted = self._get_delete_entities_from_search_output(search_output, data, filters)
@@ -346,6 +349,8 @@ class MemoryGraph:
 
     def _get_delete_entities_from_search_output(self, search_output, data, filters):
         """Get the entities to be deleted from the search output."""
+        if not search_output:
+            return []
         search_output_string = format_entities(search_output)
 
         # Compose user identification string for prompt

--- a/mem0/memory/kuzu_memory.py
+++ b/mem0/memory/kuzu_memory.py
@@ -104,6 +104,9 @@ class MemoryGraph:
             filters (dict): A dictionary containing filters to be applied during the addition.
         """
         entity_type_map = self._retrieve_nodes_from_data(data, filters)
+        if not entity_type_map:
+            return {"deleted_entities": [], "added_entities": []}
+
         to_be_added = self._establish_nodes_relations_from_data(data, filters, entity_type_map)
         search_output = self._search_graph_db(node_list=list(entity_type_map.keys()), filters=filters)
         to_be_deleted = self._get_delete_entities_from_search_output(search_output, data, filters)
@@ -370,6 +373,8 @@ class MemoryGraph:
 
     def _get_delete_entities_from_search_output(self, search_output, data, filters):
         """Get the entities to be deleted from the search output."""
+        if not search_output:
+            return []
         search_output_string = format_entities(search_output)
 
         # Compose user identification string for prompt

--- a/mem0/memory/memgraph_memory.py
+++ b/mem0/memory/memgraph_memory.py
@@ -87,6 +87,9 @@ class MemoryGraph:
             filters (dict): A dictionary containing filters to be applied during the addition.
         """
         entity_type_map = self._retrieve_nodes_from_data(data, filters)
+        if not entity_type_map:
+            return {"deleted_entities": [], "added_entities": []}
+
         to_be_added = self._establish_nodes_relations_from_data(data, filters, entity_type_map)
         search_output = self._search_graph_db(node_list=list(entity_type_map.keys()), filters=filters)
         to_be_deleted = self._get_delete_entities_from_search_output(search_output, data, filters)
@@ -358,6 +361,8 @@ class MemoryGraph:
 
     def _get_delete_entities_from_search_output(self, search_output, data, filters):
         """Get the entities to be deleted from the search output."""
+        if not search_output:
+            return []
         search_output_string = format_entities(search_output)
         system_prompt, user_prompt = get_delete_messages(search_output_string, data, filters["user_id"])
 

--- a/tests/memory/test_graph_memory.py
+++ b/tests/memory/test_graph_memory.py
@@ -1,0 +1,51 @@
+from unittest.mock import MagicMock, Mock, patch
+
+# langchain_neo4j and rank_bm25 are optional deps — mock them so tests run without install
+_neo4j_mock = Mock()
+patch.dict("sys.modules", {
+    "langchain_neo4j": _neo4j_mock,
+    "rank_bm25": Mock(),
+}).start()
+
+from mem0.memory.graph_memory import MemoryGraph  # noqa: E402
+
+
+def _make_instance():
+    with patch.object(MemoryGraph, "__init__", return_value=None):
+        instance = MemoryGraph.__new__(MemoryGraph)
+        instance.llm_provider = "openai"
+        instance.llm = MagicMock()
+        instance.embedding_model = MagicMock()
+        instance.config = MagicMock()
+        instance.config.graph_store.custom_prompt = None
+        return instance
+
+
+class TestAddEarlyReturn:
+    """Tests for early-return guards in add()."""
+
+    def test_add_returns_early_when_entity_type_map_is_empty(self):
+        """When _retrieve_nodes_from_data returns empty dict, add() should
+        skip all subsequent LLM calls and return empty results."""
+        instance = _make_instance()
+        instance.llm.generate_response.return_value = {"tool_calls": None}
+        instance._establish_nodes_relations_from_data = MagicMock()
+        instance._search_graph_db = MagicMock()
+        instance._get_delete_entities_from_search_output = MagicMock()
+
+        result = instance.add("hello world", {"user_id": "u1"})
+
+        assert result == {"deleted_entities": [], "added_entities": []}
+        instance._establish_nodes_relations_from_data.assert_not_called()
+        instance._search_graph_db.assert_not_called()
+        instance._get_delete_entities_from_search_output.assert_not_called()
+
+    def test_get_delete_entities_returns_early_when_search_output_is_empty(self):
+        """When search_output is empty, _get_delete_entities_from_search_output
+        should return [] without calling LLM."""
+        instance = _make_instance()
+
+        result = instance._get_delete_entities_from_search_output([], "some data", {"user_id": "u1"})
+
+        assert result == []
+        instance.llm.generate_response.assert_not_called()

--- a/tests/memory/test_kuzu.py
+++ b/tests/memory/test_kuzu.py
@@ -234,6 +234,38 @@ class TestRetrieveNodesFromData:
         assert result == {}
 
 
+class TestAddEarlyReturn:
+    """Tests for early-return guards in add()."""
+
+    def test_add_returns_early_when_entity_type_map_is_empty(self):
+        """When _retrieve_nodes_from_data returns empty dict, add() should
+        skip all subsequent LLM calls and return empty results."""
+        instance = _make_kuzu_instance()
+        instance.llm.generate_response.return_value = {"tool_calls": None}
+        instance._establish_nodes_relations_from_data = MagicMock()
+        instance._search_graph_db = MagicMock()
+        instance._get_delete_entities_from_search_output = MagicMock()
+
+        result = instance.add("hello world", {"user_id": "u1"})
+
+        assert result == {"deleted_entities": [], "added_entities": []}
+        instance._establish_nodes_relations_from_data.assert_not_called()
+        instance._search_graph_db.assert_not_called()
+        instance._get_delete_entities_from_search_output.assert_not_called()
+
+    def test_get_delete_entities_returns_early_when_search_output_is_empty(self):
+        """When search_output is empty, _get_delete_entities_from_search_output
+        should return [] without calling LLM."""
+        instance = _make_kuzu_instance()
+
+        result = instance._get_delete_entities_from_search_output(
+            [], "some data", {"user_id": "u1"}
+        )
+
+        assert result == []
+        instance.llm.generate_response.assert_not_called()
+
+
 def get_node_count(kuzu_memory):
     results = kuzu_memory.kuzu_execute(
         """

--- a/tests/memory/test_memgraph_memory.py
+++ b/tests/memory/test_memgraph_memory.py
@@ -72,6 +72,36 @@ class TestRetrieveNodesFromData:
         assert result == {}
 
 
+class TestAddEarlyReturn:
+    """Tests for early-return guards in add()."""
+
+    def test_add_returns_early_when_entity_type_map_is_empty(self):
+        """When _retrieve_nodes_from_data returns empty dict, add() should
+        skip all subsequent LLM calls and return empty results."""
+        instance = _make_instance()
+        instance.llm.generate_response.return_value = {"tool_calls": None}
+        instance._establish_nodes_relations_from_data = MagicMock()
+        instance._search_graph_db = MagicMock()
+        instance._get_delete_entities_from_search_output = MagicMock()
+
+        result = instance.add("hello world", {"user_id": "u1"})
+
+        assert result == {"deleted_entities": [], "added_entities": []}
+        instance._establish_nodes_relations_from_data.assert_not_called()
+        instance._search_graph_db.assert_not_called()
+        instance._get_delete_entities_from_search_output.assert_not_called()
+
+    def test_get_delete_entities_returns_early_when_search_output_is_empty(self):
+        """When search_output is empty, _get_delete_entities_from_search_output
+        should return [] without calling LLM."""
+        instance = _make_instance()
+
+        result = instance._get_delete_entities_from_search_output([], "some data", {"user_id": "u1"})
+
+        assert result == []
+        instance.llm.generate_response.assert_not_called()
+
+
 class TestEstablishNodesRelationsFromData:
     """Tests for _establish_nodes_relations_from_data in MemoryGraph."""
 

--- a/tests/memory/test_neptune_analytics_memory.py
+++ b/tests/memory/test_neptune_analytics_memory.py
@@ -114,6 +114,31 @@ class TestNeptuneMemory(unittest.TestCase):
         self.assertIn("deleted_entities", result)
         self.assertIn("added_entities", result)
 
+    def test_add_skips_pipeline_when_entity_type_map_is_empty(self):
+        """When _retrieve_nodes_from_data returns empty dict, add() should
+        skip all subsequent steps and return empty results."""
+        self.memory_graph._retrieve_nodes_from_data = MagicMock(return_value={})
+        self.memory_graph._establish_nodes_relations_from_data = MagicMock()
+        self.memory_graph._search_graph_db = MagicMock()
+        self.memory_graph._get_delete_entities_from_search_output = MagicMock()
+
+        result = self.memory_graph.add("hello world", self.test_filters)
+
+        self.assertEqual(result, {"deleted_entities": [], "added_entities": []})
+        self.memory_graph._establish_nodes_relations_from_data.assert_not_called()
+        self.memory_graph._search_graph_db.assert_not_called()
+        self.memory_graph._get_delete_entities_from_search_output.assert_not_called()
+
+    def test_get_delete_entities_skips_llm_when_search_output_is_empty(self):
+        """When search_output is empty, _get_delete_entities_from_search_output
+        should return [] without calling LLM."""
+        result = self.memory_graph._get_delete_entities_from_search_output(
+            [], "some data", self.test_filters
+        )
+
+        self.assertEqual(result, [])
+        self.mock_llm.generate_response.assert_not_called()
+
     def test_search_method(self):
         """Test the search method with mocked components."""
         # Mock the necessary methods that search() calls

--- a/tests/memory/test_neptune_memory.py
+++ b/tests/memory/test_neptune_memory.py
@@ -168,6 +168,31 @@ class TestNeptuneMemory(unittest.TestCase):
         self.assertIn("deleted_entities", result)
         self.assertIn("added_entities", result)
 
+    def test_add_skips_pipeline_when_entity_type_map_is_empty(self):
+        """When _retrieve_nodes_from_data returns empty dict, add() should
+        skip all subsequent steps and return empty results."""
+        self.memory_graph._retrieve_nodes_from_data = MagicMock(return_value={})
+        self.memory_graph._establish_nodes_relations_from_data = MagicMock()
+        self.memory_graph._search_graph_db = MagicMock()
+        self.memory_graph._get_delete_entities_from_search_output = MagicMock()
+
+        result = self.memory_graph.add("hello world", self.test_filters)
+
+        self.assertEqual(result, {"deleted_entities": [], "added_entities": []})
+        self.memory_graph._establish_nodes_relations_from_data.assert_not_called()
+        self.memory_graph._search_graph_db.assert_not_called()
+        self.memory_graph._get_delete_entities_from_search_output.assert_not_called()
+
+    def test_get_delete_entities_skips_llm_when_search_output_is_empty(self):
+        """When search_output is empty, _get_delete_entities_from_search_output
+        should return [] without calling LLM."""
+        result = self.memory_graph._get_delete_entities_from_search_output(
+            [], "some data", self.test_filters
+        )
+
+        self.assertEqual(result, [])
+        self.mock_llm.generate_response.assert_not_called()
+
     def test_search_method(self):
         """Test the search method with mocked components."""
         # Mock the necessary methods that search() calls


### PR DESCRIPTION
## Description

Summary                                                                                                                                                                                                                                            

- Skip delete-entity LLM call when search_output is empty. _get_delete_entities_from_search_output now returns [] immediately instead of calling the LLM with a blank "existing memories" prompt. This is triggered whenever new content has low similarity to existing graph entities (below the cosine threshold), or on first add with an empty graph.
- Skip the entire downstream pipeline when entity_type_map is empty. When _retrieve_nodes_from_data extracts no entities, add() now returns early, avoiding 2 unnecessary LLM calls, embedding computations, and DB queries that would all produce no useful work.                                                                                                                                                                                                                                    
- Applied to all 4 graph backends: Neo4j, Memgraph, Kùzu, and Neptune.
                                                                                                                                                                                                                                                   
Why               
                                                                                                                                                                                                                                                   
When these intermediate results are empty, the subsequent LLM calls have no useful work to do — there are no existing relationships to evaluate for deletion, and no entities to establish relations for. Continuing the pipeline in this case     
causes two problems:                   
                                                                                                                                                                                                                                                   
1. Wasted cost and latency. Each unnecessary LLM call consumes tokens and adds seconds of round-trip time for a result that is guaranteed to be empty. When entity extraction yields nothing, up to 2 additional LLM calls, multiple embedding     
computations, and DB queries can all be avoided.
2. Potential hang on thinking models. The empty-field prompt (e.g. "Here are the existing memories:  \n\n New Information: ...") can trigger an overthinking loop on reasoning models with thinking/CoT enabled, where the model enters an         
unbounded chain-of-thought and never returns — causing the request to hang indefinitely. Low decoding temperatures (mem0 defaults to 0.1) further amplify the hang rate.                                                                           

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

<!-- If this is a breaking change, describe what breaks and the migration path. Delete this section if not applicable. -->

N/A

## Test Coverage

- [x] I added/updated unit tests
- [x] I added/updated integration tests

<!-- Describe how you tested this, or link to CI results. -->

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
