### PR TITLE
Remove optional fields from SearchRequest model

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -119,9 +119,6 @@ class MemoryUpdate(BaseModel):
 
 class SearchRequest(BaseModel):
     query: str = Field(..., description="Search query.")
-    user_id: Optional[str] = None
-    run_id: Optional[str] = None
-    agent_id: Optional[str] = None
     filters: Optional[Dict[str, Any]] = None
     top_k: Optional[int] = Field(None, description="Maximum number of results to return.")
     threshold: Optional[float] = Field(None, description="Minimum similarity score for results.")


### PR DESCRIPTION
This pull request makes a small change to the `SearchRequest` model in `server/main.py`, removing the optional fields `user_id`, `run_id`, and `agent_id`. This simplifies the model and reduces the parameters expected in search requests.Removed optional fields user_id, run_id, and agent_id from SearchRequest.

## Description

After the update of Python SDK v2.0.0, it is no longer supported to pass user_i, run_i, and agent_i directly during queries, only in filters.

## Type of Change

- Bug fix (non-breaking change that fixes an issue)



N/A

## Test Coverage

- I tested manually (describe below)

<!-- Describe how you tested this, or link to CI results. -->

## Checklist

- My code follows the project's style guidelines
- I have performed a self-review of my code
- I have added tests that prove my fix/feature works
- New and existing tests pass locally
- I have updated documentation if needed
