### PR TITLE
feat: expose use_input_language config to preserve source language in extracted memories

### DIFF
--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -238,7 +238,7 @@ If the user is on a pre-current major (Python < 2, TS < 3, or Platform `output_f
 - [Reranking](https://docs.mem0.ai/open-source/features/reranking) [OSS]: Use when configuring reranking end-to-end in OSS.
 - [Async Memory](https://docs.mem0.ai/open-source/features/async-memory) [OSS]: Use when the self-hosted app needs `AsyncMemory`.
 - [OSS Multimodal Support (features)](https://docs.mem0.ai/open-source/features/multimodal-support) [OSS]: Use when handling images and PDFs self-hosted (feature guide).
-- [Custom Instructions (OSS)](https://docs.mem0.ai/open-source/features/custom-instructions) [OSS]: Use when tailoring extraction prompts in OSS.
+- [Custom Instructions (OSS)](https://docs.mem0.ai/open-source/features/custom-instructions) [OSS]: Use when tailoring extraction prompts or preserving the input language in OSS.
 - [REST API Server](https://docs.mem0.ai/open-source/features/rest-api) [OSS]: Use when exposing a self-hosted Mem0 as a FastAPI service.
 - [OpenAI Compatibility](https://docs.mem0.ai/open-source/features/openai_compatibility) [OSS]: Use when hitting an OpenAI-compatible endpoint with self-hosted.
 

--- a/docs/open-source/features/custom-instructions.mdx
+++ b/docs/open-source/features/custom-instructions.mdx
@@ -146,6 +146,31 @@ const memory = new Memory(config);
 
 ---
 
+## Preserve the input language
+
+For Python OSS deployments, set `use_input_language` when you want extracted memories to use the same language and script as the input conversation. This is useful for Chinese, Japanese, Korean, Arabic, Hindi, and other multilingual workloads where the extraction model might otherwise normalize facts into English.
+
+```python Python
+from mem0 import Memory
+
+config = {
+    "use_input_language": True,
+    "llm": {
+        "provider": "openai",
+        "config": {"model": "gpt-5-mini"},
+    },
+}
+
+memory = Memory.from_config(config)
+memory.add("我喜欢周末打乒乓球", user_id="xiaoming")
+```
+
+The option defaults to `False`, so existing deployments keep their current extraction behavior. It adds language-preservation guidance to both synchronous `Memory` and asynchronous `AsyncMemory` extraction. Model adherence can vary, so test the setting with the model and languages used in production.
+
+Use `custom_instructions` instead when you need additional language-specific rules or want to combine language preservation with domain-specific extraction guidance.
+
+---
+
 ## See it in action
 
 ### Example: Order support memory

--- a/mem0/configs/base.py
+++ b/mem0/configs/base.py
@@ -55,6 +55,15 @@ class MemoryConfig(BaseModel):
         description="Custom instructions for fact extraction",
         default=None,
     )
+    use_input_language: bool = Field(
+        description=(
+            "If True, instruct the extraction LLM to output memories in the same "
+            "language and script as the input conversation. Useful for non-English "
+            "deployments (CJK, Hindi, Arabic, etc.) where the default behavior would "
+            "otherwise translate stored facts into English."
+        ),
+        default=False,
+    )
 
 
 class AzureConfig(BaseModel):

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -345,6 +345,7 @@ class Memory(MemoryBase):
         self.collection_name = self.config.vector_store.config.collection_name
         self.api_version = self.config.version
         self.custom_instructions = self.config.custom_instructions
+        self.use_input_language = self.config.use_input_language
 
         # Initialize reranker if configured
         self.reranker = None
@@ -733,6 +734,7 @@ class Memory(MemoryBase):
             new_messages=parsed_messages,
             last_k_messages=last_messages,
             custom_instructions=custom_instr,
+            use_input_language=self.use_input_language,
         )
 
         try:
@@ -1801,6 +1803,7 @@ class AsyncMemory(MemoryBase):
         self.collection_name = self.config.vector_store.config.collection_name
         self.api_version = self.config.version
         self.custom_instructions = self.config.custom_instructions
+        self.use_input_language = self.config.use_input_language
         self._entity_store = None
 
         # Initialize reranker if configured
@@ -2140,6 +2143,7 @@ class AsyncMemory(MemoryBase):
             new_messages=parsed_messages,
             last_k_messages=last_messages,
             custom_instructions=custom_instr,
+            use_input_language=self.use_input_language,
         )
 
         try:

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -496,6 +496,7 @@ class Memory(MemoryBase):
         self.collection_name = self.config.vector_store.config.collection_name
         self.api_version = self.config.version
         self.custom_instructions = self.config.custom_instructions
+        self.use_input_language = self.config.use_input_language
 
         # Initialize reranker if configured
         self.reranker = None
@@ -945,6 +946,7 @@ class Memory(MemoryBase):
             new_messages=parsed_messages,
             last_k_messages=last_messages,
             custom_instructions=custom_instr,
+            use_input_language=self.use_input_language,
         )
 
         try:
@@ -2175,6 +2177,7 @@ class AsyncMemory(MemoryBase):
         self.collection_name = self.config.vector_store.config.collection_name
         self.api_version = self.config.version
         self.custom_instructions = self.config.custom_instructions
+        self.use_input_language = self.config.use_input_language
         self._entity_store = None
 
         # Initialize reranker if configured
@@ -2601,6 +2604,7 @@ class AsyncMemory(MemoryBase):
             new_messages=parsed_messages,
             last_k_messages=last_messages,
             custom_instructions=custom_instr,
+            use_input_language=self.use_input_language,
         )
 
         try:

--- a/tests/memory/test_use_input_language.py
+++ b/tests/memory/test_use_input_language.py
@@ -1,0 +1,31 @@
+"""Verify MemoryConfig.use_input_language propagates into the extraction prompt."""
+
+from mem0.configs.base import MemoryConfig
+from mem0.configs.prompts import generate_additive_extraction_prompt
+
+
+def test_flag_defaults_to_false():
+    cfg = MemoryConfig()
+    assert cfg.use_input_language is False
+
+
+def test_flag_off_omits_language_requirement():
+    prompt = generate_additive_extraction_prompt(
+        existing_memories=[],
+        new_messages=[{"role": "user", "content": "I like apples"}],
+        last_k_messages=[],
+        use_input_language=False,
+    )
+    assert "## Language Requirement" not in prompt
+
+
+def test_flag_on_injects_language_requirement():
+    cfg = MemoryConfig(use_input_language=True)
+    prompt = generate_additive_extraction_prompt(
+        existing_memories=[],
+        new_messages=[{"role": "user", "content": "我叫小明"}],
+        last_k_messages=[],
+        use_input_language=cfg.use_input_language,
+    )
+    assert "## Language Requirement" in prompt
+    assert "SAME LANGUAGE and SCRIPT" in prompt

--- a/tests/memory/test_use_input_language.py
+++ b/tests/memory/test_use_input_language.py
@@ -1,0 +1,66 @@
+"""Verify that MemoryConfig.use_input_language reaches the extraction prompt."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from mem0.configs.base import MemoryConfig
+from mem0.memory.main import AsyncMemory, Memory
+
+
+def _build_memory(mocker, memory_cls, *, use_input_language):
+    embedder = MagicMock()
+    embedder.embed.return_value = [0.1, 0.2, 0.3]
+    vector_store = MagicMock()
+    vector_store.search.return_value = []
+    llm = MagicMock()
+    llm.generate_response.return_value = '{"memory": []}'
+
+    mocker.patch("mem0.memory.main.EmbedderFactory.create", return_value=embedder)
+    mocker.patch("mem0.memory.main.VectorStoreFactory.create", return_value=vector_store)
+    mocker.patch("mem0.memory.main.LlmFactory.create", return_value=llm)
+    mocker.patch("mem0.memory.main.SQLiteManager", return_value=MagicMock())
+    mocker.patch("mem0.memory.main.MEM0_TELEMETRY", False)
+
+    memory = memory_cls.from_config({"use_input_language": use_input_language})
+    memory.db.get_last_messages.return_value = []
+    return memory
+
+
+def _extraction_user_prompt(memory):
+    return memory.llm.generate_response.call_args.kwargs["messages"][1]["content"]
+
+
+def test_flag_defaults_to_false():
+    assert MemoryConfig().use_input_language is False
+
+
+@pytest.mark.parametrize("use_input_language", [False, True])
+def test_sync_config_reaches_extraction_prompt(mocker, use_input_language):
+    memory = _build_memory(mocker, Memory, use_input_language=use_input_language)
+
+    memory._add_to_vector_store(
+        messages=[{"role": "user", "content": "我叫小明"}],
+        metadata={},
+        filters={"user_id": "xiaoming"},
+        infer=True,
+    )
+
+    user_prompt = _extraction_user_prompt(memory)
+    assert ("## Language Requirement" in user_prompt) is use_input_language
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_input_language", [False, True])
+async def test_async_config_reaches_extraction_prompt(mocker, use_input_language):
+    memory = _build_memory(mocker, AsyncMemory, use_input_language=use_input_language)
+
+    await memory._add_to_vector_store(
+        messages=[{"role": "user", "content": "我叫小明"}],
+        metadata={},
+        effective_filters={"user_id": "xiaoming"},
+        infer=True,
+    )
+
+    user_prompt = _extraction_user_prompt(memory)
+    assert ("## Language Requirement" in user_prompt) is use_input_language


### PR DESCRIPTION
## Linked Issues

Refs #1817, #3206, #3707, #6312.

Related implementation history:

- #1818 previously added same-language memory extraction and was merged.
- #4805 introduced the V3 additive extraction pipeline and the existing `use_input_language` prompt branch.
- #5549 also identified the same unreachable flag while working on broader CJK support.
- In #6312, maintainers confirmed that the current sync and async call sites never enable the existing language-preservation block and described exposing it as a first-class configuration option as a worthwhile product follow-up.

## Description

The V3 extraction prompt builder already supports `use_input_language`, which adds instructions to preserve the source language and script. However, `MemoryConfig` did not expose that option, and neither `Memory` nor `AsyncMemory` forwarded it. As a result, the built-in language-preservation path was unreachable through the public OSS API.

This PR:

- adds `use_input_language: bool = False` to `MemoryConfig`;
- forwards the option through synchronous and asynchronous extraction;
- verifies the public configuration path for both enabled and disabled states;
- documents the option for Python OSS users and updates the documentation index.

The default remains `False`, so existing behavior is unchanged unless users opt in.

```python
from mem0 import Memory

memory = Memory.from_config({
    "use_input_language": True,
})

memory.add("我喜欢周末打乒乓球", user_id="xiaoming")
```

`custom_instructions` remains available for applications that need additional domain-specific or language-specific extraction rules. This option provides a focused built-in path for users who only need source-language preservation.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an existing configuration gap)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Documentation update

## Breaking Changes

None. `use_input_language` defaults to `False`.

## Test Coverage

- [x] Added/updated unit tests
- [ ] Added/updated integration tests
- [x] Tested locally
- [ ] No tests needed

Validation completed on Python 3.12:

- `tests/memory/test_main.py` and `tests/memory/test_use_input_language.py`: 57 passed;
- focused input-language tests: 5 passed;
- Ruff checks passed for the touched Python files;
- `docs/llms.txt` coverage check passed.

The focused tests instantiate both `Memory` and `AsyncMemory` through `from_config()` and verify that the language requirement reaches the extraction prompt only when enabled.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review performed
- [x] Tests added that prove the fix works
- [x] New and existing related tests pass locally
- [x] Documentation updated

## Out of Scope

- TypeScript OSS support: the TypeScript prompt implementation does not currently expose an equivalent branch.
- Hosted `MemoryClient`: extraction prompts are managed server-side.