### PR TITLE
docs(mcp): document list_events and get_event_status tools

### DIFF
--- a/docs/platform/features/mcp-integration.mdx
+++ b/docs/platform/features/mcp-integration.mdx
@@ -53,7 +53,7 @@ For detailed per-client instructions, see the [Mem0 MCP Quickstart](/platform/me
 
 ## Available tools
 
-The MCP server exposes 9 memory tools to your AI client:
+The MCP server exposes 11 memory tools to your AI client:
 
 | Tool | Purpose |
 |------|---------|
@@ -66,6 +66,8 @@ The MCP server exposes 9 memory tools to your AI client:
 | `delete_entities` | Remove user/agent/app entities |
 | `get_memory` | Retrieve single memory by ID |
 | `list_entities` | View stored entities |
+| `list_events` | List memory operation events with filters and pagination |
+| `get_event_status` | Check the status of an async memory operation by `event_id` |
 
 ## How it works
 

--- a/docs/platform/mem0-mcp.mdx
+++ b/docs/platform/mem0-mcp.mdx
@@ -46,6 +46,8 @@ The MCP server exposes these memory tools to your AI client:
 | `delete_all_memories` | Bulk delete all memories in scope |
 | `delete_entities` | Delete a user/agent/app/run entity and its memories |
 | `list_entities` | Enumerate users/agents/apps/runs stored in Mem0 |
+| `list_events` | List memory operation events with filters and pagination |
+| `get_event_status` | Check the status of an async memory operation by `event_id` |
 
 ---
 


### PR DESCRIPTION
## Linked Issue

N/A — small docs gap noticed while reviewing the MCP server.

## Description

The MCP server in `platform/mcp-server` registers **11 tools**, but the public docs only enumerate **9**. The two missing tools are:

- `list_events` — list memory operation events with filters/pagination
- `get_event_status` — check the status of an async memory operation by `event_id`

This matters because `add_memory` is async and returns an `event_id` (its tool description even says "Returns an event_id for async polling via get_event_status") — but there was no public-facing reference for the polling tool, so MCP clients had no documented way to wait for completion.

### Changes

- `docs/platform/mem0-mcp.mdx` — added rows for `list_events` and `get_event_status` to the Available Tools table.
- `docs/platform/features/mcp-integration.mdx` — added the same two rows and updated the line "9 memory tools" → "11 memory tools".

Both pages are already indexed in `docs/llms.txt`, so no llms.txt update is needed.

## Type of Change

- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] No tests needed (docs-only change)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed