### PR TITLE
feat(openai): support extra chat completion headers

### DIFF
--- a/docs/components/llms/config.mdx
+++ b/docs/components/llms/config.mdx
@@ -117,6 +117,7 @@ Here's a comprehensive list of all parameters that can be used across different 
     | `stop`               | Stop sequences (max 4)                        | Sarvam            |
     | `lmstudio_base_url`  | Base URL for LM Studio API                    | LM Studio         |
     | `response_callback`  | LLM response callback function                | OpenAI            |
+    | `extra_headers`      | Additional headers for chat completion calls  | OpenAI            |
   </Tab>
   <Tab title="TypeScript">
     | Parameter            | Description                                   | Provider          |

--- a/docs/components/llms/models/openai.mdx
+++ b/docs/components/llms/models/openai.mdx
@@ -74,6 +74,25 @@ await memory.add(messages, { userId: "alice", metadata: { category: "movies" } }
 ```
 </CodeGroup>
 
+### Custom headers
+
+Use `extra_headers` when OpenAI-compatible observability or proxy services need request-specific headers on chat completion calls. These headers are sent to the LLM request only.
+
+```python
+config = {
+    "llm": {
+        "provider": "openai",
+        "config": {
+            "model": "gpt-5-mini",
+            "extra_headers": {
+                "Helicone-Auth": "Bearer <token>",
+                "X-Trace-Id": "trace-123",
+            },
+        },
+    },
+}
+```
+
 We also support the new [OpenAI structured-outputs](https://platform.openai.com/docs/guides/structured-outputs/introduction) model.
 
 ```python

--- a/mem0-ts/src/oss/src/config/manager.ts
+++ b/mem0-ts/src/oss/src/config/manager.ts
@@ -119,6 +119,9 @@ export class ConfigManager {
           const topP = userConf?.topP ?? (llmRaw?.top_p as number | undefined);
           const maxTokens =
             userConf?.maxTokens ?? (llmRaw?.max_tokens as number | undefined);
+          const extraHeaders =
+            userConf?.extraHeaders ??
+            (llmRaw?.extra_headers as Record<string, string> | undefined);
 
           return {
             baseURL: llmBaseURL,
@@ -135,6 +138,7 @@ export class ConfigManager {
             temperature,
             topP,
             maxTokens,
+            extraHeaders,
           };
         })(),
       },

--- a/mem0-ts/src/oss/src/llms/openai.ts
+++ b/mem0-ts/src/oss/src/llms/openai.ts
@@ -5,6 +5,7 @@ import { LLMConfig, Message } from "../types";
 export class OpenAILLM implements LLM {
   private openai: OpenAI;
   private model: string;
+  private extraHeaders?: Record<string, string>;
 
   constructor(config: LLMConfig) {
     this.openai = new OpenAI({
@@ -13,6 +14,7 @@ export class OpenAILLM implements LLM {
       ...(config.timeout != null && { timeout: config.timeout }),
     });
     this.model = config.model || "gpt-5-mini";
+    this.extraHeaders = config.extraHeaders;
   }
 
   async generateResponse(
@@ -20,7 +22,7 @@ export class OpenAILLM implements LLM {
     responseFormat?: { type: string },
     tools?: any[],
   ): Promise<string | LLMResponse> {
-    const completion = await this.openai.chat.completions.create({
+    const params = {
       messages: messages.map((msg) => {
         const role = msg.role as "system" | "user" | "assistant";
         return {
@@ -33,8 +35,13 @@ export class OpenAILLM implements LLM {
       }),
       model: this.model,
       response_format: responseFormat as { type: "text" | "json_object" },
-      ...(tools && { tools, tool_choice: "auto" }),
-    });
+      ...(tools && { tools, tool_choice: "auto" as const }),
+    };
+    const completion = this.extraHeaders
+      ? await this.openai.chat.completions.create(params, {
+          headers: this.extraHeaders,
+        })
+      : await this.openai.chat.completions.create(params);
 
     const response = completion.choices[0].message;
 
@@ -53,7 +60,7 @@ export class OpenAILLM implements LLM {
   }
 
   async generateChat(messages: Message[]): Promise<LLMResponse> {
-    const completion = await this.openai.chat.completions.create({
+    const params = {
       messages: messages.map((msg) => {
         const role = msg.role as "system" | "user" | "assistant";
         return {
@@ -65,7 +72,12 @@ export class OpenAILLM implements LLM {
         };
       }),
       model: this.model,
-    });
+    };
+    const completion = this.extraHeaders
+      ? await this.openai.chat.completions.create(params, {
+          headers: this.extraHeaders,
+        })
+      : await this.openai.chat.completions.create(params);
     const response = completion.choices[0].message;
     return {
       content: response.content || "",

--- a/mem0-ts/src/oss/src/llms/openai_structured.ts
+++ b/mem0-ts/src/oss/src/llms/openai_structured.ts
@@ -5,6 +5,7 @@ import { LLMConfig, Message } from "../types";
 export class OpenAIStructuredLLM implements LLM {
   private openai: OpenAI;
   private model: string;
+  private extraHeaders?: Record<string, string>;
 
   constructor(config: LLMConfig) {
     this.openai = new OpenAI({
@@ -13,6 +14,7 @@ export class OpenAIStructuredLLM implements LLM {
       ...(config.timeout != null && { timeout: config.timeout }),
     });
     this.model = config.model || "gpt-5-mini";
+    this.extraHeaders = config.extraHeaders;
   }
 
   async generateResponse(
@@ -20,7 +22,7 @@ export class OpenAIStructuredLLM implements LLM {
     responseFormat?: { type: string } | null,
     tools?: any[],
   ): Promise<string | LLMResponse> {
-    const completion = await this.openai.chat.completions.create({
+    const params = {
       messages: messages.map((msg) => ({
         role: msg.role as "system" | "user" | "assistant",
         content:
@@ -32,7 +34,7 @@ export class OpenAIStructuredLLM implements LLM {
       ...(tools
         ? {
             tools: tools.map((tool) => ({
-              type: "function",
+              type: "function" as const,
               function: {
                 name: tool.function.name,
                 description: tool.function.description,
@@ -48,7 +50,12 @@ export class OpenAIStructuredLLM implements LLM {
               },
             }
           : {}),
-    });
+    };
+    const completion = this.extraHeaders
+      ? await this.openai.chat.completions.create(params, {
+          headers: this.extraHeaders,
+        })
+      : await this.openai.chat.completions.create(params);
 
     const response = completion.choices[0].message;
 
@@ -67,7 +74,7 @@ export class OpenAIStructuredLLM implements LLM {
   }
 
   async generateChat(messages: Message[]): Promise<LLMResponse> {
-    const completion = await this.openai.chat.completions.create({
+    const params = {
       messages: messages.map((msg) => ({
         role: msg.role as "system" | "user" | "assistant",
         content:
@@ -76,7 +83,12 @@ export class OpenAIStructuredLLM implements LLM {
             : JSON.stringify(msg.content),
       })),
       model: this.model,
-    });
+    };
+    const completion = this.extraHeaders
+      ? await this.openai.chat.completions.create(params, {
+          headers: this.extraHeaders,
+        })
+      : await this.openai.chat.completions.create(params);
     const response = completion.choices[0].message;
     return {
       content: response.content || "",

--- a/mem0-ts/src/oss/src/types/index.ts
+++ b/mem0-ts/src/oss/src/types/index.ts
@@ -52,6 +52,7 @@ export interface LLMConfig {
   temperature?: number;
   topP?: number;
   maxTokens?: number;
+  extraHeaders?: Record<string, string>;
 }
 
 export interface MemoryConfig {
@@ -138,6 +139,7 @@ export const MemoryConfigSchema = z.object({
       temperature: z.number().optional(),
       topP: z.number().optional(),
       maxTokens: z.number().optional(),
+      extraHeaders: z.record(z.string(), z.string()).optional(),
     }),
   }),
   historyDbPath: z.string().optional(),

--- a/mem0-ts/src/oss/tests/config-manager.test.ts
+++ b/mem0-ts/src/oss/tests/config-manager.test.ts
@@ -306,6 +306,24 @@ describe("ConfigManager", () => {
       expect(cfg.llm.config.baseURL).toBe("http://camel:1234/v1");
     });
 
+    it("normalizes extra_headers to extraHeaders for LLM", () => {
+      const cfg = ConfigManager.mergeConfig({
+        embedder: baseEmbedder,
+        vectorStore: { provider: "memory", config: {} },
+        llm: {
+          provider: "openai",
+          config: {
+            apiKey: "k",
+            extra_headers: { "Helicone-Auth": "Bearer test" },
+          } as any,
+        },
+      });
+
+      expect(cfg.llm.config.extraHeaders).toEqual({
+        "Helicone-Auth": "Bearer test",
+      });
+    });
+
     it("falls back to default baseURL when neither is provided for LLM", () => {
       const cfg = ConfigManager.mergeConfig({
         embedder: baseEmbedder,

--- a/mem0-ts/src/oss/tests/openai-llm.test.ts
+++ b/mem0-ts/src/oss/tests/openai-llm.test.ts
@@ -104,10 +104,9 @@ describe("OpenAILLM (unit)", () => {
     });
     await llm.generateResponse([{ role: "user", content: "Hi" }]);
 
-    expect(mockCreate).toHaveBeenCalledWith(
-      expect.any(Object),
-      { headers: { "Helicone-Auth": "Bearer test" } },
-    );
+    expect(mockCreate).toHaveBeenCalledWith(expect.any(Object), {
+      headers: { "Helicone-Auth": "Bearer test" },
+    });
   });
 
   it("generateResponse() handles tool calls", async () => {

--- a/mem0-ts/src/oss/tests/openai-llm.test.ts
+++ b/mem0-ts/src/oss/tests/openai-llm.test.ts
@@ -85,6 +85,31 @@ describe("OpenAILLM (unit)", () => {
     expect(result).toBe('{"facts": ["hello"]}');
   });
 
+  it("passes extraHeaders as request headers for chat completions", async () => {
+    mockCreate.mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            content: "ok",
+            role: "assistant",
+            tool_calls: null,
+          },
+        },
+      ],
+    });
+
+    const llm = new OpenAILLM({
+      apiKey: "test-key",
+      extraHeaders: { "Helicone-Auth": "Bearer test" },
+    });
+    await llm.generateResponse([{ role: "user", content: "Hi" }]);
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.any(Object),
+      { headers: { "Helicone-Auth": "Bearer test" } },
+    );
+  });
+
   it("generateResponse() handles tool calls", async () => {
     mockCreate.mockResolvedValueOnce({
       choices: [

--- a/mem0-ts/src/oss/tests/openai-structured-llm.test.ts
+++ b/mem0-ts/src/oss/tests/openai-structured-llm.test.ts
@@ -56,4 +56,32 @@ describe("OpenAIStructuredLLM (unit)", () => {
     });
     expect(capturedConstructorArgs).not.toHaveProperty("timeout");
   });
+
+  it("passes extraHeaders as request headers for structured chat completions", async () => {
+    mockCreate.mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            content: "{\"ok\": true}",
+            role: "assistant",
+            tool_calls: null,
+          },
+        },
+      ],
+    });
+
+    const llm = new OpenAIStructuredLLM({
+      apiKey: "test-key",
+      extraHeaders: { "Helicone-Auth": "Bearer test" },
+    });
+    await llm.generateResponse(
+      [{ role: "user", content: "Hi" }],
+      { type: "json_object" },
+    );
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.any(Object),
+      { headers: { "Helicone-Auth": "Bearer test" } },
+    );
+  });
 });

--- a/mem0-ts/src/oss/tests/openai-structured-llm.test.ts
+++ b/mem0-ts/src/oss/tests/openai-structured-llm.test.ts
@@ -62,7 +62,7 @@ describe("OpenAIStructuredLLM (unit)", () => {
       choices: [
         {
           message: {
-            content: "{\"ok\": true}",
+            content: '{"ok": true}',
             role: "assistant",
             tool_calls: null,
           },
@@ -74,14 +74,12 @@ describe("OpenAIStructuredLLM (unit)", () => {
       apiKey: "test-key",
       extraHeaders: { "Helicone-Auth": "Bearer test" },
     });
-    await llm.generateResponse(
-      [{ role: "user", content: "Hi" }],
-      { type: "json_object" },
-    );
+    await llm.generateResponse([{ role: "user", content: "Hi" }], {
+      type: "json_object",
+    });
 
-    expect(mockCreate).toHaveBeenCalledWith(
-      expect.any(Object),
-      { headers: { "Helicone-Auth": "Bearer test" } },
-    );
+    expect(mockCreate).toHaveBeenCalledWith(expect.any(Object), {
+      headers: { "Helicone-Auth": "Bearer test" },
+    });
   });
 });

--- a/mem0/configs/llms/openai.py
+++ b/mem0/configs/llms/openai.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from mem0.configs.llms.base import BaseLlmConfig
 
@@ -31,6 +31,7 @@ class OpenAIConfig(BaseLlmConfig):
         site_url: Optional[str] = None,
         app_name: Optional[str] = None,
         store: Optional[bool] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
         # Response monitoring callback
         response_callback: Optional[Callable[[Any, dict, dict], None]] = None,
     ):
@@ -62,6 +63,8 @@ class OpenAIConfig(BaseLlmConfig):
                 want the value forwarded to the OpenAI API. Leaving it None
                 avoids leaking the field into OpenAI-compatible backends that
                 reject unknown fields (Gemini, Groq, vLLM, etc.).
+            extra_headers: Additional HTTP headers to send with OpenAI chat
+                completion requests, defaults to None
             response_callback: Optional callback for monitoring LLM responses.
         """
         # Initialize base parameters
@@ -87,6 +90,7 @@ class OpenAIConfig(BaseLlmConfig):
         self.site_url = site_url
         self.app_name = app_name
         self.store = store
+        self.extra_headers = extra_headers
 
         # Response monitoring
         self.response_callback = response_callback

--- a/mem0/llms/openai.py
+++ b/mem0/llms/openai.py
@@ -32,6 +32,7 @@ class OpenAILLM(LLMBase):
                 reasoning_effort=getattr(config, 'reasoning_effort', None),
                 http_client_proxies=config.http_client_proxies,
                 is_reasoning_model=getattr(config, 'is_reasoning_model', None),
+                extra_headers=getattr(config, "extra_headers", None),
             )
 
         super().__init__(config)
@@ -112,16 +113,19 @@ class OpenAILLM(LLMBase):
 
         if os.getenv("OPENROUTER_API_KEY"):
             openrouter_params = {}
+            extra_headers = dict(self.config.extra_headers or {})
             if self.config.models:
                 openrouter_params["models"] = self.config.models
                 openrouter_params["route"] = self.config.route
                 params.pop("model")
 
             if self.config.site_url and self.config.app_name:
-                extra_headers = {
+                openrouter_headers = {
                     "HTTP-Referer": self.config.site_url,
                     "X-Title": self.config.app_name,
                 }
+                extra_headers.update(openrouter_headers)
+            if extra_headers:
                 openrouter_params["extra_headers"] = extra_headers
 
             params.update(**openrouter_params)
@@ -132,6 +136,8 @@ class OpenAILLM(LLMBase):
             # reject unknown fields, so `store` must be opt-in, not opt-out.
             if self.config.store is not None:
                 params["store"] = self.config.store
+            if self.config.extra_headers:
+                params["extra_headers"] = self.config.extra_headers
 
         if response_format:
             params["response_format"] = response_format

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -287,6 +287,49 @@ def test_store_sent_when_explicitly_false(mock_openai_client):
     assert call_kwargs["store"] is False
 
 
+def test_extra_headers_are_sent_with_chat_completion(mock_openai_client):
+    """OpenAI custom headers should be scoped to chat completion requests."""
+    extra_headers = {"Helicone-Auth": "Bearer test-token", "X-Trace-Id": "trace-123"}
+    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", extra_headers=extra_headers)
+    llm = OpenAILLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Response"))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    call_kwargs = mock_openai_client.chat.completions.create.call_args.kwargs
+    assert call_kwargs["extra_headers"] == extra_headers
+
+
+def test_openrouter_extra_headers_merge_with_site_metadata(mock_openai_client, monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key")
+
+    config = OpenAIConfig(
+        model="meta-llama/llama-3.1-70b-instruct",
+        site_url="https://example.com",
+        app_name="Mem0 App",
+        extra_headers={"Helicone-Auth": "Bearer test-token"},
+    )
+    llm = OpenAILLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Response"))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    call_kwargs = mock_openai_client.chat.completions.create.call_args.kwargs
+    assert call_kwargs["extra_headers"] == {
+        "Helicone-Auth": "Bearer test-token",
+        "HTTP-Referer": "https://example.com",
+        "X-Title": "Mem0 App",
+    }
+
+
 def test_gpt5_mini_not_classified_as_reasoning(mock_openai_client):
     """Test that gpt-5.4-mini is NOT treated as a reasoning model.
 


### PR DESCRIPTION
## Linked Issue

Closes #3851

## Description

Adds `extra_headers` to the OpenAI LLM config and forwards those headers on chat completion requests. This supports OpenAI-compatible observability and proxy services that require per-request headers without applying those headers to embeddings.

For OpenRouter, configured custom headers are merged with the existing `HTTP-Referer` and `X-Title` metadata headers when those fields are set.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Ran:

```bash
env -u OPENROUTER_API_KEY .venv/bin/python -m pytest tests/llms/test_openai.py -q
.venv/bin/ruff check mem0/configs/llms/openai.py mem0/llms/openai.py tests/llms/test_openai.py
.venv/bin/python scripts/check-llms-txt-coverage.py
git diff --check
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
