### PR TITLE
Fix: set encoding_format to float for proxy compatibility.

### DIFF
--- a/mem0-ts/src/oss/src/embeddings/openai.ts
+++ b/mem0-ts/src/oss/src/embeddings/openai.ts
@@ -20,6 +20,7 @@ export class OpenAIEmbedder implements Embedder {
     const response = await this.openai.embeddings.create({
       model: this.model,
       input: text,
+      encoding_format: "float",
       ...(this.embeddingDims !== undefined && {
         dimensions: this.embeddingDims,
       }),
@@ -35,6 +36,7 @@ export class OpenAIEmbedder implements Embedder {
       const response = await this.openai.embeddings.create({
         model: this.model,
         input: chunk,
+        encoding_format: "float",
         ...(this.embeddingDims !== undefined && {
           dimensions: this.embeddingDims,
         }),


### PR DESCRIPTION
Ports the Python fix from #4058 to the TypeScript SDK.

Adds `encoding_format: "float"` to the `embed()` and `embedBatch()` methods in the OpenAI embedder to prevent silent failures when using OpenAI-compatible proxies (LiteLLM, vLLM, etc.).

Fixes #5168