### PR TITLE
security: fix SQL and Cypher injection vulnerabilities in PGVector, Azure MySQL, and Neptune

### DIFF
--- a/mem0/configs/vector_stores/azure_mysql.py
+++ b/mem0/configs/vector_stores/azure_mysql.py
@@ -1,6 +1,11 @@
+import re
 from typing import Any, Dict, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+# Rejecting any identifier that doesn't match this pattern is what keeps the
+# f-string table/column interpolations in mem0/vector_stores/azure_mysql.py safe.
+_VALID_SQL_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 class AzureMySQLConfig(BaseModel):
@@ -25,6 +30,15 @@ class AzureMySQLConfig(BaseModel):
         None,
         description="Pre-configured connection pool object (overrides other connection parameters)"
     )
+
+    @field_validator("collection_name")
+    def validate_collection_name(cls, v):
+        if not _VALID_SQL_IDENTIFIER.match(v):
+            raise ValueError(
+                f"Invalid collection_name: {v!r}. Must start with a letter or underscore and "
+                "contain only letters, digits, and underscores."
+            )
+        return v
 
     @model_validator(mode="before")
     @classmethod

--- a/mem0/configs/vector_stores/neptune.py
+++ b/mem0/configs/vector_stores/neptune.py
@@ -5,7 +5,13 @@ This module provides configuration settings for integrating with Amazon Neptune 
 as a vector store backend for Mem0's memory layer.
 """
 
-from pydantic import BaseModel, ConfigDict, Field
+import re
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+# Rejecting any identifier that doesn't match this pattern is what keeps the
+# f-string label interpolations in mem0/vector_stores/neptune_analytics.py safe.
+_VALID_CYPHER_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 class NeptuneAnalyticsConfig(BaseModel):
@@ -21,5 +27,14 @@ class NeptuneAnalyticsConfig(BaseModel):
     """
     collection_name: str = Field("mem0", description="Default name for the collection")
     endpoint: str = Field("endpoint", description="Graph ID for the runtime")
+
+    @field_validator("collection_name")
+    def validate_collection_name(cls, v):
+        if not _VALID_CYPHER_IDENTIFIER.match(v):
+            raise ValueError(
+                f"Invalid collection_name: {v!r}. Must start with a letter or underscore and "
+                "contain only letters, digits, and underscores."
+            )
+        return v
 
     model_config = ConfigDict(arbitrary_types_allowed=False)

--- a/mem0/configs/vector_stores/pgvector.py
+++ b/mem0/configs/vector_stores/pgvector.py
@@ -1,6 +1,11 @@
+import re
 from typing import Any, Dict, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+# Rejecting any identifier that doesn't match this pattern is what keeps the
+# f-string table/column interpolations in mem0/vector_stores/pgvector.py safe.
+_VALID_SQL_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 class PGVectorConfig(BaseModel):
@@ -19,6 +24,15 @@ class PGVectorConfig(BaseModel):
     sslmode: Optional[str] = Field(None, description="SSL mode for PostgreSQL connection (e.g., 'require', 'prefer', 'disable')")
     connection_string: Optional[str] = Field(None, description="PostgreSQL connection string (overrides individual connection parameters)")
     connection_pool: Optional[Any] = Field(None, description="psycopg connection pool object (overrides connection string and individual parameters)")
+
+    @field_validator("collection_name")
+    def validate_collection_name(cls, v):
+        if not _VALID_SQL_IDENTIFIER.match(v):
+            raise ValueError(
+                f"Invalid collection_name: {v!r}. Must start with a letter or underscore and "
+                "contain only letters, digits, and underscores."
+            )
+        return v
 
     @model_validator(mode="before")
     def check_auth_and_connection(cls, values):

--- a/mem0/vector_stores/azure_mysql.py
+++ b/mem0/vector_stores/azure_mysql.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 from contextlib import contextmanager
 from typing import Any, Dict, List, Optional
 
@@ -24,6 +25,10 @@ except ImportError:
 from mem0.vector_stores.base import VectorStoreBase
 
 logger = logging.getLogger(__name__)
+
+# Filter keys are interpolated into `JSON_EXTRACT(payload, '$.<key>')` strings,
+# so we whitelist identifier-safe keys and skip anything else (logged as a warning).
+_VALID_FILTER_KEY = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 class OutputData(BaseModel):
@@ -263,6 +268,9 @@ class AzureMySQL(VectorStoreBase):
 
         if filters:
             for k, v in filters.items():
