### PR TITLE
fix: prevent AttributeError in parse_vision_messages when llm is None

### DIFF
--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -169,8 +169,15 @@ def get_image_description(image_obj, llm, vision_details):
 
 def parse_vision_messages(messages, llm=None, vision_details="auto"):
     """
-    Parse the vision messages from the messages
+    Parse the vision messages from the messages.
+
+    When llm is None (vision disabled), messages are returned unchanged.
+    When llm is provided, image content is replaced with generated descriptions.
     """
+    # Fast path: no LLM means no vision processing needed
+    if llm is None:
+        return messages
+
     returned_messages = []
     for msg in messages:
         if msg["role"] == "system":
@@ -179,9 +186,16 @@ def parse_vision_messages(messages, llm=None, vision_details="auto"):
 
         # Handle message content
         if isinstance(msg["content"], list):
-            # Multiple image URLs in content
-            description = get_image_description(msg, llm, vision_details)
-            returned_messages.append({"role": msg["role"], "content": description})
+            # Check if content actually contains images before calling vision
+            has_image = any(
+                isinstance(item, dict) and item.get("type") == "image_url"
+                for item in msg["content"]
+            )
+            if has_image:
+                description = get_image_description(msg, llm, vision_details)
+                returned_messages.append({"role": msg["role"], "content": description})
+            else:
+                returned_messages.append(msg)
         elif isinstance(msg["content"], dict) and msg["content"].get("type") == "image_url":
             # Single image content
             image_url = msg["content"]["image_url"]["url"]


### PR DESCRIPTION
## Problem

`parse_vision_messages()` defaults `llm=None` (vision disabled), but unconditionally calls `get_image_description()` → `llm.generate_response()` for list-typed and `image_url`-dict content. This crashes with:

```
AttributeError: "NoneType" object has no attribute "generate_response"
```

Triggered by any standard multimodal message format (as produced by OpenAI SDK, LangChain, etc.) when `enable_vision=False` (the default).

## Repro

```python
from mem0.memory.utils import parse_vision_messages

messages = [{"role": "user", "content": [{"type": "text", "text": "Hi"}]}]
parse_vision_messages(messages)  # AttributeError
```

## Fix

- **Fast path:** return messages unchanged when `llm is None` — no vision processing needed
- **List content guard:** for list-typed content, check if items actually contain `image_url` before calling vision processing; pass through text-only lists unchanged

## Related

Fixes #4799