### PR TITLE
feat(memory): support pinned search results

### DIFF
--- a/docs/core-concepts/memory-operations/search.mdx
+++ b/docs/core-concepts/memory-operations/search.mdx
@@ -183,6 +183,32 @@ console.log(results.results[0].score_details);
 
 Each result includes `score_details` with the semantic score, normalized BM25 score, entity boost, raw combined score, maximum possible score, final score, and threshold used for filtering. The field is omitted unless `explain` is enabled, so existing response shapes stay unchanged.
 
+### Include pinned OSS memories
+
+Some memories are deterministic context, not ordinary semantic recall. Policies, personas, and hard constraints should be available without competing against conversational memories in the vector ranking. In OSS, store those memories with metadata and pass `include_pinned` at search time:
+
+```python
+from mem0 import Memory
+
+m = Memory()
+
+m.add(
+    "Refund policy: refunds are limited to 30 days.",
+    user_id="support-bot",
+    metadata={"memory_type": "policy"},
+    infer=False,
+)
+
+results = m.search(
+    "Can a customer get a refund after 45 days?",
+    filters={"user_id": "support-bot"},
+    include_pinned={"memory_type": "policy"},
+    pinned_limit=5,
+)
+```
+
+Pinned memories are returned before semantic matches with `retrieval_type="pinned"` and do not count against `top_k`. Normal semantic search, reranking, thresholds, and filters continue to work unchanged for the rest of the result set.
+
 ## Filter patterns
 
 Filters help narrow down search results. Common use cases:

--- a/docs/open-source/features/rest-api.mdx
+++ b/docs/open-source/features/rest-api.mdx
@@ -240,6 +240,21 @@ curl -X POST http://localhost:8888/search \
 
 Each returned memory includes `score_details` only when explanation mode is enabled.
 
+To include deterministic memories such as policies or personas before semantic matches, pass `include_pinned` with a metadata filter:
+
+```bash
+curl -X POST http://localhost:8888/search \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "Can I get a refund after 45 days?",
+    "user_id": "support-bot",
+    "include_pinned": {"memory_type": "policy"},
+    "pinned_limit": 5
+  }'
+```
+
+Pinned memories are returned with `retrieval_type: "pinned"` and do not replace the normal semantic result set.
+
 ### Explore with OpenAPI docs
 
 1. Navigate to `http://localhost:8888/docs` (Compose) or `http://localhost:8000/docs` (raw Docker / uvicorn).

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -325,6 +325,64 @@ def _build_session_scope(filters):
     return "&".join(parts)
 
 
+def _unwrap_vector_store_list(list_result):
+    """Normalize vector store list() return shapes to a flat row list."""
+    if isinstance(list_result, (tuple, list)) and len(list_result) > 0:
+        first_element = list_result[0]
+        if isinstance(first_element, (list, tuple)):
+            return first_element
+        return list_result
+    return list_result or []
+
+
+def _matches_filter_value(payload_value: Any, expected_value: Any) -> bool:
+    """Evaluate a portable subset of metadata filters for pinned memories."""
+    if isinstance(expected_value, dict):
+        for operator, value in expected_value.items():
+            if operator == "eq":
+                if payload_value != value:
+                    return False
+            elif operator == "ne":
+                if payload_value == value:
+                    return False
+            elif operator == "in":
+                if not isinstance(value, (list, tuple, set)) or payload_value not in value:
+                    return False
+            elif operator == "nin":
+                if isinstance(value, (list, tuple, set)) and payload_value in value:
+                    return False
+            elif operator == "contains":
+                if payload_value is None:
+                    return False
+                if isinstance(payload_value, (list, tuple, set)):
+                    if value not in payload_value:
+                        return False
+                elif str(value) not in str(payload_value):
+                    return False
+            elif operator == "icontains":
+                if payload_value is None or str(value).lower() not in str(payload_value).lower():
+                    return False
+            else:
+                raise ValueError(f"Unsupported pinned memory filter operator: {operator}")
+        return True
+
+    if expected_value == "*":
+        return payload_value is not None
+    if isinstance(expected_value, (list, tuple, set)):
+        return payload_value in expected_value
+    return payload_value == expected_value
+
+
+def _matches_pinned_filter(payload: Dict[str, Any], pinned_filter: Dict[str, Any]) -> bool:
+    """Return whether a memory payload matches an include_pinned filter."""
+    for key, expected_value in pinned_filter.items():
+        if key in ENTITY_PARAMS:
+            continue
+        if not _matches_filter_value(payload.get(key), expected_value):
+            return False
+    return True
+
+
 setup_config()
 logger = logging.getLogger(__name__)
 
@@ -1133,6 +1191,8 @@ class Memory(MemoryBase):
         threshold: float = 0.1,
         rerank: bool = False,
         explain: bool = False,
+        include_pinned: Optional[Dict[str, Any]] = None,
+        pinned_limit: int = 20,
         **kwargs,
     ):
         """
@@ -1164,6 +1224,9 @@ class Memory(MemoryBase):
             threshold (float, optional): Minimum score for a memory to be included. Defaults to 0.1.
             rerank (bool, optional): Whether to rerank results. Defaults to False.
             explain (bool, optional): Whether to include score_details for each result. Defaults to False.
+            include_pinned (dict, optional): Metadata filter for deterministic memories to include
+                before semantic results. Entity scope still comes from `filters`.
+            pinned_limit (int, optional): Maximum number of pinned memories to include. Defaults to 20.
 
         Returns:
             dict: A dictionary containing the search results under a "results" key.
@@ -1178,6 +1241,9 @@ class Memory(MemoryBase):
 
         # Validate search parameters (before applying defaults)
         _validate_search_params(threshold=threshold, top_k=top_k)
+        _validate_search_params(top_k=pinned_limit)
+        if include_pinned is not None and not isinstance(include_pinned, dict):
+            raise ValueError("include_pinned must be a dictionary of metadata filters")
 
         # Validate and trim entity IDs in filters
         effective_filters = filters.copy() if filters else {}
@@ -1212,6 +1278,10 @@ class Memory(MemoryBase):
                     effective_filters.pop(fk, None)
             effective_filters.update(processed_filters)
 
+        pinned_memories = []
+        if include_pinned and pinned_limit > 0:
+            pinned_memories = self._get_pinned_memories(effective_filters, include_pinned, pinned_limit)
+
         keys, encoded_ids = process_telemetry_filters(effective_filters)
         capture_event(
             "mem0.search",
@@ -1230,6 +1300,10 @@ class Memory(MemoryBase):
 
         original_memories = self._search_vector_store(query, effective_filters, limit, threshold, explain=explain)
 
+        if pinned_memories:
+            pinned_ids = {memory["id"] for memory in pinned_memories}
+            original_memories = [memory for memory in original_memories if memory.get("id") not in pinned_ids]
+
         # Apply reranking if enabled and reranker is available
         if rerank and self.reranker and original_memories:
             try:
@@ -1238,7 +1312,53 @@ class Memory(MemoryBase):
             except Exception as e:
                 logger.warning(f"Reranking failed, using original results: {e}")
 
-        return {"results": original_memories}
+        return {"results": pinned_memories + original_memories}
+
+    def _get_pinned_memories(self, filters: Dict[str, Any], pinned_filter: Dict[str, Any], limit: int):
+        entity_filters = {key: filters[key] for key in ENTITY_PARAMS if key in filters}
+        memories_result = self.vector_store.list(filters=entity_filters, top_k=max(limit * 5, limit))
+        actual_memories = _unwrap_vector_store_list(memories_result)
+
+        promoted_payload_keys = [
+            "user_id",
+            "agent_id",
+            "run_id",
+            "actor_id",
+            "role",
+        ]
+        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
+
+        pinned_memories = []
+        for mem in actual_memories:
+            payload = mem.payload if hasattr(mem, "payload") else {}
+            if not payload.get("data") or not _matches_pinned_filter(payload, pinned_filter):
+                continue
+
+            memory_item_dict = MemoryItem(
+                id=mem.id,
+                memory=payload.get("data", ""),
+                hash=payload.get("hash"),
+                created_at=payload.get("created_at"),
+                updated_at=payload.get("updated_at"),
+                score=1.0,
+            ).model_dump()
+            memory_item_dict["retrieval_type"] = "pinned"
+
+            for key in promoted_payload_keys:
+                if key in payload:
+                    memory_item_dict[key] = payload[key]
+
+            additional_metadata = {k: v for k, v in payload.items() if k not in core_and_promoted_keys}
+            if additional_metadata:
+                if not memory_item_dict.get("metadata"):
+                    memory_item_dict["metadata"] = {}
+                memory_item_dict["metadata"].update(additional_metadata)
+
+            pinned_memories.append(memory_item_dict)
+            if len(pinned_memories) >= limit:
+                break
+
+        return pinned_memories
 
     def _process_metadata_filters(self, metadata_filters: Dict[str, Any]) -> Dict[str, Any]:
         """
@@ -2575,6 +2695,8 @@ class AsyncMemory(MemoryBase):
         threshold: float = 0.1,
         rerank: bool = False,
         explain: bool = False,
+        include_pinned: Optional[Dict[str, Any]] = None,
+        pinned_limit: int = 20,
         **kwargs,
     ):
         """
@@ -2606,6 +2728,9 @@ class AsyncMemory(MemoryBase):
             threshold (float, optional): Minimum score for a memory to be included. Defaults to 0.1.
             rerank (bool, optional): Whether to rerank results. Defaults to False.
             explain (bool, optional): Whether to include score_details for each result. Defaults to False.
+            include_pinned (dict, optional): Metadata filter for deterministic memories to include
+                before semantic results. Entity scope still comes from `filters`.
+            pinned_limit (int, optional): Maximum number of pinned memories to include. Defaults to 20.
 
         Returns:
             dict: A dictionary containing the search results under a "results" key.
@@ -2620,6 +2745,9 @@ class AsyncMemory(MemoryBase):
 
         # Validate search parameters (before applying defaults)
         _validate_search_params(threshold=threshold, top_k=top_k)
+        _validate_search_params(top_k=pinned_limit)
+        if include_pinned is not None and not isinstance(include_pinned, dict):
+            raise ValueError("include_pinned must be a dictionary of metadata filters")
 
         # Validate and trim entity IDs in filters
         effective_filters = filters.copy() if filters else {}
@@ -2656,6 +2784,10 @@ class AsyncMemory(MemoryBase):
                     effective_filters.pop(fk, None)
             effective_filters.update(processed_filters)
 
+        pinned_memories = []
+        if include_pinned and pinned_limit > 0:
+            pinned_memories = await self._get_pinned_memories(effective_filters, include_pinned, pinned_limit)
+
         keys, encoded_ids = process_telemetry_filters(effective_filters)
         capture_event(
             "mem0.search",
@@ -2674,6 +2806,10 @@ class AsyncMemory(MemoryBase):
 
         original_memories = await self._search_vector_store(query, effective_filters, limit, threshold, explain=explain)
 
+        if pinned_memories:
+            pinned_ids = {memory["id"] for memory in pinned_memories}
+            original_memories = [memory for memory in original_memories if memory.get("id") not in pinned_ids]
+
         # Apply reranking if enabled and reranker is available
         if rerank and self.reranker and original_memories:
             try:
@@ -2685,7 +2821,55 @@ class AsyncMemory(MemoryBase):
             except Exception as e:
                 logger.warning(f"Reranking failed, using original results: {e}")
 
-        return {"results": original_memories}
+        return {"results": pinned_memories + original_memories}
+
+    async def _get_pinned_memories(self, filters: Dict[str, Any], pinned_filter: Dict[str, Any], limit: int):
+        entity_filters = {key: filters[key] for key in ENTITY_PARAMS if key in filters}
+        memories_result = await asyncio.to_thread(
+            self.vector_store.list, filters=entity_filters, top_k=max(limit * 5, limit)
+        )
+        actual_memories = _unwrap_vector_store_list(memories_result)
+
+        promoted_payload_keys = [
+            "user_id",
+            "agent_id",
+            "run_id",
+            "actor_id",
+            "role",
+        ]
+        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
+
+        pinned_memories = []
+        for mem in actual_memories:
+            payload = mem.payload if hasattr(mem, "payload") else {}
+            if not payload.get("data") or not _matches_pinned_filter(payload, pinned_filter):
+                continue
+
+            memory_item_dict = MemoryItem(
+                id=mem.id,
+                memory=payload.get("data", ""),
+                hash=payload.get("hash"),
+                created_at=payload.get("created_at"),
+                updated_at=payload.get("updated_at"),
+                score=1.0,
+            ).model_dump()
+            memory_item_dict["retrieval_type"] = "pinned"
+
+            for key in promoted_payload_keys:
+                if key in payload:
+                    memory_item_dict[key] = payload[key]
+
+            additional_metadata = {k: v for k, v in payload.items() if k not in core_and_promoted_keys}
+            if additional_metadata:
+                if not memory_item_dict.get("metadata"):
+                    memory_item_dict["metadata"] = {}
+                memory_item_dict["metadata"].update(additional_metadata)
+
+            pinned_memories.append(memory_item_dict)
+            if len(pinned_memories) >= limit:
+                break
+
+        return pinned_memories
 
     def _process_metadata_filters(self, metadata_filters: Dict[str, Any]) -> Dict[str, Any]:
         """

