### PR TITLE
fix: use tempfile.gettempdir() instead of hardcoded /tmp for vector store path

### DIFF
--- a/mem0/vector_stores/configs.py
+++ b/mem0/vector_stores/configs.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 from typing import Dict, Optional
 
 from pydantic import BaseModel, Field, model_validator
@@ -61,7 +63,7 @@ class VectorStoreConfig(BaseModel):
 
         # also check if path in allowed kays for pydantic model, and whether config extra fields are allowed
         if "path" not in config and "path" in config_class.__annotations__:
-            config["path"] = f"/tmp/{provider}"
+            config["path"] = os.path.join(tempfile.gettempdir(), provider)
 
         self.config = config_class(**config)
         return self


### PR DESCRIPTION
Fixes #4279.

**Bug**

`VectorStoreConfig` defaults the storage path to `/tmp/{provider}` when no path is configured. This fails in:
- Windows (no `/tmp` directory)
- macOS LaunchAgents and Linux systemd services (process may not have write access to `/tmp`)
- Restricted container environments

**Fix**

Replace the hardcoded path with `os.path.join(tempfile.gettempdir(), provider)`.

`tempfile.gettempdir()` returns the correct system-specific temp directory - `%TEMP%` or `%TMP%` on Windows, `/tmp` on Linux/macOS, and respects the `TMPDIR`/`TEMP`/`TMP` environment variables for custom overrides.

```python
# Before
config["path"] = f"/tmp/{provider}"

# After
config["path"] = os.path.join(tempfile.gettempdir(), provider)
```