### PR TITLE
fix(ci): remove pull_request paths filter so required checks always report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,12 @@ on:
       - '.github/workflows/**'
       - 'pyproject.toml'
   pull_request:
-    paths:
-      - 'mem0/**'
-      - 'tests/**'
-      - 'embedchain/**'
-      - 'pyproject.toml'
+    # No paths filter — the workflow runs on every PR so the required
+    # `build_mem0` / `build_embedchain` checks always report a status
+    # (otherwise they'd be stuck "Expected" on docs-only PRs forever).
+    # The inner `check_changes` job (uses dorny/paths-filter) decides
+    # whether the actual build/test work runs; jobs gated by its outputs
+    # are reported as "skipped → success" when no relevant paths changed.
 
 jobs:
   changelog_check:


### PR DESCRIPTION
## Summary

Docs-only PRs (e.g. #5152) are stuck with \`build_mem0\` and \`build_embedchain\` showing **"Expected — waiting for status to be reported"** forever, blocking merge. This is because \`ci.yml\` has an outer \`pull_request: paths:\` filter that prevents the workflow from firing at all on non-matching paths — but those two jobs are *required* by branch protection.

## Fix

Remove the outer \`pull_request: paths:\` filter. The inner \`check_changes\` job already uses \`dorny/paths-filter\` to compute \`mem0_changed\` / \`embedchain_changed\` outputs, and \`build_mem0\` / \`build_embedchain\` are gated by those outputs via \`if:\`. So:

- On a PR that touches \`mem0/**\` or \`tests/**\` or \`embedchain/**\` or \`pyproject.toml\` → builds run as before.
- On a docs-only PR → \`check_changes\` reports both flags false → \`build_mem0\` and \`build_embedchain\` are **skipped**, and GitHub branch protection counts a skipped required check as **success**.

Net: required checks always report a status; docs-only PRs become mergeable without admin override; no extra CI minutes on docs PRs (the gated jobs still skip the actual work).

The \`push\` trigger keeps its paths filter — no need to spin up CI on docs-only main commits.

## Test plan

- [ ] After merge: open a trivial docs-only PR and confirm \`build_mem0\` + \`build_embedchain\` report as **skipped** (not "Expected"), and branch protection lets it merge.
- [ ] Open a trivial \`mem0/**\` PR and confirm builds run as before.