### PR TITLE
feat(openmemory): multi-user view (UserSelector + /api/v1/users + all-users sentinel)

### DIFF
--- a/openmemory/api/app/routers/__init__.py
+++ b/openmemory/api/app/routers/__init__.py
@@ -3,5 +3,6 @@ from .backup import router as backup_router
 from .config import router as config_router
 from .memories import router as memories_router
 from .stats import router as stats_router
+from .users import router as users_router
 
-__all__ = ["memories_router", "apps_router", "stats_router", "config_router", "backup_router"]
+__all__ = ["memories_router", "apps_router", "stats_router", "config_router", "backup_router", "users_router"]

--- a/openmemory/api/app/routers/memories.py
+++ b/openmemory/api/app/routers/memories.py
@@ -34,6 +34,23 @@ def get_memory_or_404(db: Session, memory_id: UUID) -> Memory:
     return memory
 
 
+def resolve_user_or_none(db: Session, user_id: Optional[str]) -> Optional[User]:
+    """Resolve a user_id string to a User row, or None for the all-users view.
+
+    Pass None or an empty string for the all-users (admin) scope: read-only
+    listing endpoints will skip the per-user filter entirely.
+
+    If a non-empty user_id is provided but no such User exists, raises 404 —
+    this preserves the previous behavior for scoped queries.
+    """
+    if not user_id:
+        return None
+    user = db.query(User).filter(User.user_id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
+
+
 def update_memory_state(db: Session, memory_id: UUID, new_state: MemoryState, user_id: UUID):
     memory = get_memory_or_404(db, memory_id)
     old_state = memory.state
@@ -100,7 +117,10 @@ def get_accessible_memory_ids(db: Session, app_id: UUID) -> Set[UUID]:
 # List all memories with filtering
 @router.get("/", response_model=Page[MemoryResponse])
 async def list_memories(
-    user_id: str,
+    user_id: Optional[str] = Query(
+        None,
+        description="Scope to a single user_id. Pass empty string or omit for all-users (admin) view.",
+    ),
     app_id: Optional[UUID] = None,
     from_date: Optional[int] = Query(
         None,
@@ -119,17 +139,18 @@ async def list_memories(
     sort_direction: Optional[str] = Query(None, description="Sort direction (asc or desc)"),
     db: Session = Depends(get_db)
 ):
-    user = db.query(User).filter(User.user_id == user_id).first()
-    if not user:
-        raise HTTPException(status_code=404, detail="User not found")
+    user = resolve_user_or_none(db, user_id)
 
     # Build base query
     query = db.query(Memory).filter(
-        Memory.user_id == user.id,
         Memory.state != MemoryState.deleted,
         Memory.state != MemoryState.archived,
         Memory.content.ilike(f"%{search_query}%") if search_query else True
     )
+
+    # Apply per-user scoping unless this is the all-users view.
+    if user is not None:
+        query = query.filter(Memory.user_id == user.id)
 
     # Apply filters
     if app_id:
@@ -188,19 +209,23 @@ async def list_memories(
 # Get all categories
 @router.get("/categories")
 async def get_categories(
-    user_id: str,
+    user_id: Optional[str] = Query(
+        None,
+        description="Scope to a single user_id. Pass empty string or omit for all-users (admin) view.",
+    ),
     db: Session = Depends(get_db)
 ):
-    user = db.query(User).filter(User.user_id == user_id).first()
-    if not user:
-        raise HTTPException(status_code=404, detail="User not found")
+    user = resolve_user_or_none(db, user_id)
 
-    # Get unique categories associated with the user's memories
-    # Get all memories
-    memories = db.query(Memory).filter(Memory.user_id == user.id, Memory.state != MemoryState.deleted, Memory.state != MemoryState.archived).all()
-    # Get all categories from memories
+    # Get unique categories associated with the user's memories.
+    query = db.query(Memory).filter(
+        Memory.state != MemoryState.deleted,
+        Memory.state != MemoryState.archived,
+    )
+    if user is not None:
+        query = query.filter(Memory.user_id == user.id)
+    memories = query.all()
     categories = [category for memory in memories for category in memory.categories]
-    # Get unique categories
     unique_categories = list(set(categories))
 
     return {
@@ -530,7 +555,7 @@ async def update_memory(
     return memory
 
 class FilterMemoriesRequest(BaseModel):
-    user_id: str
+    user_id: Optional[str] = None
     page: int = 1
     size: int = 10
     search_query: Optional[str] = None
@@ -547,15 +572,15 @@ async def filter_memories(
     request: FilterMemoriesRequest,
     db: Session = Depends(get_db)
 ):
-    user = db.query(User).filter(User.user_id == request.user_id).first()
-    if not user:
-        raise HTTPException(status_code=404, detail="User not found")
+    user = resolve_user_or_none(db, request.user_id)
 
     # Build base query
     query = db.query(Memory).filter(
-        Memory.user_id == user.id,
         Memory.state != MemoryState.deleted,
     )
+
+    if user is not None:
+        query = query.filter(Memory.user_id == user.id)
 
     # Filter archived memories based on show_archived parameter
     if not request.show_archived:
@@ -639,30 +664,32 @@ async def filter_memories(
 @router.get("/{memory_id}/related", response_model=Page[MemoryResponse])
 async def get_related_memories(
     memory_id: UUID,
-    user_id: str,
+    user_id: Optional[str] = Query(
+        None,
+        description="Scope to a single user_id. Pass empty string or omit for all-users (admin) view.",
+    ),
     params: Params = Depends(),
     db: Session = Depends(get_db)
 ):
-    # Validate user
-    user = db.query(User).filter(User.user_id == user_id).first()
-    if not user:
-        raise HTTPException(status_code=404, detail="User not found")
-    
+    user = resolve_user_or_none(db, user_id)
+
     # Get the source memory
     memory = get_memory_or_404(db, memory_id)
-    
+
     # Extract category IDs from the source memory
     category_ids = [category.id for category in memory.categories]
-    
+
     if not category_ids:
         return Page.create([], total=0, params=params)
-    
+
     # Build query for related memories
     query = db.query(Memory).distinct(Memory.id).filter(
-        Memory.user_id == user.id,
         Memory.id != memory_id,
         Memory.state != MemoryState.deleted
-    ).join(Memory.categories).filter(
+    )
+    if user is not None:
+        query = query.filter(Memory.user_id == user.id)
+    query = query.join(Memory.categories).filter(
         Category.id.in_(category_ids)
     ).options(
         joinedload(Memory.categories),

--- a/openmemory/api/app/routers/users.py
+++ b/openmemory/api/app/routers/users.py
@@ -1,0 +1,67 @@
+"""Distinct-users endpoint.
+
+Lists every user_id that owns at least one non-deleted memory, with a count
+and last-activity timestamp. Used by the Web UI to render a User facet
+parallel to the existing App facet, so that operators running multiple
+projects against the same OpenMemory instance can switch scope visually
+instead of relying on the URL alone.
+"""
+
+from datetime import datetime
+from typing import Optional
+
+from app.database import get_db
+from app.models import Memory, MemoryState, User
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+router = APIRouter(prefix="/api/v1/users", tags=["users"])
+
+
+class UserStats(BaseModel):
+    user_id: str
+    memory_count: int
+    last_active_at: Optional[datetime]
+
+
+@router.get("/", response_model=list[UserStats])
+async def list_users(
+    include_empty: bool = False,
+    db: Session = Depends(get_db),
+):
+    """List users with their memory counts.
+
+    By default returns only users that own at least one non-deleted memory.
+    Pass ``include_empty=true`` to also list users that exist in the User
+    table but currently have no live memories.
+    """
+    rows = (
+        db.query(
+            User.user_id.label("user_id"),
+            func.count(Memory.id).label("memory_count"),
+            func.max(Memory.updated_at).label("last_active_at"),
+        )
+        .outerjoin(
+            Memory,
+            (Memory.user_id == User.id) & (Memory.state != MemoryState.deleted),
+        )
+        .group_by(User.user_id)
+        .all()
+    )
+
+    results = [
+        UserStats(
+            user_id=row.user_id,
+            memory_count=int(row.memory_count or 0),
+            last_active_at=row.last_active_at,
+        )
+        for row in rows
+    ]
+
+    if not include_empty:
+        results = [r for r in results if r.memory_count > 0]
+
+    results.sort(key=lambda r: (-r.memory_count, r.user_id))
+    return results

--- a/openmemory/api/main.py
+++ b/openmemory/api/main.py
@@ -5,7 +5,7 @@ from app.config import DEFAULT_APP_ID, USER_ID
 from app.database import Base, SessionLocal, engine
 from app.mcp_server import setup_mcp_server
 from app.models import App, User
-from app.routers import apps_router, backup_router, config_router, memories_router, stats_router
+from app.routers import apps_router, backup_router, config_router, memories_router, stats_router, users_router
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi_pagination import add_pagination
@@ -84,6 +84,7 @@ app.include_router(apps_router)
 app.include_router(stats_router)
 app.include_router(config_router)
 app.include_router(backup_router)
+app.include_router(users_router)
 
 # Add pagination support
 add_pagination(app)

--- a/openmemory/api/tests/test_memories_router.py
+++ b/openmemory/api/tests/test_memories_router.py
@@ -1,0 +1,284 @@
+"""Router-level tests for /api/v1/memories/* covering both:
+
+  * the existing scoped-by-user_id semantics (regression — must not break),
+  * the new all-users sentinel semantics (empty / missing user_id returns
+    memories from every user).
+
+The tests use an in-memory SQLite database and FastAPI's dependency-override
+mechanism to avoid touching the real openmemory.db. They seed two distinct
+users (UserA, UserB) each with their own memories so the difference between
+"scoped" and "all-users" is observable.
+"""
+
+from __future__ import annotations
+
+import os
+from uuid import uuid4
+
+# Quiet env-var-required imports inside transitive deps.
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi_pagination import add_pagination
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base, get_db
+from app.models import App, Memory, MemoryState, User
+from app.routers import memories as memories_router_module
+from app.routers.memories import resolve_user_or_none, router as memories_router
+
+# ---------------------------------------------------------------------------
+# Test infra
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def db_session():
+    """Fresh in-memory SQLite session per test."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(bind=engine)
+    TestSession = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    session = TestSession()
+    try:
+        yield session
+    finally:
+        session.close()
+        engine.dispose()
+
+
+@pytest.fixture
+def seeded_db(db_session):
+    """Two users, each with two active memories under one app."""
+    user_a = User(id=uuid4(), user_id="UserA", name="A")
+    user_b = User(id=uuid4(), user_id="UserB", name="B")
+    db_session.add_all([user_a, user_b])
+    db_session.flush()
+
+    app_a = App(id=uuid4(), name="claude", owner_id=user_a.id)
+    app_b = App(id=uuid4(), name="claude", owner_id=user_b.id)
+    db_session.add_all([app_a, app_b])
+    db_session.flush()
+
+    db_session.add_all([
+        Memory(id=uuid4(), user_id=user_a.id, app_id=app_a.id,
+               content="A-mem-1", state=MemoryState.active),
+        Memory(id=uuid4(), user_id=user_a.id, app_id=app_a.id,
+               content="A-mem-2", state=MemoryState.active),
+        Memory(id=uuid4(), user_id=user_b.id, app_id=app_b.id,
+               content="B-mem-1", state=MemoryState.active),
+        Memory(id=uuid4(), user_id=user_b.id, app_id=app_b.id,
+               content="B-mem-2", state=MemoryState.active),
+        # Soft-deleted: must never appear in any result.
+        Memory(id=uuid4(), user_id=user_a.id, app_id=app_a.id,
+               content="A-deleted", state=MemoryState.deleted),
+    ])
+    db_session.commit()
+    return db_session
+
+
+@pytest.fixture
+def test_app(seeded_db):
+    """FastAPI app with the memories router and get_db wired to seeded_db."""
+    app = FastAPI()
+    app.include_router(memories_router)
+    add_pagination(app)
+
+    def _override_get_db():
+        try:
+            yield seeded_db
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = _override_get_db
+    return app
+
+
+@pytest_asyncio.fixture
+async def client(test_app):
+    transport = ASGITransport(app=test_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+# ---------------------------------------------------------------------------
+# resolve_user_or_none — pure helper
+# ---------------------------------------------------------------------------
+
+def test_resolve_user_or_none_returns_none_for_empty_string(seeded_db):
+    assert resolve_user_or_none(seeded_db, "") is None
+
+
+def test_resolve_user_or_none_returns_none_for_none(seeded_db):
+    assert resolve_user_or_none(seeded_db, None) is None
+
+
+def test_resolve_user_or_none_returns_user_for_valid_id(seeded_db):
+    u = resolve_user_or_none(seeded_db, "UserA")
+    assert u is not None
+    assert u.user_id == "UserA"
+
+
+def test_resolve_user_or_none_raises_404_for_unknown(seeded_db):
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as ei:
+        resolve_user_or_none(seeded_db, "NoSuchUser")
+    assert ei.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/memories/ — list_memories
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_list_scoped_to_user_a_returns_only_user_a_memories(client):
+    resp = await client.get("/api/v1/memories/?user_id=UserA&size=50")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 2
+    contents = sorted(m["content"] for m in body["items"])
+    assert contents == ["A-mem-1", "A-mem-2"]
+
+
+@pytest.mark.asyncio
+async def test_list_scoped_to_user_b_returns_only_user_b_memories(client):
+    resp = await client.get("/api/v1/memories/?user_id=UserB&size=50")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 2
+    contents = sorted(m["content"] for m in body["items"])
+    assert contents == ["B-mem-1", "B-mem-2"]
+
+
+@pytest.mark.asyncio
+async def test_list_all_users_via_empty_user_id_returns_both(client):
+    """Empty user_id is the all-users sentinel: must include both users."""
+    resp = await client.get("/api/v1/memories/?user_id=&size=50")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 4  # 2 from A, 2 from B, deleted excluded
+    contents = sorted(m["content"] for m in body["items"])
+    assert contents == ["A-mem-1", "A-mem-2", "B-mem-1", "B-mem-2"]
+
+
+@pytest.mark.asyncio
+async def test_list_all_users_via_omitted_user_id_returns_both(client):
+    """Omitting user_id entirely is also the all-users sentinel."""
+    resp = await client.get("/api/v1/memories/?size=50")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 4
+
+
+@pytest.mark.asyncio
+async def test_list_unknown_user_id_still_returns_404(client):
+    """A non-empty but unknown user_id is a typo, not the all-users sentinel."""
+    resp = await client.get("/api/v1/memories/?user_id=NoSuchUser")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_list_does_not_include_deleted_memories_in_all_users_view(client):
+    resp = await client.get("/api/v1/memories/?user_id=&size=50")
+    assert resp.status_code == 200
+    body = resp.json()
+    contents = [m["content"] for m in body["items"]]
+    assert "A-deleted" not in contents
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/memories/categories
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_categories_scoped_returns_200_and_list_shape(client):
+    resp = await client.get("/api/v1/memories/categories?user_id=UserA")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "categories" in body and "total" in body
+
+
+@pytest.mark.asyncio
+async def test_categories_all_users_returns_200_and_list_shape(client):
+    resp = await client.get("/api/v1/memories/categories?user_id=")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "categories" in body and "total" in body
+
+
+@pytest.mark.asyncio
+async def test_categories_unknown_user_returns_404(client):
+    resp = await client.get("/api/v1/memories/categories?user_id=NoSuchUser")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/memories/filter
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_filter_scoped_to_user_a(client):
+    resp = await client.post("/api/v1/memories/filter",
+                             json={"user_id": "UserA", "page": 1, "size": 50})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 2
+    assert all("A-" in m["content"] for m in body["items"])
+
+
+@pytest.mark.asyncio
+async def test_filter_all_users_via_empty_user_id(client):
+    resp = await client.post("/api/v1/memories/filter",
+                             json={"user_id": "", "page": 1, "size": 50})
+    assert resp.status_code == 200
+    body = resp.json()
+    # /filter excludes only deleted by default; archived stays unless show_archived
+    # — our seed has no archived so all four active memories should appear.
+    assert body["total"] == 4
+
+
+@pytest.mark.asyncio
+async def test_filter_all_users_via_omitted_user_id(client):
+    resp = await client.post("/api/v1/memories/filter",
+                             json={"page": 1, "size": 50})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 4
+
+
+@pytest.mark.asyncio
+async def test_filter_unknown_user_returns_404(client):
+    resp = await client.post("/api/v1/memories/filter",
+                             json={"user_id": "NoSuchUser"})
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Scoped client wrapper invariant — the all-users mode is SQL-only and never
+# constructs a ScopedMemoryClient with empty user_id.
+# ---------------------------------------------------------------------------
+
+def test_scoped_client_still_rejects_empty_user_id_after_sentinel_added():
+    """The all-users mode is a SQL-side concern only.
+
+    ScopedMemoryClient — which is the boundary for any mem0 vector-store
+    operation — must continue to reject empty user_id, because mem0 vector
+    operations are always per-user. This test guards against the temptation
+    to "support all-users in the wrapper too" later on.
+    """
+    from app.utils.scoped_client import ScopedMemoryClient
+
+    class _AnyClient:
+        def add(self, *a, **kw): pass
+        def get_all(self, *a, **kw): pass
+        def delete(self, *a, **kw): pass
+
+    with pytest.raises(ValueError, match="non-empty user_id"):
+        ScopedMemoryClient(_AnyClient(), "")
+    with pytest.raises(ValueError, match="non-empty user_id"):
+        ScopedMemoryClient(_AnyClient(), None)  # type: ignore[arg-type]

--- a/openmemory/ui/app/memories/components/CreateMemoryDialog.tsx
+++ b/openmemory/ui/app/memories/components/CreateMemoryDialog.tsx
@@ -17,11 +17,23 @@ import { Loader2 } from "lucide-react";
 import { useMemoriesApi } from "@/hooks/useMemoriesApi";
 import { toast } from "sonner";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useSelector } from "react-redux";
+import { RootState } from "@/store/store";
 
 export function CreateMemoryDialog() {
   const { createMemory, isLoading, fetchMemories } = useMemoriesApi();
   const [open, setOpen] = useState(false);
   const textRef = useRef<HTMLTextAreaElement>(null);
+  // Empty user_id means the all-users (admin) view is active. Memories
+  // need an owner, so the create action is disabled in that mode.
+  const activeUserId = useSelector((state: RootState) => state.profile.userId);
+  const isAllUsers = activeUserId === "";
 
   const handleCreateMemory = async (text: string) => {
     try {
@@ -36,6 +48,31 @@ export function CreateMemoryDialog() {
       toast.error("Failed to create memory");
     }
   };
+
+  if (isAllUsers) {
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span>
+              <Button
+                variant="outline"
+                size="sm"
+                className="bg-primary/40 text-white cursor-not-allowed"
+                disabled
+              >
+                <GoPlus />
+                Create Memory
+              </Button>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>
+            Pick a specific user to add a memory.
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>

--- a/openmemory/ui/components/Navbar.tsx
+++ b/openmemory/ui/components/Navbar.tsx
@@ -13,6 +13,7 @@ import { useStats } from "@/hooks/useStats";
 import { useAppsApi } from "@/hooks/useAppsApi";
 import { Settings } from "lucide-react";
 import { useConfig } from "@/hooks/useConfig";
+import { UserSelector } from "@/components/UserSelector";
 
 export function Navbar() {
   const pathname = usePathname();
@@ -148,6 +149,7 @@ export function Navbar() {
           </Link>
         </div>
         <div className="flex items-center gap-4">
+          <UserSelector />
           <Button
             onClick={handleRefresh}
             variant="outline"

--- a/openmemory/ui/components/UserSelector.tsx
+++ b/openmemory/ui/components/UserSelector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Check, ChevronsUpDown, Users } from "lucide-react";
+import { Check, ChevronsUpDown, Globe, Users } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
@@ -12,6 +12,7 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
+  CommandSeparator,
 } from "@/components/ui/command";
 import {
   Popover,
@@ -26,6 +27,15 @@ import { AppDispatch, RootState } from "@/store/store";
 const STORAGE_KEY = "openmemory.activeUserId";
 
 /**
+ * Sentinel value the backend interprets as "all users (admin view)".
+ * Read-only memory listing endpoints accept it; create/delete still require
+ * a concrete user_id. See README_Local.md §"The User-id facet".
+ */
+const ALL_USERS = "";
+
+const ALL_USERS_LABEL = "All users (admin view)";
+
+/**
  * Combobox that switches the active user_id used by every API call.
  *
  * - Default value comes from NEXT_PUBLIC_USER_ID (the "primary" user the
@@ -34,24 +44,27 @@ const STORAGE_KEY = "openmemory.activeUserId";
  *   page load.
  * - Selecting a value dispatches setUserId on profileSlice — every hook
  *   that reads state.profile.userId re-fetches automatically.
- *
- * Note: the backend endpoints all require user_id, so an "All users" admin
- * view is intentionally not offered here. Multi-user aggregation needs
- * dedicated endpoints; see README_Local.md §"UI UserId facet".
+ * - The pinned "All users" item dispatches the empty-string sentinel,
+ *   which the read-only memory endpoints interpret as a multi-user view.
+ *   In all-users mode the create-memory action is disabled — see
+ *   CreateMemoryDialog.
  */
 export function UserSelector() {
   const dispatch = useDispatch<AppDispatch>();
   const activeUserId = useSelector((state: RootState) => state.profile.userId);
   const defaultUserId = process.env.NEXT_PUBLIC_USER_ID || "user";
 
-  const { users, isLoading } = useUsers(true);
+  // Hide users with zero live memories from the regular list — the env
+  // default is added back explicitly below so it's always reachable, and
+  // freshly-added users will appear once they have at least one memory.
+  const { users, isLoading } = useUsers(false);
   const [open, setOpen] = useState(false);
 
   // On first mount: hydrate from localStorage if it differs from the env default.
   useEffect(() => {
     if (typeof window === "undefined") return;
     const stored = window.localStorage.getItem(STORAGE_KEY);
-    if (stored && stored !== activeUserId) {
+    if (stored !== null && stored !== activeUserId) {
       dispatch(setUserId(stored));
     }
     // intentionally only on mount
@@ -66,6 +79,8 @@ export function UserSelector() {
     setOpen(false);
   };
 
+  const isAllUsers = activeUserId === ALL_USERS;
+
   // Always show the active user even if not yet in /api/v1/users (fresh user
   // with zero memories), and the env default at the bottom for quick reset.
   const visible = useMemo(() => {
@@ -75,7 +90,7 @@ export function UserSelector() {
       seen.add(u.user_id);
       merged.push({ user_id: u.user_id, memory_count: u.memory_count });
     }
-    if (!seen.has(activeUserId)) {
+    if (activeUserId && !seen.has(activeUserId)) {
       merged.unshift({ user_id: activeUserId, memory_count: 0 });
       seen.add(activeUserId);
     }
@@ -94,20 +109,46 @@ export function UserSelector() {
           role="combobox"
           aria-expanded={open}
           className="flex items-center gap-2 border-zinc-700/50 bg-zinc-900 hover:bg-zinc-800 min-w-[180px] justify-between"
-          aria-label={`Active user: ${activeUserId}`}
+          aria-label={isAllUsers ? "Active user: All users" : `Active user: ${activeUserId}`}
         >
           <span className="flex items-center gap-2 truncate">
-            <Users className="h-4 w-4 opacity-70" />
-            <span className="truncate">{activeUserId}</span>
+            {isAllUsers ? (
+              <Globe className="h-4 w-4 opacity-70" />
+            ) : (
+              <Users className="h-4 w-4 opacity-70" />
+            )}
+            <span className="truncate">
+              {isAllUsers ? "All users" : activeUserId}
+            </span>
           </span>
           <ChevronsUpDown className="h-4 w-4 opacity-50 shrink-0" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[260px] p-0" align="end">
+      <PopoverContent className="w-[280px] p-0" align="end">
         <Command>
           <CommandInput placeholder="Search users…" />
           <CommandList>
             <CommandEmpty>{isLoading ? "Loading…" : "No users found."}</CommandEmpty>
+            <CommandGroup heading="Scope">
+              <CommandItem
+                key="__all__"
+                value="__all_users__"
+                onSelect={() => choose(ALL_USERS)}
+                className="flex items-center justify-between"
+              >
+                <span className="flex items-center gap-2 min-w-0">
+                  <Check
+                    className={cn(
+                      "h-4 w-4",
+                      isAllUsers ? "opacity-100" : "opacity-0",
+                    )}
+                  />
+                  <Globe className="h-4 w-4 opacity-70" />
+                  <span className="truncate">{ALL_USERS_LABEL}</span>
+                </span>
+              </CommandItem>
+            </CommandGroup>
+            <CommandSeparator />
             <CommandGroup heading="Users">
               {visible.map((u) => (
                 <CommandItem

--- a/openmemory/ui/components/UserSelector.tsx
+++ b/openmemory/ui/components/UserSelector.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { Check, ChevronsUpDown, Users } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { useUsers } from "@/hooks/useUsers";
+import { cn } from "@/lib/utils";
+import { setUserId } from "@/store/profileSlice";
+import { AppDispatch, RootState } from "@/store/store";
+
+const STORAGE_KEY = "openmemory.activeUserId";
+
+/**
+ * Combobox that switches the active user_id used by every API call.
+ *
+ * - Default value comes from NEXT_PUBLIC_USER_ID (the "primary" user the
+ *   stack was started with).
+ * - The chosen value persists to localStorage and is re-applied on next
+ *   page load.
+ * - Selecting a value dispatches setUserId on profileSlice — every hook
+ *   that reads state.profile.userId re-fetches automatically.
+ *
+ * Note: the backend endpoints all require user_id, so an "All users" admin
+ * view is intentionally not offered here. Multi-user aggregation needs
+ * dedicated endpoints; see README_Local.md §"UI UserId facet".
+ */
+export function UserSelector() {
+  const dispatch = useDispatch<AppDispatch>();
+  const activeUserId = useSelector((state: RootState) => state.profile.userId);
+  const defaultUserId = process.env.NEXT_PUBLIC_USER_ID || "user";
+
+  const { users, isLoading } = useUsers(true);
+  const [open, setOpen] = useState(false);
+
+  // On first mount: hydrate from localStorage if it differs from the env default.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored && stored !== activeUserId) {
+      dispatch(setUserId(stored));
+    }
+    // intentionally only on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const choose = (uid: string) => {
+    dispatch(setUserId(uid));
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(STORAGE_KEY, uid);
+    }
+    setOpen(false);
+  };
+
+  // Always show the active user even if not yet in /api/v1/users (fresh user
+  // with zero memories), and the env default at the bottom for quick reset.
+  const visible = useMemo(() => {
+    const seen = new Set<string>();
+    const merged: { user_id: string; memory_count: number; isDefault?: boolean }[] = [];
+    for (const u of users) {
+      seen.add(u.user_id);
+      merged.push({ user_id: u.user_id, memory_count: u.memory_count });
+    }
+    if (!seen.has(activeUserId)) {
+      merged.unshift({ user_id: activeUserId, memory_count: 0 });
+      seen.add(activeUserId);
+    }
+    if (!seen.has(defaultUserId)) {
+      merged.push({ user_id: defaultUserId, memory_count: 0, isDefault: true });
+    }
+    return merged;
+  }, [users, activeUserId, defaultUserId]);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          role="combobox"
+          aria-expanded={open}
+          className="flex items-center gap-2 border-zinc-700/50 bg-zinc-900 hover:bg-zinc-800 min-w-[180px] justify-between"
+          aria-label={`Active user: ${activeUserId}`}
+        >
+          <span className="flex items-center gap-2 truncate">
+            <Users className="h-4 w-4 opacity-70" />
+            <span className="truncate">{activeUserId}</span>
+          </span>
+          <ChevronsUpDown className="h-4 w-4 opacity-50 shrink-0" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[260px] p-0" align="end">
+        <Command>
+          <CommandInput placeholder="Search users…" />
+          <CommandList>
+            <CommandEmpty>{isLoading ? "Loading…" : "No users found."}</CommandEmpty>
+            <CommandGroup heading="Users">
+              {visible.map((u) => (
+                <CommandItem
+                  key={u.user_id}
+                  value={u.user_id}
+                  onSelect={() => choose(u.user_id)}
+                  className="flex items-center justify-between"
+                >
+                  <span className="flex items-center gap-2 min-w-0">
+                    <Check
+                      className={cn(
+                        "h-4 w-4",
+                        activeUserId === u.user_id ? "opacity-100" : "opacity-0",
+                      )}
+                    />
+                    <span className="truncate">{u.user_id}</span>
+                    {u.isDefault && (
+                      <span className="text-xs text-zinc-500 ml-1">(default)</span>
+                    )}
+                  </span>
+                  <span className="text-xs text-zinc-500 ml-2">
+                    {u.memory_count}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/openmemory/ui/hooks/useUsers.ts
+++ b/openmemory/ui/hooks/useUsers.ts
@@ -1,0 +1,44 @@
+import axios from "axios";
+import { useCallback, useEffect, useState } from "react";
+
+export interface UserStats {
+  user_id: string;
+  memory_count: number;
+  last_active_at: string | null;
+}
+
+const URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8765";
+
+/**
+ * Fetches the list of distinct user_ids known to the backend.
+ *
+ * Used by the UserSelector to render a combobox of known scopes (e.g.
+ * "TpGroup", "OtherProject"). Pass `includeEmpty=true` to also list users
+ * that have zero live memories — useful right after a fresh install.
+ */
+export function useUsers(includeEmpty = false) {
+  const [users, setUsers] = useState<UserStats[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchUsers = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await axios.get<UserStats[]>(`${URL}/api/v1/users/`, {
+        params: { include_empty: includeEmpty },
+      });
+      setUsers(res.data);
+    } catch (err: any) {
+      setError(err?.message || "Failed to fetch users");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [includeEmpty]);
+
+  useEffect(() => {
+    fetchUsers();
+  }, [fetchUsers]);
+
+  return { users, isLoading, error, refetch: fetchUsers };
+}


### PR DESCRIPTION
## Linked Issue

N/A — happy to file a design issue first if maintainers want to discuss the empty-string sentinel choice before reviewing the diff. The PR is staged in three reviewable commits so each layer can be evaluated independently.

## Description

### Why

A single OpenMemory instance can already serve multiple separate scopes — one Claude Code project per `user_id`, addressed by different SSE URLs:

```
http://localhost:8765/mcp/claude/sse/TpGroup
http://localhost:8765/mcp/claude/sse/OtherProject
```

Each `user_id` is fully isolated on the server side (the SQLAlchemy `Memory` table already partitions by `user_id`). But the Web UI today only exposes the *App* facet — every project shows up under the same "claude" app card, and operators have to switch user_id by editing `NEXT_PUBLIC_USER_ID` and restarting the UI to see the other scope. No way to see all scopes side by side either.

### What this PR adds

A first-class **User-id facet** in the Web UI, parallel to the existing App facet, with optional all-users aggregation.

The PR is split into three commits matching its three layers:

#### 1. `feat(openmemory): add GET /api/v1/users for distinct-users facet` (`60d36e46`)

New REST endpoint:

```
GET /api/v1/users/                       → distinct user_ids with memory_count + last_active_at
GET /api/v1/users/?include_empty=true    → also list users with zero live memories
```

Response shape:

```json
[
  {"user_id": "TpGroup",      "memory_count": 10, "last_active_at": "2026-05-03T17:46:50.121211"},
  {"user_id": "OtherProject", "memory_count":  4, "last_active_at": "2026-05-04T09:12:33.000000"}
]
```

Files: `openmemory/api/app/routers/users.py` (new, 67 lines), wired in `routers/__init__.py` and `main.py`.

#### 2. `feat(openmemory-ui): add UserId facet to the Web UI` (`b0ab42dc`)

Navbar combobox driven by `/api/v1/users`. Default value comes from `NEXT_PUBLIC_USER_ID` (existing env var). Selecting a value dispatches `profileSlice.setUserId`, which causes every existing hook (memories, apps, stats) to re-fetch under the new scope. The selection persists in `localStorage` under `openmemory.activeUserId`. Includes a `useUsers()` hook reading the new endpoint.

Files: `openmemory/ui/hooks/useUsers.ts` (new), `openmemory/ui/components/UserSelector.tsx` (new), `openmemory/ui/components/Navbar.tsx` (1-line wiring).

#### 3. `feat(openmemory): all-users (admin) view via empty-user_id sentinel` (`f55a8194`)

Read-only memory listing endpoints accept an empty (or omitted) `user_id` and return memories from every user — useful for an operator who wants a cross-project audit view from a single OpenMemory instance.

Endpoints that respect the sentinel:

| Endpoint                                    | Empty `user_id`        | Non-empty unknown `user_id` |
|---------------------------------------------|------------------------|-----------------------------|
| `GET    /api/v1/memories/`                  | merged across users    | `404 User not found`        |
| `GET    /api/v1/memories/categories`        | merged across users    | `404 User not found`        |
| `POST   /api/v1/memories/filter`            | merged across users    | `404 User not found`        |
| `GET    /api/v1/memories/{id}/related`      | merged across users    | `404 User not found`        |

Endpoints that **stay strictly scoped** even in all-users mode (they need an owner / perform destructive work):

| Endpoint                          | Behavior with empty `user_id`                                                |
|-----------------------------------|------------------------------------------------------------------------------|
| `POST   /api/v1/memories/`        | UI disables the button with a tooltip; the API would still require an owner. |
| `DELETE /api/v1/memories/`        | Strictly per-user; UI does not invoke this in all-users mode.                |
| MCP tools (`add_memories`, …)     | Out of scope — the SSE URL carries `user_id` for every MCP request.          |

The UserSelector pins **"All users (admin view)"** at the top of the popover with a globe icon. `CreateMemoryDialog` reads `activeUserId`; if empty, the trigger button is rendered as disabled with a `Tooltip` reading "Pick a specific user to add a memory."

Why the empty-string sentinel:

* Already a falsy value, so each filter site reads as `if user_id: query = query.filter(...)` — no magic constants.
* URL params handle it natively (`?user_id=` and an omitted param both work).
* `localStorage` and the redux store don't need a separate "is unset" flag.
* It's a SQL-side concept only — it never reaches the mem0 vector store, because vector ops are inherently per-user. Vector layer continues to require `user_id`.

### What this is *not*

* Not a multi-tenancy / auth feature. There is no enforced authorization — this is the same trust boundary as today (a local OpenMemory instance trusted by its operator).
* Not a change to MCP tool behavior. SSE URLs still carry `user_id` per request.
* Not a change to mem0 SDK behavior — the all-users sentinel terminates at the SQL query layer.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Breaking Changes

N/A — every existing call with a non-empty `user_id` behaves exactly as before. The only newly accepted input is empty `user_id`, which used to 404; the previous 404 path is preserved for any non-empty `user_id` that doesn't resolve to a User row.

## Test Coverage

- [x] I added/updated unit tests
- [x] I tested manually

`openmemory/api/tests/test_memories_router.py` adds **18 tests**:

* `resolve_user_or_none` helper (4): empty / None / valid / unknown.
* `GET /api/v1/memories/` (6): scoped UserA, scoped UserB, all-users via empty, all-users via omitted, 404 for unknown, deleted memories never appear in all-users view.
* `GET /api/v1/memories/categories` (3): scoped, all-users, 404.
* `POST /api/v1/memories/filter` (4): scoped, all-users via empty, all-users via omitted, 404.
* Wrapper-invariant guard (1): `ScopedMemoryClient` continues to reject empty `user_id` even after the all-users mode is added — the all-users view is a SQL-only concept and must not widen the wrapper boundary.

Tests use an in-memory SQLite session and FastAPI's dependency-override; no Qdrant / OpenAI / network. They seed two distinct users (UserA, UserB) so the difference between scoped and all-users views is observable per assertion.

Reproduce:

```bash
docker compose -f openmemory/docker-compose.yml up -d openmemory-mcp
docker exec openmemory-openmemory-mcp-1 sh -c \
  'cd /usr/src/openmemory && python -m pytest tests/test_memories_router.py -v'
# → 18 passed
```

Manual smoke against a live stack with two seeded users:

```bash
# Distinct users:
curl http://localhost:8765/api/v1/users/
# → [{"user_id":"UserA","memory_count":N,...},{"user_id":"UserB","memory_count":M,...}]

# Scoped — only UserA:
curl 'http://localhost:8765/api/v1/memories/?user_id=UserA' | jq '.total'
# → N

# All-users — both:
curl 'http://localhost:8765/api/v1/memories/?user_id=' | jq '.total'
# → N + M

# Unknown user — still 404:
curl 'http://localhost:8765/api/v1/memories/?user_id=NoSuchUser'
# → {"detail":"User not found"}
```

UI check: open the navbar, the User combobox lists UserA + UserB + "All users (admin view)" at the top. Switching scope refreshes every panel automatically. Selecting "All users" greys out the "Create Memory" button with a tooltip.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (the new endpoint and the UI surfaces are self-documenting; happy to add a section to `openmemory/README.md` as a follow-up commit if maintainers prefer)
