### PR TITLE
fix(memory): handle list-typed content when vision is disabled

### DIFF
--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -179,17 +179,30 @@ def parse_vision_messages(messages, llm=None, vision_details="auto"):
 
         # Handle message content
         if isinstance(msg["content"], list):
-            # Multiple image URLs in content
-            description = get_image_description(msg, llm, vision_details)
-            returned_messages.append({"role": msg["role"], "content": description})
-        elif isinstance(msg["content"], dict) and msg["content"].get("type") == "image_url":
-            # Single image content
-            image_url = msg["content"]["image_url"]["url"]
-            try:
-                description = get_image_description(image_url, llm, vision_details)
+            if llm is not None:
+                # Vision enabled: use LLM to describe images
+                description = get_image_description(msg, llm, vision_details)
                 returned_messages.append({"role": msg["role"], "content": description})
-            except Exception:
-                raise Exception(f"Error while downloading {image_url}.")
+            else:
+                # Vision disabled: extract text parts, skip image parts
+                text_parts = [
+                    part.get("text", "")
+                    for part in msg["content"]
+                    if isinstance(part, dict) and part.get("type") == "text"
+                ]
+                returned_messages.append({"role": msg["role"], "content": " ".join(text_parts)})
+        elif isinstance(msg["content"], dict) and msg["content"].get("type") == "image_url":
+            if llm is not None:
+                # Single image content
+                image_url = msg["content"]["image_url"]["url"]
+                try:
+                    description = get_image_description(image_url, llm, vision_details)
+                    returned_messages.append({"role": msg["role"], "content": description})
+                except Exception:
+                    raise Exception(f"Error while downloading {image_url}.")
+            else:
+                # Vision disabled: skip image, return empty string
+                returned_messages.append({"role": msg["role"], "content": ""})
         else:
             # Regular text content
             returned_messages.append(msg)


### PR DESCRIPTION
## Summary

Fixes #4799

`Memory.add()` crashes with `AttributeError: 'NoneType' object has no attribute 'generate_response'` when any message has a list-typed `content` field (standard multimodal format from OpenAI SDK, LangChain, etc.) and vision is not enabled (`llm=None`, which is the default).

## Root Cause

In `parse_vision_messages()`, when `msg["content"]` is a list, it unconditionally calls `get_image_description(msg, llm, ...)`, which then calls `llm.generate_response()`. When `llm=None`, this crashes.

## Fix

- When `llm is None` and content is a list: extract text parts and join them, skipping image parts
- When `llm is None` and content is a dict with `type: "image_url"`: return empty string
- When `llm is not None`: existing behavior preserved

## Test

```python
from mem0.memory.utils import parse_vision_messages

# Before: crashes with AttributeError
# After: returns text content, skips images
messages = [
    {"role": "user", "content": [{"type": "text", "text": "Hello"}, {"type": "image_url", "image_url": {"url": "https://example.com/img.png"}}]}
]
result = parse_vision_messages(messages, llm=None)
assert result == [{"role": "user", "content": "Hello"}]
```