### PR TITLE
fix(cli): remove dead-end `mem0 link` tip from claim flow

### DIFF
--- a/cli/node/src/commands/agent-mode.ts
+++ b/cli/node/src/commands/agent-mode.ts
@@ -247,7 +247,7 @@ export async function claimViaOtp(
 		printError(`Claim failed: ${detail}`);
 		if (errCode === "email_already_claimed") {
 			console.log(
-				`  ${dim("Tip: this email already has a Mem0 account. Sign in there and run `mem0 link <key>` to attach this agent.")}`,
+				`  ${dim("Tip: this email already has a Mem0 account. Sign in at app.mem0.ai and contact support to merge this agent's data into your existing account.")}`,
 			);
 		}
 		process.exit(1);

--- a/cli/node/src/commands/agent-mode.ts
+++ b/cli/node/src/commands/agent-mode.ts
@@ -247,7 +247,7 @@ export async function claimViaOtp(
 		printError(`Claim failed: ${detail}`);
 		if (errCode === "email_already_claimed") {
 			console.log(
-				`  ${dim("Tip: this email already has a Mem0 account. Sign in at app.mem0.ai and contact support to merge this agent's data into your existing account.")}`,
+				`  ${dim("Tip: this email already has a Mem0 account. Sign in at app.mem0.ai with your existing credentials.")}`,
 			);
 		}
 		process.exit(1);

--- a/cli/python/src/mem0_cli/commands/agent_mode_cmd.py
+++ b/cli/python/src/mem0_cli/commands/agent_mode_cmd.py
@@ -218,7 +218,7 @@ def claim_via_otp(config: Mem0Config, *, email: str, code: str | None = None) ->
         print_error(err_console, f"Claim failed: {detail}")
         if code_str == "email_already_claimed":
             console.print(
-                f"  [{DIM_COLOR}]Tip: this email already has a Mem0 account. Sign in there and run `mem0 link <key>` to attach this agent.[/]"
+                f"  [{DIM_COLOR}]Tip: this email already has a Mem0 account. Sign in at app.mem0.ai and contact support to merge this agent's data into your existing account.[/]"
             )
         raise typer.Exit(1)
 

--- a/cli/python/src/mem0_cli/commands/agent_mode_cmd.py
+++ b/cli/python/src/mem0_cli/commands/agent_mode_cmd.py
@@ -218,7 +218,7 @@ def claim_via_otp(config: Mem0Config, *, email: str, code: str | None = None) ->
         print_error(err_console, f"Claim failed: {detail}")
         if code_str == "email_already_claimed":
             console.print(
-                f"  [{DIM_COLOR}]Tip: this email already has a Mem0 account. Sign in at app.mem0.ai and contact support to merge this agent's data into your existing account.[/]"
+                f"  [{DIM_COLOR}]Tip: this email already has a Mem0 account. Sign in at app.mem0.ai with your existing credentials.[/]"
             )
         raise typer.Exit(1)
 


### PR DESCRIPTION
## Summary

The "email_already_claimed" tip in \`claim_via_otp\` (Python + Node) suggested running \`mem0 link <key>\` — a command that doesn't exist. Real users hit this dead end.

Replace with honest copy pointing them to support:

> Tip: this email already has a Mem0 account. Sign in at app.mem0.ai and contact support to merge this agent's data into your existing account.

## Companion

Platform-side fix: mem0ai/platform#2790 (same dead-end message in two backend error paths).

## Test plan

- [x] \`grep -rn "mem0 link" cli/ docs/ skills/ README.md mem0-plugin/\` returns 0 hits
- [x] Python tests: 161 pass
- [x] Node tests: 112 pass
- [x] ruff + biome clean