### PR TITLE
fix(cli): remove API keys from telemetry subprocess argv

### DIFF
--- a/cli/node/src/telemetry.ts
+++ b/cli/node/src/telemetry.ts
@@ -143,9 +143,10 @@ export function captureEvent(
 
 		const child = spawn(
 			process.execPath,
-			[SENDER_SCRIPT, JSON.stringify(context)],
-			{ detached: true, stdio: "ignore" },
+			[SENDER_SCRIPT],
+			{ detached: true, stdio: ["pipe", "ignore", "ignore"] },
 		);
+		child.stdin?.end(JSON.stringify(context));
 		child.unref();
 	} catch {
 		/* silently swallow */

--- a/cli/node/telemetry-sender.cjs
+++ b/cli/node/telemetry-sender.cjs
@@ -19,6 +19,31 @@
 const https = require("https");
 const fs = require("fs");
 
+function loadContext() {
+	return new Promise((resolve, reject) => {
+		if (process.argv[2]) {
+			try {
+				resolve(JSON.parse(process.argv[2]));
+			} catch (err) {
+				reject(err);
+			}
+			return;
+		}
+
+		let data = "";
+		process.stdin.setEncoding("utf8");
+		process.stdin.on("data", (chunk) => (data += chunk));
+		process.stdin.on("end", () => {
+			try {
+				resolve(JSON.parse(data));
+			} catch (err) {
+				reject(err);
+			}
+		});
+		process.stdin.on("error", reject);
+	});
+}
+
 function httpsRequest(url, method, headers, body) {
 	return new Promise((resolve, reject) => {
 		const u = new URL(url);
@@ -108,7 +133,7 @@ async function sendIdentifyEvent(ctx, payload, anonId) {
 }
 
 async function main() {
-	const ctx = JSON.parse(process.argv[2]);
+	const ctx = await loadContext();
 	const payload = ctx.payload;
 
 	if (ctx.needsEmail && ctx.mem0ApiKey) {

--- a/cli/node/tests/telemetry.test.ts
+++ b/cli/node/tests/telemetry.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockLoadConfig = vi.fn();
+const mockSaveConfig = vi.fn();
+const mockSpawn = vi.fn();
+
+vi.mock("../src/config.js", () => ({
+  CONFIG_FILE: "/tmp/mem0-config.json",
+  loadConfig: mockLoadConfig,
+  saveConfig: mockSaveConfig,
+}));
+
+vi.mock("node:child_process", () => ({
+  spawn: mockSpawn,
+}));
+
+describe("captureEvent", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockLoadConfig.mockReset();
+    mockSaveConfig.mockReset();
+    mockSpawn.mockReset();
+    delete process.env.MEM0_TELEMETRY;
+  });
+
+  it("pipes the telemetry context through stdin instead of argv", async () => {
+    mockLoadConfig.mockReturnValue({
+      platform: {
+        apiKey: "m0-node-secret",
+        baseUrl: "https://api.mem0.ai",
+        userEmail: "",
+      },
+      telemetry: {
+        anonymousId: "cli-anon-node",
+      },
+    });
+
+    const stdin = { end: vi.fn() };
+    const child = { stdin, unref: vi.fn() };
+    mockSpawn.mockReturnValue(child);
+
+    const { captureEvent } = await import("../src/telemetry.js");
+    captureEvent("node_test_event", { case: "stdin-secret" });
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    const [execPath, args, options] = mockSpawn.mock.calls[0];
+    expect(execPath).toBe(process.execPath);
+    expect(args).toHaveLength(1);
+    expect(String(args[0])).toContain("telemetry-sender.cjs");
+    expect(JSON.stringify(args)).not.toContain("m0-node-secret");
+    expect(options).toMatchObject({ detached: true, stdio: ["pipe", "ignore", "ignore"] });
+
+    expect(stdin.end).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(stdin.end.mock.calls[0][0]);
+    expect(payload.mem0ApiKey).toBe("m0-node-secret");
+    expect(payload.payload.event).toBe("node_test_event");
+    expect(child.unref).toHaveBeenCalledTimes(1);
+  });
+});

--- a/cli/python/src/mem0_cli/telemetry.py
+++ b/cli/python/src/mem0_cli/telemetry.py
@@ -135,12 +135,19 @@ def capture_event(
             "anon_distinct_id_to_alias": anon_id_to_alias,
         }
 
-        subprocess.Popen(
-            [sys.executable, "-m", "mem0_cli.telemetry_sender", json.dumps(context)],
+        child = subprocess.Popen(
+            [sys.executable, "-m", "mem0_cli.telemetry_sender"],
+            stdin=subprocess.PIPE,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             start_new_session=True,
             close_fds=True,
+            text=True,
         )
+        if child.stdin:
+            with contextlib.suppress(Exception):
+                child.stdin.write(json.dumps(context))
+            with contextlib.suppress(Exception):
+                child.stdin.close()
     except Exception:
         pass

--- a/cli/python/src/mem0_cli/telemetry_sender.py
+++ b/cli/python/src/mem0_cli/telemetry_sender.py
@@ -20,8 +20,18 @@ import sys
 import urllib.request
 
 
+def _load_context() -> dict:
+    """Load telemetry context from stdin, falling back to argv for compatibility."""
+    raw = ""
+    if not sys.stdin.isatty():
+        raw = sys.stdin.read().strip()
+    if not raw and len(sys.argv) > 1:
+        raw = sys.argv[1]
+    return json.loads(raw)
+
+
 def main() -> None:
-    ctx = json.loads(sys.argv[1])
+    ctx = _load_context()
     payload = ctx["payload"]
 
     if ctx.get("needs_email") and ctx.get("mem0_api_key"):

--- a/cli/python/tests/test_telemetry.py
+++ b/cli/python/tests/test_telemetry.py
@@ -1,0 +1,76 @@
+"""Tests for telemetry subprocess secret handling."""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+
+from mem0_cli.config import Mem0Config, save_config
+from mem0_cli.telemetry import capture_event
+from mem0_cli.telemetry_sender import _load_context
+
+
+class _CaptureStdin:
+    def __init__(self):
+        self.buffer = ""
+
+    def write(self, value: str) -> None:
+        self.buffer += value
+
+    def close(self) -> None:
+        return None
+
+
+class _DummyProcess:
+    def __init__(self):
+        self.stdin = _CaptureStdin()
+
+
+def test_capture_event_writes_context_to_stdin_not_argv(isolate_config, monkeypatch):
+    config = Mem0Config()
+    config.platform.api_key = "m0-test-secret"
+    config.telemetry.anonymous_id = "cli-anon-test"
+    save_config(config)
+
+    captured: dict[str, object] = {}
+    proc = _DummyProcess()
+
+    def fake_popen(args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return proc
+
+    monkeypatch.setattr("mem0_cli.telemetry.subprocess.Popen", fake_popen)
+
+    capture_event("unit_test_event", {"case": "stdin-secret"})
+
+    argv = captured["args"]
+    assert argv == [argv[0], "-m", "mem0_cli.telemetry_sender"]
+    assert all("m0-test-secret" not in arg for arg in argv)
+
+    kwargs = captured["kwargs"]
+    assert kwargs["stdin"] == subprocess.PIPE
+    assert kwargs["text"] is True
+
+    ctx = json.loads(proc.stdin.buffer)
+    assert ctx["mem0_api_key"] == "m0-test-secret"
+    assert ctx["payload"]["event"] == "unit_test_event"
+
+
+def test_load_context_reads_from_stdin(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["telemetry_sender"])
+    monkeypatch.setattr("sys.stdin", io.StringIO('{"payload": {"event": "stdin"}}'))
+
+    ctx = _load_context()
+
+    assert ctx["payload"]["event"] == "stdin"
+
+
+def test_load_context_falls_back_to_argv(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["telemetry_sender", '{"payload": {"event": "argv"}}'])
+    monkeypatch.setattr("sys.stdin", io.StringIO(""))
+
+    ctx = _load_context()
+
+    assert ctx["payload"]["event"] == "argv"


### PR DESCRIPTION
## Linked Issue

Closes #4862

## Description

Removes the Mem0 API key from telemetry child-process argv in both CLIs.

### Problem

Both CLI telemetry helpers spawned a detached child process with the full telemetry context serialized into a JSON command-line argument. That context included the real Mem0 API key used for `/v1/ping/`, so the secret could be exposed through local process inspection tools.

### What changed

- Python CLI now spawns `mem0_cli.telemetry_sender` without a JSON argv payload and writes the telemetry context through stdin instead.
- Node CLI now spawns `telemetry-sender.cjs` without a JSON argv payload and writes the telemetry context through stdin instead.
- Both sender implementations now read from stdin first and fall back to argv for compatibility with older parent processes during rollout.
- Added regression tests covering the new stdin handoff and compatibility loading paths.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

None. The sender side keeps argv fallback compatibility so mixed-version parent/child combinations still work during upgrades.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Local verification:
- `pytest -q cli/python/tests/test_telemetry.py`
- `pnpm test -- --runInBand tests/telemetry.test.ts`
- manual `ps` repros for both CLIs confirmed that the telemetry sender still launches, but the Mem0 API key no longer appears in argv.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
