### PR TITLE
fix(memory): prevent silent data loss on pgvector embedding dimension mismatch

### DIFF
--- a/mem0/configs/vector_stores/pgvector.py
+++ b/mem0/configs/vector_stores/pgvector.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 class PGVectorConfig(BaseModel):
     dbname: str = Field("postgres", description="Default name for the database")
     collection_name: str = Field("mem0", description="Default name for the collection")
-    embedding_model_dims: Optional[int] = Field(1536, description="Dimensions of the embedding model")
+    embedding_model_dims: Optional[int] = Field(None, description="Dimensions of the embedding model. When None, inferred from the configured embedder at Memory init time.")
     user: Optional[str] = Field(None, description="Database user")
     password: Optional[str] = Field(None, description="Database password")
     host: Optional[str] = Field(None, description="Database host. Default is localhost")

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -328,6 +328,37 @@ setup_config()
 logger = logging.getLogger(__name__)
 
 
+def _sync_pgvector_dims(config: "MemoryConfig") -> None:
+    """Align pgvector's embedding_model_dims with the configured embedder.
+
+    Rules (applied when provider == "pgvector"):
+    - If embedding_model_dims is None → infer it from the embedder's embedding_dims.
+    - If embedding_model_dims is explicitly set and differs from the embedder's
+      embedding_dims → raise ValueError so the mismatch is caught at construction
+      time rather than silently at write time.
+    - If embedding_dims cannot be determined from the embedder, do nothing (pgvector
+      itself will raise a clear error when it tries to create/use the table).
+    """
+    embed_dims = getattr(config.embedder.config, "embedding_dims", None)
+    if embed_dims is None:
+        return
+
+    vs_config = config.vector_store.config
+    configured_dims = getattr(vs_config, "embedding_model_dims", None)
+
+    if configured_dims is None:
+        vs_config.embedding_model_dims = embed_dims
+    elif configured_dims != embed_dims:
+        raise ValueError(
+            f"Embedding dimension mismatch: the configured embedder "
+            f"({config.embedder.provider}) produces {embed_dims}-dimensional vectors, "
+            f"but pgvector collection '{vs_config.collection_name}' is configured with "
+            f"embedding_model_dims={configured_dims}. "
+            f"Either remove the explicit embedding_model_dims setting to auto-infer from "
+            f"the embedder, or set it to {embed_dims} to match the current embedder."
+        )
+
+
 class Memory(MemoryBase):
     def __init__(self, config: MemoryConfig = MemoryConfig()):
         self.config = config
@@ -337,6 +368,10 @@ class Memory(MemoryBase):
             self.config.embedder.config,
             self.config.vector_store.config,
         )
+
+        if self.config.vector_store.provider == "pgvector":
+            _sync_pgvector_dims(self.config)
+
         self.vector_store = VectorStoreFactory.create(
             self.config.vector_store.provider, self.config.vector_store.config
         )
@@ -833,12 +868,21 @@ class Memory(MemoryBase):
                 payloads=all_payloads,
             )
         except Exception:
-            # Fallback: insert one by one
+            # Batch failed — retry individually so partial failures are surfaced
+            failures = []
             for mid, vec, pay in zip(all_ids, all_vectors, all_payloads):
                 try:
                     self.vector_store.insert(vectors=[vec], ids=[mid], payloads=[pay])
                 except Exception as e:
                     logger.error(f"Failed to insert memory {mid}: {e}")
+                    failures.append((mid, e))
+            if failures:
+                first_id, first_err = failures[0]
+                raise RuntimeError(
+                    f"{len(failures)} of {len(all_ids)} memor{'y' if len(failures) == 1 else 'ies'} "
+                    f"failed to persist to the vector store. "
+                    f"First failure (memory_id={first_id}): {first_err}"
+                ) from first_err
 
         # Batch history
         history_records = [
@@ -1801,6 +1845,10 @@ class AsyncMemory(MemoryBase):
             self.config.embedder.config,
             self.config.vector_store.config,
         )
+
+        if self.config.vector_store.provider == "pgvector":
+            _sync_pgvector_dims(self.config)
+
         self.vector_store = VectorStoreFactory.create(
             self.config.vector_store.provider, self.config.vector_store.config
         )
@@ -2248,11 +2296,21 @@ class AsyncMemory(MemoryBase):
                 payloads=all_payloads,
             )
         except Exception:
+            # Batch failed — retry individually so partial failures are surfaced
+            failures = []
             for mid, vec, pay in zip(all_ids, all_vectors, all_payloads):
                 try:
                     await asyncio.to_thread(self.vector_store.insert, vectors=[vec], ids=[mid], payloads=[pay])
                 except Exception as e:
                     logger.error(f"Failed to insert memory {mid} (async): {e}")
