### PR TITLE
fix: support GPT-5 completion token parameter

### DIFF
--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -43,16 +43,22 @@ class LLMBase(ABC):
     def _is_reasoning_model(self, model: str) -> bool:
         """
         Check if the model is a reasoning model or GPT-5 series that doesn't support certain parameters.
-        
+
         Args:
             model: The model name to check
-            
+
         Returns:
             bool: True if the model is a reasoning model or GPT-5 series
         """
         reasoning_models = {
-            "o1", "o1-preview", "o3-mini", "o3",
-            "gpt-5", "gpt-5o", "gpt-5o-mini", "gpt-5o-micro",
+            "o1",
+            "o1-preview",
+            "o3-mini",
+            "o3",
+            "gpt-5",
+            "gpt-5o",
+            "gpt-5o-mini",
+            "gpt-5o-micro",
         }
 
         model_lower = model.lower()
@@ -62,9 +68,8 @@ class LLMBase(ABC):
         if base_model in reasoning_models:
             return True
 
-        # Match o1/o3 family with prefixes (o1-2024-12-17, o3-2025-04-16)
-        # but NOT gpt-5.x variants (gpt-5.4-mini supports temperature)
-        if any(base_model.startswith(prefix) for prefix in ["o1-", "o1.", "o3-", "o3."]):
+        # Match o-series/GPT-5 snapshots and aliases without catching gpt-5.x variants.
+        if any(base_model.startswith(prefix) for prefix in ["o1-", "o1.", "o3-", "o3.", "gpt-5-"]):
             return True
 
         return False
@@ -73,18 +78,18 @@ class LLMBase(ABC):
         """
         Get parameters that are supported by the current model.
         Filters out unsupported parameters for reasoning models and GPT-5 series.
-        
+
         Args:
             **kwargs: Additional parameters to include
-            
+
         Returns:
             Dict: Filtered parameters dictionary
         """
-        model = getattr(self.config, 'model', '')
-        
+        model = getattr(self.config, "model", "")
+
         if self._is_reasoning_model(model):
             supported_params = {}
-            
+
             if "messages" in kwargs:
                 supported_params["messages"] = kwargs["messages"]
             if "response_format" in kwargs:
@@ -94,8 +99,11 @@ class LLMBase(ABC):
             if "tool_choice" in kwargs:
                 supported_params["tool_choice"] = kwargs["tool_choice"]
 
-            # Add reasoning_effort if configured
-            reasoning_effort = getattr(self.config, 'reasoning_effort', None)
+            max_tokens = getattr(self.config, "max_tokens", None)
+            if max_tokens is not None:
+                supported_params["max_completion_tokens"] = max_tokens
+
+            reasoning_effort = getattr(self.config, "reasoning_effort", None)
             if reasoning_effort:
                 supported_params["reasoning_effort"] = reasoning_effort
 

--- a/tests/llms/test_azure_openai.py
+++ b/tests/llms/test_azure_openai.py
@@ -137,7 +137,7 @@ def test_generate_response_without_response_format(mock_openai_client):
 
 def test_reasoning_model_with_reasoning_effort(mock_openai_client):
     """Test that reasoning_effort is passed to the API for Azure reasoning models."""
-    config = AzureOpenAIConfig(model="o3-mini", reasoning_effort="low")
+    config = AzureOpenAIConfig(model="o3-mini", max_tokens=MAX_TOKENS, reasoning_effort="low")
     llm = AzureOpenAILLM(config)
     messages = [
         {"role": "system", "content": "You are a helpful ai."},
@@ -152,8 +152,33 @@ def test_reasoning_model_with_reasoning_effort(mock_openai_client):
 
     call_kwargs = mock_openai_client.chat.completions.create.call_args
     assert call_kwargs[1]["reasoning_effort"] == "low"
+    assert call_kwargs[1]["max_completion_tokens"] == MAX_TOKENS
+    assert "max_tokens" not in call_kwargs[1]
     assert "temperature" not in call_kwargs[1]
     assert response == "Response from o3-mini"
+
+
+def test_azure_gpt5_mini_uses_max_completion_tokens(mock_openai_client):
+    """Test that Azure gpt-5-mini translates max_tokens for Chat Completions."""
+    config = AzureOpenAIConfig(model="gpt-5-mini", max_tokens=MAX_TOKENS)
+    llm = AzureOpenAILLM(config)
+    messages = [
+        {"role": "system", "content": "You are a helpful ai."},
+        {"role": "user", "content": "Hello"},
+    ]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Response from gpt-5-mini"))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    response = llm.generate_response(messages)
+
+    call_kwargs = mock_openai_client.chat.completions.create.call_args.kwargs
+    assert call_kwargs["max_completion_tokens"] == MAX_TOKENS
+    assert "max_tokens" not in call_kwargs
+    assert "reasoning_effort" not in call_kwargs
+    assert "temperature" not in call_kwargs
+    assert response == "Response from gpt-5-mini"
 
 
 def test_azure_reasoning_effort_not_passed_when_none(mock_openai_client):

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -172,7 +172,7 @@ def test_callback_exception_handling(mock_openai_client):
 
 def test_reasoning_model_with_reasoning_effort(mock_openai_client):
     """Test that reasoning_effort is passed to the API for reasoning models."""
-    config = OpenAIConfig(model="o3-mini", reasoning_effort="low")
+    config = OpenAIConfig(model="o3-mini", max_tokens=100, reasoning_effort="low")
     llm = OpenAILLM(config)
     messages = [{"role": "user", "content": "Hello"}]
 
@@ -184,8 +184,30 @@ def test_reasoning_model_with_reasoning_effort(mock_openai_client):
 
     call_kwargs = mock_openai_client.chat.completions.create.call_args
     assert call_kwargs[1]["reasoning_effort"] == "low"
+    assert call_kwargs[1]["max_completion_tokens"] == 100
+    assert "max_tokens" not in call_kwargs[1]
     assert "temperature" not in call_kwargs[1]  # reasoning models don't get temperature
     assert response == "Response from o3-mini"
+
+
+def test_gpt5_mini_uses_max_completion_tokens(mock_openai_client):
+    """Test that gpt-5-mini translates max_tokens for Chat Completions."""
+    config = OpenAIConfig(model="gpt-5-mini", max_tokens=100)
+    llm = OpenAILLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Response from gpt-5-mini"))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    response = llm.generate_response(messages)
+
+    call_kwargs = mock_openai_client.chat.completions.create.call_args.kwargs
+    assert call_kwargs["max_completion_tokens"] == 100
+    assert "max_tokens" not in call_kwargs
+    assert "reasoning_effort" not in call_kwargs
+    assert "temperature" not in call_kwargs
+    assert response == "Response from gpt-5-mini"
 
 
 def test_reasoning_model_without_reasoning_effort(mock_openai_client):
@@ -317,6 +339,10 @@ def test_is_reasoning_model_classification(mock_openai_client):
     assert llm._is_reasoning_model("o3-mini") is True
     assert llm._is_reasoning_model("o3") is True
     assert llm._is_reasoning_model("gpt-5") is True
+    assert llm._is_reasoning_model("gpt-5-mini") is True
+    assert llm._is_reasoning_model("gpt-5-nano") is True
+    assert llm._is_reasoning_model("gpt-5-pro") is True
+    assert llm._is_reasoning_model("gpt-5-2025-08-07") is True
     assert llm._is_reasoning_model("o1-preview") is True
     assert llm._is_reasoning_model("o1-2024-12-17") is True
     assert llm._is_reasoning_model("openai/o3-mini") is True


### PR DESCRIPTION
## Description

Fixes incorrect max token parameter when using ChatGPT 5 via the OpenAI Python SDK.

Previously, requests were using an outdated/incorrect parameter and not passing the correct max token field expected by gpt-5* APIs, which leads to ignored limits. This change ensures the request uses the correct parameter for ChatGPT 5 so response length behaves as intended.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Manually verified by using mem 0 AI. Did not see the same error in my docker logs as I did earlier. 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed