### PR TITLE
feat(ts): expose latestOnly on hosted memory reads

### DIFF
--- a/mem0-ts/src/client/mem0.types.ts
+++ b/mem0-ts/src/client/mem0.types.ts
@@ -22,6 +22,7 @@ export interface SearchMemoryOptions {
   topK?: number;
   threshold?: number;
   rerank?: boolean;
+  latestOnly?: boolean;
   fields?: string[];
   categories?: string[];
 }
@@ -32,6 +33,7 @@ export interface GetAllMemoryOptions {
   pageSize?: number;
   startDate?: string;
   endDate?: string;
+  latestOnly?: boolean;
   categories?: string[];
 }
 

--- a/mem0-ts/src/client/tests/memoryClient.search.test.ts
+++ b/mem0-ts/src/client/tests/memoryClient.search.test.ts
@@ -63,6 +63,24 @@ describe("MemoryClient - search()", () => {
     expect(getFetchBody(call!).filters).toEqual({ user_id: "u1" });
   });
 
+  test("serializes latestOnly as latest_only", async () => {
+    const extra = new Map<string, { status: number; body: unknown }>();
+    extra.set("/v3/memories/search/", {
+      status: 200,
+      body: { results: [] },
+    });
+    const mock = setupMockFetch(extra);
+
+    const client = new MemoryClient({ apiKey: TEST_API_KEY });
+    await client.search("test", {
+      filters: { user_id: "u1" },
+      latestOnly: true,
+    });
+
+    const call = findFetchCall(mock, "/v3/memories/search/", "POST");
+    expect(getFetchBody(call!).latest_only).toBe(true);
+  });
+
   test("passes complex OR filters through to the API body", async () => {
     const extra = new Map<string, { status: number; body: unknown }>();
     extra.set("/v3/memories/search/", {
@@ -263,5 +281,23 @@ describe("MemoryClient - getAll() entity param rejection", () => {
     const client = new MemoryClient({ apiKey: TEST_API_KEY });
     await client.getAll({ filters: { user_id: "u1" } });
     expect(findFetchCall(mock, "/v3/memories/", "POST")).toBeDefined();
+  });
+
+  test("serializes latestOnly as latest_only", async () => {
+    const extra = new Map<string, { status: number; body: unknown }>();
+    extra.set("/v3/memories/", {
+      status: 200,
+      body: { results: [] },
+    });
+    const mock = setupMockFetch(extra);
+
+    const client = new MemoryClient({ apiKey: TEST_API_KEY });
+    await client.getAll({
+      filters: { user_id: "u1" },
+      latestOnly: true,
+    });
+
+    const call = findFetchCall(mock, "/v3/memories/", "POST");
+    expect(getFetchBody(call!).latest_only).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- expose `latestOnly?: boolean` on hosted `search()` and `getAll()` option types
- verify the Node client serializes it to the platform API as `latest_only`

## Context
Companion SDK change for the platform `latest_only` retrieval option added in mem0ai/platform#2769.

## Verification
- `npm test -- --runInBand src/client/tests/memoryClient.search.test.ts`
- `npm run build`