### PR TITLE
fix(pgvector): convert cosine distance to similarity in search()

### DIFF
--- a/mem0/vector_stores/pgvector.py
+++ b/mem0/vector_stores/pgvector.py
@@ -10,6 +10,7 @@ try:
     from psycopg import sql
     from psycopg.types.json import Json
     from psycopg_pool import ConnectionPool
+
     PSYCOPG_VERSION = 3
     logger = logging.getLogger(__name__)
     logger.info("Using psycopg (psycopg3) with ConnectionPool for PostgreSQL connections")
@@ -18,6 +19,7 @@ except ImportError:
         from psycopg2 import sql
         from psycopg2.extras import Json, execute_values
         from psycopg2.pool import ThreadedConnectionPool as ConnectionPool
+
         PSYCOPG_VERSION = 2
         logger = logging.getLogger(__name__)
         logger.info("Using psycopg2 with ThreadedConnectionPool for PostgreSQL connections")
@@ -88,10 +90,11 @@ class PGVector(VectorStoreBase):
         elif connection_string:
             if sslmode:
                 # Append sslmode to connection string if provided
-                if 'sslmode=' in connection_string:
+                if "sslmode=" in connection_string:
                     # Replace existing sslmode
                     import re
-                    connection_string = re.sub(r'sslmode=[^ ]*', f'sslmode={sslmode}', connection_string)
+
+                    connection_string = re.sub(r"sslmode=[^ ]*", f"sslmode={sslmode}", connection_string)
                 else:
                     # Add sslmode to connection string
                     connection_string = f"{connection_string} sslmode={sslmode}"
@@ -99,11 +102,13 @@ class PGVector(VectorStoreBase):
             connection_string = f"postgresql://{user}:{password}@{host}:{port}/{dbname}"
             if sslmode:
                 connection_string = f"{connection_string} sslmode={sslmode}"
-        
+
         if self.connection_pool is None:
             if PSYCOPG_VERSION == 3:
                 # psycopg3 ConnectionPool
-                self.connection_pool = ConnectionPool(conninfo=connection_string, min_size=minconn, max_size=maxconn, open=True)
+                self.connection_pool = ConnectionPool(
+                    conninfo=connection_string, min_size=minconn, max_size=maxconn, open=True
+                )
             else:
                 # psycopg2 ThreadedConnectionPool
                 self.connection_pool = ConnectionPool(minconn=minconn, maxconn=maxconn, dsn=connection_string)
@@ -260,7 +265,7 @@ class PGVector(VectorStoreBase):
             )
 
             results = cur.fetchall()
-        return [OutputData(id=str(r[0]), score=float(r[1]), payload=r[2]) for r in results]
+        return [OutputData(id=str(r[0]), score=1.0 - float(r[1]), payload=r[2]) for r in results]
 
     def keyword_search(self, query, top_k=5, filters=None):
         """
@@ -330,7 +335,7 @@ class PGVector(VectorStoreBase):
         """
         with self._get_cursor(commit=True) as cur:
             if vector:
-               cur.execute(
+                cur.execute(
                     sql.SQL("UPDATE {} SET vector = %s WHERE id = %s").format(self._col()),
                     (vector, vector_id),
                 )
@@ -348,7 +353,6 @@ class PGVector(VectorStoreBase):
                         sql.SQL("UPDATE {} SET payload = %s WHERE id = %s").format(self._col()),
                         (Json(payload), vector_id),
                     )
-
 
     def get(self, vector_id: str) -> OutputData:
         """
@@ -408,11 +412,7 @@ class PGVector(VectorStoreBase):
             result = cur.fetchone()
         return {"name": result[0], "count": result[1], "size": result[2]}
 
-    def list(
-        self,
-        filters: Optional[dict] = None,
-        top_k: Optional[int] = 100
-    ) -> List[OutputData]:
+    def list(self, filters: Optional[dict] = None, top_k: Optional[int] = 100) -> List[OutputData]:
         """
         List all vectors in a collection.
 

--- a/tests/vector_stores/test_pgvector.py
+++ b/tests/vector_stores/test_pgvector.py
@@ -450,9 +450,9 @@ class TestPGVector(unittest.TestCase):
         # Verify results
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0].id, self.test_ids[0])
-        self.assertEqual(results[0].score, 0.1)
+        self.assertEqual(results[0].score, 0.9)
         self.assertEqual(results[1].id, self.test_ids[1])
-        self.assertEqual(results[1].score, 0.2)
+        self.assertEqual(results[1].score, 0.8)
 
     @patch('mem0.vector_stores.pgvector.PSYCOPG_VERSION', 2)
     @patch('mem0.vector_stores.pgvector.ConnectionPool')
@@ -499,9 +499,9 @@ class TestPGVector(unittest.TestCase):
         # Verify results
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0].id, self.test_ids[0])
-        self.assertEqual(results[0].score, 0.1)
+        self.assertEqual(results[0].score, 0.9)
         self.assertEqual(results[1].id, self.test_ids[1])
