### PR TITLE
fix(openclaw): remove deprecated providerAuthEnvVars from plugin manifest

### DIFF
--- a/openclaw/openclaw.plugin.json
+++ b/openclaw/openclaw.plugin.json
@@ -17,10 +17,6 @@
       "memory_update", "memory_delete", "memory_event_list", "memory_event_status"
     ]
   },
-  "providerAuthEnvVars": {
-    "mem0": ["MEM0_API_KEY"],
-    "openclaw-mem0-oss": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"]
-  },
   "providerAuthChoices": [
     {
       "provider": "mem0",


### PR DESCRIPTION
Fixes #4981

## Problem

The `openclaw.plugin.json` manifest still contains the legacy `providerAuthEnvVars` field, which OpenClaw has deprecated. This causes a deprecation warning at gateway startup:

```
Config warnings
- plugins.entries.openclaw-mem0: plugin openclaw-mem0:
  providerAuthEnvVars is deprecated compatibility metadata for
  provider env-var lookup; mirror mem0, openclaw-mem0-oss env vars
  to setup.providers[].envVars before the deprecation window closes
```

## Solution

Remove the `providerAuthEnvVars` block from `openclaw.plugin.json`. The provider env-var information is already expressed through:

- `providerAuthChoices` — API key method declarations for each provider
- `configSchema` property descriptions — document which env vars each mode needs

This eliminates the deprecation warning without any loss of functionality.

## Testing

- Verified the JSON is valid after the change
- The `providerAuthChoices` entries still correctly declare `api-key` auth methods for both `mem0` and `openclaw-mem0-oss` providers

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test Coverage

- [x] No tests needed (JSON manifest change only, no code logic)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally