### PR TITLE
fix(pgvector): return similarity score instead of L2 distance

### DIFF
--- a/mem0/vector_stores/pgvector.py
+++ b/mem0/vector_stores/pgvector.py
@@ -250,10 +250,10 @@ class PGVector(VectorStoreBase):
         with self._get_cursor() as cur:
             cur.execute(
                 sql.SQL("""
-                SELECT id, vector <=> %s::vector AS distance, payload
+                SELECT id, 1 - (vector <=> %s::vector) AS score, payload
                 FROM {}
                 {}
-                ORDER BY distance
+                ORDER BY score DESC
                 LIMIT %s
                 """).format(self._col(), filter_clause),
                 (vectors, *filter_params, top_k),


### PR DESCRIPTION
# PGVector Semantic Search Score Fix

## Description

Fixes inverted similarity semantics in the PGVector backend. The `<=>` operator returns **Euclidean distance** (lower = more similar), but mem0's upstream scoring logic expects `score` to be a **similarity score** (higher = more similar). This caused threshold filtering, ranking, and hybrid scoring to behave incorrectly when using PostgreSQL / pgvector as the vector store.

## Changes

- `mem0/vector_stores/pgvector.py`
  - Changed SQL from `vector <=> %s::vector AS distance` to `1 - (vector <=> %s::vector) AS score`
  - Changed `ORDER BY distance` to `ORDER BY score DESC`

## Problem

1. **Threshold filtering was broken**: `score_and_rank` gates candidates with `if semantic_score < threshold: continue`. Because pgvector returned distance, highly similar results were incorrectly filtered out.
2. **Ranking was inverted**: In the additive scoring stage (`semantic + bm25 + entity_boost`), low distances from similar memories produced lower combined scores than high distances from dissimilar memories.
3. **Inconsistent with `keyword_search`**: `keyword_search` returns `ts_rank_cd` scores where higher = more relevant, while `search` returned distances where lower = more relevant.

## Root Cause

PGVector's `<=>` computes L2 distance:

- smaller value → vectors are closer → higher similarity
- larger value → vectors are farther → lower similarity

Mem0's `score_and_rank` (`mem0/utils/scoring.py`) expects all vector stores to return a similarity score where larger = more relevant.

## Why this fix is safe

- **Semantic consistency**: `score` now means "higher = more relevant", matching `keyword_search` and other backends.
- **Upstream compatibility**: No changes needed in `score_and_rank`, threshold logic, or hybrid scoring.
- **Bounded range**: For normalized vectors, `1 - distance` maps to `[0, 1]`, on the same scale as normalized BM25 scores.
- **Minimal change**: Only the SQL expression and sort order are modified; no API or data migration required.

## Impact

- Only affects deployments using `PGVector` as the vector store backend.
- After the fix, search result scores correctly reflect similarity, and threshold/sorting behavior is consistent with other backends.

## Verification

1. Call `/search` with a query and verify that `score` increases as relevance increases.
2. Adjust the `threshold` parameter and confirm that lower thresholds do not filter out highly relevant results.
3. Compare `search` and `keyword_search` score trends; they should now be consistent.

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update