### PR TITLE
fix: resolve incomplete delete_all pagination for large memory sets 

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -1300,9 +1300,17 @@ export class Memory {
       );
     }
 
-    const [memories] = await this.vectorStore.list(filters);
-    for (const memory of memories) {
-      await this.deleteMemory(memory.id);
+    const deleteBatchSize = 1000;
+
+    while (true) {
+      const [memories] = await this.vectorStore.list(filters, deleteBatchSize);
+      if (memories.length === 0) {
+        break;
+      }
+
+      for (const memory of memories) {
+        await this.deleteMemory(memory.id);
+      }
     }
 
     return { message: "Memories deleted successfully!" };

--- a/mem0-ts/src/oss/tests/memory.crud.test.ts
+++ b/mem0-ts/src/oss/tests/memory.crud.test.ts
@@ -257,6 +257,44 @@ describe("Memory - deleteAll()", () => {
       "At least one filter is required to delete all memories",
     );
   });
+
+  test("handles pagination by deleting all memories across pages", async () => {
+    // 1. Setup
+    const memoryWithMock = createMemory();
+    const totalMemories = 110;
+    const memoriesPage1 = Array.from({ length: 100 }, (_, i) => ({
+      id: `id_${i}`,
+      payload: {},
+    }));
+    const memoriesPage2 = Array.from({ length: 10 }, (_, i) => ({
+      id: `id_${100 + i}`,
+      payload: {},
+    }));
+
+    // 2. Mock vectorStore.list to simulate pagination
+    const listSpy = jest
+      .spyOn((memoryWithMock as any).vectorStore, "list")
+      .mockResolvedValueOnce([memoriesPage1]) // First call returns 100
+      .mockResolvedValueOnce([memoriesPage2]) // Second call returns 10
+      .mockResolvedValueOnce([[]]); // Third call returns 0
+
+    // 3. Spy on deleteMemory to track calls
+    const deleteSpy = jest.spyOn(
+      memoryWithMock as any,
+      "deleteMemory",
+    ).mockResolvedValue({ message: "Memory deleted successfully!" });
+
+    // 4. Call the function
+    await memoryWithMock.deleteAll({ userId });
+
+    // 5. Assert
+    expect(listSpy).toHaveBeenCalledTimes(3); // Two non-empty batches, then one empty terminating fetch
+    expect(deleteSpy).toHaveBeenCalledTimes(totalMemories); // Should delete ALL memories
+
+    // 6. Cleanup spies
+    listSpy.mockRestore();
+    deleteSpy.mockRestore();
+  });
 });
 
 // ─── getAll() ────────────────────────────────────────────

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -168,6 +168,20 @@ def _validate_search_params(threshold: Optional[float] = None, top_k: Optional[i
             )
 
 
+def _normalize_vector_store_list_result(memories_result):
+    """Normalize vector_store.list() output to a flat list of memory rows.
+
+    Different vector stores return different shapes:
+    - flat list: [OutputData, ...]
+    - tuple/list with rows first: ([OutputData, ...], meta)
+    """
+    if isinstance(memories_result, (tuple, list)) and len(memories_result) > 0:
+        first_element = memories_result[0]
+        if isinstance(first_element, (list, tuple)):
+            return list(first_element)
+    return memories_result
+
+
 def _is_sensitive_field(field_name: str) -> bool:
     """Check if a field should be redacted for telemetry safety.
 
@@ -1553,12 +1567,22 @@ class Memory(MemoryBase):
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "sync"})
-        # delete all vector memories and reset the collections
-        memories = self.vector_store.list(filters=filters)[0]
-        for memory in memories:
-            self._delete_memory(memory.id)
+        delete_batch_size = 1000
+        deleted_count = 0
 
-        logger.info(f"Deleted {len(memories)} memories")
+        memories_result = self.vector_store.list(filters=filters, top_k=delete_batch_size)
+        memories = _normalize_vector_store_list_result(memories_result)
+
+        while memories:
+            for memory in memories:
+                self._delete_memory(memory.id)
+                deleted_count += 1
+
+            # Re-list after each batch so stores with default page limits are drained fully.
+            memories_result = self.vector_store.list(filters=filters, top_k=delete_batch_size)
+            memories = _normalize_vector_store_list_result(memories_result)
+
+        logger.info(f"Deleted {deleted_count} memories")
 
         return {"message": "Memories deleted successfully!"}
 
@@ -2953,15 +2977,21 @@ class AsyncMemory(MemoryBase):
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "async"})
-        memories = await asyncio.to_thread(self.vector_store.list, filters=filters)
+        delete_batch_size = 1000
+        deleted_count = 0
 
-        delete_tasks = []
-        for memory in memories[0]:
-            delete_tasks.append(self._delete_memory(memory.id))
+        memories_result = await asyncio.to_thread(self.vector_store.list, filters=filters, top_k=delete_batch_size)
+        memories = _normalize_vector_store_list_result(memories_result)
 
-        await asyncio.gather(*delete_tasks)
+        while memories:
+            delete_tasks = [self._delete_memory(memory.id) for memory in memories]
+            await asyncio.gather(*delete_tasks)
+            deleted_count += len(memories)
 
-        logger.info(f"Deleted {len(memories[0])} memories")
+            memories_result = await asyncio.to_thread(self.vector_store.list, filters=filters, top_k=delete_batch_size)
+            memories = _normalize_vector_store_list_result(memories_result)
+
+        logger.info(f"Deleted {deleted_count} memories")
 
         return {"message": "Memories deleted successfully!"}
 

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -626,3 +626,18 @@ async def test_async_update_preserves_actor_id_when_different_actor_updates(mock
     assert stored["actor_id"] == "Alice"
 
 
+@pytest.mark.asyncio
+async def test_async_delete_all_drains_multiple_batches(mocker):
+    memory = _build_memory_instance(mocker, AsyncMemory)
+    batch_one = [MagicMock(id=f"id_{i}") for i in range(100)]
+    batch_two = [MagicMock(id=f"id_{100 + i}") for i in range(50)]
+    memory.vector_store.list.side_effect = [(batch_one, None), (batch_two, None), ([], None)]
+    memory._delete_memory = mocker.AsyncMock()
+
+    result = await memory.delete_all(user_id="test_user")
+
+    assert memory._delete_memory.await_count == 150
+    assert memory.vector_store.list.call_count == 3
+    memory.vector_store.list.assert_any_call(filters={"user_id": "test_user"}, top_k=1000)
+    assert result["message"] == "Memories deleted successfully!"
+

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -174,16 +174,44 @@ def test_delete(memory_instance):
 
 def test_delete_all(memory_instance):
     mock_memories = [Mock(id="1"), Mock(id="2")]
-    memory_instance.vector_store.list = Mock(return_value=(mock_memories, None))
+    memory_instance.vector_store.list = Mock(side_effect=[(mock_memories, None), ([], None)])
     memory_instance.vector_store.reset = Mock()
     memory_instance._delete_memory = Mock()
 
     result = memory_instance.delete_all(user_id="test_user")
 
     assert memory_instance._delete_memory.call_count == 2
+    assert memory_instance.vector_store.list.call_count == 2
+    memory_instance.vector_store.list.assert_any_call(filters={"user_id": "test_user"}, top_k=1000)
     # Ensure the collection is NOT dropped — only matched memories should be removed
     memory_instance.vector_store.reset.assert_not_called()
 
+    assert result["message"] == "Memories deleted successfully!"
+
+
+def test_delete_all_drains_multiple_batches(memory_instance):
+    batch_one = [Mock(id=f"id_{i}") for i in range(100)]
+    batch_two = [Mock(id=f"id_{100 + i}") for i in range(50)]
+    memory_instance.vector_store.list = Mock(side_effect=[(batch_one, None), (batch_two, None), ([], None)])
+    memory_instance._delete_memory = Mock()
+
+    result = memory_instance.delete_all(user_id="test_user")
+
+    assert memory_instance._delete_memory.call_count == 150
+    assert memory_instance.vector_store.list.call_count == 3
+    assert result["message"] == "Memories deleted successfully!"
+
+
+def test_delete_all_handles_flat_list_vector_store_results(memory_instance):
+    batch_one = [Mock(id="1"), Mock(id="2")]
+    batch_two = [Mock(id="3")]
+    memory_instance.vector_store.list = Mock(side_effect=[batch_one, batch_two, []])
+    memory_instance._delete_memory = Mock()
+
+    result = memory_instance.delete_all(user_id="test_user")
+
+    assert memory_instance._delete_memory.call_count == 3
+    assert memory_instance.vector_store.list.call_count == 3
     assert result["message"] == "Memories deleted successfully!"
 
 


### PR DESCRIPTION
## Linked Issue

Closes #4869

## Description

`Memory.delete_all()` in Python called `vector_store.list()` a single time without a loop. Vector stores like Qdrant apply a default page size (typically 100), so only the first batch of memories was deleted — the rest were silently left behind. The async implementation had the same issue.

The fix replaces the single call with a re-list loop: after deleting each batch, the store is re-queried from the start. Since deleted records are gone, this drains all remaining pages correctly. Offset-based pagination was deliberately avoided because it would skip records as items shift after deletion.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Manually verified by creating 150 memories for a single `user_id`, calling `delete_all()`, then asserting `get_all()` returns 0 results. Tests added to `tests/memory/test_main.py` and `tests/test_main.py` covering `delete_all` with more than one page of memories.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
