### PR TITLE
fix: force LF line endings on shell scripts and Dockerfiles

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Default: let Git decide, except where line endings matter for execution.
+* text=auto
+
+# Shell scripts and Dockerfiles must use LF — they are executed inside Linux
+# containers and CRLF line endings break the shebang on a Windows checkout.
+*.sh         text eol=lf
+Dockerfile*  text eol=lf
+entrypoint.* text eol=lf


### PR DESCRIPTION
## Linked Issue

N/A — small build-environment fix; happy to file an issue if maintainers prefer.

## Description

On a Windows checkout with `core.autocrlf=true` (the Git for Windows default), shell scripts in this repo end up with CRLF line terminators. The `openmemory-ui` image then fails to start with a misleading error because the kernel reads the shebang as `#!/bin/sh\r`:

```
exec /home/nextjs/entrypoint.sh: no such file or directory
```

The file exists; only the line endings are wrong, and the kernel is looking for the non-existent binary `/bin/sh\r`.

This PR adds a top-level `.gitattributes` that pins shell scripts, Dockerfiles, and `entrypoint.*` to LF regardless of the host's autocrlf setting:

```
* text=auto
*.sh         text eol=lf
Dockerfile*  text eol=lf
entrypoint.* text eol=lf
```

Non-Windows checkouts are unaffected — the working copy already had LF; only the `.gitattributes` file is new.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A.

## Test Coverage

- [x] I tested manually
- [x] No tests needed (build-environment fix)

Reproduce on a Windows host **before** the fix:

```powershell
git clone https://github.com/mem0ai/mem0
cd mem0/openmemory
file ui/entrypoint.sh   # → "POSIX shell script ... with CRLF line terminators"
docker compose up openmemory-ui
# → "exec /home/nextjs/entrypoint.sh: no such file or directory"
```

After the fix (clean clone with `.gitattributes` in tree):

```powershell
git clone https://github.com/mem0ai/mem0
cd mem0/openmemory
file ui/entrypoint.sh   # → no CRLF mention
docker compose up openmemory-ui
# → starts successfully on http://localhost:3000
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (manual repro above)
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (no doc change needed)
