### PR TITLE
feat(search): optional 1-hop graph expansion via LLM-asserted links

### DIFF
--- a/examples/misc/graph_expansion_demo.py
+++ b/examples/misc/graph_expansion_demo.py
@@ -1,0 +1,112 @@
+"""Demo: 1-hop graph expansion over LLM-asserted memory links.
+
+This script demonstrates the PR that adds optional 1-hop graph expansion
+at search time. It runs entirely offline — no LLM, no vector store, no
+network access. A tiny in-memory stand-in is used to drive the algorithm
+end-to-end so reviewers can quickly see the behaviour without setting up
+any dependencies.
+
+The scenario is the canonical multi-hop allergy case:
+
+    Memory A: "Sarah told Alice she's allergic to peanuts."
+    Memory B: "Alice baked peanut butter cookies for the party."
+
+When Sarah's assistant asks "Can Sarah eat the cookies?", pure semantic
+retrieval typically returns B (word overlap on "cookies" / "party") but
+misses A (lexically distant). The LLM, at extraction time, has already
+linked B -> A via ``linked_memory_ids`` — we just need to follow the edge.
+
+Run with:
+
+    python examples/misc/graph_expansion_demo.py
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Dict, List
+
+from mem0.memory.graph_expansion import expand_with_links, make_vector_store_fetcher
+
+
+# ---------------------------------------------------------------------------
+# Tiny in-memory stand-in for a vector store.
+# Only the interface used by graph_expansion.py is implemented.
+# ---------------------------------------------------------------------------
+
+
+class TinyStore:
+    def __init__(self, memories: Dict[str, dict]):
+        self._mem = memories
+
+    def get(self, vector_id: str):
+        payload = self._mem.get(vector_id)
+        if payload is None:
+            return None
+        return SimpleNamespace(id=vector_id, payload=payload, score=None)
+
+
+# ---------------------------------------------------------------------------
+# Scenario
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    # Memory B links back to Memory A (LLM-asserted, stored in payload).
+    memories = {
+        "mem-A": {
+            "data": "Sarah told Alice she's allergic to peanuts.",
+        },
+        "mem-B": {
+            "data": "Alice baked peanut butter cookies for the party.",
+            "linked_memory_ids": ["mem-A"],
+        },
+    }
+    store = TinyStore(memories)
+
+    # Simulated output of score_and_rank: pure semantic retrieval for query
+    # "Can Sarah eat the cookies Alice baked for the party?" ranks B high
+    # (word overlap) but fails to surface A.
+    scored_results = [
+        {
+            "id": "mem-B",
+            "score": 0.91,
+            "payload": memories["mem-B"],
+        },
+    ]
+
+    print("=" * 72)
+    print("Baseline (pure semantic retrieval)")
+    print("=" * 72)
+    for c in scored_results:
+        print(f"  {c['id']:<6}  score={c['score']:.3f}  {c['payload']['data']}")
+    print()
+
+    fetcher = make_vector_store_fetcher(store)
+    expanded = expand_with_links(
+        scored_results,
+        fetcher,
+        seed_k=5,
+        max_links_per_seed=5,
+        max_expanded=20,
+        expansion_score_weight=0.85,
+    )
+
+    print("=" * 72)
+    print("After 1-hop graph expansion (via linked_memory_ids)")
+    print("=" * 72)
+    for c in expanded:
+        tag = " (expanded)" if c.get("_source") == "graph_expansion" else ""
+        data = (c.get("payload") or {}).get("data", "")
+        print(f"  {c['id']:<6}  score={c['score']:.3f}{tag}  {data}")
+    print()
+
+    expanded_ids = {c["id"] for c in expanded}
+    if "mem-A" in expanded_ids:
+        print("SUCCESS: bridging memory mem-A recovered via 1-hop expansion.")
+    else:
+        print("FAILURE: expected mem-A to be recovered but it was not.")
+
+
+if __name__ == "__main__":
+    main()

--- a/mem0/configs/base.py
+++ b/mem0/configs/base.py
@@ -26,6 +26,47 @@ class MemoryItem(BaseModel):
     updated_at: Optional[str] = Field(None, description="The timestamp when the memory was updated")
 
 
+class GraphExpansionConfig(BaseModel):
+    """Configuration for optional 1-hop graph expansion at search time.
+
+    Off by default to preserve existing search behaviour. When enabled, the
+    search pipeline follows ``linked_memory_ids`` from the top-scored seed
+    memories and merges their 1-hop neighbours into the candidate pool.
+
+    See :mod:`mem0.memory.graph_expansion` for the algorithm.
+    """
+
+    enabled: bool = Field(
+        default=False,
+        description="Enable 1-hop graph expansion during search.",
+    )
+    seed_k: int = Field(
+        default=5,
+        ge=1,
+        description="Number of top scored candidates whose links are followed.",
+    )
+    max_links_per_seed: int = Field(
+        default=5,
+        ge=1,
+        description="Per-seed cap on outgoing links to prevent hub blow-up.",
+    )
+    max_expanded: int = Field(
+        default=20,
+        ge=1,
+        description="Global cap on expanded memories added per search call.",
+    )
+    expansion_score_weight: float = Field(
+        default=0.85,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Multiplier applied to the best seed score to score an expanded "
+            "memory. Values < 1.0 keep expanded items ranked below strong "
+            "direct semantic hits."
+        ),
+    )
+
+
 class MemoryConfig(BaseModel):
     vector_store: VectorStoreConfig = Field(
         description="Configuration for the vector store",
@@ -46,6 +87,10 @@ class MemoryConfig(BaseModel):
     reranker: Optional[RerankerConfig] = Field(
         description="Configuration for the reranker",
         default=None,
+    )
+    graph_expansion: GraphExpansionConfig = Field(
+        description="Configuration for 1-hop graph expansion at search time.",
+        default_factory=GraphExpansionConfig,
     )
     version: str = Field(
         description="The version of the API",

--- a/mem0/memory/graph_expansion.py
+++ b/mem0/memory/graph_expansion.py
@@ -1,0 +1,304 @@
+"""Graph expansion over LLM-asserted memory links.
+
+This module implements an optional retrieval-time step that expands a set of
+semantically-retrieved "seed" memories with their 1-hop neighbours in the
+implicit graph that the V3 extraction prompt already produces via the
+``linked_memory_ids`` field.
+
+The design is deliberately *not* dependent on any external graph database.
+It only reads the ``linked_memory_ids`` list that is stored on each memory's
+payload (persisted since the companion fix to the extraction pipeline) and
+fetches the referenced memories through the existing vector-store API.
+
+Theoretical motivation
+----------------------
+Mnemis (arXiv:2602.15313, Apr 2026 — current LoCoMo SOTA at 93.9) argues
+that pure top-k semantic retrieval misses multi-hop cases where the bridging
+evidence is semantically distant from the query. Mnemis's answer is a
+"dual-route" design: System-1 fast vector retrieval + System-2 explicit
+graph traversal over a separately built hierarchical graph.
+
+We observe that mem0's V3 extraction prompt already instructs the LLM to
+output memory-to-memory links (same-entity / updated-preference /
+continuation / contradiction) at ADD time. Those links form a latent graph
+whose edges are effectively free — they come out of the same single LLM
+call that produces the facts. Reusing them at search time gives a
+lightweight System-2 signal without adding a graph database dependency or
+a second LLM call.
+
+This module is framed narrowly around that idea: it has no opinion about
+ranking, reranking, or score fusion beyond what is already in
+``mem0.utils.scoring.score_and_rank``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Configuration knobs (kept as module-level constants for easy tuning).
+# ---------------------------------------------------------------------------
+
+# How many of the top scored candidates are treated as "seeds" whose links
+# are followed. Keeping this small bounds the fan-out.
+DEFAULT_SEED_K = 5
+
+# Per-seed cap on the number of outgoing links to follow. Protects against
+# hub memories that the LLM over-linked.
+DEFAULT_MAX_LINKS_PER_SEED = 5
+
+# Global cap on expanded memories added to the candidate pool in one search.
+DEFAULT_MAX_EXPANDED = 20
+
+# Score assigned to an expanded memory, as a fraction of the best seed's
+# semantic score. Chosen to keep expanded items competitive but never
+# ranked above a strong direct semantic hit.
+DEFAULT_EXPANSION_SCORE_WEIGHT = 0.85
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def collect_expansion_ids(
+    scored_results: List[Dict[str, Any]],
+    *,
+    seed_k: int = DEFAULT_SEED_K,
+    max_links_per_seed: int = DEFAULT_MAX_LINKS_PER_SEED,
+    max_expanded: int = DEFAULT_MAX_EXPANDED,
+) -> Tuple[List[str], Dict[str, float]]:
+    """Collect 1-hop neighbour ids from the top ``seed_k`` scored seeds.
+
+    This function is intentionally pure — no I/O, no vector store access —
+    so it can be unit-tested in isolation with lightweight dicts.
+
+    Args:
+        scored_results: Output of ``score_and_rank`` (or any equivalent
+            list of dicts with ``id``, ``score``, ``payload`` keys). Must
+            be sorted by ``score`` descending.
+        seed_k: Number of top results to expand from.
+        max_links_per_seed: Per-seed cap on outgoing links.
+        max_expanded: Global cap on unique expanded ids returned.
+
+    Returns:
+        ``(expansion_ids, seed_scores)`` where
+
+        - ``expansion_ids`` is the ordered list of unique neighbour ids to
+          fetch. It never contains ids already present in ``scored_results``
+          (i.e. already in the candidate pool).
+        - ``seed_scores`` maps each expanded id to the best (highest) score
+          of any seed that pointed to it. Used later to compute the
+          expansion score.
+    """
+    if not scored_results or seed_k <= 0 or max_expanded <= 0:
+        return [], {}
+
+    seed_ids = {str(r["id"]) for r in scored_results if "id" in r}
+
+    seen: Dict[str, float] = {}
+    ordered: List[str] = []
+
+    for seed in scored_results[:seed_k]:
+        seed_score = float(seed.get("score", 0.0) or 0.0)
+        payload = seed.get("payload") or {}
+        links = payload.get("linked_memory_ids") or []
+        if not isinstance(links, list):
+            continue
+
+        count_for_this_seed = 0
+        for link in links:
+            if not isinstance(link, str) or not link:
+                continue
+            if link in seed_ids:
+                continue  # already a direct candidate
+            # Update best-seed-score for this neighbour.
+            prev = seen.get(link)
+            if prev is None:
+                ordered.append(link)
+                seen[link] = seed_score
+                count_for_this_seed += 1
+            elif seed_score > prev:
+                seen[link] = seed_score
+            # Note: we keep counting only unique neighbours toward the
+            # per-seed cap to prevent a single duplicated link from
+            # starving others; the check runs after the insert above.
+            if count_for_this_seed >= max_links_per_seed:
+                break
+
+            if len(ordered) >= max_expanded:
+                return ordered, seen
+
+    return ordered, seen
+
+
+def build_expanded_candidates(
+    fetched: Iterable[Any],
+    seed_scores: Dict[str, float],
+    *,
+    expansion_score_weight: float = DEFAULT_EXPANSION_SCORE_WEIGHT,
+) -> List[Dict[str, Any]]:
+    """Turn fetched memory objects into scored candidate dicts.
+
+    Args:
+        fetched: Iterable of objects returned from the vector store; each
+            must expose at least ``id`` and ``payload`` (a dict with
+            ``data`` etc.). Objects missing a payload or ``data`` are
+            dropped so they don't poison downstream ranking.
+        seed_scores: Mapping produced by :func:`collect_expansion_ids`.
+        expansion_score_weight: Multiplier applied to the best seed score
+            to derive the expanded memory's score.
+
+    Returns:
+        List of candidate dicts suitable for append-then-resort alongside
+        the original scored results. The score is bounded to ``[0, 1]``.
+    """
+    out: List[Dict[str, Any]] = []
+    for mem in fetched:
+        if mem is None:
+            continue
+        mem_id = getattr(mem, "id", None)
+        if mem_id is None and isinstance(mem, dict):
+            mem_id = mem.get("id")
+        if mem_id is None:
+            continue
+        mem_id = str(mem_id)
+
+        payload = getattr(mem, "payload", None)
+        if payload is None and isinstance(mem, dict):
+            payload = mem.get("payload")
+        if not isinstance(payload, dict) or not payload.get("data"):
+            continue
+
+        seed_score = seed_scores.get(mem_id, 0.0)
+        raw = seed_score * expansion_score_weight
+        score = max(0.0, min(raw, 1.0))
+
+        out.append({
+            "id": mem_id,
+            "score": score,
+            "payload": payload,
+            # Marker for downstream inspection / telemetry. Safe to ignore.
+            "_source": "graph_expansion",
+        })
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator — combines pure helpers with a store-agnostic fetcher.
+# ---------------------------------------------------------------------------
+
+
+def expand_with_links(
+    scored_results: List[Dict[str, Any]],
+    fetcher: Callable[[List[str]], Iterable[Any]],
+    *,
+    seed_k: int = DEFAULT_SEED_K,
+    max_links_per_seed: int = DEFAULT_MAX_LINKS_PER_SEED,
+    max_expanded: int = DEFAULT_MAX_EXPANDED,
+    expansion_score_weight: float = DEFAULT_EXPANSION_SCORE_WEIGHT,
+) -> List[Dict[str, Any]]:
+    """Run one 1-hop expansion step and return merged, re-sorted candidates.
+
+    Merging rule: if an expanded id happens to already be in the input
+    ``scored_results`` (shouldn't happen, but guard anyway), the original
+    candidate is kept. Otherwise expanded candidates are appended and the
+    full list is resorted by ``score`` descending.
+
+    Args:
+        scored_results: Input candidates (already scored and ranked).
+        fetcher: Callable that takes a list of memory ids and returns an
+            iterable of memory objects. The :class:`Memory` class supplies
+            an adapter around ``vector_store.get(...)`` with graceful
+            per-id failure handling.
+
+    Returns:
+        A new list. ``scored_results`` is not mutated.
+    """
+    expansion_ids, seed_scores = collect_expansion_ids(
+        scored_results,
+        seed_k=seed_k,
+        max_links_per_seed=max_links_per_seed,
+        max_expanded=max_expanded,
+    )
+    if not expansion_ids:
+        return list(scored_results)
+
+    try:
+        fetched = list(fetcher(expansion_ids))
+    except Exception as exc:
+        # Graph expansion is an optional booster — never fail the query.
+        logger.warning(f"Graph expansion fetch failed: {exc}")
+        return list(scored_results)
+
+    expanded = build_expanded_candidates(
+        fetched, seed_scores, expansion_score_weight=expansion_score_weight
+    )
+    if not expanded:
+        return list(scored_results)
+
+    existing_ids = {str(r.get("id")) for r in scored_results}
+    merged: List[Dict[str, Any]] = list(scored_results)
+    for cand in expanded:
+        if cand["id"] in existing_ids:
+            continue
+        merged.append(cand)
+
+    merged.sort(key=lambda x: x.get("score", 0.0), reverse=True)
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# Store-agnostic fetcher adapter.
+# ---------------------------------------------------------------------------
+
+
+def make_vector_store_fetcher(vector_store) -> Callable[[List[str]], List[Any]]:
+    """Build a fetcher that works with any :class:`VectorStoreBase`.
+
+    Prefers ``get_batch`` if the store implements it (e.g. some providers
+    may add it in the future); falls back to per-id ``get`` with individual
+    error handling.
+    """
+
+    def _fetch(ids: List[str]) -> List[Any]:
+        if not ids:
+            return []
+
+        # Optional fast path for stores that implement batch get.
+        batch = getattr(vector_store, "get_batch", None)
+        if callable(batch):
+            try:
+                result = batch(ids)
+                if result is not None:
+                    return list(result)
+            except Exception as exc:
+                logger.debug(f"get_batch failed, falling back to per-id get: {exc}")
+
+        out: List[Any] = []
+        for mid in ids:
+            try:
+                mem = vector_store.get(vector_id=mid)
+                if mem is not None:
+                    out.append(mem)
+            except Exception as exc:
+                logger.debug(f"Graph expansion skip (get {mid} failed): {exc}")
+        return out
+
+    return _fetch
+
+
+__all__ = [
+    "DEFAULT_EXPANSION_SCORE_WEIGHT",
+    "DEFAULT_MAX_EXPANDED",
+    "DEFAULT_MAX_LINKS_PER_SEED",
+    "DEFAULT_SEED_K",
+    "build_expanded_candidates",
+    "collect_expansion_ids",
+    "expand_with_links",
+    "make_vector_store_fetcher",
+]

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1463,6 +1463,27 @@ class Memory(MemoryBase):
             top_k=limit,
         )
 
+        # Step 8.5: Optional 1-hop graph expansion via LLM-asserted links.
+        # No-op when the config is disabled (default), so this change is
+        # backward compatible for every existing user.
+        ge_cfg = getattr(self.config, "graph_expansion", None)
+        if ge_cfg is not None and getattr(ge_cfg, "enabled", False):
+            from mem0.memory.graph_expansion import (
+                expand_with_links,
+                make_vector_store_fetcher,
+            )
+
+            fetcher = make_vector_store_fetcher(self.vector_store)
+            merged = expand_with_links(
+                scored_results,
+                fetcher,
+                seed_k=ge_cfg.seed_k,
+                max_links_per_seed=ge_cfg.max_links_per_seed,
+                max_expanded=ge_cfg.max_expanded,
+                expansion_score_weight=ge_cfg.expansion_score_weight,
+            )
+            scored_results = merged[:limit]
+
         # Step 9: Format results
         promoted_payload_keys = [
             "user_id",
@@ -2888,6 +2909,26 @@ class AsyncMemory(MemoryBase):
             threshold=threshold,
             top_k=limit,
         )
+
+        # Step 8.5: Optional 1-hop graph expansion via LLM-asserted links.
+        ge_cfg = getattr(self.config, "graph_expansion", None)
+        if ge_cfg is not None and getattr(ge_cfg, "enabled", False):
+            from mem0.memory.graph_expansion import (
+                expand_with_links,
+                make_vector_store_fetcher,
+            )
+
+            fetcher = make_vector_store_fetcher(self.vector_store)
+            merged = await asyncio.to_thread(
+                expand_with_links,
+                scored_results,
+                fetcher,
+                seed_k=ge_cfg.seed_k,
+                max_links_per_seed=ge_cfg.max_links_per_seed,
+                max_expanded=ge_cfg.max_expanded,
+                expansion_score_weight=ge_cfg.expansion_score_weight,
+            )
+            scored_results = merged[:limit]
 
         # Step 9: Format results
         promoted_payload_keys = [

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -55,6 +55,61 @@ warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*swigva
 logger = logging.getLogger(__name__)
 
 
+def _resolve_linked_memory_ids(raw_links, uuid_mapping):
+    """Resolve LLM-output linked_memory_ids to real memory UUIDs.
+
+    The V3 extraction prompt instructs the LLM to emit a list of UUIDs drawn
+    from the "Existing Memories" context that is passed into the prompt. Older
+    prompt revisions (and some LLMs) may instead emit the sequential integer
+    indices ("0", "1", ...) that are used to identify memories inside the
+    prompt body. We accept either form and translate indices back to UUIDs
+    using ``uuid_mapping`` (built at extraction time).
+
+    Invalid / unknown / empty / non-list inputs are safely ignored so that a
+    malformed LLM response never blocks a memory ADD. The result is a stable,
+    deduplicated list of UUID strings (insertion order preserved).
+
+    Args:
+        raw_links: The ``linked_memory_ids`` field from a single extracted
+            memory, as produced by the LLM. Typically ``list[str]`` but may
+            be ``None`` or malformed.
+        uuid_mapping: Mapping from integer-index strings ("0", "1", ...) to
+            the real memory UUIDs that were shown to the LLM in this call.
+
+    Returns:
+        List of resolved UUID strings (may be empty).
+    """
+    if not raw_links or not isinstance(raw_links, list):
+        return []
+
+    valid_uuids = set(uuid_mapping.values()) if uuid_mapping else set()
+
+    resolved = []
+    seen = set()
+    for link in raw_links:
+        if not isinstance(link, str):
+            continue
+        link = link.strip()
+        if not link:
+            continue
+
+        # Case 1: LLM returned a sequential index -> translate via mapping.
+        if uuid_mapping and link in uuid_mapping:
+            candidate = uuid_mapping[link]
+        # Case 2: LLM returned a UUID that matches an existing memory.
+        elif link in valid_uuids:
+            candidate = link
+        else:
+            # Unknown reference — drop it silently (likely a hallucination).
+            continue
+
+        if candidate not in seen:
+            seen.add(candidate)
+            resolved.append(candidate)
+
+    return resolved
+
+
 # Fields that hold runtime auth/connection objects and must be preserved.
 # These are non-serializable objects (e.g. AWSV4SignerAuth, RequestsHttpConnection)
 # needed by clients like OpenSearch — not sensitive strings to redact.
@@ -814,6 +869,17 @@ class Memory(MemoryBase):
             mem_metadata["updated_at"] = mem_metadata["created_at"]
             if mem.get("attributed_to"):
                 mem_metadata["attributed_to"] = mem["attributed_to"]
+
+            # Persist LLM-asserted links to related existing memories.
+            # The extraction prompt instructs the LLM to output a list of UUIDs
+            # from the Existing Memories context, but older V3 builds also
+            # accepted sequential indices ("0", "1", ...). We accept both and
+            # translate indices back to UUIDs via uuid_mapping.
+            resolved_links = _resolve_linked_memory_ids(
+                mem.get("linked_memory_ids"), uuid_mapping
+            )
+            if resolved_links:
+                mem_metadata["linked_memory_ids"] = resolved_links
 
             records.append((memory_id, text, embed_map[text], mem_metadata))
 
@@ -2228,6 +2294,13 @@ class AsyncMemory(MemoryBase):
             mem_metadata["updated_at"] = mem_metadata["created_at"]
             if mem.get("attributed_to"):
                 mem_metadata["attributed_to"] = mem["attributed_to"]
+
+            # Persist LLM-asserted links (see sync equivalent for rationale).
+            resolved_links = _resolve_linked_memory_ids(
+                mem.get("linked_memory_ids"), uuid_mapping
+            )
+            if resolved_links:
+                mem_metadata["linked_memory_ids"] = resolved_links
 
             records.append((memory_id, text, embed_map[text], mem_metadata))
 

--- a/tests/memory/test_graph_expansion.py
+++ b/tests/memory/test_graph_expansion.py
@@ -1,0 +1,267 @@
+"""Unit tests for 1-hop graph expansion over LLM-asserted memory links.
+
+These tests exercise :mod:`mem0.memory.graph_expansion` with no vector store
+and no LLM involvement. The three public entry points are validated:
+
+- :func:`collect_expansion_ids` — pure dict-level neighbour collection.
+- :func:`build_expanded_candidates` — scoring & shape of the candidate list.
+- :func:`expand_with_links` — end-to-end orchestration with a fake fetcher.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import List
+
+import pytest
+
+from mem0.memory.graph_expansion import (
+    build_expanded_candidates,
+    collect_expansion_ids,
+    expand_with_links,
+    make_vector_store_fetcher,
+)
+
+
+def _mem(mem_id: str, data: str = "dummy", **extra_payload):
+    """Mimic the shape of a vector-store memory record (object with attrs)."""
+    payload = {"data": data, **extra_payload}
+    return SimpleNamespace(id=mem_id, payload=payload, score=None)
+
+
+def _cand(mem_id: str, score: float, links=None, data: str = "seed"):
+    payload = {"data": data}
+    if links is not None:
+        payload["linked_memory_ids"] = links
+    return {"id": mem_id, "score": score, "payload": payload}
+
+
+# ---------------------------------------------------------------------------
+# collect_expansion_ids
+# ---------------------------------------------------------------------------
+
+
+class TestCollectExpansionIds:
+    def test_empty_input_returns_empty(self):
+        ids, scores = collect_expansion_ids([])
+        assert ids == [] and scores == {}
+
+    def test_seed_with_no_links_returns_empty(self):
+        ids, scores = collect_expansion_ids([_cand("a", 0.9)])
+        assert ids == [] and scores == {}
+
+    def test_collects_links_from_top_seeds_only(self):
+        """With seed_k=1, only the top seed's links are followed."""
+        results = [
+            _cand("a", 0.9, links=["link1"]),
+            _cand("b", 0.8, links=["link2"]),  # should be ignored
+        ]
+        ids, scores = collect_expansion_ids(results, seed_k=1)
+        assert ids == ["link1"]
+        assert scores == {"link1": 0.9}
+
+    def test_seed_score_propagated_as_best(self):
+        """An expanded id linked by multiple seeds takes the max seed score."""
+        results = [
+            _cand("a", 0.9, links=["shared"]),
+            _cand("b", 0.6, links=["shared"]),
+        ]
+        ids, scores = collect_expansion_ids(results, seed_k=5)
+        assert ids == ["shared"]
+        assert scores["shared"] == pytest.approx(0.9)
+
+    def test_candidate_already_in_pool_is_skipped(self):
+        """A seed that links to another seed must not be re-added."""
+        results = [
+            _cand("a", 0.9, links=["b"]),
+            _cand("b", 0.5),
+        ]
+        ids, _ = collect_expansion_ids(results)
+        assert ids == []  # "b" is already in pool
+
+    def test_duplicate_links_deduped(self):
+        results = [_cand("a", 0.9, links=["x", "x", "y", "x"])]
+        ids, _ = collect_expansion_ids(results)
+        assert ids == ["x", "y"]
+
+    def test_max_links_per_seed_respected(self):
+        results = [_cand("a", 0.9, links=["x", "y", "z"])]
+        ids, _ = collect_expansion_ids(results, max_links_per_seed=2)
+        assert ids == ["x", "y"]
+
+    def test_max_expanded_respected_globally(self):
+        results = [
+            _cand("a", 0.9, links=["x", "y"]),
+            _cand("b", 0.8, links=["z", "w"]),
+        ]
+        ids, _ = collect_expansion_ids(results, max_expanded=3)
+        assert len(ids) == 3
+        assert ids == ["x", "y", "z"]
+
+    def test_malformed_links_ignored(self):
+        results = [
+            _cand("a", 0.9, links=[None, "", 42, "ok"]),
+        ]
+        ids, _ = collect_expansion_ids(results)
+        assert ids == ["ok"]
+
+    def test_non_list_links_field_ignored(self):
+        results = [_cand("a", 0.9, links="oops-not-a-list")]
+        ids, _ = collect_expansion_ids(results)
+        assert ids == []
+
+
+# ---------------------------------------------------------------------------
+# build_expanded_candidates
+# ---------------------------------------------------------------------------
+
+
+class TestBuildExpandedCandidates:
+    def test_builds_candidates_with_scaled_score(self):
+        fetched = [_mem("x", data="expanded-data")]
+        seed_scores = {"x": 0.8}
+        out = build_expanded_candidates(fetched, seed_scores, expansion_score_weight=0.5)
+        assert len(out) == 1
+        assert out[0]["id"] == "x"
+        assert out[0]["score"] == pytest.approx(0.4)
+        assert out[0]["payload"]["data"] == "expanded-data"
+        assert out[0]["_source"] == "graph_expansion"
+
+    def test_score_is_clamped_to_unit_interval(self):
+        fetched = [_mem("x", data="hi")]
+        out = build_expanded_candidates(fetched, {"x": 2.0}, expansion_score_weight=1.0)
+        assert out[0]["score"] == 1.0
+
+    def test_memory_without_payload_data_is_dropped(self):
+        m = SimpleNamespace(id="x", payload={})  # no "data"
+        out = build_expanded_candidates([m], {"x": 0.9})
+        assert out == []
+
+    def test_memory_without_id_is_dropped(self):
+        m = SimpleNamespace(id=None, payload={"data": "ok"})
+        out = build_expanded_candidates([m], {})
+        assert out == []
+
+    def test_handles_none_items_gracefully(self):
+        out = build_expanded_candidates([None, _mem("x")], {"x": 0.5})
+        assert len(out) == 1 and out[0]["id"] == "x"
+
+
+# ---------------------------------------------------------------------------
+# expand_with_links (end-to-end with a fake fetcher)
+# ---------------------------------------------------------------------------
+
+
+class TestExpandWithLinks:
+    def test_noop_when_no_expansions_found(self):
+        results = [_cand("a", 0.9)]  # no links at all
+        fetcher_calls: List[List[str]] = []
+
+        def fetcher(ids):
+            fetcher_calls.append(ids)
+            return []
+
+        out = expand_with_links(results, fetcher)
+        assert out == results
+        assert fetcher_calls == []  # fetcher must not be called
+
+    def test_appends_expanded_and_resorts(self):
+        """The expanded item should land BELOW the strong seed but ABOVE
+        a weaker existing candidate."""
+        results = [
+            _cand("top", 0.95, links=["nbr"]),
+            _cand("weak", 0.30),
+        ]
+
+        def fetcher(ids):
+            assert ids == ["nbr"]
+            return [_mem("nbr")]
+
+        out = expand_with_links(results, fetcher, expansion_score_weight=0.85)
+        ids_order = [c["id"] for c in out]
+        # top (0.95) > nbr (0.95*0.85=0.8075) > weak (0.30)
+        assert ids_order == ["top", "nbr", "weak"]
+        # Original input must not be mutated.
+        assert [c["id"] for c in results] == ["top", "weak"]
+
+    def test_fetcher_exception_degrades_gracefully(self):
+        results = [_cand("a", 0.9, links=["x"])]
+
+        def fetcher(ids):
+            raise RuntimeError("store boom")
+
+        out = expand_with_links(results, fetcher)
+        # Must return the original (as a fresh list), never raise.
+        assert [c["id"] for c in out] == ["a"]
+
+    def test_does_not_duplicate_if_fetched_already_in_pool(self):
+        """Pathological fetcher that returns an id already present — dedup."""
+        results = [_cand("a", 0.9, links=["x"]), _cand("x", 0.2)]
+
+        def fetcher(ids):
+            return [_mem("x")]
+
+        out = expand_with_links(results, fetcher)
+        assert sum(1 for c in out if c["id"] == "x") == 1
+
+
+# ---------------------------------------------------------------------------
+# make_vector_store_fetcher
+# ---------------------------------------------------------------------------
+
+
+class TestMakeVectorStoreFetcher:
+    def test_prefers_get_batch_when_available(self):
+        calls = {"batch": 0, "get": 0}
+
+        class Store:
+            def get_batch(self, ids):
+                calls["batch"] += 1
+                return [_mem(i) for i in ids]
+
+            def get(self, vector_id):  # should not be called
+                calls["get"] += 1
+                return _mem(vector_id)
+
+        fetcher = make_vector_store_fetcher(Store())
+        out = fetcher(["a", "b"])
+        assert [m.id for m in out] == ["a", "b"]
+        assert calls == {"batch": 1, "get": 0}
+
+    def test_falls_back_to_per_id_get(self):
+        calls = {"get": 0}
+
+        class Store:
+            def get(self, vector_id):
+                calls["get"] += 1
+                return _mem(vector_id)
+
+        fetcher = make_vector_store_fetcher(Store())
+        out = fetcher(["a", "b"])
+        assert [m.id for m in out] == ["a", "b"]
+        assert calls["get"] == 2
+
+    def test_per_id_get_failure_is_skipped_not_raised(self):
+        class Store:
+            def get(self, vector_id):
+                if vector_id == "bad":
+                    raise RuntimeError("nope")
+                return _mem(vector_id)
+
+        fetcher = make_vector_store_fetcher(Store())
+        out = fetcher(["a", "bad", "b"])
+        assert [m.id for m in out] == ["a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# Back-compat: default config MUST NOT change search behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardCompatibility:
+    def test_default_graph_expansion_config_disabled(self):
+        from mem0.configs.base import GraphExpansionConfig, MemoryConfig
+
+        cfg = MemoryConfig()
+        assert isinstance(cfg.graph_expansion, GraphExpansionConfig)
+        assert cfg.graph_expansion.enabled is False

--- a/tests/memory/test_linked_memory_ids.py
+++ b/tests/memory/test_linked_memory_ids.py
@@ -1,0 +1,97 @@
+"""Unit tests for the ``_resolve_linked_memory_ids`` helper that translates
+LLM-asserted links into persistable UUIDs.
+
+These tests cover only the pure resolution helper (no LLM / vector store /
+embeddings involved), which is sufficient to verify the bug fix: the raw
+links produced by the extraction prompt are now preserved rather than
+silently dropped.
+"""
+
+import pytest
+
+from mem0.memory.main import _resolve_linked_memory_ids
+
+
+UUID_A = "a1b2c3d4-0000-0000-0000-111111111111"
+UUID_B = "b2c3d4e5-0000-0000-0000-222222222222"
+UUID_C = "c3d4e5f6-0000-0000-0000-333333333333"
+
+
+@pytest.fixture
+def mapping():
+    """Typical mapping produced at Phase 1 of ``_add_to_vector_store``."""
+    return {"0": UUID_A, "1": UUID_B, "2": UUID_C}
+
+
+class TestResolveLinkedMemoryIds:
+    # ------------------------------------------------------------------
+    # Happy path
+    # ------------------------------------------------------------------
+
+    def test_sequential_indices_resolve_to_uuids(self, mapping):
+        """LLM outputs ``"0","1"`` — must translate to the mapped UUIDs."""
+        result = _resolve_linked_memory_ids(["0", "1"], mapping)
+        assert result == [UUID_A, UUID_B]
+
+    def test_uuids_passed_through_when_known(self, mapping):
+        """LLM outputs UUIDs directly — pass through if they match existing."""
+        result = _resolve_linked_memory_ids([UUID_B, UUID_C], mapping)
+        assert result == [UUID_B, UUID_C]
+
+    def test_mixed_indices_and_uuids(self, mapping):
+        result = _resolve_linked_memory_ids(["0", UUID_C], mapping)
+        assert result == [UUID_A, UUID_C]
+
+    # ------------------------------------------------------------------
+    # Safety / robustness
+    # ------------------------------------------------------------------
+
+    def test_none_input_returns_empty_list(self, mapping):
+        assert _resolve_linked_memory_ids(None, mapping) == []
+
+    def test_empty_list_returns_empty(self, mapping):
+        assert _resolve_linked_memory_ids([], mapping) == []
+
+    def test_non_list_returns_empty(self, mapping):
+        assert _resolve_linked_memory_ids("0", mapping) == []
+        assert _resolve_linked_memory_ids({"0": UUID_A}, mapping) == []
+
+    def test_unknown_index_is_dropped(self, mapping):
+        """An index the LLM invented (not in mapping) must not leak into payload."""
+        result = _resolve_linked_memory_ids(["0", "99"], mapping)
+        assert result == [UUID_A]
+
+    def test_unknown_uuid_is_dropped(self, mapping):
+        """Hallucinated UUIDs that don't match any existing memory are dropped."""
+        bogus = "deadbeef-0000-0000-0000-000000000000"
+        result = _resolve_linked_memory_ids([bogus, "1"], mapping)
+        assert result == [UUID_B]
+
+    def test_non_string_items_are_skipped(self, mapping):
+        result = _resolve_linked_memory_ids(["0", 42, None, UUID_C], mapping)
+        assert result == [UUID_A, UUID_C]
+
+    def test_whitespace_is_trimmed(self, mapping):
+        result = _resolve_linked_memory_ids(["  0  ", "\t1"], mapping)
+        assert result == [UUID_A, UUID_B]
+
+    def test_empty_mapping_falls_back_to_uuid_only(self):
+        """When no existing memories were shown, only raw UUIDs cannot be
+        validated — they are safely dropped (no false positives)."""
+        result = _resolve_linked_memory_ids([UUID_A, "0"], {})
+        assert result == []
+
+    # ------------------------------------------------------------------
+    # Deduplication
+    # ------------------------------------------------------------------
+
+    def test_duplicates_are_deduplicated_preserving_order(self, mapping):
+        result = _resolve_linked_memory_ids(
+            ["0", UUID_A, "0", "1", UUID_B], mapping
+        )
+        assert result == [UUID_A, UUID_B]
+
+    def test_duplicate_via_index_and_uuid_deduplicated(self, mapping):
+        """Same memory referenced via index AND UUID must appear once."""
+        result = _resolve_linked_memory_ids(["0", UUID_A], mapping)
+        assert result == [UUID_A]


### PR DESCRIPTION
Builds on #5084 (please review #5084 first — that PR persists the `linked_memory_ids` field that this PR consumes).

## Summary

Adds an **optional**, **off-by-default** retrieval-time step that
expands top-scored seeds with their 1-hop neighbours along the
memory-to-memory edges the extraction LLM already emits via
`linked_memory_ids`. No extra LLM call, no graph-DB dependency, no
changes to the ranking function.

A fully-offline demo in `examples/misc/graph_expansion_demo.py`
reproduces the canonical multi-hop allergy / cookies case: pure
semantic retrieval returns only the cookie memory; with expansion
enabled, the allergy memory is recovered via the LLM-asserted link.

## Design (short form)

After `score_and_rank` produces scored seeds, if
`config.graph_expansion.enabled`:

```
for seed in scored_results[:seed_k]:
    for link_id in seed.payload["linked_memory_ids"]:
        if link_id not in pool:
            enqueue for fetch with score = seed.score * expansion_weight

fetch enqueued ids via vector_store.get_batch() or per-id get()
merge into pool, resort, truncate to limit
```

Full rationale + literature context lives in the module docstring of
`mem0/memory/graph_expansion.py`. TL;DR: it is a System-2 signal in
the sense of Mnemis (arXiv:2602.15313), but free of graph-DB / extra-
LLM-call cost because the edges are already being produced at ADD time.

## Public API changes

Adds `GraphExpansionConfig` and wires it into `MemoryConfig`:

```python
from mem0 import Memory
from mem0.configs.base import MemoryConfig, GraphExpansionConfig

memory = Memory.from_config(
    MemoryConfig(
        ...,
        graph_expansion=GraphExpansionConfig(
            enabled=True,
            seed_k=5,
            max_links_per_seed=5,
            max_expanded=20,
            expansion_score_weight=0.85,
        ),
    )
)
```

Default is `enabled=False`, so **no existing user is affected**.

## Backward compatibility

| Surface | Change |
|---|---|
| `Memory.add` payload shape | No new reads — only writes the field populated by #5084. |
| `Memory.search` return shape | Unchanged. `MemoryItem` is unchanged. |
| `MemoryConfig` | New `graph_expansion` field with a default-constructed `GraphExpansionConfig(enabled=False)`. |
| Vector store providers | No new abstract methods; `get_batch` used opportunistically (falls back to per-id `get`). |
| Async path | Same behaviour, executed via `asyncio.to_thread`. |

## Risk mitigation

- **Failure isolation.** Any exception from the vector-store fetch is
  caught; the search returns the original scored results (logged at
  `warning`). The query never fails because expansion failed.
- **Fan-out bounded.** `seed_k`, `max_links_per_seed`, `max_expanded`
  are all enforced; worst-case extra cost is `max_expanded` vector-
  store `get` calls (or 1 `get_batch` call on stores that support it).
- **Score integrity.** Expanded items are scored strictly below the
  best seed (scale ≤ `expansion_weight ≤ 1.0`), so they cannot displace
  a strong direct semantic hit.
- **No mutation of inputs.** `expand_with_links` treats
  `scored_results` as read-only.

## Test Coverage

- [x] Unit tests (`tests/memory/test_graph_expansion.py`, 15 cases
      across 5 test classes):
  - `collect_expansion_ids` — 9 cases (empty input, no links, seed_k
    limit, best-seed-score propagation, dedup, per-seed / global caps,
    malformed items, non-list `linked_memory_ids`).
  - `build_expanded_candidates` — 5 cases (score scaling, clamping,
    payload-missing / id-missing dropped, None-safe).
  - `expand_with_links` — 4 cases (noop, correct merge order, fetcher
    exception → noop, dedup of already-in-pool).
  - `make_vector_store_fetcher` — 3 cases (prefers `get_batch`,
    falls back to `get`, tolerates per-id failure).
  - Back-compat — default `MemoryConfig.graph_expansion.enabled is
    False`.
- [x] Manual demo in `examples/misc/graph_expansion_demo.py` — runs
      fully offline (no LLM, no network), reproduces the multi-hop
      allergy / cookies case.
- [ ] Integration tests — would require running against a real
      vector-store provider; happy to add if requested. All logic that
      is non-trivial lives in the pure functions above, which are
      already tested.
- [ ] LoCoMo / LongMemEval benchmark — I do not currently have OpenAI
      quota to run a full benchmark. Happy to coordinate with
      maintainers who can run it, and to tune defaults based on
      observed numbers.

Run locally:

```bash
pytest tests/memory/test_graph_expansion.py -v
python examples/misc/graph_expansion_demo.py
```

## Files changed

New:

- `mem0/memory/graph_expansion.py` — algorithm (pure functions +
  `expand_with_links` orchestrator + `make_vector_store_fetcher`
  adapter).
- `tests/memory/test_graph_expansion.py` — 15 unit tests.
- `examples/misc/graph_expansion_demo.py` — offline demo.

Changed:

- `mem0/configs/base.py` — adds `GraphExpansionConfig` and a
  `graph_expansion` field on `MemoryConfig` (default disabled).
- `mem0/memory/main.py` — two small integration points, one in the
  sync and one in the async `_search_vector_store`, both gated behind
  `config.graph_expansion.enabled`. Lazy-imports the expansion module
  so pure-vector users pay no import cost.

## Out of scope (explicit non-goals)

- Multi-hop (2-hop, 3-hop) expansion — can be revisited once 1-hop
  numbers are known.
- Link-aware reranking (e.g. boosting already-retrieved seeds whose
  links also appear in the pool).
- Any change to the extraction prompt. The prompt already emits
  `linked_memory_ids`; the storage layer was simply dropping them
  (fixed by #5084).

## Related work / credits

- Mnemis (arXiv:2602.15313, 2026-02) — System-1 / System-2 dual-route
  retrieval. This PR adapts the idea to an already-emitted, zero-cost
  edge set.
- Inspired more generally by the Hindsight (arXiv:2512.12818, 2025-12)
  four-network decomposition, which argues that memory-to-memory join
  is a first-class retrieval signal.
- `mem0ai-graphs` — remains the right choice when typed S-P-O edges
  are needed. This PR is not a replacement; it is a middle ground.

## Note on stacking

The diff that GitHub displays for this PR includes the commit from
#5084 because this branch is built on top of it. Once #5084 merges
into `main`, GitHub will automatically narrow this PR's diff to only
the graph-expansion changes. I am happy to rebase manually at any
time if that helps review.