--- a/server/main.py
+++ b/server/main.py
@@ -200,6 +200,11 @@ class SearchRequest(BaseModel):
     top_k: Optional[int] = Field(None, description="Maximum number of results to return.")
     threshold: Optional[float] = Field(None, description="Minimum similarity score for results.")
     explain: Optional[bool] = Field(None, description="Include score details for each search result.")
+    include_pinned: Optional[Dict[str, Any]] = Field(
+        None,
+        description="Metadata filter for deterministic memories to include before semantic results.",
+    )
+    pinned_limit: Optional[int] = Field(None, description="Maximum number of pinned memories to include.")
 
 
 class GenerateInstructionsRequest(BaseModel):

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -217,6 +217,109 @@ def test_get_all_handles_nested_list_from_chroma(mock_sqlite, mock_llm_factory, 
     assert result[2]["memory"] == "I live in California"
 
 
+@patch('mem0.memory.main.extract_entities', return_value=[])
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+def test_search_includes_pinned_memories_before_semantic_results(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory, _mock_extract_entities
+):
+    mock_embedder = MagicMock()
+    mock_embedder.embed.return_value = [0.1, 0.2, 0.3]
+    mock_embedder_factory.return_value = mock_embedder
+
+    mock_vector_store = MagicMock()
+    mock_vector_store.list.return_value = [
+        MockVectorMemory(
+            "policy_1",
+            {"data": "Refund policy is 30 days.", "user_id": "support", "memory_type": "policy"},
+        ),
+        MockVectorMemory(
+            "profile_1",
+            {"data": "The user likes concise answers.", "user_id": "support", "memory_type": "profile"},
+        ),
+    ]
+    mock_vector_store.search.return_value = [
+        MockVectorMemory("semantic_1", {"data": "Semantic memory", "user_id": "support"}, score=0.72)
+    ]
+    mock_vector_store.keyword_search.return_value = []
+    mock_vector_factory.return_value = mock_vector_store
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+    memory = MemoryClass(MemoryConfig())
+
+    result = memory.search(
+        "Can I get a refund after 45 days?",
+        filters={"user_id": "support"},
+        include_pinned={"memory_type": "policy"},
+        pinned_limit=5,
+    )
+
+    assert [memory["id"] for memory in result["results"]] == ["policy_1", "semantic_1"]
+    assert result["results"][0]["retrieval_type"] == "pinned"
+    assert result["results"][0]["score"] == 1.0
+    assert result["results"][0]["metadata"]["memory_type"] == "policy"
+    mock_vector_store.list.assert_called_once_with(filters={"user_id": "support"}, top_k=25)
+
+
+@patch('mem0.memory.main.extract_entities', return_value=[])
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+def test_search_deduplicates_pinned_memories_from_semantic_results(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory, _mock_extract_entities
+):
+    mock_embedder = MagicMock()
+    mock_embedder.embed.return_value = [0.1, 0.2, 0.3]
+    mock_embedder_factory.return_value = mock_embedder
+
+    mock_vector_store = MagicMock()
+    payload = {"data": "Pinned policy", "user_id": "support", "memory_type": "policy"}
+    mock_vector_store.list.return_value = [MockVectorMemory("policy_1", payload)]
+    mock_vector_store.search.return_value = [
+        MockVectorMemory("policy_1", payload, score=0.95),
+        MockVectorMemory("semantic_1", {"data": "Semantic memory", "user_id": "support"}, score=0.72),
+    ]
+    mock_vector_store.keyword_search.return_value = []
+    mock_vector_factory.return_value = mock_vector_store
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+    memory = MemoryClass(MemoryConfig())
+
+    result = memory.search(
+        "refund policy",
+        filters={"user_id": "support"},
+        include_pinned={"memory_type": "policy"},
+    )
+
+    assert [memory["id"] for memory in result["results"]] == ["policy_1", "semantic_1"]
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+def test_search_rejects_invalid_include_pinned(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+    memory = MemoryClass(MemoryConfig())
+
+    with pytest.raises(ValueError, match="include_pinned must be a dictionary"):
+        memory.search("refund policy", filters={"user_id": "support"}, include_pinned=["policy"])
+
+
 @patch('mem0.utils.factory.EmbedderFactory.create')
 @patch('mem0.utils.factory.VectorStoreFactory.create')
 @patch('mem0.utils.factory.LlmFactory.create')


### PR DESCRIPTION
## Linked Issue

No linked issue. This is a focused OSS retrieval enhancement identified from the current memory search architecture and common agent workflow needs.

## Description

This adds an opt-in way to include deterministic memories before semantic search results in the OSS `Memory.search` API.

Some agent context should not compete in vector ranking: policies, personas, guardrails, account facts, and other stable context often need to be present every time a scoped query runs. Today users can encode these as normal memories, but retrieval depends on semantic similarity and `top_k` pressure.

Implemented:

- `include_pinned` metadata filter and `pinned_limit` for sync and async OSS search
- pinned results are scoped by the normal entity filters (`user_id`, `agent_id`, `run_id`)
- pinned results are returned first with `retrieval_type="pinned"` and `score=1.0`
- semantic results still run normally and duplicates are removed
- REST `/search` accepts the new parameters
- docs cover Python and REST usage

The implementation reuses existing vector-store `list()` behavior and metadata payloads. It does not add schema requirements or alter default search responses.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Manual/test commands run:

```bash
uv run --no-project --with ruff ruff check mem0/memory/main.py server/main.py tests/test_memory.py
uv run --with-editable . --with pytest --with pytest-asyncio --with pytest-mock pytest tests/test_memory.py -q
uv run --with-editable . --with pytest --with pytest-asyncio --with pytest-mock pytest tests/test_server_params.py -q
```

`tests/test_server_params.py` has no runnable tests in this local environment and was skipped by pytest.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove the fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
