### PR TITLE
fix(memory): tolerate malformed fact-extraction shapes from LLMs

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -27,6 +27,7 @@ from mem0.memory.storage import SQLiteManager
 from mem0.memory.telemetry import MEM0_TELEMETRY, capture_event
 from mem0.memory.utils import (
     extract_json,
+    normalize_extracted_memories,
     parse_messages,
     parse_vision_messages,
     process_telemetry_filters,
@@ -761,6 +762,10 @@ class Memory(MemoryBase):
         except Exception as e:
             logger.error(f"Error parsing extraction response: {e}")
             extracted_memories = []
+
+        # Tolerate malformed LLM shapes (e.g. {factText: value}) before downstream
+        # code accesses ``.text`` on each item.
+        extracted_memories = normalize_extracted_memories(extracted_memories)
 
         if not extracted_memories:
             # Save messages even if nothing extracted
@@ -2178,6 +2183,10 @@ class AsyncMemory(MemoryBase):
         except Exception as e:
             logger.error(f"Error parsing extraction response (async): {e}")
             extracted_memories = []
+
+        # Tolerate malformed LLM shapes (e.g. {factText: value}) before downstream
+        # code accesses ``.text`` on each item.
+        extracted_memories = normalize_extracted_memories(extracted_memories)
 
         if not extracted_memories:
             await asyncio.to_thread(self.db.save_messages, messages, session_scope)

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -84,9 +84,17 @@ def format_entities(entities):
 def normalize_facts(raw_facts):
     """Normalize LLM-extracted facts to a list of strings.
 
-    Smaller LLMs (e.g. llama3.1:8b) sometimes return facts as objects
-    like {"fact": "..."} or {"text": "..."} instead of plain strings.
-    This mirrors the TypeScript FactRetrievalSchema validation.
+    Tolerates the common malformed shapes that real LLMs emit:
+
+    - plain string: ``"Name is Thales"``
+    - well-formed dict: ``{"fact": "..."}`` or ``{"text": "..."}``
+    - malformed key-as-fact: ``{"Name is Thales": "<arbitrary value>"}``
+      (single-key dict where the key itself is the fact text — observed
+      with grok-style reasoning models on OpenAI-compatible APIs)
+    - other dicts: a single string value is taken as the fact text
+
+    This mirrors the TypeScript FactRetrievalSchema validation and the
+    OpenClaw zod-union patch.
     """
     if not raw_facts:
         return []
@@ -96,6 +104,13 @@ def normalize_facts(raw_facts):
             fact = item
         elif isinstance(item, dict):
             fact = item.get("fact") or item.get("text")
+            if fact is None and len(item) == 1:
+                # Malformed: LLM put the fact text as the dict key.
+                key, value = next(iter(item.items()))
+                if isinstance(key, str) and key.strip():
+                    fact = key.strip()
+                elif isinstance(value, str) and value.strip():
+                    fact = value.strip()
             if fact is None:
                 logger.warning("Unexpected fact shape from LLM, skipping: %s", item)
                 continue
@@ -103,6 +118,55 @@ def normalize_facts(raw_facts):
             fact = str(item)
         if fact:
             normalized.append(fact)
+    return normalized
+
+
+def normalize_extracted_memories(raw_memories):
+    """Normalize the ``memory`` array returned by the fact-extraction LLM.
+
+    Each ``extracted_memory`` is expected to be a dict like
+    ``{"text": "...", "event": "ADD"}``. Real LLM output sometimes deviates;
+    this helper tolerates the same malformed shapes that ``normalize_facts``
+    handles, preserving the dict shape downstream code expects (``text``,
+    ``event``, optional ``id`` / ``attributed_to``).
+
+    - Well-formed: returned as-is.
+    - ``{"fact": "..."}`` / ``{"text": ""}`` with text in ``fact``: copied.
+    - Malformed single-key ``{factText: value}``: synthesized as ``{"text": key,
+      "event": "ADD"}`` (the value is discarded; it's typically LLM noise).
+
+    Plain strings are wrapped as ``{"text": s, "event": "ADD"}`` for symmetry
+    with ``normalize_facts``.
+    """
+    if not raw_memories:
+        return []
+    normalized = []
+    for item in raw_memories:
+        if isinstance(item, str):
+            text = item.strip()
+            if text:
+                normalized.append({"text": text, "event": "ADD"})
+            continue
+        if not isinstance(item, dict):
+            continue
+        if item.get("text"):
+            normalized.append(item)
+            continue
+        fact = item.get("fact")
+        if fact:
+            new_item = dict(item)
+            new_item["text"] = fact
+            normalized.append(new_item)
+            continue
+        if len(item) == 1:
+            key, value = next(iter(item.items()))
+            if isinstance(key, str) and key.strip():
+                normalized.append({"text": key.strip(), "event": "ADD"})
+                continue
+            if isinstance(value, str) and value.strip():
+                normalized.append({"text": value.strip(), "event": "ADD"})
+                continue
+        logger.warning("Unexpected extracted-memory shape from LLM, skipping: %s", item)
     return normalized
 
 

--- a/tests/memory/test_memory_utils.py
+++ b/tests/memory/test_memory_utils.py
@@ -1,5 +1,10 @@
 import pytest
-from mem0.memory.utils import remove_spaces_from_entities, sanitize_relationship_for_cypher
+from mem0.memory.utils import (
+    normalize_extracted_memories,
+    normalize_facts,
+    remove_spaces_from_entities,
+    sanitize_relationship_for_cypher,
+)
 
 
 class TestRemoveSpacesFromEntities:
@@ -55,3 +60,76 @@ class TestRemoveSpacesFromEntities:
         f = remove_spaces_from_entities([dict(base)], sanitize_relationship=False)[0]["relationship"]
         assert t == sanitize_relationship_for_cypher("a/b")
         assert f == "a/b"
+
+
+class TestNormalizeFacts:
+    """Tolerates the malformed shapes real LLMs emit for the FACT_RETRIEVAL prompt."""
+
+    def test_plain_strings_pass_through(self):
+        assert normalize_facts(["one", "two"]) == ["one", "two"]
+
+    def test_well_formed_dicts(self):
+        assert normalize_facts([{"fact": "Name is Thales"}, {"text": "Lives in Vancouver"}]) == [
+            "Name is Thales",
+            "Lives in Vancouver",
+        ]
+
+    def test_malformed_key_as_fact(self):
+        """Observed with grok-on-OpenAI-compatible: fact text is the dict key."""
+        raw = [{"User's name is Thales.": "nova-check"}]
+        assert normalize_facts(raw) == ["User's name is Thales."]
+
+    def test_single_value_string_when_key_is_garbage(self):
+        raw = [{"_id": "abc-123"}]  # key is structurally meaningful, value is the fact? edge case
+        # We prefer the key when it's a non-empty string; this test pins that choice.
+        assert normalize_facts(raw) == ["_id"]
+
+    def test_empty_and_none_inputs(self):
+        assert normalize_facts(None) == []
+        assert normalize_facts([]) == []
+
+    def test_skip_unparseable(self, caplog):
+        # Multi-key dict with no fact/text falls through to the warning branch.
+        raw = [{"a": 1, "b": 2}]
+        out = normalize_facts(raw)
+        assert out == []
+
+
+class TestNormalizeExtractedMemories:
+    """Same shape tolerance as normalize_facts, but preserves dict structure
+    so downstream code can access .text / .event / .attributed_to."""
+
+    def test_well_formed_dicts_pass_through(self):
+        raw = [
+            {"text": "Name is Thales", "event": "ADD"},
+            {"text": "Lives in Vancouver", "event": "ADD", "attributed_to": "user"},
+        ]
+        assert normalize_extracted_memories(raw) == raw
+
+    def test_fact_key_promoted_to_text(self):
+        raw = [{"fact": "Name is Thales", "event": "ADD"}]
+        out = normalize_extracted_memories(raw)
+        assert out[0]["text"] == "Name is Thales"
+        assert out[0]["event"] == "ADD"
+
+    def test_malformed_key_as_fact_synthesizes_dict(self):
+        """The bug this patch fixes: single-key {factText: anything} from grok-style LLMs."""
+        raw = [{"User's name is Thales.": "nova-check"}]
+        out = normalize_extracted_memories(raw)
+        assert len(out) == 1
+        assert out[0] == {"text": "User's name is Thales.", "event": "ADD"}
+
+    def test_plain_string_wrapped(self):
+        out = normalize_extracted_memories(["bare string fact"])
+        assert out == [{"text": "bare string fact", "event": "ADD"}]
+
+    def test_non_dict_non_string_skipped(self):
+        assert normalize_extracted_memories([42, None, ["nested"]]) == []
+
+    def test_empty_and_none_inputs(self):
+        assert normalize_extracted_memories(None) == []
+        assert normalize_extracted_memories([]) == []
+
+    def test_multi_key_unparseable_skipped(self):
+        raw = [{"a": 1, "b": "value"}]
+        assert normalize_extracted_memories(raw) == []


### PR DESCRIPTION
## Summary

Tolerates the three malformed shapes that real LLMs (especially reasoning models on OpenAI-compatible APIs like xAI's grok endpoint) emit when extracting facts:

- `{"fact text as key": "<arbitrary value>"}` — single-key dict where the key IS the fact
- `{"fact": "..."}` — well-formed fact-key dict (already partially handled)
- plain strings

Currently the extraction path in `mem0/memory/main.py` silently drops the malformed case because downstream code does `m.get("text", "")` and gets an empty string. Memories are lost without any user-visible error.

Related to existing issues:

- #3918 (open, P1-high) — Unterminated JSON causes `new_retrieved_facts` to fail
- #4540 (closed) — Fact extraction silently fails on malformed JSON from non-OpenAI LLMs
- #4932 (open) — Fact extraction returns empty/garbage with reasoning models on OpenAI-compatible APIs
- #4662 (open PR) — robust JSON repair for malformed LLM output (complementary, different layer)

## Approach

1. Add `normalize_extracted_memories(raw)` to `memory/utils.py` that handles all three shapes and preserves the dict structure downstream code expects (`.text`, `.event`, optional `.attributed_to`).
2. Extend the existing-but-dormant `normalize_facts()` helper with the same shape tolerance.
3. Wire `normalize_extracted_memories()` into both fact-extraction parse sites in `memory/main.py` — sync `_add_to_vector_store` and async `_add_to_vector_store_async` — called immediately after JSON parsing.

## Backward compatibility

- Well-formed `{"text": "...", "event": "ADD"}` items pass through unchanged.
- Existing log-and-drop behavior is preserved for shapes that remain unparseable.
- No new dependencies.
- `normalize_facts()` previously had no callers; behavior change there is observable only to anyone who starts calling it.

## Test plan

13 new unit tests in `tests/memory/test_memory_utils.py`:

- `TestNormalizeFacts` — 6 cases (strings, well-formed dicts, malformed key-as-fact, single-value fallback, empty/None inputs, multi-key unparseable)
- `TestNormalizeExtractedMemories` — 7 cases (passthrough, fact→text promotion, malformed key synthesis, string wrapping, non-dict skipping, empty/None, multi-key unparseable)

All pass on Python 3.12 with a clean editable install (`pip install -e . && pytest tests/memory/test_memory_utils.py`).

## Repro snippet (before this PR)

```python
# This input from a grok-4-fast extraction gets silently dropped:
raw = [{"User's name is Thales.": "nova-check"}]
# downstream: [m.get("text", "") for m in raw if m.get("text")]  -> []
# memory lost without any user-visible error
```

After this PR, `normalize_extracted_memories(raw)` returns `[{"text": "User's name is Thales.", "event": "ADD"}]`, which the existing pipeline processes correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)