### PR TITLE
fix(weaviate): pass all filter keys to Weaviate, not just user_id/agent_id/run_id

### DIFF
--- a/mem0/vector_stores/weaviate.py
+++ b/mem0/vector_stores/weaviate.py
@@ -83,6 +83,21 @@ class Weaviate(VectorStoreBase):
         self.embedding_model_dims = embedding_model_dims
         self.create_col(embedding_model_dims)
 
+    def _build_filters(self, filters: Optional[Dict]) -> Optional[Filter]:
+        """
+        Build Weaviate filter conditions from a filters dict.
+
+        Supports all filter keys (not just user_id/agent_id/run_id),
+        enabling metadata filtering on any property stored in the collection.
+        """
+        if not filters:
+            return None
+        filter_conditions = []
+        for key, value in filters.items():
+            if value is not None:
+                filter_conditions.append(Filter.by_property(key).equal(value))
+        return Filter.all_of(filter_conditions) if filter_conditions else None
+
     def _parse_output(self, data: Dict) -> List[OutputData]:
         """
         Parse the output data.
@@ -185,12 +200,7 @@ class Weaviate(VectorStoreBase):
         Search for similar vectors.
         """
         collection = self.client.collections.get(str(self.collection_name))
-        filter_conditions = []
-        if filters:
-            for key, value in filters.items():
-                if value and key in ["user_id", "agent_id", "run_id"]:
-                    filter_conditions.append(Filter.by_property(key).equal(value))
-        combined_filter = Filter.all_of(filter_conditions) if filter_conditions else None
+        combined_filter = self._build_filters(filters)
         response = collection.query.hybrid(
             query="",
             vector=vectors,
@@ -230,18 +240,13 @@ class Weaviate(VectorStoreBase):
         Args:
             query (str): Search query text.
             top_k (int): Maximum number of results. Defaults to 5.
-            filters (dict, optional): Filters to apply (user_id, agent_id, run_id).
+            filters (dict, optional): Filters to apply to the search.
 
         Returns:
             List[OutputData]: Search results.
         """
         collection = self.client.collections.get(str(self.collection_name))
-        filter_conditions = []
-        if filters:
-            for key, value in filters.items():
-                if value and key in ["user_id", "agent_id", "run_id"]:
-                    filter_conditions.append(Filter.by_property(key).equal(value))
-        combined_filter = Filter.all_of(filter_conditions) if filter_conditions else None
+        combined_filter = self._build_filters(filters)
         response = collection.query.bm25(
             query=query,
             query_properties=["data"],
@@ -367,12 +372,7 @@ class Weaviate(VectorStoreBase):
         List all vectors in a collection.
         """
         collection = self.client.collections.get(self.collection_name)
-        filter_conditions = []
-        if filters:
-            for key, value in filters.items():
-                if value and key in ["user_id", "agent_id", "run_id"]:
-                    filter_conditions.append(Filter.by_property(key).equal(value))
-        combined_filter = Filter.all_of(filter_conditions) if filter_conditions else None
+        combined_filter = self._build_filters(filters)
         response = collection.query.fetch_objects(
             limit=top_k,
             filters=combined_filter,

--- a/tests/vector_stores/test_weaviate.py
+++ b/tests/vector_stores/test_weaviate.py
@@ -145,6 +145,52 @@ class TestWeaviateDB(unittest.TestCase):
         self.assertEqual(results[0].id, "id1")
         self.assertEqual(results[0].score, 0.8)
 
+    def test_search_with_metadata_filters(self):
+        """Test that custom metadata filters (e.g. category) are passed through to Weaviate."""
+        mock_response = MagicMock()
+        mock_response.objects = []
+
+        mock_hybrid = MagicMock()
+        self.client_mock.collections.get.return_value.query.hybrid = mock_hybrid
+        mock_hybrid.return_value = mock_response
+
+        vectors = [[0.1] * 1536]
+        self.weaviate_db.search(
+            query="", vectors=vectors, top_k=5, filters={"user_id": "alice", "category": "movies"}
+        )
+
+        mock_hybrid.assert_called_once()
+        call_kwargs = mock_hybrid.call_args.kwargs
+        combined_filter = call_kwargs.get("filters")
+
+        # Should be a FilterAnd with 2 conditions (user_id + category), not just user_id
+        self.assertIsNotNone(combined_filter)
+        self.assertTrue(hasattr(combined_filter, "filters"), "Expected FilterAnd with multiple conditions")
+        self.assertEqual(len(combined_filter.filters), 2)
+
+    def test_search_filters_exclude_none_values(self):
+        """Test that None-valued filter keys are excluded."""
+        mock_response = MagicMock()
+        mock_response.objects = []
+
+        mock_hybrid = MagicMock()
+        self.client_mock.collections.get.return_value.query.hybrid = mock_hybrid
+        mock_hybrid.return_value = mock_response
+
+        vectors = [[0.1] * 1536]
+        self.weaviate_db.search(
+            query="", vectors=vectors, top_k=5, filters={"user_id": "alice", "agent_id": None}
+        )
+
+        mock_hybrid.assert_called_once()
+        call_kwargs = mock_hybrid.call_args.kwargs
+        combined_filter = call_kwargs.get("filters")
+
+        # Only user_id should be included (agent_id is None)
+        self.assertIsNotNone(combined_filter)
+        # Single condition = _FilterValue, not _FilterAnd
+        self.assertFalse(hasattr(combined_filter, "filters"), "Expected single filter, not FilterAnd")
+
     def test_delete(self):
         self.weaviate_db.delete(vector_id="id1")
 


### PR DESCRIPTION
## Linked Issue

Closes #4053

## Description

The Weaviate vector store adapter hardcoded filter keys to `["user_id", "agent_id", "run_id"]` in `search()`, `keyword_search()`, and `list()`. Any custom metadata key (e.g., `category`) passed in `filters` was silently dropped, causing incorrect search results — users got back unfiltered results even when they specified metadata filters.

### Root Cause

In `mem0/vector_stores/weaviate.py`, the filter-building logic in all three methods only iterated over a hardcoded whitelist:

```python
if value and key in ["user_id", "agent_id", "run_id"]:
    filter_conditions.append(Filter.by_property(key).equal(value))
```

This meant `filters={"user_id": "alice", "category": "movies"}` would only filter by `user_id`, silently dropping the `category` condition. Other backends (Qdrant, Redis) handle all filter keys generically.

### Fix

Extracted a `_build_filters()` helper method that creates Weaviate `Filter.by_property()` conditions for **all** filter keys with non-None values. This replaces three duplicated filter-building blocks across `search()`, `keyword_search()`, and `list()`.

## Changes

- `mem0/vector_stores/weaviate.py`: Added `_build_filters()` helper, replaced 3 duplicated hardcoded-whitelist blocks
- `tests/vector_stores/test_weaviate.py`: Added 2 regression tests verifying custom metadata filters are passed through and None values are excluded

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

```bash
python -m pytest tests/vector_stores/test_weaviate.py -v
# 11 passed (9 existing + 2 new)
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed