### PR TITLE
feat(openclaw): agentDomains — per-agent domain overrides, injection allowlist, and subagent session isolation fix

### DIFF
--- a/openclaw/config.ts
+++ b/openclaw/config.ts
@@ -160,6 +160,7 @@ const ALLOWED_KEYS = [
   "topK",
   "oss",
   "skills",
+  "agentDomains",
 ];
 
 function assertAllowedKeys(
@@ -256,6 +257,12 @@ export const mem0ConfigSchema = {
         typeof cfg.skills === "object" &&
         !Array.isArray(cfg.skills)
           ? (cfg.skills as Mem0Config["skills"])
+          : undefined,
+      agentDomains:
+        cfg.agentDomains &&
+        typeof cfg.agentDomains === "object" &&
+        !Array.isArray(cfg.agentDomains)
+          ? (cfg.agentDomains as Record<string, string>)
           : undefined,
     };
   },

--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -36,6 +36,7 @@ import {
   resolveUserId,
   isNonInteractiveTrigger,
   isSubagentSession,
+  extractAgentId,
 } from "./isolation.ts";
 import {
   loadTriagePrompt,
@@ -404,8 +405,23 @@ function registerHooks(
       const isSubagent = isSubagentSession(sessionId);
       const userId = _effectiveUserId(isSubagent ? undefined : sessionId);
 
+      // Resolve per-agent domain override (agentDomains config key)
+      const _agentId = extractAgentId(sessionId);
+      const _agentDomain =
+        _agentId && cfg.agentDomains?.[_agentId]
+          ? cfg.agentDomains[_agentId]
+          : undefined;
+      const _effectiveSkills: typeof cfg.skills = _agentDomain
+        ? { ...(cfg.skills ?? {}), domain: _agentDomain }
+        : (cfg.skills ?? {});
+      if (_agentDomain) {
+        api.logger.info(
+          `openclaw-mem0: per-agent domain override: agent=${_agentId} domain=${_agentDomain}`,
+        );
+      }
+
       // Static protocol goes in prependSystemContext (cacheable across turns)
-      let systemContext = loadTriagePrompt(cfg.skills ?? {});
+      let systemContext = loadTriagePrompt(_effectiveSkills);
       if (isSubagent) {
         systemContext =
           "You are a subagent — use these memories for context but do not assume you are this user. Do NOT store new memories.\n\n" +
@@ -438,7 +454,7 @@ function registerHooks(
             provider,
             query,
             userId,
-            cfg.skills ?? {},
+            _effectiveSkills,
             sessionIdForRecall,
           );
 

--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -303,6 +303,10 @@ const memoryPlugin = definePluginEntry({
       buildSearchOptions,
       {
         setCurrentSessionId: (id: string) => {
+          // Never overwrite a real session key with a subagent session key.
+          // Subagent before_prompt_build fires in the same process — without this guard,
+          // the parent agent's memory_add calls see isSubagentSession()=true and get blocked.
+          if (!id || isSubagentSession(id)) return;
           currentSessionId = id;
         },
         getStateDir: () => pluginStateDir,

--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -405,8 +405,16 @@ function registerHooks(
       const isSubagent = isSubagentSession(sessionId);
       const userId = _effectiveUserId(isSubagent ? undefined : sessionId);
 
-      // Resolve per-agent domain override (agentDomains config key)
+      // agentDomains doubles as an injection allowlist: if set and agent not listed, skip mem0 entirely.
       const _agentId = extractAgentId(sessionId);
+      if (cfg.agentDomains && _agentId && !cfg.agentDomains[_agentId]) {
+        api.logger.info(
+          `openclaw-mem0: skipping mem0 for agent=${_agentId} (not in agentDomains)`,
+        );
+        return;
+      }
+
+      // Resolve per-agent domain override (agentDomains config key)
       const _agentDomain =
         _agentId && cfg.agentDomains?.[_agentId]
           ? cfg.agentDomains[_agentId]

--- a/openclaw/openclaw.plugin.json
+++ b/openclaw/openclaw.plugin.json
@@ -291,6 +291,11 @@
           },
           "categories": { "type": "object" }
         }
+      },
+      "agentDomains": {
+        "type": "object",
+        "description": "Per-agent domain overrides. Key = agent id, value = domain name. Overrides global skills.domain for that agent only.",
+        "additionalProperties": { "type": "string" }
       }
     },
     "required": []

--- a/openclaw/types.ts
+++ b/openclaw/types.ts
@@ -30,6 +30,8 @@ export type Mem0Config = {
   needsSetup?: boolean;
   // Agentic harness skills
   skills?: SkillsConfig;
+  // Per-agent domain overrides: key = agent id, value = domain name
+  agentDomains?: Record<string, string>;
 };
 
 export interface AddOptions {

--- a/openclaw/types.ts
+++ b/openclaw/types.ts
@@ -30,7 +30,10 @@ export type Mem0Config = {
   needsSetup?: boolean;
   // Agentic harness skills
   skills?: SkillsConfig;
-  // Per-agent domain overrides: key = agent id, value = domain name
+  // Per-agent domain overrides AND injection allowlist.
+  // key = agent id, value = domain name (e.g. "companion", "beliefs", "investing").
+  // When set, ONLY agents listed here receive mem0 injection — unlisted agents are skipped entirely.
+  // This lets multi-agent setups pay mem0 costs only for agents that actually use memory.
   agentDomains?: Record<string, string>;
 };
 

--- a/openmemory/docker-compose.yml
+++ b/openmemory/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     ports:
       - "6333:6333"
     volumes:
-      - mem0_storage:/mem0/storage
+      - mem0_storage:/qdrant/storage
   openmemory-mcp:
     image: mem0/openmemory-mcp
     build: api/


### PR DESCRIPTION
## Linked Issue

<!-- No existing issue — multi-agent openclaw-mem0 usage bugs -->

## Description

Three fixes for multi-agent openclaw-mem0 setups discovered in production:

---

### 1. `agentDomains` — per-agent domain overrides

Adds `agentDomains` config key: a map of `agent id → domain name` that overrides the global `skills.domain` per agent. Useful when different agents need different extraction domains (e.g. beliefs-tracking vs. companion).

```json
"agentDomains": { "mind": "beliefs", "trading": "investing", "food": "companion" }
```

**Files:** `types.ts`, `config.ts`, `index.ts`, `openclaw.plugin.json`

---

### 2. `agentDomains` as injection allowlist

When `agentDomains` is set, agents NOT listed are skipped entirely in `before_prompt_build` — no SKILL.md injection, no memory recall, zero token cost.

Previously `triage.enabled: true` caused the ~18k-char SKILL.md + domain overlay to inject into every agent on every turn. In a 10-agent setup, 7 exec-only agents each paid ~24k chars per turn unnecessarily.

```
agent=german → not in agentDomains → skip (0 chars)
agent=mind   → "beliefs" domain   → inject with beliefs overlay
```

Log line when skipped: `openclaw-mem0: skipping mem0 for agent=german (not in agentDomains)`

**Files:** `index.ts`

---

### 3. Subagent session ID contamination bug

**Bug:** `currentSessionId` is a shared module-level variable. When a parent agent spawns a subagent, the subagent's `before_prompt_build` fires in the same process and overwrites `currentSessionId` with the subagent's session key (`:subagent:...`). Any subsequent `memory_add` call from the parent agent then sees `isSubagentSession(currentSessionId) === true` and returns `"Memory storage is not available in subagent sessions."` — silently, with no error log.

**Confirmed impact:** 37 `memory_add` calls blocked in a 14-day session. Only 3 memories stored (those from sessions where no subagent had been spawned yet in that turn).

**Fix:** `setCurrentSessionId` now ignores subagent session keys — the parent's session key is never overwritten by a child subagent's hook.

```js
// Before:
setCurrentSessionId: (id) => { currentSessionId = id; }

// After:
setCurrentSessionId: (id) => {
  if (!id || isSubagentSession(id)) return;  // never overwrite with subagent key
  currentSessionId = id;
}
```

**Files:** `index.ts`

---

### 4. `openmemory/docker-compose.yml` — Qdrant storage path fix

Qdrant mounts storage at `/qdrant/storage`, not `/mem0/storage`. Wrong path caused data loss on container restart.

---

## Type of Change

- [x] New feature — `agentDomains` domain selector
- [x] New feature — `agentDomains` injection allowlist
- [x] Bug fix — subagent session ID contamination (memory_add silently blocked)
- [x] Bug fix — docker-compose Qdrant storage path

## Breaking Changes

N/A — all changes are additive or fix silent failures. Existing configs without `agentDomains` behave identically.

## Test Coverage

- [x] Tested manually in a 10-agent OpenClaw setup
- [x] Confirmed via gateway logs: unlisted agents log skip message, listed agents log domain override
- [x] Confirmed subagent fix: `memory_add` calls now reach Qdrant after spawning subagent in same session
- [ ] No unit tests added (would require vitest mocks for openclaw plugin API)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review performed
- [x] Existing tests pass locally
- [x] Types updated with clarifying comments
- [x] Plugin JSON schema updated for `agentDomains`