### PR TITLE
fix(server): clear stale provider api keys

### DIFF
--- a/server/dashboard/src/app/(root)/dashboard/configuration/page.tsx
+++ b/server/dashboard/src/app/(root)/dashboard/configuration/page.tsx
@@ -128,7 +128,10 @@ export default function ConfigurationPage() {
               <Label className="text-xs">Provider</Label>
               <Select
                 value={llmProvider}
-                onValueChange={setLlmProvider}
+                onValueChange={(value) => {
+                  if (value !== llmProvider) setLlmApiKey("");
+                  setLlmProvider(value);
+                }}
                 disabled={!isAdmin || !providers}
               >
                 <SelectTrigger>

--- a/server/dashboard/src/app/setup/page.tsx
+++ b/server/dashboard/src/app/setup/page.tsx
@@ -419,7 +419,10 @@ export default function SetupPage() {
                     <Label htmlFor="setup-llm-provider">LLM Provider</Label>
                     <Select
                       value={llmProvider}
-                      onValueChange={setLlmProvider}
+                      onValueChange={(value) => {
+                        if (value !== llmProvider) setLlmApiKey("");
+                        setLlmProvider(value);
+                      }}
                       disabled={!providers}
                     >
                       <SelectTrigger id="setup-llm-provider">

--- a/server/server_state.py
+++ b/server/server_state.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import json
 import logging
+import os
 import threading
 from copy import deepcopy
 from typing import Any, Callable, Dict
@@ -10,6 +13,12 @@ _state_lock = threading.RLock()
 _current_config: Dict[str, Any] = {}
 _memory_instance: Memory | None = None
 _session_factory: Callable | None = None
+
+PROVIDER_API_KEY_ENV_VARS = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "gemini": "GOOGLE_API_KEY",
+    "openai": "OPENAI_API_KEY",
+}
 
 
 def set_session_factory(factory: Callable) -> None:
@@ -73,20 +82,78 @@ def _merge_config(base: Dict[str, Any], updates: Dict[str, Any]) -> Dict[str, An
     return merged
 
 
+def _clear_api_keys_for_provider_changes(
+    base: Dict[str, Any], updates: Dict[str, Any], *, persisted_overrides: bool = False
+) -> tuple[Dict[str, Any], Dict[str, Any]]:
+    cleaned_base = deepcopy(base)
+    cleaned_updates = deepcopy(updates)
+
+    for section_name in ("llm", "embedder"):
+        section_update = cleaned_updates.get(section_name)
+        section_base = cleaned_base.get(section_name)
+        if not isinstance(section_update, dict) or not isinstance(section_base, dict):
+            continue
+        if section_update.get("provider") == section_base.get("provider"):
+            continue
+
+        base_config = section_base.get("config")
+        old_api_key = base_config.get("api_key") if isinstance(base_config, dict) else None
+        if isinstance(base_config, dict):
+            base_config.pop("api_key", None)
+
+        update_config = section_update.get("config")
+        if isinstance(update_config, dict):
+            if persisted_overrides or update_config.get("api_key") == old_api_key:
+                update_config.pop("api_key", None)
+
+    return cleaned_base, cleaned_updates
+
+
+def _apply_env_api_keys(config: Dict[str, Any]) -> Dict[str, Any]:
+    effective_config = deepcopy(config)
+
+    for section_name in ("llm", "embedder"):
+        section = effective_config.get(section_name)
+        if not isinstance(section, dict):
+            continue
+
+        provider = section.get("provider")
+        env_var = PROVIDER_API_KEY_ENV_VARS.get(provider)
+        if not env_var:
+            continue
+
+        api_key = os.environ.get(env_var)
+        if not api_key:
+            continue
+
+        section_config = section.get("config")
+        if not isinstance(section_config, dict):
+            section_config = {}
+            section["config"] = section_config
+        section_config["api_key"] = api_key
+
+    return effective_config
+
+
 def initialize_state(default_config: Dict[str, Any]) -> None:
     global _current_config, _memory_instance
     with _state_lock:
         _current_config = deepcopy(default_config)
         overrides = _load_overrides()
         if overrides:
+            _current_config, overrides = _clear_api_keys_for_provider_changes(
+                _current_config, overrides, persisted_overrides=True
+            )
             _current_config = _merge_config(_current_config, overrides)
+        _current_config = _apply_env_api_keys(_current_config)
         _memory_instance = Memory.from_config(_current_config)
 
 
 def update_config(updates: Dict[str, Any]) -> Dict[str, Any]:
     global _current_config, _memory_instance
     with _state_lock:
-        next_config = _merge_config(_current_config, updates)
+        base_config, cleaned_updates = _clear_api_keys_for_provider_changes(_current_config, updates)
+        next_config = _apply_env_api_keys(_merge_config(base_config, cleaned_updates))
         _current_config = next_config
         _memory_instance = Memory.from_config(next_config)
         overrides = _load_overrides()

--- a/tests/test_server_state.py
+++ b/tests/test_server_state.py
@@ -1,0 +1,99 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+
+class FakeMemory:
+    @staticmethod
+    def from_config(config):
+        return object()
+
+
+def load_server_state():
+    path = Path(__file__).resolve().parents[1] / "server" / "server_state.py"
+    spec = importlib.util.spec_from_file_location("server_state_for_tests", path)
+    module = importlib.util.module_from_spec(spec)
+    original_mem0 = sys.modules.get("mem0")
+    sys.modules["mem0"] = types.SimpleNamespace(Memory=FakeMemory)
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        if original_mem0 is None:
+            sys.modules.pop("mem0", None)
+        else:
+            sys.modules["mem0"] = original_mem0
+    return module
+
+
+def test_initialize_state_uses_env_key_over_database_key(monkeypatch):
+    server_state = load_server_state()
+    default_config = {
+        "llm": {"provider": "openai", "config": {"api_key": "openai-key", "model": "gpt"}},
+        "embedder": {"provider": "openai", "config": {"api_key": "openai-key", "model": "embed"}},
+    }
+    overrides = {
+        "llm": {"provider": "gemini", "config": {"api_key": "stale-openai", "model": "gemini-2.0-flash"}},
+        "embedder": {
+            "provider": "gemini",
+            "config": {"api_key": "stale-openai", "model": "models/gemini-embedding-001"},
+        },
+    }
+    monkeypatch.setenv("GOOGLE_API_KEY", "valid-google-key")
+    monkeypatch.setattr(server_state, "_load_overrides", lambda: overrides)
+
+    with patch.object(server_state.Memory, "from_config") as from_config:
+        server_state.initialize_state(default_config)
+
+    config = server_state.get_current_config()
+    assert config["llm"]["config"]["api_key"] == "valid-google-key"
+    assert config["embedder"]["config"]["api_key"] == "valid-google-key"
+    from_config.assert_called_once_with(config)
+
+
+def test_update_config_uses_env_key_for_runtime_config(monkeypatch):
+    server_state = load_server_state()
+    monkeypatch.setenv("GOOGLE_API_KEY", "valid-google-key")
+    monkeypatch.setattr(server_state, "_load_overrides", lambda: {})
+    monkeypatch.setattr(server_state, "_save_overrides", lambda overrides: None)
+
+    with patch.object(server_state.Memory, "from_config"):
+        server_state.initialize_state({"llm": {"provider": "openai", "config": {"api_key": "openai-key"}}})
+        config = server_state.update_config(
+            {"llm": {"provider": "gemini", "config": {"api_key": "openai-key", "model": "gemini-2.0-flash"}}}
+        )
+
+    assert config["llm"]["config"]["api_key"] == "valid-google-key"
+
+
+def test_provider_change_without_env_drops_previous_provider_key(monkeypatch):
+    server_state = load_server_state()
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(server_state, "_load_overrides", lambda: {})
+    monkeypatch.setattr(server_state, "_save_overrides", lambda overrides: None)
+
+    with patch.object(server_state.Memory, "from_config"):
+        server_state.initialize_state({"llm": {"provider": "openai", "config": {"api_key": "openai-key"}}})
+        config = server_state.update_config(
+            {"llm": {"provider": "gemini", "config": {"api_key": "openai-key", "model": "gemini-2.0-flash"}}}
+        )
+
+    assert config["llm"]["config"] == {"model": "gemini-2.0-flash"}
+
+
+def test_provider_change_keeps_new_key_entered_by_user(monkeypatch):
+    server_state = load_server_state()
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(server_state, "_load_overrides", lambda: {})
+    monkeypatch.setattr(server_state, "_save_overrides", lambda overrides: None)
+
+    with patch.object(server_state.Memory, "from_config"):
+        server_state.initialize_state({"llm": {"provider": "openai", "config": {"api_key": "openai-key"}}})
+        config = server_state.update_config(
+            {"llm": {"provider": "gemini", "config": {"api_key": "gemini-key", "model": "gemini-2.0-flash"}}}
+        )
+
+    assert config["llm"]["config"]["api_key"] == "gemini-key"


### PR DESCRIPTION
## Linked Issue

Closes #4984

## Description

Changing the configured provider could leave the previous provider's API key in the runtime config. Persisted overrides are now scrubbed when they switch providers, matching environment variables are applied after database overrides, and the dashboard clears the provider key field when the provider changes.

Added regression coverage for stale database overrides, runtime updates with env keys, dropping the previous provider key, and keeping a newly-entered provider key.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

`python3 -m pytest tests/test_server_state.py -q` passes locally.

`pnpm --dir server/dashboard run typecheck` currently fails before checking this change because the local install is missing the implicit `yauzl` type definition.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
