### PR TITLE
feat(server): support configurable LLM/embedder providers via env vars

### DIFF
--- a/mem0/embeddings/lmstudio.py
+++ b/mem0/embeddings/lmstudio.py
@@ -1,3 +1,4 @@
+import os
 from typing import Literal, Optional
 
 from openai import OpenAI
@@ -13,6 +14,11 @@ class LMStudioEmbedding(EmbeddingBase):
         self.config.model = self.config.model or "nomic-ai/nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.f16.gguf"
         self.config.embedding_dims = self.config.embedding_dims or 1536
         self.config.api_key = self.config.api_key or "lm-studio"
+        self.config.lmstudio_base_url = (
+            self.config.lmstudio_base_url
+            or os.getenv("LMSTUDIO_BASE_URL")
+            or "http://localhost:1234/v1"
+        )
 
         self.client = OpenAI(base_url=self.config.lmstudio_base_url, api_key=self.config.api_key)
 

--- a/mem0/llms/lmstudio.py
+++ b/mem0/llms/lmstudio.py
@@ -37,6 +37,11 @@ class LMStudioLLM(LLMBase):
             or "lmstudio-community/Meta-Llama-3.1-70B-Instruct-GGUF/Meta-Llama-3.1-70B-Instruct-IQ2_M.gguf"
         )
         self.config.api_key = self.config.api_key or "lm-studio"
+        self.config.lmstudio_base_url = (
+            self.config.lmstudio_base_url
+            or os.getenv("LMSTUDIO_BASE_URL")
+            or "http://localhost:1234/v1"
+        )
 
         self.client = OpenAI(base_url=self.config.lmstudio_base_url, api_key=self.config.api_key)
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,9 +1,44 @@
-OPENAI_API_KEY=
+# ── LLM Provider ───────────────────────────────────────────────────────
+# Provider and model. Providers are resolved by the SDK; only bundled
+# providers (see BUNDLED_LLM_PROVIDERS in server/main.py) are allowed
+# when reconfiguring via /configure at runtime.
+#   Bundled: openai | anthropic | gemini | minimax | deepseek | lmstudio
+MEM0_DEFAULT_LLM_PROVIDER=openai
+MEM0_DEFAULT_LLM_MODEL=gpt-4.1-nano-2025-04-14
 
-# Optional: other bundled LLM/embedder providers (set the key for the one you want to use)
+# Provider-specific env vars. Set only the ones your chosen provider needs.
+# Each provider class reads its own vars from the environment directly.
+
+# OpenAI
+OPENAI_API_KEY=
+# OPENAI_BASE_URL=                 # optional, defaults to https://api.openai.com/v1
+
+# Anthropic
 # ANTHROPIC_API_KEY=
+
+# Gemini
 # GOOGLE_API_KEY=
 
+# MiniMax
+# MINIMAX_API_KEY=
+# MINIMAX_API_BASE=                # optional, defaults to https://api.minimax.io/v1
+
+# DeepSeek
+# DEEPSEEK_API_KEY=
+# DEEPSEEK_API_BASE=               # optional, defaults to https://api.deepseek.com
+
+# LM Studio (local LLM — no API key needed)
+# LMSTUDIO_BASE_URL=http://localhost:1234/v1
+
+# ── Embedder Provider ───────────────────────────────────────────────────
+#   Bundled: openai | gemini | lmstudio
+MEM0_DEFAULT_EMBEDDER_PROVIDER=openai
+MEM0_DEFAULT_EMBEDDER_MODEL=text-embedding-3-small
+
+# LM Studio (local embedding — no API key needed)
+# LMSTUDIO_BASE_URL=http://localhost:1234/v1
+
+# ── Vector Store ────────────────────────────────────────────────────────
 POSTGRES_HOST=
 POSTGRES_PORT=
 POSTGRES_DB=
@@ -11,6 +46,7 @@ POSTGRES_USER=
 POSTGRES_PASSWORD=
 POSTGRES_COLLECTION_NAME=
 
+# ── Authentication ──────────────────────────────────────────────────────
 ADMIN_API_KEY=
 JWT_SECRET=
 # Local development only. Leave false in production.
@@ -18,11 +54,7 @@ AUTH_DISABLED=false
 DASHBOARD_URL=http://localhost:3000
 APP_DB_NAME=mem0_app
 
-# Default LLM and embedder models. Provider must be in BUNDLED_*_PROVIDERS
-# (see server/main.py). Override to pin a specific model without editing code.
-MEM0_DEFAULT_LLM_MODEL=gpt-4.1-nano-2025-04-14
-MEM0_DEFAULT_EMBEDDER_MODEL=text-embedding-3-small
-
+# ── Telemetry & Logging ─────────────────────────────────────────────────
 # Anonymous telemetry. Sends a single onboarding event per install
 # (install UUID, email domain, server version, source). No PII.
 # Set to false to opt out.

--- a/server/README.md
+++ b/server/README.md
@@ -101,6 +101,67 @@ Once logged in, the dashboard exposes:
 - **Configuration** — runtime LLM and embedder override. Changes persist to the app database and reapply on restart, layered over the values from your `.env`.
 - **Settings** — account profile and password.
 
+## Configuration
+
+### LLM and Embedder Providers
+
+The server bundles several LLM and embedder providers. Set these environment variables in `.env` to choose which ones to use:
+
+| Variable | Default | Description |
+|---|---|---|
+| `MEM0_DEFAULT_LLM_PROVIDER` | `openai` | LLM provider (see bundled list below) |
+| `MEM0_DEFAULT_LLM_MODEL` | `gpt-4.1-nano-2025-04-14` | Model name for the chosen LLM provider |
+| `MEM0_DEFAULT_EMBEDDER_PROVIDER` | `openai` | Embedder provider (see bundled list below) |
+| `MEM0_DEFAULT_EMBEDDER_MODEL` | `text-embedding-3-small` | Model name for the chosen embedder |
+
+**Bundled LLM providers:** `openai`, `anthropic`, `gemini`, `minimax`, `deepseek`, `lmstudio`
+
+**Bundled embedder providers:** `openai`, `gemini`, `lmstudio`
+
+Each provider class reads its own API key and base URL from the environment — the server only passes the provider name and model. Set only the variables your chosen provider needs:
+
+| Provider | Required env vars | Optional env vars |
+|---|---|---|
+| OpenAI | `OPENAI_API_KEY` | `OPENAI_BASE_URL` |
+| Anthropic | `ANTHROPIC_API_KEY` | — |
+| Gemini | `GOOGLE_API_KEY` | — |
+| MiniMax | `MINIMAX_API_KEY` | `MINIMAX_API_BASE` |
+| DeepSeek | `DEEPSEEK_API_KEY` | `DEEPSEEK_API_BASE` |
+| LM Studio | (none) | `LMSTUDIO_BASE_URL` (default: `http://localhost:1234/v1`) |
+
+**Example: MiniMax LLM + local LM Studio embedding**
+
+```bash
+MEM0_DEFAULT_LLM_PROVIDER=minimax
+MEM0_DEFAULT_LLM_MODEL=MiniMax-M2.7
+MINIMAX_API_KEY=sk-cp-xxx
+MINIMAX_API_BASE=https://api.minimaxi.com/anthropic
+
+MEM0_DEFAULT_EMBEDDER_PROVIDER=lmstudio
+MEM0_DEFAULT_EMBEDDER_MODEL=nomic-ai/nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.f16.gguf
+LMSTUDIO_BASE_URL=http://localhost:1234/v1
+```
+
+**Example: DeepSeek LLM**
+
+```bash
+MEM0_DEFAULT_LLM_PROVIDER=deepseek
+MEM0_DEFAULT_LLM_MODEL=deepseek-chat
+DEEPSEEK_API_KEY=sk-xxx
+```
+
+### Runtime Reconfiguration
+
+The `POST /configure` endpoint (available in the dashboard) allows changing the LLM and embedder at runtime. Changes persist to the app database and reapply on restart, layered over `.env` defaults. Only bundled providers are accepted.
+
+### Adding a New Provider
+
+1. Add the provider's package to `requirements.txt` if it has one (most OpenAI-compatible providers need no extra dependency).
+2. Add the provider name to `BUNDLED_LLM_PROVIDERS` or `BUNDLED_EMBEDDER_PROVIDERS` in `server/main.py`.
+3. Set `MEM0_DEFAULT_LLM_PROVIDER` (or `_EMBEDDER_PROVIDER`) and the provider's own environment variables in `.env`.
+
+The provider class in `mem0/` handles its own configuration — no server code changes are needed beyond the allowlist.
+
 ## Telemetry
 
 Enabled by default, matching the Mem0 OSS library. Sends at most two events per install to the same anonymous PostHog project the library uses:

--- a/server/main.py
+++ b/server/main.py
@@ -52,8 +52,8 @@ SENSITIVE_CONFIG_KEYS = {
 SKIPPED_REQUEST_LOG_PATHS = {"/api/health", "/docs", "/redoc", "/openapi.json"}
 SKIPPED_REQUEST_LOG_PREFIXES = ("/requests",)
 
-BUNDLED_LLM_PROVIDERS = ("openai", "anthropic", "gemini")
-BUNDLED_EMBEDDER_PROVIDERS = ("openai", "gemini")
+BUNDLED_LLM_PROVIDERS = ("openai", "anthropic", "gemini", "minimax", "deepseek", "lmstudio")
+BUNDLED_EMBEDDER_PROVIDERS = ("openai", "gemini", "lmstudio")
 
 
 def _warn_if_unconfigured() -> None:
@@ -105,10 +105,27 @@ POSTGRES_USER = os.environ.get("POSTGRES_USER", "postgres")
 POSTGRES_PASSWORD = os.environ.get("POSTGRES_PASSWORD", "postgres")
 POSTGRES_COLLECTION_NAME = os.environ.get("POSTGRES_COLLECTION_NAME", "memories")
 
-OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
 HISTORY_DB_PATH = os.environ.get("HISTORY_DB_PATH", "/app/history/history.db")
+
+DEFAULT_LLM_PROVIDER = os.environ.get("MEM0_DEFAULT_LLM_PROVIDER", "openai")
 DEFAULT_LLM_MODEL = os.environ.get("MEM0_DEFAULT_LLM_MODEL", "gpt-4.1-nano-2025-04-14")
+DEFAULT_EMBEDDER_PROVIDER = os.environ.get("MEM0_DEFAULT_EMBEDDER_PROVIDER", "openai")
 DEFAULT_EMBEDDER_MODEL = os.environ.get("MEM0_DEFAULT_EMBEDDER_MODEL", "text-embedding-3-small")
+
+def _validate_provider(kind: str, provider: str, allowed: tuple) -> None:
+    if provider not in allowed:
+        raise RuntimeError(
+            f"{kind} provider '{provider}' is not bundled. "
+            f"Bundled {kind.lower()} providers: {', '.join(allowed)}. "
+            f"Set MEM0_DEFAULT_{kind.upper()}_PROVIDER to a bundled provider "
+            "or extend BUNDLED_{kind.upper()}_PROVIDERS in server/main.py."
+        )
+
+_validate_provider("LLM", DEFAULT_LLM_PROVIDER, BUNDLED_LLM_PROVIDERS)
+_validate_provider("Embedder", DEFAULT_EMBEDDER_PROVIDER, BUNDLED_EMBEDDER_PROVIDERS)
+
+# Each provider class reads its own api_key / base_url from the
+# environment. The server only sets provider + model.
 
 DEFAULT_CONFIG = {
     "version": "v1.1",
@@ -124,10 +141,13 @@ DEFAULT_CONFIG = {
         },
     },
     "llm": {
-        "provider": "openai",
-        "config": {"api_key": OPENAI_API_KEY, "temperature": 0.2, "model": DEFAULT_LLM_MODEL},
+        "provider": DEFAULT_LLM_PROVIDER,
+        "config": {"model": DEFAULT_LLM_MODEL, "temperature": 0.2},
     },
-    "embedder": {"provider": "openai", "config": {"api_key": OPENAI_API_KEY, "model": DEFAULT_EMBEDDER_MODEL}},
+    "embedder": {
+        "provider": DEFAULT_EMBEDDER_PROVIDER,
+        "config": {"model": DEFAULT_EMBEDDER_MODEL},
+    },
     "history_db_path": HISTORY_DB_PATH,
 }
 


### PR DESCRIPTION
Add MEM0_DEFAULT_LLM_PROVIDER and MEM0_DEFAULT_EMBEDDER_PROVIDER env vars so users can switch to minimax, deepseek, or lmstudio without editing code. Each provider class resolves its own api_key / base_url from the environment, so the server only passes provider name and model.

Also add LMSTUDIO_BASE_URL env var fallback to the LM Studio LLM and embedding providers for consistency with other providers.

## Linked Issue

Closes #<!-- issue number -->

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe what breaks and the migration path. Delete this section if not applicable. -->

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

<!-- Describe how you tested this, or link to CI results. -->

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] I have updated documentation if needed
