### PR TITLE
fix(docs): resolve duplicate operationIds and expiration_date type in openapi spec

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1048,8 +1048,8 @@
 											},
 											"expiration_date": {
 												"type": "string",
-												"format": "date-time",
-												"description": "The date and time when the memory will expire. Format: YYYY-MM-DD.",
+												"format": "date",
+												"description": "The date when the memory will expire. Format: YYYY-MM-DD.",
 												"title": "Expiration date",
 												"nullable": true,
 												"default": null
@@ -1233,7 +1233,7 @@
 					"memories"
 				],
 				"description": "Delete memories by filter. At least one filter is required \u2014 previously omitting all filters silently deleted everything; now it returns a validation error.",
-				"operationId": "memories_delete",
+				"operationId": "memories_delete_all",
 				"parameters": [
 					{
 						"name": "user_id",
@@ -1393,8 +1393,8 @@
 											},
 											"expiration_date": {
 												"type": "string",
-												"format": "date-time",
-												"description": "The date and time when the memory will expire. Format: YYYY-MM-DD.",
+												"format": "date",
+												"description": "The date when the memory will expire. Format: YYYY-MM-DD.",
 												"title": "Expiration date",
 												"nullable": true,
 												"default": null
@@ -1540,8 +1540,8 @@
 											},
 											"expiration_date": {
 												"type": "string",
-												"format": "date-time",
-												"description": "The date and time when the memory will expire. Format: YYYY-MM-DD.",
+												"format": "date",
+												"description": "The date when the memory will expire. Format: YYYY-MM-DD.",
 												"title": "Expiration date",
 												"nullable": true,
 												"default": null
@@ -1675,8 +1675,8 @@
 											},
 											"expiration_date": {
 												"type": "string",
-												"format": "date-time",
-												"description": "The date and time when the memory will expire. Format: YYYY-MM-DD.",
+												"format": "date",
+												"description": "The date when the memory will expire. Format: YYYY-MM-DD.",
 												"title": "Expiration date",
 												"nullable": true,
 												"default": null
@@ -1739,7 +1739,7 @@
 				"tags": [
 					"memories"
 				],
-				"operationId": "memories_read",
+				"operationId": "memories_entity_read",
 				"responses": {
 					"200": {
 						"description": "Successfully retrieved memories.",
@@ -5176,9 +5176,10 @@
 						"nullable": true
 					},
 					"expiration_date": {
-						"description": "The date and time when the memory will expire. Format: YYYY-MM-DD",
+						"description": "The date when the memory will expire. Format: YYYY-MM-DD",
 						"title": "Expiration date",
 						"type": "string",
+						"format": "date",
 						"nullable": true
 					},
 					"org_id": {


### PR DESCRIPTION
## Linked Issue

N/A — reported by an external consumer of `docs/openapi.json` who has been having to patch the spec before running their OpenAPI code generator.

## Description

Two issues in `docs/openapi.json` were breaking OpenAPI client codegen and forcing downstream consumers to manually rewrite the spec before generation.

### 1. Duplicate `operationId`s (violates OpenAPI 3.0)

[OpenAPI 3.0](https://swagger.io/docs/specification/v3_0/paths-and-operations/#operationid) requires every `operationId` to be unique. Two were duplicated:

| `operationId` | Paths |
|---|---|
| `memories_delete` | `DELETE /v1/memories/` (bulk by filter) **and** `DELETE /v1/memories/{memory_id}/` (single by ID) |
| `memories_read` | `GET /v1/memories/{entity_type}/{entity_id}/` **and** `GET /v1/memories/{memory_id}/` |

Code generators use `operationId` as the method name for the generated client, so duplicates cause collisions.

**Fix:** rename the non-canonical variants, keeping the canonical single-resource operations under their existing IDs so existing generated clients continue to work.

| Path | Method | Before | After |
|---|---|---|---|
| `/v1/memories/` | `DELETE` | `memories_delete` | `memories_delete_all` |
| `/v1/memories/{memory_id}/` | `DELETE` | `memories_delete` | `memories_delete` *(unchanged)* |
| `/v1/memories/{entity_type}/{entity_id}/` | `GET` | `memories_read` | `memories_entity_read` |
| `/v1/memories/{memory_id}/` | `GET` | `memories_read` | `memories_read` *(unchanged)* |

### 2. `expiration_date` type mismatch

The API returns and accepts `expiration_date` in `YYYY-MM-DD` form, but the spec declared it inconsistently:

- 4 request-body schemas had `format: date-time` with a description that explicitly said `Format: YYYY-MM-DD` — self-contradictory.
- The response schema (`components/schemas`) had no `format` at all — so generators treated it as a raw string there but as a `datetime` elsewhere.

All 5 occurrences now use `format: date` with wording that matches the actual format.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

None for the underlying API. For consumers of the OpenAPI spec itself:

- Generated clients that reference the **bulk** `memories_delete` or the **entity** `memories_read` method names will need to switch to `memories_delete_all` / `memories_entity_read`. The canonical single-resource `memories_delete` and `memories_read` are unchanged.
- Generated types for `expiration_date` will change from `datetime` to `date` — which is the correct shape the API was already returning, so consumers who were working around the mismatch can remove their patches.

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (see below)
- [ ] No tests needed

Manual verification performed:

- `python3 -c "import json; json.load(open('docs/openapi.json'))"` — spec still parses as valid JSON.
- Parsed all `paths.*.*.operationId` values and confirmed **0 duplicates** across 49 operations (was 2 duplicate pairs before).
- Grepped all 5 `expiration_date` entries and confirmed each now has `type: string` + `format: date`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works *(n/a — spec-only change, verified via JSON parse + programmatic duplicate check)*
- [x] New and existing tests pass locally *(no code paths touched)*
- [x] I have updated documentation if needed *(this PR **is** the documentation fix)*