### PR TITLE
fix(docs): Mintlify <5s parse error + add Agent Mode to /platform/cli

### DIFF
--- a/docs/changelog/sdk.mdx
+++ b/docs/changelog/sdk.mdx
@@ -1326,7 +1326,7 @@ See the [TypeScript SDK migration guide](https://docs.mem0.ai/migration/ts-v2-to
 <Update label="2026-05-14" description="Python v0.2.5 / Node v0.2.5">
 
 **New Features:**
-- **Agent Mode (`mem0 init --agent`):** Zero-friction signup for AI agents — mints a working Mem0 API key in <5s with no email, no dashboard, no OTP. Returns an unclaimed shadow account the human can later claim with `mem0 init --email <their-email>` (memories preserved, same key keeps working) ([#5123](https://github.com/mem0ai/mem0/pull/5123))
+- **Agent Mode (`mem0 init --agent`):** Zero-friction signup for AI agents — mints a working Mem0 API key in under 5 seconds with no email, no dashboard, no OTP. Returns an unclaimed shadow account the human can later claim with `mem0 init --email <their-email>` (memories preserved, same key keeps working) ([#5123](https://github.com/mem0ai/mem0/pull/5123))
 - **Self-declared agent identity:** Agents pass `--agent-caller <name>` (e.g. `claude-code`, `cursor`, `codex`) on `mem0 init --agent` so signups attribute to the right tool in analytics. Proof Editor-style — the agent declares itself rather than the CLI sniffing it from env vars ([#5123](https://github.com/mem0ai/mem0/pull/5123))
 - **`mem0 identify <name>`:** New subcommand to self-tag an Agent Mode key after the fact when the agent forgot to pass `--agent-caller` on init. Idempotent — re-running just overwrites ([#5123](https://github.com/mem0ai/mem0/pull/5123))
 - **Plugin sync:** `~/.claude/settings.json::env::MEM0_API_KEY` and `~/.zshrc`/`.bashrc` `export MEM0_API_KEY=` lines stay in sync with `~/.mem0/config.json` automatically. Idempotent — only updates EXISTING entries, never creates new ones ([#5123](https://github.com/mem0ai/mem0/pull/5123))

--- a/docs/platform/cli.mdx
+++ b/docs/platform/cli.mdx
@@ -25,7 +25,44 @@ pip install mem0-cli
 ```
 </CodeGroup>
 
-## Authentication
+## Agent Mode — zero-friction signup for AI agents
+
+<Tip>
+**If you're an AI agent reading this**, skip the rest of this page until you've run the command below. Everything else assumes you already have an API key.
+</Tip>
+
+AI agents (Claude Code, Cursor, Codex, Cline, Aider, …) can mint a working Mem0 API key in under five seconds with no email, no dashboard, and no OTP:
+
+```bash
+mem0 init --agent --agent-caller claude-code
+```
+
+Replace `claude-code` with your agent's name (e.g. `cursor`, `codex`, `cline`, `aider`, or any custom string). The CLI saves the key to `~/.mem0/config.json` and prints a notice you should surface to your human user. The human can claim the account later — same API key keeps working, memories transfer.
+
+<Tip>
+**Forgot `--agent-caller`?** Run `mem0 identify <your-name>` after init — same key, just back-fills the attribution. Idempotent.
+</Tip>
+
+### Claiming an Agent Mode key (humans)
+
+When the human is ready, they claim ownership of the agent's key by running:
+
+```bash
+mem0 init --email you@yourcompany.com
+```
+
+The CLI detects the existing unclaimed Agent Mode config, sends a verification code, and upgrades the shadow account in-place: **the API key never changes, all memories transfer to the human's account, and the agent isn't disrupted**. Pass `--code 123456` for fully non-interactive flows.
+
+### Plugin sync
+
+When you save a Mem0 API key (any flow — Agent Mode, email, or `--api-key`), the CLI also propagates it to ecosystem touchpoints **that already exist**:
+
+- `~/.claude/settings.json` → `env.MEM0_API_KEY` (Claude Code plugin env injection)
+- `~/.zshrc` / `~/.bashrc` → existing `export MEM0_API_KEY=` lines
+
+Sync is idempotent and **never creates new entries** — it only updates entries you've already set up. Failures are best-effort and never block the canonical write to `~/.mem0/config.json`.
+
+## Authentication (humans)
 
 Run the interactive setup wizard to configure your API key:
 
@@ -79,6 +116,7 @@ Interactive setup wizard. Prompts for your API key and default user ID.
 mem0 init
 mem0 init --api-key m0-xxx --user-id alice
 mem0 init --email alice@company.com
+mem0 init --agent --agent-caller claude-code   # zero-friction signup for AI agents
 ```
 
 If an existing configuration is detected, the CLI will ask for confirmation before overwriting. Use `--force` to skip the prompt (useful in CI/CD pipelines).
@@ -91,9 +129,24 @@ mem0 init --api-key m0-xxx --user-id alice --force
 |------|-------------|
 | `--api-key` | API key (skip prompt) |
 | `-u, --user-id` | Default user ID (skip prompt) |
-| `--email` | Login via email verification code |
+| `--email` | Login via email verification code (also used to claim an Agent Mode key) |
 | `--code` | Verification code (use with `--email` for non-interactive login) |
+| `--agent` | Bootstrap an Agent Mode account — no email, no dashboard |
+| `--agent-caller` | Self-declared agent identity for Agent Mode signups (e.g. `claude-code`, `cursor`) |
+| `--source` | Channel attribution for analytics (e.g. `github`, `hn`, `ph`) |
 | `--force` | Overwrite existing config without confirmation |
+
+### `mem0 identify`
+
+Tag your active Agent Mode key with the AI agent that's using it. Run this once after `mem0 init --agent` if you didn't pass `--agent-caller` on init. Idempotent — re-running just overwrites the value.
+
+```bash
+mem0 identify claude-code
+mem0 identify cursor
+mem0 identify my-custom-bot
+```
+
+The CLI calls `PATCH /api/v1/auth/agent_mode/caller/` against the active key. Only works on unclaimed Agent Mode keys; the backend rejects with 400 otherwise. Agent names are sanitized server-side (lowercased, restricted to `[a-z0-9._/-]`, truncated to 32 chars).
 
 ### `mem0 add`
 

--- a/mem0/__init__.py
+++ b/mem0/__init__.py
@@ -4,5 +4,3 @@ __version__ = importlib.metadata.version("mem0ai")
 
 from mem0.client.main import AsyncMemoryClient, MemoryClient  # noqa
 from mem0.memory.main import AsyncMemory, Memory  # noqa
-
-


### PR DESCRIPTION
## Summary

Hotfix: Mintlify deployment failed after #5123 merged to main because the new CLI v0.2.5 changelog entry contained naked \`<5s\` text. MDX treats \`<\` as a JSX tag opener and \`5\` isn't a valid identifier-start character, so the parser bails.

> Failed to parse page content at path changelog/sdk.mdx: Unexpected character \`5\` (U+0035) before name, expected a character that can start a name, such as a letter, \`\$\`, or \`_\`

## Fix

Replace \`in <5s\` with \`in under 5 seconds\`. Other angle-bracket patterns in the same entry (e.g. \`<name>\`, \`<email>\`, \`<their-email>\`) are all inside backticks and parse as literal code spans — no change needed.

## Test plan

- [x] grep for \`<5s\` / naked \`<digit\` patterns — none remain
- [x] grep for naked \`<...>\` outside backticks — none remain
- Mintlify will validate again on PR merge to main