### PR TITLE
Fix data loss in metadata filters with AND operator

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1200,7 +1200,11 @@ class Memory(MemoryBase):
                     raise ValueError("AND operator requires a list of conditions")
                 for condition in value:
                     for sub_key, sub_value in condition.items():
-                        processed_filters.update(process_condition(sub_key, sub_value))
+                        sub_condition = process_condition(sub_key, sub_value)
+                        if sub_key in processed_filters and isinstance(processed_filters.get(sub_key), dict) and isinstance(sub_condition.get(sub_key), dict):
+                            processed_filters[sub_key].update(sub_condition[sub_key])
+                        else:
+                            processed_filters.update(sub_condition)
             elif key == "OR":
                 # Logical OR: Pass through to vector store for implementation-specific handling
                 if not isinstance(value, list) or not value:
@@ -2489,7 +2493,11 @@ class AsyncMemory(MemoryBase):
                     raise ValueError("AND operator requires a list of conditions")
                 for condition in value:
                     for sub_key, sub_value in condition.items():
-                        processed_filters.update(process_condition(sub_key, sub_value))
+                        sub_condition = process_condition(sub_key, sub_value)
+                        if sub_key in processed_filters and isinstance(processed_filters.get(sub_key), dict) and isinstance(sub_condition.get(sub_key), dict):
+                            processed_filters[sub_key].update(sub_condition[sub_key])
+                        else:
+                            processed_filters.update(sub_condition)
             elif key == "OR":
                 # Logical OR: Pass through to vector store for implementation-specific handling
                 if not isinstance(value, list) or not value:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -760,6 +760,14 @@ class TestProcessMetadataFiltersMerge:
             "score": {"gt": 0.5, "lt": 0.9},
         }
 
+    def test_and_operator_merges_conditions_on_same_key(self, mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
+        """Filters with AND wrapping multiple conditions on the same key must merge them instead of overwriting."""
+        memory = self._make_memory(mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory)
+        result = memory._process_metadata_filters({
+            "AND": [{"price": {"gt": 10}}, {"price": {"lt": 20}}]
+        })
+        assert result == {"price": {"gt": 10, "lt": 20}}
+
 
 # --- Issue #3040: reset() should clean up graph database ---
 


### PR DESCRIPTION
## Linked Issue

Closes #4850

## Description

The `AND` operator in metadata filters was overwriting conditions if multiple conditions applied to the same key within the same `AND` block. This caused all but the last condition for a given key to be silently dropped.

This PR updates `_process_metadata_filters` in both `Memory` and `AsyncMemory` to check if a key already exists in the processed filters. If both the existing value and the new condition are dictionaries (indicating operator-based filters like `gt`, `lt`, etc.), it now merges them using `update()` instead of overwriting the entire key.

**Files changed:**
- `mem0/memory/main.py` — Fixed filter merging logic in `Memory` and `AsyncMemory`
- `tests/test_memory.py` — Added regression test case

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update


## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Verified with the following reproduction script:
```python
from mem0.memory.main import Memory
m = Memory.__new__(Memory)
filters = {"AND": [{"price": {"gt": 10}}, {"price": {"lt": 20}}]}
processed_filters = m._process_metadata_filters(filters)
# Result: {'price': {'gt': 10, 'lt': 20}}
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed