### PR TITLE
feat(server): expose self-hosted MCP endpoint

### DIFF
--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -413,7 +413,7 @@ Editor-specific setup docs (already listed above under `## Integrations > AI Cod
 ### MCP Endpoints
 
 - Hosted MCP server: `https://mcp.mem0.ai` - requires Platform API key. See `platform/mem0-mcp`.
-- Self-hosted MCP server: ships with `openmemory/api/` (FastAPI) - runs against your own Qdrant + LLM stack.
+- Self-hosted MCP server: `server/` exposes Streamable HTTP at `/mcp/<client-name>/http/<user-id>` for the standard FastAPI/Postgres deployment; `openmemory/api/` also ships an MCP server for the OpenMemory stack.
 
 ## Community & Support
 

--- a/server/README.md
+++ b/server/README.md
@@ -105,6 +105,19 @@ Wire the command into cron or a systemd timer in production. The `created_at` co
 - Dashboard: `http://localhost:3000`
 - API: `http://localhost:8888`
 - OpenAPI docs: `http://localhost:8888/docs`
+- MCP Streamable HTTP: `http://localhost:8888/mcp/<client-name>/http/<user-id>`
+
+## MCP for agents
+
+The self-hosted server exposes the same memory backend through MCP so local agent clients can manage memories without calling REST endpoints manually. Configure your MCP client with the Streamable HTTP URL and the same API key you use for REST:
+
+```toml
+[mcp_servers.mem0_local]
+url = "http://localhost:8888/mcp/codex/http/alice"
+headers = { "X-API-Key" = "m0sk_..." }
+```
+
+The MCP tools include `add_memory`, `search_memories`, `get_memories`, `get_memory`, `update_memory`, `delete_memory`, and `delete_all_memories`. The `user_id` path segment scopes every tool call; optional `agent_id`, `run_id`, metadata, and filters can further narrow individual operations.
 
 ## Dashboard
 

--- a/server/main.py
+++ b/server/main.py
@@ -27,6 +27,7 @@ from routers import auth as auth_router
 from routers import entities as entities_router
 from routers import requests as requests_router
 from schemas import MessageResponse
+from mcp_server import setup_mcp_server
 from server_state import (
     get_current_config,
     get_memory_instance,
@@ -168,6 +169,7 @@ app.include_router(auth_router.router)
 app.include_router(api_keys_router.router)
 app.include_router(entities_router.router)
 app.include_router(requests_router.router)
+setup_mcp_server(app)
 
 
 class Message(BaseModel):

--- a/server/mcp_server.py
+++ b/server/mcp_server.py
@@ -1,0 +1,230 @@
+import asyncio
+import contextvars
+import json
+import logging
+from typing import Any, Dict, Optional
+
+import anyio
+from fastapi import Depends, FastAPI, Request
+from fastapi.routing import APIRouter
+from mcp.server.fastmcp import FastMCP
+from mcp.server.streamable_http import StreamableHTTPServerTransport
+from starlette.responses import Response
+
+from auth import verify_auth
+from server_state import get_memory_instance
+
+logger = logging.getLogger(__name__)
+
+mcp = FastMCP("mem0-self-hosted-mcp")
+mcp_router = APIRouter(prefix="/mcp")
+
+user_id_var: contextvars.ContextVar[str] = contextvars.ContextVar("mcp_user_id")
+client_name_var: contextvars.ContextVar[str] = contextvars.ContextVar("mcp_client_name")
+
+
+def _json(data: Any) -> str:
+    return json.dumps(data, indent=2, default=str)
+
+
+def _scoped_filters(
+    *,
+    agent_id: Optional[str] = None,
+    run_id: Optional[str] = None,
+    filters: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    uid = user_id_var.get(None)
+    scoped_filters = dict(filters or {})
+    scoped_filters["user_id"] = uid
+    if agent_id:
+        scoped_filters["agent_id"] = agent_id
+    if run_id:
+        scoped_filters["run_id"] = run_id
+    return scoped_filters
+
+
+@mcp.tool(name="add_memory", description="Add a memory for the current self-hosted Mem0 user.")
+async def add_memory(
+    text: str,
+    infer: bool = True,
+    agent_id: Optional[str] = None,
+    run_id: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> str:
+    uid = user_id_var.get(None)
+    client_name = client_name_var.get(None)
+    if not uid:
+        return "Error: user_id not provided"
+
+    memory_metadata = dict(metadata or {})
+    if client_name:
+        memory_metadata.setdefault("mcp_client", client_name)
+    memory_metadata.setdefault("source", "self_hosted_mcp")
+
+    kwargs = {
+        "user_id": uid,
+        "infer": infer,
+        "metadata": memory_metadata,
+    }
+    if agent_id:
+        kwargs["agent_id"] = agent_id
+    if run_id:
+        kwargs["run_id"] = run_id
+
+    try:
+        result = await asyncio.to_thread(get_memory_instance().add, text, **kwargs)
+        return _json(result)
+    except Exception as exc:
+        logger.exception("Error adding memory through MCP")
+        return f"Error adding memory: {exc}"
+
+
+@mcp.tool(name="search_memories", description="Search memories for the current self-hosted Mem0 user.")
+async def search_memories(
+    query: str,
+    top_k: int = 10,
+    agent_id: Optional[str] = None,
+    run_id: Optional[str] = None,
+    filters: Optional[Dict[str, Any]] = None,
+) -> str:
+    try:
+        result = await asyncio.to_thread(
+            get_memory_instance().search,
+            query=query,
+            top_k=top_k,
+            filters=_scoped_filters(agent_id=agent_id, run_id=run_id, filters=filters),
+        )
+        return _json(result)
+    except Exception as exc:
+        logger.exception("Error searching memories through MCP")
+        return f"Error searching memories: {exc}"
+
+
+@mcp.tool(name="get_memories", description="List memories for the current self-hosted Mem0 user.")
+async def get_memories(
+    agent_id: Optional[str] = None,
+    run_id: Optional[str] = None,
+    limit: int = 100,
+) -> str:
+    try:
+        result = await asyncio.to_thread(
+            get_memory_instance().get_all,
+            filters=_scoped_filters(agent_id=agent_id, run_id=run_id),
+            top_k=limit,
+        )
+        return _json(result)
+    except Exception as exc:
+        logger.exception("Error listing memories through MCP")
+        return f"Error listing memories: {exc}"
+
+
+@mcp.tool(name="get_memory", description="Get one memory by ID from the self-hosted Mem0 server.")
+async def get_memory(memory_id: str) -> str:
+    try:
+        result = await asyncio.to_thread(get_memory_instance().get, memory_id)
+        return _json(result)
+    except Exception as exc:
+        logger.exception("Error getting memory through MCP")
+        return f"Error getting memory: {exc}"
+
+
+@mcp.tool(name="update_memory", description="Update one memory by ID on the self-hosted Mem0 server.")
+async def update_memory(
+    memory_id: str,
+    text: str,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> str:
+    try:
+        result = await asyncio.to_thread(get_memory_instance().update, memory_id, data=text, metadata=metadata)
+        return _json(result)
+    except Exception as exc:
+        logger.exception("Error updating memory through MCP")
+        return f"Error updating memory: {exc}"
+
+
+@mcp.tool(name="delete_memory", description="Delete one memory by ID from the self-hosted Mem0 server.")
+async def delete_memory(memory_id: str) -> str:
+    try:
+        await asyncio.to_thread(get_memory_instance().delete, memory_id=memory_id)
+        return _json({"message": "Memory deleted successfully"})
+    except Exception as exc:
+        logger.exception("Error deleting memory through MCP")
+        return f"Error deleting memory: {exc}"
+
+
+@mcp.tool(name="delete_all_memories", description="Delete all memories scoped to the current self-hosted Mem0 user.")
+async def delete_all_memories(agent_id: Optional[str] = None, run_id: Optional[str] = None) -> str:
+    kwargs = {"user_id": user_id_var.get(None)}
+    if agent_id:
+        kwargs["agent_id"] = agent_id
+    if run_id:
+        kwargs["run_id"] = run_id
+
+    try:
+        await asyncio.to_thread(get_memory_instance().delete_all, **kwargs)
+        return _json({"message": "All relevant memories deleted"})
+    except Exception as exc:
+        logger.exception("Error deleting memories through MCP")
+        return f"Error deleting memories: {exc}"
+
+
+@mcp_router.api_route("/{client_name}/http/{user_id}", methods=["POST", "GET", "DELETE"], include_in_schema=False)
+async def handle_streamable_http(request: Request, _auth=Depends(verify_auth)):
+    uid = request.path_params.get("user_id")
+    user_token = user_id_var.set(uid or "")
+    client_name = request.path_params.get("client_name")
+    client_token = client_name_var.set(client_name or "")
+
+    response_started = False
+    response_status = 200
+    response_headers: list[tuple[bytes, bytes]] = []
+    response_body = bytearray()
+
+    async def capture_send(message):
+        nonlocal response_started, response_status
+        if message["type"] == "http.response.start":
+            response_started = True
+            response_status = message["status"]
+            response_headers.extend(message.get("headers", []))
+        elif message["type"] == "http.response.body":
+            response_body.extend(message.get("body", b""))
+
+    try:
+        transport = StreamableHTTPServerTransport(
+            mcp_session_id=None,
+            is_json_response_enabled=True,
+        )
+
+        async with anyio.create_task_group() as task_group:
+
+            async def run_server(*, task_status=anyio.TASK_STATUS_IGNORED):
+                async with transport.connect() as (read_stream, write_stream):
+                    task_status.started()
+                    await mcp._mcp_server.run(
+                        read_stream,
+                        write_stream,
+                        mcp._mcp_server.create_initialization_options(),
+                        stateless=True,
+                    )
+
+            await task_group.start(run_server)
+            await transport.handle_request(request.scope, request.receive, capture_send)
+            await transport.terminate()
+            task_group.cancel_scope.cancel()
+    finally:
+        user_id_var.reset(user_token)
+        client_name_var.reset(client_token)
+
+    if not response_started:
+        return Response(status_code=500, content=b"Transport did not produce a response")
+
+    return Response(
+        content=bytes(response_body),
+        status_code=response_status,
+        headers={key.decode(): value.decode() for key, value in response_headers},
+    )
+
+
+def setup_mcp_server(app: FastAPI) -> None:
+    mcp._mcp_server.name = "mem0-self-hosted-mcp"
+    app.include_router(mcp_router)

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -24,3 +24,6 @@ posthog>=3.0,<8.0
 
 # Per-IP rate limiting on auth endpoints
 slowapi>=0.1.9,<1.0
+
+# Streamable HTTP MCP endpoint for self-hosted agent integrations
+mcp[cli]>=1.3.0,<2.0

--- a/tests/test_server_mcp.py
+++ b/tests/test_server_mcp.py
@@ -1,0 +1,172 @@
+import importlib
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import pytest_asyncio
+
+pytest.importorskip("mcp", reason="mcp package not installed")
+pytest.importorskip("httpx", reason="httpx not installed")
+
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+SERVER_DIR = Path(__file__).resolve().parents[1] / "server"
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+os.environ.setdefault("AUTH_DISABLED", "true")
+os.environ.setdefault("JWT_SECRET", "test-secret")
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+mcp_server = importlib.import_module("mcp_server")
+
+MCP_HEADERS = {"Accept": "application/json, text/event-stream"}
+
+
+def _jsonrpc(method: str, params: dict | None = None, req_id: int = 1) -> dict:
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "method": method,
+        "params": params or {},
+    }
+
+
+def _initialize_payload(req_id: int = 1) -> dict:
+    return _jsonrpc(
+        "initialize",
+        {
+            "protocolVersion": "2025-03-26",
+            "capabilities": {},
+            "clientInfo": {"name": "test-client", "version": "0.1.0"},
+        },
+        req_id=req_id,
+    )
+
+
+@pytest.fixture
+def test_app():
+    app = FastAPI()
+    app.dependency_overrides[mcp_server.verify_auth] = lambda: None
+    app.include_router(mcp_server.mcp_router)
+    return app
+
+
+@pytest_asyncio.fixture
+async def client(test_app):
+    transport = ASGITransport(app=test_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as async_client:
+        yield async_client
+
+
+@pytest.mark.asyncio
+async def test_mcp_initialize(client):
+    response = await client.post(
+        "/mcp/codex/http/alice",
+        json=_initialize_payload(),
+        headers=MCP_HEADERS,
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["jsonrpc"] == "2.0"
+    assert data["id"] == 1
+    assert data["result"]["serverInfo"]["name"] == "mem0-self-hosted-mcp"
+
+
+@pytest.mark.asyncio
+async def test_mcp_tools_list_exposes_memory_tools(client):
+    await client.post("/mcp/codex/http/alice", json=_initialize_payload(), headers=MCP_HEADERS)
+
+    response = await client.post(
+        "/mcp/codex/http/alice",
+        json=_jsonrpc("tools/list", req_id=2),
+        headers=MCP_HEADERS,
+    )
+
+    assert response.status_code == 200
+    tool_names = {tool["name"] for tool in response.json()["result"]["tools"]}
+    assert {
+        "add_memory",
+        "search_memories",
+        "get_memories",
+        "get_memory",
+        "update_memory",
+        "delete_memory",
+        "delete_all_memories",
+    }.issubset(tool_names)
+
+
+@pytest.mark.asyncio
+async def test_mcp_add_memory_forwards_path_scope_and_client_metadata(client):
+    mock_memory = MagicMock()
+    mock_memory.add.return_value = {"results": [{"id": "mem-1", "memory": "Remember this.", "event": "ADD"}]}
+
+    with patch.object(mcp_server, "get_memory_instance", return_value=mock_memory):
+        response = await client.post(
+            "/mcp/codex/http/alice",
+            json=_jsonrpc(
+                "tools/call",
+                {
+                    "name": "add_memory",
+                    "arguments": {
+                        "text": "Remember this.",
+                        "infer": False,
+                        "agent_id": "agent-1",
+                        "metadata": {"kind": "preference"},
+                    },
+                },
+                req_id=3,
+            ),
+            headers=MCP_HEADERS,
+        )
+
+    assert response.status_code == 200
+    tool_text = response.json()["result"]["content"][0]["text"]
+    assert json.loads(tool_text)["results"][0]["id"] == "mem-1"
+
+    mock_memory.add.assert_called_once()
+    args, kwargs = mock_memory.add.call_args
+    assert args == ("Remember this.",)
+    assert kwargs["user_id"] == "alice"
+    assert kwargs["agent_id"] == "agent-1"
+    assert kwargs["infer"] is False
+    assert kwargs["metadata"] == {
+        "kind": "preference",
+        "mcp_client": "codex",
+        "source": "self_hosted_mcp",
+    }
+
+
+@pytest.mark.asyncio
+async def test_mcp_search_forces_path_user_over_user_filter(client):
+    mock_memory = MagicMock()
+    mock_memory.search.return_value = {"results": [{"id": "mem-1", "memory": "Scoped"}]}
+
+    with patch.object(mcp_server, "get_memory_instance", return_value=mock_memory):
+        response = await client.post(
+            "/mcp/codex/http/alice",
+            json=_jsonrpc(
+                "tools/call",
+                {
+                    "name": "search_memories",
+                    "arguments": {
+                        "query": "scoped",
+                        "top_k": 5,
+                        "filters": {"user_id": "mallory", "topic": "work"},
+                    },
+                },
+                req_id=4,
+            ),
+            headers=MCP_HEADERS,
+        )
+
+    assert response.status_code == 200
+    _, kwargs = mock_memory.search.call_args
+    assert kwargs["query"] == "scoped"
+    assert kwargs["top_k"] == 5
+    assert kwargs["filters"] == {"user_id": "alice", "topic": "work"}


### PR DESCRIPTION
## Linked Issue

No linked issue. This is a focused self-hosted server feature that closes a capability gap between the hosted/OpenMemory MCP story and the standard FastAPI/Postgres deployment.

## Description

This adds a Streamable HTTP MCP endpoint to the self-hosted `server/` package.

The hosted platform and OpenMemory stack already have MCP paths for agent clients. The standard self-hosted FastAPI server exposes REST APIs but not MCP, so users running the Postgres-backed server still need custom glue code for Codex, Claude, Cursor, and other MCP-aware tools.

Implemented:

- `server/mcp_server.py` with FastMCP + stateless Streamable HTTP transport
- authenticated route at `/mcp/<client-name>/http/<user-id>` using the existing `verify_auth` dependency
- memory tools backed by `get_memory_instance()`:
  - `add_memory`
  - `search_memories`
  - `get_memories`
  - `get_memory`
  - `update_memory`
  - `delete_memory`
  - `delete_all_memories`
- path-scoped `user_id` enforcement so tool filters cannot override the URL user scope
- server README setup example and llms.txt context update
- protocol-level tests for initialize, tools/list, add, and scoped search behavior

The route is excluded from OpenAPI schema generation because MCP clients discover tools through the MCP protocol, and excluding it avoids duplicate operation IDs for the multi-method transport route.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [x] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Manual/test commands run:

```bash
uv run --no-project --with ruff ruff check server/mcp_server.py server/main.py tests/test_server_mcp.py
uv run --with-editable . --with 'mcp[cli]>=1.3.0,<2.0' --with fastapi --with httpx --with pytest --with pytest-asyncio --with 'python-jose[cryptography]>=3.3,<4.0' --with 'passlib[bcrypt]>=1.7,<2.0' --with 'sqlalchemy>=2.0,<3.0' --with 'pydantic[email]==2.10.4' --with 'psycopg[binary]>=3.2.8' pytest tests/test_server_mcp.py -q
AUTH_DISABLED=true JWT_SECRET=test PYTHONPATH=server uv run --with-editable . --with 'mcp[cli]>=1.3.0,<2.0' --with fastapi --with httpx --with pytest --with pytest-asyncio --with 'python-jose[cryptography]>=3.3,<4.0' --with 'passlib[bcrypt]>=1.7,<2.0' --with 'sqlalchemy>=2.0,<3.0' --with 'pydantic[email]==2.10.4' --with 'psycopg[binary]>=3.2.8' --with slowapi --with python-dotenv pytest tests/test_server_params.py -q
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove the fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
