### PR TITLE
fix: pass through image-content messages when vision is disabled

### DIFF
--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -179,11 +179,19 @@ def parse_vision_messages(messages, llm=None, vision_details="auto"):
 
         # Handle message content
         if isinstance(msg["content"], list):
-            # Multiple image URLs in content
+            # Multiple image URLs in content — requires an LLM to describe them.
+            # If vision is not enabled (llm is None), pass the message through unchanged.
+            if llm is None:
+                returned_messages.append(msg)
+                continue
             description = get_image_description(msg, llm, vision_details)
             returned_messages.append({"role": msg["role"], "content": description})
         elif isinstance(msg["content"], dict) and msg["content"].get("type") == "image_url":
-            # Single image content
+            # Single image content — requires an LLM to describe it.
+            # If vision is not enabled (llm is None), pass the message through unchanged.
+            if llm is None:
+                returned_messages.append(msg)
+                continue
             image_url = msg["content"]["image_url"]["url"]
             try:
                 description = get_image_description(image_url, llm, vision_details)

--- a/tests/memory/test_memory_utils.py
+++ b/tests/memory/test_memory_utils.py
@@ -1,5 +1,5 @@
 import pytest
-from mem0.memory.utils import remove_spaces_from_entities, sanitize_relationship_for_cypher
+from mem0.memory.utils import parse_vision_messages, remove_spaces_from_entities, sanitize_relationship_for_cypher
 
 
 class TestRemoveSpacesFromEntities:
@@ -55,3 +55,68 @@ class TestRemoveSpacesFromEntities:
         f = remove_spaces_from_entities([dict(base)], sanitize_relationship=False)[0]["relationship"]
         assert t == sanitize_relationship_for_cypher("a/b")
         assert f == "a/b"
+
+
+class TestParseVisionMessages:
+    """
+    Covers parse_vision_messages, specifically that list-typed or image_url-typed
+    content does NOT crash when llm=None (vision disabled).
+    """
+
+    def test_plain_text_passthrough(self):
+        """Regular text messages are always passed through unchanged."""
+        messages = [{"role": "user", "content": "Hello"}]
+        assert parse_vision_messages(messages) == messages
+
+    def test_system_message_passthrough(self):
+        """System messages are always passed through regardless of content type."""
+        messages = [{"role": "system", "content": "You are helpful."}]
+        assert parse_vision_messages(messages) == messages
+
+    def test_list_content_no_llm_does_not_crash(self):
+        """
+        Regression test for: list-typed content with llm=None raises
+        AttributeError: 'NoneType' object has no attribute 'generate_response'.
+        When vision is disabled (llm=None) the message must be passed through as-is.
+        """
+        messages = [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "What do you see?"}],
+            }
+        ]
+        result = parse_vision_messages(messages, llm=None)
+        assert result == messages
+
+    def test_image_url_dict_content_no_llm_does_not_crash(self):
+        """
+        Regression test: single image_url dict content with llm=None must not crash.
+        """
+        messages = [
+            {
+                "role": "user",
+                "content": {"type": "image_url", "image_url": {"url": "https://example.com/img.png"}},
+            }
+        ]
+        result = parse_vision_messages(messages, llm=None)
+        assert result == messages
+
+    def test_mixed_messages_no_llm(self):
+        """Mix of text and list-content messages — all passed through when llm=None."""
+        messages = [
+            {"role": "user", "content": "plain text"},
+            {"role": "user", "content": [{"type": "image_url", "image_url": {"url": "http://x.com/a.jpg"}}]},
+            {"role": "assistant", "content": "response"},
+        ]
+        result = parse_vision_messages(messages, llm=None)
+        assert result == messages
+
+    def test_list_content_with_llm_calls_llm(self):
+        """When llm is provided, get_image_description should be called."""
+        class FakeLLM:
+            def generate_response(self, messages):
+                return "A described image"
+
+        messages = [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "http://x.com/img.jpg"}}]}]
+        result = parse_vision_messages(messages, llm=FakeLLM())
+        assert result == [{"role": "user", "content": "A described image"}]


### PR DESCRIPTION
## Linked Issue

Closes #4799

## Description

`parse_vision_messages` called `llm.generate_response()` unconditionally when `msg["content"]` was a list or an `image_url` dict, even when `llm=None` (the default, used whenever `enable_vision=False`). This caused an `AttributeError` crash in the hot path of `Memory.add()` for any caller passing messages in the standard OpenAI multimodal format without having vision enabled.

**Fix:** Guard both the list-content and `image_url`-dict branches with an `llm is None` check and pass the message through unchanged in that case. The vision-enabled path (when `llm` is provided) is unaffected.

**Files changed:**
- `mem0/memory/utils.py` — added `llm is None` guard in `parse_vision_messages`
- `tests/memory/test_memory_utils.py` — added `TestParseVisionMessages` with 6 tests

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Manually verified the crash with:

```python
from mem0.memory.utils import parse_vision_messages

# Previously raised: AttributeError: 'NoneType' object has no attribute 'generate_response'
# Now passes through the message unchanged as expected
result = parse_vision_messages([{"role": "user", "content": [{"type": "text", "text": "hi"}]}])
```

Added 6 unit tests in `TestParseVisionMessages` covering:
- Regression case: list-typed content with `llm=None` no longer crashes
- Regression case: `image_url`-dict content with `llm=None` no longer crashes
- Mixed message types all pass through when `llm=None`
- Plain text messages still work as before
- System messages still pass through unchanged
- Vision-enabled path: LLM is still called when `llm` is provided

All 14 tests pass (`pytest tests/memory/test_memory_utils.py -v`).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
