### PR TITLE
fix(proxy): repair broken MemoryClient search path

### DIFF
--- a/mem0/proxy/main.py
+++ b/mem0/proxy/main.py
@@ -167,23 +167,21 @@ class Completions:
         # Currently, only pass the last 6 messages to the search API to prevent long query
         message_input = [f"{message['role']}: {message['content']}" for message in messages][-6:]
         # TODO: Make it better by summarizing the past conversation
+        search_filters = filters.copy() if filters else {}
+        if user_id:
+            search_filters["user_id"] = user_id
+        if agent_id:
+            search_filters["agent_id"] = agent_id
+        if run_id:
+            search_filters["run_id"] = run_id
         return self.mem0_client.search(
             query="\n".join(message_input),
-            user_id=user_id,
-            agent_id=agent_id,
-            run_id=run_id,
-            filters=filters,
+            filters=search_filters,
             top_k=top_k,
         )
 
     def _format_query_with_memories(self, messages, relevant_memories):
-        # Check if self.mem0_client is an instance of Memory or MemoryClient
-
-        entities = []
-        if isinstance(self.mem0_client, mem0.memory.main.Memory):
-            memories_text = "\n".join(memory["memory"] for memory in relevant_memories["results"])
-            if relevant_memories.get("relations"):
-                entities = [entity for entity in relevant_memories["relations"]]
-        elif isinstance(self.mem0_client, mem0.client.main.MemoryClient):
-            memories_text = "\n".join(memory["memory"] for memory in relevant_memories)
+        memories_list = relevant_memories.get("results", []) if isinstance(relevant_memories, dict) else relevant_memories
+        memories_text = "\n".join(memory["memory"] for memory in memories_list)
+        entities = relevant_memories.get("relations", []) if isinstance(relevant_memories, dict) else []
         return f"- Relevant Memories/Facts: {memories_text}\n\n- Entities: {entities}\n\n- User Question: {messages[-1]['content']}"

--- a/mem0/proxy/main.py
+++ b/mem0/proxy/main.py
@@ -6,8 +6,6 @@ from typing import List, Optional, Union
 
 import httpx
 
-import mem0
-
 try:
     import litellm
 except ImportError:

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -64,7 +64,7 @@ def test_completions_create(mock_memory_client, mock_litellm):
     completions = Completions(mock_memory_client)
 
     messages = [{"role": "user", "content": "Hello, how are you?"}]
-    mock_memory_client.search.return_value = [{"memory": "Some relevant memory"}]
+    mock_memory_client.search.return_value = {"results": [{"memory": "Some relevant memory"}]}
     mock_litellm.completion.return_value = {"choices": [{"message": {"content": "I'm doing well, thank you!"}}]}
     mock_litellm.supports_function_calling.return_value = True
 
@@ -72,6 +72,11 @@ def test_completions_create(mock_memory_client, mock_litellm):
 
     mock_memory_client.add.assert_called_once()
     mock_memory_client.search.assert_called_once()
+    # Verify search was called with filters dict, not top-level entity params
+    search_call_kwargs = mock_memory_client.search.call_args[1]
+    assert "filters" in search_call_kwargs
+    assert search_call_kwargs["filters"]["user_id"] == "test_user"
+    assert "user_id" not in search_call_kwargs or search_call_kwargs["user_id"] is None
 
     mock_litellm.completion.assert_called_once()
     call_args = mock_litellm.completion.call_args[1]
@@ -89,7 +94,7 @@ def test_completions_create_with_system_message(mock_memory_client, mock_litellm
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "Hello, how are you?"},
     ]
-    mock_memory_client.search.return_value = [{"memory": "Some relevant memory"}]
+    mock_memory_client.search.return_value = {"results": [{"memory": "Some relevant memory"}]}
     mock_litellm.completion.return_value = {"choices": [{"message": {"content": "I'm doing well, thank you!"}}]}
     mock_litellm.supports_function_calling.return_value = True
 
@@ -98,3 +103,65 @@ def test_completions_create_with_system_message(mock_memory_client, mock_litellm
     call_args = mock_litellm.completion.call_args[1]
     assert call_args["messages"][0]["role"] == "system"
     assert call_args["messages"][0]["content"] == "You are a helpful assistant."
+
+
+def test_fetch_relevant_memories_with_entity_params(mock_memory_client):
+    """Test that _fetch_relevant_memories passes entity params inside filters dict (BUG-024 fix)."""
+    completions = Completions(mock_memory_client)
+    messages = [{"role": "user", "content": "Hello"}]
+    mock_memory_client.search.return_value = {"results": [{"memory": "User likes pizza"}]}
+
+    completions._fetch_relevant_memories(
+        messages=messages,
+        user_id="alice",
+        agent_id="bot_1",
+        run_id=None,
+        filters={"environment": "prod"},
+        top_k=5,
+    )
+
+    # Verify search was called with filters containing all entity params
+    search_call_kwargs = mock_memory_client.search.call_args[1]
+    assert "filters" in search_call_kwargs
+    assert search_call_kwargs["filters"]["user_id"] == "alice"
+    assert search_call_kwargs["filters"]["agent_id"] == "bot_1"
+    assert search_call_kwargs["filters"]["environment"] == "prod"
+    # Verify entity params are NOT in top-level kwargs
+    assert search_call_kwargs.get("user_id") is None
+    assert search_call_kwargs.get("agent_id") is None
+
+
+def test_format_query_with_memories_handles_dict_response(mock_memory_client):
+    """Test that _format_query_with_memories handles dict response from MemoryClient (BUG-003 fix)."""
+    completions = Completions(mock_memory_client)
+    messages = [{"role": "user", "content": "What do I like?"}]
+
+    # Simulate MemoryClient.search() response
+    response = {"results": [{"memory": "User likes pizza", "id": "1"}, {"memory": "User is vegetarian", "id": "2"}]}
+
+    result = completions._format_query_with_memories(messages, response)
+
+    # Should successfully extract memories and format them
+    assert "User likes pizza" in result
+    assert "User is vegetarian" in result
+    assert "Relevant Memories/Facts" in result
+    assert "What do I like?" in result
+
+
+def test_format_query_with_memories_handles_relations(mock_memory_client):
+    """Test that _format_query_with_memories correctly extracts relations from response."""
+    completions = Completions(mock_memory_client)
+    messages = [{"role": "user", "content": "Tell me more"}]
+
+    # Response with both results and relations
+    response = {
+        "results": [{"memory": "User likes pizza", "id": "1"}],
+        "relations": [{"source": "User", "relationship": "likes", "target": "pizza"}],
+    }
+
+    result = completions._format_query_with_memories(messages, response)
+
+    # Should include memories and entities/relations
+    assert "User likes pizza" in result
+    assert "pizza" in result  # from entities
+    assert "Entities:" in result


### PR DESCRIPTION
## Linked Issue

Closes #4907

## Description

This PR fixes two critical bugs in the proxy MemoryClient path that make `Mem0(api_key="...")` completely non-functional:

1. **_fetch_relevant_memories passes rejected top-level entity params**: Entity IDs (user_id, agent_id, run_id) were passed as top-level kwargs to search(), but both Memory.search() and MemoryClient.search() now reject these and require them in a filters dict.

2. **_format_query_with_memories iterates dict keys instead of results**: The MemoryClient branch was calling `for memory in relevant_memories` (iterating dict keys) instead of `for memory in relevant_memories["results"]` (iterating the results list), causing TypeError.

Both code paths and mock tests are now unified since both APIs return identical `{"results": [...], "relations": [...]}` response shape.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (verified with real API keys - Mem0 and OpenAI)
- [ ] No tests needed (explain why)

Updated mock return values in test_proxy.py to match actual API response shape. Added 3 new test cases:
- test_fetch_relevant_memories_with_entity_params: Verifies entity params are passed in filters dict
- test_format_query_with_memories_handles_dict_response: Verifies dict response is correctly parsed
- test_format_query_with_memories_handles_relations: Verifies relations extraction works

All 9 proxy tests pass locally.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed