### PR TITLE
fix(pgvector): convert cosine distance to similarity score

### DIFF
--- a/mem0/vector_stores/pgvector.py
+++ b/mem0/vector_stores/pgvector.py
@@ -248,7 +248,13 @@ class PGVector(VectorStoreBase):
             )
 
             results = cur.fetchall()
-        return [OutputData(id=str(r[0]), score=float(r[1]), payload=r[2]) for r in results]
+        # Convert pgvector cosine distance (lower = more similar) to a
+        # similarity score (higher = more similar) so it matches the
+        # convention assumed by score_and_rank() in the hybrid retrieval
+        # pipeline. Without this, score_and_rank() sorts reverse=True on
+        # raw distance and surfaces the LEAST-similar memories first.
+        # Mirrors the TypeScript fix in PR #4944.
+        return [OutputData(id=str(r[0]), score=float(1.0 - r[1]), payload=r[2]) for r in results]
 
     def keyword_search(self, query, top_k=5, filters=None):
         """

--- a/tests/vector_stores/test_pgvector.py
+++ b/tests/vector_stores/test_pgvector.py
@@ -433,21 +433,23 @@ class TestPGVector(unittest.TestCase):
         )
         
         results = pgvector.search("test query", [0.1, 0.2, 0.3], top_k=2)
-        
+
         # Verify the _get_cursor context manager was called
         mock_get_cursor.assert_called()
-        
+
         # Verify search query was executed
-        search_calls = [call for call in self.mock_cursor.execute.call_args_list 
+        search_calls = [call for call in self.mock_cursor.execute.call_args_list
                        if "SELECT id, vector <=" in str(call)]
         self.assertTrue(len(search_calls) > 0)
-        
-        # Verify results
+
+        # Verify results — score is similarity (1 - cosine_distance), so
+        # the row with mocked distance 0.1 yields score 0.9, the closer
+        # match coming first.
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0].id, self.test_ids[0])
-        self.assertEqual(results[0].score, 0.1)
+        self.assertAlmostEqual(results[0].score, 0.9)
         self.assertEqual(results[1].id, self.test_ids[1])
-        self.assertEqual(results[1].score, 0.2)
+        self.assertAlmostEqual(results[1].score, 0.8)
 
     @patch('mem0.vector_stores.pgvector.PSYCOPG_VERSION', 2)
     @patch('mem0.vector_stores.pgvector.ConnectionPool')
@@ -482,21 +484,21 @@ class TestPGVector(unittest.TestCase):
         )
         
         results = pgvector.search("test query", [0.1, 0.2, 0.3], top_k=2)
-        
+
         # Verify the _get_cursor context manager was called
         mock_get_cursor.assert_called()
-        
+
         # Verify search query was executed
-        search_calls = [call for call in self.mock_cursor.execute.call_args_list 
+        search_calls = [call for call in self.mock_cursor.execute.call_args_list
                        if "SELECT id, vector <=" in str(call)]
         self.assertTrue(len(search_calls) > 0)
-        
-        # Verify results
+
+        # Verify results — score is similarity (1 - cosine_distance).
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0].id, self.test_ids[0])
-        self.assertEqual(results[0].score, 0.1)
+        self.assertAlmostEqual(results[0].score, 0.9)
         self.assertEqual(results[1].id, self.test_ids[1])
-        self.assertEqual(results[1].score, 0.2)
+        self.assertAlmostEqual(results[1].score, 0.8)
 
     @patch('mem0.vector_stores.pgvector.PSYCOPG_VERSION', 3)
     @patch('mem0.vector_stores.pgvector.ConnectionPool')
@@ -1137,10 +1139,10 @@ class TestPGVector(unittest.TestCase):
                        if "SELECT id, vector <=" in str(call) and "WHERE" in str(call)]
         self.assertTrue(len(search_calls) > 0)
         
-        # Verify results
+        # Verify results — score is similarity (1 - cosine_distance).
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].id, self.test_ids[0])
-        self.assertEqual(results[0].score, 0.1)
+        self.assertAlmostEqual(results[0].score, 0.9)
         self.assertEqual(results[0].payload["user_id"], "alice")
         self.assertEqual(results[0].payload["agent_id"], "agent1")
         self.assertEqual(results[0].payload["run_id"], "run1")
@@ -1187,10 +1189,10 @@ class TestPGVector(unittest.TestCase):
                        if "SELECT id, vector <=" in str(call) and "WHERE" in str(call)]
         self.assertTrue(len(search_calls) > 0)
         
-        # Verify results
+        # Verify results — score is similarity (1 - cosine_distance).
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].id, self.test_ids[0])
-        self.assertEqual(results[0].score, 0.1)
+        self.assertAlmostEqual(results[0].score, 0.9)
         self.assertEqual(results[0].payload["user_id"], "alice")
         self.assertEqual(results[0].payload["agent_id"], "agent1")
         self.assertEqual(results[0].payload["run_id"], "run1")
@@ -1237,10 +1239,10 @@ class TestPGVector(unittest.TestCase):
                        if "SELECT id, vector <=" in str(call) and "WHERE" in str(call)]
         self.assertTrue(len(search_calls) > 0)
         
-        # Verify results
+        # Verify results — score is similarity (1 - cosine_distance).
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].id, self.test_ids[0])
-        self.assertEqual(results[0].score, 0.1)
+        self.assertAlmostEqual(results[0].score, 0.9)
         self.assertEqual(results[0].payload["user_id"], "alice")
 
     @patch('mem0.vector_stores.pgvector.PSYCOPG_VERSION', 2)
@@ -1285,10 +1287,10 @@ class TestPGVector(unittest.TestCase):
                        if "SELECT id, vector <=" in str(call) and "WHERE" in str(call)]
         self.assertTrue(len(search_calls) > 0)
         
-        # Verify results
+        # Verify results — score is similarity (1 - cosine_distance).
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].id, self.test_ids[0])
-        self.assertEqual(results[0].score, 0.1)
+        self.assertAlmostEqual(results[0].score, 0.9)
         self.assertEqual(results[0].payload["user_id"], "alice")
 
     @patch('mem0.vector_stores.pgvector.PSYCOPG_VERSION', 3)
@@ -1333,12 +1335,12 @@ class TestPGVector(unittest.TestCase):
                        if "SELECT id, vector <=" in str(call) and "WHERE" not in str(call)]
         self.assertTrue(len(search_calls) > 0)
         
-        # Verify results
+        # Verify results — score is similarity (1 - cosine_distance).
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0].id, self.test_ids[0])
-        self.assertEqual(results[0].score, 0.1)
+        self.assertAlmostEqual(results[0].score, 0.9)
         self.assertEqual(results[1].id, self.test_ids[1])
-        self.assertEqual(results[1].score, 0.2)
+        self.assertAlmostEqual(results[1].score, 0.8)
 
     @patch('mem0.vector_stores.pgvector.PSYCOPG_VERSION', 2)
     @patch('mem0.vector_stores.pgvector.ConnectionPool')
@@ -1382,12 +1384,12 @@ class TestPGVector(unittest.TestCase):
                        if "SELECT id, vector <=" in str(call) and "WHERE" not in str(call)]
         self.assertTrue(len(search_calls) > 0)
         
-        # Verify results
+        # Verify results — score is similarity (1 - cosine_distance).
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0].id, self.test_ids[0])
-        self.assertEqual(results[0].score, 0.1)
+        self.assertAlmostEqual(results[0].score, 0.9)
         self.assertEqual(results[1].id, self.test_ids[1])
-        self.assertEqual(results[1].score, 0.2)
+        self.assertAlmostEqual(results[1].score, 0.8)
 
     @patch('mem0.vector_stores.pgvector.PSYCOPG_VERSION', 3)
     @patch('mem0.vector_stores.pgvector.ConnectionPool')


### PR DESCRIPTION
## Summary

`PGVector.search()` returns the raw `vector <=> %s::vector` distance as `OutputData.score`, but `score_and_rank()` in `mem0/utils/scoring.py` (used by `Memory.search()` for hybrid retrieval) treats `score` as a similarity (higher = better) and sorts `reverse=True`. The result: semantically closest memories rank LAST while least-similar memories surface first.

This is the Python-side equivalent of the same bug fixed in the TypeScript SDK in #4944, which described the symptom identically:

> While doing the semantic search, most similar documents have to be ranked highest. Using PGVector, the scores were inverted, surfacing the least relevant documents.

## Reproduction

Set up mem0 with the pgvector backend, add a handful of memories, then query for the exact text of one of them. Without this fix, the exact-match memory ranks dead last with a low score; the highest-scoring result is whichever memory has the largest cosine distance from the query.

In a small self-hosted deployment (19 memories), before the fix:

```
query: "plan mode default for non-trivial tasks"
0.553 | User runs a homelab cluster called home-k3s on bare metal       ← top
...
0.221 | Kenneth defaults to plan mode for non-trivial tasks involving... ← LAST (exact match)
```

After the fix:

```
query: "plan mode default for non-trivial tasks"
0.779 | Kenneth defaults to plan mode for non-trivial tasks involving... ← top (exact match)
0.588 | Kenneth scopes his own next steps and does NOT want optional...
0.563 | Kenneth prefers automation over manual fixes...
```

The same pattern reproduces across queries — exact-text matches for `kubectl context home cluster`, `shell neovim notes`, and `postgres fsGroup capabilities` all moved from bottom-of-stack to top-of-stack after the fix.

Direct postgres confirmation that the embeddings themselves are fine:

```sql
-- ORDER BY vector <=> $query_emb (ASC = lowest distance first) returns
-- the exact-match row first with distance ~0.22, similarity ~0.78.
SELECT payload->>'data', vector <=> $1::vector AS dist FROM mem0_memories ORDER BY 2 LIMIT 5;
```

So the cause is purely the score convention mismatch between `pgvector.py:251` and `score_and_rank`.

## Fix

Convert distance → similarity at the boundary in `PGVector.search()`:

```python
return [OutputData(id=str(r[0]), score=float(1.0 - r[1]), payload=r[2]) for r in results]
```

This matches the convention every other ranker call site assumes and aligns with the TS fix in #4944.

`keyword_search()` is unchanged — it already returns `ts_rank_cd` which is a similarity score.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Updated the four mocked-cursor assertions in `tests/vector_stores/test_pgvector.py` to expect the converted score (mocked distance 0.1 → score 0.9, etc.) and switched to `assertAlmostEqual` since the value is now computed:

```bash
$ python -m pytest tests/vector_stores/test_pgvector.py
============================== 50 passed in 0.50s ==============================
```

## Linked Issue / PR

- TypeScript equivalent: #4944 (already merged)