### PR TITLE
fix(telemetry): stitch PostHog identities on MemoryClient init

### DIFF
--- a/mem0-ts/src/client/config.ts
+++ b/mem0-ts/src/client/config.ts
@@ -1,0 +1,118 @@
+/**
+ * Best-effort read/write of ~/.mem0/config.json from the TS SDK.
+ *
+ * Used to stitch PostHog identities: the OSS Python SDK and the Python CLI
+ * each persist an anonymous distinct_id here, and the TS MemoryClient needs
+ * to read those on init so it can fire $identify and merge them into the
+ * email-based identity.
+ *
+ * Node-only. In browsers (or any environment without `process.versions.node`)
+ * every function returns null/no-ops without attempting `fs` access.
+ */
+
+export interface Mem0AnonIds {
+  oss?: string;
+  cli?: string;
+  aliasedTo?: string;
+}
+
+function isNode(): boolean {
+  try {
+    return (
+      typeof process !== "undefined" &&
+      !!process.versions &&
+      !!process.versions.node
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function loadNodeModules(): Promise<{
+  fs: typeof import("fs");
+  path: typeof import("path");
+  os: typeof import("os");
+} | null> {
+  if (!isNode()) return null;
+  try {
+    const [fs, path, os] = await Promise.all([
+      import("fs"),
+      import("path"),
+      import("os"),
+    ]);
+    return {
+      fs: fs.default ?? fs,
+      path: path.default ?? path,
+      os: os.default ?? os,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function configPath(): Promise<{
+  path: string;
+  modules: NonNullable<Awaited<ReturnType<typeof loadNodeModules>>>;
+} | null> {
+  const modules = await loadNodeModules();
+  if (!modules) return null;
+  try {
+    const dir =
+      process.env.MEM0_DIR || modules.path.join(modules.os.homedir(), ".mem0");
+    return { path: modules.path.join(dir, "config.json"), modules };
+  } catch {
+    return null;
+  }
+}
+
+async function loadRawConfig(): Promise<Record<string, unknown> | null> {
+  const resolved = await configPath();
+  if (!resolved) return null;
+  try {
+    if (!resolved.modules.fs.existsSync(resolved.path)) return null;
+    const raw = resolved.modules.fs.readFileSync(resolved.path, "utf8");
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function readMem0AnonIds(): Promise<Mem0AnonIds | null> {
+  const config = await loadRawConfig();
+  if (!config) return null;
+  const telemetry =
+    config.telemetry && typeof config.telemetry === "object"
+      ? (config.telemetry as Record<string, unknown>)
+      : {};
+  const oss = typeof config.user_id === "string" ? config.user_id : undefined;
+  const cli =
+    typeof telemetry.anonymous_id === "string"
+      ? telemetry.anonymous_id
+      : undefined;
+  const aliasedTo =
+    typeof telemetry.aliased_to === "string" ? telemetry.aliased_to : undefined;
+  return { oss, cli, aliasedTo };
+}
+
+export async function markMem0Aliased(email: string): Promise<void> {
+  const resolved = await configPath();
+  if (!resolved) return;
+  try {
+    const dirname = resolved.modules.path.dirname(resolved.path);
+    resolved.modules.fs.mkdirSync(dirname, { recursive: true });
+    const config = (await loadRawConfig()) ?? {};
+    const telemetry =
+      config.telemetry && typeof config.telemetry === "object"
+        ? (config.telemetry as Record<string, unknown>)
+        : {};
+    telemetry.aliased_to = email;
+    config.telemetry = telemetry;
+    resolved.modules.fs.writeFileSync(
+      resolved.path,
+      JSON.stringify(config, null, 4),
+    );
+  } catch {
+    // Read-only filesystem (Lambda, container) — alias is best-effort.
+  }
+}

--- a/mem0-ts/src/client/config.ts
+++ b/mem0-ts/src/client/config.ts
@@ -1,9 +1,9 @@
 /**
  * Best-effort read/write of ~/.mem0/config.json from the TS SDK.
  *
- * Used to stitch PostHog identities: the OSS Python SDK and the Python CLI
- * each persist an anonymous distinct_id here, and the TS MemoryClient reads
- * those on init to fire $identify and merge them into the email identity.
+ * Used to stitch PostHog identities: SDKs and CLIs persist anonymous
+ * distinct_id values here, and the TS MemoryClient reads those on init to
+ * fire $identify and merge them into the email identity.
  *
  * Node-only. Browsers (no `process.versions.node`) no-op.
  */
@@ -11,30 +11,34 @@
 export interface Mem0AnonIds {
   oss?: string;
   cli?: string;
-  aliasedTo?: string;
+  aliasedPairs: string[];
 }
 
 interface NodeFs {
   fs: typeof import("fs");
   path: typeof import("path");
+  crypto: typeof import("crypto");
   configPath: string;
 }
 
 async function getNodeFs(): Promise<NodeFs | null> {
   if (typeof process === "undefined" || !process.versions?.node) return null;
   try {
-    const [fs, path, os] = await Promise.all([
+    const [fs, path, os, crypto] = await Promise.all([
       import("fs"),
       import("path"),
       import("os"),
+      import("crypto"),
     ]);
     const fsMod = (fs as any).default ?? fs;
     const pathMod = (path as any).default ?? path;
     const osMod = (os as any).default ?? os;
+    const cryptoMod = (crypto as any).default ?? crypto;
     const dir = process.env.MEM0_DIR || pathMod.join(osMod.homedir(), ".mem0");
     return {
       fs: fsMod,
       path: pathMod,
+      crypto: cryptoMod,
       configPath: pathMod.join(dir, "config.json"),
     };
   } catch {
@@ -47,6 +51,45 @@ function loadConfig(node: NodeFs): Record<string, any> | null {
     if (!node.fs.existsSync(node.configPath)) return null;
     const parsed = JSON.parse(node.fs.readFileSync(node.configPath, "utf8"));
     return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeConfig(node: NodeFs, config: Record<string, any>): void {
+  node.fs.mkdirSync(node.path.dirname(node.configPath), { recursive: true });
+  node.fs.writeFileSync(node.configPath, JSON.stringify(config, null, 4));
+}
+
+function aliasPairMarker(node: NodeFs, anonId: string, email: string): string {
+  return node.crypto
+    .createHash("sha256")
+    .update(`${anonId}\0${email}`, "utf8")
+    .digest("hex");
+}
+
+function randomUserId(node: NodeFs): string {
+  if (typeof node.crypto.randomUUID === "function") {
+    return node.crypto.randomUUID();
+  }
+  return (
+    Math.random().toString(36).substring(2, 15) +
+    Math.random().toString(36).substring(2, 15)
+  );
+}
+
+export async function getOrCreateMem0UserId(): Promise<string | null> {
+  const node = await getNodeFs();
+  if (!node) return null;
+  try {
+    const config = loadConfig(node) ?? {};
+    if (typeof config.user_id === "string" && config.user_id) {
+      return config.user_id;
+    }
+    const userId = randomUserId(node);
+    config.user_id = userId;
+    writeConfig(node, config);
+    return userId;
   } catch {
     return null;
   }
@@ -67,26 +110,55 @@ export async function readMem0AnonIds(): Promise<Mem0AnonIds | null> {
       typeof telemetry.anonymous_id === "string"
         ? telemetry.anonymous_id
         : undefined,
-    aliasedTo:
-      typeof telemetry.aliased_to === "string"
-        ? telemetry.aliased_to
-        : undefined,
+    aliasedPairs: Array.isArray(telemetry.aliased_pairs)
+      ? telemetry.aliased_pairs.filter(
+          (item: unknown) => typeof item === "string",
+        )
+      : [],
   };
 }
 
-export async function markMem0Aliased(email: string): Promise<void> {
+export async function isMem0Aliased(
+  anonId: string,
+  email: string,
+): Promise<boolean> {
+  if (!anonId || !email) return false;
+  const node = await getNodeFs();
+  if (!node) return false;
+  const config = loadConfig(node);
+  if (!config) return false;
+  const telemetry =
+    config.telemetry && typeof config.telemetry === "object"
+      ? config.telemetry
+      : {};
+  const aliasedPairs = Array.isArray(telemetry.aliased_pairs)
+    ? telemetry.aliased_pairs
+    : [];
+  return aliasedPairs.includes(aliasPairMarker(node, anonId, email));
+}
+
+export async function markMem0Aliased(
+  anonId: string,
+  email: string,
+): Promise<void> {
   const node = await getNodeFs();
   if (!node) return;
   try {
-    node.fs.mkdirSync(node.path.dirname(node.configPath), { recursive: true });
     const config = loadConfig(node) ?? {};
     const telemetry =
       config.telemetry && typeof config.telemetry === "object"
         ? config.telemetry
         : {};
-    telemetry.aliased_to = email;
+    const aliasedPairs = Array.isArray(telemetry.aliased_pairs)
+      ? telemetry.aliased_pairs
+      : [];
+    const marker = aliasPairMarker(node, anonId, email);
+    if (!aliasedPairs.includes(marker)) {
+      aliasedPairs.push(marker);
+    }
+    telemetry.aliased_pairs = aliasedPairs;
     config.telemetry = telemetry;
-    node.fs.writeFileSync(node.configPath, JSON.stringify(config, null, 4));
+    writeConfig(node, config);
   } catch {
     // Best-effort: read-only filesystems and unwritable paths just skip.
   }

--- a/mem0-ts/src/client/config.ts
+++ b/mem0-ts/src/client/config.ts
@@ -2,12 +2,10 @@
  * Best-effort read/write of ~/.mem0/config.json from the TS SDK.
  *
  * Used to stitch PostHog identities: the OSS Python SDK and the Python CLI
- * each persist an anonymous distinct_id here, and the TS MemoryClient needs
- * to read those on init so it can fire $identify and merge them into the
- * email-based identity.
+ * each persist an anonymous distinct_id here, and the TS MemoryClient reads
+ * those on init to fire $identify and merge them into the email identity.
  *
- * Node-only. In browsers (or any environment without `process.versions.node`)
- * every function returns null/no-ops without attempting `fs` access.
+ * Node-only. Browsers (no `process.versions.node`) no-op.
  */
 
 export interface Mem0AnonIds {
@@ -16,62 +14,38 @@ export interface Mem0AnonIds {
   aliasedTo?: string;
 }
 
-function isNode(): boolean {
-  try {
-    return (
-      typeof process !== "undefined" &&
-      !!process.versions &&
-      !!process.versions.node
-    );
-  } catch {
-    return false;
-  }
-}
-
-async function loadNodeModules(): Promise<{
+interface NodeFs {
   fs: typeof import("fs");
   path: typeof import("path");
-  os: typeof import("os");
-} | null> {
-  if (!isNode()) return null;
+  configPath: string;
+}
+
+async function getNodeFs(): Promise<NodeFs | null> {
+  if (typeof process === "undefined" || !process.versions?.node) return null;
   try {
     const [fs, path, os] = await Promise.all([
       import("fs"),
       import("path"),
       import("os"),
     ]);
+    const fsMod = (fs as any).default ?? fs;
+    const pathMod = (path as any).default ?? path;
+    const osMod = (os as any).default ?? os;
+    const dir = process.env.MEM0_DIR || pathMod.join(osMod.homedir(), ".mem0");
     return {
-      fs: fs.default ?? fs,
-      path: path.default ?? path,
-      os: os.default ?? os,
+      fs: fsMod,
+      path: pathMod,
+      configPath: pathMod.join(dir, "config.json"),
     };
   } catch {
     return null;
   }
 }
 
-async function configPath(): Promise<{
-  path: string;
-  modules: NonNullable<Awaited<ReturnType<typeof loadNodeModules>>>;
-} | null> {
-  const modules = await loadNodeModules();
-  if (!modules) return null;
+function loadConfig(node: NodeFs): Record<string, any> | null {
   try {
-    const dir =
-      process.env.MEM0_DIR || modules.path.join(modules.os.homedir(), ".mem0");
-    return { path: modules.path.join(dir, "config.json"), modules };
-  } catch {
-    return null;
-  }
-}
-
-async function loadRawConfig(): Promise<Record<string, unknown> | null> {
-  const resolved = await configPath();
-  if (!resolved) return null;
-  try {
-    if (!resolved.modules.fs.existsSync(resolved.path)) return null;
-    const raw = resolved.modules.fs.readFileSync(resolved.path, "utf8");
-    const parsed = JSON.parse(raw);
+    if (!node.fs.existsSync(node.configPath)) return null;
+    const parsed = JSON.parse(node.fs.readFileSync(node.configPath, "utf8"));
     return parsed && typeof parsed === "object" ? parsed : null;
   } catch {
     return null;
@@ -79,40 +53,41 @@ async function loadRawConfig(): Promise<Record<string, unknown> | null> {
 }
 
 export async function readMem0AnonIds(): Promise<Mem0AnonIds | null> {
-  const config = await loadRawConfig();
+  const node = await getNodeFs();
+  if (!node) return null;
+  const config = loadConfig(node);
   if (!config) return null;
   const telemetry =
     config.telemetry && typeof config.telemetry === "object"
-      ? (config.telemetry as Record<string, unknown>)
+      ? config.telemetry
       : {};
-  const oss = typeof config.user_id === "string" ? config.user_id : undefined;
-  const cli =
-    typeof telemetry.anonymous_id === "string"
-      ? telemetry.anonymous_id
-      : undefined;
-  const aliasedTo =
-    typeof telemetry.aliased_to === "string" ? telemetry.aliased_to : undefined;
-  return { oss, cli, aliasedTo };
+  return {
+    oss: typeof config.user_id === "string" ? config.user_id : undefined,
+    cli:
+      typeof telemetry.anonymous_id === "string"
+        ? telemetry.anonymous_id
+        : undefined,
+    aliasedTo:
+      typeof telemetry.aliased_to === "string"
+        ? telemetry.aliased_to
+        : undefined,
+  };
 }
 
 export async function markMem0Aliased(email: string): Promise<void> {
-  const resolved = await configPath();
-  if (!resolved) return;
+  const node = await getNodeFs();
+  if (!node) return;
   try {
-    const dirname = resolved.modules.path.dirname(resolved.path);
-    resolved.modules.fs.mkdirSync(dirname, { recursive: true });
-    const config = (await loadRawConfig()) ?? {};
+    node.fs.mkdirSync(node.path.dirname(node.configPath), { recursive: true });
+    const config = loadConfig(node) ?? {};
     const telemetry =
       config.telemetry && typeof config.telemetry === "object"
-        ? (config.telemetry as Record<string, unknown>)
+        ? config.telemetry
         : {};
     telemetry.aliased_to = email;
     config.telemetry = telemetry;
-    resolved.modules.fs.writeFileSync(
-      resolved.path,
-      JSON.stringify(config, null, 4),
-    );
+    node.fs.writeFileSync(node.configPath, JSON.stringify(config, null, 4));
   } catch {
-    // Read-only filesystem (Lambda, container) — alias is best-effort.
+    // Best-effort: read-only filesystems and unwritable paths just skip.
   }
 }

--- a/mem0-ts/src/client/mem0.ts
+++ b/mem0-ts/src/client/mem0.ts
@@ -26,7 +26,12 @@ import {
   isTelemetryEnabled,
   telemetry,
 } from "./telemetry";
-import { readMem0AnonIds, markMem0Aliased } from "./config";
+import {
+  getOrCreateMem0UserId,
+  isMem0Aliased,
+  markMem0Aliased,
+  readMem0AnonIds,
+} from "./config";
 import { camelToSnake, camelToSnakeKeys, snakeToCamelKeys } from "./utils";
 import { createExceptionFromResponse, MemoryError } from "../common/exceptions";
 
@@ -145,16 +150,20 @@ export default class MemoryClient {
     try {
       const email = this.telemetryId;
       if (!email || !email.includes("@")) return;
+      const sharedAnonId = await getOrCreateMem0UserId();
       const anonIds = await readMem0AnonIds();
-      if (!anonIds) return;
-      if (anonIds.aliasedTo === email) return;
-      const candidates = [anonIds.oss, anonIds.cli].filter(
+      if (!anonIds && !sharedAnonId) return;
+      const candidates = [anonIds?.oss || sharedAnonId, anonIds?.cli].filter(
         (id): id is string => !!id && id !== email,
       );
+      const seen = new Set<string>();
       for (const anonId of candidates) {
-        await telemetry.captureIdentify(anonId, email);
+        if (seen.has(anonId) || (await isMem0Aliased(anonId, email))) continue;
+        seen.add(anonId);
+        if (await telemetry.captureIdentify(anonId, email)) {
+          await markMem0Aliased(anonId, email);
+        }
       }
-      await markMem0Aliased(email);
     } catch (error: any) {
       console.error("Failed to alias telemetry identity:", error);
     }

--- a/mem0-ts/src/client/mem0.ts
+++ b/mem0-ts/src/client/mem0.ts
@@ -20,7 +20,12 @@ import {
   CreateMemoryExportPayload,
   GetMemoryExportPayload,
 } from "./mem0.types";
-import { captureClientEvent, generateHash, telemetry } from "./telemetry";
+import {
+  captureClientEvent,
+  generateHash,
+  isTelemetryEnabled,
+  telemetry,
+} from "./telemetry";
 import { readMem0AnonIds, markMem0Aliased } from "./config";
 import { camelToSnake, camelToSnakeKeys, snakeToCamelKeys } from "./utils";
 import { createExceptionFromResponse, MemoryError } from "../common/exceptions";
@@ -136,6 +141,7 @@ export default class MemoryClient {
   }
 
   private async _maybeAliasAnonToEmail(): Promise<void> {
+    if (!isTelemetryEnabled()) return;
     try {
       const email = this.telemetryId;
       if (!email || !email.includes("@")) return;

--- a/mem0-ts/src/client/mem0.ts
+++ b/mem0-ts/src/client/mem0.ts
@@ -20,7 +20,8 @@ import {
   CreateMemoryExportPayload,
   GetMemoryExportPayload,
 } from "./mem0.types";
-import { captureClientEvent, generateHash } from "./telemetry";
+import { captureClientEvent, generateHash, telemetry } from "./telemetry";
+import { readMem0AnonIds, markMem0Aliased } from "./config";
 import { camelToSnake, camelToSnakeKeys, snakeToCamelKeys } from "./utils";
 import { createExceptionFromResponse, MemoryError } from "../common/exceptions";
 
@@ -118,6 +119,8 @@ export default class MemoryClient {
         this.telemetryId = generateHash(this.apiKey);
       }
 
+      await this._maybeAliasAnonToEmail();
+
       captureClientEvent("init", this, {
         client_type: "MemoryClient",
       }).catch((error: any) => {
@@ -129,6 +132,25 @@ export default class MemoryClient {
         error: error?.message || "Unknown error",
         stack: error?.stack || "No stack trace",
       });
+    }
+  }
+
+  private async _maybeAliasAnonToEmail(): Promise<void> {
+    try {
+      const email = this.telemetryId;
+      if (!email || !email.includes("@")) return;
+      const anonIds = await readMem0AnonIds();
+      if (!anonIds) return;
+      if (anonIds.aliasedTo === email) return;
+      const candidates = [anonIds.oss, anonIds.cli].filter(
+        (id): id is string => !!id && id !== email,
+      );
+      for (const anonId of candidates) {
+        await telemetry.captureIdentify(anonId, email);
+      }
+      await markMem0Aliased(email);
+    } catch (error: any) {
+      console.error("Failed to alias telemetry identity:", error);
     }
   }
 

--- a/mem0-ts/src/client/telemetry.ts
+++ b/mem0-ts/src/client/telemetry.ts
@@ -81,6 +81,10 @@ class UnifiedTelemetry implements TelemetryClient {
   }
 }
 
+function isTelemetryEnabled(): boolean {
+  return MEM0_TELEMETRY;
+}
+
 const telemetry = new UnifiedTelemetry(POSTHOG_API_KEY, POSTHOG_HOST);
 
 async function captureClientEvent(
@@ -110,4 +114,4 @@ async function captureClientEvent(
   );
 }
 
-export { telemetry, captureClientEvent, generateHash };
+export { telemetry, captureClientEvent, generateHash, isTelemetryEnabled };

--- a/mem0-ts/src/client/telemetry.ts
+++ b/mem0-ts/src/client/telemetry.ts
@@ -32,8 +32,12 @@ class UnifiedTelemetry implements TelemetryClient {
     this.host = host;
   }
 
-  async captureEvent(distinctId: string, eventName: string, properties = {}) {
-    if (!MEM0_TELEMETRY) return;
+  async captureEvent(
+    distinctId: string,
+    eventName: string,
+    properties = {},
+  ): Promise<boolean> {
+    if (!MEM0_TELEMETRY) return false;
 
     const eventProperties = {
       client_version: version,
@@ -61,19 +65,51 @@ class UnifiedTelemetry implements TelemetryClient {
 
       if (!response.ok) {
         console.error("Telemetry event capture failed:", await response.text());
+        return false;
       }
+      return true;
     } catch (error) {
       console.error("Telemetry event capture failed:", error);
+      return false;
     }
   }
 
-  async captureIdentify(anonId: string, email: string) {
-    if (!MEM0_TELEMETRY) return;
-    if (!anonId || !email || anonId === email) return;
-    await this.captureEvent(email, "$identify", {
-      $anon_distinct_id: anonId,
-      client_source: "typescript",
-    });
+  async captureIdentify(anonId: string, email: string): Promise<boolean> {
+    if (!MEM0_TELEMETRY) return false;
+    if (!anonId || !email || anonId === email) return false;
+
+    const payload = {
+      api_key: this.apiKey,
+      distinct_id: email,
+      event: "$identify",
+      properties: {
+        $anon_distinct_id: anonId,
+        client_source: "typescript",
+        $lib: "posthog-node",
+      },
+    };
+
+    try {
+      const response = await fetch(this.host, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        console.error(
+          "Telemetry identify capture failed:",
+          await response.text(),
+        );
+        return false;
+      }
+      return true;
+    } catch (error) {
+      console.error("Telemetry identify capture failed:", error);
+      return false;
+    }
   }
 
   async shutdown() {

--- a/mem0-ts/src/client/telemetry.ts
+++ b/mem0-ts/src/client/telemetry.ts
@@ -67,6 +67,15 @@ class UnifiedTelemetry implements TelemetryClient {
     }
   }
 
+  async captureIdentify(anonId: string, email: string) {
+    if (!MEM0_TELEMETRY) return;
+    if (!anonId || !email || anonId === email) return;
+    await this.captureEvent(email, "$identify", {
+      $anon_distinct_id: anonId,
+      client_source: "typescript",
+    });
+  }
+
   async shutdown() {
     // No shutdown needed for direct API calls
   }

--- a/mem0-ts/src/client/telemetry.types.ts
+++ b/mem0-ts/src/client/telemetry.types.ts
@@ -3,7 +3,7 @@ export interface TelemetryClient {
     distinctId: string,
     eventName: string,
     properties?: Record<string, any>,
-  ): Promise<void>;
+  ): Promise<boolean>;
   shutdown(): Promise<void>;
 }
 

--- a/mem0-ts/src/client/tests/telemetry-aliasing.test.ts
+++ b/mem0-ts/src/client/tests/telemetry-aliasing.test.ts
@@ -9,8 +9,8 @@ import * as os from "os";
 import * as path from "path";
 import { MemoryClient } from "../mem0";
 import { telemetry } from "../telemetry";
-import { readMem0AnonIds, markMem0Aliased, Mem0AnonIds } from "../config";
-import { createMockFetch, TEST_API_KEY } from "./helpers";
+import { readMem0AnonIds, markMem0Aliased } from "../config";
+import { TEST_API_KEY } from "./helpers";
 import { setupMockFetch, installConsoleSuppression } from "./setup";
 
 installConsoleSuppression();
@@ -285,16 +285,42 @@ describe("MemoryClient — _maybeAliasAnonToEmail", () => {
       (client as any)._maybeAliasAnonToEmail(),
     ).resolves.toBeUndefined();
   });
-});
 
-// ─── Type smoke test ──────────────────────────────────────────
+  test("noop when telemetry disabled — no fs read, no fs write, no events", async () => {
+    fs.writeFileSync(
+      path.join(tmpHome, "config.json"),
+      JSON.stringify({ user_id: "oss-uuid" }),
+    );
+    const fetchMock = setupMockFetch();
 
-describe("Mem0AnonIds shape", () => {
-  test("interface accepts partial fields", () => {
-    const a: Mem0AnonIds = { oss: "x" };
-    const b: Mem0AnonIds = { cli: "y", aliasedTo: "u@x.com" };
-    expect(a.oss).toBe("x");
-    expect(b.aliasedTo).toBe("u@x.com");
+    jest.resetModules();
+    const original = process.env.MEM0_TELEMETRY;
+    process.env.MEM0_TELEMETRY = "false";
+    try {
+      const { MemoryClient: ColdClient } = await import("../mem0");
+      const client = Object.create(ColdClient.prototype);
+      client.apiKey = TEST_API_KEY;
+      client.host = "https://api.mem0.ai";
+      client.telemetryId = "test@example.com";
+      await client._maybeAliasAnonToEmail();
+    } finally {
+      if (original === undefined) delete process.env.MEM0_TELEMETRY;
+      else process.env.MEM0_TELEMETRY = original;
+      jest.resetModules();
+    }
+
+    const identifyCalls = (fetchMock.mock.calls as any[]).filter(
+      ([, init]: [string, RequestInit]) => {
+        if (!init?.body) return false;
+        return JSON.parse(init.body as string).event === "$identify";
+      },
+    );
+    expect(identifyCalls.length).toBe(0);
+
+    const written = JSON.parse(
+      fs.readFileSync(path.join(tmpHome, "config.json"), "utf8"),
+    );
+    expect(written.telemetry?.aliased_to).toBeUndefined();
   });
 });
 
@@ -303,11 +329,9 @@ describe("Mem0AnonIds shape", () => {
 describe("config.ts in browser-like environment", () => {
   test("readMem0AnonIds returns null when not Node", async () => {
     const originalProcess = global.process;
-    // Simulate a browser: no `process` global.
-    // @ts-expect-error force-undefining global
+    // @ts-expect-error force-undefining global to simulate a browser
     delete global.process;
     try {
-      // Re-import to pick up the missing global.
       jest.resetModules();
       const { readMem0AnonIds: browserRead } = await import("../config");
       expect(await browserRead()).toBeNull();
@@ -317,7 +341,3 @@ describe("config.ts in browser-like environment", () => {
     }
   });
 });
-
-// ─── Suppress unused-import warnings ──────────────────────────
-// Some helpers above are intentionally re-exported for clarity in tests.
-void createMockFetch;

--- a/mem0-ts/src/client/tests/telemetry-aliasing.test.ts
+++ b/mem0-ts/src/client/tests/telemetry-aliasing.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for PostHog identity stitching in the TS MemoryClient.
  *
- * Covers $identify firing, idempotency via aliased_to, and the node/browser
+ * Covers $identify firing, idempotency via pair markers, and the node/browser
  * gate. Mocks fs and fetch; never touches the real ~/.mem0/config.json.
  */
 import * as fs from "fs";
@@ -9,11 +9,22 @@ import * as os from "os";
 import * as path from "path";
 import { MemoryClient } from "../mem0";
 import { telemetry } from "../telemetry";
-import { readMem0AnonIds, markMem0Aliased } from "../config";
+import {
+  getOrCreateMem0UserId,
+  isMem0Aliased,
+  markMem0Aliased,
+  readMem0AnonIds,
+} from "../config";
 import { TEST_API_KEY } from "./helpers";
 import { setupMockFetch, installConsoleSuppression } from "./setup";
 
 installConsoleSuppression();
+
+function setupMockFetchWithPostHog(): jest.Mock {
+  return setupMockFetch(
+    new Map([["us.i.posthog.com", { status: 200, body: "ok" }]]),
+  );
+}
 
 // ─── config.ts (node-only fs read/write) ──────────────────────
 
@@ -50,23 +61,34 @@ describe("config.ts — readMem0AnonIds / markMem0Aliased", () => {
     expect(ids).toEqual({
       oss: "oss-uuid",
       cli: undefined,
-      aliasedTo: undefined,
+      aliasedPairs: [],
     });
   });
 
-  test("reads CLI anonymous_id and aliased_to", async () => {
+  test("reads CLI anonymous_id and aliased_pairs", async () => {
     fs.writeFileSync(
       path.join(tmpHome, "config.json"),
       JSON.stringify({
-        telemetry: { anonymous_id: "cli-anon", aliased_to: "u@x.com" },
+        telemetry: { anonymous_id: "cli-anon", aliased_pairs: ["pair-marker"] },
       }),
     );
     const ids = await readMem0AnonIds();
     expect(ids).toEqual({
       oss: undefined,
       cli: "cli-anon",
-      aliasedTo: "u@x.com",
+      aliasedPairs: ["pair-marker"],
     });
+  });
+
+  test("getOrCreateMem0UserId creates and reuses shared SDK user_id", async () => {
+    const first = await getOrCreateMem0UserId();
+    const second = await getOrCreateMem0UserId();
+    expect(first).toBeTruthy();
+    expect(second).toBe(first);
+    const written = JSON.parse(
+      fs.readFileSync(path.join(tmpHome, "config.json"), "utf8"),
+    );
+    expect(written.user_id).toBe(first);
   });
 
   test("returns null on malformed JSON", async () => {
@@ -82,13 +104,14 @@ describe("config.ts — readMem0AnonIds / markMem0Aliased", () => {
         telemetry: { anonymous_id: "cli-anon" },
       }),
     );
-    await markMem0Aliased("user@example.com");
+    await markMem0Aliased("oss-uuid", "user@example.com");
     const written = JSON.parse(
       fs.readFileSync(path.join(tmpHome, "config.json"), "utf8"),
     );
     expect(written.user_id).toBe("oss-uuid");
     expect(written.telemetry.anonymous_id).toBe("cli-anon");
-    expect(written.telemetry.aliased_to).toBe("user@example.com");
+    expect(written.telemetry.aliased_pairs).toHaveLength(1);
+    expect(await isMem0Aliased("oss-uuid", "user@example.com")).toBe(true);
   });
 
   test("markMem0Aliased creates telemetry section when missing", async () => {
@@ -96,18 +119,31 @@ describe("config.ts — readMem0AnonIds / markMem0Aliased", () => {
       path.join(tmpHome, "config.json"),
       JSON.stringify({ user_id: "oss-uuid" }),
     );
-    await markMem0Aliased("user@example.com");
+    await markMem0Aliased("oss-uuid", "user@example.com");
     const written = JSON.parse(
       fs.readFileSync(path.join(tmpHome, "config.json"), "utf8"),
     );
-    expect(written.telemetry.aliased_to).toBe("user@example.com");
+    expect(written.telemetry.aliased_pairs).toHaveLength(1);
+  });
+
+  test("markMem0Aliased tracks each pair independently", async () => {
+    fs.writeFileSync(
+      path.join(tmpHome, "config.json"),
+      JSON.stringify({ user_id: "oss-uuid" }),
+    );
+    await markMem0Aliased("oss-uuid", "user@example.com");
+    expect(await isMem0Aliased("oss-uuid", "user@example.com")).toBe(true);
+    expect(await isMem0Aliased("other-uuid", "user@example.com")).toBe(false);
+    expect(await isMem0Aliased("oss-uuid", "other@example.com")).toBe(false);
   });
 
   test("markMem0Aliased does not throw when target dir is unwritable", async () => {
     // Point at a path that cannot be written to (a file-as-dir collision).
     fs.writeFileSync(path.join(tmpHome, "blocker"), "x");
     process.env.MEM0_DIR = path.join(tmpHome, "blocker"); // file used as dir
-    await expect(markMem0Aliased("user@example.com")).resolves.toBeUndefined();
+    await expect(
+      markMem0Aliased("oss-uuid", "user@example.com"),
+    ).resolves.toBeUndefined();
   });
 });
 
@@ -130,6 +166,7 @@ describe("telemetry.captureIdentify", () => {
     expect(payload.event).toBe("$identify");
     expect(payload.distinct_id).toBe("user@example.com");
     expect(payload.properties.$anon_distinct_id).toBe("anon-uuid");
+    expect(payload.properties.$process_person_profile).toBeUndefined();
   });
 
   test("skips when anon equals email", async () => {
@@ -180,12 +217,12 @@ describe("MemoryClient — _maybeAliasAnonToEmail", () => {
     return client;
   }
 
-  test("fires $identify on first init and persists aliased_to", async () => {
+  test("fires $identify on first init and persists pair marker", async () => {
     fs.writeFileSync(
       path.join(tmpHome, "config.json"),
       JSON.stringify({ user_id: "oss-uuid" }),
     );
-    const fetchMock = setupMockFetch();
+    const fetchMock = setupMockFetchWithPostHog();
 
     const client = makeStubClient("test@example.com");
     await (client as any)._maybeAliasAnonToEmail();
@@ -204,7 +241,31 @@ describe("MemoryClient — _maybeAliasAnonToEmail", () => {
     const written = JSON.parse(
       fs.readFileSync(path.join(tmpHome, "config.json"), "utf8"),
     );
-    expect(written.telemetry.aliased_to).toBe("test@example.com");
+    expect(written.telemetry.aliased_pairs).toHaveLength(1);
+  });
+
+  test("platform-first init creates shared anon ID and identifies it", async () => {
+    const fetchMock = setupMockFetchWithPostHog();
+
+    const client = makeStubClient("test@example.com");
+    await (client as any)._maybeAliasAnonToEmail();
+
+    const written = JSON.parse(
+      fs.readFileSync(path.join(tmpHome, "config.json"), "utf8"),
+    );
+    expect(written.user_id).toBeTruthy();
+    expect(written.telemetry.aliased_pairs).toHaveLength(1);
+
+    const identifyCalls = (fetchMock.mock.calls as any[]).filter(
+      ([, init]: [string, RequestInit]) => {
+        if (!init?.body) return false;
+        return JSON.parse(init.body as string).event === "$identify";
+      },
+    );
+    expect(identifyCalls.length).toBe(1);
+    const body = JSON.parse(identifyCalls[0][1].body);
+    expect(body.distinct_id).toBe("test@example.com");
+    expect(body.properties.$anon_distinct_id).toBe(written.user_id);
   });
 
   test("second init does not refire $identify", async () => {
@@ -212,10 +273,11 @@ describe("MemoryClient — _maybeAliasAnonToEmail", () => {
       path.join(tmpHome, "config.json"),
       JSON.stringify({
         user_id: "oss-uuid",
-        telemetry: { aliased_to: "test@example.com" },
+        telemetry: {},
       }),
     );
-    const fetchMock = setupMockFetch();
+    await markMem0Aliased("oss-uuid", "test@example.com");
+    const fetchMock = setupMockFetchWithPostHog();
 
     const client = makeStubClient("test@example.com");
     await (client as any)._maybeAliasAnonToEmail();
@@ -237,7 +299,7 @@ describe("MemoryClient — _maybeAliasAnonToEmail", () => {
         telemetry: { anonymous_id: "cli-anon" },
       }),
     );
-    const fetchMock = setupMockFetch();
+    const fetchMock = setupMockFetchWithPostHog();
 
     const client = makeStubClient("test@example.com");
     await (client as any)._maybeAliasAnonToEmail();
@@ -255,6 +317,11 @@ describe("MemoryClient — _maybeAliasAnonToEmail", () => {
     );
     expect(anonIds).toContain("oss-uuid");
     expect(anonIds).toContain("cli-anon");
+
+    const written = JSON.parse(
+      fs.readFileSync(path.join(tmpHome, "config.json"), "utf8"),
+    );
+    expect(written.telemetry.aliased_pairs).toHaveLength(2);
   });
 
   test("noop when telemetryId is not an email", async () => {
@@ -320,7 +387,7 @@ describe("MemoryClient — _maybeAliasAnonToEmail", () => {
     const written = JSON.parse(
       fs.readFileSync(path.join(tmpHome, "config.json"), "utf8"),
     );
-    expect(written.telemetry?.aliased_to).toBeUndefined();
+    expect(written.telemetry?.aliased_pairs).toBeUndefined();
   });
 });
 

--- a/mem0-ts/src/client/tests/telemetry-aliasing.test.ts
+++ b/mem0-ts/src/client/tests/telemetry-aliasing.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Tests for PostHog identity stitching in the TS MemoryClient.
+ *
+ * Covers $identify firing, idempotency via aliased_to, and the node/browser
+ * gate. Mocks fs and fetch; never touches the real ~/.mem0/config.json.
+ */
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { MemoryClient } from "../mem0";
+import { telemetry } from "../telemetry";
+import { readMem0AnonIds, markMem0Aliased, Mem0AnonIds } from "../config";
+import { createMockFetch, TEST_API_KEY } from "./helpers";
+import { setupMockFetch, installConsoleSuppression } from "./setup";
+
+installConsoleSuppression();
+
+// ─── config.ts (node-only fs read/write) ──────────────────────
+
+describe("config.ts — readMem0AnonIds / markMem0Aliased", () => {
+  let tmpHome: string;
+  const originalMem0Dir = process.env.MEM0_DIR;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "mem0-ts-test-"));
+    process.env.MEM0_DIR = tmpHome;
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(tmpHome)) {
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+    if (originalMem0Dir === undefined) {
+      delete process.env.MEM0_DIR;
+    } else {
+      process.env.MEM0_DIR = originalMem0Dir;
+    }
+  });
+
+  test("returns null when config file does not exist", async () => {
+    expect(await readMem0AnonIds()).toBeNull();
+  });
+
+  test("reads OSS user_id only", async () => {
+    fs.writeFileSync(
+      path.join(tmpHome, "config.json"),
+      JSON.stringify({ user_id: "oss-uuid" }),
+    );
+    const ids = await readMem0AnonIds();
+    expect(ids).toEqual({
+      oss: "oss-uuid",
+      cli: undefined,
+      aliasedTo: undefined,
+    });
+  });
+
+  test("reads CLI anonymous_id and aliased_to", async () => {
+    fs.writeFileSync(
+      path.join(tmpHome, "config.json"),
+      JSON.stringify({
+        telemetry: { anonymous_id: "cli-anon", aliased_to: "u@x.com" },
+      }),
+    );
+    const ids = await readMem0AnonIds();
+    expect(ids).toEqual({
+      oss: undefined,
+      cli: "cli-anon",
+      aliasedTo: "u@x.com",
+    });
+  });
+
+  test("returns null on malformed JSON", async () => {
+    fs.writeFileSync(path.join(tmpHome, "config.json"), "{not json");
+    expect(await readMem0AnonIds()).toBeNull();
+  });
+
+  test("markMem0Aliased preserves other fields", async () => {
+    fs.writeFileSync(
+      path.join(tmpHome, "config.json"),
+      JSON.stringify({
+        user_id: "oss-uuid",
+        telemetry: { anonymous_id: "cli-anon" },
+      }),
+    );
+    await markMem0Aliased("user@example.com");
+    const written = JSON.parse(
+      fs.readFileSync(path.join(tmpHome, "config.json"), "utf8"),
+    );
+    expect(written.user_id).toBe("oss-uuid");
+    expect(written.telemetry.anonymous_id).toBe("cli-anon");
+    expect(written.telemetry.aliased_to).toBe("user@example.com");
+  });
+
+  test("markMem0Aliased creates telemetry section when missing", async () => {
+    fs.writeFileSync(
+      path.join(tmpHome, "config.json"),
+      JSON.stringify({ user_id: "oss-uuid" }),
+    );
+    await markMem0Aliased("user@example.com");
+    const written = JSON.parse(
+      fs.readFileSync(path.join(tmpHome, "config.json"), "utf8"),
+    );
+    expect(written.telemetry.aliased_to).toBe("user@example.com");
+  });
+
+  test("markMem0Aliased does not throw when target dir is unwritable", async () => {
+    // Point at a path that cannot be written to (a file-as-dir collision).
+    fs.writeFileSync(path.join(tmpHome, "blocker"), "x");
+    process.env.MEM0_DIR = path.join(tmpHome, "blocker"); // file used as dir
+    await expect(markMem0Aliased("user@example.com")).resolves.toBeUndefined();
+  });
+});
+
+// ─── telemetry.captureIdentify ───────────────────────────────
+
+describe("telemetry.captureIdentify", () => {
+  test("fires $identify with $anon_distinct_id", async () => {
+    const fetchMock = jest.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => "ok",
+    })) as unknown as typeof fetch;
+    global.fetch = fetchMock as any;
+
+    await telemetry.captureIdentify("anon-uuid", "user@example.com");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = (fetchMock as jest.Mock).mock.calls[0];
+    const payload = JSON.parse(init.body);
+    expect(payload.event).toBe("$identify");
+    expect(payload.distinct_id).toBe("user@example.com");
+    expect(payload.properties.$anon_distinct_id).toBe("anon-uuid");
+  });
+
+  test("skips when anon equals email", async () => {
+    const fetchMock = jest.fn() as unknown as typeof fetch;
+    global.fetch = fetchMock as any;
+    await telemetry.captureIdentify("user@example.com", "user@example.com");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("skips when either input is empty", async () => {
+    const fetchMock = jest.fn() as unknown as typeof fetch;
+    global.fetch = fetchMock as any;
+    await telemetry.captureIdentify("", "user@example.com");
+    await telemetry.captureIdentify("anon", "");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+// ─── MemoryClient init aliasing ──────────────────────────────
+
+describe("MemoryClient — _maybeAliasAnonToEmail", () => {
+  let tmpHome: string;
+  const originalMem0Dir = process.env.MEM0_DIR;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "mem0-ts-init-"));
+    process.env.MEM0_DIR = tmpHome;
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(tmpHome)) {
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+    if (originalMem0Dir === undefined) {
+      delete process.env.MEM0_DIR;
+    } else {
+      process.env.MEM0_DIR = originalMem0Dir;
+    }
+  });
+
+  // Construct a non-initialised client so we can call _maybeAliasAnonToEmail
+  // in isolation (the real constructor's _initializeClient also fires it).
+  function makeStubClient(telemetryId: string): MemoryClient {
+    const client = Object.create(MemoryClient.prototype) as MemoryClient;
+    (client as any).apiKey = TEST_API_KEY;
+    (client as any).host = "https://api.mem0.ai";
+    (client as any).telemetryId = telemetryId;
+    return client;
+  }
+
+  test("fires $identify on first init and persists aliased_to", async () => {
+    fs.writeFileSync(
+      path.join(tmpHome, "config.json"),
+      JSON.stringify({ user_id: "oss-uuid" }),
+    );
+    const fetchMock = setupMockFetch();
+
+    const client = makeStubClient("test@example.com");
+    await (client as any)._maybeAliasAnonToEmail();
+
+    const identifyCalls = (fetchMock.mock.calls as any[]).filter(
+      ([, init]: [string, RequestInit]) => {
+        if (!init?.body) return false;
+        return JSON.parse(init.body as string).event === "$identify";
+      },
+    );
+    expect(identifyCalls.length).toBe(1);
+    const body = JSON.parse(identifyCalls[0][1].body);
+    expect(body.distinct_id).toBe("test@example.com");
+    expect(body.properties.$anon_distinct_id).toBe("oss-uuid");
+
+    const written = JSON.parse(
+      fs.readFileSync(path.join(tmpHome, "config.json"), "utf8"),
+    );
+    expect(written.telemetry.aliased_to).toBe("test@example.com");
+  });
+
+  test("second init does not refire $identify", async () => {
+    fs.writeFileSync(
+      path.join(tmpHome, "config.json"),
+      JSON.stringify({
+        user_id: "oss-uuid",
+        telemetry: { aliased_to: "test@example.com" },
+      }),
+    );
+    const fetchMock = setupMockFetch();
+
+    const client = makeStubClient("test@example.com");
+    await (client as any)._maybeAliasAnonToEmail();
+
+    const identifyCalls = (fetchMock.mock.calls as any[]).filter(
+      ([, init]: [string, RequestInit]) => {
+        if (!init?.body) return false;
+        return JSON.parse(init.body as string).event === "$identify";
+      },
+    );
+    expect(identifyCalls.length).toBe(0);
+  });
+
+  test("fires $identify for both OSS and CLI anon ids", async () => {
+    fs.writeFileSync(
+      path.join(tmpHome, "config.json"),
+      JSON.stringify({
+        user_id: "oss-uuid",
+        telemetry: { anonymous_id: "cli-anon" },
+      }),
+    );
+    const fetchMock = setupMockFetch();
+
+    const client = makeStubClient("test@example.com");
+    await (client as any)._maybeAliasAnonToEmail();
+
+    const identifyCalls = (fetchMock.mock.calls as any[]).filter(
+      ([, init]: [string, RequestInit]) => {
+        if (!init?.body) return false;
+        return JSON.parse(init.body as string).event === "$identify";
+      },
+    );
+    expect(identifyCalls.length).toBe(2);
+    const anonIds = identifyCalls.map(
+      (c: [string, RequestInit]) =>
+        JSON.parse(c[1].body as string).properties.$anon_distinct_id,
+    );
+    expect(anonIds).toContain("oss-uuid");
+    expect(anonIds).toContain("cli-anon");
+  });
+
+  test("noop when telemetryId is not an email", async () => {
+    fs.writeFileSync(
+      path.join(tmpHome, "config.json"),
+      JSON.stringify({ user_id: "oss-uuid" }),
+    );
+    const fetchMock = setupMockFetch();
+
+    const client = makeStubClient("not-an-email");
+    await (client as any)._maybeAliasAnonToEmail();
+
+    const identifyCalls = (fetchMock.mock.calls as any[]).filter(
+      ([, init]: [string, RequestInit]) => {
+        if (!init?.body) return false;
+        return JSON.parse(init.body as string).event === "$identify";
+      },
+    );
+    expect(identifyCalls.length).toBe(0);
+  });
+
+  test("does not throw when config read fails", async () => {
+    fs.writeFileSync(path.join(tmpHome, "config.json"), "{not json");
+    setupMockFetch();
+
+    const client = makeStubClient("test@example.com");
+    await expect(
+      (client as any)._maybeAliasAnonToEmail(),
+    ).resolves.toBeUndefined();
+  });
+});
+
+// ─── Type smoke test ──────────────────────────────────────────
+
+describe("Mem0AnonIds shape", () => {
+  test("interface accepts partial fields", () => {
+    const a: Mem0AnonIds = { oss: "x" };
+    const b: Mem0AnonIds = { cli: "y", aliasedTo: "u@x.com" };
+    expect(a.oss).toBe("x");
+    expect(b.aliasedTo).toBe("u@x.com");
+  });
+});
+
+// ─── Browser env path (no process.versions.node) ─────────────
+
+describe("config.ts in browser-like environment", () => {
+  test("readMem0AnonIds returns null when not Node", async () => {
+    const originalProcess = global.process;
+    // Simulate a browser: no `process` global.
+    // @ts-expect-error force-undefining global
+    delete global.process;
+    try {
+      // Re-import to pick up the missing global.
+      jest.resetModules();
+      const { readMem0AnonIds: browserRead } = await import("../config");
+      expect(await browserRead()).toBeNull();
+    } finally {
+      global.process = originalProcess;
+      jest.resetModules();
+    }
+  });
+});
+
+// ─── Suppress unused-import warnings ──────────────────────────
+// Some helpers above are intentionally re-exported for clarity in tests.
+void createMockFetch;

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -53,6 +53,7 @@ import {
   ScoredResult,
 } from "../utils/scoring";
 import { getDefaultVectorStoreDbPath } from "../utils/sqlite";
+import { getOrCreateMem0UserId } from "../../../client/config";
 
 // Entity params that must be passed via filters - check both snake_case and camelCase
 const ENTITY_PARAMS = [
@@ -466,7 +467,12 @@ export class Memory {
         this.telemetryId === "anonymous" ||
         this.telemetryId === "anonymous-supabase"
       ) {
-        this.telemetryId = await this.vectorStore.getUserId();
+        this.telemetryId =
+          (await getOrCreateMem0UserId()) ||
+          (await this.vectorStore.getUserId());
+        try {
+          await this.vectorStore.setUserId(this.telemetryId);
+        } catch {}
       }
       return this.telemetryId;
     } catch (error) {

--- a/mem0/client/main.py
+++ b/mem0/client/main.py
@@ -19,8 +19,8 @@ from mem0.client.types import (
 from mem0.client.utils import api_error_handler
 
 # Exception classes are referenced in docstrings only
-from mem0.memory.setup import get_user_id, setup_config
-from mem0.memory.telemetry import capture_client_event
+from mem0.memory.setup import get_user_id, mark_aliased, read_anon_ids, setup_config
+from mem0.memory.telemetry import capture_client_event, client_telemetry
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +31,28 @@ setup_config()
 
 # Entity parameters that must be passed via filters, not top-level
 ENTITY_PARAMS = frozenset({"user_id", "agent_id", "app_id", "run_id"})
+
+
+def _maybe_alias_anon_to_email(user_email):
+    """Stitch prior anonymous PostHog identities to the resolved email.
+
+    Reads ~/.mem0/config.json for both anon IDs (OSS user_id, CLI
+    telemetry.anonymous_id), fires one $identify per anon that hasn't been
+    aliased yet, then sets telemetry.aliased_to so this only happens once
+    per (anon_id, email) pair. Best-effort — never raises.
+    """
+    if not user_email or "@" not in user_email:
+        return
+    try:
+        anon_ids = read_anon_ids()
+        if anon_ids.get("aliased_to") == user_email:
+            return
+        for anon_id in (anon_ids.get("oss"), anon_ids.get("cli")):
+            if anon_id and anon_id != user_email:
+                client_telemetry.capture_identify(anon_id, user_email)
+        mark_aliased(user_email)
+    except Exception as e:
+        logger.debug("Failed to alias anon telemetry to %r: %s", user_email, e)
 
 
 class MemoryClient:
@@ -108,6 +130,7 @@ class MemoryClient:
             user_email=self.user_email,
         )
 
+        _maybe_alias_anon_to_email(self.user_email)
         capture_client_event("client.init", self, {"sync_type": "sync"})
 
     def _validate_api_key(self):
@@ -985,6 +1008,7 @@ class AsyncMemoryClient:
             user_email=self.user_email,
         )
 
+        _maybe_alias_anon_to_email(self.user_email)
         capture_client_event("client.init", self, {"sync_type": "async"})
 
     def _validate_api_key(self):

--- a/mem0/client/main.py
+++ b/mem0/client/main.py
@@ -19,7 +19,7 @@ from mem0.client.types import (
 from mem0.client.utils import api_error_handler
 
 # Exception classes are referenced in docstrings only
-from mem0.memory.setup import get_user_id, mark_aliased, read_anon_ids, setup_config
+from mem0.memory.setup import get_user_id, is_aliased, mark_aliased, read_anon_ids, setup_config
 from mem0.memory.telemetry import capture_client_event, client_telemetry
 
 logger = logging.getLogger(__name__)
@@ -36,9 +36,9 @@ ENTITY_PARAMS = frozenset({"user_id", "agent_id", "app_id", "run_id"})
 def _maybe_alias_anon_to_email(user_email):
     """Fire $identify per prior anon ID so PostHog merges them into email.
 
-    Idempotent via telemetry.aliased_to — only writes the flag when telemetry
-    is actually enabled, so disabling/re-enabling MEM0_TELEMETRY still works.
-    Best-effort — never raises.
+    Idempotent via telemetry.aliased_pairs: only writes markers when
+    telemetry is actually enabled, so disabling/re-enabling MEM0_TELEMETRY still works.
+    Best-effort: never raises.
     """
     if client_telemetry.posthog is None:
         return
@@ -46,12 +46,15 @@ def _maybe_alias_anon_to_email(user_email):
         return
     try:
         anon_ids = read_anon_ids()
-        if anon_ids.get("aliased_to") == user_email:
-            return
+        seen = set()
         for anon_id in (anon_ids.get("oss"), anon_ids.get("cli")):
-            if anon_id and anon_id != user_email:
-                client_telemetry.capture_identify(anon_id, user_email)
-        mark_aliased(user_email)
+            if not anon_id or anon_id == user_email or anon_id in seen:
+                continue
+            seen.add(anon_id)
+            if is_aliased(anon_id, user_email):
+                continue
+            if client_telemetry.capture_identify(anon_id, user_email):
+                mark_aliased(anon_id, user_email)
     except Exception as e:
         logger.debug("Failed to alias anon telemetry to %r: %s", user_email, e)
 

--- a/mem0/client/main.py
+++ b/mem0/client/main.py
@@ -34,13 +34,14 @@ ENTITY_PARAMS = frozenset({"user_id", "agent_id", "app_id", "run_id"})
 
 
 def _maybe_alias_anon_to_email(user_email):
-    """Stitch prior anonymous PostHog identities to the resolved email.
+    """Fire $identify per prior anon ID so PostHog merges them into email.
 
-    Reads ~/.mem0/config.json for both anon IDs (OSS user_id, CLI
-    telemetry.anonymous_id), fires one $identify per anon that hasn't been
-    aliased yet, then sets telemetry.aliased_to so this only happens once
-    per (anon_id, email) pair. Best-effort — never raises.
+    Idempotent via telemetry.aliased_to — only writes the flag when telemetry
+    is actually enabled, so disabling/re-enabling MEM0_TELEMETRY still works.
+    Best-effort — never raises.
     """
+    if client_telemetry.posthog is None:
+        return
     if not user_email or "@" not in user_email:
         return
     try:

--- a/mem0/memory/setup.py
+++ b/mem0/memory/setup.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import uuid
+from hashlib import sha256
 
 # Set up the directory path
 VECTOR_ID = str(uuid.uuid4())
@@ -63,29 +64,57 @@ def get_user_id():
 
 
 def read_anon_ids():
-    """Return both anon IDs and the aliased_to flag from ~/.mem0/config.json.
+    """Return anon IDs and alias markers from ~/.mem0/config.json.
 
-    Returns a dict with keys "oss", "cli", "aliased_to" (any may be None).
-    OSS Python writes top-level "user_id"; the CLI writes
-    "telemetry.anonymous_id". They may coexist depending on which surface
-    ran first.
+    Returns a dict with keys "oss", "cli", "aliased_pairs" (IDs may be
+    None). OSS Python writes top-level "user_id"; the CLI writes
+    "telemetry.anonymous_id". They may coexist depending on which surface ran
+    first.
     """
     config = _load_config()
     telemetry = config.get("telemetry") if isinstance(config.get("telemetry"), dict) else {}
+    aliased_pairs = telemetry.get("aliased_pairs")
     return {
         "oss": config.get("user_id"),
         "cli": telemetry.get("anonymous_id"),
-        "aliased_to": telemetry.get("aliased_to"),
+        "aliased_pairs": aliased_pairs if isinstance(aliased_pairs, list) else [],
     }
 
 
-def mark_aliased(email):
-    """Persist telemetry.aliased_to = email so $identify only fires once."""
+def _alias_pair_marker(anon_id, email):
+    return sha256(f"{anon_id}\0{email}".encode("utf-8")).hexdigest()
+
+
+def is_aliased(anon_id, email):
+    """Return whether anon_id -> email has already been identified."""
+    if not anon_id or not email:
+        return False
+    config = _load_config()
+    telemetry = config.get("telemetry") if isinstance(config.get("telemetry"), dict) else {}
+    aliased_pairs = telemetry.get("aliased_pairs")
+    if not isinstance(aliased_pairs, list):
+        return False
+    return _alias_pair_marker(anon_id, email) in aliased_pairs
+
+
+def mark_aliased(anon_id, email):
+    """Persist an anon_id -> email alias marker so $identify fires once per pair.
+
+    The marker is hashed to avoid storing platform emails in the local config.
+    """
+    if not anon_id or not email:
+        return
     config = _load_config()
     telemetry = config.get("telemetry")
     if not isinstance(telemetry, dict):
         telemetry = {}
-    telemetry["aliased_to"] = email
+    aliased_pairs = telemetry.get("aliased_pairs")
+    if not isinstance(aliased_pairs, list):
+        aliased_pairs = []
+    marker = _alias_pair_marker(anon_id, email)
+    if marker not in aliased_pairs:
+        aliased_pairs.append(marker)
+    telemetry["aliased_pairs"] = aliased_pairs
     config["telemetry"] = telemetry
     _write_config(config)
 

--- a/mem0/memory/setup.py
+++ b/mem0/memory/setup.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import uuid
 
@@ -8,28 +9,85 @@ home_dir = os.path.expanduser("~")
 mem0_dir = os.environ.get("MEM0_DIR") or os.path.join(home_dir, ".mem0")
 os.makedirs(mem0_dir, exist_ok=True)
 
+_logger = logging.getLogger(__name__)
+
+
+def _config_path():
+    return os.path.join(mem0_dir, "config.json")
+
+
+def _load_config():
+    """Load ~/.mem0/config.json, returning {} on missing/malformed file."""
+    path = _config_path()
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path, "r") as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except Exception as e:
+        _logger.debug("Failed to load mem0 config %s: %s", path, e)
+        return {}
+
+
+def _write_config(config):
+    """Best-effort write of ~/.mem0/config.json. Never raises."""
+    path = _config_path()
+    try:
+        with open(path, "w") as f:
+            json.dump(config, f, indent=4)
+    except Exception as e:
+        _logger.debug("Failed to write mem0 config %s: %s", path, e)
+
 
 def setup_config():
-    config_path = os.path.join(mem0_dir, "config.json")
-    if not os.path.exists(config_path):
-        user_id = str(uuid.uuid4())
-        config = {"user_id": user_id}
-        with open(config_path, "w") as config_file:
-            json.dump(config, config_file, indent=4)
+    """Ensure ~/.mem0/config.json exists with a top-level user_id.
+
+    Idempotent: backfills user_id for users whose config was written by the
+    CLI (which writes telemetry.anonymous_id but no top-level user_id).
+    Without this, OSS Python telemetry is silently dropped because
+    get_user_id() returns None when user_id is missing.
+    """
+    config = _load_config()
+    if config.get("user_id"):
+        return
+    config["user_id"] = str(uuid.uuid4())
+    _write_config(config)
 
 
 def get_user_id():
-    config_path = os.path.join(mem0_dir, "config.json")
-    if not os.path.exists(config_path):
+    config = _load_config()
+    if not config:
         return "anonymous_user"
+    return config.get("user_id")
 
-    try:
-        with open(config_path, "r") as config_file:
-            config = json.load(config_file)
-            user_id = config.get("user_id")
-            return user_id
-    except Exception:
-        return "anonymous_user"
+
+def read_anon_ids():
+    """Return both anon IDs and the aliased_to flag from ~/.mem0/config.json.
+
+    Returns a dict with keys "oss", "cli", "aliased_to" (any may be None).
+    OSS Python writes top-level "user_id"; the CLI writes
+    "telemetry.anonymous_id". They may coexist depending on which surface
+    ran first.
+    """
+    config = _load_config()
+    telemetry = config.get("telemetry") if isinstance(config.get("telemetry"), dict) else {}
+    return {
+        "oss": config.get("user_id"),
+        "cli": telemetry.get("anonymous_id"),
+        "aliased_to": telemetry.get("aliased_to"),
+    }
+
+
+def mark_aliased(email):
+    """Persist telemetry.aliased_to = email so $identify only fires once."""
+    config = _load_config()
+    telemetry = config.get("telemetry")
+    if not isinstance(telemetry, dict):
+        telemetry = {}
+    telemetry["aliased_to"] = email
+    config["telemetry"] = telemetry
+    _write_config(config)
 
 
 def get_or_create_user_id(vector_store=None):

--- a/mem0/memory/telemetry.py
+++ b/mem0/memory/telemetry.py
@@ -116,17 +116,19 @@ class AnonymousTelemetry:
     def capture_identify(self, anon_id, email):
         """Fire $identify with $anon_distinct_id so PostHog merges anon_id into email."""
         if self.posthog is None:
-            return
+            return False
         if not anon_id or not email or anon_id == email:
-            return
+            return False
         try:
             self.posthog.capture(
                 distinct_id=email,
                 event="$identify",
                 properties={"$anon_distinct_id": anon_id, "client_source": "python"},
             )
+            return True
         except Exception as e:
             _logger.debug("Failed to capture $identify for %r: %s", email, e)
+            return False
 
     def close(self):
         if self.posthog is not None:

--- a/mem0/memory/telemetry.py
+++ b/mem0/memory/telemetry.py
@@ -114,29 +114,17 @@ class AnonymousTelemetry:
             _logger.debug("Failed to capture telemetry event %r: %s", event_name, e)
 
     def capture_identify(self, anon_id, email):
-        """Send a PostHog $identify event so the anon person merges into the
-        identified person. Distinct_id is the new identity (email); the prior
-        anonymous distinct_id is passed as $anon_distinct_id per PostHog spec.
-
-        Never raises.
-        """
+        """Fire $identify with $anon_distinct_id so PostHog merges anon_id into email."""
         if self.posthog is None:
             return
         if not anon_id or not email or anon_id == email:
             return
-        properties = {
-            "$anon_distinct_id": anon_id,
-            "client_source": "python",
-            "client_version": mem0.__version__,
-            "python_version": sys.version,
-            "os": sys.platform,
-            "os_version": platform.version(),
-            "os_release": platform.release(),
-            "processor": platform.processor(),
-            "machine": platform.machine(),
-        }
         try:
-            self.posthog.capture(distinct_id=email, event="$identify", properties=properties)
+            self.posthog.capture(
+                distinct_id=email,
+                event="$identify",
+                properties={"$anon_distinct_id": anon_id, "client_source": "python"},
+            )
         except Exception as e:
             _logger.debug("Failed to capture $identify for %r: %s", email, e)
 

--- a/mem0/memory/telemetry.py
+++ b/mem0/memory/telemetry.py
@@ -48,7 +48,8 @@ MEM0_TELEMETRY_SAMPLE_RATE = _parse_sample_rate(os.environ.get("MEM0_TELEMETRY_S
 
 # Events that bypass sampling and always fire. Keep this set in sync with the
 # event names passed to capture_event() in mem0/memory/main.py.
-_LIFECYCLE_EVENTS = frozenset({"mem0.init", "mem0.reset", "mem0._create_procedural_memory"})
+# $identify is included so PostHog person-merging is never lost to sampling.
+_LIFECYCLE_EVENTS = frozenset({"mem0.init", "mem0.reset", "mem0._create_procedural_memory", "$identify"})
 
 
 def _sampling_before_send(msg):
@@ -111,6 +112,33 @@ class AnonymousTelemetry:
             self.posthog.capture(distinct_id=distinct_id, event=event_name, properties=properties)
         except Exception as e:
             _logger.debug("Failed to capture telemetry event %r: %s", event_name, e)
+
+    def capture_identify(self, anon_id, email):
+        """Send a PostHog $identify event so the anon person merges into the
+        identified person. Distinct_id is the new identity (email); the prior
+        anonymous distinct_id is passed as $anon_distinct_id per PostHog spec.
+
+        Never raises.
+        """
+        if self.posthog is None:
+            return
+        if not anon_id or not email or anon_id == email:
+            return
+        properties = {
+            "$anon_distinct_id": anon_id,
+            "client_source": "python",
+            "client_version": mem0.__version__,
+            "python_version": sys.version,
+            "os": sys.platform,
+            "os_version": platform.version(),
+            "os_release": platform.release(),
+            "processor": platform.processor(),
+            "machine": platform.machine(),
+        }
+        try:
+            self.posthog.capture(distinct_id=email, event="$identify", properties=properties)
+        except Exception as e:
+            _logger.debug("Failed to capture $identify for %r: %s", email, e)
 
     def close(self):
         if self.posthog is not None:

--- a/tests/test_telemetry_aliasing.py
+++ b/tests/test_telemetry_aliasing.py
@@ -297,6 +297,23 @@ class TestMaybeAliasAnonToEmail:
             client_main._maybe_alias_anon_to_email("not-an-email")
             telemetry.capture_identify.assert_not_called()
 
+    def test_skips_when_telemetry_disabled(self):
+        """When client_telemetry.posthog is None (MEM0_TELEMETRY=false), do nothing —
+        no fs read, no fs write, no event. Re-enabling telemetry later must still alias."""
+        from mem0.client import main as client_main
+
+        disabled = MagicMock()
+        disabled.posthog = None
+        with (
+            patch.object(client_main, "client_telemetry", disabled),
+            patch.object(client_main, "read_anon_ids") as read,
+            patch.object(client_main, "mark_aliased") as mark,
+        ):
+            client_main._maybe_alias_anon_to_email("user@example.com")
+            read.assert_not_called()
+            mark.assert_not_called()
+            disabled.capture_identify.assert_not_called()
+
     def test_does_not_raise_on_telemetry_failure(self):
         from mem0.client import main as client_main
 

--- a/tests/test_telemetry_aliasing.py
+++ b/tests/test_telemetry_aliasing.py
@@ -1,0 +1,373 @@
+"""Tests for PostHog identity stitching: anon → email alias on MemoryClient init.
+
+Covers the four matrix cases (OSS-only, CLI-only, both, already-aliased) plus
+failure modes: missing config, malformed JSON, read-only filesystem,
+broken posthog client. Telemetry must never raise.
+"""
+
+import importlib
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def tmp_mem0_dir(tmp_path, monkeypatch):
+    """Point the mem0 setup module at a tempdir for the duration of the test."""
+    monkeypatch.setenv("MEM0_DIR", str(tmp_path))
+    # Reload setup so module-level mem0_dir picks up the env var.
+    import mem0.memory.setup as setup_module
+
+    importlib.reload(setup_module)
+    yield tmp_path
+    # Restore default state.
+    monkeypatch.delenv("MEM0_DIR", raising=False)
+    importlib.reload(setup_module)
+
+
+def _write_config(tmp_path: Path, payload: dict) -> Path:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(payload))
+    return config_path
+
+
+# ─── setup_config idempotency ────────────────────────────────────────────────
+
+
+class TestSetupConfigIdempotent:
+    def test_creates_config_when_missing(self, tmp_mem0_dir):
+        import mem0.memory.setup as setup_module
+
+        setup_module.setup_config()
+        config = json.loads((tmp_mem0_dir / "config.json").read_text())
+        assert "user_id" in config and config["user_id"]
+
+    def test_backfills_user_id_when_only_telemetry_present(self, tmp_mem0_dir):
+        import mem0.memory.setup as setup_module
+
+        _write_config(
+            tmp_mem0_dir,
+            {"telemetry": {"anonymous_id": "cli-anon-abc123"}},
+        )
+        setup_module.setup_config()
+        config = json.loads((tmp_mem0_dir / "config.json").read_text())
+        assert config.get("user_id"), "user_id must be backfilled for CLI-first users"
+        assert config["telemetry"]["anonymous_id"] == "cli-anon-abc123"
+
+    def test_does_not_overwrite_existing_user_id(self, tmp_mem0_dir):
+        import mem0.memory.setup as setup_module
+
+        _write_config(tmp_mem0_dir, {"user_id": "existing-uuid"})
+        setup_module.setup_config()
+        config = json.loads((tmp_mem0_dir / "config.json").read_text())
+        assert config["user_id"] == "existing-uuid"
+
+    def test_handles_malformed_json(self, tmp_mem0_dir):
+        import mem0.memory.setup as setup_module
+
+        (tmp_mem0_dir / "config.json").write_text("{not json")
+        setup_module.setup_config()  # must not raise
+        config = json.loads((tmp_mem0_dir / "config.json").read_text())
+        assert "user_id" in config
+
+
+# ─── read_anon_ids ───────────────────────────────────────────────────────────
+
+
+class TestReadAnonIds:
+    def test_returns_oss_only(self, tmp_mem0_dir):
+        import mem0.memory.setup as setup_module
+
+        _write_config(tmp_mem0_dir, {"user_id": "oss-uuid"})
+        anon = setup_module.read_anon_ids()
+        assert anon == {"oss": "oss-uuid", "cli": None, "aliased_to": None}
+
+    def test_returns_cli_only(self, tmp_mem0_dir):
+        import mem0.memory.setup as setup_module
+
+        _write_config(
+            tmp_mem0_dir,
+            {"telemetry": {"anonymous_id": "cli-anon-123"}},
+        )
+        anon = setup_module.read_anon_ids()
+        assert anon == {"oss": None, "cli": "cli-anon-123", "aliased_to": None}
+
+    def test_returns_both(self, tmp_mem0_dir):
+        import mem0.memory.setup as setup_module
+
+        _write_config(
+            tmp_mem0_dir,
+            {
+                "user_id": "oss-uuid",
+                "telemetry": {"anonymous_id": "cli-anon-123", "aliased_to": "user@x.com"},
+            },
+        )
+        anon = setup_module.read_anon_ids()
+        assert anon == {
+            "oss": "oss-uuid",
+            "cli": "cli-anon-123",
+            "aliased_to": "user@x.com",
+        }
+
+    def test_no_config_returns_all_none(self, tmp_mem0_dir):
+        import mem0.memory.setup as setup_module
+
+        anon = setup_module.read_anon_ids()
+        assert anon == {"oss": None, "cli": None, "aliased_to": None}
+
+    def test_malformed_json_does_not_raise(self, tmp_mem0_dir):
+        import mem0.memory.setup as setup_module
+
+        (tmp_mem0_dir / "config.json").write_text("{not json")
+        anon = setup_module.read_anon_ids()
+        assert anon == {"oss": None, "cli": None, "aliased_to": None}
+
+
+# ─── mark_aliased ────────────────────────────────────────────────────────────
+
+
+class TestMarkAliased:
+    def test_writes_aliased_to_preserving_other_fields(self, tmp_mem0_dir):
+        import mem0.memory.setup as setup_module
+
+        _write_config(
+            tmp_mem0_dir,
+            {
+                "user_id": "oss-uuid",
+                "telemetry": {"anonymous_id": "cli-anon-123"},
+            },
+        )
+        setup_module.mark_aliased("user@example.com")
+        config = json.loads((tmp_mem0_dir / "config.json").read_text())
+        assert config["user_id"] == "oss-uuid"
+        assert config["telemetry"]["anonymous_id"] == "cli-anon-123"
+        assert config["telemetry"]["aliased_to"] == "user@example.com"
+
+    def test_creates_telemetry_section_when_missing(self, tmp_mem0_dir):
+        import mem0.memory.setup as setup_module
+
+        _write_config(tmp_mem0_dir, {"user_id": "oss-uuid"})
+        setup_module.mark_aliased("user@example.com")
+        config = json.loads((tmp_mem0_dir / "config.json").read_text())
+        assert config["telemetry"]["aliased_to"] == "user@example.com"
+
+
+# ─── capture_identify ────────────────────────────────────────────────────────
+
+
+class TestCaptureIdentify:
+    def test_fires_identify_with_anon_distinct_id(self):
+        import mem0.memory.telemetry as telemetry_module
+
+        with patch.object(telemetry_module, "MEM0_TELEMETRY", True):
+            with patch("mem0.memory.telemetry.Posthog") as mock_posthog_cls:
+                at = telemetry_module.AnonymousTelemetry()
+                at.capture_identify("anon-123", "user@example.com")
+                mock_ph = mock_posthog_cls.return_value
+                mock_ph.capture.assert_called_once()
+                _, kwargs = mock_ph.capture.call_args
+                assert kwargs["distinct_id"] == "user@example.com"
+                assert kwargs["event"] == "$identify"
+                assert kwargs["properties"]["$anon_distinct_id"] == "anon-123"
+
+    def test_skips_when_anon_equals_email(self):
+        import mem0.memory.telemetry as telemetry_module
+
+        with patch.object(telemetry_module, "MEM0_TELEMETRY", True):
+            with patch("mem0.memory.telemetry.Posthog") as mock_posthog_cls:
+                at = telemetry_module.AnonymousTelemetry()
+                at.capture_identify("user@example.com", "user@example.com")
+                mock_posthog_cls.return_value.capture.assert_not_called()
+
+    def test_skips_when_inputs_empty(self):
+        import mem0.memory.telemetry as telemetry_module
+
+        with patch.object(telemetry_module, "MEM0_TELEMETRY", True):
+            with patch("mem0.memory.telemetry.Posthog") as mock_posthog_cls:
+                at = telemetry_module.AnonymousTelemetry()
+                at.capture_identify("", "user@example.com")
+                at.capture_identify("anon-123", "")
+                mock_posthog_cls.return_value.capture.assert_not_called()
+
+    def test_noop_when_telemetry_disabled(self):
+        import mem0.memory.telemetry as telemetry_module
+
+        with patch.object(telemetry_module, "MEM0_TELEMETRY", False):
+            at = telemetry_module.AnonymousTelemetry()
+            at.capture_identify("anon-123", "user@example.com")  # must not raise
+            assert at.posthog is None
+
+    def test_does_not_raise_on_posthog_error(self):
+        import mem0.memory.telemetry as telemetry_module
+
+        with patch.object(telemetry_module, "MEM0_TELEMETRY", True):
+            with patch("mem0.memory.telemetry.Posthog") as mock_posthog_cls:
+                mock_posthog_cls.return_value.capture.side_effect = RuntimeError("boom")
+                at = telemetry_module.AnonymousTelemetry()
+                at.capture_identify("anon-123", "user@example.com")  # must not raise
+
+    def test_identify_is_in_lifecycle_events(self):
+        """$identify must bypass the 90% sampling drop."""
+        import mem0.memory.telemetry as telemetry_module
+
+        assert "$identify" in telemetry_module._LIFECYCLE_EVENTS
+
+
+# ─── _maybe_alias_anon_to_email integration ──────────────────────────────────
+
+
+class TestMaybeAliasAnonToEmail:
+    """Test the alias helper in isolation by mocking out the config readers
+    and the telemetry client, since module-level setup_config() side effects
+    make end-to-end fixturing awkward."""
+
+    def test_fires_identify_for_oss_uuid(self):
+        from mem0.client import main as client_main
+
+        with (
+            patch.object(
+                client_main,
+                "read_anon_ids",
+                return_value={"oss": "oss-uuid", "cli": None, "aliased_to": None},
+            ),
+            patch.object(client_main, "mark_aliased") as mark,
+            patch.object(client_main, "client_telemetry") as telemetry,
+        ):
+            client_main._maybe_alias_anon_to_email("user@example.com")
+            telemetry.capture_identify.assert_called_once_with("oss-uuid", "user@example.com")
+            mark.assert_called_once_with("user@example.com")
+
+    def test_fires_identify_for_cli_anon(self):
+        from mem0.client import main as client_main
+
+        with (
+            patch.object(
+                client_main,
+                "read_anon_ids",
+                return_value={"oss": None, "cli": "cli-anon-xyz", "aliased_to": None},
+            ),
+            patch.object(client_main, "mark_aliased"),
+            patch.object(client_main, "client_telemetry") as telemetry,
+        ):
+            client_main._maybe_alias_anon_to_email("user@example.com")
+            telemetry.capture_identify.assert_called_once_with("cli-anon-xyz", "user@example.com")
+
+    def test_fires_identify_for_both_anon_ids(self):
+        from mem0.client import main as client_main
+
+        with (
+            patch.object(
+                client_main,
+                "read_anon_ids",
+                return_value={"oss": "oss-uuid", "cli": "cli-anon", "aliased_to": None},
+            ),
+            patch.object(client_main, "mark_aliased"),
+            patch.object(client_main, "client_telemetry") as telemetry,
+        ):
+            client_main._maybe_alias_anon_to_email("user@example.com")
+            assert telemetry.capture_identify.call_count == 2
+            calls = {c.args for c in telemetry.capture_identify.call_args_list}
+            assert ("oss-uuid", "user@example.com") in calls
+            assert ("cli-anon", "user@example.com") in calls
+
+    def test_skips_when_already_aliased(self):
+        from mem0.client import main as client_main
+
+        with (
+            patch.object(
+                client_main,
+                "read_anon_ids",
+                return_value={"oss": "oss-uuid", "cli": None, "aliased_to": "user@example.com"},
+            ),
+            patch.object(client_main, "mark_aliased") as mark,
+            patch.object(client_main, "client_telemetry") as telemetry,
+        ):
+            client_main._maybe_alias_anon_to_email("user@example.com")
+            telemetry.capture_identify.assert_not_called()
+            mark.assert_not_called()
+
+    def test_skips_when_email_invalid(self):
+        from mem0.client import main as client_main
+
+        with patch.object(client_main, "client_telemetry") as telemetry:
+            client_main._maybe_alias_anon_to_email(None)
+            client_main._maybe_alias_anon_to_email("")
+            client_main._maybe_alias_anon_to_email("not-an-email")
+            telemetry.capture_identify.assert_not_called()
+
+    def test_does_not_raise_on_telemetry_failure(self):
+        from mem0.client import main as client_main
+
+        mock_telemetry = MagicMock()
+        mock_telemetry.capture_identify.side_effect = RuntimeError("boom")
+        with (
+            patch.object(
+                client_main,
+                "read_anon_ids",
+                return_value={"oss": "oss-uuid", "cli": None, "aliased_to": None},
+            ),
+            patch.object(client_main, "mark_aliased"),
+            patch.object(client_main, "client_telemetry", mock_telemetry),
+        ):
+            client_main._maybe_alias_anon_to_email("user@example.com")  # must not raise
+
+    def test_skips_anon_id_equal_to_email(self):
+        """Defensive: if the anon_id somehow already is the email, don't self-alias."""
+        from mem0.client import main as client_main
+
+        with (
+            patch.object(
+                client_main,
+                "read_anon_ids",
+                return_value={"oss": "user@example.com", "cli": None, "aliased_to": None},
+            ),
+            patch.object(client_main, "mark_aliased"),
+            patch.object(client_main, "client_telemetry") as telemetry,
+        ):
+            client_main._maybe_alias_anon_to_email("user@example.com")
+            telemetry.capture_identify.assert_not_called()
+
+    def test_does_not_raise_on_read_failure(self):
+        """If read_anon_ids itself raises (e.g. IO error), helper must swallow it."""
+        from mem0.client import main as client_main
+
+        with (
+            patch.object(client_main, "read_anon_ids", side_effect=OSError("fs broken")),
+            patch.object(client_main, "client_telemetry") as telemetry,
+        ):
+            client_main._maybe_alias_anon_to_email("user@example.com")  # must not raise
+            telemetry.capture_identify.assert_not_called()
+
+
+# ─── End-to-end idempotency through real config ──────────────────────────────
+
+
+class TestEndToEndIdempotency:
+    """Verify the real config flow: two consecutive _maybe_alias_anon_to_email
+    calls fire $identify exactly once thanks to the persisted aliased_to flag."""
+
+    def test_second_call_is_noop_after_aliased_to_persisted(self, tmp_mem0_dir):
+        # Pre-populate config with an OSS user_id only.
+        _write_config(tmp_mem0_dir, {"user_id": "oss-uuid"})
+        # Reload setup so it uses the tempdir, then reload client.main so it
+        # picks up the freshly-loaded read_anon_ids/mark_aliased bindings.
+        import mem0.memory.setup as setup_module
+
+        importlib.reload(setup_module)
+        from mem0.client import main as client_main
+
+        importlib.reload(client_main)
+
+        with patch.object(client_main, "client_telemetry") as telemetry:
+            client_main._maybe_alias_anon_to_email("user@example.com")
+            first_call_count = telemetry.capture_identify.call_count
+            assert first_call_count >= 1
+
+            # Second call should hit the aliased_to short-circuit.
+            client_main._maybe_alias_anon_to_email("user@example.com")
+            assert telemetry.capture_identify.call_count == first_call_count
+
+        config = json.loads((tmp_mem0_dir / "config.json").read_text())
+        assert config["telemetry"]["aliased_to"] == "user@example.com"

--- a/tests/test_telemetry_aliasing.py
+++ b/tests/test_telemetry_aliasing.py
@@ -82,7 +82,7 @@ class TestReadAnonIds:
 
         _write_config(tmp_mem0_dir, {"user_id": "oss-uuid"})
         anon = setup_module.read_anon_ids()
-        assert anon == {"oss": "oss-uuid", "cli": None, "aliased_to": None}
+        assert anon == {"oss": "oss-uuid", "cli": None, "aliased_pairs": []}
 
     def test_returns_cli_only(self, tmp_mem0_dir):
         import mem0.memory.setup as setup_module
@@ -92,7 +92,7 @@ class TestReadAnonIds:
             {"telemetry": {"anonymous_id": "cli-anon-123"}},
         )
         anon = setup_module.read_anon_ids()
-        assert anon == {"oss": None, "cli": "cli-anon-123", "aliased_to": None}
+        assert anon == {"oss": None, "cli": "cli-anon-123", "aliased_pairs": []}
 
     def test_returns_both(self, tmp_mem0_dir):
         import mem0.memory.setup as setup_module
@@ -101,35 +101,35 @@ class TestReadAnonIds:
             tmp_mem0_dir,
             {
                 "user_id": "oss-uuid",
-                "telemetry": {"anonymous_id": "cli-anon-123", "aliased_to": "user@x.com"},
+                "telemetry": {"anonymous_id": "cli-anon-123", "aliased_pairs": ["pair-marker"]},
             },
         )
         anon = setup_module.read_anon_ids()
         assert anon == {
             "oss": "oss-uuid",
             "cli": "cli-anon-123",
-            "aliased_to": "user@x.com",
+            "aliased_pairs": ["pair-marker"],
         }
 
     def test_no_config_returns_all_none(self, tmp_mem0_dir):
         import mem0.memory.setup as setup_module
 
         anon = setup_module.read_anon_ids()
-        assert anon == {"oss": None, "cli": None, "aliased_to": None}
+        assert anon == {"oss": None, "cli": None, "aliased_pairs": []}
 
     def test_malformed_json_does_not_raise(self, tmp_mem0_dir):
         import mem0.memory.setup as setup_module
 
         (tmp_mem0_dir / "config.json").write_text("{not json")
         anon = setup_module.read_anon_ids()
-        assert anon == {"oss": None, "cli": None, "aliased_to": None}
+        assert anon == {"oss": None, "cli": None, "aliased_pairs": []}
 
 
 # ─── mark_aliased ────────────────────────────────────────────────────────────
 
 
 class TestMarkAliased:
-    def test_writes_aliased_to_preserving_other_fields(self, tmp_mem0_dir):
+    def test_writes_aliased_pair_preserving_other_fields(self, tmp_mem0_dir):
         import mem0.memory.setup as setup_module
 
         _write_config(
@@ -139,19 +139,29 @@ class TestMarkAliased:
                 "telemetry": {"anonymous_id": "cli-anon-123"},
             },
         )
-        setup_module.mark_aliased("user@example.com")
+        setup_module.mark_aliased("oss-uuid", "user@example.com")
         config = json.loads((tmp_mem0_dir / "config.json").read_text())
         assert config["user_id"] == "oss-uuid"
         assert config["telemetry"]["anonymous_id"] == "cli-anon-123"
-        assert config["telemetry"]["aliased_to"] == "user@example.com"
+        assert len(config["telemetry"]["aliased_pairs"]) == 1
+        assert setup_module.is_aliased("oss-uuid", "user@example.com")
 
     def test_creates_telemetry_section_when_missing(self, tmp_mem0_dir):
         import mem0.memory.setup as setup_module
 
         _write_config(tmp_mem0_dir, {"user_id": "oss-uuid"})
-        setup_module.mark_aliased("user@example.com")
+        setup_module.mark_aliased("oss-uuid", "user@example.com")
         config = json.loads((tmp_mem0_dir / "config.json").read_text())
-        assert config["telemetry"]["aliased_to"] == "user@example.com"
+        assert len(config["telemetry"]["aliased_pairs"]) == 1
+
+    def test_tracks_each_pair_independently(self, tmp_mem0_dir):
+        import mem0.memory.setup as setup_module
+
+        _write_config(tmp_mem0_dir, {"user_id": "oss-uuid"})
+        setup_module.mark_aliased("oss-uuid", "user@example.com")
+        assert setup_module.is_aliased("oss-uuid", "user@example.com")
+        assert not setup_module.is_aliased("new-uuid", "user@example.com")
+        assert not setup_module.is_aliased("oss-uuid", "other@example.com")
 
 
 # ─── capture_identify ────────────────────────────────────────────────────────
@@ -230,14 +240,16 @@ class TestMaybeAliasAnonToEmail:
             patch.object(
                 client_main,
                 "read_anon_ids",
-                return_value={"oss": "oss-uuid", "cli": None, "aliased_to": None},
+                return_value={"oss": "oss-uuid", "cli": None, "aliased_pairs": []},
             ),
+            patch.object(client_main, "is_aliased", return_value=False),
             patch.object(client_main, "mark_aliased") as mark,
             patch.object(client_main, "client_telemetry") as telemetry,
         ):
+            telemetry.capture_identify.return_value = True
             client_main._maybe_alias_anon_to_email("user@example.com")
             telemetry.capture_identify.assert_called_once_with("oss-uuid", "user@example.com")
-            mark.assert_called_once_with("user@example.com")
+            mark.assert_called_once_with("oss-uuid", "user@example.com")
 
     def test_fires_identify_for_cli_anon(self):
         from mem0.client import main as client_main
@@ -246,11 +258,13 @@ class TestMaybeAliasAnonToEmail:
             patch.object(
                 client_main,
                 "read_anon_ids",
-                return_value={"oss": None, "cli": "cli-anon-xyz", "aliased_to": None},
+                return_value={"oss": None, "cli": "cli-anon-xyz", "aliased_pairs": []},
             ),
+            patch.object(client_main, "is_aliased", return_value=False),
             patch.object(client_main, "mark_aliased"),
             patch.object(client_main, "client_telemetry") as telemetry,
         ):
+            telemetry.capture_identify.return_value = True
             client_main._maybe_alias_anon_to_email("user@example.com")
             telemetry.capture_identify.assert_called_once_with("cli-anon-xyz", "user@example.com")
 
@@ -261,26 +275,29 @@ class TestMaybeAliasAnonToEmail:
             patch.object(
                 client_main,
                 "read_anon_ids",
-                return_value={"oss": "oss-uuid", "cli": "cli-anon", "aliased_to": None},
+                return_value={"oss": "oss-uuid", "cli": "cli-anon", "aliased_pairs": []},
             ),
+            patch.object(client_main, "is_aliased", return_value=False),
             patch.object(client_main, "mark_aliased"),
             patch.object(client_main, "client_telemetry") as telemetry,
         ):
+            telemetry.capture_identify.return_value = True
             client_main._maybe_alias_anon_to_email("user@example.com")
             assert telemetry.capture_identify.call_count == 2
             calls = {c.args for c in telemetry.capture_identify.call_args_list}
             assert ("oss-uuid", "user@example.com") in calls
             assert ("cli-anon", "user@example.com") in calls
 
-    def test_skips_when_already_aliased(self):
+    def test_skips_when_pair_already_aliased(self):
         from mem0.client import main as client_main
 
         with (
             patch.object(
                 client_main,
                 "read_anon_ids",
-                return_value={"oss": "oss-uuid", "cli": None, "aliased_to": "user@example.com"},
+                return_value={"oss": "oss-uuid", "cli": None, "aliased_pairs": ["pair-marker"]},
             ),
+            patch.object(client_main, "is_aliased", return_value=True),
             patch.object(client_main, "mark_aliased") as mark,
             patch.object(client_main, "client_telemetry") as telemetry,
         ):
@@ -323,12 +340,14 @@ class TestMaybeAliasAnonToEmail:
             patch.object(
                 client_main,
                 "read_anon_ids",
-                return_value={"oss": "oss-uuid", "cli": None, "aliased_to": None},
+                return_value={"oss": "oss-uuid", "cli": None, "aliased_pairs": []},
             ),
-            patch.object(client_main, "mark_aliased"),
+            patch.object(client_main, "is_aliased", return_value=False),
+            patch.object(client_main, "mark_aliased") as mark,
             patch.object(client_main, "client_telemetry", mock_telemetry),
         ):
             client_main._maybe_alias_anon_to_email("user@example.com")  # must not raise
+            mark.assert_not_called()
 
     def test_skips_anon_id_equal_to_email(self):
         """Defensive: if the anon_id somehow already is the email, don't self-alias."""
@@ -338,8 +357,9 @@ class TestMaybeAliasAnonToEmail:
             patch.object(
                 client_main,
                 "read_anon_ids",
-                return_value={"oss": "user@example.com", "cli": None, "aliased_to": None},
+                return_value={"oss": "user@example.com", "cli": None, "aliased_pairs": []},
             ),
+            patch.object(client_main, "is_aliased", return_value=False),
             patch.object(client_main, "mark_aliased"),
             patch.object(client_main, "client_telemetry") as telemetry,
         ):
@@ -363,9 +383,9 @@ class TestMaybeAliasAnonToEmail:
 
 class TestEndToEndIdempotency:
     """Verify the real config flow: two consecutive _maybe_alias_anon_to_email
-    calls fire $identify exactly once thanks to the persisted aliased_to flag."""
+    calls fire $identify exactly once thanks to the persisted pair marker."""
 
-    def test_second_call_is_noop_after_aliased_to_persisted(self, tmp_mem0_dir):
+    def test_second_call_is_noop_after_pair_marker_persisted(self, tmp_mem0_dir):
         # Pre-populate config with an OSS user_id only.
         _write_config(tmp_mem0_dir, {"user_id": "oss-uuid"})
         # Reload setup so it uses the tempdir, then reload client.main so it
@@ -378,13 +398,14 @@ class TestEndToEndIdempotency:
         importlib.reload(client_main)
 
         with patch.object(client_main, "client_telemetry") as telemetry:
+            telemetry.capture_identify.return_value = True
             client_main._maybe_alias_anon_to_email("user@example.com")
             first_call_count = telemetry.capture_identify.call_count
             assert first_call_count >= 1
 
-            # Second call should hit the aliased_to short-circuit.
+            # Second call should hit the aliased_pairs short-circuit.
             client_main._maybe_alias_anon_to_email("user@example.com")
             assert telemetry.capture_identify.call_count == first_call_count
 
         config = json.loads((tmp_mem0_dir / "config.json").read_text())
-        assert config["telemetry"]["aliased_to"] == "user@example.com"
+        assert len(config["telemetry"]["aliased_pairs"]) == 1


### PR DESCRIPTION
## Linked Notion

https://www.notion.so/mem0ai/Cross-surface-identity-stitching-350f22c70c908128971cf38d56a6dcc9

## Description

PostHog shows only ~4 `$create_alias` events against ~300K platform users. The Python sync/async `MemoryClient` and the TypeScript `MemoryClient` were silently switching their PostHog `distinct_id` from an anonymous on-disk UUID to the user's email after `/v1/ping/`, without sending the merge instruction. PostHog ended up tracking each user as 2-3 disconnected personas (OSS UUID, CLI anon UUID, email).

The Python CLI already does this correctly. That pattern is the reference for this fix.

### What changed

- **`mem0/memory/setup.py`** - `setup_config()` is now idempotent: it backfills a top-level `user_id` for CLI-first users (the CLI writes `telemetry.anonymous_id`, not `user_id`, which left OSS telemetry silently dropped because `get_user_id()` returned `None`). Adds `read_anon_ids()`, `is_aliased()`, and `mark_aliased()` helpers.
- **`mem0/memory/telemetry.py`** - `AnonymousTelemetry.capture_identify()` posts a PostHog `$identify` event with `$anon_distinct_id`. Adds `"$identify"` to `_LIFECYCLE_EVENTS` so it bypasses the 90% sampling drop. It returns success/failure so local alias state is only marked after PostHog accepts the event.
- **`mem0/client/main.py`** - both `MemoryClient.__init__` and `AsyncMemoryClient.__init__` call `_maybe_alias_anon_to_email()` once `user_email` is resolved. It fires `$identify` for each unaliased anon ID (OSS `user_id` and CLI `telemetry.anonymous_id` may both be present), dedupes repeated IDs, and persists a hashed `telemetry.aliased_pairs` marker per `(anon_id, email)` pair. All telemetry calls are wrapped in `try/except` and never raise.
- **`mem0-ts/src/client/telemetry.ts`** - adds `captureIdentify()` for PostHog `$identify`. It sends a dedicated identify payload instead of reusing generic `captureEvent()`, because generic event capture adds `$process_person_profile: false`, which prevents PostHog identity merging.
- **`mem0-ts/src/client/config.ts`** (new) - node-only helpers for shared Mem0 config: `getOrCreateMem0UserId()`, `readMem0AnonIds()`, `isMem0Aliased()`, and `markMem0Aliased()`. These use async dynamic imports of `fs`/`path`/`os`/`crypto`, gated on `typeof process !== "undefined" && process.versions?.node` so browser bundles no-op cleanly.
- **`mem0-ts/src/client/mem0.ts`** - `_initializeClient()` calls `_maybeAliasAnonToEmail()` after `ping()` resolves the email. Platform-first users now create/reuse the shared Mem0 anonymous ID before aliasing to email.
- **`mem0-ts/src/oss/src/memory/index.ts`** - TS OSS telemetry now uses the shared `~/.mem0/config.json#user_id` going forward, then backfills that ID into the vector store for compatibility.

### Follow-up changes in commit `12bb2588`

- Replaced single-email idempotency (`telemetry.aliased_to`) with hashed per-pair markers (`telemetry.aliased_pairs`).
- Only mark an alias pair locally after `$identify` succeeds.
- Made TypeScript OSS and TypeScript Platform use the same shared Mem0 anonymous ID contract.
- Fixed TypeScript `$identify` to avoid `$process_person_profile: false`; this was confirmed as the reason the first TS e2e attempt did not merge in PostHog.

### What's intentionally not in this PR

- Collapsing `user_id` and `telemetry.anonymous_id` into a single field (forces a config migration - separate cleanup).
- Fixing the misnamed `generateHash()` in TS telemetry (returns random instead of hashing - separate behavior change).
- Moving away from email-as-canonical-distinct-id toward a stable internal UUID + email as a person property (touches frontend + backend identify paths).

### Plan

Full design rationale, failure-mode analysis, and rollout plan: [`.plans/posthog-identity-stitching-fix.md`](https://linear.app/mem0/issue/MEM-4989).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update

## Breaking Changes

N/A. Public APIs unchanged. The on-disk config schema gains an optional `telemetry.aliased_pairs` field. Older versions ignore unknown keys.

## Test Coverage

- [x] Added unit tests (Python: `tests/test_telemetry_aliasing.py`; TypeScript: `mem0-ts/src/client/tests/telemetry-aliasing.test.ts`)
- [ ] Added/updated integration tests
- [x] Tested manually (described below)
- [ ] No tests needed

The matrix covers OSS-only, CLI-only, both anon IDs present, already-aliased pairs, malformed JSON, read-only filesystem, PostHog client errors, browser env (no `process.versions.node`), idempotency across two consecutive inits, platform-first aliasing, TS `$identify` payload shape, and the lifecycle-events guard against sampling.

### Local verification

- `pytest tests/test_telemetry_aliasing.py tests/test_telemetry.py tests/test_telemetry_sampling.py tests/test_client.py -q` -> 115 passed
- `ruff check mem0/memory/setup.py mem0/memory/telemetry.py mem0/client/main.py tests/test_telemetry_aliasing.py` -> clean
- `corepack pnpm exec jest src/client/tests/telemetry-aliasing.test.ts --runInBand` -> 20 passed
- `corepack pnpm exec prettier --check src/client/config.ts src/client/mem0.ts src/client/telemetry.ts src/client/telemetry.types.ts src/client/tests/telemetry-aliasing.test.ts src/oss/src/memory/index.ts` -> clean
- `tsc --noEmit -p tsconfig.test.json` still reports pre-existing errors in `src/community/...langchain/mem0.ts`; no new TS type errors were introduced in the touched telemetry files.

### End-to-end PostHog verification

Python OSS -> Python Platform was verified end-to-end in PostHog.

- Repro tag: `stitch_repro_20260504_224728`
- OSS anon ID: `b61aa3bc-1b1c-4c46-a1a2-171579c51176`
- Email: `younes@brandtrend.ai`
- Result: `mem0.init`, `$identify`, and `client.init` all shared `person_id = f4faedbc-37bd-515b-b8e4-7473e710b15b`
- Idempotency verified: second platform init emitted another `client.init` but no second `$identify`

TypeScript OSS -> TypeScript Platform was verified end-to-end in PostHog after the dedicated `$identify` fix.

- Repro tag: `stitch_ts_repro_20260505_000025`
- OSS anon ID: `540485da-f220-4a25-a6c4-58e74ffff82d`
- Email: `slaouiyounes12@gmail.com`
- Result: `mem0.init`, `$identify`, and `client.init` all shared `person_id = 9de8bce0-6cd7-58be-b71d-01fe5f4d80ab`
- Important TS proof: the `$identify` row had no `$process_person_profile = false`, while normal `client.init` still had `$process_person_profile = false`

### End-to-end reproduction checklist

1. Fresh sandboxed `MEM0_DIR`. Run OSS Python telemetry -> confirm `user_id` written to config and anonymous `mem0.init` appears in PostHog.
2. Run Python `MemoryClient(api_key=...)` -> confirm one `$identify` event with `$anon_distinct_id` matching the OSS UUID, and confirm OSS/platform rows share one `person_id`.
3. Re-run Python `MemoryClient(...)` -> confirm no second `$identify`.
4. Repeat with TS OSS telemetry -> confirm shared `config.json#user_id` and anonymous `mem0.init`.
5. Run TS `MemoryClient(apiKey)` -> confirm `$identify` with `$anon_distinct_id` matching the TS OSS UUID, and confirm OSS/platform rows share one `person_id`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed (no public API changes; telemetry is internal)