### PR TITLE
feat: add Bedrock API key (bearer token) authentication support

### DIFF
--- a/mem0/configs/embeddings/base.py
+++ b/mem0/configs/embeddings/base.py
@@ -40,6 +40,7 @@ class BaseEmbedderConfig(ABC):
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
         aws_region: Optional[str] = None,
+        auth_mode: Optional[str] = None,
     ):
         """
         Initializes a configuration class instance for the Embeddings.
@@ -107,4 +108,5 @@ class BaseEmbedderConfig(ABC):
         self.aws_access_key_id = aws_access_key_id
         self.aws_secret_access_key = aws_secret_access_key
         self.aws_region = aws_region or os.environ.get("AWS_REGION") or "us-west-2"
+        self.auth_mode = auth_mode or "sigv4"
 

--- a/mem0/configs/llms/aws_bedrock.py
+++ b/mem0/configs/llms/aws_bedrock.py
@@ -24,6 +24,7 @@ class AWSBedrockConfig(BaseLlmConfig):
         aws_session_token: Optional[str] = None,
         aws_profile: Optional[str] = None,
         model_kwargs: Optional[Dict[str, Any]] = None,
+        auth_mode: str = "sigv4",
         **kwargs,
     ):
         """
@@ -42,6 +43,7 @@ class AWSBedrockConfig(BaseLlmConfig):
             aws_session_token: AWS session token for temporary credentials
             aws_profile: AWS profile name for credentials
             model_kwargs: Additional model-specific parameters
+            auth_mode: Authentication mode - "sigv4" (default) or "api_key" (bearer token)
             **kwargs: Additional arguments passed to base class
         """
         super().__init__(
@@ -59,6 +61,7 @@ class AWSBedrockConfig(BaseLlmConfig):
         self.aws_session_token = aws_session_token
         self.aws_profile = aws_profile
         self.model_kwargs = model_kwargs or {}
+        self.auth_mode = auth_mode
 
     @property
     def provider(self) -> str:

--- a/mem0/embeddings/aws_bedrock.py
+++ b/mem0/embeddings/aws_bedrock.py
@@ -1,6 +1,9 @@
+import io
 import json
 import os
+import time
 from typing import Literal, Optional
+from urllib.parse import quote
 
 try:
     import boto3
@@ -8,9 +11,49 @@ except ImportError:
     raise ImportError("The 'boto3' library is required. Please install it using 'pip install boto3'.")
 
 import numpy as np
+import requests as _requests
 
 from mem0.configs.embeddings.base import BaseEmbedderConfig
 from mem0.embeddings.base import EmbeddingBase
+
+
+class _EmbeddingBearerTokenProvider:
+    """Generates and caches short-term Bedrock bearer tokens for embedding client."""
+
+    def __init__(self, region: str):
+        self._region = region
+        self._token: Optional[str] = None
+        self._expires_at: float = 0
+
+    def get_token(self) -> str:
+        if self._token and time.time() < self._expires_at:
+            return self._token
+        from aws_bedrock_token_generator import provide_token
+        self._token = provide_token(region=self._region)
+        self._expires_at = time.time() + 11 * 3600
+        return self._token
+
+
+class _EmbeddingBearerClient:
+    """Bearer token client for bedrock-runtime invoke_model (embeddings)."""
+
+    def __init__(self, region: str):
+        self._region = region
+        self._base_url = f"https://bedrock-runtime.{region}.amazonaws.com"
+        self._token_provider = _EmbeddingBearerTokenProvider(region)
+
+    def invoke_model(self, **kwargs):
+        model_id = kwargs.get("modelId")
+        body = kwargs.get("body")
+        token = self._token_provider.get_token()
+        url = f"{self._base_url}/model/{quote(model_id, safe='')}/invoke"
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+        resp = _requests.post(url, headers=headers, data=body)
+        resp.raise_for_status()
+        return {"body": io.BytesIO(resp.content)}
 
 
 class AWSBedrockEmbedding(EmbeddingBase):
@@ -24,27 +67,28 @@ class AWSBedrockEmbedding(EmbeddingBase):
 
         self.config.model = self.config.model or "amazon.titan-embed-text-v1"
 
-        # Get AWS config from environment variables or use defaults
-        aws_access_key = os.environ.get("AWS_ACCESS_KEY_ID", "")
-        aws_secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
-        aws_session_token = os.environ.get("AWS_SESSION_TOKEN", "")
-
-        # Check if AWS config is provided in the config
-        if hasattr(self.config, "aws_access_key_id"):
-            aws_access_key = self.config.aws_access_key_id
-        if hasattr(self.config, "aws_secret_access_key"):
-            aws_secret_key = self.config.aws_secret_access_key
-        
-        # AWS region is always set in config - see BaseEmbedderConfig
         aws_region = self.config.aws_region or "us-west-2"
+        auth_mode = getattr(self.config, "auth_mode", "sigv4")
 
-        self.client = boto3.client(
-            "bedrock-runtime",
-            region_name=aws_region,
-            aws_access_key_id=aws_access_key if aws_access_key else None,
-            aws_secret_access_key=aws_secret_key if aws_secret_key else None,
-            aws_session_token=aws_session_token if aws_session_token else None,
-        )
+        if auth_mode == "api_key":
+            self.client = _EmbeddingBearerClient(region=aws_region)
+        else:
+            aws_access_key = os.environ.get("AWS_ACCESS_KEY_ID", "")
+            aws_secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
+            aws_session_token = os.environ.get("AWS_SESSION_TOKEN", "")
+
+            if hasattr(self.config, "aws_access_key_id"):
+                aws_access_key = self.config.aws_access_key_id
+            if hasattr(self.config, "aws_secret_access_key"):
+                aws_secret_key = self.config.aws_secret_access_key
+
+            self.client = boto3.client(
+                "bedrock-runtime",
+                region_name=aws_region,
+                aws_access_key_id=aws_access_key if aws_access_key else None,
+                aws_secret_access_key=aws_secret_key if aws_secret_key else None,
+                aws_session_token=aws_session_token if aws_session_token else None,
+            )
 
     def _normalize_vector(self, embeddings):
         """Normalize the embedding to a unit vector."""

--- a/mem0/llms/aws_bedrock.py
+++ b/mem0/llms/aws_bedrock.py
@@ -1,13 +1,17 @@
 import json
 import logging
 import re
+import time
 from typing import Any, Dict, List, Optional, Union
+from urllib.parse import quote
 
 try:
     import boto3
     from botocore.exceptions import ClientError, NoCredentialsError
 except ImportError:
     raise ImportError("The 'boto3' library is required. Please install it using 'pip install boto3'.")
+
+import requests as _requests
 
 from mem0.configs.llms.base import BaseLlmConfig
 from mem0.configs.llms.aws_bedrock import AWSBedrockConfig
@@ -21,6 +25,55 @@ PROVIDERS = [
     "deepseek", "gpt-oss", "perplexity", "snowflake", "titan", "command", "j2", "llama",
     "minimax",
 ]
+
+
+class _BearerTokenProvider:
+    """Generates and caches short-term Bedrock bearer tokens."""
+
+    def __init__(self, region: str):
+        self._region = region
+        self._token: Optional[str] = None
+        self._expires_at: float = 0
+
+    def get_token(self) -> str:
+        if self._token and time.time() < self._expires_at:
+            return self._token
+        from aws_bedrock_token_generator import provide_token
+        self._token = provide_token(region=self._region)
+        # Token is valid up to 12h; refresh after 11h to be safe
+        self._expires_at = time.time() + 11 * 3600
+        return self._token
+
+
+class _BedrockBearerClient:
+    """Drop-in replacement for boto3 bedrock-runtime client using bearer token auth."""
+
+    def __init__(self, region: str):
+        self._region = region
+        self._base_url = f"https://bedrock-runtime.{region}.amazonaws.com"
+        self._token_provider = _BearerTokenProvider(region)
+
+    def _headers(self) -> Dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._token_provider.get_token()}",
+            "Content-Type": "application/json",
+        }
+
+    def converse(self, **kwargs) -> Dict[str, Any]:
+        model_id = kwargs.pop("modelId")
+        url = f"{self._base_url}/model/{quote(model_id, safe='')}/converse"
+        resp = _requests.post(url, headers=self._headers(), json=kwargs)
+        resp.raise_for_status()
+        return resp.json()
+
+    def invoke_model(self, **kwargs) -> Dict[str, Any]:
+        model_id = kwargs.pop("modelId")
+        body = kwargs.get("body")
+        url = f"{self._base_url}/model/{quote(model_id, safe='')}/invoke"
+        resp = _requests.post(url, headers=self._headers(), data=body)
+        resp.raise_for_status()
+        import io
+        return {"body": io.BytesIO(resp.content)}
 
 
 def extract_provider(model: str) -> str:
@@ -76,6 +129,11 @@ class AWSBedrockLLM(LLMBase):
 
     def _initialize_aws_client(self):
         """Initialize AWS Bedrock client with proper credentials."""
+        if getattr(self.config, "auth_mode", "sigv4") == "api_key":
+            self.client = _BedrockBearerClient(region=self.config.aws_region)
+            self.available_models = []
+            return
+
         try:
             aws_config = self.config.get_aws_config()
 
@@ -108,8 +166,13 @@ class AWSBedrockLLM(LLMBase):
             response = bedrock_client.list_foundation_models()
             self.available_models = [model["modelId"] for model in response["modelSummaries"]]
 
-            # Check if our model is available
-            if self.config.model not in self.available_models:
+            # Check if our model is available.
+            # Cross-region inference profile IDs have a regional prefix (e.g.
+            # "us.anthropic.claude-sonnet-4-6") that won't appear in the
+            # foundation model list. Strip the prefix before comparing.
+            model_id = self.config.model
+            base_model_id = re.sub(r"^(us|eu|ap)\.", "", model_id)
+            if model_id not in self.available_models and base_model_id not in self.available_models:
                 logger.warning(f"Model {self.config.model} may not be available in region {self.config.aws_region}")
                 logger.info(f"Available models: {', '.join(self.available_models[:5])}...")
 


### PR DESCRIPTION
Add `auth_mode: "api_key"` option to the AWS Bedrock LLM and embedding providers, enabling authentication via short-term bearer tokens generated by `aws-bedrock-token-generator` instead of SigV4 signing.

This implements the new AWS Bedrock API Keys feature (https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html) which simplifies authentication by using `Authorization: Bearer <token>` headers with direct HTTPS calls to the Bedrock runtime API.

Key changes:
- Added `auth_mode` parameter ("sigv4" default, "api_key" for bearer token)
- Added _BearerTokenProvider with automatic token caching and refresh
- Added _BedrockBearerClient as drop-in replacement for boto3 client
- Bearer client implements converse() and invoke_model() over HTTPS
- Fully backward-compatible: existing sigv4 behavior unchanged

## Linked Issue

Closes #<!-- issue number -->

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe what breaks and the migration path. Delete this section if not applicable. -->

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

<!-- Describe how you tested this, or link to CI results. -->

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] I have updated documentation if needed
