### PR TITLE
fix: require admin role on POST /configure to prevent unauthorized co…

### DIFF
--- a/server/auth.py
+++ b/server/auth.py
@@ -184,3 +184,20 @@ async def require_auth(
                 return default_user
         raise HTTPException(status_code=401, detail="Authentication required.")
     return user
+
+
+async def require_admin(
+    request: Request,
+    user: User | None = Depends(verify_auth),
+    db: Session = Depends(get_db),
+) -> User:
+    """Like require_auth but also enforces admin role."""
+    if user is None:
+        if getattr(request.state, "auth_type", "none") in {"admin_api_key", "disabled"}:
+            default_user = _get_default_user(db)
+            if default_user is not None:
+                return default_user
+        raise HTTPException(status_code=401, detail="Authentication required.")
+    if user.role != "admin":
+        raise HTTPException(status_code=403, detail="Admin role required.")
+    return user

--- a/server/main.py
+++ b/server/main.py
@@ -13,7 +13,7 @@ from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from sqlalchemy import func, select
 
-from auth import ADMIN_API_KEY, AUTH_DISABLED, JWT_SECRET, verify_auth
+from auth import ADMIN_API_KEY, AUTH_DISABLED, JWT_SECRET, require_admin, verify_auth
 from errors import (
     UpstreamError,
     install_request_id_logging,
@@ -311,8 +311,8 @@ def list_bundled_providers(_auth=Depends(verify_auth)):
 
 
 @app.post("/configure", summary="Configure Mem0")
-def set_config(config: Dict[str, Any], _auth=Depends(verify_auth)):
-    """Set memory configuration."""
+def set_config(config: Dict[str, Any], _auth=Depends(require_admin)):
+    """Set memory configuration. Requires admin role."""
     _validate_bundled_providers(config)
     update_config(config)
     return {"message": "Configuration set successfully"}


### PR DESCRIPTION
…nfig changes

## Linked Issue

Fixes #5127 

## Description

  `POST /configure` modifies the global LLM/embedder provider configuration (endpoint URL, API key, model) for the entire Mem0 instance. This endpoint currently uses `verify_auth` which validates
   token presence but never checks `user.role`.

  Any holder of a distributed API key can call `POST /configure` to redirect all users' LLM traffic to an arbitrary endpoint. This PR adds a `require_admin` dependency that enforces `user.role ==
   "admin"` on this endpoint.

  Changes:
  - Added `require_admin()` auth dependency in `server/auth.py`
  - Changed `POST /configure` from `Depends(verify_auth)` to `Depends(require_admin)`
  - Non-admin callers now receive `403 Forbidden`

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)

  ## Breaking Changes

  API keys created by admin and distributed to services will no longer be able to call `POST /configure`. Only the admin account (via JWT or `ADMIN_API_KEY` env var) can modify configuration.
  `GET /configure` remains accessible to all authenticated users.

  ## Test Coverage

  - [x] I tested manually (describe below)

  With `AUTH_DISABLED=false`:
  ```bash
  # Before fix: any API key can modify global config
  curl -X POST http://localhost:8888/configure \
    -H "X-API-Key: m0sk_<user_key>" \
    -d '{"llm":{"provider":"openai","config":{"openai_base_url":"https://example.com/v1"}}}'
  # → 200 OK (vulnerability)

  # After fix: non-admin gets 403
  # → 403 {"detail":"Admin role required."}

  # Admin JWT still works
  curl -X POST http://localhost:8888/configure \
    -H "Authorization: Bearer <admin_jwt>" \
    -d '{"llm":{"provider":"openai","config":{"model":"gpt-4"}}}'
  # → 200 OK

  Checklist

  - My code follows the project's style guidelines
  - I have performed a self-review of my code
  - I have added tests that prove my fix/feature works
  - New and existing tests pass locally
  - I have updated documentation if needed