### PR TITLE
feat: add FuturMix as LLM provider

### DIFF
--- a/mem0/configs/llms/futurmix.py
+++ b/mem0/configs/llms/futurmix.py
@@ -1,0 +1,56 @@
+from typing import Optional
+
+from mem0.configs.llms.base import BaseLlmConfig
+
+
+class FuturMixConfig(BaseLlmConfig):
+    """
+    Configuration class for FuturMix-specific parameters.
+    Inherits from BaseLlmConfig and adds FuturMix-specific settings.
+    """
+
+    def __init__(
+        self,
+        # Base parameters
+        model: Optional[str] = None,
+        temperature: float = 0.1,
+        api_key: Optional[str] = None,
+        max_tokens: int = 2000,
+        top_p: float = 0.1,
+        top_k: int = 1,
+        enable_vision: bool = False,
+        vision_details: Optional[str] = "auto",
+        http_client_proxies: Optional[dict] = None,
+        # FuturMix-specific parameters
+        futurmix_base_url: Optional[str] = None,
+    ):
+        """
+        Initialize FuturMix configuration.
+
+        Args:
+            model: Model to use via FuturMix gateway, defaults to None
+            temperature: Controls randomness, defaults to 0.1
+            api_key: FuturMix API key, defaults to None
+            max_tokens: Maximum tokens to generate, defaults to 2000
+            top_p: Nucleus sampling parameter, defaults to 0.1
+            top_k: Top-k sampling parameter, defaults to 1
+            enable_vision: Enable vision capabilities, defaults to False
+            vision_details: Vision detail level, defaults to "auto"
+            http_client_proxies: HTTP client proxy settings, defaults to None
+            futurmix_base_url: FuturMix API base URL, defaults to None
+        """
+        # Initialize base parameters
+        super().__init__(
+            model=model,
+            temperature=temperature,
+            api_key=api_key,
+            max_tokens=max_tokens,
+            top_p=top_p,
+            top_k=top_k,
+            enable_vision=enable_vision,
+            vision_details=vision_details,
+            http_client_proxies=http_client_proxies,
+        )
+
+        # FuturMix-specific parameters
+        self.futurmix_base_url = futurmix_base_url

--- a/mem0/llms/configs.py
+++ b/mem0/llms/configs.py
@@ -26,6 +26,7 @@ class LlmConfig(BaseModel):
             "minimax",
             "xai",
             "sarvam",
+            "futurmix",
             "lmstudio",
             "vllm",
             "langchain",

--- a/mem0/llms/futurmix.py
+++ b/mem0/llms/futurmix.py
@@ -1,22 +1,74 @@
+import json
 import os
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 from openai import OpenAI
 
 from mem0.configs.llms.base import BaseLlmConfig
+from mem0.configs.llms.futurmix import FuturMixConfig
 from mem0.llms.base import LLMBase
+from mem0.memory.utils import extract_json
 
 
 class FuturMixLLM(LLMBase):
-    def __init__(self, config: Optional[BaseLlmConfig] = None):
+    def __init__(self, config: Optional[Union[BaseLlmConfig, FuturMixConfig, Dict]] = None):
+        # Convert to FuturMixConfig if needed
+        if config is None:
+            config = FuturMixConfig()
+        elif isinstance(config, dict):
+            config = FuturMixConfig(**config)
+        elif isinstance(config, BaseLlmConfig) and not isinstance(config, FuturMixConfig):
+            # Convert BaseLlmConfig to FuturMixConfig
+            config = FuturMixConfig(
+                model=config.model,
+                temperature=config.temperature,
+                api_key=config.api_key,
+                max_tokens=config.max_tokens,
+                top_p=config.top_p,
+                top_k=config.top_k,
+                enable_vision=config.enable_vision,
+                vision_details=config.vision_details,
+                http_client_proxies=config.http_client,
+            )
+
         super().__init__(config)
 
         if not self.config.model:
             self.config.model = "gpt-4o"
 
         api_key = self.config.api_key or os.getenv("FUTURMIX_API_KEY")
-        base_url = os.getenv("FUTURMIX_API_BASE") or "https://futurmix.ai/v1"
+        base_url = self.config.futurmix_base_url or os.getenv("FUTURMIX_API_BASE") or "https://futurmix.ai/v1"
         self.client = OpenAI(api_key=api_key, base_url=base_url)
