### PR TITLE
fix(plugin): deterministic mem0 user_id resolution

### DIFF
--- a/mem0-plugin/scripts/_identity.py
+++ b/mem0-plugin/scripts/_identity.py
@@ -1,0 +1,59 @@
+"""Resolve mem0 user_id with deterministic priority.
+
+Resolution priority:
+  1. MEM0_USER_ID env var (explicit override)
+  2. ~/.mem0/identity.json cache (pinned to current MEM0_API_KEY fingerprint)
+  3. Derived: "mem0-" + sha256(MEM0_API_KEY)[:12]
+  4. Fallback: $USER, else "default"
+
+Same MEM0_API_KEY across machines yields the same user_id, which fixes
+the "47 user buckets per account" symptom from running on multiple
+laptops with different $USER values.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from datetime import datetime, timezone
+
+_CACHE_PATH = os.path.expanduser("~/.mem0/identity.json")
+
+
+def resolve_user_id() -> str:
+    explicit = os.environ.get("MEM0_USER_ID", "").strip()
+    if explicit:
+        return explicit
+
+    api_key = os.environ.get("MEM0_API_KEY", "").strip()
+    if api_key:
+        digest = hashlib.sha256(api_key.encode("utf-8")).hexdigest()
+        fingerprint = digest[:8]
+
+        try:
+            with open(_CACHE_PATH, "r") as f:
+                cached = json.load(f)
+            if cached.get("api_key_fingerprint") == fingerprint and cached.get("user_id"):
+                return cached["user_id"]
+        except (OSError, json.JSONDecodeError):
+            pass
+
+        derived = "mem0-" + digest[:12]
+        try:
+            os.makedirs(os.path.dirname(_CACHE_PATH), exist_ok=True)
+            with open(_CACHE_PATH, "w") as f:
+                json.dump(
+                    {
+                        "user_id": derived,
+                        "source": "api_key",
+                        "api_key_fingerprint": fingerprint,
+                        "resolved_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    },
+                    f,
+                )
+        except OSError:
+            pass
+        return derived
+
+    return os.environ.get("USER") or "default"

--- a/mem0-plugin/scripts/_identity.sh
+++ b/mem0-plugin/scripts/_identity.sh
@@ -1,0 +1,57 @@
+# Source this file. Sets MEM0_RESOLVED_USER_ID.
+#
+# Resolution priority:
+#   1. MEM0_USER_ID env var (explicit override)
+#   2. ~/.mem0/identity.json cache (pinned to current MEM0_API_KEY fingerprint)
+#   3. Derived: "mem0-" + sha256(MEM0_API_KEY)[:12]
+#   4. Fallback: $USER, else "default"
+#
+# Same MEM0_API_KEY across machines yields the same user_id, which fixes
+# the "47 user buckets per account" symptom from running on multiple
+# laptops with different $USER values.
+
+_mem0_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | cut -d' ' -f1
+  else
+    shasum -a 256 | cut -d' ' -f1
+  fi
+}
+
+_mem0_resolve_identity() {
+  if [ -n "${MEM0_USER_ID:-}" ]; then
+    printf '%s' "$MEM0_USER_ID"
+    return
+  fi
+
+  local api_key="${MEM0_API_KEY:-}"
+  local cache="$HOME/.mem0/identity.json"
+
+  if [ -n "$api_key" ]; then
+    local digest
+    digest=$(printf '%s' "$api_key" | _mem0_sha256)
+    local fp="${digest:0:8}"
+
+    if [ -f "$cache" ]; then
+      local cached_fp cached_id
+      cached_fp=$(jq -r '.api_key_fingerprint // ""' "$cache" 2>/dev/null)
+      cached_id=$(jq -r '.user_id // ""' "$cache" 2>/dev/null)
+      if [ "$cached_fp" = "$fp" ] && [ -n "$cached_id" ]; then
+        printf '%s' "$cached_id"
+        return
+      fi
+    fi
+
+    local derived="mem0-${digest:0:12}"
+    mkdir -p "$HOME/.mem0" 2>/dev/null && \
+      printf '{"user_id":"%s","source":"api_key","api_key_fingerprint":"%s","resolved_at":"%s"}\n' \
+        "$derived" "$fp" "$(date -u +%FT%TZ)" > "$cache" 2>/dev/null
+    printf '%s' "$derived"
+    return
+  fi
+
+  printf '%s' "${USER:-default}"
+}
+
+MEM0_RESOLVED_USER_ID="$(_mem0_resolve_identity)"
+export MEM0_RESOLVED_USER_ID

--- a/mem0-plugin/scripts/on_pre_compact.py
+++ b/mem0-plugin/scripts/on_pre_compact.py
@@ -18,8 +18,11 @@ import json
 import logging
 import os
 import sys
-import urllib.request
 import urllib.error
+import urllib.request
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _identity import resolve_user_id
 
 log = logging.getLogger("mem0-capture")
 log.setLevel(logging.DEBUG)
@@ -207,7 +210,7 @@ def main():
         log.debug("No transcript_path provided")
         return
 
-    user_id = os.environ.get("MEM0_USER_ID", os.environ.get("USER", "default"))
+    user_id = resolve_user_id()
 
     lines = tail_lines(transcript_path, MAX_TAIL_LINES)
     if not lines:

--- a/mem0-plugin/scripts/on_session_start.sh
+++ b/mem0-plugin/scripts/on_session_start.sh
@@ -11,8 +11,23 @@
 # even if jq is missing or stdin is malformed.
 set -uo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=_identity.sh
+. "$SCRIPT_DIR/_identity.sh"
+
 INPUT=$(cat)
 SOURCE=$(echo "$INPUT" | jq -r '.source // "startup"' 2>/dev/null || echo "startup")
+
+# Identity line is emitted before every bootstrap variant so the agent
+# uses the same user_id the hooks resolved. Without this, the agent's
+# search_memories/add_memory MCP calls may bind to a different bucket
+# than what the hooks write to.
+echo "## Mem0 Identity"
+echo ""
+echo "Active user_id: \`$MEM0_RESOLVED_USER_ID\`"
+echo ""
+echo "Always include \`{\"user_id\": \"$MEM0_RESOLVED_USER_ID\"}\` (wrapped in an \`AND\` clause) in every \`search_memories\` filter and as \`user_id\` on every \`add_memory\` call. This keeps memories under one bucket regardless of which machine you're on."
+echo ""
 
 if [ "$SOURCE" = "startup" ]; then
   cat <<'EOF'

--- a/mem0-plugin/scripts/on_user_prompt.sh
+++ b/mem0-plugin/scripts/on_user_prompt.sh
@@ -26,7 +26,10 @@ if [ -z "${MEM0_API_KEY:-}" ]; then
   exit 0
 fi
 
-USER_ID="${MEM0_USER_ID:-${USER:-default}}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=_identity.sh
+. "$SCRIPT_DIR/_identity.sh"
+USER_ID="$MEM0_RESOLVED_USER_ID"
 
 cat <<EOF
 ## Memory check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,3 +154,4 @@ known-first-party = ["mem0", "mem0_cli"]
 profile = "black"
 known_first_party = ["mem0", "mem0_cli"]
 # isort scope kept aligned with [tool.ruff.lint.isort] above.
+# Plugin-only PRs need a touch here to fire required CI checks (path-filter trap).


### PR DESCRIPTION
## Summary

Hooks previously fell back to `\$USER` when `MEM0_USER_ID` wasn't set, producing a different `user_id` on every machine for the same person. Result: a single account with memories scattered across many `user_id` buckets, none of which can see each other.

This PR replaces the inline `\${MEM0_USER_ID:-\${USER:-default}}` pattern with a single resolver that produces a deterministic identity from the `MEM0_API_KEY`. Same key on any machine → same `user_id`.

## Resolution priority

Identical algorithm in bash and python:

1. `MEM0_USER_ID` env var — explicit override always wins.
2. `~/.mem0/identity.json` cache — pinned to the current `MEM0_API_KEY` fingerprint, so a key rotation invalidates it.
3. Derived: `\"mem0-\" + sha256(MEM0_API_KEY)[:12]`. Stable across machines.
4. Fallback: `\$USER`, else `\"default\"`.

## Files

- New: `mem0-plugin/scripts/_identity.sh` — sourced by bash hooks, exports `MEM0_RESOLVED_USER_ID`.
- New: `mem0-plugin/scripts/_identity.py` — imported by `on_pre_compact.py`, exposes `resolve_user_id()`.
- Modified: `on_user_prompt.sh` — sources resolver, interpolates resolved id into the search rubric.
- Modified: `on_session_start.sh` — emits an explicit `Active user_id: <X>` block before the bootstrap text. The agent now reads the same `user_id` the hooks resolved and uses it in its MCP `search_memories` / `add_memory` calls. This closes the agent-side half of the symptom — the previous rubric used a `<your_user_id>` placeholder, so even with hooks aligned, the agent could pick something different.
- Modified: `on_pre_compact.py` — replaces the inline env lookup with `resolve_user_id()`.

## What this does NOT do

- **No auto-migration of existing memories** stored under previous `\$USER` values. Those entries remain accessible if you query with the old `user_id` explicitly. We chose not to auto-migrate because the captured session-state entries have low salvage value and an automatic copy would silently double-count.
- **No change to the cloud MCP server's `_with_default_filters` injection.** The agent now passes `user_id` explicitly thanks to the SessionStart bootstrap, so the server's auto-injection becomes a no-op when filters are present. The deeper fix lives in #28 (org-shared scope) on the platform side.
- **No `agent_id` or `run_id` resolution** — only `user_id`. Those entity scopes can be added later if needed.

## Test plan

Each priority level was exercised before commit. Bash and python implementations produce **identical** output:

- [x] `MEM0_USER_ID=alice` set → both resolvers return `alice`, regardless of cache or key.
- [x] Same `MEM0_API_KEY` → both resolvers return the same `mem0-<12-hex>` string. Verified deterministic with two synthetic keys.
- [x] Cache file (`~/.mem0/identity.json`) is created with `user_id`, `source`, `api_key_fingerprint`, `resolved_at`.
- [x] Different `MEM0_API_KEY` → cache is replaced (fingerprint mismatch detected, new derivation cached).
- [x] Cache hit on second run with same key (no re-derivation).
- [x] No key, no override → falls back to `\$USER` (e.g. `mragankshekhar`).
- [x] `on_session_start.sh` output starts with the identity header followed by the original bootstrap.
- [x] `on_user_prompt.sh` rubric interpolates the resolved `user_id` into every example filter.

## CI nudge

Plugin-only PRs trip the same `build_mem0` / `build_embedchain` required-check trap that hit the previous two PRs. One-line comment added to `pyproject.toml` to fire the workflow. Track the proper fix (path-conditional CI) as a follow-up.

## Note

This branches off `main` (post-#4992). PR #5076 is still in review; this PR will conflict on rebase once #5076 merges (both touch `on_user_prompt.sh`, `on_session_start.sh`, `on_pre_compact.py`). Conflicts are mechanical — both changes coexist cleanly, just need a merge.