### PR TITLE
fix(ts): drain all pages in deleteAll, not just the first batch

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -1300,9 +1300,20 @@ export class Memory {
       );
     }
 
-    const [memories] = await this.vectorStore.list(filters);
-    for (const memory of memories) {
-      await this.deleteMemory(memory.id);
+    // Use a large batch size and re-list from the start after each batch.
+    // Offset-based pagination is deliberately avoided: as memories are deleted
+    // the remaining items shift, so re-querying from offset 0 after each batch
+    // is the safest way to drain all pages.
+    const DELETE_BATCH_SIZE = 1000;
+    let deletedCount = 0;
+
+    let [memories] = await this.vectorStore.list(filters, DELETE_BATCH_SIZE);
+    while (memories.length > 0) {
+      for (const memory of memories) {
+        await this.deleteMemory(memory.id);
+        deletedCount++;
+      }
+      [memories] = await this.vectorStore.list(filters, DELETE_BATCH_SIZE);
     }
 
     return { message: "Memories deleted successfully!" };

--- a/mem0-ts/src/oss/tests/memory.crud.test.ts
+++ b/mem0-ts/src/oss/tests/memory.crud.test.ts
@@ -257,6 +257,40 @@ describe("Memory - deleteAll()", () => {
       "At least one filter is required to delete all memories",
     );
   });
+
+  test("drains multiple pages when vector store returns paginated results", async () => {
+    // Simulate a vector store that returns results in two batches then empty,
+    // which is what happens when there are more memories than the page size.
+    const batchOne = Array.from({ length: 100 }, (_, i) => ({
+      id: `page1-id-${i}`,
+      payload: {},
+    }));
+    const batchTwo = Array.from({ length: 50 }, (_, i) => ({
+      id: `page2-id-${i}`,
+      payload: {},
+    }));
+
+    const listSpy = jest
+      .spyOn((memory as any).vectorStore, "list")
+      .mockResolvedValueOnce([batchOne, batchOne.length])
+      .mockResolvedValueOnce([batchTwo, batchTwo.length])
+      .mockResolvedValue([[], 0]);
+
+    const deleteMemorySpy = jest
+      .spyOn(memory as any, "deleteMemory")
+      .mockResolvedValue(undefined);
+
+    const result = await memory.deleteAll({ userId: "paginated-user" });
+
+    expect(result.message).toBe("Memories deleted successfully!");
+    // All 150 memories across both pages must be deleted
+    expect(deleteMemorySpy).toHaveBeenCalledTimes(150);
+    // list must be called until it returns empty (3 calls total)
+    expect(listSpy).toHaveBeenCalledTimes(3);
+
+    listSpy.mockRestore();
+    deleteMemorySpy.mockRestore();
+  });
 });
 
 // ─── getAll() ────────────────────────────────────────────


### PR DESCRIPTION
## Linked Issue

Closes #4869

## Description

`Memory.deleteAll()` in TypeScript called `vectorStore.list(filters)` once with the default `topK` of 100, so only the first 100 memories were deleted when more than 100 existed for a given scope.

This is the TypeScript counterpart of the Python fix in #4872. The comment on issue #4869 noted that a separate PR for the TypeScript `deleteAll` fix would follow.

**Root cause:** `list()` defaults to `topK = 100`. A single call returns at most one page.

**Fix:** Replace the single call with a re-list loop that keeps fetching from offset 0 after each batch. Offset-based pagination is deliberately avoided — as memories are deleted the remaining items shift, so re-querying from the start is the only safe way to drain all pages.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added a regression test in `memory.crud.test.ts` that mocks `vectorStore.list` to return two batches (100 + 50 items) followed by an empty sentinel. Verifies that `deleteAll` calls `deleteMemory` exactly 150 times and calls `list` exactly 3 times (two non-empty batches + one empty confirmation).

All 23 existing `memory.crud.test.ts` tests pass.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed