### PR TITLE
fix(memory): re-raise LLM extraction failures instead of returning []

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -744,8 +744,11 @@ class Memory(MemoryBase):
                 response_format={"type": "json_object"},
             )
         except Exception as e:
+            # PATCH (openclaw): re-raise so callers can implement provider fallback.
+            # The original silent ``return []`` makes upstream callers unable to
+            # distinguish "LLM unavailable" from "LLM extracted no facts".
             logger.error(f"LLM extraction failed: {e}")
-            return []
+            raise
 
         # Parse response
         try:
@@ -2161,8 +2164,9 @@ class AsyncMemory(MemoryBase):
                 response_format={"type": "json_object"},
             )
         except Exception as e:
+            # PATCH (openclaw): re-raise so callers can implement provider fallback.
             logger.error(f"LLM extraction failed (async): {e}")
-            return []
+            raise
 
         # Parse response
         try:


### PR DESCRIPTION
## Summary

Today, when ``self.llm.generate_response`` raises during fact extraction in ``_add_to_vector_store`` (and its async counterpart), mem0 catches the exception, logs ``LLM extraction failed: {e}``, and returns an empty list. The caller has no way to distinguish "LLM unavailable" from "LLM extracted no facts" — both look like ``[]``.

This makes provider-fallback wrappers impossible to build cleanly: anything wanting to retry on ``429`` / ``5xx`` / connection error / timeout can't tell whether to fall through.

## Change

Re-raise after logging, in both sync (``_add_to_vector_store``) and async (``_add_to_vector_store_async``) paths. The error is still logged at ERROR level for visibility.

## Why this is safe

- Existing callers that don't ``try/except`` around ``.add()`` will surface previously-silent failures. **This is the goal** — callers should be told the LLM is down, not given a silent empty result.
- Embedding failures already propagate (no analogous swallow), so this aligns ``.add()``'s contract: external dependency failures bubble; internal parsing/extraction-empty cases continue to return ``[]``.
- The parsing path immediately below (the second ``try/except``) still swallows ``json.JSONDecodeError`` — that's a different class of failure (LLM responded with non-JSON) and isn't changed.

## Use case driving this

Building a fallback chain in a wrapper service: primary LLM (xAI grok) → fallback (Anthropic) → fallback (local). The wrapper needs to retry ``.add()`` on the next provider when the current one errors. With the current behavior the wrapper sees an empty success and stops.

## Test plan

- Existing unit tests in ``tests/memory/`` still pass (no test currently asserts the silent-empty behavior).
- Manual: with an invalid ``openai_base_url``, ``.add()`` previously returned ``[]``; after this change, it raises ``openai.APIConnectionError`` (or similar).

## Companion PR

The same fork also has [#5176 (fact-shape normalization)](https://github.com/mem0ai/mem0/pull/5176) which is unrelated and can land independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)