### PR TITLE
fix(examples) make demo app poll for event updates

### DIFF
--- a/examples/mem0-demo/app/api/chat/route.ts
+++ b/examples/mem0-demo/app/api/chat/route.ts
@@ -3,6 +3,7 @@
 import { createDataStreamResponse, jsonSchema, streamText } from "ai";
 import { addMemories, getMemories } from "@mem0/vercel-ai-provider";
 import { openai } from "@ai-sdk/openai";
+import { pollMemoryEvent } from "@/lib/utils";
 
 export const runtime = "edge";
 export const maxDuration = 30;
@@ -69,6 +70,7 @@ const retrieveMemories = (memories: any) => {
 
 export async function POST(req: Request) {
   const { messages, system, tools, userId } = await req.json();
+  const apiKey = process.env.MEM0_API_KEY ?? "";
 
   const memories = await getMemories(messages, { user_id: userId, rerank: true, threshold: 0.1 });
   const mem0Instructions = retrieveMemories(memories);
@@ -100,7 +102,15 @@ export async function POST(req: Request) {
 
       result.mergeIntoDataStream(writer);
 
-      const newMemories = await addMemoriesTask;
+      const pendingResponse = await addMemoriesTask;
+      const eventIds = pendingResponse.map(
+        (m: { event_id: string }) => m.event_id,
+      );
+      const newMemories = (
+        await Promise.all(
+          eventIds.map((id: string) => pollMemoryEvent(id, apiKey)),
+        )
+      ).flat();
       if (newMemories.length > 0) {
         writer.writeMessageAnnotation({
           type: "mem0-update",

--- a/examples/mem0-demo/lib/utils.ts
+++ b/examples/mem0-demo/lib/utils.ts
@@ -22,10 +22,10 @@ export async function pollMemoryEvent(
     const res = await fetch(`https://api.mem0.ai/v1/event/${eventId}/`, {
       headers: { Authorization: `Token ${apiKey}` },
     });
-    const event = await res.json();
     if (!res.ok) {
       throw new Error(`Failed to poll memory event: ${res.statusText}`);
     }
+    const event = await res.json();
     if (event.status === "SUCCEEDED") {
       return event.results ?? [];
     }

--- a/examples/mem0-demo/lib/utils.ts
+++ b/examples/mem0-demo/lib/utils.ts
@@ -4,3 +4,36 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export type Memory = {
+  id: string;
+  event: "ADD" | "DELETE";
+  data: { memory: string };
+};
+
+export async function pollMemoryEvent(
+  eventId: string,
+  apiKey: string,
+  pollIntervalMs: number = 1000,
+  maxAttempts: number = 10,
+): Promise<Memory[]> {
+  for (let i = 0; i < maxAttempts; i++) {
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+    const res = await fetch(`https://api.mem0.ai/v1/event/${eventId}/`, {
+      headers: { Authorization: `Token ${apiKey}` },
+    });
+    const event = await res.json();
+    if (!res.ok) {
+      throw new Error(`Failed to poll memory event: ${res.statusText}`);
+    }
+    if (event.status === "SUCCEEDED") {
+      return event.results ?? [];
+    }
+    if (event.status === "FAILED") {
+      throw new Error(`Failed to poll memory event: ${JSON.stringify(event)}`);
+    }
+  }
+  throw new Error(
+    `Failed to poll memory event ${eventId} after ${maxAttempts} attempts`,
+  );
+}

--- a/examples/mem0-demo/package.json
+++ b/examples/mem0-demo/package.json
@@ -13,7 +13,7 @@
     "@assistant-ui/react": "^0.8.2",
     "@assistant-ui/react-ai-sdk": "^0.8.0",
     "@assistant-ui/react-markdown": "^0.8.0",
-    "@mem0/vercel-ai-provider": "^1.0.4",
+    "@mem0/vercel-ai-provider": "^2.0.5",
     "@radix-ui/react-alert-dialog": "^1.1.6",
     "@radix-ui/react-avatar": "^1.1.3",
     "@radix-ui/react-popover": "^1.1.6",


### PR DESCRIPTION
## Linked Issue

Closes #4933

## Description

This fixes a bug where the [Quickstart Demo App](https://docs.mem0.ai/cookbooks/companions/quickstart-demo) crashes after the user enters a message in the text input.

The root cause is a change in the response payload between v1 and v2 of the [Add Memories API](https://docs.mem0.ai/api-reference/memory/add-memories). The v1 API provides a sync response like this:
```
[
  {
    "id": "<string>",
    "data": {
      "memory": "<string>"
    },
    "event": "ADD"
  }
]
```

While the v2 API provides an async response like this:
```
[
    {
        "message": "Memory processing has been queued for background execution",
        "status": "PENDING",
        "event_id": "0ddf149c-fb26-476f-aa73-db551c3ee4ea"
    }
]
```

The problem is the demo app was expecting the v1 response but receiving the v2 response from the API. This PR updates the demo app to expect the v2 response and poll to get memory events for the given `event_id`.


## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed

I tested running the demo app (as described in [the quickstart guide](https://docs.mem0.ai/cookbooks/companions/quickstart-demo)) and observed the new memory event appears in the popover. Before this page would not load because of the bug.

<img width="1206" height="501" alt="Screenshot 2026-04-22 at 7 28 46 PM" src="https://github.com/user-attachments/assets/a35645e4-494d-4a76-a6bc-103ab55907ea" />


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] I have updated documentation if needed
