### PR TITLE
docs(faqs): add self-serve account deletion FAQ

### DIFF
--- a/docs/platform/faqs.mdx
+++ b/docs/platform/faqs.mdx
@@ -142,6 +142,24 @@ iconType: "solid"
         Setting this environment variable will prevent Mem0 from collecting and sending any usage data, ensuring complete privacy for your application.
     </Accordion>
 
+    <Accordion title="How do I delete my Mem0 account?">
+        You can delete your Mem0 account at any time directly from the dashboard:
+
+        1. Sign in at [app.mem0.ai](https://app.mem0.ai).
+        2. Go to **Settings → Account**.
+        3. Click **Delete account** and confirm.
+
+        Deletion is immediate and irreversible. The following is removed:
+
+        - Your user profile and login credentials
+        - All memories, agents, and runs you created
+        - API keys and access tokens issued to your account
+        - Organizations you solely own, along with their data
+        - Your membership in any shared organizations (the orgs themselves are not affected)
+
+        Any application still using your old API keys will start receiving `401 Unauthorized` responses immediately. If you'd like to use Mem0 again later, you can create a new account at any time — it will start fresh with no data carried over.
+    </Accordion>
+
 </AccordionGroup>
 
 


### PR DESCRIPTION
## Summary
- Adds a new FAQ entry documenting the self-serve account deletion flow now live in the dashboard (**Settings → Account → Delete account**).
- Covers what gets removed (profile, memories, API keys, solely-owned orgs, membership in shared orgs), the immediate `401` behavior for in-use API keys, and re-signup behavior.

## Test plan
- [ ] Mintlify preview renders the new accordion at the bottom of `/platform/faqs`.
- [ ] Steps match the live UI on `app.mem0.ai`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)