### PR TITLE
fix(vector-stores): index Valkey memory as text

### DIFF
--- a/mem0/vector_stores/valkey.py
+++ b/mem0/vector_stores/valkey.py
@@ -21,7 +21,7 @@ DEFAULT_FIELDS = [
     {"name": "agent_id", "type": "tag"},
     {"name": "run_id", "type": "tag"},
     {"name": "user_id", "type": "tag"},
-    {"name": "memory", "type": "tag"},  # Using TAG instead of TEXT for Valkey compatibility
+    {"name": "memory", "type": "text"},
     {"name": "metadata", "type": "tag"},  # Using TAG instead of TEXT for Valkey compatibility
     {"name": "created_at", "type": "numeric"},
     {"name": "updated_at", "type": "numeric"},
@@ -169,7 +169,7 @@ class ValkeyDB(VectorStoreBase):
             "user_id",
             "TAG",
             "memory",
-            "TAG",
+            "TEXT",
             "metadata",
             "TAG",
             "created_at",

--- a/tests/vector_stores/test_valkey.py
+++ b/tests/vector_stores/test_valkey.py
@@ -383,6 +383,14 @@ def test_create_col(valkey_db, mock_valkey_client):
     assert args[dim_index + 1] == "768"
 
 
+def test_build_index_schema_uses_text_for_memory(valkey_db):
+    """Test that memory content is indexed as searchable text."""
+    cmd = valkey_db._build_index_schema("test_collection", 1536, "COSINE", "mem0:test_collection")
+
+    memory_index = cmd.index("memory")
+    assert cmd[memory_index + 1] == "TEXT"
+
+
 def test_list(valkey_db, mock_valkey_client):
     """Test listing vectors."""
     # Mock search results


### PR DESCRIPTION
## Summary

- Change the Valkey vector store index schema so the `memory` field is created as `TEXT` instead of `TAG`.
- Add a regression test for the generated `FT.CREATE` schema.

Closes #5006.

## Testing

- `uv run --with pytest --with ruff --with valkey python -m pytest tests/vector_stores/test_valkey.py -q`
- `uv run --with ruff ruff check mem0/vector_stores/valkey.py tests/vector_stores/test_valkey.py`