+                    failures.append((mid, e))
+            if failures:
+                first_id, first_err = failures[0]
+                raise RuntimeError(
+                    f"{len(failures)} of {len(all_ids)} memor{'y' if len(failures) == 1 else 'ies'} "
+                    f"failed to persist to the vector store. "
+                    f"First failure (memory_id={first_id}): {first_err}"
+                ) from first_err
 
         # Batch history
         history_records = [

--- a/mem0/vector_stores/pgvector.py
+++ b/mem0/vector_stores/pgvector.py
@@ -106,9 +106,18 @@ class PGVector(VectorStoreBase):
                 # psycopg2 ThreadedConnectionPool
                 self.connection_pool = ConnectionPool(minconn=minconn, maxconn=maxconn, dsn=connection_string)
 
+        if self.embedding_model_dims is None:
+            raise ValueError(
+                "PGVector requires 'embedding_model_dims' to be set. "
+                "Either pass it explicitly in the vector store config or configure an "
+                "embedder provider so that mem0 can infer the dimension automatically."
+            )
+
         collections = self.list_cols()
         if collection_name not in collections:
             self.create_col()
+        else:
+            self._validate_schema_dims()
 
     @contextmanager
     def _get_cursor(self, commit: bool = False):
@@ -143,6 +152,36 @@ class PGVector(VectorStoreBase):
             finally:
                 cur.close()
                 self.connection_pool.putconn(conn)
+
+    def _get_table_vector_dim(self) -> Optional[int]:
+        """Return the declared dimension of the 'vector' column for this table, or None."""
+        with self._get_cursor() as cur:
+            cur.execute(
+                """
+                SELECT a.atttypmod
+                FROM pg_attribute a
+                JOIN pg_class c ON a.attrelid = c.oid
+                WHERE c.relname = %s
+                  AND a.attname = 'vector'
+                  AND a.atttypmod > 0
+                """,
+                (self.collection_name,),
+            )
+            row = cur.fetchone()
+            return row[0] if row else None
+
+    def _validate_schema_dims(self) -> None:
+        """Raise if the existing table's vector dimension differs from the configured one."""
+        actual_dims = self._get_table_vector_dim()
+        if actual_dims is not None and actual_dims != self.embedding_model_dims:
+            raise ValueError(
+                f"Vector dimension mismatch for collection '{self.collection_name}': "
+                f"the existing table was created with {actual_dims}-dimensional vectors, "
+                f"but the current configuration expects {self.embedding_model_dims} dimensions. "
+                f"To resolve: use a different collection_name for the new embedder, drop the "
+                f"existing table and let mem0 recreate it, or reconfigure the embedder to "
+                f"produce {actual_dims}-dimensional vectors."
+            )
 
     def create_col(self) -> None:
         """

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -663,3 +663,95 @@ async def test_async_update_preserves_actor_id_when_different_actor_updates(mock
     assert stored["actor_id"] == "Alice"
 
 
+
+# ---------------------------------------------------------------------------
+# Regression tests for vector-store insert failure propagation (issue #4985)
+# ---------------------------------------------------------------------------
+
+class TestInsertFailurePropagation:
+    """Ensure that vector_store.insert failures in the v3 pipeline are NOT silently dropped."""
+
+    @pytest.fixture
+    def mock_memory(self, mocker):
+        mock_llm, mock_vector_store = _setup_mocks(mocker)
+
+        # Make LLM return a valid single-pass response with one memory to add
+        mock_llm.return_value.generate_response.return_value = (
+            '{"memory": [{"text": "User likes Python", "event": "ADD", "tags": []}]}'
+        )
+
+        memory = Memory()
+        # embed_batch must return a real list so Phase 3 populates embed_map
+        memory.embedding_model.embed_batch.return_value = [[0.1, 0.2, 0.3]]
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        memory.db.batch_add_history = MagicMock()
+
+        return memory
+
+    def test_batch_insert_failure_raises(self, mock_memory):
+        """Both batch and per-record inserts fail -> _add_to_vector_store should raise."""
+        mock_memory.vector_store.insert.side_effect = Exception("vector dimension mismatch")
+        mock_memory.vector_store.search.return_value = []
+
+        with pytest.raises(RuntimeError, match="failed to persist"):
+            mock_memory._add_to_vector_store(
+                messages=[{"role": "user", "content": "I like Python"}],
+                metadata={},
+                filters={},
+                infer=True,
+            )
+
+    def test_batch_insert_failure_per_record_success_does_not_raise(self, mock_memory):
+        """Batch insert fails but per-record retries succeed -> should NOT raise."""
+        call_count = {"n": 0}
+
+        def flaky_insert(**kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise Exception("transient batch error")
+
+        mock_memory.vector_store.insert.side_effect = flaky_insert
+        mock_memory.vector_store.search.return_value = []
+
+        # Should complete without raising
+        mock_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "I like Python"}],
+            metadata={},
+            filters={},
+            infer=True,
+        )
+
+    def test_partial_per_record_failure_raises_with_count(self, mock_memory, mocker):
+        """If per-record inserts all fail, RuntimeError must mention the count."""
+        batch_called = {"done": False}
+
+        def selective_insert(vectors, ids, payloads):
+            if not batch_called["done"]:
+                batch_called["done"] = True
+                raise Exception("batch failed")
+            # Per-record: always fail
+            raise Exception("per-record dim mismatch")
+
+        mock_memory.vector_store.insert.side_effect = selective_insert
+
+        # Make LLM produce 2 memories so we can verify the count in the error
+        mock_memory.llm.generate_response.return_value = (
+            '{"memory": ['
+            '{"text": "Mem one", "event": "ADD", "tags": []},'
+            '{"text": "Mem two", "event": "ADD", "tags": []}'
+            ']}'
+        )
+        # embed_batch must return 2 vectors for 2 memories
+        mock_memory.embedding_model.embed_batch.return_value = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+        mock_memory.vector_store.search.return_value = []
+
+        with pytest.raises(RuntimeError) as exc_info:
+            mock_memory._add_to_vector_store(
+                messages=[{"role": "user", "content": "test"}],
+                metadata={},
+                filters={},
+                infer=True,
+            )
+
+        assert "failed to persist" in str(exc_info.value)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -6,6 +6,7 @@ import pytest
 
 from mem0 import Memory
 from mem0.configs.base import MemoryConfig
+from mem0.memory.main import _sync_pgvector_dims
 from mem0.memory.utils import normalize_facts
 
 
@@ -935,3 +936,141 @@ async def test_async_create_memory_stores_text_lemmatized(mock_sqlite, mock_llm_
     )
     assert payload[0]["text_lemmatized"] != "", "text_lemmatized must not be empty"
 
+# ---------------------------------------------------------------------------
+# Regression tests for pgvector dimension inference / mismatch (issue #4985)
+# ---------------------------------------------------------------------------
+
+def _make_pgvector_memory_config(embedder_dims=None, pgvector_dims=None):
+    """Build a MemoryConfig-shaped mock for testing _sync_pgvector_dims."""
+    config = MagicMock()
+    config.vector_store.provider = "pgvector"
+    config.vector_store.config.collection_name = "test_collection"
+    config.vector_store.config.embedding_model_dims = pgvector_dims
+    config.embedder.config.embedding_dims = embedder_dims
+    config.embedder.provider = "openai"
+    return config
+
+
+class TestPgvectorDimsInference:
+    """Unit tests for _sync_pgvector_dims helper (issue #4985)."""
+
+    def test_infers_dims_from_embedder_when_unset(self):
+        """When embedding_model_dims is None, it should be set from the embedder."""
+        config = _make_pgvector_memory_config(embedder_dims=768, pgvector_dims=None)
+        _sync_pgvector_dims(config)
+        assert config.vector_store.config.embedding_model_dims == 768
+
+    def test_no_change_when_dims_already_match(self):
+        """When both dims are already equal, no error should be raised."""
+        config = _make_pgvector_memory_config(embedder_dims=1536, pgvector_dims=1536)
+        _sync_pgvector_dims(config)
+        assert config.vector_store.config.embedding_model_dims == 1536
+
+    def test_raises_on_explicit_mismatch(self):
+        """When pgvector dims are explicitly set and differ from the embedder, raise ValueError."""
+        config = _make_pgvector_memory_config(embedder_dims=768, pgvector_dims=1536)
+        with pytest.raises(ValueError, match="768") as exc_info:
+            _sync_pgvector_dims(config)
+        assert "1536" in str(exc_info.value)
+
+    def test_raises_message_includes_provider_and_collection(self):
+        """The ValueError message must identify the provider and collection for easy diagnosis."""
+        config = _make_pgvector_memory_config(embedder_dims=384, pgvector_dims=1536)
+        with pytest.raises(ValueError) as exc_info:
+            _sync_pgvector_dims(config)
+        msg = str(exc_info.value)
+        assert "openai" in msg
+        assert "test_collection" in msg
+
+    def test_noop_when_embedder_dims_unknown(self):
+        """When the embedder config has no embedding_dims (None), do nothing."""
+        config = _make_pgvector_memory_config(embedder_dims=None, pgvector_dims=None)
+        _sync_pgvector_dims(config)
+        # pgvector dims remain None -- pgvector itself will raise on table creation
+        assert config.vector_store.config.embedding_model_dims is None
+
+
+class TestMemoryInitDimsMismatchIntegration:
+    """Integration-level test: Memory() must raise at construction on explicit pgvector dim mismatch."""
+
+    @patch("mem0.utils.factory.EmbedderFactory.create")
+    @patch("mem0.utils.factory.VectorStoreFactory.create")
+    @patch("mem0.utils.factory.LlmFactory.create")
+    @patch("mem0.memory.storage.SQLiteManager")
+    def test_memory_init_raises_on_pgvector_dim_mismatch(
+        self, mock_sqlite, mock_llm_factory, mock_vs_factory, mock_embedder_factory
+    ):
+        """Memory() must raise ValueError when pgvector dims conflict with the embedder."""
+        embedder = MagicMock()
+        embedder.config.embedding_dims = 768
+        mock_embedder_factory.return_value = embedder
+
+        mock_vs_factory.return_value = MagicMock()
+        mock_llm_factory.return_value = MagicMock()
+        mock_sqlite.return_value = MagicMock()
+
+        vs_config = MagicMock()
+        vs_config.provider = "pgvector"
+        vs_config.config = MagicMock()
+        vs_config.config.embedding_model_dims = 1536
+        vs_config.config.collection_name = "mem0"
+
+        embedder_config = MagicMock()
+        embedder_config.provider = "openai"
+        embedder_config.config = MagicMock()
+        embedder_config.config.embedding_dims = 768
+
+        config = MagicMock(spec=MemoryConfig)
+        config.vector_store = vs_config
+        config.embedder = embedder_config
+        config.llm = MagicMock()
+        config.history_db_path = "/tmp/test_history.db"
+        config.version = "v1.1"
+        config.custom_instructions = None
+        config.reranker = None
+
+        with pytest.raises(ValueError, match="768"):
+            from mem0.memory.main import Memory as MemoryClass
+            MemoryClass(config)
+
+    @patch("mem0.utils.factory.EmbedderFactory.create")
+    @patch("mem0.utils.factory.VectorStoreFactory.create")
+    @patch("mem0.utils.factory.LlmFactory.create")
+    @patch("mem0.memory.storage.SQLiteManager")
+    def test_memory_init_infers_pgvector_dims_from_embedder(
+        self, mock_sqlite, mock_llm_factory, mock_vs_factory, mock_embedder_factory
+    ):
+        """Memory() must pass the embedder's embedding_dims to pgvector when dims were unset."""
+        embedder = MagicMock()
+        embedder.config.embedding_dims = 768
+        mock_embedder_factory.return_value = embedder
+
+        mock_vs_factory.return_value = MagicMock()
+        mock_llm_factory.return_value = MagicMock()
+        mock_sqlite.return_value = MagicMock()
+
+        vs_config = MagicMock()
+        vs_config.provider = "pgvector"
+        vs_config.config = MagicMock()
+        vs_config.config.embedding_model_dims = None
+        vs_config.config.collection_name = "mem0"
+
+        embedder_config = MagicMock()
+        embedder_config.provider = "openai"
+        embedder_config.config = MagicMock()
+        embedder_config.config.embedding_dims = 768
+
+        config = MagicMock(spec=MemoryConfig)
+        config.vector_store = vs_config
+        config.embedder = embedder_config
+        config.llm = MagicMock()
+        config.history_db_path = "/tmp/test_history.db"
+        config.version = "v1.1"
+        config.custom_instructions = None
+        config.reranker = None
+
+        from mem0.memory.main import Memory as MemoryClass
+        MemoryClass(config)
+
+        # The dims should have been inferred and set on the vector store config
+        assert vs_config.config.embedding_model_dims == 768

--- a/tests/vector_stores/test_pgvector.py
+++ b/tests/vector_stores/test_pgvector.py
@@ -2228,3 +2228,88 @@ class TestPGVector(unittest.TestCase):
     def tearDown(self):
         """Clean up after each test."""
         pass
+
+class TestPGVectorSchemaDimValidation(unittest.TestCase):
+    """Regression tests for dimension mismatch detection (issue #4985)."""
+
+    @patch("mem0.vector_stores.pgvector.PSYCOPG_VERSION", 3)
+    @patch("mem0.vector_stores.pgvector.ConnectionPool")
+    @patch.object(PGVector, "_get_cursor")
+    def test_raises_on_schema_dim_mismatch(self, mock_get_cursor, mock_pool_cls):
+        """PGVector.__init__ must raise ValueError when the existing table has wrong dims."""
+        mock_cursor = MagicMock()
+        mock_get_cursor.return_value.__enter__.return_value = mock_cursor
+        mock_get_cursor.return_value.__exit__.return_value = None
+
+        # list_cols: table already exists
+        mock_cursor.fetchall.return_value = [("test_collection",)]
+        # _get_table_vector_dim: returns 1536 (old schema)
+        mock_cursor.fetchone.return_value = (1536,)
+
+        mock_pool_cls.return_value = MagicMock()
+
+        with self.assertRaises(ValueError) as ctx:
+            PGVector(
+                dbname="test_db",
+                collection_name="test_collection",
+                embedding_model_dims=768,
+                user="user",
+                password="pass",
+                host="localhost",
+                port=5432,
+                diskann=False,
+                hnsw=False,
+            )
+
+        msg = str(ctx.exception)
+        self.assertIn("1536", msg)
+        self.assertIn("768", msg)
+        self.assertIn("test_collection", msg)
+
+    @patch("mem0.vector_stores.pgvector.PSYCOPG_VERSION", 3)
+    @patch("mem0.vector_stores.pgvector.ConnectionPool")
+    @patch.object(PGVector, "_get_cursor")
+    def test_no_error_when_dims_match(self, mock_get_cursor, mock_pool_cls):
+        """PGVector.__init__ must succeed when the existing table dims match the config."""
+        mock_cursor = MagicMock()
+        mock_get_cursor.return_value.__enter__.return_value = mock_cursor
+        mock_get_cursor.return_value.__exit__.return_value = None
+
+        # list_cols: table already exists
+        mock_cursor.fetchall.return_value = [("test_collection",)]
+        # _get_table_vector_dim: returns same 768
+        mock_cursor.fetchone.return_value = (768,)
+
+        mock_pool_cls.return_value = MagicMock()
+
+        pgvector = PGVector(
+            dbname="test_db",
+            collection_name="test_collection",
+            embedding_model_dims=768,
+            user="user",
+            password="pass",
+            host="localhost",
+            port=5432,
+            diskann=False,
+            hnsw=False,
+        )
+        self.assertEqual(pgvector.embedding_model_dims, 768)
+
+    @patch("mem0.vector_stores.pgvector.PSYCOPG_VERSION", 3)
+    @patch("mem0.vector_stores.pgvector.ConnectionPool")
+    def test_raises_when_embedding_model_dims_is_none(self, mock_pool_cls):
+        """PGVector.__init__ must raise immediately if embedding_model_dims is None."""
+        mock_pool_cls.return_value = MagicMock()
+
+        with self.assertRaises(ValueError):
+            PGVector(
+                dbname="test_db",
+                collection_name="test_collection",
+                embedding_model_dims=None,
+                user="user",
+                password="pass",
+                host="localhost",
+                port=5432,
+                diskann=False,
+                hnsw=False,
+            )


### PR DESCRIPTION
## Linked Issue

Closes #4985

## Description

This PR fixes silent data loss when the configured embedding model’s vector size no longer matches the PostgreSQL/pgvector table (for example after switching from an OpenAI-sized model to another provider). Previously, `PGVectorConfig` defaulted `embedding_model_dims` to `1536`, and the OSS v3 pipeline could swallow `vector_store.insert` failures, so APIs could look successful while nothing was persisted.

Changes:

- Default `embedding_model_dims` to `None` and infer it from the embedder’s `embedding_dims` during `Memory` / `AsyncMemory` initialization when using pgvector; raise a clear `ValueError` if an explicit pgvector dimension conflicts with the embedder.
- On pgvector startup, validate the existing table’s `vector` column dimension against configuration and raise with remediation hints when they differ.
- Refuse `PGVector` construction when `embedding_model_dims` is still unset (no silent table creation with wrong semantics).
- After a failed batch insert in the v3 path, retry per record but **raise** `RuntimeError` if any insert still fails, instead of only logging.
- Add regression tests for inference, mismatch errors, schema validation, and insert failure propagation.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added/updated tests in `tests/test_memory.py`, `tests/memory/test_main.py`, and `tests/vector_stores/test_pgvector.py` (13 targeted cases). Locally: `ruff check mem0/ tests/` and the new regression subset under `pytest` passed. Full `pytest tests/` should be confirmed in CI or via `make test` with the same optional extras as `.github/workflows/ci.yml`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] I have updated documentation if needed
