### PR TITLE
Add optional NeMo Flow integration

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -398,6 +398,7 @@
                     "pages": [
                       "integrations/langchain",
                       "integrations/langgraph",
+                      "integrations/nemo-flow",
                       "integrations/llama-index",
                       "integrations/crewai",
                       "integrations/autogen",

--- a/docs/integrations/nemo-flow.mdx
+++ b/docs/integrations/nemo-flow.mdx
@@ -1,0 +1,242 @@
+---
+title: NeMo Flow
+description: "Use NeMo Flow as a hidden runtime layer for automatic Mem0 recall and capture around instrumented LLM calls."
+---
+
+This page describes the optional Mem0 + NeMo Flow integration added in this branch.
+
+The integration is an adapter layer: Mem0 owns memory, identity, recall, and writes; NeMo Flow owns the LLM execution interception point and observability lifecycle.
+
+## Current DX
+
+Install the optional dependency:
+
+```bash
+pip install "mem0ai[nemo_flow]"
+```
+
+Use the integration module as the namespace:
+
+```python
+from mem0 import MemoryClient
+from mem0.integrations import nemo_flow
+
+memory = MemoryClient(api_key="...")
+
+handle = nemo_flow.install(memory)
+
+with nemo_flow.memory_scope(user_id="alex", thread_id="thread-123"):
+    result = await agent.ainvoke(...)
+
+handle.uninstall()
+```
+
+`thread_id` is a LangGraph-friendly alias for Mem0 `run_id`. You can also use `run_id` directly.
+
+## What It Does
+
+`nemo_flow.install(memory)` registers a NeMo Flow LLM execution intercept that:
+
+1. Resolves Mem0 identity from `memory_scope(...)` or NeMo Flow scope metadata.
+2. Extracts the latest user query from the LLM request.
+3. Calls `memory.search(...)` with Mem0 filters.
+4. Injects formatted memories into a copied LLM request.
+5. Calls the downstream model.
+6. Extracts the user/assistant exchange from the request and response.
+7. Calls `memory.add(...)` with top-level Mem0 session IDs.
+
+The integration supports `Memory`, `AsyncMemory`, `MemoryClient`, and `AsyncMemoryClient`-style objects as long as they expose compatible `search` and `add` methods.
+
+## Read Path
+
+The read path runs before the downstream model call.
+
+```text
+instrumented LLM call
+  -> NeMo Flow LLM execution pipeline
+  -> Mem0 execution intercept
+  -> resolve memory identity
+  -> extract latest user query
+  -> memory.search(...)
+  -> format memories
+  -> inject memory system message
+  -> downstream model call
+```
+
+The identity usually comes from `memory_scope(...)`:
+
+```python
+with nemo_flow.memory_scope(user_id="alex", thread_id="thread-123"):
+    await agent.ainvoke(...)
+```
+
+That scope produces Mem0 filters such as:
+
+```python
+{"user_id": "alex", "run_id": "thread-123"}
+```
+
+The adapter then calls:
+
+```python
+memory.search(
+    query,
+    filters={"user_id": "alex", "run_id": "thread-123"},
+    top_k=5,
+    threshold=0.1,
+)
+```
+
+If memories are found, the default formatter produces:
+
+```text
+Relevant memories:
+- Alex prefers jasmine tea in the afternoon.
+```
+
+The adapter copies the original LLM request and inserts that text as a system message after any existing system messages and before the latest user message. The original request object is not mutated in place.
+
+The read path is fail-open by default. If recall fails and `fail_open=True`, the model call continues with the original request.
+
+## Write Path
+
+The write path runs after the downstream model call returns.
+
+```text
+downstream model response
+  -> Mem0 execution intercept resumes
+  -> extract user message from original request
+  -> extract assistant message from response
+  -> memory.add(...)
+  -> return original model response
+```
+
+The adapter stores a two-message interaction:
+
+```python
+[
+    {"role": "user", "content": "What tea do I prefer?"},
+    {"role": "assistant", "content": "You prefer jasmine tea."},
+]
+```
+
+For hosted Mem0, session identity is passed as top-level arguments, not as `filters`:
+
+```python
+memory.add(
+    messages,
+    user_id="alex",
+    run_id="thread-123",
+    metadata={"user_id": "alex", "run_id": "thread-123"},
+    infer=True,
+)
+```
+
+This top-level write shape is important because hosted `MemoryClient.add(...)` requires at least one entity ID such as `user_id`, `agent_id`, or `run_id`.
+
+The write path is also fail-open by default. If capture fails and `fail_open=True`, the model response is still returned to the caller.
+
+## Important Boundary
+
+Installing this package does not automatically patch LangGraph, LangChain, OpenAI, or every model client.
+
+The Mem0 intercept runs only when the actual LLM call enters NeMo Flow, for example through:
+
+```python
+await nemo_flow_runtime.llm.execute("model-name", request, real_llm_call)
+```
+
+or through a framework/provider integration that calls NeMo Flow internally.
+
+That means the current PR gives us the Mem0 + NeMo Flow adapter, but not the full vanilla LangGraph story. For ordinary LangGraph apps, the next useful layer is likely a model wrapper such as:
+
+```python
+model = nemo_flow.wrap_model(ChatOpenAI(...))
+agent = create_react_agent(model, tools=[])
+```
+
+That wrapper is not part of this PR.
+
+## Observability
+
+The adapter emits NeMo Flow scopes, not standalone mark events:
+
+- `mem0.memory` as a custom scope for the active memory identity.
+- `mem0.recall` as a retriever scope around `memory.search(...)`.
+- `mem0.capture` as a custom scope around `memory.add(...)`.
+
+Recall and capture have natural start/end lifecycles, so scopes are a better fit than mark events. Mark events are still useful for future one-off milestones, such as compaction decisions or policy skips.
+
+Scope payloads intentionally avoid raw query text and memory text. They record operational metadata such as query length, `top_k`, result count, injection status, message count, and stored status.
+
+## Public API
+
+```python
+from mem0.integrations import nemo_flow
+
+handle = nemo_flow.install(
+    memory,
+    name="mem0.memory",
+    priority=50,
+    auto_recall=True,
+    auto_capture=True,
+    top_k=5,
+    threshold=0.1,
+    infer=True,
+    metadata=None,
+    fail_open=True,
+    enable_observability=True,
+    activate_runtime=True,
+)
+
+with nemo_flow.memory_scope(
+    user_id="alex",
+    agent_id=None,
+    run_id=None,
+    thread_id="thread-123",
+    filters=None,
+):
+    ...
+```
+
+Backward-compatible aliases are available:
+
+- `nemo_flow.memory_context`
+- `nemo_flow.mem0_context`
+- `nemo_flow.install_mem0`
+
+## What Was Verified
+
+The branch includes:
+
+- Unit tests for install/uninstall, recall, prompt injection, capture, identity resolution, top-level hosted session IDs, and legacy aliases.
+- `examples/misc/nemo_flow_memory.py`, a no-credentials smoke test using a Mem0-compatible in-memory object and real `nemo_flow.llm.execute(...)`.
+- `tests/test_nemo_flow_platform_smoke.py`, an opt-in hosted Mem0 Platform smoke test.
+
+The hosted smoke was run against Mem0 Platform and verified:
+
+1. Seed real hosted memory.
+2. Recall through the NeMo Flow intercept.
+3. Inject recalled memory into the LLM request.
+4. Capture the assistant response back into Mem0.
+5. Search for the written marker.
+6. Best-effort delete the temporary test user.
+
+## Current Limitations
+
+- Non-streaming LLM execution only. Streaming needs a `register_llm_stream_execution(...)` path.
+- Vanilla LangGraph/LangChain calls are not automatically visible to NeMo Flow.
+- The default memory formatter injects a system message with `Relevant memories:`; production applications may want a custom formatter.
+- The response extractor is best-effort across common OpenAI-style and text-like responses.
+
+## Assessment
+
+This is the right first lane for the integration:
+
+- It keeps NeMo Flow optional via `mem0ai[nemo_flow]`.
+- It keeps the user-facing API in Mem0.
+- It avoids adding premature first-class memory concepts to NeMo Flow core.
+- It uses NeMo Flow execution intercepts for pre-call recall and post-call capture.
+- It uses scopes for observability rather than duplicate mark events.
+
+The main remaining product gap is a wrapper or instrumentation helper that makes vanilla LangGraph/LangChain model calls enter NeMo Flow without requiring patched framework packages.

--- a/docs/integrations/nemo-flow.mdx
+++ b/docs/integrations/nemo-flow.mdx
@@ -3,17 +3,19 @@ title: NeMo Flow
 description: "Use NeMo Flow as a hidden runtime layer for automatic Mem0 recall and capture around instrumented LLM calls."
 ---
 
-This page describes the optional Mem0 + NeMo Flow integration added in this branch.
+Use the optional Mem0 + NeMo Flow integration to add automatic Mem0 recall and capture around LLM calls that run through NeMo Flow.
 
 The integration is an adapter layer: Mem0 owns memory, identity, recall, and writes; NeMo Flow owns the LLM execution interception point and observability lifecycle.
 
-## Current DX
+## Install
 
 Install the optional dependency:
 
 ```bash
 pip install "mem0ai[nemo_flow]"
 ```
+
+The optional NeMo Flow extra installs on Python 3.11+.
 
 Use the integration module as the namespace:
 
@@ -148,24 +150,29 @@ await nemo_flow_runtime.llm.execute("model-name", request, real_llm_call)
 
 or through a framework/provider integration that calls NeMo Flow internally.
 
-That means the current PR gives us the Mem0 + NeMo Flow adapter, but not the full vanilla LangGraph story. For ordinary LangGraph apps, the next useful layer is likely a model wrapper such as:
-
-```python
-model = nemo_flow.wrap_model(ChatOpenAI(...))
-agent = create_react_agent(model, tools=[])
-```
-
-That wrapper is not part of this PR.
+For ordinary LangGraph or LangChain apps, pair this adapter with the NeMo Flow instrumentation layer that routes provider calls into NeMo Flow.
 
 ## Observability
 
-The adapter emits NeMo Flow scopes, not standalone mark events:
+The adapter emits NeMo Flow scopes:
 
 - `mem0.memory` as a custom scope for the active memory identity.
 - `mem0.recall` as a retriever scope around `memory.search(...)`.
 - `mem0.capture` as a custom scope around `memory.add(...)`.
 
-Recall and capture have natural start/end lifecycles, so scopes are a better fit than mark events. Mark events are still useful for future one-off milestones, such as compaction decisions or policy skips.
+The adapter also emits NeMo Flow mark events for one-off milestones:
+
+| Event | Meaning |
+| --- | --- |
+| `mem0.identity.resolved` | Memory identity was resolved for an intercepted LLM call. |
+| `mem0.recall.context_built` | Memories were found and converted into recall context candidates. |
+| `mem0.recall.injected` | Formatted memory context was inserted into the LLM request. |
+| `mem0.recall.skipped` | Recall did not mutate the LLM request. |
+| `mem0.recall.failed` | Recall raised an exception. |
+| `mem0.capture.extracted` | The user/assistant exchange was extracted from the request and response. |
+| `mem0.capture.stored` | The extracted exchange was stored through Mem0. |
+| `mem0.capture.skipped` | Capture did not store an interaction. |
+| `mem0.capture.failed` | Capture raised an exception. |
 
 Scope payloads intentionally avoid raw query text and memory text. They record operational metadata such as query length, `top_k`, result count, injection status, message count, and stored status.
 
@@ -186,6 +193,8 @@ handle = nemo_flow.install(
     metadata=None,
     fail_open=True,
     enable_observability=True,
+    emit_mark_events=True,
+    emit_identity_events=True,
     activate_runtime=True,
 )
 
@@ -220,7 +229,8 @@ The hosted smoke was run against Mem0 Platform and verified:
 3. Inject recalled memory into the LLM request.
 4. Capture the assistant response back into Mem0.
 5. Search for the written marker.
-6. Best-effort delete the temporary test user.
+6. Observe Mem0 scopes and mark events.
+7. Best-effort delete the temporary test user.
 
 ## Current Limitations
 
@@ -229,14 +239,13 @@ The hosted smoke was run against Mem0 Platform and verified:
 - The default memory formatter injects a system message with `Relevant memories:`; production applications may want a custom formatter.
 - The response extractor is best-effort across common OpenAI-style and text-like responses.
 
-## Assessment
+## Why This Shape
 
-This is the right first lane for the integration:
+The integration is intentionally small:
 
 - It keeps NeMo Flow optional via `mem0ai[nemo_flow]`.
 - It keeps the user-facing API in Mem0.
-- It avoids adding premature first-class memory concepts to NeMo Flow core.
 - It uses NeMo Flow execution intercepts for pre-call recall and post-call capture.
-- It uses scopes for observability rather than duplicate mark events.
+- It uses scopes for lifecycles and mark events for milestones.
 
-The main remaining product gap is a wrapper or instrumentation helper that makes vanilla LangGraph/LangChain model calls enter NeMo Flow without requiring patched framework packages.
+The main remaining product gap is an instrumentation helper that makes vanilla LangGraph/LangChain model calls enter NeMo Flow without requiring patched framework packages.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -229,6 +229,7 @@ If the user is on a pre-current major (Python < 2, TS < 3, or Platform `output_f
 ### Agent Frameworks
 - [LangChain](https://docs.mem0.ai/integrations/langchain) [Both]: Use when the user is on LangChain.
 - [LangGraph](https://docs.mem0.ai/integrations/langgraph) [Both]: Use when building stateful multi-actor LangGraph apps.
+- [NeMo Flow](https://docs.mem0.ai/integrations/nemo-flow) [Both]: Use when routing LLM calls through NeMo Flow for automatic Mem0 recall, capture, and observability.
 - [LangChain Tools](https://docs.mem0.ai/integrations/langchain-tools) [Both]: Use when Mem0 should be exposed as a LangChain tool.
 - [LlamaIndex](https://docs.mem0.ai/integrations/llama-index) [Both]: Use when layering memory on a LlamaIndex RAG app.
 - [CrewAI](https://docs.mem0.ai/integrations/crewai) [Both]: Use when building CrewAI multi-agent systems.

--- a/examples/misc/nemo_flow_memory.py
+++ b/examples/misc/nemo_flow_memory.py
@@ -1,0 +1,100 @@
+"""Run Mem0's NeMo Flow integration without external API keys.
+
+This example uses a tiny in-memory object with the same `search` and `add`
+methods that the integration expects from `MemoryClient`. Replace
+`DemoMemoryClient` with `mem0.MemoryClient` in a real application.
+
+Install the optional dependency before running:
+
+    pip install "mem0ai[nemo_flow]"
+    python examples/misc/nemo_flow_memory.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+
+class DemoMemoryClient:
+    """Small Mem0-compatible memory client for a no-credentials smoke run."""
+
+    def __init__(self) -> None:
+        self.search_calls: list[dict[str, Any]] = []
+        self.add_calls: list[dict[str, Any]] = []
+
+    def search(self, query: str, **kwargs: Any) -> dict[str, Any]:
+        self.search_calls.append({"query": query, "kwargs": kwargs})
+        return {"results": [{"memory": "Alex prefers tea in the afternoon."}]}
+
+    def add(self, messages: list[dict[str, str]], **kwargs: Any) -> dict[str, Any]:
+        self.add_calls.append({"messages": messages, "kwargs": kwargs})
+        return {"results": [{"memory": messages[-1]["content"], "event": "ADD"}]}
+
+
+async def run_demo() -> dict[str, Any]:
+    from mem0.integrations import nemo_flow
+
+    memory = DemoMemoryClient()
+    handle = nemo_flow.install(memory, name="mem0.example.nemo_flow")
+    provider_requests = []
+
+    async def demo_llm(request: Any) -> dict[str, Any]:
+        provider_requests.append(request.content)
+        system_context = "\n".join(
+            message["content"]
+            for message in request.content["messages"]
+            if message.get("role") == "system" and "Relevant memories:" in message.get("content", "")
+        )
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": f"I found your memory: {system_context}",
+                    }
+                }
+            ]
+        }
+
+    try:
+        with nemo_flow.memory_scope(user_id="alex", thread_id="demo-thread"):
+            response = await _run_instrumented_framework_llm(
+                "demo-llm",
+                {
+                    "model": "demo-model",
+                    "messages": [{"role": "user", "content": "What do I like to drink?"}],
+                },
+                demo_llm,
+            )
+    finally:
+        handle.uninstall()
+
+    return {
+        "response": response,
+        "provider_requests": provider_requests,
+        "search_calls": memory.search_calls,
+        "add_calls": memory.add_calls,
+    }
+
+
+async def _run_instrumented_framework_llm(
+    name: str,
+    content: dict[str, Any],
+    provider: Any,
+) -> dict[str, Any]:
+    """Simulate the LLM boundary that a patched framework would own."""
+
+    import nemo_flow
+
+    request = nemo_flow.LLMRequest({}, content)
+    return await nemo_flow.llm.execute(name, request, provider)
+
+
+def main() -> None:
+    print(json.dumps(asyncio.run(run_demo()), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/mem0/integrations/__init__.py
+++ b/mem0/integrations/__init__.py
@@ -1,0 +1,5 @@
+"""Optional Mem0 integrations."""
+
+from . import nemo_flow
+
+__all__ = ["nemo_flow"]

--- a/mem0/integrations/nemo_flow.py
+++ b/mem0/integrations/nemo_flow.py
@@ -1,0 +1,686 @@
+"""Optional NeMo Flow integration for Mem0 memory clients."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import inspect
+import logging
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import nemo_flow
+
+logger = logging.getLogger(__name__)
+
+_SESSION_KEYS = ("user_id", "agent_id", "run_id")
+_RESERVED_IDENTITY_KEYS = {"filters", "provider"}
+_memory_identity: ContextVar["MemoryIdentity | None"] = ContextVar("mem0_nemo_flow_identity", default=None)
+
+
+@dataclass(frozen=True)
+class MemoryIdentity:
+    """Mem0 memory scope used by the NeMo Flow intercept."""
+
+    user_id: str | None = None
+    agent_id: str | None = None
+    run_id: str | None = None
+    filters: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "MemoryIdentity":
+        filters: dict[str, Any] = {}
+        nested_filters = value.get("filters")
+        if isinstance(nested_filters, Mapping):
+            filters.update({str(key): item for key, item in nested_filters.items() if item is not None})
+
+        for key, item in value.items():
+            if key in _SESSION_KEYS or key in _RESERVED_IDENTITY_KEYS or item is None:
+                continue
+            filters[str(key)] = item
+
+        return cls(
+            user_id=_string_or_none(value.get("user_id")),
+            agent_id=_string_or_none(value.get("agent_id")),
+            run_id=_string_or_none(value.get("run_id")),
+            filters=filters,
+        )
+
+    def search_filters(self) -> dict[str, Any]:
+        filters = dict(self.filters)
+        for key in _SESSION_KEYS:
+            value = getattr(self, key)
+            if value:
+                filters[key] = value
+        return filters
+
+    def local_kwargs(self) -> dict[str, str]:
+        return {key: value for key in _SESSION_KEYS if (value := getattr(self, key)) is not None}
+
+    def has_scope(self) -> bool:
+        return bool(self.search_filters())
+
+
+@dataclass(frozen=True)
+class NemoFlowTurnContext:
+    """Context passed to a custom identity resolver."""
+
+    llm_name: str
+    request: "nemo_flow.LLMRequest"
+    scope_metadata: Mapping[str, Any] | None
+
+
+IdentityResolver = Callable[[NemoFlowTurnContext], MemoryIdentity | Mapping[str, Any] | None]
+QueryExtractor = Callable[["nemo_flow.LLMRequest"], str | None]
+InteractionExtractor = Callable[["nemo_flow.LLMRequest", "nemo_flow.Json"], Sequence[Mapping[str, Any]] | None]
+MemoryFormatter = Callable[[Sequence[Mapping[str, Any]]], str]
+
+
+@dataclass(frozen=True)
+class NemoFlowMem0Config:
+    """Configuration for the Mem0 NeMo Flow execution intercept."""
+
+    name: str = "mem0.memory"
+    priority: int = 50
+    auto_recall: bool = True
+    auto_capture: bool = True
+    top_k: int = 5
+    threshold: float | None = 0.1
+    infer: bool = True
+    metadata: Mapping[str, Any] | None = None
+    fail_open: bool = True
+    enable_observability: bool = True
+    run_sync_in_thread: bool = False
+    identity_resolver: IdentityResolver | None = None
+    query_extractor: QueryExtractor | None = None
+    interaction_extractor: InteractionExtractor | None = None
+    memory_formatter: MemoryFormatter | None = None
+
+
+class NemoFlowMem0Handle:
+    """Registration handle returned by `install`."""
+
+    def __init__(self, name: str, nemo_flow_module: Any, intercept: "_Mem0NemoFlowIntercept"):
+        self.name = name
+        self._nemo_flow = nemo_flow_module
+        self._intercept = intercept
+        self._active = True
+
+    @property
+    def active(self) -> bool:
+        return self._active
+
+    @property
+    def intercept(
+        self,
+    ) -> Callable[
+        [str, "nemo_flow.LLMRequest", Callable[["nemo_flow.LLMRequest"], Any]],
+        Any,
+    ]:
+        return self._intercept
+
+    def uninstall(self) -> bool:
+        """Deregister the NeMo Flow execution intercept."""
+
+        if not self._active:
+            return False
+        removed = self._nemo_flow.intercepts.deregister_llm_execution(self.name)
+        self._active = False
+        return bool(removed)
+
+
+@contextmanager
+def memory_scope(
+    user_id: str | None = None,
+    *,
+    agent_id: str | None = None,
+    run_id: str | None = None,
+    thread_id: str | None = None,
+    filters: Mapping[str, Any] | None = None,
+    activate_runtime: bool = True,
+) -> Iterator[MemoryIdentity]:
+    """Set Mem0 identity for framework calls in the current lexical scope.
+
+    When NeMo Flow is installed, this also activates a NeMo Flow scope stack so
+    patched framework integrations can route LLM calls through the Mem0
+    intercept without requiring application code to import NeMo Flow directly.
+    The LangGraph-friendly ``thread_id`` argument is treated as Mem0 ``run_id``.
+    """
+
+    run_id = _resolve_run_id(run_id=run_id, thread_id=thread_id)
+    identity = MemoryIdentity(user_id=user_id, agent_id=agent_id, run_id=run_id, filters=filters or {})
+    token = _memory_identity.set(identity)
+    nemo_flow_module = _maybe_load_nemo_flow() if activate_runtime else None
+    scope_handle = (
+        _push_memory_context_scope(nemo_flow_module, identity)
+        if nemo_flow_module is not None and identity.has_scope()
+        else None
+    )
+    try:
+        yield identity
+    finally:
+        _pop_memory_context_scope(nemo_flow_module, scope_handle)
+        _memory_identity.reset(token)
+
+
+memory_context = memory_scope
+mem0_context = memory_scope
+
+
+def install(
+    memory: Any,
+    *,
+    name: str = "mem0.memory",
+    priority: int = 50,
+    auto_recall: bool = True,
+    auto_capture: bool = True,
+    top_k: int = 5,
+    threshold: float | None = 0.1,
+    infer: bool = True,
+    metadata: Mapping[str, Any] | None = None,
+    fail_open: bool = True,
+    enable_observability: bool = True,
+    activate_runtime: bool = True,
+    run_sync_in_thread: bool = False,
+    identity_resolver: IdentityResolver | None = None,
+    query_extractor: QueryExtractor | None = None,
+    interaction_extractor: InteractionExtractor | None = None,
+    memory_formatter: MemoryFormatter | None = None,
+) -> NemoFlowMem0Handle:
+    """Register Mem0 on NeMo Flow's non-streaming LLM execution path.
+
+    The provided memory object can be a Mem0 `Memory`, `AsyncMemory`,
+    `MemoryClient`, or `AsyncMemoryClient`. Install the optional dependency
+    with `mem0ai[nemo_flow]`. NeMo Flow is imported only when this function is
+    called so the integration remains optional for regular Mem0 users. When
+    observability is enabled, the adapter records nested NeMo Flow scopes for
+    recall and capture instead of standalone mark events.
+    """
+
+    nemo_flow = _load_nemo_flow()
+    if activate_runtime:
+        _activate_runtime(nemo_flow)
+    config = NemoFlowMem0Config(
+        name=name,
+        priority=priority,
+        auto_recall=auto_recall,
+        auto_capture=auto_capture,
+        top_k=top_k,
+        threshold=threshold,
+        infer=infer,
+        metadata=metadata,
+        fail_open=fail_open,
+        enable_observability=enable_observability,
+        run_sync_in_thread=run_sync_in_thread,
+        identity_resolver=identity_resolver,
+        query_extractor=query_extractor,
+        interaction_extractor=interaction_extractor,
+        memory_formatter=memory_formatter,
+    )
+    intercept = _Mem0NemoFlowIntercept(memory, config, nemo_flow)
+    nemo_flow.intercepts.register_llm_execution(name, priority, intercept)
+    return NemoFlowMem0Handle(name, nemo_flow, intercept)
+
+
+install_mem0 = install
+
+
+class _Mem0NemoFlowIntercept:
+    def __init__(self, memory: Any, config: NemoFlowMem0Config, nemo_flow_module: Any):
+        self.memory = memory
+        self.config = config
+        self._nemo_flow = nemo_flow_module
+
+    async def __call__(
+        self,
+        llm_name: str,
+        request: "nemo_flow.LLMRequest",
+        next_call: Callable[["nemo_flow.LLMRequest"], Any],
+    ) -> "nemo_flow.Json":
+        identity = self._resolve_identity(llm_name, request)
+        if identity is None or not identity.has_scope():
+            return await next_call(request)
+
+        request_for_call = request
+        if self.config.auto_recall:
+            try:
+                request_for_call = await self._recall(request, identity)
+            except Exception:
+                if not self.config.fail_open:
+                    raise
+                logger.warning("Mem0 recall failed in NeMo Flow intercept", exc_info=True)
+
+        response = await next_call(request_for_call)
+
+        if self.config.auto_capture:
+            try:
+                await self._capture(request, response, identity)
+            except Exception:
+                if not self.config.fail_open:
+                    raise
+                logger.warning("Mem0 capture failed in NeMo Flow intercept", exc_info=True)
+
+        return response
+
+    def _resolve_identity(self, llm_name: str, request: "nemo_flow.LLMRequest") -> MemoryIdentity | None:
+        scope_metadata = _current_scope_metadata(self._nemo_flow)
+        context = NemoFlowTurnContext(llm_name=llm_name, request=request, scope_metadata=scope_metadata)
+
+        if self.config.identity_resolver is not None:
+            identity = _coerce_identity(self.config.identity_resolver(context))
+            if identity is not None:
+                return identity
+
+        context_identity = _memory_identity.get()
+        if context_identity is not None and context_identity.has_scope():
+            return context_identity
+
+        return _identity_from_metadata(scope_metadata)
+
+    async def _recall(self, request: "nemo_flow.LLMRequest", identity: MemoryIdentity) -> "nemo_flow.LLMRequest":
+        query_extractor = self.config.query_extractor or _default_query_extractor
+        query = query_extractor(request)
+        if not query:
+            return request
+
+        search_kwargs: dict[str, Any] = {
+            "filters": identity.search_filters(),
+            "top_k": self.config.top_k,
+        }
+        if self.config.threshold is not None:
+            search_kwargs["threshold"] = self.config.threshold
+
+        scope_handle = self._start_scope(
+            "mem0.recall",
+            "Retriever",
+            input={
+                "query_length": len(query),
+                "top_k": self.config.top_k,
+                "threshold": self.config.threshold,
+            },
+            metadata=_identity_observability_metadata(identity),
+        )
+        scope_output: dict[str, Any] = {"result_count": 0, "injected": False}
+
+        try:
+            result = await self._invoke(self.memory.search, query, **search_kwargs)
+            memories = _extract_memory_results(result)
+            if not memories:
+                return request
+
+            formatter = self.config.memory_formatter or _default_memory_formatter
+            memory_text = formatter(memories)
+            scope_output = {"result_count": len(memories), "injected": False}
+            if not memory_text:
+                return request
+
+            content = _content_with_memory(request.content, memory_text)
+            if content is request.content:
+                return request
+            scope_output = {"result_count": len(memories), "injected": True}
+            return self._nemo_flow.LLMRequest(request.headers, content)
+        except Exception as exc:
+            scope_output = {"error_type": type(exc).__name__}
+            raise
+        finally:
+            self._end_scope(scope_handle, output=scope_output)
+
+    async def _capture(
+        self,
+        request: "nemo_flow.LLMRequest",
+        response: "nemo_flow.Json",
+        identity: MemoryIdentity,
+    ) -> None:
+        interaction_extractor = self.config.interaction_extractor or _default_interaction_extractor
+        messages = interaction_extractor(request, response)
+        if not messages:
+            return
+
+        add_kwargs: dict[str, Any] = {
+            "metadata": _capture_metadata(identity, self.config.metadata),
+            "infer": self.config.infer,
+        }
+        local_kwargs = identity.local_kwargs()
+        if not local_kwargs:
+            logger.debug("Skipping Mem0 capture because Memory.add needs user_id, agent_id, or run_id")
+            return
+        add_kwargs.update(local_kwargs)
+
+        scope_handle = self._start_scope(
+            "mem0.capture",
+            "Custom",
+            input={"message_count": len(messages), "infer": self.config.infer},
+            metadata=_identity_observability_metadata(identity),
+        )
+        scope_output: dict[str, Any] = {"message_count": len(messages), "stored": False}
+        try:
+            await self._invoke(self.memory.add, list(messages), **add_kwargs)
+            scope_output = {"message_count": len(messages), "stored": True}
+        except Exception as exc:
+            scope_output = {"message_count": len(messages), "stored": False, "error_type": type(exc).__name__}
+            raise
+        finally:
+            self._end_scope(scope_handle, output=scope_output)
+
+    async def _invoke(self, method: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        if inspect.iscoroutinefunction(method):
+            return await method(*args, **kwargs)
+        if self.config.run_sync_in_thread:
+            return await asyncio.to_thread(method, *args, **kwargs)
+        result = method(*args, **kwargs)
+        if inspect.isawaitable(result):
+            return await result
+        return result
+
+    def _start_scope(
+        self,
+        name: str,
+        scope_type_name: str,
+        *,
+        input: Mapping[str, Any] | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> Any | None:
+        if not self.config.enable_observability:
+            return None
+
+        try:
+            scope_type = getattr(self._nemo_flow.ScopeType, scope_type_name)
+            return self._nemo_flow.scope.push(
+                name,
+                scope_type,
+                input=dict(input or {}),
+                metadata={"integration": "mem0", **dict(metadata or {})},
+            )
+        except Exception:
+            logger.debug("Failed to start NeMo Flow Mem0 scope", exc_info=True)
+            return None
+
+    def _end_scope(self, handle: Any | None, *, output: Mapping[str, Any] | None = None) -> None:
+        if handle is None:
+            return
+
+        try:
+            self._nemo_flow.scope.pop(handle, output=dict(output or {}))
+        except Exception:
+            logger.debug("Failed to end NeMo Flow Mem0 scope", exc_info=True)
+
+
+def _load_nemo_flow() -> Any:
+    try:
+        import nemo_flow
+
+        return nemo_flow
+    except ImportError as exc:
+        raise ImportError(
+            "mem0.integrations.nemo_flow requires NeMo Flow. Install it with `mem0ai[nemo_flow]` "
+            "in the process that owns the NeMo Flow runtime before calling install()."
+        ) from exc
+
+
+def _maybe_load_nemo_flow() -> Any | None:
+    try:
+        return _load_nemo_flow()
+    except ImportError:
+        return None
+
+
+def activate_runtime() -> None:
+    """Activate NeMo Flow in the current context without exposing its API."""
+
+    _activate_runtime(_load_nemo_flow())
+
+
+def _activate_runtime(nemo_flow_module: Any) -> None:
+    try:
+        nemo_flow_module.get_scope_stack()
+    except Exception:
+        logger.debug("Failed to activate NeMo Flow scope stack for Mem0 integration", exc_info=True)
+
+
+def _push_memory_context_scope(nemo_flow_module: Any, identity: MemoryIdentity) -> Any | None:
+    _activate_runtime(nemo_flow_module)
+    try:
+        return nemo_flow_module.scope.push(
+            "mem0.memory",
+            nemo_flow_module.ScopeType.Custom,
+            metadata={"integration": "mem0", "mem0": _identity_scope_metadata(identity)},
+        )
+    except Exception:
+        logger.debug("Failed to push NeMo Flow Mem0 memory context scope", exc_info=True)
+        return None
+
+
+def _pop_memory_context_scope(nemo_flow_module: Any | None, handle: Any | None) -> None:
+    if nemo_flow_module is None or handle is None:
+        return
+
+    try:
+        nemo_flow_module.scope.pop(handle)
+    except Exception:
+        logger.debug("Failed to pop NeMo Flow Mem0 memory context scope", exc_info=True)
+
+
+def _current_scope_metadata(nemo_flow_module: Any) -> Mapping[str, Any] | None:
+    try:
+        handle = nemo_flow_module.scope.get_handle()
+    except Exception:
+        return None
+    metadata = getattr(handle, "metadata", None) if handle is not None else None
+    return metadata if isinstance(metadata, Mapping) else None
+
+
+def _identity_from_metadata(metadata: Mapping[str, Any] | None) -> MemoryIdentity | None:
+    if metadata is None:
+        return None
+
+    mem0_metadata = metadata.get("mem0")
+    if isinstance(mem0_metadata, Mapping):
+        return MemoryIdentity.from_mapping(mem0_metadata)
+
+    memory_metadata = metadata.get("memory")
+    if isinstance(memory_metadata, Mapping) and memory_metadata.get("provider") in (None, "mem0"):
+        return MemoryIdentity.from_mapping(memory_metadata)
+
+    if any(key in metadata for key in _SESSION_KEYS) or "filters" in metadata:
+        return MemoryIdentity.from_mapping(metadata)
+
+    return None
+
+
+def _coerce_identity(identity: MemoryIdentity | Mapping[str, Any] | None) -> MemoryIdentity | None:
+    if identity is None or isinstance(identity, MemoryIdentity):
+        return identity
+    if isinstance(identity, Mapping):
+        return MemoryIdentity.from_mapping(identity)
+    raise TypeError("identity_resolver must return MemoryIdentity, mapping, or None")
+
+
+def _capture_metadata(identity: MemoryIdentity, metadata: Mapping[str, Any] | None) -> dict[str, Any]:
+    captured = dict(metadata or {})
+    for key, value in identity.search_filters().items():
+        captured.setdefault(key, value)
+    return captured
+
+
+def _resolve_run_id(*, run_id: str | None, thread_id: str | None) -> str | None:
+    if run_id is not None and thread_id is not None and run_id != thread_id:
+        raise ValueError("run_id and thread_id cannot both be set to different values")
+    return run_id if run_id is not None else thread_id
+
+
+def _identity_scope_metadata(identity: MemoryIdentity) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    if identity.user_id is not None:
+        metadata["user_id"] = identity.user_id
+    if identity.agent_id is not None:
+        metadata["agent_id"] = identity.agent_id
+    if identity.run_id is not None:
+        metadata["run_id"] = identity.run_id
+    if identity.filters:
+        metadata["filters"] = dict(identity.filters)
+    return metadata
+
+
+def _identity_observability_metadata(identity: MemoryIdentity) -> dict[str, Any]:
+    filters = identity.search_filters()
+    return {
+        "filter_keys": sorted(filters),
+        "has_user_id": identity.user_id is not None,
+        "has_agent_id": identity.agent_id is not None,
+        "has_run_id": identity.run_id is not None,
+    }
+
+
+def _default_query_extractor(request: "nemo_flow.LLMRequest") -> str | None:
+    content = request.content
+    if not isinstance(content, Mapping):
+        return None
+
+    messages = content.get("messages")
+    if isinstance(messages, Sequence) and not isinstance(messages, (str, bytes)):
+        for message in reversed(messages):
+            if isinstance(message, Mapping) and message.get("role") == "user":
+                text = _text_from_content(message.get("content"))
+                if text:
+                    return text
+
+    for key in ("input", "prompt", "query"):
+        text = _text_from_content(content.get(key))
+        if text:
+            return text
+    return None
+
+
+def _default_interaction_extractor(
+    request: "nemo_flow.LLMRequest",
+    response: "nemo_flow.Json",
+) -> Sequence[Mapping[str, Any]] | None:
+    user_text = _default_query_extractor(request)
+    assistant_text = _assistant_text_from_response(response)
+    if not user_text or not assistant_text:
+        return None
+    return (
+        {"role": "user", "content": user_text},
+        {"role": "assistant", "content": assistant_text},
+    )
+
+
+def _assistant_text_from_response(response: Any) -> str | None:
+    if isinstance(response, str):
+        return response
+    if not isinstance(response, Mapping):
+        return _text_from_content(getattr(response, "content", None))
+
+    choices = response.get("choices")
+    if isinstance(choices, Sequence) and not isinstance(choices, (str, bytes)) and choices:
+        first = choices[0]
+        if isinstance(first, Mapping):
+            message = first.get("message")
+            if isinstance(message, Mapping):
+                text = _text_from_content(message.get("content"))
+                if text:
+                    return text
+            text = _text_from_content(first.get("text"))
+            if text:
+                return text
+
+    for key in ("output_text", "text", "content", "response"):
+        text = _text_from_content(response.get(key))
+        if text:
+            return text
+
+    output = response.get("output")
+    if isinstance(output, Sequence) and not isinstance(output, (str, bytes)):
+        return _text_from_content(output)
+    return None
+
+
+def _extract_memory_results(response: Any) -> list[Mapping[str, Any]]:
+    if isinstance(response, Mapping):
+        candidates = response.get("results", response.get("memories", []))
+    else:
+        candidates = response
+
+    if not isinstance(candidates, Sequence) or isinstance(candidates, (str, bytes)):
+        return []
+
+    memories: list[Mapping[str, Any]] = []
+    for candidate in candidates:
+        if isinstance(candidate, Mapping):
+            memories.append(candidate)
+        elif isinstance(candidate, str):
+            memories.append({"memory": candidate})
+    return memories
+
+
+def _default_memory_formatter(memories: Sequence[Mapping[str, Any]]) -> str:
+    lines = []
+    for memory in memories:
+        text = _text_from_content(memory.get("memory") or memory.get("text") or memory.get("content"))
+        if text:
+            lines.append(f"- {text}")
+
+    if not lines:
+        return ""
+    return "Relevant memories:\n" + "\n".join(lines)
+
+
+def _content_with_memory(content: Mapping[str, Any], memory_text: str) -> Mapping[str, Any]:
+    messages = content.get("messages")
+    if not isinstance(messages, Sequence) or isinstance(messages, (str, bytes)):
+        return content
+
+    new_content = copy.deepcopy(dict(content))
+    new_messages = list(copy.deepcopy(messages))
+    insert_at = 0
+    while insert_at < len(new_messages):
+        message = new_messages[insert_at]
+        if not isinstance(message, Mapping) or message.get("role") != "system":
+            break
+        insert_at += 1
+
+    new_messages.insert(insert_at, {"role": "system", "content": memory_text})
+    new_content["messages"] = new_messages
+    return new_content
+
+
+def _text_from_content(content: Any) -> str | None:
+    if content is None:
+        return None
+    if isinstance(content, str):
+        return content
+    if isinstance(content, Mapping):
+        for key in ("text", "content"):
+            text = _text_from_content(content.get(key))
+            if text:
+                return text
+        return None
+    if isinstance(content, Sequence) and not isinstance(content, (str, bytes)):
+        parts = [_text_from_content(item) for item in content]
+        text = "\n".join(part for part in parts if part)
+        return text or None
+    return str(content)
+
+
+def _string_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+__all__ = [
+    "MemoryIdentity",
+    "NemoFlowMem0Config",
+    "NemoFlowMem0Handle",
+    "NemoFlowTurnContext",
+    "activate_runtime",
+    "install",
+    "install_mem0",
+    "mem0_context",
+    "memory_context",
+    "memory_scope",
+]

--- a/mem0/integrations/nemo_flow.py
+++ b/mem0/integrations/nemo_flow.py
@@ -10,6 +10,7 @@ from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -80,6 +81,137 @@ InteractionExtractor = Callable[["nemo_flow.LLMRequest", "nemo_flow.Json"], Sequ
 MemoryFormatter = Callable[[Sequence[Mapping[str, Any]]], str]
 
 
+class NemoFlowScope(str, Enum):
+    """Named NeMo Flow scopes emitted by the integration."""
+
+    MEMORY = "mem0.memory"
+    RECALL = "mem0.recall"
+    CAPTURE = "mem0.capture"
+
+
+class NemoFlowEvent(str, Enum):
+    """Named NeMo Flow mark events emitted by the integration."""
+
+    IDENTITY_RESOLVED = "mem0.identity.resolved"
+    RECALL_SKIPPED = "mem0.recall.skipped"
+    RECALL_CONTEXT_BUILT = "mem0.recall.context_built"
+    RECALL_INJECTED = "mem0.recall.injected"
+    RECALL_FAILED = "mem0.recall.failed"
+    CAPTURE_SKIPPED = "mem0.capture.skipped"
+    CAPTURE_EXTRACTED = "mem0.capture.extracted"
+    CAPTURE_STORED = "mem0.capture.stored"
+    CAPTURE_FAILED = "mem0.capture.failed"
+
+
+class NemoFlowIdentitySource(str, Enum):
+    """Where memory identity came from for an intercepted LLM call."""
+
+    IDENTITY_RESOLVER = "identity_resolver"
+    MEMORY_SCOPE = "memory_scope"
+    SCOPE_METADATA = "scope_metadata"
+
+
+class NemoFlowSkipReason(str, Enum):
+    """Known reasons a recall or capture operation was skipped."""
+
+    EMPTY_QUERY = "empty_query"
+    NO_MEMORIES = "no_memories"
+    EMPTY_FORMATTED_CONTEXT = "empty_formatted_context"
+    UNSUPPORTED_REQUEST_CONTENT = "unsupported_request_content"
+    NO_SESSION_ID = "no_session_id"
+    NO_INTERACTION = "no_interaction"
+
+
+@dataclass(frozen=True)
+class NemoFlowScopeDefinition:
+    """Registry entry describing a NeMo Flow scope."""
+
+    name: NemoFlowScope
+    scope_type_name: str
+    description: str
+
+
+@dataclass(frozen=True)
+class NemoFlowEventDefinition:
+    """Registry entry describing a NeMo Flow mark event."""
+
+    name: NemoFlowEvent
+    description: str
+
+
+NEMO_FLOW_SCOPE_REGISTRY: Mapping[NemoFlowScope, NemoFlowScopeDefinition] = {
+    NemoFlowScope.MEMORY: NemoFlowScopeDefinition(
+        NemoFlowScope.MEMORY,
+        "Custom",
+        "Lexical scope carrying Mem0 memory identity.",
+    ),
+    NemoFlowScope.RECALL: NemoFlowScopeDefinition(
+        NemoFlowScope.RECALL,
+        "Retriever",
+        "Recall Mem0 memories before the provider LLM call.",
+    ),
+    NemoFlowScope.CAPTURE: NemoFlowScopeDefinition(
+        NemoFlowScope.CAPTURE,
+        "Custom",
+        "Capture the user/assistant interaction after the provider LLM call.",
+    ),
+}
+
+NEMO_FLOW_EVENT_REGISTRY: Mapping[NemoFlowEvent, NemoFlowEventDefinition] = {
+    NemoFlowEvent.IDENTITY_RESOLVED: NemoFlowEventDefinition(
+        NemoFlowEvent.IDENTITY_RESOLVED,
+        "Memory identity was resolved for an intercepted LLM call.",
+    ),
+    NemoFlowEvent.RECALL_SKIPPED: NemoFlowEventDefinition(
+        NemoFlowEvent.RECALL_SKIPPED,
+        "Recall did not mutate the LLM request.",
+    ),
+    NemoFlowEvent.RECALL_CONTEXT_BUILT: NemoFlowEventDefinition(
+        NemoFlowEvent.RECALL_CONTEXT_BUILT,
+        "Recall found memories and built formatted context candidates.",
+    ),
+    NemoFlowEvent.RECALL_INJECTED: NemoFlowEventDefinition(
+        NemoFlowEvent.RECALL_INJECTED,
+        "Recall injected formatted memory context into the LLM request.",
+    ),
+    NemoFlowEvent.RECALL_FAILED: NemoFlowEventDefinition(
+        NemoFlowEvent.RECALL_FAILED,
+        "Recall raised an exception.",
+    ),
+    NemoFlowEvent.CAPTURE_SKIPPED: NemoFlowEventDefinition(
+        NemoFlowEvent.CAPTURE_SKIPPED,
+        "Capture did not store an interaction.",
+    ),
+    NemoFlowEvent.CAPTURE_EXTRACTED: NemoFlowEventDefinition(
+        NemoFlowEvent.CAPTURE_EXTRACTED,
+        "Capture extracted messages from the LLM request and response.",
+    ),
+    NemoFlowEvent.CAPTURE_STORED: NemoFlowEventDefinition(
+        NemoFlowEvent.CAPTURE_STORED,
+        "Capture completed storage for the extracted interaction.",
+    ),
+    NemoFlowEvent.CAPTURE_FAILED: NemoFlowEventDefinition(
+        NemoFlowEvent.CAPTURE_FAILED,
+        "Capture raised an exception.",
+    ),
+}
+
+
+@dataclass(frozen=True)
+class ResolvedMemoryIdentity:
+    identity: MemoryIdentity
+    source: NemoFlowIdentitySource
+
+
+@dataclass(frozen=True)
+class MemoryInjection:
+    content: Mapping[str, Any]
+    mutated: bool
+    message_count_before: int = 0
+    message_count_after: int = 0
+    insert_at: int | None = None
+
+
 @dataclass(frozen=True)
 class NemoFlowMem0Config:
     """Configuration for the Mem0 NeMo Flow execution intercept."""
@@ -94,6 +226,8 @@ class NemoFlowMem0Config:
     metadata: Mapping[str, Any] | None = None
     fail_open: bool = True
     enable_observability: bool = True
+    emit_mark_events: bool = True
+    emit_identity_events: bool = True
     run_sync_in_thread: bool = False
     identity_resolver: IdentityResolver | None = None
     query_extractor: QueryExtractor | None = None
@@ -184,6 +318,8 @@ def install(
     metadata: Mapping[str, Any] | None = None,
     fail_open: bool = True,
     enable_observability: bool = True,
+    emit_mark_events: bool = True,
+    emit_identity_events: bool = True,
     activate_runtime: bool = True,
     run_sync_in_thread: bool = False,
     identity_resolver: IdentityResolver | None = None,
@@ -198,7 +334,8 @@ def install(
     with `mem0ai[nemo_flow]`. NeMo Flow is imported only when this function is
     called so the integration remains optional for regular Mem0 users. When
     observability is enabled, the adapter records nested NeMo Flow scopes for
-    recall and capture instead of standalone mark events.
+    recall and capture and emits NeMo Flow mark events for recall/capture
+    milestones.
     """
 
     nemo_flow = _load_nemo_flow()
@@ -215,6 +352,8 @@ def install(
         metadata=metadata,
         fail_open=fail_open,
         enable_observability=enable_observability,
+        emit_mark_events=emit_mark_events,
+        emit_identity_events=emit_identity_events,
         run_sync_in_thread=run_sync_in_thread,
         identity_resolver=identity_resolver,
         query_extractor=query_extractor,
@@ -241,9 +380,12 @@ class _Mem0NemoFlowIntercept:
         request: "nemo_flow.LLMRequest",
         next_call: Callable[["nemo_flow.LLMRequest"], Any],
     ) -> "nemo_flow.Json":
-        identity = self._resolve_identity(llm_name, request)
-        if identity is None or not identity.has_scope():
+        resolved = self._resolve_identity(llm_name, request)
+        if resolved is None or not resolved.identity.has_scope():
             return await next_call(request)
+
+        identity = resolved.identity
+        self._emit_identity_resolved(identity, resolved.source)
 
         request_for_call = request
         if self.config.auto_recall:
@@ -266,25 +408,34 @@ class _Mem0NemoFlowIntercept:
 
         return response
 
-    def _resolve_identity(self, llm_name: str, request: "nemo_flow.LLMRequest") -> MemoryIdentity | None:
+    def _resolve_identity(self, llm_name: str, request: "nemo_flow.LLMRequest") -> ResolvedMemoryIdentity | None:
         scope_metadata = _current_scope_metadata(self._nemo_flow)
         context = NemoFlowTurnContext(llm_name=llm_name, request=request, scope_metadata=scope_metadata)
 
         if self.config.identity_resolver is not None:
             identity = _coerce_identity(self.config.identity_resolver(context))
             if identity is not None:
-                return identity
+                return ResolvedMemoryIdentity(identity, NemoFlowIdentitySource.IDENTITY_RESOLVER)
 
         context_identity = _memory_identity.get()
         if context_identity is not None and context_identity.has_scope():
-            return context_identity
+            return ResolvedMemoryIdentity(context_identity, NemoFlowIdentitySource.MEMORY_SCOPE)
 
-        return _identity_from_metadata(scope_metadata)
+        metadata_identity = _identity_from_metadata(scope_metadata)
+        if metadata_identity is not None:
+            return ResolvedMemoryIdentity(metadata_identity, NemoFlowIdentitySource.SCOPE_METADATA)
+
+        return None
 
     async def _recall(self, request: "nemo_flow.LLMRequest", identity: MemoryIdentity) -> "nemo_flow.LLMRequest":
         query_extractor = self.config.query_extractor or _default_query_extractor
         query = query_extractor(request)
         if not query:
+            self._emit_event(
+                NemoFlowEvent.RECALL_SKIPPED,
+                data={"reason": NemoFlowSkipReason.EMPTY_QUERY.value},
+                metadata=_identity_observability_metadata(identity),
+            )
             return request
 
         search_kwargs: dict[str, Any] = {
@@ -295,8 +446,7 @@ class _Mem0NemoFlowIntercept:
             search_kwargs["threshold"] = self.config.threshold
 
         scope_handle = self._start_scope(
-            "mem0.recall",
-            "Retriever",
+            NemoFlowScope.RECALL,
             input={
                 "query_length": len(query),
                 "top_k": self.config.top_k,
@@ -310,21 +460,70 @@ class _Mem0NemoFlowIntercept:
             result = await self._invoke(self.memory.search, query, **search_kwargs)
             memories = _extract_memory_results(result)
             if not memories:
+                self._emit_event(
+                    NemoFlowEvent.RECALL_SKIPPED,
+                    handle=scope_handle,
+                    data={"reason": NemoFlowSkipReason.NO_MEMORIES.value, "result_count": 0},
+                    metadata=_identity_observability_metadata(identity),
+                )
                 return request
 
+            context_event_data = _recall_context_event_data(memories)
+            self._emit_event(
+                NemoFlowEvent.RECALL_CONTEXT_BUILT,
+                handle=scope_handle,
+                data=context_event_data,
+                metadata=_identity_observability_metadata(identity),
+            )
             formatter = self.config.memory_formatter or _default_memory_formatter
             memory_text = formatter(memories)
-            scope_output = {"result_count": len(memories), "injected": False}
+            scope_output = {
+                **context_event_data,
+                "formatted_context_chars": len(memory_text),
+                "injected": False,
+            }
             if not memory_text:
+                self._emit_event(
+                    NemoFlowEvent.RECALL_SKIPPED,
+                    handle=scope_handle,
+                    data={"reason": NemoFlowSkipReason.EMPTY_FORMATTED_CONTEXT.value},
+                    metadata=_identity_observability_metadata(identity),
+                )
                 return request
 
-            content = _content_with_memory(request.content, memory_text)
-            if content is request.content:
+            injection = _content_with_memory(request.content, memory_text)
+            if not injection.mutated:
+                self._emit_event(
+                    NemoFlowEvent.RECALL_SKIPPED,
+                    handle=scope_handle,
+                    data={"reason": NemoFlowSkipReason.UNSUPPORTED_REQUEST_CONTENT.value},
+                    metadata=_identity_observability_metadata(identity),
+                )
                 return request
-            scope_output = {"result_count": len(memories), "injected": True}
-            return self._nemo_flow.LLMRequest(request.headers, content)
+
+            scope_output = {
+                **context_event_data,
+                "formatted_context_chars": len(memory_text),
+                "message_count_before": injection.message_count_before,
+                "message_count_after": injection.message_count_after,
+                "insertion_index": injection.insert_at,
+                "injected": True,
+            }
+            self._emit_event(
+                NemoFlowEvent.RECALL_INJECTED,
+                handle=scope_handle,
+                data=scope_output,
+                metadata=_identity_observability_metadata(identity),
+            )
+            return self._nemo_flow.LLMRequest(request.headers, injection.content)
         except Exception as exc:
             scope_output = {"error_type": type(exc).__name__}
+            self._emit_event(
+                NemoFlowEvent.RECALL_FAILED,
+                handle=scope_handle,
+                data={"error_type": type(exc).__name__},
+                metadata=_identity_observability_metadata(identity),
+            )
             raise
         finally:
             self._end_scope(scope_handle, output=scope_output)
@@ -335,11 +534,6 @@ class _Mem0NemoFlowIntercept:
         response: "nemo_flow.Json",
         identity: MemoryIdentity,
     ) -> None:
-        interaction_extractor = self.config.interaction_extractor or _default_interaction_extractor
-        messages = interaction_extractor(request, response)
-        if not messages:
-            return
-
         add_kwargs: dict[str, Any] = {
             "metadata": _capture_metadata(identity, self.config.metadata),
             "infer": self.config.infer,
@@ -347,21 +541,54 @@ class _Mem0NemoFlowIntercept:
         local_kwargs = identity.local_kwargs()
         if not local_kwargs:
             logger.debug("Skipping Mem0 capture because Memory.add needs user_id, agent_id, or run_id")
+            self._emit_event(
+                NemoFlowEvent.CAPTURE_SKIPPED,
+                data={"reason": NemoFlowSkipReason.NO_SESSION_ID.value},
+                metadata=_identity_observability_metadata(identity),
+            )
             return
         add_kwargs.update(local_kwargs)
 
+        interaction_extractor = self.config.interaction_extractor or _default_interaction_extractor
+        messages = interaction_extractor(request, response)
+        if not messages:
+            self._emit_event(
+                NemoFlowEvent.CAPTURE_SKIPPED,
+                data={"reason": NemoFlowSkipReason.NO_INTERACTION.value},
+                metadata=_identity_observability_metadata(identity),
+            )
+            return
+
+        extracted_event_data = _interaction_event_data(messages)
         scope_handle = self._start_scope(
-            "mem0.capture",
-            "Custom",
-            input={"message_count": len(messages), "infer": self.config.infer},
+            NemoFlowScope.CAPTURE,
+            input={**extracted_event_data, "infer": self.config.infer},
             metadata=_identity_observability_metadata(identity),
         )
-        scope_output: dict[str, Any] = {"message_count": len(messages), "stored": False}
+        self._emit_event(
+            NemoFlowEvent.CAPTURE_EXTRACTED,
+            handle=scope_handle,
+            data=extracted_event_data,
+            metadata=_identity_observability_metadata(identity),
+        )
+        scope_output: dict[str, Any] = {**extracted_event_data, "stored": False}
         try:
             await self._invoke(self.memory.add, list(messages), **add_kwargs)
-            scope_output = {"message_count": len(messages), "stored": True}
+            scope_output = {**extracted_event_data, "stored": True}
+            self._emit_event(
+                NemoFlowEvent.CAPTURE_STORED,
+                handle=scope_handle,
+                data=scope_output,
+                metadata=_identity_observability_metadata(identity),
+            )
         except Exception as exc:
-            scope_output = {"message_count": len(messages), "stored": False, "error_type": type(exc).__name__}
+            scope_output = {**extracted_event_data, "stored": False, "error_type": type(exc).__name__}
+            self._emit_event(
+                NemoFlowEvent.CAPTURE_FAILED,
+                handle=scope_handle,
+                data=scope_output,
+                metadata=_identity_observability_metadata(identity),
+            )
             raise
         finally:
             self._end_scope(scope_handle, output=scope_output)
@@ -378,8 +605,7 @@ class _Mem0NemoFlowIntercept:
 
     def _start_scope(
         self,
-        name: str,
-        scope_type_name: str,
+        scope: NemoFlowScope,
         *,
         input: Mapping[str, Any] | None = None,
         metadata: Mapping[str, Any] | None = None,
@@ -388,9 +614,10 @@ class _Mem0NemoFlowIntercept:
             return None
 
         try:
-            scope_type = getattr(self._nemo_flow.ScopeType, scope_type_name)
+            definition = NEMO_FLOW_SCOPE_REGISTRY[scope]
+            scope_type = getattr(self._nemo_flow.ScopeType, definition.scope_type_name)
             return self._nemo_flow.scope.push(
-                name,
+                definition.name.value,
                 scope_type,
                 input=dict(input or {}),
                 metadata={"integration": "mem0", **dict(metadata or {})},
@@ -407,6 +634,42 @@ class _Mem0NemoFlowIntercept:
             self._nemo_flow.scope.pop(handle, output=dict(output or {}))
         except Exception:
             logger.debug("Failed to end NeMo Flow Mem0 scope", exc_info=True)
+
+    def _emit_identity_resolved(self, identity: MemoryIdentity, source: NemoFlowIdentitySource) -> None:
+        if not self.config.emit_identity_events:
+            return
+
+        self._emit_event(
+            NemoFlowEvent.IDENTITY_RESOLVED,
+            data={
+                "source": source.value,
+                "has_scope": identity.has_scope(),
+                "filter_count": len(identity.search_filters()),
+            },
+            metadata=_identity_observability_metadata(identity),
+        )
+
+    def _emit_event(
+        self,
+        event: NemoFlowEvent,
+        *,
+        handle: Any | None = None,
+        data: Mapping[str, Any] | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> None:
+        if not self.config.enable_observability or not self.config.emit_mark_events:
+            return
+
+        try:
+            definition = NEMO_FLOW_EVENT_REGISTRY[event]
+            self._nemo_flow.scope.event(
+                definition.name.value,
+                handle=handle,
+                data=dict(data or {}),
+                metadata={"integration": "mem0", **dict(metadata or {})},
+            )
+        except Exception:
+            logger.debug("Failed to emit NeMo Flow Mem0 mark event", exc_info=True)
 
 
 def _load_nemo_flow() -> Any:
@@ -444,9 +707,10 @@ def _activate_runtime(nemo_flow_module: Any) -> None:
 def _push_memory_context_scope(nemo_flow_module: Any, identity: MemoryIdentity) -> Any | None:
     _activate_runtime(nemo_flow_module)
     try:
+        definition = NEMO_FLOW_SCOPE_REGISTRY[NemoFlowScope.MEMORY]
         return nemo_flow_module.scope.push(
-            "mem0.memory",
-            nemo_flow_module.ScopeType.Custom,
+            definition.name.value,
+            getattr(nemo_flow_module.ScopeType, definition.scope_type_name),
             metadata={"integration": "mem0", "mem0": _identity_scope_metadata(identity)},
         )
     except Exception:
@@ -532,6 +796,39 @@ def _identity_observability_metadata(identity: MemoryIdentity) -> dict[str, Any]
         "has_user_id": identity.user_id is not None,
         "has_agent_id": identity.agent_id is not None,
         "has_run_id": identity.run_id is not None,
+    }
+
+
+def _recall_context_event_data(memories: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    memory_chars = 0
+    for memory in memories:
+        text = _text_from_content(memory.get("memory") or memory.get("text") or memory.get("content"))
+        if text:
+            memory_chars += len(text)
+    return {"result_count": len(memories), "memory_chars": memory_chars}
+
+
+def _interaction_event_data(messages: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    roles: list[str] = []
+    role_counts: dict[str, int] = {}
+    content_chars_by_role: dict[str, int] = {}
+    content_chars = 0
+
+    for message in messages:
+        role = str(message.get("role", "unknown"))
+        text = _text_from_content(message.get("content")) or ""
+        text_length = len(text)
+        roles.append(role)
+        role_counts[role] = role_counts.get(role, 0) + 1
+        content_chars_by_role[role] = content_chars_by_role.get(role, 0) + text_length
+        content_chars += text_length
+
+    return {
+        "message_count": len(messages),
+        "roles": roles,
+        "role_counts": role_counts,
+        "content_chars": content_chars,
+        "content_chars_by_role": content_chars_by_role,
     }
 
 
@@ -629,10 +926,13 @@ def _default_memory_formatter(memories: Sequence[Mapping[str, Any]]) -> str:
     return "Relevant memories:\n" + "\n".join(lines)
 
 
-def _content_with_memory(content: Mapping[str, Any], memory_text: str) -> Mapping[str, Any]:
+def _content_with_memory(content: Any, memory_text: str) -> MemoryInjection:
+    if not isinstance(content, Mapping):
+        return MemoryInjection(content={}, mutated=False)
+
     messages = content.get("messages")
     if not isinstance(messages, Sequence) or isinstance(messages, (str, bytes)):
-        return content
+        return MemoryInjection(content=dict(content), mutated=False)
 
     new_content = copy.deepcopy(dict(content))
     new_messages = list(copy.deepcopy(messages))
@@ -645,7 +945,13 @@ def _content_with_memory(content: Mapping[str, Any], memory_text: str) -> Mappin
 
     new_messages.insert(insert_at, {"role": "system", "content": memory_text})
     new_content["messages"] = new_messages
-    return new_content
+    return MemoryInjection(
+        content=new_content,
+        mutated=True,
+        message_count_before=len(messages),
+        message_count_after=len(new_messages),
+        insert_at=insert_at,
+    )
 
 
 def _text_from_content(content: Any) -> str | None:
@@ -673,9 +979,17 @@ def _string_or_none(value: Any) -> str | None:
 
 
 __all__ = [
+    "NEMO_FLOW_EVENT_REGISTRY",
+    "NEMO_FLOW_SCOPE_REGISTRY",
     "MemoryIdentity",
+    "NemoFlowEvent",
+    "NemoFlowEventDefinition",
+    "NemoFlowIdentitySource",
     "NemoFlowMem0Config",
     "NemoFlowMem0Handle",
+    "NemoFlowScope",
+    "NemoFlowScopeDefinition",
+    "NemoFlowSkipReason",
     "NemoFlowTurnContext",
     "activate_runtime",
     "install",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ llms = [
     "google-generativeai>=0.3.0",
     "google-genai>=1.0.0",
 ]
+nemo_flow = [
+    "nemo-flow>=0.1.0rc5,<0.2.0",
+]
 extras = [
     "boto3>=1.34.0",
     "langchain>=0.3.0,<1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ llms = [
     "google-genai>=1.0.0",
 ]
 nemo_flow = [
-    "nemo-flow>=0.1.0rc5,<0.2.0",
+    "nemo-flow>=0.1.0rc5,<0.2.0; python_version >= '3.11'",
 ]
 extras = [
     "boto3>=1.34.0",

--- a/tests/test_nemo_flow_example.py
+++ b/tests/test_nemo_flow_example.py
@@ -1,0 +1,69 @@
+import importlib.util
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+nemo_flow = pytest.importorskip("nemo_flow", reason="nemo-flow optional dependency is not installed")
+
+
+def _load_example_module():
+    path = Path(__file__).resolve().parents[1] / "examples" / "misc" / "nemo_flow_memory.py"
+    spec = importlib.util.spec_from_file_location("nemo_flow_memory_example", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _has_scope_event(events, name: str, scope_category: str, category: str | None = None) -> bool:
+    return any(
+        isinstance(event, nemo_flow.ScopeEvent)
+        and event.name == name
+        and event.scope_category == scope_category
+        and (category is None or event.category == category)
+        for event in events
+    )
+
+
+@pytest.mark.asyncio
+async def test_nemo_flow_memory_example_smoke():
+    module = _load_example_module()
+    events = []
+    subscriber_name = f"mem0-nemo-flow-example-{uuid4().hex}"
+
+    nemo_flow.subscribers.register(subscriber_name, lambda event: events.append(event))
+    try:
+        result = await module.run_demo()
+    finally:
+        nemo_flow.subscribers.deregister(subscriber_name)
+
+    assert result["search_calls"] == [
+        {
+            "query": "What do I like to drink?",
+            "kwargs": {
+                "filters": {"user_id": "alex", "run_id": "demo-thread"},
+                "top_k": 5,
+                "threshold": 0.1,
+            },
+        }
+    ]
+    assert result["provider_requests"][0]["messages"][0] == {
+        "role": "system",
+        "content": "Relevant memories:\n- Alex prefers tea in the afternoon.",
+    }
+    assert result["add_calls"][0]["messages"] == [
+        {"role": "user", "content": "What do I like to drink?"},
+        {
+            "role": "assistant",
+            "content": "I found your memory: Relevant memories:\n- Alex prefers tea in the afternoon.",
+        },
+    ]
+    assert _has_scope_event(events, "mem0.memory", "start", "custom")
+    assert _has_scope_event(events, "mem0.memory", "end", "custom")
+    assert _has_scope_event(events, "mem0.recall", "start", "retriever")
+    assert _has_scope_event(events, "mem0.recall", "end", "retriever")
+    assert _has_scope_event(events, "mem0.capture", "start", "custom")
+    assert _has_scope_event(events, "mem0.capture", "end", "custom")
+    assert _has_scope_event(events, "demo-llm", "start", "llm")
+    assert _has_scope_event(events, "demo-llm", "end", "llm")

--- a/tests/test_nemo_flow_example.py
+++ b/tests/test_nemo_flow_example.py
@@ -26,6 +26,10 @@ def _has_scope_event(events, name: str, scope_category: str, category: str | Non
     )
 
 
+def _has_mark_event(events, name: str) -> bool:
+    return any(getattr(event, "name", None) == name and type(event).__name__ == "MarkEvent" for event in events)
+
+
 @pytest.mark.asyncio
 async def test_nemo_flow_memory_example_smoke():
     module = _load_example_module()
@@ -67,3 +71,8 @@ async def test_nemo_flow_memory_example_smoke():
     assert _has_scope_event(events, "mem0.capture", "end", "custom")
     assert _has_scope_event(events, "demo-llm", "start", "llm")
     assert _has_scope_event(events, "demo-llm", "end", "llm")
+    assert _has_mark_event(events, "mem0.identity.resolved")
+    assert _has_mark_event(events, "mem0.recall.context_built")
+    assert _has_mark_event(events, "mem0.recall.injected")
+    assert _has_mark_event(events, "mem0.capture.extracted")
+    assert _has_mark_event(events, "mem0.capture.stored")

--- a/tests/test_nemo_flow_integration.py
+++ b/tests/test_nemo_flow_integration.py
@@ -1,0 +1,320 @@
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from mem0.integrations import nemo_flow
+
+
+class FakeLLMRequest:
+    def __init__(self, headers, content):
+        self.headers = dict(headers)
+        self.content = dict(content)
+
+
+class FakeInterceptors:
+    def __init__(self):
+        self.registered = {}
+        self.deregistered = []
+
+    def register_llm_execution(self, name, priority, callback):
+        self.registered[name] = {"priority": priority, "callback": callback}
+
+    def deregister_llm_execution(self, name):
+        self.deregistered.append(name)
+        return self.registered.pop(name, None) is not None
+
+
+class FakeScope:
+    def __init__(self):
+        self.handle = None
+        self.stack = []
+        self.pushed = []
+        self.popped = []
+
+    def get_handle(self):
+        return self.handle
+
+    def push(self, name, scope_type, *, input=None, metadata=None, **kwargs):
+        handle = SimpleNamespace(name=name, scope_type=scope_type, input=input, metadata=metadata)
+        self.stack.append(handle)
+        self.handle = handle
+        self.pushed.append(
+            {
+                "name": name,
+                "scope_type": scope_type,
+                "input": input,
+                "metadata": metadata,
+                "handle": handle,
+            }
+        )
+        return handle
+
+    def pop(self, handle, *, output=None):
+        self.popped.append({"name": handle.name, "output": output, "handle": handle})
+        if self.stack and self.stack[-1] is handle:
+            self.stack.pop()
+        elif handle in self.stack:
+            self.stack.remove(handle)
+        self.handle = self.stack[-1] if self.stack else None
+
+
+class HostedMemory:
+    def __init__(self):
+        self.search_calls = []
+        self.add_calls = []
+
+    def search(self, query, **kwargs):
+        self.search_calls.append({"query": query, "kwargs": kwargs})
+        return {"results": [{"memory": "User prefers tea."}]}
+
+    def add(self, messages, **kwargs):
+        self.add_calls.append({"messages": messages, "kwargs": kwargs})
+        return {"results": [{"memory": "User prefers tea.", "event": "ADD"}]}
+
+
+class LocalMemory:
+    def __init__(self):
+        self.search_calls = []
+        self.add_calls = []
+
+    def search(self, query, *, filters=None, top_k=20, threshold=0.1):
+        self.search_calls.append(
+            {
+                "query": query,
+                "kwargs": {"filters": filters, "top_k": top_k, "threshold": threshold},
+            }
+        )
+        return {"results": [{"memory": "User prefers tea."}]}
+
+    def add(self, messages, *, user_id=None, agent_id=None, run_id=None, metadata=None, infer=True):
+        self.add_calls.append(
+            {
+                "messages": messages,
+                "kwargs": {
+                    "user_id": user_id,
+                    "agent_id": agent_id,
+                    "run_id": run_id,
+                    "metadata": metadata,
+                    "infer": infer,
+                },
+            }
+        )
+        return {"results": [{"memory": "User prefers tea.", "event": "ADD"}]}
+
+
+@pytest.fixture
+def fake_nemo_flow(monkeypatch):
+    intercepts = FakeInterceptors()
+    scope = FakeScope()
+    module = SimpleNamespace(
+        LLMRequest=FakeLLMRequest,
+        Json=dict,
+        ScopeType=SimpleNamespace(Agent="agent", Retriever="retriever", Custom="custom"),
+        intercepts=intercepts,
+        scope=scope,
+        get_scope_stack=lambda: SimpleNamespace(),
+    )
+    monkeypatch.setitem(sys.modules, "nemo_flow", module)
+    return module
+
+
+def test_install_registers_and_uninstalls_execution_intercept(fake_nemo_flow):
+    memory = HostedMemory()
+
+    handle = nemo_flow.install(memory, name="mem0.test", priority=12)
+
+    assert handle.active is True
+    assert fake_nemo_flow.intercepts.registered["mem0.test"]["priority"] == 12
+    assert fake_nemo_flow.intercepts.registered["mem0.test"]["callback"] is handle.intercept
+    assert handle.uninstall() is True
+    assert handle.active is False
+    assert handle.uninstall() is False
+    assert fake_nemo_flow.intercepts.deregistered == ["mem0.test"]
+
+
+@pytest.mark.asyncio
+async def test_context_identity_recalls_and_captures_with_hosted_memory(fake_nemo_flow):
+    memory = HostedMemory()
+    nemo_flow.install(memory, name="mem0.context")
+    intercept = fake_nemo_flow.intercepts.registered["mem0.context"]["callback"]
+    seen_requests = []
+    request = fake_nemo_flow.LLMRequest(
+        {"x-trace": "abc"},
+        {
+            "model": "test-model",
+            "messages": [
+                {"role": "system", "content": "Be concise."},
+                {"role": "user", "content": "What should I drink?"},
+            ],
+        },
+    )
+
+    async def next_call(next_request):
+        seen_requests.append(next_request)
+        return {"choices": [{"message": {"content": "Drink tea."}}]}
+
+    with nemo_flow.memory_scope(user_id="user-1", thread_id="thread-1"):
+        response = await intercept("gpt-test", request, next_call)
+
+    assert response == {"choices": [{"message": {"content": "Drink tea."}}]}
+    assert len(seen_requests) == 1
+    assert isinstance(seen_requests[0], FakeLLMRequest)
+    assert seen_requests[0] is not request
+    assert seen_requests[0].headers == {"x-trace": "abc"}
+
+    messages = seen_requests[0].content["messages"]
+    assert [message["role"] for message in messages] == ["system", "system", "user"]
+    assert messages[1]["content"] == "Relevant memories:\n- User prefers tea."
+
+    assert memory.search_calls == [
+        {
+            "query": "What should I drink?",
+            "kwargs": {
+                "filters": {"user_id": "user-1", "run_id": "thread-1"},
+                "top_k": 5,
+                "threshold": 0.1,
+            },
+        }
+    ]
+    assert memory.add_calls == [
+        {
+            "messages": [
+                {"role": "user", "content": "What should I drink?"},
+                {"role": "assistant", "content": "Drink tea."},
+            ],
+            "kwargs": {
+                "user_id": "user-1",
+                "run_id": "thread-1",
+                "metadata": {"user_id": "user-1", "run_id": "thread-1"},
+                "infer": True,
+            },
+        }
+    ]
+    assert [
+        {
+            "name": item["name"],
+            "scope_type": item["scope_type"],
+            "input": item["input"],
+            "metadata": item["metadata"],
+        }
+        for item in fake_nemo_flow.scope.pushed
+    ] == [
+        {
+            "name": "mem0.memory",
+            "scope_type": "custom",
+            "input": None,
+            "metadata": {"integration": "mem0", "mem0": {"user_id": "user-1", "run_id": "thread-1"}},
+        },
+        {
+            "name": "mem0.recall",
+            "scope_type": "retriever",
+            "input": {
+                "query_length": len("What should I drink?"),
+                "top_k": 5,
+                "threshold": 0.1,
+            },
+            "metadata": {
+                "integration": "mem0",
+                "filter_keys": ["run_id", "user_id"],
+                "has_user_id": True,
+                "has_agent_id": False,
+                "has_run_id": True,
+            },
+        },
+        {
+            "name": "mem0.capture",
+            "scope_type": "custom",
+            "input": {"message_count": 2, "infer": True},
+            "metadata": {
+                "integration": "mem0",
+                "filter_keys": ["run_id", "user_id"],
+                "has_user_id": True,
+                "has_agent_id": False,
+                "has_run_id": True,
+            },
+        },
+    ]
+    assert [{"name": item["name"], "output": item["output"]} for item in fake_nemo_flow.scope.popped] == [
+        {"name": "mem0.recall", "output": {"result_count": 1, "injected": True}},
+        {"name": "mem0.capture", "output": {"message_count": 2, "stored": True}},
+        {"name": "mem0.memory", "output": None},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_scope_metadata_can_supply_mem0_identity(fake_nemo_flow):
+    memory = HostedMemory()
+    nemo_flow.install(memory, name="mem0.scope", top_k=2, threshold=None)
+    intercept = fake_nemo_flow.intercepts.registered["mem0.scope"]["callback"]
+    fake_nemo_flow.scope.handle = SimpleNamespace(
+        metadata={"mem0": {"user_id": "scope-user", "filters": {"tenant_id": "tenant-1"}}}
+    )
+    request = fake_nemo_flow.LLMRequest({}, {"messages": [{"role": "user", "content": "Remember this?"}]})
+
+    async def next_call(next_request):
+        return {"content": "I will remember."}
+
+    await intercept("gpt-test", request, next_call)
+
+    assert memory.search_calls[0]["kwargs"] == {
+        "filters": {"tenant_id": "tenant-1", "user_id": "scope-user"},
+        "top_k": 2,
+    }
+    assert memory.add_calls[0]["kwargs"]["user_id"] == "scope-user"
+    assert memory.add_calls[0]["kwargs"]["metadata"] == {"tenant_id": "tenant-1", "user_id": "scope-user"}
+
+
+@pytest.mark.asyncio
+async def test_no_identity_skips_mem0_and_calls_next_with_original_request(fake_nemo_flow):
+    memory = HostedMemory()
+    nemo_flow.install(memory, name="mem0.no_identity")
+    intercept = fake_nemo_flow.intercepts.registered["mem0.no_identity"]["callback"]
+    request = fake_nemo_flow.LLMRequest({}, {"messages": [{"role": "user", "content": "Hi"}]})
+    seen_requests = []
+
+    async def next_call(next_request):
+        seen_requests.append(next_request)
+        return {"content": "Hello"}
+
+    assert await intercept("gpt-test", request, next_call) == {"content": "Hello"}
+    assert seen_requests == [request]
+    assert memory.search_calls == []
+    assert memory.add_calls == []
+    assert fake_nemo_flow.scope.pushed == []
+    assert fake_nemo_flow.scope.popped == []
+
+
+@pytest.mark.asyncio
+async def test_local_memory_capture_uses_top_level_session_ids(fake_nemo_flow):
+    memory = LocalMemory()
+    nemo_flow.install(memory, name="mem0.local")
+    intercept = fake_nemo_flow.intercepts.registered["mem0.local"]["callback"]
+    request = fake_nemo_flow.LLMRequest({}, {"messages": [{"role": "user", "content": "What should I drink?"}]})
+
+    async def next_call(next_request):
+        return {"content": "Drink tea."}
+
+    with nemo_flow.memory_scope(user_id="local-user", agent_id="agent-1"):
+        await intercept("gpt-test", request, next_call)
+
+    assert memory.search_calls[0]["kwargs"]["filters"] == {"user_id": "local-user", "agent_id": "agent-1"}
+    assert memory.add_calls[0]["kwargs"] == {
+        "user_id": "local-user",
+        "agent_id": "agent-1",
+        "run_id": None,
+        "metadata": {"user_id": "local-user", "agent_id": "agent-1"},
+        "infer": True,
+    }
+
+
+def test_legacy_names_remain_available():
+    assert nemo_flow.memory_context is nemo_flow.memory_scope
+    assert nemo_flow.mem0_context is nemo_flow.memory_scope
+    assert nemo_flow.install_mem0 is nemo_flow.install
+
+
+def test_thread_id_conflict_is_rejected():
+    with pytest.raises(ValueError, match="run_id and thread_id"):
+        with nemo_flow.memory_scope(user_id="user-1", run_id="run-1", thread_id="thread-1"):
+            pass

--- a/tests/test_nemo_flow_integration.py
+++ b/tests/test_nemo_flow_integration.py
@@ -31,6 +31,7 @@ class FakeScope:
         self.stack = []
         self.pushed = []
         self.popped = []
+        self.events = []
 
     def get_handle(self):
         return self.handle
@@ -57,6 +58,9 @@ class FakeScope:
         elif handle in self.stack:
             self.stack.remove(handle)
         self.handle = self.stack[-1] if self.stack else None
+
+    def event(self, name, *, handle=None, data=None, metadata=None):
+        self.events.append({"name": name, "handle": handle, "data": data, "metadata": metadata})
 
 
 class HostedMemory:
@@ -225,7 +229,14 @@ async def test_context_identity_recalls_and_captures_with_hosted_memory(fake_nem
         {
             "name": "mem0.capture",
             "scope_type": "custom",
-            "input": {"message_count": 2, "infer": True},
+            "input": {
+                "message_count": 2,
+                "roles": ["user", "assistant"],
+                "role_counts": {"user": 1, "assistant": 1},
+                "content_chars": 30,
+                "content_chars_by_role": {"user": 20, "assistant": 10},
+                "infer": True,
+            },
             "metadata": {
                 "integration": "mem0",
                 "filter_keys": ["run_id", "user_id"],
@@ -235,9 +246,67 @@ async def test_context_identity_recalls_and_captures_with_hosted_memory(fake_nem
             },
         },
     ]
+    assert [item["name"] for item in fake_nemo_flow.scope.events] == [
+        "mem0.identity.resolved",
+        "mem0.recall.context_built",
+        "mem0.recall.injected",
+        "mem0.capture.extracted",
+        "mem0.capture.stored",
+    ]
+    assert fake_nemo_flow.scope.events[0]["data"] == {
+        "source": "memory_scope",
+        "has_scope": True,
+        "filter_count": 2,
+    }
+    assert fake_nemo_flow.scope.events[1]["data"] == {"result_count": 1, "memory_chars": 17}
+    assert fake_nemo_flow.scope.events[2]["data"] == {
+        "result_count": 1,
+        "memory_chars": 17,
+        "formatted_context_chars": len("Relevant memories:\n- User prefers tea."),
+        "message_count_before": 2,
+        "message_count_after": 3,
+        "insertion_index": 1,
+        "injected": True,
+    }
+    assert fake_nemo_flow.scope.events[3]["data"] == {
+        "message_count": 2,
+        "roles": ["user", "assistant"],
+        "role_counts": {"user": 1, "assistant": 1},
+        "content_chars": 30,
+        "content_chars_by_role": {"user": 20, "assistant": 10},
+    }
+    assert fake_nemo_flow.scope.events[4]["data"] == {
+        "message_count": 2,
+        "roles": ["user", "assistant"],
+        "role_counts": {"user": 1, "assistant": 1},
+        "content_chars": 30,
+        "content_chars_by_role": {"user": 20, "assistant": 10},
+        "stored": True,
+    }
     assert [{"name": item["name"], "output": item["output"]} for item in fake_nemo_flow.scope.popped] == [
-        {"name": "mem0.recall", "output": {"result_count": 1, "injected": True}},
-        {"name": "mem0.capture", "output": {"message_count": 2, "stored": True}},
+        {
+            "name": "mem0.recall",
+            "output": {
+                "result_count": 1,
+                "memory_chars": 17,
+                "formatted_context_chars": len("Relevant memories:\n- User prefers tea."),
+                "message_count_before": 2,
+                "message_count_after": 3,
+                "insertion_index": 1,
+                "injected": True,
+            },
+        },
+        {
+            "name": "mem0.capture",
+            "output": {
+                "message_count": 2,
+                "roles": ["user", "assistant"],
+                "role_counts": {"user": 1, "assistant": 1},
+                "content_chars": 30,
+                "content_chars_by_role": {"user": 20, "assistant": 10},
+                "stored": True,
+            },
+        },
         {"name": "mem0.memory", "output": None},
     ]
 
@@ -283,6 +352,7 @@ async def test_no_identity_skips_mem0_and_calls_next_with_original_request(fake_
     assert memory.add_calls == []
     assert fake_nemo_flow.scope.pushed == []
     assert fake_nemo_flow.scope.popped == []
+    assert fake_nemo_flow.scope.events == []
 
 
 @pytest.mark.asyncio
@@ -312,6 +382,22 @@ def test_legacy_names_remain_available():
     assert nemo_flow.memory_context is nemo_flow.memory_scope
     assert nemo_flow.mem0_context is nemo_flow.memory_scope
     assert nemo_flow.install_mem0 is nemo_flow.install
+
+
+def test_scope_and_event_registries_are_public():
+    assert nemo_flow.NEMO_FLOW_SCOPE_REGISTRY[nemo_flow.NemoFlowScope.MEMORY].name.value == "mem0.memory"
+    assert nemo_flow.NEMO_FLOW_SCOPE_REGISTRY[nemo_flow.NemoFlowScope.RECALL].scope_type_name == "Retriever"
+    assert nemo_flow.NEMO_FLOW_SCOPE_REGISTRY[nemo_flow.NemoFlowScope.CAPTURE].scope_type_name == "Custom"
+    assert (
+        nemo_flow.NEMO_FLOW_EVENT_REGISTRY[nemo_flow.NemoFlowEvent.IDENTITY_RESOLVED].name.value
+        == "mem0.identity.resolved"
+    )
+    assert nemo_flow.NEMO_FLOW_EVENT_REGISTRY[nemo_flow.NemoFlowEvent.RECALL_INJECTED].name.value == (
+        "mem0.recall.injected"
+    )
+    assert nemo_flow.NEMO_FLOW_EVENT_REGISTRY[nemo_flow.NemoFlowEvent.CAPTURE_STORED].name.value == (
+        "mem0.capture.stored"
+    )
 
 
 def test_thread_id_conflict_is_rejected():

--- a/tests/test_nemo_flow_platform_smoke.py
+++ b/tests/test_nemo_flow_platform_smoke.py
@@ -1,0 +1,113 @@
+import os
+import uuid
+
+import pytest
+
+
+def _contains_text(response, expected: str) -> bool:
+    expected = expected.lower()
+    stack = [response]
+    while stack:
+        item = stack.pop()
+        if isinstance(item, str) and expected in item.lower():
+            return True
+        if isinstance(item, dict):
+            stack.extend(item.values())
+        elif isinstance(item, list):
+            stack.extend(item)
+    return False
+
+
+def _best_effort_delete_user(client, user_id: str) -> None:
+    try:
+        client.delete_users(user_id=user_id)
+    except Exception:
+        pass
+
+
+def _has_scope_event(events, nemo_flow, name: str, scope_category: str, category: str | None = None) -> bool:
+    return any(
+        isinstance(event, nemo_flow.ScopeEvent)
+        and event.name == name
+        and event.scope_category == scope_category
+        and (category is None or event.category == category)
+        for event in events
+    )
+
+
+@pytest.mark.asyncio
+async def test_nemo_flow_platform_storage_smoke():
+    if os.getenv("RUN_MEM0_NEMO_FLOW_PLATFORM_SMOKE") != "1":
+        pytest.skip("set RUN_MEM0_NEMO_FLOW_PLATFORM_SMOKE=1 to run the real Mem0 Platform smoke")
+
+    pytest.importorskip("nemo_flow", reason="nemo-flow optional dependency is not installed")
+
+    import nemo_flow
+
+    from mem0 import MemoryClient
+    from mem0.integrations import nemo_flow as mem0_nemo_flow
+
+    api_key = os.getenv("MEM0_API_KEY")
+    if not api_key:
+        pytest.skip("MEM0_API_KEY is required for the real Mem0 Platform smoke")
+
+    user_id = f"nemo-flow-smoke-{uuid.uuid4().hex}"
+    run_id = "storage-smoke"
+    seed_memory = f"{user_id} prefers jasmine tea in the afternoon."
+    write_marker = f"nemo-flow-write-{uuid.uuid4().hex}"
+    filters = {"user_id": user_id, "run_id": run_id}
+    client = MemoryClient(api_key=api_key)
+    handle = None
+    events = []
+    subscriber_name = f"mem0-nemo-flow-platform-{uuid.uuid4().hex}"
+
+    try:
+        nemo_flow.subscribers.register(subscriber_name, lambda event: events.append(event))
+        client.add(seed_memory, user_id=user_id, run_id=run_id, infer=False)
+        seed_search = client.search("jasmine tea afternoon", filters=filters, top_k=5, threshold=0)
+        assert _contains_text(seed_search, "jasmine tea")
+
+        handle = mem0_nemo_flow.install(client, name=f"mem0.platform.{user_id}", infer=False, threshold=0)
+        provider_requests = []
+
+        async def demo_llm(request: nemo_flow.LLMRequest) -> dict:
+            provider_requests.append(request.content)
+            return {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": f"I will remember this marker: {write_marker}",
+                        }
+                    }
+                ]
+            }
+
+        request = nemo_flow.LLMRequest(
+            {},
+            {
+                "model": "demo-model",
+                "messages": [{"role": "user", "content": "What tea do I prefer?"}],
+            },
+        )
+        with mem0_nemo_flow.memory_scope(user_id=user_id, run_id=run_id):
+            await nemo_flow.llm.execute("demo-llm", request, demo_llm)
+
+        assert _contains_text(provider_requests, "jasmine tea")
+
+        write_search = client.search(write_marker, filters=filters, top_k=5, threshold=0)
+        assert _contains_text(write_search, write_marker)
+
+        assert _has_scope_event(events, nemo_flow, "mem0.memory", "start", "custom")
+        assert _has_scope_event(events, nemo_flow, "mem0.memory", "end", "custom")
+        assert _has_scope_event(events, nemo_flow, "mem0.recall", "start", "retriever")
+        assert _has_scope_event(events, nemo_flow, "mem0.recall", "end", "retriever")
+        assert _has_scope_event(events, nemo_flow, "mem0.capture", "start", "custom")
+        assert _has_scope_event(events, nemo_flow, "mem0.capture", "end", "custom")
+        assert _has_scope_event(events, nemo_flow, "demo-llm", "start", "llm")
+        assert _has_scope_event(events, nemo_flow, "demo-llm", "end", "llm")
+    finally:
+        nemo_flow.subscribers.deregister(subscriber_name)
+        if handle is not None:
+            handle.uninstall()
+        _best_effort_delete_user(client, user_id)

--- a/tests/test_nemo_flow_platform_smoke.py
+++ b/tests/test_nemo_flow_platform_smoke.py
@@ -35,6 +35,10 @@ def _has_scope_event(events, nemo_flow, name: str, scope_category: str, category
     )
 
 
+def _has_mark_event(events, name: str) -> bool:
+    return any(getattr(event, "name", None) == name and type(event).__name__ == "MarkEvent" for event in events)
+
+
 @pytest.mark.asyncio
 async def test_nemo_flow_platform_storage_smoke():
     if os.getenv("RUN_MEM0_NEMO_FLOW_PLATFORM_SMOKE") != "1":
@@ -106,6 +110,11 @@ async def test_nemo_flow_platform_storage_smoke():
         assert _has_scope_event(events, nemo_flow, "mem0.capture", "end", "custom")
         assert _has_scope_event(events, nemo_flow, "demo-llm", "start", "llm")
         assert _has_scope_event(events, nemo_flow, "demo-llm", "end", "llm")
+        assert _has_mark_event(events, "mem0.identity.resolved")
+        assert _has_mark_event(events, "mem0.recall.context_built")
+        assert _has_mark_event(events, "mem0.recall.injected")
+        assert _has_mark_event(events, "mem0.capture.extracted")
+        assert _has_mark_event(events, "mem0.capture.stored")
     finally:
         nemo_flow.subscribers.deregister(subscriber_name)
         if handle is not None:


### PR DESCRIPTION
DO NOT MERGE. This is a demo of NVIDIA NeMo Flow (pre-release build) + Mem0. Simply a proof of concept. Do not take public api / dx as gospel. 

## Linked Issue




## Description

Adds an optional Mem0 integration for NeMo Flow's non-streaming LLM execution intercept path. The adapter can recall relevant Mem0 memories before an LLM call, inject them into a new NeMo Flow LLMRequest, and capture the user/assistant exchange back into Mem0 after the call.

The public DX is Mem0-native and uses the integration module as the namespace:

```python
from mem0.integrations import nemo_flow

handle = nemo_flow.install(memory)

with nemo_flow.memory_scope(user_id="alex", thread_id="thread-123"):
    await agent.ainvoke(...)
```

`thread_id` is accepted as a LangGraph-friendly alias for Mem0 `run_id`. Legacy aliases remain available: `memory_context`, `mem0_context`, and `install_mem0`.

The integration keeps NeMo Flow optional through the `mem0ai[nemo_flow]` extra and lazy imports. Application code does not need to import `nemo_flow`; patched framework/model integrations can see the active runtime through `memory_scope(...)`.

For observability, the adapter records nested NeMo Flow scopes for `mem0.memory`, `mem0.recall`, and `mem0.capture`. It does not add custom mark events for recall/capture because those operations have natural start/end lifecycles. Scope input/output payloads include counts and status, not raw query or memory text.

This PR also adds:

- `docs/integrations/nemo-flow.mdx`, a README-style integration guide covering the DX, read path, write path, observability behavior, validation, and current limitations.
- `examples/misc/nemo_flow_memory.py`, a no-credentials example that uses a tiny in-memory Mem0-compatible client and a local instrumented LLM boundary.
- `tests/test_nemo_flow_platform_smoke.py`, an opt-in Mem0 Platform smoke gated by `RUN_MEM0_NEMO_FLOW_PLATFORM_SMOKE=1` and `MEM0_API_KEY`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [x] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Tested locally:

- `PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' UV_CACHE_DIR=/tmp/uv-cache uv run --no-project --with-editable . --with pytest --with pytest-asyncio python -m pytest tests/test_nemo_flow_integration.py -q`
- `PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' UV_CACHE_DIR=/tmp/uv-cache uv run --no-project --with-editable . --with pytest --with pytest-asyncio --with 'nemo-flow==0.1.0rc5' python -m pytest tests/test_nemo_flow_example.py -q`
- `RUN_MEM0_NEMO_FLOW_PLATFORM_SMOKE=1 MEM0_API_KEY=<redacted> PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='-p no:cacheprovider' UV_CACHE_DIR=/tmp/uv-cache uv run --no-project --with-editable . --with pytest --with pytest-asyncio --with 'nemo-flow==0.1.0rc5' python -m pytest tests/test_nemo_flow_platform_smoke.py -q -rs`
- `UV_CACHE_DIR=/tmp/uv-cache uv run --no-project --with ruff ruff check mem0/integrations/__init__.py mem0/integrations/nemo_flow.py tests/test_nemo_flow_integration.py tests/test_nemo_flow_example.py tests/test_nemo_flow_platform_smoke.py examples/misc/nemo_flow_memory.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run --no-project --with ruff ruff format mem0/integrations/__init__.py mem0/integrations/nemo_flow.py tests/test_nemo_flow_integration.py tests/test_nemo_flow_platform_smoke.py examples/misc/nemo_flow_memory.py`
- `python3 -c 'import json; json.load(open("docs/docs.json")); print("docs.json ok")'`

The hosted smoke seeds real Mem0 Platform memory, verifies recall through the NeMo Flow intercept, captures a post-LLM write, searches for the written marker, and best-effort deletes the temporary test user.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
