### PR TITLE
fix(server): Move load_dotenv() call to the top of main.py

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -13,6 +13,8 @@ from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from sqlalchemy import func, select
 
+load_dotenv()
+
 from auth import ADMIN_API_KEY, AUTH_DISABLED, JWT_SECRET, verify_auth
 from errors import (
     UpstreamError,
@@ -32,8 +34,6 @@ from routers import entities as entities_router
 from routers import requests as requests_router
 from schemas import MessageResponse
 from server_state import get_current_config, get_memory_instance, initialize_state, set_session_factory, update_config
-
-load_dotenv()
 
 install_request_id_logging()
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - [%(request_id)s] %(message)s")


### PR DESCRIPTION
Load environment variables using load_dotenv() at the beginning of the file for better configuration management.

## Description

load_dotenv() is called after importing auth, so .env variables are not available in auth.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

1. Set AUTH_DISABLED=true in .env
2. Check `AUTH_DISABLED` in main.py
3. Result:
    - before: AUTH_DISABLED is false
    - after: AUTH_DISABLED is true

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
