### PR TITLE
docs: remove unverified SOC2/GDPR compliance claims

### DIFF
--- a/docs/migration/oss-to-platform.mdx
+++ b/docs/migration/oss-to-platform.mdx
@@ -18,7 +18,7 @@ Move your Mem0 implementation to managed infrastructure with enterprise features
   **Why migrate to Platform?**
 
   - **Time to Market**: Set up in 5 minutes vs 30+ minutes for OSS configuration
-  - **Enterprise Ready**: SOC2 Type II compliance, GDPR support, audit logs
+  - **Enterprise Ready**: Audit logs, workspace governance, and dedicated support
   - **Advanced Features**: Webhooks, memory export, analytics dashboard, custom categories
   - **Multi-tenancy**: Organizations, projects, and team management out of the box
   - **Zero Infrastructure**: No vector database, LLM provider, or maintenance overhead

--- a/docs/platform/overview.mdx
+++ b/docs/platform/overview.mdx
@@ -12,7 +12,7 @@ Mem0 is the memory engine that keeps conversations contextual so users never rep
 
 - **Personalized replies**: Memories persist across users and agents, cutting prompt bloat and repeat questions.
 - **Hosted stack**: Mem0 runs the vector store, graph services, and rerankers—no provisioning, tuning, or maintenance.
-- **Enterprise controls**: SOC 2, audit logs, and workspace governance ship by default for production readiness.
+- **Enterprise controls**: Audit logs and workspace governance ship by default for production readiness.
 
 <AccordionGroup>
   <Accordion title="What you get with Mem0 Platform" icon="sparkles">
@@ -22,7 +22,7 @@ Mem0 is the memory engine that keeps conversations contextual so users never rep
     | Fast setup | Add a few lines of code and you’re production-ready—no vector database or LLM configuration required. |
     | Production scale | Automatic scaling, high availability, and managed infrastructure so you focus on product work. |
     | Advanced features | Graph memory, webhooks, multimodal support, and custom categories are ready to enable. |
-    | Enterprise ready | SOC 2 Type II, GDPR compliance, and dedicated support keep security and governance covered. |
+    | Enterprise ready | Audit logs, workspace governance, and dedicated support keep security and governance covered. |
   </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
Removes unverified SOC2 Type II and GDPR compliance claims from documentation.

**Changes:**
- `docs/migration/oss-to-platform.mdx` — replaced "SOC2 Type II compliance, GDPR support, audit logs" with "Audit logs, workspace governance, and dedicated support"
- `docs/platform/overview.mdx` — replaced SOC 2 references with accurate descriptions of current capabilities (audit logs, workspace governance, dedicated support)

These compliance claims are not yet certified. Keeping them in docs creates legal/trust risk.