### PR TITLE
fix: preserve custom metadata fields during memory update

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1670,23 +1670,21 @@ class Memory(MemoryBase):
 
         new_metadata = deepcopy(metadata) if metadata is not None else {}
 
+        # Preserve all existing payload fields (including custom metadata) that are
+        # not being explicitly overwritten by the caller or recalculated below.
+        for key, value in existing_memory.payload.items():
+            if key not in new_metadata:
+                new_metadata[key] = value
+
         new_metadata["data"] = data
         new_metadata["hash"] = hashlib.md5(data.encode()).hexdigest()
         new_metadata["text_lemmatized"] = lemmatize_for_bm25(data)
         new_metadata["created_at"] = existing_memory.payload.get("created_at")
         new_metadata["updated_at"] = datetime.now(timezone.utc).isoformat()
 
-        # Preserve session identifiers from existing memory only if not provided in new metadata
-        if "user_id" not in new_metadata and "user_id" in existing_memory.payload:
-            new_metadata["user_id"] = existing_memory.payload["user_id"]
-        if "agent_id" not in new_metadata and "agent_id" in existing_memory.payload:
-            new_metadata["agent_id"] = existing_memory.payload["agent_id"]
-        if "run_id" not in new_metadata and "run_id" in existing_memory.payload:
-            new_metadata["run_id"] = existing_memory.payload["run_id"]
+        # actor_id is always preserved from existing memory (immutable origin marker)
         if "actor_id" in existing_memory.payload:
             new_metadata["actor_id"] = existing_memory.payload["actor_id"]
-        if "role" not in new_metadata and "role" in existing_memory.payload:
-            new_metadata["role"] = existing_memory.payload["role"]
 
         if data in existing_embeddings:
             embeddings = existing_embeddings[data]
@@ -3101,24 +3099,21 @@ class AsyncMemory(MemoryBase):
 
         new_metadata = deepcopy(metadata) if metadata is not None else {}
 
+        # Preserve all existing payload fields (including custom metadata) that are
+        # not being explicitly overwritten by the caller or recalculated below.
+        for key, value in existing_memory.payload.items():
+            if key not in new_metadata:
+                new_metadata[key] = value
+
         new_metadata["data"] = data
         new_metadata["hash"] = hashlib.md5(data.encode()).hexdigest()
         new_metadata["text_lemmatized"] = lemmatize_for_bm25(data)
         new_metadata["created_at"] = existing_memory.payload.get("created_at")
         new_metadata["updated_at"] = datetime.now(timezone.utc).isoformat()
 
-        # Preserve session identifiers from existing memory only if not provided in new metadata
-        if "user_id" not in new_metadata and "user_id" in existing_memory.payload:
-            new_metadata["user_id"] = existing_memory.payload["user_id"]
-        if "agent_id" not in new_metadata and "agent_id" in existing_memory.payload:
-            new_metadata["agent_id"] = existing_memory.payload["agent_id"]
-        if "run_id" not in new_metadata and "run_id" in existing_memory.payload:
-            new_metadata["run_id"] = existing_memory.payload["run_id"]
-
+        # actor_id is always preserved from existing memory (immutable origin marker)
         if "actor_id" in existing_memory.payload:
             new_metadata["actor_id"] = existing_memory.payload["actor_id"]
-        if "role" not in new_metadata and "role" in existing_memory.payload:
-            new_metadata["role"] = existing_memory.payload["role"]
 
         if data in existing_embeddings:
             embeddings = existing_embeddings[data]


### PR DESCRIPTION
## Linked Issue

Closes #5160

## Description

`_update_memory()` only preserved 5 hard-coded session identifiers (`user_id`, `agent_id`, `run_id`, `actor_id`, `role`) from the existing payload when updating a memory, silently dropping all custom metadata fields (e.g., `category`, `priority`, `source`).

This PR replaces the whitelist-only pattern with a full merge of existing payload fields into `new_metadata`. Caller-provided metadata and recalculated fields (`data`, `hash`, `text_lemmatized`, `created_at`, `updated_at`) take precedence over existing values. `actor_id` remains unconditionally preserved as an immutable origin marker.

Applies the same fix to both sync `Memory._update_memory()` and async `AsyncMemory._update_memory()`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)