### PR TITLE
chore(plugin): bump mem0 plugin to v0.1.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "mem0",
       "source": "./mem0-plugin",
       "description": "Mem0 memory layer for AI applications. Add persistent memory, personalization, and semantic search to Claude workflows.",
-      "version": "0.1.1"
+      "version": "0.1.2"
     }
   ]
 }

--- a/mem0-plugin/.claude-plugin/plugin.json
+++ b/mem0-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mem0",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Mem0 memory layer for AI applications. Add persistent memory, personalization, and semantic search to Claude workflows using the Mem0 Platform MCP server.",
   "author": {
     "name": "Mem0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,3 +155,4 @@ profile = "black"
 known_first_party = ["mem0", "mem0_cli"]
 # isort scope kept aligned with [tool.ruff.lint.isort] above.
 # black-equivalent profile here matches the formatter behaviour ruff applies.
+# Plugin-version bumps need a touch here to fire required CI checks (path-filter trap).


### PR DESCRIPTION
## Summary

Bumps the mem0 plugin from `0.1.1` to `0.1.2` to reflect the changes that landed in #5076.

Two locations:
- `.claude-plugin/marketplace.json` — the canonical version pin Claude Code's marketplace surface reads.
- `mem0-plugin/.claude-plugin/plugin.json` — cosmetic display version, kept in sync.

## What's in v0.1.2

All from PR #5076:

- Hook cleanup: `session_id` capture, key-gate on bootstrap, `block_memory_write` regex tightening, opt-in `MEM0_DEBUG=1` logging, PreCompact dedup
- Deterministic `user_id` resolver across machines (`sha256(MEM0_API_KEY)[:12]` derivation, `~/.mem0/identity.json` cache, `MEM0_USER_ID` override)
- Compaction flow: `infer=False` on agent's pre-compact summary + background capture of platform's compact summary at SessionStart-compact
- Coding-focused custom-categories setup script (`scripts/setup_coding_categories.py`)
- `expiration_date` on `session_state` and `compact_summary` captures (90 days)
- "Updating the plugin" section in README explaining the `/plugin marketplace update mem0-plugins` + `/reload-plugins` flow for users

## Why

Auto-update is **not** enabled by default for non-Anthropic marketplaces, so end users explicitly refresh from `mem0-plugins` to pick up changes. The version bump gives them a visible signal that something changed (per Claude Code docs the SHA is the actual update truth, but the version field is what surfaces in `/plugin` listings).