### PR TITLE
 Preserve custom metadata in _update_memory 

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1668,25 +1668,23 @@ class Memory(MemoryBase):
 
         prev_value = existing_memory.payload.get("data")
 
-        new_metadata = deepcopy(metadata) if metadata is not None else {}
+        # Start from the full existing payload so ALL custom metadata is preserved (fixes #5160).
+        new_metadata = deepcopy(existing_memory.payload)
 
+        # Overlay caller-supplied metadata, but exclude actor_id which is immutable (see #4490).
+        if metadata is not None:
+            new_metadata.update({k: v for k, v in metadata.items() if k != "actor_id"})
+
+        # Update managed fields
         new_metadata["data"] = data
         new_metadata["hash"] = hashlib.md5(data.encode()).hexdigest()
         new_metadata["text_lemmatized"] = lemmatize_for_bm25(data)
         new_metadata["created_at"] = existing_memory.payload.get("created_at")
         new_metadata["updated_at"] = datetime.now(timezone.utc).isoformat()
 
-        # Preserve session identifiers from existing memory only if not provided in new metadata
-        if "user_id" not in new_metadata and "user_id" in existing_memory.payload:
-            new_metadata["user_id"] = existing_memory.payload["user_id"]
-        if "agent_id" not in new_metadata and "agent_id" in existing_memory.payload:
-            new_metadata["agent_id"] = existing_memory.payload["agent_id"]
-        if "run_id" not in new_metadata and "run_id" in existing_memory.payload:
-            new_metadata["run_id"] = existing_memory.payload["run_id"]
+        # actor_id is immutable — always preserve from the original memory
         if "actor_id" in existing_memory.payload:
             new_metadata["actor_id"] = existing_memory.payload["actor_id"]
-        if "role" not in new_metadata and "role" in existing_memory.payload:
-            new_metadata["role"] = existing_memory.payload["role"]
 
         if data in existing_embeddings:
             embeddings = existing_embeddings[data]
@@ -3099,26 +3097,23 @@ class AsyncMemory(MemoryBase):
 
         prev_value = existing_memory.payload.get("data")
 
-        new_metadata = deepcopy(metadata) if metadata is not None else {}
+        # Start from the full existing payload so ALL custom metadata is preserved (fixes #5160).
+        new_metadata = deepcopy(existing_memory.payload)
 
+        # Overlay caller-supplied metadata, but exclude actor_id which is immutable (see #4490).
+        if metadata is not None:
+            new_metadata.update({k: v for k, v in metadata.items() if k != "actor_id"})
+
+        # Update managed fields
         new_metadata["data"] = data
         new_metadata["hash"] = hashlib.md5(data.encode()).hexdigest()
         new_metadata["text_lemmatized"] = lemmatize_for_bm25(data)
         new_metadata["created_at"] = existing_memory.payload.get("created_at")
         new_metadata["updated_at"] = datetime.now(timezone.utc).isoformat()
 
-        # Preserve session identifiers from existing memory only if not provided in new metadata
-        if "user_id" not in new_metadata and "user_id" in existing_memory.payload:
-            new_metadata["user_id"] = existing_memory.payload["user_id"]
-        if "agent_id" not in new_metadata and "agent_id" in existing_memory.payload:
-            new_metadata["agent_id"] = existing_memory.payload["agent_id"]
-        if "run_id" not in new_metadata and "run_id" in existing_memory.payload:
-            new_metadata["run_id"] = existing_memory.payload["run_id"]
-
+        # actor_id is immutable — always preserve from the original memory
         if "actor_id" in existing_memory.payload:
             new_metadata["actor_id"] = existing_memory.payload["actor_id"]