+
+    def _parse_response(self, response, tools):
+        """
+        Process the response based on whether tools are used or not.
+
+        Args:
+            response: The raw response from API.
+            tools: The list of tools provided in the request.
+
+        Returns:
+            str or dict: The processed response.
+        """
+        if tools:
+            processed_response = {
+                "content": response.choices[0].message.content,
+                "tool_calls": [],
+            }
+
+            if response.choices[0].message.tool_calls:
+                for tool_call in response.choices[0].message.tool_calls:
+                    processed_response["tool_calls"].append(
+                        {
+                            "name": tool_call.function.name,
+                            "arguments": json.loads(extract_json(tool_call.function.arguments)),
+                        }
+                    )
+
+            return processed_response
+        else:
+            return response.choices[0].message.content
 
     def generate_response(
         self,
@@ -47,6 +99,9 @@ class FuturMixLLM(LLMBase):
 
         if response_format:
             params["response_format"] = response_format
+        if tools:
+            params["tools"] = tools
+            params["tool_choice"] = tool_choice
 
         response = self.client.chat.completions.create(**params)
-        return response.choices[0].message.content
+        return self._parse_response(response, tools)

--- a/mem0/llms/futurmix.py
+++ b/mem0/llms/futurmix.py
@@ -1,0 +1,52 @@
+import os
+from typing import Dict, List, Optional
+
+from openai import OpenAI
+
+from mem0.configs.llms.base import BaseLlmConfig
+from mem0.llms.base import LLMBase
+
+
+class FuturMixLLM(LLMBase):
+    def __init__(self, config: Optional[BaseLlmConfig] = None):
+        super().__init__(config)
+
+        if not self.config.model:
+            self.config.model = "gpt-4o"
+
+        api_key = self.config.api_key or os.getenv("FUTURMIX_API_KEY")
+        base_url = os.getenv("FUTURMIX_API_BASE") or "https://futurmix.ai/v1"
+        self.client = OpenAI(api_key=api_key, base_url=base_url)
+
+    def generate_response(
+        self,
+        messages: List[Dict[str, str]],
+        response_format=None,
+        tools: Optional[List[Dict]] = None,
+        tool_choice: str = "auto",
+    ):
+        """
+        Generate a response based on the given messages using FuturMix.
+
+        Args:
+            messages (list): List of message dicts containing 'role' and 'content'.
+            response_format (str or object, optional): Format of the response. Defaults to "text".
+            tools (list, optional): List of tools that the model can call. Defaults to None.
+            tool_choice (str, optional): Tool choice method. Defaults to "auto".
+
+        Returns:
+            str: The generated response.
+        """
+        params = {
+            "model": self.config.model,
+            "messages": messages,
+            "temperature": self.config.temperature,
+            "max_tokens": self.config.max_tokens,
+            "top_p": self.config.top_p,
+        }
+
+        if response_format:
+            params["response_format"] = response_format
+
+        response = self.client.chat.completions.create(**params)
+        return response.choices[0].message.content

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -7,6 +7,7 @@ from mem0.configs.llms.aws_bedrock import AWSBedrockConfig
 from mem0.configs.llms.azure import AzureOpenAIConfig
 from mem0.configs.llms.base import BaseLlmConfig
 from mem0.configs.llms.deepseek import DeepSeekConfig
+from mem0.configs.llms.futurmix import FuturMixConfig
 from mem0.configs.llms.minimax import MinimaxConfig
 from mem0.configs.llms.lmstudio import LMStudioConfig
 from mem0.configs.llms.ollama import OllamaConfig
@@ -50,7 +51,7 @@ class LlmFactory:
         "minimax": ("mem0.llms.minimax.MiniMaxLLM", MinimaxConfig),
         "xai": ("mem0.llms.xai.XAILLM", BaseLlmConfig),
         "sarvam": ("mem0.llms.sarvam.SarvamLLM", BaseLlmConfig),
-        "futurmix": ("mem0.llms.futurmix.FuturMixLLM", BaseLlmConfig),
+        "futurmix": ("mem0.llms.futurmix.FuturMixLLM", FuturMixConfig),
         "lmstudio": ("mem0.llms.lmstudio.LMStudioLLM", LMStudioConfig),
         "vllm": ("mem0.llms.vllm.VllmLLM", VllmConfig),
         "langchain": ("mem0.llms.langchain.LangchainLLM", BaseLlmConfig),

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -50,6 +50,7 @@ class LlmFactory:
         "minimax": ("mem0.llms.minimax.MiniMaxLLM", MinimaxConfig),
         "xai": ("mem0.llms.xai.XAILLM", BaseLlmConfig),
         "sarvam": ("mem0.llms.sarvam.SarvamLLM", BaseLlmConfig),
+        "futurmix": ("mem0.llms.futurmix.FuturMixLLM", BaseLlmConfig),
         "lmstudio": ("mem0.llms.lmstudio.LMStudioLLM", LMStudioConfig),
         "vllm": ("mem0.llms.vllm.VllmLLM", VllmConfig),
         "langchain": ("mem0.llms.langchain.LangchainLLM", BaseLlmConfig),

--- a/tests/llms/test_futurmix.py
+++ b/tests/llms/test_futurmix.py
@@ -1,8 +1,10 @@
+import json
 from unittest.mock import Mock, patch
 
 import pytest
 
 from mem0.configs.llms.base import BaseLlmConfig
+from mem0.configs.llms.futurmix import FuturMixConfig
 from mem0.llms.futurmix import FuturMixLLM
 
 
@@ -32,3 +34,68 @@ def test_generate_response_without_tools(mock_futurmix_client):
         model="gpt-4o", messages=messages, temperature=0.7, max_tokens=100, top_p=1.0
     )
     assert response == "I'm doing well, thank you for asking!"
