### PR TITLE
fix(openclaw): move provider env vars into setup metadata

### DIFF
--- a/openclaw/openclaw.plugin.json
+++ b/openclaw/openclaw.plugin.json
@@ -17,9 +17,18 @@
       "memory_update", "memory_delete", "memory_event_list", "memory_event_status"
     ]
   },
-  "providerAuthEnvVars": {
-    "mem0": ["MEM0_API_KEY"],
-    "openclaw-mem0-oss": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"]
+  "setup": {
+    "providers": [
+      {
+        "id": "mem0",
+        "authMethods": ["api-key"],
+        "envVars": ["MEM0_API_KEY"]
+      },
+      {
+        "id": "openclaw-mem0-oss",
+        "envVars": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"]
+      }
+    ]
   },
   "providerAuthChoices": [
     {


### PR DESCRIPTION
## Summary
- replace deprecated `providerAuthEnvVars` in the OpenClaw mem0 manifest
- declare provider env vars under `setup.providers` for both platform and OSS providers
- keep existing auth choice metadata intact

## Testing
- reloaded the installed OpenClaw mem0 plugin locally and verified doctor no longer warns about deprecated provider env var metadata
