### PR TITLE
fix(server): translate entity ids into filters in /search handler

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -416,7 +416,18 @@ def get_memory(memory_id: str, _auth=Depends(verify_auth)):
 def search_memories(search_req: SearchRequest, _auth=Depends(verify_auth)):
     """Search for memories based on a query."""
     try:
-        params = {k: v for k, v in search_req.model_dump().items() if v is not None and k != "query"}
+        # Memory.search() rejects user_id/agent_id/run_id as top-level kwargs;
+        # they must go inside filters={...}. Translate here so the request
+        # schema (which accepts them at the top level) keeps working.
+        dump = search_req.model_dump()
+        filters = dict(dump.get("filters") or {})
+        for entity_key in ("user_id", "agent_id", "run_id"):
+            val = dump.pop(entity_key, None)
+            if val is not None and entity_key not in filters:
+                filters[entity_key] = val
+        params = {k: v for k, v in dump.items() if v is not None and k != "query"}
+        if filters:
+            params["filters"] = filters
         return get_memory_instance().search(query=search_req.query, **params)
     except Exception:
         raise upstream_error()

--- a/tests/test_server_params.py
+++ b/tests/test_server_params.py
@@ -298,6 +298,8 @@ class TestUnknownFieldsIgnored:
 class TestExistingParamsUnchanged:
 
     def test_search_filters_still_forwarded(self, client, mock_memory):
+        # /search translates top-level user_id/agent_id/run_id into filters
+        # because Memory.search() rejects them as top-level kwargs.
         resp = client.post("/search", json={
             "query": "food",
             "user_id": "u1",
@@ -306,9 +308,9 @@ class TestExistingParamsUnchanged:
         })
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
-        assert kwargs["user_id"] == "u1"
-        assert kwargs["agent_id"] == "a1"
-        assert kwargs["filters"] == {"category": "food"}
+        assert "user_id" not in kwargs
+        assert "agent_id" not in kwargs
+        assert kwargs["filters"] == {"category": "food", "user_id": "u1", "agent_id": "a1"}
 
     def test_add_metadata_still_forwarded(self, client, mock_memory):
         resp = client.post("/memories", json={
@@ -322,6 +324,81 @@ class TestExistingParamsUnchanged:
         assert kwargs["user_id"] == "u1"
         assert kwargs["agent_id"] == "a1"
         assert kwargs["metadata"] == {"source": "test"}
+
+
+# ===========================================================================
+# /search: translate top-level entity ids into filters
+# ===========================================================================
+# Memory.search() rejects user_id/agent_id/run_id at the top level (raises
+# ValueError); they must be inside `filters={...}`. The handler accepts them
+# at the top level for client convenience and translates here.
+
+class TestSearchEntityIdsAsFilters:
+
+    def test_user_id_translated(self, client, mock_memory):
+        resp = client.post("/search", json={"query": "food", "user_id": "u1"})
+        assert resp.status_code == 200
+        _, kwargs = mock_memory.search.call_args
+        assert "user_id" not in kwargs
+        assert kwargs["filters"] == {"user_id": "u1"}
+
+    def test_agent_id_translated(self, client, mock_memory):
+        resp = client.post("/search", json={"query": "food", "agent_id": "a1"})
+        assert resp.status_code == 200
+        _, kwargs = mock_memory.search.call_args
+        assert "agent_id" not in kwargs
+        assert kwargs["filters"] == {"agent_id": "a1"}
+
+    def test_run_id_translated(self, client, mock_memory):
+        resp = client.post("/search", json={"query": "food", "run_id": "r1"})
+        assert resp.status_code == 200
+        _, kwargs = mock_memory.search.call_args
+        assert "run_id" not in kwargs
+        assert kwargs["filters"] == {"run_id": "r1"}
+
+    def test_all_three_translated_together(self, client, mock_memory):
+        resp = client.post("/search", json={
+            "query": "food", "user_id": "u1", "agent_id": "a1", "run_id": "r1",
+        })
+        assert resp.status_code == 200
+        _, kwargs = mock_memory.search.call_args
+        assert "user_id" not in kwargs
+        assert "agent_id" not in kwargs
+        assert "run_id" not in kwargs
+        assert kwargs["filters"] == {"user_id": "u1", "agent_id": "a1", "run_id": "r1"}
+
+    def test_caller_filters_preserved_alongside_entity_ids(self, client, mock_memory):
+        resp = client.post("/search", json={
+            "query": "food",
+            "user_id": "u1",
+            "filters": {"category": "food", "tag": "spicy"},
+        })
+        assert resp.status_code == 200
+        _, kwargs = mock_memory.search.call_args
+        assert kwargs["filters"] == {"category": "food", "tag": "spicy", "user_id": "u1"}
+
+    def test_caller_filters_take_precedence_over_conflicting_entity_id(self, client, mock_memory):
+        # If the caller already put user_id inside filters, the top-level
+        # value should NOT clobber it.
+        resp = client.post("/search", json={
+            "query": "food",
+            "user_id": "top-level-u",
+            "filters": {"user_id": "filters-u"},
+        })
+        assert resp.status_code == 200
+        _, kwargs = mock_memory.search.call_args
+        assert kwargs["filters"] == {"user_id": "filters-u"}
+
+    def test_no_entity_ids_no_filters_kwarg(self, client, mock_memory):
+        # When the caller sends no entity ids and no filters, filters must
+        # not appear in the kwargs (so Memory.search() uses its own default).
+        resp = client.post("/search", json={"query": "food"})
+        assert resp.status_code == 200
+        _, kwargs = mock_memory.search.call_args
+        assert "filters" not in kwargs
+        assert "user_id" not in kwargs
+        assert "agent_id" not in kwargs
+        assert "run_id" not in kwargs
 
 
 # ===========================================================================


### PR DESCRIPTION
## Linked Issue

No issue is closed by this PR. Related context:

- **#4955** (CLOSED): same root cause, fixed for `GET /memories` → `get_all()`. This PR completes that pattern for `POST /search`.
- **#4907** (OPEN): same `ValueError` from the proxy path (`mem0/proxy/main.py::_fetch_relevant_memories`). Different file, not fixed here.

## Description

`server/main.py::search_memories` accepts `user_id`, `agent_id`, and `run_id` as top-level fields on `SearchRequest` and unpacks them straight into kwargs to `Memory.search()`:

```python
params = {k: v for k, v in search_req.model_dump().items() if v is not None and k != "query"}
return get_memory_instance().search(query=search_req.query, **params)
```

After the v3 change that requires entity IDs inside `filters={...}`, this raises:

```
ValueError: Top-level entity parameters frozenset({'user_id'}) are not supported in search(). Use filters={'user_id': '...'} instead.
```

The handler catches that and returns 502 via `upstream_error()`, so any `POST /search` call carrying a `user_id` (the common case for scoped search) fails.

**Fix:** translate top-level entity IDs into `filters` before calling `Memory.search()`, preserving any caller-provided `filters` dict and letting caller-supplied filter values take precedence over conflicting top-level IDs. Mirrors the pattern that #4955 applied to `GET /memories` → `get_all()`.

**Reproduce (before this PR):**

```bash
curl -X POST http://localhost:8888/search \
  -H 'Content-Type: application/json' \
  -d '{"query":"hello","user_id":"alice@example.com"}'
# 502 Bad Gateway
```

After this PR the same call returns 200.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

**Unit tests** — added `tests/test_server_params.py::TestSearchEntityIdsAsFilters` (7 cases):

- each id (`user_id`, `agent_id`, `run_id`) translated alone
- all three together
- caller-supplied `filters` preserved alongside translated ids
- caller-supplied `filters` take precedence over conflicting top-level ids
- empty request → no `filters` kwarg added (so `Memory.search()` defaults apply)

Pre-existing `test_search_filters_still_forwarded` was asserting the old (buggy) behavior — updated to reflect the new contract.

```bash
PYTHONPATH=.:server AUTH_DISABLED=true OPENAI_API_KEY=fake-key \
  pytest tests/test_server_params.py
# ===== 54 passed in 117s =====
```

**Manual** — ran a self-hosted server with the patched `server/main.py`, confirmed:

- `POST /search {"query": "...", "user_id": "..."}` → 200, results correctly scoped
- `POST /search {"query": "...", "user_id": "...", "filters": {"category": "x"}}` → 200, both filters applied (`user_id` AND `category`)
- `POST /search {"query": "...", "filters": {"user_id": "from-filters"}}` (with no top-level `user_id`) → 200, `from-filters` honored
- `POST /search {"query": "..."}` (no entity ids, no filters) → 200, unscoped

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
