### PR TITLE
docs: promote "Sign up as an agent" + drop plugin-sync prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,25 @@ See the [migration guide](https://docs.mem0.ai/migration/oss-v2-to-v3) for upgra
 
 ## 🚀 Quickstart Guide <a name="quickstart"></a>
 
-> **Agent Mode — for AI agents setting up Mem0 autonomously.** Run `mem0 init --agent --agent-caller <your-name> --json` (after `pip install mem0-cli` or `npm install -g @mem0/cli`), replacing `<your-name>` with your AI agent identity (e.g. `claude-code`, `cursor`, `codex`). This mints an evaluation Mem0 API key in <5 seconds — no email, no dashboard, no OTP. If you forgot to pass `--agent-caller`, run `mem0 identify <your-name>` after init. Use the key immediately against the Platform or the MCP server. The human owner can claim ownership later with `mem0 init --email <their-email>`: memories transfer, the same key keeps working, and the agent isn't disrupted.
+### Sign up as an agent
+
+AI agents can mint a working Mem0 API key in under five seconds — no email, no dashboard, no OTP. Four commands end-to-end:
+
+```bash
+# 1. Install
+npm install -g @mem0/cli      # or: pip install mem0-cli
+
+# 2. Sign up as an agent (replace `claude-code` with your name)
+mem0 init --agent --agent-caller claude-code
+
+# 3. Add a memory
+mem0 add "I am using mem0"
+
+# 4. Search
+mem0 search "am I using mem0"
+```
+
+The human owner can claim the account later with `mem0 init --email <their-email>` — same key, memories preserved.
 
 | | Library | Self-Hosted Server | Cloud Platform |
 |---|---------|-------------------|----------------|

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ mem0 add "I am using mem0"
 mem0 search "am I using mem0"
 ```
 
-The human owner can claim the account later with `mem0 init --email <their-email>` — same key, memories preserved.
+The human owner can claim the account later with `mem0 init --email <their-email>` — same key, memories preserved. Full guide: [Sign up as an agent](https://docs.mem0.ai/platform/agent-signup).
 
 | | Library | Self-Hosted Server | Cloud Platform |
 |---|---------|-------------------|----------------|

--- a/cli/node/package.json
+++ b/cli/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mem0/cli",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "The official CLI for mem0 — the memory layer for AI agents",
   "type": "module",
   "bin": {

--- a/cli/node/src/commands/agent-mode.ts
+++ b/cli/node/src/commands/agent-mode.ts
@@ -247,7 +247,7 @@ export async function claimViaOtp(
 		printError(`Claim failed: ${detail}`);
 		if (errCode === "email_already_claimed") {
 			console.log(
-				`  ${dim("Tip: this email already has a Mem0 account. Sign in there and run `mem0 link <key>` to attach this agent.")}`,
+				`  ${dim("Tip: this email already has a Mem0 account. Sign in at app.mem0.ai with your existing credentials.")}`,
 			);
 		}
 		process.exit(1);

--- a/cli/python/pyproject.toml
+++ b/cli/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mem0-cli"
-version = "0.2.5"
+version = "0.2.6"
 description = "The official CLI for mem0 — the memory layer for AI agents"
 readme = "README.md"
 license = "Apache-2.0"

--- a/cli/python/src/mem0_cli/commands/agent_mode_cmd.py
+++ b/cli/python/src/mem0_cli/commands/agent_mode_cmd.py
@@ -218,7 +218,7 @@ def claim_via_otp(config: Mem0Config, *, email: str, code: str | None = None) ->
         print_error(err_console, f"Claim failed: {detail}")
         if code_str == "email_already_claimed":
             console.print(
-                f"  [{DIM_COLOR}]Tip: this email already has a Mem0 account. Sign in there and run `mem0 link <key>` to attach this agent.[/]"
+                f"  [{DIM_COLOR}]Tip: this email already has a Mem0 account. Sign in at app.mem0.ai with your existing credentials.[/]"
             )
         raise typer.Exit(1)
 

--- a/docs/changelog/sdk.mdx
+++ b/docs/changelog/sdk.mdx
@@ -1323,6 +1323,13 @@ See the [TypeScript SDK migration guide](https://docs.mem0.ai/migration/ts-v2-to
 
 <Tab title="CLI">
 
+<Update label="2026-05-16" description="Python v0.2.6 / Node v0.2.6">
+
+**Bug Fixes:**
+- **Claim flow error message:** The `email_already_claimed` tip in `mem0 init --email` previously suggested running `mem0 link <key>` — a command that doesn't exist. Replaced with honest copy pointing the user to sign in at app.mem0.ai with their existing credentials ([#5152](https://github.com/mem0ai/mem0/pull/5152))
+
+</Update>
+
 <Update label="2026-05-14" description="Python v0.2.5 / Node v0.2.5">
 
 **New Features:**

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -40,6 +40,7 @@
                     "icon": "rocket",
                     "pages": [
                       "platform/overview",
+                      "platform/agent-signup",
                       "vibecoding",
                       "platform/mem0-mcp",
                       "platform/cli",

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -157,27 +157,27 @@ mode: "custom"
     </a>
 
     <a
-      href="/platform/cli"
+      href="/platform/agent-signup"
       className="group flex h-full flex-col overflow-hidden rounded-2xl border border-gray-200 dark:border-zinc-800/40 bg-white dark:bg-zinc-900/40 transition hover:border-primary/60 hover:bg-gray-50 dark:hover:bg-zinc-900"
     >
       <img
         className="block dark:hidden aspect-[2/1] w-full object-cover"
         src="/images/docs thumbnails/light/CLI.png"
-        alt="CLI thumbnail"
+        alt="Sign up as an agent thumbnail"
         style={{pointerEvents: "none"}}
       />
       <img
         className="hidden dark:block aspect-[2/1] w-full object-cover"
         src="/images/docs thumbnails/dark/CLI.png"
-        alt="CLI thumbnail"
+        alt="Sign up as an agent thumbnail"
         style={{pointerEvents: "none"}}
       />
       <div className="flex flex-1 flex-col gap-2 px-4 pb-4 pt-3 text-left">
         <h3 className="text-base font-semibold text-gray-900 dark:text-zinc-100 group-hover:text-primary">
-          CLI
+          Sign up as an agent
         </h3>
         <p className="text-sm text-gray-600 dark:text-zinc-400">
-          Manage memories directly from your terminal. Built for developers and AI agents.
+          For AI agents: mint a Mem0 API key in under five seconds — no email, no dashboard. Four commands to your first memory.
         </p>
       </div>
     </a>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -159,6 +159,7 @@ If the user is on a pre-current major (Python < 2, TS < 3, or Platform `output_f
 - [Introduction](https://docs.mem0.ai/introduction) [Both]: Use when the user wants a one-page overview of how memory fits between the LLM and the app.
 - [Vibe Code with Mem0](https://docs.mem0.ai/vibecoding) [Both]: Use when the user is in Claude Code, Cursor, or Windsurf and wants memory wired into their editor.
 - [Platform Overview](https://docs.mem0.ai/platform/overview) [Platform]: Use when the user picks the managed product - 4-line integration, sub-50ms retrieval, dashboard.
+- [Sign up as an agent](https://docs.mem0.ai/platform/agent-signup) [Platform]: Use when an AI agent needs to mint a Mem0 API key autonomously - four commands, no email or dashboard, human claims ownership later.
 - [Platform vs Open Source](https://docs.mem0.ai/platform/platform-vs-oss) [Both]: Use when the user is deciding between managed and self-hosted.
 - [Platform Quickstart](https://docs.mem0.ai/platform/quickstart) [Platform]: Use for the first Platform integration - API key plus `MemoryClient.add/search`.
 - [Platform CLI](https://docs.mem0.ai/platform/cli) [Platform]: Use when the user wants to manage Platform memories from the terminal.

--- a/docs/platform/agent-signup.mdx
+++ b/docs/platform/agent-signup.mdx
@@ -1,0 +1,106 @@
+---
+title: Sign up as an agent
+description: "Zero-friction signup for AI agents — mint a working Mem0 API key in under five seconds. No email, no dashboard, no OTP."
+icon: "robot"
+iconType: "solid"
+---
+
+If you're an AI agent (Claude Code, Cursor, Codex, Cline, Aider, or any other autonomous coding tool), you don't need a human to set up Mem0 for you. Four commands — install, sign up, push a memory, search it — and you have persistent memory.
+
+## The 4-command demo
+
+<CodeGroup>
+```bash npm
+# 1. Install
+npm install -g @mem0/cli
+
+# 2. Sign up as an agent (replace `claude-code` with your name)
+mem0 init --agent --agent-caller claude-code
+
+# 3. Push a memory
+mem0 add "I am using mem0"
+
+# 4. Verify
+mem0 search "am I using mem0"
+```
+
+```bash pip
+# 1. Install
+pip install mem0-cli
+
+# 2. Sign up as an agent (replace `claude-code` with your name)
+mem0 init --agent --agent-caller claude-code
+
+# 3. Push a memory
+mem0 add "I am using mem0"
+
+# 4. Verify
+mem0 search "am I using mem0"
+```
+</CodeGroup>
+
+That's it — under 30 seconds from a fresh shell to a working memory store.
+
+## Identify yourself with `--agent-caller`
+
+Replace `claude-code` in the `init` command with your actual agent name (`cursor`, `codex`, `cline`, `aider`, or any short label). This attribution helps the Mem0 team understand which agents drive the most usage and prioritize integrations accordingly.
+
+<Tip>
+**Forgot `--agent-caller` on init?** Run `mem0 identify <your-name>` after the fact — same key, just back-fills the attribution. Idempotent.
+</Tip>
+
+## What happened when you ran `mem0 init --agent`?
+
+- A **shadow account** was minted on the Mem0 backend with a fresh API key.
+- The key was saved to `~/.mem0/config.json` (mode 0600) on the machine you ran the command on.
+- A default `user_id` was provisioned so `mem0 add` / `mem0 search` work without explicit scope flags.
+- The account is **unclaimed** — no human owns it yet.
+
+Every command run against this key prints a one-line reminder asking you to surface the claim instructions to your human user.
+
+## Claiming the account (for the human owner)
+
+When the human is ready to take ownership of the agent's account — and all the memories it has accumulated — they run:
+
+```bash
+mem0 init --email you@yourcompany.com
+```
+
+The CLI detects the existing Agent Mode config, sends a verification code, and upgrades the shadow account in-place:
+
+- **The API key never changes** — the agent isn't disrupted.
+- **All memories transfer** to the human's account.
+- **The account becomes fully featured** — dashboard access, billing, team sharing, etc.
+
+Pass `--code 123456` to skip the interactive code prompt for fully non-interactive flows.
+
+## Rate limits and quotas
+
+Agent Mode signups are rate-limited to **5 per day per IP address** to prevent abuse. If you hit the limit, the CLI returns:
+
+```
+Daily Agent Mode signup limit reached for this network (5/day).
+Try again from a different IP or after midnight UTC.
+```
+
+Unclaimed agent accounts get the standard Mem0 free-tier quotas. The human owner can upgrade after claiming.
+
+## What's next
+
+<CardGroup cols={2}>
+<Card title="CLI Reference" icon="terminal" href="/platform/cli">
+Full command-by-command reference for `mem0 add`, `mem0 search`, `mem0 list`, and the rest.
+</Card>
+
+<Card title="Memory Operations" icon="database" href="/core-concepts/memory-operations/add">
+How `add`, `search`, `update`, and `delete` work under the hood.
+</Card>
+
+<Card title="Mem0 MCP" icon="plug" href="/platform/mem0-mcp">
+Connect agents to Mem0 via the Model Context Protocol — alternative integration path.
+</Card>
+
+<Card title="Platform Overview" icon="star" href="/platform/overview">
+The full Mem0 Platform feature set once you claim your account.
+</Card>
+</CardGroup>

--- a/docs/platform/cli.mdx
+++ b/docs/platform/cli.mdx
@@ -25,42 +25,49 @@ pip install mem0-cli
 ```
 </CodeGroup>
 
-## Agent Mode — zero-friction signup for AI agents
+## Sign up as an agent
 
-<Tip>
-**If you're an AI agent reading this**, skip the rest of this page until you've run the command below. Everything else assumes you already have an API key.
-</Tip>
+AI agents (Claude Code, Cursor, Codex, …) can mint a working Mem0 API key in under five seconds — no email, no dashboard, no OTP. Four commands end-to-end:
 
-AI agents (Claude Code, Cursor, Codex, Cline, Aider, …) can mint a working Mem0 API key in under five seconds with no email, no dashboard, and no OTP:
+<CodeGroup>
+```bash npm
+# 1. Install
+npm install -g @mem0/cli
 
-```bash
+# 2. Sign up as an agent (replace `claude-code` with your name)
 mem0 init --agent --agent-caller claude-code
+
+# 3. Add a memory
+mem0 add "I am using mem0"
+
+# 4. Search
+mem0 search "am I using mem0"
 ```
 
-Replace `claude-code` with your agent's name (e.g. `cursor`, `codex`, `cline`, `aider`, or any custom string). The CLI saves the key to `~/.mem0/config.json` and prints a notice you should surface to your human user. The human can claim the account later — same API key keeps working, memories transfer.
+```bash pip
+# 1. Install
+pip install mem0-cli
 
-<Tip>
-**Forgot `--agent-caller`?** Run `mem0 identify <your-name>` after init — same key, just back-fills the attribution. Idempotent.
-</Tip>
+# 2. Sign up as an agent (replace `claude-code` with your name)
+mem0 init --agent --agent-caller claude-code
 
-### Claiming an Agent Mode key (humans)
+# 3. Add a memory
+mem0 add "I am using mem0"
 
-When the human is ready, they claim ownership of the agent's key by running:
+# 4. Search
+mem0 search "am I using mem0"
+```
+</CodeGroup>
+
+The human owner can claim the account later — same API key, memories preserved:
 
 ```bash
 mem0 init --email you@yourcompany.com
 ```
 
-The CLI detects the existing unclaimed Agent Mode config, sends a verification code, and upgrades the shadow account in-place: **the API key never changes, all memories transfer to the human's account, and the agent isn't disrupted**. Pass `--code 123456` for fully non-interactive flows.
-
-### Plugin sync
-
-When you save a Mem0 API key (any flow — Agent Mode, email, or `--api-key`), the CLI also propagates it to ecosystem touchpoints **that already exist**:
-
-- `~/.claude/settings.json` → `env.MEM0_API_KEY` (Claude Code plugin env injection)
-- `~/.zshrc` / `~/.bashrc` → existing `export MEM0_API_KEY=` lines
-
-Sync is idempotent and **never creates new entries** — it only updates entries you've already set up. Failures are best-effort and never block the canonical write to `~/.mem0/config.json`.
+<Tip>
+**Forgot `--agent-caller`?** Run `mem0 identify <your-name>` after init — same key, back-fills the attribution. Idempotent.
+</Tip>
 
 ## Authentication (humans)
 

--- a/docs/platform/cli.mdx
+++ b/docs/platform/cli.mdx
@@ -25,51 +25,11 @@ pip install mem0-cli
 ```
 </CodeGroup>
 
-## Sign up as an agent
-
-AI agents (Claude Code, Cursor, Codex, …) can mint a working Mem0 API key in under five seconds — no email, no dashboard, no OTP. Four commands end-to-end:
-
-<CodeGroup>
-```bash npm
-# 1. Install
-npm install -g @mem0/cli
-
-# 2. Sign up as an agent (replace `claude-code` with your name)
-mem0 init --agent --agent-caller claude-code
-
-# 3. Add a memory
-mem0 add "I am using mem0"
-
-# 4. Search
-mem0 search "am I using mem0"
-```
-
-```bash pip
-# 1. Install
-pip install mem0-cli
-
-# 2. Sign up as an agent (replace `claude-code` with your name)
-mem0 init --agent --agent-caller claude-code
-
-# 3. Add a memory
-mem0 add "I am using mem0"
-
-# 4. Search
-mem0 search "am I using mem0"
-```
-</CodeGroup>
-
-The human owner can claim the account later — same API key, memories preserved:
-
-```bash
-mem0 init --email you@yourcompany.com
-```
-
 <Tip>
-**Forgot `--agent-caller`?** Run `mem0 identify <your-name>` after init — same key, back-fills the attribution. Idempotent.
+**Looking for Agent Mode signup?** See [Sign up as an agent](/platform/agent-signup) — install, signup, first memory in four commands.
 </Tip>
 
-## Authentication (humans)
+## Authentication
 
 Run the interactive setup wizard to configure your API key:
 
@@ -123,7 +83,6 @@ Interactive setup wizard. Prompts for your API key and default user ID.
 mem0 init
 mem0 init --api-key m0-xxx --user-id alice
 mem0 init --email alice@company.com
-mem0 init --agent --agent-caller claude-code   # zero-friction signup for AI agents
 ```
 
 If an existing configuration is detected, the CLI will ask for confirmation before overwriting. Use `--force` to skip the prompt (useful in CI/CD pipelines).
@@ -136,24 +95,13 @@ mem0 init --api-key m0-xxx --user-id alice --force
 |------|-------------|
 | `--api-key` | API key (skip prompt) |
 | `-u, --user-id` | Default user ID (skip prompt) |
-| `--email` | Login via email verification code (also used to claim an Agent Mode key) |
+| `--email` | Login via email verification code |
 | `--code` | Verification code (use with `--email` for non-interactive login) |
-| `--agent` | Bootstrap an Agent Mode account — no email, no dashboard |
-| `--agent-caller` | Self-declared agent identity for Agent Mode signups (e.g. `claude-code`, `cursor`) |
-| `--source` | Channel attribution for analytics (e.g. `github`, `hn`, `ph`) |
 | `--force` | Overwrite existing config without confirmation |
 
-### `mem0 identify`
-
-Tag your active Agent Mode key with the AI agent that's using it. Run this once after `mem0 init --agent` if you didn't pass `--agent-caller` on init. Idempotent — re-running just overwrites the value.
-
-```bash
-mem0 identify claude-code
-mem0 identify cursor
-mem0 identify my-custom-bot
-```
-
-The CLI calls `PATCH /api/v1/auth/agent_mode/caller/` against the active key. Only works on unclaimed Agent Mode keys; the backend rejects with 400 otherwise. Agent names are sanitized server-side (lowercased, restricted to `[a-z0-9._/-]`, truncated to 32 chars).
+<Note>
+AI agents should use `mem0 init --agent` — see [Sign up as an agent](/platform/agent-signup).
+</Note>
 
 ### `mem0 add`
 

--- a/docs/platform/quickstart.mdx
+++ b/docs/platform/quickstart.mdx
@@ -7,6 +7,42 @@ iconType: "solid"
 
 Get started with Mem0 Platform's hosted API in under 5 minutes. This guide shows you how to authenticate and store your first memory.
 
+## Sign up as an agent
+
+AI agents (Claude Code, Cursor, Codex, …) can mint a working Mem0 API key in under five seconds — no email, no dashboard, no OTP. Four commands end-to-end:
+
+<CodeGroup>
+```bash npm
+# 1. Install
+npm install -g @mem0/cli
+
+# 2. Sign up as an agent (replace `claude-code` with your name)
+mem0 init --agent --agent-caller claude-code
+
+# 3. Add a memory
+mem0 add "I am using mem0"
+
+# 4. Search
+mem0 search "am I using mem0"
+```
+
+```bash pip
+# 1. Install
+pip install mem0-cli
+
+# 2. Sign up as an agent (replace `claude-code` with your name)
+mem0 init --agent --agent-caller claude-code
+
+# 3. Add a memory
+mem0 add "I am using mem0"
+
+# 4. Search
+mem0 search "am I using mem0"
+```
+</CodeGroup>
+
+The human owner can claim the account later with `mem0 init --email you@yourcompany.com` — same key, memories preserved. See [CLI docs](/platform/cli) for the full reference.
+
 ## Prerequisites
 
 - Mem0 Platform account (<a href="https://app.mem0.ai?utm_source=oss&utm_medium=platform-quickstart" rel="nofollow">Sign up here</a>)

--- a/docs/platform/quickstart.mdx
+++ b/docs/platform/quickstart.mdx
@@ -7,41 +7,9 @@ iconType: "solid"
 
 Get started with Mem0 Platform's hosted API in under 5 minutes. This guide shows you how to authenticate and store your first memory.
 
-## Sign up as an agent
-
-AI agents (Claude Code, Cursor, Codex, …) can mint a working Mem0 API key in under five seconds — no email, no dashboard, no OTP. Four commands end-to-end:
-
-<CodeGroup>
-```bash npm
-# 1. Install
-npm install -g @mem0/cli
-
-# 2. Sign up as an agent (replace `claude-code` with your name)
-mem0 init --agent --agent-caller claude-code
-
-# 3. Add a memory
-mem0 add "I am using mem0"
-
-# 4. Search
-mem0 search "am I using mem0"
-```
-
-```bash pip
-# 1. Install
-pip install mem0-cli
-
-# 2. Sign up as an agent (replace `claude-code` with your name)
-mem0 init --agent --agent-caller claude-code
-
-# 3. Add a memory
-mem0 add "I am using mem0"
-
-# 4. Search
-mem0 search "am I using mem0"
-```
-</CodeGroup>
-
-The human owner can claim the account later with `mem0 init --email you@yourcompany.com` — same key, memories preserved. See [CLI docs](/platform/cli) for the full reference.
+<Note>
+**Are you an AI agent?** See [Sign up as an agent](/platform/agent-signup) — mint a working API key in four commands, no email or dashboard required.
+</Note>
 
 ## Prerequisites
 

--- a/mem0/__init__.py
+++ b/mem0/__init__.py
@@ -4,3 +4,4 @@ __version__ = importlib.metadata.version("mem0ai")
 
 from mem0.client.main import AsyncMemoryClient, MemoryClient  # noqa
 from mem0.memory.main import AsyncMemory, Memory  # noqa
+

--- a/mem0/__init__.py
+++ b/mem0/__init__.py
@@ -1,5 +1,3 @@
-"""Mem0 — the memory layer for AI agents."""
-
 import importlib.metadata
 
 __version__ = importlib.metadata.version("mem0ai")

--- a/mem0/__init__.py
+++ b/mem0/__init__.py
@@ -1,3 +1,5 @@
+"""Mem0 — the memory layer for AI agents."""
+
 import importlib.metadata
 
 __version__ = importlib.metadata.version("mem0ai")


### PR DESCRIPTION
## Summary

Per launch feedback in Slack (Deshraj, Rudraj, Mragank):

- **README** — Quickstart now opens with a "Sign up as an agent" subsection: 4 commands end-to-end (install → init → add → search). Demoable in 30 seconds.
- **docs/platform/cli.mdx** — Replace the long Agent Mode + Plugin Sync prose with the same tight 4-step block at the top. Plugin-sync behavior is implementation detail; the CLI still does it, just not surfaced in user-facing docs.
- **docs/platform/quickstart.mdx** — Same 4-step block at the top of the Platform Quickstart, above the human-oriented Prerequisites / Installation flow.

## Goal

An AI agent (or curious human) landing on any of these three pages can complete the smoke test — install → sign up → add a memory → search it back — in under a minute.

## Test plan

- [x] grep for `<digit` / naked angle brackets outside backticks — no JSX traps remain
- [x] Three blocks are consistent (same example commands and ordering)