### PR TITLE
fix(llms/aws_bedrock): route profile_name through Session, not client kwarg

### DIFF
--- a/mem0/llms/aws_bedrock.py
+++ b/mem0/llms/aws_bedrock.py
@@ -79,8 +79,10 @@ class AWSBedrockLLM(LLMBase):
         try:
             aws_config = self.config.get_aws_config()
 
-            # Create Bedrock runtime client
-            self.client = boto3.client("bedrock-runtime", **aws_config)
+            # Create Bedrock runtime client. boto3.client() does NOT accept
+            # `profile_name` as a kwarg — only boto3.Session() does. If
+            # `profile_name` is in aws_config, build a Session first.
+            self.client = self._build_client("bedrock-runtime", aws_config)
 
             # Test connection
             self._test_connection()
@@ -100,11 +102,21 @@ class AWSBedrockLLM(LLMBase):
             else:
                 raise ValueError(f"AWS Bedrock error: {e}")
 
+    @staticmethod
+    def _build_client(service_name: str, aws_config: Dict[str, Any]):
+        """Build a boto3 client, routing `profile_name` through Session()."""
+        cfg = dict(aws_config)
+        profile_name = cfg.pop("profile_name", None)
+        if profile_name:
+            session = boto3.Session(profile_name=profile_name)
+            return session.client(service_name, **cfg)
+        return boto3.client(service_name, **cfg)
+
     def _test_connection(self):
         """Test connection to AWS Bedrock service."""
         try:
             # List available models to test connection
-            bedrock_client = boto3.client("bedrock", **self.config.get_aws_config())
+            bedrock_client = self._build_client("bedrock", self.config.get_aws_config())
             response = bedrock_client.list_foundation_models()
             self.available_models = [model["modelId"] for model in response["modelSummaries"]]
 

--- a/tests/llms/test_aws_bedrock.py
+++ b/tests/llms/test_aws_bedrock.py
@@ -424,3 +424,92 @@ class TestMiniMaxProvider:
             assert msg["role"] != "system"
         # user message must be present
         assert kwargs["messages"][0]["role"] == "user"
+
+
+# ---------------------------------------------------------------------------
+# profile_name routing
+#
+# AWSBedrockConfig.get_aws_config() can include `profile_name` (when the user
+# sets aws_profile=). boto3.client() rejects that kwarg — only
+# boto3.Session() accepts it. Verify the construction is routed accordingly.
+# ---------------------------------------------------------------------------
+
+class TestProfileNameRouting:
+
+    def test_no_profile_uses_boto3_client_directly(self):
+        """Without aws_profile, AWSBedrockLLM should call boto3.client(...) directly."""
+        with patch("mem0.llms.aws_bedrock.boto3") as mock_b3:
+            runtime_client = MagicMock()
+            bedrock_client = MagicMock()
+            bedrock_client.list_foundation_models.return_value = {"modelSummaries": []}
+            mock_b3.client.side_effect = lambda service, **_: (
+                runtime_client if service == "bedrock-runtime" else bedrock_client
+            )
+
+            AWSBedrockLLM(AWSBedrockConfig(
+                model="anthropic.claude-3-5-sonnet-20240620-v1:0",
+                aws_region="us-west-2",
+            ))
+
+            # Session() must NOT be touched at all when no profile is set.
+            mock_b3.Session.assert_not_called()
+            # boto3.client was called with region_name and no profile_name.
+            for call in mock_b3.client.call_args_list:
+                args, kwargs = call
+                assert "profile_name" not in kwargs
+
+    def test_with_profile_routes_through_session(self):
+        """With aws_profile, construction must go through boto3.Session(profile_name=...)
+        rather than boto3.client(profile_name=...) — the latter raises TypeError."""
+        with patch("mem0.llms.aws_bedrock.boto3") as mock_b3:
+            session = MagicMock(name="Session")
+            runtime_client = MagicMock(name="bedrock-runtime")
+            bedrock_client = MagicMock(name="bedrock")
+            bedrock_client.list_foundation_models.return_value = {"modelSummaries": []}
+            session.client.side_effect = lambda service, **_: (
+                runtime_client if service == "bedrock-runtime" else bedrock_client
+            )
+            mock_b3.Session.return_value = session
+
+            AWSBedrockLLM(AWSBedrockConfig(
+                model="anthropic.claude-3-5-sonnet-20240620-v1:0",
+                aws_region="us-west-2",
+                aws_profile="my-sso-profile",
+            ))
+
+            # boto3.Session(profile_name=...) was called.
+            mock_b3.Session.assert_called_with(profile_name="my-sso-profile")
+            # boto3.client(...) was NOT called directly.
+            mock_b3.client.assert_not_called()
+            # Both bedrock-runtime and bedrock were created via session.client(...).
+            services_called = [c.args[0] for c in session.client.call_args_list]
+            assert "bedrock-runtime" in services_called
+            assert "bedrock" in services_called
+            # No call passed profile_name as a kwarg (would TypeError on real boto3).
+            for c in session.client.call_args_list:
+                assert "profile_name" not in c.kwargs
+
+    def test_profile_name_stripped_from_session_client_kwargs(self):
+        """Even when profile_name is in aws_config, it must not leak through to
+        Session.client() — only Session(profile_name=...) accepts it."""
+        with patch("mem0.llms.aws_bedrock.boto3") as mock_b3:
+            session = MagicMock()
+            runtime_client = MagicMock()
+            bedrock_client = MagicMock()
+            bedrock_client.list_foundation_models.return_value = {"modelSummaries": []}
+            session.client.side_effect = lambda service, **_: (
+                runtime_client if service == "bedrock-runtime" else bedrock_client
+            )
+            mock_b3.Session.return_value = session
+
+            AWSBedrockLLM(AWSBedrockConfig(
+                model="anthropic.claude-3-5-sonnet-20240620-v1:0",
+                aws_region="us-east-1",
+                aws_profile="dev",
+            ))
+
+            for call in session.client.call_args_list:
+                # region_name should still be forwarded
+                assert call.kwargs.get("region_name") == "us-east-1"
+                # profile_name must be popped before this call
+                assert "profile_name" not in call.kwargs


### PR DESCRIPTION
## Linked Issue

No existing issue. Bug surfaced while wiring up `aws_profile` (SSO-based auth) for the OSS REST server pointed at AWS Bedrock.

## Description

`AWSBedrockConfig.get_aws_config()` includes `profile_name` in the returned dict when `aws_profile` is set:

```python
# mem0/configs/llms/aws_bedrock.py
def get_aws_config(self) -> Dict[str, Any]:
    config = {"region_name": self.aws_region}
    ...
    if self.aws_profile:
        config["profile_name"] = self.aws_profile or os.getenv("AWS_PROFILE")
    return config
```

That dict is forwarded straight to `boto3.client("bedrock-runtime", **aws_config)` in `AWSBedrockLLM._initialize_aws_client`:

```python
# mem0/llms/aws_bedrock.py
self.client = boto3.client("bedrock-runtime", **aws_config)
```

`boto3.client()` does NOT accept `profile_name` as a kwarg — only `boto3.Session()` does. So setting `aws_profile=...` raises:

```
TypeError: Session.client() got an unexpected keyword argument 'profile_name'
```

The same bug exists in `_test_connection` which uses `boto3.client("bedrock", **self.config.get_aws_config())`.

**Result:** `AWSBedrockLLM` cannot be initialized with `aws_profile` set, forcing users onto access-key auth even when an SSO/named profile is the cleaner option.

### Reproduce (before this PR)

```python
from mem0.llms.aws_bedrock import AWSBedrockLLM
AWSBedrockLLM({
    "model": "us.anthropic.claude-sonnet-4-6",
    "aws_region": "us-west-2",
    "aws_profile": "my-sso-profile",
})
# TypeError: Session.client() got an unexpected keyword argument 'profile_name'
```

After this PR, the same call succeeds and the LLM is wired to a `boto3.Session` for the named profile.

## Fix

Add a small `_build_client(service_name, aws_config)` helper that pops `profile_name` from the config dict and routes through `boto3.Session(profile_name=...)` when it's present, falling back to direct `boto3.client(...)` otherwise:

```python
@staticmethod
def _build_client(service_name: str, aws_config: Dict[str, Any]):
    """Build a boto3 client, routing `profile_name` through Session()."""
    cfg = dict(aws_config)
    profile_name = cfg.pop("profile_name", None)
    if profile_name:
        session = boto3.Session(profile_name=profile_name)
        return session.client(service_name, **cfg)
    return boto3.client(service_name, **cfg)
```

Use it in both client construction sites (`_initialize_aws_client` for `bedrock-runtime` and `_test_connection` for `bedrock`).

The no-profile path is unchanged for users who don't set `aws_profile`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A — pure bug fix. Users without `aws_profile` set continue to get the same `boto3.client(...)` path.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (described in Description above via reproducer)
- [ ] No tests needed (explain why)

**Unit tests** — added `tests/llms/test_aws_bedrock.py::TestProfileNameRouting` (3 cases):

- `test_no_profile_uses_boto3_client_directly` — without `aws_profile`, `boto3.Session` is never touched and `boto3.client(...)` is called directly with no `profile_name` kwarg
- `test_with_profile_routes_through_session` — with `aws_profile=...`, `boto3.Session(profile_name=...)` is constructed, both `bedrock-runtime` and `bedrock` clients are obtained from `session.client(...)`, and `boto3.client` is never called directly
- `test_profile_name_stripped_from_session_client_kwargs` — `profile_name` is popped from the config before reaching `Session.client(...)` (which would TypeError on real boto3); `region_name` is still forwarded

39 pre-existing tests in the file still pass — no regressions.

```bash
PYTHONPATH=. pytest tests/llms/test_aws_bedrock.py
# ============================== 42 passed in 0.58s ==============================
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
