### PR TITLE
fix: keep Valkey hashes aligned with index schema

### DIFF
--- a/mem0/vector_stores/valkey.py
+++ b/mem0/vector_stores/valkey.py
@@ -33,6 +33,7 @@ DEFAULT_FIELDS = [
 ]
 
 excluded_keys = {"user_id", "agent_id", "run_id", "hash", "data", "created_at", "updated_at"}
+optional_tag_fields = ["agent_id", "run_id", "user_id"]
 
 
 class OutputData(BaseModel):
@@ -272,6 +273,11 @@ class ValkeyDB(VectorStoreBase):
             logger.exception(f"Error creating collection {collection_name}: {e}")
             raise
 
+    def _ensure_indexed_fields(self, hash_data):
+        for field in optional_tag_fields:
+            hash_data.setdefault(field, "")
+        hash_data.setdefault("updated_at", 0)
+
     def insert(self, vectors: list, payloads: list = None, ids: list = None):
         """
         Insert vectors and their payloads into the index.
@@ -305,12 +311,13 @@ class ValkeyDB(VectorStoreBase):
                 }
 
                 # Add optional fields
-                for field in ["agent_id", "run_id", "user_id"]:
+                for field in optional_tag_fields:
                     if field in payload:
                         hash_data[field] = payload[field]
 
                 # Add metadata
                 hash_data["metadata"] = json.dumps({k: v for k, v in payload.items() if k not in excluded_keys})
+                self._ensure_indexed_fields(hash_data)
 
                 # Store in Valkey
                 self.client.hset(key, mapping=hash_data)
@@ -400,11 +407,16 @@ class ValkeyDB(VectorStoreBase):
 
             # Add updated_at if available
             if hasattr(doc, "updated_at"):
-                payload["updated_at"] = self._format_timestamp(int(doc.updated_at), self.timezone)
+                try:
+                    updated_at = int(doc.updated_at)
+                    if updated_at > 0:
+                        payload["updated_at"] = self._format_timestamp(updated_at, self.timezone)
+                except (ValueError, TypeError):
+                    payload["updated_at"] = doc.updated_at
 
             # Add optional fields
-            for field in ["agent_id", "run_id", "user_id"]:
-                if hasattr(doc, field):
+            for field in optional_tag_fields:
+                if hasattr(doc, field) and getattr(doc, field) != "":
                     payload[field] = getattr(doc, field)
 
             # Add metadata
@@ -512,12 +524,13 @@ class ValkeyDB(VectorStoreBase):
                 hash_data["updated_at"] = int(datetime.fromisoformat(payload["updated_at"]).timestamp())
 
             # Add optional fields
-            for field in ["agent_id", "run_id", "user_id"]:
+            for field in optional_tag_fields:
                 if field in payload:
                     hash_data[field] = payload[field]
 
             # Add metadata
             hash_data["metadata"] = json.dumps({k: v for k, v in payload.items() if k not in excluded_keys})
+            self._ensure_indexed_fields(hash_data)
 
             # Update in Valkey
             self.client.hset(key, mapping=hash_data)
@@ -596,13 +609,15 @@ class ValkeyDB(VectorStoreBase):
         # Add updated_at if available
         if "updated_at" in result:
             try:
-                payload["updated_at"] = self._format_timestamp(int(result["updated_at"]), self.timezone)
+                updated_at = int(result["updated_at"])
+                if updated_at > 0:
+                    payload["updated_at"] = self._format_timestamp(updated_at, self.timezone)
             except (ValueError, TypeError):
                 payload["updated_at"] = result["updated_at"]
 
         # Add optional fields
-        for field in ["agent_id", "run_id", "user_id"]:
-            if field in result:
+        for field in optional_tag_fields:
+            if field in result and result[field] != "":
                 payload[field] = result[field]
 
         # Add metadata

--- a/tests/vector_stores/test_valkey.py
+++ b/tests/vector_stores/test_valkey.py
@@ -119,6 +119,39 @@ def test_search_without_filters(valkey_db, mock_valkey_client):
     assert "created_at" in results[0].payload
 
 
+def test_search_ignores_empty_index_placeholders(valkey_db, mock_valkey_client):
+    """Test that placeholder fields for Valkey indexing do not leak into search payloads."""
+    mock_doc = MagicMock()
+    mock_doc.memory_id = "test_id"
+    mock_doc.hash = "test_hash"
+    mock_doc.memory = "test_data"
+    mock_doc.created_at = str(int(datetime.now().timestamp()))
+    mock_doc.updated_at = "0"
+    mock_doc.user_id = ""
+    mock_doc.agent_id = ""
+    mock_doc.run_id = ""
+    mock_doc.metadata = json.dumps({})
+    mock_doc.vector_score = "0.5"
+
+    mock_results = MagicMock()
+    mock_results.docs = [mock_doc]
+
+    mock_ft = mock_valkey_client.ft.return_value
+    mock_ft.search.return_value = mock_results
+
+    results = valkey_db.search(
+        query="test query",
+        vectors=np.random.rand(1536).tolist(),
+        top_k=5,
+    )
+
+    payload = results[0].payload
+    assert "updated_at" not in payload
+    assert "user_id" not in payload
+    assert "agent_id" not in payload
+    assert "run_id" not in payload
+
+
 def test_insert(valkey_db, mock_valkey_client):
     """Test inserting vectors."""
     # Prepare test data
@@ -138,6 +171,9 @@ def test_insert(valkey_db, mock_valkey_client):
     assert kwargs["mapping"]["hash"] == "test_hash"
     assert kwargs["mapping"]["memory"] == "test_data"
     assert kwargs["mapping"]["user_id"] == "test_user"
+    assert kwargs["mapping"]["agent_id"] == ""
+    assert kwargs["mapping"]["run_id"] == ""
+    assert kwargs["mapping"]["updated_at"] == 0
     assert "created_at" in kwargs["mapping"]
     assert "embedding" in kwargs["mapping"]
 
@@ -156,6 +192,10 @@ def test_insert_handles_missing_created_at(valkey_db, mock_valkey_client):
     mock_valkey_client.hset.assert_called_once()
     args, kwargs = mock_valkey_client.hset.call_args
     assert "created_at" in kwargs["mapping"]  # Should be added automatically
+    assert kwargs["mapping"]["agent_id"] == ""
+    assert kwargs["mapping"]["run_id"] == ""
+    assert kwargs["mapping"]["user_id"] == ""
+    assert kwargs["mapping"]["updated_at"] == 0
 
 
 def test_delete(valkey_db, mock_valkey_client):
@@ -553,6 +593,24 @@ def test_process_document_fields(valkey_db):
     assert payload["hash"] == "test_hash"
     assert "data" in payload  # Should have default value
     assert "created_at" in payload  # Should have default value
+
+    # Test with Valkey indexing placeholders
+    result = {
+        "hash": "test_hash",
+        "memory": "test_data",
+        "created_at": "1625097600",
+        "updated_at": "0",
+        "user_id": "",
+        "agent_id": "",
+        "run_id": "",
+    }
+
+    payload, memory_id = valkey_db._process_document_fields(result, "default_id")
+
+    assert "updated_at" not in payload
+    assert "user_id" not in payload
+    assert "agent_id" not in payload
+    assert "run_id" not in payload
 
 
 def test_init_connection_error():


### PR DESCRIPTION
## Summary
- Populate Valkey hash fields that are present in the FT.CREATE schema but optional in mem0 payloads.
- Use empty tag placeholders and an `updated_at` value of `0` so older Valkey Search/ElastiCache versions do not skip indexing documents with missing schema fields.
- Keep those placeholders out of search/get payloads returned to users.

Fixes #3948.

## Tests
- `uv run --with pytest --with ruff --with valkey python -m pytest tests/vector_stores/test_valkey.py -q`
- `uv run --with ruff ruff check mem0/vector_stores/valkey.py tests/vector_stores/test_valkey.py`
- `uv run --with ruff ruff format --check mem0/vector_stores/valkey.py tests/vector_stores/test_valkey.py`