### PR TITLE
fix(vector-stores): pass custom Weaviate filters

### DIFF
--- a/mem0/vector_stores/weaviate.py
+++ b/mem0/vector_stores/weaviate.py
@@ -116,6 +116,15 @@ class Weaviate(VectorStoreBase):
 
         return result
 
+    def _build_filters(self, filters: Optional[Dict]):
+        if not filters:
+            return None
+
+        filter_conditions = [
+            Filter.by_property(key).equal(value) for key, value in filters.items() if value is not None
+        ]
+        return Filter.all_of(filter_conditions) if filter_conditions else None
+
     def create_col(self, vector_size, distance="cosine"):
         """
         Create a new collection with the specified schema.
@@ -185,12 +194,7 @@ class Weaviate(VectorStoreBase):
         Search for similar vectors.
         """
         collection = self.client.collections.get(str(self.collection_name))
-        filter_conditions = []
-        if filters:
-            for key, value in filters.items():
-                if value and key in ["user_id", "agent_id", "run_id"]:
-                    filter_conditions.append(Filter.by_property(key).equal(value))
-        combined_filter = Filter.all_of(filter_conditions) if filter_conditions else None
+        combined_filter = self._build_filters(filters)
         response = collection.query.hybrid(
             query="",
             vector=vectors,
@@ -230,18 +234,13 @@ class Weaviate(VectorStoreBase):
         Args:
             query (str): Search query text.
             top_k (int): Maximum number of results. Defaults to 5.
-            filters (dict, optional): Filters to apply (user_id, agent_id, run_id).
+            filters (dict, optional): Filters to apply.
 
         Returns:
             List[OutputData]: Search results.
         """
         collection = self.client.collections.get(str(self.collection_name))
-        filter_conditions = []
-        if filters:
-            for key, value in filters.items():
-                if value and key in ["user_id", "agent_id", "run_id"]:
-                    filter_conditions.append(Filter.by_property(key).equal(value))
-        combined_filter = Filter.all_of(filter_conditions) if filter_conditions else None
+        combined_filter = self._build_filters(filters)
         response = collection.query.bm25(
             query=query,
             query_properties=["data"],
@@ -367,12 +366,7 @@ class Weaviate(VectorStoreBase):
         List all vectors in a collection.
         """
         collection = self.client.collections.get(self.collection_name)
-        filter_conditions = []
-        if filters:
-            for key, value in filters.items():
-                if value and key in ["user_id", "agent_id", "run_id"]:
-                    filter_conditions.append(Filter.by_property(key).equal(value))
-        combined_filter = Filter.all_of(filter_conditions) if filter_conditions else None
+        combined_filter = self._build_filters(filters)
         response = collection.query.fetch_objects(
             limit=top_k,
             filters=combined_filter,

--- a/tests/vector_stores/test_weaviate.py
+++ b/tests/vector_stores/test_weaviate.py
@@ -145,6 +145,25 @@ class TestWeaviateDB(unittest.TestCase):
         self.assertEqual(results[0].id, "id1")
         self.assertEqual(results[0].score, 0.8)
 
+    def test_filters_include_custom_metadata_keys(self):
+        mock_filter = MagicMock()
+        mock_filter.equal.side_effect = lambda value: f"filter:{value}"
+
+        with (
+            patch("mem0.vector_stores.weaviate.Filter.by_property", return_value=mock_filter) as mock_by_property,
+            patch("mem0.vector_stores.weaviate.Filter.all_of", return_value="combined-filter") as mock_all_of,
+        ):
+            combined_filter = self.weaviate_db._build_filters(
+                {"user_id": "alice", "category": "movies", "test": 0, "agent_id": None}
+            )
+
+        self.assertEqual(combined_filter, "combined-filter")
+        mock_by_property.assert_any_call("user_id")
+        mock_by_property.assert_any_call("category")
+        mock_by_property.assert_any_call("test")
+        self.assertEqual(mock_by_property.call_count, 3)
+        mock_all_of.assert_called_once_with(["filter:alice", "filter:movies", "filter:0"])
+
     def test_delete(self):
         self.weaviate_db.delete(vector_id="id1")
 


### PR DESCRIPTION
## What changed

- Stop hardcoding Weaviate filters to only `user_id`, `agent_id`, and `run_id`.
- Reuse one filter builder for `search()`, `keyword_search()`, and `list()`.
- Preserve valid falsy metadata filter values like `0` while still skipping `None`.
- Add a regression test that custom metadata keys are included in the Weaviate filter.

Fixes #4053.

Note: #4848 was closed in favor of #4853, but #4853 fixed same-key metadata filter merging in `Memory`; it does not change the Weaviate vector store whitelist that still drops custom metadata keys.

## Testing

- `uv run --with pytest --with pytest-mock --with ruff --with weaviate-client --with python-dotenv python -m pytest tests/vector_stores/test_weaviate.py -q`
- `uv run --with ruff ruff check mem0/vector_stores/weaviate.py tests/vector_stores/test_weaviate.py`
- `uv run --with ruff ruff format --check mem0/vector_stores/weaviate.py tests/vector_stores/test_weaviate.py`
