### PR TITLE
fix(memory): truncate conversation before Phase 1 embed to avoid 8192-token crash (#5148)

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -26,11 +26,13 @@ from mem0.memory.setup import mem0_dir, setup_config
 from mem0.memory.storage import SQLiteManager
 from mem0.memory.telemetry import MEM0_TELEMETRY, capture_event
 from mem0.memory.utils import (
+    DEFAULT_EMBED_TOKEN_LIMIT,
     extract_json,
     parse_messages,
     parse_vision_messages,
     process_telemetry_filters,
     remove_code_blocks,
+    truncate_text_to_token_limit,
 )
 from mem0.utils.entity_extraction import extract_entities, extract_entities_batch
 from mem0.utils.factory import (
@@ -704,10 +706,25 @@ class Memory(MemoryBase):
         parsed_messages = parse_messages(messages)
 
         # Phase 1: Existing memory retrieval
+        #
+        # The full concatenated conversation is used as the embedding query so
+        # we can dedupe against semantically-similar existing memories. Long
+        # conversations can exceed the embedding model's input limit
+        # (e.g. 8192 tokens for all current OpenAI embedding models), which
+        # would otherwise raise a 400 and fail the entire add() call before any
+        # extraction or storage runs (issue #5148). Truncate defensively here —
+        # Phase 2 (LLM fact extraction) still sees the full conversation.
         search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
-        query_embedding = self.embedding_model.embed(parsed_messages, "search")
+        embed_query = truncate_text_to_token_limit(parsed_messages, DEFAULT_EMBED_TOKEN_LIMIT)
+        if embed_query is not parsed_messages and len(embed_query) < len(parsed_messages):
+            logger.warning(
+                "Conversation text exceeds embedding token limit (~%d tokens); "
+                "truncating Phase 1 retrieval query. Fact extraction still uses the full conversation.",
+                DEFAULT_EMBED_TOKEN_LIMIT,
+            )
+        query_embedding = self.embedding_model.embed(embed_query, "search")
         existing_results = self.vector_store.search(
-            query=parsed_messages,
+            query=embed_query,
             vectors=query_embedding,
             top_k=10,
             filters=search_filters,
@@ -2119,11 +2136,20 @@ class AsyncMemory(MemoryBase):
         parsed_messages = parse_messages(messages)
 
         # Phase 1: Existing memory retrieval
+        # See sync `_add_to_vector_store` for rationale — embedding the raw
+        # concatenated conversation can exceed model token limits (issue #5148).
         search_filters = {k: v for k, v in effective_filters.items() if k in ("user_id", "agent_id", "run_id") and v}
-        query_embedding = await asyncio.to_thread(self.embedding_model.embed, parsed_messages, "search")
+        embed_query = truncate_text_to_token_limit(parsed_messages, DEFAULT_EMBED_TOKEN_LIMIT)
+        if embed_query is not parsed_messages and len(embed_query) < len(parsed_messages):
+            logger.warning(
+                "Conversation text exceeds embedding token limit (~%d tokens); "
+                "truncating Phase 1 retrieval query. Fact extraction still uses the full conversation.",
+                DEFAULT_EMBED_TOKEN_LIMIT,
+            )
+        query_embedding = await asyncio.to_thread(self.embedding_model.embed, embed_query, "search")
         existing_results = await asyncio.to_thread(
             self.vector_store.search,
-            query=parsed_messages,
+            query=embed_query,
             vectors=query_embedding,
             top_k=10,
             filters=search_filters,

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -70,6 +70,55 @@ def parse_messages(messages):
     return response
 
 
+# Conservative ceiling that fits every current OpenAI embedding model
+# (text-embedding-3-small/large and ada-002 all top out at 8192 tokens).
+# We leave a small safety margin so encoding overhead / BOS tokens don't
+# push us over the hard model limit.
+DEFAULT_EMBED_TOKEN_LIMIT = 8000
+
+
+def truncate_text_to_token_limit(text: str, max_tokens: int = DEFAULT_EMBED_TOKEN_LIMIT) -> str:
+    """Truncate ``text`` so that its tokenized length does not exceed ``max_tokens``.
+
+    Used before passing concatenated conversation text to an embedding model. All
+    current OpenAI embedding models cap input at 8192 tokens; sending more raises
+    a 400 error which, in ``Memory.add()`` Phase 1, fails the entire add() call
+    before any memory is extracted or stored (see issue #5148).
+
+    Token counting prefers ``tiktoken`` (already a transitive dependency via the
+    OpenAI SDK) and falls back to a conservative ~4 chars/token heuristic when
+    tiktoken or the encoding is unavailable. The fallback intentionally
+    over-truncates rather than risking an over-the-limit call.
+
+    The function is a no-op when ``text`` is below the limit.
+    """
+    if not text:
+        return text
+
+    try:
+        import tiktoken  # type: ignore
+
+        try:
+            encoding = tiktoken.get_encoding("cl100k_base")
+        except Exception:  # pragma: no cover - very narrow tiktoken init failure
+            encoding = None
+
+        if encoding is not None:
+            tokens = encoding.encode(text)
+            if len(tokens) <= max_tokens:
+                return text
+            return encoding.decode(tokens[:max_tokens])
+    except ImportError:
+        pass
+
+    # Fallback: char-based heuristic. Average English token ~= 4 chars; we use 4
+    # so the resulting string is *under* the token budget rather than at it.
+    char_budget = max_tokens * 4
+    if len(text) <= char_budget:
+        return text
+    return text[:char_budget]
+
+
 def format_entities(entities):
     if not entities:
         return ""

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -217,6 +217,147 @@ class TestAsyncAddToVectorStoreErrors:
         assert mock_async_memory.llm.generate_response.call_count == 1
 
 
+class TestLongConversationPhase1Embed:
+    """Regression tests for issue #5148.
+
+    Phase 1 of ``Memory.add()`` previously embedded the *entire* concatenated
+    conversation in one shot. Conversations beyond the embedding model's input
+    limit (8192 tokens for all current OpenAI embedding models) raised a
+    400 error that crashed the whole ``add()`` call before any extraction or
+    storage happened. We now truncate the Phase 1 query before embedding so
+    long inputs no longer crash, while Phase 2 fact extraction continues to
+    see the full conversation.
+    """
+
+    @pytest.fixture
+    def mock_memory(self, mocker):
+        mock_llm, _ = _setup_mocks(mocker)
+        # Phase 2 LLM returns a single extracted memory so Phase 3 also runs.
+        mock_llm.return_value.generate_response.return_value = (
+            '{"memory": [{"text": "user is planning a trip to Japan"}]}'
+        )
+
+        memory = Memory()
+        memory.config = mocker.MagicMock()
+        memory.config.custom_instructions = None
+        memory.config.custom_update_memory_prompt = None
+        memory.custom_instructions = None
+        memory.api_version = "v1.1"
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        return memory
+
+    @staticmethod
+    def _make_long_messages(num_turns: int = 400):
+        """Build a multi-turn conversation well over the 8192-token embedding limit.
+
+        Each turn contributes ~80 tokens of content; 400 turns lands around
+        30k+ tokens — comfortably past every OpenAI embedding model's cap.
+        """
+        filler = (
+            "I've been thinking through a bunch of unrelated topics today including "
+            "Japan travel plans, my current side project in Rust, dinner ideas, "
+            "and a tricky bug at work involving Kafka consumer rebalancing."
+        )
+        messages = []
+        for i in range(num_turns):
+            messages.append({"role": "user", "content": f"Turn {i} (user): {filler}"})
+            messages.append({"role": "assistant", "content": f"Turn {i} (assistant): {filler}"})
+        return messages
+
+    def test_long_conversation_does_not_crash_phase1_embed(self, mock_memory, caplog):
+        """Long conversations must not blow past the embedding model's token limit.
+
+        Pins the fix for #5148: before the fix, Phase 1 passed the full raw
+        conversation to ``embedding_model.embed`` and crashed with a 400 on
+        anything over ~8192 tokens. After the fix, the conversation is
+        truncated for the Phase 1 retrieval embed only.
+        """
+        embed_calls = []
+
+        def _record_embed(text, mode):  # noqa: D401 - test stub
+            embed_calls.append((text, mode))
+            # Simulate the real-world failure mode: any input over the model's
+            # token limit raises. If the production code forgets to truncate,
+            # this test will fail loudly — exactly the bug we're guarding.
+            # cl100k_base tokenizes ~4 chars/token, so 8192 tokens ~= 32k chars.
+            if mode == "search" and len(text) > 8192 * 5:
+                raise RuntimeError(
+                    "Embedding input exceeds model token limit "
+                    "(simulated OpenAI 400 BadRequest from issue #5148)"
+                )
+            return [0.1, 0.2, 0.3]
+
+        mock_memory.embedding_model = Mock()
+        mock_memory.embedding_model.embed = Mock(side_effect=_record_embed)
+        mock_memory.embedding_model.embed_batch = Mock(return_value=[[0.1, 0.2, 0.3]])
+        # Empty existing memory set keeps Phase 1 simple.
+        mock_memory.vector_store = Mock()
+        mock_memory.vector_store.search = Mock(return_value=[])
+        mock_memory.vector_store.insert = Mock()
+        mock_memory.db.add_history = MagicMock()
+
+        long_messages = self._make_long_messages(num_turns=400)
+
+        with caplog.at_level(logging.WARNING):
+            result = mock_memory._add_to_vector_store(
+                messages=long_messages, metadata={}, filters={}, infer=True
+            )
+
+        # Phase 1 must have been invoked with a *truncated* search query.
+        search_embed_calls = [c for c in embed_calls if c[1] == "search"]
+        assert len(search_embed_calls) == 1, "Expected exactly one Phase 1 search embed"
+        truncated_query = search_embed_calls[0][0]
+        assert len(truncated_query) <= 8192 * 5, (
+            "Phase 1 search embed was not truncated under the token limit"
+        )
+
+        # And the user-visible behaviour: add() returned the extracted memory
+        # rather than crashing.
+        assert isinstance(result, list)
+        assert any(item.get("memory") == "user is planning a trip to Japan" for item in result), (
+            f"Expected the extracted memory to be returned; got {result!r}"
+        )
+
+        # A warning should be logged so operators can see truncation happened.
+        assert any(
+            "embedding token limit" in record.message.lower() for record in caplog.records
+        ), "Expected a warning log when the Phase 1 query is truncated"
+
+    def test_short_conversation_is_not_truncated(self, mock_memory, caplog):
+        """Short conversations must pass through Phase 1 unchanged (no regression)."""
+        embed_calls = []
+
+        def _record_embed(text, mode):
+            embed_calls.append((text, mode))
+            return [0.1, 0.2, 0.3]
+
+        mock_memory.embedding_model = Mock()
+        mock_memory.embedding_model.embed = Mock(side_effect=_record_embed)
+        mock_memory.embedding_model.embed_batch = Mock(return_value=[[0.1, 0.2, 0.3]])
+        mock_memory.vector_store = Mock()
+        mock_memory.vector_store.search = Mock(return_value=[])
+        mock_memory.vector_store.insert = Mock()
+        mock_memory.db.add_history = MagicMock()
+
+        short_messages = [{"role": "user", "content": "Hello, I love sushi."}]
+
+        with caplog.at_level(logging.WARNING):
+            mock_memory._add_to_vector_store(
+                messages=short_messages, metadata={}, filters={}, infer=True
+            )
+
+        search_embed_calls = [c for c in embed_calls if c[1] == "search"]
+        assert len(search_embed_calls) == 1
+        # The Phase 1 query is the parsed conversation, which for one user
+        # turn is "user: Hello, I love sushi.\n" — must be passed through
+        # untouched.
+        assert "Hello, I love sushi." in search_embed_calls[0][0]
+        assert not any(
+            "embedding token limit" in record.message.lower() for record in caplog.records
+        ), "Did not expect a truncation warning for a short conversation"
+
+
 def _build_memory_instance(mocker, memory_cls):
     _setup_mocks(mocker)
     mocker.patch("mem0.memory.main.SQLiteManager", mocker.MagicMock())


### PR DESCRIPTION
## Problem

`Memory.add()` Phase 1 concatenates the full raw conversation into one string and passes it directly to `self.embedding_model.embed(parsed_messages, "search")` to look up existing memories for deduplication. All current OpenAI embedding models (`text-embedding-3-small`, `text-embedding-3-large`, `ada-002`) cap input at **8192 tokens** — anything longer raises a 400 `BadRequest` that fails the entire `add()` call before any fact extraction or storage runs.

This means a single long conversation (or one accumulated chat history) reliably crashes `add()` on production setups. Reported in #5148.

## Fix

Truncate the Phase 1 retrieval query to a conservative 8000-token ceiling before embedding. Critically, **Phase 2 (LLM fact extraction) continues to see the full conversation**, so memory content coverage is unchanged — only the dedup-lookup query is shortened.

- New helper `truncate_text_to_token_limit` in `mem0/memory/utils.py` — prefers `tiktoken` (already transitive via the OpenAI SDK), falls back to a ~4 chars/token heuristic if tiktoken is missing.
- Applied to both `Memory._add_to_vector_store` and `AsyncMemory._add_to_vector_store`.
- Logs a `WARNING` when truncation happens, so operators can see it.

## Test

New `TestLongConversationPhase1Embed` in `tests/memory/test_main.py`:
- Builds a ~400-turn conversation (~30k+ tokens).
- Mocks `embedding_model.embed` to raise if called with input over the model limit, simulating the real OpenAI 400.
- Asserts `_add_to_vector_store` completes, returns the extracted memory, and logs the truncation warning.
- Companion test asserts short conversations are passed through unchanged (no regression).

```
$ pytest tests/memory/test_main.py -q
36 passed in 18.15s
```

## Design alternatives considered

| Option | Pro | Con |
|---|---|---|
| **A. Truncate before embed (this PR)** | Tiny diff, removes the crash with no behavioural change for normal inputs. Phase 2/3 untouched. | Long conversations still embed only a prefix of the conversation for dedup — recall on multi-topic inputs is unchanged from today. |
| B. Use only the last N turns / N tokens for Phase 1 | Often improves recall (recent context is more relevant). | Changes Phase 1 semantics; requires a design decision and config knob. |
| C. Per-message embed + max similarity | Best recall on multi-topic conversations. | More embedding calls (cost + latency); larger code change. |
| D. Skip Phase 1 entirely above a token threshold | Simple; preserves recall for normal-sized inputs. | Large-conversation users silently lose the dedup optimization. |

Picked **A** because the bug is a crash, the user-visible fix is "don't crash," and that doesn't require a design discussion. Happy to do B or D as follow-ups if maintainers prefer; A and B/D are independently mergeable.

## Scope

- Python only. The TypeScript SDK has the same bug at `mem0-ts/src/oss/src/memory/index.ts` (`Memory.addToVectorStore`, Phase 1) and should get a parallel fix — left out of this PR because picking a JS tokenizer (`tiktoken-wasm` vs `gpt-tokenizer`) is its own discussion. Happy to open a follow-up PR for it.
- The 8000-token ceiling is a constant; it could be lifted to `MemoryConfig` if maintainers want it configurable per-deployment. Kept it constant here for the smallest possible diff.

Fixes #5148
