### PR TITLE
fix(proxy): pass entity ids in filters and iterate results key in MemoryClient path

### DIFF
--- a/mem0/proxy/main.py
+++ b/mem0/proxy/main.py
@@ -167,12 +167,16 @@ class Completions:
         # Currently, only pass the last 6 messages to the search API to prevent long query
         message_input = [f"{message['role']}: {message['content']}" for message in messages][-6:]
         # TODO: Make it better by summarizing the past conversation
+        entity_filters = dict(filters) if filters else {}
+        if user_id:
+            entity_filters["user_id"] = user_id
+        if agent_id:
+            entity_filters["agent_id"] = agent_id
+        if run_id:
+            entity_filters["run_id"] = run_id
         return self.mem0_client.search(
             query="\n".join(message_input),
-            user_id=user_id,
-            agent_id=agent_id,
-            run_id=run_id,
-            filters=filters,
+            filters=entity_filters,
             top_k=top_k,
         )
 
@@ -185,5 +189,5 @@ class Completions:
             if relevant_memories.get("relations"):
                 entities = [entity for entity in relevant_memories["relations"]]
         elif isinstance(self.mem0_client, mem0.client.main.MemoryClient):
-            memories_text = "\n".join(memory["memory"] for memory in relevant_memories)
+            memories_text = "\n".join(memory["memory"] for memory in relevant_memories["results"])
         return f"- Relevant Memories/Facts: {memories_text}\n\n- Entities: {entities}\n\n- User Question: {messages[-1]['content']}"

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -64,11 +64,13 @@ def test_completions_create(mock_memory_client, mock_litellm):
     completions = Completions(mock_memory_client)
 
     messages = [{"role": "user", "content": "Hello, how are you?"}]
-    mock_memory_client.search.return_value = [{"memory": "Some relevant memory"}]
+    mock_memory_client.search.return_value = {"results": [{"memory": "Some relevant memory"}]}
     mock_litellm.completion.return_value = {"choices": [{"message": {"content": "I'm doing well, thank you!"}}]}
     mock_litellm.supports_function_calling.return_value = True
 
-    response = completions.create(model="gpt-4.1-nano-2025-04-14", messages=messages, user_id="test_user", temperature=0.7)
+    response = completions.create(
+        model="gpt-4.1-nano-2025-04-14", messages=messages, user_id="test_user", temperature=0.7
+    )
 
     mock_memory_client.add.assert_called_once()
     mock_memory_client.search.assert_called_once()
@@ -82,6 +84,53 @@ def test_completions_create(mock_memory_client, mock_litellm):
     assert response == {"choices": [{"message": {"content": "I'm doing well, thank you!"}}]}
 
 
+def test_fetch_relevant_memories_passes_entity_ids_in_filters(mock_memory_client):
+    """_fetch_relevant_memories must pass user_id/agent_id/run_id inside filters={}
+    not as top-level kwargs — regression test for #4907 Bug 1.
+
+    Both Memory.search() and MemoryClient.search() now reject top-level entity
+    params with ValueError. Passing them inside filters avoids this.
+    """
+    completions = Completions(mock_memory_client)
+    mock_memory_client.search.return_value = {"results": []}
+
+    completions._fetch_relevant_memories(
+        messages=[{"role": "user", "content": "Hi"}],
+        user_id="u1",
+        agent_id="a1",
+        run_id="r1",
+        filters=None,
+        top_k=5,
+    )
+
+    call_kwargs = mock_memory_client.search.call_args[1]
+    assert "user_id" not in call_kwargs, "user_id must not be a top-level kwarg"
+    assert "agent_id" not in call_kwargs, "agent_id must not be a top-level kwarg"
+    assert "run_id" not in call_kwargs, "run_id must not be a top-level kwarg"
+    assert call_kwargs["filters"]["user_id"] == "u1"
+    assert call_kwargs["filters"]["agent_id"] == "a1"
+    assert call_kwargs["filters"]["run_id"] == "r1"
+
+
+def test_format_query_with_memories_iterates_results_for_memory_client(mock_memory_client):
+    """_format_query_with_memories must index relevant_memories['results'] for MemoryClient,
+    not iterate the dict directly — regression test for #4907 Bug 2.
+
+    MemoryClient.search() returns {'results': [...], ...}. The old code iterated
+    the dict itself (yielding string keys like 'results', 'relations') and crashed
+    with: TypeError: string indices must be integers, not 'str'
+    """
+    completions = Completions(mock_memory_client)
+    relevant_memories = {"results": [{"memory": "I like hiking"}, {"memory": "I dislike coffee"}]}
+    messages = [{"role": "user", "content": "What do I like?"}]
+
+    result = completions._format_query_with_memories(messages, relevant_memories)
+
+    assert "I like hiking" in result
+    assert "I dislike coffee" in result
+    assert "What do I like?" in result
+
+
 def test_completions_create_with_system_message(mock_memory_client, mock_litellm):
     completions = Completions(mock_memory_client)
 
@@ -89,7 +138,7 @@ def test_completions_create_with_system_message(mock_memory_client, mock_litellm
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "Hello, how are you?"},
     ]
-    mock_memory_client.search.return_value = [{"memory": "Some relevant memory"}]
+    mock_memory_client.search.return_value = {"results": [{"memory": "Some relevant memory"}]}
     mock_litellm.completion.return_value = {"choices": [{"message": {"content": "I'm doing well, thank you!"}}]}
     mock_litellm.supports_function_calling.return_value = True
 


### PR DESCRIPTION
## Linked Issue

Closes #4907

## Description

Two bugs in `mem0/proxy/main.py` broke all chat completions when using `MemoryClient` (i.e. `Mem0(api_key="...")`).

### Bug 1 — `_fetch_relevant_memories`: entity params rejected by `search()`

`user_id`, `agent_id`, and `run_id` were passed as top-level kwargs to `search()`. Both `Memory.search()` and `MemoryClient.search()` now reject these with:

```
ValueError: Top-level entity parameters {...} are not supported in search().
Use filters={'user_id': '...'} instead.
```

**Fix:** merge the entity ids into the `filters` dict before calling `search()`, matching the documented API.

### Bug 2 — `_format_query_with_memories`: `TypeError` iterating dict instead of `dict["results"]`

Even after Bug 1 was resolved, the `MemoryClient` branch iterated `relevant_memories` (the full dict) directly instead of `relevant_memories["results"]`, yielding string keys (`"results"`, `"relations"`) and crashing with:

```
TypeError: string indices must be integers, not 'str'
```

The `Memory` branch already used `relevant_memories["results"]` correctly. The `MemoryClient` branch was missing the `["results"]` key.

**Fix:** index `relevant_memories["results"]` in the `MemoryClient` branch.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

Added two regression tests to `tests/test_proxy.py`:
- `test_fetch_relevant_memories_passes_entity_ids_in_filters` — asserts `user_id`/`agent_id`/`run_id` are **not** top-level kwargs, and are correctly forwarded inside `filters`
- `test_format_query_with_memories_iterates_results_for_memory_client` — asserts memory content is extracted from `results` list, not dict keys

Also updated the two existing tests that used the old `[{"memory": "..."}]` list format to use `{"results": [{"memory": "..."}]}` matching the current `MemoryClient.search()` return shape.

All 8 tests pass: `pytest tests/test_proxy.py` — 8 passed, 0 failed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed