### PR TITLE
docs: add FastEmbed embedding provider documentation

### DIFF
--- a/docs/components/embedders/models/fastembed.mdx
+++ b/docs/components/embedders/models/fastembed.mdx
@@ -1,0 +1,44 @@
+---
+title: FastEmbed
+description: "Configure FastEmbed as an embedding provider in Mem0 for fast, local embedding generation using ONNX runtime."
+---
+
+You can use [FastEmbed](https://github.com/qdrant/fastembed) to run Mem0 locally with fast, CPU-friendly embeddings powered by the ONNX runtime. No API key is required.
+
+<Note> Install FastEmbed separately: `pip install fastembed` </Note>
+
+### Usage
+
+```python
+import os
+from mem0 import Memory
+
+os.environ["OPENAI_API_KEY"] = "your_api_key" # For LLM
+
+config = {
+    "embedder": {
+        "provider": "fastembed",
+        "config": {
+            "model": "thenlper/gte-large"
+        }
+    }
+}
+
+m = Memory.from_config(config)
+messages = [
+    {"role": "user", "content": "I'm planning to watch a movie tonight. Any recommendations?"},
+    {"role": "assistant", "content": "How about thriller movies? They can be quite engaging."},
+    {"role": "user", "content": "I'm not a big fan of thriller movies but I love sci-fi movies."},
+    {"role": "assistant", "content": "Got it! I'll avoid thriller recommendations and suggest sci-fi movies in the future."}
+]
+m.add(messages, user_id="john")
+```
+
+### Config
+
+Here are the parameters available for configuring FastEmbed embedder:
+
+| Parameter | Description | Default Value |
+| --- | --- | --- |
+| `model` | The name of the FastEmbed model to use | `thenlper/gte-large` |
+| `embedding_dims` | Dimensions of the embedding model | Auto-detected from model |

--- a/docs/components/embedders/overview.mdx
+++ b/docs/components/embedders/overview.mdx
@@ -24,6 +24,7 @@ See the list of supported embedders below.
   <Card title="LM Studio" href="/components/embedders/models/lmstudio"></Card>
   <Card title="Langchain" href="/components/embedders/models/langchain"></Card>
   <Card title="AWS Bedrock" href="/components/embedders/models/aws_bedrock"></Card>
+  <Card title="FastEmbed" href="/components/embedders/models/fastembed"></Card>
 </CardGroup>
 
 ## Usage

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -269,7 +269,8 @@
                               "components/embedders/models/lmstudio",
                               "components/embedders/models/together",
                               "components/embedders/models/langchain",
-                              "components/embedders/models/aws_bedrock"
+                              "components/embedders/models/aws_bedrock",
+                              "components/embedders/models/fastembed"
                             ]
                           }
                         ]

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -440,6 +440,7 @@ Everything below is OSS-only provider configuration. Skip this entire section wh
 - [LM Studio Embeddings](https://docs.mem0.ai/components/embedders/models/lmstudio) [OSS]: Use when embeddings run through LM Studio.
 - [Together Embeddings](https://docs.mem0.ai/components/embedders/models/together) [OSS]: Use when embeddings run on Together.
 - [LangChain Embeddings](https://docs.mem0.ai/components/embedders/models/langchain) [OSS]: Use when embeddings are wrapped behind a LangChain adapter.
+- [FastEmbed Embeddings](https://docs.mem0.ai/components/embedders/models/fastembed) [OSS]: Use for fast, local CPU-based embeddings via ONNX runtime with no API key.
 
 ### Vector Databases [OSS]
 - [Vector Database Overview](https://docs.mem0.ai/components/vectordbs/overview) [OSS]: Use when choosing a vector store.


### PR DESCRIPTION
## Linked Issue

Closes #5163

## Description

The FastEmbed embedding provider (`mem0/embeddings/fastembed.py`) is fully implemented and registered in `mem0/embeddings/configs.py`, but it is the only registered embedding provider without a documentation page.

This PR adds:
- `docs/components/embedders/models/fastembed.mdx` — provider doc page (usage example + config table)
- A card in `docs/components/embedders/overview.mdx`
- A navigation entry in `docs/docs.json`
- An index entry in `docs/llms.txt`

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Ran `python3 scripts/check-llms-txt-coverage.py` — confirms llms.txt is in sync.
Previewed locally with `mintlify dev` — page renders correctly and navigation works.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
