### PR TITLE
fix(memory): pass through messages unchanged when llm=None in parse_vision_messages

### DIFF
--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -14,11 +14,11 @@ logger = logging.getLogger(__name__)
 
 def get_fact_retrieval_messages(message, is_agent_memory=False):
     """Get fact retrieval messages based on the memory type.
-    
+
     Args:
         message: The message content to extract facts from
         is_agent_memory: If True, use agent memory extraction prompt, else use user memory extraction prompt
-        
+
     Returns:
         tuple: (system_prompt, user_prompt)
     """
@@ -52,8 +52,7 @@ def ensure_json_instruction(system_prompt, user_prompt):
     combined = (system_prompt + user_prompt).lower()
     if "json" not in combined:
         system_prompt += (
-            "\n\nYou must return your response in valid JSON format "
-            "with a 'facts' key containing an array of strings."
+            "\n\nYou must return your response in valid JSON format with a 'facts' key containing an array of strings."
         )
     return system_prompt, user_prompt
 
@@ -80,6 +79,7 @@ def format_entities(entities):
         formatted_lines.append(simplified)
 
     return "\n".join(formatted_lines)
+
 
 def normalize_facts(raw_facts):
     """Normalize LLM-extracted facts to a list of strings.
@@ -117,9 +117,8 @@ def remove_code_blocks(content: str) -> str:
     """
     pattern = r"^```[a-zA-Z0-9]*\n([\s\S]*?)\n```$"
     match = re.match(pattern, content.strip())
-    match_res=match.group(1).strip() if match else content.strip()
+    match_res = match.group(1).strip() if match else content.strip()
     return re.sub(r"<think>.*?</think>", "", match_res, flags=re.DOTALL).strip()
-
 
 
 def extract_json(text):
@@ -180,10 +179,16 @@ def parse_vision_messages(messages, llm=None, vision_details="auto"):
         # Handle message content
         if isinstance(msg["content"], list):
             # Multiple image URLs in content
+            if llm is None:
+                returned_messages.append(msg)
+                continue
             description = get_image_description(msg, llm, vision_details)
             returned_messages.append({"role": msg["role"], "content": description})
         elif isinstance(msg["content"], dict) and msg["content"].get("type") == "image_url":
             # Single image content
+            if llm is None:
+                returned_messages.append(msg)
+                continue
             image_url = msg["content"]["image_url"]["url"]
             try:
                 description = get_image_description(image_url, llm, vision_details)
@@ -292,4 +297,3 @@ def remove_spaces_from_entities(
         item["destination"] = item["destination"].lower().replace(" ", "_")
         cleaned.append(item)
     return cleaned
-

--- a/tests/utils/test_parse_vision_messages.py
+++ b/tests/utils/test_parse_vision_messages.py
@@ -1,0 +1,55 @@
+from mem0.memory.utils import parse_vision_messages
+
+
+def test_list_content_passes_through_when_llm_is_none():
+    """parse_vision_messages must not crash when llm=None and content is a list.
+
+    Regression test for #4799: Memory.add() calls parse_vision_messages without
+    an LLM when enable_vision=False (the default). Previously, list-typed content
+    triggered get_image_description() which called llm.generate_response() on a
+    None object, raising AttributeError.
+    """
+    messages = [{"role": "user", "content": [{"type": "text", "text": "I love hiking"}]}]
+    result = parse_vision_messages(messages, llm=None)
+    assert result == messages
+
+
+def test_image_url_dict_content_passes_through_when_llm_is_none():
+    """parse_vision_messages must not crash when llm=None and content is an image_url dict."""
+    messages = [
+        {
+            "role": "user",
+            "content": {"type": "image_url", "image_url": {"url": "https://example.com/img.png"}},
+        }
+    ]
+    result = parse_vision_messages(messages, llm=None)
+    assert result == messages
+
+
+def test_plain_text_content_passes_through_unchanged():
+    """Plain text messages are unaffected by the fix."""
+    messages = [{"role": "user", "content": "Hello world"}]
+    result = parse_vision_messages(messages, llm=None)
+    assert result == messages
+
+
+def test_system_message_passes_through_unchanged():
+    """System messages are always returned as-is regardless of llm."""
+    messages = [{"role": "system", "content": "You are helpful."}]
+    result = parse_vision_messages(messages, llm=None)
+    assert result == messages
+
+
+def test_mixed_messages_with_null_llm():
+    """Mix of system, plain text, list-content, and image_url-dict all pass through when llm=None."""
+    messages = [
+        {"role": "system", "content": "System prompt"},
+        {"role": "user", "content": "plain text"},
+        {"role": "user", "content": [{"type": "text", "text": "list content"}]},
+        {
+            "role": "user",
+            "content": {"type": "image_url", "image_url": {"url": "https://example.com/x.png"}},
+        },
+    ]
+    result = parse_vision_messages(messages, llm=None)
+    assert result == messages


### PR DESCRIPTION
## Linked Issue

Closes #4799

## Description

`Memory.add()` crashes with `AttributeError: 'NoneType' object has no attribute 'generate_response'` when any message has a list-typed or `image_url`-dict `content` field and vision is not enabled (the default).

**Root cause:** `parse_vision_messages` defaults to `llm=None`. When `enable_vision=False`, `Memory.add()` calls `parse_vision_messages(messages)` without passing an LLM. The list-content and `image_url`-dict branches unconditionally call `get_image_description()` → `llm.generate_response()` without first checking whether `llm` is `None`.

**Fix:** Add an explicit `if llm is None` guard in both branches that returns the message unchanged — matching the behaviour of plain text messages. When no LLM is available there is nothing to do, so the original message is the correct pass-through value.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

Added `tests/utils/test_parse_vision_messages.py` with 5 regression tests:
- `test_list_content_passes_through_when_llm_is_none` — the primary crash scenario from the issue
- `test_image_url_dict_content_passes_through_when_llm_is_none` — the dict-content variant
- `test_plain_text_content_passes_through_unchanged` — regression guard for existing behaviour
- `test_system_message_passes_through_unchanged` — system messages always pass through
- `test_mixed_messages_with_null_llm` — all four message types together

All 5 pass: `pytest tests/utils/test_parse_vision_messages.py` — 5 passed, 0 failed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed