### PR TITLE
docs(memory-decay): use SDK calls in code samples

### DIFF
--- a/docs/platform/features/memory-decay.mdx
+++ b/docs/platform/features/memory-decay.mdx
@@ -59,39 +59,19 @@ The toggle lives on the project. You enable decay by patching the project's `dec
 The toggle is exposed on the standard project-update endpoint, the same place where `multilingual` and `custom_categories` live.
 
 <CodeGroup>
+```python Python
+client.project.update(decay=True)
+```
+
+```javascript JavaScript
+await client.project.update({ decay: true });
+```
+
 ```bash cURL
 curl -X PATCH https://api.mem0.ai/api/v1/orgs/organizations/$ORG_ID/projects/$PROJECT_ID/ \
   -H "Authorization: Token $MEM0_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"decay": true}'
-```
-
-```python Python
-import os
-import requests
-
-org_id = os.environ["MEM0_ORG_ID"]
-project_id = os.environ["MEM0_PROJECT_ID"]
-
-requests.patch(
-    f"https://api.mem0.ai/api/v1/orgs/organizations/{org_id}/projects/{project_id}/",
-    headers={"Authorization": f"Token {os.environ['MEM0_API_KEY']}"},
-    json={"decay": True},
-)
-```
-
-```javascript Node.js
-const res = await fetch(
-  `https://api.mem0.ai/api/v1/orgs/organizations/${process.env.MEM0_ORG_ID}/projects/${process.env.MEM0_PROJECT_ID}/`,
-  {
-    method: "PATCH",
-    headers: {
-      Authorization: `Token ${process.env.MEM0_API_KEY}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ decay: true }),
-  },
-);
 ```
 
 ```json Response
@@ -104,6 +84,16 @@ const res = await fetch(
 `decay` is returned on every project read. To fetch only this field, use `?fields=decay`.
 
 <CodeGroup>
+```python Python
+response = client.project.get(fields=["decay"])
+print(response["decay"])
+```
+
+```javascript JavaScript
+const response = await client.project.get({ fields: ["decay"] });
+console.log(response.decay);
+```
+
 ```bash cURL
 curl "https://api.mem0.ai/api/v1/orgs/organizations/$ORG_ID/projects/$PROJECT_ID/?fields=decay" \
   -H "Authorization: Token $MEM0_API_KEY"
@@ -119,6 +109,14 @@ curl "https://api.mem0.ai/api/v1/orgs/organizations/$ORG_ID/projects/$PROJECT_ID
 The toggle is fully reversible. Setting it to `false` immediately restores the pre-decay ranking; nothing about your stored memories is modified or lost.
 
 <CodeGroup>
+```python Python
+client.project.update(decay=False)
+```
+
+```javascript JavaScript
+await client.project.update({ decay: false });
+```
+
 ```bash cURL
 curl -X PATCH https://api.mem0.ai/api/v1/orgs/organizations/$ORG_ID/projects/$PROJECT_ID/ \
   -H "Authorization: Token $MEM0_API_KEY" \


### PR DESCRIPTION
## Summary

Follow-up to #5056 (now merged). The Memory Decay docs were written before the SDK exposed `decay`, so they used raw `curl` / `requests.patch` / `fetch`. Now that PR #5062 has shipped in **Python v2.0.2** and **TypeScript v3.0.3** (released via #5078), the docs should lead with the SDK call — the same `client.project.update(...)` shape readers already know from `custom_instructions`, `multilingual`, etc.

## Changes (only `docs/platform/features/memory-decay.mdx`)

- **"Turn the flag on"** — replace `requests.patch` / `fetch` with `client.project.update(decay=True)` and `await client.project.update({ decay: true })`.
- **"Confirm the state"** — add SDK examples via `client.project.get(fields=["decay"])`.
- **"Turn it back off"** — add SDK examples for the off path.
- Each section still keeps a cURL block as a fallback for non-SDK users.

## Test plan

- [ ] Mintlify preview renders \`<CodeGroup>\` cleanly with Python / JavaScript / cURL / Response tabs in each section
- [ ] SDK call shapes match the merged decay PR (#5062): Python kwarg \`decay\`, TypeScript field \`decay\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)