### PR TITLE
fix(llms): narrow reasoning-model detection so gpt-5.4-mini keeps temperature

### DIFF
--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -1,7 +1,22 @@
+import re
 from abc import ABC, abstractmethod
 from typing import Dict, List, Optional, Union
 
 from mem0.configs.llms.base import BaseLlmConfig
+
+# Reasoning models (OpenAI o-series and GPT-5 family) reject parameters like
+# temperature. A substring check ("gpt-5" in name) misfires on model names
+# such as "gpt-5.4-mini" that happen to share a prefix but support the full
+# chat-completion parameter set. Match explicitly:
+#   o1, o3, o4, o5 (with optional "-suffix" like -preview, -mini, -pro)
+#   gpt-5 exactly, or gpt-5 followed by an alphabetic suffix (gpt-5o),
+#     each optionally followed by "-suffix" (gpt-5-mini, gpt-5o-mini).
+# A digit or "." after the core identifier breaks the match, so gpt-5.4-mini,
+# gpt-5.5, etc. are treated as regular chat models.
+_REASONING_MODEL_PATTERN = re.compile(
+    r"^(?:o[1-9])(?:-[a-z0-9]+(?:-[a-z0-9]+)*)?$"
+    r"|^gpt-5[a-z]*(?:-[a-z0-9]+(?:-[a-z0-9]+)*)?$"
+)
 
 
 class LLMBase(ABC):
@@ -43,26 +58,14 @@ class LLMBase(ABC):
     def _is_reasoning_model(self, model: str) -> bool:
         """
         Check if the model is a reasoning model or GPT-5 series that doesn't support certain parameters.
-        
+
         Args:
             model: The model name to check
-            
+
         Returns:
             bool: True if the model is a reasoning model or GPT-5 series
         """
