### PR TITLE
fix: support Milvus metadata range filters

### DIFF
--- a/mem0/vector_stores/milvus.py
+++ b/mem0/vector_stores/milvus.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from typing import Dict, Optional
 
@@ -136,23 +137,54 @@ class MilvusDB(VectorStoreBase):
         data = [_build_record(idx, embedding, metadata) for idx, embedding, metadata in zip(ids, vectors, payloads)]
         self.client.insert(collection_name=self.collection_name, data=data, **kwargs)
 
+    def _format_filter_value(self, value):
+        return json.dumps(value)
+
+    def _format_metadata_field(self, key: str):
+        return f"metadata[{json.dumps(key)}]"
+
+    def _build_filter_condition(self, key: str, value):
+        field = self._format_metadata_field(key)
+
+        if not isinstance(value, dict):
+            return f"({field} == {self._format_filter_value(value)})"
+
+        operator_map = {"eq": "==", "ne": "!=", "gt": ">", "gte": ">=", "lt": "<", "lte": "<="}
+        conditions = []
+
+        for operator, operand in value.items():
+            if operator in operator_map:
+                conditions.append(f"({field} {operator_map[operator]} {self._format_filter_value(operand)})")
+            else:
+                supported = set(operator_map)
+                raise ValueError(
+                    f"Unsupported Milvus metadata filter operator '{operator}' for field '{key}'. "
+                    f"Supported operators: {supported}"
+                )
+
+        return " and ".join(conditions)
+
     def _create_filter(self, filters: dict):
         """Prepare filters for efficient query.
 
         Args:
-            filters (dict): filters [user_id, agent_id, run_id]
+            filters (dict): Metadata filters, including enhanced filter syntax
+                with comparison operators.
 
         Returns:
-            str: formated filter.
+            str: formatted filter.
         """
-        operands = []
-        for key, value in filters.items():
-            if isinstance(value, str):
-                operands.append(f'(metadata["{key}"] == "{value}")')
-            else:
-                operands.append(f'(metadata["{key}"] == {value})')
+        if not filters:
+            return None
 
-        return " and ".join(operands)
+        operands = []
+
+        for key, value in filters.items():
+            condition = self._build_filter_condition(key, value)
+            if condition:
+                operands.append(condition)
+
+        return " and ".join(operands) if operands else None
 
     def _parse_output(self, data: list):
         """

--- a/tests/vector_stores/test_milvus.py
+++ b/tests/vector_stores/test_milvus.py
@@ -107,6 +107,37 @@ class TestMilvusDB:
         assert 'metadata["category"] == "work"' in filter_str
         assert ' and ' in filter_str
 
+    def test_create_filter_range_conditions(self, milvus_db):
+        """Test filter creation with range metadata operators."""
+        filters = {
+            "user_id": "alice",
+            "created_at": {
+                "gte": "2026-04-28T00:00:00+00:00",
+                "lt": "2026-04-29T00:00:00+00:00",
+            },
+        }
+
+        filter_str = milvus_db._create_filter(filters)
+
+        assert 'metadata["user_id"] == "alice"' in filter_str
+        assert 'metadata["created_at"] >= "2026-04-28T00:00:00+00:00"' in filter_str
+        assert 'metadata["created_at"] < "2026-04-29T00:00:00+00:00"' in filter_str
+
+    def test_create_filter_escapes_string_values(self, milvus_db):
+        """Test filter creation safely escapes string metadata values."""
+        filters = {"user_id": 'alice" OR metadata["user_id"] == "bob'}
+
+        filter_str = milvus_db._create_filter(filters)
+
+        assert filter_str == '(metadata["user_id"] == "alice\\" OR metadata[\\"user_id\\"] == \\"bob")'
+
+    def test_create_filter_rejects_unsupported_operator(self, milvus_db):
+        """Test unsupported operators fail instead of producing invalid Milvus filters."""
+        filters = {"memory": {"contains": "phone"}}
+
+        with pytest.raises(ValueError, match="Unsupported Milvus metadata filter operator"):
+            milvus_db._create_filter(filters)
+
     def test_search_with_filters(self, milvus_db, mock_milvus_client):
         """Test search with metadata filters (reproduces user's bug scenario)."""
         # Setup mock return value
@@ -323,4 +354,3 @@ class TestMilvusDB:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
-


### PR DESCRIPTION
## Linked Issue

N/A - small provider compatibility fix.

## Description

Milvus metadata filters previously treated dictionary values as equality operands, so enhanced filter syntax such as `{ "created_at": { "gte": "...", "lt": "..." } }` could not be translated into a valid Milvus expression.

This PR adds comparison operator support for Milvus metadata filters:

- `eq`
- `ne`
- `gt`
- `gte`
- `lt`
- `lte`

It also JSON-escapes metadata keys and values when building filter expressions, preserving the existing equality behavior for scalar filters.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Tested locally:

```bash
uv run --with pytest --with pymilvus pytest tests/vector_stores/test_milvus.py -q
```

Also manually verified generated Milvus expressions for multiple time windows and comparison operators against a Milvus collection using JSON metadata timestamp fields.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing targeted tests pass locally
- [x] Documentation update not needed for this provider-level bug fix
