### PR TITLE
fix(openclaw): clear recall timer to avoid phantom 'timed out' log

### DIFF
--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -799,17 +799,23 @@ function registerHooks(
       };
 
       try {
+        // Race the recall against a timer, but `clearTimeout` the timer when
+        // recall settles first — otherwise the orphaned setTimeout fires
+        // RECALL_TIMEOUT_MS later and emits a phantom "recall timed out"
+        // warning even though the recall already succeeded. `.finally()`
+        // covers both fulfilled and rejected outcomes.
+        let timer: ReturnType<typeof setTimeout>;
         const timeout = new Promise<undefined>((resolve) => {
-          setTimeout(() => resolve(undefined), RECALL_TIMEOUT_MS);
-        });
-        const result = await Promise.race([
-          recallWork(),
-          timeout.then(() => {
+          timer = setTimeout(() => {
             api.logger.warn(
               `openclaw-mem0: recall timed out after ${RECALL_TIMEOUT_MS}ms, skipping`,
             );
-            return undefined;
-          }),
+            resolve(undefined);
+          }, RECALL_TIMEOUT_MS);
+        });
+        const result = await Promise.race([
+          recallWork().finally(() => clearTimeout(timer)),
+          timeout,
         ]);
         return result;
       } catch (err) {


### PR DESCRIPTION
The hookRecall race between recallWork() and a timeout Promise selects the right return value, but the underlying setTimeout is never cleared when recallWork() wins. The orphaned timer fires RECALL_TIMEOUT_MS later and logs

  openclaw-mem0: recall timed out after 8000ms, skipping

even though the recall already succeeded — every successful recall emits a paired 'injecting N memories' + phantom 'recall timed out' ~8s apart, polluting logs and any UI that surfaces the warning.

Fix: hold the timer handle, clearTimeout in .finally() on the recall promise so it fires only when recall genuinely outraces it. .finally() covers both fulfilled and rejected outcomes.

No behaviour change for actual timeouts.

## Linked Issue

Closes #<!-- issue number -->

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe what breaks and the migration path. Delete this section if not applicable. -->

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

<!-- Describe how you tested this, or link to CI results. -->

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] I have updated documentation if needed
