### PR TITLE
fix: updating docs with v3 integrations updates

### DIFF
--- a/docs/cookbooks/companions/travel-assistant.mdx
+++ b/docs/cookbooks/companions/travel-assistant.mdx
@@ -54,7 +54,6 @@ config = {
             "embedding_model_dims": 3072,
         }
     },
-    "version": "v1.1",
 }
 
 class PersonalTravelAssistant:
@@ -154,7 +153,7 @@ class PersonalTravelAssistant:
         return answer
 
     def get_memories(self, user_id):
-        memories = self.memory.get_all(user_id=user_id)
+        memories = self.memory.get_all(filters={"user_id": user_id})
         return [m['memory'] for m in memories.get('results', [])]
 
     def search_memories(self, query, user_id):

--- a/docs/cookbooks/integrations/aws-bedrock.mdx
+++ b/docs/cookbooks/integrations/aws-bedrock.mdx
@@ -42,7 +42,7 @@ This sets up Mem0 with:
 ```python
 import boto3
 from opensearchpy import RequestsHttpConnection, AWSV4SignerAuth
-from mem0.memory.main import Memory
+from mem0 import Memory
 
 region = 'us-west-2'
 service = 'aoss'

--- a/docs/integrations/aws-bedrock.mdx
+++ b/docs/integrations/aws-bedrock.mdx
@@ -49,7 +49,7 @@ Import necessary modules and configure Mem0:
 ```python
 import boto3
 from opensearchpy import OpenSearch, RequestsHttpConnection, AWSV4SignerAuth
-from mem0.memory.main import Memory
+from mem0 import Memory
 
 region = 'us-west-2'
 service = 'aoss'

--- a/docs/integrations/keywords.mdx
+++ b/docs/integrations/keywords.mdx
@@ -24,7 +24,7 @@ You can get your Mem0 API key from the <a href="https://app.mem0.ai/" rel="nofol
 Install the necessary libraries:
 
 ```bash
-pip install mem0 keywordsai-sdk
+pip install mem0ai keywordsai-sdk
 ```
 
 Set up your environment variables:
@@ -65,7 +65,7 @@ config = {
 }
 
 # Initialize Memory
-memory = Memory.from_config(config_dict=config)
+memory = Memory.from_config(config)
 
 # Add a memory
 result = memory.add(

--- a/docs/integrations/llama-index.mdx
+++ b/docs/integrations/llama-index.mdx
@@ -92,7 +92,6 @@ config = {
         "provider": "openai",
         "config": {"model": "text-embedding-3-small"},
     },
-    "version": "v1.1",
 }
 ```
 

--- a/docs/integrations/openai-agents-sdk.mdx
+++ b/docs/integrations/openai-agents-sdk.mdx
@@ -214,7 +214,7 @@ Customize memory behavior:
 # Configure memory search
 memories = mem0.search(
     query="travel preferences",
-    user_id="alex",
+    filters={"user_id": "alex"},
     top_k=5  # Number of memories to retrieve
 )
 

--- a/docs/open-source/features/custom-instructions.mdx
+++ b/docs/open-source/features/custom-instructions.mdx
@@ -115,17 +115,15 @@ config = {
         }
     },
     "custom_instructions": custom_instructions,
-    "version": "v1.1"
 }
 
-m = Memory.from_config(config_dict=config)
+m = Memory.from_config(config)
 ```
 
 ```ts TypeScript
 import { Memory } from "mem0ai/oss";
 
 const config = {
-  version: "v1.1",
   llm: {
     provider: "openai",
     config: {

--- a/docs/open-source/features/metadata-filtering.mdx
+++ b/docs/open-source/features/metadata-filtering.mdx
@@ -51,8 +51,7 @@ m = Memory()
 # Search with simple metadata filters
 results = m.search(
     "What are my preferences?",
-    user_id="alice",
-    filters={"category": "preferences"}
+    filters={"user_id": "alice", "category": "preferences"}
 )
 ```
 
@@ -68,8 +67,8 @@ Layer greater-than/less-than comparisons to rank results by score, confidence, o
 # Greater than / Less than
 results = m.search(
     "recent activities",
-    user_id="alice",
     filters={
+        "user_id": "alice",
         "score": {"gt": 0.8},
         "priority": {"gte": 5},
         "confidence": {"lt": 0.9},
@@ -80,8 +79,8 @@ results = m.search(
 # Equality operators
 results = m.search(
     "specific content",
-    user_id="alice",
     filters={
+        "user_id": "alice",
         "status": {"eq": "active"},
         "archived": {"ne": True}
     }
@@ -96,8 +95,8 @@ Use `in` and `nin` when you want to pre-approve or exclude specific values witho
 # In / Not in operators
 results = m.search(
     "multi-category search",
-    user_id="alice",
     filters={
+        "user_id": "alice",
         "category": {"in": ["food", "travel", "entertainment"]},
         "status": {"nin": ["deleted", "archived"]}
     }
@@ -116,8 +115,8 @@ results = m.search(
 # Text matching operators
 results = m.search(
     "content search",
-    user_id="alice",
     filters={
+        "user_id": "alice",
         "title": {"contains": "meeting"},
         "description": {"icontains": "important"},
         "tags": {"contains": "urgent"}
@@ -133,8 +132,8 @@ Allow any value for a field while still requiring the field to exist—handy whe
 # Match any value for a field
 results = m.search(
     "all with category",
-    user_id="alice",
     filters={
+        "user_id": "alice",
         "category": "*"
     }
 )
@@ -148,9 +147,9 @@ Combine filters with `AND`, `OR`, and `NOT` to express complex decision trees. N
 # Logical AND
 results = m.search(
     "complex query",
-    user_id="alice",
     filters={
         "AND": [
+            {"user_id": "alice"},
             {"category": "work"},
             {"priority": {"gte": 7}},
             {"status": {"ne": "completed"}}
@@ -161,12 +160,16 @@ results = m.search(
 # Logical OR
 results = m.search(
     "flexible query",
-    user_id="alice",
     filters={
-        "OR": [
-            {"category": "urgent"},
-            {"priority": {"gte": 9}},
-            {"deadline": {"contains": "today"}}
+        "AND": [
+            {"user_id": "alice"},
+            {
+                "OR": [
+                    {"category": "urgent"},
+                    {"priority": {"gte": 9}},
+                    {"deadline": {"contains": "today"}}
+                ]
+            }
         ]
     }
 )
@@ -174,11 +177,15 @@ results = m.search(
 # Logical NOT
 results = m.search(
     "exclusion query",
-    user_id="alice",
     filters={
-        "NOT": [
-            {"category": "archived"},
-            {"status": "deleted"}
+        "AND": [
+            {"user_id": "alice"},
+            {
+                "NOT": [
+                    {"category": "archived"},
+                    {"status": "deleted"}
+                ]
+            }
         ]
     }
 )
@@ -186,9 +193,9 @@ results = m.search(
 # Complex nested logic
 results = m.search(
     "advanced query",
-    user_id="alice",
     filters={
         "AND": [
+            {"user_id": "alice"},
             {
                 "OR": [
                     {"category": "work"},
@@ -288,16 +295,15 @@ Vector store support varies. Confirm operator coverage before shipping:
 # Before (v0.x) - simple key-value filtering only
 results = m.search(
     "query",
-    user_id="alice",
-    filters={"category": "work", "status": "active"}
+    filters={"user_id": "alice", "category": "work", "status": "active"}
 )
 
 # After (v1.0.0) - enhanced filtering with operators
 results = m.search(
     "query",
-    user_id="alice",
     filters={
         "AND": [
+            {"user_id": "alice"},
             {"category": "work"},
             {"status": {"ne": "archived"}},
             {"priority": {"gte": 5}}
@@ -320,9 +326,9 @@ results = m.search(
 # Find high-priority active tasks
 results = m.search(
     "What tasks need attention?",
-    user_id="project_manager",
     filters={
         "AND": [
+            {"user_id": "project_manager"},
             {"project": {"in": ["alpha", ""]}},
             {"priority": {"gte": 8}},
             {"status": {"ne": "completed"}},
@@ -347,9 +353,9 @@ results = m.search(
 # Find recent unresolved tickets
 results = m.search(
     "pending support issues",
-    agent_id="support_bot",
     filters={
         "AND": [
+            {"agent_id": "support_bot"},
             {"ticket_status": {"ne": "resolved"}},
             {"priority": {"in": ["high", "critical"]}},
             {"created_date": {"gte": "2024-01-01"}},
@@ -364,7 +370,7 @@ results = m.search(
 ```
 
 <Tip>
-  Pair `agent_id` filters with ticket-specific metadata so shared support bots return only the tickets they can act on in the current session.
+  Pair agent ID filters with ticket-specific metadata so shared support bots return only the tickets they can act on in the current session.
 </Tip>
 
 ### Content recommendation filtering
@@ -373,9 +379,9 @@ results = m.search(
 # Personalized content filtering
 results = m.search(
     "recommend content",
-    user_id="reader123",
     filters={
         "AND": [
+            {"user_id": "reader123"},
             {
                 "OR": [
                     {"genre": {"in": ["sci-fi", "fantasy"]}},
@@ -400,8 +406,8 @@ results = m.search(
 try:
     results = m.search(
         "test query",
-        user_id="alice",
         filters={
+            "user_id": "alice",
             "invalid_operator": {"unknown": "value"}
         }
     )
@@ -409,8 +415,7 @@ except ValueError as e:
     print(f"Filter error: {e}")
     results = m.search(
         "test query",
-        user_id="alice",
-        filters={"category": "general"}
+        filters={"user_id": "alice", "category": "general"}
     )
 ```
 

--- a/docs/open-source/features/reranker-search.mdx
+++ b/docs/open-source/features/reranker-search.mdx
@@ -189,7 +189,7 @@ async_memory = AsyncMemory.from_config(config)
 async def search_with_rerank():
     return await async_memory.search(
         "What are my preferences?",
-        user_id="alice",
+        filters={"user_id": "alice"},
         rerank=True
     )
 
@@ -272,7 +272,7 @@ results = m.search("query", filters={"user_id": "alice"})
 ```python
 results = m.search(
     "What are my food preferences?",
-    user_id="alice"
+    filters={"user_id": "alice"}
 )
 
 for result in results["results"]:
@@ -289,13 +289,13 @@ for result in results["results"]:
 ```python
 results_with_rerank = m.search(
     "What movies do I like?",
-    user_id="alice",
+    filters={"user_id": "alice"},
     rerank=True
 )
 
 results_without_rerank = m.search(
     "What movies do I like?",
-    user_id="alice",
+    filters={"user_id": "alice"},
     rerank=False
 )
 ```
@@ -313,9 +313,9 @@ results_without_rerank = m.search(
 ```python
 results = m.search(
     "important work tasks",
-    user_id="alice",
     filters={
         "AND": [
+            {"user_id": "alice"},
             {"category": "work"},
             {"priority": {"gte": 7}}
         ]
@@ -348,8 +348,7 @@ m = Memory.from_config(config)
 
 results = m.search(
     "customer having login issues with mobile app",
-    agent_id="support_bot",
-    filters={"category": "technical_support"},
+    filters={"agent_id": "support_bot", "category": "technical_support"},
     rerank=True
 )
 ```
@@ -363,8 +362,7 @@ results = m.search(
 ```python
 results = m.search(
     "science fiction books with space exploration themes",
-    user_id="reader123",
-    filters={"content_type": "book_recommendation"},
+    filters={"user_id": "reader123", "content_type": "book_recommendation"},
     rerank=True,
     top_k=10
 )
@@ -383,9 +381,9 @@ for result in results["results"]:
 ```python
 results = m.search(
     "What restaurants did I enjoy last month that had good vegetarian options?",
-    user_id="foodie_user",
     filters={
         "AND": [
+            {"user_id": "foodie_user"},
             {"category": "dining"},
             {"rating": {"gte": 4}},
             {"date": {"gte": "2024-01-01"}}

--- a/docs/open-source/node-quickstart.mdx
+++ b/docs/open-source/node-quickstart.mdx
@@ -76,7 +76,6 @@ By default the Node SDK uses local-friendly settings (OpenAI `gpt-5-mini`, `text
 import { Memory } from "mem0ai/oss";
 
 const memory = new Memory({
-  version: "v1.1",
   embedder: {
     provider: "openai",
     config: {
@@ -221,7 +220,6 @@ Mem0 offers granular configuration across vector stores, LLMs, embedders, and hi
 | Parameter | Description | Default |
 | --- | --- | --- |
 | `historyDbPath` | Path to history database | `"{mem0_dir}/history.db"` |
-| `version` | API version | `"v1.0"` |
 | `customInstructions` | Custom processing prompt | `undefined` |
   </Accordion>
   <Accordion title="History store">
@@ -234,7 +232,6 @@ Mem0 offers granular configuration across vector stores, LLMs, embedders, and hi
   <Accordion title="Complete config example">
 ```ts
 const config = {
-  version: "v1.1",
   embedder: {
     provider: "openai",
     config: {


### PR DESCRIPTION
Description                                                                                                                                                                                        

 Migrates all documentation (integrations, open-source guides, and cookbooks) to use v3 memory algorithm API patterns. In v3, search() and get_all() require entity IDs (user_id, agent_id, run_id) inside filters={} instead of as top-level kwargs. Also removes deprecated version config key, fixes wrong package names, and fixes internal import paths across 10 files.
                                                                                                                                                                                                     
  Type of Change
                                        
  - Documentation update                 
                                                                                                                                                                                                    