-        if "role" not in new_metadata and "role" in existing_memory.payload:
-            new_metadata["role"] = existing_memory.payload["role"]
 
         if data in existing_embeddings:
             embeddings = existing_embeddings[data]

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -663,3 +663,101 @@ async def test_async_update_preserves_actor_id_when_different_actor_updates(mock
     assert stored["actor_id"] == "Alice"
 
 
+def test_update_memory_preserves_custom_metadata(mocker):
+    """Custom metadata fields must survive a text-only update (issue #5160)."""
+    memory = _build_memory_instance(mocker, Memory)
+    memory.vector_store.get.return_value = MagicMock(
+        payload={
+            "data": "old data",
+            "user_id": "alice",
+            "category": "hobbies",
+            "priority": "high",
+            "source": "chat",
+            "created_at": "2026-01-01T00:00:00+00:00",
+        }
+    )
+
+    memory._update_memory("mem-id", "new data", {"new data": [0.1, 0.2, 0.3]})
+
+    stored = memory.vector_store.update.call_args.kwargs["payload"]
+    assert stored["category"] == "hobbies"
+    assert stored["priority"] == "high"
+    assert stored["source"] == "chat"
+    assert stored["user_id"] == "alice"
+    assert stored["data"] == "new data"
+
+
+def test_update_memory_caller_metadata_overrides_existing(mocker):
+    """Caller-provided metadata should override existing fields while preserving untouched ones."""
+    memory = _build_memory_instance(mocker, Memory)
+    memory.vector_store.get.return_value = MagicMock(
+        payload={
+            "data": "old data",
+            "category": "hobbies",
+            "priority": "low",
+            "created_at": "2026-01-01T00:00:00+00:00",
+        }
+    )
+
+    memory._update_memory(
+        "mem-id",
+        "new data",
+        {"new data": [0.1, 0.2, 0.3]},
+        metadata={"priority": "critical", "new_field": "added"},
+    )
+
+    stored = memory.vector_store.update.call_args.kwargs["payload"]
+    assert stored["category"] == "hobbies"  # preserved
+    assert stored["priority"] == "critical"  # overridden by caller
+    assert stored["new_field"] == "added"  # new field from caller
+
+
+@pytest.mark.asyncio
+async def test_async_update_memory_preserves_custom_metadata(mocker):
+    """Async: custom metadata must survive a text-only update (issue #5160)."""
+    memory = _build_memory_instance(mocker, AsyncMemory)
+    memory.vector_store.get.return_value = MagicMock(
+        payload={
+            "data": "old data",
+            "user_id": "bob",
+            "bucket_id": "bucket-42",
+            "tags": ["important"],
+            "created_at": "2026-01-01T00:00:00+00:00",
+        }
+    )
+
+    await memory._update_memory("mem-id", "new data", {"new data": [0.1, 0.2, 0.3]})
+
+    stored = memory.vector_store.update.call_args.kwargs["payload"]
+    assert stored["bucket_id"] == "bucket-42"
+    assert stored["tags"] == ["important"]
+    assert stored["user_id"] == "bob"
+    assert stored["data"] == "new data"
+
+
+@pytest.mark.asyncio
+async def test_async_update_memory_caller_metadata_overrides_existing(mocker):
+    """Async: caller-provided metadata should override existing fields while preserving untouched ones."""
+    memory = _build_memory_instance(mocker, AsyncMemory)
+    memory.vector_store.get.return_value = MagicMock(
+        payload={
+            "data": "old data",
+            "user_id": "carol",
+            "category": "work",
+            "priority": "low",
+            "created_at": "2026-01-01T00:00:00+00:00",
+        }
+    )
+
+    await memory._update_memory(
+        "mem-id",
+        "new data",
+        {"new data": [0.1, 0.2, 0.3]},
+        metadata={"priority": "urgent", "department": "engineering"},
+    )
+
+    stored = memory.vector_store.update.call_args.kwargs["payload"]
+    assert stored["category"] == "work"  # preserved
+    assert stored["priority"] == "urgent"  # overridden by caller
+    assert stored["department"] == "engineering"  # new field from caller
+    assert stored["user_id"] == "carol"  # session field preserved


### PR DESCRIPTION
Fixes #5160

## Description

`_update_memory()` initializes `new_metadata` as an empty dict when `metadata=None`, then only copies 5 hard-coded session identifiers (`user_id`, `agent_id`, `run_id`, `actor_id`, `role`) from `existing_memory.payload`. All other user-defined metadata fields (e.g., `category`, `priority`, `source`, `bucket_id`) are silently discarded on every update call.

**Root cause:**
```python
# Starts empty — all custom metadata lost
new_metadata = deepcopy(metadata) if metadata is not None else {}
```

**Fix:**
```python
# Starts from full existing payload — all custom metadata preserved
new_metadata = deepcopy(existing_memory.payload)
if metadata is not None:
    new_metadata.update({k: v for k, v in metadata.items() if k != "actor_id"})
```

- Uses `deepcopy(existing_memory.payload)` as the baseline instead of an empty dict
- Caller-supplied metadata overlays existing values; managed fields (`data`, `hash`, `text_lemmatized`, timestamps) are always recalculated
- `actor_id` is excluded from caller overrides to maintain immutability (see #4490)
- Removes the now-redundant 5-field session-identifier copy blocks
- Applied to both `Memory._update_memory()` (sync) and `AsyncMemory._update_memory()` (async)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

4 regression tests added to `tests/memory/test_main.py`:

- `test_update_memory_preserves_custom_metadata` — sync: `category`, `priority`, `source` survive text-only update
- `test_update_memory_caller_metadata_overrides_existing` — sync: caller overrides existing fields + adds new ones, untouched fields preserved
- `test_async_update_memory_preserves_custom_metadata` — async: `bucket_id`, `tags` (list) survive text-only update
- `test_async_update_memory_caller_metadata_overrides_existing` — async: same override + preserve behavior

Local results:

```
$ python -m pytest tests/memory/test_main.py -v
============================= 38 passed in 9.75s ==============================

$ ruff check mem0/memory/main.py tests/memory/test_main.py
All checks passed!

$ isort --check-only --profile black mem0/memory/main.py tests/memory/test_main.py
(passes)
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
