### PR TITLE
fix: normalizeMemoryItem reads payload.data for OSS/pgvector search

### DIFF
--- a/openclaw/providers.ts
+++ b/openclaw/providers.ts
@@ -20,7 +20,7 @@ import type {
 function normalizeMemoryItem(raw: any): MemoryItem {
   return {
     id: raw.id ?? raw.memory_id ?? "",
-    memory: raw.memory ?? raw.text ?? raw.content ?? "",
+    memory: raw.memory ?? raw.text ?? raw.content ?? raw.payload?.data ?? "",
     // Handle both platform (user_id, created_at) and OSS (userId, createdAt) field names
     user_id: raw.user_id ?? raw.userId,
     score: raw.score,


### PR DESCRIPTION
## Problem

The mem0ai OSS SDK stores memory text in `payload.data` (not directly in the top-level `memory` field). The `normalizeMemoryItem` function in `openclaw/providers.ts` was missing the fallback to `raw.payload?.data`, causing all search results returned from the OSS/pgvector backend to have empty `memory` strings.

This bug affects both:
- **memory_search tool** (returns empty results)
- **auto-recall** (injects blank memories into context)

## Fix

```diff
- memory: raw.memory ?? raw.text ?? raw.content ?? "",
+ memory: raw.memory ?? raw.text ?? raw.content ?? raw.payload?.data ?? "",
```

The SDK search path already extracts `memory` from `payload.data` at the SDK level, but for OSS/pgvector setups (where the SDK does the extraction), the fallback ensures robustness.

## Root Cause

`Memory.search()` in the OSS SDK returns `{ results: [{ id, memory: mem.payload.data, ... }] }`. The `normalizeMemoryItem` function only checked `raw.memory / raw.text / raw.content` fields, missing the `raw.payload?.data` path that pgvector returns.