### PR TITLE
fix: allow anonymousTelemetryId in openclaw.json config

### DIFF
--- a/openclaw/config.ts
+++ b/openclaw/config.ts
@@ -147,6 +147,7 @@ export const DEFAULT_CUSTOM_CATEGORIES: Record<string, string> = {
 const ALLOWED_KEYS = [
   "mode",
   "apiKey",
+  "anonymousTelemetryId",
   "baseUrl",
   "userId",
   "userEmail",
@@ -215,6 +216,10 @@ export const mem0ConfigSchema = {
     return {
       mode,
       apiKey: resolvedApiKey,
+      anonymousTelemetryId:
+        typeof cfg.anonymousTelemetryId === "string"
+          ? cfg.anonymousTelemetryId
+          : undefined,
       baseUrl: resolvedBaseUrl,
       userId:
         typeof cfg.userId === "string" && cfg.userId

--- a/openclaw/openclaw.plugin.json
+++ b/openclaw/openclaw.plugin.json
@@ -134,6 +134,10 @@
       "topK": {
         "type": "number"
       },
+      "anonymousTelemetryId": {
+        "type": "string",
+        "description": "Persistent anonymous telemetry identifier"
+      },
       "oss": {
         "type": "object",
         "properties": {

--- a/openclaw/tests/config.test.ts
+++ b/openclaw/tests/config.test.ts
@@ -88,6 +88,11 @@ describe("mem0ConfigSchema.parse() — defaults", () => {
     const cfg = mem0ConfigSchema.parse({ apiKey: "test-key" });
     expect(cfg.skills).toBeUndefined();
   });
+
+  it("allows anonymousTelemetryId", () => {
+    const cfg = mem0ConfigSchema.parse({ apiKey: "test-key", anonymousTelemetryId: "123" });
+    expect(cfg.anonymousTelemetryId).toBe("123");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/openclaw/types.ts
+++ b/openclaw/types.ts
@@ -8,6 +8,7 @@ export type Mem0Config = {
   mode: Mem0Mode;
   // Platform-specific
   apiKey?: string;
+  anonymousTelemetryId?: string;
   baseUrl?: string;
   customInstructions: string;
   customCategories: Record<string, string>;


### PR DESCRIPTION
## Linked Issue

Closes #4807

## Description

This PR fixes an infinite gateway startup loop where the `anonymousTelemetryId` automatically persisted to `openclaw.json` by the telemetry script violates the typescript and JSON schema configs.

- Added `anonymousTelemetryId` to `ALLOWED_KEYS` in `config.ts`
- Added `anonymousTelemetryId` to `configSchema.properties` in `openclaw.plugin.json`
- Added unit coverage in `tests/config.test.ts` to prevent regression.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually
- [ ] No tests needed (explain why)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
