### PR TITLE
fix: merge same-key AND conditions in _process_metadata_filters

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1193,6 +1193,14 @@ class Memory(MemoryBase):
                     raise ValueError(f"Unsupported metadata filter operator: {operator}")
             return result
 
+        def _merge_condition(target: Dict[str, Any], source: Dict[str, Any]) -> None:
+            """Merge source into target, combining nested operator dicts for the same key."""
+            for k, v in source.items():
+                if k in target and isinstance(target[k], dict) and isinstance(v, dict):
+                    target[k].update(v)
+                else:
+                    target[k] = v
+
         for key, value in metadata_filters.items():
             if key == "AND":
                 # Logical AND: combine multiple conditions
@@ -1200,7 +1208,7 @@ class Memory(MemoryBase):
                     raise ValueError("AND operator requires a list of conditions")
                 for condition in value:
                     for sub_key, sub_value in condition.items():
-                        processed_filters.update(process_condition(sub_key, sub_value))
+                        _merge_condition(processed_filters, process_condition(sub_key, sub_value))
             elif key == "OR":
                 # Logical OR: Pass through to vector store for implementation-specific handling
                 if not isinstance(value, list) or not value:
@@ -1223,14 +1231,14 @@ class Memory(MemoryBase):
                         not_condition.update(process_condition(sub_key, sub_value))
                     processed_filters["$not"].append(not_condition)
             else:
-                processed_filters.update(process_condition(key, value))
-        
+                _merge_condition(processed_filters, process_condition(key, value))
+
         return processed_filters
 
     def _has_advanced_operators(self, filters: Dict[str, Any]) -> bool:
         """
         Check if filters contain advanced operators that need special processing.
-        
+
         Args:
             filters: Dictionary of filters to check
             
@@ -2482,6 +2490,14 @@ class AsyncMemory(MemoryBase):
                     raise ValueError(f"Unsupported metadata filter operator: {operator}")
             return result
 
+        def _merge_condition(target: Dict[str, Any], source: Dict[str, Any]) -> None:
+            """Merge source into target, combining nested operator dicts for the same key."""
+            for k, v in source.items():
+                if k in target and isinstance(target[k], dict) and isinstance(v, dict):
+                    target[k].update(v)
+                else:
+                    target[k] = v
+
         for key, value in metadata_filters.items():
             if key == "AND":
                 # Logical AND: combine multiple conditions
@@ -2489,7 +2505,7 @@ class AsyncMemory(MemoryBase):
                     raise ValueError("AND operator requires a list of conditions")
                 for condition in value:
                     for sub_key, sub_value in condition.items():
-                        processed_filters.update(process_condition(sub_key, sub_value))
+                        _merge_condition(processed_filters, process_condition(sub_key, sub_value))
             elif key == "OR":
                 # Logical OR: Pass through to vector store for implementation-specific handling
                 if not isinstance(value, list) or not value:
@@ -2512,7 +2528,7 @@ class AsyncMemory(MemoryBase):
                         not_condition.update(process_condition(sub_key, sub_value))
                     processed_filters["$not"].append(not_condition)
             else:
-                processed_filters.update(process_condition(key, value))
+                _merge_condition(processed_filters, process_condition(key, value))
 
         return processed_filters
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -760,6 +760,30 @@ class TestProcessMetadataFiltersMerge:
             "score": {"gt": 0.5, "lt": 0.9},
         }
 
+    def test_and_same_key_separate_conditions_merged(self, mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
+        """AND conditions on the same key in separate dicts must be merged, not overwritten (issue #4850)."""
+        memory = self._make_memory(mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory)
+        result = memory._process_metadata_filters({
+            "AND": [{"price": {"gt": 10}}, {"price": {"lt": 20}}]
+        })
+        assert result == {"price": {"gt": 10, "lt": 20}}
+
+    def test_and_same_key_three_conditions_merged(self, mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
+        """Three AND conditions on the same key must all be preserved."""
+        memory = self._make_memory(mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory)
+        result = memory._process_metadata_filters({
+            "AND": [{"price": {"gt": 10}}, {"price": {"lt": 100}}, {"price": {"ne": 50}}]
+        })
+        assert result == {"price": {"gt": 10, "lt": 100, "ne": 50}}
+
+    def test_and_mixed_same_and_different_keys(self, mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
+        """AND with both same-key and different-key conditions."""
+        memory = self._make_memory(mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory)
+        result = memory._process_metadata_filters({
+            "AND": [{"price": {"gt": 10}}, {"price": {"lt": 20}}, {"rating": {"gte": 4}}]
+        })
+        assert result == {"price": {"gt": 10, "lt": 20}, "rating": {"gte": 4}}
+
 
 # --- Issue #3040: reset() should clean up graph database ---
 


### PR DESCRIPTION
## Linked Issue

Closes #4850

## Description

`_process_metadata_filters` silently drops conditions when the `AND` operator contains multiple conditions on the same key. For example:

```python
{"AND": [{"price": {"gt": 10}}, {"price": {"lt": 20}}]}
```

**Before (bug):** `{"price": {"lt": 20}}` — the `gt` condition is lost  
**After (fix):** `{"price": {"gt": 10, "lt": 20}}` — both conditions preserved

### Root Cause

The AND handler uses `dict.update()` to accumulate processed conditions into `processed_filters`. When two conditions share the same key, the second call to `update()` overwrites the first entirely, even though the values are nested operator dicts that should be merged.

### Fix

Added a `_merge_condition` helper that deep-merges nested operator dicts for the same key instead of overwriting. Applied to both the AND handler and the top-level else branch, in both `Memory` and `AsyncMemory` classes.

### Regression note

PR #4559 (merged 2026-03-26) fixed the related case where operators within a **single** condition dict were not merged (e.g. `{"created_at": {"gte": X, "lte": Y}}`). This PR fixes the remaining case where the same key appears in **separate** dicts within an AND list.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

### Tests added

3 new regression tests in `TestProcessMetadataFiltersMerge`:
- `test_and_same_key_separate_conditions_merged` — two conditions on same key
- `test_and_same_key_three_conditions_merged` — three conditions on same key
- `test_and_mixed_same_and_different_keys` — mixed same-key and different-key conditions

### Manual verification

```python
from mem0.memory.main import Memory
m = Memory.__new__(Memory)
result = m._process_metadata_filters({"AND": [{"price": {"gt": 10}}, {"price": {"lt": 20}}]})
assert result == {"price": {"gt": 10, "lt": 20}}  # passes
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed