### PR TITLE
fix(scoring): handle None score in score_and_rank to avoid TypeError

### DIFF
--- a/mem0/utils/scoring.py
+++ b/mem0/utils/scoring.py
@@ -98,7 +98,8 @@ def score_and_rank(
         if mem_id is None:
             continue
 
-        semantic_score = result.get("score", 0.0)
+        _score = result.get("score")
+        semantic_score = 0.0 if _score is None else _score
         if semantic_score < threshold:
             continue
 

--- a/tests/utils/test_scoring.py
+++ b/tests/utils/test_scoring.py
@@ -1,10 +1,10 @@
 import pytest
 
 from mem0.utils.scoring import (
+    ENTITY_BOOST_WEIGHT,
     get_bm25_params,
     normalize_bm25,
     score_and_rank,
-    ENTITY_BOOST_WEIGHT,
 )
 
 
@@ -125,6 +125,27 @@ class TestScoreAndRank:
         entity = {"a": 0.5}
         scored = score_and_rank(results, bm25, entity, threshold=0.1, top_k=10)
         assert scored[0]["score"] <= 1.0
+
+    def test_none_score_treated_as_zero(self):
+        # LangChain vector store returns Documents without scores, so score=None.
+        # dict.get("score", 0.0) returns None (key exists), causing TypeError on
+        # comparison. score=None must be treated as 0.0.
+        results = [
+            {"id": "a", "score": None, "payload": {"data": "mem a"}},
+            {"id": "b", "score": 0.8, "payload": {"data": "mem b"}},
+        ]
+        scored = score_and_rank(results, {}, {}, threshold=0.1, top_k=10)
+        # "a" has None score → treated as 0.0 → below threshold=0.1 → excluded
+        assert len(scored) == 1
+        assert scored[0]["id"] == "b"
+
+    def test_none_score_no_type_error_at_zero_threshold(self):
+        # Regression: None score must not raise TypeError even when threshold=0.0.
+        results = [{"id": "a", "score": None, "payload": {}}]
+        scored = score_and_rank(results, {}, {}, threshold=0.0, top_k=10)
+        # None → 0.0, and 0.0 is not < 0.0, so the result passes the gate.
+        assert len(scored) == 1
+        assert scored[0]["score"] == pytest.approx(0.0)
 
 
 class TestEntityBoostWeight:


### PR DESCRIPTION
## Linked Issue

Closes #5071

## Description

`score_and_rank` in `mem0/utils/scoring.py` crashed with a `TypeError` whenever the LangChain vector store was used as a backend. The LangChain `VectorStore` base contract requires `similarity_search_by_vector` to return `List[Document]` — objects that carry no relevance score. `langchain.py`'s `_parse_output` therefore sets `score=None` on those results.

The bug is on this line in `score_and_rank`:

```python
# BEFORE — buggy
semantic_score = result.get("score", 0.0)  # returns None when key exists with value None
if semantic_score < threshold:             # TypeError: '<' not supported between NoneType and float
```

`dict.get(key, default)` only substitutes the default when the **key is absent** — not when the value is `None`. Because `langchain.py` explicitly stores `score=None`, `get("score", 0.0)` returns `None`, which then crashes on the `<` comparison.

The fix treats `None` as `0.0` (no score information available) inside `score_and_rank`, making it robust regardless of which vector store is in use:

```python
# AFTER — fixed
_score = result.get("score")
semantic_score = 0.0 if _score is None else _score
```

Two regression tests were added to `tests/utils/test_scoring.py` to cover:
1. A `None`-scored result mixed with a normal result (verifies no `TypeError` and correct filtering).
2. A `None`-scored result at `threshold=0.0` (verifies it passes the gate with a combined score of 0.0).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Two tests added in `tests/utils/test_scoring.py`:
- `test_none_score_treated_as_zero` — confirms `None` score is treated as `0.0` and filtered by threshold.
- `test_none_score_no_type_error_at_zero_threshold` — confirms no `TypeError` even when `threshold=0.0`.

## Local verification

```
$ ruff check mem0/utils/scoring.py tests/utils/test_scoring.py
All checks passed!

$ isort --check-only --profile black mem0/utils/scoring.py tests/utils/test_scoring.py
All checks passed

$ pre-commit run --files mem0/utils/scoring.py tests/utils/test_scoring.py
ruff.................................................................Passed
isort................................................................Passed

$ python -m pytest tests/utils/test_scoring.py -v
============================= test session starts ==============================
platform linux -- Python 3.11.15, pytest-9.0.3, pluggy-1.6.0
collected 20 items

tests/utils/test_scoring.py::TestGetBm25Params::test_short_query PASSED  [  5%]
tests/utils/test_scoring.py::TestGetBm25Params::test_medium_query PASSED [ 10%]
tests/utils/test_scoring.py::TestGetBm25Params::test_long_query PASSED   [ 15%]
tests/utils/test_scoring.py::TestGetBm25Params::test_empty_lemmatized PASSED [ 20%]
tests/utils/test_scoring.py::TestNormalizeBm25::test_at_midpoint PASSED  [ 25%]
tests/utils/test_scoring.py::TestNormalizeBm25::test_high_score PASSED   [ 30%]
tests/utils/test_scoring.py::TestNormalizeBm25::test_low_score PASSED    [ 35%]
tests/utils/test_scoring.py::TestNormalizeBm25::test_range PASSED        [ 40%]
tests/utils/test_scoring.py::TestScoreAndRank::test_semantic_only PASSED [ 45%]
tests/utils/test_scoring.py::TestScoreAndRank::test_semantic_plus_bm25 PASSED [ 50%]
tests/utils/test_scoring.py::TestScoreAndRank::test_all_three_signals PASSED [ 55%]
tests/utils/test_scoring.py::TestScoreAndRank::test_threshold_gates_on_semantic PASSED [ 60%]
tests/utils/test_scoring.py::TestScoreAndRank::test_top_k_limit PASSED   [ 65%]
tests/utils/test_scoring.py::TestScoreAndRank::test_adaptive_divisor_semantic_only PASSED [ 70%]
tests/utils/test_scoring.py::TestScoreAndRank::test_adaptive_divisor_semantic_plus_entity PASSED [ 75%]
tests/utils/test_scoring.py::TestScoreAndRank::test_empty_results PASSED [ 80%]
tests/utils/test_scoring.py::TestScoreAndRank::test_score_clamped_to_1 PASSED [ 85%]
tests/utils/test_scoring.py::TestScoreAndRank::test_none_score_treated_as_zero PASSED [ 90%]
tests/utils/test_scoring.py::TestScoreAndRank::test_none_score_no_type_error_at_zero_threshold PASSED [ 95%]
tests/utils/test_scoring.py::TestEntityBoostWeight::test_weight_value PASSED [100%]

============================== 20 passed in 1.18s ==============================
=== LOCAL_TEST_PASSED ===
```

## Risk

Very low. The change is confined to a two-line guard inside the hot loop of `score_and_rank`. The only behavior change is that a candidate with `score=None` is now treated as `score=0.0` rather than crashing. For all other vector stores that already return numeric scores the code path is identical: a non-None float skips the guard and continues as before.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
