### PR TITLE
fix(openclaw-mem0): ship compiled JS in published package (#5106)

### DIFF
--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -31,6 +31,8 @@
   ],
   "scripts": {
     "build": "tsup",
+    "prepare": "npm run build",
+    "prepublishOnly": "npm run build",
     "test": "vitest run"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

Fixes #5106 — the `@mem0/openclaw-mem0` package was publishing raw TypeScript instead of compiled JS.

### Changes
- Added `"prepare": "npm run build"` script to `openclaw/package.json`
- Added `"prepublishOnly": "npm run build"` as an extra safety net
- `dist/` was already in the `files` array and already gitignored — just needed the build lifecycle hooks
