### PR TITLE
feat(openmemory): make default LLM and embedder models configurable via env vars

### DIFF
--- a/openmemory/api/app/routers/config.py
+++ b/openmemory/api/app/routers/config.py
@@ -48,6 +48,9 @@ class ConfigSchema(BaseModel):
 
 def get_default_configuration():
     """Get the default configuration with sensible defaults for LLM and embedder."""
+    import os
+    llm_model = os.getenv("LLM_MODEL", "gpt-4o-mini")
+    embedder_model = os.getenv("EMBEDDER_MODEL", "text-embedding-3-small")
     return {
         "openmemory": {
             "custom_instructions": None
@@ -56,7 +59,7 @@ def get_default_configuration():
             "llm": {
                 "provider": "openai",
                 "config": {
-                    "model": "gpt-4o-mini",
+                    "model": llm_model,
                     "temperature": 0.1,
                     "max_tokens": 2000,
                     "api_key": "env:OPENAI_API_KEY"
@@ -65,7 +68,7 @@ def get_default_configuration():
             "embedder": {
                 "provider": "openai",
                 "config": {
-                    "model": "text-embedding-3-small",
+                    "model": embedder_model,
                     "api_key": "env:OPENAI_API_KEY"
                 }
             },


### PR DESCRIPTION
## Linked Issue

N/A — small QoL improvement; happy to file an issue if maintainers prefer.

## Description

`openmemory/api/app/routers/config.py:get_default_configuration` previously hard-coded the default model names:

* LLM: `gpt-4o-mini`
* Embedder: `text-embedding-3-small`

Operators using a non-OpenAI provider — Azure OpenAI with custom deployment names, a litellm proxy that routes to a different model, or a self-hosted endpoint exposed via the OpenAI-compatible interface — currently have to fork the file or do a runtime DB-config edit to change the defaults seen by a fresh install.

This PR keeps the existing defaults but reads `LLM_MODEL` and `EMBEDDER_MODEL` env vars first, so operators can change them from `.env` (which is already mounted into the `openmemory-mcp` container) without touching source:

```python
import os
llm_model = os.getenv("LLM_MODEL", "gpt-4o-mini")
embedder_model = os.getenv("EMBEDDER_MODEL", "text-embedding-3-small")
```

No public API change. Existing installs see identical behavior because the env-var defaults match the previous literals.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Breaking Changes

N/A — new env vars default to the previous hard-coded values.

## Test Coverage

- [x] I tested manually

Reproduce:

```bash
# Default — unchanged behavior:
curl http://localhost:8765/api/v1/config/default
# → "model": "gpt-4o-mini", "model": "text-embedding-3-small"

# With override:
LLM_MODEL=gpt-4o EMBEDDER_MODEL=text-embedding-3-large \
  docker compose up openmemory-mcp
curl http://localhost:8765/api/v1/config/default
# → "model": "gpt-4o", "model": "text-embedding-3-large"
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (manual repro above)
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed — happy to add `LLM_MODEL` / `EMBEDDER_MODEL` to `openmemory/api/.env.example` as a follow-up commit on this PR if maintainers prefer.
