### PR TITLE
feat: add FuturMix as LLM provider

### DIFF
--- a/mem0/llms/configs.py
+++ b/mem0/llms/configs.py
@@ -26,6 +26,7 @@ class LlmConfig(BaseModel):
             "minimax",
             "xai",
             "sarvam",
+            "futurmix",
             "lmstudio",
             "vllm",
             "langchain",

--- a/mem0/llms/futurmix.py
+++ b/mem0/llms/futurmix.py
@@ -1,0 +1,52 @@
+import os
+from typing import Dict, List, Optional
+
+from openai import OpenAI
+
+from mem0.configs.llms.base import BaseLlmConfig
+from mem0.llms.base import LLMBase
+
+
+class FuturMixLLM(LLMBase):
+    def __init__(self, config: Optional[BaseLlmConfig] = None):
+        super().__init__(config)
+
+        if not self.config.model:
+            self.config.model = "gpt-4o"
+
+        api_key = self.config.api_key or os.getenv("FUTURMIX_API_KEY")
+        base_url = os.getenv("FUTURMIX_API_BASE") or "https://futurmix.ai/v1"
+        self.client = OpenAI(api_key=api_key, base_url=base_url)
+
+    def generate_response(
+        self,
+        messages: List[Dict[str, str]],
+        response_format=None,
+        tools: Optional[List[Dict]] = None,
+        tool_choice: str = "auto",
+    ):
+        """
+        Generate a response based on the given messages using FuturMix.
+
+        Args:
+            messages (list): List of message dicts containing 'role' and 'content'.
+            response_format (str or object, optional): Format of the response. Defaults to "text".
+            tools (list, optional): List of tools that the model can call. Defaults to None.
+            tool_choice (str, optional): Tool choice method. Defaults to "auto".
+
+        Returns:
+            str: The generated response.
+        """
+        params = {
+            "model": self.config.model,
+            "messages": messages,
+            "temperature": self.config.temperature,
+            "max_tokens": self.config.max_tokens,
+            "top_p": self.config.top_p,
+        }
+
+        if response_format:
+            params["response_format"] = response_format
+
+        response = self.client.chat.completions.create(**params)
+        return response.choices[0].message.content

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -50,6 +50,7 @@ class LlmFactory:
         "minimax": ("mem0.llms.minimax.MiniMaxLLM", MinimaxConfig),
         "xai": ("mem0.llms.xai.XAILLM", BaseLlmConfig),
         "sarvam": ("mem0.llms.sarvam.SarvamLLM", BaseLlmConfig),
+        "futurmix": ("mem0.llms.futurmix.FuturMixLLM", BaseLlmConfig),
         "lmstudio": ("mem0.llms.lmstudio.LMStudioLLM", LMStudioConfig),
         "vllm": ("mem0.llms.vllm.VllmLLM", VllmConfig),
         "langchain": ("mem0.llms.langchain.LangchainLLM", BaseLlmConfig),

--- a/tests/llms/test_futurmix.py
+++ b/tests/llms/test_futurmix.py
@@ -1,0 +1,34 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mem0.configs.llms.base import BaseLlmConfig
+from mem0.llms.futurmix import FuturMixLLM
+
+
+@pytest.fixture
+def mock_futurmix_client():
+    with patch("mem0.llms.futurmix.OpenAI") as mock_openai:
+        mock_client = Mock()
+        mock_openai.return_value = mock_client
+        yield mock_client
+
+
+def test_generate_response_without_tools(mock_futurmix_client):
+    config = BaseLlmConfig(model="gpt-4o", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = FuturMixLLM(config)
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello, how are you?"},
+    ]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="I'm doing well, thank you for asking!"))]
+    mock_futurmix_client.chat.completions.create.return_value = mock_response
+
+    response = llm.generate_response(messages)
+
+    mock_futurmix_client.chat.completions.create.assert_called_once_with(
+        model="gpt-4o", messages=messages, temperature=0.7, max_tokens=100, top_p=1.0
+    )
+    assert response == "I'm doing well, thank you for asking!"


### PR DESCRIPTION
## Summary

Adds [FuturMix.ai](https://futurmix.ai) as a new LLM provider for Mem0. FuturMix is a enterprise AI agent platform providing OpenAI-compatible access to 22+ models (Claude, GPT, Gemini) .

## Changes

- Added `FuturMixLLM` class in `mem0/llms/futurmix.py` (follows existing xAI/Sarvam pattern)
- Registered provider in `mem0/llms/configs.py` and `mem0/utils/factory.py`
- Added unit tests in `tests/llms/test_futurmix.py`

## Usage

```python
from mem0 import Memory

m = Memory.from_config({
    "llm": {
        "provider": "futurmix",
        "config": {
            "model": "gpt-4o",
            "api_key": "your-futurmix-key"
        }
    }
})
```

Environment variable: `FUTURMIX_API_KEY`