### PR TITLE
chore(release): bump mem0ai to 2.0.2 (py) and 3.0.3 (ts)

### DIFF
--- a/docs/changelog/highlights.mdx
+++ b/docs/changelog/highlights.mdx
@@ -4,6 +4,19 @@ description: "Major product launches, headline features, and milestones for Mem0
 mode: "wide"
 ---
 
+<Update label="2026-05-08" description="Memory Decay">
+
+**Memory Decay — Recently-Used Memories Surface Higher, Automatically**
+
+Per-project search-time ranking bias that boosts recently-touched memories and gently dampens stale ones. Off by default; opt in per project via the `decay` field on the project endpoint, or via `client.project.update(decay=True)` in the SDKs (Python `v2.0.2` / TypeScript `v3.0.3`).
+
+- **Soft bias, never a filter.** The scaling factor stays in `0.3×–1.5×`. Decay can reorder candidates but never zeros them out — anything that surfaced before decay can still surface after.
+- **Reinforcement loop.** Every memory returned in a search has its access history updated, so frequently-used facts naturally float to the top over time.
+- **Public score still clamped to `[0, 1]`.** Existing API contract preserved; no client-side changes needed.
+- **v3 search only**, fully reversible. See [Memory Decay docs](/platform/features/memory-decay).
+
+</Update>
+
 <Update label="2026-04-14" description="Mem0 SDK v2.0.0 / v3.0.0">
 
 **New Memory Algorithm — State-of-the-Art Accuracy at ~3-4x Lower Cost**

--- a/docs/changelog/sdk.mdx
+++ b/docs/changelog/sdk.mdx
@@ -7,6 +7,20 @@ mode: "wide"
 <Tabs>
 <Tab title="Python">
 
+<Update label="2026-05-08" description="v2.0.2">
+
+**Bug Fixes:**
+- **Telemetry:** Stitch OSS and platform PostHog identities on `MemoryClient` init so `$identify` events fire and a single user is no longer tracked as two or three disconnected personas ([#5040](https://github.com/mem0ai/mem0/pull/5040))
+- **Security:** Harden against SQL injection and prompt injection ([#4997](https://github.com/mem0ai/mem0/pull/4997))
+
+**New Features:**
+- **SDK:** Expose `decay` on `project.update` ([#5062](https://github.com/mem0ai/mem0/pull/5062))
+
+**Improvements:**
+- **Plugin:** Hand `mem0` search decisions to the agent ([#4992](https://github.com/mem0ai/mem0/pull/4992))
+
+</Update>
+
 <Update label="2026-04-25" description="v2.0.1">
 
 **Bug Fixes:**
@@ -910,6 +924,18 @@ See the [OSS v1 to v2 migration guide](https://docs.mem0.ai/migration/oss-v1-to-
 </Tab>
 
 <Tab title="TypeScript">
+<Update label="2026-05-08" description="v3.0.3">
+
+**Bug Fixes:**
+- **Telemetry:** Stitch OSS and platform PostHog identities on `MemoryClient` init so `$identify` events fire and a single user is no longer tracked as two or three disconnected personas ([#5040](https://github.com/mem0ai/mem0/pull/5040))
+- **Vector Stores:** Fix inverted vector distance in PGVector implementation ([#4944](https://github.com/mem0ai/mem0/pull/4944))
+- **Security:** Harden against SQL injection and prompt injection ([#4997](https://github.com/mem0ai/mem0/pull/4997))
+
+**New Features:**
+- **SDK:** Expose `decay` on `project.update` ([#5062](https://github.com/mem0ai/mem0/pull/5062))
+
+</Update>
+
 <Update label="2026-04-25" description="v3.0.2">
 
 **Bug Fixes:**

--- a/mem0-ts/package.json
+++ b/mem0-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mem0ai",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "The Memory Layer For Your AI Apps",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mem0ai"
-version = "2.0.1"
+version = "2.0.2"
 description = "Long-term memory for AI Agents"
 authors = [
     { name = "Mem0", email = "support@mem0.ai" }


### PR DESCRIPTION
## Linked Issue

N/A — release-cadence cleanup. The PostHog identity-stitching fix in #5040 has been merged but never shipped to PyPI/npm, so installed-package users have not been firing `\$identify` events. Latest published versions (`mem0ai` 2.0.1 / 3.0.2) were both cut on 2026-04-25, predating the merge.

## Description

Patch-bumps the Python SDK (`mem0ai`) from 2.0.1 → 2.0.2 and the TypeScript SDK (`mem0ai`) from 3.0.2 → 3.0.3 so the CD workflows publish the backlog of merged-but-unreleased changes.

### Python 2.0.1 → 2.0.2

- fix(telemetry): stitch OSS and platform identities (#5040)
- feat(sdk): expose decay on `project.update` (#5062)
- fix: SQL injection / prompt injection (#4997)
- refactor(plugin): hand mem0 search decisions to the agent (#4992)

### TypeScript 3.0.2 → 3.0.3

- fix(telemetry): stitch OSS and platform identities (#5040)
- feat(sdk): expose decay on `project.update` (#5062)
- fix: SQL injection / prompt injection (#4997)
- fix: PGVector inverted vector distance (#4944)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update
- [x] Release / version bump

## Breaking Changes

N/A — patch bumps only.

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Verified the telemetry-stitching code is wired into both shipped entry points:
- Python: `mem0/client/main.py:137` and `:1015` invoke `_maybe_alias_anon_to_email` from both sync and async client `__init__`.
- TS: `mem0-ts/src/client/mem0.ts:132` invokes `_maybeAliasAnonToEmail` inside `_initializeClient`; `config.ts` and `telemetry.ts` are reachable from `src/client/index.ts`, which is the tsup entry that ships in `dist/`.

CI on this branch covers ruff + pytest (Python) and prettier + jest (TS). Once merged, tag `v2.0.2` and `ts-v3.0.3` to trigger `cd.yml` and `ts-sdk-cd.yml` respectively.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed