### PR TITLE
fix(examples): skip PENDING memories in demo memory-ui to prevent crash

### DIFF
--- a/examples/mem0-demo/components/assistant-ui/memory-ui.tsx
+++ b/examples/mem0-demo/components/assistant-ui/memory-ui.tsx
@@ -16,10 +16,11 @@ type RetrievedMemory = {
 
 type NewMemory = {
   id: string;
-  data: {
+  data?: {
     memory: string;
-  };
-  event: "ADD" | "DELETE";
+  } | null;
+  event?: "ADD" | "DELETE";
+  status?: string;
 };
 
 type NewMemoryAnnotation = {
@@ -47,14 +48,18 @@ const useMemories = (): Memory[] => {
     () =>
       annotations?.filter(isMemoryAnnotation).flatMap((a) => {
         if (a.type === "mem0-update") {
-          return a.memories.map(
-            (m): Memory => ({
-              event: m.event,
-              id: m.id,
-              memory: m.data.memory,
-              score: 1,
-            })
-          );
+          return a.memories
+            .filter((m): m is NewMemory & { data: { memory: string }; event: "ADD" | "DELETE" } =>
+              m.data != null && m.event != null
+            )
+            .map(
+              (m): Memory => ({
+                event: m.event,
+                id: m.id,
+                memory: m.data.memory,
+                score: 1,
+              })
+            );
         } else if (a.type === "mem0-get") {
           return a.memories.map((m) => ({
             event: "GET",


### PR DESCRIPTION
Fixes #4933

## Problem

When the Mem0 API processes memories asynchronously, it returns PENDING
entries in the `mem0-update` annotation that look like:

```json
{
  "message": "Memory processing has been queued for background execution",
  "status": "PENDING",
  "event_id": "0ddf149c-fb26-476f-aa73-db551c3ee4ea"
}
```

These entries have no `data` or `event` fields. The previous code in
`memory-ui.tsx` called `m.data.memory` unconditionally, throwing
`Cannot read properties of undefined (reading 'memory')` and crashing
the demo app.

## Solution

- Update the `NewMemory` type to make `data` and `event` optional (and
  add a `status` field), accurately reflecting that PENDING entries may
  not carry full memory content.
- Add a `.filter()` guard before `.map()` to skip entries where `data`
  is `null`/`undefined`. PENDING entries are silently ignored in the UI
  since there is no memory string to display.

## Testing

- Verified the type changes remove the TypeScript compile error.
- PENDING memory objects are now filtered out rather than causing a
  runtime crash; resolved/committed memories continue to render normally.