-        self.assertEqual(results[1].score, 0.2)
+        self.assertEqual(results[1].score, 0.8)
 
     @patch('mem0.vector_stores.pgvector.PSYCOPG_VERSION', 3)
     @patch('mem0.vector_stores.pgvector.ConnectionPool')
@@ -1145,7 +1145,7 @@ class TestPGVector(unittest.TestCase):
         # Verify results
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].id, self.test_ids[0])
-        self.assertEqual(results[0].score, 0.1)
+        self.assertEqual(results[0].score, 0.9)
         self.assertEqual(results[0].payload["user_id"], "alice")
         self.assertEqual(results[0].payload["agent_id"], "agent1")
         self.assertEqual(results[0].payload["run_id"], "run1")
@@ -1195,7 +1195,7 @@ class TestPGVector(unittest.TestCase):
         # Verify results
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].id, self.test_ids[0])
-        self.assertEqual(results[0].score, 0.1)
+        self.assertEqual(results[0].score, 0.9)
         self.assertEqual(results[0].payload["user_id"], "alice")
         self.assertEqual(results[0].payload["agent_id"], "agent1")
         self.assertEqual(results[0].payload["run_id"], "run1")
@@ -1245,7 +1245,7 @@ class TestPGVector(unittest.TestCase):
         # Verify results
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].id, self.test_ids[0])
-        self.assertEqual(results[0].score, 0.1)
+        self.assertEqual(results[0].score, 0.9)
         self.assertEqual(results[0].payload["user_id"], "alice")
 
     @patch('mem0.vector_stores.pgvector.PSYCOPG_VERSION', 2)
@@ -1293,7 +1293,7 @@ class TestPGVector(unittest.TestCase):
         # Verify results
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].id, self.test_ids[0])
-        self.assertEqual(results[0].score, 0.1)
+        self.assertEqual(results[0].score, 0.9)
         self.assertEqual(results[0].payload["user_id"], "alice")
 
     @patch('mem0.vector_stores.pgvector.PSYCOPG_VERSION', 3)
@@ -1341,9 +1341,9 @@ class TestPGVector(unittest.TestCase):
         # Verify results
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0].id, self.test_ids[0])
-        self.assertEqual(results[0].score, 0.1)
+        self.assertEqual(results[0].score, 0.9)
         self.assertEqual(results[1].id, self.test_ids[1])
-        self.assertEqual(results[1].score, 0.2)
+        self.assertEqual(results[1].score, 0.8)
 
     @patch('mem0.vector_stores.pgvector.PSYCOPG_VERSION', 2)
     @patch('mem0.vector_stores.pgvector.ConnectionPool')
@@ -1390,9 +1390,9 @@ class TestPGVector(unittest.TestCase):
         # Verify results
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0].id, self.test_ids[0])
-        self.assertEqual(results[0].score, 0.1)
+        self.assertEqual(results[0].score, 0.9)
         self.assertEqual(results[1].id, self.test_ids[1])
-        self.assertEqual(results[1].score, 0.2)
+        self.assertEqual(results[1].score, 0.8)
 
     @patch('mem0.vector_stores.pgvector.PSYCOPG_VERSION', 3)
     @patch('mem0.vector_stores.pgvector.ConnectionPool')


### PR DESCRIPTION
## Linked Issue

No existing issue — root cause discovered while debugging self-hosted mem0 with pgvector.

## Description

`PGVector.search()` returns the raw cosine **distance** from the `<=>` operator (range [0,2], lower = more similar) as the `score` field of each `OutputData`. Downstream, `mem0/utils/scoring.py:score_and_rank` treats `score` as a **similarity** value (higher = better, with `if semantic_score < threshold: continue` as the filter gate). This inversion causes the most-relevant memories to rank last and be filtered out of `top_k`.

**Fix:** convert distance to similarity before returning:

\`\`\`python
# before
score=float(r[1])

# after
score=1.0 - float(r[1])
\`\`\`

\`keyword_search()\` is unaffected — it uses \`ts_rank_cd\` which already returns a similarity-style score (higher = more relevant).

All other vector store backends (Qdrant, Chroma, Pinecone, etc.) return similarity. This aligns pgvector with them.

**Observed locally:** query "peanut allergy" against a collection containing "User is allergic to peanuts" (cosine distance ≈ 0.32) was ranked last instead of first; patch confirmed fix.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

Users who consumed the raw `score` field from pgvector search results and expected it to be a cosine distance (lower = more similar) will now receive `1 - distance` (higher = more similar). Internal mem0 consumers (`score_and_rank`) benefit from the fix. External consumers relying on the old behaviour should subtract from 1.

## Test Coverage

- [x] I added/updated unit tests

Updated `tests/vector_stores/test_pgvector.py`: existing search tests mocked cursor rows returning distance values of `0.1`/`0.2`; updated assertions to expect `0.9`/`0.8` (i.e. `1 - distance`). All 50 tests pass locally.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed