### PR TITLE
test(reranker): add unit tests for Cohere, HuggingFace, SentenceTransformer, and ZeroEntropy rerankers

### DIFF
--- a/tests/rerankers/test_cohere_reranker.py
+++ b/tests/rerankers/test_cohere_reranker.py
@@ -1,0 +1,196 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mem0.configs.rerankers.cohere import CohereRerankerConfig
+from mem0.reranker.cohere_reranker import CohereReranker
+
+
+@pytest.fixture
+def mock_cohere():
+    with (
+        patch("mem0.reranker.cohere_reranker.cohere", create=True) as mock_cohere_module,
+        patch("mem0.reranker.cohere_reranker.COHERE_AVAILABLE", True),
+    ):
+        mock_client = MagicMock()
+        mock_cohere_module.Client.return_value = mock_client
+        yield mock_cohere_module, mock_client
+
+
+def _make_response(results):
+    """Create a fake Cohere rerank response."""
+    response = MagicMock()
+    response.results = []
+    for index, score in results:
+        result = MagicMock()
+        result.index = index
+        result.relevance_score = score
+        response.results.append(result)
+    return response
+
+
+# --- Init tests ---
+
+
+class TestInit:
+    def test_init_sets_config_and_client(self, mock_cohere):
+        mock_cohere_module, mock_client = mock_cohere
+        config = CohereRerankerConfig(api_key="test-key", model="rerank-v3")
+        reranker = CohereReranker(config)
+
+        assert reranker.config is config
+        assert reranker.api_key == "test-key"
+        assert reranker.model == "rerank-v3"
+        mock_cohere_module.Client.assert_called_once_with("test-key")
+
+    def test_init_reads_api_key_from_env(self, mock_cohere):
+        mock_cohere_module, mock_client = mock_cohere
+        config = CohereRerankerConfig(api_key=None)
+        with patch.dict("os.environ", {"COHERE_API_KEY": "env-key"}):
+            reranker = CohereReranker(config)
+
+        assert reranker.api_key == "env-key"
+
+    def test_init_raises_without_api_key(self, mock_cohere):
+        mock_cohere_module, mock_client = mock_cohere
+        config = CohereRerankerConfig(api_key=None)
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(ValueError, match="Cohere API key is required"):
+                CohereReranker(config)
+
+    def test_import_error_when_cohere_missing(self):
+        with patch("mem0.reranker.cohere_reranker.COHERE_AVAILABLE", False):
+            with pytest.raises(ImportError, match="cohere package is required"):
+                CohereReranker(CohereRerankerConfig(api_key="test-key"))
+
+
+# --- Rerank tests ---
+
+
+class TestRerank:
+    def test_empty_documents(self, mock_cohere):
+        _, mock_client = mock_cohere
+        reranker = CohereReranker(CohereRerankerConfig(api_key="test-key"))
+        result = reranker.rerank("query", [])
+
+        assert result == []
+        mock_client.rerank.assert_not_called()
+
+    def test_documents_reranked_with_scores(self, mock_cohere):
+        _, mock_client = mock_cohere
+        mock_client.rerank.return_value = _make_response([
+            (0, 0.3),
+            (1, 0.9),
+            (2, 0.5),
+        ])
+
+        config = CohereRerankerConfig(api_key="test-key", top_k=None)
+        reranker = CohereReranker(config)
+        docs = [{"memory": "low"}, {"memory": "high"}, {"memory": "mid"}]
+        result = reranker.rerank("test query", docs)
+
+        assert len(result) == 3
+        assert result[0]["memory"] == "low"
+        assert result[0]["rerank_score"] == 0.3
+        assert result[1]["memory"] == "high"
+        assert result[1]["rerank_score"] == 0.9
+        assert result[2]["memory"] == "mid"
+        assert result[2]["rerank_score"] == 0.5
+
+    def test_top_k_passed_to_api(self, mock_cohere):
+        _, mock_client = mock_cohere
+        mock_client.rerank.return_value = _make_response([(0, 0.9), (1, 0.3)])
+
+        config = CohereRerankerConfig(api_key="test-key", top_k=None)
+        reranker = CohereReranker(config)
+        docs = [{"memory": "a"}, {"memory": "b"}, {"memory": "c"}]
+        result = reranker.rerank("query", docs, top_k=2)
+
+        assert len(result) == 2
+        call_kwargs = mock_client.rerank.call_args[1]
+        assert call_kwargs["top_n"] == 2
+
+    def test_config_top_k_passed_to_api(self, mock_cohere):
+        _, mock_client = mock_cohere
+        mock_client.rerank.return_value = _make_response([(0, 0.9)])
+
+        config = CohereRerankerConfig(api_key="test-key", top_k=1)
+        reranker = CohereReranker(config)
+        docs = [{"memory": "a"}, {"memory": "b"}]
+        reranker.rerank("query", docs)
+
+        call_kwargs = mock_client.rerank.call_args[1]
+        assert call_kwargs["top_n"] == 1
+
+    def test_text_field_extraction(self, mock_cohere):
+        _, mock_client = mock_cohere
+        mock_client.rerank.return_value = _make_response([(0, 0.8)])
+
+        reranker = CohereReranker(CohereRerankerConfig(api_key="test-key"))
+        reranker.rerank("query", [{"text": "some text"}])
+
+        call_kwargs = mock_client.rerank.call_args[1]
+        assert call_kwargs["documents"] == ["some text"]
+
+    def test_content_field_extraction(self, mock_cohere):
+        _, mock_client = mock_cohere
+        mock_client.rerank.return_value = _make_response([(0, 0.8)])
+
+        reranker = CohereReranker(CohereRerankerConfig(api_key="test-key"))
+        reranker.rerank("query", [{"content": "some content"}])
+
+        call_kwargs = mock_client.rerank.call_args[1]
+        assert call_kwargs["documents"] == ["some content"]
+
+    def test_api_call_params(self, mock_cohere):
+        _, mock_client = mock_cohere
+        mock_client.rerank.return_value = _make_response([(0, 0.9)])
+
+        config = CohereRerankerConfig(
+            api_key="test-key",
+            model="rerank-english-v3.0",
+            return_documents=False,
+            max_chunks_per_doc=5,
+        )
+        reranker = CohereReranker(config)
+        docs = [{"memory": "test"}]
+        reranker.rerank("query", docs)
+
+        call_kwargs = mock_client.rerank.call_args[1]
+        assert call_kwargs["model"] == "rerank-english-v3.0"
+        assert call_kwargs["query"] == "query"
+        assert call_kwargs["return_documents"] is False
+        assert call_kwargs["max_chunks_per_doc"] == 5
+
+    def test_fallback_on_api_error(self, mock_cohere):
+        _, mock_client = mock_cohere
+        mock_client.rerank.side_effect = RuntimeError("API error")
+
+        reranker = CohereReranker(CohereRerankerConfig(api_key="test-key"))
+        docs = [{"memory": "doc1"}, {"memory": "doc2"}]
+        result = reranker.rerank("query", docs)
+
+        assert len(result) == 2
+        assert result[0]["rerank_score"] == 0.0
+        assert result[1]["rerank_score"] == 0.0
+
+    def test_fallback_respects_top_k(self, mock_cohere):
+        _, mock_client = mock_cohere
+        mock_client.rerank.side_effect = RuntimeError("API error")
+
+        reranker = CohereReranker(CohereRerankerConfig(api_key="test-key"))
+        docs = [{"memory": f"doc{i}"} for i in range(3)]
+        result = reranker.rerank("query", docs, top_k=1)
+
+        assert len(result) == 1
+
+    def test_original_doc_not_mutated(self, mock_cohere):
+        _, mock_client = mock_cohere
+        mock_client.rerank.return_value = _make_response([(0, 0.9)])
+
+        reranker = CohereReranker(CohereRerankerConfig(api_key="test-key"))
+        original_doc = {"memory": "test", "id": "123"}
+        result = reranker.rerank("query", [original_doc])
+
+        assert "rerank_score" not in original_doc
+        assert "rerank_score" in result[0]

--- a/tests/rerankers/test_huggingface_reranker.py
+++ b/tests/rerankers/test_huggingface_reranker.py
@@ -1,0 +1,236 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from mem0.configs.rerankers.base import BaseRerankerConfig
+from mem0.configs.rerankers.huggingface import HuggingFaceRerankerConfig
+from mem0.reranker.huggingface_reranker import HuggingFaceReranker
+
+
+@pytest.fixture
+def mock_hf_components():
+    """Mock AutoTokenizer, AutoModelForSequenceClassification, and torch.cuda."""
+    with (
+        patch("mem0.reranker.huggingface_reranker.AutoTokenizer") as mock_tokenizer_cls,
+        patch("mem0.reranker.huggingface_reranker.AutoModelForSequenceClassification") as mock_model_cls,
+        patch("mem0.reranker.huggingface_reranker.torch") as mock_torch,
+    ):
+        mock_tokenizer = MagicMock()
+        mock_tokenizer_cls.from_pretrained.return_value = mock_tokenizer
+
+        mock_model = MagicMock()
+        mock_model_cls.from_pretrained.return_value = mock_model
+
+        # Default: CPU
+        mock_torch.cuda.is_available.return_value = False
+
+        yield mock_tokenizer, mock_model, mock_torch
+
+
+def _make_outputs(logits_values):
+    """Create a fake model output with given logit values."""
+    mock_outputs = MagicMock()
+    logits = torch.tensor(logits_values).unsqueeze(-1).float()
+    mock_outputs.logits = logits
+    return mock_outputs
+
+
+# --- Init tests ---
+
+
+class TestInit:
+    def test_init_from_dict(self, mock_hf_components):
+        mock_tokenizer, mock_model, mock_torch = mock_hf_components
+        config = {"model": "test-model", "batch_size": 16}
+        reranker = HuggingFaceReranker(config)
+
+        assert isinstance(reranker.config, HuggingFaceRerankerConfig)
+        assert reranker.config.model == "test-model"
+        assert reranker.config.batch_size == 16
+        assert reranker.device == "cpu"
+
+    def test_init_from_huggingface_config(self, mock_hf_components):
+        config = HuggingFaceRerankerConfig(model="my-model", device="cuda")
+        reranker = HuggingFaceReranker(config)
+
+        assert reranker.device == "cuda"
+
+    def test_init_from_base_config_converts(self, mock_hf_components):
+        base_config = BaseRerankerConfig(provider="huggingface", top_k=5)
+        reranker = HuggingFaceReranker(base_config)
+
+        assert isinstance(reranker.config, HuggingFaceRerankerConfig)
+        assert reranker.config.top_k == 5
+
+    def test_init_auto_detects_cuda(self, mock_hf_components):
+        _, _, mock_torch = mock_hf_components
+        mock_torch.cuda.is_available.return_value = True
+
+        reranker = HuggingFaceReranker({"model": "test"})
+
+        assert reranker.device == "cuda"
+
+    def test_import_error_when_transformers_missing(self):
+        with patch("mem0.reranker.huggingface_reranker.TRANSFORMERS_AVAILABLE", False):
+            with pytest.raises(ImportError, match="transformers package is required"):
+                HuggingFaceReranker({"model": "test"})
+
+
+# --- Rerank tests ---
+
+
+class TestRerank:
+    def test_empty_documents(self, mock_hf_components):
+        reranker = HuggingFaceReranker({"model": "test"})
+        result = reranker.rerank("query", [])
+        assert result == []
+
+    def test_single_document(self, mock_hf_components):
+        mock_tokenizer, mock_model, _ = mock_hf_components
+        mock_model.side_effect = lambda *a, **kw: _make_outputs([5.0])
+        mock_tokenizer.return_value.to.return_value = MagicMock()
+
+        reranker = HuggingFaceReranker({"model": "test", "normalize": False})
+        docs = [{"memory": "hello world"}]
+        result = reranker.rerank("query", docs)
+
+        assert len(result) == 1
+        assert "rerank_score" in result[0]
+        assert result[0]["memory"] == "hello world"
+
+    def test_documents_sorted_by_score_descending(self, mock_hf_components):
+        mock_tokenizer, mock_model, _ = mock_hf_components
+        # Simulate: doc0 gets score 2.0, doc1 gets score 9.0, doc2 gets score 4.0
+        mock_model.side_effect = lambda *a, **kw: _make_outputs([2.0, 9.0, 4.0])
+        mock_tokenizer.return_value.to.return_value = MagicMock()
+
+        reranker = HuggingFaceReranker({"model": "test", "normalize": False})
+        docs = [
+            {"memory": "low"},
+            {"memory": "high"},
+            {"memory": "mid"},
+        ]
+        result = reranker.rerank("test query", docs)
+
+        assert len(result) == 3
+        assert result[0]["memory"] == "high"
+        assert result[1]["memory"] == "mid"
+        assert result[2]["memory"] == "low"
+
+    def test_top_k_limits_results(self, mock_hf_components):
+        mock_tokenizer, mock_model, _ = mock_hf_components
+        mock_model.side_effect = lambda *a, **kw: _make_outputs([1.0, 3.0, 2.0])
+        mock_tokenizer.return_value.to.return_value = MagicMock()
+
+        reranker = HuggingFaceReranker({"model": "test", "normalize": False})
+        docs = [{"memory": f"doc{i}"} for i in range(3)]
+        result = reranker.rerank("query", docs, top_k=2)
+
+        assert len(result) == 2
+
+    def test_config_top_k_used_when_arg_not_provided(self, mock_hf_components):
+        mock_tokenizer, mock_model, _ = mock_hf_components
+        mock_model.side_effect = lambda *a, **kw: _make_outputs([1.0, 3.0, 2.0])
+        mock_tokenizer.return_value.to.return_value = MagicMock()
+
+        reranker = HuggingFaceReranker({"model": "test", "normalize": False, "top_k": 1})
+        docs = [{"memory": f"doc{i}"} for i in range(3)]
+        result = reranker.rerank("query", docs)
+
+        assert len(result) == 1
+
+    def test_text_field_extraction(self, mock_hf_components):
+        mock_tokenizer, mock_model, _ = mock_hf_components
+        mock_model.side_effect = lambda *a, **kw: _make_outputs([5.0])
+        mock_tokenizer.return_value.to.return_value = MagicMock()
+
+        reranker = HuggingFaceReranker({"model": "test", "normalize": False})
+        reranker.rerank("query", [{"text": "some text"}])
+
+        call_args = mock_tokenizer.call_args[0][0]
+        assert any("some text" in pair for pair in call_args)
+
+    def test_content_field_extraction(self, mock_hf_components):
+        mock_tokenizer, mock_model, _ = mock_hf_components
+        mock_model.side_effect = lambda *a, **kw: _make_outputs([5.0])
+        mock_tokenizer.return_value.to.return_value = MagicMock()
+
+        reranker = HuggingFaceReranker({"model": "test", "normalize": False})
+        reranker.rerank("query", [{"content": "some content"}])
+
+        call_args = mock_tokenizer.call_args[0][0]
+        assert any("some content" in pair for pair in call_args)
+
+    def test_fallback_score_on_model_error(self, mock_hf_components):
+        mock_tokenizer, mock_model, _ = mock_hf_components
+        mock_model.side_effect = RuntimeError("model error")
+
+        reranker = HuggingFaceReranker({"model": "test"})
+        docs = [{"memory": "doc1"}, {"memory": "doc2"}]
+        result = reranker.rerank("query", docs)
+
+        assert len(result) == 2
+        assert result[0]["rerank_score"] == 0.0
+        assert result[1]["rerank_score"] == 0.0
+
+    def test_fallback_respects_top_k(self, mock_hf_components):
+        mock_tokenizer, mock_model, _ = mock_hf_components
+        mock_model.side_effect = RuntimeError("model error")
+
+        reranker = HuggingFaceReranker({"model": "test", "top_k": 1})
+        docs = [{"memory": f"doc{i}"} for i in range(3)]
+        result = reranker.rerank("query", docs)
+
+        assert len(result) == 1
+
+    def test_normalize_scores(self, mock_hf_components):
+        mock_tokenizer, mock_model, _ = mock_hf_components
+        # Raw scores: 2.0, 8.0, 5.0 → normalized: 0.0, 1.0, 0.5
+        mock_model.side_effect = lambda *a, **kw: _make_outputs([2.0, 8.0, 5.0])
+        mock_tokenizer.return_value.to.return_value = MagicMock()
+
+        reranker = HuggingFaceReranker({"model": "test", "normalize": True})
+        docs = [{"memory": "low"}, {"memory": "high"}, {"memory": "mid"}]
+        result = reranker.rerank("query", docs)
+
+        assert result[0]["rerank_score"] == pytest.approx(1.0)
+        assert result[1]["rerank_score"] == pytest.approx(0.5)
+        assert result[2]["rerank_score"] == pytest.approx(0.0)
+
+    def test_no_normalize_when_disabled(self, mock_hf_components):
+        mock_tokenizer, mock_model, _ = mock_hf_components
+        mock_model.side_effect = lambda *a, **kw: _make_outputs([2.0, 8.0])
+        mock_tokenizer.return_value.to.return_value = MagicMock()
+
+        reranker = HuggingFaceReranker({"model": "test", "normalize": False})
+        docs = [{"memory": "a"}, {"memory": "b"}]
+        result = reranker.rerank("query", docs)
+
+        assert result[0]["rerank_score"] == 8.0
+        assert result[1]["rerank_score"] == 2.0
+
+    def test_batch_processing(self, mock_hf_components):
+        """When docs exceed batch_size, tokenizer should be called multiple times."""
+        mock_tokenizer, mock_model, _ = mock_hf_components
+        mock_model.side_effect = lambda *a, **kw: _make_outputs([1.0, 2.0, 3.0, 4.0])
+        mock_tokenizer.return_value.to.return_value = MagicMock()
+
+        reranker = HuggingFaceReranker({"model": "test", "normalize": False, "batch_size": 2})
+        docs = [{"memory": f"doc{i}"} for i in range(4)]
+        reranker.rerank("query", docs)
+
+        # batch_size=2, 4 docs → 2 batches
+        assert mock_tokenizer.call_count == 2
+
+    def test_original_doc_not_mutated(self, mock_hf_components):
+        mock_tokenizer, mock_model, _ = mock_hf_components
+        mock_model.side_effect = lambda *a, **kw: _make_outputs([5.0])
+        mock_tokenizer.return_value.to.return_value = MagicMock()
+
+        reranker = HuggingFaceReranker({"model": "test", "normalize": False})
+        original_doc = {"memory": "test", "id": "123"}
+        result = reranker.rerank("query", [original_doc])
+
+        assert "rerank_score" not in original_doc
+        assert "rerank_score" in result[0]