+                if not _VALID_FILTER_KEY.match(k):
+                    logger.warning("Skipping invalid filter key: %r", k)
+                    continue
                 filter_conditions.append("JSON_EXTRACT(payload, %s) = %s")
                 filter_params.extend([f"$.{k}", json.dumps(v)])
 
@@ -423,6 +431,9 @@ class AzureMySQL(VectorStoreBase):
 
         if filters:
             for k, v in filters.items():
+                if not _VALID_FILTER_KEY.match(k):
+                    logger.warning("Skipping invalid filter key: %r", k)
+                    continue
                 filter_conditions.append("JSON_EXTRACT(payload, %s) = %s")
                 filter_params.extend([f"$.{k}", json.dumps(v)])
 

--- a/mem0/vector_stores/neptune_analytics.py
+++ b/mem0/vector_stores/neptune_analytics.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import time
 import uuid
 from typing import Dict, List, Optional
@@ -35,6 +36,7 @@ class NeptuneAnalyticsVector(VectorStoreBase):
     _FIELD_SCORE = 'score'
     _FIELD_LABEL = 'label'
     _TIMEZONE =  "UTC"
+    _VALID_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
     def __init__(
         self,
@@ -155,19 +157,24 @@ class NeptuneAnalyticsVector(VectorStoreBase):
             filters = {}
         filters[self._FIELD_LABEL] = self.collection_name
 
-        filter_clause = self._get_node_filter_clause(filters)
+        filter_obj = self._get_node_filter_clause(filters)
 
-        query_string = f"""
-            CALL neptune.algo.vectors.topKByEmbeddingWithFiltering({{
-                    topK: {top_k},
-                    embedding: {vectors}
-                    {filter_clause}
-                  }}
+        query_string = """
+            CALL neptune.algo.vectors.topKByEmbeddingWithFiltering({
+                    topK: $top_k,
+                    embedding: $vectors,
+                    nodeFilter: $node_filter
+                  }
                 )
             YIELD node, score
             RETURN node as n, score
             """
-        query_response = self.execute_query(query_string)
+        params = {
+            "top_k": top_k,
+            "vectors": vectors,
+            "node_filter": filter_obj
+        }
+        query_response = self.execute_query(query_string, params)
         if len(query_response) > 0:
             return self._parse_query_responses(query_response, with_score=True)
         else :
@@ -322,10 +329,11 @@ class NeptuneAnalyticsVector(VectorStoreBase):
         Returns:
             List[OutputData]: List of vectors with their metadata.
         """
-        where_clause = self._get_where_clause(filters) if filters else ""
+        where_clause, filter_params = self._get_where_clause(filters) if filters else ("", {})
 
         para = {
             "limit": top_k,
+            **filter_params
         }
         query_string = f"""
             MATCH (n :{self.collection_name})
@@ -399,8 +407,8 @@ class NeptuneAnalyticsVector(VectorStoreBase):
         return self.graph.query(query_string, params)
 
 
-    @staticmethod
-    def _get_where_clause(filters: dict):
+    @classmethod
+    def _get_where_clause(cls, filters: dict):
         """
         Build WHERE clause for Cypher queries from filters.
         
@@ -408,18 +416,23 @@ class NeptuneAnalyticsVector(VectorStoreBase):
             filters (dict): Filter conditions as key-value pairs.
             
         Returns:
-            str: Formatted WHERE clause for Cypher query.
+            tuple: (where_clause_string, params_dict)
         """
-        where_clause = ""
+        where_clauses = []
+        params = {}
         for i, (k, v) in enumerate(filters.items()):
-            if i == 0:
-                where_clause += f"WHERE n.{k} = '{v}' "
-            else:
-                where_clause += f"AND n.{k} = '{v}' "
-        return where_clause
+            if not cls._VALID_IDENTIFIER.match(k):
+                logger.warning(f"Skipping invalid filter key: {k}")
+                continue
+            param_name = f"filter_{i}"
+            where_clauses.append(f"n.`{k}` = ${param_name}")
+            params[param_name] = v
+        
+        where_clause = "WHERE " + " AND ".join(where_clauses) if where_clauses else ""
+        return where_clause, params
 
-    @staticmethod
-    def _get_node_filter_clause(filters: dict):
+    @classmethod
+    def _get_node_filter_clause(cls, filters: dict):
         """
         Build node filter clause for vector search operations.
 
@@ -430,19 +443,21 @@ class NeptuneAnalyticsVector(VectorStoreBase):
             filters (dict): Filter conditions as key-value pairs.
 
         Returns:
-            str: Formatted node filter clause for vector search.
+            dict: Node filter object for parameterized query.
         """
         conditions = []
         for k, v in filters.items():
-            conditions.append(f"{{equals:{{property: '{k}', value: '{v}'}}}}")
+            if not cls._VALID_IDENTIFIER.match(k):
+                logger.warning(f"Skipping invalid filter key: {k}")
+                continue
+            conditions.append({"equals": {"property": k, "value": v}})
 
+        if not conditions:
+            return {}
         if len(conditions) == 1:
-            filter_clause = f", nodeFilter: {conditions[0]}"
+            return conditions[0]
         else:
-            filter_clause = f"""
-                      , nodeFilter: {{andAll: [ {", ".join(conditions)} ]}} 
-                  """
-        return filter_clause
+            return {"andAll": conditions}
 
 
     @staticmethod

--- a/tests/vector_stores/test_security_injection.py
+++ b/tests/vector_stores/test_security_injection.py
@@ -1,0 +1,146 @@
+"""Regression tests for CWE-89 fixes on PGVector, Azure MySQL, and Neptune Analytics.
+
+Covers issue #4875: collection_name / filter-value interpolation that previously
+allowed SQL / Cypher injection. These tests verify that:
+
+1. Pydantic config validators reject collection_name values that aren't safe
+   SQL/Cypher identifiers (the entry point that guards every downstream
+   f-string interpolation of ``self.collection_name``).
+2. The Neptune Analytics query builders produce parameterized Cypher and
+   structured node filters instead of concatenating user-controlled values.
+"""
+
+import importlib.util
+
+import pytest
+from pydantic import ValidationError
+
+from mem0.configs.vector_stores.azure_mysql import AzureMySQLConfig
+from mem0.configs.vector_stores.neptune import NeptuneAnalyticsConfig
+from mem0.configs.vector_stores.pgvector import PGVectorConfig
+
+# A sampling of real-world injection payloads from the original issue report.
+INJECTION_PAYLOADS = [
+    "memories; DROP TABLE users; --",
+    "memories` OR 1=1; --",
+    "memories:Label {prop: 'val'}) DELETE n; --",
+    "valid_name OR 1=1",
+    "1_starts_with_digit",
+    "has space",
+    "",
+]
+
+
+class TestPGVectorConfigCollectionNameValidation:
+    def test_accepts_valid_identifier(self):
+        config = PGVectorConfig(
+            collection_name="valid_name",
+            user="user",
+            password="password",
+            host="localhost",
+            port=5432,
+        )
+        assert config.collection_name == "valid_name"
+
+    @pytest.mark.parametrize("payload", INJECTION_PAYLOADS)
+    def test_rejects_injection_payload(self, payload):
+        with pytest.raises(ValidationError, match="Invalid collection_name"):
+            PGVectorConfig(
+                collection_name=payload,
+                user="user",
+                password="password",
+                host="localhost",
+                port=5432,
+            )
+
+
+class TestAzureMySQLConfigCollectionNameValidation:
+    def test_accepts_valid_identifier(self):
+        config = AzureMySQLConfig(
+            collection_name="valid_name",
+            host="host",
+            user="user",
+            database="db",
+            password="pw",
+        )
+        assert config.collection_name == "valid_name"
+
+    @pytest.mark.parametrize("payload", INJECTION_PAYLOADS)
+    def test_rejects_injection_payload(self, payload):
+        with pytest.raises(ValidationError, match="Invalid collection_name"):
+            AzureMySQLConfig(
+                collection_name=payload,
+                host="host",
+                user="user",
+                database="db",
+                password="pw",
+            )
+
+
+class TestNeptuneAnalyticsConfigCollectionNameValidation:
+    def test_accepts_valid_identifier(self):
+        config = NeptuneAnalyticsConfig(collection_name="valid_name")
+        assert config.collection_name == "valid_name"
+
+    @pytest.mark.parametrize("payload", INJECTION_PAYLOADS)
+    def test_rejects_injection_payload(self, payload):
+        with pytest.raises(ValidationError, match="Invalid collection_name"):
+            NeptuneAnalyticsConfig(collection_name=payload)
+
+
+# The Neptune Analytics vector store module hard-raises on missing `langchain_aws`,
+# so guard the query-builder tests with a skipif when the optional dep isn't present.
+_HAS_LANGCHAIN_AWS = importlib.util.find_spec("langchain_aws") is not None
+
+
+@pytest.mark.skipif(not _HAS_LANGCHAIN_AWS, reason="langchain_aws package not installed")
+class TestNeptuneWhereClauseParameterization:
+    def test_filters_are_parameterized(self):
+        from mem0.vector_stores.neptune_analytics import NeptuneAnalyticsVector
+
+        where_clause, params = NeptuneAnalyticsVector._get_where_clause({"user_id": "123", "agent_id": "abc"})
+
+        assert "$filter_0" in where_clause
+        assert "$filter_1" in where_clause
+        assert params == {"filter_0": "123", "filter_1": "abc"}
+
+    def test_injection_value_does_not_leak_into_clause(self):
+        from mem0.vector_stores.neptune_analytics import NeptuneAnalyticsVector
+
+        payload = "x' RETURN n UNION MATCH (m) DETACH DELETE m //"
+        where_clause, params = NeptuneAnalyticsVector._get_where_clause({"user_id": payload})
+
+        assert payload not in where_clause
+        assert params["filter_0"] == payload
+
+    def test_invalid_filter_key_is_skipped(self, caplog):
+        from mem0.vector_stores.neptune_analytics import NeptuneAnalyticsVector
+
+        with caplog.at_level("WARNING"):
+            where_clause, params = NeptuneAnalyticsVector._get_where_clause({"user_id' OR 1=1 --": "val"})
+
+        assert where_clause == ""
+        assert params == {}
+        assert any("Skipping invalid filter key" in m for m in caplog.messages)
+
+
+@pytest.mark.skipif(not _HAS_LANGCHAIN_AWS, reason="langchain_aws package not installed")
+class TestNeptuneNodeFilterClause:
+    def test_single_filter_returns_equals_object(self):
+        from mem0.vector_stores.neptune_analytics import NeptuneAnalyticsVector
+
+        filter_obj = NeptuneAnalyticsVector._get_node_filter_clause({"user_id": "123"})
+        assert filter_obj == {"equals": {"property": "user_id", "value": "123"}}
+
+    def test_multiple_filters_combine_with_and_all(self):
+        from mem0.vector_stores.neptune_analytics import NeptuneAnalyticsVector
+
+        filter_obj = NeptuneAnalyticsVector._get_node_filter_clause({"user_id": "123", "agent_id": "456"})
+        assert "andAll" in filter_obj
+        assert len(filter_obj["andAll"]) == 2
+
+    def test_invalid_filter_key_is_skipped(self):
+        from mem0.vector_stores.neptune_analytics import NeptuneAnalyticsVector
+
+        filter_obj = NeptuneAnalyticsVector._get_node_filter_clause({"user_id' OR 1=1 --": "val"})
+        assert filter_obj == {}


### PR DESCRIPTION
## Linked Issue

Closes #4875

## Description

This PR remediates several SQL and Cypher injection vulnerabilities (CWE-89) in the PGVector, Azure MySQL, and Neptune Analytics vector store backends. These vulnerabilities were caused by direct f-string interpolation of user-controlled `collection_name` and filter values into database queries.

### Key Changes:
- **Strict Configuration Validation**: Added Pydantic `field_validator` to `PGVectorConfig`, `AzureMySQLConfig`, and `NeptuneAnalyticsConfig` to ensure `collection_name` only contains safe alphanumeric characters and underscores, starting with a letter or underscore. This prevents injection into any query string where the table name or label is interpolated.
- **Parameterized Neptune Queries**: Refactored the `NeptuneAnalyticsVector` search and list methods to use parameterized queries instead of string interpolation for filters. Vector search now uses the structured `nodeFilter` parameter object.
- **Filter Key Validation**: Added regex validation for filter property keys in `AzureMySQL` and `NeptuneAnalyticsVector` to guard against injection via metadata property paths.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

This change introduces stricter validation for the `collection_name` field in PGVector, Azure MySQL, and Neptune configurations. Collection names must now match the regex `^[a-zA-Z_][a-zA-Z0-9_]*$`. Users with existing non-standard collection names (e.g., those containing spaces or starting with digits) will need to rename their collections to remain compliant with the new security standards.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Manual testing was performed using a dedicated security test script (`tests/vector_stores/test_security_injection.py`) that attempts various injection payloads (SQL/Cypher) in both configuration and filter parameters, verifying they
