### PR TITLE
fix(memory): handle text-array content in parse_vision_messages

### DIFF
--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -188,12 +188,12 @@ def parse_vision_messages(messages, llm=None, vision_details="auto"):
                     try:
                         desc = get_image_description(image_url, llm, vision_details)
                         parts_out.append(desc)
-                    except Exception:
-                        raise Exception(f"Error while downloading {image_url}.")
+                    except Exception as e:
+                        raise Exception(f"Error processing image {image_url}: {e}") from e
                 elif isinstance(part, dict) and part.get("type") == "text":
                     parts_out.append(part["text"])
                 # Ignore unknown part types silently
-            returned_messages.append({"role": msg["role"], "content": " ".join(parts_out)})
+            returned_messages.append({"role": msg["role"], "content": "\n".join(parts_out)})
         elif isinstance(msg["content"], dict) and msg["content"].get("type") == "image_url":
             # Single image content
             image_url = msg["content"]["image_url"]["url"]

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -179,9 +179,21 @@ def parse_vision_messages(messages, llm=None, vision_details="auto"):
 
         # Handle message content
         if isinstance(msg["content"], list):
-            # Multiple image URLs in content
-            description = get_image_description(msg, llm, vision_details)
-            returned_messages.append({"role": msg["role"], "content": description})
+            # Content is a list of parts — may contain text and/or image_url items.
+            # Iterate parts: collect descriptions for image_url items, pass text items through.
+            parts_out = []
+            for part in msg["content"]:
+                if isinstance(part, dict) and part.get("type") == "image_url":
+                    image_url = part["image_url"]["url"]
+                    try:
+                        desc = get_image_description(image_url, llm, vision_details)
+                        parts_out.append(desc)
+                    except Exception:
+                        raise Exception(f"Error while downloading {image_url}.")
+                elif isinstance(part, dict) and part.get("type") == "text":
+                    parts_out.append(part["text"])
+                # Ignore unknown part types silently
+            returned_messages.append({"role": msg["role"], "content": " ".join(parts_out)})
         elif isinstance(msg["content"], dict) and msg["content"].get("type") == "image_url":
             # Single image content
             image_url = msg["content"]["image_url"]["url"]


### PR DESCRIPTION
Fixes #3646

## Problem

The OpenAI API allows `content` to be a list of typed parts:
```json
[{"type": "text", "text": "..."}, {"type": "image_url", "image_url": {...}}]
```

When `parse_vision_messages` encountered list-type content, it passed the entire message `dict` to `get_image_description()` instead of iterating the list, causing a crash for messages with text-only content arrays (no images).

## Fix

Iterate each part in the list:
- `image_url` parts → call `get_image_description()` as before
- `text` parts → pass the text through directly

The resulting strings are joined with a space and set as the message content, correctly handling mixed text+image arrays while preserving all text content.

No change to existing behaviour for single-dict or plain-string content.