### PR TITLE
fix: allow dashboard refresh cookie on http deployments

### DIFF
--- a/server/dashboard/src/app/api/auth/refresh/route.ts
+++ b/server/dashboard/src/app/api/auth/refresh/route.ts
@@ -4,9 +4,23 @@ import { AUTH_ENDPOINTS } from "@/utils/api-endpoints";
 import { getServerApiUrl } from "@/lib/server-api-url";
 
 const COOKIE_NAME = "mem0_refresh_token";
+
+function shouldUseSecureCookie() {
+  const dashboardUrl = process.env.DASHBOARD_URL;
+  if (!dashboardUrl) {
+    return process.env.NODE_ENV === "production";
+  }
+
+  try {
+    return new URL(dashboardUrl).protocol === "https:";
+  } catch {
+    return process.env.NODE_ENV === "production";
+  }
+}
+
 const COOKIE_OPTIONS = {
   httpOnly: true,
-  secure: process.env.NODE_ENV === "production",
+  secure: shouldUseSecureCookie(),
   sameSite: "lax" as const,
   path: "/",
   maxAge: 30 * 24 * 60 * 60, // 30 days


### PR DESCRIPTION
## Summary
- derive the dashboard refresh cookie `secure` flag from `DASHBOARD_URL` when it is configured
- keep secure cookies for HTTPS deployments and production deployments without an explicit dashboard URL
- allow documented self-hosted HTTP/IP deployments to retain the refresh cookie after login

Fixes #5024

## Tests
- `pnpm exec prettier --write src/app/api/auth/refresh/route.ts`
- `pnpm run typecheck`
- `pnpm exec prettier --check src/app/api/auth/refresh/route.ts`