### PR TITLE
fix(memory): entity-store-pgvector-linked-memory-cleanup

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -470,8 +470,14 @@ class Memory(MemoryBase):
             return
         search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
         try:
-            listed = self.entity_store.list(filters=search_filters, top_k=10000)
-            rows = listed[0] if isinstance(listed, (list, tuple)) and listed and isinstance(listed[0], list) else listed
+            rows = self.entity_store.list_with_linked_memory_id(memory_id, search_filters)
+            if rows is None:
+                listed = self.entity_store.list(filters=search_filters, top_k=10000)
+                rows = (
+                    listed[0]
+                    if isinstance(listed, (list, tuple)) and listed and isinstance(listed[0], list)
+                    else listed
+                )
             for row in rows or []:
                 try:
                     payload = getattr(row, "payload", None) or {}
@@ -1903,8 +1909,16 @@ class AsyncMemory(MemoryBase):
             return
         search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
         try:
-            listed = await asyncio.to_thread(self.entity_store.list, filters=search_filters, top_k=10000)
-            rows = listed[0] if isinstance(listed, (list, tuple)) and listed and isinstance(listed[0], list) else listed
+            rows = await asyncio.to_thread(
+                self.entity_store.list_with_linked_memory_id, memory_id, search_filters
+            )
+            if rows is None:
+                listed = await asyncio.to_thread(self.entity_store.list, filters=search_filters, top_k=10000)
+                rows = (
+                    listed[0]
+                    if isinstance(listed, (list, tuple)) and listed and isinstance(listed[0], list)
+                    else listed
+                )
             for row in rows or []:
                 try:
                     payload = getattr(row, "payload", None) or {}

--- a/mem0/vector_stores/base.py
+++ b/mem0/vector_stores/base.py
@@ -74,6 +74,22 @@ class VectorStoreBase(ABC):
         """
         return None
 
+    def list_with_linked_memory_id(self, memory_id: str, filters=None):
+        """List rows whose payload links this memory_id (e.g. linked_memory_ids).
+
+        Used for targeted entity-store cleanup on memory delete/update.
+        Override in subclasses that can query efficiently (e.g. JSONB on PostgreSQL).
+        Default None means callers should fall back to list() + Python filtering.
+
+        Args:
+            memory_id: Memory id that must appear in the store's linked_memory_ids payload.
+            filters: Optional metadata filters (same keys as list(): user_id, agent_id, run_id).
+
+        Returns:
+            Flat list of row objects with id and payload attributes, or None if unsupported.
+        """
+        return None
+
     def search_batch(self, queries: list, vectors_list: list, top_k: int = 1, filters: dict = None):
         """Batch search for multiple queries at once.
 

--- a/mem0/vector_stores/pgvector.py
+++ b/mem0/vector_stores/pgvector.py
@@ -435,6 +435,32 @@ class PGVector(VectorStoreBase):
             results = cur.fetchall()
         return [[OutputData(id=str(r[0]), score=None, payload=r[2]) for r in results]]
 
