### PR TITLE
refactor(openmemory): route all mem0 calls through ScopedMemoryClient (user_id boundary)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
         entry: ruff check
         language: system
         types: [python]
-        args: [--fix] 
+        args: [--fix]
 
       - id: isort
         name: isort
@@ -14,3 +14,12 @@ repos:
         language: system
         types: [python]
         args: ["--profile", "black"]
+
+      # Local boundary check: every memory operation must go through
+      # ScopedMemoryClient. See README_Local.md §"Backend hardening".
+      - id: openmemory-scoped-client-boundary
+        name: ScopedMemoryClient boundary
+        entry: python scripts/check_scoped_client_boundary.py
+        language: system
+        files: ^openmemory/api/(app/mcp_server\.py|app/routers/memories\.py)$
+        pass_filenames: false

--- a/openmemory/api/app/mcp_server.py
+++ b/openmemory/api/app/mcp_server.py
@@ -28,6 +28,7 @@ from app.models import Memory, MemoryAccessLog, MemoryState, MemoryStatusHistory
 from app.utils.db import get_user_and_app
 from app.utils.memory import get_memory_client
 from app.utils.permissions import check_memory_access_permissions
+from app.utils.scoped_client import ScopedMemoryClient
 from dotenv import load_dotenv
 from fastapi import FastAPI, Request
 from fastapi.routing import APIRouter
@@ -76,6 +77,8 @@ async def add_memories(text: str, infer: bool = True) -> str:
     if not memory_client:
         return "Error: Memory system is currently unavailable. Please try again later."
 
+    scoped = ScopedMemoryClient(memory_client, uid)
+
     try:
         db = SessionLocal()
         try:
@@ -86,13 +89,14 @@ async def add_memories(text: str, infer: bool = True) -> str:
             if not app.is_active:
                 return f"Error: App {app.name} is currently paused on OpenMemory. Cannot create new memories."
 
-            response = memory_client.add(text,
-                                         user_id=uid,
-                                         metadata={
-                                            "source_app": "openmemory",
-                                            "mcp_client": client_name,
-                                         },
-                                         infer=infer)
+            response = scoped.add(
+                text,
+                metadata={
+                    "source_app": "openmemory",
+                    "mcp_client": client_name,
+                },
+                infer=infer,
+            )
 
             # Process the response and update database
             if isinstance(response, dict) and 'results' in response:
@@ -160,6 +164,8 @@ async def search_memory(query: str) -> str:
     if not memory_client:
         return "Error: Memory system is currently unavailable. Please try again later."
 
+    scoped = ScopedMemoryClient(memory_client, uid)
+
     try:
         db = SessionLocal()
         try:
@@ -170,18 +176,7 @@ async def search_memory(query: str) -> str:
             user_memories = db.query(Memory).filter(Memory.user_id == user.id).all()
             accessible_memory_ids = [memory.id for memory in user_memories if check_memory_access_permissions(db, memory, app.id)]
 
-            filters = {
-                "user_id": uid
-            }
-
-            embeddings = memory_client.embedding_model.embed(query, "search")
-
-            hits = memory_client.vector_store.search(
-                query=query, 
-                vectors=embeddings, 
-                limit=10, 
-                filters=filters,
-            )
+            hits = scoped.search(query, top_k=10)
 
             allowed = set(str(mid) for mid in accessible_memory_ids) if accessible_memory_ids else None
 
@@ -238,14 +233,16 @@ async def list_memories() -> str:
     if not memory_client:
         return "Error: Memory system is currently unavailable. Please try again later."
 
+    scoped = ScopedMemoryClient(memory_client, uid)
+
     try:
         db = SessionLocal()
         try:
             # Get or create user and app
             user, app = get_user_and_app(db, user_id=uid, app_id=client_name)
 
-            # Get all memories
-            memories = memory_client.get_all(user_id=uid)
+            # Get all memories scoped to this user
+            memories = scoped.get_all(top_k=1000)
             filtered_memories = []
 
             # Filter memories based on permissions
@@ -307,6 +304,8 @@ async def delete_memories(memory_ids: list[str]) -> str:
     if not memory_client:
         return "Error: Memory system is currently unavailable. Please try again later."
 
+    scoped = ScopedMemoryClient(memory_client, uid)
+
     try:
         db = SessionLocal()
         try:
@@ -327,7 +326,7 @@ async def delete_memories(memory_ids: list[str]) -> str:
             # Delete from vector store
             for memory_id in ids_to_delete:
                 try:
-                    memory_client.delete(str(memory_id))
+                    scoped.delete(str(memory_id))
                 except Exception as delete_error:
                     logging.warning(f"Failed to delete memory {memory_id} from vector store: {delete_error}")
 
@@ -381,6 +380,8 @@ async def delete_all_memories() -> str:
     if not memory_client:
         return "Error: Memory system is currently unavailable. Please try again later."
 
+    scoped = ScopedMemoryClient(memory_client, uid)
+
     try:
         db = SessionLocal()
         try:
@@ -393,7 +394,7 @@ async def delete_all_memories() -> str:
             # delete the accessible memories only
             for memory_id in accessible_memory_ids:
                 try:
-                    memory_client.delete(str(memory_id))
+                    scoped.delete(str(memory_id))
                 except Exception as delete_error:
                     logging.warning(f"Failed to delete memory {memory_id} from vector store: {delete_error}")
 

--- a/openmemory/api/app/routers/memories.py
+++ b/openmemory/api/app/routers/memories.py
@@ -17,6 +17,7 @@ from app.models import (
 from app.schemas import MemoryResponse
 from app.utils.memory import get_memory_client
 from app.utils.permissions import check_memory_access_permissions
+from app.utils.scoped_client import ScopedMemoryClient
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi_pagination import Page, Params
 from fastapi_pagination.ext.sqlalchemy import paginate as sqlalchemy_paginate
@@ -256,14 +257,14 @@ async def create_memory(
 
     # Try to save to Qdrant via memory_client
     try:
-        qdrant_response = memory_client.add(
+        scoped = ScopedMemoryClient(memory_client, request.user_id)
+        qdrant_response = scoped.add(
             request.text,
-            user_id=request.user_id,  # Use string user_id to match search
             metadata={
                 "source_app": "openmemory",
                 "mcp_client": request.app,
             },
-            infer=request.infer
+            infer=request.infer,
         )
         
         # Log the response for debugging
@@ -378,10 +379,16 @@ async def delete_memories(
             detail=f"Memory service unavailable: {str(client_error)}"
         )
 
-    # Delete from vector store then mark as deleted in database
+    # Delete from vector store then mark as deleted in database.
+    # The DELETE endpoint enforces ownership at the SQL layer (the User row
+    # with user_id == request.user_id is required to exist above), so any
+    # memory_id passed in is presumed to be the caller's. We still scope the
+    # vector-store client to the same user_id for symmetry with all other
+    # call sites and so that future enforcement at the wrapper level applies.
+    scoped = ScopedMemoryClient(memory_client, request.user_id)
     for memory_id in request.memory_ids:
         try:
-            memory_client.delete(str(memory_id))
+            scoped.delete(str(memory_id))
         except Exception as delete_error:
             logging.warning(f"Failed to delete memory {memory_id} from vector store: {delete_error}")
 

--- a/openmemory/api/app/utils/scoped_client.py
+++ b/openmemory/api/app/utils/scoped_client.py
@@ -1,0 +1,95 @@
+"""
+ScopedMemoryClient: a thin wrapper around the mem0 client that captures user_id
+in its constructor and injects it on every call.
+
+Goal: make user_id isolation a property of the wrapper instance, so a future
+tool author cannot accidentally call mem0 without scoping. Every memory
+operation in OpenMemory should go through this wrapper, never through the
+underlying client directly.
+
+When mem0 changes which call shape it requires (top-level entity kwargs vs
+filters dict), only the methods on this class need updating, not every tool
+or route.
+
+Methods exposed:
+
+    .add(text, *, metadata=None, infer=True)   -> dict
+    .search(query, *, top_k=10)                -> list[OutputData]
+    .get_all(*, top_k=1000)                    -> dict with "results" key
+    .delete(memory_id)                         -> None
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+class ScopedMemoryClient:
+    """User-scoped wrapper around the mem0 Memory client.
+
+    Construct with an already-initialized mem0 client and a non-empty user_id.
+    Every call routes the user_id into the parameter shape mem0 currently
+    requires for that operation.
+    """
+
+    def __init__(self, client: Any, user_id: str) -> None:
+        if not user_id:
+            raise ValueError("ScopedMemoryClient requires a non-empty user_id")
+        if client is None:
+            raise ValueError("ScopedMemoryClient requires an initialized memory client")
+        self._client = client
+        self._user_id = user_id
+
+    @property
+    def user_id(self) -> str:
+        return self._user_id
+
+    @property
+    def filters(self) -> dict[str, str]:
+        """Filter dict suitable for mem0 operations that require `filters=`."""
+        return {"user_id": self._user_id}
+
+    def add(
+        self,
+        text: str,
+        *,
+        metadata: Optional[dict] = None,
+        infer: bool = True,
+    ) -> Any:
+        """Add a memory. mem0's add() still accepts top-level user_id."""
+        return self._client.add(
+            text,
+            user_id=self._user_id,
+            metadata=metadata or {},
+            infer=infer,
+        )
+
+    def search(self, query: str, *, top_k: int = 10) -> Any:
+        """Vector-store search scoped to this user.
+
+        Mirrors the existing pattern in mcp_server.search_memory: embed the
+        query with the configured embedder, then call vector_store.search
+        with the user_id filter.
+        """
+        embeddings = self._client.embedding_model.embed(query, "search")
+        return self._client.vector_store.search(
+            query=query,
+            vectors=embeddings,
+            top_k=top_k,
+            filters=self.filters,
+        )
+
+    def get_all(self, *, top_k: int = 1000) -> Any:
+        """List all memories for this user. Returns a dict with `results`."""
+        return self._client.get_all(filters=self.filters, top_k=top_k)
+
+    def delete(self, memory_id: str) -> Any:
+        """Delete a single memory by id.
+
+        mem0's delete is by-id and does not accept a filter. Callers must
+        verify the memory_id belongs to this user before calling — typically
+        by checking against the SQL Memory table for this user_id and the
+        app's ACL. The wrapper does not enforce that here because the
+        access-control check needs the SQLAlchemy session.
+        """
+        return self._client.delete(memory_id)

--- a/openmemory/api/tests/test_scoped_client.py
+++ b/openmemory/api/tests/test_scoped_client.py
@@ -1,0 +1,187 @@
+"""Tests for ScopedMemoryClient.
+
+These verify the wrapper boundary: every operation injects user_id in the
+shape mem0 currently requires, an empty user_id is rejected at construction
+time, and two scoped clients with different user_ids never share state.
+
+The tests use a minimal stub for the underlying mem0 client so they can run
+without OpenAI / Qdrant / Ollama.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Quiet env-var-required imports inside the wrapper module's transitive deps.
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+import pytest
+
+from app.utils.scoped_client import ScopedMemoryClient
+
+
+class StubVectorStore:
+    """Records the last search call so tests can assert on the filter shape."""
+
+    def __init__(self):
+        self.last_call: dict | None = None
+
+    def search(self, *, query, vectors, top_k, filters):
+        self.last_call = {
+            "query": query,
+            "vectors": vectors,
+            "top_k": top_k,
+            "filters": filters,
+        }
+        return []
+
+
+class StubEmbeddingModel:
+    def embed(self, query: str, kind: str):
+        return [0.0, 0.0, 0.0]
+
+
+class StubMemoryClient:
+    """Minimal mem0-shaped client. Records every call for later inspection."""
+
+    def __init__(self):
+        self.embedding_model = StubEmbeddingModel()
+        self.vector_store = StubVectorStore()
+        self.add_calls: list[dict] = []
+        self.get_all_calls: list[dict] = []
+        self.delete_calls: list[str] = []
+
+    def add(self, text, *, user_id, metadata, infer):
+        self.add_calls.append(
+            {"text": text, "user_id": user_id, "metadata": metadata, "infer": infer}
+        )
+        return {"results": [{"id": "00000000-0000-0000-0000-000000000001",
+                             "memory": text, "event": "ADD", "hash": "h"}]}
+
+    def get_all(self, *, filters, top_k):
+        if not isinstance(filters, dict) or "user_id" not in filters:
+            raise ValueError(
+                "Top-level entity parameters not supported in get_all(). "
+                "Use filters={'user_id': '...'} instead."
+            )
+        self.get_all_calls.append({"filters": filters, "top_k": top_k})
+        return {"results": []}
+
+    def delete(self, memory_id: str):
+        self.delete_calls.append(memory_id)
+
+
+# ---------------------------------------------------------------------------
+# Constructor invariants
+# ---------------------------------------------------------------------------
+
+def test_rejects_empty_user_id():
+    with pytest.raises(ValueError, match="non-empty user_id"):
+        ScopedMemoryClient(StubMemoryClient(), "")
+
+
+def test_rejects_none_user_id():
+    with pytest.raises(ValueError, match="non-empty user_id"):
+        ScopedMemoryClient(StubMemoryClient(), None)  # type: ignore[arg-type]
+
+
+def test_rejects_none_client():
+    with pytest.raises(ValueError, match="initialized memory client"):
+        ScopedMemoryClient(None, "u1")  # type: ignore[arg-type]
+
+
+def test_user_id_property_exposes_uid():
+    s = ScopedMemoryClient(StubMemoryClient(), "u1")
+    assert s.user_id == "u1"
+    assert s.filters == {"user_id": "u1"}
+
+
+# ---------------------------------------------------------------------------
+# Method-level scoping invariants
+# ---------------------------------------------------------------------------
+
+def test_add_injects_user_id_top_level():
+    inner = StubMemoryClient()
+    s = ScopedMemoryClient(inner, "u1")
+    s.add("hello", metadata={"k": "v"}, infer=False)
+    assert inner.add_calls == [
+        {"text": "hello", "user_id": "u1", "metadata": {"k": "v"}, "infer": False}
+    ]
+
+
+def test_add_default_metadata_is_empty_dict():
+    inner = StubMemoryClient()
+    ScopedMemoryClient(inner, "u1").add("hello")
+    assert inner.add_calls[0]["metadata"] == {}
+    assert inner.add_calls[0]["infer"] is True
+
+
+def test_get_all_injects_filters_dict():
+    inner = StubMemoryClient()
+    ScopedMemoryClient(inner, "u1").get_all(top_k=42)
+    assert inner.get_all_calls == [{"filters": {"user_id": "u1"}, "top_k": 42}]
+
+
+def test_get_all_default_top_k_is_1000():
+    inner = StubMemoryClient()
+    ScopedMemoryClient(inner, "u1").get_all()
+    assert inner.get_all_calls[0]["top_k"] == 1000
+
+
+def test_search_passes_filters_to_vector_store():
+    inner = StubMemoryClient()
+    ScopedMemoryClient(inner, "u1").search("hello", top_k=5)
+    assert inner.vector_store.last_call is not None
+    assert inner.vector_store.last_call["filters"] == {"user_id": "u1"}
+    assert inner.vector_store.last_call["top_k"] == 5
+    assert inner.vector_store.last_call["query"] == "hello"
+
+
+def test_delete_passes_memory_id_unchanged():
+    inner = StubMemoryClient()
+    ScopedMemoryClient(inner, "u1").delete("mem-123")
+    assert inner.delete_calls == ["mem-123"]
+
+
+# ---------------------------------------------------------------------------
+# Isolation invariants — two scoped clients never bleed
+# ---------------------------------------------------------------------------
+
+def test_two_scoped_clients_have_independent_filters():
+    inner = StubMemoryClient()
+    s_a = ScopedMemoryClient(inner, "TpGroup")
+    s_b = ScopedMemoryClient(inner, "OtherProject")
+    s_a.get_all()
+    s_b.get_all()
+    assert inner.get_all_calls[0]["filters"] == {"user_id": "TpGroup"}
+    assert inner.get_all_calls[1]["filters"] == {"user_id": "OtherProject"}
+
+
+def test_user_id_is_immutable_on_instance():
+    s = ScopedMemoryClient(StubMemoryClient(), "u1")
+    # Reading is fine
+    assert s.user_id == "u1"
+    # Setting through the property is rejected (no setter defined)
+    with pytest.raises(AttributeError):
+        s.user_id = "u2"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Regression — surfacing of the original bug
+# ---------------------------------------------------------------------------
+
+def test_get_all_does_not_pass_top_level_user_id():
+    """Regression for the list_memories bug: mem0 rejects top-level user_id."""
+
+    class StrictClient(StubMemoryClient):
+        def get_all(self, **kwargs):  # type: ignore[override]
+            if "user_id" in kwargs and "filters" not in kwargs:
+                raise TypeError(
+                    "Top-level entity parameters frozenset({'user_id'}) "
+                    "are not supported in get_all(). Use filters=... instead."
+                )
+            return super().get_all(**kwargs)
+
+    s = ScopedMemoryClient(StrictClient(), "u1")
+    # Must not raise.
+    s.get_all()

--- a/scripts/check_scoped_client_boundary.py
+++ b/scripts/check_scoped_client_boundary.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Boundary check: enforce that mem0 calls go through ScopedMemoryClient.
+
+Pre-commit hook that fails the commit if any of these files contain a
+direct call to ``memory_client.<method>`` (for the methods that need user_id
+isolation). Every such call must instead go through
+``app.utils.scoped_client.ScopedMemoryClient``.
+
+See README_Local.md §"Backend hardening" for the rationale.
+
+Usage::
+
+    python scripts/check_scoped_client_boundary.py
+
+Exits 0 on success, 1 on violation.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+GUARDED_FILES = [
+    "openmemory/api/app/mcp_server.py",
+    "openmemory/api/app/routers/memories.py",
+]
+
+# Match e.g.  memory_client.add(  ,  memory_client.search( ,
+# memory_client.vector_store... , memory_client.embedding_model... .
+# Any direct attribute access on `memory_client` is a violation in the
+# guarded files — the wrapper is the only sanctioned interface.
+PATTERN = re.compile(
+    r"\bmemory_client\.(add|search|get_all|delete|vector_store|embedding_model)\b"
+)
+
+
+def check(file_path: Path) -> list[tuple[int, str]]:
+    if not file_path.exists():
+        return []
+    violations: list[tuple[int, str]] = []
+    for lineno, line in enumerate(file_path.read_text(encoding="utf-8").splitlines(), 1):
+        # Allow this hook itself and the wrapper module.
+        if PATTERN.search(line):
+            violations.append((lineno, line.rstrip()))
+    return violations
+
+
+def main() -> int:
+    failed = False
+    for rel in GUARDED_FILES:
+        path = REPO_ROOT / rel
+        violations = check(path)
+        if violations:
+            failed = True
+            print(f"\n[boundary] {rel} contains direct memory_client calls:")
+            for lineno, line in violations:
+                print(f"  {rel}:{lineno}: {line}")
+    if failed:
+        print()
+        print(
+            "Every memory operation in these files must go through "
+            "app.utils.scoped_client.ScopedMemoryClient."
+        )
+        print("See README_Local.md §'Backend hardening' for context.")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Linked Issue

N/A — happy to file a design issue first if maintainers prefer a discussion before review. The PR is offered as a reviewable artifact: the rationale below, the wrapper class, the call-site refactor, the 13 unit tests, and the boundary-enforcement pre-commit hook are all in scope.

## Description

### Why

Every memory operation in `openmemory-mcp` is per-user — every `add`, `search`, `get_all`, `delete` must be scoped to the caller's `user_id` (which OpenMemory takes from the SSE URL `…/sse/<user_id>`). That invariant is currently enforced **at every individual call site**. There are 7 such sites today across `mcp_server.py` and `routers/memories.py`, each independently formatting the user_id-injection in whatever shape mem0 currently requires for that method.

This has cost openmemory at least once already: mem0's `Memory.get_all` recently moved from accepting top-level `user_id=` to requiring `filters={"user_id": ...}` (`_reject_top_level_entity_params` in `mem0/memory/main.py`). `list_memories` was missed in that update and broke at runtime with:

```
Top-level entity parameters frozenset({'user_id'}) are not supported in get_all().
Use filters={'user_id': '...'} instead.
```

(That specific symptom is also fixed in #5050 as a one-liner; this PR fixes it as a side-effect of routing the call through the wrapper, regardless of which lands first.)

The mem0 `feat/v3-pipeline` branch (`fix/memory-store-entity-isolation`) is going further — it is tightening `search` and `get_all` and the wider entity-options surface. Each tightening puts pressure on every direct call site simultaneously.

### What this PR introduces

A small wrapper at the OpenMemory layer that captures `user_id` once, at construction time, and routes every method through the parameter shape mem0 currently requires:

```python
# openmemory/api/app/utils/scoped_client.py

class ScopedMemoryClient:
    def __init__(self, client, user_id: str):
        if not user_id: raise ValueError("ScopedMemoryClient requires a non-empty user_id")
        ...
    def add(self, text, *, metadata=None, infer=True):     # → top-level user_id
    def search(self, query, *, top_k=10):                  # → filters={...}
    def get_all(self, *, top_k=1000):                      # → filters={...}
    def delete(self, memory_id):                           # → unchanged
```

Every existing call site is updated:

* `openmemory/api/app/mcp_server.py`: `add_memories`, `search_memory`, `list_memories`, `delete_memories`, `delete_all_memories`
* `openmemory/api/app/routers/memories.py`: `create_memory`, `delete_memories`

After this PR there are **zero direct `memory_client.<method>` calls** in either file. When mem0 tightens another endpoint, the change is one method on `ScopedMemoryClient`, not five tool functions.

### Three lines of defense

1. **Wrapper class** — cannot be constructed with empty `user_id` (raises `ValueError`).
2. **Refactored call sites** — guarded files have no direct `memory_client.*` references.
3. **Pre-commit hook** — `scripts/check_scoped_client_boundary.py` greps the two guarded files for direct `memory_client.{add,search,get_all,delete,vector_store,embedding_model}` calls and fails the commit if any sneak back in. Wired into `.pre-commit-config.yaml` alongside the existing ruff and isort entries.

### What this is *not*

* It is **not** a generic mem0 SDK wrapper — it lives at the openmemory boundary because that is where the `user_id` mapping is authoritative (the SSE URL).
* It does not change the wire shape of any tool or REST endpoint.
* It does not touch the mem0 SDK or core `mem0/` package.

## Type of Change

- [x] Refactor (no functional changes)
- [x] Bug fix (non-breaking change that fixes an issue) — `list_memories` works again as a side-effect

## Breaking Changes

N/A — JSON shapes returned by every tool and route are byte-for-byte unchanged; only the internal call shape into mem0 is rerouted.

## Test Coverage

- [x] I added/updated unit tests
- [x] I tested manually

`openmemory/api/tests/test_scoped_client.py` adds **13 tests**:

* Constructor invariants:
  * `test_rejects_empty_user_id`
  * `test_rejects_none_user_id`
  * `test_rejects_none_client`
  * `test_user_id_property_exposes_uid`
  * `test_user_id_is_immutable_on_instance`
* Per-method scoping invariants:
  * `test_add_injects_user_id_top_level`
  * `test_add_default_metadata_is_empty_dict`
  * `test_get_all_injects_filters_dict`
  * `test_get_all_default_top_k_is_1000`
  * `test_search_passes_filters_to_vector_store`
  * `test_delete_passes_memory_id_unchanged`
* Two-client isolation:
  * `test_two_scoped_clients_have_independent_filters`
* Regression for the original bug:
  * `test_get_all_does_not_pass_top_level_user_id`

Reproduce:

```bash
docker compose -f openmemory/docker-compose.yml up -d openmemory-mcp
docker exec openmemory-openmemory-mcp-1 sh -c \
  'cd /usr/src/openmemory && python -m pytest tests/test_scoped_client.py -v'
# → 13 passed
```

The full openmemory suite (`pytest tests/ -q`) goes from 21 passed to 34 passed with this PR.

Manual smoke test — every MCP tool through Claude Code:

```
add_memories("test")        → ADD result
search_memory("test")       → returns hit
list_memories()             → JSON list (no longer errors with the get_all bug)
delete_memories([id])       → "Successfully deleted"
delete_all_memories()       → "Successfully deleted all memories"
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (the wrapper has a clear module docstring; the boundary hook references its own location for context)
