### PR TITLE
Fix OpenAI embedder encoding format

### DIFF
--- a/mem0-ts/src/oss/src/embeddings/openai.ts
+++ b/mem0-ts/src/oss/src/embeddings/openai.ts
@@ -20,6 +20,7 @@ export class OpenAIEmbedder implements Embedder {
     const response = await this.openai.embeddings.create({
       model: this.model,
       input: text,
+      encoding_format: "float",
       ...(this.embeddingDims !== undefined && {
         dimensions: this.embeddingDims,
       }),
@@ -35,6 +36,7 @@ export class OpenAIEmbedder implements Embedder {
       const response = await this.openai.embeddings.create({
         model: this.model,
         input: chunk,
+        encoding_format: "float",
         ...(this.embeddingDims !== undefined && {
           dimensions: this.embeddingDims,
         }),

--- a/mem0-ts/src/oss/tests/openai-embedder.test.ts
+++ b/mem0-ts/src/oss/tests/openai-embedder.test.ts
@@ -1,8 +1,8 @@
 /// <reference types="jest" />
 /**
  * OpenAI Embedder — unit tests (mocked OpenAI client).
- * Verifies that the `dimensions` parameter is only passed to the API
- * when the user explicitly configures `embeddingDims`.
+ * Verifies that OpenAI requests use float embeddings and only pass the
+ * `dimensions` parameter when the user explicitly configures `embeddingDims`.
  */
 
 const mockEmbeddingsCreate = jest.fn();
@@ -42,6 +42,7 @@ describe("OpenAIEmbedder (unit)", () => {
       expect(callArgs).toEqual({
         model: "text-embedding-3-small",
         input: "hello",
+        encoding_format: "float",
       });
     });
 
@@ -58,6 +59,7 @@ describe("OpenAIEmbedder (unit)", () => {
       expect(callArgs).toEqual({
         model: "text-embedding-3-small",
         input: "hello",
+        encoding_format: "float",
         dimensions: 1024,
       });
     });
@@ -87,6 +89,7 @@ describe("OpenAIEmbedder (unit)", () => {
 
       const callArgs = mockEmbeddingsCreate.mock.calls[0][0];
       expect(callArgs).not.toHaveProperty("dimensions");
+      expect(callArgs).toHaveProperty("encoding_format", "float");
     });
 
     it("passes dimensions in embedBatch when embeddingDims is explicitly set", async () => {
@@ -105,8 +108,37 @@ describe("OpenAIEmbedder (unit)", () => {
       expect(callArgs).toEqual({
         model: "text-embedding-3-small",
         input: ["hello", "world"],
+        encoding_format: "float",
         dimensions: 512,
       });
+    });
+  });
+
+  describe("encoding format", () => {
+    it("embed() explicitly requests float embeddings", async () => {
+      const embedder = new OpenAIEmbedder({
+        apiKey: "test-key",
+      });
+
+      await embedder.embed("hello");
+
+      const callArgs = mockEmbeddingsCreate.mock.calls[0][0];
+      expect(callArgs).toHaveProperty("encoding_format", "float");
+    });
+
+    it("embedBatch() explicitly requests float embeddings", async () => {
+      mockEmbeddingsCreate.mockResolvedValue({
+        data: [{ embedding: mockEmbedding }, { embedding: mockEmbedding }],
+      });
+
+      const embedder = new OpenAIEmbedder({
+        apiKey: "test-key",
+      });
+
+      await embedder.embedBatch(["hello", "world"]);
+
+      const callArgs = mockEmbeddingsCreate.mock.calls[0][0];
+      expect(callArgs).toHaveProperty("encoding_format", "float");
     });
   });
 


### PR DESCRIPTION
## Summary
- pass `encoding_format: "float"` for OpenAI embedder single and batch embedding requests
- keep `dimensions` behavior unchanged when `embeddingDims` is configured
- add unit coverage so both embed paths continue to request float embeddings

Fixes #5168.

## Verification
- `npx --yes pnpm@10.5.2 exec jest src/oss/tests/openai-embedder.test.ts --runInBand`
- `npx --yes pnpm@10.5.2 exec prettier --check src/oss/src/embeddings/openai.ts src/oss/tests/openai-embedder.test.ts`
- `git diff --check`

## Notes
- `npx --yes pnpm@10.5.2 exec tsc --noEmit` currently fails on existing unrelated test/community type errors under `src/client/tests/*` and `src/community/src/integrations/langchain/mem0.ts`.
- `npx --yes pnpm@10.5.2 --dir src/oss run build` currently fails on existing unrelated OSS package build issues: `src/client/config.ts` outside the package `rootDir` and unresolved `__MEM0_SDK_VERSION__` in telemetry.
