### PR TITLE
fix: LLM-driven contradiction resolution in v2 ADD-only pipeline

### DIFF
--- a/mem0/configs/prompts.py
+++ b/mem0/configs/prompts.py
@@ -696,9 +696,27 @@ When extracting a new memory, check if it relates to any Existing Memory. Add re
 - **Same entity/topic**: New fact about a person, place, or thing already mentioned
 - **Updated preference**: A changed or evolved opinion on something previously captured
 - **Continuation**: Follow-up event or next step in a previously captured narrative
-- **Contradiction**: New information that conflicts with an existing memory
 
 Do NOT link memories that merely share a vague theme. Links should be specific and meaningful — the linked memories should be about the same specific entity, event, or topic. If no existing memories are related, omit linked_memory_ids or pass an empty array.
+
+
+## Contradiction Detection
+
+When a new memory is **mutually exclusive** with an existing memory — meaning the old fact can no longer be true once the new one is accepted — set `"contradicts": "<existing-memory-integer-id>"` using that memory's integer ID from the Existing Memories list. Do NOT use `linked_memory_ids` for contradictions; use `contradicts` instead.
+
+**CONTRADICTIONS** (one truth replaces the other — use `contradicts`):
+- Name changed: "User's name is Alice" → "User's name is Bob"
+- Primary job changed: "User is a software engineer" → "User is a product manager"
+- Relationship status changed: "User is single" → "User is married to Elena"
+- Home city changed: "User lives in New York" → "User lives in San Francisco"
+
+**NOT contradictions** (both can be true simultaneously — use `linked_memory_ids` or nothing):
+- "User loves coffee" + "User loves tea" — two separate preferences, both valid
+- "User speaks Python" + "User speaks JavaScript" — two skills, both valid
+- "User has a dog named Max" + "User has a cat named Luna" — additive facts
+- Any new event, experience, or activity involving a known entity
+
+If a new memory does not contradict any existing memory, omit `contradicts` entirely.
 
 
 # EXAMPLES
@@ -856,6 +874,36 @@ Output:
 ]}
 
 Both new memories link to related existing memories — the vet checkup links to the existing Poppy memory, and the team switch links to the existing Shopify memory. This enables the system to build a graph of related memories.
+
+
+## Example 13: Contradiction — Single-Slot Fact Replaced
+
+Existing Memories: [{"id": "0", "text": "User's name is Alice"}]
+New Messages:
+[{"role": "user", "content": "Actually, my name is Bob, not Alice."}]
+Observation Date: 2025-08-19
+
+Output:
+{"memory": [
+  {"id": "0", "text": "User's name is Bob", "contradicts": "0"}
+]}
+
+A name is a single-slot fact — only one can be true. `contradicts: "0"` signals that the existing memory should be replaced, not kept alongside. Do NOT use `linked_memory_ids` here.
+
+
+## Example 14: Not a Contradiction — Additive Preferences
+
+Existing Memories: [{"id": "0", "text": "User loves coffee"}]
+New Messages:
+[{"role": "user", "content": "I also really love tea."}]
+Observation Date: 2025-08-19
+
+Output:
+{"memory": [
+  {"id": "0", "text": "User loves tea", "linked_memory_ids": ["<uuid-of-coffee-memory>"]}
+]}
+
+Both preferences can be true simultaneously — this is additive, not a replacement. No `contradicts` field. Use `linked_memory_ids` to connect related preferences.
 
 
 ## Example 11: Long Multi-Topic Conversation — Don't Stop After First Topic

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -767,6 +767,28 @@ class Memory(MemoryBase):
             self.db.save_messages(messages, session_scope)
             return []
 
