### PR TITLE
[codex] fix: normalize text content blocks when vision is disabled

### DIFF
--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -167,6 +167,23 @@ def get_image_description(image_obj, llm, vision_details):
     return response
 
 
+def _flatten_text_content_blocks(content_blocks):
+    """Flatten OpenAI-style text content blocks into plain text."""
+    text_parts = []
+
+    for block in content_blocks:
+        if isinstance(block, str):
+            text_parts.append(block)
+            continue
+
+        if isinstance(block, dict) and block.get("type") == "text":
+            text = block.get("text")
+            if text:
+                text_parts.append(text)
+
+    return "\n".join(text_parts).strip()
+
+
 def parse_vision_messages(messages, llm=None, vision_details="auto"):
     """
     Parse the vision messages from the messages
@@ -179,15 +196,27 @@ def parse_vision_messages(messages, llm=None, vision_details="auto"):
 
         # Handle message content
         if isinstance(msg["content"], list):
+            if llm is None:
+                flattened_text = _flatten_text_content_blocks(msg["content"])
+                if flattened_text:
+                    normalized_msg = dict(msg)
+                    normalized_msg["content"] = flattened_text
+                    returned_messages.append(normalized_msg)
+                continue
+
             # Multiple image URLs in content
             description = get_image_description(msg, llm, vision_details)
-            returned_messages.append({"role": msg["role"], "content": description})
+            normalized_msg = dict(msg)
+            normalized_msg["content"] = description
+            returned_messages.append(normalized_msg)
         elif isinstance(msg["content"], dict) and msg["content"].get("type") == "image_url":
             # Single image content
             image_url = msg["content"]["image_url"]["url"]
             try:
                 description = get_image_description(image_url, llm, vision_details)
-                returned_messages.append({"role": msg["role"], "content": description})
+                normalized_msg = dict(msg)
+                normalized_msg["content"] = description
+                returned_messages.append(normalized_msg)
             except Exception:
                 raise Exception(f"Error while downloading {image_url}.")
         else:

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -115,6 +115,53 @@ class TestPromptOverridesCustomInstructions:
         assert "config-level instructions" in user_prompt
 
 
+class TestContentBlockNormalization:
+    def test_add_flattens_text_only_content_blocks_when_vision_is_disabled(self, mocker):
+        _setup_mocks(mocker)
+        memory = Memory()
+        memory._add_to_vector_store = MagicMock(return_value=[{"id": "1"}])
+
+        result = memory.add(
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "First line"},
+                        {"type": "text", "text": "Second line"},
+                    ],
+                }
+            ],
+            user_id="user-1",
+        )
+
+        assert result == {"results": [{"id": "1"}]}
+        normalized_messages = memory._add_to_vector_store.call_args.args[0]
+        assert normalized_messages == [{"role": "user", "content": "First line\nSecond line"}]
+
+    @pytest.mark.asyncio
+    async def test_async_add_flattens_text_only_content_blocks_when_vision_is_disabled(self, mocker):
+        _setup_mocks(mocker)
+        memory = AsyncMemory()
+        memory._add_to_vector_store = mocker.AsyncMock(return_value=[{"id": "1"}])
+
+        result = await memory.add(
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "First line"},
+                        {"type": "text", "text": "Second line"},
+                    ],
+                }
+            ],
+            user_id="user-1",
+        )
+
+        assert result == {"results": [{"id": "1"}]}
+        normalized_messages = memory._add_to_vector_store.call_args.args[0]
+        assert normalized_messages == [{"role": "user", "content": "First line\nSecond line"}]
+
+
 class TestAsyncUpdate:
     @pytest.fixture
     def mock_async_memory(self, mocker):


### PR DESCRIPTION
## Summary

This fixes a crash in the Python SDK when `Memory.add()` or `AsyncMemory.add()` receives OpenAI-style text content blocks while vision is disabled.

## What changed

- Normalize text-only content block lists into plain text before further message processing.
- Preserve the existing vision-enabled path for multimodal list content.
- Add sync and async regression tests covering the non-vision behavior.

## Root cause

`parse_vision_messages()` treated any list-shaped `content` as image-oriented multimodal input. When vision was disabled, that path still attempted to generate an image description with `llm=None`, which raised an `AttributeError` instead of handling text blocks safely.

## Impact

- Text-only content blocks no longer crash the add flow when vision is off.
- OpenAI-compatible content block payloads degrade gracefully to plain text in non-vision mode.
- Existing multimodal behavior remains unchanged when vision is enabled.

## Validation

- Ran `python -m pytest tests/memory/test_main.py`
- Result: `36 passed`
