### PR TITLE
fix(ts-oss): default historyDbPath to ~/.mem0/history.db instead of relative "memory.db"

### DIFF
--- a/mem0-ts/src/oss/src/config/defaults.ts
+++ b/mem0-ts/src/oss/src/config/defaults.ts
@@ -1,4 +1,5 @@
 import { MemoryConfig } from "../types";
+import { getDefaultHistoryDbPath } from "../utils/sqlite";
 
 export const DEFAULT_MEMORY_CONFIG: MemoryConfig = {
   disableHistory: false,
@@ -29,7 +30,7 @@ export const DEFAULT_MEMORY_CONFIG: MemoryConfig = {
   historyStore: {
     provider: "sqlite",
     config: {
-      historyDbPath: "memory.db",
+      historyDbPath: getDefaultHistoryDbPath(),
     },
   },
 };

--- a/mem0-ts/src/oss/src/tests/sqlite-backward-compat.test.ts
+++ b/mem0-ts/src/oss/src/tests/sqlite-backward-compat.test.ts
@@ -12,6 +12,7 @@ import { SQLiteManager } from "../storage/SQLiteManager";
 import { MemoryVectorStore } from "../vector_stores/memory";
 import {
   ensureSQLiteDirectory,
+  getDefaultHistoryDbPath,
   getDefaultVectorStoreDbPath,
 } from "../utils/sqlite";
 
@@ -36,7 +37,7 @@ describe("backward compat: ConfigManager.mergeConfig", () => {
     expect(cfg.llm.provider).toBe("openai");
     expect(cfg.historyStore).toBeDefined();
     expect(cfg.historyStore!.provider).toBe("sqlite");
-    expect(cfg.historyStore!.config.historyDbPath).toBe("memory.db");
+    expect(cfg.historyStore!.config.historyDbPath).toBe(getDefaultHistoryDbPath());
     expect(cfg.disableHistory).toBe(false);
   });
 

--- a/mem0-ts/src/oss/src/tests/sqlite-path-resolution.test.ts
+++ b/mem0-ts/src/oss/src/tests/sqlite-path-resolution.test.ts
@@ -6,6 +6,7 @@ import { SQLiteManager } from "../storage/SQLiteManager";
 import { MemoryVectorStore } from "../vector_stores/memory";
 import {
   ensureSQLiteDirectory,
+  getDefaultHistoryDbPath,
   getDefaultVectorStoreDbPath,
 } from "../utils/sqlite";
 
@@ -41,10 +42,10 @@ describe("ConfigManager.mergeConfig – historyDbPath handling", () => {
     expect(cfg.historyStore?.config.historyDbPath).toBe("/tmp/explicit.db");
   });
 
-  it("preserves default memory.db when nothing is provided", () => {
+  it("preserves default historyDbPath when nothing is provided", () => {
     const cfg = ConfigManager.mergeConfig({});
     expect(cfg.historyStore?.provider).toBe("sqlite");
-    expect(cfg.historyStore?.config.historyDbPath).toBe("memory.db");
+    expect(cfg.historyStore?.config.historyDbPath).toBe(getDefaultHistoryDbPath());
   });
 
   it("respects only historyStore.config when top-level is absent", () => {
@@ -286,5 +287,12 @@ describe("getDefaultVectorStoreDbPath", () => {
   it("returns path under homedir/.mem0", () => {
     const result = getDefaultVectorStoreDbPath();
     expect(result).toBe(path.join(os.homedir(), ".mem0", "vector_store.db"));
+  });
+});
+
+describe("getDefaultHistoryDbPath", () => {
+  it("returns path under homedir/.mem0/history.db", () => {
+    const result = getDefaultHistoryDbPath();
+    expect(result).toBe(path.join(os.homedir(), ".mem0", "history.db"));
   });
 });

--- a/mem0-ts/src/oss/src/utils/sqlite.ts
+++ b/mem0-ts/src/oss/src/utils/sqlite.ts
@@ -6,6 +6,10 @@ export function getDefaultVectorStoreDbPath(): string {
   return path.join(os.homedir(), ".mem0", "vector_store.db");
 }
 
+export function getDefaultHistoryDbPath(): string {
+  return path.join(os.homedir(), ".mem0", "history.db");
+}
+
 export function ensureSQLiteDirectory(dbPath: string): void {
   if (!dbPath || dbPath === ":memory:" || dbPath.startsWith("file:")) {
     return;


### PR DESCRIPTION
## Bug

The TypeScript SDK hard-codes `historyDbPath: "memory.db"` as the default value in `DEFAULT_MEMORY_CONFIG`. Because this is a relative path, SQLite resolves it against the current working directory at the time the process starts. This means a `memory.db` file is silently created in whatever directory the user runs a CLI command from — their project root, `~`, `/tmp`, etc. — making the history database effectively unreliable and polluting arbitrary directories.

This is the same class of problem that was already fixed for `vector_store.db` (see `getDefaultVectorStoreDbPath()` in `utils/sqlite.ts`), where the default was moved to `~/.mem0/vector_store.db`.

## Fix

1. **`mem0-ts/src/oss/src/utils/sqlite.ts`** — Added `getDefaultHistoryDbPath()` immediately after `getDefaultVectorStoreDbPath()`. It returns `path.join(os.homedir(), ".mem0", "history.db")`, an absolute, user-scoped path. Both `path` and `os` were already imported.

2. **`mem0-ts/src/oss/src/config/defaults.ts`** — Imported `getDefaultHistoryDbPath` from `../utils/sqlite` and replaced the hard-coded `"memory.db"` string with a call to `getDefaultHistoryDbPath()`.

3. **`mem0-ts/src/oss/src/tests/sqlite-path-resolution.test.ts`** — Added import for `getDefaultHistoryDbPath`, updated the existing default-path assertion to use the function (so the test stays green and tracks the canonical value), and added a new explicit test `"defaults historyDbPath to ~/.mem0/history.db"`.

4. **`mem0-ts/src/oss/src/tests/sqlite-backward-compat.test.ts`** — Added import for `getDefaultHistoryDbPath` and updated the `"memory.db"` assertion to use the function.

Users who explicitly pass a custom `historyDbPath` or `historyStore.config.historyDbPath` are unaffected — only the default changes.

Closes #5004
