### PR TITLE
docs: memory decay v0.5 — platform feature page + API reference

### DIFF
--- a/docs/api-reference/organizations-projects.mdx
+++ b/docs/api-reference/organizations-projects.mdx
@@ -109,6 +109,19 @@ client.project.update(
 )
 ```
 
+#### Toggle Memory Decay
+
+`decay_enabled` is a per-project boolean that turns on [Memory Decay](/platform/features/memory-decay) — a search-time ranking bias that reinforces recently-accessed memories and gently dampens stale ones. The flag is `false` by default; set it via the same project-update endpoint:
+
+```bash cURL
+curl -X PATCH https://api.mem0.ai/api/v1/orgs/organizations/$ORG_ID/projects/$PROJECT_ID/ \
+  -H "Authorization: Token $MEM0_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"decay_enabled": true}'
+```
+
+The current state is returned on every project read (and supports `?fields=decay_enabled` for a minimal response). Toggling has no effect on stored memories, only on how v3 search ranks them.
+
 ### Delete Project
 
 <Warning>

--- a/docs/api-reference/organizations-projects.mdx
+++ b/docs/api-reference/organizations-projects.mdx
@@ -111,16 +111,16 @@ client.project.update(
 
 #### Toggle Memory Decay
 
-`decay_enabled` is a per-project boolean that turns on [Memory Decay](/platform/features/memory-decay) — a search-time ranking bias that reinforces recently-accessed memories and gently dampens stale ones. The flag is `false` by default; set it via the same project-update endpoint:
+`decay` is a per-project boolean that turns on [Memory Decay](/platform/features/memory-decay) — a search-time ranking bias that reinforces recently-accessed memories and gently dampens stale ones. The flag is `false` by default; set it via the same project-update endpoint:
 
 ```bash cURL
 curl -X PATCH https://api.mem0.ai/api/v1/orgs/organizations/$ORG_ID/projects/$PROJECT_ID/ \
   -H "Authorization: Token $MEM0_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"decay_enabled": true}'
+  -d '{"decay": true}'
 ```
 
-The current state is returned on every project read (and supports `?fields=decay_enabled` for a minimal response). Toggling has no effect on stored memories, only on how v3 search ranks them.
+The current state is returned on every project read (and supports `?fields=decay` for a minimal response). Toggling has no effect on stored memories, only on how v3 search ranks them.
 
 ### Delete Project
 

--- a/docs/changelog/highlights.mdx
+++ b/docs/changelog/highlights.mdx
@@ -4,19 +4,6 @@ description: "Major product launches, headline features, and milestones for Mem0
 mode: "wide"
 ---
 
-<Update label="2026-05-04" description="Memory Decay">
-
-**Memory Decay — Recently-Used Memories Surface Higher, Automatically**
-
-Per-project search-time ranking bias that boosts recently-touched memories and gently dampens stale ones — off by default, opt in per project via the `decay` field on the project endpoint.
-
-- **Soft bias, never a filter.** The scaling factor stays in `0.3×–1.5×`. Decay can reorder candidates but never zeros them out — anything that surfaced before decay can still surface after.
-- **Reinforcement loop.** Every memory returned in a search has its access history updated, so frequently-used facts naturally float to the top over time.
-- **Public score still clamped to `[0, 1]`.** Existing API contract preserved; no client-side changes needed.
-- **v3 search only**, fully reversible — flip it off and ranking returns to the pre-decay behavior. See [Memory Decay docs](/platform/features/memory-decay).
-
-</Update>
-
 <Update label="2026-04-14" description="Mem0 SDK v2.0.0 / v3.0.0">
 
 **New Memory Algorithm — State-of-the-Art Accuracy at ~3-4x Lower Cost**

--- a/docs/changelog/highlights.mdx
+++ b/docs/changelog/highlights.mdx
@@ -4,6 +4,19 @@ description: "Major product launches, headline features, and milestones for Mem0
 mode: "wide"
 ---
 
+<Update label="2026-05-04" description="Memory Decay">
+
+**Memory Decay — Recently-Used Memories Surface Higher, Automatically**
+
+Per-project search-time ranking bias that boosts recently-touched memories and gently dampens stale ones — off by default, opt in per project via the `decay` field on the project endpoint.
+
+- **Soft bias, never a filter.** The scaling factor stays in `0.3×–1.5×`. Decay can reorder candidates but never zeros them out — anything that surfaced before decay can still surface after.
+- **Reinforcement loop.** Every memory returned in a search has its access history updated, so frequently-used facts naturally float to the top over time.
+- **Public score still clamped to `[0, 1]`.** Existing API contract preserved; no client-side changes needed.
+- **v3 search only**, fully reversible — flip it off and ranking returns to the pre-decay behavior. See [Memory Decay docs](/platform/features/memory-decay).
+
+</Update>
+
 <Update label="2026-04-14" description="Mem0 SDK v2.0.0 / v3.0.0">
 
 **New Memory Algorithm — State-of-the-Art Accuracy at ~3-4x Lower Cost**

--- a/docs/changelog/platform.mdx
+++ b/docs/changelog/platform.mdx
@@ -7,7 +7,7 @@ mode: "wide"
 <Update label="2026-05-04" description="">
 
 **New Features:**
-- **Memory Decay:** Per-project search-time ranking bias that boosts recently-used memories and gently dampens stale ones. Opt-in via `decay_enabled` on the project endpoint; off by default. The scaling factor stays in `0.3×–1.5×`, the public `score` remains clamped to `[0, 1]`, and the bias never filters a candidate out. See [Memory Decay docs](/platform/features/memory-decay).
+- **Memory Decay:** Per-project search-time ranking bias that boosts recently-used memories and gently dampens stale ones. Opt-in via `decay` on the project endpoint; off by default. The scaling factor stays in `0.3×–1.5×`, the public `score` remains clamped to `[0, 1]`, and the bias never filters a candidate out. See [Memory Decay docs](/platform/features/memory-decay).
 
 </Update>
 

--- a/docs/changelog/platform.mdx
+++ b/docs/changelog/platform.mdx
@@ -7,7 +7,7 @@ mode: "wide"
 <Update label="2026-05-04" description="">
 
 **New Features:**
-- **Memory Decay (v0.5):** Per-project search-time ranking bias that boosts recently-reinforced memories and dampens stale ones using ACT-R base-level activation. Opt-in via `decay_enabled` on the project endpoint; off by default. Multiplier stays in `[0.3, 1.5]`, public score remains clamped to `[0, 1]`, and the bias never filters a candidate out. See [Memory Decay docs](/platform/features/memory-decay).
+- **Memory Decay:** Per-project search-time ranking bias that boosts recently-used memories and gently dampens stale ones. Opt-in via `decay_enabled` on the project endpoint; off by default. The scaling factor stays in `0.3×–1.5×`, the public `score` remains clamped to `[0, 1]`, and the bias never filters a candidate out. See [Memory Decay docs](/platform/features/memory-decay).
 
 </Update>
 

--- a/docs/changelog/platform.mdx
+++ b/docs/changelog/platform.mdx
@@ -4,6 +4,13 @@ description: "Release notes for the Mem0 hosted platform — backend, dashboard,
 mode: "wide"
 ---
 
+<Update label="2026-05-04" description="">
+
+**New Features:**
+- **Memory Decay (v0.5):** Per-project search-time ranking bias that boosts recently-reinforced memories and dampens stale ones using ACT-R base-level activation. Opt-in via `decay_enabled` on the project endpoint; off by default. Multiplier stays in `[0.3, 1.5]`, public score remains clamped to `[0, 1]`, and the bias never filters a candidate out. See [Memory Decay docs](/platform/features/memory-decay).
+
+</Update>
+
 <Update label="2026-04-16" description="">
 
 **Improvements:**

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -83,7 +83,8 @@
                           "platform/advanced-memory-operations",
                           "platform/features/criteria-retrieval",
                           "platform/features/contextual-add",
-                          "platform/features/custom-instructions"
+                          "platform/features/custom-instructions",
+                          "platform/features/memory-decay"
                         ]
                       },
                       {

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -187,6 +187,7 @@ If the user is on a pre-current major (Python < 2, TS < 3, or Platform `output_f
 - [Criteria-Based Retrieval](https://docs.mem0.ai/platform/features/criteria-retrieval) [Platform]: Use when targeting memories by custom criteria, not just semantic similarity.
 - [Contextual Add](https://docs.mem0.ai/platform/features/contextual-add) [Platform]: Use when `add()` should consider the surrounding conversation, not just the latest turn.
 - [Custom Instructions](https://docs.mem0.ai/platform/features/custom-instructions) [Platform]: Use when tailoring what Mem0 extracts and stores on Platform.
+- [Memory Decay](https://docs.mem0.ai/platform/features/memory-decay) [Platform]: Use when search results should boost recently-reinforced memories and dampen stale ones — opt-in per project, search-time only, never filters candidates out.
 - [Advanced Memory Operations](https://docs.mem0.ai/platform/advanced-memory-operations) [Platform]: Use when basic CRUD is not enough - batch ops, complex filters, workflows.
 
 ### Features - Data Management

--- a/docs/platform/features/memory-decay.mdx
+++ b/docs/platform/features/memory-decay.mdx
@@ -30,7 +30,7 @@ Every memory carries a small piece of bookkeeping: when was it last retrieved, a
 | Touched today | 1.2 – 1.4× | Mild boost |
 | Idle for a few days | 0.6 – 1.0× | Mild dampening |
 | Idle for weeks | 0.4 – 0.6× | Stronger dampening |
-| No history yet | ≈ **0.3×** | Floor — won't go lower |
+| Idle for many months / years | ≈ **0.3×** | Floor — never lower |
 
 The bounds matter: `0.3` is the floor and `1.5` is the ceiling, so decay can meaningfully reorder candidates without ever dominating the underlying relevance score.
 
@@ -43,7 +43,7 @@ At search time the pipeline:
 5. Truncates to the `top_k` you requested.
 6. Records a fire-and-forget reinforcement against each returned memory — its access history grows by one, capped at the most recent 20 touches.
 
-Memories created before decay was enabled don't yet have an access history. They use a sensible fallback — their last update is treated as a single past touch — so they don't get pinned to the floor on the first retrieval. As they're surfaced in subsequent searches they accumulate access history naturally.
+Memories created before decay was enabled don't yet have an access history. They use a sensible fallback: their `updated_at` is treated as a single past touch, so the same scale above applies based on how stale that update is — a recently-updated legacy memory enters near the neutral band, a long-stale one sits closer to the floor. Once surfaced in a search after decay is on, they accumulate access history naturally and behave like any other memory.
 
 ## Configure access
 
@@ -56,7 +56,7 @@ The toggle lives on the project. You enable decay by patching the project's `dec
 
 ### 1. Turn the flag on
 
-The toggle is exposed on the standard project-update endpoint, the same place where `enable_graph`, `multilingual`, and `custom_categories` live.
+The toggle is exposed on the standard project-update endpoint, the same place where `multilingual` and `custom_categories` live.
 
 <CodeGroup>
 ```bash cURL
@@ -156,7 +156,7 @@ curl -X PATCH https://api.mem0.ai/api/v1/orgs/organizations/$ORG_ID/projects/$PR
 | Reinforced on a recent search | 1.2 – 1.5× | Sustains its boost for the next several searches. |
 | Idle for a few days | 0.6 – 1.0× | Falls back into the neutral band. |
 | Idle for weeks | 0.4 – 0.6× | Mild dampening — can still surface for strong matches. |
-| Never reinforced (legacy) | Mid-band | Computed from the memory's last update — not pinned to the floor. |
+| Pre-decay legacy memory (no access history) | 0.3 – 1.0× | Falls back to `updated_at`: recently-updated entries land near 1.0×, long-stale entries approach the 0.3× floor. |
 
 The reinforcement is bounded: each memory tracks at most the last 20 access timestamps, so the boost stays well-behaved no matter how many times a memory is retrieved.
 
@@ -172,7 +172,7 @@ The threshold is applied to the candidate pool pre-decay; the scaling factor the
 No. The `client.add(...)` path is unchanged. Decay is a search-time ranking adjustment.
 
 **What if I had memories before turning decay on?**
-They use a fallback — the memory's last-update timestamp is treated as its single historical touch — so they get a fair starting point on the very first search after you flip the flag. As they're retrieved they accumulate access history naturally.
+They use a fallback: the memory's `updated_at` is treated as a single historical touch, so the same scaling applies based on how stale that update is — a recently-updated legacy memory enters near the neutral band (~1.0×), a long-stale one closer to the floor (~0.3×). Once retrieved they accumulate access history and behave like any other memory.
 
 **Can I tune how aggressively decay scales scores?**
 Not in this version. The current scaling is calibrated to be conservative — wide enough to meaningfully reorder candidates, narrow enough to never dominate the underlying relevance score. Per-project tuning is on the roadmap.

--- a/docs/platform/features/memory-decay.mdx
+++ b/docs/platform/features/memory-decay.mdx
@@ -50,7 +50,7 @@ Memories created before decay was enabled don't yet have an access history. They
 - Set `MEM0_API_KEY` in your environment, or pass it to the SDK constructor.
 - Initialize the client with the organization and project you want to scope to.
 
-The toggle lives on the project. You enable decay by patching the project's `decay_enabled` field; everything else — your `add` calls, your `search` calls, your application code — stays exactly the same.
+The toggle lives on the project. You enable decay by patching the project's `decay` field; everything else — your `add` calls, your `search` calls, your application code — stays exactly the same.
 
 ## Enable decay for a project
 
@@ -63,7 +63,7 @@ The toggle is exposed on the standard project-update endpoint, the same place wh
 curl -X PATCH https://api.mem0.ai/api/v1/orgs/organizations/$ORG_ID/projects/$PROJECT_ID/ \
   -H "Authorization: Token $MEM0_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"decay_enabled": true}'
+  -d '{"decay": true}'
 ```
 
 ```python Python
@@ -76,7 +76,7 @@ project_id = os.environ["MEM0_PROJECT_ID"]
 requests.patch(
     f"https://api.mem0.ai/api/v1/orgs/organizations/{org_id}/projects/{project_id}/",
     headers={"Authorization": f"Token {os.environ['MEM0_API_KEY']}"},
-    json={"decay_enabled": True},
+    json={"decay": True},
 )
 ```
 
@@ -89,7 +89,7 @@ const res = await fetch(
       Authorization: `Token ${process.env.MEM0_API_KEY}`,
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ decay_enabled: true }),
+    body: JSON.stringify({ decay: true }),
   },
 );
 ```
@@ -101,16 +101,16 @@ const res = await fetch(
 
 ### 2. Confirm the state
 
-`decay_enabled` is returned on every project read. To fetch only this field, use `?fields=decay_enabled`.
+`decay` is returned on every project read. To fetch only this field, use `?fields=decay`.
 
 <CodeGroup>
 ```bash cURL
-curl "https://api.mem0.ai/api/v1/orgs/organizations/$ORG_ID/projects/$PROJECT_ID/?fields=decay_enabled" \
+curl "https://api.mem0.ai/api/v1/orgs/organizations/$ORG_ID/projects/$PROJECT_ID/?fields=decay" \
   -H "Authorization: Token $MEM0_API_KEY"
 ```
 
 ```json Response
-{ "decay_enabled": true }
+{ "decay": true }
 ```
 </CodeGroup>
 
@@ -123,7 +123,7 @@ The toggle is fully reversible. Setting it to `false` immediately restores the p
 curl -X PATCH https://api.mem0.ai/api/v1/orgs/organizations/$ORG_ID/projects/$PROJECT_ID/ \
   -H "Authorization: Token $MEM0_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"decay_enabled": false}'
+  -d '{"decay": false}'
 ```
 </CodeGroup>
 

--- a/docs/platform/features/memory-decay.mdx
+++ b/docs/platform/features/memory-decay.mdx
@@ -1,0 +1,198 @@
+---
+title: Memory Decay
+description: "Boost recently-reinforced memories and gently dampen stale ones at search time, without filtering anything out."
+---
+
+# Memory Decay
+
+Older memories drift out of relevance at different speeds. A fact about a user's coffee order matters every morning; a one-off project name from last quarter rarely matters again. Memory Decay makes that intuition explicit at retrieval time: every time a memory is returned in a search, it gets a small reinforcement, and memories that have not been touched in a while have their ranking score gently dampened.
+
+It is **a soft ranking bias, never a filter**. Decay never zeroes a candidate out — at worst it scales its score by `0.3`. Anything that would have surfaced without decay can still surface with decay on, just with a different ranking among similarly-scored results.
+
+<Info>
+  **Use Memory Decay when…**
+  - Your search results are crowded with old facts that the user no longer cares about.
+  - You want recently-reinforced memories to drift to the top *automatically* without writing custom scoring logic.
+  - You want this preference applied per project so that you can compare cohorts side-by-side.
+</Info>
+
+<Warning>
+  Memory Decay is **opt-in per project** and **off by default**. Search behavior is bit-identical to today until you turn it on. The toggle applies to v3 search only.
+</Warning>
+
+## How it works
+
+Memory Decay uses a well-studied cognitive model — ACT-R base-level activation (Anderson & Schooler, 1991) — to convert a memory's access history into a single number we call *activation*:
+
+$$
+A_m(t) = \ln\!\left( \sum_{k} (t - t_k)^{-d} \right)
+$$
+
+where `t_k` are the past times the memory was retrieved, `t` is now, and `d = 0.5`. Recent or repeated accesses dominate the sum; long-idle memories trail off as a power law.
+
+Activation is then mapped through a sigmoid clamped to `[0.3, 1.5]` to produce a **multiplier**:
+
+| Activation regime | Multiplier | Meaning |
+|---|---|---|
+| Just accessed (Δt ≈ 0) | ≈ **1.5** (ceiling) | Strong boost |
+| Accessed today | ≈ 1.2–1.4 | Mild boost |
+| No history at all | ≈ 0.3 (floor) | Strong dampening |
+| Accessed weeks ago | ≈ 0.4–0.7 | Mild dampening |
+
+At search time the pipeline:
+
+1. Over-fetches a candidate pool (`max(50, top_k × 3)`) so reordering has room.
+2. Computes the multiplier per candidate and multiplies it into the rank score.
+3. Sorts on the **unclamped** internal product so the full `[0.3, 1.5]` range can rearrange candidates.
+4. Clamps the **public** `score` field to `[0, 1]` so the API contract is preserved.
+5. Truncates to your requested `top_k`.
+6. Records a fire-and-forget reinforcement (appends `now` to each returned memory's access history, capped at 20 entries).
+
+Memories created before decay was enabled don't yet have an access history. They use a lazy fallback: their `updated_at` is treated as a single past touch, so they don't get pinned to the floor unfairly.
+
+## Configure access
+
+- Set `MEM0_API_KEY` in your environment, or pass it to the SDK constructor.
+- Initialise the client with the organization and project you want to scope to.
+
+The toggle lives on the project. You enable decay by patching the project's `decay_enabled` field; everything else — your `add` calls, your `search` calls, your application code — stays exactly the same.
+
+## Enable decay for a project
+
+### 1. Turn the flag on
+
+The toggle is exposed on the standard project-update endpoint, the same place where `enable_graph`, `multilingual`, and `custom_categories` live.
+
+<CodeGroup>
+```bash cURL
+curl -X PATCH https://api.mem0.ai/api/v1/orgs/organizations/$ORG_ID/projects/$PROJECT_ID/ \
+  -H "Authorization: Token $MEM0_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"decay_enabled": true}'
+```
+
+```python Python
+import os
+import requests
+
+org_id = os.environ["MEM0_ORG_ID"]
+project_id = os.environ["MEM0_PROJECT_ID"]
+
+requests.patch(
+    f"https://api.mem0.ai/api/v1/orgs/organizations/{org_id}/projects/{project_id}/",
+    headers={"Authorization": f"Token {os.environ['MEM0_API_KEY']}"},
+    json={"decay_enabled": True},
+)
+```
+
+```javascript Node.js
+const res = await fetch(
+  `https://api.mem0.ai/api/v1/orgs/organizations/${process.env.MEM0_ORG_ID}/projects/${process.env.MEM0_PROJECT_ID}/`,
+  {
+    method: "PATCH",
+    headers: {
+      Authorization: `Token ${process.env.MEM0_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ decay_enabled: true }),
+  },
+);
+```
+
+```json Response
+{ "message": "Updated decay" }
+```
+</CodeGroup>
+
+### 2. Confirm the state
+
+`decay_enabled` is returned on every project read. To fetch *only* this field, use `?fields=decay_enabled`.
+
+<CodeGroup>
+```bash cURL
+curl "https://api.mem0.ai/api/v1/orgs/organizations/$ORG_ID/projects/$PROJECT_ID/?fields=decay_enabled" \
+  -H "Authorization: Token $MEM0_API_KEY"
+```
+
+```json Response
+{ "decay_enabled": true }
+```
+</CodeGroup>
+
+### 3. Turn it back off
+
+The toggle is fully reversible. Setting it back to `false` immediately restores the pre-decay ranking; nothing about your stored memories is modified or lost.
+
+<CodeGroup>
+```bash cURL
+curl -X PATCH https://api.mem0.ai/api/v1/orgs/organizations/$ORG_ID/projects/$PROJECT_ID/ \
+  -H "Authorization: Token $MEM0_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"decay_enabled": false}'
+```
+</CodeGroup>
+
+<Note>
+  The toggle is idempotent. Re-applying the same value is a no-op, and access history accumulated while decay was on is preserved if you flip it back on later.
+</Note>
+
+## What changes when decay is on
+
+- **Search ranking reorders.** A relevant memory you reinforced an hour ago will tend to outrank an equally-relevant memory that was last touched a month ago.
+- **The candidate pool over-fetches** to give the multiplier room to reorder. You still get exactly the `top_k` you requested, but the items returned can come from a deeper slice of the pre-decay ranking than before.
+- **The public `score` field stays in `[0, 1]`.** Even when the internal product (`score × multiplier`) exceeds 1, the field returned to the client is clamped, so existing assertions and downstream UI logic continue to work.
+
+## What stays the same
+
+- **Public API shape** — every endpoint accepts the same parameters and returns the same fields. You don't touch your client code.
+- **Threshold semantics on the request side** — your `threshold` is still applied during candidate selection.
+- **Memory creation and storage** — every new memory still lands the same way. Decay is a search-time concern.
+- **Per-memory data** — categories, metadata, timestamps, embeddings: untouched.
+
+<Warning>
+  Because the multiplier scales the public `score` *after* the threshold filter has already run, an item that passed the request `threshold` can come back with a public `score` slightly below it (a stale candidate dampened by a 0.3 multiplier). This is intentional — decay is a soft bias, not a filter. If you require a hard `score >= threshold` invariant on the response, filter client-side after the call.
+</Warning>
+
+## Lifecycle of a memory under decay
+
+| Stage | Activation | Multiplier | Effect |
+|---|---|---|---|
+| Just added | ~3.5 (ceiling) | ~1.5 | Strong boost — fresh facts surface easily. |
+| Reinforced on a recent search | High | 1.2–1.5 | Sustains its boost for the next several searches. |
+| Idle for a few days | Drops gradually | 0.6–1.0 | Falls back into the neutral band. |
+| Idle for weeks | Low | 0.4–0.6 | Mild dampening, can still surface for strong matches. |
+| Never reinforced (legacy) | Lazy fallback | Mid-band | Computed from `updated_at` — not pinned to the floor. |
+
+The reinforcement is bounded: each memory tracks at most the last 20 access timestamps as a ring buffer, so activation stays well-behaved no matter how many times a memory is retrieved.
+
+## FAQ
+
+**Will decay ever drop a result that would otherwise surface?**
+No. The multiplier floor is `0.3` — it can dampen a score, never zero it. Threshold filtering happens *before* decay, so any candidate that cleared the threshold is in the pool decay reorders.
+
+**Why is the public score sometimes below my requested threshold?**
+The threshold is applied to the candidate pool pre-decay; the multiplier then reshapes scores in `[0.3, 1.5]×`. A stale-but-relevant candidate can come back with a final score slightly under your threshold by design (so the candidate is *visible* but visibly dampened). Filter client-side if you need a hard floor on the response.
+
+**Does decay change how I add memories?**
+No. The `client.add(...)` path is unchanged. Decay is a search-time ranking adjustment.
+
+**What if I had memories before turning decay on?**
+They use a lazy fallback — their `updated_at` timestamp is treated as their single historical touch, so they get a fair, non-pinned activation on the very first search after you flip the flag. As they're retrieved, they accumulate access history naturally.
+
+**Can I tune the decay rate `d`?**
+Not in this version. v0.5 is shipped with `d = 0.5` (the canonical ACT-R value, modal estimate across published tasks). Per-project tuning will land alongside the importance prior in v1.
+
+**Can I see the multiplier per result?**
+Internal scoring details — activation, multiplier, internal product — are persisted on the search Event for support and debugging. They are not exposed in the public response by design (the response surface stays a single `score` field).
+
+**Does decay affect rerank?**
+Decay layers on top of reranking when both are enabled. The reranker produces a richer score; decay then biases that score by reinforcement history before final truncation to `top_k`.
+
+## What's next
+
+This release is the **uniform-priors build** of memory decay: every memory contributes to ranking through its access history alone. We deliberately shipped this slice first so the access-history signal can be evaluated in isolation. On the roadmap:
+
+- **v1 — Importance prior `S_m`.** A per-memory or per-category prior that biases activation, so a fact tagged `health` can carry more weight than a passing observation tagged `misc`.
+- **v1.5 — Bayesian `τ` updates.** Project-scoped automatic tuning of the decay rate from observed access patterns, replacing the fixed `d = 0.5`.
+
+The toggle and storage shape are forward-compatible with both — no migration on your side will be needed.

--- a/docs/platform/features/memory-decay.mdx
+++ b/docs/platform/features/memory-decay.mdx
@@ -1,19 +1,19 @@
 ---
 title: Memory Decay
-description: "Boost recently-reinforced memories and gently dampen stale ones at search time, without filtering anything out."
+description: "Boost recently-used memories and gently dampen stale ones at search time, without filtering anything out."
 ---
 
 # Memory Decay
 
-Older memories drift out of relevance at different speeds. A fact about a user's coffee order matters every morning; a one-off project name from last quarter rarely matters again. Memory Decay makes that intuition explicit at retrieval time: every time a memory is returned in a search, it gets a small reinforcement, and memories that have not been touched in a while have their ranking score gently dampened.
+Older memories drift in relevance at different speeds. A user's coffee order matters every morning; a one-off project name from last quarter rarely matters again. Memory Decay makes that intuition explicit at search time: every time a memory is returned in a search it gets a small reinforcement, and memories that haven't been touched in a while have their ranking score gently dampened.
 
-It is **a soft ranking bias, never a filter**. Decay never zeroes a candidate out — at worst it scales its score by `0.3`. Anything that would have surfaced without decay can still surface with decay on, just with a different ranking among similarly-scored results.
+It is **a soft ranking bias, never a filter.** Decay never zeroes a candidate out — at worst it scales its score by `0.3×`. Anything that would have surfaced without decay can still surface with decay on, just with a different ranking among similarly-scored results.
 
 <Info>
   **Use Memory Decay when…**
-  - Your search results are crowded with old facts that the user no longer cares about.
-  - You want recently-reinforced memories to drift to the top *automatically* without writing custom scoring logic.
-  - You want this preference applied per project so that you can compare cohorts side-by-side.
+  - Search results are crowded with old facts the user no longer cares about.
+  - You want recently-used memories to drift to the top automatically — without writing custom scoring logic.
+  - You want this preference applied per project so cohorts can be compared side-by-side.
 </Info>
 
 <Warning>
@@ -22,38 +22,33 @@ It is **a soft ranking bias, never a filter**. Decay never zeroes a candidate ou
 
 ## How it works
 
-Memory Decay uses a well-studied cognitive model — ACT-R base-level activation (Anderson & Schooler, 1991) — to convert a memory's access history into a single number we call *activation*:
+Every memory carries a small piece of bookkeeping: when was it last retrieved, and how often. Memory Decay turns that history into a *scaling factor* in the range `0.3×` to `1.5×` and multiplies it into the ranking score at search time.
 
-$$
-A_m(t) = \ln\!\left( \sum_{k} (t - t_k)^{-d} \right)
-$$
-
-where `t_k` are the past times the memory was retrieved, `t` is now, and `d = 0.5`. Recent or repeated accesses dominate the sum; long-idle memories trail off as a power law.
-
-Activation is then mapped through a sigmoid clamped to `[0.3, 1.5]` to produce a **multiplier**:
-
-| Activation regime | Multiplier | Meaning |
+| Memory state | Scaling factor | Ranking effect |
 |---|---|---|
-| Just accessed (Δt ≈ 0) | ≈ **1.5** (ceiling) | Strong boost |
-| Accessed today | ≈ 1.2–1.4 | Mild boost |
-| No history at all | ≈ 0.3 (floor) | Strong dampening |
-| Accessed weeks ago | ≈ 0.4–0.7 | Mild dampening |
+| Just accessed | ≈ **1.5×** | Strong boost |
+| Touched today | 1.2 – 1.4× | Mild boost |
+| Idle for a few days | 0.6 – 1.0× | Mild dampening |
+| Idle for weeks | 0.4 – 0.6× | Stronger dampening |
+| No history yet | ≈ **0.3×** | Floor — won't go lower |
+
+The bounds matter: `0.3` is the floor and `1.5` is the ceiling, so decay can meaningfully reorder candidates without ever dominating the underlying relevance score.
 
 At search time the pipeline:
 
-1. Over-fetches a candidate pool (`max(50, top_k × 3)`) so reordering has room.
-2. Computes the multiplier per candidate and multiplies it into the rank score.
-3. Sorts on the **unclamped** internal product so the full `[0.3, 1.5]` range can rearrange candidates.
-4. Clamps the **public** `score` field to `[0, 1]` so the API contract is preserved.
-5. Truncates to your requested `top_k`.
-6. Records a fire-and-forget reinforcement (appends `now` to each returned memory's access history, capped at 20 entries).
+1. Widens the candidate pool (`top_k × 3`, with a floor of 50) so reordering has room.
+2. Multiplies each candidate's score by its scaling factor.
+3. Sorts on the unclamped product so the full `0.3×–1.5×` range can rearrange candidates.
+4. Returns the public `score` clamped to `[0, 1]` so the API contract is preserved.
+5. Truncates to the `top_k` you requested.
+6. Records a fire-and-forget reinforcement against each returned memory — its access history grows by one, capped at the most recent 20 touches.
 
-Memories created before decay was enabled don't yet have an access history. They use a lazy fallback: their `updated_at` is treated as a single past touch, so they don't get pinned to the floor unfairly.
+Memories created before decay was enabled don't yet have an access history. They use a sensible fallback — their last update is treated as a single past touch — so they don't get pinned to the floor on the first retrieval. As they're surfaced in subsequent searches they accumulate access history naturally.
 
 ## Configure access
 
 - Set `MEM0_API_KEY` in your environment, or pass it to the SDK constructor.
-- Initialise the client with the organization and project you want to scope to.
+- Initialize the client with the organization and project you want to scope to.
 
 The toggle lives on the project. You enable decay by patching the project's `decay_enabled` field; everything else — your `add` calls, your `search` calls, your application code — stays exactly the same.
 
@@ -106,7 +101,7 @@ const res = await fetch(
 
 ### 2. Confirm the state
 
-`decay_enabled` is returned on every project read. To fetch *only* this field, use `?fields=decay_enabled`.
+`decay_enabled` is returned on every project read. To fetch only this field, use `?fields=decay_enabled`.
 
 <CodeGroup>
 ```bash cURL
@@ -121,7 +116,7 @@ curl "https://api.mem0.ai/api/v1/orgs/organizations/$ORG_ID/projects/$PROJECT_ID
 
 ### 3. Turn it back off
 
-The toggle is fully reversible. Setting it back to `false` immediately restores the pre-decay ranking; nothing about your stored memories is modified or lost.
+The toggle is fully reversible. Setting it to `false` immediately restores the pre-decay ranking; nothing about your stored memories is modified or lost.
 
 <CodeGroup>
 ```bash cURL
@@ -139,8 +134,8 @@ curl -X PATCH https://api.mem0.ai/api/v1/orgs/organizations/$ORG_ID/projects/$PR
 ## What changes when decay is on
 
 - **Search ranking reorders.** A relevant memory you reinforced an hour ago will tend to outrank an equally-relevant memory that was last touched a month ago.
-- **The candidate pool over-fetches** to give the multiplier room to reorder. You still get exactly the `top_k` you requested, but the items returned can come from a deeper slice of the pre-decay ranking than before.
-- **The public `score` field stays in `[0, 1]`.** Even when the internal product (`score × multiplier`) exceeds 1, the field returned to the client is clamped, so existing assertions and downstream UI logic continue to work.
+- **The candidate pool over-fetches** to give the scaling factor room to reorder. You still get exactly the `top_k` you requested, but the items returned can come from a deeper slice of the pre-decay ranking than before.
+- **The public `score` field stays in `[0, 1]`.** Even when the internal product exceeds 1, the field returned to the client is clamped, so existing assertions and downstream UI logic continue to work.
 
 ## What stays the same
 
@@ -150,49 +145,49 @@ curl -X PATCH https://api.mem0.ai/api/v1/orgs/organizations/$ORG_ID/projects/$PR
 - **Per-memory data** — categories, metadata, timestamps, embeddings: untouched.
 
 <Warning>
-  Because the multiplier scales the public `score` *after* the threshold filter has already run, an item that passed the request `threshold` can come back with a public `score` slightly below it (a stale candidate dampened by a 0.3 multiplier). This is intentional — decay is a soft bias, not a filter. If you require a hard `score >= threshold` invariant on the response, filter client-side after the call.
+  Because the scaling factor is applied *after* the threshold filter has already run, an item that passed the request `threshold` can come back with a public `score` slightly below it (a stale candidate dampened by `0.3×`). This is intentional — decay is a soft bias, not a filter. If you require a hard `score >= threshold` invariant on the response, filter client-side after the call.
 </Warning>
 
 ## Lifecycle of a memory under decay
 
-| Stage | Activation | Multiplier | Effect |
-|---|---|---|---|
-| Just added | ~3.5 (ceiling) | ~1.5 | Strong boost — fresh facts surface easily. |
-| Reinforced on a recent search | High | 1.2–1.5 | Sustains its boost for the next several searches. |
-| Idle for a few days | Drops gradually | 0.6–1.0 | Falls back into the neutral band. |
-| Idle for weeks | Low | 0.4–0.6 | Mild dampening, can still surface for strong matches. |
-| Never reinforced (legacy) | Lazy fallback | Mid-band | Computed from `updated_at` — not pinned to the floor. |
+| Stage | Scaling factor | Effect |
+|---|---|---|
+| Just added | ≈ 1.5× | Strong boost — fresh facts surface easily. |
+| Reinforced on a recent search | 1.2 – 1.5× | Sustains its boost for the next several searches. |
+| Idle for a few days | 0.6 – 1.0× | Falls back into the neutral band. |
+| Idle for weeks | 0.4 – 0.6× | Mild dampening — can still surface for strong matches. |
+| Never reinforced (legacy) | Mid-band | Computed from the memory's last update — not pinned to the floor. |
 
-The reinforcement is bounded: each memory tracks at most the last 20 access timestamps as a ring buffer, so activation stays well-behaved no matter how many times a memory is retrieved.
+The reinforcement is bounded: each memory tracks at most the last 20 access timestamps, so the boost stays well-behaved no matter how many times a memory is retrieved.
 
 ## FAQ
 
 **Will decay ever drop a result that would otherwise surface?**
-No. The multiplier floor is `0.3` — it can dampen a score, never zero it. Threshold filtering happens *before* decay, so any candidate that cleared the threshold is in the pool decay reorders.
+No. The floor is `0.3×` — the scaling factor can dampen a score, never zero it. Threshold filtering happens *before* decay, so any candidate that cleared the threshold is in the pool decay reorders.
 
 **Why is the public score sometimes below my requested threshold?**
-The threshold is applied to the candidate pool pre-decay; the multiplier then reshapes scores in `[0.3, 1.5]×`. A stale-but-relevant candidate can come back with a final score slightly under your threshold by design (so the candidate is *visible* but visibly dampened). Filter client-side if you need a hard floor on the response.
+The threshold is applied to the candidate pool pre-decay; the scaling factor then reshapes scores in the `0.3×–1.5×` band. A stale-but-relevant candidate can come back with a final score slightly under your threshold by design — the candidate stays visible but visibly dampened. Filter client-side if you need a hard floor on the response.
 
 **Does decay change how I add memories?**
 No. The `client.add(...)` path is unchanged. Decay is a search-time ranking adjustment.
 
 **What if I had memories before turning decay on?**
-They use a lazy fallback — their `updated_at` timestamp is treated as their single historical touch, so they get a fair, non-pinned activation on the very first search after you flip the flag. As they're retrieved, they accumulate access history naturally.
+They use a fallback — the memory's last-update timestamp is treated as its single historical touch — so they get a fair starting point on the very first search after you flip the flag. As they're retrieved they accumulate access history naturally.
 
-**Can I tune the decay rate `d`?**
-Not in this version. v0.5 is shipped with `d = 0.5` (the canonical ACT-R value, modal estimate across published tasks). Per-project tuning will land alongside the importance prior in v1.
+**Can I tune how aggressively decay scales scores?**
+Not in this version. The current scaling is calibrated to be conservative — wide enough to meaningfully reorder candidates, narrow enough to never dominate the underlying relevance score. Per-project tuning is on the roadmap.
 
-**Can I see the multiplier per result?**
-Internal scoring details — activation, multiplier, internal product — are persisted on the search Event for support and debugging. They are not exposed in the public response by design (the response surface stays a single `score` field).
+**Can I see the scaling factor per result?**
+Internal scoring details are persisted on the search Event for support and debugging. They aren't exposed in the public response by design — the response surface stays a single `score` field.
 
-**Does decay affect rerank?**
-Decay layers on top of reranking when both are enabled. The reranker produces a richer score; decay then biases that score by reinforcement history before final truncation to `top_k`.
+**Does decay interact with reranking?**
+Yes — they layer cleanly. The reranker produces a richer relevance score; decay then biases that score by reinforcement history before final truncation to `top_k`.
 
 ## What's next
 
-This release is the **uniform-priors build** of memory decay: every memory contributes to ranking through its access history alone. We deliberately shipped this slice first so the access-history signal can be evaluated in isolation. On the roadmap:
+This release is deliberately the simplest version of decay we could ship — every memory contributes to ranking through its access history alone, so the signal can be evaluated in isolation. On the roadmap:
 
-- **v1 — Importance prior `S_m`.** A per-memory or per-category prior that biases activation, so a fact tagged `health` can carry more weight than a passing observation tagged `misc`.
-- **v1.5 — Bayesian `τ` updates.** Project-scoped automatic tuning of the decay rate from observed access patterns, replacing the fixed `d = 0.5`.
+- **Category-aware weighting.** A fact tagged `health` will be able to carry more weight than a passing observation tagged `misc`, so important categories don't get dampened the same way as noise.
+- **Auto-tuning per project.** Project-scoped automatic adjustment of how aggressively decay scales scores, based on observed access patterns — replacing the fixed scaling band with one that fits your workload.
 
-The toggle and storage shape are forward-compatible with both — no migration on your side will be needed.
+Both extensions are forward-compatible — no migration on your side will be needed when they ship.


### PR DESCRIPTION
## Summary

Adds first-class documentation for the per-project Memory Decay toggle shipped on the platform (off-by-default search-time ranking bias).

- **`platform/features/memory-decay.mdx`** (new) — concept, scaling-factor table (0.3×–1.5×), lifecycle, REST + Python + Node.js enable/confirm/disable examples, FAQ covering the threshold-vs-clamp interaction and the lazy-fallback for pre-existing memories.
- **`api-reference/organizations-projects.mdx`** — adds `decay` to the project-update reference alongside `multilingual` / `custom_categories`, with a cURL example.
- **`docs.json`** — registers the new page under *Advanced Features*.
- **`llms.txt`** — canonical entry so agents can route users to the feature.
- **`changelog/platform.mdx`** — release note for 2026-05-04.

The customer-facing field is `decay` (matching the bare-noun `multilingual` pattern). All examples and references use that name.

## Scope

Docs only. The `decay` toggle is exposed today via the project-update REST endpoint, and SDK-native examples (Python + Node.js) work once the SDK PR (mem0ai/mem0#5062) ships to PyPI/npm.

## Test plan

- [ ] `mintlify dev` renders the new page, callouts (Info / Warning / Note), `<CodeGroup>` blocks, and the lifecycle table.
- [ ] Navigation shows *Memory Decay* under *Platform → Platform Features → Advanced Features*.
- [ ] cURL examples copy-paste cleanly with `\$ORG_ID` / `\$PROJECT_ID` / `\$MEM0_API_KEY` substituted.
- [ ] `?fields=decay` example matches the actual API response shape.
- [ ] `llms.txt` entry is reachable from the *Features - Advanced Features* section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)