### PR TITLE
(TS) Fix PGVector implementation, where vector distance was inverted.

### DIFF
--- a/mem0-ts/src/oss/src/vector_stores/pgvector.ts
+++ b/mem0-ts/src/oss/src/vector_stores/pgvector.ts
@@ -251,9 +251,6 @@ export class PGVector implements VectorStore {
     return result.rows.map((row) => ({
       id: row.id,
       payload: row.payload,
-      // The hybrid search pipeline expects semantic scores where higher is
-      // better. pgvector's `<=>` returns cosine distance, where lower is better.
-      // Convert it back into a bounded similarity score before returning it.
       score: Math.max(0, Math.min(1, 1 - Number(row.distance))),
     }));
   }

--- a/mem0-ts/src/oss/src/vector_stores/pgvector.ts
+++ b/mem0-ts/src/oss/src/vector_stores/pgvector.ts
@@ -251,7 +251,10 @@ export class PGVector implements VectorStore {
     return result.rows.map((row) => ({
       id: row.id,
       payload: row.payload,
-      score: row.distance,
+      // The hybrid search pipeline expects semantic scores where higher is
+      // better. pgvector's `<=>` returns cosine distance, where lower is better.
+      // Convert it back into a bounded similarity score before returning it.
+      score: Math.max(0, Math.min(1, 1 - Number(row.distance))),
     }));
   }
 

--- a/mem0-ts/src/oss/tests/pgvector.unit.test.ts
+++ b/mem0-ts/src/oss/tests/pgvector.unit.test.ts
@@ -47,7 +47,9 @@ jest.mock("pg", () => {
       config,
       connect: jest.fn().mockResolvedValue(undefined),
       end: jest.fn().mockResolvedValue(undefined),
-      query: jest.fn().mockImplementation(async (sql: string) => mockPgQuery(sql)),
+      query: jest
+        .fn()
+        .mockImplementation(async (sql: string) => mockPgQuery(sql)),
     };
 
     clients.push(client);

--- a/mem0-ts/src/oss/tests/pgvector.unit.test.ts
+++ b/mem0-ts/src/oss/tests/pgvector.unit.test.ts
@@ -1,0 +1,126 @@
+/// <reference types="jest" />
+
+const searchRows = [
+  {
+    id: "a",
+    payload: { data: "exactly x-axis" },
+    distance: "0",
+  },
+  {
+    id: "b",
+    payload: { data: "close to x-axis" },
+    distance: "0.006116251198662548",
+  },
+  {
+    id: "c",
+    payload: { data: "y-axis" },
+    distance: "1",
+  },
+  {
+    id: "d",
+    payload: { data: "opposite x-axis" },
+    distance: "2",
+  },
+];
+
+function mockPgQuery(sql: string) {
+  if (sql.includes("SELECT 1 FROM pg_database")) {
+    return { rows: [{ "?column?": 1 }] };
+  }
+
+  if (sql.includes("FROM information_schema.tables")) {
+    return { rows: [{ table_name: "memories" }] };
+  }
+
+  if (sql.includes("vector <=> $1::vector AS distance")) {
+    return { rows: searchRows };
+  }
+
+  return { rows: [] };
+}
+
+jest.mock("pg", () => {
+  const clients: any[] = [];
+
+  const Client = jest.fn().mockImplementation((config: any) => {
+    const client = {
+      config,
+      connect: jest.fn().mockResolvedValue(undefined),
+      end: jest.fn().mockResolvedValue(undefined),
+      query: jest.fn().mockImplementation(async (sql: string) => mockPgQuery(sql)),
+    };
+
+    clients.push(client);
+    return client;
+  });
+
+  return {
+    __esModule: true,
+    default: { Client },
+    Client,
+    __mock: { Client, clients },
+  };
+});
+
+import { PGVector } from "../src/vector_stores/pgvector";
+
+describe("PGVector - search()", () => {
+  beforeEach(() => {
+    const pg = require("pg");
+    pg.__mock.Client.mockClear();
+    pg.__mock.clients.length = 0;
+  });
+
+  test("converts cosine distance into a clamped similarity score", async () => {
+    const store = new PGVector({
+      collectionName: "memories",
+      user: "postgres",
+      password: "postgres",
+      host: "localhost",
+      port: 5432,
+      embeddingModelDims: 3,
+      dimension: 3,
+    } as any);
+
+    await store.initialize();
+
+    const results = await store.search([1, 0, 0], 4);
+
+    expect(results).toEqual([
+      {
+        id: "a",
+        payload: { data: "exactly x-axis" },
+        score: 1,
+      },
+      {
+        id: "b",
+        payload: { data: "close to x-axis" },
+        score: 0.9938837488013375,
+      },
+      {
+        id: "c",
+        payload: { data: "y-axis" },
+        score: 0,
+      },
+      {
+        id: "d",
+        payload: { data: "opposite x-axis" },
+        score: 0,
+      },
+    ]);
+
+    const pg = require("pg");
+    expect(pg.__mock.Client).toHaveBeenCalledTimes(2);
+
+    const activeClient = pg.__mock.clients[1];
+    expect(activeClient.query).toHaveBeenCalledWith(
+      expect.stringContaining("vector <=> $1::vector AS distance"),
+      ["[1,0,0]", 4],
+    );
+
+    for (const result of results) {
+      expect(result.score).toBeGreaterThanOrEqual(0);
+      expect(result.score).toBeLessThanOrEqual(1);
+    }
+  });
+});


### PR DESCRIPTION
The hybrid search pipeline expects semantic scores where higher is better. pgvector's `<=>` returns cosine distance, where lower is better. Convert it back into a bounded similarity score before returning it.

## Linked Issue

No issue opened. 

## Description

While doing the semantic search, most similar documents have to be ranked highest. Using PGVector, the scores were inverted, surfacing the least relevant documents I suppose. 

This fix actually returns the most similar documents.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

I ran .search() in my (proprietary) app, got very bad results, installed my local version with the fix and now the results are very relevant as expected.

Run this SQL to confirm the distance function in PGVector indeed behaves as I'm describing:
```sql
 WITH memories(id, embedding, payload) AS (
    VALUES
      ('a', '[1,0,0]'::vector, '{"data":"exactly x-axis"}'::jsonb),
      ('b', '[0.9,0.1,0]'::vector, '{"data":"close to x-axis"}'::jsonb),
      ('c', '[0,1,0]'::vector, '{"data":"y-axis"}'::jsonb),
      ('d', '[-1,0,0]'::vector, '{"data":"opposite x-axis"}'::jsonb)
  )
  SELECT
    id,
    payload->>'data' AS text,
    embedding <=> '[1,0,0]'::vector AS distance,
    GREATEST(0, LEAST(1, 1 - (embedding <=> '[1,0,0]'::vector))) AS score
  FROM memories
  ORDER BY distance ASC;
  ```
which outputs: 

 | id | text | distance | score |
  |---|---|---:|---:|
  | a | exactly x-axis | 0.0 | 1.0 |
  | b | close to x-axis | 0.006116251198662548 | 0.9938837488013375 |
  | c | y-axis | 1.0 | 0.0 |
  | d | opposite x-axis | 2.0 | 0.0 |

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works 
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed (NA)
