### PR TITLE
Fix incorrect use of SentenceTransformer for cross-encoder reranker models

### DIFF
--- a/mem0/reranker/sentence_transformer_reranker.py
+++ b/mem0/reranker/sentence_transformer_reranker.py
@@ -6,7 +6,7 @@ from mem0.configs.rerankers.base import BaseRerankerConfig
 from mem0.configs.rerankers.sentence_transformer import SentenceTransformerRerankerConfig
 
 try:
-    from sentence_transformers import SentenceTransformer
+    from sentence_transformers import CrossEncoder
     SENTENCE_TRANSFORMERS_AVAILABLE = True
 except ImportError:
     SENTENCE_TRANSFORMERS_AVAILABLE = False
@@ -41,7 +41,7 @@ class SentenceTransformerReranker(BaseReranker):
             )
 
         self.config = config
-        self.model = SentenceTransformer(self.config.model, device=self.config.device)
+        self.model = CrossEncoder(self.config.model, device=self.config.device)
         
     def rerank(self, query: str, documents: List[Dict[str, Any]], top_k: int = None) -> List[Dict[str, Any]]:
         """
@@ -74,8 +74,11 @@ class SentenceTransformerReranker(BaseReranker):
             # Create query-document pairs
             pairs = [[query, doc_text] for doc_text in doc_texts]
             
-            # Get similarity scores
-            scores = self.model.predict(pairs)
+            scores = self.model.predict(
+                pairs,
+                batch_size=self.config.batch_size,
+                show_progress_bar=self.config.show_progress_bar,
+            )
             if isinstance(scores, np.ndarray):
                 scores = scores.tolist()
             


### PR DESCRIPTION
## Issue

The default reranker model is a Hugging Face cross-encoder (`cross-encoder/ms-marco-MiniLM-L-6-v2`), but the implementation loads it using `SentenceTransformer`, which is designed for bi-encoder (embedding) models, not cross-encoders.

## Problem

This mismatch can lead to incorrect behavior or scoring during reranking, as cross-encoder models expect query-document pairs to be processed jointly using the `CrossEncoder` API.

## Fix

- Switched model loading from `SentenceTransformer` to `CrossEncoder`
- Updated scoring to use `CrossEncoder.predict()`
- Passed `batch_size` and `show_progress_bar` from config so they are respected during inference

## Behavior

- No change in failure handling
- On prediction failure, documents still fall back to original order with `rerank_score = 0.0`