### PR TITLE
fix(memory): extract JSON after reasoning noise

### DIFF
--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -1,4 +1,5 @@
 import hashlib
+import json
 import logging
 import re
 from typing import Any, Dict, List
@@ -125,18 +126,25 @@ def remove_code_blocks(content: str) -> str:
 def extract_json(text):
     """
     Extracts JSON content from a string, removing enclosing triple backticks and optional 'json' tag if present.
-    If no code block is found, attempts to locate JSON by finding the first '{' and last '}'.
+    If no code block is found, attempts to locate the first valid JSON object or array in the text.
     If that also fails, returns the text as-is.
     """
     text = text.strip()
+    text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL).strip()
     match = re.search(r"```(?:json)?\s*(.*?)\s*```", text, re.DOTALL)
     if match:
         json_str = match.group(1)
     else:
-        start_idx = text.find("{")
-        end_idx = text.rfind("}")
-        if start_idx != -1 and end_idx != -1 and end_idx > start_idx:
-            json_str = text[start_idx : end_idx + 1]
+        decoder = json.JSONDecoder(strict=False)
+        for start_idx, char in enumerate(text):
+            if char not in "{[":
+                continue
+            try:
+                _, end_idx = decoder.raw_decode(text[start_idx:])
+                json_str = text[start_idx : start_idx + end_idx]
+                break
+            except json.JSONDecodeError:
+                continue
         else:
             json_str = text
     return json_str
@@ -292,4 +300,3 @@ def remove_spaces_from_entities(
         item["destination"] = item["destination"].lower().replace(" ", "_")
         cleaned.append(item)
     return cleaned
-

--- a/tests/test_chatty_llm_parsing.py
+++ b/tests/test_chatty_llm_parsing.py
@@ -91,6 +91,22 @@ That's the result."""
         parsed = json.loads(result)
         assert parsed["memory"][0]["id"] == "0"
 
+    def test_skips_invalid_reasoning_braces_before_json(self):
+        """Reasoning leakage can contain malformed braces before the final JSON."""
+        text = """I first considered {not valid JSON.
+The final answer is:
+{"memory": [{"id": "0", "text": "likes hiking", "event": "ADD"}]}
+"""
+        result = extract_json(text)
+        parsed = json.loads(result)
+        assert parsed["memory"][0]["text"] == "likes hiking"
+
+    def test_extracts_json_array(self):
+        text = 'Facts:\n["likes hiking", "owns a bike"]\nDone.'
+        result = extract_json(text)
+        parsed = json.loads(result)
+        assert parsed == ["likes hiking", "owns a bike"]
+
 
 # --- Test remove_code_blocks ---
 
@@ -194,6 +210,13 @@ I hope this helps!"""
         response = '<think>Let me process this...</think>\n```json\n{"memory": [{"id": "0", "text": "test", "event": "ADD"}]}\n```'
         result = self._parse_with_fallback(response)
         assert result["memory"][0]["text"] == "test"
+
+    def test_reasoning_noise_with_invalid_braces_before_json(self):
+        response = """Reasoning: {candidate memory is incomplete
+Final:
+{"memory": [{"id": "0", "text": "Name is Alex", "event": "ADD"}]}"""
+        result = self._parse_with_fallback(response)
+        assert result["memory"][0]["text"] == "Name is Alex"
 
     def test_lmstudio_style_response(self):
         """Mimics the actual LM Studio response format from the issue."""


### PR DESCRIPTION
## Summary
- make `extract_json` scan for the first JSON object or array that can actually be decoded
- strip leaked `<think>...</think>` blocks before extraction
- add regression coverage for malformed reasoning braces before the final memory JSON

Fixes #3918

## Testing
- `uv run --with pytest --with ruff python -m pytest tests/test_chatty_llm_parsing.py -q`
- `uv run --with pytest --with pytest-asyncio --with pytest-mock --with ruff python -m pytest tests/memory/test_main.py tests/test_chatty_llm_parsing.py -q`
- `uv run --with ruff ruff check mem0/memory/utils.py tests/test_chatty_llm_parsing.py`
