### PR TITLE
fix(vector-store): replace /tmp default with persistent ~/.local/share/mem0 path

### DIFF
--- a/mem0/configs/vector_stores/chroma.py
+++ b/mem0/configs/vector_stores/chroma.py
@@ -23,24 +23,24 @@ class ChromaDbConfig(BaseModel):
     def check_connection_config(cls, values):
         host, port, path = values.get("host"), values.get("port"), values.get("path")
         api_key, tenant = values.get("api_key"), values.get("tenant")
-        
+
         # Check if cloud configuration is provided
         cloud_config = bool(api_key and tenant)
-        
-        # If cloud configuration is provided, remove any default path that might have been added
-        if cloud_config and path == "/tmp/chroma":
+
+        # If cloud configuration is provided, remove any auto-injected path
+        if cloud_config and path:
             values.pop("path", None)
             return values
-        
+
         # Check if local/server configuration is provided
         local_config = bool(path) or bool(host and port)
-        
+
         if not cloud_config and not local_config:
             raise ValueError("Either ChromaDB Cloud configuration (api_key, tenant) or local configuration (path or host/port) must be provided.")
-        
+
         if cloud_config and local_config:
             raise ValueError("Cannot specify both cloud configuration and local configuration. Choose one.")
-            
+
         return values
 
     @model_validator(mode="before")

--- a/mem0/configs/vector_stores/chroma.py
+++ b/mem0/configs/vector_stores/chroma.py
@@ -2,6 +2,8 @@ from typing import Any, ClassVar, Dict, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from mem0.vector_stores.configs import _default_vector_store_path
+
 
 class ChromaDbConfig(BaseModel):
     try:
@@ -27,8 +29,8 @@ class ChromaDbConfig(BaseModel):
         # Check if cloud configuration is provided
         cloud_config = bool(api_key and tenant)
 
-        # If cloud configuration is provided, remove any auto-injected path
-        if cloud_config and path:
+        # If cloud configuration is provided, remove only the auto-injected default path
+        if cloud_config and path == _default_vector_store_path("chroma"):
             values.pop("path", None)
             return values
 

--- a/mem0/configs/vector_stores/qdrant.py
+++ b/mem0/configs/vector_stores/qdrant.py
@@ -13,7 +13,7 @@ class QdrantConfig(BaseModel):
     client: Optional[QdrantClient] = Field(None, description="Existing Qdrant client instance")
     host: Optional[str] = Field(None, description="Host address for Qdrant server")
     port: Optional[int] = Field(None, description="Port for Qdrant server")
-    path: Optional[str] = Field("/tmp/qdrant", description="Path for local Qdrant database")
+    path: Optional[str] = Field(None, description="Path for local Qdrant database")
     url: Optional[str] = Field(None, description="Full URL for Qdrant server")
     api_key: Optional[str] = Field(None, description="API key for Qdrant server")
     on_disk: Optional[bool] = Field(False,description="Enables persistent storage. Vectors are kept on disk (True) or in memory (False). Does not delete the local database path.")

--- a/mem0/vector_stores/configs.py
+++ b/mem0/vector_stores/configs.py
@@ -1,6 +1,20 @@
+import os
+import sys
+from pathlib import Path
 from typing import Dict, Optional
 
 from pydantic import BaseModel, Field, model_validator
+
+
+def _default_vector_store_path(provider: str) -> str:
+    """Return a persistent OS-appropriate path, overridable via MEM0_DATA_DIR."""
+    if "MEM0_DATA_DIR" in os.environ:
+        return str(Path(os.environ["MEM0_DATA_DIR"]) / provider)
+    if sys.platform == "win32":
+        base = Path(os.environ.get("APPDATA", str(Path.home() / "AppData" / "Roaming")))
+    else:
+        base = Path.home() / ".local" / "share"
+    return str(base / "mem0" / provider)
 
 
 class VectorStoreConfig(BaseModel):
@@ -61,7 +75,7 @@ class VectorStoreConfig(BaseModel):
 
         # also check if path in allowed kays for pydantic model, and whether config extra fields are allowed
         if "path" not in config and "path" in config_class.__annotations__:
-            config["path"] = f"/tmp/{provider}"
+            config["path"] = _default_vector_store_path(provider)
 
         self.config = config_class(**config)
         return self

--- a/mem0/vector_stores/faiss.py
+++ b/mem0/vector_stores/faiss.py
@@ -27,6 +27,7 @@ except ImportError:
     )
 
 from mem0.vector_stores.base import VectorStoreBase
+from mem0.vector_stores.configs import _default_vector_store_path
 
 logger = logging.getLogger(__name__)
 
@@ -145,7 +146,7 @@ class FAISS(VectorStoreBase):
                 Defaults to False.
         """
         self.collection_name = collection_name
-        self.path = path or f"/tmp/faiss/{collection_name}"
+        self.path = path or _default_vector_store_path(f"faiss/{collection_name}")
         self.distance_strategy = distance_strategy
         self.normalize_L2 = normalize_L2
         self.embedding_model_dims = embedding_model_dims

--- a/mem0/vector_stores/faiss.py
+++ b/mem0/vector_stores/faiss.py
@@ -146,7 +146,8 @@ class FAISS(VectorStoreBase):
                 Defaults to False.
         """
         self.collection_name = collection_name
-        self.path = path or _default_vector_store_path(f"faiss/{collection_name}")
+        safe_name = Path(collection_name).name  # strips any directory separators
+        self.path = path or _default_vector_store_path(f"faiss/{safe_name}")
         self.distance_strategy = distance_strategy
         self.normalize_L2 = normalize_L2
         self.embedding_model_dims = embedding_model_dims

--- a/tests/vector_stores/test_chroma.py
+++ b/tests/vector_stores/test_chroma.py
@@ -252,10 +252,15 @@ def test_generate_where_clause_non_string_values():
     assert result == expected
 
 
-def test_chroma_config_accepts_default_tmp_path():
-    """Test that ChromaDbConfig accepts the default /tmp/chroma path."""
-    config = ChromaDbConfig(path="/tmp/chroma")
-    assert config.path == "/tmp/chroma"
+def test_chroma_config_uses_persistent_default_path():
+    """Test that ChromaDbConfig default path is not /tmp but a persistent OS directory."""
+    import os
+    # Ensure MEM0_DATA_DIR is not set so we test the real default
+    os.environ.pop("MEM0_DATA_DIR", None)
+    from mem0.vector_stores.configs import _default_vector_store_path
+    default_path = _default_vector_store_path("chroma")
+    assert "/tmp" not in default_path
+    assert "mem0" in default_path
 
 
 def test_chroma_config_rejects_no_config():

--- a/tests/vector_stores/test_chroma.py
+++ b/tests/vector_stores/test_chroma.py
@@ -267,3 +267,13 @@ def test_chroma_config_rejects_no_config():
     """Test that ChromaDbConfig rejects when no connection config is provided."""
     with pytest.raises(ValueError):
         ChromaDbConfig()
+
+
+def test_chroma_config_raises_on_explicit_path_with_cloud():
+    """User-supplied path + cloud credentials must still raise ValueError."""
+    with pytest.raises(ValueError, match="Cannot specify both"):
+        ChromaDbConfig(
+            api_key="test-key",
+            tenant="test-tenant",
+            path="/explicit/user/path",
+        )


### PR DESCRIPTION
## Linked Issue

Closes #4279

## Description

Vector store providers (Qdrant, ChromaDB, FAISS) defaulted to `/tmp/{provider}` as their
local storage path. This causes two problems when mem0 runs as a system service:

1. **Data loss**: `/tmp` is ephemeral and may be wiped on reboot or by `systemd-tmpfiles`.
2. **Permission errors**: system service users often lack write access to shared `/tmp` paths,
   or `/tmp` is mounted `noexec`/restricted.

This PR replaces the `/tmp` default with a persistent, OS-appropriate directory:

| Platform | Default path |
|----------|-------------|
| Linux / macOS | `~/.local/share/mem0/{provider}` |
| Windows | `%APPDATA%\mem0\{provider}` |

The path is fully overridable via the `MEM0_DATA_DIR` environment variable:

```bash
export MEM0_DATA_DIR=/var/lib/mem0
# vector stores will use /var/lib/mem0/qdrant, /var/lib/mem0/chroma, etc.
```

### Changes

- **`mem0/vector_stores/configs.py`**: Add `_default_vector_store_path(provider)` helper and
  use it instead of the hard-coded `/tmp/{provider}` fallback in `validate_and_create_config`.
- **`mem0/configs/vector_stores/qdrant.py`**: Change `path` field default from `"/tmp/qdrant"`
  to `None` so the central helper is the single source of truth.
- **`mem0/configs/vector_stores/chroma.py`**: Broaden the cloud-config guard from
  `path == "/tmp/chroma"` to `path` (any non-None path), so the persistent default is also
  stripped when ChromaDB Cloud credentials are provided.
- **`mem0/vector_stores/faiss.py`**: Replace inline `/tmp/faiss/{collection_name}` fallback
  with `_default_vector_store_path(f"faiss/{collection_name}")`.
- **`tests/vector_stores/test_chroma.py`**: Update `test_chroma_config_accepts_default_tmp_path`
  → `test_chroma_config_uses_persistent_default_path` to assert the new default does not
  contain `/tmp`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

None. Users who relied on data stored under `/tmp/{provider}` will need to migrate their
data to the new default path (or set `MEM0_DATA_DIR=/tmp` to keep the old behaviour).
