### PR TITLE
docs(claude-code): split marketplace install into two separate steps

### DIFF
--- a/docs/integrations/claude-code.mdx
+++ b/docs/integrations/claude-code.mdx
@@ -32,12 +32,19 @@ export MEM0_API_KEY="m0-your-api-key"
 
 ### Option A — Plugin Marketplace (Recommended)
 
-Install the full plugin including MCP server, lifecycle hooks, and SDK skill:
+Install the full plugin including MCP server, lifecycle hooks, and SDK skill.
 
-```
-/plugin marketplace add mem0ai/mem0
-/plugin install mem0@mem0-plugins
-```
+1. Add the Mem0 marketplace:
+
+   ```
+   /plugin marketplace add mem0ai/mem0
+   ```
+
+2. Install the plugin:
+
+   ```
+   /plugin install mem0@mem0-plugins
+   ```
 
 **Claude Cowork desktop app:** Open the Cowork tab, click **Customize** in the sidebar, click **Browse plugins**, and install Mem0.
 


### PR DESCRIPTION
## Linked Issue

N/A — minor docs clarification.

## Description

The Plugin Marketplace install section on the [Claude Code integration page](https://docs.mem0.ai/integrations/claude-code) currently presents the two required slash commands (`/plugin marketplace add` and `/plugin install`) inside a single code block, which makes them easy to copy as one blob. Claude Code's slash command input only takes one command at a time, so pasting both together does not work.

This PR splits them into two numbered steps, each with its own code block, so users copy and run them one at a time.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [x] No tests needed (docs-only change)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed