### PR TITLE
fix(vector-stores): add agent_id and run_id to Elasticsearch/OpenSearch default mappings

### DIFF
--- a/mem0/vector_stores/elasticsearch.py
+++ b/mem0/vector_stores/elasticsearch.py
@@ -66,7 +66,14 @@ class ElasticsearchDB(VectorStoreBase):
                         "index": True,
                         "similarity": "cosine",
                     },
-                    "metadata": {"type": "object", "properties": {"user_id": {"type": "keyword"}}},
+                    "metadata": {
+                        "type": "object",
+                        "properties": {
+                            "user_id": {"type": "keyword"},
+                            "agent_id": {"type": "keyword"},
+                            "run_id": {"type": "keyword"},
+                        },
+                    },
                 }
             },
         }

--- a/mem0/vector_stores/opensearch.py
+++ b/mem0/vector_stores/opensearch.py
@@ -55,7 +55,14 @@ class OpenSearchDB(VectorStoreBase):
                         "dimension": self.embedding_model_dims,
                         "method": {"engine": "nmslib", "name": "hnsw", "space_type": "cosinesimil"},
                     },
-                    "metadata": {"type": "object", "properties": {"user_id": {"type": "keyword"}}},
+                    "metadata": {
+                        "type": "object",
+                        "properties": {
+                            "user_id": {"type": "keyword"},
+                            "agent_id": {"type": "keyword"},
+                            "run_id": {"type": "keyword"},
+                        },
+                    },
                 }
             },
         }

--- a/tests/vector_stores/test_elasticsearch.py
+++ b/tests/vector_stores/test_elasticsearch.py
@@ -96,6 +96,10 @@ class TestElasticsearchDB(unittest.TestCase):
         self.assertEqual(mappings["vector"]["index"], True)
         self.assertEqual(mappings["vector"]["similarity"], "cosine")
         self.assertEqual(mappings["metadata"]["type"], "object")
+        metadata_props = mappings["metadata"]["properties"]
+        self.assertEqual(metadata_props["user_id"]["type"], "keyword")
+        self.assertEqual(metadata_props["agent_id"]["type"], "keyword")
+        self.assertEqual(metadata_props["run_id"]["type"], "keyword")
 
         # Reset mocks for next test
         self.client_mock.reset_mock()

--- a/tests/vector_stores/test_opensearch.py
+++ b/tests/vector_stores/test_opensearch.py
@@ -142,6 +142,10 @@ class TestOpenSearchDB(unittest.TestCase):
         mappings = create_args["body"]["mappings"]["properties"]
         self.assertEqual(mappings["vector_field"]["type"], "knn_vector")
         self.assertEqual(mappings["vector_field"]["dimension"], 1536)
+        metadata_props = mappings["metadata"]["properties"]
+        self.assertEqual(metadata_props["user_id"]["type"], "keyword")
+        self.assertEqual(metadata_props["agent_id"]["type"], "keyword")
+        self.assertEqual(metadata_props["run_id"]["type"], "keyword")
         self.client_mock.reset_mock()
         self.client_mock.indices.exists.return_value = True
         self.os_db.create_index()


### PR DESCRIPTION
## Linked Issue

Closes #3744

## Root Cause

`create_index()` in both `ElasticsearchDB` and `OpenSearchDB` only declared `user_id` as a `keyword` in the metadata mapping:

```python
# Before — only user_id is explicit
"metadata": {"type": "object", "properties": {"user_id": {"type": "keyword"}}}
```

mem0 scopes memories by **three** canonical entity IDs: `user_id`, `agent_id`, and `run_id` (see `memory/main.py:292–297`). When a memory with `agent_id` or `run_id` is inserted first, both Elasticsearch and OpenSearch dynamically infer a type for those fields from the first value seen. If the inferred type differs from `keyword` (e.g. ES may infer `object` when an enum-style value is encountered), subsequent `term` filter queries on `metadata.agent_id` or `metadata.run_id` silently return empty results or raise a `TypeError`.

## Fix

Explicitly declare `agent_id` and `run_id` as `keyword` in the mapping for both stores, matching the existing `user_id` declaration:

```python
# After — all three scoping IDs are explicit keywords
"metadata": {
    "type": "object",
    "properties": {
        "user_id": {"type": "keyword"},
        "agent_id": {"type": "keyword"},
        "run_id": {"type": "keyword"},
    },
},
```

## Files Changed

| File | Change |
|------|--------|
| `mem0/vector_stores/elasticsearch.py` | Add `agent_id`, `run_id` keyword fields to `create_index` mapping |
| `mem0/vector_stores/opensearch.py` | Same fix — identical bug in parallel implementation |
| `tests/vector_stores/test_elasticsearch.py` | Assert all three ID fields are present as `keyword` |
| `tests/vector_stores/test_opensearch.py` | Same assertion |

## Notes

- **No migration needed** for existing indices — ES/OS `PUT mapping` allows adding new explicit fields to an existing dynamic mapping without reindexing.
- The OpenSearch file had the same pattern as reported in #3744 for Elasticsearch; both are fixed together to keep the two backends consistent.