### PR TITLE
feat(retrieval): warn once on non-Latin BM25/entity input

### DIFF
--- a/mem0/utils/entity_extraction.py
+++ b/mem0/utils/entity_extraction.py
@@ -20,7 +20,26 @@ import logging
 import re
 from typing import List, Tuple
 
+from mem0.utils.script_detection import contains_non_latin_letters
+
 logger = logging.getLogger(__name__)
+
+_warned_non_latin_entities = False
+
+
+def _warn_non_latin_once() -> None:
+    global _warned_non_latin_entities
+    if _warned_non_latin_entities:
+        return
+    _warned_non_latin_entities = True
+    logger.warning(
+        "Entity extraction received non-Latin input; the English spaCy "
+        "pipeline does not recognise CJK / Arabic / Thai / Cyrillic "
+        "proper nouns, so no entity boost will be applied for this "
+        "query. Semantic retrieval continues to work. See issue #4884 "
+        "for multilingual support tracking. This warning is logged once "
+        "per process."
+    )
 
 # Words that are too generic to be useful as entity heads
 _GENERIC_HEADS = {
@@ -133,8 +152,17 @@ def extract_entities(text: str) -> List[Tuple[str, str]]:
         Deduplicated list of (entity_type, entity_text) tuples.
         Entity types: PROPER, QUOTED, COMPOUND, NOUN.
         Returns empty list if spaCy is unavailable.
+
+    Note:
+        The underlying pipeline (``en_core_web_sm``) does not recognise
+        non-Latin scripts. Mixed-script input still returns any Latin
+        entities that are detected. A single warning is logged per
+        process when non-Latin text is seen; see issue #4884.
     """
     from mem0.utils.spacy_models import get_nlp_full
+
+    if contains_non_latin_letters(text):
+        _warn_non_latin_once()
 
     nlp = get_nlp_full()
     if nlp is None:
@@ -163,6 +191,9 @@ def extract_entities_batch(texts: List[str], batch_size: int = 32) -> List[List[
         return []
 
     from mem0.utils.spacy_models import get_nlp_full
+
+    if any(contains_non_latin_letters(t) for t in texts):
+        _warn_non_latin_once()
 
     nlp = get_nlp_full()
     if nlp is None:

--- a/mem0/utils/lemmatization.py
+++ b/mem0/utils/lemmatization.py
@@ -10,13 +10,40 @@ Uses spaCy's lemmatizer for better handling of:
 Also includes original -ing forms alongside lemmas to handle cases
 where spaCy's context-dependent lemmatization produces inconsistent
 results (e.g., "meeting" as noun vs verb -> different lemmas).
+
+The loaded spaCy model is the English ``en_core_web_sm`` pipeline. On
+non-Latin input it produces degenerate output (a single unsegmented
+token for CJK / Arabic / Cyrillic, empty output for Thai). The
+behaviour is intentionally *not* changed here - see GitHub issue #4884
+for the broader i18n discussion - but callers are warned once per
+process via :func:`mem0.utils.script_detection.contains_non_latin_letters`
+so operators know BM25 is silently degraded.
 """
 
 from __future__ import annotations
 
 import logging
 
+from mem0.utils.script_detection import contains_non_latin_letters
+
 logger = logging.getLogger(__name__)
+
+_warned_non_latin_bm25 = False
+
+
+def _warn_non_latin_once() -> None:
+    global _warned_non_latin_bm25
+    if _warned_non_latin_bm25:
+        return
+    _warned_non_latin_bm25 = True
+    logger.warning(
+        "BM25 lemmatization received non-Latin input; the English spaCy "
+        "pipeline will produce a single unsegmented token (or empty "
+        "output for some scripts) and keyword-match recall will be near "
+        "zero. Semantic retrieval continues to work. See issue #4884 "
+        "for multilingual support tracking. This warning is logged once "
+        "per process."
+    )
 
 
 def lemmatize_for_bm25(text: str) -> str:
@@ -26,6 +53,9 @@ def lemmatize_for_bm25(text: str) -> str:
     the original text if spaCy is unavailable.
     """
     from mem0.utils.spacy_models import get_nlp_lemma
+
+    if contains_non_latin_letters(text):
+        _warn_non_latin_once()
 
     nlp = get_nlp_lemma()
     if nlp is None:

--- a/mem0/utils/script_detection.py
+++ b/mem0/utils/script_detection.py
@@ -1,0 +1,54 @@
+"""Script detection for retrieval preprocessing.
+
+The English spaCy pipeline used by :mod:`mem0.utils.lemmatization` and
+:mod:`mem0.utils.entity_extraction` silently produces degenerate output
+on non-Latin input: single-token BM25 lemmas for CJK / Arabic /
+Cyrillic, empty output for Thai, and no entities for any of them.
+
+Instead of changing retrieval behaviour here, this module only provides
+a lightweight detector so callers can emit a single warning and surface
+the issue to operators. See GitHub issue #4884 for background.
+"""
+
+from __future__ import annotations
+
+# Latin Unicode blocks we treat as "supported by the English pipeline":
+# Basic Latin, Latin-1 Supplement, Latin Extended A/B, IPA, plus the
+# Latin Extended Additional / -C / -D / -E ranges. Together these cover
+# essentially every language written with a Latin alphabet.
+_LATIN_RANGES: tuple[tuple[int, int], ...] = (
+    (0x0000, 0x007F),  # Basic Latin (ASCII)
+    (0x0080, 0x00FF),  # Latin-1 Supplement
+    (0x0100, 0x017F),  # Latin Extended-A
+    (0x0180, 0x024F),  # Latin Extended-B
+    (0x0250, 0x02AF),  # IPA Extensions
+    (0x02B0, 0x02FF),  # Spacing Modifier Letters
+    (0x1E00, 0x1EFF),  # Latin Extended Additional
+    (0x2C60, 0x2C7F),  # Latin Extended-C
+    (0xA720, 0xA7FF),  # Latin Extended-D
+    (0xAB30, 0xAB6F),  # Latin Extended-E
+)
+
+
+def _is_latin_codepoint(cp: int) -> bool:
+    for start, end in _LATIN_RANGES:
+        if start <= cp <= end:
+            return True
+    return False
+
+
+def contains_non_latin_letters(text: str) -> bool:
+    """Return True if *text* contains any letter outside the Latin script.
+
+    Only cased / alphabetic characters count - spaces, digits, and
+    punctuation are ignored so that strings like ``"2024-Q1"`` or
+    ``"price: $100"`` don't trigger a warning.
+    """
+    if not text:
+        return False
+    for ch in text:
+        if not ch.isalpha():
+            continue
+        if not _is_latin_codepoint(ord(ch)):
+            return True
+    return False

--- a/tests/utils/test_entity_extraction.py
+++ b/tests/utils/test_entity_extraction.py
@@ -99,3 +99,55 @@ class TestExtractEntitiesBatch:
         assert len(batch) == 1
         # Both should extract the same entities
         assert set(t for _, t in single) == set(t for _, t in batch[0])
+
+
+class TestNonLatinWarning:
+    """Entity extraction must warn (once) when the pipeline cannot help."""
+
+    def _reset_warn_flag(self):
+        import mem0.utils.entity_extraction as ee
+
+        ee._warned_non_latin_entities = False
+
+    def test_latin_input_does_not_warn(self, caplog):
+        import logging
+
+        self._reset_warn_flag()
+        from mem0.utils.entity_extraction import extract_entities
+
+        with caplog.at_level(logging.WARNING, logger="mem0.utils.entity_extraction"):
+            extract_entities("John Smith works at Google")
+        assert not any("non-Latin" in r.message for r in caplog.records)
+
+    def test_chinese_input_warns_once(self, caplog):
+        import logging
+
+        self._reset_warn_flag()
+        from mem0.utils.entity_extraction import extract_entities
+
+        with caplog.at_level(logging.WARNING, logger="mem0.utils.entity_extraction"):
+            extract_entities("阿宁住在苏州养了一只猫叫年糕")
+            extract_entities("東京で美味しいラーメンを食べた")
+        warnings = [r for r in caplog.records if "non-Latin" in r.message]
+        assert len(warnings) == 1
+
+    def test_batch_with_non_latin_warns_once(self, caplog):
+        import logging
+
+        self._reset_warn_flag()
+        from mem0.utils.entity_extraction import extract_entities_batch
+
+        with caplog.at_level(logging.WARNING, logger="mem0.utils.entity_extraction"):
+            extract_entities_batch(
+                ["John lives in Paris", "阿宁住在苏州", "東京で食べた"]
+            )
+        warnings = [r for r in caplog.records if "non-Latin" in r.message]
+        assert len(warnings) == 1
+
+    def test_non_latin_returns_empty_entities(self):
+        """Behaviour pin: current pipeline returns [] for pure non-Latin."""
+        self._reset_warn_flag()
+        from mem0.utils.entity_extraction import extract_entities
+
+        assert extract_entities("阿宁住在苏州") == []
+        assert extract_entities("東京で食べた") == []

--- a/tests/utils/test_lemmatization.py
+++ b/tests/utils/test_lemmatization.py
@@ -65,3 +65,70 @@ class TestLemmatizeForBm25:
         tokens = result.split()
         for stop in ["this", "is", "a", "very", "of", "the"]:
             assert stop not in tokens
+
+
+class TestNonLatinWarning:
+    """Verify non-Latin input surfaces a one-time warning.
+
+    Background: the English spaCy pipeline produces degenerate output on
+    non-Latin input (a single unsegmented token for CJK / Arabic /
+    Cyrillic, empty output for Thai). Behaviour is intentionally
+    unchanged; only a warning is logged. See GitHub issue #4884.
+    """
+
+    def _reset_warn_flag(self):
+        import mem0.utils.lemmatization as lemm
+
+        lemm._warned_non_latin_bm25 = False
+
+    def test_latin_input_does_not_warn(self, caplog):
+        import logging
+
+        self._reset_warn_flag()
+        from mem0.utils.lemmatization import lemmatize_for_bm25
+
+        with caplog.at_level(logging.WARNING, logger="mem0.utils.lemmatization"):
+            lemmatize_for_bm25("The cat runs quickly")
+        assert not any("non-Latin" in rec.message for rec in caplog.records)
+
+    def test_chinese_input_triggers_warning(self, caplog):
+        import logging
+
+        self._reset_warn_flag()
+        from mem0.utils.lemmatization import lemmatize_for_bm25
+
+        with caplog.at_level(logging.WARNING, logger="mem0.utils.lemmatization"):
+            lemmatize_for_bm25("我喜欢喝榛子拿铁")
+        assert any("non-Latin" in rec.message for rec in caplog.records)
+
+    def test_warning_fires_only_once_per_process(self, caplog):
+        import logging
+
+        self._reset_warn_flag()
+        from mem0.utils.lemmatization import lemmatize_for_bm25
+
+        with caplog.at_level(logging.WARNING, logger="mem0.utils.lemmatization"):
+            lemmatize_for_bm25("我喜欢喝榛子拿铁")
+            lemmatize_for_bm25("東京で美味しいラーメンを食べた")
+            lemmatize_for_bm25("서울에서 김치를 먹었다")
+        warnings = [r for r in caplog.records if "non-Latin" in r.message]
+        assert len(warnings) == 1
+
+    def test_non_latin_behaviour_unchanged(self):
+        """Whatever spaCy currently does on non-Latin input, keep doing it.
+
+        This PR does not promise any retrieval-quality improvement; it
+        only promises to surface the issue. The exact output here is
+        pinned to today's behaviour so future retrieval changes are
+        visible as a test update, not a silent regression.
+        """
+        self._reset_warn_flag()
+        from mem0.utils.lemmatization import lemmatize_for_bm25
+
+        # Chinese: spaCy returns the full string as a single token.
+        result = lemmatize_for_bm25("我喜欢喝榛子拿铁")
+        assert result  # non-empty
+        assert len(result.split()) == 1
+
+        # Semantic path still gets a string back; behaviour unchanged.
+        assert isinstance(lemmatize_for_bm25("ฉันชอบดื่มกาแฟ"), str)

--- a/tests/utils/test_script_detection.py
+++ b/tests/utils/test_script_detection.py
@@ -1,0 +1,43 @@
+from mem0.utils.script_detection import contains_non_latin_letters
+
+
+class TestContainsNonLatinLetters:
+    def test_empty_string(self):
+        assert contains_non_latin_letters("") is False
+
+    def test_pure_ascii(self):
+        assert contains_non_latin_letters("John Smith works at Google") is False
+
+    def test_latin_with_accents(self):
+        # French, Spanish, German etc. must NOT trigger the warning.
+        assert contains_non_latin_letters("café naïve résumé") is False
+        assert contains_non_latin_letters("München Straße") is False
+        assert contains_non_latin_letters("São Paulo") is False
+
+    def test_digits_punctuation_only(self):
+        # Strings with no letters at all shouldn't trigger either.
+        assert contains_non_latin_letters("2024-Q1") is False
+        assert contains_non_latin_letters("$100.00") is False
+        assert contains_non_latin_letters("!!! ???") is False
+
+    def test_chinese(self):
+        assert contains_non_latin_letters("我喜欢喝咖啡") is True
+
+    def test_japanese(self):
+        assert contains_non_latin_letters("東京で美味しいラーメンを食べた") is True
+
+    def test_korean(self):
+        assert contains_non_latin_letters("서울에서 김치를 먹었다") is True
+
+    def test_arabic(self):
+        assert contains_non_latin_letters("أحب شرب القهوة") is True
+
+    def test_thai(self):
+        assert contains_non_latin_letters("ฉันชอบดื่มกาแฟ") is True
+
+    def test_cyrillic(self):
+        assert contains_non_latin_letters("Я люблю кофе") is True
+
+    def test_mixed_script(self):
+        # Mixed input with any non-Latin letter must return True.
+        assert contains_non_latin_letters("I met 阿宁 at Google") is True


### PR DESCRIPTION
Refs #4884. Related issue: #4942.

## Problem

The v3 hybrid retrieval pipeline (BM25 + entity boost + semantic) loads `en_core_web_sm` unconditionally. On non-Latin input the pipeline degrades silently:

| Script | `lemmatize_for_bm25` output | `extract_entities` output |
|:---|:---|:---|
| Latin (English / French / German / Portuguese) | proper lemmas | proper nouns extracted |
| Chinese / Japanese / Korean / Arabic / Cyrillic | **full string as one unsegmented token** | `[]` |
| Thai | **empty string** | `[]` |

Net effect for non-English deployments: BM25 matches only on whole-string duplicates (near-zero recall), the entity boost is always zero, the combined-score divisor in `scoring.py` stays at 1.0, and the v3 hybrid pipeline silently collapses to semantic-only. No exception, no warning, no documentation — users just miss the precision improvements v3 was supposed to deliver.

Full minimal repro in #4884 and in #4942.

## What this PR does (scope)

Deliberately narrow. **No retrieval behaviour change.** No new config, no API change, zero regression for Latin users. Only observability.

- New helper `mem0/utils/script_detection.py`: `contains_non_latin_letters(text)`. Unicode-range check that ignores digits / punctuation and treats all Latin extensions (including accented Latin like `café`, `München`, `São Paulo`) as Latin.
- `lemmatize_for_bm25` logs a `warning` **once per process** when non-Latin input is detected. Message points at #4884 for multilingual tracking.
- `extract_entities` / `extract_entities_batch` do the same.
- Docstrings on both public functions explain the current non-Latin behaviour.
- 19 new unit tests (all passing; existing utils tests still green):
  - 11 for `script_detection`: CJK / Arabic / Thai / Cyrillic detection, accented-Latin negatives, digit / punctuation negatives, mixed-script input.
  - 4 for `lemmatize_for_bm25`: Latin-does-not-warn, Chinese warns, warn-once semantics across CJK/KO/JA calls, behaviour pin that non-Latin output is unchanged.
  - 4 for `extract_entities` / `_batch`: same pattern, plus behaviour pin that non-Latin returns `[]`.

## What this PR deliberately does NOT do

- No language dispatch (`zh_core_web_sm`, `ja_core_news_sm`, etc.).
- No CJK / Thai tokenisation (jieba, character n-grams, vector-store-delegated keyword search).
- No `scoring.py` change; the divisor logic continues to work as-is.
- No new public config. If this scope is accepted, a follow-up PR can introduce a `retrieval.language` knob and dispatch — discussed in #4884.
- No default change for Latin input. `lemmatize_for_bm25("The cats are running")` returns the exact same string as before, with no log output.

## Files changed

```
mem0/utils/script_detection.py        (new, 55 lines)
mem0/utils/lemmatization.py           (+33 / -3)
mem0/utils/entity_extraction.py       (+36 / -1)
tests/utils/test_script_detection.py  (new, 44 lines)
tests/utils/test_lemmatization.py     (+69 appended)
tests/utils/test_entity_extraction.py (+53 appended)
```

## Test

```bash
pytest tests/utils/ -v
# 54 passed in 10.69s  (existing 35 + new 19)

ruff check mem0/utils/ tests/utils/
# All checks passed!
```

## Why merge this before the bigger #4884 work

The multilingual retrieval design (per-language spaCy models vs. script-aware tokenisers vs. vector-store-delegated BM25) is a real RFC-level question. Until that's resolved, non-English deployments can't even tell that anything is wrong. This PR makes the degradation visible and hands off cleanly to whichever direction #4884 takes — with a behaviour pin so the future PR's wins show up as test diffs instead of silent improvements.