### PR TITLE
docs(crewai): update Mem0 memory setup

### DIFF
--- a/docs/integrations/crewai.mdx
+++ b/docs/integrations/crewai.mdx
@@ -28,6 +28,7 @@ Import required modules and set up configurations:
 import os
 from mem0 import MemoryClient
 from crewai import Agent, Task, Crew, Process
+from crewai.memory.external.external_memory import ExternalMemory
 from crewai_tools import SerperDevTool
 
 # Configuration
@@ -107,17 +108,23 @@ def create_planning_task(agent, destination: str):
 Configure the crew with memory integration:
 
 ```python
-def setup_crew(agents: list, tasks: list):
+def setup_crew(agents: list, tasks: list, user_id: str):
     """Set up a crew with Mem0 memory integration"""
+    external_memory = ExternalMemory(
+        embedder_config={
+            "provider": "mem0",
+            "config": {
+                "user_id": user_id,
+                "api_key": os.environ["MEM0_API_KEY"],
+            },
+        }
+    )
+
     return Crew(
         agents=agents,
         tasks=tasks,
         process=Process.sequential,
-        memory=True,
-        memory_config={
-            "provider": "mem0",
-            "config": {"user_id": "crew_user_1"},
-        }
+        external_memory=external_memory,
     )
 ```
 
@@ -134,7 +141,7 @@ def plan_trip(destination: str, user_id: str):
     planning_task = create_planning_task(travel_agent, destination)
 
     # Setup crew
-    crew = setup_crew([travel_agent], [planning_task])
+    crew = setup_crew([travel_agent], [planning_task], user_id)
 
     # Execute and return results
     return crew.kickoff()


### PR DESCRIPTION
## Linked Issue

Closes #4924

## Description

Updates the CrewAI integration docs to use the current CrewAI memory API.

The previous example used `memory_config`, which newer CrewAI versions no longer support. This replaces it with `ExternalMemory` configured with the Mem0 provider and passes the existing `user_id` into the memory setup.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [x] No tests needed (explain why)

Manual validation:
- Confirmed `memory_config` is no longer present in `docs/integrations/crewai.mdx`.
- Ran `git diff --check`.
- Verified the change is docs-only.

No tests needed because this only updates documentation.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [x] I have updated documentation if needed
