### PR TITLE
anthropic: use output_config.format for json_schema + fix extraction call sites

### DIFF
--- a/mem0/configs/prompts.py
+++ b/mem0/configs/prompts.py
@@ -957,6 +957,32 @@ The attributed_to field should still reflect the original source: "user" for fac
 """
 
 
+ADDITIVE_EXTRACTION_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "memory": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "text": {"type": "string"},
+                    "attributed_to": {"type": "string"},
+                    "linked_memory_ids": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                },
+                "required": ["id", "text", "attributed_to"],
+                "additionalProperties": False,
+            },
+        }
+    },
+    "required": ["memory"],
+    "additionalProperties": False,
+}
+
+
 # ---------------------------------------------------------------------------
 # V3 Prompt Builder — constructs the user-side prompt for additive extraction
 # Ported from platform/backend/shared/core/utils/prompt_builder.py

--- a/mem0/llms/anthropic.py
+++ b/mem0/llms/anthropic.py
@@ -9,6 +9,7 @@ except ImportError:
 from mem0.configs.llms.anthropic import AnthropicConfig
 from mem0.configs.llms.base import BaseLlmConfig
 from mem0.llms.base import LLMBase
+from mem0.memory.utils import extract_json
 
 
 class AnthropicLLM(LLMBase):
@@ -108,5 +109,35 @@ class AnthropicLLM(LLMBase):
             params["tools"] = tools
             params["tool_choice"] = tool_choice
 
+        wants_json_prefill = False
+        if response_format and isinstance(response_format, dict):
+            format_type = response_format.get("type")
+            if format_type == "json_schema" and "json_schema" in response_format:
+                # Use Anthropic structured outputs via output_config
+                schema = response_format["json_schema"]
+                if isinstance(schema, dict) and "schema" in schema:
+                    schema = schema["schema"]
+                params["output_config"] = {"format": {"type": "json_schema", "schema": schema}}
+            elif format_type == "json_object":
+                # Use assistant prefill to guide JSON output
+                wants_json_prefill = True
+                json_instruction = (
+                    "\n\nYou must respond with valid JSON only. "
+                    "Do not include any other text, markdown formatting, or code fences."
+                )
+                if params.get("system"):
+                    params["system"] += json_instruction
+                else:
+                    params["system"] = json_instruction.strip()
+                params["messages"] = list(params["messages"]) + [
+                    {"role": "assistant", "content": "{"}
+                ]
+
         response = self.client.messages.create(**params)
-        return response.content[0].text
+        content = response.content[0].text
+
+        if wants_json_prefill:
+            content = "{" + content
+            content = extract_json(content)
+
+        return content

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -16,6 +16,7 @@ from mem0.configs.base import MemoryConfig, MemoryItem
 from mem0.configs.enums import MemoryType
 from mem0.configs.prompts import (
     ADDITIVE_EXTRACTION_PROMPT,
+    ADDITIVE_EXTRACTION_SCHEMA,
     AGENT_CONTEXT_SUFFIX,
     PROCEDURAL_MEMORY_SYSTEM_PROMPT,
     generate_additive_extraction_prompt,
@@ -741,7 +742,10 @@ class Memory(MemoryBase):
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_prompt},
                 ],
-                response_format={"type": "json_object"},
+                response_format={
+                    "type": "json_schema",
+                    "json_schema": {"schema": ADDITIVE_EXTRACTION_SCHEMA},
+                },
             )
         except Exception as e:
             logger.error(f"LLM extraction failed: {e}")
@@ -2157,7 +2161,10 @@ class AsyncMemory(MemoryBase):
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_prompt},
                 ],
-                response_format={"type": "json_object"},
+                response_format={
+                    "type": "json_schema",
+                    "json_schema": {"schema": ADDITIVE_EXTRACTION_SCHEMA},
+                },
             )
         except Exception as e:
             logger.error(f"LLM extraction failed (async): {e}")

--- a/tests/llms/test_anthropic.py
+++ b/tests/llms/test_anthropic.py
@@ -2,15 +2,18 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+
 pytest.importorskip("anthropic", reason="anthropic package not installed")
 
 from mem0.configs.llms.anthropic import AnthropicConfig
 from mem0.configs.llms.base import BaseLlmConfig
+
 from mem0.llms.anthropic import AnthropicLLM
 
 
 @pytest.fixture
 def mock_anthropic_client():
+
     with patch("mem0.llms.anthropic.anthropic") as mock_anthropic:
         mock_client = Mock()
         mock_anthropic.Anthropic.return_value = mock_client
@@ -98,3 +101,118 @@ def test_base_config_conversion_does_not_send_both(mock_anthropic_client):
     call_kwargs = mock_anthropic_client.messages.create.call_args[1]
     assert "temperature" in call_kwargs
     assert "top_p" not in call_kwargs
+def test_generate_response_without_response_format(mock_anthropic_client):
+    config = AnthropicConfig(model="claude-sonnet-4-20250514", api_key="test-key", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = AnthropicLLM(config)
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello, how are you?"},
+    ]
+
+    mock_response = Mock()
+    mock_response.content = [Mock(text="I'm doing well, thank you for asking!")]
+    mock_anthropic_client.messages.create.return_value = mock_response
+
+    response = llm.generate_response(messages)
+
+    call_kwargs = mock_anthropic_client.messages.create.call_args[1]
+    assert not any(m.get("content") == "{" for m in call_kwargs["messages"])
+    assert "output_config" not in call_kwargs
+    assert response == "I'm doing well, thank you for asking!"
+
+
+def test_generate_response_with_json_object_format(mock_anthropic_client):
+    config = AnthropicConfig(model="claude-sonnet-4-20250514", api_key="test-key", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = AnthropicLLM(config)
+    messages = [
+        {"role": "system", "content": "Extract facts."},
+        {"role": "user", "content": "My name is Alice."},
+    ]
+
+    mock_response = Mock()
+    mock_response.content = [Mock(text='"facts": ["Name is Alice"]}')]
+    mock_anthropic_client.messages.create.return_value = mock_response
+
+    response = llm.generate_response(messages, response_format={"type": "json_object"})
+
+    assert response == '{"facts": ["Name is Alice"]}'
+    call_kwargs = mock_anthropic_client.messages.create.call_args[1]
+    assert call_kwargs["messages"][-1] == {"role": "assistant", "content": "{"}
+    assert "valid JSON only" in call_kwargs["system"]
+
+
+def test_generate_response_json_object_without_system_message(mock_anthropic_client):
+    config = AnthropicConfig(model="claude-sonnet-4-20250514", api_key="test-key", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = AnthropicLLM(config)
+    messages = [
+        {"role": "user", "content": "My name is Bob."},
+    ]
+
+    mock_response = Mock()
+    mock_response.content = [Mock(text='"facts": ["Name is Bob"]}')]
+    mock_anthropic_client.messages.create.return_value = mock_response
+
+    response = llm.generate_response(messages, response_format={"type": "json_object"})
+
+    assert response == '{"facts": ["Name is Bob"]}'
+    call_kwargs = mock_anthropic_client.messages.create.call_args[1]
+    assert "valid JSON only" in call_kwargs["system"]
+
+
+def test_generate_response_json_object_strips_code_fences(mock_anthropic_client):
+    config = AnthropicConfig(model="claude-sonnet-4-20250514", api_key="test-key", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = AnthropicLLM(config)
+    messages = [{"role": "user", "content": "Extract facts."}]
+
+    mock_response = Mock()
+    mock_response.content = [Mock(text='"facts": []}')]
+    mock_anthropic_client.messages.create.return_value = mock_response
+
+    response = llm.generate_response(messages, response_format={"type": "json_object"})
+
+    assert response == '{"facts": []}'
+
+
+def test_generate_response_with_json_schema_format(mock_anthropic_client):
+    config = AnthropicConfig(model="claude-sonnet-4-20250514", api_key="test-key", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = AnthropicLLM(config)
+    messages = [{"role": "user", "content": "Extract info."}]
+    schema = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "required": ["name"],
+    }
+
+    mock_response = Mock()
+    mock_response.content = [Mock(text='{"name": "Alice"}')]
+    mock_anthropic_client.messages.create.return_value = mock_response
+
+    response = llm.generate_response(
+        messages,
+        response_format={"type": "json_schema", "json_schema": {"schema": schema}},
+    )
+
+    assert response == '{"name": "Alice"}'
+    call_kwargs = mock_anthropic_client.messages.create.call_args[1]
+    assert call_kwargs["output_config"]["format"]["type"] == "json_schema"
+    assert call_kwargs["output_config"]["format"]["schema"] == schema
+    assert not any(isinstance(m, dict) and m.get("content") == "{" for m in call_kwargs["messages"])
+
+
+def test_generate_response_with_tools(mock_anthropic_client):
+    config = AnthropicConfig(model="claude-sonnet-4-20250514", api_key="test-key", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = AnthropicLLM(config)
+    messages = [{"role": "user", "content": "What is the weather?"}]
+    tools = [{"name": "get_weather", "description": "Get weather", "input_schema": {"type": "object"}}]
+
+    mock_response = Mock()
+    mock_response.content = [Mock(text="It's sunny.")]
+    mock_anthropic_client.messages.create.return_value = mock_response
+
+    response = llm.generate_response(messages, tools=tools, tool_choice="any")
+
+    call_kwargs = mock_anthropic_client.messages.create.call_args[1]
+    assert call_kwargs["tools"] == tools
+    assert call_kwargs["tool_choice"] == "any"
+    assert response == "It's sunny."
+


### PR DESCRIPTION
Combines [#4484](https://github.com/mem0ai/mem0/pull/4484) (rebased on current `main`, test conflict in `tests/llms/test_anthropic.py` resolved) with a follow-on call-site upgrade in `mem0/memory/main.py`.

## Commits

1. `fix(anthropic): handle response_format in AnthropicLLM.generate_response` — from @limsaehyun in #4484. Adds `output_config.format` for `response_format={type:"json_schema"}` and assistant-prefill `{` for `response_format={type:"json_object"}` (since Anthropic's API does not have a schema-less json-mode like OpenAI's).
2. `memory: use json_schema response_format for additive extraction` — adds `ADDITIVE_EXTRACTION_SCHEMA` mirroring the documented `{memory:[{id,text,attributed_to,linked_memory_ids?}]}` shape from `ADDITIVE_EXTRACTION_PROMPT`, and switches both sync + async extraction calls (`memory/main.py:744` and `:2160`) to `response_format={type:"json_schema", json_schema:{schema:...}}`.

## Why the call-site upgrade is needed

PR #4484 alone is necessary but not sufficient. When `main.py` sends `response_format={type:"json_object"}`, the patched `AnthropicLLM` uses the assistant-prefill `{` path and relies on the system prompt to declare output shape. On long structured inputs, Claude can emit freelance JSON keys (e.g. `summary`, `key_findings`, `files_analyzed`) instead of the mem0-expected `{memory:[…]}`. `extract_json` then returns `[]` and mem0 silently stores zero memories.

With Anthropic's native Structured Outputs (`output_config.format.type=json_schema`), the model is constrained to the mem0 schema and emits the expected shape. On a 24-episode coding-digest corpus against `claude-haiku-4-5`, this fix took parse rate from **0/24 → 24/24** and extracted **109 facts** at a median **6.0 s per episode**.

The OpenAI adapter is unchanged; stock `{type:"json_object"}` already works end-to-end there because OpenAI's json-mode does not require a schema.

## Tests

- `tests/llms/test_anthropic.py` — 11/11 pass locally (5 pre-existing temperature/top_p tests + 6 new `response_format` tests from #4484).
- End-to-end validation against Anthropic Messages API with `output_config.format` on `claude-haiku-4-5`: `stop_reason=end_turn`, valid JSON matching the schema in `content[0].text`.

## References

- Anthropic Structured Outputs (GA): https://platform.claude.com/docs/en/build-with-claude/structured-outputs
- Upstream PR this builds on: #4484
