### PR TITLE
fix(memory): don't crash `parse_vision_messages` when vision is disabled

### DIFF
--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -180,10 +180,19 @@ def parse_vision_messages(messages, llm=None, vision_details="auto"):
         # Handle message content
         if isinstance(msg["content"], list):
             # Multiple image URLs in content
+            if llm is None:
+                # Vision disabled — pass multimodal content through unchanged
+                # rather than calling a non-existent LLM.
+                returned_messages.append(msg)
+                continue
             description = get_image_description(msg, llm, vision_details)
             returned_messages.append({"role": msg["role"], "content": description})
         elif isinstance(msg["content"], dict) and msg["content"].get("type") == "image_url":
             # Single image content
+            if llm is None:
+                # Vision disabled — pass image dict through unchanged.
+                returned_messages.append(msg)
+                continue
             image_url = msg["content"]["image_url"]["url"]
             try:
                 description = get_image_description(image_url, llm, vision_details)

--- a/tests/memory/test_memory_utils.py
+++ b/tests/memory/test_memory_utils.py
@@ -1,5 +1,9 @@
 import pytest
-from mem0.memory.utils import remove_spaces_from_entities, sanitize_relationship_for_cypher
+from mem0.memory.utils import (
+    parse_vision_messages,
+    remove_spaces_from_entities,
+    sanitize_relationship_for_cypher,
+)
 
 
 class TestRemoveSpacesFromEntities:
@@ -55,3 +59,45 @@ class TestRemoveSpacesFromEntities:
         f = remove_spaces_from_entities([dict(base)], sanitize_relationship=False)[0]["relationship"]
         assert t == sanitize_relationship_for_cypher("a/b")
         assert f == "a/b"
+
+
+class TestParseVisionMessagesNoLLM:
+    """
+    When enable_vision=False (the default), Memory.add() calls
+    parse_vision_messages(messages) without an LLM. Messages whose
+    content is a list or an image_url dict must pass through unchanged
+    instead of crashing on llm.generate_response().
+    """
+
+    def test_list_content_passes_through_without_llm(self):
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "hi"}]}
+        ]
+        out = parse_vision_messages(messages)
+        assert out == messages
+
+    def test_image_url_dict_content_passes_through_without_llm(self):
+        messages = [
+            {
+                "role": "user",
+                "content": {
+                    "type": "image_url",
+                    "image_url": {"url": "https://example.com/cat.png"},
+                },
+            }
+        ]
+        out = parse_vision_messages(messages)
+        assert out == messages
+
+    def test_system_message_preserved(self):
+        messages = [
+            {"role": "system", "content": "you are a bot"},
+            {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+        ]
+        out = parse_vision_messages(messages)
+        assert out == messages
+
+    def test_plain_text_message_unchanged(self):
+        messages = [{"role": "user", "content": "plain text"}]
+        out = parse_vision_messages(messages)
+        assert out == messages


### PR DESCRIPTION
## Linked Issue

Closes #4799

## Description

`Memory.add()` calls `parse_vision_messages(messages)` without an LLM whenever `enable_vision=False` (the default). The list-content and `image_url`-dict branches unconditionally invoke `llm.generate_response`, so any standard multimodal message (e.g. `{\"type\": \"text\", \"text\": ...}` blocks as produced by the OpenAI SDK, LangChain, etc.) crashes with `AttributeError: 'NoneType' object has no attribute 'generate_response'` before it ever reaches the vector store.

Reproducer from the issue:

```python
from mem0 import Memory

m = Memory()
m.add(
    messages=[{\"role\": \"user\", \"content\": [{\"type\": \"text\", \"text\": \"I love hiking\"}]}],
    user_id=\"alice\",
)
```

## Fix

When `llm is None`, pass multimodal content through unchanged — the user has explicitly opted out of vision handling, so there's nothing to describe.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

Added `TestParseVisionMessagesNoLLM` in `tests/memory/test_memory_utils.py` covering list content, `image_url` dict content, a system-message-first sequence, and plain text. All pass; they would have raised `AttributeError` before this fix.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally

_AI-assisted contribution._