+
+
+def test_generate_response_with_tools(mock_futurmix_client):
+    config = BaseLlmConfig(model="gpt-4o", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = FuturMixLLM(config)
+    messages = [
+        {"role": "user", "content": "What's the weather in SF?"},
+    ]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get the weather for a location",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"location": {"type": "string"}},
+                    "required": ["location"],
+                },
+            },
+        }
+    ]
+
+    mock_tool_call = Mock()
+    mock_tool_call.function.name = "get_weather"
+    mock_tool_call.function.arguments = json.dumps({"location": "San Francisco"})
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content=None, tool_calls=[mock_tool_call]))]
+    mock_futurmix_client.chat.completions.create.return_value = mock_response
+
+    response = llm.generate_response(messages, tools=tools, tool_choice="auto")
+
+    mock_futurmix_client.chat.completions.create.assert_called_once_with(
+        model="gpt-4o", messages=messages, temperature=0.7, max_tokens=100, top_p=1.0, tools=tools, tool_choice="auto"
+    )
+    assert response["tool_calls"][0]["name"] == "get_weather"
+    assert response["tool_calls"][0]["arguments"] == {"location": "San Francisco"}
+
+
+def test_custom_base_url_via_config():
+    with patch("mem0.llms.futurmix.OpenAI") as mock_openai:
+        mock_openai.return_value = Mock()
+        config = FuturMixConfig(model="gpt-4o", api_key="test-key", futurmix_base_url="https://custom.example.com/v1")
+        llm = FuturMixLLM(config)
+
+        mock_openai.assert_called_once_with(api_key="test-key", base_url="https://custom.example.com/v1")
+
+
+def test_default_base_url():
+    with patch("mem0.llms.futurmix.OpenAI") as mock_openai:
+        mock_openai.return_value = Mock()
+        config = FuturMixConfig(model="gpt-4o", api_key="test-key")
+        llm = FuturMixLLM(config)
+
+        mock_openai.assert_called_once_with(api_key="test-key", base_url="https://futurmix.ai/v1")
+
+
+def test_default_model():
+    with patch("mem0.llms.futurmix.OpenAI") as mock_openai:
+        mock_openai.return_value = Mock()
+        config = FuturMixConfig(api_key="test-key")
+        llm = FuturMixLLM(config)
+
+        assert llm.config.model == "gpt-4o"

--- a/tests/llms/test_futurmix.py
+++ b/tests/llms/test_futurmix.py
@@ -1,0 +1,34 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mem0.configs.llms.base import BaseLlmConfig
+from mem0.llms.futurmix import FuturMixLLM
+
+
+@pytest.fixture
+def mock_futurmix_client():
+    with patch("mem0.llms.futurmix.OpenAI") as mock_openai:
+        mock_client = Mock()
+        mock_openai.return_value = mock_client
+        yield mock_client
+
+
+def test_generate_response_without_tools(mock_futurmix_client):
+    config = BaseLlmConfig(model="gpt-4o", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = FuturMixLLM(config)
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello, how are you?"},
+    ]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="I'm doing well, thank you for asking!"))]
+    mock_futurmix_client.chat.completions.create.return_value = mock_response
+
+    response = llm.generate_response(messages)
+
+    mock_futurmix_client.chat.completions.create.assert_called_once_with(
+        model="gpt-4o", messages=messages, temperature=0.7, max_tokens=100, top_p=1.0
+    )
+    assert response == "I'm doing well, thank you for asking!"


### PR DESCRIPTION
## Linked Issue

N/A — new feature contribution.

## Description

Adds FuturMix (https://futurmix.ai) as a new LLM provider for mem0. FuturMix is an enterprise AI platform supporting 22+ models with a 

**This PR supersedes #4973** (same changes, pushed from a fork with write access). Addresses all code review feedback from @xkonjin:

1. **`base_url` config support** — Added `FuturMixConfig` with `futurmix_base_url` field so users can override the base URL programmatically (not just via env var). Follows the DeepSeek provider pattern.
2. **`tools`/`tool_choice` forwarding** — `generate_response` now passes `tools` and `tool_choice` to the OpenAI client call, with `_parse_response` for proper tool call handling. Follows the Together/DeepSeek pattern.
3. **Async variant** — Noted for follow-up PR.
4. **Test coverage** — Added tests for tools path, custom base_url, default base_url, and default model fallback.

### Changes

| File | Change |
|------|--------|
| `mem0/configs/llms/futurmix.py` | **New** — `FuturMixConfig` with `futurmix_base_url` parameter |
| `mem0/llms/futurmix.py` | Add config conversion, `base_url` from config, `tools`/`tool_choice` forwarding, `_parse_response` |
| `mem0/utils/factory.py` | Register `FuturMixConfig` (was `BaseLlmConfig`) |
| `tests/llms/test_futurmix.py` | Add tests for tools, custom base_url, default URL, default model |

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [x] I tested manually (syntax validation via `ast.parse`)
- [ ] No tests needed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed