### PR TITLE
fix(proxy): pass entity ids via filters and read results key for MemoryClient

### DIFF
--- a/mem0/proxy/main.py
+++ b/mem0/proxy/main.py
@@ -167,23 +167,27 @@ class Completions:
         # Currently, only pass the last 6 messages to the search API to prevent long query
         message_input = [f"{message['role']}: {message['content']}" for message in messages][-6:]
         # TODO: Make it better by summarizing the past conversation
+        # Both ``Memory.search()`` and ``MemoryClient.search()`` reject
+        # top-level entity params and require them inside ``filters`` (#4907).
+        merged_filters = dict(filters) if filters else {}
+        for key, value in (("user_id", user_id), ("agent_id", agent_id), ("run_id", run_id)):
+            if value is not None and key not in merged_filters:
+                merged_filters[key] = value
         return self.mem0_client.search(
             query="\n".join(message_input),
-            user_id=user_id,
-            agent_id=agent_id,
-            run_id=run_id,
-            filters=filters,
+            filters=merged_filters or None,
             top_k=top_k,
         )
 
     def _format_query_with_memories(self, messages, relevant_memories):
-        # Check if self.mem0_client is an instance of Memory or MemoryClient
-
+        # Both ``Memory.search()`` and ``MemoryClient.search()`` return
+        # ``{"results": [...]}`` in the current API; iterate that key for
+        # both backends rather than the dict's top-level keys (#4907).
         entities = []
-        if isinstance(self.mem0_client, mem0.memory.main.Memory):
-            memories_text = "\n".join(memory["memory"] for memory in relevant_memories["results"])
-            if relevant_memories.get("relations"):
-                entities = [entity for entity in relevant_memories["relations"]]
-        elif isinstance(self.mem0_client, mem0.client.main.MemoryClient):
-            memories_text = "\n".join(memory["memory"] for memory in relevant_memories)
+        results = relevant_memories.get("results", []) if isinstance(relevant_memories, dict) else relevant_memories
+        memories_text = "\n".join(memory["memory"] for memory in results)
+        if isinstance(self.mem0_client, mem0.memory.main.Memory) and isinstance(relevant_memories, dict):
+            relations = relevant_memories.get("relations")
+            if relations:
+                entities = list(relations)
         return f"- Relevant Memories/Facts: {memories_text}\n\n- Entities: {entities}\n\n- User Question: {messages[-1]['content']}"

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -64,7 +64,7 @@ def test_completions_create(mock_memory_client, mock_litellm):
     completions = Completions(mock_memory_client)
 
     messages = [{"role": "user", "content": "Hello, how are you?"}]
-    mock_memory_client.search.return_value = [{"memory": "Some relevant memory"}]
+    mock_memory_client.search.return_value = {"results": [{"memory": "Some relevant memory"}]}
     mock_litellm.completion.return_value = {"choices": [{"message": {"content": "I'm doing well, thank you!"}}]}
     mock_litellm.supports_function_calling.return_value = True
 
@@ -89,7 +89,7 @@ def test_completions_create_with_system_message(mock_memory_client, mock_litellm
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "Hello, how are you?"},
     ]
-    mock_memory_client.search.return_value = [{"memory": "Some relevant memory"}]
+    mock_memory_client.search.return_value = {"results": [{"memory": "Some relevant memory"}]}
     mock_litellm.completion.return_value = {"choices": [{"message": {"content": "I'm doing well, thank you!"}}]}
     mock_litellm.supports_function_calling.return_value = True
 
