### PR TITLE
fix(llms): anthropic base url config

### DIFF
--- a/mem0-ts/src/oss/src/llms/anthropic.ts
+++ b/mem0-ts/src/oss/src/llms/anthropic.ts
@@ -8,10 +8,11 @@ export class AnthropicLLM implements LLM {
 
   constructor(config: LLMConfig) {
     const apiKey = config.apiKey || process.env.ANTHROPIC_API_KEY;
+    const baseURL = config.baseURL || process.env.ANTHROPIC_BASE_URL;
     if (!apiKey) {
       throw new Error("Anthropic API key is required");
     }
-    this.client = new Anthropic({ apiKey });
+    this.client = new Anthropic({ apiKey, baseURL });
     this.model = config.model || "claude-3-sonnet-20240229";
   }
 

--- a/mem0-ts/src/oss/tests/anthropic-llm.test.ts
+++ b/mem0-ts/src/oss/tests/anthropic-llm.test.ts
@@ -1,0 +1,73 @@
+/// <reference types="jest" />
+/**
+ * Anthropic LLM - unit tests (mocked Anthropic SDK).
+ */
+
+let capturedConstructorArgs: any;
+const mockCreate = jest.fn();
+
+jest.mock("@anthropic-ai/sdk", () => {
+  return jest.fn().mockImplementation((args: any) => {
+    capturedConstructorArgs = args;
+    return {
+      messages: { create: mockCreate },
+    };
+  });
+});
+
+import { AnthropicLLM } from "../src/llms/anthropic";
+
+describe("AnthropicLLM (unit)", () => {
+  const originalBaseURL = process.env.ANTHROPIC_BASE_URL;
+
+  beforeEach(() => {
+    capturedConstructorArgs = undefined;
+    mockCreate.mockClear();
+    delete process.env.ANTHROPIC_BASE_URL;
+  });
+
+  afterAll(() => {
+    if (originalBaseURL === undefined) {
+      delete process.env.ANTHROPIC_BASE_URL;
+    } else {
+      process.env.ANTHROPIC_BASE_URL = originalBaseURL;
+    }
+  });
+
+  it("forwards baseURL to the Anthropic client constructor", () => {
+    new AnthropicLLM({
+      apiKey: "test-key",
+      baseURL: "https://api.config.com",
+    });
+
+    expect(capturedConstructorArgs).toMatchObject({
+      apiKey: "test-key",
+      baseURL: "https://api.config.com",
+    });
+  });
+
+  it("uses ANTHROPIC_BASE_URL when config baseURL is missing", () => {
+    process.env.ANTHROPIC_BASE_URL = "https://api.provider.com";
+
+    new AnthropicLLM({ apiKey: "test-key" });
+
+    expect(capturedConstructorArgs).toMatchObject({
+      apiKey: "test-key",
+      baseURL: "https://api.provider.com",
+    });
+  });
+
+  it("prefers config baseURL over ANTHROPIC_BASE_URL", () => {
+    process.env.ANTHROPIC_BASE_URL = "https://api.provider.com";
+
+    new AnthropicLLM({
+      apiKey: "test-key",
+      baseURL: "https://api.config.com",
+    });
+
+    expect(capturedConstructorArgs).toMatchObject({
+      apiKey: "test-key",
+      baseURL: "https://api.config.com",
+    });
+  });
+});

--- a/mem0/llms/anthropic.py
+++ b/mem0/llms/anthropic.py
@@ -38,7 +38,9 @@ class AnthropicLLM(LLMBase):
             self.config.model = "claude-3-5-sonnet-20240620"
 
         api_key = self.config.api_key or os.getenv("ANTHROPIC_API_KEY")
-        self.client = anthropic.Anthropic(api_key=api_key)
+        base_url = self.config.anthropic_base_url or os.getenv("ANTHROPIC_BASE_URL") or None
+
+        self.client = anthropic.Anthropic(api_key=api_key, base_url=base_url)
 
     def _get_common_params(self, **kwargs) -> Dict:
         """Get common parameters, avoiding sending both temperature and top_p together.

--- a/tests/llms/test_anthropic.py
+++ b/tests/llms/test_anthropic.py
@@ -24,6 +24,33 @@ def test_default_config_omits_top_p(mock_anthropic_client):
     assert config.temperature == 0.1
 
 
+def test_anthropic_llm_uses_config_base_url():
+    """AnthropicLLM should pass AnthropicConfig.anthropic_base_url to the SDK client."""
+    with patch("mem0.llms.anthropic.anthropic") as mock_anthropic:
+        config_base_url = "https://api.config.com"
+        config = AnthropicConfig(
+            model="claude-3-5-sonnet-20240620",
+            api_key="test-key",
+            anthropic_base_url=config_base_url,
+        )
+
+        AnthropicLLM(config)
+
+        mock_anthropic.Anthropic.assert_called_once_with(api_key="test-key", base_url=config_base_url)
+
+
+def test_anthropic_llm_uses_env_base_url_when_config_missing():
+    """AnthropicLLM should fall back to ANTHROPIC_BASE_URL when config has no base URL."""
+    with patch("mem0.llms.anthropic.anthropic") as mock_anthropic:
+        provider_base_url = "https://api.provider.com"
+        config = AnthropicConfig(model="claude-3-5-sonnet-20240620", api_key="test-key")
+
+        with patch.dict("os.environ", {"ANTHROPIC_BASE_URL": provider_base_url}):
+            AnthropicLLM(config)
+
+        mock_anthropic.Anthropic.assert_called_once_with(api_key="test-key", base_url=provider_base_url)
+
+
 def test_generate_response_does_not_send_top_p_by_default(mock_anthropic_client):
     """Anthropic API rejects temperature and top_p together; top_p must be omitted by default."""
     config = AnthropicConfig(model="claude-3-5-sonnet-20240620", api_key="test-key")


### PR DESCRIPTION
## Linked Issue

N/A — no linked issue. This fixes custom Anthropic base URL handling discovered during SDK configuration.

## Description

This PR fixes Anthropic LLM initialization so configured custom base URLs are passed to the Anthropic SDK clients.

Changes included:

- Python SDK: `AnthropicConfig.anthropic_base_url` is now used when creating `anthropic.Anthropic`
- Python SDK: falls back to `ANTHROPIC_BASE_URL` when config is not provided
- TypeScript OSS SDK: `config.baseURL` is now passed to `new Anthropic(...)`
- TypeScript OSS SDK: falls back to `ANTHROPIC_BASE_URL` when config is not provided
- Added unit tests for Python and TypeScript Anthropic base URL behavior

This is needed because the config fields existed but were not being used, so users could not point Anthropic requests to custom/proxy-compatible endpoints.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Tested locally with:

```bash
hatch run pytest tests/llms/test_anthropic.py -q
hatch run lint

cd mem0-ts
pnpm exec jest src/oss/tests/anthropic-llm.test.ts src/oss/tests/factory.unit.test.ts --runInBand
pnpm exec prettier --check src/oss/src/llms/anthropic.ts src/oss/tests/anthropic-llm.test.ts
```

Results:

- Python Anthropic tests passed: `7 passed`
- Python lint passed: `All checks passed`
- TypeScript targeted tests passed: `2 test suites passed, 41 tests passed`
- TypeScript formatting check passed

Note: I also tried TypeScript project-wide `tsc`, but it currently fails on existing unrelated `src/community/...` and client test type issues outside this PR.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing relevant tests pass locally
- [x] I have updated documentation if needed
