### PR TITLE
docs: add missing period to example sentence

### DIFF
--- a/docs/open-source/features/custom-instructions.mdx
+++ b/docs/open-source/features/custom-instructions.mdx
@@ -179,11 +179,11 @@ await memory.add("Yesterday, I ordered a laptop, the order id is 12345", { userI
 
 <CodeGroup>
 ```python Python
-m.add("I like going to hikes", user_id="alice")
+m.add("I like going to hikes.", user_id="alice")
 ```
 
 ```ts TypeScript
-await memory.add("I like going to hikes", { userId: "user123" });
+await memory.add("I like going to hikes.", { userId: "user123" });
 ```
 
 ```json Output


### PR DESCRIPTION
## Summary
Adds a missing period to the example sentence 'I like going to hikes' in the custom-instructions documentation for consistency with other examples.

## Changes
- Added period to the Python example: 
- Added period to the TypeScript example: 

Fixes #4924