-        reasoning_models = {
-            "o1", "o1-preview", "o3-mini", "o3",
-            "gpt-5", "gpt-5o", "gpt-5o-mini", "gpt-5o-micro",
-        }
-        
-        if model.lower() in reasoning_models:
-            return True
-        
-        model_lower = model.lower()
-        if any(reasoning_model in model_lower for reasoning_model in ["gpt-5", "o1", "o3"]):
-            return True
-            
-        return False
+        return bool(_REASONING_MODEL_PATTERN.match(model.lower()))
 
     def _get_supported_params(self, **kwargs) -> Dict:
         """

--- a/tests/llms/test_base.py
+++ b/tests/llms/test_base.py
@@ -1,0 +1,86 @@
+"""Unit tests for mem0.llms.base.LLMBase helpers."""
+
+import pytest
+
+from mem0.llms.base import LLMBase
+
+
+class _DummyLLM(LLMBase):
+    def generate_response(self, messages, tools=None, tool_choice="auto", **kwargs):
+        return "dummy"
+
+
+@pytest.fixture
+def llm():
+    return _DummyLLM()
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "o1",
+        "o1-preview",
+        "o1-mini",
+        "o3",
+        "o3-mini",
+        "o3-pro",
+        "o4-mini",
+        "gpt-5",
+        "gpt-5-mini",
+        "gpt-5o",
+        "gpt-5o-mini",
+        "gpt-5o-micro",
+        "GPT-5",
+    ],
+)
+def test_is_reasoning_model_recognizes_reasoning_variants(llm, model):
+    assert llm._is_reasoning_model(model) is True
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "gpt-4",
+        "gpt-4.1-nano-2025-04-14",
+        "gpt-4o",
+        "gpt-4o-mini",
+        # Decimal-versioned GPT-5 families (e.g. gpt-5.4-mini) are NOT
+        # reasoning models and must retain full parameter support (issue #4738).
+        "gpt-5.4-mini",
+        "gpt-5.5",
+        "gpt-5.0-preview",
+        # Substrings that used to false-positive with the old "in" check.
+        "llama-o1-chat",
+        "mistral-o3-8b",
+        "custom-gpt-5-adapter",
+    ],
+)
+def test_is_reasoning_model_rejects_non_reasoning_variants(llm, model):
+    assert llm._is_reasoning_model(model) is False
+
+
+def test_get_supported_params_keeps_temperature_for_gpt_5_decimal(llm):
+    """Regression guard for issue #4738: temperature must not be stripped
+    for decimal-versioned GPT-5 models like gpt-5.4-mini."""
+    llm.config.model = "gpt-5.4-mini"
+    llm.config.temperature = 0.1
+    llm.config.max_tokens = 2000
+    llm.config.top_p = 0.1
+
+    params = llm._get_supported_params(messages=[{"role": "user", "content": "hi"}])
+
+    assert params["temperature"] == 0.1
+    assert params["max_tokens"] == 2000
+    assert params["top_p"] == 0.1
+
+
+def test_get_supported_params_strips_temperature_for_real_reasoning_model(llm):
+    """Reasoning models (e.g. o3-mini) must keep the strict parameter whitelist."""
+    llm.config.model = "o3-mini"
+
+    params = llm._get_supported_params(messages=[{"role": "user", "content": "hi"}])
+
+    assert "temperature" not in params
+    assert "max_tokens" not in params
+    assert "top_p" not in params
+    assert params["messages"] == [{"role": "user", "content": "hi"}]


### PR DESCRIPTION
## Linked Issue

Closes #4738

## Description

\`_is_reasoning_model\` in \`mem0/llms/base.py\` used a substring match:

\`\`\`python
if any(reasoning_model in model_lower for reasoning_model in [\"gpt-5\", \"o1\", \"o3\"]):
    return True
\`\`\`

This misclassifies any model name that *contains* \`gpt-5\`, \`o1\`, or \`o3\` as a reasoning model, causing \`_get_supported_params()\` to strip \`temperature\`, \`max_tokens\`, and \`top_p\` before the API call. Concretely, \`gpt-5.4-mini\` (and future point releases like \`gpt-5.5\`) match the \`gpt-5\` substring but actually support temperature, so \`temperature: 0.1\` set in the config is silently ignored. Other false positives include model names like \`llama-o1-chat\` and \`mistral-o3-8b\`.

## Fix

Replace the substring check with a compiled regex that requires a clean boundary after the core identifier:

- \`oN\` or \`oN-<suffix>\` for single-digit o-series models (e.g. \`o1\`, \`o1-mini\`, \`o3\`, \`o3-pro\`, \`o4-mini\`).
- \`gpt-5\` exactly, or \`gpt-5<alpha>\` (e.g. \`gpt-5o\`), each optionally followed by a \`-<suffix>\` chain (e.g. \`gpt-5-mini\`, \`gpt-5o-mini\`).

A digit or \`.\` directly after the core identifier breaks the match, so \`gpt-5.4-mini\`, \`gpt-5.5\`, and \`gpt-5.0-preview\` are treated as regular chat models. The previously-maintained \`reasoning_models\` set is redundant — the regex covers every name it had.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A — names that correctly mapped to reasoning behavior before (the base \`o1\`/\`o3\` and \`gpt-5\`/\`gpt-5o\` families with \`-suffix\` variants) still map to reasoning behavior.

## Test Coverage

- [x] Added \`tests/llms/test_base.py\` with:
  - A parametrized positive-case table across 13 reasoning variants (o1, o1-preview, o1-mini, o3, o3-mini, o3-pro, o4-mini, gpt-5, gpt-5-mini, gpt-5o, gpt-5o-mini, gpt-5o-micro, GPT-5).
  - A parametrized negative-case table for decimal GPT-5 names (\`gpt-5.4-mini\`, \`gpt-5.5\`, \`gpt-5.0-preview\`), substring false-positives (\`llama-o1-chat\`, \`mistral-o3-8b\`, \`custom-gpt-5-adapter\`), and gpt-4 baselines.
  - Two end-to-end \`_get_supported_params\` assertions confirming temperature is kept for \`gpt-5.4-mini\` and stripped for \`o3-mini\`.
- [x] \`pytest tests/llms/test_base.py\` — 25 passed.
- [x] \`pytest tests/llms/test_openai.py\` — 14 passed (no regression on existing reasoning-effort tests).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] No documentation update needed (internal helper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)