### PR TITLE
fix: include metadata filters in `add()` retrieval and session scoping

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -315,11 +315,11 @@ def _build_filters_and_metadata(
 
 
 def _build_session_scope(filters):
-    """Build deterministic session scope string from entity IDs."""
+    """Build deterministic session scope string from entity IDs and metadata."""
     parts = []
-    for key in sorted(["user_id", "agent_id", "run_id"]):
+    for key in sorted(filters.keys()):
         val = filters.get(key)
-        if val:
+        if val and isinstance(val, (str, int, float, bool)):
             parts.append(f"{key}={val}")
     return "&".join(parts)
 
@@ -704,7 +704,7 @@ class Memory(MemoryBase):
         parsed_messages = parse_messages(messages)
 
         # Phase 1: Existing memory retrieval
-        search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
+        search_filters = {k: v for k, v in filters.items() if v}
         query_embedding = self.embedding_model.embed(parsed_messages, "search")
         existing_results = self.vector_store.search(
             query=parsed_messages,
@@ -2118,7 +2118,7 @@ class AsyncMemory(MemoryBase):
         parsed_messages = parse_messages(messages)
 
         # Phase 1: Existing memory retrieval
-        search_filters = {k: v for k, v in effective_filters.items() if k in ("user_id", "agent_id", "run_id") and v}
+        search_filters = {k: v for k, v in effective_filters.items() if v}
         query_embedding = await asyncio.to_thread(self.embedding_model.embed, parsed_messages, "search")
         existing_results = await asyncio.to_thread(
             self.vector_store.search,


### PR DESCRIPTION
## Summary

- `Memory.add()` and `AsyncMemory.add()` Phase 1 retrieval filter was hardcoded to only `user_id`/`agent_id`/`run_id`, dropping custom metadata keys like `app_id`
- `_build_session_scope()` similarly only used those three keys for message partitioning
- This caused cross-context contamination in multi-app setups: memories from app-a leaked into app-b when sharing the same `user_id`
- Fix: pass all truthy filter keys through to vector store search (matching `search()` behavior), and include all scalar metadata keys in the session scope

Closes #5121

## Test plan

- [x] `pytest tests/test_memory.py tests/test_main.py` — 65 passed, 0 failed
- [ ] Verify `add(messages, user_id="u1", metadata={"app_id": "a"})` only retrieves memories with matching `app_id`
- [ ] Verify session scoping isolates message history per `app_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)