### PR TITLE
fix(llms/litellm): only require function-calling support when tools are passed

### DIFF
--- a/mem0/llms/litellm.py
+++ b/mem0/llms/litellm.py
@@ -67,9 +67,6 @@ class LiteLLM(LLMBase):
         Returns:
             str: The generated response.
         """
-        if not litellm.supports_function_calling(self.config.model):
-            raise ValueError(f"Model '{self.config.model}' in litellm does not support function calling.")
-
         params = {
             "model": self.config.model,
             "messages": messages,
@@ -80,6 +77,8 @@ class LiteLLM(LLMBase):
         if response_format:
             params["response_format"] = response_format
         if tools:  # TODO: Remove tools if no issues found with new memory addition logic
+            if not litellm.supports_function_calling(self.config.model):
+                raise ValueError(f"Model '{self.config.model}' in litellm does not support function calling.")
             params["tools"] = tools
             params["tool_choice"] = tool_choice
 

--- a/tests/llms/test_litellm.py
+++ b/tests/llms/test_litellm.py
@@ -12,15 +12,44 @@ def mock_litellm():
         yield mock_litellm
 
 
-def test_generate_response_with_unsupported_model(mock_litellm):
+def test_generate_response_with_unsupported_model_and_tools(mock_litellm):
+    """When tools are requested but the model can't function-call, raise."""
     config = BaseLlmConfig(model="unsupported-model", temperature=0.7, max_tokens=100, top_p=1)
     llm = litellm.LiteLLM(config)
     messages = [{"role": "user", "content": "Hello"}]
+    tools = [
+        {
+            "type": "function",
+            "function": {"name": "noop", "description": "x", "parameters": {"type": "object", "properties": {}}},
+        }
+    ]
 
     mock_litellm.supports_function_calling.return_value = False
 
     with pytest.raises(ValueError, match="Model 'unsupported-model' in litellm does not support function calling."):
-        llm.generate_response(messages)
+        llm.generate_response(messages, tools=tools)
+
+
+def test_generate_response_with_unsupported_model_no_tools(mock_litellm):
+    """Models that don't support function calling are still usable when no tools are passed.
+
+    Mem0's main code paths (fact extraction via response_format=json_object, procedural
+    memory) call ``generate_response`` without tools, so the function-calling check must
+    not fire in that case.
+    """
+    config = BaseLlmConfig(model="unsupported-model", temperature=0.7, max_tokens=100, top_p=1)
+    llm = litellm.LiteLLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="hi"))]
+    mock_litellm.completion.return_value = mock_response
+    mock_litellm.supports_function_calling.return_value = False
+
+    response = llm.generate_response(messages)
+
+    assert response == "hi"
+    mock_litellm.supports_function_calling.assert_not_called()
 
 
 def test_generate_response_without_tools(mock_litellm):
@@ -82,7 +111,13 @@ def test_generate_response_with_tools(mock_litellm):
     response = llm.generate_response(messages, tools=tools)
 
     mock_litellm.completion.assert_called_once_with(
-        model="gpt-4.1-nano-2025-04-14", messages=messages, temperature=0.7, max_tokens=100, top_p=1, tools=tools, tool_choice="auto"
+        model="gpt-4.1-nano-2025-04-14",
+        messages=messages,
+        temperature=0.7,
+        max_tokens=100,
+        top_p=1,
+        tools=tools,
+        tool_choice="auto",
     )
 
     assert response["content"] == "I've added the memory for you."


### PR DESCRIPTION
## Linked Issue

No existing issue — filing the fix and explanation together.

## Description

`LiteLLM.generate_response` unconditionally invokes `litellm.supports_function_calling(model)` and raises `ValueError` if it returns `False`, regardless of whether the caller actually requested tools (`mem0/llms/litellm.py:70-71` on `main`).

But the main code paths in `Memory` do not pass `tools` to the LLM:

- `Memory._add_to_vector_store` (sync) — `mem0/memory/main.py:739` — uses `response_format={"type": "json_object"}` with no `tools=`.
- `Memory._create_procedural_memory` (sync) — `mem0/memory/main.py:1639` — no `tools=`, no `response_format`.
- The async equivalents at `main.py:2156` and `main.py:3069`.

Because `supports_function_calling` is consulted before tools are even examined, the LiteLLM provider becomes unusable with any model that doesn't advertise function-calling support — even though those code paths never actually exercise function calling. Common cases this breaks:

- A locally-served model routed via LiteLLM whose metadata doesn't include `function_calling: true`.
- LiteLLM proxy aliases pointing at simpler completion endpoints.

### Fix

Move the function-calling-support check inside the `if tools:` branch in `mem0/llms/litellm.py` so it only fires when tools are actually passed. No change to behavior when tools *are* passed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update

## Breaking Changes

None. Behavior with tools is unchanged. Behavior without tools changes from \"raises for non-function-calling models\" to \"works\" — which is the documented intent of `generate_response(messages)`.

## Test Coverage

- [x] I added/updated unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] No tests needed

Updated `tests/llms/test_litellm.py`:

1. Renamed the existing `test_generate_response_with_unsupported_model` to `test_generate_response_with_unsupported_model_and_tools` and added a `tools=[…]` argument so it actually exercises the code path that should raise.
2. Added `test_generate_response_with_unsupported_model_no_tools` — asserts the call returns successfully and that `supports_function_calling` is *not* invoked (regression test for this bug).

The previous test was passing only because the buggy unconditional check happened to fire before tools were inspected; in other words it codified the bug. The new tests express the correct contract.

I verified the new logic against a stubbed `litellm` module and the three cases (unsupported+no_tools → ok, unsupported+tools → raises, supported+tools → ok) all behave as expected.

## Checklist

- [x] My code follows the project's style guidelines (`ruff format` clean)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally (verified test logic against stubbed `litellm`; full suite requires the project's hatch env which I don't have local Python deps for)
- [ ] I have updated documentation if needed (no public-API change)