### PR TITLE
fix(oss): initialize entity cleanup in fresh Python SDK processes

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -461,16 +461,18 @@ class Memory(MemoryBase):
           - otherwise re-embed the entity text and update the payload
             (the vector store's update() requires a vector).
 
-        No-op if the entity store has never been initialized in this process.
         Errors on individual entities are swallowed at debug level; outer
         failures are swallowed at warning level so the primary delete/update
         path is never broken by entity cleanup.
         """
-        if self._entity_store is None:
+        try:
+            entity_store = self.entity_store
+        except Exception as e:
+            logger.warning(f"Entity store initialization failed for memory_id={memory_id}: {e}")
             return
         search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
         try:
-            listed = self.entity_store.list(filters=search_filters, top_k=10000)
+            listed = entity_store.list(filters=search_filters, top_k=10000)
             rows = listed[0] if isinstance(listed, (list, tuple)) and listed and isinstance(listed[0], list) else listed
             for row in rows or []:
                 try:
@@ -481,7 +483,7 @@ class Memory(MemoryBase):
                     remaining = [mid for mid in linked if mid != memory_id]
                     if not remaining:
                         try:
-                            self.entity_store.delete(vector_id=row.id)
+                            entity_store.delete(vector_id=row.id)
                         except Exception as e:
                             logger.debug(f"Entity delete failed for id={row.id}: {e}")
                     else:
@@ -496,7 +498,7 @@ class Memory(MemoryBase):
                             continue
                         new_payload = {**payload, "linked_memory_ids": remaining}
                         try:
-                            self.entity_store.update(
+                            entity_store.update(
                                 vector_id=row.id,
                                 vector=vec,
                                 payload=new_payload,
@@ -1891,11 +1893,14 @@ class AsyncMemory(MemoryBase):
 
     async def _remove_memory_from_entity_store(self, memory_id, filters):
         """Async variant of `Memory._remove_memory_from_entity_store`."""
-        if self._entity_store is None:
+        try:
+            entity_store = self.entity_store
+        except Exception as e:
+            logger.warning(f"Entity store initialization failed for memory_id={memory_id} (async): {e}")
             return
         search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
         try:
-            listed = await asyncio.to_thread(self.entity_store.list, filters=search_filters, top_k=10000)
+            listed = await asyncio.to_thread(entity_store.list, filters=search_filters, top_k=10000)
             rows = listed[0] if isinstance(listed, (list, tuple)) and listed and isinstance(listed[0], list) else listed
             for row in rows or []:
                 try:
@@ -1906,7 +1911,7 @@ class AsyncMemory(MemoryBase):
                     remaining = [mid for mid in linked if mid != memory_id]
                     if not remaining:
                         try:
-                            await asyncio.to_thread(self.entity_store.delete, vector_id=row.id)
+                            await asyncio.to_thread(entity_store.delete, vector_id=row.id)
                         except Exception as e:
                             logger.debug(f"Entity delete failed for id={row.id} (async): {e}")
                     else:
@@ -1922,7 +1927,7 @@ class AsyncMemory(MemoryBase):
                         new_payload = {**payload, "linked_memory_ids": remaining}
                         try:
                             await asyncio.to_thread(
-                                self.entity_store.update,
+                                entity_store.update,
                                 vector_id=row.id,
                                 vector=vec,
                                 payload=new_payload,

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock
 
 import pytest
@@ -194,6 +195,20 @@ def _build_memory_instance(mocker, memory_cls):
     return memory
 
 
+class _ProbeMemory(Memory):
+    @property
+    def entity_store(self):
+        self.entity_store_accesses += 1
+        return self._dummy_entity_store
+
+
+class _ProbeAsyncMemory(AsyncMemory):
+    @property
+    def entity_store(self):
+        self.entity_store_accesses += 1
+        return self._dummy_entity_store
+
+
 def _assert_utc_timestamp(timestamp: str):
     parsed = datetime.fromisoformat(timestamp)
     assert parsed.tzinfo == timezone.utc
@@ -282,6 +297,61 @@ async def test_async_update_memory_uses_utc_timestamps(mocker):
     payload = memory.vector_store.update.call_args.kwargs["payload"]
     assert payload["created_at"] == "2026-03-17T17:00:00-07:00"
     assert payload["updated_at"] is not None
+
+
+def test_delete_initializes_entity_store_before_cleanup():
+    stale_row = SimpleNamespace(id="entity-1", payload={"data": "Paris", "linked_memory_ids": ["mem-1"]})
+    entity_store = MagicMock()
+    entity_store.list.return_value = [stale_row]
+
+    memory = _ProbeMemory.__new__(_ProbeMemory)
+    memory._entity_store = None
+    memory._dummy_entity_store = entity_store
+    memory.entity_store_accesses = 0
+    memory.vector_store = MagicMock()
+    memory.db = MagicMock()
+
+    existing_memory = SimpleNamespace(
+        payload={
+            "data": "trip to Paris",
+            "created_at": "2026-04-16T00:00:00+00:00",
+            "user_id": "user-1",
+        }
+    )
+
+    memory._delete_memory("mem-1", existing_memory=existing_memory)
+
+    assert memory.entity_store_accesses == 1
+    entity_store.list.assert_called_once_with(filters={"user_id": "user-1"}, top_k=10000)
+    entity_store.delete.assert_called_once_with(vector_id="entity-1")
+
+
+@pytest.mark.asyncio
+async def test_async_delete_initializes_entity_store_before_cleanup():
+    stale_row = SimpleNamespace(id="entity-1", payload={"data": "Paris", "linked_memory_ids": ["mem-1"]})
+    entity_store = MagicMock()
+    entity_store.list.return_value = [stale_row]
+
+    memory = _ProbeAsyncMemory.__new__(_ProbeAsyncMemory)
+    memory._entity_store = None
+    memory._dummy_entity_store = entity_store
+    memory.entity_store_accesses = 0
+    memory.vector_store = MagicMock()
+    memory.db = MagicMock()
+
+    existing_memory = SimpleNamespace(
+        payload={
+            "data": "trip to Paris",
+            "created_at": "2026-04-16T00:00:00+00:00",
+            "user_id": "user-1",
+        }
+    )
+
+    await memory._delete_memory("mem-1", existing_memory=existing_memory)
+
+    assert memory.entity_store_accesses == 1
+    entity_store.list.assert_called_once_with(filters={"user_id": "user-1"}, top_k=10000)
+    entity_store.delete.assert_called_once_with(vector_id="entity-1")
 
 
 def test_create_then_search_and_get_all_return_same_timestamps(mocker):
@@ -624,5 +694,3 @@ async def test_async_update_preserves_actor_id_when_different_actor_updates(mock
 
     stored = memory.vector_store.update.call_args.kwargs["payload"]
     assert stored["actor_id"] == "Alice"
-
-


### PR DESCRIPTION
## Linked Issue

Closes #4863

## Description

Fixes a fresh-process cleanup gap in the Python SDK's entity-link maintenance.

### Problem

`_remove_memory_from_entity_store()` returned immediately when `_entity_store` was unset. Because the entity store is lazy-initialized, delete/update flows could skip cleanup after a process restart, leaving stale `linked_memory_ids` behind.

### What changed

- resolve the entity store through the lazy `entity_store` property before cleanup,
- keep cleanup best-effort / non-fatal if entity-store initialization fails,
- reuse the initialized store for the list / delete / update operations,
- add regression tests for both sync and async delete flows.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

None.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Local verification:
- `pytest -q tests/memory/test_main.py`
- added regression tests proving that both sync and async delete paths now initialize the entity store before cleanup in a fresh process.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
