### PR TITLE
feat(cookbooks): AWS developer knowledge graph with mem0, Qdrant, Neo4j, and Claude

### DIFF
--- a/cookbooks/aws-developer-knowledge-graph.ipynb
+++ b/cookbooks/aws-developer-knowledge-graph.ipynb
@@ -1,0 +1,221 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# AWS Developer Knowledge Graph with mem0, Qdrant, Neo4j, and Claude\n",
+    "\n",
+    "This cookbook shows how to build a **three-layer memory pipeline** that turns raw GitHub activity into a structured, queryable knowledge graph — and uses Claude to reason over it.\n",
+    "\n",
+    "Unlike plain RAG (retrieve → answer), this pipeline:\n",
+    "- **Extracts structured facts** from raw event text via mem0\n",
+    "- **Stores vector embeddings** in Qdrant for semantic search\n",
+    "- **Builds an entity graph** in Neo4j (developer → PR → repository)\n",
+    "- **Reasons across both layers** using Claude for deep insights\n",
+    "\n",
+    "**DEMO_MODE=true by default** — runs fully without GitHub credentials, Qdrant, or Neo4j."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## Install dependencies"]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install mem0ai anthropic qdrant-client neo4j ollama --quiet"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## Configuration"]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "DEMO_MODE = os.getenv('DEMO_MODE', 'true').lower() == 'true'\n",
+    "ANTHROPIC_API_KEY = os.getenv('ANTHROPIC_API_KEY', '')\n",
+    "MODEL = 'claude-opus-4-7'\n",
+    "\n",
+    "print(f'DEMO_MODE: {DEMO_MODE}')\n",
+    "print(f'API key set: {bool(ANTHROPIC_API_KEY)}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## Mock GitHub events (used in DEMO_MODE)"]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MOCK_EVENTS = [\n",
+    "    'alice merged PR #45 which refactored the auth-service module on 2026-04-11',\n",
+    "    'bob opened PR #46 adding rate limiting to the api-gateway on 2026-04-11',\n",
+    "    'alice reviewed PR #46 and requested changes to the token validation logic',\n",
+    "    'carol committed a TLS certificate rotation fix to the auth-service on 2026-04-12',\n",
+    "    'bob merged PR #47 which added Redis caching to the api-gateway on 2026-04-12',\n",
+    "    'alice opened PR #48 to migrate auth-service database from Postgres to Aurora',\n",
+    "    'dave closed issue #123 — memory leak in the notification-service worker',\n",
+    "    'carol reviewed PR #48 and approved the Aurora migration approach',\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## Key insight: structured sentences beat raw JSON for mem0 ingestion\n",
+    "\n",
+    "Structured natural-language sentences give the LLM better signal for both embedding and entity extraction than raw key-value data.\n",
+    "\n",
+    "```python\n",
+    "# Good — preserves context, extracts cleanly\n",
+    "'alice merged PR #45 which refactored the auth module on 2026-04-11'\n",
+    "\n",
+    "# Bad — LLM produces noisy, low-quality entities\n",
+    "{\"author\": \"alice\", \"pr\": 45, \"repo\": \"auth-service\"}\n",
+    "```"]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## Set up mem0 with Qdrant + Neo4j (or in-memory for demo)"]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mem0 import Memory\n",
+    "\n",
+    "if DEMO_MODE:\n",
+    "    # In-memory config — no external services needed\n",
+    "    memory = Memory()\n",
+    "    print('Running with in-memory store (DEMO_MODE)')\n",
+    "else:\n",
+    "    config = {\n",
+    "        'vector_store': {\n",
+    "            'provider': 'qdrant',\n",
+    "            'config': {'host': 'localhost', 'port': 6333, 'collection_name': 'dev-activity'},\n",
+    "        },\n",
+    "        'graph_store': {\n",
+    "            'provider': 'neo4j',\n",
+    "            'config': {\n",
+    "                'url': os.getenv('NEO4J_URI', 'bolt://localhost:7687'),\n",
+    "                'username': os.getenv('NEO4J_USER', 'neo4j'),\n",
+    "                'password': os.getenv('NEO4J_PASSWORD', 'password'),\n",
+    "            },\n",
+    "        },\n",
+    "        'custom_fact_extraction_prompt': (\n",
+    "            'Only extract entities that are: a specific person (exact username), '\n",
+    "            'a specific repository name, or a specific technical component. '\n",
+    "            'Do NOT extract states, ratios, abstract concepts, or generic words.'\n",
+    "        ),\n",
+    "    }\n",
+    "    memory = Memory.from_config(config)\n",
+    "    print('Running with Qdrant + Neo4j')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## Ingest GitHub events into mem0"]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Ingesting GitHub events into mem0...')\n",
+    "for event in MOCK_EVENTS:\n",
+    "    memory.add(event, user_id='dev-team')\n",
+    "    print(f'  + {event[:70]}...')\n",
+    "\n",
+    "print(f'\\nIngested {len(MOCK_EVENTS)} events')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## Query: who has the most context on auth-service?"]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = memory.search('auth-service contributors and changes', user_id='dev-team')\n",
+    "print('Relevant memories:')\n",
+    "for r in results:\n",
+    "    print(f'  - {r[\"memory\"]}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["## Generate developer insight with Claude"]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import anthropic\n",
+    "\n",
+    "client = anthropic.Anthropic(api_key=ANTHROPIC_API_KEY)\n",
+    "\n",
+    "# Retrieve facts from mem0\n",
+    "facts = memory.search('auth-service contributors and changes', user_id='dev-team')\n",
+    "context = '\\n'.join(f'- {r[\"memory\"]}' for r in facts)\n",
+    "\n",
+    "response = client.messages.create(\n",
+    "    model=MODEL,\n",
+    "    max_tokens=512,\n",
+    "    messages=[{\n",
+    "        'role': 'user',\n",
+    "        'content': f'Based on these developer activity facts:\\n{context}\\n\\nWho has the most context on auth-service and why?',\n",
+    "    }],\n",
+    ")\n",
+    "\n",
+    "print('Claude insight:')\n",
+    "print(response.content[0].text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What to explore next\n",
+    "\n",
+    "- Add real GitHub events via `PyGithub` — replace `MOCK_EVENTS` with `repo.get_events()`\n",
+    "- Switch to Qdrant + Neo4j for persistent, queryable storage\n",
+    "- Use mem0's graph store to traverse relationships (`alice → auth-service → PR #48`)\n",
+    "- See the full production pipeline: [mem0-pipeline](https://github.com/TanishkaMarrott/mem0-pipeline)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},
+  "language_info": {"name": "python", "version": "3.12.0"}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary

Adds a new cookbook demonstrating a **three-layer memory pipeline** that turns raw GitHub activity into a structured knowledge graph — and uses Claude to reason over it.

Unlike plain RAG, this pipeline:
- **Extracts structured facts** from raw event text via mem0
- **Stores vector embeddings** in Qdrant for semantic search
- **Builds an entity graph** in Neo4j (developer → PR → repository)
- **Reasons across both layers** using Claude for deep insights

## Key insight documented

Structured natural-language sentences give the LLM better signal than raw JSON for both embedding and entity extraction — covered with a clear before/after example in the notebook.

## Test plan

- [ ] Run top to bottom — `DEMO_MODE=true` by default, no Qdrant/Neo4j/GitHub credentials needed
- [ ] Set `ANTHROPIC_API_KEY` and run the Claude insight cell live
- [ ] Switch `DEMO_MODE=false`, add Qdrant + Neo4j config to run the full three-layer pipeline

## Source

Distilled from [mem0-pipeline](https://github.com/TanishkaMarrott/mem0-pipeline) — a production-style pipeline validated with real GitHub activity data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)