+    def list_with_linked_memory_id(
+        self,
+        memory_id: str,
+        filters: Optional[dict] = None,
+    ) -> List[OutputData]:
+        """Return entity rows that list memory_id in payload linked_memory_ids (no vector I/O)."""
+        filter_conditions = ["(payload->'linked_memory_ids') @> %s::jsonb"]
+        filter_params: list[Any] = [Json([memory_id])]
+
+        if filters:
+            for k, v in filters.items():
+                filter_conditions.append("payload->>%s = %s")
+                filter_params.extend([k, str(v)])
+
+        where_clause = "WHERE " + " AND ".join(filter_conditions)
+        query = f"""
+            SELECT id, payload
+            FROM {self.collection_name}
+            {where_clause}
+        """
+
+        with self._get_cursor() as cur:
+            cur.execute(query, tuple(filter_params))
+            results = cur.fetchall()
+        return [OutputData(id=str(r[0]), score=None, payload=r[1]) for r in results]
+
     def __del__(self) -> None:
         """
         Close the database connection pool when the object is deleted.

--- a/tests/vector_stores/test_pgvector.py
+++ b/tests/vector_stores/test_pgvector.py
@@ -1438,6 +1438,64 @@ class TestPGVector(unittest.TestCase):
         self.assertEqual(results[0][0].payload["user_id"], "alice")
         self.assertEqual(results[0][0].payload["agent_id"], "agent1")
 
+    @patch('mem0.vector_stores.pgvector.PSYCOPG_VERSION', 3)
+    @patch('mem0.vector_stores.pgvector.ConnectionPool')
+    @patch.object(PGVector, '_get_cursor')
+    def test_list_with_linked_memory_id_psycopg3(self, mock_get_cursor, mock_connection_pool):
+        """Targeted list for entity cleanup: jsonb @> linked_memory_ids, no vector column."""
+        mock_pool = MagicMock()
+        mock_connection_pool.return_value = mock_pool
+
+        mock_get_cursor.return_value.__enter__.return_value = self.mock_cursor
+        mock_get_cursor.return_value.__exit__.return_value = None
+
+        payload = {
+            "user_id": "alice",
+            "agent_id": "agent1",
+            "linked_memory_ids": ["mem-1", "mem-2"],
+            "data": "Acme Corp",
+        }
+        self.mock_cursor.fetchall.return_value = [(self.test_ids[0], payload)]
+
+        pgvector = PGVector(
+            dbname="test_db",
+            collection_name="test_collection",
+            embedding_model_dims=3,
+            user="test_user",
+            password="test_pass",
+            host="localhost",
+            port=5432,
+            diskann=False,
+            hnsw=False,
+            minconn=1,
+            maxconn=4,
+        )
+
+        memory_id = "mem-1"
+        filters = {"user_id": "alice", "agent_id": "agent1"}
+        results = pgvector.list_with_linked_memory_id(memory_id, filters=filters)
+
+        mock_get_cursor.assert_called()
+        link_calls = [
+            call
+            for call in self.mock_cursor.execute.call_args_list
+            if "SELECT id, payload" in str(call)
+            and "linked_memory_ids" in str(call)
+            and "@>" in str(call)
+        ]
+        self.assertTrue(len(link_calls) > 0, "expected jsonb containment query")
+        bad_calls = [
+            call
+            for call in self.mock_cursor.execute.call_args_list
+            if "SELECT id, vector, payload" in str(call) and "linked_memory_ids" in str(call)
+        ]
+        self.assertEqual(len(bad_calls), 0, "entity unlink query must not load embedding vectors")
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].id, self.test_ids[0])
+        self.assertIsNone(results[0].score)
+        self.assertEqual(results[0].payload, payload)
+
     @patch('mem0.vector_stores.pgvector.PSYCOPG_VERSION', 2)
     @patch('mem0.vector_stores.pgvector.ConnectionPool')
     @patch.object(PGVector, '_get_cursor')


### PR DESCRIPTION
## Linked Issue

Closes #4988

## Description

This change fixes slow and incomplete entity-store cleanup when using the pgvector backend. Previously, `_remove_memory_from_entity_store` loaded up to 10,000 rows with full embedding vectors via `entity_store.list`, then scanned `linked_memory_ids` in Python. That wasted I/O on every memory delete/update and could skip entities beyond the fixed limit.

The fix adds an optional vector-store hook, `list_with_linked_memory_id`, with a PostgreSQL implementation that selects only `id` and `payload`, filtered by `(payload->'linked_memory_ids') @> $memory_id` together with existing `user_id` / `agent_id` / `run_id` metadata filters. Other vector stores fall back to the previous `list(..., top_k=10000)` behavior unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added `test_list_with_linked_memory_id_psycopg3` in `tests/vector_stores/test_pgvector.py`. Ran `pytest tests/vector_stores/test_pgvector.py tests/test_memory.py` locally (all passed).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