@@ -98,3 +98,76 @@ def test_completions_create_with_system_message(mock_memory_client, mock_litellm
     call_args = mock_litellm.completion.call_args[1]
     assert call_args["messages"][0]["role"] == "system"
     assert call_args["messages"][0]["content"] == "You are a helpful assistant."
+
+
+def test_fetch_relevant_memories_passes_entities_via_filters(mock_memory_client):
+    """Regression for #4907 bug 1: top-level entity params must be wrapped in filters."""
+    completions = Completions(mock_memory_client)
+    mock_memory_client.search.return_value = {"results": []}
+
+    completions._fetch_relevant_memories(
+        messages=[{"role": "user", "content": "hi"}],
+        user_id="u1",
+        agent_id="a1",
+        run_id=None,
+        filters=None,
+        top_k=5,
+    )
+
+    call_kwargs = mock_memory_client.search.call_args.kwargs
+    # The buggy code passed user_id/agent_id/run_id as top-level kwargs which
+    # both Memory.search and MemoryClient.search now reject.
+    assert "user_id" not in call_kwargs
+    assert "agent_id" not in call_kwargs
+    assert "run_id" not in call_kwargs
+    # They must be inside filters instead.
+    assert call_kwargs["filters"] == {"user_id": "u1", "agent_id": "a1"}
+    assert call_kwargs["top_k"] == 5
+
+
+def test_fetch_relevant_memories_preserves_caller_filters(mock_memory_client):
+    """User-supplied filters must merge with entity ids, not be clobbered."""
+    completions = Completions(mock_memory_client)
+    mock_memory_client.search.return_value = {"results": []}
+
+    completions._fetch_relevant_memories(
+        messages=[{"role": "user", "content": "hi"}],
+        user_id="u1",
+        agent_id=None,
+        run_id=None,
+        filters={"category": "work", "user_id": "explicit"},
+        top_k=10,
+    )
+
+    filters = mock_memory_client.search.call_args.kwargs["filters"]
+    # Caller-provided user_id wins over the param (don't silently overwrite).
+    assert filters["user_id"] == "explicit"
+    assert filters["category"] == "work"
+
+
+def test_format_query_with_memoryclient_uses_results_key(mock_memory_client):
+    """Regression for #4907 bug 2: MemoryClient.search returns {'results': [...]}."""
+    completions = Completions(mock_memory_client)
+
+    relevant = {"results": [{"memory": "fact one"}, {"memory": "fact two"}]}
+    out = completions._format_query_with_memories(
+        messages=[{"role": "user", "content": "Q?"}],
+        relevant_memories=relevant,
+    )
+
+    # Should contain both memory strings (proves we iterated results, not dict keys).
+    assert "fact one" in out
+    assert "fact two" in out
+    assert "Q?" in out
+
+
+def test_format_query_handles_empty_results(mock_memory_client):
+    """Empty result set must produce a valid prompt, not crash."""
+    completions = Completions(mock_memory_client)
+
+    out = completions._format_query_with_memories(
+        messages=[{"role": "user", "content": "Q?"}],
+        relevant_memories={"results": []},
+    )
+    assert "Relevant Memories/Facts: " in out
+    assert "Q?" in out


### PR DESCRIPTION
Fixes #4907

## The bugs

`mem0/proxy/main.py` had two unrelated bugs that together broke `Mem0(api_key=...).chat.completions.create()` end-to-end against the hosted MemoryClient:

### Bug 1 — `_fetch_relevant_memories` passed entity ids as top-level kwargs

Both `Memory.search()` (`mem0/memory/main.py:1174`) and `MemoryClient.search()` (`mem0/client/main.py:273`) explicitly reject `user_id` / `agent_id` / `run_id` / `app_id` at the top level and require them inside `filters`. The proxy was passing them as kwargs:

```python
return self.mem0_client.search(
    query=...,
    user_id=user_id,        # ValueError: top-level entity params not supported
    agent_id=agent_id,
    run_id=run_id,
    filters=filters,
    top_k=top_k,
)
```

Every chat completion crashed with `ValueError: Top-level entity parameters {...} are not supported in search().`

### Bug 2 — `_format_query_with_memories` MemoryClient branch iterated dict keys

`MemoryClient.search()` returns `{"results": [...]}` (per its own docstring), but the MemoryClient branch did:

```python
elif isinstance(self.mem0_client, mem0.client.main.MemoryClient):
    memories_text = "\n".join(memory["memory"] for memory in relevant_memories)
```

Iterating the dict yields its keys (strings like `"results"`), and `"results"["memory"]` then crashes with `TypeError: string indices must be integers, not 'str'`.

## Fix

- **`_fetch_relevant_memories`**: build a merged `filters` dict from the entity ids before calling `search()`. Caller-provided keys win over implicit ones (don't silently overwrite user intent).
- **`_format_query_with_memories`**: collapse both backend branches to read `relevant_memories.get("results", [])`, since both `Memory.search()` and `MemoryClient.search()` now return the same `{"results": [...]}` shape. Backward-compatible: if a caller hands in a list directly, it still iterates correctly.

## Why the existing tests didn't catch this

`tests/test_proxy.py` had `mock_memory_client.search.return_value = [{"memory": "..."}]` — a bare list, which is **not** what `MemoryClient.search()` actually returns. Updated those mocks to use the realistic `{"results": [...]}` shape so future regressions surface immediately.

## New regression tests (4)

- `test_fetch_relevant_memories_passes_entities_via_filters` — asserts `user_id` / `agent_id` / `run_id` are NOT passed as top-level kwargs and ARE present inside `filters`.
- `test_fetch_relevant_memories_preserves_caller_filters` — caller-supplied filter keys aren't overwritten by entity-id parameters; unrelated keys (e.g. `category`) are preserved.
- `test_format_query_with_memoryclient_uses_results_key` — proves the formatter actually iterates `["results"]` and surfaces the memory strings (the original bug would crash here).
- `test_format_query_handles_empty_results` — empty result set produces a valid prompt without raising.

## Verification

```
$ python -m pytest tests/test_proxy.py -v
============================== 10 passed in 4.06s ==============================
```

## Notes

- Minimal diff. No new dependencies.
- No public API change.
- Same logic applies to async paths but the async proxy doesn't seem to have an analogous `_fetch_relevant_memories` — happy to mirror the fix there in a follow-up if maintainers point me at it.