### PR TITLE
feat(sdk): expose decay on project.update (Python + TypeScript)

### DIFF
--- a/mem0-ts/src/client/mem0.types.ts
+++ b/mem0-ts/src/client/mem0.types.ts
@@ -50,6 +50,13 @@ export interface PromptUpdatePayload {
   memoryDepth?: string | null;
   usecaseSetting?: string | number;
   multilingual?: boolean;
+  /**
+   * Toggle Memory Decay for this project. When `true`, search-time ranking
+   * boosts recently-used memories and gently dampens stale ones; when `false`,
+   * ranking is restored to the pre-decay behaviour. Off by default.
+   * See https://docs.mem0.ai/platform/features/memory-decay
+   */
+  decayEnabled?: boolean;
   [key: string]: any;
 }
 

--- a/mem0-ts/src/client/mem0.types.ts
+++ b/mem0-ts/src/client/mem0.types.ts
@@ -56,7 +56,7 @@ export interface PromptUpdatePayload {
    * ranking is restored to the pre-decay behaviour. Off by default.
    * See https://docs.mem0.ai/platform/features/memory-decay
    */
-  decayEnabled?: boolean;
+  decay?: boolean;
   [key: string]: any;
 }
 

--- a/mem0/client/project.py
+++ b/mem0/client/project.py
@@ -398,6 +398,7 @@ class Project(BaseProject):
         custom_categories: Optional[List[str]] = None,
         retrieval_criteria: Optional[List[Dict[str, Any]]] = None,
         multilingual: Optional[bool] = None,
+        decay_enabled: Optional[bool] = None,
     ) -> Dict[str, Any]:
         """
         Update project settings.
@@ -407,6 +408,9 @@ class Project(BaseProject):
             custom_categories: New categories for the project
             retrieval_criteria: New retrieval criteria for the project
             multilingual: Whether to use the input language for memory storage and retrieval
+            decay_enabled: Toggle Memory Decay for this project. When True, search-time
+                ranking boosts recently-used memories and gently dampens stale ones; when
+                False, ranking is restored to the pre-decay behaviour. Off by default.
 
         Returns:
             Dictionary containing the API response.
@@ -423,11 +427,12 @@ class Project(BaseProject):
             and custom_categories is None
             and retrieval_criteria is None
             and multilingual is None
+            and decay_enabled is None
         ):
             raise ValueError(
                 "At least one parameter must be provided for update: "
                 "custom_instructions, custom_categories, retrieval_criteria, "
-                "multilingual"
+                "multilingual, decay_enabled"
             )
 
         payload = self._prepare_params(
@@ -436,6 +441,7 @@ class Project(BaseProject):
                 "custom_categories": custom_categories,
                 "retrieval_criteria": retrieval_criteria,
                 "multilingual": multilingual,
+                "decay_enabled": decay_enabled,
             }
         )
         response = self._client.patch(
@@ -451,6 +457,7 @@ class Project(BaseProject):
                 "custom_categories": custom_categories,
                 "retrieval_criteria": retrieval_criteria,
                 "multilingual": multilingual,
+                "decay_enabled": decay_enabled,
                 "sync_type": "sync",
             },
         )
@@ -715,6 +722,7 @@ class AsyncProject(BaseProject):
         custom_categories: Optional[List[str]] = None,
         retrieval_criteria: Optional[List[Dict[str, Any]]] = None,
         multilingual: Optional[bool] = None,
+        decay_enabled: Optional[bool] = None,
     ) -> Dict[str, Any]:
         """
         Update project settings.
@@ -724,6 +732,9 @@ class AsyncProject(BaseProject):
             custom_categories: New categories for the project
             retrieval_criteria: New retrieval criteria for the project
             multilingual: Whether to use the input language for memory storage and retrieval
+            decay_enabled: Toggle Memory Decay for this project. When True, search-time
+                ranking boosts recently-used memories and gently dampens stale ones; when
+                False, ranking is restored to the pre-decay behaviour. Off by default.
 
         Returns:
             Dictionary containing the API response.
@@ -740,11 +751,12 @@ class AsyncProject(BaseProject):
             and custom_categories is None
             and retrieval_criteria is None
             and multilingual is None
+            and decay_enabled is None
         ):
             raise ValueError(
                 "At least one parameter must be provided for update: "
                 "custom_instructions, custom_categories, retrieval_criteria, "
-                "multilingual"
+                "multilingual, decay_enabled"
             )
 
         payload = self._prepare_params(
@@ -753,6 +765,7 @@ class AsyncProject(BaseProject):
                 "custom_categories": custom_categories,
                 "retrieval_criteria": retrieval_criteria,
                 "multilingual": multilingual,
+                "decay_enabled": decay_enabled,
             }
         )
         response = await self._client.patch(
@@ -768,6 +781,7 @@ class AsyncProject(BaseProject):
                 "custom_categories": custom_categories,
                 "retrieval_criteria": retrieval_criteria,
                 "multilingual": multilingual,
+                "decay_enabled": decay_enabled,
                 "sync_type": "async",
             },
         )

--- a/mem0/client/project.py
+++ b/mem0/client/project.py
@@ -398,7 +398,7 @@ class Project(BaseProject):
         custom_categories: Optional[List[str]] = None,
         retrieval_criteria: Optional[List[Dict[str, Any]]] = None,
         multilingual: Optional[bool] = None,
-        decay_enabled: Optional[bool] = None,
+        decay: Optional[bool] = None,
     ) -> Dict[str, Any]:
         """
         Update project settings.
@@ -408,7 +408,7 @@ class Project(BaseProject):
             custom_categories: New categories for the project
             retrieval_criteria: New retrieval criteria for the project
             multilingual: Whether to use the input language for memory storage and retrieval
-            decay_enabled: Toggle Memory Decay for this project. When True, search-time
+            decay: Toggle Memory Decay for this project. When True, search-time
                 ranking boosts recently-used memories and gently dampens stale ones; when
                 False, ranking is restored to the pre-decay behaviour. Off by default.
 
@@ -427,12 +427,12 @@ class Project(BaseProject):
             and custom_categories is None
             and retrieval_criteria is None
             and multilingual is None
-            and decay_enabled is None
+            and decay is None
         ):
             raise ValueError(
                 "At least one parameter must be provided for update: "
                 "custom_instructions, custom_categories, retrieval_criteria, "
-                "multilingual, decay_enabled"
+                "multilingual, decay"
             )
 
         payload = self._prepare_params(
@@ -441,7 +441,7 @@ class Project(BaseProject):
                 "custom_categories": custom_categories,
                 "retrieval_criteria": retrieval_criteria,
                 "multilingual": multilingual,
-                "decay_enabled": decay_enabled,
+                "decay": decay,
             }
         )
         response = self._client.patch(
@@ -457,7 +457,7 @@ class Project(BaseProject):
                 "custom_categories": custom_categories,
                 "retrieval_criteria": retrieval_criteria,
                 "multilingual": multilingual,
-                "decay_enabled": decay_enabled,
+                "decay": decay,
                 "sync_type": "sync",
             },
         )
@@ -722,7 +722,7 @@ class AsyncProject(BaseProject):
         custom_categories: Optional[List[str]] = None,
         retrieval_criteria: Optional[List[Dict[str, Any]]] = None,
         multilingual: Optional[bool] = None,
-        decay_enabled: Optional[bool] = None,
+        decay: Optional[bool] = None,
     ) -> Dict[str, Any]:
         """
         Update project settings.
@@ -732,7 +732,7 @@ class AsyncProject(BaseProject):
             custom_categories: New categories for the project
             retrieval_criteria: New retrieval criteria for the project
             multilingual: Whether to use the input language for memory storage and retrieval
-            decay_enabled: Toggle Memory Decay for this project. When True, search-time
+            decay: Toggle Memory Decay for this project. When True, search-time
                 ranking boosts recently-used memories and gently dampens stale ones; when
                 False, ranking is restored to the pre-decay behaviour. Off by default.
 
@@ -751,12 +751,12 @@ class AsyncProject(BaseProject):
             and custom_categories is None
             and retrieval_criteria is None
             and multilingual is None
-            and decay_enabled is None
+            and decay is None
         ):
             raise ValueError(
                 "At least one parameter must be provided for update: "
                 "custom_instructions, custom_categories, retrieval_criteria, "
-                "multilingual, decay_enabled"
+                "multilingual, decay"
             )
 
         payload = self._prepare_params(
@@ -765,7 +765,7 @@ class AsyncProject(BaseProject):
                 "custom_categories": custom_categories,
                 "retrieval_criteria": retrieval_criteria,
                 "multilingual": multilingual,
-                "decay_enabled": decay_enabled,
+                "decay": decay,
             }
         )
         response = await self._client.patch(
@@ -781,7 +781,7 @@ class AsyncProject(BaseProject):
                 "custom_categories": custom_categories,
                 "retrieval_criteria": retrieval_criteria,
                 "multilingual": multilingual,
-                "decay_enabled": decay_enabled,
+                "decay": decay,
                 "sync_type": "async",
             },
         )

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,0 +1,97 @@
+"""Tests for ``mem0.client.project.Project.update`` — focused on the
+parameter-passthrough surface.
+
+Verifies the kwarg → JSON payload mapping for every supported field
+(``custom_instructions``, ``custom_categories``, ``retrieval_criteria``,
+``multilingual``, ``decay_enabled``), the ValueError when no field is
+provided, and the URL/method shape. The HTTP layer is mocked.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def project():
+    """Build a ``Project`` with a mocked httpx client.
+
+    Bypasses ``MemoryClient`` so the test stays focused on
+    ``Project.update`` payload construction.
+    """
+    http = MagicMock()
+    http.patch.return_value = MagicMock(
+        json=lambda: {"message": "Updated"},
+        raise_for_status=lambda: None,
+    )
+    with patch("mem0.client.project.capture_client_event"):
+        from mem0.client.project import Project
+
+        proj = Project(client=http, org_id="org1", project_id="proj1")
+        yield proj, http
+
+
+def _patch_payload(http):
+    """Return the JSON body sent on the last PATCH, stripped of the SDK's
+    standard auth params (``org_id``, ``project_id``) that ``_prepare_params``
+    injects on every request."""
+    assert http.patch.called, "expected a PATCH call"
+    _, kwargs = http.patch.call_args
+    body = dict(kwargs.get("json", {}))
+    body.pop("org_id", None)
+    body.pop("project_id", None)
+    return body
+
+
+class TestProjectUpdateDecay:
+    def test_decay_enabled_true_sent_in_payload(self, project):
+        proj, http = project
+        proj.update(decay_enabled=True)
+        assert _patch_payload(http) == {"decay_enabled": True}
+
+    def test_decay_enabled_false_sent_in_payload(self, project):
+        """Explicit ``False`` must round-trip — not be filtered as falsy."""
+        proj, http = project
+        proj.update(decay_enabled=False)
+        assert _patch_payload(http) == {"decay_enabled": False}
+
+    def test_decay_enabled_combined_with_multilingual(self, project):
+        proj, http = project
+        proj.update(multilingual=True, decay_enabled=True)
+        assert _patch_payload(http) == {
+            "multilingual": True,
+            "decay_enabled": True,
+        }
+
+    def test_decay_enabled_omitted_when_none(self, project):
+        """When the caller doesn't pass ``decay_enabled``, it must not appear in
+        the payload — backwards compatible with pre-decay callers."""
+        proj, http = project
+        proj.update(multilingual=False)
+        payload = _patch_payload(http)
+        assert payload == {"multilingual": False}
+        assert "decay_enabled" not in payload
+
+    def test_no_args_raises_with_decay_enabled_in_message(self, project):
+        proj, _ = project
+        with pytest.raises(ValueError, match=r"decay_enabled"):
+            proj.update()
+
+    def test_url_targets_project_endpoint(self, project):
+        proj, http = project
+        proj.update(decay_enabled=True)
+        args, _ = http.patch.call_args
+        assert args[0] == "/api/v1/orgs/organizations/org1/projects/proj1/"
+
+
+class TestProjectUpdateBackwardsCompat:
+    def test_multilingual_only_still_works(self, project):
+        """Pre-decay callers (multilingual only) keep working unchanged."""
+        proj, http = project
+        proj.update(multilingual=True)
+        assert _patch_payload(http) == {"multilingual": True}
+
+    def test_custom_instructions_only_still_works(self, project):
+        proj, http = project
+        proj.update(custom_instructions="be concise")
+        assert _patch_payload(http) == {"custom_instructions": "be concise"}

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -3,7 +3,7 @@ parameter-passthrough surface.
 
 Verifies the kwarg → JSON payload mapping for every supported field
 (``custom_instructions``, ``custom_categories``, ``retrieval_criteria``,
-``multilingual``, ``decay_enabled``), the ValueError when no field is
+``multilingual``, ``decay``), the ValueError when no field is
 provided, and the URL/method shape. The HTTP layer is mocked.
 """
 
@@ -44,42 +44,42 @@ def _patch_payload(http):
 
 
 class TestProjectUpdateDecay:
-    def test_decay_enabled_true_sent_in_payload(self, project):
+    def test_decay_true_sent_in_payload(self, project):
         proj, http = project
-        proj.update(decay_enabled=True)
-        assert _patch_payload(http) == {"decay_enabled": True}
+        proj.update(decay=True)
+        assert _patch_payload(http) == {"decay": True}
 
-    def test_decay_enabled_false_sent_in_payload(self, project):
+    def test_decay_false_sent_in_payload(self, project):
         """Explicit ``False`` must round-trip — not be filtered as falsy."""
         proj, http = project
-        proj.update(decay_enabled=False)
-        assert _patch_payload(http) == {"decay_enabled": False}
+        proj.update(decay=False)
+        assert _patch_payload(http) == {"decay": False}
 
-    def test_decay_enabled_combined_with_multilingual(self, project):
+    def test_decay_combined_with_multilingual(self, project):
         proj, http = project
-        proj.update(multilingual=True, decay_enabled=True)
+        proj.update(multilingual=True, decay=True)
         assert _patch_payload(http) == {
             "multilingual": True,
-            "decay_enabled": True,
+            "decay": True,
         }
 
-    def test_decay_enabled_omitted_when_none(self, project):
-        """When the caller doesn't pass ``decay_enabled``, it must not appear in
+    def test_decay_omitted_when_none(self, project):
+        """When the caller doesn't pass ``decay``, it must not appear in
         the payload — backwards compatible with pre-decay callers."""
         proj, http = project
         proj.update(multilingual=False)
         payload = _patch_payload(http)
         assert payload == {"multilingual": False}
-        assert "decay_enabled" not in payload
+        assert "decay" not in payload
 
-    def test_no_args_raises_with_decay_enabled_in_message(self, project):
+    def test_no_args_raises_with_decay_in_message(self, project):
         proj, _ = project
-        with pytest.raises(ValueError, match=r"decay_enabled"):
+        with pytest.raises(ValueError, match=r"decay"):
             proj.update()
 
     def test_url_targets_project_endpoint(self, project):
         proj, http = project
-        proj.update(decay_enabled=True)
+        proj.update(decay=True)
         args, _ = http.patch.call_args
         assert args[0] == "/api/v1/orgs/organizations/org1/projects/proj1/"
 


### PR DESCRIPTION
## Summary

Adds first-class SDK support for the platform's per-project Memory Decay toggle so callers stop having to fall back to raw HTTP PATCH. Mirrors the existing `multilingual` plumbing exactly.

- **Python** (sync + async): `client.project.update(decay=True)` is now a typed kwarg, included in the `ValueError` validation tuple, the payload, and the telemetry capture.
- **TypeScript**: `PromptUpdatePayload.decay?: boolean` is exposed for autocomplete and type-checking. Wire conversion was already correct via `camelToSnakeKeys`; this just surfaces the field.
- **Tests**: 8 mocked Python tests covering the full passthrough surface — `True`/`False`/combined-with-multilingual/omitted/no-args/URL/backwards-compat.

Backwards-compatible: every existing caller continues to work unchanged. The `multilingual`-only callsites and `custom_instructions`-only callsites have explicit regression tests.

## Coordinated with platform

Platform PR (mem0ai/platform#2746, merged) renamed the wire field from `decay_enabled` → `decay`. This PR ships the matching SDK-side kwarg name so the next `mem0ai` PyPI/npm release reaches an API that accepts `decay`.

## Files changed

| File | Lines | Notes |
|---|---|---|
| `mem0/client/project.py` | +18 | sync `Project.update` and async `AsyncProject.update` — new arg, validation, payload, telemetry, docstring |
| `mem0-ts/src/client/mem0.types.ts` | +7 | `decay?: boolean` with JSDoc comment linking to docs |
| `tests/test_project.py` | +97 (new) | 8 tests, all passing locally |

## Test plan

- [x] `pytest tests/test_project.py -v` — 8/8 pass
- [x] `npx tsc --noEmit src/client/mem0.types.ts src/client/mem0.ts` — no new errors
- [x] Existing `multilingual`-only and `custom_instructions`-only callers verified unchanged via regression tests
- [ ] CI: `hatch run test` (full suite) on this branch

## Related

- Backend feature: mem0ai/platform#2695 (already on main, deployed)
- Backend rename: mem0ai/platform#2746 (already on main, deployed)
- Docs PR: #5056

🤖 Generated with [Claude Code](https://claude.com/claude-code)