### PR TITLE
fix(tests): use top_k instead of limit in test_server_params

### DIFF
--- a/tests/test_server_params.py
+++ b/tests/test_server_params.py
@@ -2,7 +2,7 @@
 
 Verifies that the Pydantic request models in server/main.py correctly accept
 and forward all parameters supported by the underlying Memory class methods,
-including limit, threshold, infer, memory_type, and prompt — which were
+including top_k, threshold, infer, memory_type, and prompt — which were
 previously silently dropped by Pydantic v2's default extra='ignore' behavior.
 """
 
@@ -55,31 +55,31 @@ def mock_memory(_mock_memory):
 
 
 # ===========================================================================
-# SearchRequest: limit parameter
+# SearchRequest: top_k parameter
 # ===========================================================================
 
 class TestSearchLimit:
-    """Verify that the limit parameter is accepted and forwarded to Memory.search()."""
+    """Verify that the top_k parameter is accepted and forwarded to Memory.search()."""
 
     def test_limit_forwarded(self, client, mock_memory):
-        resp = client.post("/search", json={"query": "food", "user_id": "u1", "limit": 5})
+        resp = client.post("/search", json={"query": "food", "user_id": "u1", "top_k": 5})
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
-        assert kwargs["limit"] == 5
+        assert kwargs["top_k"] == 5
 
     def test_limit_one(self, client, mock_memory):
-        resp = client.post("/search", json={"query": "food", "user_id": "u1", "limit": 1})
+        resp = client.post("/search", json={"query": "food", "user_id": "u1", "top_k": 1})
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
-        assert kwargs["limit"] == 1
+        assert kwargs["top_k"] == 1
 
     def test_limit_omitted_uses_memory_default(self, client, mock_memory):
-        """When limit is not sent, it should not appear in the kwargs,
+        """When top_k is not sent, it should not appear in the kwargs,
         allowing Memory.search() to use its own default (100)."""
         resp = client.post("/search", json={"query": "food", "user_id": "u1"})
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
-        assert "limit" not in kwargs
+        assert "top_k" not in kwargs
 
 
 # ===========================================================================
@@ -110,18 +110,18 @@ class TestSearchThreshold:
 
 
 # ===========================================================================
-# SearchRequest: limit + threshold together
+# SearchRequest: top_k + threshold together
 # ===========================================================================
 
 class TestSearchLimitAndThreshold:
 
     def test_both_forwarded(self, client, mock_memory):
         resp = client.post("/search", json={
-            "query": "food", "user_id": "u1", "limit": 10, "threshold": 0.5
+            "query": "food", "user_id": "u1", "top_k": 10, "threshold": 0.5
         })
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
-        assert kwargs["limit"] == 10
+        assert kwargs["top_k"] == 10
         assert kwargs["threshold"] == 0.5
 
 
@@ -334,8 +334,8 @@ class TestOpenAPISchema:
     def test_search_schema_includes_limit(self, client):
         schema = client.get("/openapi.json").json()
         search_props = schema["components"]["schemas"]["SearchRequest"]["properties"]
-        assert "limit" in search_props
-        assert search_props["limit"]["description"] == "Maximum number of results to return."
+        assert "top_k" in search_props
+        assert search_props["top_k"]["description"] == "Maximum number of results to return."
 
     def test_search_schema_includes_threshold(self, client):
         schema = client.get("/openapi.json").json()
@@ -367,7 +367,7 @@ class TestTypeValidation:
 
     def test_limit_string_rejected(self, client):
         resp = client.post("/search", json={
-            "query": "food", "user_id": "u1", "limit": "not_a_number",
+            "query": "food", "user_id": "u1", "top_k": "not_a_number",
         })
         assert resp.status_code == 422
 
@@ -399,7 +399,7 @@ class TestTypeValidation:
 
     def test_limit_float_rejected(self, client):
         resp = client.post("/search", json={
-            "query": "food", "user_id": "u1", "limit": 5.7,
+            "query": "food", "user_id": "u1", "top_k": 5.7,
         })
         assert resp.status_code == 422
 
@@ -422,11 +422,11 @@ class TestExplicitNull:
 
     def test_limit_null_uses_memory_default(self, client, mock_memory):
         resp = client.post("/search", json={
-            "query": "food", "user_id": "u1", "limit": None,
+            "query": "food", "user_id": "u1", "top_k": None,
         })
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
-        assert "limit" not in kwargs
+        assert "top_k" not in kwargs
 
     def test_infer_null_uses_memory_default(self, client, mock_memory):
         resp = client.post("/memories", json={
@@ -462,12 +462,12 @@ class TestCallSignatureMatch:
         resp = client.post("/search", json={
             "query": "food", "user_id": "u1", "agent_id": "a1",
             "run_id": "r1", "filters": {"k": "v"},
-            "limit": 10, "threshold": 0.5,
+            "top_k": 10, "threshold": 0.5,
         })
         assert resp.status_code == 200
         # The handler passes query= as a keyword arg, so it appears in kwargs too
         _, kwargs = mock_memory.search.call_args
-        valid_params = {"query", "user_id", "agent_id", "run_id", "limit", "filters", "threshold", "rerank"}
+        valid_params = {"query", "user_id", "agent_id", "run_id", "top_k", "filters", "threshold", "rerank"}
         for key in kwargs:
             assert key in valid_params, f"Unexpected kwarg '{key}' forwarded to Memory.search()"
 


### PR DESCRIPTION
## Linked Issue

Closes #4819

## Description

Commit `e44b46ef` renamed `SearchRequest.limit` → `SearchRequest.top_k` in
`server/main.py` to align the REST API field with `Memory.search(top_k=)`, but
did not update the 6 tests in `tests/test_server_params.py` that were introduced
alongside the original `limit` field. This PR updates those tests.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

All 6 previously failing tests now pass. Full run:

```bash
pytest tests/test_server_params.py -v
# 46 passed

pytest tests/ --ignore=tests/llms --ignore=tests/embeddings \
  --ignore=tests/vector_stores \
  --ignore=tests/memory/test_apache_age_e2e.py \
  --ignore=tests/memory/test_neptune_analytics_memory.py \
  --ignore=tests/memory/test_neptune_memory.py \
  --ignore=tests/memory/test_kuzu.py
# 566 passed, 23 skipped
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
