### PR TITLE
docs: link platform migration guide from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ See the [self-hosted docs](https://docs.mem0.ai/open-source/overview) for config
 
 1. Sign up on [Mem0 Platform](https://app.mem0.ai?utm_source=oss&utm_medium=readme)
 2. Embed the memory layer via SDK or API keys
+3. Using hosted Qdrant vectors? See the [Platform migration guide](https://docs.mem0.ai/migration/oss-to-platform) to import them into Mem0 Platform.
 
 ### CLI
 


### PR DESCRIPTION
## Linked Issue

N/A - README discoverability update.

## Description

Adds a Cloud Platform README step that points users with hosted Qdrant vectors to the Platform migration guide.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [x] No tests needed (explain why)

README-only documentation link change. Verified the diff is limited to README.md and ran git diff --check.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] No tests needed for this docs-only change
- [x] New and existing tests pass locally, where applicable
- [x] I have updated documentation if needed