### PR TITLE
chore(release): promote Python SDK to 2.0.0 and TS SDK to 3.0.0

### DIFF
--- a/mem0-ts/package.json
+++ b/mem0-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mem0ai",
-  "version": "3.0.0-beta.2",
+  "version": "3.0.0",
   "description": "The Memory Layer For Your AI Apps",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mem0ai"
-version = "2.0.0b2"
+version = "2.0.0"
 description = "Long-term memory for AI Agents"
 authors = [
     { name = "Mem0", email = "support@mem0.ai" }


### PR DESCRIPTION
## Linked Issue

Closes #<!-- issue number -->

## Description

Promotes both SDKs from their beta tags to stable major releases:

- `mem0ai` (PyPI): `2.0.0b2` → `2.0.0`
- `mem0ai` (npm): `3.0.0-beta.2` → `3.0.0`

No code changes — version bumps only in `pyproject.toml` and `mem0-ts/package.json`. Once merged and tagged (`v2.0.0` for Python, `ts-v3.0.0` for TypeScript), the CD workflows will publish to PyPI and npm via OIDC.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

These are the stable cuts of the 2.x (Python) and 3.x (TypeScript) major lines whose breaking changes landed across the prior beta releases. Users upgrading from 1.x (Python) or 2.x (TypeScript) should review the release notes / changelog for the migration path; upgrading from the latest beta (`2.0.0b2` / `3.0.0-beta.2`) requires no code changes.

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [x] No tests needed (explain why)

Release-only change — no source code is modified. Existing CI on this branch validates that the current beta codebase still builds and passes tests at the new stable version strings.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)