### PR TITLE
feat(memory): Add Voyage AI embedding provider

### DIFF
--- a/docs/components/embedders/models/voyageai.mdx
+++ b/docs/components/embedders/models/voyageai.mdx
@@ -43,7 +43,7 @@ Here are the parameters available for configuring the Voyage AI embedder:
 | Parameter                      | Description                                               | Default Value |
 | ------------------------------ | --------------------------------------------------------- | ------------- |
 | `model`                        | The name of the Voyage AI embedding model to use          | `voyage-3`    |
-| `embedding_dims`               | Dimensions of the embedding model                         | `1024`        |
+| `embedding_dims`               | Dimensions of the embedding model                         | `None`        |
 | `memory_add_embedding_type`    | The type of embedding to use for the add memory action    | `document`    |
 | `memory_update_embedding_type` | The type of embedding to use for the update memory action | `document`    |
 | `memory_search_embedding_type` | The type of embedding to use for the search memory action | `query`       |

--- a/docs/components/embedders/models/voyageai.mdx
+++ b/docs/components/embedders/models/voyageai.mdx
@@ -1,0 +1,49 @@
+---
+title: "Voyage AI"
+description: "Configure Voyage AI as an embedding provider in Mem0 using models like voyage-3 for vector generation."
+---
+
+To use VoyageAI embedding models, set the `VOYAGEAI_API_KEY` environment variable. You can obtain the Voyage AI API key from the [Voyage AI platform](https://dashboard.voyageai.com/organization/api-keys).
+
+### Usage
+
+```python
+import os
+from mem0 import Memory
+
+os.environ["VOYAGEAI_API_KEY"] = "your_api_key"
+
+config = {
+    "embedder": {
+        "provider": "voyageai",
+        "config": {
+            "model": "voyage-3"
+            "memory_add_embedding_type": "document",
+            "memory_update_embedding_type": "document",
+            "memory_search_embedding_type": "query"
+        }
+    }
+}
+
+m = Memory.from_config(config)
+messages = [
+    {"role": "user", "content": "I'm planning to watch a movie tonight. Any recommendations?"},
+    {"role": "assistant", "content": "How about thriller movies? They can be quite engaging."},
+    {"role": "user", "content": "I’m not a big fan of thriller movies but I love sci-fi movies."},
+    {"role": "assistant", "content": "Got it! I'll avoid thriller recommendations and suggest sci-fi movies in the future."}
+]
+m.add(messages, user_id="john")
+
+```
+
+### Config
+
+Here are the parameters available for configuring the Voyage AI embedder:
+
+| Parameter                      | Description                                               | Default Value |
+| ------------------------------ | --------------------------------------------------------- | ------------- |
+| `model`                        | The name of the Voyage AI embedding model to use          | `voyage-3`    |
+| `embedding_dims`               | Dimensions of the embedding model                         | `1024`        |
+| `memory_add_embedding_type`    | The type of embedding to use for the add memory action    | `document`    |
+| `memory_update_embedding_type` | The type of embedding to use for the update memory action | `document`    |
+| `memory_search_embedding_type` | The type of embedding to use for the search memory action | `query`       |

--- a/docs/components/embedders/overview.mdx
+++ b/docs/components/embedders/overview.mdx
@@ -24,6 +24,7 @@ See the list of supported embedders below.
   <Card title="LM Studio" href="/components/embedders/models/lmstudio"></Card>
   <Card title="Langchain" href="/components/embedders/models/langchain"></Card>
   <Card title="AWS Bedrock" href="/components/embedders/models/aws_bedrock"></Card>
+  <Card title="Voyage AI" href="/components/embedders/models/voyageai"></Card>
 </CardGroup>
 
 ## Usage

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -269,7 +269,8 @@
                               "components/embedders/models/lmstudio",
                               "components/embedders/models/together",
                               "components/embedders/models/langchain",
-                              "components/embedders/models/aws_bedrock"
+                              "components/embedders/models/aws_bedrock",
+                              "components/embedders/models/voyageai"
                             ]
                           }
                         ]

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -434,6 +434,7 @@ Everything below is OSS-only provider configuration. Skip this entire section wh
 - [LM Studio Embeddings](https://docs.mem0.ai/components/embedders/models/lmstudio) [OSS]: Use when embeddings run through LM Studio.
 - [Together Embeddings](https://docs.mem0.ai/components/embedders/models/together) [OSS]: Use when embeddings run on Together.
 - [LangChain Embeddings](https://docs.mem0.ai/components/embedders/models/langchain) [OSS]: Use when embeddings are wrapped behind a LangChain adapter.
+- [Voyage AI Embeddings](https://docs.mem0.ai/components/embedders/models/voyageai) [OSS]: Use when embeddings come from Voyage AI.
 
 ### Vector Databases [OSS]
 - [Vector Database Overview](https://docs.mem0.ai/components/vectordbs/overview) [OSS]: Use when choosing a vector store.

--- a/mem0/embeddings/configs.py
+++ b/mem0/embeddings/configs.py
@@ -25,6 +25,7 @@ class EmbedderConfig(BaseModel):
             "langchain",
             "aws_bedrock",
             "fastembed",
+            "voyageai",
         ]:
             return v
         else:

--- a/mem0/embeddings/voyageai.py
+++ b/mem0/embeddings/voyageai.py
@@ -1,0 +1,51 @@
+import os
+from typing import Literal, Optional
+
+from mem0.configs.embeddings.base import BaseEmbedderConfig
+from mem0.embeddings.base import EmbeddingBase
+
+try:
+    import voyageai
+except ImportError:
+    raise ImportError("VoyageAI is not installed. Please install it using `pip install voyageai`")
+
+
+class VoyageAIEmbedding(EmbeddingBase):
+    def __init__(self, config: Optional[BaseEmbedderConfig] = None):
+        super().__init__(config)
+
+        self.config.model = self.config.model or "voyage-3"
+        self.embedding_types = {
+            "add": self.config.memory_add_embedding_type or "document",
+            "update": self.config.memory_update_embedding_type or "document",
+            "search": self.config.memory_search_embedding_type or "query",
+        }
+
+        api_key = self.config.api_key or os.getenv("VOYAGEAI_API_KEY")
+        self.client = voyageai.Client(api_key=api_key)
+
+    def embed(self, text, memory_action: Optional[Literal["add", "search", "update"]] = None):
+        """
+        Get the embedding for the given text using VoyageAI.
+
+        Args:
+            text (str): The text to embed.
+            memory_action (optional): The type of embedding to use. Must be one of "add", "search", or "update". Defaults to None.
+        Returns:
+            list: The embedding vector.
+        """
+        input_type = self.embedding_types.get(memory_action) if memory_action else None
+        kwargs = {"model": self.config.model, "input_type": input_type}
+        if self.config.embedding_dims:
+            kwargs["output_dimension"] = self.config.embedding_dims
+        response = self.client.embed([text], **kwargs)
+        return response.embeddings[0]
+
+    def embed_batch(self, texts, memory_action="add"):
+        """Embed multiple texts in a single VoyageAI API call."""
+        input_type = self.embedding_types.get(memory_action) if memory_action else None
+        kwargs = {"model": self.config.model, "input_type": input_type}
+        if self.config.embedding_dims:
+            kwargs["output_dimension"] = self.config.embedding_dims
+        response = self.client.embed(list(texts), **kwargs)
+        return response.embeddings

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -149,6 +149,7 @@ class EmbedderFactory:
         "langchain": "mem0.embeddings.langchain.LangchainEmbedding",
         "aws_bedrock": "mem0.embeddings.aws_bedrock.AWSBedrockEmbedding",
         "fastembed": "mem0.embeddings.fastembed.FastEmbedEmbedding",
+        "voyageai": "mem0.embeddings.voyageai.VoyageAIEmbedding",
     }
 
     @classmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ extras = [
     "elasticsearch>=8.0.0,<9.0.0",
     "opensearch-py>=2.0.0",
     "fastembed>=0.3.1",
+    "voyageai>=0.2.0",
 ]
 test = [
     "pytest>=8.2.2",

--- a/tests/embeddings/test_voyageai_embeddings.py
+++ b/tests/embeddings/test_voyageai_embeddings.py
@@ -1,0 +1,99 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mem0.configs.embeddings.base import BaseEmbedderConfig
+from mem0.embeddings.voyageai import VoyageAIEmbedding
+
+
+@pytest.fixture
+def mock_voyageai_client():
+    with patch("mem0.embeddings.voyageai.voyageai.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        yield mock_client
+
+
+def test_embed_default_model(mock_voyageai_client):
+    config = BaseEmbedderConfig()
+    embedder = VoyageAIEmbedding(config)
+    mock_response = MagicMock()
+    mock_response.embeddings = [[0.1, 0.2, 0.3]]
+    mock_voyageai_client.embed.return_value = mock_response
+
+    result = embedder.embed("Hello world")
+
+    mock_voyageai_client.embed.assert_called_once_with(["Hello world"], model="voyage-3", input_type=None)
+    assert result == [0.1, 0.2, 0.3]
+
+
+def test_embed_custom_model(mock_voyageai_client):
+    config = BaseEmbedderConfig(model="voyage-3-large", embedding_dims=2048)
+    embedder = VoyageAIEmbedding(config)
+    mock_response = MagicMock()
+    mock_response.embeddings = [[0.4, 0.5, 0.6]]
+    mock_voyageai_client.embed.return_value = mock_response
+
+    result = embedder.embed("Test embedding")
+
+    mock_voyageai_client.embed.assert_called_once_with(["Test embedding"], model="voyage-3-large", input_type=None, output_dimension=2048)
+    assert result == [0.4, 0.5, 0.6]
+
+
+def test_embed_with_memory_action(mock_voyageai_client):
+    expected_input_types = {
+        "add": "document",
+        "update": "document",
+        "search": "query",
+    }
+    for action, input_type in expected_input_types.items():
+        config = BaseEmbedderConfig()
+        embedder = VoyageAIEmbedding(config)
+        mock_response = MagicMock()
+        mock_response.embeddings = [[0.1, 0.2, 0.3]]
+        mock_voyageai_client.embed.return_value = mock_response
+
+        result = embedder.embed("Hello world", memory_action=action)
+
+        mock_voyageai_client.embed.assert_called_with(["Hello world"], model="voyage-3", input_type=input_type)
+        assert result == [0.1, 0.2, 0.3]
+
+
+def test_embed_without_api_key_env_var(mock_voyageai_client):
+    config = BaseEmbedderConfig(api_key="test_key")
+    embedder = VoyageAIEmbedding(config)
+    mock_response = MagicMock()
+    mock_response.embeddings = [[1.0, 1.1, 1.2]]
+    mock_voyageai_client.embed.return_value = mock_response
+
+    result = embedder.embed("Testing API key")
+
+    mock_voyageai_client.embed.assert_called_once_with(["Testing API key"], model="voyage-3", input_type=None)
+    assert result == [1.0, 1.1, 1.2]
+
+
+def test_embed_uses_environment_api_key(mock_voyageai_client, monkeypatch):
+    monkeypatch.setenv("VOYAGEAI_API_KEY", "env_key")
+    config = BaseEmbedderConfig()
+    embedder = VoyageAIEmbedding(config)
+    mock_response = MagicMock()
+    mock_response.embeddings = [[1.3, 1.4, 1.5]]
+    mock_voyageai_client.embed.return_value = mock_response
+
+    result = embedder.embed("Environment key test")
+
+    mock_voyageai_client.embed.assert_called_once_with(["Environment key test"], model="voyage-3", input_type=None)
+    assert result == [1.3, 1.4, 1.5]
+
+
+def test_embed_batch(mock_voyageai_client):
+    config = BaseEmbedderConfig()
+    embedder = VoyageAIEmbedding(config)
+    mock_response = MagicMock()
+    mock_response.embeddings = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+    mock_voyageai_client.embed.return_value = mock_response
+
+    result = embedder.embed_batch(["Hello world", "Goodbye world"])
+
+    mock_voyageai_client.embed.assert_called_once_with(["Hello world", "Goodbye world"], model="voyage-3", input_type="document")
+    assert result == [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]


### PR DESCRIPTION
## Linked Issue

Closes #4838

## Description

Add Voyage AI as an embedding provider. Created a `VoyageAIEmbedder` class following the existing embedder pattern.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Tested manually by initializing and using the SDK with this config:
```
        config = {
            "embedder": {
                "provider": "voyageai",
                "config": {
                    "model": "voyage-3",
                    "memory_add_embedding_type": "document",
                    "memory_update_embedding_type": "document",
                    "memory_search_embedding_type": "query"
                }
            },
            "vector_store": {
                "provider": "qdrant",
                "config": {
                    "embedding_model_dims": 1024
                }
            },
            "llm": {
                "provider": "openai",
                "config": {
                    "model": "gpt-4o-mini"
                }
            }
        }
        self.memory = Memory.from_config(config)
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
