### PR TITLE
fix(ts-sdk): default historyDbPath to ~/.mem0/history.db instead of r…

### DIFF
--- a/mem0-ts/src/oss/src/config/defaults.ts
+++ b/mem0-ts/src/oss/src/config/defaults.ts
@@ -1,4 +1,5 @@
 import { MemoryConfig } from "../types";
+import { getDefaultHistoryDbPath } from "../utils/sqlite";
 
 export const DEFAULT_MEMORY_CONFIG: MemoryConfig = {
   disableHistory: false,
@@ -29,7 +30,7 @@ export const DEFAULT_MEMORY_CONFIG: MemoryConfig = {
   historyStore: {
     provider: "sqlite",
     config: {
-      historyDbPath: "memory.db",
+      historyDbPath: getDefaultHistoryDbPath(),
     },
   },
 };

--- a/mem0-ts/src/oss/src/tests/sqlite-backward-compat.test.ts
+++ b/mem0-ts/src/oss/src/tests/sqlite-backward-compat.test.ts
@@ -36,7 +36,9 @@ describe("backward compat: ConfigManager.mergeConfig", () => {
     expect(cfg.llm.provider).toBe("openai");
     expect(cfg.historyStore).toBeDefined();
     expect(cfg.historyStore!.provider).toBe("sqlite");
-    expect(cfg.historyStore!.config.historyDbPath).toBe("memory.db");
+    expect(cfg.historyStore!.config.historyDbPath).toBe(
+      path.join(os.homedir(), ".mem0", "history.db"),
+    );
     expect(cfg.disableHistory).toBe(false);
   });
 

--- a/mem0-ts/src/oss/src/tests/sqlite-path-resolution.test.ts
+++ b/mem0-ts/src/oss/src/tests/sqlite-path-resolution.test.ts
@@ -41,10 +41,12 @@ describe("ConfigManager.mergeConfig – historyDbPath handling", () => {
     expect(cfg.historyStore?.config.historyDbPath).toBe("/tmp/explicit.db");
   });
 
-  it("preserves default memory.db when nothing is provided", () => {
+  it("preserves default history.db under ~/.mem0 when nothing is provided", () => {
     const cfg = ConfigManager.mergeConfig({});
     expect(cfg.historyStore?.provider).toBe("sqlite");
-    expect(cfg.historyStore?.config.historyDbPath).toBe("memory.db");
+    expect(cfg.historyStore?.config.historyDbPath).toBe(
+      path.join(os.homedir(), ".mem0", "history.db"),
+    );
   });
 
   it("respects only historyStore.config when top-level is absent", () => {

--- a/mem0-ts/src/oss/src/utils/sqlite.ts
+++ b/mem0-ts/src/oss/src/utils/sqlite.ts
@@ -6,6 +6,10 @@ export function getDefaultVectorStoreDbPath(): string {
   return path.join(os.homedir(), ".mem0", "vector_store.db");
 }
 
+export function getDefaultHistoryDbPath(): string {
+  return path.join(os.homedir(), ".mem0", "history.db");
+}
+
 export function ensureSQLiteDirectory(dbPath: string): void {
   if (!dbPath || dbPath === ":memory:" || dbPath.startsWith("file:")) {
     return;


### PR DESCRIPTION
## Linked Issue

Closes #5004

## Description
Default historyDbPath was set to "memory.db" (relative), causing
better-sqlite3 to create a fresh SQLite file in every CWD. Mirrors the
existing getDefaultVectorStoreDbPath() pattern — now defaults to
~/.mem0/history.db.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
