### PR TITLE
feature(docs): add docs for Add Memories v2 api

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1138,41 +1138,102 @@
 				},
 				"responses": {
 					"200": {
-						"description": "Successful memory creation.",
+						"description": "Successful memory creation. Response format depends on the `version` field in the request body.",
 						"content": {
 							"application/json": {
 								"schema": {
 									"type": "array",
+									"description": "Response format depends on the `version` field in the request body.",
 									"items": {
-										"type": "object",
-										"properties": {
-											"id": {
-												"type": "string"
-											},
-											"data": {
+										"oneOf": [
+											{
+												"title": "v1",
+												"description": "Returned when `version` is `\"v1\"` or omitted.",
 												"type": "object",
 												"properties": {
-													"memory": {
+													"id": {
 														"type": "string"
+													},
+													"data": {
+														"type": "object",
+														"properties": {
+															"memory": {
+																"type": "string"
+															}
+														},
+														"required": [
+															"memory"
+														]
+													},
+													"event": {
+														"type": "string",
+														"enum": [
+															"ADD",
+															"UPDATE",
+															"DELETE"
+														]
 													}
 												},
 												"required": [
-													"memory"
+													"id",
+													"data",
+													"event"
 												]
 											},
-											"event": {
-												"type": "string",
-												"enum": [
-													"ADD",
-													"UPDATE",
-													"DELETE"
+											{
+												"title": "v2",
+												"description": "Returned when `version` is `\"v2\"`. Memory processing is queued for background execution.",
+												"type": "object",
+												"properties": {
+													"message": {
+														"type": "string"
+													},
+													"status": {
+														"type": "string",
+														"enum": [
+															"PENDING",
+															"RUNNING",
+															"FAILED",
+															"SUCCEEDED"
+														],
+														"description": "The current status of the event."
+													},
+													"event_id": {
+														"type": "string",
+														"format": "uuid",
+														"description": "The unique identifier of the event."
+													}
+												},
+												"required": [
+													"message",
+													"status",
+													"event_id"
 												]
 											}
-										},
-										"required": [
-											"id",
-											"data",
-											"event"
+										]
+									}
+								},
+								"examples": {
+									"v1": {
+										"summary": "v1 response",
+										"value": [
+											{
+												"id": "<string>",
+												"data": {
+													"memory": "<string>"
+												},
+												"event": "ADD"
+											}
+										]
+									},
+									"v2": {
+										"summary": "v2 response",
+										"value": [
+											{
+												"message": "<string>",
+												"status": "PENDING",
+												"event_id": "<string>"
+											}
 										]
 									}
 								}


### PR DESCRIPTION
## Linked Issue

Closes #4949

## Description

The [Add Memories API](https://docs.mem0.ai/api-reference/memory/add-memories) is missing documentation for the v2 response format. The current docs only show the v1 (default) response format. This PR adds docs for the v2 response.

### Before

Before this change, the docs only show the v1 response:

<img width="563" height="416" alt="Screenshot 2026-04-23 at 11 19 31 AM" src="https://github.com/user-attachments/assets/bf897ee1-f1b8-4857-b912-5a6cfc2b0acb" />


### After

This change adds tabs to toggle between v1 and v2 response formats:

<img width="560" height="617" alt="Screenshot 2026-04-23 at 11 37 36 AM" src="https://github.com/user-attachments/assets/b84e8136-ea61-498e-886e-5ddd13284aca" />

Also adds a dropdown to toggle between v1 and v2 response examples:

<img width="458" height="232" alt="Screenshot 2026-04-23 at 11 18 34 AM" src="https://github.com/user-attachments/assets/8dbb0da6-5cec-415b-9b60-15167a0f08fe" />


## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Used `mintlify dev` to generate the docs locally.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [x] I have updated documentation if needed
