### PR TITLE
fix(server): accept multimodal message content

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import os
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from dotenv import load_dotenv
 from fastapi import Depends, FastAPI, HTTPException, Request
@@ -165,9 +165,12 @@ app.include_router(entities_router.router)
 app.include_router(requests_router.router)
 
 
+MessageContent = Union[str, Dict[str, Any], List[Dict[str, Any]]]
+
+
 class Message(BaseModel):
     role: str = Field(..., description="Role of the message (user or assistant).")
-    content: str = Field(..., description="Message content.")
+    content: MessageContent = Field(..., description="Message content.")
 
 
 class MemoryCreate(BaseModel):

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -89,6 +89,43 @@ class TestAuthDisabled:
         })
         assert resp.status_code == 200
 
+    def test_create_memory_accepts_image_url_content_without_key(self):
+        image_content = {
+            "type": "image_url",
+            "image_url": {"url": "https://example.com/receipt.jpg"},
+        }
+
+        resp = self.client.post("/memories", json={
+            "messages": [{"role": "user", "content": image_content}],
+            "user_id": "Alice",
+        })
+
+        assert resp.status_code == 200
+        self.mock.add.assert_called_with(
+            messages=[{"role": "user", "content": image_content}],
+            user_id="Alice",
+        )
+
+    def test_create_memory_accepts_openai_multimodal_content_list_without_key(self):
+        multimodal_content = [
+            {"type": "text", "text": "Please remember this receipt."},
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://example.com/receipt.jpg"},
+            },
+        ]
+
+        resp = self.client.post("/memories", json={
+            "messages": [{"role": "user", "content": multimodal_content}],
+            "user_id": "Alice",
+        })
+
+        assert resp.status_code == 200
+        self.mock.add.assert_called_with(
+            messages=[{"role": "user", "content": multimodal_content}],
+            user_id="Alice",
+        )
+
     def test_search_without_key(self):
         resp = self.client.post("/search", json={"query": "pizza", "user_id": "alice"})
         assert resp.status_code == 200


### PR DESCRIPTION
## Linked Issue

Closes #5068

## Description

Updates the REST server memory creation schema to accept multimodal message content.

The core memory layer already supports vision-style messages through `parse_vision_messages`, including `image_url` content. However, the server request model required `Message.content` to be a string, so valid multimodal payloads were rejected by FastAPI/Pydantic before reaching `Memory.add`.

This change allows string, object, and OpenAI-style list message content while preserving existing string message behavior.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Manual validation:
- Confirmed `POST /memories` still accepts plain string message content.
- Confirmed `POST /memories` accepts `image_url` object content.
- Confirmed `POST /memories` accepts OpenAI-style multimodal content lists.
- Ran `git diff --check`.

Test command:
```powershell
$env:PYTHONPATH='server;.'
$env:AUTH_DISABLED='true'
.\.venv\Scripts\python -m pytest tests\test_server_auth.py::TestAuthDisabled::test_create_memory_without_key tests\test_server_auth.py::TestAuthDisabled::test_create_memory_accepts_image_url_content_without_key tests\test_server_auth.py::TestAuthDisabled::test_create_memory_accepts_openai_multimodal_content_list_without_key -q
