### PR TITLE
fix: handle missing keys in FunctionCalling tool response from Dify

### DIFF
--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -61,12 +61,16 @@ def ensure_json_instruction(system_prompt, user_prompt):
 def parse_messages(messages):
     response = ""
     for msg in messages:
-        if msg["role"] == "system":
-            response += f"system: {msg['content']}\n"
-        if msg["role"] == "user":
-            response += f"user: {msg['content']}\n"
-        if msg["role"] == "assistant":
-            response += f"assistant: {msg['content']}\n"
+        role = msg.get("role")
+        content = msg.get("content")
+        if content is None:
+            continue
+        if role == "system":
+            response += f"system: {content}\n"
+        elif role == "user":
+            response += f"user: {content}\n"
+        elif role == "assistant":
+            response += f"assistant: {content}\n"
     return response
 
 
@@ -173,21 +177,29 @@ def parse_vision_messages(messages, llm=None, vision_details="auto"):
     """
     returned_messages = []
     for msg in messages:
-        if msg["role"] == "system":
+        role = msg.get("role")
+        content = msg.get("content")
+        if role is None:
+            continue
+        if role == "system":
             returned_messages.append(msg)
             continue
 
+        # Skip messages without content (e.g. assistant tool_calls without text)
+        if content is None:
+            continue
+
         # Handle message content
-        if isinstance(msg["content"], list):
+        if isinstance(content, list):
             # Multiple image URLs in content
             description = get_image_description(msg, llm, vision_details)
-            returned_messages.append({"role": msg["role"], "content": description})
-        elif isinstance(msg["content"], dict) and msg["content"].get("type") == "image_url":
+            returned_messages.append({"role": role, "content": description})
+        elif isinstance(content, dict) and content.get("type") == "image_url":
             # Single image content
-            image_url = msg["content"]["image_url"]["url"]
+            image_url = content["image_url"]["url"]
             try:
                 description = get_image_description(image_url, llm, vision_details)
-                returned_messages.append({"role": msg["role"], "content": description})
+                returned_messages.append({"role": role, "content": description})
             except Exception:
                 raise Exception(f"Error while downloading {image_url}.")
         else:

--- a/tests/memory/test_memory_utils.py
+++ b/tests/memory/test_memory_utils.py
@@ -1,5 +1,10 @@
 import pytest
-from mem0.memory.utils import remove_spaces_from_entities, sanitize_relationship_for_cypher
+from mem0.memory.utils import (
+    parse_messages,
+    parse_vision_messages,
+    remove_spaces_from_entities,
+    sanitize_relationship_for_cypher,
+)
 
 
 class TestRemoveSpacesFromEntities:
@@ -55,3 +60,133 @@ class TestRemoveSpacesFromEntities:
         f = remove_spaces_from_entities([dict(base)], sanitize_relationship=False)[0]["relationship"]
         assert t == sanitize_relationship_for_cypher("a/b")
         assert f == "a/b"
+
+
+class TestParseMessagesSafeAccess:
+    """Test that parse_messages handles messages with missing keys (issue #5067).
+
+    When Dify's FunctionCalling agent calls Mem0 as a tool, it may send assistant
+    messages with tool_calls but no content key, or tool-role messages. These should
+    be gracefully skipped rather than raising a KeyError.
+    """
+
+    def test_assistant_message_without_content_is_skipped(self):
+        """Assistant message with tool_calls but no content should not raise KeyError."""
+        messages = [
+            {"role": "user", "content": "Remember I like tennis"},
+            {"role": "assistant", "tool_calls": [{"id": "call_1", "function": {"name": "add_memory"}}]},
+        ]
+        result = parse_messages(messages)
+        assert "user: Remember I like tennis" in result
+        assert "assistant" not in result
+
+    def test_tool_role_message_is_skipped(self):
+        """Tool-role messages (from function calling) should be skipped."""
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "tool", "tool_call_id": "call_1", "content": "Memory stored"},
+        ]
+        result = parse_messages(messages)
+        assert "user: Hello" in result
+        assert "Memory stored" not in result
+
+    def test_message_without_role_key_is_skipped(self):
+        """Messages missing the role key entirely should be skipped."""
+        messages = [
+            {"content": "orphan message"},
+            {"role": "user", "content": "valid message"},
+        ]
+        result = parse_messages(messages)
+        assert "orphan" not in result
+        assert "valid message" in result
+
+    def test_message_without_content_key_is_skipped(self):
+        """Messages missing the content key should be skipped."""
+        messages = [
+            {"role": "user"},
+            {"role": "assistant", "content": "valid"},
+        ]
+        result = parse_messages(messages)
+        assert "valid" in result
+
+    def test_empty_messages_list(self):
+        result = parse_messages([])
+        assert result == ""
+
+    def test_normal_messages_still_work(self):
+        """Ensure normal message parsing is unaffected by the fix."""
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+        ]
+        result = parse_messages(messages)
+        assert "system: You are a helpful assistant." in result
+        assert "user: Hello" in result
+        assert "assistant: Hi there!" in result
+
+    def test_dify_function_calling_conversation(self):
+        """Simulate a full Dify FunctionCalling conversation."""
+        messages = [
+            {"role": "system", "content": "You have access to mem0 tools."},
+            {"role": "user", "content": "Remember I like tennis"},
+            {"role": "assistant", "tool_calls": [
+                {"id": "call_abc", "function": {"name": "add_memory", "arguments": "{...}"}}
+            ]},
+            {"role": "tool", "tool_call_id": "call_abc", "content": "{\"results\": []}"},
+            {"role": "assistant", "content": "Done!"},
+        ]
+        result = parse_messages(messages)
+        assert "system: You have access to mem0 tools." in result
+        assert "user: Remember I like tennis" in result
+        assert "assistant: Done!" in result
+        # tool_calls-only assistant message should be skipped
+        assert "tool_calls" not in result
+
+
+class TestParseVisionMessagesSafeAccess:
+    """Test that parse_vision_messages handles messages with missing keys (issue #5067)."""
+
+    def test_assistant_message_without_content_is_skipped(self):
+        """Assistant tool_calls message without content should be skipped, not KeyError."""
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "tool_calls": [{"id": "call_1"}]},
+        ]
+        result = parse_vision_messages(messages)
+        assert len(result) == 1
+        assert result[0]["role"] == "user"
+
+    def test_tool_role_message_is_skipped(self):
+        """Tool messages without content should be skipped."""
+        messages = [
+            {"role": "user", "content": "Hi"},
+            {"role": "tool", "tool_call_id": "call_1"},
+        ]
+        result = parse_vision_messages(messages)
+        assert len(result) == 1
+
+    def test_system_message_without_content_passthrough(self):
+        """System messages are passed through directly even if content is missing."""
+        messages = [{"role": "system", "content": "You are helpful."}]
+        result = parse_vision_messages(messages)
+        assert len(result) == 1
+
+    def test_message_without_role_is_skipped(self):
+        messages = [
+            {"content": "orphan"},
+            {"role": "user", "content": "valid"},
+        ]
+        result = parse_vision_messages(messages)
+        assert len(result) == 1
+        assert result[0]["role"] == "user"
+
+    def test_normal_messages_still_work(self):
+        """Ensure normal vision message parsing is unaffected."""
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi!"},
+        ]
+        result = parse_vision_messages(messages)
+        assert len(result) == 3


### PR DESCRIPTION
Fixes #5067

## Summary

When Mem0 is used as a tool in Dify FunctionCalling agent, the tool response may contain keys that Mem0 plugin handler does not expect, causing a KeyError.

This fix adds safe key access with .get() defaults in `mem0/memory/utils.py`.

## Context

I am a contributor to Dify (merged PRs #35897, #35922) and encountered this issue while integrating Mem0 with Dify agent framework.

## Changes

- `mem0/memory/utils.py`: Added safe key access for FunctionCalling tool response
- `tests/memory/test_memory_utils.py`: Added test coverage for missing key scenarios