### PR TITLE
feat(oss): opt-in parallel entity-boost in Memory.search() — 2-4x recall speedup

### DIFF
--- a/mem0-ts/src/oss/src/config/manager.ts
+++ b/mem0-ts/src/oss/src/config/manager.ts
@@ -155,6 +155,7 @@ export class ConfigManager {
       })(),
       disableHistory:
         userConfig.disableHistory || DEFAULT_MEMORY_CONFIG.disableHistory,
+      parallelEntityBoost: userConfig.parallelEntityBoost === true,
     };
 
     // Validate the merged config

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -1164,7 +1164,13 @@ export class Memory {
         if (deduped.length > 0) {
           const entityStore = await this.getEntityStore();
 
-          for (const entity of deduped) {
+          // Per-entity worker. Writes to entityBoosts via Math.max, which is
+          // order-independent under interleaved single-threaded JS writes,
+          // so this is safe to run sequentially or concurrently.
+          const processEntity = async (entity: {
+            type: string;
+            text: string;
+          }): Promise<void> => {
             try {
               const entityEmbedding = await this.embedder.embed(entity.text);
               const matches = await entityStore.search(
@@ -1200,6 +1206,21 @@ export class Memory {
               }
             } catch (e) {
               // Individual entity boost failed — continue
+            }
+          };
+
+          if (this.config.parallelEntityBoost) {
+            // Opt-in: fire entity embeds + lookups concurrently. For remote
+            // embedders (e.g. ollama over network) this turns N+1 sequential
+            // RTTs into ~1 RTT, giving 2-4x recall speedup. Backend must
+            // handle concurrent embed requests (multi-slot ollama, managed
+            // embed APIs, etc.).
+            await Promise.all(deduped.map(processEntity));
+          } else {
+            // Default: preserve prior sequential behavior to avoid surprising
+            // users on rate-limited or single-slot embedder backends.
+            for (const entity of deduped) {
+              await processEntity(entity);
             }
           }
         }

--- a/mem0-ts/src/oss/src/types/index.ts
+++ b/mem0-ts/src/oss/src/types/index.ts
@@ -69,6 +69,14 @@ export interface MemoryConfig {
   disableHistory?: boolean;
   historyDbPath?: string;
   customInstructions?: string;
+  /**
+   * When true, run the entity-boost embed+search loop in Memory.search()
+   * concurrently via Promise.all instead of sequential await. Speeds up
+   * recall by 2-4x with remote embedders. Default: false (preserves prior
+   * behavior). Safe to enable when the embedder backend handles concurrent
+   * requests well (multi-slot ollama, managed embed APIs, batched backends).
+   */
+  parallelEntityBoost?: boolean;
 }
 
 export interface MemoryItem {
@@ -142,4 +150,5 @@ export const MemoryConfigSchema = z.object({
     })
     .optional(),
   disableHistory: z.boolean().optional(),
+  parallelEntityBoost: z.boolean().optional(),
 });


### PR DESCRIPTION
# feat(oss): opt-in parallel entity-boost in Memory.search() — 2-4x recall speedup with remote embedders

## Problem

`Memory.search()` runs the entity-boost computation as a sequential `for...await` loop:

```ts
for (const entity of deduped) {
  const entityEmbedding = await this.embedder.embed(entity.text);  // SEQUENTIAL
  const matches = await entityStore.search(entityEmbedding, 500, ...);
  // accumulate boosts...
}
```

With remote embedders this becomes the dominant latency. We measured a single
`recall` for an entity-rich query (9 entities) taking **~6.5 seconds**, with
~95% of that time spent waiting on serial embed RTTs.

The block has up to 8 iterations (`.slice(0, 8)`) plus the initial query embed,
so worst case is **9 sequential embedder.embed() calls** per search.

This regressed real production latency for us when v3.0.0 added the multi-signal
hybrid retrieval (entity boost). Before v3.0.0 a single `Memory.search()` did
exactly one embed call.

## Fix

Add an opt-in config flag `parallelEntityBoost` (default: `false`, preserves
upstream behavior). When `true`, the entity-boost loop runs via
`Promise.all(deduped.map(...))`.

Safety: each iteration writes to `entityBoosts[memId] = Math.max(prev, boost)`.
This is order-independent and safe under JS's single-threaded event loop —
interleaved Promise resolutions cannot race because each `Math.max + assign`
is one synchronous block per microtask.

Default kept at `false` to:
- preserve back-compat for users with rate-limited embedders (e.g. tight
  OpenAI plans, single-slot ollama)
- avoid surprise behavior change in 1-1 patch upgrades

Users with parallel-friendly embedders (managed services, multi-slot ollama,
batched embedder backends) opt in via:

```ts
const memory = new Memory({
  ...,
  parallelEntityBoost: true,
});
```

## Measurements

Reproduced on production setup: ollama embed:latest (qwen3-embedding 4B Q4) on
RTX 5090 with `OLLAMA_NUM_PARALLEL=2`, accessed via WireGuard tunnel
(~218ms RTT), through a multi-threaded HTTP proxy.

Same prompts, same Qdrant collection (~15k memories), same gateway process —
only difference is `parallelEntityBoost` flag flipped:

| prompt (chars) | embed_calls | sequential ms | parallel ms | **speedup** |
|---|---|---|---|---|
| 320 (entity-rich) | 7 | 5852 | 2089 | **2.80x** |
| 475 (entity-rich) | 9 | 6561 | 1595 | **4.11x** |
| 821 (long+entity) | 9 | 6595 | 2557 | **2.58x** |
| 633 (entity-rich, agent dev) | 9 | 6669 | 2540 | **2.63x** |

Sequential `embed_ms` (sum of all per-call durations) ≈ wallclock `total_ms`
in baseline (each call blocks the next). Parallel `embed_ms` (sum) is
2-3x larger than wallclock — direct evidence the calls overlap.

For prompts that extract no entities (≤1 embed call, common for short
conversational queries), behavior is identical — no regression possible
since the patched branch is only entered when `deduped.length > 0`.

## Files changed

- `mem0-ts/src/oss/src/types/index.ts` — add `parallelEntityBoost` to
  `MemoryConfigSchema`
- `mem0-ts/src/oss/src/config/manager.ts` — propagate the flag through
  `ConfigManager.mergeConfig` (default `false`)
- `mem0-ts/src/oss/src/memory/index.ts` — gate the entity-boost loop on
  `this.config.parallelEntityBoost`

## Backward compatibility

- Default is `false` → identical to current behavior
- Flag is `optional` in schema → existing configs validate unchanged
- No public API surface change for users who don't opt in
- No dependency changes
