### PR TITLE
fix: use absolute path for default historyDbPath to prevent CWD pollution

### DIFF
--- a/mem0-ts/src/oss/src/config/defaults.ts
+++ b/mem0-ts/src/oss/src/config/defaults.ts
@@ -1,4 +1,6 @@
 import { MemoryConfig } from "../types";
+import os from "os";
+import path from "path";
 
 export const DEFAULT_MEMORY_CONFIG: MemoryConfig = {
   disableHistory: false,
@@ -29,7 +31,7 @@ export const DEFAULT_MEMORY_CONFIG: MemoryConfig = {
   historyStore: {
     provider: "sqlite",
     config: {
-      historyDbPath: "memory.db",
+      historyDbPath: path.join(os.homedir(), ".mem0", "history.db"),
     },
   },
 };


### PR DESCRIPTION
## Summary

Fixes #5004

The default `historyDbPath` was set to `"memory.db"` (a relative path), causing SQLite database files to be created in whatever directory the user runs commands from.

## Changes

1. **`defaults.ts`**: Changed default from `"memory.db"` to `path.join(os.homedir(), ".mem0", "history.db")`
2. **`SQLiteManager.ts`**: Added `mkdirSync({ recursive: true })` before creating the database

Closes #5004