+        # Phase 2.5: Collect LLM-signalled contradictions
+        # The LLM outputs `"contradicts": "<integer-id>"` when a new fact is mutually
+        # exclusive with an existing memory (e.g. name change, job change). We resolve
+        # the integer ID to the real UUID via uuid_mapping and defer the _update_memory
+        # call until Phase 3 has computed embeddings.
+        update_results = []
+        contradiction_map = {}  # new_text → existing UUID
+
+        for mem in extracted_memories:
+            contradicts_id = mem.get("contradicts")
+            if not contradicts_id:
+                continue
+            existing_uuid = uuid_mapping.get(str(contradicts_id))
+            if not existing_uuid:
+                logger.warning(
+                    f"LLM contradicts ID '{contradicts_id}' not in uuid_mapping; treating as ADD"
+                )
+                continue
+            text = mem.get("text", "")
+            if text:
+                contradiction_map[text] = existing_uuid
+
         # Phase 3: Batch embed all extracted memory texts
         mem_texts = [m.get("text", "") for m in extracted_memories if m.get("text")]
         try:
@@ -780,6 +802,24 @@ class Memory(MemoryBase):
                     embed_map[text] = self.embedding_model.embed(text, "add")
                 except Exception as e:
                     logger.warning(f"Failed to embed memory text: {e}")
+
+        # Phase 3.5: Execute LLM-signalled contradiction updates
+        # Now that embed_map is ready, call _update_memory for every text the LLM
+        # flagged as contradicting an existing memory.
+        resolved_contradictions = set()
+
+        for text, existing_uuid in contradiction_map.items():
+            if text not in embed_map:
+                logger.warning(f"No embedding for contradiction text '{text[:50]}'; skipping")
+                continue
+            try:
+                self._update_memory(existing_uuid, text, {text: embed_map[text]}, metadata)
+            except Exception as e:
+                logger.error(f"Failed to update contradicted memory {existing_uuid}: {e}")
+                continue
+            logger.debug(f"Contradiction resolved: '{text[:50]}' replaced memory {existing_uuid}")
+            update_results.append({"id": existing_uuid, "memory": text, "event": "UPDATE"})
+            resolved_contradictions.add(text)
 
         # Phase 4: Per-memory CPU processing + Phase 5: Hash dedup
         # Build set of existing hashes for dedup
@@ -795,6 +835,9 @@ class Memory(MemoryBase):
             text = mem.get("text")
             if not text or text not in embed_map:
                 continue
+
+            if text in resolved_contradictions:
+                continue  # Already resolved as UPDATE above
 
             mem_hash = hashlib.md5(text.encode()).hexdigest()
             if mem_hash in existing_hashes or mem_hash in seen_hashes:
@@ -819,7 +862,7 @@ class Memory(MemoryBase):
 
         if not records:
             self.db.save_messages(messages, session_scope)
-            return []
+            return update_results  # [] if nothing extracted, or UPDATE results
 
         # Phase 6: Batch persist
         all_vectors = [r[2] for r in records]
@@ -960,7 +1003,7 @@ class Memory(MemoryBase):
         returned_memories = [
             {"id": r[0], "memory": r[1], "event": "ADD"}
             for r in records
-        ]
+        ] + update_results
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event(

--- a/tests/test_conflict_resolution.py
+++ b/tests/test_conflict_resolution.py
@@ -1,0 +1,335 @@
+"""
+TDD tests for LLM-driven conflict resolution in the v2 ADD-only pipeline.
+
+Issue: mem0ai/mem0#4904
+Branch: feat/conflict-resolution-fix
+
+When a new fact contradicts an existing memory (e.g., a name change), the LLM
+signals the contradiction via a `contradicts` field in its output. The pipeline
+routes that memory to UPDATE instead of ADD, replacing the outdated fact rather
+than accumulating both.
+"""
+import hashlib
+import json
+import os
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from mem0.configs.base import MemoryConfig
+from mem0.memory.main import Memory
+
+
+@pytest.fixture(autouse=True)
+def set_openai_key(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key-123")
+
+
+@pytest.fixture
+def memory_with_mocks():
+    """
+    Builds a Memory instance with all external dependencies mocked out.
+
+    Why mock at the factory level? Memory.__init__ calls EmbedderFactory.create(),
+    VectorStoreFactory.create(), etc. Patching those factories lets us control
+    what self.embedding_model, self.vector_store, and self.llm are — without
+    needing a real OpenAI key, a running Qdrant instance, or a network connection.
+
+    Why patch mem0.memory.main.SQLiteManager (not mem0.memory.storage.SQLiteManager)?
+    main.py does `from mem0.memory.storage import SQLiteManager`, which creates a
+    local binding in main's namespace at import time. Patching the source module
+    doesn't intercept the already-bound local name. Patching the usage site does.
+    """
+    with (
+        patch("mem0.utils.factory.EmbedderFactory.create") as mock_embedder_create,
+        patch("mem0.utils.factory.VectorStoreFactory.create") as mock_vs_create,
+        patch("mem0.utils.factory.LlmFactory.create") as mock_llm_create,
+        patch("mem0.memory.main.SQLiteManager") as mock_sqlite,
+        patch("mem0.memory.telemetry.capture_event"),
+    ):
+        mock_embedder = MagicMock()
+        mock_vs = MagicMock()
+        mock_llm = MagicMock()
+        mock_db = MagicMock()
+
+        mock_embedder_create.return_value = mock_embedder
+        mock_vs_create.return_value = mock_vs
+        mock_llm_create.return_value = mock_llm
+        mock_sqlite.return_value = mock_db
+        mock_db.get_last_messages.return_value = []
+
+        config = MemoryConfig()
+        memory = Memory(config)
+
+        yield memory, mock_vs, mock_embedder, mock_llm, mock_db
+
+
+def _make_existing_memory(memory_id, text, user_id, score=0.92):
+    """Helper: build a mock vector store result with realistic fields."""
+    mem = Mock()
+    mem.id = memory_id
+    mem.payload = {
+        "data": text,
+        "user_id": user_id,
+        "hash": hashlib.md5(text.encode()).hexdigest(),
+        "created_at": "2024-01-01T00:00:00+00:00",
+    }
+    mem.score = score
+    return mem
+
+
+def _contradiction_llm_response(new_text, contradicts_id="0"):
+    """
+    Build a mock LLM response where the extracted memory signals a contradiction.
+
+    The `contradicts` field uses the integer ID from the Existing Memories list
+    (not a UUID). The pipeline resolves it via uuid_mapping.
+    """
+    return json.dumps(
+        {"memory": [{"id": "0", "text": new_text, "contradicts": contradicts_id}]}
+    )
+
+
+def _additive_llm_response(new_text, linked_ids=None):
+    """Build a mock LLM response for a normal, non-contradictory ADD."""
+    mem = {"id": "0", "text": new_text}
+    if linked_ids:
+        mem["linked_memory_ids"] = linked_ids
+    return json.dumps({"memory": [mem]})
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 — adding a contradictory fact returns UPDATE, not ADD
+# ---------------------------------------------------------------------------
+
+
+def test_contradictory_name_returns_update_event(memory_with_mocks):
+    """
+    Cycle 1: adding "my name is Bob" when "User's name is Alice" already exists
+    should produce an UPDATE event, not a second ADD.
+
+    How it works: Phase 1 retrieves the existing Alice memory and builds
+    uuid_mapping = {"0": "existing-alice-id"}. The LLM sees Alice in its context
+    and outputs `contradicts: "0"`. Phase 2.5 resolves that to the real UUID and
+    routes to _update_memory instead of ADD.
+    """
+    memory, mock_vs, mock_embedder, mock_llm, mock_db = memory_with_mocks
+
+    existing = _make_existing_memory("existing-alice-id", "User's name is Alice", "test_user")
+    # Phase 1 search returns existing memory → uuid_mapping["0"] = "existing-alice-id"
+    mock_vs.search.return_value = [existing]
+    mock_embedder.embed.return_value = [0.1, 0.2, 0.3]
+    mock_embedder.embed_batch.return_value = [[0.9, 0.1, 0.0]]
+    mock_llm.generate_response.return_value = _contradiction_llm_response("User's name is Bob")
+    mock_vs.get.return_value = existing  # needed by _update_memory
+
+    result = memory.add("my name is Bob", user_id="test_user")
+
+    events = [r["event"] for r in result["results"]]
+    assert "UPDATE" in events, (
+        f"Expected contradiction to produce UPDATE event, got: {events}. "
+        "The LLM signals contradictions via the `contradicts` field."
+    )
+    assert "ADD" not in events, (
+        f"Expected no ADD event for a contradictory fact, got: {events}. "
+        "A second ADD stores both names, degrading memory quality."
+    )
+
+
+def test_contradictory_name_update_targets_correct_memory(memory_with_mocks):
+    """
+    Cycle 1 (companion): the UPDATE result must carry the existing memory's ID.
+    This ensures the old record is replaced in the vector store, not a ghost
+    record created alongside it.
+    """
+    memory, mock_vs, mock_embedder, mock_llm, mock_db = memory_with_mocks
+
+    existing = _make_existing_memory("existing-alice-id", "User's name is Alice", "test_user")
+    mock_vs.search.return_value = [existing]
+    mock_embedder.embed.return_value = [0.1, 0.2, 0.3]
+    mock_embedder.embed_batch.return_value = [[0.9, 0.1, 0.0]]
+    mock_llm.generate_response.return_value = _contradiction_llm_response("User's name is Bob")
+    mock_vs.get.return_value = existing
+
+    result = memory.add("my name is Bob", user_id="test_user")
+
+    update_results = [r for r in result["results"] if r.get("event") == "UPDATE"]
+    assert update_results, "Expected at least one UPDATE result"
+    assert update_results[0]["id"] == "existing-alice-id", (
+        f"UPDATE must reference the existing memory ID, got: {update_results[0]['id']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 — after conflict resolution the vector store has ONE record, not two
+# ---------------------------------------------------------------------------
+
+
+def test_conflict_calls_update_not_insert(memory_with_mocks):
+    """
+    Cycle 2: resolving a contradiction must call vector_store.update() on the
+    existing ID and must NOT call vector_store.insert() — which would create a
+    second, duplicate entry.
+    """
+    memory, mock_vs, mock_embedder, mock_llm, mock_db = memory_with_mocks
+
+    existing = _make_existing_memory("existing-alice-id", "User's name is Alice", "test_user")
+    mock_vs.search.return_value = [existing]
+    mock_embedder.embed.return_value = [0.1, 0.2, 0.3]
+    mock_embedder.embed_batch.return_value = [[0.9, 0.1, 0.0]]
+    mock_llm.generate_response.return_value = _contradiction_llm_response("User's name is Bob")
+    mock_vs.get.return_value = existing
+
+    memory.add("my name is Bob", user_id="test_user")
+
+    mock_vs.update.assert_called_once()
+    assert mock_vs.update.call_args.kwargs.get("vector_id") == "existing-alice-id", (
+        f"update() must target the existing memory ID, got: {mock_vs.update.call_args}"
+    )
+    mock_vs.insert.assert_not_called()
+
+
+def test_get_all_returns_one_result_after_conflict(memory_with_mocks):
+    """
+    Cycle 2 (end-to-end): after a contradiction-resolution add, get_all() returns
+    exactly 1 memory containing the newer value, not the old one.
+    """
+    memory, mock_vs, mock_embedder, mock_llm, mock_db = memory_with_mocks
+
+    existing = _make_existing_memory("existing-alice-id", "User's name is Alice", "test_user")
+    mock_vs.search.return_value = [existing]
+    mock_embedder.embed.return_value = [0.1, 0.2, 0.3]
+    mock_embedder.embed_batch.return_value = [[0.9, 0.1, 0.0]]
+    mock_llm.generate_response.return_value = _contradiction_llm_response("User's name is Bob")
+    mock_vs.get.return_value = existing
+
+    memory.add("my name is Bob", user_id="test_user")
+
+    updated_record = _make_existing_memory("existing-alice-id", "User's name is Bob", "test_user")
+    mock_vs.list.return_value = [updated_record]
+
+    all_mem = memory.get_all(filters={"user_id": "test_user"})
+
+    assert len(all_mem["results"]) == 1, (
+        f"Expected 1 memory after conflict resolution, got {len(all_mem['results'])}"
+    )
+    assert "Bob" in all_mem["results"][0]["memory"]
+    assert "Alice" not in all_mem["results"][0]["memory"]
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — conflict resolution writes a correct UPDATE history entry
+# ---------------------------------------------------------------------------
+
+
+def test_conflict_writes_update_history(memory_with_mocks):
+    """
+    Cycle 3: when a contradiction is resolved, db.add_history() must be called
+    with event="UPDATE", the old memory text, and the new memory text.
+    """
+    memory, mock_vs, mock_embedder, mock_llm, mock_db = memory_with_mocks
+
+    existing = _make_existing_memory("existing-alice-id", "User's name is Alice", "test_user")
+    mock_vs.search.return_value = [existing]
+    mock_embedder.embed.return_value = [0.1, 0.2, 0.3]
+    mock_embedder.embed_batch.return_value = [[0.9, 0.1, 0.0]]
+    mock_llm.generate_response.return_value = _contradiction_llm_response("User's name is Bob")
+    mock_vs.get.return_value = existing
+
+    memory.add("my name is Bob", user_id="test_user")
+
+    mock_db.add_history.assert_called_once()
+    call_args = mock_db.add_history.call_args
+
+    # Positional args: (memory_id, old_memory, new_memory, event, ...)
+    assert call_args.args[0] == "existing-alice-id"
+    assert call_args.args[1] == "User's name is Alice", (
+        f"old_memory must be the original text, got: {call_args.args[1]}"
+    )
+    assert call_args.args[2] == "User's name is Bob", (
+        f"new_memory must be the replacement text, got: {call_args.args[2]}"
+    )
+    assert call_args.args[3] == "UPDATE"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 — no `contradicts` field in LLM output → ADD (no false positives)
+# ---------------------------------------------------------------------------
+
+
+def test_no_contradicts_field_produces_add(memory_with_mocks):
+    """
+    Cycle 4a: when the LLM does NOT include a `contradicts` field, the memory
+    is stored as a new ADD regardless of how similar it is to existing memories.
+
+    This is the core guard against false positives. Similarity alone no longer
+    triggers UPDATE — only an explicit LLM judgment does.
+    """
+    memory, mock_vs, mock_embedder, mock_llm, mock_db = memory_with_mocks
+
+    existing = _make_existing_memory("coffee-id", "User loves coffee", "test_user")
+    mock_vs.search.return_value = [existing]
+    mock_embedder.embed.return_value = [0.1, 0.2, 0.3]
+    mock_embedder.embed_batch.return_value = [[0.2, 0.9, 0.1]]
+    # LLM correctly identifies this as additive, not a contradiction
+    mock_llm.generate_response.return_value = _additive_llm_response(
+        "User loves tea", linked_ids=["<uuid-of-coffee-memory>"]
+    )
+
+    result = memory.add("I also really love tea", user_id="test_user")
+
+    events = [r["event"] for r in result["results"]]
+    assert events == ["ADD"], (
+        f"Additive preference should produce ADD, got: {events}. "
+        "Both coffee and tea preferences can be true simultaneously."
+    )
+    mock_vs.insert.assert_called_once()
+    mock_vs.update.assert_not_called()
+
+
+def test_no_existing_memories_produces_add(memory_with_mocks):
+    """
+    Cycle 4b: when there are no existing memories at all (empty vector store),
+    adding any fact must produce an ADD event. This is the baseline case.
+    """
+    memory, mock_vs, mock_embedder, mock_llm, mock_db = memory_with_mocks
+
+    mock_vs.search.return_value = []
+    mock_embedder.embed.return_value = [0.1, 0.2, 0.3]
+    mock_embedder.embed_batch.return_value = [[0.5, 0.5, 0.0]]
+    mock_llm.generate_response.return_value = _additive_llm_response("User's name is Alice")
+
+    result = memory.add("my name is Alice", user_id="new_user")
+
+    events = [r["event"] for r in result["results"]]
+    assert events == ["ADD"]
+    mock_vs.insert.assert_called_once()
+    mock_vs.update.assert_not_called()
+
+
+def test_contradicts_id_not_in_mapping_falls_back_to_add(memory_with_mocks):
+    """
+    Cycle 4c: if the LLM hallucinates a `contradicts` ID that doesn't correspond
+    to any existing memory in uuid_mapping, the pipeline logs a warning and falls
+    back to ADD rather than crashing or silently dropping the memory.
+    """
+    memory, mock_vs, mock_embedder, mock_llm, mock_db = memory_with_mocks
+
+    # Phase 1 returns one existing memory → uuid_mapping = {"0": "some-id"}
+    existing = _make_existing_memory("some-id", "User's name is Alice", "test_user")
+    mock_vs.search.return_value = [existing]
+    mock_embedder.embed.return_value = [0.1, 0.2, 0.3]
+    mock_embedder.embed_batch.return_value = [[0.9, 0.1, 0.0]]
+    # LLM outputs contradicts: "99" — an ID that doesn't exist in uuid_mapping
+    mock_llm.generate_response.return_value = _contradiction_llm_response(
+        "User's name is Bob", contradicts_id="99"
+    )
+
+    result = memory.add("my name is Bob", user_id="test_user")
+
+    # Should fall back to ADD, not crash
+    events = [r["event"] for r in result["results"]]
+    assert "ADD" in events, (
+        f"Hallucinated contradicts ID should fall back to ADD, got: {events}"
+    )
+    mock_vs.update.assert_not_called()


### PR DESCRIPTION
## Linked Issue

Closes mem0ai/mem0#4904
Closes mem0ai/mem0#4896

## Description

When a user updates a single-slot fact (name, job title, relationship status), the v2 ADD-only pipeline was accumulating contradictory memories — e.g. both "User's name is Alice" and "User's name is Bob" — instead of replacing the outdated one.

This PR fixes that by teaching the LLM to signal contradictions explicitly via a new `contradicts` field in its output, then routing those memories to `_update_memory` instead of insert.

**What changed:**
- `mem0/configs/prompts.py`: Added a "Contradiction Detection" section to `ADDITIVE_EXTRACTION_PROMPT` that defines the `contradicts` field, explains when to use it vs `linked_memory_ids`, and includes worked examples (Example 13: name change, Example 14: additive preferences)
- `mem0/memory/main.py`: Added Phase 2.5 (collect `contradicts` markers from LLM output → resolve integer IDs to real UUIDs via `uuid_mapping`) and Phase 3.5 (call `_update_memory` for flagged memories after embeddings are computed in Phase 3). Memories resolved as contradictions are skipped in the ADD flow and returned as UPDATE events.
- `tests/test_conflict_resolution.py`: New test file with 8 tests covering the full behavior surface

**Why this approach instead of similarity thresholds:**
A cosine-similarity gate (≥ 0.85) has a critical false-positive problem: "User loves coffee" and "User loves tea" score ~0.90+ and would incorrectly UPDATE coffee with tea. The LLM already receives all top-10 existing memories in its context window and can distinguish mutually-exclusive facts from additive preferences. Adding a `contradicts` field costs zero extra LLM calls and zero extra vector searches.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

`tests/test_conflict_resolution.py` — 8 tests, all passing:

| Test | Behavior verified |
|------|-------------------|
| `test_contradictory_name_returns_update_event` | Contradiction → UPDATE event, not ADD |
| `test_contradictory_name_update_targets_correct_memory` | UPDATE carries the existing memory's UUID |
| `test_conflict_calls_update_not_insert` | `vector_store.update()` called, `insert()` not called |
| `test_get_all_returns_one_result_after_conflict` | One record in store after resolution, not two |
| `test_conflict_writes_update_history` | `db.add_history()` called with correct old/new text and event=UPDATE |
| `test_no_contradicts_field_produces_add` | Additive fact (coffee→tea) → ADD, no false positive |
| `test_no_existing_memories_produces_add` | Empty store → ADD baseline |
| `test_contradicts_id_not_in_mapping_falls_back_to_add` | Hallucinated LLM ID → warning + fallback ADD, no crash |

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed