### PR TITLE
test: verify CI changelog gate fires on version bump without changelog

### DIFF
--- a/mem0-ts/package.json
+++ b/mem0-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mem0ai",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "The Memory Layer For Your AI Apps",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mem0ai"
-version = "2.0.0"
+version = "2.0.1"
 description = "Long-term memory for AI Agents"
 authors = [
     { name = "Mem0", email = "support@mem0.ai" }


### PR DESCRIPTION
## Linked Issue

N/A — this PR is a deliberate CI test. **Do not merge.**

## Description

Verifies that the `changelog_check` jobs added in #4900 actually block a PR when both SDK versions are bumped without a matching `docs/changelog/sdk.mdx` update.

This PR bumps:
- `pyproject.toml` version `2.0.0` → `2.0.1`
- `mem0-ts/package.json` version `3.0.1` → `3.0.2`

…and does **not** touch `docs/changelog/sdk.mdx`. Expected CI outcome:

- `ci.yml → changelog_check` (Python) should fail with the "add a new `<Update>` entry under the Python tab" error.
- `ts-sdk-ci.yml → changelog_check` (TS) should fail with the "add a new `<Update>` entry under the TypeScript tab" error.

If both fire as expected, the gate works and this PR will be closed without merging.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update
- [x] Test / CI verification (do not merge)

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

The test IS the manual verification. I'm watching the CI runs on this PR to confirm both changelog_check jobs fail with the expected error messages.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] I have updated documentation if needed (deliberately not updated — that's the point)