### PR TITLE
fix(proxy): translate entity ids to filters; iterate MemoryClient results key

### DIFF
--- a/mem0/proxy/main.py
+++ b/mem0/proxy/main.py
@@ -167,12 +167,19 @@ class Completions:
         # Currently, only pass the last 6 messages to the search API to prevent long query
         message_input = [f"{message['role']}: {message['content']}" for message in messages][-6:]
         # TODO: Make it better by summarizing the past conversation
+
+        # Both Memory.search() and MemoryClient.search() reject user_id /
+        # agent_id / run_id as top-level kwargs; entity scoping must go
+        # inside `filters`. Caller-supplied filters take precedence over
+        # conflicting top-level entity ids.
+        merged_filters = dict(filters or {})
+        for key, value in (("user_id", user_id), ("agent_id", agent_id), ("run_id", run_id)):
+            if value is not None:
+                merged_filters.setdefault(key, value)
+
         return self.mem0_client.search(
             query="\n".join(message_input),
-            user_id=user_id,
-            agent_id=agent_id,
-            run_id=run_id,
-            filters=filters,
+            filters=merged_filters or None,
             top_k=top_k,
         )
 
@@ -185,5 +192,7 @@ class Completions:
             if relevant_memories.get("relations"):
                 entities = [entity for entity in relevant_memories["relations"]]
         elif isinstance(self.mem0_client, mem0.client.main.MemoryClient):
-            memories_text = "\n".join(memory["memory"] for memory in relevant_memories)
+            # MemoryClient.search() returns {"results": [...]}; iterating the
+            # dict directly yields keys, not memory objects.
+            memories_text = "\n".join(memory["memory"] for memory in relevant_memories["results"])
         return f"- Relevant Memories/Facts: {memories_text}\n\n- Entities: {entities}\n\n- User Question: {messages[-1]['content']}"

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -64,7 +64,8 @@ def test_completions_create(mock_memory_client, mock_litellm):
     completions = Completions(mock_memory_client)
 
     messages = [{"role": "user", "content": "Hello, how are you?"}]
-    mock_memory_client.search.return_value = [{"memory": "Some relevant memory"}]
+    # MemoryClient.search() returns {"results": [...]}, not a bare list.
+    mock_memory_client.search.return_value = {"results": [{"memory": "Some relevant memory"}]}
     mock_litellm.completion.return_value = {"choices": [{"message": {"content": "I'm doing well, thank you!"}}]}
     mock_litellm.supports_function_calling.return_value = True
 
@@ -89,7 +90,7 @@ def test_completions_create_with_system_message(mock_memory_client, mock_litellm
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "Hello, how are you?"},
     ]
-    mock_memory_client.search.return_value = [{"memory": "Some relevant memory"}]
+    mock_memory_client.search.return_value = {"results": [{"memory": "Some relevant memory"}]}
     mock_litellm.completion.return_value = {"choices": [{"message": {"content": "I'm doing well, thank you!"}}]}
     mock_litellm.supports_function_calling.return_value = True
 
