### PR TITLE
fix(server): use filters dict for get_all to match lib API

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -395,10 +395,10 @@ def get_all_memories(
     try:
         if not any([user_id, run_id, agent_id]):
             return _list_all_memories()
-        params = {
+        filters = {
             k: v for k, v in {"user_id": user_id, "run_id": run_id, "agent_id": agent_id}.items() if v is not None
         }
-        return get_memory_instance().get_all(**params)
+        return get_memory_instance().get_all(filters=filters)
     except Exception:
         raise upstream_error()
 


### PR DESCRIPTION
## Problem

The `get_all_memories` route in `server/main.py` passes entity IDs (`user_id`, `agent_id`, `run_id`) as top-level keyword arguments:

```python
get_memory_instance().get_all(**params)
```

However, the mem0 library's `get_all()` method now requires these IDs to be passed via the `filters` dict parameter, and explicitly rejects top-level entity params via `_reject_top_level_entity_params()`. This causes a **500 Internal Server Error** when querying memories with any entity filter.

## Fix

Wrap the query parameters into a `filters` dict before calling `get_all()`:

```python
filters = {k: v for k, v in {...}.items() if v is not None}
get_memory_instance().get_all(filters=filters)
```

## Testing

Verified on a self-hosted mem0 OSS deployment:
- `GET /memories?user_id=test` — was 502, now returns 200 with correct results
- All other memory endpoints unaffected