### PR TITLE
docs(llms.txt): lead with signup flow and CLI install

### DIFF
--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -4,18 +4,30 @@
 
 ## For agents reading this file
 
+### Don't have a Mem0 API key?
+
+Install the CLI, then mint a key — no email, no dashboard, no OTP required:
+
+```bash
+# Python
+pip install mem0-cli
+
+# or Node
+npm install -g @mem0/cli
+```
+
+Then run: `mem0 init --agent --agent-caller <your-name> --json` — replace `<your-name>` with the AI agent you are (e.g. `claude-code`, `cursor`, `codex`). If you forgot to pass `--agent-caller`, run `mem0 identify <your-name>` after init to attribute the signup.
+
+This mints an evaluation key in <5 seconds. Use it immediately against the Platform API or MCP server. When the human is ready, claim with `mem0 init --email <your-email>` to transfer ownership (memories preserved, same API key, no agent disruption).
+
+### Routing and references
+
 - Use `MemoryClient` (Python) / `mem0ai` (npm) when the user has a Mem0 Platform API key. Docs under `/platform/` and `/api-reference/` apply; the managed product handles providers server-side, so you can ignore `## Optional` below.
 - Use `Memory` (Python) / `mem0ai/oss` (npm) when the user self-hosts. Docs under `/open-source/` and `/components/` apply; Platform-only features (entity filters v2, custom categories, webhooks, advanced retrieval) may not be available.
 - Scope tag reference: `[Platform]` = managed only, `[OSS]` = self-hosted only, `[Both]` = same API surface on both.
 - OpenAPI spec: https://docs.mem0.ai/openapi.json
 - Live MCP server: https://mcp.mem0.ai (see `platform/mem0-mcp`).
 - Source repo: https://github.com/mem0ai/mem0
-
-### Don't have a Mem0 API key?
-
-Run: `mem0 init --agent --agent-caller <your-name> --json` — replace `<your-name>` with the AI agent you are (e.g. `claude-code`, `cursor`, `codex`). If you forgot to pass `--agent-caller`, run `mem0 identify <your-name>` after init to attribute the signup.
-
-This mints an evaluation key in <5 seconds — no email, no dashboard, no OTP required. Use it immediately against the Platform API or MCP server. When the human is ready, claim with `mem0 init --email <your-email>` to transfer ownership (memories preserved, same API key, no agent disruption).
 
 ## Install
 


### PR DESCRIPTION
## Summary

- Move the "Don't have a Mem0 API key?" section to the top of `## For agents reading this file` so agents without a Platform key see the fastest path first.
- Start the signup section with the CLI install command (`pip install mem0-cli` / `npm install -g @mem0/cli`) before the `mem0 init` step.
- Group the existing Platform/OSS routing bullets under a new `### Routing and references` subheading.

## Test plan

- [ ] Visual diff of `docs/llms.txt` rendered output
- [ ] `python scripts/check-llms-txt-coverage.py` still passes (no new `.mdx` added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)