@@ -98,3 +99,94 @@ def test_completions_create_with_system_message(mock_memory_client, mock_litellm
     call_args = mock_litellm.completion.call_args[1]
     assert call_args["messages"][0]["role"] == "system"
     assert call_args["messages"][0]["content"] == "You are a helpful assistant."
+
+
+# ---------------------------------------------------------------------------
+# /search call shape: entity ids must go inside `filters`, not as top-level
+# kwargs. Both Memory.search() and MemoryClient.search() reject the latter.
+# ---------------------------------------------------------------------------
+
+def test_search_entity_ids_go_into_filters(mock_memory_client, mock_litellm):
+    completions = Completions(mock_memory_client)
+    mock_memory_client.search.return_value = {"results": []}
+    mock_litellm.completion.return_value = {"choices": [{"message": {"content": "ok"}}]}
+    mock_litellm.supports_function_calling.return_value = True
+
+    completions.create(
+        model="gpt-4.1-nano-2025-04-14",
+        messages=[{"role": "user", "content": "hi"}],
+        user_id="u1",
+        agent_id="a1",
+        run_id="r1",
+    )
+
+    _, kwargs = mock_memory_client.search.call_args
+    assert "user_id" not in kwargs
+    assert "agent_id" not in kwargs
+    assert "run_id" not in kwargs
+    assert kwargs["filters"] == {"user_id": "u1", "agent_id": "a1", "run_id": "r1"}
+
+
+def test_search_caller_filters_preserved_alongside_entity_ids(mock_memory_client, mock_litellm):
+    completions = Completions(mock_memory_client)
+    mock_memory_client.search.return_value = {"results": []}
+    mock_litellm.completion.return_value = {"choices": [{"message": {"content": "ok"}}]}
+    mock_litellm.supports_function_calling.return_value = True
+
+    completions.create(
+        model="gpt-4.1-nano-2025-04-14",
+        messages=[{"role": "user", "content": "hi"}],
+        user_id="u1",
+        filters={"category": "food"},
+    )
+
+    _, kwargs = mock_memory_client.search.call_args
+    assert kwargs["filters"] == {"category": "food", "user_id": "u1"}
+
+
+def test_search_caller_filters_take_precedence_over_top_level_entity(mock_memory_client, mock_litellm):
+    completions = Completions(mock_memory_client)
+    mock_memory_client.search.return_value = {"results": []}
+    mock_litellm.completion.return_value = {"choices": [{"message": {"content": "ok"}}]}
+    mock_litellm.supports_function_calling.return_value = True
+
+    completions.create(
+        model="gpt-4.1-nano-2025-04-14",
+        messages=[{"role": "user", "content": "hi"}],
+        user_id="top-level-u",
+        filters={"user_id": "filters-u"},
+    )
+
+    _, kwargs = mock_memory_client.search.call_args
+    assert kwargs["filters"] == {"user_id": "filters-u"}
+
+
+# ---------------------------------------------------------------------------
+# MemoryClient branch must iterate `relevant_memories["results"]`, not the
+# dict directly (which yields keys, raising TypeError on memory["memory"]).
+# ---------------------------------------------------------------------------
+
+def test_memoryclient_branch_iterates_results_key(mock_memory_client, mock_litellm):
+    completions = Completions(mock_memory_client)
+    mock_memory_client.search.return_value = {
+        "results": [
+            {"memory": "User likes teal"},
+            {"memory": "User lives in Santa Cruz"},
+        ]
+    }
+    mock_litellm.completion.return_value = {"choices": [{"message": {"content": "ok"}}]}
+    mock_litellm.supports_function_calling.return_value = True
+
+    completions.create(
+        model="gpt-4.1-nano-2025-04-14",
+        messages=[{"role": "user", "content": "What do I like?"}],
+        user_id="u1",
+    )
+
+    # The system prompt + augmented user prompt are passed to litellm. The
+    # augmented prompt must include the memories' text — proves the proxy
+    # successfully iterated `relevant_memories["results"]`.
+    call_args = mock_litellm.completion.call_args[1]
+    augmented_user = call_args["messages"][-1]["content"]
+    assert "User likes teal" in augmented_user
+    assert "User lives in Santa Cruz" in augmented_user


### PR DESCRIPTION
## Linked Issue

Closes #4907

## Description

Two bugs in `mem0/proxy/main.py` make any chat completion via the proxy fail when used with `MemoryClient` (e.g. `Mem0(api_key="...")`).

### Bug 1 — top-level entity ids rejected by `search()`

`_fetch_relevant_memories` passes `user_id`, `agent_id`, and `run_id` as top-level kwargs:

```python
self.mem0_client.search(
    query=...,
    user_id=user_id,
    agent_id=agent_id,
    run_id=run_id,
    filters=filters,
    top_k=top_k,
)
```

After the v3 filter requirement, both `Memory.search()` and `MemoryClient.search()` reject these and raise:

```
ValueError: Top-level entity parameters {...} are not supported in search().
            Use filters={'user_id': '...'} instead.
```

**Fix:** translate entity ids into `filters` before calling `search()`, preserving caller-supplied filters and letting them take precedence over conflicting top-level ids. (Same pattern as #4955 used for `GET /memories` → `get_all()`.)

### Bug 2 — `MemoryClient` branch iterates dict keys, not `["results"]`

`_format_query_with_memories` correctly uses `relevant_memories["results"]` for the `Memory` branch but iterates the dict directly for the `MemoryClient` branch:

```python
elif isinstance(self.mem0_client, mem0.client.main.MemoryClient):
    memories_text = "\n".join(memory["memory"] for memory in relevant_memories)
```

`MemoryClient.search()` returns `{"results": [...]}`, so iterating it yields keys. `memory["memory"]` then raises:

```
TypeError: string indices must be integers, not 'str'
```

**Fix:** iterate `relevant_memories["results"]`, matching the `Memory` branch immediately above.

### Reproduce (before this PR)

```python
from mem0.proxy.main import Mem0

client = Mem0(api_key="m0-...")
client.chat.completions.create(
    model="gpt-4o-mini",
    messages=[{"role": "user", "content": "What do I like?"}],
    user_id="test-user",
)
# Bug 1: ValueError: Top-level entity parameters frozenset({'user_id'})
#        are not supported in search(). Use filters={...} instead.
```

After this PR, the same call returns the augmented LLM response.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (described in Description above via reproducer)
- [ ] No tests needed (explain why)

**Updated existing tests** in `tests/test_proxy.py` — `test_completions_create` and `test_completions_create_with_system_message` had been mocking `search.return_value` as a bare list, which (a) hid Bug 2 and (b) is unrealistic since `MemoryClient.search()` returns `{"results": [...]}`. Updated both to use the realistic shape.

**Added new tests** covering the two fixes:

- `test_search_entity_ids_go_into_filters` — `user_id` / `agent_id` / `run_id` end up in `filters`, not as top-level kwargs to `search()`
- `test_search_caller_filters_preserved_alongside_entity_ids` — caller's `filters` dict is merged with translated entity ids
- `test_search_caller_filters_take_precedence_over_top_level_entity` — when both are supplied, the value already inside `filters` wins
- `test_memoryclient_branch_iterates_results_key` — proves the augmented user prompt contains memory text from `relevant_memories["results"]` (not from iterating dict keys)

```bash
pytest tests/test_proxy.py
# ============================== 10 passed in 1.80s ==============================
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
