### PR TITLE
Add LLM cost change analysis to CI

### DIFF
--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -1,0 +1,18 @@
+name: LLM Cost Analysis
+
+on:
+  pull_request:
+    branches: [main, master]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  cost-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: Jwrede/tokentoll@753ca4d1150c74169b52a843439049b65e256d2b  # v0.6.1


### PR DESCRIPTION
## Summary

Add [tokentoll](https://github.com/Jwrede/tokentoll) GitHub Action to analyze LLM API cost changes on pull requests.

When a PR modifies code that makes LLM API calls (model swaps, max_tokens changes, new call sites), tokentoll posts a comment showing the projected cost impact. It stays silent on PRs that don't touch LLM code.

## What it detects

tokentoll uses Python AST analysis (zero runtime dependencies) to find calls to:
- OpenAI (`chat.completions.create`, `responses.create`, `embeddings.create`)
- Anthropic (`messages.create`)
- Google GenAI (`generate_content`)
- LiteLLM (`completion`, `embedding`)
- LangChain (`ChatOpenAI`, `ChatAnthropic`, `init_chat_model`)
- Zhipu AI / GLM (`ZhipuAiClient`, `ZhipuAI`)

## Current scan of this project

## tokentoll Scan Report

| File | Line | SDK | Model | Est. Cost/Call | Monthly |
|------|------|-----|-------|---------------|---------|
| `embedchain/embedchain/evaluation/metrics/answer_relevancy.py` | 43 | openai | gpt-4o (default) | $0.04 | $40.96 |
| `embedchain/embedchain/evaluation/metrics/answer_relevancy.py` | 53 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `embedchain/embedchain/evaluation/metrics/context_relevancy.py` | 42 | openai | gpt-4o (default) | $0.04 | $40.96 |
| `embedchain/embedchain/evaluation/metrics/groundedness.py` | 42 | openai | gpt-4o (default) | $0.04 | $40.96 |
| `embedchain/embedchain/evaluation/metrics/groundedness.py` | 63 | openai | gpt-4o (default) | $0.04 | $40.96 |
| `embedchain/embedchain/llm/anthropic.py` | 49 | langchain | gpt-4o (default) | $0.04 | $42.21 |
| `embedchain/embedchain/llm/azure_openai.py` | 26 | langchain | gpt-4o (default) | $0.04 | $42.21 |
| `embedchain/embedchain/llm/openai.py` | 81 | langchain | gpt-4o (default) | $0.04 | $42.21 |
| `embedchain/embedchain/llm/openai.py` | 91 | langchain | gpt-4o (default) | $0.04 | $42.21 |
| `embedchain/embedchain/loaders/image.py` | 29 | openai | gpt-4o | $0.04 | $40.96 |
| `evaluation/metrics/llm_judge.py` | 41 | openai | gpt-4o-mini | $0.002458 | $2.46 |
| `evaluation/src/langmem.py` | 35 | openai | gpt-4o (default) | $0.04 | $40.96 |
| `evaluation/src/memzero/search.py` | 113 | openai | gpt-4o (default) | $0.04 | $40.96 |
| `evaluation/src/openai/predict.py` | 97 | openai | gpt-4o (default) | $0.04 | $40.96 |
| `evaluation/src/rag.py` | 76 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `evaluation/src/rag.py` | 44 | openai | gpt-4o (default) | $0.04 | $41.15 |
| `evaluation/src/zep/search.py` | 106 | openai | gpt-4o (default) | $0.04 | $40.96 |
| `examples/misc/movie_recommendation_grok3.py` | 55 | openai | grok-3-beta | $0.49 | $491.52 |
| `examples/misc/multillm_memory.py` | 87 | litellm | gpt-4o (default) | $0.04 | $40.97 |
| `examples/misc/personalized_search.py` | 38 | langchain | gpt-4.1-nano-2025-04-14 | $0.003327 | $3.33 |
| `examples/misc/voice_assistant_elevenlabs.py` | 150 | openai | whisper-1 | N/A | N/A |
| `mem0/embeddings/azure_openai.py` | 67 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `mem0/embeddings/azure_openai.py` | 55 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `mem0/embeddings/huggingface.py` | 40 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `mem0/embeddings/lmstudio.py` | 29 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `mem0/embeddings/openai.py` | 74 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `mem0/embeddings/openai.py` | 55 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `mem0/llms/anthropic.py` | 111 | anthropic | claude-sonnet-4-20250514 (default) | $0.24 | $241.50 |
| `mem0/llms/azure_openai.py` | 143 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `mem0/llms/azure_openai_structured.py` | 88 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `mem0/llms/deepseek.py` | 108 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `mem0/llms/gemini.py` | 200 | google_genai | gemini-2.0-flash (default) | $0.000869 | $0.87 |
| `mem0/llms/litellm.py` | 86 | litellm | gpt-4o (default) | $0.04 | $42.21 |
| `mem0/llms/lmstudio.py` | 113 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `mem0/llms/minimax.py` | 113 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `mem0/llms/openai.py` | 140 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `mem0/llms/vllm.py` | 108 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `mem0/llms/xai.py` | 51 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `mem0/proxy/main.py` | 110 | litellm | gpt-4o (default) | $0.04 | $42.21 |

**Total estimated monthly cost: $2119.07**

<details>
<summary>Assumptions</summary>

- 1000 calls/month per call site

</details>

*Generated by [tokentoll](https://github.com/Jwrede/tokentoll)*

## How it works

- Runs only on PRs, compares base vs head
- Posts a sticky comment (updates in place, no duplicates)
- Only comments when LLM calls are added, removed, or modified
- First run posts an initial scan (this PR) so you can see the output
- Zero runtime dependencies, ~1s scan time for most projects
- [PyPI](https://pypi.org/project/tokentoll/) | [GitHub](https://github.com/Jwrede/tokentoll)

## Changes

- Adds `.github/workflows/llm-costs.yml` (17 lines)
- No code changes, no new dependencies
