### PR TITLE
fix(llms): use max_completion_tokens for gpt-5.x models in _get_common_params

### DIFF
--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -129,9 +129,15 @@ class LLMBase(ABC):
         Returns:
             Dict: Common parameters dictionary.
         """
+        model = getattr(self.config, "model", "")
+        base_model = model.lower().rsplit("/", 1)[-1]
+        # gpt-5.x variants (e.g. gpt-5.4-mini) require max_completion_tokens;
+        # older models use the legacy max_tokens parameter.
+        token_param = "max_completion_tokens" if base_model.startswith("gpt-5.") else "max_tokens"
+
         params = {
             "temperature": self.config.temperature,
-            "max_tokens": self.config.max_tokens,
+            token_param: self.config.max_tokens,
             "top_p": self.config.top_p,
         }
 

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -365,3 +365,44 @@ def test_callback_with_tools(mock_openai_client):
     mock_callback.assert_called_once()
     # Check that tool_calls exists in the message
     assert hasattr(mock_callback.call_args[0][1].choices[0].message, 'tool_calls')
+
+
+def test_gpt5x_uses_max_completion_tokens(mock_openai_client):
+    """gpt-5.x variants must use max_completion_tokens, not max_tokens.
+
+    Regression test for https://github.com/mem0ai/mem0/issues/5054.
+    The OpenAI API rejects max_tokens for gpt-5.x models and requires
+    max_completion_tokens instead.
+    """
+    config = OpenAIConfig(model="gpt-5.4-mini", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = OpenAILLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Response"))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    call_kwargs = mock_openai_client.chat.completions.create.call_args[1]
+    assert "max_completion_tokens" in call_kwargs, "gpt-5.x should use max_completion_tokens"
+    assert "max_tokens" not in call_kwargs, "gpt-5.x should not send max_tokens"
+    assert call_kwargs["max_completion_tokens"] == 100
+
+
+def test_gpt4_uses_max_tokens(mock_openai_client):
+    """Non-gpt-5.x models must continue using max_tokens (not max_completion_tokens)."""
+    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = OpenAILLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Response"))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    call_kwargs = mock_openai_client.chat.completions.create.call_args[1]
+    assert "max_tokens" in call_kwargs, "gpt-4.x should keep using max_tokens"
+    assert "max_completion_tokens" not in call_kwargs, "gpt-4.x should not use max_completion_tokens"
+    assert call_kwargs["max_tokens"] == 100


### PR DESCRIPTION
## Summary

`_get_common_params()` in `mem0/llms/base.py` unconditionally passes `max_tokens` to the OpenAI API. The `gpt-5.x` model family (e.g. `gpt-5.4-mini`, `gpt-5.1-mini`) requires `max_completion_tokens` instead — the API returns HTTP 400 `"Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead."` for every request. These models correctly pass through the `_is_reasoning_model()` check (they support `temperature`), but then hit the uncorrected `_get_common_params()` path, making all `client.add()` and `client.search()` calls fail for users on `gpt-5.x` variants.

The fix detects `gpt-5.x` variants by checking whether the base model name starts with `"gpt-5."` (the dot disambiguates `gpt-5.4-mini`-style version numbers from exact `gpt-5` / `gpt-5o` reasoning models that are already handled upstream). For matching models `max_completion_tokens` is used as the parameter key; all other models continue to use `max_tokens`, preserving backward compatibility.

Two tests are added: one that asserts `gpt-5.4-mini` sends `max_completion_tokens` (and not `max_tokens`), and one that asserts `gpt-4.x` models still send `max_tokens`.

## Issue

Fixes #5054

## Local verification

```
$ cd /tmp/mem0
$ ruff check mem0/llms/base.py tests/llms/test_openai.py
All checks passed!

$ python -m pytest tests/llms/test_openai.py -v
============================= test session starts ==============================
platform linux -- Python 3.11.15, pytest-9.0.3, pluggy-1.6.0 -- /usr/local/bin/python
cachedir: .pytest_cache
rootdir: /tmp/mem0
configfile: pyproject.toml
plugins: anyio-4.13.0
collecting ... collected 18 items

tests/llms/test_openai.py::test_openai_llm_base_url PASSED               [  5%]
tests/llms/test_openai.py::test_generate_response_without_tools PASSED   [ 11%]
tests/llms/test_openai.py::test_generate_response_with_tools PASSED      [ 16%]
tests/llms/test_openai.py::test_response_callback_invocation PASSED      [ 22%]
tests/llms/test_openai.py::test_no_response_callback PASSED              [ 27%]
tests/llms/test_openai.py::test_callback_exception_handling PASSED       [ 33%]
tests/llms/test_openai.py::test_reasoning_model_with_reasoning_effort PASSED [ 38%]
tests/llms/test_openai.py::test_reasoning_model_without_reasoning_effort PASSED [ 44%]
tests/llms/test_openai.py::test_non_reasoning_model_ignores_reasoning_effort PASSED [ 50%]
tests/llms/test_openai.py::test_reasoning_effort_config_values PASSED    [ 55%]
tests/llms/test_openai.py::test_store_not_sent_by_default PASSED         [ 61%]
tests/llms/test_openai.py::test_store_sent_when_explicitly_true PASSED   [ 66%]
tests/llms/test_openai.py::test_store_sent_when_explicitly_false PASSED  [ 72%]
tests/llms/test_openai.py::test_gpt5_mini_not_classified_as_reasoning PASSED [ 77%]
tests/llms/test_openai.py::test_is_reasoning_model_classification PASSED [ 83%]
tests/llms/test_openai.py::test_callback_with_tools PASSED               [ 88%]
tests/llms/test_openai.py::test_gpt5x_uses_max_completion_tokens PASSED  [ 94%]
tests/llms/test_openai.py::test_gpt4_uses_max_tokens PASSED              [100%]

============================== 18 passed in 1.79s ==============================
=== LOCAL_TEST_PASSED ===
```

## Risk

Only `_get_common_params()` is changed. The condition is narrow: it fires only when the base model name starts with `"gpt-5."` (with a dot), which matches `gpt-5.4-mini` and similar versioned variants but not `gpt-5`, `gpt-5o`, or `gpt-5o-mini` (those are already classified as reasoning models and never reach this path). All other providers (Anthropic, Groq, Azure OpenAI, vLLM, etc.) inherit `LLMBase` and call `_get_common_params()` too; they are unaffected because none of their model names match `gpt-5.*`. The `max_tokens` field passed to `self.config.max_tokens` is unchanged — only the key name in the outgoing dict is swapped.
