### PR TITLE
make _iso() timezone handling explicit and add tests

### DIFF
--- a/openmemory/api/app/routers/backup.py
+++ b/openmemory/api/app/routers/backup.py
@@ -30,13 +30,14 @@ class ExportRequest(BaseModel):
     to_date: Optional[int] = None
     include_vectors: bool = True
 
-def _iso(dt: Optional[datetime]) -> Optional[str]: 
-    if isinstance(dt, datetime): 
-        try: 
-            return dt.astimezone(UTC).isoformat()
-        except: 
-            return dt.replace(tzinfo=UTC).isoformat()
-    return None
+def _iso(dt: Optional[datetime]) -> Optional[str]:
+    if not isinstance(dt, datetime):
+        return None
+
+    if dt.tzinfo is None or dt.tzinfo.utcoffset(dt) is None:
+        return dt.replace(tzinfo=UTC).isoformat()
+
+    return dt.astimezone(UTC).isoformat()
 
 def _parse_iso(dt: Optional[str]) -> Optional[datetime]:
     if not dt:

--- a/openmemory/api/tests/test_backup_iso.py
+++ b/openmemory/api/tests/test_backup_iso.py
@@ -1,0 +1,33 @@
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+from datetime import datetime, timezone, timedelta
+
+from app.routers.backup import _iso
+
+
+def test_iso_none_input():
+    assert _iso(None) is None
+
+
+def test_iso_naive_datetime():
+    dt = datetime(2026, 1, 1, 10, 0, 0)  # naive
+    result = _iso(dt)
+    assert result == "2026-01-01T10:00:00+00:00"
+
+
+def test_iso_aware_non_utc():
+    dt = datetime(
+        2026, 1, 1, 10, 0, 0,
+        tzinfo=timezone(timedelta(hours=5, minutes=30))  # IST
+    )
+    result = _iso(dt)
+    # 10:00 IST -> 04:30 UTC
+    assert result == "2026-01-01T04:30:00+00:00"
+
+
+def test_iso_aware_utc():
+    dt = datetime(2026, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+    result = _iso(dt)
+    assert result == "2026-01-01T10:00:00+00:00"


### PR DESCRIPTION
Removes bare except in `_iso()` and replaces it with explicit naive vs aware datetime handling.

- non-datetime -> None  
- naive datetime -> assume UTC (replace)  
- aware datetime -> convert to UTC (astimezone)  

No behavior change intended but it avoids masking unexpected errors.

Note: Tests for `_iso()` are included. Local execution on Python 3.10 fails due to `datetime.UTC` usage in models (Python 3.11+), which appears inconsistent with the declared `>=3.10` support. 
although this is unrelated to the changes in this PR.