### PR TITLE
fix: merge same-key operator dicts in AND metadata filters

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1161,15 +1161,15 @@ class Memory(MemoryBase):
     def _process_metadata_filters(self, metadata_filters: Dict[str, Any]) -> Dict[str, Any]:
         """
         Process enhanced metadata filters and convert them to vector store compatible format.
-        
+
         Args:
             metadata_filters: Enhanced metadata filters with operators
-            
+
         Returns:
             Dict of processed filters compatible with vector store
         """
         processed_filters = {}
-        
+
         def process_condition(key: str, condition: Any) -> Dict[str, Any]:
             if not isinstance(condition, dict):
                 # Simple equality: {"key": "value"}
@@ -1177,7 +1177,7 @@ class Memory(MemoryBase):
                     # Wildcard: match everything for this field (implementation depends on vector store)
                     return {key: "*"}
                 return {key: condition}
-            
+
             result = {}
             for operator, value in condition.items():
                 # Map platform operators to universal format that can be translated by each vector store
@@ -1193,6 +1193,14 @@ class Memory(MemoryBase):
                     raise ValueError(f"Unsupported metadata filter operator: {operator}")
             return result
 
+        def merge_filters(target: Dict[str, Any], source: Dict[str, Any]) -> None:
+            """Merge source into target, deep-merging nested operator dicts for the same key."""
+            for key, value in source.items():
+                if key in target and isinstance(target[key], dict) and isinstance(value, dict):
+                    target[key].update(value)
+                else:
+                    target[key] = value
+
         for key, value in metadata_filters.items():
             if key == "AND":
                 # Logical AND: combine multiple conditions
@@ -1200,7 +1208,7 @@ class Memory(MemoryBase):
                     raise ValueError("AND operator requires a list of conditions")
                 for condition in value:
                     for sub_key, sub_value in condition.items():
-                        processed_filters.update(process_condition(sub_key, sub_value))
+                        merge_filters(processed_filters, process_condition(sub_key, sub_value))
             elif key == "OR":
                 # Logical OR: Pass through to vector store for implementation-specific handling
                 if not isinstance(value, list) or not value:
@@ -1210,7 +1218,7 @@ class Memory(MemoryBase):
                 for condition in value:
                     or_condition = {}
                     for sub_key, sub_value in condition.items():
-                        or_condition.update(process_condition(sub_key, sub_value))
+                        merge_filters(or_condition, process_condition(sub_key, sub_value))
                     processed_filters["$or"].append(or_condition)
             elif key == "NOT":
                 # Logical NOT: Pass through to vector store for implementation-specific handling
@@ -1220,11 +1228,11 @@ class Memory(MemoryBase):
                 for condition in value:
                     not_condition = {}
                     for sub_key, sub_value in condition.items():
-                        not_condition.update(process_condition(sub_key, sub_value))
+                        merge_filters(not_condition, process_condition(sub_key, sub_value))
                     processed_filters["$not"].append(not_condition)
             else:
-                processed_filters.update(process_condition(key, value))
-        
+                merge_filters(processed_filters, process_condition(key, value))
+
         return processed_filters
 
     def _has_advanced_operators(self, filters: Dict[str, Any]) -> bool:
@@ -2482,6 +2490,14 @@ class AsyncMemory(MemoryBase):
                     raise ValueError(f"Unsupported metadata filter operator: {operator}")
             return result
 
+        def merge_filters(target: Dict[str, Any], source: Dict[str, Any]) -> None:
+            """Merge source into target, deep-merging nested operator dicts for the same key."""
+            for key, value in source.items():
+                if key in target and isinstance(target[key], dict) and isinstance(value, dict):
+                    target[key].update(value)
+                else:
+                    target[key] = value
+
         for key, value in metadata_filters.items():
             if key == "AND":
                 # Logical AND: combine multiple conditions
@@ -2489,7 +2505,7 @@ class AsyncMemory(MemoryBase):
                     raise ValueError("AND operator requires a list of conditions")
                 for condition in value:
                     for sub_key, sub_value in condition.items():
-                        processed_filters.update(process_condition(sub_key, sub_value))
+                        merge_filters(processed_filters, process_condition(sub_key, sub_value))
             elif key == "OR":
                 # Logical OR: Pass through to vector store for implementation-specific handling
                 if not isinstance(value, list) or not value:
@@ -2499,7 +2515,7 @@ class AsyncMemory(MemoryBase):
                 for condition in value:
                     or_condition = {}
                     for sub_key, sub_value in condition.items():
-                        or_condition.update(process_condition(sub_key, sub_value))
+                        merge_filters(or_condition, process_condition(sub_key, sub_value))
                     processed_filters["$or"].append(or_condition)
             elif key == "NOT":
                 # Logical NOT: Pass through to vector store for implementation-specific handling
@@ -2509,10 +2525,10 @@ class AsyncMemory(MemoryBase):
                 for condition in value:
                     not_condition = {}
                     for sub_key, sub_value in condition.items():
-                        not_condition.update(process_condition(sub_key, sub_value))
+                        merge_filters(not_condition, process_condition(sub_key, sub_value))
                     processed_filters["$not"].append(not_condition)
             else:
-                processed_filters.update(process_condition(key, value))
+                merge_filters(processed_filters, process_condition(key, value))
 
         return processed_filters
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -760,6 +760,38 @@ class TestProcessMetadataFiltersMerge:
             "score": {"gt": 0.5, "lt": 0.9},
         }
 
+    def test_and_same_key_different_operators_merged(self, mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
+        """AND with same key in separate conditions must merge operators (issue #4850)."""
+        memory = self._make_memory(mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory)
+        result = memory._process_metadata_filters({
+            "AND": [{"price": {"gt": 10}}, {"price": {"lt": 20}}]
+        })
+        assert result == {"price": {"gt": 10, "lt": 20}}
+
+    def test_and_same_key_three_operators_merged(self, mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
+        """AND with three conditions on the same key must merge all operators."""
+        memory = self._make_memory(mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory)
+        result = memory._process_metadata_filters({
+            "AND": [{"price": {"gte": 5}}, {"price": {"lte": 100}}, {"price": {"ne": 50}}]
+        })
+        assert result == {"price": {"gte": 5, "lte": 100, "ne": 50}}
+
+    def test_and_mixed_keys_with_same_key_overlap(self, mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
+        """AND with a mix of same-key and different-key conditions."""
+        memory = self._make_memory(mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory)
+        result = memory._process_metadata_filters({
+            "AND": [{"price": {"gt": 10}}, {"category": "electronics"}, {"price": {"lt": 20}}]
+        })
+        assert result == {"price": {"gt": 10, "lt": 20}, "category": "electronics"}
+
+    def test_and_simple_equality_no_merge(self, mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
+        """AND with simple equality values on the same key — last value wins."""
+        memory = self._make_memory(mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory)
+        result = memory._process_metadata_filters({
+            "AND": [{"status": "active"}, {"status": "pending"}]
+        })
+        assert result == {"status": "pending"}
+
 
 # --- Issue #3040: reset() should clean up graph database ---
 


### PR DESCRIPTION
## Linked Issue

Closes #4850

## Description

`_process_metadata_filters` silently drops filter conditions when multiple AND conditions target the same field with different operators. For example:

```python
filters = {"AND": [{"price": {"gt": 10}}, {"price": {"lt": 20}}]}
# Before fix: {"price": {"lt": 20}}  — gt:10 silently lost
# After fix:  {"price": {"gt": 10, "lt": 20}}  — both preserved
```

**Root cause:** `dict.update()` replaces existing keys entirely. When two conditions share the same field name, the second condition's operator dict overwrites the first instead of merging.

**Fix:** Added a `merge_filters()` helper that deep-merges nested operator dicts when the same key already exists in the target. Applied consistently to:
- AND block (the reported bug)
- OR block (same pattern within per-element accumulation)
- NOT block (same pattern)
- Top-level else branch

Both `Memory` (sync) and `AsyncMemory` classes are fixed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

### Manual testing

Reproduced the bug before the fix — confirmed `{"price": {"lt": 20}}` with `gt:10` silently dropped. After the fix, output is `{"price": {"gt": 10, "lt": 20}}`.

### New regression tests (4 tests)

| Test | Description |
|------|-------------|
| `test_and_same_key_different_operators_merged` | Two operators on same key in AND |
| `test_and_same_key_three_operators_merged` | Three operators on same key in AND |
| `test_and_mixed_keys_with_same_key_overlap` | Mixed same-key + different-key in AND |
| `test_and_simple_equality_no_merge` | Simple equality values (non-dict) use last-writer-wins |

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed