### PR TITLE
docs(platform/mem0-mcp): note Settings UI fallback for Claude Desktop HTTP MCP

### DIFF
--- a/docs/platform/mem0-mcp.mdx
+++ b/docs/platform/mem0-mcp.mdx
@@ -76,6 +76,10 @@ You can also configure individual clients:
       }
     }
     ```
+
+    <Note>
+      Some Claude Desktop builds reject HTTP MCP servers defined in `claude_desktop_config.json` ("not a valid MCP server"). If that happens, add the same URL via **Settings → Connectors → Add custom connector** instead — no `npx` step is required.
+    </Note>
   </Accordion>
 
   <Accordion title="Claude Code">


### PR DESCRIPTION
## Linked Issue

Closes #5133

## Description

The `platform/mem0-mcp` setup page documents two ways to wire the hosted MCP server into Claude Desktop:

1. `npx mcp-add --type http --url … --clients claude`
2. A manual `claude_desktop_config.json` block with `"type": "http"`

The reporter in #5133 hit a real failure on at least one Claude Desktop build: both routes ended up writing the HTTP entry to `claude_desktop_config.json`, but Claude Desktop then rejected the server with `not a valid MCP server`. The same URL worked when they added it via **Settings → Customise → Connectors → Add custom connector** — no `npx` required.

This is a known cross-version surface in Claude Desktop: stdio servers go in the JSON config file, while HTTP/SSE servers are typically configured through the Connectors UI on most current builds. The mem0 docs didn't mention the UI fallback at all, so users hitting the rejection have no way to recover from the page itself.

This PR adds a small `<Note>` block inside the existing **Claude Desktop** accordion pointing at the Settings UI fallback. It does **not** remove the `npx` / JSON instructions — those still work on builds that accept HTTP servers from the config file — it just gives users a second path when the first one errors out.

## Type of Change

- [x] Documentation update

## Breaking Changes

N/A.

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [x] No tests needed — pure docs note, no API or runtime change.

`python scripts/check-llms-txt-coverage.py` reports `docs/llms.txt` already in sync with `docs/**/*.mdx`; no new pages added, only inline content on an existing page.

## Checklist

- [x] My code follows the project's style guidelines (Mintlify `<Note>` block matching the existing one inside the Codex accordion on the same page)
- [x] I have performed a self-review of my code
- [x] No tests required (docs-only change)
- [x] Existing tests should still pass (no code touched)
- [x] Documentation updated — that's the change itself
