### PR TITLE
fix: resolve semantic conflict resolution in memory architecture

### DIFF
--- a/mem0/configs/prompts.py
+++ b/mem0/configs/prompts.py
@@ -212,7 +212,7 @@ There are specific guidelines to select which operation to perform:
 
         }
 
-2. **Update**: If the retrieved facts contain information that is already present in the memory but the information is totally different, then you have to update it. 
+2. **Update**: If the retrieved facts contain information that contradicts the information present in the memory or is already present in the memory but the information is totally different, then you have to update it (replace the old memory with the new fact). 
 If the retrieved fact contains information that conveys the same thing as the elements present in the memory, then you have to keep the fact which has the most information. 
 Example (a) -- if the memory contains "User likes to play cricket" and the retrieved fact is "Loves to play cricket with friends", then update the memory with the retrieved facts.
 Example (b) -- if the memory contains "Likes cheese pizza" and the retrieved fact is "Loves cheese pizza", then you do not need to update it because they convey the same information.
@@ -260,7 +260,7 @@ Please note to return the IDs in the output from the input IDs only and do not g
         }
 
 
-3. **Delete**: If the retrieved facts contain information that contradicts the information present in the memory, then you have to delete it. Or if the direction is to delete the memory, then you have to delete it.
+3. **Delete**: If the direction is to delete the memory, then you have to delete it.
 Please note to return the IDs in the output from the input IDs only and do not generate any new ID.
 - **Example**:
     - Old Memory:


### PR DESCRIPTION
## Linked Issue

Closes #4896

---

## Description

This PR fixes a bug in the memory addition architecture where adding contradictory but semantically similar facts produced duplicate `ADD` events (ignoring the **"Latest truth wins"** paradigm) or erroneously updated the memory node while retaining the original outdated string.

### Root Cause

The `DEFAULT_UPDATE_MEMORY_PROMPT` previously instructed the Memory LLM to **`DELETE` contradictions**, which prevented safe overwriting behavior.

When the LLM was forced to `UPDATE`, it frequently hallucinated and replaced the `text` field with the **old string** rather than the newly conflicting fact.

---

## Fix Details

* Removed the conflicting instruction that attempted to `DELETE` a memory upon contradiction.
* Added a **minimal, explicit instruction** under the **`#2 Update`** logic clarifying that:

  > Contradictions **must trigger an `UPDATE` event**, replacing the old memory with the newly retrieved fact (**latest truth wins**).

This ensures that:

* The existing memory node is reused.
* The outdated value is replaced.
* The system maintains a single authoritative version of the fact.

---

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Refactor (no functional changes)
* [ ] Documentation update

---

## Breaking Changes

N/A

---

## Test Coverage

* [ ] I added/updated unit tests
* [ ] I added/updated integration tests
* [x] I tested manually (see below)
* [ ] No tests needed (explain why)

---

## Manual Reproduction & Testing

Verified locally using an OpenAI model to process contradictory inputs.

### Test Script

```python
from mem0 import Memory

memory = Memory()

# Sequence of contradictory updates
r1 = memory.add('my name is LGY', user_id='test')
r2 = memory.add('my name is LGS', user_id='test')

all_mem = memory.get_all(user_id='test')

print("r1:", r1)
print("r2:", r2)
print("all_mem count:", len(all_mem))
print(all_mem[0])
```

---

## Before the Fix

The LLM incorrectly generated an `UPDATE` event that retained the original outdated memory, effectively discarding the new truth.

```text
r1: {'results': [{'id': '63e1863a-677f-4524-b621-72cfefd77e09', 'memory': 'Name is LGY', 'event': 'ADD'}]}

r2: {'results': [{'id': '63e1863a-677f-4524-b621-72cfefd77e09',
'memory': 'Name is LGY',
'event': 'UPDATE',
'previous_memory': 'Name is LGY'}]}

all_mem count: 1

{'id': '63e1863a-677f-4524-b621-72cfefd77e09',
'memory': 'Name is LGY',
'hash': '374dd5faee0e17864f3adc545cbd2de0',
'metadata': None,
'created_at': '2026-04-20T15:22:03.559956+00:00',
'updated_at': '2026-04-20T15:22:06.793354+00:00',
'user_id': 'test'}
```

---

## After the Fix

The system successfully overrides the old memory element and cleanly captures the **latest truth** inside the `.text` property, matching the expected behavior.

```text
r1: {'results': [{'id': '528b0e2c-abec-4b81-bfb4-f080d897a364',
'memory': 'Name is LGY',
'event': 'ADD'}]}

r2: {'results': [{'id': '528b0e2c-abec-4b81-bfb4-f080d897a364',
'memory': 'Name is LGS',
'event': 'UPDATE',
'previous_memory': 'Name is LGY'}]}

all_mem count: 1

{'id': '528b0e2c-abec-4b81-bfb4-f080d897a364',
'memory': 'Name is LGS',
'hash': '0159766a86ff0e803a14b8eb2b78f3dd',
'metadata': None,
'created_at': '2026-04-20T15:40:00.306695+00:00',
'updated_at': '2026-04-20T15:40:03.393890+00:00',
'user_id': 'test'}
```

---

## Summary

This fix restores correct **"Latest truth wins"** behavior by ensuring that contradictory updates overwrite outdated memory values instead of deleting or preserving stale content. It also reduces hallucination risk during `UPDATE` events by clarifying expected overwrite semantics.
