### PR TITLE
fix(memory): exclude score from get() to match get_all()/search() shape

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1001,7 +1001,7 @@ class Memory(MemoryBase):
             hash=memory.payload.get("hash"),
             created_at=memory.payload.get("created_at"),
             updated_at=memory.payload.get("updated_at"),
-        ).model_dump()
+        ).model_dump(exclude={"score"})
 
         for key in promoted_payload_keys:
             if key in memory.payload:
@@ -2416,7 +2416,7 @@ class AsyncMemory(MemoryBase):
             hash=memory.payload.get("hash"),
             created_at=memory.payload.get("created_at"),
             updated_at=memory.payload.get("updated_at"),
-        ).model_dump()
+        ).model_dump(exclude={"score"})
 
         for key in promoted_payload_keys:
             if key in memory.payload:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -90,6 +90,85 @@ def test_get(memory_instance):
     assert result["metadata"] == {"extra_field": "extra_value"}
 
 
+def test_get_shape_matches_get_all(memory_instance):
+    """`Memory.get(id)` and `Memory.get_all()[i]` should return the same key set
+    for the same underlying record. Today `get()` leaks a `score: None` field
+    that `get_all()` strips via `model_dump(exclude={"score"})`, so a caller that
+    iterates either result with the same code path sees a different shape.
+    """
+    payload = {
+        "data": "Test memory",
+        "user_id": "test_user",
+        "hash": "test_hash",
+        "created_at": "2023-01-01T00:00:00",
+        "updated_at": "2023-01-02T00:00:00",
+        "extra_field": "extra_value",
+    }
+    mock_memory = Mock(id="test_id", payload=payload)
+
+    memory_instance.vector_store.get = Mock(return_value=mock_memory)
+    memory_instance.vector_store.list = Mock(return_value=([mock_memory], None))
+
+    got = memory_instance.get("test_id")
+    got_all_item = memory_instance.get_all(filters={"user_id": "test_user"})["results"][0]
+
+    # Same record should produce the same key set across the two read APIs.
+    assert set(got.keys()) == set(got_all_item.keys()), (
+        f"get() vs get_all() shape mismatch: "
+        f"only-in-get={set(got) - set(got_all_item)}, "
+        f"only-in-get_all={set(got_all_item) - set(got)}"
+    )
+
+    # Specifically, the search-only `score` field must not leak into get().
+    assert "score" not in got, "Memory.get() must not include a score field"
+
+
+@pytest.mark.asyncio
+async def test_async_get_shape_matches_async_get_all():
+    """Async parity with `test_get_shape_matches_get_all` — `AsyncMemory.get(id)`
+    must not leak a `score` field that `AsyncMemory.get_all()` would have excluded.
+    """
+    from mem0.memory.main import AsyncMemory
+
+    with (
+        patch("mem0.utils.factory.EmbedderFactory") as mock_embedder,
+        patch("mem0.memory.main.VectorStoreFactory") as mock_vector_store,
+        patch("mem0.utils.factory.LlmFactory") as mock_llm,
+        patch("mem0.memory.telemetry.capture_event"),
+    ):
+        mock_embedder.create.return_value = Mock()
+        mock_vector_store.create.return_value = Mock()
+        mock_vector_store.create.return_value.search.return_value = []
+        mock_llm.create.return_value = Mock()
+
+        config = MemoryConfig(version="v1.1")
+        amem = AsyncMemory(config)
+
+    payload = {
+        "data": "Test memory",
+        "user_id": "test_user",
+        "hash": "test_hash",
+        "created_at": "2023-01-01T00:00:00",
+        "updated_at": "2023-01-02T00:00:00",
+        "extra_field": "extra_value",
+    }
+    mock_memory = Mock(id="test_id", payload=payload)
+
+    amem.vector_store.get = Mock(return_value=mock_memory)
+    amem.vector_store.list = Mock(return_value=([mock_memory], None))
+
+    got = await amem.get("test_id")
+    got_all = await amem.get_all(filters={"user_id": "test_user"})
+    got_all_item = got_all["results"][0]
+
+    assert set(got.keys()) == set(got_all_item.keys()), (
+        f"async get() vs get_all() shape mismatch: "
+        f"only-in-get={set(got) - set(got_all_item)}, "
+        f"only-in-get_all={set(got_all_item) - set(got)}"
+    )
+    assert "score" not in got, "AsyncMemory.get() must not include a score field"
+
+
 def test_search(memory_instance):
     mock_memories = [
         Mock(id="1", payload={"data": "Memory 1", "user_id": "test_user"}, score=0.9),


### PR DESCRIPTION
## Summary

`Memory.get()` / `AsyncMemory.get()` returned records with `score: null`, while `get_all()` and `search()` (which both build via the get_all path) explicitly call `model_dump(exclude={"score"})`. Same record, different keys — broke any consumer that shared a single dict-shape contract between point reads and listings.

## Fix

`mem0/memory/main.py`:
- `Memory.get()` (sync, line 1004): add `exclude={"score"}` to `model_dump()`.
- `AsyncMemory.get()` (async, line 2419): same.

2 LOC of production change.

## Test

`tests/test_main.py`:
- `test_get_shape_matches_get_all` (sync)
- `test_async_get_shape_matches_async_get_all` (async)

Both build the same mocked record, call `get()` + `get_all()`, assert key sets match and `"score" not in got`.

`pytest` 414 passed / 19 skipped (network-dependent). `ruff` clean.

## Risk notes
- Callers that previously read `.get("score")` from `Memory.get()` output will see the key absent (it was always `None` anyway). The intended convergence with `get_all()` / `search()` shape — `score` is a search-time field.