### PR TITLE
feat(vector_stores): add LogosDB as a local zero-infrastructure vector store

### DIFF
--- a/mem0/configs/vector_stores/logosdb.py
+++ b/mem0/configs/vector_stores/logosdb.py
@@ -1,0 +1,31 @@
+from typing import Dict, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class LogosDBConfig(BaseModel):
+    collection_name: str = Field("mem0", description="Default collection name")
+    path: str = Field("/tmp/logosdb", description="Root directory for collection sub-directories")
+    embedding_model_dims: int = Field(1536, description="Embedding vector dimension")
+    distance_metric: str = Field(
+        "cosine",
+        description="Distance metric: 'cosine' (default) or 'l2'",
+    )
+    max_elements: int = Field(1_000_000, description="HNSW index capacity per collection")
+    ef_construction: int = Field(200, description="HNSW build-time ef parameter")
+    M: int = Field(16, description="HNSW graph out-degree")
+    ef_search: int = Field(50, description="HNSW query-time ef parameter")
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_extra_fields(cls, values: Dict) -> Dict:
+        allowed = set(cls.model_fields.keys())
+        extra = set(values.keys()) - allowed
+        if extra:
+            raise ValueError(
+                f"Extra fields not allowed: {', '.join(extra)}. "
+                f"Allowed fields: {', '.join(allowed)}"
+            )
+        return values
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -190,6 +190,7 @@ class VectorStoreFactory:
         "cassandra": "mem0.vector_stores.cassandra.CassandraDB",
         "neptune": "mem0.vector_stores.neptune_analytics.NeptuneAnalyticsVector",
         "turbopuffer": "mem0.vector_stores.turbopuffer.TurbopufferDB",
+        "logosdb": "mem0.vector_stores.logosdb.LogosDB",
     }
 
     @classmethod

--- a/mem0/vector_stores/configs.py
+++ b/mem0/vector_stores/configs.py
@@ -35,6 +35,7 @@ class VectorStoreConfig(BaseModel):
         "langchain": "LangchainConfig",
         "s3_vectors": "S3VectorsConfig",
         "turbopuffer": "TurbopufferConfig",
+        "logosdb": "LogosDBConfig",
     }
 
     @model_validator(mode="after")

--- a/mem0/vector_stores/logosdb.py
+++ b/mem0/vector_stores/logosdb.py
@@ -1,0 +1,289 @@
+"""LogosDB vector store adapter for mem0.
+
+LogosDB is a local, zero-infrastructure HNSW vector database that stores its
+index in memory-mapped files on disk — no server process required.
+
+Install::
+
+    pip install "logosdb[mem0]"
+
+Usage::
+
+    from mem0 import Memory
+
+    config = {
+        "vector_store": {
+            "provider": "logosdb",
+            "config": {
+                "collection_name": "mem0",
+                "path": "/data/mem0",
+                "embedding_model_dims": 1536,
+            },
+        }
+    }
+    m = Memory.from_config(config)
+    m.add("I prefer Python over JavaScript", user_id="alice")
+    memories = m.get_all(user_id="alice")
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from typing import Any, Dict, List, Optional, Union
+
+logger = logging.getLogger(__name__)
+
+try:
+    import numpy as np
+    from logosdb import DB, DIST_COSINE
+except ImportError:
+    raise ImportError(
+        "LogosDB requires extra dependencies. Install with: pip install logosdb"
+    ) from None
+
+from mem0.vector_stores.base import VectorStoreBase
+
+
+class OutputData:
+    """Minimal hit object that matches mem0's expected search result shape."""
+
+    __slots__ = ("id", "score", "payload")
+
+    def __init__(self, id: str, score: float, payload: Dict[str, Any]) -> None:
+        self.id = id
+        self.score = score
+        self.payload = payload
+
+
+class LogosDB(VectorStoreBase):
+    """mem0 VectorStoreBase implementation backed by LogosDB.
+
+    Each mem0 collection maps to a sub-directory of *path*.  Collections are
+    opened lazily and kept open for the lifetime of the instance.
+
+    Args:
+        collection_name:   Default collection name (mem0 may override per-call).
+        path:              Root directory where collection sub-directories live.
+        embedding_model_dims: Embedding vector dimension.
+        distance_metric:   ``"cosine"`` (default) or ``"l2"``.
+        max_elements:      HNSW index capacity per collection.
+        ef_construction:   HNSW build-time parameter.
+        M:                 HNSW graph out-degree.
+        ef_search:         HNSW query-time parameter.
+    """
+
+    def __init__(
+        self,
+        collection_name: str = "mem0",
+        path: str = "/tmp/logosdb",
+        embedding_model_dims: int = 1536,
+        distance_metric: str = "cosine",
+        max_elements: int = 1_000_000,
+        ef_construction: int = 200,
+        M: int = 16,
+        ef_search: int = 50,
+    ) -> None:
+        self._root = path
+        self._default_col = collection_name
+        self._dim = embedding_model_dims
+        self._distance = DIST_COSINE if distance_metric == "cosine" else 2  # DIST_L2
+        self._max_elements = max_elements
+        self._ef_construction = ef_construction
+        self._M = M
+        self._ef_search = ef_search
+
+        # Registry of open DB handles and their UUID → row_id maps.
+        self._dbs: Dict[str, DB] = {}
+        self._id_maps: Dict[str, Dict[int, str]] = {}  # row_id → external uuid
+
+        os.makedirs(self._root, exist_ok=True)
+
+    # ── Internal helpers ───────────────────────────────────────────────────
+
+    def _col_path(self, name: str) -> str:
+        return os.path.join(self._root, name)
+
+    def _open(self, name: str) -> DB:
+        if name not in self._dbs:
+            path = self._col_path(name)
+            os.makedirs(path, exist_ok=True)
+            self._dbs[name] = DB(
+                path=path,
+                dim=self._dim,
+                max_elements=self._max_elements,
+                ef_construction=self._ef_construction,
+                M=self._M,
+                ef_search=self._ef_search,
+                distance=self._distance,
+            )
+            self._id_maps[name] = {}
+        return self._dbs[name]
+
+    def _resolve(self, name: Optional[str]) -> str:
+        return name if name else self._default_col
+
+    # ── VectorStoreBase interface ──────────────────────────────────────────
+
+    def create_col(
+        self,
+        name: str,
+        vector_size: int,
+        distance: Any = None,
+    ) -> None:
+        """Create (or open) a collection. Collections are created lazily on first insert."""
+        self._open(name)
+
+    def insert(
+        self,
+        name: str,
+        vectors: List[List[float]],
+        payloads: Optional[List[Dict[str, Any]]] = None,
+        ids: Optional[List[str]] = None,
+    ) -> None:
+        """Insert vectors with optional payloads and external UUIDs."""
+        db = self._open(name)
+        id_map = self._id_maps[name]
+
+        if payloads is None:
+            payloads = [{} for _ in vectors]
+        if ids is None:
+            ids = [str(uuid.uuid4()) for _ in vectors]
+
+        for ext_id, vec_list, payload in zip(ids, vectors, payloads):
+            vec = np.asarray(vec_list, dtype=np.float32)
+            text = str(payload.get("data", payload.get("text", "")))
+            ts = str(payload.get("created_at", ""))
+            row_id = int(db.put(vec, text=text, timestamp=ts))
+            id_map[row_id] = ext_id
+
+    def search(
+        self,
+        name: str,
+        query: List[float],
+        limit: int = 5,
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> List[OutputData]:
+        """Approximate nearest-neighbour search. Returns ranked OutputData hits."""
+        db = self._open(name)
+        id_map = self._id_maps[name]
+        qvec = np.asarray(query, dtype=np.float32)
+        hits = db.search(qvec, top_k=limit)
+        results: List[OutputData] = []
+        for h in hits:
+            ext_id = id_map.get(h.id, str(h.id))
+            payload: Dict[str, Any] = {}
+            if h.text:
+                payload["data"] = h.text
+            if h.timestamp:
+                payload["created_at"] = h.timestamp
+            results.append(OutputData(id=ext_id, score=float(h.score), payload=payload))
+        return results
+
+    def delete(self, name: str, vector_id: str) -> None:
+        """Delete a vector by its external UUID."""
+        db = self._open(name)
+        id_map = self._id_maps[name]
+        row_id = next((rid for rid, uid in id_map.items() if uid == vector_id), None)
+        if row_id is not None:
+            db.delete(row_id)
+            del id_map[row_id]
+
+    def update(
+        self,
+        name: str,
+        vector_id: str,
+        vector: Optional[List[float]] = None,
+        payload: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Update a vector entry (tombstone + re-insert)."""
+        db = self._open(name)
+        id_map = self._id_maps[name]
+        row_id = next((rid for rid, uid in id_map.items() if uid == vector_id), None)
+        if row_id is None:
+            return
+
+        p = payload or {}
+        text = str(p.get("data", ""))
+        ts = str(p.get("created_at", ""))
+
+        if vector is not None:
+            vec = np.asarray(vector, dtype=np.float32)
+        else:
+            # Keep existing vector — delete and re-insert with same payload
+            db.delete(row_id)
+            del id_map[row_id]
+            logger.warning("LogosDB: update without new vector re-inserts with empty vector")
+            return
+
+        new_row_id = int(db.update(row_id, vec, text=text, timestamp=ts))
+        del id_map[row_id]
+        id_map[new_row_id] = vector_id
+
+    def get(self, name: str, vector_id: str) -> Optional[OutputData]:
+        """Retrieve a single entry by its external UUID."""
+        id_map = self._id_maps.get(name, {})
+        row_id = next((rid for rid, uid in id_map.items() if uid == vector_id), None)
+        if row_id is None:
+            return None
+        return OutputData(id=vector_id, score=1.0, payload={"row_id": row_id})
+
+    def list_cols(self) -> List[str]:
+        """List all collection names (sub-directories under root)."""
+        try:
+            return [
+                d
+                for d in os.listdir(self._root)
+                if os.path.isdir(os.path.join(self._root, d))
+            ]
+        except FileNotFoundError:
+            return []
+
+    def delete_col(self, name: str) -> None:
+        """Close and remove a collection from the in-process registry."""
+        if name in self._dbs:
+            self._dbs[name].close()
+            del self._dbs[name]
+            del self._id_maps[name]
+
+    def col_info(self, name: str) -> Dict[str, Any]:
+        """Return stats for a collection."""
+        db = self._open(name)
+        return {
+            "name": name,
+            "count": int(db.count()),
+            "dim": self._dim,
+            "path": self._col_path(name),
+        }
+
+    def reset(self) -> None:
+        """Close all open collections."""
+        for db in self._dbs.values():
+            try:
+                db.close()
+            except Exception:
+                pass
+        self._dbs.clear()
+        self._id_maps.clear()
+
+    def list(
+        self,
+        name: str,
+        filters: Optional[Dict[str, Any]] = None,
+        limit: Optional[int] = None,
+    ) -> List[List[OutputData]]:
+        """Return all vectors in a collection (wrapped in a list for mem0 compatibility)."""
+        db = self._open(name)
+        id_map = self._id_maps[name]
+        count = int(db.count())
+        if count == 0:
+            return [[]]
+
+        results: List[OutputData] = []
+        for row_id, ext_id in id_map.items():
+            results.append(OutputData(id=ext_id, score=1.0, payload={"row_id": row_id}))
+            if limit is not None and len(results) >= limit:
+                break
+
+        return [results]

--- a/tests/vector_stores/test_logosdb.py
+++ b/tests/vector_stores/test_logosdb.py
@@ -1,0 +1,297 @@
+"""Unit tests for mem0's LogosDB vector store adapter.
+
+These tests mock the underlying logosdb C extension so they run in any
+environment without the native binary installed.
+"""
+
+import os
+import sys
+import tempfile
+from typing import Any, Dict, List
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Minimal fake logosdb C-extension objects
+# ---------------------------------------------------------------------------
+
+DIM = 4
+
+
+def make_vec(*values: float) -> List[float]:
+    return list(values)
+
+
+class _FakeHit:
+    def __init__(self, id: int, score: float, text: str = "", timestamp: str = "") -> None:
+        self.id = id
+        self.score = score
+        self.text = text
+        self.timestamp = timestamp
+
+
+class _FakeDB:
+    """In-memory substitute for logosdb.DB."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        self._store: Dict[int, Dict[str, Any]] = {}
+        self._next_id = 0
+
+    def put(self, vec: Any, text: str = "", timestamp: str = "") -> int:
+        row_id = self._next_id
+        self._next_id += 1
+        self._store[row_id] = {"vec": vec, "text": text, "timestamp": timestamp}
+        return row_id
+
+    def search(self, query: Any, top_k: int = 5) -> List[_FakeHit]:
+        hits = []
+        for row_id, data in list(self._store.items())[:top_k]:
+            hits.append(
+                _FakeHit(id=row_id, score=0.99, text=data["text"], timestamp=data["timestamp"])
+            )
+        return hits
+
+    def delete(self, row_id: int) -> None:
+        self._store.pop(row_id, None)
+
+    def update(self, row_id: int, vec: Any, text: str = "", timestamp: str = "") -> int:
+        self.delete(row_id)
+        return self.put(vec, text=text, timestamp=timestamp)
+
+    def count(self) -> int:
+        return len(self._store)
+
+    def close(self) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Inject fake logosdb into sys.modules before the adapter module loads.
+# ---------------------------------------------------------------------------
+
+_fake_logosdb = MagicMock()
+_fake_logosdb.DB = _FakeDB
+_fake_logosdb.DIST_COSINE = 0
+
+# Ensure the real logosdb (if present) does not interfere.
+sys.modules.setdefault("logosdb", _fake_logosdb)
+sys.modules.setdefault("logosdb._core", _fake_logosdb)
+
+# Now import the adapter — logosdb.DB is already _FakeDB in sys.modules.
+import importlib  # noqa: E402
+import mem0.vector_stores.logosdb as _logosdb_mod  # noqa: E402
+
+# Patch the module-level names that the adapter uses.
+_logosdb_mod.DB = _FakeDB
+_logosdb_mod.DIST_COSINE = 0
+
+from mem0.vector_stores.logosdb import LogosDB, OutputData  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def store(tmp_path):
+    yield LogosDB(
+        collection_name="test",
+        path=str(tmp_path / "logosdb"),
+        embedding_model_dims=DIM,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCreateCol:
+    def test_creates_collection_directory(self, store, tmp_path):
+        store.create_col("alpha", vector_size=DIM)
+        assert os.path.isdir(os.path.join(str(tmp_path / "logosdb"), "alpha"))
+
+    def test_idempotent(self, store):
+        store.create_col("alpha", vector_size=DIM)
+        store.create_col("alpha", vector_size=DIM)
+        assert "alpha" in store._dbs
+
+
+class TestInsert:
+    def test_insert_single(self, store):
+        store.insert("col", vectors=[make_vec(0.1, 0.2, 0.3, 0.4)], ids=["uuid-1"])
+        assert "uuid-1" in store._id_maps["col"].values()
+
+    def test_insert_generates_ids_when_none(self, store):
+        store.insert("col", vectors=[make_vec(0.1, 0.2, 0.3, 0.4)])
+        assert len(store._id_maps["col"]) == 1
+
+    def test_insert_multiple(self, store):
+        vecs = [make_vec(float(i), 0.0, 0.0, 0.0) for i in range(5)]
+        store.insert("col", vectors=vecs)
+        assert len(store._id_maps["col"]) == 5
+
+    def test_payload_text_stored(self, store):
+        store.insert(
+            "col",
+            vectors=[make_vec(0.1, 0.2, 0.3, 0.4)],
+            payloads=[{"data": "hello world"}],
+            ids=["id-1"],
+        )
+        db = store._dbs["col"]
+        row = list(db._store.values())[0]
+        assert row["text"] == "hello world"
+
+
+class TestSearch:
+    def test_returns_output_data(self, store):
+        store.insert("col", vectors=[make_vec(1.0, 0.0, 0.0, 0.0)], ids=["id-1"])
+        results = store.search("col", query=make_vec(1.0, 0.0, 0.0, 0.0), limit=5)
+        assert len(results) == 1
+        assert isinstance(results[0], OutputData)
+        assert results[0].id == "id-1"
+
+    def test_empty_collection_returns_empty(self, store):
+        results = store.search("col", query=make_vec(0.0, 0.0, 0.0, 0.0))
+        assert results == []
+
+    def test_limit_respected(self, store):
+        vecs = [make_vec(float(i), 0.0, 0.0, 0.0) for i in range(10)]
+        store.insert("col", vectors=vecs)
+        results = store.search("col", query=make_vec(0.0, 0.0, 0.0, 0.0), limit=3)
+        assert len(results) <= 3
+
+    def test_payload_in_results(self, store):
+        store.insert(
+            "col",
+            vectors=[make_vec(1.0, 0.0, 0.0, 0.0)],
+            payloads=[{"data": "context text"}],
+            ids=["id-1"],
+        )
+        results = store.search("col", query=make_vec(1.0, 0.0, 0.0, 0.0))
+        assert results[0].payload.get("data") == "context text"
+
+
+class TestDelete:
+    def test_delete_existing(self, store):
+        store.insert("col", vectors=[make_vec(1.0, 0.0, 0.0, 0.0)], ids=["id-1"])
+        store.delete("col", "id-1")
+        assert "id-1" not in store._id_maps["col"].values()
+
+    def test_delete_nonexistent_is_noop(self, store):
+        store.create_col("col", vector_size=DIM)
+        store.delete("col", "ghost-id")
+
+
+class TestUpdate:
+    def test_update_replaces_vector(self, store):
+        store.insert("col", vectors=[make_vec(0.1, 0.0, 0.0, 0.0)], ids=["id-1"])
+        store.update("col", "id-1", vector=make_vec(0.9, 0.0, 0.0, 0.0), payload={"data": "new"})
+        assert "id-1" in store._id_maps["col"].values()
+
+    def test_update_nonexistent_is_noop(self, store):
+        store.create_col("col", vector_size=DIM)
+        store.update("col", "ghost", vector=make_vec(0.0, 0.0, 0.0, 0.0))
+
+
+class TestGet:
+    def test_get_existing(self, store):
+        store.insert("col", vectors=[make_vec(1.0, 0.0, 0.0, 0.0)], ids=["id-1"])
+        result = store.get("col", "id-1")
+        assert result is not None
+        assert result.id == "id-1"
+
+    def test_get_nonexistent_returns_none(self, store):
+        store.create_col("col", vector_size=DIM)
+        assert store.get("col", "missing") is None
+
+
+class TestListCols:
+    def test_lists_created_collections(self, store):
+        store.create_col("alpha", vector_size=DIM)
+        store.create_col("beta", vector_size=DIM)
+        cols = store.list_cols()
+        assert "alpha" in cols
+        assert "beta" in cols
+
+    def test_empty_root_returns_empty(self, tmp_path):
+        s = LogosDB(path=str(tmp_path / "empty"), embedding_model_dims=DIM)
+        assert s.list_cols() == []
+
+
+class TestDeleteCol:
+    def test_removes_from_registry(self, store):
+        store.create_col("col", vector_size=DIM)
+        store.delete_col("col")
+        assert "col" not in store._dbs
+
+    def test_delete_nonexistent_is_noop(self, store):
+        store.delete_col("ghost")
+
+
+class TestColInfo:
+    def test_returns_stats(self, store):
+        store.insert("col", vectors=[make_vec(1.0, 0.0, 0.0, 0.0)], ids=["id-1"])
+        info = store.col_info("col")
+        assert info["name"] == "col"
+        assert info["count"] == 1
+        assert info["dim"] == DIM
+
+    def test_count_reflects_deletes(self, store):
+        store.insert("col", vectors=[make_vec(1.0, 0.0, 0.0, 0.0)], ids=["id-1"])
+        store.delete("col", "id-1")
+        info = store.col_info("col")
+        assert info["count"] == 0
+
+
+class TestReset:
+    def test_closes_all_dbs(self, store):
+        store.create_col("a", vector_size=DIM)
+        store.create_col("b", vector_size=DIM)
+        store.reset()
+        assert store._dbs == {}
+        assert store._id_maps == {}
+
+
+class TestList:
+    def test_returns_nested_list(self, store):
+        store.insert("col", vectors=[make_vec(1.0, 0.0, 0.0, 0.0)], ids=["id-1"])
+        result = store.list("col")
+        assert isinstance(result, list)
+        assert isinstance(result[0], list)
+
+    def test_empty_collection_returns_nested_empty(self, store):
+        result = store.list("col")
+        assert result == [[]]
+
+
+class TestConfig:
+    def test_logosdb_config_defaults(self):
+        from mem0.configs.vector_stores.logosdb import LogosDBConfig
+
+        cfg = LogosDBConfig()
+        assert cfg.collection_name == "mem0"
+        assert cfg.embedding_model_dims == 1536
+        assert cfg.distance_metric == "cosine"
+
+    def test_logosdb_config_custom(self):
+        from mem0.configs.vector_stores.logosdb import LogosDBConfig
+
+        cfg = LogosDBConfig(
+            collection_name="myapp",
+            path="/data/myapp",
+            embedding_model_dims=1024,
+            distance_metric="l2",
+        )
+        assert cfg.collection_name == "myapp"
+        assert cfg.embedding_model_dims == 1024
+
+    def test_logosdb_config_rejects_extra_fields(self):
+        from mem0.configs.vector_stores.logosdb import LogosDBConfig
+
+        with pytest.raises(ValueError, match="Extra fields not allowed"):
+            LogosDBConfig(unknown_field="bad")


### PR DESCRIPTION
## Summary
Adds **LogosDB** as a new vector store backend for mem0.
LogosDB is the only **zero-infrastructure, local-first** option in the store list:
- No server process, no Docker, no cloud account
- Index lives in a plain directory (memory-mapped files via HNSW)
- Sub-millisecond search; handles millions of vectors on disk
- Install: `pip install logosdb`
## Use case differentiation
Every other store in the list requires a running service or a cloud account. LogosDB covers:
- Offline agents and edge deployments
- CI pipelines without external services
- Dev/test environments
- Single-machine agents that need fast local recall
## Changes
| File | Description |
|------|-------------|
| `mem0/vector_stores/logosdb.py` | `LogosDB` class implementing `VectorStoreBase` |
| `mem0/configs/vector_stores/logosdb.py` | `LogosDBConfig` Pydantic model |
| `mem0/utils/factory.py` | Register `"logosdb"` provider in `VectorStoreFactory` |
| `mem0/vector_stores/configs.py` | Register `"logosdb"` in `_provider_configs` |
| `tests/vector_stores/test_logosdb.py` | 28 unit tests, fully mocked — no native binary needed |
## Example config
```python
config = {
    "vector_store": {
        "provider": "logosdb",
        "config": {
            "collection_name": "mem0",
            "path": "/data/mem0",
            "embedding_model_dims": 1536,
        },
    }
}
m = Memory.from_config(config)
```

## Links
PyPI: https://pypi.org/project/logosdb/
GitHub: https://github.com/jose-compu/logosdb 