### PR TITLE
fix(memory): metadata scoping in Memory.add Phase 1 (#5121)

### DIFF
--- a/docs/open-source/features/metadata-filtering.mdx
+++ b/docs/open-source/features/metadata-filtering.mdx
@@ -219,6 +219,43 @@ results = m.search(
 
 ---
 
+## Scope `Memory.add` by extra metadata keys
+
+`Memory.search` filters on any metadata field you pass. `Memory.add` does not: its candidate-retrieval pool and recent-message window are scoped only by `user_id`, `agent_id`, and `run_id`. So two `add` calls that share a `user_id` but differ in (say) `metadata["app_id"]` end up seeing each other's candidates, which can short-circuit fact extraction in multi-tenant setups.
+
+Pass `scoping_metadata_keys` on `Memory.add` (or `AsyncMemory.add`) to fold extra metadata keys into the retrieval filter and the SQLite session scope. Omit it and the call shape is unchanged.
+
+```python
+from mem0 import Memory
+
+m = Memory()
+
+m.add(
+    messages=[{"role": "user", "content": "prefers dark mode."}],
+    user_id="alice",
+    metadata={"app_id": "app-a"},
+    scoping_metadata_keys=["app_id"],
+)
+
+# Same user_id, different app_id, but isolated:
+m.add(
+    messages=[{"role": "user", "content": "prefers dark mode."}],
+    user_id="alice",
+    metadata={"app_id": "app-b"},
+    scoping_metadata_keys=["app_id"],
+)
+```
+
+<Info icon="check">
+  Each `add` partitions both the vector-store candidate pool and the SQLite recent-message window by the resolved keys. The two calls above stay independent even though they share `user_id="alice"`.
+</Info>
+
+<Warning>
+  Once you start using `scoping_metadata_keys`, new SQLite rows live under a longer scope string. Older rows written without the parameter stay under the 3-key scope and remain reachable on their own, but the two scopes don't intersect. Plan for that if your recent-message window needs to span both regimes.
+</Warning>
+
+---
+
 ## Configure it
 
 Tune your vector store so filter-heavy queries stay fast. Index fields you frequently filter on and keep complex checks for later in the evaluation order.

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -8,7 +8,7 @@ import uuid
 import warnings
 from copy import deepcopy
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import ValidationError
 
@@ -314,14 +314,55 @@ def _build_filters_and_metadata(
     return base_metadata_template, effective_query_filters
 
 
-def _build_session_scope(filters):
-    """Build deterministic session scope string from entity IDs."""
-    parts = []
-    for key in sorted(["user_id", "agent_id", "run_id"]):
+def _build_session_scope(filters, scoping_filters=None):
+    """Build the SQLite session scope string from entity IDs and optional extra keys.
+
+    With no extra keys (default), output matches the legacy 3-key form so existing
+    rows remain reachable.
+    """
+    parts = {}
+    for key in ("user_id", "agent_id", "run_id"):
         val = filters.get(key)
         if val:
-            parts.append(f"{key}={val}")
-    return "&".join(parts)
+            parts[key] = val
+    if scoping_filters:
+        for key, val in scoping_filters.items():
+            if val is None or val == "":
+                continue
+            parts[key] = val
+    return "&".join(f"{k}={parts[k]}" for k in sorted(parts))
+
+
+def _resolve_scoping_filters(metadata, scoping_metadata_keys):
+    """Resolve the caller-named scoping keys against ``metadata``.
+
+    Rejects a bare string (common typo: Python would otherwise iterate characters)
+    and any of the canonical session-id keys (those have dedicated parameters).
+    Missing or empty values are skipped, matching how empty session ids are
+    handled upstream.
+    """
+    if not scoping_metadata_keys:
+        return {}
+    if isinstance(scoping_metadata_keys, str):
+        raise TypeError(
+            "scoping_metadata_keys must be a list/tuple/set of key names, not a bare string. "
+            f"Did you mean [{scoping_metadata_keys!r}]?"
+        )
+    reserved = {"user_id", "agent_id", "run_id"}.intersection(scoping_metadata_keys)
+    if reserved:
+        raise ValueError(
+            f"scoping_metadata_keys must not include session-id keys {sorted(reserved)}; "
+            "pass those as the dedicated user_id / agent_id / run_id arguments instead."
+        )
+    if not metadata:
+        return {}
+    resolved = {}
+    for key in scoping_metadata_keys:
+        val = metadata.get(key)
+        if val is None or val == "":
+            continue
+        resolved[key] = val
+    return resolved
 
 
 setup_config()
@@ -581,6 +622,7 @@ class Memory(MemoryBase):
         infer: bool = True,
         memory_type: Optional[str] = None,
         prompt: Optional[str] = None,
+        scoping_metadata_keys: Optional[List[str]] = None,
     ):
         """
         Create a new memory.
@@ -603,6 +645,12 @@ class Memory(MemoryBase):
                 creating procedural memories (typically requires 'agent_id'). Otherwise, memories
                 are treated as general conversational/factual memories.
             prompt (str, optional): Prompt to use for the memory creation. Defaults to None.
+            scoping_metadata_keys (List[str], optional): Extra ``metadata`` keys to
+                include in the candidate retrieval filter, the entity store filter,
+                and the SQLite recent-message scope. Use to partition multi-app
+                deployments that share a single ``user_id`` (e.g. via ``app_id``).
+                Cannot include ``user_id``/``agent_id``/``run_id``. Defaults to None,
+                in which case behavior is identical to previous releases.
 
 
         Returns:
@@ -624,6 +672,7 @@ class Memory(MemoryBase):
             run_id=run_id,
             input_metadata=metadata,
         )
+        scoping_filters = _resolve_scoping_filters(metadata, scoping_metadata_keys)
 
         if memory_type is not None and memory_type != MemoryType.PROCEDURAL.value:
             raise Mem0ValidationError(
@@ -656,10 +705,17 @@ class Memory(MemoryBase):
         else:
             messages = parse_vision_messages(messages)
 
-        vector_store_result = self._add_to_vector_store(messages, processed_metadata, effective_filters, infer, prompt=prompt)
+        vector_store_result = self._add_to_vector_store(
+            messages,
+            processed_metadata,
+            effective_filters,
+            infer,
+            prompt=prompt,
+            scoping_filters=scoping_filters,
+        )
         return {"results": vector_store_result}
 
-    def _add_to_vector_store(self, messages, metadata, filters, infer, prompt=None):
+    def _add_to_vector_store(self, messages, metadata, filters, infer, prompt=None, scoping_filters=None):
         if not infer:
             returned_memories = []
             for message_dict in messages:
@@ -699,12 +755,16 @@ class Memory(MemoryBase):
         # === V3 PHASED BATCH PIPELINE ===
 
         # Phase 0: Context gathering
-        session_scope = _build_session_scope(filters)
+        session_scope = _build_session_scope(filters, scoping_filters=scoping_filters)
         last_messages = self.db.get_last_messages(session_scope, limit=10)
         parsed_messages = parse_messages(messages)
 
         # Phase 1: Existing memory retrieval
         search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
+        if scoping_filters:
+            # NOTE: Phase 7 below reads the same `search_filters` dict for the
+            # entity_store calls, so this mutation partitions entities too.
+            search_filters.update(scoping_filters)
         query_embedding = self.embedding_model.embed(parsed_messages, "search")
         existing_results = self.vector_store.search(
             query=parsed_messages,
@@ -2012,6 +2072,7 @@ class AsyncMemory(MemoryBase):
         memory_type: Optional[str] = None,
         prompt: Optional[str] = None,
         llm=None,
+        scoping_metadata_keys: Optional[List[str]] = None,
     ):
         """
         Create a new memory asynchronously.
@@ -2027,12 +2088,18 @@ class AsyncMemory(MemoryBase):
                                          Pass "procedural_memory" to create procedural memories.
             prompt (str, optional): Prompt to use for the memory creation. Defaults to None.
             llm (BaseChatModel, optional): LLM class to use for generating procedural memories. Defaults to None. Useful when user is using LangChain ChatModel.
+            scoping_metadata_keys (List[str], optional): Async mirror of the sync
+                ``Memory.add`` option. Same rules: extra ``metadata`` keys to thread
+                into the candidate retrieval filter, the entity store filter, and the
+                SQLite recent-message scope; cannot include
+                ``user_id``/``agent_id``/``run_id``; defaults to None (no change).
         Returns:
             dict: A dictionary containing the result of the memory addition operation.
         """
         processed_metadata, effective_filters = _build_filters_and_metadata(
             user_id=user_id, agent_id=agent_id, run_id=run_id, input_metadata=metadata
         )
+        scoping_filters = _resolve_scoping_filters(metadata, scoping_metadata_keys)
 
         if memory_type is not None and memory_type != MemoryType.PROCEDURAL.value:
             raise ValueError(
@@ -2064,7 +2131,14 @@ class AsyncMemory(MemoryBase):
         else:
             messages = parse_vision_messages(messages)
 
-        vector_store_result = await self._add_to_vector_store(messages, processed_metadata, effective_filters, infer, prompt=prompt)
+        vector_store_result = await self._add_to_vector_store(
+            messages,
+            processed_metadata,
+            effective_filters,
+            infer,
+            prompt=prompt,
+            scoping_filters=scoping_filters,
+        )
         return {"results": vector_store_result}
 
     async def _add_to_vector_store(
@@ -2074,6 +2148,7 @@ class AsyncMemory(MemoryBase):
         effective_filters: dict,
         infer: bool,
         prompt: Optional[str] = None,
+        scoping_filters: Optional[Dict[str, Any]] = None,
     ):
         if not infer:
             returned_memories = []
@@ -2114,12 +2189,16 @@ class AsyncMemory(MemoryBase):
         # === V3 PHASED BATCH PIPELINE (async) ===
 
         # Phase 0: Context gathering
-        session_scope = _build_session_scope(effective_filters)
+        session_scope = _build_session_scope(effective_filters, scoping_filters=scoping_filters)
         last_messages = await asyncio.to_thread(self.db.get_last_messages, session_scope, 10)
         parsed_messages = parse_messages(messages)
 
         # Phase 1: Existing memory retrieval
         search_filters = {k: v for k, v in effective_filters.items() if k in ("user_id", "agent_id", "run_id") and v}
+        if scoping_filters:
+            # NOTE: Phase 7 below reads the same `search_filters` dict for the
+            # entity_store calls, so this mutation partitions entities too.
+            search_filters.update(scoping_filters)
         query_embedding = await asyncio.to_thread(self.embedding_model.embed, parsed_messages, "search")
         existing_results = await asyncio.to_thread(
             self.vector_store.search,

--- a/tests/memory/test_metadata_partitioning.py
+++ b/tests/memory/test_metadata_partitioning.py
@@ -1,0 +1,259 @@
+"""Tests for ``scoping_metadata_keys`` on Memory.add / AsyncMemory.add (#5121).
+
+Covers the helper, validation, the two-app repro from the issue, the
+default-unchanged baseline, and the async mirror.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from mem0.memory.main import AsyncMemory, Memory, _build_session_scope
+
+
+def _setup_mocks(mocker):
+    mock_embedder = mocker.MagicMock()
+    mock_embedder.return_value.embed.return_value = [0.1, 0.2, 0.3]
+    mock_embedder.return_value.embed_batch.return_value = [[0.1, 0.2, 0.3]]
+    mocker.patch("mem0.utils.factory.EmbedderFactory.create", mock_embedder)
+
+    mock_vector_store = mocker.MagicMock()
+    mock_vector_store.return_value.search.return_value = []
+    mocker.patch(
+        "mem0.utils.factory.VectorStoreFactory.create",
+        side_effect=[mock_vector_store.return_value, mocker.MagicMock()],
+    )
+
+    mock_llm = mocker.MagicMock()
+    mocker.patch("mem0.utils.factory.LlmFactory.create", mock_llm)
+
+    mocker.patch("mem0.memory.storage.SQLiteManager", mocker.MagicMock())
+    mocker.patch("mem0.memory.main.capture_event")
+    return mock_llm, mock_vector_store
+
+
+def _make_sync_memory(mocker):
+    mock_llm, _ = _setup_mocks(mocker)
+    mock_llm.return_value.generate_response.return_value = '{"memory": []}'
+    memory = Memory()
+    memory.config = mocker.MagicMock()
+    memory.custom_instructions = None
+    memory.api_version = "v1.1"
+    memory.db.get_last_messages = MagicMock(return_value=[])
+    memory.db.save_messages = MagicMock()
+    return memory
+
+
+def _make_async_memory(mocker):
+    mock_llm, _ = _setup_mocks(mocker)
+    mock_llm.return_value.generate_response.return_value = '{"memory": []}'
+    memory = AsyncMemory()
+    memory.config = mocker.MagicMock()
+    memory.custom_instructions = None
+    memory.api_version = "v1.1"
+    memory.db.get_last_messages = MagicMock(return_value=[])
+    memory.db.save_messages = MagicMock()
+    return memory
+
+
+class TestBuildSessionScope:
+    """Pure unit tests for the scope-string helper."""
+
+    def test_default_three_key_scope_unchanged(self):
+        # Backward-compat baseline: no extra keys -> legacy 3-key format.
+        scope = _build_session_scope({"user_id": "u1", "agent_id": "a1", "run_id": "r1"})
+        assert scope == "agent_id=a1&run_id=r1&user_id=u1"
+
+    def test_empty_scoping_filters_unchanged(self):
+        scope = _build_session_scope({"user_id": "u1"}, scoping_filters={})
+        assert scope == "user_id=u1"
+
+    def test_none_scoping_filters_unchanged(self):
+        scope = _build_session_scope({"user_id": "u1"}, scoping_filters=None)
+        assert scope == "user_id=u1"
+
+    def test_scope_includes_extra_keys_sorted(self):
+        scope = _build_session_scope(
+            {"user_id": "u1"},
+            scoping_filters={"app_id": "app-a"},
+        )
+        assert scope == "app_id=app-a&user_id=u1"
+
+    def test_two_apps_produce_disjoint_scopes(self):
+        a = _build_session_scope({"user_id": "u1"}, scoping_filters={"app_id": "app-a"})
+        b = _build_session_scope({"user_id": "u1"}, scoping_filters={"app_id": "app-b"})
+        assert a != b
+
+
+class TestScopingMetadataKeysValidation:
+    """Surface misuse of ``scoping_metadata_keys`` loudly instead of silently no-op'ing."""
+
+    def test_bare_string_raises_type_error(self, mocker):
+        memory = _make_sync_memory(mocker)
+        with pytest.raises(TypeError, match="bare string"):
+            memory.add(
+                messages=[{"role": "user", "content": "x"}],
+                user_id="user-1",
+                metadata={"app_id": "app-a"},
+                scoping_metadata_keys="app_id",
+            )
+
+    @pytest.mark.parametrize("reserved", ["user_id", "agent_id", "run_id"])
+    def test_session_id_key_raises_value_error(self, mocker, reserved):
+        memory = _make_sync_memory(mocker)
+        with pytest.raises(ValueError, match="session-id keys"):
+            memory.add(
+                messages=[{"role": "user", "content": "x"}],
+                user_id="user-1",
+                metadata={"app_id": "app-a", reserved: "spoofed"},
+                scoping_metadata_keys=[reserved, "app_id"],
+            )
+
+    def test_tuple_and_set_are_accepted(self, mocker):
+        # Type signature says List[str] but any iterable-of-strings should work.
+        memory = _make_sync_memory(mocker)
+        memory.add(
+            messages=[{"role": "user", "content": "x"}],
+            user_id="user-1",
+            metadata={"app_id": "app-a"},
+            scoping_metadata_keys=("app_id",),
+        )
+        assert memory.vector_store.search.call_args.kwargs["filters"] == {
+            "user_id": "user-1",
+            "app_id": "app-a",
+        }
+
+
+class TestSyncAddDefaultBehaviorUnchanged:
+    """Without ``scoping_metadata_keys``, behavior must match current main."""
+
+    def test_phase1_search_filters_only_session_ids(self, mocker):
+        memory = _make_sync_memory(mocker)
+
+        memory.add(
+            messages=[{"role": "user", "content": "prefers dark mode."}],
+            user_id="user-1",
+            metadata={"app_id": "app-a"},
+        )
+
+        search_kwargs = memory.vector_store.search.call_args.kwargs
+        assert search_kwargs["filters"] == {"user_id": "user-1"}, (
+            "Default-behavior baseline: app_id must NOT leak into Phase 1 filters "
+            "when scoping_metadata_keys is not supplied."
+        )
+
+    def test_session_scope_only_session_ids(self, mocker):
+        memory = _make_sync_memory(mocker)
+
+        memory.add(
+            messages=[{"role": "user", "content": "prefers dark mode."}],
+            user_id="user-1",
+            metadata={"app_id": "app-a"},
+        )
+
+        save_messages_args = memory.db.save_messages.call_args[0]
+        session_scope = save_messages_args[1]
+        assert session_scope == "user_id=user-1"
+
+
+class TestSyncAddWithScopingMetadataKeys:
+    """Opt-in path: scoping_metadata_keys must thread into Phase 1 + SQLite."""
+
+    @pytest.fixture
+    def memory(self, mocker):
+        return _make_sync_memory(mocker)
+
+    def test_phase1_search_filter_includes_app_id(self, memory):
+        memory.add(
+            messages=[{"role": "user", "content": "prefers dark mode."}],
+            user_id="user-1",
+            metadata={"app_id": "app-a"},
+            scoping_metadata_keys=["app_id"],
+        )
+
+        search_kwargs = memory.vector_store.search.call_args.kwargs
+        assert search_kwargs["filters"] == {"user_id": "user-1", "app_id": "app-a"}
+
+    def test_session_scope_includes_app_id(self, memory):
+        memory.add(
+            messages=[{"role": "user", "content": "prefers dark mode."}],
+            user_id="user-1",
+            metadata={"app_id": "app-a"},
+            scoping_metadata_keys=["app_id"],
+        )
+
+        session_scope = memory.db.save_messages.call_args[0][1]
+        assert session_scope == "app_id=app-a&user_id=user-1"
+
+    def test_two_apps_produce_isolated_scopes_and_filters(self, memory):
+        memory.add(
+            messages=[{"role": "user", "content": "prefers dark mode."}],
+            user_id="user-1",
+            metadata={"app_id": "app-a"},
+            scoping_metadata_keys=["app_id"],
+        )
+        memory.add(
+            messages=[{"role": "user", "content": "prefers dark mode."}],
+            user_id="user-1",
+            metadata={"app_id": "app-b"},
+            scoping_metadata_keys=["app_id"],
+        )
+
+        first_search, second_search = memory.vector_store.search.call_args_list
+        assert first_search.kwargs["filters"]["app_id"] == "app-a"
+        assert second_search.kwargs["filters"]["app_id"] == "app-b"
+
+        first_save, second_save = memory.db.save_messages.call_args_list
+        assert first_save[0][1] != second_save[0][1]
+        assert "app_id=app-a" in first_save[0][1]
+        assert "app_id=app-b" in second_save[0][1]
+
+    def test_missing_metadata_value_is_skipped(self, memory):
+        # If a key is named but not present in metadata (or set to None / ""),
+        # skip it rather than raising. Matches how empty session ids are handled.
+        memory.add(
+            messages=[{"role": "user", "content": "prefers dark mode."}],
+            user_id="user-1",
+            metadata={"app_id": None, "tenant_id": "t1"},
+            scoping_metadata_keys=["app_id", "tenant_id"],
+        )
+
+        search_kwargs = memory.vector_store.search.call_args.kwargs
+        assert search_kwargs["filters"] == {"user_id": "user-1", "tenant_id": "t1"}
+
+
+@pytest.mark.asyncio
+class TestAsyncAddWithScopingMetadataKeys:
+    """Mirror of the sync opt-in path on AsyncMemory.add."""
+
+    async def test_async_default_phase1_filters_unchanged(self, mocker):
+        memory = _make_async_memory(mocker)
+        await memory.add(
+            messages=[{"role": "user", "content": "prefers dark mode."}],
+            user_id="user-1",
+            metadata={"app_id": "app-a"},
+        )
+        search_kwargs = memory.vector_store.search.call_args.kwargs
+        assert search_kwargs["filters"] == {"user_id": "user-1"}
+
+    async def test_async_phase1_includes_app_id_when_opted_in(self, mocker):
+        memory = _make_async_memory(mocker)
+        await memory.add(
+            messages=[{"role": "user", "content": "prefers dark mode."}],
+            user_id="user-1",
+            metadata={"app_id": "app-a"},
+            scoping_metadata_keys=["app_id"],
+        )
+        search_kwargs = memory.vector_store.search.call_args.kwargs
+        assert search_kwargs["filters"] == {"user_id": "user-1", "app_id": "app-a"}
+
+    async def test_async_session_scope_includes_app_id_when_opted_in(self, mocker):
+        memory = _make_async_memory(mocker)
+        await memory.add(
+            messages=[{"role": "user", "content": "prefers dark mode."}],
+            user_id="user-1",
+            metadata={"app_id": "app-a"},
+            scoping_metadata_keys=["app_id"],
+        )
+        session_scope = memory.db.save_messages.call_args[0][1]
+        assert session_scope == "app_id=app-a&user_id=user-1"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -61,7 +61,12 @@ def test_add(memory_instance):
     assert result["results"] == [{"memory": "Test memory", "event": "ADD"}]
 
     memory_instance._add_to_vector_store.assert_called_once_with(
-        [{"role": "user", "content": "Test message"}], {"user_id": "test_user"}, {"user_id": "test_user"}, True, prompt=None
+        [{"role": "user", "content": "Test message"}],
+        {"user_id": "test_user"},
+        {"user_id": "test_user"},
+        True,
+        prompt=None,
+        scoping_filters={},
     )
 
 
@@ -99,8 +104,10 @@ def test_search(memory_instance):
     memory_instance.vector_store.keyword_search = Mock(return_value=None)  # No BM25
     memory_instance.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
 
-    with patch("mem0.memory.main.lemmatize_for_bm25", return_value="test query"), \
-         patch("mem0.memory.main.extract_entities", return_value=[]):
+    with (
+        patch("mem0.memory.main.lemmatize_for_bm25", return_value="test query"),
+        patch("mem0.memory.main.extract_entities", return_value=[]),
+    ):
         result = memory_instance.search("test query", filters={"user_id": "test_user"})
 
     assert "results" in result
@@ -317,8 +324,10 @@ class TestSearchParamValidation:
         memory_instance.vector_store.keyword_search = Mock(return_value=None)
         memory_instance.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
 
-        with patch("mem0.memory.main.lemmatize_for_bm25", return_value="test"), \
-             patch("mem0.memory.main.extract_entities", return_value=[]):
+        with (
+            patch("mem0.memory.main.lemmatize_for_bm25", return_value="test"),
+            patch("mem0.memory.main.extract_entities", return_value=[]),
+        ):
             result = memory_instance.search("test", filters={"user_id": "test"}, threshold=0)
 
         assert "results" in result
@@ -330,8 +339,10 @@ class TestSearchParamValidation:
         memory_instance.vector_store.keyword_search = Mock(return_value=None)
         memory_instance.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
 
-        with patch("mem0.memory.main.lemmatize_for_bm25", return_value="test"), \
-             patch("mem0.memory.main.extract_entities", return_value=[]):
+        with (
+            patch("mem0.memory.main.lemmatize_for_bm25", return_value="test"),
+            patch("mem0.memory.main.extract_entities", return_value=[]),
+        ):
             result = memory_instance.search("test", filters={"user_id": "test"}, threshold=1.0)
 
         assert "results" in result
@@ -343,8 +354,10 @@ class TestSearchParamValidation:
         memory_instance.vector_store.keyword_search = Mock(return_value=None)
         memory_instance.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
 
-        with patch("mem0.memory.main.lemmatize_for_bm25", return_value="test"), \
-             patch("mem0.memory.main.extract_entities", return_value=[]):
+        with (
+            patch("mem0.memory.main.lemmatize_for_bm25", return_value="test"),
+            patch("mem0.memory.main.extract_entities", return_value=[]),
+        ):
             result = memory_instance.search("test", filters={"user_id": "test"}, top_k=0)
 
         assert "results" in result


### PR DESCRIPTION
## Linked Issue

Closes #5121

## Description

`Memory.add` Phase 1 retrieval and the SQLite `session_scope` string both filter only by `user_id`, `agent_id`, and `run_id`. Two `add()` calls that share a `user_id` but differ in `metadata` (e.g. `app_id`) therefore see each other's candidate pool and recent-message window, even though `Memory.search` correctly filters them apart. The reporter's repro hits exactly this case.

This PR adds an optional `scoping_metadata_keys: list[str] | None = None` parameter on `Memory.add` and `AsyncMemory.add`. When supplied, the named metadata keys are merged into:

1. The Phase 1 `search_filters` passed to `vector_store.search`.
2. The `session_scope` string used by `SQLiteManager.save_messages` / `get_last_messages`. No schema change is needed; `session_scope` is already a single TEXT column.

The mutation reuses the existing `search_filters` dict, so the Phase 7 entity-store calls (`entity_store.search_batch` and the new-entity payload spread) inherit the same partitioning without a second code path.

Input validation: a bare string raises `TypeError` (Python would otherwise iterate it character-by-character and silently no-op). Naming a session-id key (`user_id` / `agent_id` / `run_id`) raises `ValueError`.

### What's not in this PR

The same 3-key allowlist pattern still appears in:

* `_upsert_entity` (lines 447 / 1906): reached only via `Memory.update`, not `add`.
* `_remove_memory_from_entity_store` (lines 501 / 1950): reached via `Memory.update` / `Memory.delete`.
* `_compute_entity_boosts` (lines 1509 / 2933): reached via `Memory.search`'s entity-boost path.

Fixing those properly means either adding the same kwarg to `update` / `delete` / `search`, or moving to a constructor-level config (the second shape mentioned in the issue's "Expected" section). I'd rather settle that question first (see the [claim comment](https://github.com/mem0ai/mem0/issues/5121#issuecomment-4443457176)) and ship a follow-up PR once we agree.

Docs: new section in `docs/open-source/features/metadata-filtering.mdx` covering the two-`app_id` example and the SQLite scope-migration note. `docs/llms.txt` is already in sync (verified with `python scripts/check-llms-txt-coverage.py`).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A. With no `scoping_metadata_keys` argument, `_build_session_scope` returns the same string and Phase 1 calls `vector_store.search` with exactly the same filter set as before. Existing rows under the legacy 3-key scope remain reachable; only new rows that explicitly opt in carry the longer scope.

## Test Coverage

- [x] I added/updated unit tests (`tests/memory/test_metadata_partitioning.py`, 19 tests: helper, validation, sync default-unchanged, sync opt-in, async mirror)
- [ ] I added/updated integration tests
- [x] I tested manually (described below)
- [ ] No tests needed (explain why)

Local checks on Python 3.11:

* `pytest tests/memory/test_metadata_partitioning.py`: 19 passed.
* `pytest tests/`: 1150 passed, 31 skipped (matches a clean `main` baseline).
* `ruff check` and `ruff format --check` on the changed Python files: clean.
* `pre-commit run --files <changed-files>`: Ruff and isort hooks both pass.
* `python scripts/check-llms-txt-coverage.py`: clean (the touched `.mdx` is already indexed).

`tests/test_main.py::test_add` had a strict `assert_called_once_with` on the internal `_add_to_vector_store` call; I updated it to include the new `scoping_filters={}` kwarg.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed