### PR TITLE
fix(ts): preserve user-defined metadata keys in snakeToCamelKeys

### DIFF
--- a/mem0-ts/src/client/utils.ts
+++ b/mem0-ts/src/client/utils.ts
@@ -43,7 +43,8 @@ export function snakeToCamelKeys(obj: any): any {
   return Object.fromEntries(
     Object.entries(obj).map(([key, value]) => [
       snakeToCamel(key),
-      snakeToCamelKeys(value),
+      // Preserve user-defined metadata keys as-is (no case conversion)
+      key === "metadata" ? value : snakeToCamelKeys(value),
     ]),
   );
 }


### PR DESCRIPTION
## Summary

Fixes #5055

## Bug

The `snakeToCamelKeys` function recursively converts all keys in the response, including user-defined keys inside `metadata`. This breaks round-trip consistency:

```typescript
add({ metadata: { message_id: "x" } })  // stored as message_id
get()                                   // returns metadata.messageId
```

User-defined metadata keys should be preserved as-is.

## Fix

Add special handling for the `metadata` key to skip case conversion:

```typescript
Object.entries(obj).map(([key, value]) => [
  snakeToCamel(key),
  // Preserve user-defined metadata keys as-is (no case conversion)
  key === "metadata" ? value : snakeToCamelKeys(value),
])
```

## Impact

- User-defined metadata keys are now preserved exactly as provided
- Round-trip consistency maintained: `add({ metadata: { my_key: "x" } })` → `get()` returns `{ my_key: "x" }`
- No behavior change for API-level keys (still converted to camelCase)