--- a/tests/rerankers/test_huggingface_reranker_config.py
+++ b/tests/rerankers/test_huggingface_reranker_config.py
@@ -1,0 +1,138 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mem0.configs.rerankers.base import BaseRerankerConfig
+from mem0.configs.rerankers.huggingface import HuggingFaceRerankerConfig
+
+
+class TestHuggingFaceRerankerConfig:
+    def test_default_config(self):
+        config = HuggingFaceRerankerConfig()
+        assert config.model == "BAAI/bge-reranker-base"
+        assert config.device is None
+        assert config.batch_size == 32
+        assert config.max_length == 512
+        assert config.normalize is True
+        assert config.top_k is None
+        assert config.provider is None
+        assert config.api_key is None
+
+    def test_custom_values(self):
+        config = HuggingFaceRerankerConfig(
+            model="cross-encoder/ms-marco-MiniLM-L-6-v2",
+            device="cuda",
+            batch_size=16,
+            max_length=256,
+            normalize=False,
+            top_k=5,
+        )
+        assert config.model == "cross-encoder/ms-marco-MiniLM-L-6-v2"
+        assert config.device == "cuda"
+        assert config.batch_size == 16
+        assert config.max_length == 256
+        assert config.normalize is False
+        assert config.top_k == 5
+
+    def test_partial_override(self):
+        config = HuggingFaceRerankerConfig(batch_size=8)
+        assert config.model == "BAAI/bge-reranker-base"  # default preserved
+        assert config.batch_size == 8  # overridden
+        assert config.normalize is True  # default preserved
+
+
+class TestHuggingFaceRerankerInit:
+    @pytest.fixture
+    def mock_hf_components(self):
+        with (
+            patch("mem0.reranker.huggingface_reranker.AutoTokenizer") as mock_tokenizer_cls,
+            patch("mem0.reranker.huggingface_reranker.AutoModelForSequenceClassification") as mock_model_cls,
+            patch("mem0.reranker.huggingface_reranker.torch") as mock_torch,
+        ):
+            mock_tokenizer = MagicMock()
+            mock_tokenizer_cls.from_pretrained.return_value = mock_tokenizer
+
+            mock_model = MagicMock()
+            mock_model_cls.from_pretrained.return_value = mock_model
+
+            mock_torch.cuda.is_available.return_value = False
+
+            yield {
+                "tokenizer_cls": mock_tokenizer_cls,
+                "model_cls": mock_model_cls,
+                "tokenizer": mock_tokenizer,
+                "model": mock_model,
+                "torch": mock_torch,
+            }
+
+    def test_init_from_dict(self, mock_hf_components):
+        from mem0.reranker.huggingface_reranker import HuggingFaceReranker
+
+        reranker = HuggingFaceReranker({"model": "test-model", "batch_size": 16})
+
+        assert isinstance(reranker.config, HuggingFaceRerankerConfig)
+        assert reranker.config.model == "test-model"
+        assert reranker.config.batch_size == 16
+        assert reranker.device == "cpu"
+
+    def test_init_from_huggingface_config(self, mock_hf_components):
+        from mem0.reranker.huggingface_reranker import HuggingFaceReranker
+
+        config = HuggingFaceRerankerConfig(model="my-model", device="cuda")
+        reranker = HuggingFaceReranker(config)
+
+        assert reranker.device == "cuda"
+
+    def test_init_from_base_config_converts(self, mock_hf_components):
+        from mem0.reranker.huggingface_reranker import HuggingFaceReranker
+
+        base_config = BaseRerankerConfig(provider="huggingface", top_k=5)
+        reranker = HuggingFaceReranker(base_config)
+
+        assert isinstance(reranker.config, HuggingFaceRerankerConfig)
+        assert reranker.config.top_k == 5
+        assert reranker.config.device is None
+        assert reranker.config.batch_size == 32
+
+    def test_init_from_base_config_preserves_model(self, mock_hf_components):
+        from mem0.reranker.huggingface_reranker import HuggingFaceReranker
+
+        base_config = BaseRerankerConfig(model="custom-model")
+        reranker = HuggingFaceReranker(base_config)
+
+        assert reranker.config.model == "custom-model"
+
+    def test_init_auto_detects_cuda(self, mock_hf_components):
+        from mem0.reranker.huggingface_reranker import HuggingFaceReranker
+
+        mock_hf_components["torch"].cuda.is_available.return_value = True
+
+        reranker = HuggingFaceReranker({"model": "test"})
+
+        assert reranker.device == "cuda"
+
+    def test_explicit_device_overrides_auto_detect(self, mock_hf_components):
+        from mem0.reranker.huggingface_reranker import HuggingFaceReranker
+
+        mock_hf_components["torch"].cuda.is_available.return_value = True
+
+        reranker = HuggingFaceReranker({"model": "test", "device": "cpu"})
+
+        assert reranker.device == "cpu"
+
+    def test_model_loaded_and_set_to_eval(self, mock_hf_components):
+        from mem0.reranker.huggingface_reranker import HuggingFaceReranker
+
+        HuggingFaceReranker({"model": "test-model"})
+
+        mock_hf_components["tokenizer_cls"].from_pretrained.assert_called_once_with("test-model")
+        mock_hf_components["model_cls"].from_pretrained.assert_called_once_with("test-model")
+        mock_hf_components["model"].to.assert_called_once_with("cpu")
+        mock_hf_components["model"].eval.assert_called_once()
+
+    def test_import_error_when_transformers_missing(self):
+        from mem0.reranker.huggingface_reranker import HuggingFaceReranker
+
+        with patch("mem0.reranker.huggingface_reranker.TRANSFORMERS_AVAILABLE", False):
+            with pytest.raises(ImportError, match="transformers package is required"):
+                HuggingFaceReranker({"model": "test"})

--- a/tests/rerankers/test_sentence_transformer_reranker.py
+++ b/tests/rerankers/test_sentence_transformer_reranker.py
@@ -1,0 +1,186 @@
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from mem0.configs.rerankers.base import BaseRerankerConfig
+from mem0.configs.rerankers.sentence_transformer import (
+    SentenceTransformerRerankerConfig,
+)
+from mem0.reranker.sentence_transformer_reranker import SentenceTransformerReranker
+
+
+@pytest.fixture
+def mock_cross_encoder():
+    with patch("mem0.reranker.sentence_transformer_reranker.CrossEncoder") as mock_ce_cls:
+        mock_model = MagicMock()
+        mock_ce_cls.return_value = mock_model
+        yield mock_ce_cls, mock_model
+
+
+# --- Init tests ---
+
+
+class TestInit:
+    def test_init_from_dict(self, mock_cross_encoder):
+        mock_ce_cls, _ = mock_cross_encoder
+        config = {"model": "cross-encoder/test", "batch_size": 16}
+        reranker = SentenceTransformerReranker(config)
+
+        assert isinstance(reranker.config, SentenceTransformerRerankerConfig)
+        assert reranker.config.model == "cross-encoder/test"
+        assert reranker.config.batch_size == 16
+
+    def test_init_from_sentence_transformer_config(self, mock_cross_encoder):
+        mock_ce_cls, _ = mock_cross_encoder
+        config = SentenceTransformerRerankerConfig(model="my-model", device="cuda")
+        SentenceTransformerReranker(config)
+
+        mock_ce_cls.assert_called_once_with("my-model", device="cuda")
+
+    def test_init_from_base_config_converts(self, mock_cross_encoder):
+        base_config = BaseRerankerConfig(provider="sentence_transformer", top_k=5)
+        reranker = SentenceTransformerReranker(base_config)
+
+        assert isinstance(reranker.config, SentenceTransformerRerankerConfig)
+        assert reranker.config.top_k == 5
+
+    def test_init_import_error_when_missing(self):
+        with patch("mem0.reranker.sentence_transformer_reranker.SENTENCE_TRANSFORMERS_AVAILABLE", False):
+            with pytest.raises(ImportError, match="sentence-transformers package is required"):
+                SentenceTransformerReranker({"model": "test"})
+
+
+# --- Rerank tests ---
+
+
+class TestRerank:
+    def test_empty_documents(self, mock_cross_encoder):
+        _, mock_model = mock_cross_encoder
+        reranker = SentenceTransformerReranker({"model": "test"})
+        result = reranker.rerank("query", [])
+
+        assert result == []
+        mock_model.predict.assert_not_called()
+
+    def test_single_document(self, mock_cross_encoder):
+        _, mock_model = mock_cross_encoder
+        mock_model.predict.return_value = np.array([5.0])
+
+        reranker = SentenceTransformerReranker({"model": "test"})
+        docs = [{"memory": "hello world"}]
+        result = reranker.rerank("query", docs)
+
+        assert len(result) == 1
+        assert "rerank_score" in result[0]
+        assert result[0]["memory"] == "hello world"
+
+    def test_documents_sorted_by_score_descending(self, mock_cross_encoder):
+        _, mock_model = mock_cross_encoder
+        mock_model.predict.return_value = np.array([2.0, 9.0, 4.0])
+
+        reranker = SentenceTransformerReranker({"model": "test"})
+        docs = [{"memory": "low"}, {"memory": "high"}, {"memory": "mid"}]
+        result = reranker.rerank("test query", docs)
+
+        assert len(result) == 3
+        assert result[0]["memory"] == "high"
+        assert result[1]["memory"] == "mid"
+        assert result[2]["memory"] == "low"
+
+    def test_top_k_limits_results(self, mock_cross_encoder):
+        _, mock_model = mock_cross_encoder
+        mock_model.predict.return_value = np.array([1.0, 3.0, 2.0])
+
+        reranker = SentenceTransformerReranker({"model": "test"})
+        docs = [{"memory": f"doc{i}"} for i in range(3)]
+        result = reranker.rerank("query", docs, top_k=2)
+
+        assert len(result) == 2
+
+    def test_config_top_k_used_when_arg_not_provided(self, mock_cross_encoder):
+        _, mock_model = mock_cross_encoder
+        mock_model.predict.return_value = np.array([1.0, 3.0, 2.0])
+
+        reranker = SentenceTransformerReranker({"model": "test", "top_k": 1})
+        docs = [{"memory": f"doc{i}"} for i in range(3)]
+        result = reranker.rerank("query", docs)
+
+        assert len(result) == 1
+
+    def test_text_field_extraction(self, mock_cross_encoder):
+        _, mock_model = mock_cross_encoder
+        mock_model.predict.return_value = np.array([5.0])
+
+        reranker = SentenceTransformerReranker({"model": "test"})
+        reranker.rerank("query", [{"text": "some text"}])
+
+        call_args = mock_model.predict.call_args
+        pairs = call_args[0][0]
+        assert any("some text" in pair for pair in pairs)
+
+    def test_content_field_extraction(self, mock_cross_encoder):
+        _, mock_model = mock_cross_encoder
+        mock_model.predict.return_value = np.array([5.0])
+
+        reranker = SentenceTransformerReranker({"model": "test"})
+        reranker.rerank("query", [{"content": "some content"}])
+
+        call_args = mock_model.predict.call_args
+        pairs = call_args[0][0]
+        assert any("some content" in pair for pair in pairs)
+
+    def test_predict_called_with_correct_params(self, mock_cross_encoder):
+        _, mock_model = mock_cross_encoder
+        mock_model.predict.return_value = np.array([1.0])
+
+        reranker = SentenceTransformerReranker({"model": "test", "batch_size": 16, "show_progress_bar": False})
+        reranker.rerank("query", [{"memory": "doc"}])
+
+        call_kwargs = mock_model.predict.call_args[1]
+        assert call_kwargs["batch_size"] == 16
+        assert call_kwargs["show_progress_bar"] is False
+
+    def test_predict_returns_list_converted(self, mock_cross_encoder):
+        _, mock_model = mock_cross_encoder
+        mock_model.predict.return_value = [1.0, 3.0, 2.0]
+
+        reranker = SentenceTransformerReranker({"model": "test"})
+        docs = [{"memory": "a"}, {"memory": "b"}, {"memory": "c"}]
+        result = reranker.rerank("query", docs)
+
+        assert len(result) == 3
+        assert result[0]["memory"] == "b"
+
+    def test_fallback_on_model_error(self, mock_cross_encoder):
+        _, mock_model = mock_cross_encoder
+        mock_model.predict.side_effect = RuntimeError("model error")
+
+        reranker = SentenceTransformerReranker({"model": "test"})
+        docs = [{"memory": "doc1"}, {"memory": "doc2"}]
+        result = reranker.rerank("query", docs)
+
+        assert len(result) == 2
+        assert result[0]["rerank_score"] == 0.0
+        assert result[1]["rerank_score"] == 0.0
+
+    def test_fallback_respects_top_k(self, mock_cross_encoder):
+        _, mock_model = mock_cross_encoder
+        mock_model.predict.side_effect = RuntimeError("model error")
+
+        reranker = SentenceTransformerReranker({"model": "test", "top_k": 1})
+        docs = [{"memory": f"doc{i}"} for i in range(3)]
+        result = reranker.rerank("query", docs)
+
+        assert len(result) == 1
+
+    def test_original_doc_not_mutated(self, mock_cross_encoder):
+        _, mock_model = mock_cross_encoder
+        mock_model.predict.return_value = np.array([5.0])
+
+        reranker = SentenceTransformerReranker({"model": "test"})
+        original_doc = {"memory": "test", "id": "123"}
+        result = reranker.rerank("query", [original_doc])
+
+        assert "rerank_score" not in original_doc
+        assert "rerank_score" in result[0]

--- a/tests/rerankers/test_zero_entropy_reranker.py
+++ b/tests/rerankers/test_zero_entropy_reranker.py
@@ -1,0 +1,199 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mem0.configs.rerankers.zero_entropy import ZeroEntropyRerankerConfig
+from mem0.reranker.zero_entropy_reranker import ZeroEntropyReranker
+
+
+@pytest.fixture
+def mock_zero_entropy():
+    with (
+        patch("mem0.reranker.zero_entropy_reranker.ZeroEntropy", create=True) as mock_ze_cls,
+        patch("mem0.reranker.zero_entropy_reranker.ZERO_ENTROPY_AVAILABLE", True),
+    ):
+        mock_client = MagicMock()
+        mock_ze_cls.return_value = mock_client
+        yield mock_ze_cls, mock_client
+
+
+def _make_response(results):
+    """Create a fake ZeroEntropy rerank response."""
+    response = MagicMock()
+    response.results = []
+    for index, score in results:
+        result = MagicMock()
+        result.index = index
+        result.relevance_score = score
+        response.results.append(result)
+    return response
+
+
+# --- Init tests ---
+
+
+class TestInit:
+    def test_init_sets_config_and_client(self, mock_zero_entropy):
+        mock_ze_cls, mock_client = mock_zero_entropy
+        config = ZeroEntropyRerankerConfig(api_key="test-key", model="zerank-1")
+        reranker = ZeroEntropyReranker(config)
+
+        assert reranker.config is config
+        assert reranker.api_key == "test-key"
+        assert reranker.model == "zerank-1"
+        mock_ze_cls.assert_called_once_with(api_key="test-key")
+
+    def test_init_reads_api_key_from_env(self, mock_zero_entropy):
+        mock_ze_cls, _ = mock_zero_entropy
+        config = ZeroEntropyRerankerConfig(api_key=None)
+        with patch.dict("os.environ", {"ZERO_ENTROPY_API_KEY": "env-key"}):
+            reranker = ZeroEntropyReranker(config)
+
+        assert reranker.api_key == "env-key"
+
+    def test_init_raises_without_api_key(self, mock_zero_entropy):
+        mock_ze_cls, _ = mock_zero_entropy
+        config = ZeroEntropyRerankerConfig(api_key=None)
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(ValueError, match="Zero Entropy API key is required"):
+                ZeroEntropyReranker(config)
+
+    def test_init_defaults_model(self, mock_zero_entropy):
+        mock_ze_cls, _ = mock_zero_entropy
+        config = ZeroEntropyRerankerConfig(api_key="test-key")
+        reranker = ZeroEntropyReranker(config)
+
+        assert reranker.model == "zerank-1"
+
+    def test_import_error_when_zero_entropy_missing(self):
+        with patch("mem0.reranker.zero_entropy_reranker.ZERO_ENTROPY_AVAILABLE", False):
+            with pytest.raises(ImportError, match="zeroentropy package is required"):
+                ZeroEntropyReranker(ZeroEntropyRerankerConfig(api_key="test-key"))
+
+
+# --- Rerank tests ---
+
+
+class TestRerank:
+    def test_empty_documents(self, mock_zero_entropy):
+        _, mock_client = mock_zero_entropy
+        reranker = ZeroEntropyReranker(ZeroEntropyRerankerConfig(api_key="test-key"))
+        result = reranker.rerank("query", [])
+
+        assert result == []
+        mock_client.models.rerank.assert_not_called()
+
+    def test_documents_reranked_with_scores(self, mock_zero_entropy):
+        _, mock_client = mock_zero_entropy
+        mock_client.models.rerank.return_value = _make_response([
+            (0, 0.3),
+            (1, 0.9),
+            (2, 0.5),
+        ])
+
+        reranker = ZeroEntropyReranker(ZeroEntropyRerankerConfig(api_key="test-key"))
+        docs = [{"memory": "low"}, {"memory": "high"}, {"memory": "mid"}]
+        result = reranker.rerank("test query", docs)
+
+        assert len(result) == 3
+        # ZeroEntropy sorts by score descending after mapping
+        assert result[0]["memory"] == "high"
+        assert result[0]["rerank_score"] == 0.9
+        assert result[1]["memory"] == "mid"
+        assert result[1]["rerank_score"] == 0.5
+        assert result[2]["memory"] == "low"
+        assert result[2]["rerank_score"] == 0.3
+
+    def test_top_k_limits_results(self, mock_zero_entropy):
+        _, mock_client = mock_zero_entropy
+        mock_client.models.rerank.return_value = _make_response([
+            (0, 0.9),
+            (1, 0.8),
+            (2, 0.3),
+        ])
+
+        reranker = ZeroEntropyReranker(ZeroEntropyRerankerConfig(api_key="test-key"))
+        docs = [{"memory": f"doc{i}"} for i in range(3)]
+        result = reranker.rerank("query", docs, top_k=2)
+
+        assert len(result) == 2
+
+    def test_config_top_k_limits_results(self, mock_zero_entropy):
+        _, mock_client = mock_zero_entropy
+        mock_client.models.rerank.return_value = _make_response([
+            (0, 0.9),
+            (1, 0.8),
+            (2, 0.3),
+        ])
+
+        reranker = ZeroEntropyReranker(ZeroEntropyRerankerConfig(api_key="test-key", top_k=1))
+        docs = [{"memory": f"doc{i}"} for i in range(3)]
+        result = reranker.rerank("query", docs)
+
+        assert len(result) == 1
+
+    def test_text_field_extraction(self, mock_zero_entropy):
+        _, mock_client = mock_zero_entropy
+        mock_client.models.rerank.return_value = _make_response([(0, 0.8)])
+
+        reranker = ZeroEntropyReranker(ZeroEntropyRerankerConfig(api_key="test-key"))
+        reranker.rerank("query", [{"text": "some text"}])
+
+        call_kwargs = mock_client.models.rerank.call_args[1]
+        assert call_kwargs["documents"] == ["some text"]
+
+    def test_content_field_extraction(self, mock_zero_entropy):
+        _, mock_client = mock_zero_entropy
+        mock_client.models.rerank.return_value = _make_response([(0, 0.8)])
+
+        reranker = ZeroEntropyReranker(ZeroEntropyRerankerConfig(api_key="test-key"))
+        reranker.rerank("query", [{"content": "some content"}])
+
+        call_kwargs = mock_client.models.rerank.call_args[1]
+        assert call_kwargs["documents"] == ["some content"]
+
+    def test_api_call_params(self, mock_zero_entropy):
+        _, mock_client = mock_zero_entropy
+        mock_client.models.rerank.return_value = _make_response([(0, 0.9)])
+
+        reranker = ZeroEntropyReranker(ZeroEntropyRerankerConfig(api_key="test-key", model="zerank-1"))
+        docs = [{"memory": "test"}]
+        reranker.rerank("query", docs)
+
+        call_kwargs = mock_client.models.rerank.call_args[1]
+        assert call_kwargs["model"] == "zerank-1"
+        assert call_kwargs["query"] == "query"
+        assert call_kwargs["documents"] == ["test"]
+
+    def test_fallback_on_api_error(self, mock_zero_entropy):
+        _, mock_client = mock_zero_entropy
+        mock_client.models.rerank.side_effect = RuntimeError("API error")
+
+        reranker = ZeroEntropyReranker(ZeroEntropyRerankerConfig(api_key="test-key"))
+        docs = [{"memory": "doc1"}, {"memory": "doc2"}]
+        result = reranker.rerank("query", docs)
+
+        assert len(result) == 2
+        assert result[0]["rerank_score"] == 0.0
+        assert result[1]["rerank_score"] == 0.0
+
+    def test_fallback_respects_top_k(self, mock_zero_entropy):
+        _, mock_client = mock_zero_entropy
+        mock_client.models.rerank.side_effect = RuntimeError("API error")
+
+        reranker = ZeroEntropyReranker(ZeroEntropyRerankerConfig(api_key="test-key"))
+        docs = [{"memory": f"doc{i}"} for i in range(3)]
+        result = reranker.rerank("query", docs, top_k=1)
+
+        assert len(result) == 1
+
+    def test_original_doc_not_mutated(self, mock_zero_entropy):
+        _, mock_client = mock_zero_entropy
+        mock_client.models.rerank.return_value = _make_response([(0, 0.9)])
+
+        reranker = ZeroEntropyReranker(ZeroEntropyRerankerConfig(api_key="test-key"))
+        original_doc = {"memory": "test", "id": "123"}
+        result = reranker.rerank("query", [original_doc])
+
+        assert "rerank_score" not in original_doc
+        assert "rerank_score" in result[0]


### PR DESCRIPTION
## Linked Issue

N/A — no existing issue for this. Adding test coverage for untested reranker providers.

## Description

All 4 reranker providers (Cohere, HuggingFace, SentenceTransformer, ZeroEntropy) had zero test coverage — only `llm_reranker` had tests. This PR adds comprehensive unit tests for each provider.

## Test Coverage

| Provider | Tests | What's covered |
|----------|-------|----------------|
| CohereReranker | 14 | init (config, env api_key, missing key, import error), rerank (scores, top_k, field extraction, API params, error fallback, doc immutability) |
| HuggingFaceReranker | 18 | init (dict/config/base config, CUDA detect, import error), rerank (sorting, top_k, normalize/no-normalize, batch processing, field extraction, error fallback, doc immutability) |
| SentenceTransformerReranker | 15 | init (dict/config/base config, import error), rerank (sorting, top_k, predict params, list conversion, field extraction, error fallback, doc immutability) |
| ZeroEntropyReranker | 15 | init (config, env api_key, missing key, default model, import error), rerank (sorting, top_k, field extraction, API params, error fallback, doc immutability) |

All tests use mocking — no real API keys or model downloads required.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed