### PR TITLE
fix: upgrade gradio to 4.14.0 (CVE-2023-6572)

### DIFF
--- a/embedchain/embedchain/deployment/gradio.app/requirements.txt
+++ b/embedchain/embedchain/deployment/gradio.app/requirements.txt
@@ -1,2 +1,2 @@
-gradio==4.11.0
+gradio==4.14.0
 embedchain


### PR DESCRIPTION
## Summary
Upgrade gradio from 4.11.0 to 4.14.0 to fix CVE-2023-6572.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2023-6572 |
| **Severity** | CRITICAL |
| **Scanner** | trivy |
| **Rule** | `CVE-2023-6572` |
| **File** | `embedchain/embedchain/deployment/gradio.app/requirements.txt` |

**Description**: Gradio Exposure of Sensitive Information to an Unauthorized Actor vulnerability

## Changes
- `embedchain/embedchain/deployment/gradio.app/requirements.txt`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
