### PR TITLE
fix(api): map entity params to filters in GET /memories (#4955)

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -395,10 +395,10 @@ def get_all_memories(
     try:
         if not any([user_id, run_id, agent_id]):
             return _list_all_memories()
-        params = {
+        filters = {
             k: v for k, v in {"user_id": user_id, "run_id": run_id, "agent_id": agent_id}.items() if v is not None
         }
-        return get_memory_instance().get_all(**params)
+        return get_memory_instance().get_all(filters=filters)
     except Exception:
         raise upstream_error()
 

--- a/tests/test_server_params.py
+++ b/tests/test_server_params.py
@@ -561,3 +561,30 @@ class TestUpdateOpenAPISchema:
         schema = client.get("/openapi.json").json()
         update_props = schema["components"]["schemas"]["MemoryUpdate"]["properties"]
         assert "metadata" in update_props
+
+# ===========================================================================
+# GetMemories: Entity parameters to filters mapping (fix for #4955)
+# ===========================================================================
+
+class TestGetMemories:
+    """Verify that GET /memories correctly maps entity parameters to the filters dict."""
+
+    def test_get_memories_entity_filters_routing(self, client, mock_memory):
+        """
+        Issue #4955: Test that the GET /memories route correctly handles 
+        top-level entity parameters by mapping them to the filters dictionary
+        instead of passing them as direct kwargs to get_all()
+        """
+        # Send a request with a valid top-level entity parameter
+        response = client.get("/memories?user_id=test_routing_user")
+        
+        # 1. Verify the endpoint doesn't crash with a 500 error
+        assert response.status_code == 200
+        
+        # 2. Verify the response is structured correctly
+        data = response.json()
+        assert isinstance(data, list)
+        
+        # 3. Verify the core logic: the param was mapped to the filters dict!
+        _, kwargs = mock_memory.get_all.call_args
+        assert kwargs["filters"] == {"user_id": "test_routing_user"}


### PR DESCRIPTION
## Linked Issue

Closes #4955

## Description

This PR resolves a version mismatch between the OSS REST API server and the Core Memory backend (v3). 

Following the v3 update, the `Memory.get_all()` method now requires entity-level parameters (`user_id`, `agent_id`, `run_id`) to be encapsulated within a `filters` dictionary. The API route was previously passing these as top-level keyword arguments, resulting in a `RuntimeError`.

**Key Changes:**
- Updated the `get_all_memories` route in `server/main.py` to intercept query parameters.
- Implemented a dictionary comprehension to bundle active entity IDs into a `filters` object.
- Updated the backend call to use the `filters=filters` keyword argument.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A - This restores expected functionality for the `/memories` GET endpoint.

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

**Manual Validation:**
1. Booted the FastAPI server locally using `uvicorn`.
2. Verified that the application successfully initializes and imports the updated routing logic.
3. Confirmed via code execution path that query parameters are now correctly mapped to the `filters` dictionary before being dispatched to the core memory instance.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed