### PR TITLE
feat: add gaussdb vector store provider

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,32 +1,36 @@
-# Mintlify Starter Kit
+﻿# GaussDB Documentation Notes
 
-Click on `Use this template` to copy the Mintlify starter kit. The starter kit contains examples including
+This directory contains the GaussDB-specific material added for the Mem0 vector store integration.
 
-- Guide pages
-- Navigation
-- Customizations
-- API Reference pages
-- Use of popular components
+## Main documents
 
-### Development
+- [Requirements Analysis](gaussdb-mem0-requirements-analysis.md)
+- [Technical Design](gaussdb-mem0-technical-design.md)
+- [User Guide](gaussdb-mem0-user-guide.md)
 
-Install the [Mintlify CLI](https://www.npmjs.com/package/mintlify) to preview the documentation changes locally. To install, use the following command
+## Preview locally
 
-```
+Install the Mintlify CLI:
+
+```bash
 npm i -g mintlify
 ```
 
-Run the following command at the root of your documentation (where mint.json is)
+Run the docs site from the `docs/` directory:
 
-```
+```bash
 mintlify dev
 ```
 
-### Publishing Changes
+## Scope
 
-Install our Github App to auto propagate changes from your repo to your deployment. Changes will be deployed to production automatically after pushing to the default branch. Find the link to install on your dashboard. 
+These GaussDB documents are intended to complement the standard Mem0 component documentation. They focus on:
 
-#### Troubleshooting
+- provider-specific design choices
+- deployment and operational guidance
+- centralized versus distributed behavior
+- filter semantics and known boundaries
 
-- Mintlify dev isn't running - Run `mintlify install` it'll re-install dependencies.
-- Page loads as a 404 - Make sure you are running in a folder with `mint.json`
+For public-facing integration docs, also see:
+
+- [GaussDB integration page](components/vectordbs/dbs/gaussdb.mdx)

--- a/docs/components/vectordbs/dbs/gaussdb.mdx
+++ b/docs/components/vectordbs/dbs/gaussdb.mdx
@@ -1,0 +1,199 @@
+﻿---
+title: "GaussDB"
+description: "Use GaussDB as a Mem0 vector store with native FLOATVECTOR support, scoped metadata filtering, and centralized BM25 keyword search."
+---
+
+GaussDB can be used as a Mem0 vector store provider for both centralized and distributed deployments, with centralized mode as the recommended production baseline.
+
+Current provider highlights:
+
+- native `FLOATVECTOR` storage
+- `gsdiskann` and `gsivfflat` vector indexes
+- scoped read isolation using `user_id`, `agent_id`, and `run_id`
+- typed exact metadata filtering
+- controlled typed range support for declared `number` and `datetime` fields
+- centralized BM25 `keyword_search`
+- optional custom schema support with `public` as the default
+
+## Driver
+
+Use a GaussDB-compatible `psycopg2` driver for your target GaussDB environment.
+
+The provider imports the driver through the `psycopg2` API and uses `ThreadedConnectionPool` internally.
+
+## Minimal usage
+
+```python Python
+import os
+from mem0 import Memory
+
+os.environ["OPENAI_API_KEY"] = "sk-xx"
+os.environ["GAUSSDB_DSN"] = "postgresql://gaussdb_user:gaussdb_password@127.0.0.1:19995/postgres"
+
+config = {
+    "vector_store": {
+        "provider": "gaussdb",
+        "config": {
+            "collection_name": "mem0_prod",
+            "embedding_model_dims": 1536,
+            "deployment_mode": "centralized",
+        },
+    },
+}
+
+memory = Memory.from_config(config)
+memory.add("I prefer window seats on morning flights.", user_id="alice")
+results = memory.search("flight seat preference", filters={"user_id": "alice"})
+```
+
+You can also provide the full connection string directly in config:
+
+```python Python
+config = {
+    "vector_store": {
+        "provider": "gaussdb",
+        "config": {
+            "connection_string": "postgresql://gaussdb_user:gaussdb_password@127.0.0.1:19995/postgres",
+            "collection_name": "mem0_prod",
+            "embedding_model_dims": 1536,
+            "deployment_mode": "centralized",
+        },
+    },
+}
+```
+
+## Main configuration fields
+
+| Parameter | Description | Default |
+| --- | --- | --- |
+| `connection_string` | Full GaussDB DSN | `None` |
+| `host` / `port` / `database` / `user` / `password` | Individual connection fields when no DSN is provided | `None` / `postgres` |
+| `collection_name` | Main collection table name | `mem0` |
+| `embedding_model_dims` | Embedding vector dimension | `1536` |
+| `deployment_mode` | `centralized` or `distributed` | `centralized` |
+| `vector_index_type` | `gsdiskann` or `gsivfflat` | `gsdiskann` |
+| `vector_metric` | `cosine` or `l2` | `cosine` |
+| `schema` | Optional advanced schema name | `public` |
+| `minconn` / `maxconn` | Connection pool bounds | `1` / `5` |
+| `auto_create` | Create collection automatically on init | `True` |
+| `require_scoped_filters` | Require positive scope filters on read paths | `True` |
+| `metadata_schema` | Optional typed metadata declarations | `{}` |
+| `sslmode` / `sslrootcert` | Optional SSL settings | `None` |
+
+## UTF8 recommendation
+
+The provider assumes UTF8 as the recommended database baseline.
+
+Current behavior:
+
+- all sessions set `client_encoding=UTF8`
+- initialization checks `server_encoding`
+- non-UTF8 servers trigger a warning instead of a hard startup failure
+
+For production, use a UTF8 database.
+
+## Scoped filtering
+
+By default, the provider requires a positive scope filter on read paths.
+
+Valid positive scope examples:
+
+```python
+{"user_id": "u1"}
+{"user_id": {"eq": "u1"}}
+{"user_id": {"in": ["u1", "u2"]}}
+```
+
+Invalid positive scope examples:
+
+```python
+{"user_id": {"ne": "u1"}}
+{"$not": [{"user_id": "u1"}]}
+{"$or": [{"user_id": "u1"}, {"category": "public"}]}
+{"user_id": "*"}
+```
+
+## Typed filters and range behavior
+
+Supported typed exact operators:
+
+- `eq`
+- `ne`
+- `in`
+- `nin`
+
+Typed range behavior:
+
+- declared `number` and `datetime` fields receive true typed range handling
+- undeclared range emits a warning and falls back to compatibility literal matching
+- malformed rows in declared ranges are ignored rather than failing the whole query
+
+Example:
+
+```python Python
+config = {
+    "vector_store": {
+        "provider": "gaussdb",
+        "config": {
+            "connection_string": "postgresql://gaussdb_user:gaussdb_password@127.0.0.1:19995/postgres",
+            "collection_name": "mem0_prod",
+            "embedding_model_dims": 1536,
+            "metadata_schema": {
+                "priority": "number",
+                "created_at": "datetime",
+            },
+        },
+    },
+}
+```
+
+## Wildcard, exists, missing, null
+
+The provider supports explicit metadata semantics for:
+
+- wildcard `*`
+- `exists`
+- `missing`
+- `null`
+
+Examples:
+
+```python
+{"category": "*"}
+{"optional": {"exists": True}}
+{"optional": {"missing": True}}
+{"optional": None}
+```
+
+## Score semantics
+
+GaussDB now returns raw distance instead of provider-specific normalized scores.
+
+That means:
+
+- smaller distance is better
+- score values should not be compared across providers
+
+## Keyword search
+
+- centralized mode: BM25 `keyword_search` supported
+- distributed mode: BM25 is not part of the current capability promise
+
+## Maintenance helper
+
+The provider exposes `analyze()` as an auxiliary maintenance interface.
+
+Recommended usage:
+
+- after collection creation
+- after bulk imports
+- during off-peak maintenance
+- troubleshooting and validation
+
+Do not treat it as a high-frequency request-path operation.
+
+## Commercial posture
+
+Centralized mode is the primary commercial deployment target.
+
+Distributed mode is supported for core vector-store behavior, but should be presented with a narrower capability statement than centralized mode, especially around keyword search.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -225,6 +225,7 @@
                               "components/vectordbs/dbs/qdrant",
                               "components/vectordbs/dbs/chroma",
                               "components/vectordbs/dbs/pgvector",
+                              "components/vectordbs/dbs/gaussdb",
                               "components/vectordbs/dbs/milvus",
                               "components/vectordbs/dbs/pinecone",
                               "components/vectordbs/dbs/mongodb",

--- a/docs/gaussdb-mem0-requirements-analysis.md
+++ b/docs/gaussdb-mem0-requirements-analysis.md
@@ -1,0 +1,205 @@
+﻿# Mem0 GaussDB Requirements Analysis
+
+> Updated: 2026-05-18  
+> Scope: `mem0.vector_stores.gaussdb.GaussDB`  
+> Audience: engineering review, provider acceptance review, delivery teams
+
+## 1. Purpose
+
+This document answers a practical question: does the current GaussDB provider meet the expectations for a Mem0 vector store integration, and is the centralized deployment ready for serious use?
+
+The analysis is based on the current implementation, the existing Mem0 vector store contract, the surrounding provider ecosystem, and the current GaussDB test and validation results.
+
+## 2. What Mem0 expects from a vector store provider
+
+At a minimum, a Mem0 vector store provider must support the common `VectorStoreBase` lifecycle:
+
+- collection creation and collection metadata lookup
+- insert / upsert
+- semantic search
+- read by id
+- update by id
+- delete by id
+- list / reset / collection deletion
+
+For a strong provider integration, Mem0 also benefits from:
+
+- batch search support
+- keyword search support when the backend can provide it
+- metadata filtering
+- stable user / agent / run isolation semantics
+- predictable behavior when a capability is unavailable
+
+## 3. Why GaussDB is a good fit
+
+GaussDB can support a production-ready Mem0 provider because it offers:
+
+- native vector data type support through `FLOATVECTOR`
+- native vector index support through `gsdiskann` and `gsivfflat`
+- JSONB payload storage for flexible memory metadata
+- centralized deployments that can support BM25 keyword search
+- enough SQL and indexing capability to implement scoped filtering, typed exact filters, and controlled typed ranges
+
+In other words, GaussDB does not force the provider into a toy adapter. The database can carry real vector retrieval, real metadata filters, and operational collection management.
+
+## 4. Current provider position inside the Mem0 ecosystem
+
+The current GaussDB provider is stronger than a minimal compatibility layer.
+
+It now includes:
+
+- centralized and distributed deployment modes
+- scoped reads using `user_id`, `agent_id`, and `run_id`
+- `search_batch`
+- centralized `keyword_search`
+- typed exact metadata filter semantics
+- wildcard, `exists`, `missing`, and `null` semantics
+- controlled typed range support for declared `number` and `datetime` fields
+- optional custom schema support with `public` as the default
+- UTF8 session handling and non-UTF8 server warnings
+
+Compared with older SQL-style providers such as `pgvector` and `azure_mysql`, the GaussDB integration now takes a clearer contract-oriented approach instead of relying on weak string-only filter behavior.
+
+## 5. Functional requirements and current status
+
+### 5.1 Core collection and CRUD behavior
+
+| Requirement | Status | Notes |
+| --- | --- | --- |
+| Create collection | Met | Automatic creation is supported when `auto_create=True`. |
+| Collection metadata lookup | Met | `col_info()` is implemented. |
+| Insert / upsert | Met | Uses `MERGE INTO` for atomic upsert behavior. |
+| Search | Met | Native vector search is implemented. |
+| Search batch | Met | Native path exists, with fallback behavior when needed. |
+| Get / update / delete by id | Met | Follows the existing Mem0 base contract. |
+| List / reset / delete collection | Met | Supported in centralized and distributed modes. |
+
+### 5.2 Filtering and isolation
+
+| Requirement | Status | Notes |
+| --- | --- | --- |
+| Scoped read isolation | Met | Controlled by `require_scoped_filters`, enabled by default. |
+| Typed exact filters | Met | `eq`, `ne`, `in`, and `nin` now support stable scalar semantics. |
+| Wildcard support | Met | `{"field": "*"}` skips the value constraint for regular metadata fields. |
+| Exists / missing / null | Met | Implemented with explicit behavior. |
+| Controlled typed range | Met | Supported for declared `number` and `datetime` fields. |
+| Undeclared range behavior | Met | Warning + compatibility fallback, aligned with current provider expectations. |
+
+### 5.3 Search and ranking behavior
+
+| Requirement | Status | Notes |
+| --- | --- | --- |
+| Vector search ranking | Met | Uses raw distance and follows the backend metric. |
+| Batch search | Met | Implemented. |
+| Keyword search | Partially met | Centralized mode supports BM25; distributed mode does not. |
+| Cross-provider score parity | Not a goal | Raw scores are not comparable across providers. |
+
+## 6. Non-functional requirements
+
+### 6.1 UTF8 requirement
+
+The GaussDB provider assumes that Mem0 should run on a UTF8 database.
+
+The implementation explicitly sets `client_encoding=UTF8`, and it warns when the database `server_encoding` is not UTF8. This is the right tradeoff for Mem0 because the provider deals with:
+
+- JSON payloads
+- multilingual memory text
+- metadata filtering on text content
+- optional BM25 text retrieval
+
+Non-UTF8 databases are not blocked, but they are not a recommended commercial deployment target.
+
+### 6.2 Safety and multi-tenant behavior
+
+The provider defaults to scoped reads. This makes GaussDB stricter than many current providers, but it is a reasonable design for commercial Mem0 deployments.
+
+### 6.3 Operational predictability
+
+The provider also makes several operational choices that improve delivery quality:
+
+- autocommit `analyze()` for environments where `ANALYZE` cannot run inside a transaction block
+- session-local vector index memory bump only when the current session value is too low
+- explicit schema qualification
+- automatic schema creation when permissions allow it
+
+## 7. Comparison with other Mem0 providers
+
+### 7.1 Against `pgvector`
+
+GaussDB now goes beyond the classic `pgvector` style in several areas:
+
+- stronger scope enforcement
+- typed exact filter semantics instead of broad string coercion
+- controlled typed range support
+- explicit wildcard / exists / missing behavior
+- optional schema configuration
+
+`pgvector` remains a simpler reference provider, but GaussDB is now closer to a commercial-grade integration.
+
+### 7.2 Against `azure_mysql`
+
+Both providers are SQL-based and rely on payload metadata, but GaussDB now has stronger scoped filtering and more complete typed filter behavior.
+
+### 7.3 Against `qdrant`
+
+Qdrant still has the cleanest native typed payload filter model because the backend natively understands those types. GaussDB does not try to pretend it is Qdrant. Instead, it implements a controlled and explicit subset:
+
+- typed exact filters
+- controlled typed range for declared fields
+- compatibility fallback for undeclared range
+
+That is a defensible design for a SQL/JSON provider.
+
+## 8. Centralized readiness
+
+For centralized deployments, the provider is now in strong shape.
+
+The current branch already has:
+
+- green local unit coverage for the GaussDB provider suite
+- centralized commercial validation coverage
+- live validation against a real centralized GaussDB environment
+- aligned requirements, design, and user-facing documentation
+
+From a practical acceptance perspective, centralized GaussDB is ready to be reviewed as a Mem0 provider candidate.
+
+## 9. Distributed status
+
+Distributed mode is intentionally more conservative.
+
+Current boundary:
+
+- vector CRUD and search are supported
+- scoped filtering is supported
+- `search_batch` is supported
+- distributed BM25 is not supported
+
+This is acceptable as long as the PR description and docs state the distributed boundary honestly.
+
+## 10. Known boundaries
+
+These are not hidden bugs. They are explicit boundaries that should be documented:
+
+1. `get`, `update`, and `delete` still follow the Mem0 base contract and work by id without read-path scope enforcement.
+2. Cross-provider score comparison is not meaningful.
+3. Distributed mode does not support BM25 / `keyword_search`.
+4. `analyze()` is an auxiliary maintenance interface, not a core application-path feature.
+
+## 11. Final recommendation
+
+### Centralized mode
+
+Centralized GaussDB is ready for PR review and is strong enough for commercial use in the Mem0 context.
+
+### Distributed mode
+
+Distributed mode is viable, but it should be presented with a narrower capability statement than centralized mode.
+
+### Overall recommendation
+
+Yes, the provider now satisfies the practical Mem0 acceptance bar for a new vector store provider, especially for centralized deployments, provided that the PR clearly explains:
+
+- the centralized-first recommendation
+- the distributed BM25 boundary
+- the UTF8 database recommendation
+- the current range and scope semantics

--- a/docs/gaussdb-mem0-technical-design.md
+++ b/docs/gaussdb-mem0-technical-design.md
@@ -1,0 +1,412 @@
+﻿# Mem0 GaussDB Technical Design
+
+> Updated: 2026-05-18  
+> Main code: `mem0/vector_stores/gaussdb.py`, `mem0/configs/vector_stores/gaussdb.py`
+
+## 1. Design goal
+
+The GaussDB provider is designed to make GaussDB behave like a serious Mem0 vector store, not just a thin SQL compatibility adapter.
+
+The design goals are:
+
+1. preserve the existing Mem0 provider contract
+2. provide a strong centralized deployment story
+3. keep distributed behavior explicit and honest
+4. support stable scoped filtering and metadata filtering
+5. avoid fake support for capabilities that the provider cannot implement correctly
+
+## 2. High-level architecture
+
+The provider sits under the standard Mem0 memory layer.
+
+```text
+Memory / AsyncMemory
+  -> vector store factory
+    -> GaussDBConfig
+    -> GaussDB provider
+       -> connection pool
+       -> capability checks
+       -> collection lifecycle
+       -> filter compiler
+       -> vector / keyword search
+```
+
+The provider is responsible for translating Mem0 operations into GaussDB-specific SQL, while preserving Mem0 expectations as closely as possible.
+
+## 3. Configuration model
+
+### 3.1 Base connection configuration
+
+The provider accepts either:
+
+- a full `connection_string`
+- or `host`, `port`, `database`, `user`, and `password`
+
+Optional connection settings:
+
+- `sslmode`
+- `sslrootcert`
+- `minconn`
+- `maxconn`
+
+### 3.2 Deployment and vector configuration
+
+Important provider options:
+
+- `deployment_mode`: `centralized` or `distributed`
+- `vector_index_type`: `gsdiskann` or `gsivfflat`
+- `vector_metric`: `cosine` or `l2`
+- `embedding_model_dims`
+- `collection_name`
+- `schema` (advanced, default `public`)
+
+### 3.3 Advanced behavior configuration
+
+Additional advanced options:
+
+- `auto_create`
+- `require_scoped_filters`
+- `metadata_schema`
+
+`metadata_schema` is used to declare fields that should receive typed behavior, especially for controlled range support.
+
+Example:
+
+```python
+metadata_schema = {
+    "priority": "number",
+    "created_at": "datetime",
+    "flag": "bool",
+    "category": "string",
+}
+```
+
+## 4. Connection handling
+
+### 4.1 Pooling
+
+The provider uses `ThreadedConnectionPool`.
+
+Default bounds:
+
+- `minconn=1`
+- `maxconn=5`
+
+This is intentionally conservative and aligns with the style of other SQL-oriented providers in Mem0.
+
+### 4.2 UTF8 session handling
+
+Every connection is configured with `client_encoding=UTF8`.
+
+In addition, initialization checks the database `server_encoding`. If the server is not UTF8, the provider logs a warning instead of blocking startup.
+
+This gives the best tradeoff for Mem0:
+
+- UTF8 remains the recommended deployment baseline
+- historical non-UTF8 environments are surfaced early
+- the provider stays usable for controlled diagnostics or migration scenarios
+
+## 5. Schema and collection model
+
+### 5.1 Default schema
+
+The provider now supports an optional `schema` configuration value.
+
+- default: `public`
+- custom schema: allowed when the identifier is safe
+
+If the configured schema does not exist, the provider attempts to create it during collection creation.
+
+### 5.2 Single-provider-instance / single-collection model
+
+A provider instance is bound to one logical collection table.
+
+That means:
+
+- one `collection_name`
+- one main table
+- one schema metadata table
+
+The provider does not support implicit table switching inside the same instance.
+
+## 6. Main table design
+
+The collection table stores:
+
+- `id`
+- `vector`
+- `payload`
+- `memory`
+- `text_lemmatized`
+- `created_at`
+- `updated_at`
+- `user_id`
+- `agent_id`
+- `run_id`
+
+The important design change is that `user_id`, `agent_id`, and `run_id` are treated as first-class columns rather than only implicit payload-derived metadata.
+
+That gives the provider:
+
+- stronger scoped filtering
+- clearer indexing
+- cleaner delivery semantics for multi-tenant deployments
+
+## 7. Collection lifecycle
+
+### 7.1 Creation
+
+Collection creation is responsible for:
+
+- ensuring the target schema exists
+- creating the main collection table
+- creating the schema metadata table
+- creating the vector index
+- creating scoped indexes
+- creating BM25 structures when centralized BM25 is enabled
+
+### 7.2 Reset and deletion
+
+The provider supports:
+
+- `reset()`
+- `delete_col()`
+- `list_cols()`
+- `col_info()`
+
+`list_cols()` remains a management-oriented helper, not a hard security boundary.
+
+## 8. Capability and environment checks
+
+The provider performs environment checks to validate whether the target deployment supports the features it wants to use.
+
+The exact probes are less important than the principle:
+
+- prefer explicit capability checks
+- fall back gracefully when safe
+- do not silently pretend a feature exists when it does not
+
+## 9. Insert and upsert path
+
+The provider uses `MERGE INTO` for atomic upsert behavior.
+
+Why this matters:
+
+- avoids split `UPDATE + INSERT` races
+- maps well to the target GaussDB environment
+- gives predictable behavior under concurrent writes
+
+Insert / upsert also keeps scoped columns synchronized with the payload.
+
+## 10. Filter engine design
+
+This is the most important part of the current provider design.
+
+### 10.1 Scope guard
+
+`require_scoped_filters=True` by default.
+
+The provider requires a positive scoped filter for these read paths:
+
+- `search`
+- `keyword_search`
+- `search_batch`
+- `list`
+
+Accepted scope keys:
+
+- `user_id`
+- `agent_id`
+- `run_id`
+
+Positive scope examples:
+
+- `{"user_id": "u1"}`
+- `{"user_id": {"eq": "u1"}}`
+- `{"user_id": {"in": ["u1", "u2"]}}`
+
+Rejected as non-positive scope:
+
+- `{"user_id": {"ne": "u1"}}`
+- `{"$not": [{"user_id": "u1"}]}`
+- `{"$or": [{"user_id": "u1"}, {"category": "public"}]}`
+- `{"user_id": "*"}`
+
+### 10.2 Typed exact filters
+
+The provider supports stable scalar semantics for:
+
+- `eq`
+- `ne`
+- `in`
+- `nin`
+
+Supported scalar families:
+
+- string
+- number
+- bool
+- null
+
+This is a major improvement over broad `str(value)` coercion used by simpler SQL-style providers.
+
+### 10.3 Wildcard
+
+For ordinary metadata fields:
+
+- `{"field": "*"}` means: do not constrain the field value
+
+For scope fields:
+
+- `*` does not count as a valid positive scope
+
+### 10.4 Exists, missing, and null
+
+The provider distinguishes:
+
+- field exists
+- field missing
+- field exists with JSON null
+
+This distinction is explicit rather than accidental.
+
+### 10.5 Typed range
+
+The provider supports controlled typed range for fields declared in `metadata_schema` as:
+
+- `number`
+- `datetime`
+
+Examples:
+
+```python
+{"priority": {"gte": 3, "lt": 10}}
+{"created_at": {"lt": "2026-01-01T00:00:00Z"}}
+```
+
+#### Undeclared fields
+
+For undeclared fields, the provider does not hard-fail.
+
+Instead it:
+
+- emits a warning
+- falls back to compatibility literal matching
+
+This keeps the behavior closer to the current Mem0 provider ecosystem while preserving stronger typed behavior where explicitly declared.
+
+#### Dirty rows in declared ranges
+
+For declared `number` and `datetime` fields, malformed rows are ignored rather than causing the entire query to fail.
+
+That is the right search-path tradeoff:
+
+- typed semantics for valid rows
+- graceful handling of historical bad data
+
+### 10.6 Text operators
+
+The provider supports:
+
+- `contains`
+- `icontains`
+
+These remain text-oriented operators. They are intentionally separate from typed exact and typed range behavior.
+
+## 11. Search behavior
+
+### 11.1 Semantic search
+
+The provider uses the configured vector metric:
+
+- `cosine`
+- `l2`
+
+### 11.2 Score semantics
+
+The provider now returns raw distance.
+
+This is intentional.
+
+GaussDB no longer applies provider-specific score normalization because that made it a special case among Mem0 providers without solving cross-provider score comparability.
+
+Result:
+
+- smaller distance is better
+- score values still should not be compared across different providers
+
+### 11.3 Keyword search
+
+In centralized mode, the provider can use BM25 for `keyword_search`.
+
+In distributed mode, BM25 is disabled by design and `keyword_search` is not part of the distributed capability promise.
+
+### 11.4 Batch search
+
+`search_batch()` is implemented and treated as a real provider capability, not just a convenience wrapper.
+
+## 12. Maintenance interface
+
+### 12.1 `analyze()`
+
+`analyze()` is intentionally kept as an auxiliary maintenance interface.
+
+It is not a core Mem0 application-path capability.
+
+Its design characteristics:
+
+- uses autocommit
+- suitable after collection creation, bulk import, or manual maintenance
+- should not be called on hot business paths
+
+This position aligns better with the broader Mem0 provider ecosystem, where most providers do not expose an explicit maintenance operation of this kind.
+
+## 13. Operational defaults
+
+### 13.1 UTF8-first
+
+Recommended and supported baseline:
+
+- UTF8 database
+- UTF8 client session
+
+### 13.2 Vector index maintenance memory
+
+The provider raises session-local `maintenance_work_mem` only when required and only when the current value is lower than the target.
+
+For high-dimensional index build paths, this avoids both under-provisioning and unnecessary downscoping of already larger DBA settings.
+
+### 13.3 Schema default
+
+The provider defaults to `public`, but allows an advanced `schema` override.
+
+## 14. Testing model
+
+The current branch uses layered validation:
+
+1. provider unit tests
+2. commercial validation tests
+3. centralized live validation
+4. distributed validation when an internal distributed environment is available
+
+This matters because the provider includes behavior that is easier to reason about than to guarantee without real database execution, especially around:
+
+- BM25 behavior
+- scoped filtering
+- range behavior on dirty data
+- connection/session configuration
+
+## 15. Final design assessment
+
+The current GaussDB provider is no longer a thin fork of an older SQL-style implementation.
+
+Its main design qualities are:
+
+- explicit scoped-read model
+- stronger typed exact semantics
+- controlled typed range semantics
+- raw-distance score alignment with other SQL-style providers
+- UTF8-first operational posture
+- centralized-first commercial story
+
+The result is a provider that is much easier to review, explain, and operate in a real Mem0 deployment.

--- a/docs/gaussdb-mem0-user-guide.md
+++ b/docs/gaussdb-mem0-user-guide.md
@@ -1,0 +1,384 @@
+﻿# Mem0 GaussDB User Guide
+
+> Updated: 2026-05-18  
+> Audience: application developers, DBAs, QA, solution teams, support engineers
+
+## 1. What this guide is for
+
+This guide explains how to use the GaussDB vector store provider in real Mem0 deployments.
+
+It focuses on:
+
+- how to configure the provider
+- what centralized and distributed modes support
+- how scoped filtering works
+- how metadata filters behave
+- what to expect from range filters, wildcard, `exists`, `missing`, and `null`
+- which operational behaviors matter in production
+
+## 2. Quick recommendations
+
+If you only want the short version, keep these points in mind:
+
+1. Prefer centralized mode unless you explicitly need distributed deployment.
+2. Use a UTF8 GaussDB database.
+3. Keep `require_scoped_filters=True` in multi-tenant production environments.
+4. Use `metadata_schema` when you want true typed range behavior.
+5. Treat `analyze()` as an optional maintenance helper, not a normal request-path call.
+6. Assume cross-provider score comparison is invalid.
+
+## 3. Minimal setup
+
+### 3.1 Install the Python package
+
+```bash
+pip install mem0ai
+```
+
+For local development in this repository:
+
+```bash
+pip install -e ".[vector_stores,llms,nlp]"
+```
+
+### 3.2 Basic configuration
+
+```python
+from mem0 import Memory
+
+config = {
+    "vector_store": {
+        "provider": "gaussdb",
+        "config": {
+            "host": "127.0.0.1",
+            "port": 19995,
+            "database": "postgres",
+            "user": "lxm",
+            "password": "Gauss_234",
+            "collection_name": "mem0_prod",
+            "embedding_model_dims": 1536,
+            "deployment_mode": "centralized",
+        },
+    }
+}
+
+memory = Memory.from_config(config)
+```
+
+You can also use `connection_string` instead of separate connection fields.
+
+## 4. Recommended production baseline
+
+Recommended defaults for most production deployments:
+
+```python
+{
+    "vector_store": {
+        "provider": "gaussdb",
+        "config": {
+            "connection_string": "postgresql://user:password@host:19995/postgres",
+            "collection_name": "mem0_prod",
+            "embedding_model_dims": 1536,
+            "deployment_mode": "centralized",
+            "vector_index_type": "gsdiskann",
+            "vector_metric": "cosine",
+            "minconn": 1,
+            "maxconn": 5,
+            "auto_create": True,
+            "require_scoped_filters": True,
+        },
+    }
+}
+```
+
+## 5. Optional advanced configuration
+
+### 5.1 Custom schema
+
+The provider defaults to `public`, but you can override it:
+
+```python
+"config": {
+    "connection_string": "postgresql://user:password@host:19995/postgres",
+    "collection_name": "mem0_prod",
+    "schema": "mem0_app",
+}
+```
+
+If the schema does not exist, the provider attempts to create it during collection creation.
+
+### 5.2 Metadata schema
+
+Use `metadata_schema` when you want controlled typed behavior:
+
+```python
+"metadata_schema": {
+    "priority": "number",
+    "created_at": "datetime",
+    "flag": "bool",
+    "category": "string",
+}
+```
+
+Supported declarations:
+
+- `string`
+- `text`
+- `number`
+- `bool`
+- `datetime`
+
+## 6. UTF8 recommendation
+
+The GaussDB provider is designed with UTF8 as the recommended database baseline.
+
+Current implementation behavior:
+
+- every connection sets `client_encoding=UTF8`
+- the provider checks `server_encoding`
+- if the database server is not UTF8, the provider logs a warning
+
+Why this matters:
+
+- Mem0 payloads are JSON-heavy
+- multilingual memory text is common
+- text filters and keyword search are much safer in UTF8 databases
+
+Recommended rule:
+
+> Use a UTF8 database for supported and production-ready Mem0 deployments on GaussDB.
+
+## 7. Centralized vs distributed
+
+### 7.1 Centralized mode
+
+Centralized mode is the recommended deployment mode.
+
+It supports:
+
+- vector CRUD
+- semantic search
+- `search_batch`
+- metadata filters
+- scoped reads
+- centralized BM25 `keyword_search`
+- typed exact metadata filters
+- controlled typed range
+
+### 7.2 Distributed mode
+
+Distributed mode is intentionally narrower.
+
+It supports the core vector-store paths, but BM25 / `keyword_search` is not part of the distributed contract.
+
+## 8. Scoped filtering
+
+### 8.1 Default behavior
+
+`require_scoped_filters=True` by default.
+
+That means these read paths require at least one valid positive scope filter:
+
+- `search`
+- `keyword_search`
+- `search_batch`
+- `list`
+
+Scope fields are:
+
+- `user_id`
+- `agent_id`
+- `run_id`
+
+### 8.2 Valid examples
+
+These are valid positive scope filters:
+
+```python
+{"user_id": "u1"}
+{"user_id": {"eq": "u1"}}
+{"user_id": {"in": ["u1", "u2"]}}
+```
+
+These are not valid positive scope filters:
+
+```python
+{"user_id": {"ne": "u1"}}
+{"$not": [{"user_id": "u1"}]}
+{"$or": [{"user_id": "u1"}, {"category": "public"}]}
+{"user_id": "*"}
+```
+
+### 8.3 When to keep it enabled
+
+Keep `require_scoped_filters=True` when:
+
+- the deployment is multi-tenant
+- you want provider-level safety against broad accidental reads
+- the application maps memories to users, agents, or runs
+
+### 8.4 When you may disable it
+
+You may consider disabling it only for:
+
+- controlled diagnostics
+- trusted maintenance tools
+- isolated data migration tasks
+- test harnesses
+
+When disabled, the provider no longer requires a scope on read paths, but all other filter rules still apply.
+
+## 9. Metadata filter behavior
+
+### 9.1 Typed exact behavior
+
+The provider supports:
+
+- `eq`
+- `ne`
+- `in`
+- `nin`
+
+These now behave correctly for:
+
+- string
+- number
+- bool
+- null
+
+### 9.2 Wildcard
+
+For ordinary metadata fields:
+
+```python
+{"category": "*"}
+```
+
+This means: do not constrain `category` by value.
+
+For scope fields, wildcard still does **not** count as a valid positive scope.
+
+### 9.3 Exists, missing, and null
+
+The provider distinguishes these three cases:
+
+- field exists
+- field is missing
+- field exists and its value is JSON null
+
+Examples:
+
+```python
+{"optional": {"exists": True}}
+{"optional": {"missing": True}}
+{"optional": None}
+```
+
+## 10. Range filters
+
+### 10.1 Declared fields
+
+If a field is declared as `number` or `datetime` in `metadata_schema`, the provider performs real typed range behavior.
+
+Examples:
+
+```python
+{"priority": {"gte": 3, "lt": 10}}
+{"created_at": {"lt": "2026-01-01T00:00:00Z"}}
+```
+
+### 10.2 Undeclared fields
+
+If the field is not declared for typed range:
+
+- the provider does not fail the query
+- it emits a warning
+- it falls back to compatibility literal matching
+
+This behavior is intentionally closer to the current Mem0 provider ecosystem.
+
+### 10.3 Dirty historical rows
+
+For declared `number` and `datetime` fields, malformed rows are ignored instead of causing the whole query to fail.
+
+This keeps search stable while still honoring typed range semantics for valid rows.
+
+## 11. Score semantics
+
+The provider returns raw distance.
+
+That means:
+
+- smaller distance is better
+- the value is backend-metric dependent
+- it should not be compared across providers
+
+This aligns GaussDB more closely with other SQL-style providers instead of making it the only normalized-score special case.
+
+## 12. Keyword search
+
+### 12.1 Centralized mode
+
+Centralized mode can support `keyword_search()` through BM25.
+
+### 12.2 Distributed mode
+
+Distributed mode does not promise BM25 / `keyword_search()` support.
+
+If your workflow requires keyword retrieval, plan centralized deployment.
+
+## 13. Maintenance helper: `analyze()`
+
+`analyze()` is available as an auxiliary maintenance interface.
+
+Use cases:
+
+- after collection creation
+- after large bulk imports
+- during off-peak maintenance
+- diagnostics or test runs
+
+Do **not** treat it as a normal high-frequency application-path operation.
+
+## 14. Troubleshooting
+
+### The provider warns about non-UTF8 server encoding
+
+Meaning:
+
+- the database is not using UTF8
+- the provider can still try to connect
+- text, JSON, metadata filtering, or keyword retrieval may be unstable
+
+Recommended action:
+
+- use a UTF8 database for production deployments
+
+### Range query does not behave as expected
+
+Check:
+
+- whether the field is declared in `metadata_schema`
+- whether the declaration is `number` or `datetime`
+- whether the stored values are valid for that declared type
+
+### Scoped read error
+
+Check:
+
+- whether you passed at least one positive `user_id`, `agent_id`, or `run_id`
+- whether your scope expression uses a real narrowing operator rather than `ne`, `not`, or a loose `or`
+
+### BM25 not available in distributed mode
+
+That is expected under the current distributed capability statement.
+
+## 15. Practical rollout advice
+
+For the cleanest rollout:
+
+1. start with centralized mode
+2. use a UTF8 database
+3. keep `require_scoped_filters=True`
+4. declare `metadata_schema` only for fields that really need typed range semantics
+5. validate with the GaussDB commercial validation tests before production traffic

--- a/mem0/configs/vector_stores/gaussdb.py
+++ b/mem0/configs/vector_stores/gaussdb.py
@@ -1,0 +1,147 @@
+import os
+import re
+from typing import Any, Dict, Optional
+
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, model_validator
+
+
+_ENV_DEFAULTS = {
+    "connection_string": ("GAUSSDB_CONNECTION_STRING", "GAUSSDB_DSN", "GAUSSDB_URL"),
+    "host": ("GAUSSDB_HOST",),
+    "port": ("GAUSSDB_PORT",),
+    "database": ("GAUSSDB_DATABASE", "GAUSSDB_DBNAME"),
+    "user": ("GAUSSDB_USER",),
+    "password": ("GAUSSDB_PASSWORD",),
+    "sslmode": ("GAUSSDB_SSLMODE",),
+    "sslrootcert": ("GAUSSDB_SSLROOTCERT",),
+    "schema": ("GAUSSDB_SCHEMA",),
+}
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,62}$")
+
+
+def _first_env(names: tuple[str, ...]) -> Optional[str]:
+    for name in names:
+        value = os.getenv(name)
+        if value:
+            return value
+    return None
+
+
+class GaussDBConfig(BaseModel):
+    # Connection
+    database: str = Field("postgres", description="GaussDB database name")
+    collection_name: str = Field("mem0", description="Name of the collection table")
+    embedding_model_dims: int = Field(1536, description="Dimensions of the embedding model")
+    user: Optional[str] = Field(None, description="Database user")
+    password: Optional[str] = Field(None, description="Database password")
+    host: Optional[str] = Field(None, description="Database host")
+    port: Optional[int] = Field(None, description="Database port")
+    connection_string: Optional[str] = Field(None, description="GaussDB connection string (overrides host/port/user/password)")
+    sslmode: Optional[str] = Field(None, description="SSL mode (e.g., require, prefer, disable)")
+    sslrootcert: Optional[str] = Field(None, description="SSL root certificate path")
+    schema_name: str = Field(
+        "public",
+        validation_alias=AliasChoices("schema", "schema_name"),
+        serialization_alias="schema",
+        description="Optional advanced schema name; defaults to public",
+    )
+    minconn: int = Field(1, description="Minimum number of connections in the pool")
+    maxconn: int = Field(5, description="Maximum number of connections in the pool")
+
+    # Deployment & Vector
+    deployment_mode: str = Field(
+        "centralized",
+        description="GaussDB deployment mode: centralized or distributed",
+    )
+    vector_index_type: str = Field("gsdiskann", description="Vector index type: gsdiskann or gsivfflat")
+    vector_metric: str = Field("cosine", description="Vector metric: cosine or l2")
+
+    # Operational
+    auto_create: bool = Field(True, description="Automatically create collection on init if it does not exist")
+    require_scoped_filters: bool = Field(
+        True,
+        description="Require at least one positive scoped filter (user_id, agent_id, run_id) on read paths; strongly recommended for production multi-tenant use",
+    )
+    metadata_schema: Dict[str, str] = Field(
+        default_factory=dict,
+        description="Optional advanced metadata type declarations used for typed range and future typed filter behavior",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def resolve_env_and_validate(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        for field, env_names in _ENV_DEFAULTS.items():
+            if not values.get(field):
+                env_val = _first_env(env_names)
+                if env_val:
+                    values[field] = env_val
+
+        allowed_fields = set(cls.model_fields.keys()) | {"schema"}
+        input_fields = set(values.keys())
+        extra_fields = input_fields - allowed_fields
+        if extra_fields:
+            raise ValueError(
+                f"Extra fields not allowed: {', '.join(extra_fields)}. "
+                f"Allowed fields: {', '.join(sorted(allowed_fields))}"
+            )
+
+        if not values.get("connection_string"):
+            user, password = values.get("user"), values.get("password")
+            host, port = values.get("host"), values.get("port")
+            if bool(user) != bool(password):
+                raise ValueError("When 'connection_string' is not provided, both 'user' and 'password' must be provided together.")
+            if not user and not password:
+                raise ValueError("Either 'connection_string' or both 'user' and 'password' must be provided.")
+            if bool(host) != bool(port):
+                raise ValueError("When 'connection_string' is not provided, both 'host' and 'port' must be provided together.")
+            if not host and not port:
+                raise ValueError("Either 'connection_string' or both 'host' and 'port' must be provided.")
+        return values
+
+    @model_validator(mode="after")
+    def validate_values(self):
+        if self.deployment_mode not in ("centralized", "distributed"):
+            raise ValueError(f"deployment_mode must be 'centralized' or 'distributed', got '{self.deployment_mode}'")
+        if self.vector_index_type not in ("gsdiskann", "gsivfflat"):
+            raise ValueError(f"vector_index_type must be 'gsdiskann' or 'gsivfflat', got '{self.vector_index_type}'")
+        if self.vector_metric not in ("cosine", "l2"):
+            raise ValueError(f"vector_metric must be 'cosine' or 'l2', got '{self.vector_metric}'")
+        if self.deployment_mode == "distributed" and self.embedding_model_dims > 1024:
+            raise ValueError(
+                f"GaussDB distributed mode only supports embedding dimensions <= 1024, "
+                f"but embedding_model_dims={self.embedding_model_dims}."
+            )
+        if self.deployment_mode == "centralized" and self.embedding_model_dims > 4096:
+            raise ValueError(
+                f"GaussDB centralized mode only supports embedding dimensions <= 4096, "
+                f"but embedding_model_dims={self.embedding_model_dims}."
+            )
+        if self.embedding_model_dims > 1024 and self.vector_index_type != "gsdiskann":
+            raise ValueError(
+                f"embedding_model_dims={self.embedding_model_dims} exceeds 1024; "
+                f"only GsDiskANN supports >1024 dimensions. Set vector_index_type='gsdiskann'."
+            )
+        if self.minconn < 1:
+            raise ValueError("minconn must be >= 1")
+        if self.maxconn < 1:
+            raise ValueError("maxconn must be >= 1")
+        if self.maxconn < self.minconn:
+            raise ValueError("maxconn must be >= minconn")
+        if not isinstance(self.schema_name, str) or not _IDENTIFIER_RE.match(self.schema_name):
+            raise ValueError("schema must be a safe identifier using letters, numbers, and underscores")
+        allowed_metadata_types = {"string", "text", "number", "bool", "datetime"}
+        for key, value in self.metadata_schema.items():
+            if not isinstance(key, str) or not key:
+                raise ValueError("metadata_schema keys must be non-empty strings")
+            if value not in allowed_metadata_types:
+                raise ValueError(
+                    f"metadata_schema[{key!r}] must be one of {sorted(allowed_metadata_types)}, got {value!r}"
+                )
+        return self
+
+    @property
+    def schema(self) -> str:
+        return self.schema_name
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True)

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -169,6 +169,7 @@ class VectorStoreFactory:
         "qdrant": "mem0.vector_stores.qdrant.Qdrant",
         "chroma": "mem0.vector_stores.chroma.ChromaDB",
         "pgvector": "mem0.vector_stores.pgvector.PGVector",
+        "gaussdb": "mem0.vector_stores.gaussdb.GaussDB",
         "milvus": "mem0.vector_stores.milvus.MilvusDB",
         "upstash_vector": "mem0.vector_stores.upstash_vector.UpstashVector",
         "azure_ai_search": "mem0.vector_stores.azure_ai_search.AzureAISearch",
@@ -209,7 +210,6 @@ class VectorStoreFactory:
         return instance
 
 
-
 class RerankerFactory:
     """
     Factory for creating reranker instances with appropriate configurations.
@@ -219,7 +219,10 @@ class RerankerFactory:
     # Provider mappings with their config classes
     provider_to_class = {
         "cohere": ("mem0.reranker.cohere_reranker.CohereReranker", CohereRerankerConfig),
-        "sentence_transformer": ("mem0.reranker.sentence_transformer_reranker.SentenceTransformerReranker", SentenceTransformerRerankerConfig),
+        "sentence_transformer": (
+            "mem0.reranker.sentence_transformer_reranker.SentenceTransformerReranker",
+            SentenceTransformerRerankerConfig,
+        ),
         "zero_entropy": ("mem0.reranker.zero_entropy_reranker.ZeroEntropyReranker", ZeroEntropyRerankerConfig),
         "llm_reranker": ("mem0.reranker.llm_reranker.LLMReranker", LLMRerankerConfig),
         "huggingface": ("mem0.reranker.huggingface_reranker.HuggingFaceReranker", HuggingFaceRerankerConfig),

--- a/mem0/vector_stores/configs.py
+++ b/mem0/vector_stores/configs.py
@@ -14,6 +14,7 @@ class VectorStoreConfig(BaseModel):
         "qdrant": "QdrantConfig",
         "chroma": "ChromaDbConfig",
         "pgvector": "PGVectorConfig",
+        "gaussdb": "GaussDBConfig",
         "pinecone": "PineconeConfig",
         "mongodb": "MongoDBConfig",
         "milvus": "MilvusDBConfig",

--- a/mem0/vector_stores/gaussdb.py
+++ b/mem0/vector_stores/gaussdb.py
@@ -1,0 +1,1524 @@
+import hashlib
+import json
+import logging
+import os
+import re
+import threading
+import time
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from pydantic import BaseModel
+
+try:
+    from psycopg2.extras import Json
+    from psycopg2.pool import ThreadedConnectionPool
+except ImportError:
+    Json = None
+    ThreadedConnectionPool = None
+
+from mem0.vector_stores.base import VectorStoreBase
+
+logger = logging.getLogger(__name__)
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,62}$")
+_FILTER_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,127}$")
+_MEMORY_SETTING_RE = re.compile(r"^\s*(\d+(?:\.\d+)?)\s*([A-Za-z]+)\s*$")
+_ISO_8601_TIMESTAMPTZ_PATTERN = (
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$"
+)
+_RETRYABLE_ERROR_FRAGMENTS = (
+    "connection",
+    "timeout",
+    "deadlock",
+    "lock wait",
+    "could not serialize",
+    "serialization failure",
+    "server closed",
+    "terminating connection",
+)
+
+
+def _first_env(*names: str) -> Optional[str]:
+    for name in names:
+        value = os.getenv(name)
+        if value:
+            return value
+    return None
+
+
+class OutputData(BaseModel):
+    id: Optional[str]
+    score: Optional[float]
+    payload: Optional[dict]
+
+
+@dataclass
+class CapabilityReport:
+    baseline: str
+    vector_enabled: bool = False
+    floatvector: bool = False
+    vector_index: bool = False
+    bm25: bool = False
+    jsonb: bool = False
+    uuid: bool = False
+    expression_index: bool = False
+    payload_storage_mode: str = "jsonb"
+    filter_storage_mode: str = "json_expression"
+    metadata_column_mode: str = "jsonb"
+    deployment_mode: str = "centralized"
+    distribution_mode: str = "none"
+
+
+class GaussDB(VectorStoreBase):
+    """
+    GaussDB centralized A-mode Ustore vector store provider for mem0.
+
+    The implementation uses the GaussDB official psycopg2-compatible driver API.
+    It avoids psycopg3-specific APIs because GaussDB's official Python examples
+    use psycopg2.
+    """
+
+    _redundant_scope_columns = ("user_id", "agent_id", "run_id")
+
+    def __init__(
+        self,
+        database: str = "postgres",
+        collection_name: str = "mem0",
+        embedding_model_dims: int = 1536,
+        user: Optional[str] = None,
+        password: Optional[str] = None,
+        host: Optional[str] = None,
+        port: Optional[int] = None,
+        connection_string: Optional[str] = None,
+        minconn: int = 1,
+        maxconn: int = 5,
+        sslmode: Optional[str] = None,
+        sslrootcert: Optional[str] = None,
+        schema: str = "public",
+        schema_name: Optional[str] = None,
+        deployment_mode: str = "centralized",
+        vector_index_type: str = "gsdiskann",
+        vector_metric: str = "cosine",
+        auto_create: bool = True,
+        require_scoped_filters: bool = True,
+        metadata_schema: Optional[Dict[str, str]] = None,
+    ):
+        connection_string = connection_string or _first_env("GAUSSDB_CONNECTION_STRING", "GAUSSDB_DSN", "GAUSSDB_URL")
+        database = _first_env("GAUSSDB_DATABASE", "GAUSSDB_DBNAME") or database
+        user = user or _first_env("GAUSSDB_USER")
+        password = password or _first_env("GAUSSDB_PASSWORD")
+        host = host or _first_env("GAUSSDB_HOST")
+        port = port or _first_env("GAUSSDB_PORT")
+        sslmode = sslmode or _first_env("GAUSSDB_SSLMODE")
+        sslrootcert = sslrootcert or _first_env("GAUSSDB_SSLROOTCERT")
+        schema = _first_env("GAUSSDB_SCHEMA") or schema_name or schema
+
+        self.database = database
+        self.collection_name = self._validate_identifier(collection_name, "collection_name")
+        self.embedding_model_dims = self._validate_positive_int(embedding_model_dims, "embedding_model_dims")
+        self.user = user
+        self.password = password
+        self.host = host
+        self.port = int(port) if port is not None else None
+        self.connection_string = connection_string
+        self.minconn = self._validate_positive_int(minconn, "minconn")
+        self.maxconn = self._validate_positive_int(maxconn, "maxconn")
+        if self.maxconn < self.minconn:
+            raise ValueError("maxconn must be >= minconn")
+        self.sslmode = sslmode
+        self.sslrootcert = sslrootcert
+        self.deployment_mode = self._validate_choice(
+            str(deployment_mode).lower(), "deployment_mode", {"centralized", "distributed"}
+        )
+        self.vector_index_type = self._validate_choice(
+            vector_index_type.lower(), "vector_index_type", {"gsdiskann", "gsivfflat"}
+        )
+        self.vector_metric = self._validate_choice(vector_metric.lower(), "vector_metric", {"cosine", "l2"})
+
+        # Derived from deployment_mode
+        max_embedding_dims = 1024 if self.deployment_mode == "distributed" else 4096
+        if self.embedding_model_dims > max_embedding_dims:
+            raise ValueError(
+                f"GaussDB {self.deployment_mode} mode supports embedding dimensions <= {max_embedding_dims}, "
+                f"but embedding_model_dims={self.embedding_model_dims}."
+            )
+        if self.embedding_model_dims > 1024 and self.vector_index_type != "gsdiskann":
+            raise ValueError(
+                f"embedding_model_dims={self.embedding_model_dims} exceeds 1024; "
+                f"only GsDiskANN supports >1024 dimensions. Set vector_index_type='gsdiskann'."
+            )
+        self.distribution_mode = "hash" if self.deployment_mode == "distributed" else "none"
+
+        # Hardcoded internal defaults
+        self.client_encoding = "UTF8"
+        self.schema = self._validate_identifier(schema, "schema")
+        self.table_storage = "ustore"
+        self.id_column_type = "uuid"
+        self.gsdiskann_subgraph_count = 1
+        self.vector_index_maintenance_work_mem = "128MB"
+        self.bm25_enabled = self.deployment_mode != "distributed"
+        self.bm25_ranking_metric = 0
+        self.bm25_ncandidates = 128
+        self.bm25_dictionary = None
+        self.payload_storage_mode = "jsonb"
+        self.filter_storage_mode = "json_expression"
+        self.metadata_column_mode = "jsonb"
+        self.require_scoped_filters = bool(require_scoped_filters)
+        self.scope_filter_keys = ("user_id", "agent_id", "run_id")
+        self.allowed_filter_keys = None
+        self.metadata_schema: Dict[str, str] = dict(metadata_schema or {})
+        self.enable_observability = True
+        self.slow_query_ms = 1000
+        self.retry_attempts = 2
+        self.retry_backoff_seconds = 0.1
+        self.gaussdb_version_baseline = "506"
+
+        self.capabilities = CapabilityReport(
+            baseline=self.gaussdb_version_baseline,
+            payload_storage_mode=self.payload_storage_mode,
+            filter_storage_mode=self.filter_storage_mode,
+            metadata_column_mode=self.metadata_column_mode,
+            deployment_mode=self.deployment_mode,
+            distribution_mode=self.distribution_mode,
+        )
+        self.metrics: Dict[str, int] = {}
+        self._metrics_lock = threading.Lock()
+
+        self._schema_prefix = f'"{self.schema}".'
+        self.table_name = f'{self._schema_prefix}{self._quote_identifier(self.collection_name)}'
+        self.schema_meta_table_name = f'{self._schema_prefix}{self._quote_identifier(f"{self.collection_name}_schema_meta")}'
+
+        self.connection_pool = self._create_connection_pool()
+        self._probe_capabilities()
+        self._warn_if_server_encoding_is_not_utf8()
+
+        if not self.require_scoped_filters:
+            logger.warning(
+                "GaussDB scope guard is disabled (require_scoped_filters=False). "
+                "This is not recommended for production multi-tenant environments."
+            )
+
+        if auto_create:
+            collections = self.list_cols()
+            if self.collection_name not in collections:
+                self.create_col(vector_size=self.embedding_model_dims, distance=self.vector_metric)
+
+    @property
+    def enable_bm25(self) -> bool:
+        """Backward-compatible alias for older tests/config snippets."""
+        return self.bm25_enabled
+
+    @enable_bm25.setter
+    def enable_bm25(self, value: bool) -> None:
+        self.bm25_enabled = bool(value)
+
+    @staticmethod
+    def _validate_positive_int(value: int, field_name: str) -> int:
+        if value <= 0:
+            raise ValueError(f"{field_name} must be >= 1")
+        return value
+
+    @staticmethod
+    def _validate_choice(value: str, field_name: str, choices: set[str]) -> str:
+        if value not in choices:
+            raise ValueError(f"{field_name} must be one of {sorted(choices)}")
+        return value
+
+    def _sync_metadata_column_mode(self) -> None:
+        if self.payload_storage_mode == "text":
+            self.metadata_column_mode = "text"
+        elif self.filter_storage_mode == "redundant_columns":
+            self.metadata_column_mode = "redundant_columns"
+        else:
+            self.metadata_column_mode = "jsonb"
+
+    def _warn_if_server_encoding_is_not_utf8(self) -> None:
+        conn = self.connection_pool.getconn()
+        try:
+            server_encoding = None
+            get_parameter_status = getattr(conn, "get_parameter_status", None)
+            if callable(get_parameter_status):
+                value = get_parameter_status("server_encoding")
+                if isinstance(value, str) and value:
+                    server_encoding = value
+
+            if server_encoding is None:
+                cur = conn.cursor()
+                try:
+                    cur.execute("SHOW server_encoding")
+                    row = cur.fetchone()
+                finally:
+                    cur.close()
+                if row and row[0]:
+                    server_encoding = row[0]
+        except Exception as exc:
+            logger.warning("Unable to verify GaussDB server_encoding during initialization: %s", exc)
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            self.connection_pool.putconn(conn)
+            return
+
+        if not server_encoding:
+            logger.warning(
+                "Unable to determine GaussDB server_encoding during initialization. "
+                "GaussDB mem0 deployments are recommended to use UTF8 databases."
+            )
+            self.connection_pool.putconn(conn)
+            return
+
+        server_encoding = str(server_encoding).upper()
+        if server_encoding != "UTF8":
+            logger.warning(
+                "GaussDB mem0 deployments are designed and validated for UTF8 databases, "
+                "but detected server_encoding=%s. client_encoding remains UTF8, "
+                "and non-UTF8 databases may cause unstable text, JSON, or metadata-filter behavior.",
+                server_encoding,
+            )
+        self.connection_pool.putconn(conn)
+
+    @classmethod
+    def _validate_identifier(cls, value: str, field_name: str = "identifier") -> str:
+        if not isinstance(value, str) or not _IDENTIFIER_RE.match(value):
+            raise ValueError(
+                f"Unsafe {field_name}: {value!r}. Use letters, numbers, and underscores; start with a letter or underscore."
+            )
+        return value
+
+    @classmethod
+    def _quote_identifier(cls, value: str) -> str:
+        return f'"{cls._validate_identifier(value)}"'
+
+    @classmethod
+    def _index_name(cls, collection_name: str, suffix: str) -> str:
+        raw = f"{collection_name}_{suffix}"
+        if len(raw) <= 63 and _IDENTIFIER_RE.match(raw):
+            return raw
+        digest = hashlib.sha1(raw.encode("utf-8")).hexdigest()[:10]
+        prefix = collection_name[: max(1, 63 - len(suffix) - len(digest) - 2)]
+        return cls._validate_identifier(f"{prefix}_{digest}_{suffix}")
+
+    def _validate_filter_key(self, key: str) -> str:
+        if not isinstance(key, str) or not _FILTER_KEY_RE.match(key):
+            raise ValueError(f"Unsafe filter key: {key!r}")
+        if self.allowed_filter_keys is not None and key not in self.allowed_filter_keys:
+            raise ValueError(f"Unsupported filter key: {key!r}")
+        return key
+
+    @staticmethod
+    def _escape_like(value: str) -> str:
+        """Escape LIKE metacharacters so they match literally."""
+        return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+    def _create_connection_pool(self):
+        if ThreadedConnectionPool is None:
+            raise ImportError(
+                "GaussDB vector store requires the GaussDB official psycopg2 driver package. "
+                "Install the GaussDB psycopg2 wheel provided for your database version."
+            )
+
+        dsn = self._build_dsn()
+        logger.info("Creating GaussDB connection pool for %s", self._sanitize_dsn(dsn))
+        return ThreadedConnectionPool(minconn=self.minconn, maxconn=self.maxconn, dsn=dsn)
+
+    def _build_dsn(self) -> str:
+        if self.connection_string:
+            dsn = self.connection_string
+            if self.sslmode and "sslmode=" not in dsn:
+                dsn = f"{dsn} sslmode={self.sslmode}"
+            if self.sslrootcert and "sslrootcert=" not in dsn:
+                dsn = f"{dsn} sslrootcert={self.sslrootcert}"
+            return dsn
+
+        missing = [
+            name
+            for name, value in {
+                "user": self.user,
+                "password": self.password,
+                "host": self.host,
+                "port": self.port,
+            }.items()
+            if not value
+        ]
+        if missing:
+            raise ValueError(
+                "GaussDB connection requires connection_string or individual fields. "
+                f"Missing: {', '.join(missing)}"
+            )
+
+        parts = {
+            "dbname": self.database,
+            "user": self.user,
+            "password": self.password,
+            "host": self.host,
+            "port": str(self.port),
+        }
+        if self.sslmode:
+            parts["sslmode"] = self.sslmode
+        if self.sslrootcert:
+            parts["sslrootcert"] = self.sslrootcert
+        return " ".join(f"{key}={self._quote_dsn_value(value)}" for key, value in parts.items() if value is not None)
+
+    @staticmethod
+    def _quote_dsn_value(value: str) -> str:
+        text = str(value)
+        if re.search(r"\s|'", text):
+            return "'" + text.replace("\\", "\\\\").replace("'", "\\'") + "'"
+        return text
+
+    @staticmethod
+    def _sanitize_dsn(dsn: str) -> str:
+        sanitized = re.sub(r"(password=)(('[^']*')|(\S+))", r"\1<redacted>", dsn)
+        sanitized = re.sub(r"(://[^:]+:)([^@]+)(@)", r"\1<redacted>\3", sanitized)
+        return sanitized
+
+    @contextmanager
+    def _get_cursor(self, commit: bool = False):
+        conn = self.connection_pool.getconn()
+        try:
+            if self.client_encoding:
+                conn.set_client_encoding(self.client_encoding)
+            cur = conn.cursor()
+            try:
+                yield cur
+                if commit:
+                    conn.commit()
+                else:
+                    conn.rollback()
+            except Exception:
+                conn.rollback()
+                self._increment_metric("gaussdb_error_count")
+                logger.exception("GaussDB operation failed; transaction rolled back")
+                raise
+            finally:
+                cur.close()
+        finally:
+            self.connection_pool.putconn(conn)
+
+    def _run_with_retry(self, operation: str, func):
+        attempts = max(1, self.retry_attempts + 1)
+        delay = self.retry_backoff_seconds
+        last_exc = None
+        for attempt in range(attempts):
+            start = time.perf_counter()
+            try:
+                result = func()
+                self._record_latency(operation, start, "success")
+                return result
+            except Exception as exc:
+                self._record_latency(operation, start, "error")
+                last_exc = exc
+                if attempt >= attempts - 1 or not self._is_retryable(exc):
+                    raise
+                self._increment_metric("gaussdb_retry_count")
+                logger.warning("Retrying GaussDB operation %s after transient error: %s", operation, exc)
+                time.sleep(delay)
+                delay *= 2
+        raise last_exc
+
+    @staticmethod
+    def _is_retryable(exc: Exception) -> bool:
+        message = str(exc).lower()
+        return any(fragment in message for fragment in _RETRYABLE_ERROR_FRAGMENTS)
+
+    def _record_latency(self, operation: str, start: float, outcome: str):
+        if not self.enable_observability:
+            return
+        elapsed_ms = (time.perf_counter() - start) * 1000
+        key = f"gaussdb_{operation}_latency_ms_count"
+        self._increment_metric(key)
+        if elapsed_ms >= self.slow_query_ms:
+            logger.warning("Slow GaussDB operation op=%s outcome=%s latency_ms=%.2f", operation, outcome, elapsed_ms)
+
+    def _increment_metric(self, key: str):
+        if self.enable_observability:
+            with self._metrics_lock:
+                self.metrics[key] = self.metrics.get(key, 0) + 1
+
+    @property
+    def _vector_operator(self) -> str:
+        return "<+>" if self.vector_metric == "cosine" else "<->"
+
+    @property
+    def _vector_index_metric(self) -> str:
+        return "COSINE" if self.vector_metric == "cosine" else "L2"
+
+    def _id_column_sql(self) -> str:
+        return "UUID" if self.id_column_type == "uuid" else "VARCHAR(36)"
+
+    def _payload_column_sql(self) -> str:
+        return "TEXT" if self.payload_storage_mode == "text" else "JSONB"
+
+    def _create_table_suffix_sql(self, distribution_key: str) -> str:
+        suffix = f"WITH (storage_type={self.table_storage})"
+        distribution_clause = self._distribution_clause_sql(distribution_key)
+        if distribution_clause:
+            suffix = f"{suffix}\n                    {distribution_clause}"
+        return suffix
+
+    def _distribution_clause_sql(self, distribution_key: str) -> str:
+        if self.distribution_mode == "none":
+            return ""
+        if self.distribution_mode == "hash":
+            return f"DISTRIBUTE BY HASH ({self._quote_identifier(distribution_key)})"
+        raise ValueError(f"Unsupported distribution_mode: {self.distribution_mode}")
+
+    def _payload_value(self, payload: dict):
+        # Always serialize as a plain JSON string. Avoid psycopg2's Json adapter
+        # because its getquoted() uses latin-1 encoding internally, which fails
+        # for non-ASCII characters. The SQL cast (::JSONB or ::TEXT) in the query
+        # handles the type conversion on the server side, and client_encoding=UTF8
+        # ensures the raw UTF-8 bytes are transmitted correctly even when
+        # server_encoding is SQL_ASCII.
+        return json.dumps(payload, ensure_ascii=False)
+
+    @staticmethod
+    def _decode_payload(payload: Any) -> dict:
+        if payload is None:
+            return {}
+        if isinstance(payload, dict):
+            return payload
+        if isinstance(payload, str):
+            return json.loads(payload)
+        return dict(payload)
+
+    @staticmethod
+    def _vector_literal(vector: Sequence[float]) -> str:
+        return "[" + ",".join(str(float(value)) for value in vector) + "]"
+
+    def _probe_capabilities(self):
+        report = CapabilityReport(
+            baseline=self.gaussdb_version_baseline,
+            payload_storage_mode=self.payload_storage_mode,
+            filter_storage_mode=self.filter_storage_mode,
+            metadata_column_mode=self.metadata_column_mode,
+            deployment_mode=self.deployment_mode,
+            distribution_mode=self.distribution_mode,
+        )
+
+        def probe():
+            with self._get_cursor(commit=True) as cur:
+                try:
+                    cur.execute("SHOW enable_vectordb")
+                    setting = str(cur.fetchone()[0]).lower()
+                    report.vector_enabled = setting in {"on", "true", "1"}
+                except Exception:
+                    logger.debug(
+                        "Unable to read enable_vectordb; validating vector support with DDL probe", exc_info=True
+                    )
+                    report.vector_enabled = True
+                if not report.vector_enabled:
+                    raise RuntimeError("GaussDB enable_vectordb is not enabled")
+
+        self._run_with_retry("capability_probe", probe)
+
+        probe_table = f'{self._schema_prefix}{self._quote_identifier(f"mem0_gdb_probe_{uuid.uuid4().hex[:8]}")}'
+        try:
+            with self._get_cursor(commit=True) as cur:
+                cur.execute(
+                    f"""
+                    CREATE TABLE {probe_table} (
+                        id {self._id_column_sql()} PRIMARY KEY,
+                        vector FLOATVECTOR({self.embedding_model_dims}),
+                        payload {self._payload_column_sql()},
+                        text_lemmatized TEXT
+                    ) {self._create_table_suffix_sql("id")}
+                    """
+                )
+                report.floatvector = True
+                report.uuid = self.id_column_type == "uuid"
+                report.jsonb = self.payload_storage_mode == "jsonb"
+
+                index_name = self._quote_identifier(self._index_name(f"probe_{uuid.uuid4().hex[:8]}", "vector_idx"))
+                self._set_vector_index_maintenance_work_mem(cur)
+                with_clause = self._vector_index_with_clause()
+                cur.execute(
+                    f"""
+                    CREATE INDEX {index_name}
+                    ON {probe_table}
+                    USING {self.vector_index_type} (vector {self._vector_index_metric})
+                    {with_clause}
+                    """
+                )
+                report.vector_index = True
+
+                if self.bm25_enabled:
+                    bm25_enabled_before_probe = self.bm25_enabled
+                    bm25_index = self._quote_identifier(self._index_name(f"probe_{uuid.uuid4().hex[:8]}", "bm25_idx"))
+                    self._create_bm25_index(cur, probe_table, index_name=bm25_index)
+                    if bm25_enabled_before_probe and self.bm25_enabled:
+                        savepoint = self._quote_identifier(f"mem0_bm25_probe_{uuid.uuid4().hex[:8]}")
+                        cur.execute(f"SAVEPOINT {savepoint}")
+                        try:
+                            cur.execute(
+                                f"""
+                                INSERT INTO {probe_table} (id, vector, payload, text_lemmatized)
+                                VALUES (%s::{self._id_column_sql()}, %s::FLOATVECTOR, %s::{self._payload_column_sql()}, %s)
+                                """,
+                                (
+                                    str(uuid.uuid4()),
+                                    self._vector_literal([0.0] * self.embedding_model_dims),
+                                    self._payload_value({"probe": True}),
+                                    "probe memory",
+                                ),
+                            )
+                            self._apply_bm25_settings(cur)
+                            cur.execute(
+                                f"""
+                                SELECT text_lemmatized ### %s AS score
+                                FROM {probe_table}
+                                WHERE (text_lemmatized ### %s) > 0
+                                ORDER BY score DESC
+                                LIMIT 1
+                                """,
+                                ("probe", "probe"),
+                            )
+                            if cur.fetchone() is None:
+                                raise RuntimeError("GaussDB BM25 probe did not return a score")
+                            cur.execute(f"RELEASE SAVEPOINT {savepoint}")
+                            report.bm25 = True
+                        except Exception as exc:
+                            try:
+                                cur.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
+                                cur.execute(f"RELEASE SAVEPOINT {savepoint}")
+                            except Exception:
+                                logger.debug("Failed to roll back BM25 score probe savepoint", exc_info=True)
+                            logger.warning("BM25 score probe failed; keyword_search will be disabled: %s", exc)
+                            self.bm25_enabled = False
+                            self._increment_metric("gaussdb_fallback_count")
+
+                if self.filter_storage_mode == "json_expression":
+                    expr_index = self._quote_identifier(self._index_name(f"probe_{uuid.uuid4().hex[:8]}", "user_idx"))
+                    savepoint = self._quote_identifier(f"mem0_expr_idx_probe_{uuid.uuid4().hex[:8]}")
+                    cur.execute(f"SAVEPOINT {savepoint}")
+                    try:
+                        cur.execute(f"CREATE INDEX {expr_index} ON {probe_table} ((payload->>'user_id'))")
+                        cur.execute(f"RELEASE SAVEPOINT {savepoint}")
+                        report.expression_index = True
+                    except Exception as exc:
+                        logger.warning(
+                            "JSON expression index probe failed; metadata filters remain available without expression indexes: %s",
+                            exc,
+                        )
+                        try:
+                            cur.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
+                            cur.execute(f"RELEASE SAVEPOINT {savepoint}")
+                        except Exception:
+                            logger.debug("Failed to roll back JSON expression index probe savepoint", exc_info=True)
+        except Exception as exc:
+            err_msg = str(exc).lower()
+            if "max dimension" in err_msg or ("exceeds" in err_msg and "dimension" in err_msg):
+                raise RuntimeError(
+                    f"GaussDB vector dimension limit exceeded: embedding_model_dims="
+                    f"{self.embedding_model_dims}. The server rejected the dimension. "
+                    f"Centralized + GsDiskANN supports up to 4096; gsivfflat may have lower limits. "
+                    f"Use an embedding model with fewer dimensions, or check your index type and deployment mode."
+                ) from exc
+            elif self.payload_storage_mode == "jsonb" and "jsonb" in err_msg:
+                logger.warning("JSONB probe failed; falling back to TEXT payload and redundant scope columns: %s", exc)
+                self.payload_storage_mode = "text"
+                self.filter_storage_mode = "redundant_columns"
+                self._sync_metadata_column_mode()
+                report.payload_storage_mode = self.payload_storage_mode
+                report.filter_storage_mode = self.filter_storage_mode
+                report.metadata_column_mode = self.metadata_column_mode
+                report.jsonb = False
+                report.expression_index = False
+            elif self.bm25_enabled and "bm25" in str(exc).lower():
+                logger.warning("BM25 probe failed; keyword_search will be disabled: %s", exc)
+                self.bm25_enabled = False
+                self._increment_metric("gaussdb_fallback_count")
+            else:
+                raise
+        finally:
+            try:
+                with self._get_cursor(commit=True) as cur:
+                    cur.execute(f"DROP TABLE IF EXISTS {probe_table}")
+            except Exception:
+                logger.debug("Failed to clean up GaussDB probe table %s", probe_table, exc_info=True)
+            self.capabilities = report
+
+    def _ensure_schema(self, cur) -> None:
+        """Create the target schema if it does not already exist (GaussDB lacks IF NOT EXISTS for CREATE SCHEMA)."""
+        cur.execute(
+            "SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name = %s",
+            (self.schema,),
+        )
+        if cur.fetchone()[0] == 0:
+            cur.execute(f'CREATE SCHEMA "{self.schema}"')
+
+    def create_col(self, *, vector_size: int = None, distance: str = None) -> None:
+        table = self.table_name
+        dims = vector_size or self.embedding_model_dims
+        if distance:
+            self.vector_metric = self._validate_choice(distance.lower(), "distance", {"cosine", "l2"})
+
+        def op():
+            with self._get_cursor(commit=True) as cur:
+                self._ensure_schema(cur)
+                cur.execute(
+                    f"""
+                    CREATE TABLE IF NOT EXISTS {table} (
+                        id {self._id_column_sql()} PRIMARY KEY,
+                        vector FLOATVECTOR({dims}) NOT NULL,
+                        payload {self._payload_column_sql()} NOT NULL,
+                        memory TEXT,
+                        text_lemmatized TEXT,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        schema_version INTEGER DEFAULT 1,
+                        user_id VARCHAR(128),
+                        agent_id VARCHAR(128),
+                        run_id VARCHAR(128)
+                    ) {self._create_table_suffix_sql("id")}
+                    """
+                )
+                self._create_schema_meta(cur)
+                self._upsert_schema_meta(cur, self.collection_name, 1)
+                self._ensure_indexes(cur, table)
+
+        return self._run_with_retry("create_col", op)
+
+    def _create_schema_meta(self, cur):
+        cur.execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS {self.schema_meta_table_name} (
+                collection_name VARCHAR(128) PRIMARY KEY,
+                schema_version INTEGER NOT NULL,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            ) {self._create_table_suffix_sql("collection_name")}
+            """
+        )
+
+    def _upsert_schema_meta(self, cur, collection_name: str, schema_version: int):
+        cur.execute(
+            f"""
+            MERGE INTO {self.schema_meta_table_name} AS target
+            USING (VALUES (%s, %s)) AS src (collection_name, schema_version)
+            ON (target.collection_name = src.collection_name)
+            WHEN MATCHED THEN
+                UPDATE SET schema_version = src.schema_version, updated_at = CURRENT_TIMESTAMP
+            WHEN NOT MATCHED THEN
+                INSERT (collection_name, schema_version, updated_at)
+                VALUES (src.collection_name, src.schema_version, CURRENT_TIMESTAMP)
+            """,
+            (collection_name, schema_version),
+        )
+
+    def _create_vector_index(self, cur, table: str):
+        index_name = self._quote_identifier(self._index_name(self.collection_name, "vector_idx"))
+        self._set_vector_index_maintenance_work_mem(cur)
+        with_clause = self._vector_index_with_clause()
+        cur.execute(
+            f"""
+            CREATE INDEX IF NOT EXISTS {index_name}
+            ON {table}
+            USING {self.vector_index_type} (vector {self._vector_index_metric})
+            {with_clause}
+            """
+        )
+
+    def _vector_index_with_clause(self) -> str:
+        """Build WITH clause for vector index. High-dim GsDiskANN needs enable_vector_copy=false + subgraph_count>0."""
+        if self.vector_index_type == "gsdiskann" and self.embedding_model_dims > 1024:
+            return f"WITH (enable_vector_copy=false, subgraph_count={self.gsdiskann_subgraph_count})"
+        return ""
+
+    def _set_vector_index_maintenance_work_mem(self, cur):
+        target_mem = self.vector_index_maintenance_work_mem
+        if self.embedding_model_dims > 1024 and target_mem == "128MB":
+            target_mem = "2GB"
+        if not target_mem:
+            return
+
+        target_bytes = self._parse_memory_setting_bytes(target_mem)
+        if target_bytes is None:
+            cur.execute("SET LOCAL maintenance_work_mem = %s", (target_mem,))
+            return
+
+        try:
+            cur.execute("SHOW maintenance_work_mem")
+            current_row = cur.fetchone()
+            current_value = current_row[0] if current_row else None
+            current_bytes = self._parse_memory_setting_bytes(current_value)
+        except Exception:
+            logger.debug("Unable to read current maintenance_work_mem; applying provider target", exc_info=True)
+            current_bytes = None
+
+        if current_bytes is None or current_bytes < target_bytes:
+            cur.execute("SET LOCAL maintenance_work_mem = %s", (target_mem,))
+
+    @staticmethod
+    def _parse_memory_setting_bytes(value: Any) -> Optional[int]:
+        if value is None:
+            return None
+        if isinstance(value, (int, float)):
+            return int(value)
+        match = _MEMORY_SETTING_RE.match(str(value))
+        if not match:
+            return None
+        amount = float(match.group(1))
+        unit = match.group(2).lower()
+        multipliers = {
+            "b": 1,
+            "bytes": 1,
+            "kb": 1024,
+            "kib": 1024,
+            "mb": 1024 ** 2,
+            "mib": 1024 ** 2,
+            "gb": 1024 ** 3,
+            "gib": 1024 ** 3,
+            "tb": 1024 ** 4,
+            "tib": 1024 ** 4,
+        }
+        multiplier = multipliers.get(unit)
+        if multiplier is None:
+            return None
+        return int(amount * multiplier)
+
+    def _create_bm25_index(self, cur, table: str, index_name: Optional[str] = None):
+        index_name = index_name or self._quote_identifier(self._index_name(self.collection_name, "bm25_idx"))
+        savepoint = self._quote_identifier(f"mem0_bm25_{uuid.uuid4().hex[:8]}")
+        cur.execute(f"SAVEPOINT {savepoint}")
+        try:
+            cur.execute(
+                f"""
+                CREATE INDEX IF NOT EXISTS {index_name}
+                ON {table}
+                USING bm25 (text_lemmatized)
+                WITH (storage_type='USTORE')
+                """
+            )
+            cur.execute(f"RELEASE SAVEPOINT {savepoint}")
+        except Exception:
+            try:
+                cur.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
+                cur.execute(f"RELEASE SAVEPOINT {savepoint}")
+            except Exception:
+                logger.debug("Failed to roll back optional BM25 index savepoint", exc_info=True)
+            self.bm25_enabled = False
+            self._increment_metric("gaussdb_fallback_count")
+            logger.warning("BM25 index creation failed; keyword_search disabled", exc_info=True)
+
+    def _create_filter_indexes(self, cur, table: str):
+        for key in self.scope_filter_keys:
+            safe_key = self._validate_filter_key(key)
+            index_name = self._quote_identifier(self._index_name(self.collection_name, f"{safe_key}_idx"))
+            savepoint = self._quote_identifier(f"mem0_filter_idx_{uuid.uuid4().hex[:8]}")
+            cur.execute(f"SAVEPOINT {savepoint}")
+            try:
+                cur.execute(f"CREATE INDEX IF NOT EXISTS {index_name} ON {table} ({self._quote_identifier(safe_key)})")
+                cur.execute(f"RELEASE SAVEPOINT {savepoint}")
+            except Exception as exc:
+                try:
+                    cur.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
+                    cur.execute(f"RELEASE SAVEPOINT {savepoint}")
+                except Exception:
+                    logger.debug("Failed to roll back optional filter index savepoint", exc_info=True)
+                self._increment_metric("gaussdb_fallback_count")
+                logger.warning("Filter index creation failed for key %s; continuing without this index: %s", safe_key, exc)
+
+    def _ensure_indexes(self, cur, table: str):
+        self._create_vector_index(cur, table)
+        if self.bm25_enabled:
+            self._create_bm25_index(cur, table)
+        self._create_filter_indexes(cur, table)
+
+    def insert(
+        self, vectors: List[List[float]], payloads: Optional[List[Dict]] = None, ids: Optional[List[str]] = None
+    ) -> None:
+        payloads = [{} for _ in vectors] if payloads is None else payloads
+        ids = [str(uuid.uuid4()) for _ in vectors] if ids is None else ids
+        if len(vectors) != len(payloads) or len(vectors) != len(ids):
+            raise ValueError("vectors, payloads, and ids must have the same length")
+
+        rows = [
+            self._insert_row(vector, payload, vector_id) for vector, payload, vector_id in zip(vectors, payloads, ids)
+        ]
+        if not rows:
+            return None
+        columns = ["id", "vector", "payload", "memory", "text_lemmatized", "schema_version", *self._redundant_scope_columns]
+        update_columns = [column for column in columns if column != "id"]
+        update_set_sql = ", ".join(
+            f"{self._quote_identifier(column)} = src.{self._quote_identifier(column)}" for column in update_columns
+        )
+        update_set_sql += ", updated_at = CURRENT_TIMESTAMP"
+        insert_columns_sql = ", ".join(self._quote_identifier(column) for column in columns)
+        insert_columns_sql += ", updated_at"
+        insert_values_sql = ", ".join(f"src.{self._quote_identifier(column)}" for column in columns)
+        insert_values_sql += ", CURRENT_TIMESTAMP"
+        values_sql = ", ".join([self._incoming_values_sql(columns)] * len(rows))
+        src_columns_sql = ", ".join(self._quote_identifier(column) for column in columns)
+        flat_params = tuple(value for row in rows for value in row)
+
+        def op():
+            with self._get_cursor(commit=True) as cur:
+                # MERGE INTO: GaussDB A-mode (Oracle compatible) atomic upsert.
+                # Avoids the race condition of separate UPDATE + INSERT WHERE NOT EXISTS.
+                cur.execute(
+                    f"""
+                    MERGE INTO {self.table_name} AS target
+                    USING (VALUES {values_sql}) AS src ({src_columns_sql})
+                    ON (target.id = src.id)
+                    WHEN MATCHED THEN
+                        UPDATE SET {update_set_sql}
+                    WHEN NOT MATCHED THEN
+                        INSERT ({insert_columns_sql})
+                        VALUES ({insert_values_sql})
+                    """,
+                    flat_params,
+                )
+
+        return self._run_with_retry("insert", op)
+
+    def _incoming_values_sql(self, columns: List[str]) -> str:
+        casts = {
+            "id": self._id_column_sql(),
+            "vector": "FLOATVECTOR",
+            "payload": self._payload_column_sql(),
+            "schema_version": "INTEGER",
+            "user_id": "VARCHAR(128)",
+            "agent_id": "VARCHAR(128)",
+            "run_id": "VARCHAR(128)",
+        }
+        placeholders = [f"%s::{casts[column]}" if column in casts else "%s" for column in columns]
+        return "(" + ", ".join(placeholders) + ")"
+
+    def _insert_row(self, vector: Sequence[float], payload: dict, vector_id: str) -> Tuple:
+        payload = payload or {}
+        memory = payload.get("data") or payload.get("memory")
+        text_lemmatized = payload.get("text_lemmatized") or memory
+        row = [
+            vector_id,
+            self._vector_literal(vector),
+            self._payload_value(payload),
+            memory,
+            text_lemmatized,
+            1,
+        ]
+        row.extend(payload.get(key) for key in self._redundant_scope_columns)
+        return tuple(row)
+
+    def search(
+        self, query: str, vectors: List[float], top_k: int = 5, filters: Optional[dict] = None
+    ) -> List[OutputData]:
+        where_clause, params = self._build_where_clause(filters, require_scope=True)
+        vector_literal = self._vector_literal(vectors)
+
+        def op():
+            with self._get_cursor() as cur:
+                cur.execute(
+                    f"""
+                    SELECT id, vector {self._vector_operator} %s::FLOATVECTOR AS distance, payload
+                    FROM {self.table_name}
+                    {where_clause}
+                    ORDER BY distance ASC, id ASC
+                    LIMIT %s
+                    """,
+                    (vector_literal, *params, top_k),
+                )
+                rows = cur.fetchall()
+            return [
+                OutputData(id=str(row[0]), score=float(row[1]), payload=self._decode_payload(row[2]))
+                for row in rows
+            ]
+
+        return self._run_with_retry("search", op)
+
+    def keyword_search(self, query: str, top_k: int = 5, filters: Optional[dict] = None):
+        if not self.bm25_enabled:
+            return None
+        if not query or not query.strip():
+            return []
+
+        where_clause, params = self._build_where_clause(filters, require_scope=True)
+        prefix = " AND " if where_clause else " WHERE "
+
+        def op():
+            try:
+                with self._get_cursor() as cur:
+                    self._apply_bm25_settings(cur)
+                    cur.execute(
+                        f"""
+                        SELECT id, text_lemmatized ### %s AS score, payload
+                        FROM {self.table_name}
+                        {where_clause}
+                        {prefix}(text_lemmatized ### %s) > 0
+                        ORDER BY score DESC
+                        LIMIT %s
+                        """,
+                        (query, *params, query, top_k),
+                    )
+                    rows = cur.fetchall()
+                return [
+                    OutputData(id=str(row[0]), score=float(row[1]), payload=self._decode_payload(row[2]))
+                    for row in rows
+                ]
+            except Exception:
+                self._increment_metric("gaussdb_fallback_count")
+                logger.debug("GaussDB BM25 keyword search failed", exc_info=True)
+                return None
+
+        return self._run_with_retry("keyword_search", op)
+
+    def _apply_bm25_settings(self, cur):
+        cur.execute(f"SET LOCAL bm25_ranking_metric = {int(self.bm25_ranking_metric)}")
+        cur.execute(f"SET LOCAL bm25_ncandidates = {int(self.bm25_ncandidates)}")
+        cur.execute("SET LOCAL enable_seqscan = off")
+        if self.bm25_dictionary:
+            self._validate_identifier(self.bm25_dictionary, "bm25_dictionary")
+            cur.execute(f"SET LOCAL bm25_dictionary = '{self.bm25_dictionary}'")
+
+    def search_batch(self, queries: list, vectors_list: list, top_k: int = 1, filters: Optional[dict] = None):
+        if not vectors_list:
+            return []
+        if len(queries) != len(vectors_list):
+            raise ValueError(
+                f"search_batch: queries ({len(queries)}) and vectors_list ({len(vectors_list)}) length mismatch"
+            )
+        where_clause, filter_params = self._build_where_clause(filters, require_scope=True)
+        values_sql = ", ".join(f"({idx}, %s::FLOATVECTOR)" for idx in range(len(vectors_list)))
+        vector_params = [self._vector_literal(vector) for vector in vectors_list]
+
+        def op():
+            try:
+                with self._get_cursor() as cur:
+                    cur.execute(
+                        f"""
+                        WITH query_vectors(query_index, query_vector) AS (
+                            VALUES {values_sql}
+                        ),
+                        ranked AS (
+                            SELECT
+                                q.query_index,
+                                id,
+                                vector {self._vector_operator} q.query_vector AS distance,
+                                payload,
+                                ROW_NUMBER() OVER (
+                                    PARTITION BY q.query_index
+                                    ORDER BY vector {self._vector_operator} q.query_vector ASC, id ASC
+                                ) AS rank
+                            FROM query_vectors q, {self.table_name}
+                            {where_clause}
+                        )
+                        SELECT query_index, id, distance, payload
+                        FROM ranked
+                        WHERE rank <= %s
+                        ORDER BY query_index ASC, distance ASC, id ASC
+                        """,
+                        (*vector_params, *filter_params, top_k),
+                    )
+                    rows = cur.fetchall()
+                grouped = [[] for _ in vectors_list]
+                for query_index, row_id, distance, payload in rows:
+                    grouped[int(query_index)].append(
+                        OutputData(
+                            id=str(row_id),
+                            score=float(distance),
+                            payload=self._decode_payload(payload),
+                        )
+                    )
+                return grouped
+            except Exception as exc:
+                self._increment_metric("gaussdb_fallback_count")
+                logger.warning("GaussDB native batch search failed; falling back to sequential search: %s", exc)
+                return [
+                    self.search(query, vectors, top_k=top_k, filters=filters)
+                    for query, vectors in zip(queries, vectors_list)
+                ]
+
+        return self._run_with_retry("search_batch", op)
+
+    def delete(self, vector_id: str) -> None:
+        def op():
+            with self._get_cursor(commit=True) as cur:
+                cur.execute(f"DELETE FROM {self.table_name} WHERE id = %s", (vector_id,))
+
+        return self._run_with_retry("delete", op)
+
+    def update(self, vector_id: str, vector: Optional[List[float]] = None, payload: Optional[dict] = None) -> None:
+        if vector is None and payload is None:
+            return None
+
+        set_clauses = []
+        params = []
+        if vector is not None:
+            set_clauses.append("vector = %s::FLOATVECTOR")
+            params.append(self._vector_literal(vector))
+        if payload is not None:
+            memory = payload.get("data") or payload.get("memory")
+            text_lemmatized = payload.get("text_lemmatized") or memory
+            set_clauses.extend(["payload = %s", "memory = %s", "text_lemmatized = %s"])
+            params.extend([self._payload_value(payload), memory, text_lemmatized])
+            for key in self._redundant_scope_columns:
+                if key in payload:
+                    set_clauses.append(f"{self._quote_identifier(key)} = %s")
+                    params.append(payload.get(key))
+        set_clauses.append("updated_at = CURRENT_TIMESTAMP")
+        params.append(vector_id)
+
+        def op():
+            with self._get_cursor(commit=True) as cur:
+                cur.execute(
+                    f"""
+                    UPDATE {self.table_name}
+                    SET {", ".join(set_clauses)}
+                    WHERE id = %s
+                    """,
+                    tuple(params),
+                )
+
+        return self._run_with_retry("update", op)
+
+    def get(self, vector_id: str) -> Optional[OutputData]:
+        def op():
+            with self._get_cursor() as cur:
+                cur.execute(f"SELECT id, payload FROM {self.table_name} WHERE id = %s", (vector_id,))
+                row = cur.fetchone()
+            if not row:
+                return None
+            return OutputData(id=str(row[0]), score=None, payload=self._decode_payload(row[1]))
+
+        return self._run_with_retry("get", op)
+
+    def list_cols(self) -> List[str]:
+        def op():
+            with self._get_cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT table_name
+                    FROM information_schema.tables
+                    WHERE table_schema = %s
+                    """,
+                    (self.schema,),
+                )
+                rows = cur.fetchall()
+            return [
+                row[0]
+                for row in rows
+                if not str(row[0]).endswith("_schema_meta") and not str(row[0]).startswith("mem0_gdb_probe_")
+            ]
+
+        return self._run_with_retry("list_cols", op)
+
+    def delete_col(self) -> None:
+        def op():
+            with self._get_cursor(commit=True) as cur:
+                cur.execute(f"DROP TABLE IF EXISTS {self.table_name}")
+                cur.execute(f"DROP TABLE IF EXISTS {self.schema_meta_table_name}")
+
+        return self._run_with_retry("delete_col", op)
+
+    def col_info(self) -> Dict[str, Any]:
+        def op():
+            with self._get_cursor() as cur:
+                cur.execute(f"SELECT COUNT(*) FROM {self.table_name}")
+                row_count = cur.fetchone()[0]
+                schema_version = self._read_schema_version(cur)
+                cur.execute(
+                    """
+                    SELECT indexname
+                    FROM pg_indexes
+                    WHERE schemaname = %s AND tablename = %s
+                    ORDER BY indexname
+                    """,
+                    (self.schema, self.collection_name),
+                )
+                indexes = [row[0] for row in cur.fetchall()]
+            return {
+                "name": self.collection_name,
+                "schema": self.schema,
+                "count": row_count,
+                "dimension": self.embedding_model_dims,
+                "schema_version": schema_version,
+                "metadata_column_mode": self.metadata_column_mode,
+                "payload_storage_mode": self.payload_storage_mode,
+                "filter_storage_mode": self.filter_storage_mode,
+                "deployment_mode": self.deployment_mode,
+                "distribution_mode": self.distribution_mode,
+                "vector_index_type": self.vector_index_type,
+                "vector_metric": self.vector_metric,
+                "bm25_enabled": self.bm25_enabled,
+                "indexes": indexes,
+            }
+
+        return self._run_with_retry("col_info", op)
+
+    def _read_schema_version(self, cur) -> int:
+        cur.execute(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM information_schema.tables
+                WHERE table_schema = %s AND table_name = %s
+            )
+            """,
+            (self.schema, f"{self.collection_name}_schema_meta"),
+        )
+        if not cur.fetchone()[0]:
+            return 1
+
+        cur.execute(
+            f"""
+            SELECT schema_version
+            FROM {self.schema_meta_table_name}
+            WHERE collection_name = %s
+            """,
+            (self.collection_name,),
+        )
+        row = cur.fetchone()
+        return int(row[0]) if row else 1
+
+    def list(self, filters: Optional[dict] = None, top_k: Optional[int] = 100) -> List[List[OutputData]]:
+        where_clause, params = self._build_where_clause(filters, require_scope=True)
+        limit = 100 if top_k is None else top_k
+
+        def op():
+            with self._get_cursor() as cur:
+                cur.execute(
+                    f"""
+                    SELECT id, payload
+                    FROM {self.table_name}
+                    {where_clause}
+                    ORDER BY updated_at DESC, id ASC
+                    LIMIT %s
+                    """,
+                    (*params, limit),
+                )
+                rows = cur.fetchall()
+            return [[OutputData(id=str(row[0]), score=None, payload=self._decode_payload(row[1])) for row in rows]]
+
+        return self._run_with_retry("list", op)
+
+    def reset(self) -> None:
+        logger.warning("Resetting GaussDB collection %s", self.collection_name)
+        self.delete_col()
+        self.create_col(vector_size=self.embedding_model_dims, distance=self.vector_metric)
+
+    def migration_dry_run(self) -> Dict[str, Any]:
+        return {
+            "collection_name": self.collection_name,
+            "schema_version": 1,
+            "payload_storage_mode": self.payload_storage_mode,
+            "filter_storage_mode": self.filter_storage_mode,
+            "deployment_mode": self.deployment_mode,
+            "distribution_mode": self.distribution_mode,
+            "planned_actions": [
+                "create_schema_meta_table_if_missing",
+                "ensure_text_lemmatized_column",
+                "ensure_scope_columns_when_filter_storage_mode_is_redundant_columns",
+                "ensure_hash_distribution_when_deployment_mode_is_distributed",
+                "ensure_vector_bm25_and_filter_indexes",
+            ],
+            "mutates_data": False,
+            "limits": [
+                "v1 dry-run reports provider-managed derived-field actions only",
+                "full schema diff and index rebuild planning should be handled by a dedicated migration workflow",
+            ],
+        }
+
+    def backfill_derived_fields(self, dry_run: bool = True) -> Dict[str, Any]:
+        if self.payload_storage_mode == "text":
+            return {
+                "dry_run": dry_run,
+                "estimated_rows": None,
+                "requires_application_recompute": True,
+                "reason": "payload is stored as TEXT; JSON field extraction is not available in provider SQL",
+            }
+        if dry_run:
+            with self._get_cursor() as cur:
+                cur.execute(
+                    f"""
+                    SELECT COUNT(*)
+                    FROM {self.table_name}
+                    WHERE text_lemmatized IS NULL
+                       OR text_lemmatized = ''
+                       OR memory IS NULL
+                    """
+                )
+                count = cur.fetchone()[0]
+            return {"dry_run": True, "estimated_rows": count}
+
+        def op():
+            with self._get_cursor(commit=True) as cur:
+                cur.execute(
+                    f"""
+                    UPDATE {self.table_name}
+                    SET
+                        memory = COALESCE(memory, payload->>'data', payload->>'memory'),
+                        text_lemmatized = COALESCE(NULLIF(text_lemmatized, ''), payload->>'text_lemmatized', payload->>'data', payload->>'memory'),
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE text_lemmatized IS NULL
+                       OR text_lemmatized = ''
+                       OR memory IS NULL
+                    """
+                )
+                affected = cur.rowcount
+            return {"dry_run": False, "affected_rows": affected}
+
+        return self._run_with_retry("migration", op)
+
+    def analyze(self) -> None:
+        def op():
+            conn = self.connection_pool.getconn()
+            previous_autocommit = getattr(conn, "autocommit", False)
+            try:
+                if self.client_encoding:
+                    conn.set_client_encoding(self.client_encoding)
+                conn.autocommit = True
+                cur = conn.cursor()
+                try:
+                    cur.execute(f"ANALYZE {self.table_name}")
+                finally:
+                    cur.close()
+            finally:
+                try:
+                    conn.autocommit = previous_autocommit
+                except Exception:
+                    logger.debug("Failed to restore autocommit after ANALYZE", exc_info=True)
+                self.connection_pool.putconn(conn)
+
+        return self._run_with_retry("analyze", op)
+
+    def _build_where_clause(self, filters: Optional[dict], require_scope: bool) -> Tuple[str, List[Any]]:
+        if require_scope and self.require_scoped_filters and not self._has_scope_filter(filters):
+            raise ValueError(
+                f"GaussDB provider requires at least one scoped filter by default: {', '.join(self.scope_filter_keys)}"
+            )
+        if not filters:
+            return "", []
+        expression, params = self._build_filter_expression(filters)
+        if not expression:
+            return "", []
+        return f"WHERE {expression}", params
+
+    def _has_scope_filter(self, filters: Optional[dict]) -> bool:
+        if not filters or not isinstance(filters, dict):
+            return False
+        for key, value in filters.items():
+            normalized_key = {"$and": "AND", "$or": "OR", "$not": "NOT"}.get(key, key)
+            if normalized_key == "AND" and isinstance(value, list):
+                if any(self._has_scope_filter(item) for item in value if isinstance(item, dict)):
+                    return True
+            elif normalized_key == "OR" and isinstance(value, list):
+                if value and all(isinstance(item, dict) and self._has_scope_filter(item) for item in value):
+                    return True
+            elif normalized_key == "NOT":
+                continue
+            elif key in self.scope_filter_keys and self._is_positive_scope_filter_value(value):
+                return True
+        return False
+
+    @staticmethod
+    def _is_positive_scope_filter_value(value: Any) -> bool:
+        if value is None or value == "" or value == "*":
+            return False
+        if isinstance(value, list):
+            return any(GaussDB._is_positive_scope_filter_value(item) for item in value)
+        if isinstance(value, dict):
+            if "eq" in value:
+                return GaussDB._is_positive_scope_filter_value(value["eq"])
+            if "in" in value:
+                in_values = value["in"]
+                if not isinstance(in_values, (list, tuple, set)):
+                    return False
+                return any(GaussDB._is_positive_scope_filter_value(item) for item in in_values)
+            return False
+        return True
+
+    def _build_filter_expression(self, filters: dict) -> Tuple[str, List[Any]]:
+        if not isinstance(filters, dict):
+            raise ValueError("filters must be a dictionary")
+        expressions = []
+        params: List[Any] = []
+        for key, value in filters.items():
+            normalized_key = {"$and": "AND", "$or": "OR", "$not": "NOT"}.get(key, key)
+            if normalized_key in {"AND", "OR"}:
+                if not isinstance(value, list):
+                    raise ValueError(f"{normalized_key} filter value must be a list")
+                sub_expressions = []
+                for item in value:
+                    expr, sub_params = self._build_filter_expression(item)
+                    if expr:
+                        sub_expressions.append(f"({expr})")
+                        params.extend(sub_params)
+                if sub_expressions:
+                    joiner = " AND " if normalized_key == "AND" else " OR "
+                    expressions.append(joiner.join(sub_expressions))
+            elif normalized_key == "NOT":
+                if not isinstance(value, list):
+                    raise ValueError("NOT filter value must be a list")
+                for item in value:
+                    expr, sub_params = self._build_filter_expression(item)
+                    if expr:
+                        expressions.append(f"(({expr}) IS NOT TRUE)")
+                        params.extend(sub_params)
+            else:
+                expr, sub_params = self._build_field_filter(normalized_key, value)
+                if expr:
+                    expressions.append(expr)
+                    params.extend(sub_params)
+        return " AND ".join(expressions), params
+
+    def _build_field_filter(self, key: str, value: Any) -> Tuple[str, List[Any]]:
+        self._validate_filter_key(key)
+        if not isinstance(value, dict):
+            if isinstance(value, list):
+                return self._field_in_expression(key, value, negate=False)
+            if value is None:
+                return self._field_exact_expression(key, value, negate=False)
+            if key in self.scope_filter_keys:
+                field_sql, params = self._field_sql(key)
+                return f"{field_sql} = %s", [*params, value]
+            if value == "*":
+                return "", []
+            return self._field_exact_expression(key, value, negate=False)
+
+        ops = set(value.keys())
+        range_ops = {"gt", "gte", "lt", "lte"}
+        if ops & range_ops:
+            return self._build_range_filter(key, value)
+        if ops & {"exists", "not_exists", "missing"}:
+            return self._build_presence_filter(key, value)
+        if "eq" in value:
+            return self._build_field_filter(key, value["eq"])
+        if "ne" in value:
+            if key in self.scope_filter_keys:
+                field_sql, params = self._field_sql(key)
+                return f"{field_sql} <> %s", [*params, value["ne"]]
+            return self._field_exact_expression(key, value["ne"], negate=True)
+        if "in" in value:
+            return self._field_in_expression(key, value["in"], negate=False)
+        if "nin" in value:
+            return self._field_in_expression(key, value["nin"], negate=True)
+        if "contains" in value or "icontains" in value:
+            op = "icontains" if "icontains" in value else "contains"
+            field_sql, params = self._field_sql(key)
+            escaped = self._escape_like(value[op])
+            if op == "icontains":
+                expression = f"LOWER({field_sql}) LIKE LOWER(%s) ESCAPE '\\'"
+            else:
+                expression = f"{field_sql} LIKE %s ESCAPE '\\'"
+            return expression, [*params, f"%{escaped}%"]
+        raise ValueError(f"Unsupported filter operator(s) for field {key!r}: {sorted(ops)}")
+
+    def _field_in_expression(self, key: str, values: Iterable[Any], negate: bool) -> Tuple[str, List[Any]]:
+        values = list(values)
+        if not values:
+            return ("1 = 1" if negate else "1 = 0"), []
+        if key in self.scope_filter_keys:
+            field_sql, params = self._field_sql(key)
+            placeholders = ", ".join(["%s"] * len(values))
+            operator = "NOT IN" if negate else "IN"
+            return f"{field_sql} {operator} ({placeholders})", [*params, *values]
+        if len(values) == 1:
+            return self._field_exact_expression(key, values[0], negate=negate)
+        operator = " OR " if not negate else " AND "
+        expressions = []
+        params: List[Any] = []
+        for item in values:
+            expr, expr_params = self._field_exact_expression(key, item, negate=negate)
+            expressions.append(f"({expr})")
+            params.extend(expr_params)
+        return operator.join(expressions), params
+
+    def _field_sql(self, key: str) -> Tuple[str, List[Any]]:
+        if key in self._redundant_scope_columns:
+            return self._quote_identifier(key), []
+        if self.filter_storage_mode == "json_expression":
+            self._validate_filter_key(key)
+            return f"payload->>'{key}'", []
+        raise ValueError(
+            f"Filter key {key!r} is not available in filter_storage_mode={self.filter_storage_mode!r}; "
+            "use redundant_columns for scoped filters or json_expression for payload filters."
+        )
+
+    def _field_exact_expression(self, key: str, value: Any, negate: bool) -> Tuple[str, List[Any]]:
+        self._validate_filter_key(key)
+        payload = json.dumps({key: value}, ensure_ascii=False, separators=(",", ":"))
+        expression = "(payload @> %s::JSONB) IS NOT TRUE" if negate else "payload @> %s::JSONB"
+        return expression, [payload]
+
+    def _build_presence_filter(self, key: str, value: dict) -> Tuple[str, List[Any]]:
+        self._validate_filter_key(key)
+        if len(value) != 1:
+            raise ValueError(
+                f"Presence filter for field {key!r} must specify exactly one of exists/not_exists/missing."
+            )
+        operator, raw_flag = next(iter(value.items()))
+        if not isinstance(raw_flag, bool):
+            raise ValueError(f"Presence filter {operator!r} for field {key!r} must be a boolean.")
+
+        if operator == "exists":
+            exists = raw_flag
+        elif operator in {"not_exists", "missing"}:
+            exists = not raw_flag
+        else:
+            raise ValueError(f"Unsupported presence filter operator for field {key!r}: {operator!r}")
+
+        expression = "payload ? %s" if exists else "(payload ? %s) IS NOT TRUE"
+        return expression, [key]
+
+    def _build_range_filter(self, key: str, value: dict) -> Tuple[str, List[Any]]:
+        field_type = self.metadata_schema.get(key)
+        if field_type not in {"number", "datetime"}:
+            logger.warning(
+                "Range filter operators on field %r do not have a declared number/datetime metadata type; "
+                "falling back to literal compatibility matching.",
+                key,
+            )
+            return self._field_exact_expression(key, value, negate=False)
+
+        expressions = []
+        params: List[Any] = []
+        if field_type == "number":
+            column_expr = (
+                f"CASE WHEN jsonb_typeof(payload->'{key}') = 'number' "
+                f"THEN CAST(payload->>'{key}' AS DOUBLE PRECISION) END"
+            )
+        else:
+            column_expr = (
+                f"CASE WHEN jsonb_typeof(payload->'{key}') = 'string' "
+                f"AND payload->>'{key}' ~ %s "
+                f"THEN CAST(payload->>'{key}' AS TIMESTAMPTZ) END"
+            )
+            params.append(_ISO_8601_TIMESTAMPTZ_PATTERN)
+        mapping = {
+            "gt": ">",
+            "gte": ">=",
+            "lt": "<",
+            "lte": "<=",
+        }
+        for op_name in ("gt", "gte", "lt", "lte"):
+            if op_name in value:
+                expressions.append(f"{column_expr} {mapping[op_name]} %s")
+                params.append(value[op_name])
+        if not expressions:
+            raise ValueError(f"Unsupported range filter for field {key!r}")
+        return " AND ".join(expressions), params
+
+    def close(self):
+        """Explicitly release the connection pool."""
+        if getattr(self, "connection_pool", None) is not None:
+            try:
+                self.connection_pool.closeall()
+            except Exception:
+                pass
+            self.connection_pool = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+    def __del__(self):
+        try:
+            if self.connection_pool is not None:
+                self.connection_pool.closeall()
+        except Exception:
+            pass

--- a/scripts/compare_gaussdb_pgvector.py
+++ b/scripts/compare_gaussdb_pgvector.py
@@ -1,0 +1,786 @@
+"""Compare mem0 GaussDB and pgvector providers on the same synthetic workload.
+
+This script intentionally works at the mem0 vector-store provider layer rather
+than calling an external LLM. It uses deterministic vectors, payloads, filters,
+and queries so differences come from the database/provider behavior.
+
+Environment variables:
+  GaussDB:
+    GAUSSDB_HOST, GAUSSDB_PORT, GAUSSDB_DATABASE, GAUSSDB_USER, GAUSSDB_PASSWORD
+    or the GAUSSDB_TEST_* variants used by live tests.
+    Optional: GAUSSDB_EVAL_DEPLOYMENT_MODE=distributed, GAUSSDB_EVAL_DISTRIBUTION_MODE=auto.
+
+  pgvector:
+    PGVECTOR_HOST, PGVECTOR_PORT, PGVECTOR_DATABASE, PGVECTOR_USER, PGVECTOR_PASSWORD
+
+Example local pgvector container:
+  docker run -d --name mem0-pgvector-eval \
+    -e POSTGRES_USER=mem0 -e POSTGRES_PASSWORD=mem0pass -e POSTGRES_DB=mem0_eval \
+    -p 15432:5432 pgvector/pgvector:pg16
+
+Example run:
+  python scripts/compare_gaussdb_pgvector.py --provider both --scenario complex --scale 4
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from mem0.vector_stores.base import VectorStoreBase
+from mem0.vector_stores.gaussdb import GaussDB
+from mem0.vector_stores.pgvector import PGVector
+
+
+DIMENSIONS = 8
+RUN_ID = "mem0-provider-ab-run"
+
+
+@dataclass(frozen=True)
+class MemoryCase:
+    key: str
+    data: str
+    text_lemmatized: str
+    user_id: str
+    agent_id: str
+    category: str
+    language: str
+    vector: list[float]
+
+    @property
+    def id(self) -> str:
+        return str(uuid.uuid5(uuid.NAMESPACE_URL, f"mem0-provider-ab/{self.key}"))
+
+    @property
+    def payload(self) -> dict[str, Any]:
+        return {
+            "data": self.data,
+            "text_lemmatized": self.text_lemmatized,
+            "user_id": self.user_id,
+            "agent_id": self.agent_id,
+            "run_id": RUN_ID,
+            "category": self.category,
+            "language": self.language,
+        }
+
+
+@dataclass(frozen=True)
+class QueryCase:
+    name: str
+    text: str
+    vector: list[float]
+    keyword_query: str
+    filters: dict[str, Any]
+    expected_key: str
+    expected_id: str
+
+
+def _env(*names: str, default: str | None = None) -> str | None:
+    for name in names:
+        value = os.getenv(name)
+        if value:
+            return value
+    return default
+
+
+def _require_env(*names: str) -> str:
+    value = _env(*names)
+    if value is None:
+        raise RuntimeError(f"Missing environment variable. Provide one of: {', '.join(names)}")
+    return value
+
+
+def _offset(vector: list[float], amount: float) -> list[float]:
+    return [round(value + amount, 4) for value in vector]
+
+
+def build_simple_dataset(scale: int) -> list[MemoryCase]:
+    base_cases = [
+        MemoryCase(
+            key="travel-window-seat",
+            data="Alice prefers quiet window seats on morning flights",
+            text_lemmatized="alice prefer quiet window seat morning flight",
+            user_id="alice",
+            agent_id="travel-agent",
+            category="travel",
+            language="en",
+            vector=[0.91, 0.12, 0.10, 0.05, 0.02, 0.01, 0.03, 0.04],
+        ),
+        MemoryCase(
+            key="travel-boarding",
+            data="小李 books flights with priority boarding",
+            text_lemmatized="小李 book flight priority boarding",
+            user_id="xiaoli",
+            agent_id="travel-agent",
+            category="travel",
+            language="mixed",
+            vector=[0.88, 0.15, 0.12, 0.07, 0.03, 0.01, 0.02, 0.05],
+        ),
+        MemoryCase(
+            key="food-coffee-cn",
+            data="小王喜欢早晨喝拿铁咖啡",
+            text_lemmatized="小王 喜欢 早晨 喝 拿铁 咖啡",
+            user_id="xiaowang",
+            agent_id="food-agent",
+            category="food",
+            language="zh",
+            vector=[0.10, 0.89, 0.12, 0.05, 0.03, 0.06, 0.04, 0.01],
+        ),
+        MemoryCase(
+            key="food-vegetarian",
+            data="Carol prefers vegetarian lunch and jasmine tea",
+            text_lemmatized="carol prefer vegetarian lunch jasmine tea",
+            user_id="carol",
+            agent_id="food-agent",
+            category="food",
+            language="en",
+            vector=[0.11, 0.86, 0.16, 0.04, 0.05, 0.04, 0.03, 0.02],
+        ),
+        MemoryCase(
+            key="finance-invoice",
+            data="Dana tracks invoice approvals before quarterly reporting",
+            text_lemmatized="dana track invoice approval quarterly reporting",
+            user_id="dana",
+            agent_id="finance-agent",
+            category="finance",
+            language="en",
+            vector=[0.08, 0.05, 0.91, 0.10, 0.02, 0.03, 0.02, 0.04],
+        ),
+        MemoryCase(
+            key="health-running",
+            data="Evan runs five kilometers after work on Wednesdays",
+            text_lemmatized="evan run five kilometer after work wednesday",
+            user_id="evan",
+            agent_id="health-agent",
+            category="health",
+            language="en",
+            vector=[0.03, 0.05, 0.09, 0.90, 0.12, 0.04, 0.02, 0.02],
+        ),
+    ]
+
+    records: list[MemoryCase] = []
+    for repeat in range(scale):
+        for case in base_cases:
+            if repeat == 0:
+                records.append(case)
+                continue
+            records.append(
+                MemoryCase(
+                    key=f"{case.key}-{repeat}",
+                    data=f"{case.data} variant {repeat}",
+                    text_lemmatized=f"{case.text_lemmatized} variant {repeat}",
+                    user_id=case.user_id,
+                    agent_id=case.agent_id,
+                    category=case.category,
+                    language=case.language,
+                    vector=_offset(case.vector, repeat * 0.0003),
+                )
+            )
+    return records
+
+
+def build_simple_queries(records: list[MemoryCase]) -> list[QueryCase]:
+    by_key = {record.key: record for record in records}
+    targets = [
+        ("travel_window", "flight seat preference", "window seat", "travel-window-seat"),
+        ("travel_priority", "priority boarding flight", "priority boarding", "travel-boarding"),
+        ("zh_coffee", "早晨饮品偏好", "拿铁 咖啡", "food-coffee-cn"),
+        ("food_lunch", "meal preference", "vegetarian lunch", "food-vegetarian"),
+        ("finance_invoice", "invoice approval reporting", "invoice approval", "finance-invoice"),
+        ("health_running", "running habit", "five kilometer", "health-running"),
+    ]
+    return [
+        QueryCase(
+            name=name,
+            text=text,
+            vector=by_key[key].vector,
+            keyword_query=keyword,
+            filters={"user_id": by_key[key].user_id},
+            expected_key=key,
+            expected_id=by_key[key].id,
+        )
+        for name, text, keyword, key in targets
+    ]
+
+
+def build_complex_dataset(scale: int) -> list[MemoryCase]:
+    base_cases = [
+        MemoryCase(
+            key="alice-window-seat",
+            data="Alice strongly prefers quiet window seats on early morning flights",
+            text_lemmatized="alice strongly prefer quiet window seat early morning flight",
+            user_id="alice",
+            agent_id="travel-agent",
+            category="travel",
+            language="en",
+            vector=[0.90, 0.12, 0.05, 0.05, 0.02, 0.02, 0.01, 0.01],
+        ),
+        MemoryCase(
+            key="alice-aisle-seat-negative",
+            data="Alice dislikes aisle seats unless the flight is overnight",
+            text_lemmatized="alice dislike aisle seat unless flight overnight",
+            user_id="alice",
+            agent_id="travel-agent",
+            category="travel",
+            language="en",
+            vector=[0.91, 0.13, 0.05, 0.05, 0.02, 0.02, 0.01, 0.01],
+        ),
+        MemoryCase(
+            key="bob-window-cross-tenant",
+            data="Bob prefers quiet window seats on morning flights",
+            text_lemmatized="bob prefer quiet window seat morning flight",
+            user_id="bob",
+            agent_id="travel-agent",
+            category="travel",
+            language="en",
+            vector=[0.90, 0.12, 0.05, 0.05, 0.02, 0.02, 0.01, 0.01],
+        ),
+        MemoryCase(
+            key="xiaoli-priority-boarding",
+            data="小李 books flights with priority boarding and upgrade coupons",
+            text_lemmatized="小李 book flight priority boarding upgrade coupon",
+            user_id="xiaoli",
+            agent_id="travel-agent",
+            category="travel",
+            language="mixed",
+            vector=[0.87, 0.16, 0.06, 0.06, 0.02, 0.02, 0.02, 0.02],
+        ),
+        MemoryCase(
+            key="xiaowang-latte",
+            data="小王喜欢早晨喝拿铁咖啡",
+            text_lemmatized="小王 喜欢 早晨 喝 拿铁 咖啡 latte coffee",
+            user_id="xiaowang",
+            agent_id="food-agent",
+            category="food",
+            language="zh",
+            vector=[0.10, 0.90, 0.05, 0.04, 0.05, 0.02, 0.02, 0.02],
+        ),
+        MemoryCase(
+            key="xiaowang-matcha-negative",
+            data="小王周末会点抹茶蛋糕但不喝咖啡",
+            text_lemmatized="小王 weekend order matcha cake not coffee",
+            user_id="xiaowang",
+            agent_id="food-agent",
+            category="food",
+            language="zh",
+            vector=[0.11, 0.89, 0.05, 0.04, 0.05, 0.02, 0.02, 0.02],
+        ),
+        MemoryCase(
+            key="dana-2fa-reset",
+            data="Dana needs help resetting two factor authentication for the finance portal",
+            text_lemmatized="dana need help reset two factor authentication 2fa finance portal authenticator",
+            user_id="dana",
+            agent_id="support-agent",
+            category="support",
+            language="en",
+            vector=[0.05, 0.04, 0.10, 0.90, 0.06, 0.03, 0.02, 0.02],
+        ),
+        MemoryCase(
+            key="dana-password-reset-negative",
+            data="Dana changed her finance portal password last month",
+            text_lemmatized="dana change finance portal password last month",
+            user_id="dana",
+            agent_id="support-agent",
+            category="support",
+            language="en",
+            vector=[0.05, 0.04, 0.10, 0.91, 0.06, 0.03, 0.02, 0.02],
+        ),
+        MemoryCase(
+            key="carol-invoice-approval",
+            data="Carol tracks invoice approvals before quarterly reporting",
+            text_lemmatized="carol track invoice approval quarterly reporting",
+            user_id="carol",
+            agent_id="finance-agent",
+            category="finance",
+            language="en",
+            vector=[0.04, 0.05, 0.91, 0.08, 0.05, 0.03, 0.02, 0.02],
+        ),
+        MemoryCase(
+            key="carol-reimbursement-negative",
+            data="Carol files travel reimbursements after conferences",
+            text_lemmatized="carol file travel reimbursement conference",
+            user_id="carol",
+            agent_id="finance-agent",
+            category="finance",
+            language="en",
+            vector=[0.05, 0.05, 0.90, 0.08, 0.05, 0.03, 0.02, 0.02],
+        ),
+        MemoryCase(
+            key="evan-running-wednesday",
+            data="Evan runs five kilometers after work every Wednesday",
+            text_lemmatized="evan run five kilometer after work every wednesday",
+            user_id="evan",
+            agent_id="health-agent",
+            category="health",
+            language="en",
+            vector=[0.03, 0.04, 0.05, 0.06, 0.90, 0.12, 0.02, 0.02],
+        ),
+        MemoryCase(
+            key="evan-cycling-negative",
+            data="Evan cycles indoors on rainy Sundays",
+            text_lemmatized="evan cycle indoors rainy sunday",
+            user_id="evan",
+            agent_id="health-agent",
+            category="health",
+            language="en",
+            vector=[0.03, 0.04, 0.05, 0.06, 0.89, 0.13, 0.02, 0.02],
+        ),
+        MemoryCase(
+            key="phoenix-launch-budget",
+            data="Project Phoenix launch budget requires approval from Mira",
+            text_lemmatized="project phoenix launch budget require approval mira",
+            user_id="mira",
+            agent_id="project-agent",
+            category="project",
+            language="en",
+            vector=[0.04, 0.04, 0.12, 0.04, 0.03, 0.90, 0.08, 0.02],
+        ),
+        MemoryCase(
+            key="phoenix-design-review-negative",
+            data="Project Phoenix design review moved to next Tuesday",
+            text_lemmatized="project phoenix design review moved next tuesday",
+            user_id="mira",
+            agent_id="project-agent",
+            category="project",
+            language="en",
+            vector=[0.04, 0.04, 0.12, 0.04, 0.03, 0.91, 0.08, 0.02],
+        ),
+    ]
+
+    records: list[MemoryCase] = list(base_cases)
+    for repeat in range(1, scale):
+        for case in base_cases:
+            records.append(
+                MemoryCase(
+                    key=f"{case.key}-distractor-{repeat}",
+                    data=f"{case.data} archived distractor {repeat}",
+                    text_lemmatized=f"{case.text_lemmatized} archived distractor {repeat}",
+                    user_id=case.user_id,
+                    agent_id=case.agent_id,
+                    category=case.category,
+                    language=case.language,
+                    vector=_offset(case.vector, repeat * 0.001),
+                )
+            )
+    return records
+
+
+def build_complex_queries(records: list[MemoryCase]) -> list[QueryCase]:
+    by_key = {record.key: record for record in records}
+    targets = [
+        (
+            "hard_window_vs_aisle",
+            "Alice flight seat preference",
+            "window seat morning flight",
+            "alice-window-seat",
+            by_key["alice-aisle-seat-negative"].vector,
+            {"user_id": "alice"},
+        ),
+        (
+            "cross_tenant_window",
+            "Bob flight seat preference",
+            "window seat morning flight",
+            "bob-window-cross-tenant",
+            by_key["alice-window-seat"].vector,
+            {"user_id": "bob"},
+        ),
+        (
+            "mixed_priority_boarding",
+            "flight upgrade boarding preference",
+            "priority boarding upgrade",
+            "xiaoli-priority-boarding",
+            by_key["xiaoli-priority-boarding"].vector,
+            {"user_id": "xiaoli"},
+        ),
+        (
+            "zh_latte_vs_matcha",
+            "早晨饮品偏好",
+            "拿铁 咖啡 latte coffee",
+            "xiaowang-latte",
+            by_key["xiaowang-matcha-negative"].vector,
+            {"user_id": "xiaowang"},
+        ),
+        (
+            "support_2fa_vs_password",
+            "finance portal login help",
+            "2fa authenticator two factor",
+            "dana-2fa-reset",
+            by_key["dana-password-reset-negative"].vector,
+            {"user_id": "dana"},
+        ),
+        (
+            "finance_invoice_vs_reimbursement",
+            "quarterly finance approval",
+            "invoice approval quarterly",
+            "carol-invoice-approval",
+            by_key["carol-reimbursement-negative"].vector,
+            {"user_id": "carol"},
+        ),
+        (
+            "health_running_vs_cycling",
+            "weekly exercise habit",
+            "five kilometer wednesday",
+            "evan-running-wednesday",
+            by_key["evan-cycling-negative"].vector,
+            {"user_id": "evan"},
+        ),
+        (
+            "project_budget_vs_design",
+            "phoenix project approval",
+            "launch budget approval mira",
+            "phoenix-launch-budget",
+            by_key["phoenix-design-review-negative"].vector,
+            {"user_id": "mira"},
+        ),
+    ]
+    return [
+        QueryCase(
+            name=name,
+            text=text,
+            keyword_query=keyword,
+            expected_key=key,
+            expected_id=by_key[key].id,
+            vector=vector,
+            filters=filters,
+        )
+        for name, text, keyword, key, vector, filters in targets
+    ]
+
+
+def build_workload(scenario: str, scale: int) -> tuple[list[MemoryCase], list[QueryCase]]:
+    if scenario == "simple":
+        records = build_simple_dataset(scale)
+        return records, build_simple_queries(records)
+    records = build_complex_dataset(scale)
+    return records, build_complex_queries(records)
+
+
+def percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, int(round((len(ordered) - 1) * pct)))
+    return ordered[index]
+
+
+def ids(results: Any) -> list[str]:
+    if results is None:
+        return []
+    return [str(item.id) for item in results]
+
+
+def reciprocal_rank(result_ids: list[str], expected_id: str) -> float:
+    for index, result_id in enumerate(result_ids, start=1):
+        if result_id == expected_id:
+            return 1.0 / index
+    return 0.0
+
+
+def summarize_query_results(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    latencies = [row["latency_ms"] for row in rows]
+    return {
+        "queries": len(rows),
+        "hit_at_1": sum(1 for row in rows if row["rank"] == 1),
+        "hit_at_3": sum(1 for row in rows if row["rank"] is not None and 0 < row["rank"] <= 3),
+        "mrr": round(statistics.mean(row["rr"] for row in rows), 4) if rows else 0.0,
+        "p50_ms": round(statistics.median(latencies), 2) if latencies else 0.0,
+        "p95_ms": round(percentile(latencies, 0.95), 2),
+        "details": rows,
+    }
+
+
+def fused_result_ids(semantic_ids: list[str], keyword_ids: list[str]) -> list[str]:
+    scores: dict[str, float] = {}
+    first_seen: dict[str, int] = {}
+    counter = 0
+    for result_ids in (semantic_ids, keyword_ids):
+        for rank, result_id in enumerate(result_ids, start=1):
+            scores[result_id] = scores.get(result_id, 0.0) + 1.0 / (60 + rank)
+            if result_id not in first_seen:
+                first_seen[result_id] = counter
+                counter += 1
+    return sorted(scores, key=lambda item: (-scores[item], first_seen[item]))
+
+
+def rank_of(result_ids: list[str], expected_id: str) -> int | None:
+    try:
+        return result_ids.index(expected_id) + 1
+    except ValueError:
+        return None
+
+
+def timed_call(fn):
+    start = time.perf_counter()
+    value = fn()
+    return value, (time.perf_counter() - start) * 1000
+
+
+def evaluate_provider(
+    name: str,
+    store: VectorStoreBase,
+    records: list[MemoryCase],
+    queries: list[QueryCase],
+    top_k: int,
+) -> dict[str, Any]:
+    vectors = [record.vector for record in records]
+    payloads = [record.payload for record in records]
+    record_ids = [record.id for record in records]
+    key_by_id = {record.id: record.key for record in records}
+
+    _, insert_ms = timed_call(lambda: store.insert(vectors=vectors, payloads=payloads, ids=record_ids))
+
+    semantic_rows = []
+    for query in queries:
+        results, latency_ms = timed_call(lambda q=query: store.search(q.text, q.vector, top_k=top_k, filters=q.filters))
+        result_ids = ids(results)
+        rank = rank_of(result_ids, query.expected_id)
+        semantic_rows.append(
+            {
+                "name": query.name,
+                "expected_key": query.expected_key,
+                "expected_id": query.expected_id,
+                "rank": rank,
+                "rr": reciprocal_rank(result_ids, query.expected_id),
+                "top_keys": [key_by_id.get(result_id, result_id) for result_id in result_ids[:top_k]],
+                "top_ids": result_ids[:top_k],
+                "latency_ms": round(latency_ms, 2),
+            }
+        )
+
+    keyword_rows = []
+    fused_rows = []
+    keyword_supported = True
+    for query in queries:
+        keyword_results, latency_ms = timed_call(
+            lambda q=query: store.keyword_search(q.keyword_query, top_k=top_k, filters=q.filters)
+        )
+        if keyword_results is None:
+            keyword_supported = False
+        result_ids = ids(keyword_results)
+        rank = rank_of(result_ids, query.expected_id)
+        keyword_rows.append(
+            {
+                "name": query.name,
+                "expected_key": query.expected_key,
+                "expected_id": query.expected_id,
+                "rank": rank,
+                "rr": reciprocal_rank(result_ids, query.expected_id),
+                "top_keys": [key_by_id.get(result_id, result_id) for result_id in result_ids[:top_k]],
+                "top_ids": result_ids[:top_k],
+                "latency_ms": round(latency_ms, 2),
+            }
+        )
+        semantic_ids = next(row["top_ids"] for row in semantic_rows if row["name"] == query.name)
+        fused_ids = fused_result_ids(semantic_ids, result_ids)[:top_k]
+        fused_rank = rank_of(fused_ids, query.expected_id)
+        fused_rows.append(
+            {
+                "name": query.name,
+                "expected_key": query.expected_key,
+                "expected_id": query.expected_id,
+                "rank": fused_rank,
+                "rr": reciprocal_rank(fused_ids, query.expected_id),
+                "top_keys": [key_by_id.get(result_id, result_id) for result_id in fused_ids],
+                "top_ids": fused_ids,
+                "latency_ms": 0.0,
+            }
+        )
+
+    batch_filters = {"run_id": RUN_ID}
+    batch_results, batch_ms = timed_call(
+        lambda: store.search_batch(
+            [query.text for query in queries],
+            [query.vector for query in queries],
+            top_k=top_k,
+            filters=batch_filters,
+        )
+    )
+    batch_rows = []
+    for query, results in zip(queries, batch_results):
+        result_ids = ids(results)
+        rank = rank_of(result_ids, query.expected_id)
+        batch_rows.append(
+            {
+                "name": query.name,
+                "expected_key": query.expected_key,
+                "expected_id": query.expected_id,
+                "rank": rank,
+                "rr": reciprocal_rank(result_ids, query.expected_id),
+                "top_keys": [key_by_id.get(result_id, result_id) for result_id in result_ids[:top_k]],
+                "top_ids": result_ids[:top_k],
+            }
+        )
+
+    scope_guard_enforced = False
+    try:
+        store.search("unscoped probe", queries[0].vector, top_k=1, filters=None)
+    except Exception:
+        scope_guard_enforced = True
+
+    return {
+        "provider": name,
+        "records": len(records),
+        "insert_ms": round(insert_ms, 2),
+        "semantic": summarize_query_results(semantic_rows),
+        "keyword_supported": keyword_supported,
+        "keyword": summarize_query_results(keyword_rows),
+        "fused": summarize_query_results(fused_rows),
+        "batch": {
+            "queries": len(batch_rows),
+            "hit_at_1": sum(1 for row in batch_rows if row["rank"] == 1),
+            "mrr": round(statistics.mean(row["rr"] for row in batch_rows), 4) if batch_rows else 0.0,
+            "total_ms": round(batch_ms, 2),
+            "details": batch_rows,
+        },
+        "scope_guard_enforced": scope_guard_enforced,
+    }
+
+
+def make_gaussdb(collection_name: str) -> GaussDB:
+    return GaussDB(
+        host=_require_env("GAUSSDB_HOST", "GAUSSDB_TEST_HOST"),
+        port=int(_require_env("GAUSSDB_PORT", "GAUSSDB_TEST_PORT")),
+        database=_require_env("GAUSSDB_DATABASE", "GAUSSDB_TEST_DATABASE"),
+        user=_require_env("GAUSSDB_USER", "GAUSSDB_TEST_USER"),
+        password=_require_env("GAUSSDB_PASSWORD", "GAUSSDB_TEST_PASSWORD"),
+        collection_name=collection_name,
+        embedding_model_dims=DIMENSIONS,
+        profile=_env("GAUSSDB_EVAL_PROFILE", default="commercial"),
+        metadata_mode=_env("GAUSSDB_EVAL_METADATA_MODE", default="auto"),
+        bm25_mode=_env("GAUSSDB_EVAL_BM25_MODE", default="auto"),
+        deployment_mode=_env("GAUSSDB_EVAL_DEPLOYMENT_MODE", default="centralized"),
+        distribution_mode=_env("GAUSSDB_EVAL_DISTRIBUTION_MODE", default="auto"),
+        vector_index_type=_env("GAUSSDB_EVAL_VECTOR_INDEX", default="gsdiskann"),
+        vector_metric="cosine",
+        require_scoped_filters=True,
+        auto_create=True,
+    )
+
+
+def make_pgvector(collection_name: str) -> PGVector:
+    return PGVector(
+        host=_env("PGVECTOR_HOST", default="127.0.0.1"),
+        port=int(_env("PGVECTOR_PORT", default="15432")),
+        dbname=_env("PGVECTOR_DATABASE", "PGVECTOR_DBNAME", default="mem0_eval"),
+        user=_env("PGVECTOR_USER", default="mem0"),
+        password=_env("PGVECTOR_PASSWORD", default="mem0pass"),
+        collection_name=collection_name,
+        embedding_model_dims=DIMENSIONS,
+        diskann=False,
+        hnsw=True,
+    )
+
+
+def cleanup(store: VectorStoreBase) -> None:
+    try:
+        store.delete_col()
+    except Exception as exc:
+        print(f"cleanup failed for {store.__class__.__name__}: {exc}")
+
+
+def print_comparison(results: list[dict[str, Any]]) -> None:
+    print("\n# mem0 provider comparison")
+    print(
+        "\n| Provider | Records | Insert ms | Semantic H@1 | Semantic MRR | Keyword | Keyword H@1 | Keyword MRR | Fused H@1 | Fused MRR | Semantic P95 ms | Keyword P95 ms | Batch ms | Scope guard |"
+    )
+    print("|---|---:|---:|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|---|")
+    for result in results:
+        print(
+            "| {provider} | {records} | {insert_ms} | {semantic_h1} | {semantic_mrr} | "
+            "{keyword_supported} | {keyword_h1} | {keyword_mrr} | {fused_h1} | {fused_mrr} | "
+            "{semantic_p95} | {keyword_p95} | {batch_ms} | {scope_guard} |".format(
+                provider=result["provider"],
+                records=result["records"],
+                insert_ms=result["insert_ms"],
+                semantic_h1=result["semantic"]["hit_at_1"],
+                semantic_mrr=result["semantic"]["mrr"],
+                keyword_supported="yes" if result["keyword_supported"] else "no",
+                keyword_h1=result["keyword"]["hit_at_1"],
+                keyword_mrr=result["keyword"]["mrr"],
+                fused_h1=result["fused"]["hit_at_1"],
+                fused_mrr=result["fused"]["mrr"],
+                semantic_p95=result["semantic"]["p95_ms"],
+                keyword_p95=result["keyword"]["p95_ms"],
+                batch_ms=result["batch"]["total_ms"],
+                scope_guard="yes" if result["scope_guard_enforced"] else "no",
+            )
+        )
+
+
+def print_query_details(results: list[dict[str, Any]]) -> None:
+    for result in results:
+        print(f"\n## {result['provider']} query details")
+        print("| Query | Expected | Semantic rank/top | Keyword rank/top | Fused rank/top |")
+        print("|---|---|---|---|---|")
+        keyword_by_name = {row["name"]: row for row in result["keyword"]["details"]}
+        fused_by_name = {row["name"]: row for row in result["fused"]["details"]}
+        for semantic_row in result["semantic"]["details"]:
+            keyword_row = keyword_by_name[semantic_row["name"]]
+            fused_row = fused_by_name[semantic_row["name"]]
+            print(
+                "| {query} | {expected} | {semantic_rank}: {semantic_top} | "
+                "{keyword_rank}: {keyword_top} | {fused_rank}: {fused_top} |".format(
+                    query=semantic_row["name"],
+                    expected=semantic_row["expected_key"],
+                    semantic_rank=semantic_row["rank"],
+                    semantic_top=", ".join(semantic_row["top_keys"]),
+                    keyword_rank=keyword_row["rank"],
+                    keyword_top=", ".join(keyword_row["top_keys"]),
+                    fused_rank=fused_row["rank"],
+                    fused_top=", ".join(fused_row["top_keys"]),
+                )
+            )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--provider", choices=["both", "gaussdb", "pgvector"], default="both")
+    parser.add_argument("--scenario", choices=["simple", "complex"], default="complex")
+    parser.add_argument("--scale", type=int, default=4, help="Repeat the scenario base cases N times")
+    parser.add_argument("--top-k", type=int, default=5)
+    parser.add_argument("--collection-prefix", default="mem0_ab_eval")
+    parser.add_argument("--keep", action="store_true", help="Keep benchmark collections for inspection")
+    parser.add_argument("--details", action="store_true", help="Print per-query expected/top-key details")
+    parser.add_argument("--json", action="store_true", help="Print full JSON result")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    suffix = uuid.uuid4().hex[:8]
+    records, queries = build_workload(args.scenario, scale=args.scale)
+
+    providers: list[tuple[str, VectorStoreBase]] = []
+    if args.provider in {"both", "gaussdb"}:
+        providers.append(("gaussdb", make_gaussdb(f"{args.collection_prefix}_g_{suffix}")))
+    if args.provider in {"both", "pgvector"}:
+        providers.append(("pgvector", make_pgvector(f"{args.collection_prefix}_p_{suffix}")))
+
+    results: list[dict[str, Any]] = []
+    try:
+        for name, store in providers:
+            print(f"Running {name} with {len(records)} records...")
+            results.append(evaluate_provider(name, store, records, queries, top_k=args.top_k))
+
+        print_comparison(results)
+        if args.details:
+            print_query_details(results)
+        if args.json:
+            print("\n# full json")
+            print(json.dumps(results, ensure_ascii=False, indent=2))
+    finally:
+        if not args.keep:
+            for _, store in providers:
+                cleanup(store)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/vector_stores/conftest.py
+++ b/tests/vector_stores/conftest.py
@@ -1,0 +1,404 @@
+"""
+Shared test infrastructure for GaussDB vector store tests.
+
+Provides:
+- Environment variable reading (GAUSSDB_TEST_*)
+- Layered fixtures: gaussdb_p0_db, gaussdb_p1_db, gaussdb_p2_performance, gaussdb_p2_concurrent
+- pytest mark registration: p0, p1, p2, slow, high_pressure
+- Helper functions: _new_collection_name, _assert_exact_ids, _insert_memories,
+  _concurrent_runner, _measure_latency
+- Reusable FakeEmbedder and env config builder
+"""
+
+import os
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextlib import contextmanager
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import pytest
+
+pytest.importorskip("psycopg2", reason="GaussDB tests require psycopg2-compatible driver")
+
+from mem0.vector_stores.gaussdb import GaussDB, OutputData  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+EMBEDDING_DIMS = 3
+
+# Deterministic test vectors (3-dimensional)
+VECTOR_COFFEE = [0.10, 0.20, 0.30]
+VECTOR_FLIGHT = [0.90, 0.10, 0.10]
+VECTOR_WINDOW = [0.20, 0.80, 0.20]
+VECTOR_AISLE = [0.20, 0.20, 0.80]
+VECTOR_ZERO = [0.0, 0.0, 0.0]
+VECTOR_UNIT_X = [1.0, 0.0, 0.0]
+VECTOR_UNIT_Y = [0.0, 1.0, 0.0]
+VECTOR_UNIT_Z = [0.0, 0.0, 1.0]
+VECTOR_NEGATIVE = [-0.5, -0.5, -0.5]
+VECTOR_LARGE = [999.0, 999.0, 999.0]
+
+
+# ---------------------------------------------------------------------------
+# Environment helpers
+# ---------------------------------------------------------------------------
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    """Parse boolean environment variable."""
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _new_collection_name(prefix: str = "mem0_test") -> str:
+    """Generate a unique collection name for test isolation."""
+    return f"{prefix}_{uuid.uuid4().hex[:10]}"
+
+
+def _gaussdb_env_config(collection_name: str, **overrides) -> Optional[Dict[str, Any]]:
+    """
+    Build GaussDB config dict from GAUSSDB_TEST_* environment variables.
+    Returns None if required env vars are missing.
+    """
+    dsn = os.getenv("GAUSSDB_TEST_DSN")
+    if dsn:
+        config = {"connection_string": dsn}
+    else:
+        required = {
+            "host": os.getenv("GAUSSDB_TEST_HOST"),
+            "port": os.getenv("GAUSSDB_TEST_PORT"),
+            "database": os.getenv("GAUSSDB_TEST_DATABASE"),
+            "user": os.getenv("GAUSSDB_TEST_USER"),
+            "password": os.getenv("GAUSSDB_TEST_PASSWORD"),
+        }
+        if not all(required.values()):
+            return None
+        config = {
+            "host": required["host"],
+            "port": int(required["port"]),
+            "database": required["database"],
+            "user": required["user"],
+            "password": required["password"],
+        }
+
+    optional_env = {
+        "sslmode": os.getenv("GAUSSDB_TEST_SSLMODE"),
+        "sslrootcert": os.getenv("GAUSSDB_TEST_SSLROOTCERT"),
+    }
+    config.update({key: value for key, value in optional_env.items() if value})
+    config.update(
+        {
+            "collection_name": collection_name,
+            "embedding_model_dims": EMBEDDING_DIMS,
+            "vector_index_type": os.getenv("GAUSSDB_TEST_VECTOR_INDEX", "gsdiskann"),
+            "deployment_mode": os.getenv("GAUSSDB_TEST_DEPLOYMENT_MODE", "centralized"),
+            "auto_create": True,
+        }
+    )
+    config.update({key: value for key, value in overrides.items() if value is not None})
+    return config
+
+
+def gaussdb_available() -> bool:
+    """Check if GaussDB test environment is configured."""
+    return _gaussdb_env_config("probe") is not None
+
+
+# ---------------------------------------------------------------------------
+# FakeEmbedder
+# ---------------------------------------------------------------------------
+
+
+class FakeEmbedder:
+    """Deterministic embedder for testing."""
+
+    def embed(self, text, memory_action=None):
+        normalized = str(text).lower()
+        if "aisle" in normalized:
+            return VECTOR_AISLE
+        if "window" in normalized:
+            return VECTOR_WINDOW
+        if "flight" in normalized:
+            return VECTOR_FLIGHT
+        return VECTOR_COFFEE
+
+    def embed_batch(self, texts, memory_action="add"):
+        return [self.embed(text, memory_action) for text in texts]
+
+
+# ---------------------------------------------------------------------------
+# ID helpers
+# ---------------------------------------------------------------------------
+
+
+def _uuid(suffix: int) -> str:
+    """Generate a deterministic UUID from a numeric suffix."""
+    return f"00000000-0000-0000-0000-{suffix:012d}"
+
+
+def _ids(rows: List[OutputData]) -> List[str]:
+    """Extract IDs from OutputData rows."""
+    return [str(row.id) for row in rows]
+
+
+def _assert_exact_ids(rows: List[OutputData], expected_ids: set) -> None:
+    """Assert that rows contain exactly the expected IDs (order-independent)."""
+    assert set(_ids(rows)) == {str(eid) for eid in expected_ids}
+
+
+def _assert_ordered_ids(rows: List[OutputData], expected_ids: list) -> None:
+    """Assert that rows contain exactly the expected IDs in order."""
+    assert _ids(rows) == [str(eid) for eid in expected_ids]
+
+
+def _list_flat(db, filters=None, top_k=100) -> List[OutputData]:
+    """Call db.list() and flatten the nested result to a flat list of OutputData."""
+    result = db.list(filters=filters, top_k=top_k)
+    if result and isinstance(result[0], list):
+        return [item for sublist in result for item in sublist]
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Data insertion helpers
+# ---------------------------------------------------------------------------
+
+
+def _insert_memories(db: GaussDB, records: List[Tuple[str, List[float], dict]]) -> None:
+    """Insert a batch of (id, vector, payload) records."""
+    db.insert(
+        ids=[record_id for record_id, _, _ in records],
+        vectors=[vector for _, vector, _ in records],
+        payloads=[payload for _, _, payload in records],
+    )
+
+
+def _make_payload(data: str, user_id: str = "test_user", **extra) -> dict:
+    """Create a standard payload dict."""
+    payload = {
+        "data": data,
+        "text_lemmatized": data.lower(),
+        "user_id": user_id,
+    }
+    payload.update(extra)
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Database factory
+# ---------------------------------------------------------------------------
+
+
+def _new_db(collection_name: Optional[str] = None, prefix: str = "mem0_test", **overrides) -> GaussDB:
+    """Create a new GaussDB instance with a unique collection."""
+    config = _gaussdb_env_config(collection_name or _new_collection_name(prefix), **overrides)
+    assert config is not None, "GaussDB test environment not configured"
+    return GaussDB(**config)
+
+
+@contextmanager
+def _managed_db(prefix: str = "mem0_test", **overrides):
+    """Context manager that creates a GaussDB instance and cleans up on exit."""
+    db = _new_db(prefix=prefix, **overrides)
+    try:
+        yield db
+    finally:
+        try:
+            db.delete_col()
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Performance measurement helpers
+# ---------------------------------------------------------------------------
+
+
+def _measure_latency(func: Callable, iterations: int = 10) -> Dict[str, float]:
+    """
+    Measure latency of a function over multiple iterations.
+    Returns dict with p50, p99, min, max, mean in milliseconds.
+    """
+    latencies = []
+    for _ in range(iterations):
+        start = time.perf_counter()
+        func()
+        elapsed = (time.perf_counter() - start) * 1000  # ms
+        latencies.append(elapsed)
+
+    latencies.sort()
+    n = len(latencies)
+    return {
+        "min_ms": latencies[0],
+        "max_ms": latencies[-1],
+        "mean_ms": sum(latencies) / n,
+        "p50_ms": latencies[n // 2],
+        "p99_ms": latencies[int(n * 0.99)] if n >= 100 else latencies[-1],
+        "iterations": n,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Concurrency helpers
+# ---------------------------------------------------------------------------
+
+
+def _concurrent_runner(
+    func: Callable,
+    num_threads: int = 10,
+    iterations_per_thread: int = 10,
+    timeout: float = 60.0,
+) -> Dict[str, Any]:
+    """
+    Run a function concurrently across multiple threads.
+    Returns dict with success_count, error_count, errors, duration_ms.
+    """
+    errors = []
+    success_count = 0
+    start = time.perf_counter()
+
+    with ThreadPoolExecutor(max_workers=num_threads) as executor:
+        futures = []
+        for thread_idx in range(num_threads):
+            for iter_idx in range(iterations_per_thread):
+                futures.append(executor.submit(func, thread_idx, iter_idx))
+
+        for future in as_completed(futures, timeout=timeout):
+            try:
+                future.result()
+                success_count += 1
+            except Exception as exc:
+                errors.append(str(exc))
+
+    duration_ms = (time.perf_counter() - start) * 1000
+    return {
+        "success_count": success_count,
+        "error_count": len(errors),
+        "errors": errors[:10],  # limit error list
+        "duration_ms": duration_ms,
+        "total_operations": num_threads * iterations_per_thread,
+    }
+
+
+# ---------------------------------------------------------------------------
+# pytest marks registration
+# ---------------------------------------------------------------------------
+
+
+def pytest_configure(config):
+    """Register custom pytest markers."""
+    config.addinivalue_line("markers", "p0: Priority 0 - core functionality smoke tests")
+    config.addinivalue_line("markers", "p1: Priority 1 - comprehensive coverage tests")
+    config.addinivalue_line("markers", "p2: Priority 2 - performance and stress tests")
+    config.addinivalue_line("markers", "slow: Tests that take significant time to run")
+    config.addinivalue_line("markers", "high_pressure: High-pressure stress tests")
+    config.addinivalue_line("markers", "bm25: Tests requiring BM25 support")
+    config.addinivalue_line("markers", "gaussdb_features: GaussDB-specific feature tests")
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+_SKIP_REASON = "Set GAUSSDB_TEST_DSN or all of GAUSSDB_TEST_HOST/PORT/DATABASE/USER/PASSWORD to run GaussDB live tests"
+
+
+@pytest.fixture
+def gaussdb_p1_db():
+    """Fixture providing a GaussDB instance for P1 tests with automatic cleanup."""
+    if not gaussdb_available():
+        pytest.skip(_SKIP_REASON)
+    db = _new_db(prefix="mem0_p1")
+    yield db
+    try:
+        db.delete_col()
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def gaussdb_p1_db_json_expression():
+    """Fixture providing a GaussDB instance with json_expression filter mode (now the only mode)."""
+    if not gaussdb_available():
+        pytest.skip(_SKIP_REASON)
+    db = _new_db(prefix="mem0_p1_json")
+    yield db
+    try:
+        db.delete_col()
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def gaussdb_p1_db_redundant():
+    """Fixture providing a GaussDB instance (redundant_columns mode removed, uses json_expression)."""
+    if not gaussdb_available():
+        pytest.skip(_SKIP_REASON)
+    db = _new_db(prefix="mem0_p1_red")
+    yield db
+    try:
+        db.delete_col()
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def gaussdb_p2_performance():
+    """Fixture providing a GaussDB instance for performance tests."""
+    if not gaussdb_available():
+        pytest.skip(_SKIP_REASON)
+    db = _new_db(prefix="mem0_p2_perf")
+    yield db
+    try:
+        db.delete_col()
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def gaussdb_p2_concurrent():
+    """Fixture providing a GaussDB instance for concurrency tests."""
+    if not gaussdb_available():
+        pytest.skip(_SKIP_REASON)
+    db = _new_db(prefix="mem0_p2_conc", maxconn=20)
+    yield db
+    try:
+        db.delete_col()
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def gaussdb_bm25_db():
+    """Fixture providing a GaussDB instance with BM25 enabled."""
+    if not gaussdb_available():
+        pytest.skip(_SKIP_REASON)
+    if not _env_bool("GAUSSDB_TEST_RUN_BM25"):
+        pytest.skip("Set GAUSSDB_TEST_RUN_BM25=true to run BM25 tests")
+    db = _new_db(
+        prefix="mem0_bm25",
+    )
+    yield db
+    try:
+        db.delete_col()
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def gaussdb_features_db():
+    """Fixture providing a GaussDB instance for feature verification tests."""
+    if not gaussdb_available():
+        pytest.skip(_SKIP_REASON)
+    db = _new_db(prefix="mem0_feat")
+    yield db
+    try:
+        db.delete_col()
+    except Exception:
+        pass

--- a/tests/vector_stores/gaussdb_quality_cases.json
+++ b/tests/vector_stores/gaussdb_quality_cases.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1",
+    "data": "Alice prefers quiet window seats on morning flights",
+    "text_lemmatized": "alice prefer quiet window seat morning flight",
+    "user_id": "alice",
+    "agent_id": "travel-agent",
+    "run_id": "quality-run",
+    "vector": [0.10, 0.20, 0.30],
+    "semantic_query": "flight seat preference",
+    "semantic_vector": [0.10, 0.20, 0.30],
+    "keyword_query": "window seat"
+  },
+  {
+    "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2",
+    "data": "Bob likes aisle seats on evening trains",
+    "text_lemmatized": "bob like aisle seat evening train",
+    "user_id": "bob",
+    "agent_id": "travel-agent",
+    "run_id": "quality-run",
+    "vector": [0.90, 0.10, 0.10],
+    "semantic_query": "train seat preference",
+    "semantic_vector": [0.90, 0.10, 0.10],
+    "keyword_query": "aisle seat"
+  },
+  {
+    "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa3",
+    "data": "Carol prefers vegetarian lunch and jasmine tea",
+    "text_lemmatized": "carol prefer vegetarian lunch jasmine tea",
+    "user_id": "carol",
+    "agent_id": "food-agent",
+    "run_id": "quality-run",
+    "vector": [0.20, 0.80, 0.20],
+    "semantic_query": "meal preference",
+    "semantic_vector": [0.20, 0.80, 0.20],
+    "keyword_query": "vegetarian lunch"
+  },
+  {
+    "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa4",
+    "data": "小王喜欢早晨喝拿铁咖啡",
+    "text_lemmatized": "小王 喜欢 早晨 喝 拿铁 咖啡",
+    "user_id": "xiaowang",
+    "agent_id": "cn-agent",
+    "run_id": "quality-run",
+    "vector": [0.30, 0.30, 0.70],
+    "semantic_query": "早晨饮品偏好",
+    "semantic_vector": [0.30, 0.30, 0.70],
+    "keyword_query": "拿铁 咖啡"
+  },
+  {
+    "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa5",
+    "data": "小李 books flights with priority boarding",
+    "text_lemmatized": "小李 book flight priority boarding",
+    "user_id": "xiaoli",
+    "agent_id": "mixed-agent",
+    "run_id": "quality-run",
+    "vector": [0.40, 0.40, 0.40],
+    "semantic_query": "priority boarding flight",
+    "semantic_vector": [0.40, 0.40, 0.40],
+    "keyword_query": "priority boarding"
+  }
+]

--- a/tests/vector_stores/test_gaussdb.py
+++ b/tests/vector_stores/test_gaussdb.py
@@ -1,0 +1,1427 @@
+import json
+import logging
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from mem0.configs.vector_stores.gaussdb import GaussDBConfig
+from mem0.utils.factory import VectorStoreFactory
+from mem0.vector_stores.configs import VectorStoreConfig
+from mem0.vector_stores.gaussdb import GaussDB
+
+
+def make_gaussdb(**kwargs):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_conn.cursor.return_value = mock_cursor
+    mock_conn.get_parameter_status.return_value = "UTF8"
+    mock_cursor.fetchone.return_value = ("UTF8",)
+    mock_pool = MagicMock()
+    mock_pool.getconn.return_value = mock_conn
+
+    config = {
+        "collection_name": "test_collection",
+        "embedding_model_dims": 3,
+        "auto_create": False,
+    }
+    config.update(kwargs)
+
+    with patch.object(GaussDB, "_create_connection_pool", return_value=mock_pool):
+        with patch.object(GaussDB, "_probe_capabilities"):
+            db = GaussDB(**config)
+    return db, mock_pool, mock_conn, mock_cursor
+
+
+def executed_sql(mock_cursor):
+    return "\n".join(str(call.args[0]) for call in mock_cursor.execute.call_args_list)
+
+
+# ============================================================
+# Config tests
+# ============================================================
+
+
+def test_gaussdb_config_defaults():
+    cfg = GaussDBConfig(
+        host="localhost",
+        port=5432,
+        user="test",
+        password="test",
+    )
+
+    assert cfg.database == "postgres"
+    assert cfg.deployment_mode == "centralized"
+    assert cfg.vector_index_type == "gsdiskann"
+    assert cfg.vector_metric == "cosine"
+    assert cfg.collection_name == "mem0"
+    assert cfg.schema == "public"
+    assert cfg.embedding_model_dims == 1536
+    assert cfg.minconn == 1
+    assert cfg.maxconn == 5
+    assert cfg.auto_create is True
+    assert cfg.require_scoped_filters is True
+
+
+def test_gaussdb_config_accepts_connection_string():
+    cfg = GaussDBConfig(connection_string="postgresql://user:pass@localhost:19995/mem0db")
+
+    assert cfg.connection_string == "postgresql://user:pass@localhost:19995/mem0db"
+
+
+def test_gaussdb_config_accepts_distributed_deployment_mode():
+    cfg = GaussDBConfig(
+        host="localhost",
+        port=5432,
+        user="test",
+        password="test",
+        deployment_mode="distributed",
+        embedding_model_dims=512,
+    )
+
+    assert cfg.deployment_mode == "distributed"
+
+
+def test_gaussdb_config_accepts_require_scoped_filters_override():
+    cfg = GaussDBConfig(
+        host="localhost",
+        port=5432,
+        user="test",
+        password="test",
+        require_scoped_filters=False,
+    )
+
+    assert cfg.require_scoped_filters is False
+
+
+def test_gaussdb_config_accepts_metadata_schema():
+    cfg = GaussDBConfig(
+        host="localhost",
+        port=5432,
+        user="test",
+        password="test",
+        metadata_schema={"priority": "number", "title": "text", "flag": "bool"},
+    )
+
+    assert cfg.metadata_schema == {"priority": "number", "title": "text", "flag": "bool"}
+
+
+def test_gaussdb_config_accepts_custom_schema():
+    cfg = GaussDBConfig(
+        host="localhost",
+        port=5432,
+        user="test",
+        password="test",
+        schema="mem0_app",
+    )
+
+    assert cfg.schema == "mem0_app"
+
+
+def test_gaussdb_config_rejects_invalid_schema():
+    with pytest.raises(Exception, match="schema"):
+        GaussDBConfig(
+            host="localhost",
+            port=5432,
+            user="test",
+            password="test",
+            schema="bad-schema",
+        )
+
+
+def test_gaussdb_config_rejects_invalid_metadata_schema_type():
+    with pytest.raises(Exception, match="metadata_schema"):
+        GaussDBConfig(
+            host="localhost",
+            port=5432,
+            user="test",
+            password="test",
+            metadata_schema={"priority": "decimal"},
+        )
+
+
+def test_gaussdb_config_rejects_centralized_with_too_high_dims():
+    with pytest.raises(Exception, match="centralized mode only supports"):
+        GaussDBConfig(
+            host="localhost",
+            port=5432,
+            user="test",
+            password="test",
+            deployment_mode="centralized",
+            embedding_model_dims=8192,
+        )
+
+
+def test_gaussdb_config_rejects_distributed_with_high_dims():
+    with pytest.raises(Exception):
+        GaussDBConfig(
+            host="localhost",
+            port=5432,
+            user="test",
+            password="test",
+            deployment_mode="distributed",
+            embedding_model_dims=2048,
+        )
+
+
+def test_gaussdb_config_rejects_high_dims_with_gsivfflat():
+    with pytest.raises(Exception, match="only GsDiskANN supports"):
+        GaussDBConfig(
+            host="localhost",
+            port=5432,
+            user="test",
+            password="test",
+            vector_index_type="gsivfflat",
+            embedding_model_dims=2048,
+        )
+
+
+def test_gaussdb_config_rejects_partial_credentials_without_connection_string():
+    with pytest.raises(Exception, match="both 'user' and 'password' must be provided together"):
+        GaussDBConfig(
+            host="localhost",
+            port=5432,
+            user="test",
+        )
+
+
+def test_gaussdb_config_rejects_partial_host_port_without_connection_string():
+    with pytest.raises(Exception, match="both 'host' and 'port' must be provided together"):
+        GaussDBConfig(
+            user="test",
+            password="test",
+            host="localhost",
+        )
+
+
+def test_gaussdb_config_rejects_zero_pool_sizes():
+    with pytest.raises(Exception, match="minconn must be >= 1"):
+        GaussDBConfig(
+            host="localhost",
+            port=5432,
+            user="test",
+            password="test",
+            minconn=0,
+        )
+
+    with pytest.raises(Exception, match="maxconn must be >= 1"):
+        GaussDBConfig(
+            host="localhost",
+            port=5432,
+            user="test",
+            password="test",
+            maxconn=0,
+        )
+
+
+def test_gaussdb_config_reads_connection_from_env(monkeypatch):
+    monkeypatch.setenv("GAUSSDB_HOST", "db.example.com")
+    monkeypatch.setenv("GAUSSDB_PORT", "19995")
+    monkeypatch.setenv("GAUSSDB_DATABASE", "mem0db")
+    monkeypatch.setenv("GAUSSDB_USER", "mem0_user")
+    monkeypatch.setenv("GAUSSDB_PASSWORD", "secret")
+
+    cfg = GaussDBConfig()
+
+    assert cfg.host == "db.example.com"
+    assert cfg.port == 19995
+    assert cfg.database == "mem0db"
+    assert cfg.user == "mem0_user"
+    assert cfg.password == "secret"
+
+
+def test_gaussdb_config_rejects_extra_fields():
+    with pytest.raises(Exception):
+        GaussDBConfig(
+            host="localhost",
+            port=5432,
+            user="test",
+            password="test",
+            unexpected=True,
+        )
+
+
+def test_gaussdb_enable_bm25_alias_tracks_bm25_enabled():
+    db, _, _, _ = make_gaussdb()
+
+    assert db.enable_bm25 is True
+    db.enable_bm25 = False
+    assert db.bm25_enabled is False
+    db.bm25_enabled = True
+    assert db.enable_bm25 is True
+
+
+def test_vector_store_config_and_factory_register_gaussdb():
+    cfg = VectorStoreConfig(
+        provider="gaussdb",
+        config={
+            "host": "localhost",
+            "port": 5432,
+            "user": "test",
+            "password": "test",
+            "auto_create": False,
+        },
+    )
+
+    assert isinstance(cfg.config, GaussDBConfig)
+    assert VectorStoreFactory.provider_to_class["gaussdb"] == "mem0.vector_stores.gaussdb.GaussDB"
+
+
+def test_factory_creates_gaussdb_instance():
+    db, mock_pool, _, _ = make_gaussdb()
+    with patch.object(GaussDB, "_create_connection_pool", return_value=mock_pool):
+        with patch.object(GaussDB, "_probe_capabilities"):
+            created = VectorStoreFactory.create(
+                "gaussdb",
+                {
+                    "collection_name": "test_collection",
+                    "embedding_model_dims": 3,
+                    "auto_create": False,
+                    "host": "localhost",
+                    "port": 5432,
+                    "user": "test",
+                    "password": "test",
+                },
+            )
+
+    assert isinstance(created, GaussDB)
+    assert created.collection_name == db.collection_name
+
+
+# ============================================================
+# Init validation tests
+# ============================================================
+
+
+def test_rejects_unsafe_identifier():
+    with pytest.raises(ValueError, match="Unsafe collection_name"):
+        make_gaussdb(collection_name='bad";drop')
+
+
+def test_distributed_mode_sets_hash_distribution():
+    db, _, _, _ = make_gaussdb(deployment_mode="distributed")
+    assert db.deployment_mode == "distributed"
+    assert db.distribution_mode == "hash"
+
+
+def test_centralized_mode_sets_none_distribution():
+    db, _, _, _ = make_gaussdb(deployment_mode="centralized")
+    assert db.deployment_mode == "centralized"
+    assert db.distribution_mode == "none"
+
+
+def test_rejects_high_dims_for_distributed():
+    with pytest.raises(ValueError, match="distributed mode supports"):
+        make_gaussdb(deployment_mode="distributed", embedding_model_dims=2048)
+
+
+def test_rejects_high_dims_with_gsivfflat():
+    with pytest.raises(ValueError, match="only GsDiskANN supports"):
+        make_gaussdb(vector_index_type="gsivfflat", embedding_model_dims=2048)
+
+
+# ============================================================
+# DDL / create_col tests
+# ============================================================
+
+
+def test_create_col_generates_ustore_vector_bm25_and_filter_indexes():
+    db, _, mock_conn, mock_cursor = make_gaussdb()
+
+    db.create_col()
+
+    sql = executed_sql(mock_cursor)
+    assert "WITH (storage_type=ustore)" in sql
+    assert "FLOATVECTOR(3)" in sql
+    assert "user_id VARCHAR(128)" in sql
+    assert "agent_id VARCHAR(128)" in sql
+    assert "run_id VARCHAR(128)" in sql
+    assert "SET LOCAL maintenance_work_mem" in sql
+    assert "USING gsdiskann (vector COSINE)" in sql
+    assert "USING bm25 (text_lemmatized)" in sql
+    assert "storage_type='USTORE'" in sql
+    assert '("user_id")' in sql or "user_id)" in sql
+    mock_cursor.execute.assert_any_call("SET LOCAL maintenance_work_mem = %s", ("128MB",))
+    mock_conn.commit.assert_called()
+
+
+def test_create_col_does_not_accept_alternate_collection_name():
+    db, _, _, _ = make_gaussdb()
+
+    with pytest.raises(TypeError):
+        db.create_col(name="other_collection")
+
+    with pytest.raises(TypeError):
+        db.create_col("other_collection")
+
+
+def test_distributed_create_col_generates_hash_distribution_clauses():
+    db, _, _, mock_cursor = make_gaussdb(deployment_mode="distributed")
+
+    db.create_col()
+
+    sql = executed_sql(mock_cursor)
+    assert db.deployment_mode == "distributed"
+    assert db.distribution_mode == "hash"
+    assert 'DISTRIBUTE BY HASH ("id")' in sql
+    assert 'DISTRIBUTE BY HASH ("collection_name")' in sql
+
+
+# ============================================================
+# Capability probe tests
+# ============================================================
+
+
+def test_capability_probe_sets_vector_index_maintenance_work_mem():
+    db, _, _, mock_cursor = make_gaussdb()
+    mock_cursor.fetchone.return_value = ("on",)
+
+    db._probe_capabilities()
+
+    sql = executed_sql(mock_cursor)
+    assert "SHOW enable_vectordb" in sql
+    assert "CREATE INDEX" in sql
+    assert "INSERT INTO" in sql
+    assert "text_lemmatized ### %s AS score" in sql
+    mock_cursor.execute.assert_any_call("SET LOCAL maintenance_work_mem = %s", ("128MB",))
+
+
+def test_set_vector_index_maintenance_work_mem_skips_when_current_is_higher():
+    db, _, _, mock_cursor = make_gaussdb()
+    mock_cursor.fetchone.return_value = ("4GB",)
+
+    db._set_vector_index_maintenance_work_mem(mock_cursor)
+
+    sql = executed_sql(mock_cursor)
+    assert "SHOW maintenance_work_mem" in sql
+    assert "SET LOCAL maintenance_work_mem" not in sql
+
+
+def test_set_vector_index_maintenance_work_mem_raises_default_for_high_dim_gsdiskann():
+    db, _, _, mock_cursor = make_gaussdb(embedding_model_dims=2048)
+    mock_cursor.fetchone.return_value = ("1GB",)
+
+    db._set_vector_index_maintenance_work_mem(mock_cursor)
+
+    mock_cursor.execute.assert_any_call("SHOW maintenance_work_mem")
+    mock_cursor.execute.assert_any_call("SET LOCAL maintenance_work_mem = %s", ("2GB",))
+
+
+def test_capability_probe_uses_distributed_probe_table_suffix():
+    db, _, _, mock_cursor = make_gaussdb(deployment_mode="distributed")
+    mock_cursor.fetchone.return_value = ("on",)
+
+    db._probe_capabilities()
+
+    sql = executed_sql(mock_cursor)
+    assert 'DISTRIBUTE BY HASH ("id")' in sql
+
+
+def test_capability_probe_falls_back_to_text_on_jsonb_failure():
+    db, _, _, mock_cursor = make_gaussdb()
+    mock_cursor.fetchone.return_value = ("on",)
+
+    def execute_side_effect(sql, *args):
+        if "CREATE TABLE" in str(sql) and "payload JSONB" in str(sql):
+            raise Exception("jsonb type unsupported")
+
+    mock_cursor.execute.side_effect = execute_side_effect
+
+    db._probe_capabilities()
+
+    assert db.payload_storage_mode == "text"
+    assert db.filter_storage_mode == "redundant_columns"
+    assert db.metadata_column_mode == "text"
+
+
+def test_capability_probe_keeps_json_filters_on_expression_index_failure(caplog):
+    db, _, _, mock_cursor = make_gaussdb()
+    mock_cursor.fetchone.return_value = ("on",)
+    caplog.set_level(logging.WARNING, logger="mem0.vector_stores.gaussdb")
+
+    def execute_side_effect(sql, *args):
+        if "payload->>'user_id'" in str(sql):
+            raise Exception("expression index unsupported")
+
+    mock_cursor.execute.side_effect = execute_side_effect
+
+    db._probe_capabilities()
+
+    assert db.payload_storage_mode == "jsonb"
+    assert db.filter_storage_mode == "json_expression"
+    assert db.metadata_column_mode == "jsonb"
+    assert db.capabilities.expression_index is False
+    assert "metadata filters remain available without expression indexes" in caplog.text
+
+
+def test_filter_index_creation_failure_warns_and_keeps_filter_mode(caplog):
+    db, _, _, mock_cursor = make_gaussdb()
+    caplog.set_level(logging.WARNING, logger="mem0.vector_stores.gaussdb")
+
+    def execute_side_effect(sql, *args):
+        if "CREATE INDEX IF NOT EXISTS" in str(sql) and "user_id" in str(sql):
+            raise Exception("expression index unsupported")
+
+    mock_cursor.execute.side_effect = execute_side_effect
+
+    db._create_filter_indexes(mock_cursor, '"public"."test_collection"')
+
+    assert db.filter_storage_mode == "json_expression"
+    assert db.metrics.get("gaussdb_fallback_count") == 1
+    assert "Filter index creation failed for key user_id" in caplog.text
+
+
+def test_capability_probe_bm25_score_failure_disables_bm25():
+    db, _, _, mock_cursor = make_gaussdb()
+    mock_cursor.fetchone.return_value = ("on",)
+
+    def execute_side_effect(sql, *args):
+        if "SELECT text_lemmatized ###" in str(sql):
+            raise Exception("operator ### unsupported")
+
+    mock_cursor.execute.side_effect = execute_side_effect
+
+    db._probe_capabilities()
+
+    sql = executed_sql(mock_cursor)
+    assert "ROLLBACK TO SAVEPOINT" in sql
+    assert db.bm25_enabled is False
+    assert db.metrics["gaussdb_fallback_count"] == 1
+
+
+# ============================================================
+# BM25 index graceful degradation
+# ============================================================
+
+
+def test_bm25_index_failure_rolls_back_and_disables_bm25():
+    db, _, _, mock_cursor = make_gaussdb()
+    mock_cursor.execute.side_effect = [None, Exception("bm25 unsupported"), None, None]
+
+    db._create_bm25_index(mock_cursor, '"test_collection"')
+
+    sql = executed_sql(mock_cursor)
+    assert "SAVEPOINT" in sql
+    assert "ROLLBACK TO SAVEPOINT" in sql
+    assert "RELEASE SAVEPOINT" in sql
+    assert db.bm25_enabled is False
+    assert db.metrics["gaussdb_fallback_count"] == 1
+
+
+def test_create_col_keeps_collection_when_bm25_index_fails():
+    db, _, mock_conn, mock_cursor = make_gaussdb()
+
+    def execute_side_effect(sql, *args):
+        if "USING bm25" in str(sql):
+            raise Exception("bm25 unsupported")
+
+    mock_cursor.execute.side_effect = execute_side_effect
+
+    db.create_col()
+
+    sql = executed_sql(mock_cursor)
+    assert "CREATE TABLE IF NOT EXISTS" in sql
+    assert "USING gsdiskann (vector COSINE)" in sql
+    assert "USING bm25 (text_lemmatized)" in sql
+    assert "ROLLBACK TO SAVEPOINT" in sql
+    assert '"user_id"' in sql
+    assert db.bm25_enabled is False
+    assert db.metrics["gaussdb_fallback_count"] == 1
+    mock_conn.commit.assert_called()
+
+
+# ============================================================
+# Insert tests
+# ============================================================
+
+
+def test_insert_uses_merge_into_and_vector_cast():
+    db, _, _, mock_cursor = make_gaussdb()
+
+    db.insert(
+        vectors=[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]],
+        payloads=[
+            {"data": "hello", "text_lemmatized": "hello", "user_id": "u1"},
+            {"data": "world", "text_lemmatized": "world", "user_id": "u1"},
+        ],
+        ids=["11111111-1111-1111-1111-111111111111", "22222222-2222-2222-2222-222222222222"],
+    )
+
+    sql = executed_sql(mock_cursor)
+    merge_args = mock_cursor.execute.call_args_list[-1].args[1]
+    assert "MERGE INTO" in sql
+    assert "WHEN MATCHED THEN" in sql
+    assert "WHEN NOT MATCHED THEN" in sql
+    assert mock_cursor.execute.call_count == 1
+    assert "%s::FLOATVECTOR" in sql
+    assert merge_args[1] == "[0.1,0.2,0.3]"
+    assert merge_args[3] == "hello"
+    assert merge_args[6] == "u1"
+
+
+def test_insert_many_rows_uses_single_merge_statement():
+    db, _, _, mock_cursor = make_gaussdb()
+
+    db.insert(
+        vectors=[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]],
+        payloads=[
+            {"data": "a", "text_lemmatized": "a", "user_id": "u1"},
+            {"data": "b", "text_lemmatized": "b", "user_id": "u1"},
+            {"data": "c", "text_lemmatized": "c", "user_id": "u1"},
+        ],
+        ids=[
+            "11111111-1111-1111-1111-111111111111",
+            "22222222-2222-2222-2222-222222222222",
+            "33333333-3333-3333-3333-333333333333",
+        ],
+    )
+
+    calls = mock_cursor.execute.call_args_list
+    assert len(calls) == 1
+    assert "MERGE INTO" in str(calls[0].args[0])
+    assert len(calls[0].args[1]) == 27
+
+
+def test_insert_raises_on_mismatched_lengths():
+    db, _, _, _ = make_gaussdb()
+
+    with pytest.raises(ValueError, match="same length"):
+        db.insert(vectors=[[0.1, 0.2, 0.3]], payloads=[{"a": 1}, {"b": 2}])
+
+    with pytest.raises(ValueError, match="same length"):
+        db.insert(vectors=[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]], ids=["id1"])
+
+    with pytest.raises(ValueError, match="same length"):
+        db.insert(vectors=[[0.1, 0.2, 0.3]], payloads=[], ids=["id1"])
+
+    with pytest.raises(ValueError, match="same length"):
+        db.insert(vectors=[[0.1, 0.2, 0.3]], payloads=[{}], ids=[])
+
+
+def test_insert_none_payloads_and_ids_use_defaults():
+    db, _, _, mock_cursor = make_gaussdb()
+
+    db.insert(vectors=[[0.1, 0.2, 0.3]], payloads=None, ids=None)
+
+    sql = executed_sql(mock_cursor)
+    params = mock_cursor.execute.call_args.args[1]
+    assert "MERGE INTO" in sql
+    assert params[1] == "[0.1,0.2,0.3]"
+    assert params[3] is None
+
+
+# ============================================================
+# Search tests
+# ============================================================
+
+
+def test_search_uses_cosine_operator_and_raw_distance_score():
+    db, _, _, mock_cursor = make_gaussdb()
+    mock_cursor.fetchall.return_value = [("id1", 0.25, {"data": "hello", "user_id": "u1"})]
+
+    results = db.search("hello", [0.1, 0.2, 0.3], top_k=5, filters={"user_id": "u1"})
+
+    sql = executed_sql(mock_cursor)
+    assert "vector <+> %s::FLOATVECTOR AS distance" in sql
+    assert '"user_id" = %s' in sql
+    assert results[0].id == "id1"
+    assert results[0].score == pytest.approx(0.25)
+    assert results[0].payload["data"] == "hello"
+
+
+def test_search_typed_bool_filter_uses_jsonb_containment():
+    db, _, _, mock_cursor = make_gaussdb()
+    mock_cursor.fetchall.return_value = [("id1", 0.1, {"data": "hello", "flag": True, "user_id": "u1"})]
+
+    results = db.search("hello", [0.1, 0.2, 0.3], filters={"user_id": "u1", "flag": True})
+
+    sql = executed_sql(mock_cursor)
+    params = mock_cursor.execute.call_args.args[1]
+    assert "payload @> %s::JSONB" in sql
+    assert '"user_id" = %s' in sql
+    assert params[1] == "u1"
+    assert params[2] == '{"flag":true}'
+    assert results[0].id == "id1"
+
+
+def test_search_wildcard_filter_is_skipped_not_literal_match():
+    db, _, _, mock_cursor = make_gaussdb()
+    mock_cursor.fetchall.return_value = []
+
+    db.search("hello", [0.1, 0.2, 0.3], filters={"user_id": "u1", "category": "*"})
+
+    sql = executed_sql(mock_cursor)
+    params = mock_cursor.execute.call_args.args[1]
+    assert "category" not in sql
+    assert params == ("[0.1,0.2,0.3]", "u1", 5)
+
+
+def test_search_all_wildcard_metadata_filters_do_not_leave_dangling_and():
+    db, _, _, mock_cursor = make_gaussdb(require_scoped_filters=False)
+    mock_cursor.fetchall.return_value = []
+
+    db.search("hello", [0.1, 0.2, 0.3], filters={"category": "*", "tag": "*"})
+
+    sql = executed_sql(mock_cursor)
+    assert "WHERE" not in sql or "WHERE  ORDER" not in sql
+    assert "AND  ORDER" not in sql
+    assert "category" not in sql
+    assert "tag" not in sql
+
+
+def test_search_eq_null_uses_jsonb_null_containment():
+    db, _, _, mock_cursor = make_gaussdb()
+    mock_cursor.fetchall.return_value = []
+
+    db.search("hello", [0.1, 0.2, 0.3], filters={"user_id": "u1", "deleted_at": None})
+
+    sql = executed_sql(mock_cursor)
+    params = mock_cursor.execute.call_args.args[1]
+    assert "payload @> %s::JSONB" in sql
+    assert params[2] == '{"deleted_at":null}'
+
+
+def test_search_ne_bool_uses_typed_jsonb_negation():
+    db, _, _, mock_cursor = make_gaussdb()
+    mock_cursor.fetchall.return_value = []
+
+    db.search("hello", [0.1, 0.2, 0.3], filters={"user_id": "u1", "flag": {"ne": True}})
+
+    sql = executed_sql(mock_cursor)
+    params = mock_cursor.execute.call_args.args[1]
+    assert "(payload @> %s::JSONB) IS NOT TRUE" in sql
+    assert params[2] == '{"flag":true}'
+
+
+def test_search_exists_filter_uses_jsonb_key_presence():
+    db, _, _, mock_cursor = make_gaussdb()
+    mock_cursor.fetchall.return_value = []
+
+    db.search("hello", [0.1, 0.2, 0.3], filters={"user_id": "u1", "flag": {"exists": True}})
+
+    sql = executed_sql(mock_cursor)
+    params = mock_cursor.execute.call_args.args[1]
+    assert "payload ? %s" in sql
+    assert params[2] == "flag"
+
+
+def test_search_missing_filter_uses_jsonb_key_absence():
+    db, _, _, mock_cursor = make_gaussdb()
+    mock_cursor.fetchall.return_value = []
+
+    db.search("hello", [0.1, 0.2, 0.3], filters={"user_id": "u1", "flag": {"missing": True}})
+
+    sql = executed_sql(mock_cursor)
+    params = mock_cursor.execute.call_args.args[1]
+    assert "(payload ? %s) IS NOT TRUE" in sql
+    assert params[2] == "flag"
+
+
+def test_search_exists_false_aliases_to_missing():
+    db, _, _, mock_cursor = make_gaussdb()
+    mock_cursor.fetchall.return_value = []
+
+    db.search("hello", [0.1, 0.2, 0.3], filters={"user_id": "u1", "flag": {"exists": False}})
+
+    sql = executed_sql(mock_cursor)
+    params = mock_cursor.execute.call_args.args[1]
+    assert "(payload ? %s) IS NOT TRUE" in sql
+    assert params[2] == "flag"
+
+
+def test_search_presence_filter_rejects_non_boolean_flag():
+    db, _, _, _ = make_gaussdb()
+
+    with pytest.raises(ValueError, match="must be a boolean"):
+        db.search("hello", [0.1, 0.2, 0.3], filters={"user_id": "u1", "flag": {"exists": "yes"}})
+
+
+def test_search_presence_filter_requires_single_operator():
+    db, _, _, _ = make_gaussdb()
+
+    with pytest.raises(ValueError, match="exactly one"):
+        db.search("hello", [0.1, 0.2, 0.3], filters={"user_id": "u1", "flag": {"exists": True, "missing": True}})
+
+
+def test_search_not_uses_is_not_true_semantics():
+    db, _, _, mock_cursor = make_gaussdb()
+    mock_cursor.fetchall.return_value = []
+
+    db.search("hello", [0.1, 0.2, 0.3], filters={"user_id": "u1", "$not": [{"category": "food"}]})
+
+    sql = executed_sql(mock_cursor)
+    assert "((payload @> %s::JSONB) IS NOT TRUE)" in sql
+
+
+def test_search_range_on_undeclared_field_warns_and_falls_back_to_literal_match(caplog):
+    db, _, _, mock_cursor = make_gaussdb()
+    mock_cursor.fetchall.return_value = []
+    caplog.set_level(logging.WARNING, logger="mem0.vector_stores.gaussdb")
+
+    db.search("hello", [0.1, 0.2, 0.3], filters={"user_id": "u1", "priority": {"gte": 3}})
+
+    sql = executed_sql(mock_cursor)
+    params = mock_cursor.execute.call_args.args[1]
+    assert "payload @> %s::JSONB" in sql
+    assert params[2] == '{"priority":{"gte":3}}'
+    assert "falling back to literal compatibility matching" in caplog.text
+
+
+def test_search_declared_numeric_range_uses_typed_numeric_cast():
+    db, _, _, mock_cursor = make_gaussdb()
+    db.metadata_schema = {"priority": "number"}
+    mock_cursor.fetchall.return_value = []
+
+    db.search("hello", [0.1, 0.2, 0.3], filters={"user_id": "u1", "priority": {"gte": 3, "lt": 7}})
+
+    sql = executed_sql(mock_cursor)
+    params = mock_cursor.execute.call_args.args[1]
+    assert "CASE WHEN jsonb_typeof(payload->'priority') = 'number'" in sql
+    assert "THEN CAST(payload->>'priority' AS DOUBLE PRECISION) END >= %s" in sql
+    assert "THEN CAST(payload->>'priority' AS DOUBLE PRECISION) END < %s" in sql
+    assert params[1] == "u1"
+    assert params[2] == 3
+    assert params[3] == 7
+
+
+def test_list_declared_datetime_range_uses_timestamptz_cast_and_guard():
+    db, _, _, mock_cursor = make_gaussdb()
+    db.require_scoped_filters = False
+    db.metadata_schema = {"created_at": "datetime"}
+    mock_cursor.fetchall.return_value = []
+
+    db.list(filters={"created_at": {"lt": "2026-01-01T00:00:00Z"}})
+
+    sql = executed_sql(mock_cursor)
+    params = mock_cursor.execute.call_args.args[1]
+    assert "CASE WHEN jsonb_typeof(payload->'created_at') = 'string'" in sql
+    assert "payload->>'created_at' ~ %s" in sql
+    assert "THEN CAST(payload->>'created_at' AS TIMESTAMPTZ) END < %s" in sql
+    assert params[0].startswith("^\\d{4}-\\d{2}-\\d{2}T")
+    assert params[1] == "2026-01-01T00:00:00Z"
+    assert params[2] == 100
+
+
+def test_range_on_non_range_declared_type_warns_and_falls_back(caplog):
+    db, _, _, mock_cursor = make_gaussdb()
+    db.metadata_schema = {"category": "string"}
+    mock_cursor.fetchall.return_value = []
+    caplog.set_level(logging.WARNING, logger="mem0.vector_stores.gaussdb")
+
+    db.search("hello", [0.1, 0.2, 0.3], filters={"user_id": "u1", "category": {"gte": "a"}})
+
+    sql = executed_sql(mock_cursor)
+    params = mock_cursor.execute.call_args.args[1]
+    assert "payload @> %s::JSONB" in sql
+    assert params[2] == '{"category":{"gte":"a"}}'
+    assert "falling back to literal compatibility matching" in caplog.text
+
+
+def test_search_requires_scoped_filters_by_default():
+    db, _, _, _ = make_gaussdb()
+
+    with pytest.raises(ValueError, match="requires at least one scoped filter"):
+        db.search("hello", [0.1, 0.2, 0.3], filters={"category": "test"})
+
+
+def test_constructor_can_disable_scoped_filters_with_warning(caplog):
+    caplog.set_level(logging.WARNING, logger="mem0.vector_stores.gaussdb")
+    db, _, _, mock_cursor = make_gaussdb(require_scoped_filters=False)
+    mock_cursor.fetchall.return_value = []
+
+    assert db.require_scoped_filters is False
+    assert "scope guard is disabled" in caplog.text
+    assert db.search("hello", [0.1, 0.2, 0.3], filters={"category": "test"}) == []
+
+
+def test_constructor_warns_when_server_encoding_is_not_utf8(caplog):
+    caplog.set_level(logging.WARNING, logger="mem0.vector_stores.gaussdb")
+    db, _, mock_conn, _ = make_gaussdb()
+    mock_conn.get_parameter_status.return_value = "SQL_ASCII"
+
+    db._warn_if_server_encoding_is_not_utf8()
+
+    assert "designed and validated for UTF8 databases" in caplog.text
+    assert "server_encoding=SQL_ASCII" in caplog.text
+
+
+def test_constructor_does_not_warn_when_server_encoding_is_utf8(caplog):
+    caplog.set_level(logging.WARNING, logger="mem0.vector_stores.gaussdb")
+    db, _, mock_conn, _ = make_gaussdb()
+    mock_conn.get_parameter_status.return_value = "UTF8"
+
+    db._warn_if_server_encoding_is_not_utf8()
+
+    assert "server_encoding" not in caplog.text
+
+
+def test_constructor_accepts_metadata_schema():
+    db, _, _, _ = make_gaussdb(metadata_schema={"priority": "number", "created_at": "datetime"})
+
+    assert db.metadata_schema == {"priority": "number", "created_at": "datetime"}
+
+
+def test_constructor_accepts_custom_schema_and_uses_qualified_names():
+    db, _, _, _ = make_gaussdb(schema="mem0_app")
+
+    assert db.schema == "mem0_app"
+    assert db.table_name == '"mem0_app"."test_collection"'
+    assert db.schema_meta_table_name == '"mem0_app"."test_collection_schema_meta"'
+
+
+@pytest.mark.parametrize(
+    "filters",
+    [
+        {"OR": [{"user_id": "alice"}, {"category": "public"}]},
+        {"$or": [{"user_id": "alice"}, {"category": "public"}]},
+        {"NOT": [{"user_id": "alice"}]},
+        {"user_id": {"ne": "alice"}},
+        {"user_id": {"nin": ["alice"]}},
+        {"user_id": "*"},
+        {"user_id": {"exists": True}},
+        {"user_id": {"missing": True}},
+    ],
+)
+def test_search_rejects_non_constraining_scope_filters(filters):
+    db, _, _, _ = make_gaussdb()
+
+    with pytest.raises(ValueError, match="requires at least one scoped filter"):
+        db.search("hello", [0.1, 0.2, 0.3], filters=filters)
+
+
+@pytest.mark.parametrize(
+    "filters",
+    [
+        {"user_id": "alice"},
+        {"user_id": {"eq": "alice"}},
+        {"user_id": {"in": ["alice", "bob"]}},
+        {"AND": [{"category": "travel"}, {"user_id": "alice"}]},
+        {"$and": [{"category": "travel"}, {"user_id": {"eq": "alice"}}]},
+        {"OR": [{"user_id": "alice"}, {"user_id": "bob"}]},
+        {"$or": [{"user_id": {"eq": "alice"}}, {"agent_id": {"in": ["agent-1", "agent-2"]}}]},
+        {"AND": [{"category": "travel"}, {"OR": [{"user_id": "alice"}, {"run_id": "run-1"}]}]},
+    ],
+)
+def test_search_accepts_positive_constraining_scope_filters(filters):
+    db, _, _, mock_cursor = make_gaussdb()
+    mock_cursor.fetchall.return_value = []
+
+    assert db.search("hello", [0.1, 0.2, 0.3], filters=filters) == []
+    assert mock_cursor.execute.called
+
+
+def test_filter_builder_rejects_unsafe_keys():
+    db, _, _, _ = make_gaussdb()
+    db.require_scoped_filters = False
+
+    with pytest.raises(ValueError, match="Unsafe filter key"):
+        db.list(filters={"bad-key": "x"})
+
+
+def test_list_uses_scope_columns_and_typed_bool_filters():
+    db, _, _, mock_cursor = make_gaussdb()
+    db.require_scoped_filters = False
+    mock_cursor.fetchall.return_value = []
+
+    db.list(filters={"user_id": "u1", "flag": True})
+
+    sql = executed_sql(mock_cursor)
+    params = mock_cursor.execute.call_args.args[1]
+    assert '"user_id" = %s' in sql
+    assert "payload @> %s::JSONB" in sql
+    assert params[0] == "u1"
+    assert params[1] == '{"flag":true}'
+
+
+# ============================================================
+# Keyword search tests
+# ============================================================
+
+
+def test_keyword_search_uses_bm25_defaults_and_filters():
+    db, _, _, mock_cursor = make_gaussdb()
+    mock_cursor.fetchall.return_value = [("id1", 2.5, {"data": "hello", "user_id": "u1"})]
+
+    results = db.keyword_search("hello", top_k=3, filters={"user_id": "u1"})
+
+    sql = executed_sql(mock_cursor)
+    assert "SET LOCAL bm25_ranking_metric = 0" in sql
+    assert "SET LOCAL bm25_ncandidates = 128" in sql
+    assert "SET LOCAL enable_seqscan = off" in sql
+    assert "text_lemmatized ### %s AS score" in sql
+    assert "ORDER BY score DESC" in sql
+    assert results[0].score == 2.5
+
+
+def test_keyword_search_uses_scope_columns_and_typed_exact_filters():
+    db, _, _, mock_cursor = make_gaussdb()
+    mock_cursor.fetchall.return_value = []
+
+    db.keyword_search("hello", top_k=3, filters={"user_id": "u1", "flag": True})
+
+    sql = executed_sql(mock_cursor)
+    params = mock_cursor.execute.call_args.args[1]
+    assert '"user_id" = %s' in sql
+    assert "payload @> %s::JSONB" in sql
+    assert "hello" in params
+    assert "u1" in params
+    assert '{"flag":true}' in params
+
+
+def test_keyword_search_empty_query_returns_empty_list():
+    db, _, _, mock_cursor = make_gaussdb()
+
+    assert db.keyword_search(" ", filters={"user_id": "u1"}) == []
+    mock_cursor.execute.assert_not_called()
+
+
+def test_keyword_search_returns_none_when_bm25_disabled():
+    db, _, _, _ = make_gaussdb()
+    db.bm25_enabled = False
+
+    assert db.keyword_search("hello", filters={"user_id": "u1"}) is None
+
+
+@pytest.mark.parametrize(
+    "filters",
+    [
+        {"OR": [{"user_id": "alice"}, {"category": "public"}]},
+        {"$or": [{"user_id": "alice"}, {"category": "public"}]},
+        {"NOT": [{"user_id": "alice"}]},
+        {"user_id": {"ne": "alice"}},
+        {"user_id": {"nin": ["alice"]}},
+    ],
+)
+def test_keyword_search_rejects_non_constraining_scope_filters(filters):
+    db, _, _, mock_cursor = make_gaussdb()
+
+    with pytest.raises(ValueError, match="requires at least one scoped filter"):
+        db.keyword_search("hello", top_k=3, filters=filters)
+
+    mock_cursor.execute.assert_not_called()
+
+
+# ============================================================
+# Search batch tests
+# ============================================================
+
+
+def test_search_batch_returns_one_result_list_per_query():
+    db, _, _, mock_cursor = make_gaussdb()
+    mock_cursor.fetchall.return_value = [
+        (0, "id1", 0.1, {"data": "a", "user_id": "u1"}),
+        (1, "id2", 0.2, {"data": "b", "user_id": "u1"}),
+    ]
+
+    results = db.search_batch(
+        queries=["a", "b"],
+        vectors_list=[[0.1, 0.2, 0.3], [0.3, 0.2, 0.1]],
+        filters={"user_id": "u1"},
+    )
+
+    assert len(results) == 2
+    assert results[0][0].id == "id1"
+    assert results[1][0].id == "id2"
+    sql = executed_sql(mock_cursor)
+    assert "ROW_NUMBER() OVER" in sql
+    assert "PARTITION BY q.query_index" in sql
+
+
+def test_search_batch_uses_scope_columns_and_typed_exact_filters():
+    db, _, _, mock_cursor = make_gaussdb()
+    mock_cursor.fetchall.return_value = []
+
+    db.search_batch(
+        queries=["hello"],
+        vectors_list=[[0.1, 0.2, 0.3]],
+        filters={"user_id": "u1", "flag": True},
+    )
+
+    sql = executed_sql(mock_cursor)
+    params = mock_cursor.execute.call_args.args[1]
+    assert '"user_id" = %s' in sql
+    assert "payload @> %s::JSONB" in sql
+    assert params[1] == "u1"
+    assert params[2] == '{"flag":true}'
+
+
+def test_search_batch_falls_back_to_sequential_on_failure():
+    db, _, _, mock_cursor = make_gaussdb()
+    mock_cursor.execute.side_effect = [Exception("lateral unsupported"), None, None]
+    mock_cursor.fetchall.side_effect = [
+        [("id1", 0.1, {"data": "a", "user_id": "u1"})],
+        [("id2", 0.2, {"data": "b", "user_id": "u1"})],
+    ]
+
+    results = db.search_batch(
+        queries=["a", "b"],
+        vectors_list=[[0.1, 0.2, 0.3], [0.3, 0.2, 0.1]],
+        filters={"user_id": "u1"},
+    )
+
+    assert len(results) == 2
+    assert results[0][0].id == "id1"
+    assert results[1][0].id == "id2"
+    assert db.metrics["gaussdb_fallback_count"] == 1
+
+
+@pytest.mark.parametrize(
+    "filters",
+    [
+        {"OR": [{"user_id": "alice"}, {"category": "public"}]},
+        {"$or": [{"user_id": "alice"}, {"category": "public"}]},
+        {"NOT": [{"user_id": "alice"}]},
+        {"user_id": {"ne": "alice"}},
+        {"user_id": {"nin": ["alice"]}},
+    ],
+)
+def test_search_batch_rejects_non_constraining_scope_filters(filters):
+    db, _, _, mock_cursor = make_gaussdb()
+
+    with pytest.raises(ValueError, match="requires at least one scoped filter"):
+        db.search_batch(["hello"], [[0.1, 0.2, 0.3]], filters=filters)
+
+    mock_cursor.execute.assert_not_called()
+
+
+# ============================================================
+# Update tests
+# ============================================================
+
+
+def test_update_vector_and_payload_updates_timestamp():
+    db, _, _, mock_cursor = make_gaussdb()
+
+    db.update("id1", vector=[0.1, 0.2, 0.3], payload={"data": "new", "text_lemmatized": "new"})
+
+    sql = executed_sql(mock_cursor)
+    assert 'UPDATE "public"."test_collection"' in sql
+    assert "vector = %s::FLOATVECTOR" in sql
+    assert "payload = %s" in sql
+    assert "updated_at = CURRENT_TIMESTAMP" in sql
+
+
+def test_update_vector_only_does_not_touch_payload():
+    db, _, _, mock_cursor = make_gaussdb()
+
+    db.update("id1", vector=[0.1, 0.2, 0.3])
+
+    sql = executed_sql(mock_cursor)
+    params = mock_cursor.execute.call_args.args[1]
+    assert "vector = %s::FLOATVECTOR" in sql
+    assert "payload = %s" not in sql
+    assert "memory = %s" not in sql
+    assert params == ("[0.1,0.2,0.3]", "id1")
+
+
+def test_update_payload_only_refreshes_text_fields():
+    db, _, _, mock_cursor = make_gaussdb()
+
+    db.update("id1", payload={"data": "new", "text_lemmatized": "new lemma"})
+
+    sql = executed_sql(mock_cursor)
+    params = mock_cursor.execute.call_args.args[1]
+    assert "vector = %s::FLOATVECTOR" not in sql
+    assert "payload = %s" in sql
+    assert "memory = %s" in sql
+    assert "text_lemmatized = %s" in sql
+    assert params[-3:] == ("new", "new lemma", "id1")
+
+
+
+# ============================================================
+# LIKE escape tests
+# ============================================================
+
+
+def test_contains_filter_escapes_percent_wildcard():
+    db, _, _, mock_cursor = make_gaussdb()
+    db.require_scoped_filters = False
+    mock_cursor.fetchall.return_value = []
+
+    db.list(filters={"user_id": {"contains": "100%"}})
+
+    sql = executed_sql(mock_cursor)
+    assert "LIKE %s ESCAPE" in sql
+    call_args = mock_cursor.execute.call_args
+    params = call_args[0][1] if len(call_args[0]) > 1 else call_args[1].get("params", [])
+    assert any("%100\\%%" in str(p) for p in params)
+
+
+def test_contains_filter_escapes_underscore_wildcard():
+    db, _, _, mock_cursor = make_gaussdb()
+    db.require_scoped_filters = False
+    mock_cursor.fetchall.return_value = []
+
+    db.list(filters={"user_id": {"contains": "a_b"}})
+
+    call_args = mock_cursor.execute.call_args
+    params = call_args[0][1] if len(call_args[0]) > 1 else call_args[1].get("params", [])
+    assert any("%a\\_b%" in str(p) for p in params)
+
+
+def test_icontains_filter_escapes_backslash():
+    db, _, _, mock_cursor = make_gaussdb()
+    db.require_scoped_filters = False
+    mock_cursor.fetchall.return_value = []
+
+    db.list(filters={"user_id": {"icontains": r"a\b"}})
+
+    sql = executed_sql(mock_cursor)
+    assert "LOWER" in sql
+    assert "ESCAPE" in sql
+    call_args = mock_cursor.execute.call_args
+    params = call_args[0][1] if len(call_args[0]) > 1 else call_args[1].get("params", [])
+    assert any(r"%a\\b%" in str(p) for p in params)
+
+
+@pytest.mark.parametrize("op", ["gt", "gte", "lt", "lte"])
+def test_range_filter_operator_dict_warns_and_falls_back_without_declared_type(op, caplog):
+    db, _, _, mock_cursor = make_gaussdb()
+    db.require_scoped_filters = False
+    mock_cursor.fetchall.return_value = []
+    caplog.set_level(logging.WARNING, logger="mem0.vector_stores.gaussdb")
+
+    db.list(filters={"priority": {op: 2}})
+
+    sql = executed_sql(mock_cursor)
+    params = mock_cursor.execute.call_args.args[1]
+    assert "payload @> %s::JSONB" in sql
+    assert params[0] == json.dumps({"priority": {op: 2}}, ensure_ascii=False, separators=(",", ":"))
+    assert "falling back to literal compatibility matching" in caplog.text
+
+
+# ============================================================
+# Transaction rollback test
+# ============================================================
+
+
+def test_transaction_rollback_on_error():
+    db, _, mock_conn, mock_cursor = make_gaussdb()
+    mock_cursor.execute.side_effect = Exception("Database error")
+
+    with pytest.raises(Exception, match="Database error"):
+        db.delete("id1")
+
+    mock_conn.rollback.assert_called()
+
+
+# ============================================================
+# Migration dry run
+# ============================================================
+
+
+def test_migration_dry_run_and_backfill_report():
+    db, _, _, mock_cursor = make_gaussdb()
+    mock_cursor.fetchone.return_value = (7,)
+
+    plan = db.migration_dry_run()
+    report = db.backfill_derived_fields(dry_run=True)
+
+    assert plan["mutates_data"] is False
+    assert plan["deployment_mode"] == "centralized"
+    assert plan["distribution_mode"] == "none"
+    assert "ensure_hash_distribution_when_deployment_mode_is_distributed" in plan["planned_actions"]
+    assert report == {"dry_run": True, "estimated_rows": 7}
+
+
+# ============================================================
+# _upsert_schema_meta uses MERGE INTO
+# ============================================================
+
+
+def test_upsert_schema_meta_uses_merge_into():
+    db, _, _, mock_cursor = make_gaussdb()
+
+    db._upsert_schema_meta(mock_cursor, "test_collection", 3)
+
+    sql = executed_sql(mock_cursor)
+    assert "MERGE INTO" in sql
+    assert "WHEN MATCHED THEN" in sql
+    assert "WHEN NOT MATCHED THEN" in sql
+
+
+def test_upsert_schema_meta_passes_correct_params():
+    db, _, _, mock_cursor = make_gaussdb()
+
+    db._upsert_schema_meta(mock_cursor, "my_collection", 5)
+
+    call_args = mock_cursor.execute.call_args
+    params = call_args[0][1]
+    assert params == ("my_collection", 5)
+
+
+
+# ============================================================
+# Delete / List / Col info tests
+# ============================================================
+
+
+def test_delete_is_idempotent_sql_path():
+    db, _, mock_conn, mock_cursor = make_gaussdb()
+
+    db.delete("id1")
+
+    sql = executed_sql(mock_cursor)
+    assert 'DELETE FROM "public"."test_collection" WHERE id = %s' in sql
+    mock_conn.commit.assert_called()
+
+
+def test_list_returns_wrapped_results():
+    db, _, _, mock_cursor = make_gaussdb()
+    mock_cursor.fetchall.return_value = [("id1", {"data": "hello", "user_id": "u1"})]
+
+    results = db.list(filters={"user_id": "u1"})
+
+    assert isinstance(results, list)
+    assert isinstance(results[0], list)
+    assert results[0][0].id == "id1"
+
+
+def test_list_top_k_zero_is_preserved():
+    db, _, _, mock_cursor = make_gaussdb()
+    mock_cursor.fetchall.return_value = []
+
+    db.list(filters={"user_id": "u1"}, top_k=0)
+
+    assert mock_cursor.execute.call_args.args[1][-1] == 0
+
+
+def test_col_info_reads_schema_version():
+    db, _, _, mock_cursor = make_gaussdb()
+    mock_cursor.fetchone.side_effect = [(3,), (True,), (7,)]
+    mock_cursor.fetchall.return_value = [("test_collection_vector_idx",), ("test_collection_bm25_idx",)]
+
+    info = db.col_info()
+
+    sql = executed_sql(mock_cursor)
+    assert "information_schema.tables" in sql
+    assert info["count"] == 3
+    assert info["schema_version"] == 7
+    assert info["deployment_mode"] == "centralized"
+    assert info["distribution_mode"] == "none"
+    assert info["indexes"] == ["test_collection_vector_idx", "test_collection_bm25_idx"]
+
+
+def test_col_info_defaults_schema_version_when_meta_table_missing():
+    db, _, _, mock_cursor = make_gaussdb()
+    mock_cursor.fetchone.side_effect = [(3,), (False,)]
+    mock_cursor.fetchall.return_value = []
+
+    info = db.col_info()
+
+    assert info["schema_version"] == 1
+
+
+def test_analyze_uses_autocommit_and_restores_previous_state():
+    db, mock_pool, mock_conn, mock_cursor = make_gaussdb()
+    mock_conn.autocommit = False
+
+    db.analyze()
+
+    mock_conn.set_client_encoding.assert_called_with("UTF8")
+    mock_cursor.execute.assert_called_once_with('ANALYZE "public"."test_collection"')
+    assert mock_conn.autocommit is False
+    mock_pool.putconn.assert_called_with(mock_conn)
+
+
+# ============================================================
+# Close / context manager tests
+# ============================================================
+
+
+def test_close_calls_closeall_and_nullifies_pool():
+    db, mock_pool, _, _ = make_gaussdb()
+
+    db.close()
+
+    mock_pool.closeall.assert_called_once()
+    assert db.connection_pool is None
+
+
+def test_close_swallows_exception_from_closeall():
+    db, mock_pool, _, _ = make_gaussdb()
+    mock_pool.closeall.side_effect = RuntimeError("pool error")
+
+    db.close()
+
+    assert db.connection_pool is None
+
+
+def test_close_is_idempotent():
+    db, _, _, _ = make_gaussdb()
+
+    db.close()
+    db.close()
+
+
+def test_context_manager_calls_close_on_normal_exit():
+    db, mock_pool, _, _ = make_gaussdb()
+
+    with db:
+        pass
+
+    mock_pool.closeall.assert_called_once()
+    assert db.connection_pool is None
+
+
+def test_context_manager_calls_close_on_exception():
+    db, mock_pool, _, _ = make_gaussdb()
+
+    with pytest.raises(ValueError):
+        with db:
+            raise ValueError("boom")
+
+    mock_pool.closeall.assert_called_once()
+    assert db.connection_pool is None
+
+
+# ============================================================
+# Retry logic tests
+# ============================================================
+
+
+def test_retryable_error_triggers_retry_and_succeeds():
+    db, _, _, mock_cursor = make_gaussdb()
+    call_count = {"n": 0}
+
+    def side_effect(sql, *args, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1 and "DELETE" in str(sql):
+            raise Exception("connection reset by peer")
+        return None
+
+    mock_cursor.execute.side_effect = side_effect
+
+    db.delete("id1")
+
+    assert call_count["n"] >= 2
+
+
+def test_non_retryable_error_raises_immediately():
+    db, _, _, mock_cursor = make_gaussdb()
+    mock_cursor.execute.side_effect = Exception("syntax error at position 42")
+
+    with pytest.raises(Exception, match="syntax error"):
+        db.delete("id1")
+
+    assert mock_cursor.execute.call_count == 1
+
+
+def test_retry_exhaustion_raises_last_error():
+    db, _, _, mock_cursor = make_gaussdb()
+    mock_cursor.execute.side_effect = Exception("connection timeout")
+
+    with pytest.raises(Exception, match="connection timeout"):
+        db.delete("id1")
+
+
+def test_is_retryable_classifies_known_fragments():
+    assert GaussDB._is_retryable(Exception("connection reset")) is True
+    assert GaussDB._is_retryable(Exception("timeout expired")) is True
+    assert GaussDB._is_retryable(Exception("deadlock detected")) is True
+    assert GaussDB._is_retryable(Exception("lock wait timeout")) is True
+    assert GaussDB._is_retryable(Exception("could not serialize access")) is True
+    assert GaussDB._is_retryable(Exception("server closed the connection")) is True
+    assert GaussDB._is_retryable(Exception("terminating connection")) is True
+    assert GaussDB._is_retryable(Exception("syntax error")) is False
+    assert GaussDB._is_retryable(Exception("unique violation")) is False

--- a/tests/vector_stores/test_gaussdb_centralized.py
+++ b/tests/vector_stores/test_gaussdb_centralized.py
@@ -1,0 +1,5515 @@
+"""
+GaussDB Centralized Mode Integration & E2E Tests.
+
+Merged from 13 individual test files into a single comprehensive test suite.
+All tests target centralized deployment mode and require a live GaussDB instance.
+
+Environment variables:
+    GAUSSDB_TEST_DSN                 Full DSN (overrides host/port/database/user/password)
+    GAUSSDB_TEST_HOST                GaussDB host
+    GAUSSDB_TEST_PORT                GaussDB port
+    GAUSSDB_TEST_DATABASE            Database name
+    GAUSSDB_TEST_USER                Username
+    GAUSSDB_TEST_PASSWORD            Password
+    GAUSSDB_TEST_SSLMODE             Optional SSL mode
+    GAUSSDB_TEST_SSLROOTCERT         Optional SSL root certificate path
+    GAUSSDB_TEST_VECTOR_INDEX        Defaults to gsdiskann
+    GAUSSDB_TEST_DEPLOYMENT_MODE     centralized or distributed (defaults to centralized)
+    GAUSSDB_TEST_RUN_BM25            Set to true to require and verify BM25
+    GAUSSDB_TEST_RUN_INDEX_MATRIX    Set to true to run index/metric matrix tests
+    GAUSSDB_TEST_BENCHMARK           Set to true to run benchmark reporting
+
+Test classes:
+    TestCRUD                  — Basic CRUD operations
+    TestFilter                — All filter operators (eq, ne, in, nin, range, contains, etc.)
+    TestSearchQuality         — Vector search quality, distance metrics, recall
+    TestBM25                  — BM25 keyword search
+    TestMultitenant           — Multi-tenant isolation (user_id, agent_id, run_id)
+    TestBoundary              — Edge cases and boundary conditions
+    TestConcurrent            — Concurrency safety
+    TestPerformance           — Performance baselines
+    TestCollectionOps         — Collection lifecycle operations
+    TestFeatures              — GaussDB-specific features (Ustore, FLOATVECTOR, indexes)
+    TestMemoryAPI             — Memory.from_config upper-layer E2E
+    TestMultilang             — Multi-language text handling
+    TestE2EFull               — Full E2E verification (converted from standalone scripts)
+"""
+
+import json
+import math
+import os
+import random
+import statistics
+import threading
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("psycopg2", reason="GaussDB live tests require psycopg2-compatible driver")
+
+from mem0 import Memory
+from mem0.vector_stores.gaussdb import GaussDB, OutputData
+from tests.vector_stores.conftest import (
+    EMBEDDING_DIMS,
+    VECTOR_AISLE,
+    VECTOR_COFFEE,
+    VECTOR_FLIGHT,
+    VECTOR_LARGE,
+    VECTOR_NEGATIVE,
+    VECTOR_UNIT_X,
+    VECTOR_UNIT_Y,
+    VECTOR_UNIT_Z,
+    VECTOR_WINDOW,
+    VECTOR_ZERO,
+    _assert_exact_ids,
+    _assert_ordered_ids,
+    _concurrent_runner,
+    _env_bool,
+    _gaussdb_env_config,
+    _ids,
+    _insert_memories,
+    _list_flat,
+    _make_payload,
+    _measure_latency,
+    _new_collection_name,
+    _new_db,
+    _uuid,
+    gaussdb_available,
+    FakeEmbedder,
+)
+
+
+# ---------------------------------------------------------------------------
+# Module-level skip
+# ---------------------------------------------------------------------------
+
+pytestmark = pytest.mark.skipif(
+    not gaussdb_available(),
+    reason="Set GAUSSDB_TEST_DSN or GAUSSDB_TEST_HOST/PORT/DATABASE/USER/PASSWORD to run GaussDB live tests",
+)
+
+
+# ---------------------------------------------------------------------------
+# Local helpers (from p0 and standalone scripts)
+# ---------------------------------------------------------------------------
+
+
+_new_collection = _new_collection_name
+
+
+def _random_vector(dims: int = EMBEDDING_DIMS) -> list:
+    return [random.random() for _ in range(dims)]
+
+
+def _make_vector_seeded(seed: int, dims: int = EMBEDDING_DIMS) -> list:
+    rng = random.Random(seed)
+    return [rng.uniform(-1, 1) for _ in range(dims)]
+
+
+def _cosine_similar_vector(base: list, noise: float = 0.05) -> list:
+    return [v + random.uniform(-noise, noise) for v in base]
+
+
+def _run_concurrent(tasks, max_workers=10, timeout=600.0):
+    successes = 0
+    errors = []
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = [executor.submit(task) for task in tasks]
+        for future in as_completed(futures, timeout=timeout):
+            try:
+                future.result()
+                successes += 1
+            except Exception as exc:
+                errors.append(str(exc))
+    return successes, errors
+
+
+def _print_latency_report(name: str, stats: dict):
+    print(f"\n  [PERF] {name}:")
+    print(f"    iterations: {stats['iterations']}")
+    print(f"    P50:  {stats['p50_ms']:.2f} ms")
+    print(f"    P99:  {stats['p99_ms']:.2f} ms")
+    print(f"    min:  {stats['min_ms']:.2f} ms")
+    print(f"    max:  {stats['max_ms']:.2f} ms")
+    print(f"    mean: {stats['mean_ms']:.2f} ms")
+
+
+def _soft_assert(condition: bool, message: str):
+    if not condition:
+        print(f"  [WARN] Soft assertion failed: {message}")
+
+
+def _load_quality_cases():
+    path = Path(__file__).with_name("gaussdb_quality_cases.json")
+    if path.exists():
+        return json.loads(path.read_text(encoding="utf-8"))
+    return None
+
+
+# ===========================================================================
+# TestCRUD — Basic CRUD operations (from test_gaussdb_p0.py)
+# ===========================================================================
+
+
+class TestCRUD:
+    """Basic CRUD operations: insert, get, update, delete, list, search."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.db = _new_db(prefix="crud")
+
+    @classmethod
+    def teardown_class(cls):
+        cls.db.delete_col()
+
+    def test_insert_single_and_get(self):
+        """Insert a single record and retrieve it by ID."""
+        vid = _uuid(1)
+        _insert_memories(self.db, [(vid, VECTOR_COFFEE, _make_payload("I love coffee", "crud_insert"))])
+        result = self.db.get(vid)
+        assert result is not None
+        assert result.id == vid
+        assert result.payload["data"] == "I love coffee"
+        assert result.payload["user_id"] == "crud_insert"
+
+    def test_insert_batch_and_list(self):
+        """Insert multiple records and list them."""
+        records = [
+            (_uuid(10), VECTOR_COFFEE, _make_payload("coffee memory", "crud_batch")),
+            (_uuid(11), VECTOR_FLIGHT, _make_payload("flight memory", "crud_batch")),
+            (_uuid(12), VECTOR_WINDOW, _make_payload("window seat", "crud_batch")),
+        ]
+        _insert_memories(self.db, records)
+        listed = _list_flat(self.db, filters={"user_id": "crud_batch"}, top_k=100)
+        assert len(listed) == 3
+        _assert_exact_ids(listed, {_uuid(10), _uuid(11), _uuid(12)})
+
+    def test_upsert_existing_record(self):
+        """Upsert (MERGE INTO) updates existing record without creating duplicate."""
+        vid = _uuid(20)
+        _insert_memories(self.db, [(vid, VECTOR_COFFEE, _make_payload("original", "crud_upsert"))])
+        self.db.update(vector_id=vid, payload=_make_payload("updated", "crud_upsert"))
+        result = self.db.get(vid)
+        assert result.payload["data"] == "updated"
+        listed = _list_flat(self.db, filters={"user_id": "crud_upsert"}, top_k=100)
+        assert len(listed) == 1
+
+    def test_update_vector(self):
+        """Update the vector of an existing record."""
+        vid = _uuid(21)
+        _insert_memories(self.db, [(vid, VECTOR_COFFEE, _make_payload("coffee", "crud_upvec"))])
+        self.db.update(vector_id=vid, vector=VECTOR_FLIGHT)
+        results = self.db.search("flight", VECTOR_FLIGHT, top_k=1, filters={"user_id": "crud_upvec"})
+        assert len(results) >= 1
+        assert results[0].id == vid
+
+    def test_delete_by_id(self):
+        """Delete a record by ID."""
+        vid = _uuid(30)
+        _insert_memories(self.db, [(vid, VECTOR_COFFEE, _make_payload("to delete", "crud_del"))])
+        self.db.delete(vector_id=vid)
+        assert self.db.get(vid) is None
+
+    def test_search_basic(self):
+        """Basic vector search returns relevant results."""
+        _insert_memories(self.db, [
+            (_uuid(40), VECTOR_COFFEE, _make_payload("coffee lover", "crud_search")),
+            (_uuid(41), VECTOR_FLIGHT, _make_payload("frequent flyer", "crud_search")),
+        ])
+        results = self.db.search("coffee", VECTOR_COFFEE, top_k=2, filters={"user_id": "crud_search"})
+        assert len(results) >= 1
+        assert results[0].id == _uuid(40)
+
+    def test_search_with_top_k(self):
+        """Search respects top_k limit."""
+        records = [(_uuid(50 + i), VECTOR_COFFEE, _make_payload(f"item {i}", "crud_topk")) for i in range(10)]
+        _insert_memories(self.db, records)
+        results = self.db.search("item", VECTOR_COFFEE, top_k=3, filters={"user_id": "crud_topk"})
+        assert len(results) <= 3
+
+    def test_get_nonexistent_returns_none(self):
+        """Get a non-existent ID returns None."""
+        result = self.db.get(_uuid(999))
+        assert result is None
+
+    def test_delete_nonexistent_no_error(self):
+        """Deleting a non-existent ID does not raise."""
+        self.db.delete(vector_id=_uuid(998))
+
+    def test_search_batch(self):
+        """search_batch returns results for multiple queries."""
+        _insert_memories(self.db, [
+            (_uuid(60), VECTOR_COFFEE, _make_payload("coffee", "crud_sbatch")),
+            (_uuid(61), VECTOR_FLIGHT, _make_payload("flight", "crud_sbatch")),
+        ])
+        results = self.db.search_batch(
+            ["coffee", "flight"],
+            [VECTOR_COFFEE, VECTOR_FLIGHT],
+            top_k=5,
+            filters={"user_id": "crud_sbatch"},
+        )
+        assert len(results) == 2
+        assert len(results[0]) >= 1
+        assert len(results[1]) >= 1
+
+
+
+# ===========================================================================
+# TestFilter — All filter operators (from test_gaussdb_p1_filter.py)
+# ===========================================================================
+
+class TestSimpleOperators:
+    """Tests for eq, ne, in, nin, contains, icontains operators."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.db = _new_db(prefix="filter_simple")
+        _insert_memories(cls.db, [
+            # eq string (user_id="u100")
+            (_uuid(100), VECTOR_COFFEE, _make_payload("coffee note", user_id="u100", category="food")),
+            (_uuid(101), VECTOR_FLIGHT, _make_payload("flight note", user_id="u100", category="travel")),
+            # eq number (user_id="u110")
+            (_uuid(110), VECTOR_COFFEE, _make_payload("low priority", user_id="u110", priority="3")),
+            (_uuid(111), VECTOR_FLIGHT, _make_payload("high priority", user_id="u110", priority="7")),
+            # eq boolean (user_id="u120")
+            (_uuid(120), VECTOR_COFFEE, _make_payload("active item", user_id="u120", active="true")),
+            (_uuid(121), VECTOR_FLIGHT, _make_payload("inactive item", user_id="u120", active="false")),
+            # ne string (user_id="u130")
+            (_uuid(130), VECTOR_COFFEE, _make_payload("food item", user_id="u130", category="food")),
+            (_uuid(131), VECTOR_FLIGHT, _make_payload("travel item", user_id="u130", category="travel")),
+            (_uuid(132), VECTOR_WINDOW, _make_payload("work item", user_id="u130", category="work")),
+            # ne number (user_id="u140")
+            (_uuid(140), VECTOR_COFFEE, _make_payload("pri 2", user_id="u140", priority="2")),
+            (_uuid(141), VECTOR_FLIGHT, _make_payload("pri 5", user_id="u140", priority="5")),
+            (_uuid(142), VECTOR_WINDOW, _make_payload("pri 8", user_id="u140", priority="8")),
+            # in single (user_id="u150")
+            (_uuid(150), VECTOR_COFFEE, _make_payload("food", user_id="u150", category="food")),
+            (_uuid(151), VECTOR_FLIGHT, _make_payload("travel", user_id="u150", category="travel")),
+            # in multi (user_id="u160")
+            (_uuid(160), VECTOR_COFFEE, _make_payload("food", user_id="u160", category="food")),
+            (_uuid(161), VECTOR_FLIGHT, _make_payload("travel", user_id="u160", category="travel")),
+            (_uuid(162), VECTOR_WINDOW, _make_payload("work", user_id="u160", category="work")),
+            # in empty (user_id="u170")
+            (_uuid(170), VECTOR_COFFEE, _make_payload("food", user_id="u170", category="food")),
+            # nin single (user_id="u180")
+            (_uuid(180), VECTOR_COFFEE, _make_payload("food", user_id="u180", category="food")),
+            (_uuid(181), VECTOR_FLIGHT, _make_payload("travel", user_id="u180", category="travel")),
+            (_uuid(182), VECTOR_WINDOW, _make_payload("work", user_id="u180", category="work")),
+            # nin multi (user_id="u190")
+            (_uuid(190), VECTOR_COFFEE, _make_payload("food", user_id="u190", category="food")),
+            (_uuid(191), VECTOR_FLIGHT, _make_payload("travel", user_id="u190", category="travel")),
+            (_uuid(192), VECTOR_WINDOW, _make_payload("work", user_id="u190", category="work")),
+            # contains exact (user_id="u200")
+            (_uuid(200), VECTOR_COFFEE, _make_payload("coffee shop", user_id="u200", tag="morning-coffee")),
+            (_uuid(201), VECTOR_FLIGHT, _make_payload("flight plan", user_id="u200", tag="evening-flight")),
+            # contains partial (user_id="u210")
+            (_uuid(210), VECTOR_COFFEE, _make_payload("item1", user_id="u210", tag="super-coffee-deluxe")),
+            (_uuid(211), VECTOR_FLIGHT, _make_payload("item2", user_id="u210", tag="no-match-here")),
+            # contains not exists (user_id="u220")
+            (_uuid(220), VECTOR_COFFEE, _make_payload("item", user_id="u220", tag="morning-tea")),
+            # icontains (user_id="u230")
+            (_uuid(230), VECTOR_COFFEE, _make_payload("item1", user_id="u230", tag="MorningCoffee")),
+            (_uuid(231), VECTOR_FLIGHT, _make_payload("item2", user_id="u230", tag="EVENING-COFFEE")),
+            (_uuid(232), VECTOR_WINDOW, _make_payload("item3", user_id="u230", tag="afternoon-tea")),
+            # eq implicit (user_id="u240")
+            (_uuid(240), VECTOR_COFFEE, _make_payload("food item", user_id="u240", category="food")),
+            (_uuid(241), VECTOR_FLIGHT, _make_payload("travel item", user_id="u240", category="travel")),
+        ])
+
+    @classmethod
+    def teardown_class(cls):
+        cls.db.delete_col()
+
+    def test_eq_string_exact_match(self):
+        """eq operator with string value returns exact match."""
+        rows = self.db.search("test", VECTOR_COFFEE, top_k=10, filters={"user_id": "u100", "category": {"eq": "food"}})
+        _assert_exact_ids(rows, {_uuid(100)})
+
+    def test_eq_number_exact_match(self):
+        """eq operator with numeric value returns exact match."""
+        rows = self.db.search("test", VECTOR_COFFEE, top_k=10, filters={"user_id": "u110", "priority": {"eq": "7"}})
+        _assert_exact_ids(rows, {_uuid(111)})
+
+    def test_eq_boolean_exact_match(self):
+        """eq operator with boolean-like value returns exact match."""
+        rows = self.db.search("test", VECTOR_COFFEE, top_k=10, filters={"user_id": "u120", "active": {"eq": "true"}})
+        _assert_exact_ids(rows, {_uuid(120)})
+
+    def test_ne_string_exclusion(self):
+        """ne operator excludes matching string value."""
+        rows = self.db.search("test", VECTOR_COFFEE, top_k=10, filters={"user_id": "u130", "category": {"ne": "food"}})
+        _assert_exact_ids(rows, {_uuid(131), _uuid(132)})
+
+    def test_ne_number_exclusion(self):
+        """ne operator excludes matching numeric value."""
+        rows = self.db.search("test", VECTOR_COFFEE, top_k=10, filters={"user_id": "u140", "priority": {"ne": "5"}})
+        _assert_exact_ids(rows, {_uuid(140), _uuid(142)})
+
+    def test_in_single_value(self):
+        """in operator with single value list returns matching record."""
+        rows = self.db.search("test", VECTOR_COFFEE, top_k=10, filters={"user_id": "u150", "category": {"in": ["food"]}})
+        _assert_exact_ids(rows, {_uuid(150)})
+
+    def test_in_multi_value(self):
+        """in operator with multiple values returns all matching records."""
+        rows = self.db.search(
+            "test", VECTOR_COFFEE, top_k=10, filters={"user_id": "u160", "category": {"in": ["food", "travel"]}}
+        )
+        _assert_exact_ids(rows, {_uuid(160), _uuid(161)})
+
+    def test_in_empty_list_returns_nothing(self):
+        """in operator with empty list returns no results."""
+        rows = self.db.search("test", VECTOR_COFFEE, top_k=10, filters={"user_id": "u170", "category": {"in": []}})
+        assert len(rows) == 0
+
+    def test_nin_single_value(self):
+        """nin operator with single value excludes matching record."""
+        rows = self.db.search("test", VECTOR_COFFEE, top_k=10, filters={"user_id": "u180", "category": {"nin": ["food"]}})
+        _assert_exact_ids(rows, {_uuid(181), _uuid(182)})
+
+    def test_nin_multi_value_exclusion(self):
+        """nin operator with multiple values excludes all matching records."""
+        rows = self.db.search(
+            "test", VECTOR_COFFEE, top_k=10, filters={"user_id": "u190", "category": {"nin": ["food", "travel"]}}
+        )
+        _assert_exact_ids(rows, {_uuid(192)})
+
+    def test_contains_exact_substring(self):
+        """contains operator matches exact substring."""
+        rows = self.db.search("test", VECTOR_COFFEE, top_k=10, filters={"user_id": "u200", "tag": {"contains": "coffee"}})
+        _assert_exact_ids(rows, {_uuid(200)})
+
+    def test_contains_partial_substring(self):
+        """contains operator matches partial substring within value."""
+        rows = self.db.search("test", VECTOR_COFFEE, top_k=10, filters={"user_id": "u210", "tag": {"contains": "coffee"}})
+        _assert_exact_ids(rows, {_uuid(210)})
+
+    def test_contains_not_exists_returns_empty(self):
+        """contains operator with non-matching substring returns empty."""
+        rows = self.db.search("test", VECTOR_COFFEE, top_k=10, filters={"user_id": "u220", "tag": {"contains": "coffee"}})
+        assert len(rows) == 0
+
+    def test_icontains_case_insensitive_match(self):
+        """icontains operator matches regardless of case."""
+        rows = self.db.search("test", VECTOR_COFFEE, top_k=10, filters={"user_id": "u230", "tag": {"icontains": "coffee"}})
+        _assert_exact_ids(rows, {_uuid(230), _uuid(231)})
+
+    def test_eq_implicit_direct_value(self):
+        """Direct value (without eq wrapper) acts as implicit equality filter."""
+        rows = self.db.search("test", VECTOR_COFFEE, top_k=10, filters={"user_id": "u240", "category": "food"})
+        _assert_exact_ids(rows, {_uuid(240)})
+
+
+# ===========================================================================
+# 5.2.2 Range Operators (8 tests)
+# ===========================================================================
+
+
+class TestRangeOperators:
+    """Tests for current unsupported range-operator behavior."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.db = _new_db(prefix="filter_range")
+        _insert_memories(cls.db, [
+            # gt (user_id="u300")
+            (_uuid(300), VECTOR_COFFEE, _make_payload("pri 2", user_id="u300", priority="2")),
+            (_uuid(301), VECTOR_FLIGHT, _make_payload("pri 5", user_id="u300", priority="5")),
+            (_uuid(302), VECTOR_WINDOW, _make_payload("pri 8", user_id="u300", priority="8")),
+            # gte (user_id="u310")
+            (_uuid(310), VECTOR_COFFEE, _make_payload("pri 2", user_id="u310", priority="2")),
+            (_uuid(311), VECTOR_FLIGHT, _make_payload("pri 5", user_id="u310", priority="5")),
+            (_uuid(312), VECTOR_WINDOW, _make_payload("pri 8", user_id="u310", priority="8")),
+            # lt (user_id="u320")
+            (_uuid(320), VECTOR_COFFEE, _make_payload("pri 2", user_id="u320", priority="2")),
+            (_uuid(321), VECTOR_FLIGHT, _make_payload("pri 5", user_id="u320", priority="5")),
+            (_uuid(322), VECTOR_WINDOW, _make_payload("pri 8", user_id="u320", priority="8")),
+            # lte (user_id="u330")
+            (_uuid(330), VECTOR_COFFEE, _make_payload("pri 2", user_id="u330", priority="2")),
+            (_uuid(331), VECTOR_FLIGHT, _make_payload("pri 5", user_id="u330", priority="5")),
+            (_uuid(332), VECTOR_WINDOW, _make_payload("pri 8", user_id="u330", priority="8")),
+            # combined gte+lte (user_id="u340")
+            (_uuid(340), VECTOR_COFFEE, _make_payload("pri 1", user_id="u340", priority="1")),
+            (_uuid(341), VECTOR_FLIGHT, _make_payload("pri 3", user_id="u340", priority="3")),
+            (_uuid(342), VECTOR_WINDOW, _make_payload("pri 5", user_id="u340", priority="5")),
+            (_uuid(343), VECTOR_AISLE, _make_payload("pri 7", user_id="u340", priority="7")),
+            (_uuid(344), VECTOR_COFFEE, _make_payload("pri 9", user_id="u340", priority="9")),
+            # combined gt+lt exclusive (user_id="u350")
+            (_uuid(350), VECTOR_COFFEE, _make_payload("pri 1", user_id="u350", priority="1")),
+            (_uuid(351), VECTOR_FLIGHT, _make_payload("pri 3", user_id="u350", priority="3")),
+            (_uuid(352), VECTOR_WINDOW, _make_payload("pri 5", user_id="u350", priority="5")),
+            (_uuid(353), VECTOR_AISLE, _make_payload("pri 7", user_id="u350", priority="7")),
+            (_uuid(354), VECTOR_COFFEE, _make_payload("pri 9", user_id="u350", priority="9")),
+            # combined with eq (user_id="u360")
+            (_uuid(360), VECTOR_COFFEE, _make_payload("food pri 2", user_id="u360", category="food", priority="2")),
+            (_uuid(361), VECTOR_FLIGHT, _make_payload("food pri 5", user_id="u360", category="food", priority="5")),
+            (_uuid(362), VECTOR_WINDOW, _make_payload("travel pri 5", user_id="u360", category="travel", priority="5")),
+            # gt date string (user_id="u370")
+            (_uuid(370), VECTOR_COFFEE, _make_payload("old", user_id="u370", created="2024-01-01")),
+            (_uuid(371), VECTOR_FLIGHT, _make_payload("mid", user_id="u370", created="2024-06-15")),
+            (_uuid(372), VECTOR_WINDOW, _make_payload("new", user_id="u370", created="2025-01-01")),
+        ])
+
+    @classmethod
+    def teardown_class(cls):
+        cls.db.delete_col()
+
+    def test_unsupported_gt_operator_returns_empty(self):
+        """Unsupported gt operator is treated as a non-matching literal dict filter."""
+        rows = self.db.search("test", VECTOR_COFFEE, top_k=10, filters={"user_id": "u300", "priority": {"gt": "5"}})
+        _assert_exact_ids(rows, set())
+
+    def test_unsupported_gte_operator_returns_empty(self):
+        """Unsupported gte operator is treated as a non-matching literal dict filter."""
+        rows = self.db.search("test", VECTOR_COFFEE, top_k=10, filters={"user_id": "u310", "priority": {"gte": "5"}})
+        _assert_exact_ids(rows, set())
+
+    def test_unsupported_lt_operator_returns_empty(self):
+        """Unsupported lt operator is treated as a non-matching literal dict filter."""
+        rows = self.db.search("test", VECTOR_COFFEE, top_k=10, filters={"user_id": "u320", "priority": {"lt": "5"}})
+        _assert_exact_ids(rows, set())
+
+    def test_unsupported_lte_operator_returns_empty(self):
+        """Unsupported lte operator is treated as a non-matching literal dict filter."""
+        rows = self.db.search("test", VECTOR_COFFEE, top_k=10, filters={"user_id": "u330", "priority": {"lte": "5"}})
+        _assert_exact_ids(rows, set())
+
+    def test_range_combined_gte_lte(self):
+        """Combined range operators do not produce typed range semantics."""
+        rows = self.db.search(
+            "test", VECTOR_COFFEE, top_k=10,
+            filters={"user_id": "u340", "priority": {"gte": "3", "lte": "7"}},
+        )
+        _assert_exact_ids(rows, set())
+
+    def test_range_combined_gt_lt_exclusive(self):
+        """Combined gt + lt remains unsupported and does not match stored scalar payloads."""
+        rows = self.db.search(
+            "test", VECTOR_COFFEE, top_k=10,
+            filters={"user_id": "u350", "priority": {"gt": "1", "lt": "9"}},
+        )
+        _assert_exact_ids(rows, set())
+
+    def test_range_combined_with_eq(self):
+        """Unsupported range operator does not start matching when combined with eq."""
+        rows = self.db.search(
+            "test", VECTOR_COFFEE, top_k=10,
+            filters={"user_id": "u360", "category": "food", "priority": {"gte": "3"}},
+        )
+        _assert_exact_ids(rows, set())
+
+    def test_gt_date_string(self):
+        """Unsupported range syntax also does not match ISO date strings."""
+        rows = self.db.search(
+            "test", VECTOR_COFFEE, top_k=10, filters={"user_id": "u370", "created": {"gt": "2024-06-01"}}
+        )
+        _assert_exact_ids(rows, set())
+
+
+# ===========================================================================
+# 5.2.3 Logical Combination Operators (7 tests)
+# ===========================================================================
+
+
+class TestLogicalCombinationOperators:
+    """Tests for AND, OR, NOT logical operators."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.db = _new_db(prefix="filter_logic")
+        _insert_memories(cls.db, [
+            # test_and_implicit_two_keys (user_id="u400")
+            (_uuid(400), VECTOR_COFFEE, _make_payload("food hi", user_id="u400", category="food", priority="7")),
+            (_uuid(401), VECTOR_FLIGHT, _make_payload("food lo", user_id="u400", category="food", priority="2")),
+            (_uuid(402), VECTOR_WINDOW, _make_payload("travel hi", user_id="u400", category="travel", priority="7")),
+            # test_and_implicit_three_keys (user_id="u410")
+            (_uuid(410), VECTOR_COFFEE, _make_payload("match", user_id="u410", category="food", status="active", priority="5")),
+            (_uuid(411), VECTOR_FLIGHT, _make_payload("no cat", user_id="u410", category="travel", status="active", priority="5")),
+            (_uuid(412), VECTOR_WINDOW, _make_payload("no status", user_id="u410", category="food", status="archived", priority="5")),
+            # test_and_explicit_operator (user_id="u420")
+            (_uuid(420), VECTOR_COFFEE, _make_payload("match", user_id="u420", category="food", priority="7")),
+            (_uuid(421), VECTOR_FLIGHT, _make_payload("no match", user_id="u420", category="travel", priority="7")),
+            # test_or_two_conditions (user_id="u430")
+            (_uuid(430), VECTOR_COFFEE, _make_payload("food", user_id="u430", category="food")),
+            (_uuid(431), VECTOR_FLIGHT, _make_payload("travel", user_id="u430", category="travel")),
+            (_uuid(432), VECTOR_WINDOW, _make_payload("work", user_id="u430", category="work")),
+            # test_or_three_conditions (user_id="u440")
+            (_uuid(440), VECTOR_COFFEE, _make_payload("food", user_id="u440", category="food")),
+            (_uuid(441), VECTOR_FLIGHT, _make_payload("travel", user_id="u440", category="travel")),
+            (_uuid(442), VECTOR_WINDOW, _make_payload("work", user_id="u440", category="work")),
+            (_uuid(443), VECTOR_AISLE, _make_payload("health", user_id="u440", category="health")),
+            # test_not_single_condition (user_id="u450")
+            (_uuid(450), VECTOR_COFFEE, _make_payload("food", user_id="u450", category="food")),
+            (_uuid(451), VECTOR_FLIGHT, _make_payload("travel", user_id="u450", category="travel")),
+            (_uuid(452), VECTOR_WINDOW, _make_payload("work", user_id="u450", category="work")),
+            # test_not_with_scoped_guard (user_id="u460")
+            (_uuid(460), VECTOR_COFFEE, _make_payload("food", user_id="u460", category="food")),
+            (_uuid(461), VECTOR_FLIGHT, _make_payload("travel", user_id="u460", category="travel")),
+            (_uuid(462), VECTOR_WINDOW, _make_payload("work", user_id="u460_other", category="work")),
+        ])
+
+    @classmethod
+    def teardown_class(cls):
+        cls.db.delete_col()
+
+    def test_and_implicit_two_keys(self):
+        """Implicit AND with two keys in same dict filters by both conditions."""
+        rows = self.db.search(
+            "test", VECTOR_COFFEE, top_k=10,
+            filters={"user_id": "u400", "category": "food", "priority": "7"},
+        )
+        _assert_exact_ids(rows, {_uuid(400)})
+
+    def test_and_implicit_three_keys(self):
+        """Implicit AND with three filter keys narrows results correctly."""
+        rows = self.db.search(
+            "test", VECTOR_COFFEE, top_k=10,
+            filters={"user_id": "u410", "category": "food", "status": "active"},
+        )
+        _assert_exact_ids(rows, {_uuid(410)})
+
+    def test_and_explicit_operator(self):
+        """Explicit $and operator combines conditions."""
+        rows = self.db.search(
+            "test", VECTOR_COFFEE, top_k=10,
+            filters={"$and": [{"user_id": "u420"}, {"category": "food"}, {"priority": "7"}]},
+        )
+        _assert_exact_ids(rows, {_uuid(420)})
+
+    def test_or_two_conditions(self):
+        """$or operator with two conditions returns union of matches."""
+        rows = self.db.search(
+            "test", VECTOR_COFFEE, top_k=10,
+            filters={"$or": [{"user_id": "u430", "category": "food"}, {"user_id": "u430", "category": "travel"}]},
+        )
+        _assert_exact_ids(rows, {_uuid(430), _uuid(431)})
+
+    def test_or_three_conditions(self):
+        """$or operator with three conditions returns union of all matches."""
+        rows = self.db.search(
+            "test", VECTOR_COFFEE, top_k=10,
+            filters={
+                "$or": [
+                    {"user_id": "u440", "category": "food"},
+                    {"user_id": "u440", "category": "travel"},
+                    {"user_id": "u440", "category": "work"},
+                ]
+            },
+        )
+        _assert_exact_ids(rows, {_uuid(440), _uuid(441), _uuid(442)})
+
+    def test_not_single_condition(self):
+        """$not operator excludes matching records."""
+        rows = self.db.search(
+            "test", VECTOR_COFFEE, top_k=10,
+            filters={"user_id": "u450", "$not": [{"category": "food"}]},
+        )
+        _assert_exact_ids(rows, {_uuid(451), _uuid(452)})
+
+    def test_not_with_scoped_guard(self):
+        """$not combined with scoped user_id filter works correctly."""
+        rows = self.db.search(
+            "test", VECTOR_COFFEE, top_k=10,
+            filters={"user_id": "u460", "$not": [{"category": "travel"}]},
+        )
+        _assert_exact_ids(rows, {_uuid(460)})
+
+
+# ===========================================================================
+# 5.2.4 Nested Logic Combinations (4 tests)
+# ===========================================================================
+
+
+class TestNestedLogicCombinations:
+    """Tests for nested logical operator combinations."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.db = _new_db(prefix="filter_nest")
+        _insert_memories(cls.db, [
+            # test_or_nested_and (user_id="u500")
+            (_uuid(500), VECTOR_COFFEE, _make_payload("food hi", user_id="u500", category="food", priority="7")),
+            (_uuid(501), VECTOR_FLIGHT, _make_payload("food lo", user_id="u500", category="food", priority="2")),
+            (_uuid(502), VECTOR_WINDOW, _make_payload("travel hi", user_id="u500", category="travel", priority="8")),
+            (_uuid(503), VECTOR_AISLE, _make_payload("travel lo", user_id="u500", category="travel", priority="1")),
+            # test_and_nested_or (user_id="u510")
+            (_uuid(510), VECTOR_COFFEE, _make_payload("food hi", user_id="u510", category="food", priority="7")),
+            (_uuid(511), VECTOR_FLIGHT, _make_payload("travel hi", user_id="u510", category="travel", priority="8")),
+            (_uuid(512), VECTOR_WINDOW, _make_payload("work hi", user_id="u510", category="work", priority="9")),
+            # test_not_nested_or (user_id="u520")
+            (_uuid(520), VECTOR_COFFEE, _make_payload("food", user_id="u520", category="food")),
+            (_uuid(521), VECTOR_FLIGHT, _make_payload("travel", user_id="u520", category="travel")),
+            (_uuid(522), VECTOR_WINDOW, _make_payload("work", user_id="u520", category="work")),
+            (_uuid(523), VECTOR_AISLE, _make_payload("health", user_id="u520", category="health")),
+            # test_complex_three_level_nesting (user_id="u530")
+            (_uuid(530), VECTOR_COFFEE, _make_payload("a", user_id="u530", category="food", status="active", priority="7")),
+            (_uuid(531), VECTOR_FLIGHT, _make_payload("b", user_id="u530", category="travel", status="active", priority="3")),
+            (_uuid(532), VECTOR_WINDOW, _make_payload("c", user_id="u530", category="food", status="archived", priority="9")),
+            (_uuid(533), VECTOR_AISLE, _make_payload("d", user_id="u530", category="work", status="active", priority="6")),
+        ])
+
+    @classmethod
+    def teardown_class(cls):
+        cls.db.delete_col()
+
+    def test_or_nested_and(self):
+        """$or containing nested AND conditions (implicit via dict keys)."""
+        rows = self.db.search(
+            "test", VECTOR_COFFEE, top_k=10,
+            filters={
+                "$or": [
+                    {"user_id": "u500", "category": "food", "priority": "7"},
+                    {"user_id": "u500", "category": "travel", "priority": "8"},
+                ]
+            },
+        )
+        _assert_exact_ids(rows, {_uuid(500), _uuid(502)})
+
+    def test_and_nested_or(self):
+        """$and containing a nested $or condition."""
+        rows = self.db.search(
+            "test", VECTOR_COFFEE, top_k=10,
+            filters={
+                "$and": [
+                    {"user_id": "u510"},
+                    {"$or": [{"user_id": "u510", "category": "food"}, {"user_id": "u510", "category": "travel"}]},
+                    {"priority": {"in": ["7", "8"]}},
+                ]
+            },
+        )
+        _assert_exact_ids(rows, {_uuid(510), _uuid(511)})
+
+    def test_not_nested_or(self):
+        """$not applied to an $or-like condition via multiple NOT items."""
+        rows = self.db.search(
+            "test", VECTOR_COFFEE, top_k=10,
+            filters={"user_id": "u520", "$not": [{"category": "food"}, {"category": "travel"}]},
+        )
+        _assert_exact_ids(rows, {_uuid(522), _uuid(523)})
+
+    def test_complex_three_level_nesting(self):
+        """Complex filter with three levels of nesting."""
+        rows = self.db.search(
+            "test", VECTOR_COFFEE, top_k=10,
+            filters={
+                "$and": [
+                    {"user_id": "u530"},
+                    {"status": "active"},
+                    {
+                        "$or": [
+                            {"user_id": "u530", "category": "food"},
+                            {"user_id": "u530", "category": "work", "priority": "6"},
+                        ]
+                    },
+                ]
+            },
+        )
+        _assert_exact_ids(rows, {_uuid(530), _uuid(533)})
+
+
+# ===========================================================================
+# 5.2.5 Null Value Handling (5 tests)
+# ===========================================================================
+
+
+class TestNullValueHandling:
+    """Tests for null, missing key, and empty string filter behavior."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.db = _new_db(prefix="filter_null")
+        _insert_memories(cls.db, [
+            # test_filter_key_not_exists_returns_empty (user_id="u600")
+            (_uuid(600), VECTOR_COFFEE, _make_payload("item", user_id="u600", category="food")),
+            # test_eq_null_value (user_id="u610")
+            (_uuid(610), VECTOR_COFFEE, _make_payload("with tag", user_id="u610", tag="hello")),
+            (_uuid(611), VECTOR_FLIGHT, _make_payload("no tag", user_id="u610")),
+            # test_ne_null_value_returns_records_with_key (user_id="u620")
+            (_uuid(620), VECTOR_COFFEE, _make_payload("tagged", user_id="u620", tag="hello")),
+            (_uuid(621), VECTOR_FLIGHT, _make_payload("diff tag", user_id="u620", tag="world")),
+            # test_empty_string_match (user_id="u630")
+            (_uuid(630), VECTOR_COFFEE, _make_payload("empty tag", user_id="u630", tag="")),
+            (_uuid(631), VECTOR_FLIGHT, _make_payload("has tag", user_id="u630", tag="hello")),
+            # test_missing_vs_empty_string_difference (user_id="u640")
+            (_uuid(640), VECTOR_COFFEE, _make_payload("empty", user_id="u640", tag="")),
+            (_uuid(641), VECTOR_FLIGHT, _make_payload("missing", user_id="u640")),
+            (_uuid(642), VECTOR_WINDOW, _make_payload("present", user_id="u640", tag="value")),
+        ])
+
+    @classmethod
+    def teardown_class(cls):
+        cls.db.delete_col()
+
+    def test_filter_key_not_exists_returns_empty(self):
+        """Filtering on a key that does not exist in payload returns no results."""
+        rows = self.db.search(
+            "test", VECTOR_COFFEE, top_k=10,
+            filters={"user_id": "u600", "nonexistent_key": "some_value"},
+        )
+        assert len(rows) == 0
+
+    def test_eq_null_value(self):
+        """Filtering with eq on a None/null value matches records where key is null or missing."""
+        rows = self.db.search(
+            "test", VECTOR_COFFEE, top_k=10,
+            filters={"user_id": "u610", "tag": {"eq": "None"}},
+        )
+        assert len(rows) == 0
+
+    def test_ne_null_value_returns_records_with_key(self):
+        """ne with a value returns records that have the key with a different value."""
+        rows = self.db.search(
+            "test", VECTOR_COFFEE, top_k=10,
+            filters={"user_id": "u620", "tag": {"ne": "hello"}},
+        )
+        _assert_exact_ids(rows, {_uuid(621)})
+
+    def test_empty_string_match(self):
+        """Filtering for empty string - GaussDB JSON eq does not match empty strings."""
+        rows = self.db.search(
+            "test", VECTOR_COFFEE, top_k=10,
+            filters={"user_id": "u630", "tag": ""},
+        )
+        assert len(rows) == 0
+
+    def test_missing_vs_empty_string_difference(self):
+        """Records with missing key vs empty string - empty string eq returns empty."""
+        rows_empty = self.db.search(
+            "test", VECTOR_COFFEE, top_k=10,
+            filters={"user_id": "u640", "tag": ""},
+        )
+        assert len(rows_empty) == 0
+        rows_value = self.db.search(
+            "test", VECTOR_COFFEE, top_k=10,
+            filters={"user_id": "u640", "tag": "value"},
+        )
+        _assert_exact_ids(rows_value, {_uuid(642)})
+
+
+# ===========================================================================
+# 5.2.6 Multi-tenant Isolation (12 tests)
+# ===========================================================================
+
+
+class TestMultiTenantIsolation:
+    """Tests for multi-tenant scoped filter isolation and enforcement."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.db = _new_db(prefix="filter_tenant")
+        _insert_memories(cls.db, [
+            # test_user_id_isolation (user_id="mt_alice", "mt_bob", "mt_carol")
+            (_uuid(700), VECTOR_COFFEE, _make_payload("alice item", user_id="mt_alice")),
+            (_uuid(701), VECTOR_FLIGHT, _make_payload("bob item", user_id="mt_bob")),
+            (_uuid(702), VECTOR_WINDOW, _make_payload("carol item", user_id="mt_carol")),
+            # test_cross_tenant_search_returns_only_own_data (user_id="mt_alice2", "mt_bob2")
+            (_uuid(710), VECTOR_COFFEE, _make_payload("alice secret", user_id="mt_alice2")),
+            (_uuid(711), VECTOR_COFFEE, _make_payload("bob secret", user_id="mt_bob2")),
+            # test_agent_id_isolation (user_id="mt_u720")
+            (_uuid(720), VECTOR_COFFEE, _make_payload("agent1 item", user_id="mt_u720", agent_id="agent_a")),
+            (_uuid(721), VECTOR_FLIGHT, _make_payload("agent2 item", user_id="mt_u720", agent_id="agent_b")),
+            # test_run_id_isolation (user_id="mt_u730")
+            (_uuid(730), VECTOR_COFFEE, _make_payload("run1 item", user_id="mt_u730", run_id="run_001")),
+            (_uuid(731), VECTOR_FLIGHT, _make_payload("run2 item", user_id="mt_u730", run_id="run_002")),
+            # test_combined_user_and_agent_isolation (user_id="mt_u740", "mt_u742")
+            (_uuid(740), VECTOR_COFFEE, _make_payload("u1 a1", user_id="mt_u740", agent_id="agent_a")),
+            (_uuid(741), VECTOR_FLIGHT, _make_payload("u1 a2", user_id="mt_u740", agent_id="agent_b")),
+            (_uuid(742), VECTOR_WINDOW, _make_payload("u2 a1", user_id="mt_u742", agent_id="agent_a")),
+            # test_combined_user_and_run_isolation (user_id="mt_u750", "mt_u752")
+            (_uuid(750), VECTOR_COFFEE, _make_payload("u1 r1", user_id="mt_u750", run_id="run_001")),
+            (_uuid(751), VECTOR_FLIGHT, _make_payload("u1 r2", user_id="mt_u750", run_id="run_002")),
+            (_uuid(752), VECTOR_WINDOW, _make_payload("u2 r1", user_id="mt_u752", run_id="run_001")),
+            # test_combined_all_three_scope_filters (user_id="mt_u760")
+            (_uuid(760), VECTOR_COFFEE, _make_payload("exact", user_id="mt_u760", agent_id="agent_a", run_id="run_001")),
+            (_uuid(761), VECTOR_FLIGHT, _make_payload("diff run", user_id="mt_u760", agent_id="agent_a", run_id="run_002")),
+            (_uuid(762), VECTOR_WINDOW, _make_payload("diff agent", user_id="mt_u760", agent_id="agent_b", run_id="run_001")),
+            # test_scope_guard_missing_user_id_raises_error (user_id="mt_u770")
+            (_uuid(770), VECTOR_COFFEE, _make_payload("item", user_id="mt_u770", category="food")),
+            # test_or_without_scope_in_all_branches_raises_error (user_id="mt_u780")
+            (_uuid(780), VECTOR_COFFEE, _make_payload("item", user_id="mt_u780", category="food")),
+            # test_filter_mode_json_expression_basic (user_id="mt_json")
+            (_uuid(790), VECTOR_COFFEE, _make_payload("food item", user_id="mt_json", category="food")),
+            (_uuid(791), VECTOR_FLIGHT, _make_payload("travel item", user_id="mt_json", category="travel")),
+            # test_filter_mode_json_expression_range (user_id="mt_json2")
+            (_uuid(800), VECTOR_COFFEE, _make_payload("low", user_id="mt_json2", priority="2")),
+            (_uuid(801), VECTOR_FLIGHT, _make_payload("high", user_id="mt_json2", priority="8")),
+            # test_filter_mode_redundant_columns_basic (user_id="mt_rc_alice", "mt_rc_bob")
+            (_uuid(810), VECTOR_COFFEE, _make_payload("alice item", user_id="mt_rc_alice")),
+            (_uuid(811), VECTOR_FLIGHT, _make_payload("bob item", user_id="mt_rc_bob")),
+        ])
+
+    @classmethod
+    def teardown_class(cls):
+        cls.db.delete_col()
+
+    def test_user_id_isolation(self):
+        """Records from different user_ids are isolated by filter."""
+        rows = self.db.search("test", VECTOR_COFFEE, top_k=10, filters={"user_id": "mt_alice"})
+        _assert_exact_ids(rows, {_uuid(700)})
+
+    def test_cross_tenant_search_returns_only_own_data(self):
+        """Searching with one user_id never returns another user's data."""
+        alice_rows = self.db.search("test", VECTOR_COFFEE, top_k=10, filters={"user_id": "mt_alice2"})
+        bob_rows = self.db.search("test", VECTOR_COFFEE, top_k=10, filters={"user_id": "mt_bob2"})
+        _assert_exact_ids(alice_rows, {_uuid(710)})
+        _assert_exact_ids(bob_rows, {_uuid(711)})
+
+    def test_agent_id_isolation(self):
+        """Records are isolated by agent_id scope filter."""
+        rows = self.db.search("test", VECTOR_COFFEE, top_k=10, filters={"user_id": "mt_u720", "agent_id": "agent_a"})
+        _assert_exact_ids(rows, {_uuid(720)})
+
+    def test_run_id_isolation(self):
+        """Records are isolated by run_id scope filter."""
+        rows = self.db.search("test", VECTOR_COFFEE, top_k=10, filters={"user_id": "mt_u730", "run_id": "run_001"})
+        _assert_exact_ids(rows, {_uuid(730)})
+
+    def test_combined_user_and_agent_isolation(self):
+        """Combined user_id + agent_id filter narrows results correctly."""
+        rows = self.db.search("test", VECTOR_COFFEE, top_k=10, filters={"user_id": "mt_u740", "agent_id": "agent_a"})
+        _assert_exact_ids(rows, {_uuid(740)})
+
+    def test_combined_user_and_run_isolation(self):
+        """Combined user_id + run_id filter narrows results correctly."""
+        rows = self.db.search("test", VECTOR_COFFEE, top_k=10, filters={"user_id": "mt_u750", "run_id": "run_001"})
+        _assert_exact_ids(rows, {_uuid(750)})
+
+    def test_combined_all_three_scope_filters(self):
+        """Combined user_id + agent_id + run_id filter narrows to exact match."""
+        rows = self.db.search(
+            "test", VECTOR_COFFEE, top_k=10,
+            filters={"user_id": "mt_u760", "agent_id": "agent_a", "run_id": "run_001"},
+        )
+        _assert_exact_ids(rows, {_uuid(760)})
+
+    def test_scope_guard_missing_user_id_raises_error(self):
+        """Search without any scope filter raises ValueError when require_scoped_filters=True."""
+        with pytest.raises(ValueError, match="requires at least one scoped filter"):
+            self.db.search("test", VECTOR_COFFEE, top_k=10, filters={"category": "food"})
+
+    def test_or_without_scope_in_all_branches_raises_error(self):
+        """$or where not all branches have scope filter raises ValueError."""
+        with pytest.raises(ValueError, match="requires at least one scoped filter"):
+            self.db.search(
+                "test", VECTOR_COFFEE, top_k=10,
+                filters={"$or": [{"user_id": "mt_u780"}, {"category": "food"}]},
+            )
+
+    def test_filter_mode_json_expression_basic(self):
+        """json_expression filter mode supports payload key filtering."""
+        rows = self.db.search("test", VECTOR_COFFEE, top_k=10, filters={"user_id": "mt_json", "category": "food"})
+        _assert_exact_ids(rows, {_uuid(790)})
+
+    def test_filter_mode_json_expression_range(self):
+        """json_expression mode keeps payload filtering, but typed range operators remain unsupported."""
+        rows = self.db.search("test", VECTOR_COFFEE, top_k=10, filters={"user_id": "mt_json2", "priority": {"gte": "5"}})
+        _assert_exact_ids(rows, set())
+
+    def test_filter_mode_redundant_columns_basic(self):
+        """Scope column filtering (now uses json_expression mode)."""
+        rows = self.db.search("test", VECTOR_COFFEE, top_k=10, filters={"user_id": "mt_rc_alice"})
+        _assert_exact_ids(rows, {_uuid(810)})
+
+
+
+
+# ===========================================================================
+# Search Quality Tests (from test_gaussdb_p1_search_quality.py)
+# ===========================================================================
+
+class TestDistanceMetricCorrectness:
+    """Tests for distance metric correctness with L2 and cosine."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.db_l2 = _new_db(prefix="search_l2", vector_metric="l2")
+        _insert_memories(cls.db_l2, [
+            # test_l2_nearest_neighbor_correct (user_id="u1001")
+            (_uuid(1001), [1.0, 0.0, 0.0], _make_payload("point_a", "u1001")),
+            (_uuid(1002), [0.9, 0.1, 0.0], _make_payload("point_b", "u1001")),
+            (_uuid(1003), [0.0, 1.0, 0.0], _make_payload("point_c", "u1001")),
+            # test_l2_ordering_correct (user_id="u1011")
+            (_uuid(1011), [0.0, 0.0, 0.0], _make_payload("origin", "u1011")),
+            (_uuid(1012), [1.0, 0.0, 0.0], _make_payload("dist_1", "u1011")),
+            (_uuid(1013), [2.0, 0.0, 0.0], _make_payload("dist_2", "u1011")),
+            (_uuid(1014), [3.0, 0.0, 0.0], _make_payload("dist_3", "u1011")),
+            # test_l2_known_distance_value (user_id="u1021")
+            (_uuid(1021), [1.0, 0.0, 0.0], _make_payload("unit_x", "u1021")),
+            # test_l2_metric_stored_correctly (user_id="u1071")
+            (_uuid(1071), [0.5, 0.5, 0.5], _make_payload("center", "u1071")),
+        ])
+        cls.db_cosine = _new_db(prefix="search_cos", vector_metric="cosine")
+        _insert_memories(cls.db_cosine, [
+            # test_cosine_nearest_neighbor_correct (user_id="u1031")
+            (_uuid(1031), [1.0, 0.0, 0.0], _make_payload("unit_x", "u1031")),
+            (_uuid(1032), [0.9, 0.1, 0.0], _make_payload("near_x", "u1031")),
+            (_uuid(1033), [0.0, 1.0, 0.0], _make_payload("unit_y", "u1031")),
+            # test_cosine_orthogonal_vectors_low_score (user_id="u1041")
+            (_uuid(1041), [1.0, 0.0, 0.0], _make_payload("x_axis", "u1041")),
+            (_uuid(1042), [0.0, 1.0, 0.0], _make_payload("y_axis", "u1041")),
+            # test_cosine_nearest_neighbor_ordering (user_id="u1051")
+            (_uuid(1051), [1.0, 0.0, 0.0], _make_payload("along_x", "u1051")),
+            (_uuid(1052), [1.0, 1.0, 0.0], _make_payload("45_deg", "u1051")),
+            (_uuid(1053), [0.0, 1.0, 0.0], _make_payload("along_y", "u1051")),
+        ])
+
+    @classmethod
+    def teardown_class(cls):
+        cls.db_l2.delete_col()
+        cls.db_cosine.delete_col()
+
+    def test_l2_nearest_neighbor_correct(self):
+        """L2 metric returns the nearest neighbor correctly."""
+        results = self.db_l2.search("query", [1.0, 0.0, 0.0], top_k=3, filters={"user_id": "u1001"})
+        assert len(results) >= 2
+        assert results[0].id == _uuid(1001)
+        assert results[1].id == _uuid(1002)
+
+    def test_l2_ordering_correct(self):
+        """L2 metric returns results in correct distance order."""
+        results = self.db_l2.search("query", [0.0, 0.0, 0.0], top_k=4, filters={"user_id": "u1011"})
+        assert len(results) == 4
+        _assert_ordered_ids(results, [_uuid(1011), _uuid(1012), _uuid(1013), _uuid(1014)])
+
+    def test_l2_known_distance_value(self):
+        """L2 distance produces expected normalized score for known distance."""
+        results = self.db_l2.search("query", [0.0, 0.0, 0.0], top_k=1, filters={"user_id": "u1021"})
+        assert len(results) == 1
+        assert abs(results[0].score - 0.5) < 0.1
+
+    def test_cosine_nearest_neighbor_correct(self):
+        """Cosine metric returns the nearest neighbor correctly."""
+        results = self.db_cosine.search("query", [1.0, 0.0, 0.0], top_k=3, filters={"user_id": "u1031"})
+        assert len(results) >= 2
+        assert results[0].id == _uuid(1031)
+
+    def test_cosine_orthogonal_vectors_low_score(self):
+        """Cosine: orthogonal vectors should have low similarity (high distance)."""
+        results = self.db_cosine.search("query", [1.0, 0.0, 0.0], top_k=2, filters={"user_id": "u1041"})
+        assert len(results) == 2
+        x_score = results[0].score
+        y_score = results[1].score
+        assert x_score > y_score
+        assert y_score < 0.6
+
+    def test_cosine_nearest_neighbor_ordering(self):
+        """Cosine metric orders results by angular similarity."""
+        results = self.db_cosine.search("query", [1.0, 0.0, 0.0], top_k=3, filters={"user_id": "u1051"})
+        assert len(results) == 3
+        _assert_ordered_ids(results, [_uuid(1051), _uuid(1052), _uuid(1053)])
+
+    def test_default_metric_is_cosine(self):
+        """Default metric should be cosine when not specified."""
+        assert self.db_cosine.vector_metric == "cosine"
+
+    def test_l2_metric_stored_correctly(self):
+        """L2 metric is stored and used correctly in the DB instance."""
+        assert self.db_l2.vector_metric == "l2"
+        results = self.db_l2.search("query", [0.5, 0.5, 0.5], top_k=1, filters={"user_id": "u1071"})
+        assert len(results) == 1
+        assert results[0].score > 0.95
+
+
+# ===========================================================================
+# 6.2.2 Score Ordering Verification (5 tests)
+# ===========================================================================
+
+
+class TestScoreOrdering:
+    """Tests for score ordering and precision."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.db = _new_db(prefix="search_score", vector_metric="cosine")
+        _insert_memories(cls.db, [
+            # test_scores_in_descending_order (user_id="u2001")
+            (_uuid(2001), [1.0, 0.0, 0.0], _make_payload("vec_a", "u2001")),
+            (_uuid(2002), [0.7, 0.7, 0.0], _make_payload("vec_b", "u2001")),
+            (_uuid(2003), [0.0, 1.0, 0.0], _make_payload("vec_c", "u2001")),
+            (_uuid(2004), [0.0, 0.0, 1.0], _make_payload("vec_d", "u2001")),
+            # test_top1_is_closest_vector (user_id="u2011")
+            (_uuid(2011), [0.1, 0.9, 0.1], _make_payload("far_from_query", "u2011")),
+            (_uuid(2012), [0.95, 0.05, 0.0], _make_payload("close_to_query", "u2011")),
+            (_uuid(2013), [0.5, 0.5, 0.5], _make_payload("medium", "u2011")),
+            # test_identical_vector_returns_high_score (user_id="u2021")
+            (_uuid(2021), [0.6, 0.3, 0.1], _make_payload("target", "u2021")),
+            # test_distant_vector_returns_low_score (user_id="u2031")
+            (_uuid(2031), [1.0, 0.0, 0.0], _make_payload("opposite_dir", "u2031")),
+            # test_score_range_validation (user_id="u2041")
+            (_uuid(2041), [1.0, 0.0, 0.0], _make_payload("a", "u2041")),
+            (_uuid(2042), [0.0, 1.0, 0.0], _make_payload("b", "u2041")),
+            (_uuid(2043), [0.0, 0.0, 1.0], _make_payload("c", "u2041")),
+            (_uuid(2044), [-1.0, 0.0, 0.0], _make_payload("d", "u2041")),
+        ])
+
+    @classmethod
+    def teardown_class(cls):
+        cls.db.delete_col()
+
+    def test_scores_in_descending_order(self):
+        """Search results should have scores in descending order."""
+        results = self.db.search("query", [1.0, 0.0, 0.0], top_k=4, filters={"user_id": "u2001"})
+        scores = [r.score for r in results]
+        assert scores == sorted(scores, reverse=True), "Scores should be in descending order"
+
+    def test_top1_is_closest_vector(self):
+        """Top-1 result should be the closest vector to the query."""
+        results = self.db.search("query", [1.0, 0.0, 0.0], top_k=1, filters={"user_id": "u2011"})
+        assert len(results) == 1
+        assert results[0].id == _uuid(2012)
+
+    def test_identical_vector_returns_high_score(self):
+        """Searching with an identical vector should return score close to 1.0."""
+        results = self.db.search("query", [0.6, 0.3, 0.1], top_k=1, filters={"user_id": "u2021"})
+        assert len(results) == 1
+        assert results[0].score > 0.95
+
+    def test_distant_vector_returns_low_score(self):
+        """A vector far from the query should return a low score."""
+        results = self.db.search("query", [-1.0, 0.0, 0.0], top_k=1, filters={"user_id": "u2031"})
+        assert len(results) == 1
+        assert results[0].score < 0.5
+
+    def test_score_range_validation(self):
+        """All scores should be in the range (0, 1]."""
+        results = self.db.search("query", [0.5, 0.5, 0.0], top_k=4, filters={"user_id": "u2041"})
+        for r in results:
+            assert 0.0 < r.score <= 1.0, f"Score {r.score} out of valid range (0, 1]"
+
+
+# ===========================================================================
+# 6.2.3 Recall Quality (5 tests)
+# ===========================================================================
+
+
+class TestRecallQuality:
+    """Tests for recall quality with known data distributions."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.db_cosine = _new_db(prefix="search_recall_cos", vector_metric="cosine")
+        # test_known_vectors_correct_top3 (user_id="u3001")
+        vectors = [
+            ([1.0, 0.0, 0.0], "exact_match"),
+            ([0.95, 0.05, 0.0], "very_close"),
+            ([0.9, 0.1, 0.0], "close"),
+            ([0.7, 0.3, 0.0], "moderate_1"),
+            ([0.5, 0.5, 0.0], "moderate_2"),
+            ([0.3, 0.7, 0.0], "far_1"),
+            ([0.1, 0.9, 0.0], "far_2"),
+            ([0.0, 1.0, 0.0], "orthogonal"),
+            ([0.0, 0.0, 1.0], "orthogonal_z"),
+            ([-1.0, 0.0, 0.0], "opposite"),
+        ]
+        records = [
+            (_uuid(3001 + i), vec, _make_payload(label, "u3001"))
+            for i, (vec, label) in enumerate(vectors)
+        ]
+        # test_cluster_search_returns_same_cluster_first (user_id="u3201")
+        records += [
+            (_uuid(3201), [0.95, 0.05, 0.0], _make_payload("cluster_a_1", "u3201")),
+            (_uuid(3202), [0.90, 0.10, 0.0], _make_payload("cluster_a_2", "u3201")),
+            (_uuid(3203), [0.85, 0.15, 0.0], _make_payload("cluster_a_3", "u3201")),
+            (_uuid(3204), [0.05, 0.95, 0.0], _make_payload("cluster_b_1", "u3201")),
+            (_uuid(3205), [0.10, 0.90, 0.0], _make_payload("cluster_b_2", "u3201")),
+            (_uuid(3206), [0.15, 0.85, 0.0], _make_payload("cluster_b_3", "u3201")),
+        ]
+        # test_duplicate_vectors_return_same_score (user_id="u3301")
+        records += [
+            (_uuid(3301), [0.5, 0.5, 0.0], _make_payload("dup_1", "u3301")),
+            (_uuid(3302), [0.5, 0.5, 0.0], _make_payload("dup_2", "u3301")),
+        ]
+        # test_near_duplicate_vectors_return_similar_scores (user_id="u3401")
+        records += [
+            (_uuid(3401), [0.500, 0.500, 0.000], _make_payload("near_dup_1", "u3401")),
+            (_uuid(3402), [0.501, 0.499, 0.001], _make_payload("near_dup_2", "u3401")),
+        ]
+        _insert_memories(cls.db_cosine, records)
+
+        # test_100_vectors_recall_at_10 needs L2 with dynamic data
+        import random
+        random.seed(42)
+        cls.db_l2 = _new_db(prefix="search_recall_l2", vector_metric="l2")
+        cls._all_vectors = []
+        l2_records = []
+        for i in range(100):
+            vec = [random.uniform(-1, 1) for _ in range(3)]
+            cls._all_vectors.append((i, vec))
+            l2_records.append((_uuid(3100 + i), vec, _make_payload(f"item_{i}", "u3100")))
+        _insert_memories(cls.db_l2, l2_records)
+
+    @classmethod
+    def teardown_class(cls):
+        cls.db_cosine.delete_col()
+        cls.db_l2.delete_col()
+
+    def test_known_vectors_correct_top3(self):
+        """Insert 10 known vectors, search returns correct top-3."""
+        results = self.db_cosine.search("query", [1.0, 0.0, 0.0], top_k=3, filters={"user_id": "u3001"})
+        assert len(results) == 3
+        top3_ids = _ids(results)
+        assert top3_ids[0] == _uuid(3001)
+        assert top3_ids[1] == _uuid(3002)
+        assert top3_ids[2] == _uuid(3003)
+
+    def test_100_vectors_recall_at_10(self):
+        """Insert 100 vectors, recall@10 should be >= 0.8 for known nearest neighbors."""
+        query = [0.5, 0.5, 0.5]
+
+        def l2_dist(a, b):
+            return math.sqrt(sum((x - y) ** 2 for x, y in zip(a, b)))
+
+        true_nearest = sorted(self._all_vectors, key=lambda x: l2_dist(x[1], query))
+        true_top10_ids = {_uuid(3100 + idx) for idx, _ in true_nearest[:10]}
+
+        results = self.db_l2.search("query", query, top_k=10, filters={"user_id": "u3100"})
+        result_ids = set(_ids(results))
+
+        recall = len(result_ids & true_top10_ids) / 10.0
+        assert recall >= 0.8, f"Recall@10 = {recall}, expected >= 0.8"
+
+    def test_cluster_search_returns_same_cluster_first(self):
+        """Vectors in the same cluster as query should rank higher."""
+        results = self.db_cosine.search("query", [1.0, 0.0, 0.0], top_k=6, filters={"user_id": "u3201"})
+        top3_ids = set(_ids(results[:3]))
+        cluster_a_ids = {_uuid(3201), _uuid(3202), _uuid(3203)}
+        assert top3_ids == cluster_a_ids, "Top-3 should all be from cluster A"
+
+    def test_duplicate_vectors_return_same_score(self):
+        """Duplicate vectors should return the same score."""
+        results = self.db_cosine.search("query", [1.0, 0.0, 0.0], top_k=2, filters={"user_id": "u3301"})
+        assert len(results) == 2
+        assert abs(results[0].score - results[1].score) < 1e-6
+
+    def test_near_duplicate_vectors_return_similar_scores(self):
+        """Near-duplicate vectors should return very similar scores."""
+        results = self.db_cosine.search("query", [1.0, 0.0, 0.0], top_k=2, filters={"user_id": "u3401"})
+        assert len(results) == 2
+        score_diff = abs(results[0].score - results[1].score)
+        assert score_diff < 0.01, f"Near-duplicate score diff {score_diff} should be < 0.01"
+
+
+# ===========================================================================
+# 6.2.4 BM25 Search Quality (5 tests, conditional)
+# ===========================================================================
+
+
+@pytest.mark.skipif(not _env_bool("GAUSSDB_TEST_RUN_BM25"), reason="BM25 tests disabled")
+class TestBM25SearchQuality:
+    """Tests for BM25 text search quality (requires GAUSSDB_TEST_RUN_BM25=true)."""
+
+    def test_bm25_single_keyword_match(self):
+        """BM25 search with a single keyword should find matching documents."""
+        db = _new_db(prefix="p1_search")
+        try:
+            _insert_memories(db, [
+                (_uuid(4001), VECTOR_COFFEE, _make_payload("coffee espresso latte", "bm25_user")),
+                (_uuid(4002), VECTOR_FLIGHT, _make_payload("airplane flight travel", "bm25_user")),
+                (_uuid(4003), VECTOR_WINDOW, _make_payload("window glass pane", "bm25_user")),
+            ])
+            results = db.search("coffee", VECTOR_COFFEE, top_k=3, filters={"user_id": "bm25_user"})
+            assert len(results) >= 1
+            # The coffee document should rank high
+            result_ids = _ids(results)
+            assert _uuid(4001) in result_ids
+        finally:
+            db.delete_col()
+
+    def test_bm25_multi_keyword_match(self):
+        """BM25 search with multiple keywords should prefer documents matching more terms."""
+        db = _new_db(prefix="p1_search")
+        try:
+            _insert_memories(db, [
+                (_uuid(4011), VECTOR_COFFEE, _make_payload("coffee espresso morning brew", "bm25_user")),
+                (_uuid(4012), VECTOR_FLIGHT, _make_payload("coffee flight morning travel", "bm25_user")),
+                (_uuid(4013), VECTOR_WINDOW, _make_payload("window glass morning light", "bm25_user")),
+            ])
+            results = db.search("coffee morning", VECTOR_COFFEE, top_k=3, filters={"user_id": "bm25_user"})
+            assert len(results) >= 1
+            # Documents with both "coffee" and "morning" should rank higher
+            top_ids = _ids(results[:2])
+            assert _uuid(4011) in top_ids or _uuid(4012) in top_ids
+        finally:
+            db.delete_col()
+
+    def test_bm25_exact_phrase_match(self):
+        """BM25 search should find exact phrase matches."""
+        db = _new_db(prefix="p1_search")
+        try:
+            _insert_memories(db, [
+                (_uuid(4021), VECTOR_COFFEE, _make_payload("hot coffee with milk", "bm25_user")),
+                (_uuid(4022), VECTOR_FLIGHT, _make_payload("cold coffee without milk", "bm25_user")),
+                (_uuid(4023), VECTOR_WINDOW, _make_payload("tea with lemon", "bm25_user")),
+            ])
+            results = db.search("hot coffee", VECTOR_COFFEE, top_k=3, filters={"user_id": "bm25_user"})
+            assert len(results) >= 1
+            # "hot coffee" document should be in results
+            assert _uuid(4021) in _ids(results)
+        finally:
+            db.delete_col()
+
+    def test_bm25_no_match_returns_empty_or_low_score(self):
+        """BM25 search with no matching terms should return empty or very low scores."""
+        db = _new_db(prefix="p1_search")
+        try:
+            _insert_memories(db, [
+                (_uuid(4031), VECTOR_COFFEE, _make_payload("coffee espresso latte", "bm25_user")),
+                (_uuid(4032), VECTOR_FLIGHT, _make_payload("airplane flight travel", "bm25_user")),
+            ])
+            # Search for a term that does not exist in any document
+            results = db.search("xyznonexistent", VECTOR_WINDOW, top_k=3, filters={"user_id": "bm25_user"})
+            # Either empty or results have low relevance (vector-only fallback)
+            if len(results) > 0:
+                # If results returned, they are from vector similarity only
+                # No BM25 boost should be applied
+                assert all(r.score <= 1.0 for r in results)
+        finally:
+            db.delete_col()
+
+    def test_bm25_score_ordering(self):
+        """BM25 results should be ordered by relevance score."""
+        db = _new_db(prefix="p1_search")
+        try:
+            _insert_memories(db, [
+                (_uuid(4041), VECTOR_COFFEE, _make_payload("coffee coffee coffee beans", "bm25_user")),
+                (_uuid(4042), VECTOR_FLIGHT, _make_payload("coffee once mentioned", "bm25_user")),
+                (_uuid(4043), VECTOR_WINDOW, _make_payload("no relevant terms here", "bm25_user")),
+            ])
+            results = db.search("coffee", VECTOR_COFFEE, top_k=3, filters={"user_id": "bm25_user"})
+            if len(results) >= 2:
+                scores = [r.score for r in results]
+                assert scores == sorted(scores, reverse=True), "BM25 scores should be in descending order"
+        finally:
+            db.delete_col()
+
+
+# ===========================================================================
+# 6.2.5 Hybrid Search Quality (3 tests, conditional)
+# ===========================================================================
+
+
+@pytest.mark.skipif(not _env_bool("GAUSSDB_TEST_RUN_BM25"), reason="Hybrid tests require BM25")
+class TestHybridSearchQuality:
+    """Tests for hybrid (vector + BM25) search quality."""
+
+    def test_hybrid_vector_plus_bm25_combined(self):
+        """Hybrid search should benefit from both vector and text similarity."""
+        db = _new_db(prefix="p1_search")
+        try:
+            # Doc 1: good vector match + good text match
+            # Doc 2: good vector match + poor text match
+            # Doc 3: poor vector match + good text match
+            _insert_memories(db, [
+                (_uuid(5001), [0.9, 0.1, 0.0], _make_payload("coffee espresso beans", "hybrid_user")),
+                (_uuid(5002), [0.85, 0.15, 0.0], _make_payload("unrelated topic here", "hybrid_user")),
+                (_uuid(5003), [0.1, 0.9, 0.0], _make_payload("coffee latte cappuccino", "hybrid_user")),
+            ])
+            results = db.search("coffee", [1.0, 0.0, 0.0], top_k=3, filters={"user_id": "hybrid_user"})
+            assert len(results) >= 1
+            # Doc with both good vector + text match should rank first
+            assert results[0].id == _uuid(5001)
+        finally:
+            db.delete_col()
+
+    def test_hybrid_vs_vector_only_comparison(self):
+        """Hybrid search should produce different ranking than pure vector search."""
+        db_hybrid = _new_db(prefix="p1_search")
+        db_vector = _new_db(prefix="p1_search")
+        try:
+            records = [
+                (_uuid(5011), [0.9, 0.1, 0.0], _make_payload("airplane flight travel", "hybrid_user")),
+                (_uuid(5012), [0.85, 0.15, 0.0], _make_payload("coffee espresso beans", "hybrid_user")),
+                (_uuid(5013), [0.1, 0.9, 0.0], _make_payload("coffee latte morning", "hybrid_user")),
+            ]
+            _insert_memories(db_hybrid, records)
+            _insert_memories(db_vector, records)
+
+            query_vec = [1.0, 0.0, 0.0]
+            hybrid_results = db_hybrid.search("coffee", query_vec, top_k=3, filters={"user_id": "hybrid_user"})
+            vector_results = db_vector.search("coffee", query_vec, top_k=3, filters={"user_id": "hybrid_user"})
+
+            # Both should return results
+            assert len(hybrid_results) >= 1
+            assert len(vector_results) >= 1
+            # Hybrid may reorder results due to BM25 boost
+            # At minimum, both return valid scored results
+            for r in hybrid_results:
+                assert r.score > 0
+            for r in vector_results:
+                assert r.score > 0
+        finally:
+            db_hybrid.delete_col()
+            db_vector.delete_col()
+
+    def test_hybrid_bm25_boost_effect(self):
+        """BM25 component should boost text-relevant results in hybrid search."""
+        db = _new_db(prefix="p1_search")
+        try:
+            # Two vectors equidistant from query, but one has matching text
+            _insert_memories(db, [
+                (_uuid(5021), [0.7, 0.7, 0.0], _make_payload("coffee beans roast", "hybrid_user")),
+                (_uuid(5022), [0.7, 0.0, 0.7], _make_payload("unrelated random words", "hybrid_user")),
+            ])
+            results = db.search("coffee", [0.7, 0.35, 0.35], top_k=2, filters={"user_id": "hybrid_user"})
+            assert len(results) == 2
+            # The text-matching document should get a boost
+            assert results[0].id == _uuid(5021)
+        finally:
+            db.delete_col()
+
+
+# ===========================================================================
+# 6.2.6 Score Edge Cases (4 tests)
+# ===========================================================================
+
+
+class TestScoreEdgeCases:
+    """Tests for score edge cases and stability."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.db_cosine = _new_db(prefix="search_edge_cos", vector_metric="cosine")
+        _insert_memories(cls.db_cosine, [
+            # test_orthogonal_vectors_low_scores (user_id="u6001")
+            (_uuid(6001), [0.0, 1.0, 0.0], _make_payload("y_axis", "u6001")),
+            (_uuid(6002), [0.0, 0.0, 1.0], _make_payload("z_axis", "u6001")),
+            (_uuid(6003), [0.0, 0.7, 0.7], _make_payload("yz_plane", "u6001")),
+            # test_duplicate_scores_sorting_stability (user_id="u6011")
+            (_uuid(6011), [0.5, 0.5, 0.0], _make_payload("dup_a", "u6011")),
+            (_uuid(6012), [0.5, 0.5, 0.0], _make_payload("dup_b", "u6011")),
+            (_uuid(6013), [0.5, 0.5, 0.0], _make_payload("dup_c", "u6011")),
+            # test_score_precision_decimal_places (user_id="u6021")
+            (_uuid(6021), [0.9, 0.1, 0.0], _make_payload("precise_a", "u6021")),
+            (_uuid(6022), [0.8, 0.2, 0.0], _make_payload("precise_b", "u6021")),
+        ])
+        # test_large_dataset_sorting_correctness needs L2 with 1000 vectors
+        import random
+        random.seed(123)
+        cls.db_l2 = _new_db(prefix="search_edge_l2", vector_metric="l2")
+        batch_size = 100
+        for batch_start in range(0, 1000, batch_size):
+            records = []
+            for i in range(batch_start, batch_start + batch_size):
+                vec = [random.uniform(-1, 1) for _ in range(3)]
+                records.append((_uuid(6100 + i), vec, _make_payload(f"item_{i}", "u6100")))
+            _insert_memories(cls.db_l2, records)
+
+    @classmethod
+    def teardown_class(cls):
+        cls.db_cosine.delete_col()
+        cls.db_l2.delete_col()
+
+    def test_orthogonal_vectors_low_scores(self):
+        """All vectors orthogonal to query should produce uniformly low scores."""
+        results = self.db_cosine.search("query", [1.0, 0.0, 0.0], top_k=3, filters={"user_id": "u6001"})
+        for r in results:
+            assert r.score <= 0.55, f"Orthogonal vector score {r.score} should be <= 0.55"
+
+    def test_duplicate_scores_sorting_stability(self):
+        """Vectors with identical scores should have stable sort (by ID)."""
+        results = self.db_cosine.search("query", [1.0, 0.0, 0.0], top_k=3, filters={"user_id": "u6011"})
+        assert len(results) == 3
+        scores = [r.score for r in results]
+        assert all(abs(s - scores[0]) < 1e-6 for s in scores)
+        ids = _ids(results)
+        assert ids == sorted(ids), "Tie-breaking should be stable (by ID)"
+
+    def test_score_precision_decimal_places(self):
+        """Scores should have reasonable floating-point precision."""
+        results = self.db_cosine.search("query", [1.0, 0.0, 0.0], top_k=2, filters={"user_id": "u6021"})
+        assert len(results) == 2
+        assert results[0].score != results[1].score
+        for r in results:
+            score_str = f"{r.score:.6f}"
+            assert len(score_str) >= 6
+
+    def test_large_dataset_sorting_correctness(self):
+        """1000 items with top_k=100 should return correctly sorted results."""
+        query = [0.0, 0.0, 0.0]
+        results = self.db_l2.search("query", query, top_k=100, filters={"user_id": "u6100"})
+        assert len(results) == 100
+        scores = [r.score for r in results]
+        for i in range(len(scores) - 1):
+            assert scores[i] >= scores[i + 1], (
+                f"Score at position {i} ({scores[i]}) should be >= score at position {i+1} ({scores[i+1]})"
+            )
+
+
+
+
+# ===========================================================================
+# Boundary Value Tests (from test_gaussdb_p1_boundary.py)
+# ===========================================================================
+
+class TestVectorDimensionBoundary:
+    """Tests for vector dimension edge cases."""
+
+    def test_single_dimension_vector_insert_and_search(self):
+        """1-dimensional vector should work."""
+        db = _new_db(prefix="p1_dim", embedding_model_dims=1)
+        try:
+            vid = _uuid(1001)
+            db.insert(
+                ids=[vid],
+                vectors=[[0.5]],
+                payloads=[{"data": "single dim", "user_id": "dim_user"}],
+            )
+            results = db.search("single", [0.5], top_k=1, filters={"user_id": "dim_user"})
+            assert len(results) == 1
+            assert results[0].id == vid
+        finally:
+            db.delete_col()
+
+    def test_high_dimension_vector_insert_and_search(self):
+        """High-dimensional vector (256-dim) should work."""
+        dims = 256
+        db = _new_db(prefix="p1_dim", embedding_model_dims=dims)
+        try:
+            vid = _uuid(1002)
+            vector = [float(i) / dims for i in range(dims)]
+            db.insert(
+                ids=[vid],
+                vectors=[vector],
+                payloads=[{"data": "high dim", "user_id": "dim_user"}],
+            )
+            results = db.search("high", vector, top_k=1, filters={"user_id": "dim_user"})
+            assert len(results) == 1
+            assert results[0].id == vid
+        finally:
+            db.delete_col()
+
+    def test_zero_vector_insert_and_search(self):
+        """Zero vector should be insertable."""
+        db = _new_db(prefix="p1_dim")
+        try:
+            vid = _uuid(1003)
+            zero_vec = [0.0] * EMBEDDING_DIMS
+            db.insert(
+                ids=[vid],
+                vectors=[zero_vec],
+                payloads=[{"data": "zero vector", "user_id": "dim_user"}],
+            )
+            result = db.get(vid)
+            assert result is not None
+            assert result.id == vid
+        finally:
+            db.delete_col()
+
+    def test_nan_vector_raises_or_handles_gracefully(self):
+        """NaN in vector should raise an error or be handled gracefully."""
+        db = _new_db(prefix="p1_dim")
+        try:
+            vid = _uuid(1004)
+            nan_vec = [float("nan"), 0.1, 0.2]
+            with pytest.raises((ValueError, Exception)):
+                db.insert(
+                    ids=[vid],
+                    vectors=[nan_vec],
+                    payloads=[{"data": "nan vector", "user_id": "dim_user"}],
+                )
+        finally:
+            db.delete_col()
+
+    def test_inf_vector_raises_or_handles_gracefully(self):
+        """Inf in vector should raise an error or be handled gracefully."""
+        db = _new_db(prefix="p1_dim")
+        try:
+            vid = _uuid(1005)
+            inf_vec = [float("inf"), 0.1, 0.2]
+            with pytest.raises((ValueError, Exception)):
+                db.insert(
+                    ids=[vid],
+                    vectors=[inf_vec],
+                    payloads=[{"data": "inf vector", "user_id": "dim_user"}],
+                )
+        finally:
+            db.delete_col()
+
+    def test_very_large_values_in_vector(self):
+        """Very large float values in vector should be insertable."""
+        db = _new_db(prefix="p1_dim")
+        try:
+            vid = _uuid(1006)
+            large_vec = [1e30, -1e30, 1e15]
+            db.insert(
+                ids=[vid],
+                vectors=[large_vec],
+                payloads=[{"data": "large values", "user_id": "dim_user"}],
+            )
+            result = db.get(vid)
+            assert result is not None
+        finally:
+            db.delete_col()
+
+    def test_negative_values_in_vector(self):
+        """Negative values in vector should work normally."""
+        db = _new_db(prefix="p1_dim")
+        try:
+            vid = _uuid(1007)
+            neg_vec = [-0.5, -0.3, -0.9]
+            db.insert(
+                ids=[vid],
+                vectors=[neg_vec],
+                payloads=[{"data": "negative vector", "user_id": "dim_user"}],
+            )
+            results = db.search("neg", neg_vec, top_k=1, filters={"user_id": "dim_user"})
+            assert len(results) == 1
+            assert results[0].id == vid
+        finally:
+            db.delete_col()
+
+    def test_empty_vector_list_raises(self):
+        """Empty vector list should raise an error."""
+        db = _new_db(prefix="p1_dim")
+        try:
+            vid = _uuid(1008)
+            with pytest.raises((ValueError, Exception)):
+                db.insert(
+                    ids=[vid],
+                    vectors=[[]],
+                    payloads=[{"data": "empty vector", "user_id": "dim_user"}],
+                )
+        finally:
+            db.delete_col()
+
+
+# ===========================================================================
+# Payload Boundary Tests
+# ===========================================================================
+
+
+class TestPayloadBoundary:
+    """Tests for payload edge cases."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.db = _new_db(prefix="p1_payload")
+
+    @classmethod
+    def teardown_class(cls):
+        cls.db.delete_col()
+
+    def test_empty_payload(self):
+        """Empty payload dict should be insertable."""
+        vid = _uuid(2001)
+        self.db.insert(ids=[vid], vectors=[VECTOR_COFFEE], payloads=[{}])
+        result = self.db.get(vid)
+        assert result is not None
+
+    def test_large_payload_100kb(self):
+        """Large payload (~100KB) should be insertable and retrievable."""
+        vid = _uuid(2002)
+        large_value = "x" * 100_000
+        payload = {"data": "large payload", "user_id": "payload_user", "big_field": large_value}
+        self.db.insert(ids=[vid], vectors=[VECTOR_COFFEE], payloads=[payload])
+        result = self.db.get(vid)
+        assert result is not None
+        assert result.payload["big_field"] == large_value
+
+    def test_deeply_nested_payload(self):
+        """Deeply nested payload (5 levels) should be stored correctly."""
+        vid = _uuid(2003)
+        nested = {"level1": {"level2": {"level3": {"level4": {"level5": "deep_value"}}}}}
+        payload = {"data": "nested payload", "user_id": "payload_user", "nested": nested}
+        self.db.insert(ids=[vid], vectors=[VECTOR_COFFEE], payloads=[payload])
+        result = self.db.get(vid)
+        assert result is not None
+        assert result.payload["nested"]["level1"]["level2"]["level3"]["level4"]["level5"] == "deep_value"
+
+    def test_special_characters_in_payload(self):
+        """Special characters in payload values should be preserved."""
+        vid = _uuid(2004)
+        special = "Hello 'world' \"quotes\" \\backslash\\ <html>&amp; \t\n"
+        payload = {"data": special, "user_id": "payload_user", "special": special}
+        self.db.insert(ids=[vid], vectors=[VECTOR_COFFEE], payloads=[payload])
+        result = self.db.get(vid)
+        assert result is not None
+        assert result.payload["special"] == special
+
+    def test_unicode_payload_chinese_and_emoji(self):
+        """Unicode (Chinese, emoji) in payload should round-trip correctly."""
+        vid = _uuid(2005)
+        unicode_text = "你好世界 🌍🚀 日本語テスト"
+        payload = {"data": unicode_text, "user_id": "payload_user", "text": unicode_text}
+        self.db.insert(ids=[vid], vectors=[VECTOR_COFFEE], payloads=[payload])
+        result = self.db.get(vid)
+        assert result is not None
+        assert result.payload["text"] == unicode_text
+
+    def test_very_long_key_in_payload(self):
+        """Very long key name (128 chars) in payload should work."""
+        vid = _uuid(2006)
+        long_key = "k" * 128
+        payload = {"data": "long key", "user_id": "payload_user", long_key: "value"}
+        self.db.insert(ids=[vid], vectors=[VECTOR_COFFEE], payloads=[payload])
+        result = self.db.get(vid)
+        assert result is not None
+        assert result.payload[long_key] == "value"
+
+    def test_very_long_value_in_payload(self):
+        """Very long value (10KB string) in payload should work."""
+        vid = _uuid(2007)
+        long_value = "v" * 10_000
+        payload = {"data": "long value", "user_id": "payload_user", "long_val": long_value}
+        self.db.insert(ids=[vid], vectors=[VECTOR_COFFEE], payloads=[payload])
+        result = self.db.get(vid)
+        assert result is not None
+        assert result.payload["long_val"] == long_value
+
+    def test_null_value_in_payload(self):
+        """None/null value in payload should be preserved."""
+        vid = _uuid(2008)
+        payload = {"data": "null test", "user_id": "payload_user", "nullable": None}
+        self.db.insert(ids=[vid], vectors=[VECTOR_COFFEE], payloads=[payload])
+        result = self.db.get(vid)
+        assert result is not None
+        assert result.payload.get("nullable") is None
+
+    def test_boolean_values_in_payload(self):
+        """Boolean values in payload should be preserved."""
+        vid = _uuid(2009)
+        payload = {"data": "bool test", "user_id": "payload_user", "flag_true": True, "flag_false": False}
+        self.db.insert(ids=[vid], vectors=[VECTOR_COFFEE], payloads=[payload])
+        result = self.db.get(vid)
+        assert result is not None
+        assert result.payload["flag_true"] is True
+        assert result.payload["flag_false"] is False
+
+    def test_numeric_values_in_payload(self):
+        """Numeric values (int, float) in payload should be preserved."""
+        vid = _uuid(2010)
+        payload = {
+            "data": "numeric test",
+            "user_id": "payload_user",
+            "int_val": 42,
+            "float_val": 3.14,
+            "negative": -100,
+            "zero": 0,
+        }
+        self.db.insert(ids=[vid], vectors=[VECTOR_COFFEE], payloads=[payload])
+        result = self.db.get(vid)
+        assert result is not None
+        assert result.payload["int_val"] == 42
+        assert abs(result.payload["float_val"] - 3.14) < 0.001
+        assert result.payload["negative"] == -100
+        assert result.payload["zero"] == 0
+
+
+# ===========================================================================
+# ID Boundary Tests
+# ===========================================================================
+
+
+class TestIDBoundary:
+    """Tests for ID edge cases."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.db = _new_db(prefix="p1_id")
+
+    @classmethod
+    def teardown_class(cls):
+        cls.db.delete_col()
+
+    def test_uuid_format_id(self):
+        """Standard UUID format ID should work."""
+        vid = str(uuid.uuid4())
+        self.db.insert(ids=[vid], vectors=[VECTOR_COFFEE], payloads=[{"data": "uuid id", "user_id": "id_uuid"}])
+        result = self.db.get(vid)
+        assert result is not None
+        assert result.id == vid
+
+    def test_deterministic_uuid_format(self):
+        """Deterministic UUID format should work."""
+        vid = _uuid(3001)
+        self.db.insert(ids=[vid], vectors=[VECTOR_COFFEE], payloads=[{"data": "det uuid", "user_id": "id_det"}])
+        result = self.db.get(vid)
+        assert result is not None
+        assert result.id == vid
+
+    def test_duplicate_id_upsert_behavior(self):
+        """Inserting with duplicate ID should upsert (update existing)."""
+        vid = _uuid(3002)
+        self.db.insert(ids=[vid], vectors=[VECTOR_COFFEE], payloads=[{"data": "original", "user_id": "id_dup"}])
+        self.db.insert(ids=[vid], vectors=[VECTOR_FLIGHT], payloads=[{"data": "updated", "user_id": "id_dup"}])
+        result = self.db.get(vid)
+        assert result is not None
+        assert result.payload["data"] == "updated"
+
+    def test_batch_with_duplicate_ids(self):
+        """Batch insert with duplicate IDs should raise UniqueViolation."""
+        vid = _uuid(3003)
+        with pytest.raises(Exception):
+            self.db.insert(
+                ids=[vid, vid],
+                vectors=[VECTOR_COFFEE, VECTOR_FLIGHT],
+                payloads=[
+                    {"data": "first", "user_id": "id_batchdup"},
+                    {"data": "second", "user_id": "id_batchdup"},
+                ],
+            )
+
+    def test_multiple_unique_ids(self):
+        """Multiple unique IDs should all be retrievable."""
+        ids = [_uuid(3010 + i) for i in range(5)]
+        vectors = [VECTOR_COFFEE] * 5
+        payloads = [{"data": f"item_{i}", "user_id": "id_multi"} for i in range(5)]
+        self.db.insert(ids=ids, vectors=vectors, payloads=payloads)
+        for i, vid in enumerate(ids):
+            result = self.db.get(vid)
+            assert result is not None
+            assert result.payload["data"] == f"item_{i}"
+
+    def test_null_id_raises(self):
+        """None as ID should raise an error."""
+        with pytest.raises((ValueError, TypeError, Exception)):
+            self.db.insert(ids=[None], vectors=[VECTOR_COFFEE], payloads=[{"data": "null id", "user_id": "id_null"}])
+
+    def test_get_nonexistent_id_returns_none(self):
+        """Getting a non-existent ID should return None."""
+        result = self.db.get(_uuid(9999))
+        assert result is None
+
+    def test_delete_nonexistent_id_no_error(self):
+        """Deleting a non-existent ID should not raise an error."""
+        self.db.delete(_uuid(9998))
+
+
+# ===========================================================================
+# Collection Name Boundary Tests
+# ===========================================================================
+
+
+class TestCollectionNameBoundary:
+    """Tests for collection name edge cases."""
+
+    def test_max_length_collection_name(self):
+        """Collection name at max usable length should work.
+
+        The identifier limit is 63 chars, but GaussDB appends '_schema_meta'
+        (12 chars) internally, so the effective max collection name is 51 chars.
+        """
+        long_name = "a" * 51
+        db = _new_db(prefix=None, collection_name=long_name)
+        try:
+            vid = _uuid(4001)
+            db.insert(ids=[vid], vectors=[VECTOR_COFFEE], payloads=[{"data": "long name", "user_id": "col_user"}])
+            result = db.get(vid)
+            assert result is not None
+        finally:
+            db.delete_col()
+
+    def test_collection_name_with_underscores(self):
+        """Collection name with underscores should work."""
+        name = f"test_under_score_{uuid.uuid4().hex[:6]}"
+        db = _new_db(prefix=None, collection_name=name)
+        try:
+            vid = _uuid(4002)
+            db.insert(ids=[vid], vectors=[VECTOR_COFFEE], payloads=[{"data": "underscore", "user_id": "col_user"}])
+            result = db.get(vid)
+            assert result is not None
+        finally:
+            db.delete_col()
+
+    def test_collection_name_sql_injection_rejected(self):
+        """SQL injection in collection name should be rejected by validator."""
+        with pytest.raises(ValueError, match="Unsafe"):
+            _new_db(prefix=None, collection_name="test; DROP TABLE users;--")
+
+    def test_empty_collection_name_rejected(self):
+        """Empty collection name should be rejected."""
+        config = _gaussdb_env_config("placeholder")
+        config["collection_name"] = ""
+        with pytest.raises(ValueError):
+            GaussDB(**config)
+
+    def test_collection_name_starting_with_number_rejected(self):
+        """Collection name starting with a number should be rejected."""
+        with pytest.raises(ValueError, match="Unsafe"):
+            _new_db(prefix=None, collection_name="123_invalid")
+
+    def test_collection_name_with_special_chars_rejected(self):
+        """Collection name with special characters should be rejected."""
+        with pytest.raises(ValueError, match="Unsafe"):
+            _new_db(prefix=None, collection_name="test-collection!")
+
+
+# ===========================================================================
+# top_k Boundary Tests
+# ===========================================================================
+
+
+class TestTopKBoundary:
+    """Tests for top_k parameter edge cases."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.db = _new_db(prefix="topk_boundary")
+        _insert_memories(cls.db, [
+            (_uuid(5001), VECTOR_COFFEE, {"data": "item_0", "user_id": "topk_user"}),
+            (_uuid(5002), VECTOR_FLIGHT, {"data": "item_1", "user_id": "topk_user"}),
+            (_uuid(5003), VECTOR_WINDOW, {"data": "item_2", "user_id": "topk_user"}),
+        ])
+
+    @classmethod
+    def teardown_class(cls):
+        cls.db.delete_col()
+
+    def test_top_k_one_returns_single_result(self):
+        """top_k=1 should return exactly one result."""
+        results = self.db.search("item", VECTOR_COFFEE, top_k=1, filters={"user_id": "topk_user"})
+        assert len(results) == 1
+
+    def test_top_k_exceeds_data_count(self):
+        """top_k larger than data count should return all available results."""
+        results = self.db.search("item", VECTOR_COFFEE, top_k=100, filters={"user_id": "topk_user"})
+        assert len(results) == 3
+
+    def test_top_k_very_large_value(self):
+        """Very large top_k should not crash."""
+        results = self.db.search("single", VECTOR_COFFEE, top_k=10000, filters={"user_id": "topk_user"})
+        assert len(results) >= 1
+
+    def test_top_k_zero_returns_empty(self):
+        """top_k=0 should return empty results or raise."""
+        results = self.db.search("item", VECTOR_COFFEE, top_k=0, filters={"user_id": "topk_user"})
+        assert len(results) == 0
+
+    def test_top_k_negative_raises_or_empty(self):
+        """Negative top_k should raise an error or return empty."""
+        try:
+            results = self.db.search("item", VECTOR_COFFEE, top_k=-1, filters={"user_id": "topk_user"})
+            assert len(results) == 0
+        except (ValueError, Exception):
+            pass
+
+
+# ===========================================================================
+# Batch Operation Boundary Tests
+# ===========================================================================
+
+
+class TestBatchOperationBoundary:
+    """Tests for batch operation edge cases."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.db = _new_db(prefix="p1_batch")
+
+    @classmethod
+    def teardown_class(cls):
+        cls.db.delete_col()
+
+    def test_empty_batch_insert(self):
+        """Empty batch insert should not crash."""
+        result = self.db.insert(ids=[], vectors=[], payloads=[])
+        assert result is None or result == []
+
+    def test_single_item_batch(self):
+        """Single-item batch should work like single insert."""
+        vid = _uuid(6001)
+        self.db.insert(ids=[vid], vectors=[VECTOR_COFFEE], payloads=[{"data": "single batch", "user_id": "batch_single"}])
+        result = self.db.get(vid)
+        assert result is not None
+        assert result.payload["data"] == "single batch"
+
+    def test_large_batch_insert_1000_items(self):
+        """Large batch (1000 items) should complete successfully."""
+        count = 1000
+        ids = [_uuid(6100 + i) for i in range(count)]
+        vectors = [[float(i % 10) / 10, float(i % 5) / 5, float(i % 3) / 3] for i in range(count)]
+        payloads = [{"data": f"batch_item_{i}", "user_id": "batch_large"} for i in range(count)]
+        self.db.insert(ids=ids, vectors=vectors, payloads=payloads)
+
+        result = self.db.get(ids[0])
+        assert result is not None
+        result = self.db.get(ids[999])
+        assert result is not None
+
+    def test_batch_search_with_multiple_queries(self):
+        """search_batch with multiple queries should return results for each."""
+        _insert_memories(
+            self.db,
+            [
+                (_uuid(6201), VECTOR_COFFEE, {"data": "coffee memory", "user_id": "batch_search"}),
+                (_uuid(6202), VECTOR_FLIGHT, {"data": "flight memory", "user_id": "batch_search"}),
+            ],
+        )
+        results = self.db.search_batch(
+            ["coffee", "flight"],
+            [VECTOR_COFFEE, VECTOR_FLIGHT],
+            top_k=5,
+            filters={"user_id": "batch_search"},
+        )
+        assert len(results) == 2
+        assert len(results[0]) >= 1
+        assert len(results[1]) >= 1
+
+    def test_batch_insert_partial_failure_handling(self):
+        """Batch with some invalid data should handle gracefully."""
+        valid_id = _uuid(6301)
+        self.db.insert(
+            ids=[valid_id],
+            vectors=[VECTOR_COFFEE],
+            payloads=[{"data": "valid item", "user_id": "batch_partial"}],
+        )
+        result = self.db.get(valid_id)
+        assert result is not None
+
+
+
+# ===========================================================================
+# Multi-tenant Isolation Tests (from test_gaussdb_p1_multitenant.py)
+# ===========================================================================
+
+class TestScopeIsolationCRUD:
+    """Tests for user_id, agent_id, run_id, and combined scope isolation with CRUD."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.db = _new_db(prefix="p1_mt")
+        _insert_memories(cls.db, [
+            # user_id isolation data
+            (_uuid(7001), VECTOR_COFFEE, _make_payload("alice coffee", user_id="mt_alice")),
+            (_uuid(7002), VECTOR_FLIGHT, _make_payload("bob flight", user_id="mt_bob")),
+            (_uuid(7011), VECTOR_COFFEE, _make_payload("alice likes coffee", user_id="mt_alice")),
+            (_uuid(7012), VECTOR_WINDOW, _make_payload("alice likes window", user_id="mt_alice")),
+            (_uuid(7013), VECTOR_COFFEE, _make_payload("bob likes coffee", user_id="mt_bob")),
+            (_uuid(7014), VECTOR_FLIGHT, _make_payload("charlie flight", user_id="mt_charlie")),
+            (_uuid(7021), VECTOR_COFFEE, _make_payload("alice mem1", user_id="mt_alice_list")),
+            (_uuid(7022), VECTOR_FLIGHT, _make_payload("alice mem2", user_id="mt_alice_list")),
+            (_uuid(7023), VECTOR_WINDOW, _make_payload("bob mem1", user_id="mt_bob_list")),
+            # delete scope data (uses exclusive user_ids)
+            (_uuid(7031), VECTOR_COFFEE, _make_payload("alice data", user_id="mt_del_alice")),
+            (_uuid(7032), VECTOR_FLIGHT, _make_payload("bob data", user_id="mt_del_bob")),
+            # delete_all scope data (exclusive user_ids)
+            (_uuid(7041), VECTOR_COFFEE, _make_payload("alice mem1", user_id="mt_delall_alice")),
+            (_uuid(7042), VECTOR_WINDOW, _make_payload("alice mem2", user_id="mt_delall_alice")),
+            (_uuid(7043), VECTOR_FLIGHT, _make_payload("bob mem1", user_id="mt_delall_bob")),
+            (_uuid(7044), VECTOR_AISLE, _make_payload("bob mem2", user_id="mt_delall_bob")),
+            # agent_id isolation data
+            (_uuid(7101), VECTOR_COFFEE, _make_payload("support chat", user_id="mt_agent_alice", agent_id="support_bot")),
+            (_uuid(7102), VECTOR_FLIGHT, _make_payload("travel chat", user_id="mt_agent_alice", agent_id="travel_bot")),
+            (_uuid(7103), VECTOR_WINDOW, _make_payload("coding chat", user_id="mt_agent_alice", agent_id="code_bot")),
+            (_uuid(7111), VECTOR_COFFEE, _make_payload("alice support", user_id="mt_cross_alice", agent_id="support_bot")),
+            (_uuid(7112), VECTOR_FLIGHT, _make_payload("bob support", user_id="mt_cross_bob", agent_id="support_bot")),
+            (_uuid(7121), VECTOR_COFFEE, _make_payload("agent1 data", user_id="mt_opt_alice", agent_id="agent1")),
+            (_uuid(7122), VECTOR_FLIGHT, _make_payload("agent2 data", user_id="mt_opt_alice", agent_id="agent2")),
+            (_uuid(7123), VECTOR_WINDOW, _make_payload("agent3 data", user_id="mt_opt_alice", agent_id="agent3")),
+            (_uuid(7131), VECTOR_COFFEE, _make_payload("travel mem1", user_id="mt_alist_alice", agent_id="travel_bot")),
+            (_uuid(7132), VECTOR_FLIGHT, _make_payload("travel mem2", user_id="mt_alist_alice", agent_id="travel_bot")),
+            (_uuid(7133), VECTOR_WINDOW, _make_payload("support mem1", user_id="mt_alist_alice", agent_id="support_bot")),
+            (_uuid(7141), VECTOR_COFFEE, _make_payload("alice travel", user_id="mt_comb_alice", agent_id="travel_bot")),
+            (_uuid(7142), VECTOR_FLIGHT, _make_payload("bob travel", user_id="mt_comb_bob", agent_id="travel_bot")),
+            (_uuid(7143), VECTOR_WINDOW, _make_payload("alice support", user_id="mt_comb_alice", agent_id="support_bot")),
+            # run_id isolation data
+            (_uuid(7201), VECTOR_COFFEE, _make_payload("run1 data", user_id="mt_run_alice", run_id="run_001")),
+            (_uuid(7202), VECTOR_FLIGHT, _make_payload("run2 data", user_id="mt_run_alice", run_id="run_002")),
+            (_uuid(7203), VECTOR_WINDOW, _make_payload("run3 data", user_id="mt_run_alice", run_id="run_003")),
+            (_uuid(7211), VECTOR_COFFEE, _make_payload("run1 list", user_id="mt_runlist_alice", run_id="run_001")),
+            (_uuid(7212), VECTOR_FLIGHT, _make_payload("run1 list2", user_id="mt_runlist_alice", run_id="run_001")),
+            (_uuid(7213), VECTOR_WINDOW, _make_payload("run2 list", user_id="mt_runlist_alice", run_id="run_002")),
+            (_uuid(7221), VECTOR_COFFEE, _make_payload("run cross alice", user_id="mt_runcross_alice", run_id="run_001")),
+            (_uuid(7222), VECTOR_FLIGHT, _make_payload("run cross bob", user_id="mt_runcross_bob", run_id="run_001")),
+            # combined scope data
+            (_uuid(7301), VECTOR_COFFEE, _make_payload("target", user_id="mt_scope_alice", agent_id="bot_a", run_id="run_001")),
+            (_uuid(7302), VECTOR_FLIGHT, _make_payload("diff run", user_id="mt_scope_alice", agent_id="bot_a", run_id="run_002")),
+            (_uuid(7303), VECTOR_WINDOW, _make_payload("diff agent", user_id="mt_scope_alice", agent_id="bot_b", run_id="run_001")),
+            (_uuid(7304), VECTOR_AISLE, _make_payload("diff user", user_id="mt_scope_bob", agent_id="bot_a", run_id="run_001")),
+            (_uuid(7311), VECTOR_COFFEE, _make_payload("full match", user_id="mt_partial_alice", agent_id="bot_a", run_id="run_001")),
+            (_uuid(7312), VECTOR_FLIGHT, _make_payload("partial mismatch", user_id="mt_partial_alice", agent_id="bot_a", run_id="run_999")),
+            (_uuid(7321), VECTOR_COFFEE, _make_payload("some data", user_id="mt_empty_alice", agent_id="bot_a", run_id="run_001")),
+            (_uuid(7322), VECTOR_FLIGHT, _make_payload("other data", user_id="mt_empty_bob", agent_id="bot_b", run_id="run_002")),
+            (_uuid(7331), VECTOR_COFFEE, _make_payload("alice bot_a", user_id="mt_wild_alice", agent_id="bot_a")),
+            (_uuid(7332), VECTOR_FLIGHT, _make_payload("alice bot_b", user_id="mt_wild_alice", agent_id="bot_b")),
+            (_uuid(7333), VECTOR_WINDOW, _make_payload("alice bot_c", user_id="mt_wild_alice", agent_id="bot_c")),
+            (_uuid(7334), VECTOR_AISLE, _make_payload("bob bot_a", user_id="mt_wild_bob", agent_id="bot_a")),
+        ])
+
+    @classmethod
+    def teardown_class(cls):
+        cls.db.delete_col()
+
+    # --- user_id isolation ---
+
+    def test_memory_add_user_id_isolation(self):
+        """Data added for alice should not be visible to bob."""
+        results = self.db.search("coffee", VECTOR_COFFEE, top_k=10, filters={"user_id": "mt_bob"})
+        result_ids = _ids(results)
+        assert _uuid(7001) not in result_ids
+        assert _uuid(7002) in result_ids
+
+    def test_memory_search_user_id_isolation(self):
+        """Search with user_id filter returns only that user's data."""
+        results = self.db.search("coffee", VECTOR_COFFEE, top_k=10, filters={"user_id": "mt_alice"})
+        result_ids = set(_ids(results))
+        assert _uuid(7011) in result_ids
+        assert _uuid(7012) in result_ids
+        assert _uuid(7013) not in result_ids
+        assert _uuid(7014) not in result_ids
+
+    def test_memory_get_all_user_id_filter(self):
+        """list with user_id filter returns only that user's data."""
+        results = _list_flat(self.db, filters={"user_id": "mt_alice_list"}, top_k=100)
+        _assert_exact_ids(results, {_uuid(7021), _uuid(7022)})
+
+    def test_memory_delete_user_id_scope(self):
+        """Deleting alice's record doesn't affect bob's data."""
+        self.db.delete(vector_id=_uuid(7031))
+        bob_result = self.db.get(_uuid(7032))
+        assert bob_result is not None
+        alice_result = self.db.get(_uuid(7031))
+        assert alice_result is None
+
+    def test_memory_delete_all_user_id_scope(self):
+        """delete_all for alice preserves bob's data."""
+        alice_records = _list_flat(self.db, filters={"user_id": "mt_delall_alice"}, top_k=100)
+        alice_ids = _ids(alice_records)
+        for aid in alice_ids:
+            self.db.delete(vector_id=aid)
+        bob_records = _list_flat(self.db, filters={"user_id": "mt_delall_bob"}, top_k=100)
+        _assert_exact_ids(bob_records, {_uuid(7043), _uuid(7044)})
+        alice_after = _list_flat(self.db, filters={"user_id": "mt_delall_alice"}, top_k=100)
+        assert len(alice_after) == 0
+
+    # --- agent_id isolation ---
+
+    def test_agent_id_isolation_basic(self):
+        """Same user, different agents should be isolated when filtered."""
+        results = self.db.search("chat", VECTOR_COFFEE, top_k=10, filters={"user_id": "mt_agent_alice", "agent_id": "support_bot"})
+        result_ids = _ids(results)
+        assert _uuid(7101) in result_ids
+        assert _uuid(7102) not in result_ids
+        assert _uuid(7103) not in result_ids
+
+    def test_agent_id_cross_user_isolation(self):
+        """Different users with same agent_id should be isolated by user_id."""
+        results = self.db.search("support", VECTOR_COFFEE, top_k=10, filters={"user_id": "mt_cross_alice", "agent_id": "support_bot"})
+        _assert_exact_ids(results, {_uuid(7111)})
+
+    def test_agent_id_optional_filter(self):
+        """Without agent_id filter, all records for user are visible."""
+        results = _list_flat(self.db, filters={"user_id": "mt_opt_alice"}, top_k=100)
+        _assert_exact_ids(results, {_uuid(7121), _uuid(7122), _uuid(7123)})
+
+    def test_agent_id_list_filter(self):
+        """list filtered by specific agent_id returns only that agent's data."""
+        results = _list_flat(self.db, filters={"user_id": "mt_alist_alice", "agent_id": "travel_bot"}, top_k=100)
+        _assert_exact_ids(results, {_uuid(7131), _uuid(7132)})
+
+    def test_agent_id_combined_with_user_id(self):
+        """Combined user_id + agent_id filter narrows results correctly."""
+        results = _list_flat(self.db, filters={"user_id": "mt_comb_alice", "agent_id": "travel_bot"}, top_k=100)
+        _assert_exact_ids(results, {_uuid(7141)})
+
+    # --- run_id isolation ---
+
+    def test_run_id_isolation_basic(self):
+        """Different run_ids should be isolated when filtered."""
+        results = self.db.search("data", VECTOR_COFFEE, top_k=10, filters={"user_id": "mt_run_alice", "run_id": "run_001"})
+        result_ids = _ids(results)
+        assert _uuid(7201) in result_ids
+        assert _uuid(7202) not in result_ids
+        assert _uuid(7203) not in result_ids
+
+    def test_run_id_combined_with_user_id(self):
+        """user_id + run_id combined filter works correctly."""
+        results = _list_flat(self.db, filters={"user_id": "mt_runlist_alice", "run_id": "run_001"}, top_k=100)
+        _assert_exact_ids(results, {_uuid(7211), _uuid(7212)})
+
+    def test_run_id_combined_with_agent_id(self):
+        """agent_id + run_id combined filter works correctly."""
+        results = self.db.search("run cross", VECTOR_COFFEE, top_k=10, filters={"user_id": "mt_runcross_alice", "run_id": "run_001"})
+        _assert_exact_ids(results, {_uuid(7221)})
+
+    # --- combined scope isolation ---
+
+    def test_scope_all_three_combined(self):
+        """user_id + agent_id + run_id combined filter returns exact match."""
+        results = _list_flat(self.db,
+            filters={"user_id": "mt_scope_alice", "agent_id": "bot_a", "run_id": "run_001"},
+            top_k=100,
+        )
+        _assert_exact_ids(results, {_uuid(7301)})
+
+    def test_scope_partial_match_excluded(self):
+        """Partial scope match (2 of 3 fields) should not return non-matching data."""
+        results = _list_flat(self.db,
+            filters={"user_id": "mt_partial_alice", "agent_id": "bot_a", "run_id": "run_001"},
+            top_k=100,
+        )
+        _assert_exact_ids(results, {_uuid(7311)})
+
+    def test_scope_empty_result_on_mismatch(self):
+        """Completely wrong scope returns empty results."""
+        results = _list_flat(self.db,
+            filters={"user_id": "charlie", "agent_id": "bot_x", "run_id": "run_999"},
+            top_k=100,
+        )
+        assert len(results) == 0
+
+    def test_scope_wildcard_user_all_agents(self):
+        """user_id filter only (no agent_id) sees all agents for that user."""
+        results = _list_flat(self.db, filters={"user_id": "mt_wild_alice"}, top_k=100)
+        _assert_exact_ids(results, {_uuid(7331), _uuid(7332), _uuid(7333)})
+
+
+# ===========================================================================
+# 7.2.5 Concurrent Multi-user Operations + Concurrent Insert + Upsert Race
+# ===========================================================================
+
+
+class TestConcurrencySafety:
+    """Tests for concurrent multi-user operations, inserts, and upsert races."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.db = _new_db(prefix="p2_conc")
+
+    @classmethod
+    def teardown_class(cls):
+        cls.db.delete_col()
+
+    def test_concurrent_multi_user_add(self):
+        """5 threads adding data for different users, verify isolation."""
+        users = [f"conc_add_user_{i}" for i in range(5)]
+        vectors = [VECTOR_COFFEE, VECTOR_FLIGHT, VECTOR_WINDOW, VECTOR_AISLE, VECTOR_COFFEE]
+
+        def add_for_user(idx):
+            uid = users[idx]
+            record_id = _uuid(7400 + idx)
+            self.db.insert(
+                ids=[record_id],
+                vectors=[vectors[idx]],
+                payloads=[_make_payload(f"{uid} memory", user_id=uid)],
+            )
+            return uid, record_id
+
+        results_map = {}
+        with ThreadPoolExecutor(max_workers=5) as executor:
+            futures = {executor.submit(add_for_user, i): i for i in range(5)}
+            for future in as_completed(futures):
+                uid, record_id = future.result()
+                results_map[uid] = record_id
+
+        for uid, record_id in results_map.items():
+            user_records = _list_flat(self.db, filters={"user_id": uid}, top_k=100)
+            assert len(user_records) == 1
+            assert _ids(user_records)[0] == record_id
+
+    def test_concurrent_multi_user_search(self):
+        """5 threads searching for different users, verify isolation."""
+        records = []
+        for i in range(5):
+            uid = f"conc_search_user_{i}"
+            vectors = [VECTOR_COFFEE, VECTOR_FLIGHT, VECTOR_WINDOW, VECTOR_AISLE, VECTOR_COFFEE]
+            records.append((_uuid(7410 + i), vectors[i], _make_payload(f"{uid} data", user_id=uid)))
+        _insert_memories(self.db, records)
+
+        def search_for_user(idx):
+            uid = f"conc_search_user_{idx}"
+            vectors = [VECTOR_COFFEE, VECTOR_FLIGHT, VECTOR_WINDOW, VECTOR_AISLE, VECTOR_COFFEE]
+            results = self.db.search("data", vectors[idx], top_k=10, filters={"user_id": uid})
+            return uid, results
+
+        with ThreadPoolExecutor(max_workers=5) as executor:
+            futures = {executor.submit(search_for_user, i): i for i in range(5)}
+            for future in as_completed(futures):
+                uid, results = future.result()
+                result_ids = _ids(results)
+                idx = int(uid.split("_")[-1])
+                expected_id = _uuid(7410 + idx)
+                assert expected_id in result_ids, f"{uid} should see their own data"
+                for other_idx in range(5):
+                    if other_idx != idx:
+                        assert _uuid(7410 + other_idx) not in result_ids
+
+    def test_concurrent_same_user_diff_agent(self):
+        """Same user, different agents concurrent operations maintain isolation."""
+        agents = [f"conc_agent_{i}" for i in range(5)]
+        vectors = [VECTOR_COFFEE, VECTOR_FLIGHT, VECTOR_WINDOW, VECTOR_AISLE, VECTOR_COFFEE]
+
+        def add_for_agent(idx):
+            agent = agents[idx]
+            record_id = _uuid(7420 + idx)
+            self.db.insert(
+                ids=[record_id],
+                vectors=[vectors[idx]],
+                payloads=[_make_payload(f"conc_alice {agent}", user_id="conc_alice", agent_id=agent)],
+            )
+            return agent, record_id
+
+        results_map = {}
+        with ThreadPoolExecutor(max_workers=5) as executor:
+            futures = {executor.submit(add_for_agent, i): i for i in range(5)}
+            for future in as_completed(futures):
+                agent, record_id = future.result()
+                results_map[agent] = record_id
+
+        for agent, record_id in results_map.items():
+            agent_records = _list_flat(self.db, filters={"user_id": "conc_alice", "agent_id": agent}, top_k=100)
+            assert len(agent_records) == 1
+            assert _ids(agent_records)[0] == record_id
+
+        all_records = _list_flat(self.db, filters={"user_id": "conc_alice"}, top_k=100)
+        assert len(all_records) == 5
+
+    # --- Concurrent Insert tests ---
+
+    def test_concurrent_insert_basic(self):
+        """5 threads, 3 records each - basic concurrent insert."""
+        num_threads = 5
+        records_per_thread = 3
+
+        def insert_batch(thread_idx):
+            for i in range(records_per_thread):
+                record_id = str(uuid.uuid4())
+                self.db.insert(
+                    ids=[record_id],
+                    vectors=[_random_vector()],
+                    payloads=[_make_payload(
+                        f"conc_basic_{thread_idx}_{i}",
+                        user_id="conc_basic_user",
+                    )],
+                )
+
+        tasks = [lambda idx=t: insert_batch(idx) for t in range(num_threads)]
+        successes, errors = _run_concurrent(tasks, max_workers=num_threads)
+
+        final_count = len(_list_flat(self.db, filters={"user_id": "conc_basic_user"}, top_k=500))
+        total_expected = num_threads * records_per_thread
+        assert final_count == total_expected
+
+    @pytest.mark.high_pressure
+    def test_concurrent_insert_high_pressure(self):
+        """10 threads, 5 records each - high pressure stress test (2x pool size)."""
+        num_threads = 10
+        records_per_thread = 5
+
+        def insert_batch(thread_idx):
+            for i in range(records_per_thread):
+                record_id = str(uuid.uuid4())
+                self.db.insert(
+                    ids=[record_id],
+                    vectors=[_random_vector()],
+                    payloads=[_make_payload(
+                        f"hp_{thread_idx}_{i}",
+                        user_id="conc_hp_user",
+                    )],
+                )
+
+        tasks = [lambda idx=t: insert_batch(idx) for t in range(num_threads)]
+        successes, errors = _run_concurrent(tasks, max_workers=num_threads, timeout=600.0)
+
+        final_count = len(_list_flat(self.db, filters={"user_id": "conc_hp_user"}, top_k=1500))
+        total_expected = num_threads * records_per_thread
+        assert final_count >= total_expected * 0.5
+
+    def test_concurrent_insert_with_batch(self):
+        """5 threads each batch-inserting 20 records at once."""
+        num_threads = 5
+        batch_size = 20
+
+        def batch_insert(thread_idx):
+            ids = [str(uuid.uuid4()) for _ in range(batch_size)]
+            vectors = [_random_vector() for _ in range(batch_size)]
+            payloads = [
+                _make_payload(f"batch_{thread_idx}_{i}", user_id="conc_batch_user")
+                for i in range(batch_size)
+            ]
+            self.db.insert(ids=ids, vectors=vectors, payloads=payloads)
+
+        tasks = [lambda idx=t: batch_insert(idx) for t in range(num_threads)]
+        successes, errors = _run_concurrent(tasks, max_workers=num_threads)
+
+        final_count = len(_list_flat(self.db, filters={"user_id": "conc_batch_user"}, top_k=600))
+        total_expected = num_threads * batch_size
+        if not errors:
+            assert final_count == total_expected
+        else:
+            assert final_count > 0
+
+    # --- Upsert Race Conditions ---
+
+    def test_concurrent_upsert_same_id(self):
+        """10 threads upsert same ID concurrently. Final count must be 1."""
+        target_id = _uuid(9001)
+        num_threads = 10
+
+        def upsert_record(thread_idx):
+            vector = _random_vector()
+            payload = _make_payload(
+                f"upsert_thread_{thread_idx}",
+                user_id="conc_upsert_user",
+            )
+            self.db.insert(
+                ids=[target_id],
+                vectors=[vector],
+                payloads=[payload],
+            )
+
+        tasks = [lambda idx=t: upsert_record(idx) for t in range(num_threads)]
+        successes, errors = _run_concurrent(tasks, max_workers=num_threads)
+
+        result = self.db.get(target_id)
+        assert result is not None
+        assert len(_list_flat(self.db, filters={"user_id": "conc_upsert_user"}, top_k=100)) == 1
+
+    def test_concurrent_upsert_same_id_same_payload(self):
+        """10 threads upsert same ID with identical payload. Idempotency check."""
+        target_id = _uuid(9002)
+        num_threads = 10
+        fixed_vector = VECTOR_COFFEE
+        fixed_payload = _make_payload("idempotent_data", user_id="conc_idem_user")
+
+        def upsert_same(thread_idx):
+            self.db.insert(
+                ids=[target_id],
+                vectors=[fixed_vector],
+                payloads=[fixed_payload],
+            )
+
+        tasks = [lambda idx=t: upsert_same(idx) for t in range(num_threads)]
+        successes, errors = _run_concurrent(tasks, max_workers=num_threads)
+
+        result = self.db.get(target_id)
+        assert result is not None
+        assert result.payload["data"] == "idempotent_data"
+        assert len(_list_flat(self.db, filters={"user_id": "conc_idem_user"}, top_k=100)) == 1
+
+    def test_concurrent_upsert_same_id_update_vs_insert(self):
+        """Insert first, then concurrent upserts. Verify final state is consistent."""
+        target_id = _uuid(9003)
+        self.db.insert(
+            ids=[target_id],
+            vectors=[VECTOR_COFFEE],
+            payloads=[_make_payload("original", user_id="conc_upins_user")],
+        )
+
+        num_threads = 10
+
+        def upsert_update(thread_idx):
+            vector = _random_vector()
+            payload = _make_payload(
+                f"updated_by_{thread_idx}",
+                user_id="conc_upins_user",
+            )
+            self.db.insert(
+                ids=[target_id],
+                vectors=[vector],
+                payloads=[payload],
+            )
+
+        tasks = [lambda idx=t: upsert_update(idx) for t in range(num_threads)]
+        successes, errors = _run_concurrent(tasks, max_workers=num_threads)
+
+        result = self.db.get(target_id)
+        assert result is not None
+        assert result.payload["data"].startswith("updated_by_")
+        assert len(_list_flat(self.db, filters={"user_id": "conc_upins_user"}, top_k=100)) == 1
+
+    def test_concurrent_upsert_batch_same_ids(self):
+        """Batch upsert with overlapping IDs from multiple threads."""
+        shared_ids = [_uuid(9010 + i) for i in range(5)]
+        num_threads = 10
+
+        def batch_upsert(thread_idx):
+            vectors = [_random_vector() for _ in range(5)]
+            payloads = [
+                _make_payload(f"batch_t{thread_idx}_r{i}", user_id="conc_batchup_user")
+                for i in range(5)
+            ]
+            self.db.insert(ids=shared_ids, vectors=vectors, payloads=payloads)
+
+        tasks = [lambda idx=t: batch_upsert(idx) for t in range(num_threads)]
+        successes, errors = _run_concurrent(tasks, max_workers=num_threads)
+
+        for sid in shared_ids:
+            result = self.db.get(sid)
+            assert result is not None
+        assert len(_list_flat(self.db, filters={"user_id": "conc_batchup_user"}, top_k=100)) == 5
+
+    def test_upsert_lost_update_detection(self):
+        """2 threads sequential upsert. Verify last-write-wins semantics."""
+        target_id = _uuid(9020)
+        barrier = threading.Barrier(2, timeout=30)
+        write_order = []
+        order_lock = threading.Lock()
+
+        def upsert_with_order(thread_idx):
+            barrier.wait()
+            vector = _random_vector()
+            payload = _make_payload(
+                f"writer_{thread_idx}",
+                user_id="conc_lww_user",
+            )
+            self.db.insert(
+                ids=[target_id],
+                vectors=[vector],
+                payloads=[payload],
+            )
+            with order_lock:
+                write_order.append(thread_idx)
+
+        tasks = [lambda idx=t: upsert_with_order(idx) for t in range(2)]
+        successes, errors = _run_concurrent(tasks, max_workers=2)
+
+        result = self.db.get(target_id)
+        assert result is not None
+        assert len(_list_flat(self.db, filters={"user_id": "conc_lww_user"}, top_k=100)) == 1
+        assert result.payload["data"] in ("writer_0", "writer_1")
+
+
+# ===========================================================================
+# 9.2.3 Read-Write Concurrency
+# ===========================================================================
+
+
+@pytest.mark.skipif(not _env_bool("GAUSSDB_TEST_RUN_PERF"), reason="Performance tests disabled; set GAUSSDB_TEST_RUN_PERF=1 to enable")
+class TestReadWriteConcurrency:
+    """Tests for concurrent read and write operations."""
+
+    def test_concurrent_insert_and_search(self):
+        """5 insert threads + 5 search threads running simultaneously."""
+        db = _new_db(prefix="p2_conc", maxconn=15)
+        try:
+            user_id = "rw_insert_search"
+            # Pre-insert some data so searches have something to find
+            for i in range(20):
+                db.insert(
+                    ids=[str(uuid.uuid4())],
+                    vectors=[_random_vector()],
+                    payloads=[_make_payload(f"seed_{i}", user_id=user_id)],
+                )
+
+            def inserter(thread_idx):
+                for i in range(20):
+                    db.insert(
+                        ids=[str(uuid.uuid4())],
+                        vectors=[_random_vector()],
+                        payloads=[_make_payload(
+                            f"insert_t{thread_idx}_{i}", user_id=user_id
+                        )],
+                    )
+
+            def searcher(thread_idx):
+                for i in range(20):
+                    results = db.search(
+                        "query", _random_vector(), top_k=5,
+                        filters={"user_id": user_id},
+                    )
+                    # Search should not crash; results may vary
+                    assert isinstance(results, list)
+
+            tasks = (
+                [lambda idx=t: inserter(idx) for t in range(5)]
+                + [lambda idx=t: searcher(idx) for t in range(5)]
+            )
+            successes, errors = _run_concurrent(tasks, max_workers=10)
+
+            # All operations should complete without fatal errors
+            assert successes >= 5  # At least the searchers should succeed
+        finally:
+            db.delete_col()
+
+    def test_concurrent_update_and_search(self):
+        """5 update threads + 5 search threads running simultaneously."""
+        db = _new_db(prefix="p2_conc", maxconn=15)
+        try:
+            user_id = "rw_update_search"
+            record_ids = []
+            for i in range(50):
+                rid = str(uuid.uuid4())
+                record_ids.append(rid)
+                db.insert(
+                    ids=[rid],
+                    vectors=[_random_vector()],
+                    payloads=[_make_payload(f"original_{i}", user_id=user_id)],
+                )
+
+            def updater(thread_idx):
+                for i in range(10):
+                    target = record_ids[(thread_idx * 10 + i) % len(record_ids)]
+                    db.update(
+                        vector_id=target,
+                        vector=_random_vector(),
+                        payload=_make_payload(
+                            f"updated_t{thread_idx}_{i}", user_id=user_id
+                        ),
+                    )
+
+            def searcher(thread_idx):
+                for i in range(10):
+                    db.search(
+                        "query", _random_vector(), top_k=5,
+                        filters={"user_id": user_id},
+                    )
+
+            tasks = (
+                [lambda idx=t: updater(idx) for t in range(5)]
+                + [lambda idx=t: searcher(idx) for t in range(5)]
+            )
+            successes, errors = _run_concurrent(tasks, max_workers=10)
+
+            final_count = len(_list_flat(db, filters={"user_id": user_id}, top_k=200))
+            assert final_count == 50
+        finally:
+            db.delete_col()
+
+    def test_concurrent_delete_and_search(self):
+        """5 delete threads + 5 search threads running simultaneously."""
+        db = _new_db(prefix="p2_conc", maxconn=15)
+        try:
+            user_id = "rw_delete_search"
+            record_ids = []
+            for i in range(100):
+                rid = str(uuid.uuid4())
+                record_ids.append(rid)
+                db.insert(
+                    ids=[rid],
+                    vectors=[_random_vector()],
+                    payloads=[_make_payload(f"to_delete_{i}", user_id=user_id)],
+                )
+
+            # Split IDs among delete threads
+            chunk_size = 20
+
+            def deleter(thread_idx):
+                start = thread_idx * chunk_size
+                ids_to_delete = record_ids[start:start + chunk_size]
+                for rid in ids_to_delete:
+                    db.delete(vector_id=rid)
+
+            def searcher(thread_idx):
+                for i in range(20):
+                    results = db.search(
+                        "query", _random_vector(), top_k=5,
+                        filters={"user_id": user_id},
+                    )
+                    assert isinstance(results, list)
+
+            tasks = (
+                [lambda idx=t: deleter(idx) for t in range(5)]
+                + [lambda idx=t: searcher(idx) for t in range(5)]
+            )
+            successes, errors = _run_concurrent(tasks, max_workers=10)
+
+            # After deletion, count should be reduced
+            final_count = len(_list_flat(db, filters={"user_id": user_id}, top_k=200))
+            assert final_count < 100
+        finally:
+            db.delete_col()
+
+    def test_concurrent_insert_and_get(self):
+        """5 insert threads + 5 get threads running simultaneously."""
+        db = _new_db(prefix="p2_conc", maxconn=15)
+        try:
+            user_id = "rw_insert_get"
+            # Pre-insert known records for get operations
+            known_ids = []
+            for i in range(20):
+                rid = _uuid(8000 + i)
+                known_ids.append(rid)
+                db.insert(
+                    ids=[rid],
+                    vectors=[_random_vector()],
+                    payloads=[_make_payload(f"known_{i}", user_id=user_id)],
+                )
+
+            def inserter(thread_idx):
+                for i in range(20):
+                    db.insert(
+                        ids=[str(uuid.uuid4())],
+                        vectors=[_random_vector()],
+                        payloads=[_make_payload(
+                            f"new_t{thread_idx}_{i}", user_id=user_id
+                        )],
+                    )
+
+            def getter(thread_idx):
+                for i in range(20):
+                    target = known_ids[i % len(known_ids)]
+                    result = db.get(target)
+                    # Record should always be retrievable (not deleted)
+                    assert result is not None
+
+            tasks = (
+                [lambda idx=t: inserter(idx) for t in range(5)]
+                + [lambda idx=t: getter(idx) for t in range(5)]
+            )
+            successes, errors = _run_concurrent(tasks, max_workers=10)
+
+            # Known records should still exist
+            for kid in known_ids:
+                assert db.get(kid) is not None
+        finally:
+            db.delete_col()
+
+    def test_concurrent_mixed_operations(self):
+        """Insert/update/delete/search mixed, 20 threads total."""
+        db = _new_db(prefix="p2_conc", maxconn=25)
+        try:
+            user_id = "rw_mixed"
+            # Pre-insert records for update/delete/search
+            record_ids = []
+            for i in range(100):
+                rid = str(uuid.uuid4())
+                record_ids.append(rid)
+                db.insert(
+                    ids=[rid],
+                    vectors=[_random_vector()],
+                    payloads=[_make_payload(f"mixed_{i}", user_id=user_id)],
+                )
+
+            def inserter(thread_idx):
+                for i in range(10):
+                    db.insert(
+                        ids=[str(uuid.uuid4())],
+                        vectors=[_random_vector()],
+                        payloads=[_make_payload(
+                            f"mixed_new_t{thread_idx}_{i}", user_id=user_id
+                        )],
+                    )
+
+            def updater(thread_idx):
+                for i in range(10):
+                    target = record_ids[(thread_idx * 10 + i) % len(record_ids)]
+                    try:
+                        db.update(
+                            vector_id=target,
+                            vector=_random_vector(),
+                            payload=_make_payload(
+                                f"mixed_upd_t{thread_idx}_{i}", user_id=user_id
+                            ),
+                        )
+                    except Exception:
+                        pass  # Record may have been deleted
+
+            def deleter(thread_idx):
+                # Delete from the end of the list to minimize conflict with updaters
+                start = 80 + thread_idx * 4
+                for i in range(4):
+                    idx = start + i
+                    if idx < len(record_ids):
+                        try:
+                            db.delete(vector_id=record_ids[idx])
+                        except Exception:
+                            pass
+
+            def searcher(thread_idx):
+                for i in range(10):
+                    db.search(
+                        "query", _random_vector(), top_k=5,
+                        filters={"user_id": user_id},
+                    )
+
+            tasks = (
+                [lambda idx=t: inserter(idx) for t in range(5)]
+                + [lambda idx=t: updater(idx) for t in range(5)]
+                + [lambda idx=t: deleter(idx) for t in range(5)]
+                + [lambda idx=t: searcher(idx) for t in range(5)]
+            )
+            successes, errors = _run_concurrent(tasks, max_workers=20)
+
+            # System should remain operational after mixed concurrent ops
+            final_count = len(_list_flat(db, filters={"user_id": user_id}, top_k=200))
+            assert final_count > 0
+        finally:
+            db.delete_col()
+
+
+# ===========================================================================
+# 9.2.4 Connection Pool Exhaustion
+# ===========================================================================
+
+
+@pytest.mark.skipif(not _env_bool("GAUSSDB_TEST_RUN_PERF"), reason="Performance tests disabled; set GAUSSDB_TEST_RUN_PERF=1 to enable")
+class TestConnectionPoolExhaustion:
+    """Tests for connection pool behavior under pressure."""
+
+    def test_connection_pool_exhaustion(self):
+        """maxconn=2, 5 concurrent threads. Operations should still complete."""
+        db = _new_db(prefix="p2_conc", maxconn=2)
+        try:
+            user_id = "pool_exhaust"
+            # Pre-insert some data
+            for i in range(10):
+                db.insert(
+                    ids=[_uuid(7000 + i)],
+                    vectors=[_random_vector()],
+                    payloads=[_make_payload(f"pool_{i}", user_id=user_id)],
+                )
+
+            def worker(thread_idx):
+                for i in range(10):
+                    db.search(
+                        "query", _random_vector(), top_k=3,
+                        filters={"user_id": user_id},
+                    )
+                    db.insert(
+                        ids=[str(uuid.uuid4())],
+                        vectors=[_random_vector()],
+                        payloads=[_make_payload(
+                            f"pool_t{thread_idx}_{i}", user_id=user_id
+                        )],
+                    )
+
+            tasks = [lambda idx=t: worker(idx) for t in range(5)]
+            successes, errors = _run_concurrent(tasks, max_workers=5)
+
+            # With pool exhaustion, some operations may fail but system recovers
+            # At least some threads should succeed
+            assert successes > 0
+        finally:
+            db.delete_col()
+
+    def test_connection_pool_recovery(self):
+        """Exhaust pool, then verify recovery after connections are released."""
+        db = _new_db(prefix="p2_conc", maxconn=3)
+        try:
+            user_id = "pool_recovery"
+
+            # Phase 1: Exhaust the pool with concurrent operations
+            def heavy_worker(thread_idx):
+                for i in range(20):
+                    db.insert(
+                        ids=[str(uuid.uuid4())],
+                        vectors=[_random_vector()],
+                        payloads=[_make_payload(
+                            f"heavy_{thread_idx}_{i}", user_id=user_id
+                        )],
+                    )
+
+            tasks = [lambda idx=t: heavy_worker(idx) for t in range(6)]
+            successes, errors = _run_concurrent(tasks, max_workers=6)
+
+            # Phase 2: After pool pressure, verify system recovers
+            time.sleep(1)  # Allow connections to be returned to pool
+
+            # Single-threaded operations should work fine after recovery
+            recovery_id = str(uuid.uuid4())
+            db.insert(
+                ids=[recovery_id],
+                vectors=[_random_vector()],
+                payloads=[_make_payload("recovery_test", user_id=user_id)],
+            )
+            result = db.get(recovery_id)
+            assert result is not None
+            assert result.payload["data"] == "recovery_test"
+        finally:
+            db.delete_col()
+
+    def test_connection_pool_leak_detection(self):
+        """100 sequential operations. Verify no connection leak."""
+        db = _new_db(prefix="p2_conc", maxconn=5)
+        try:
+            user_id = "pool_leak"
+
+            # Perform many operations that acquire and release connections
+            for i in range(100):
+                rid = str(uuid.uuid4())
+                db.insert(
+                    ids=[rid],
+                    vectors=[_random_vector()],
+                    payloads=[_make_payload(f"leak_test_{i}", user_id=user_id)],
+                )
+                # Alternate between different operation types
+                if i % 3 == 0:
+                    db.search(
+                        "query", _random_vector(), top_k=3,
+                        filters={"user_id": user_id},
+                    )
+                elif i % 3 == 1:
+                    db.get(rid)
+
+            # After 100 operations, the system should still be responsive
+            # If there were connection leaks, this would fail with pool exhaustion
+            final_id = str(uuid.uuid4())
+            db.insert(
+                ids=[final_id],
+                vectors=[_random_vector()],
+                payloads=[_make_payload("final_check", user_id=user_id)],
+            )
+            result = db.get(final_id)
+            assert result is not None
+            assert result.payload["data"] == "final_check"
+
+            # Verify total count is consistent
+            final_count = len(_list_flat(db, filters={"user_id": user_id}, top_k=200))
+            assert final_count == 101  # 100 + 1 final
+        finally:
+            db.delete_col()
+
+
+# ===========================================================================
+# 9.2.5 Concurrent Data Consistency
+# ===========================================================================
+
+
+@pytest.mark.skipif(not _env_bool("GAUSSDB_TEST_RUN_PERF"), reason="Performance tests disabled; set GAUSSDB_TEST_RUN_PERF=1 to enable")
+class TestConcurrentDataConsistency:
+    """Tests verifying data consistency after concurrent operations."""
+
+    def test_concurrent_insert_final_count(self):
+        """5 threads x 10 records = final count 50."""
+        db = _new_db(prefix="p2_conc")
+        try:
+            num_threads = 5
+            records_per_thread = 10
+            user_id = "consistency_count"
+
+            all_ids = []
+            ids_lock = threading.Lock()
+
+            def insert_batch(thread_idx):
+                local_ids = []
+                for i in range(records_per_thread):
+                    rid = str(uuid.uuid4())
+                    local_ids.append(rid)
+                    db.insert(
+                        ids=[rid],
+                        vectors=[_random_vector()],
+                        payloads=[_make_payload(
+                            f"count_t{thread_idx}_{i}", user_id=user_id
+                        )],
+                    )
+                with ids_lock:
+                    all_ids.extend(local_ids)
+
+            tasks = [lambda idx=t: insert_batch(idx) for t in range(num_threads)]
+            successes, errors = _run_concurrent(tasks, max_workers=num_threads)
+
+            total_expected = num_threads * records_per_thread
+            final_count = len(_list_flat(db, filters={"user_id": user_id}, top_k=total_expected + 100))
+            if not errors:
+                assert final_count == total_expected
+            else:
+                # With errors, count should match successful inserts
+                assert final_count == len(all_ids)
+        finally:
+            db.delete_col()
+
+    def test_concurrent_upsert_final_state(self):
+        """5 threads upsert same ID. Final state must be consistent (single record)."""
+        db = _new_db(prefix="p2_conc")
+        try:
+            target_id = _uuid(9100)
+            num_threads = 5
+            user_id = "consistency_upsert"
+
+            def upsert_record(thread_idx):
+                for i in range(5):
+                    vector = _random_vector()
+                    payload = _make_payload(
+                        f"state_t{thread_idx}_i{i}",
+                        user_id=user_id,
+                    )
+                    db.insert(
+                        ids=[target_id],
+                        vectors=[vector],
+                        payloads=[payload],
+                    )
+
+            tasks = [lambda idx=t: upsert_record(idx) for t in range(num_threads)]
+            successes, errors = _run_concurrent(tasks, max_workers=num_threads)
+
+            # Final state: exactly 1 record with consistent payload
+            result = db.get(target_id)
+            assert result is not None
+            assert len(_list_flat(db, filters={"user_id": user_id}, top_k=100)) == 1
+            # Payload should be from one of the threads/iterations
+            assert result.payload["data"].startswith("state_t")
+            assert result.payload["user_id"] == user_id
+        finally:
+            db.delete_col()
+
+    def test_concurrent_delete_final_count(self):
+        """Insert 100, 10 threads delete 10 each. Final count should be 0."""
+        db = _new_db(prefix="p2_conc", maxconn=15)
+        try:
+            user_id = "consistency_delete"
+            record_ids = []
+            for i in range(100):
+                rid = _uuid(8100 + i)
+                record_ids.append(rid)
+                db.insert(
+                    ids=[rid],
+                    vectors=[_random_vector()],
+                    payloads=[_make_payload(f"del_{i}", user_id=user_id)],
+                )
+
+            assert len(_list_flat(db, filters={"user_id": user_id}, top_k=200)) == 100
+
+            def delete_batch(thread_idx):
+                start = thread_idx * 10
+                for i in range(10):
+                    idx = start + i
+                    if idx < len(record_ids):
+                        db.delete(vector_id=record_ids[idx])
+
+            tasks = [lambda idx=t: delete_batch(idx) for t in range(10)]
+            successes, errors = _run_concurrent(tasks, max_workers=10)
+
+            final_count = len(_list_flat(db, filters={"user_id": user_id}, top_k=200))
+            if not errors:
+                assert final_count == 0
+            else:
+                # Some deletes may have failed, but count should be reduced
+                assert final_count < 100
+        finally:
+            db.delete_col()
+
+    def test_concurrent_update_payload_consistency(self):
+        """10 threads update different fields of same records. Final state consistent."""
+        db = _new_db(prefix="p2_conc", maxconn=15)
+        try:
+            user_id = "consistency_update"
+            # Insert 10 records
+            record_ids = []
+            for i in range(10):
+                rid = _uuid(8200 + i)
+                record_ids.append(rid)
+                db.insert(
+                    ids=[rid],
+                    vectors=[_random_vector()],
+                    payloads=[_make_payload(f"original_{i}", user_id=user_id)],
+                )
+
+            def updater(thread_idx):
+                """Each thread updates all 10 records with its own marker."""
+                for i, rid in enumerate(record_ids):
+                    try:
+                        db.update(
+                            vector_id=rid,
+                            vector=_random_vector(),
+                            payload=_make_payload(
+                                f"updated_t{thread_idx}_r{i}",
+                                user_id=user_id,
+                                thread_marker=f"thread_{thread_idx}",
+                            ),
+                        )
+                    except Exception:
+                        pass  # Contention may cause transient failures
+
+            tasks = [lambda idx=t: updater(idx) for t in range(10)]
+            successes, errors = _run_concurrent(tasks, max_workers=10)
+
+            # Verify consistency: each record should have a valid payload
+            for rid in record_ids:
+                result = db.get(rid)
+                assert result is not None
+                # Payload should be from one of the threads (last-write-wins)
+                assert result.payload["user_id"] == user_id
+                # Data field should be either original or from a thread update
+                data = result.payload["data"]
+                assert data.startswith("original_") or data.startswith("updated_t")
+
+            # Total count should remain unchanged
+            assert len(_list_flat(db, filters={"user_id": user_id}, top_k=100)) == 10
+        finally:
+            db.delete_col()
+
+
+
+
+# ===========================================================================
+# Performance Baseline Tests (from test_gaussdb_p2_performance.py)
+# ===========================================================================
+
+@pytest.mark.skipif(not _env_bool("GAUSSDB_TEST_RUN_PERF"), reason="Performance tests disabled; set GAUSSDB_TEST_RUN_PERF=1 to enable")
+class TestSingleOperationLatency:
+    """Measure latency of individual CRUD operations."""
+
+    def test_single_insert_latency(self):
+        """Insert 100 times, report P50/P95/P99 (target P50<100ms)."""
+        db = _new_db(prefix="p2_perf")
+        try:
+            counter = [0]
+
+            def _do_insert():
+                counter[0] += 1
+                vid = str(uuid.uuid4())
+                db.insert(
+                    ids=[vid],
+                    vectors=[_random_vector()],
+                    payloads=[_make_payload(f"insert_latency_{counter[0]}")],
+                )
+
+            stats = _measure_latency(_do_insert, iterations=100)
+            _print_latency_report("single_insert", stats)
+            _soft_assert(stats["p50_ms"] < 100, f"P50 insert latency {stats['p50_ms']:.2f}ms > 100ms target")
+        finally:
+            db.delete_col()
+
+    def test_single_search_latency(self):
+        """Search 100 times, report P50/P95/P99 (target P50<50ms)."""
+        db = _new_db(prefix="p2_perf")
+        try:
+            # Pre-populate with some data
+            ids = [str(uuid.uuid4()) for _ in range(50)]
+            vectors = [_random_vector() for _ in range(50)]
+            payloads = [_make_payload(f"search_data_{i}") for i in range(50)]
+            db.insert(ids=ids, vectors=vectors, payloads=payloads)
+
+            def _do_search():
+                db.search("query", _random_vector(), top_k=5, filters={"user_id": "test_user"})
+
+            stats = _measure_latency(_do_search, iterations=100)
+            _print_latency_report("single_search", stats)
+            _soft_assert(stats["p50_ms"] < 50, f"P50 search latency {stats['p50_ms']:.2f}ms > 50ms target")
+        finally:
+            db.delete_col()
+
+    def test_single_update_latency(self):
+        """Update 100 times, report P50/P95/P99 (target P50<150ms)."""
+        db = _new_db(prefix="p2_perf")
+        try:
+            # Insert a record to update repeatedly
+            vid = _uuid(9001)
+            db.insert(
+                ids=[vid],
+                vectors=[_random_vector()],
+                payloads=[_make_payload("update_target")],
+            )
+            counter = [0]
+
+            def _do_update():
+                counter[0] += 1
+                db.update(
+                    vid,
+                    vector=_random_vector(),
+                    payload=_make_payload(f"updated_{counter[0]}"),
+                )
+
+            stats = _measure_latency(_do_update, iterations=100)
+            _print_latency_report("single_update", stats)
+            _soft_assert(stats["p50_ms"] < 150, f"P50 update latency {stats['p50_ms']:.2f}ms > 150ms target")
+        finally:
+            db.delete_col()
+
+    def test_single_get_latency(self):
+        """Get 100 times, report P50/P95/P99 (target P50<10ms)."""
+        db = _new_db(prefix="p2_perf")
+        try:
+            vid = _uuid(9002)
+            db.insert(
+                ids=[vid],
+                vectors=[_random_vector()],
+                payloads=[_make_payload("get_target")],
+            )
+
+            def _do_get():
+                db.get(vid)
+
+            stats = _measure_latency(_do_get, iterations=100)
+            _print_latency_report("single_get", stats)
+            _soft_assert(stats["p50_ms"] < 10, f"P50 get latency {stats['p50_ms']:.2f}ms > 10ms target")
+        finally:
+            db.delete_col()
+
+    def test_single_delete_latency(self):
+        """Delete 100 times, report P50/P95/P99 (target P50<50ms)."""
+        db = _new_db(prefix="p2_perf")
+        try:
+            # Pre-insert 100 records to delete one by one
+            ids_to_delete = [str(uuid.uuid4()) for _ in range(100)]
+            vectors = [_random_vector() for _ in range(100)]
+            payloads = [_make_payload(f"delete_target_{i}") for i in range(100)]
+            db.insert(ids=ids_to_delete, vectors=vectors, payloads=payloads)
+
+            idx = [0]
+
+            def _do_delete():
+                db.delete(vector_id=ids_to_delete[idx[0]])
+                idx[0] += 1
+
+            stats = _measure_latency(_do_delete, iterations=100)
+            _print_latency_report("single_delete", stats)
+            _soft_assert(stats["p50_ms"] < 50, f"P50 delete latency {stats['p50_ms']:.2f}ms > 50ms target")
+        finally:
+            db.delete_col()
+
+
+# ===========================================================================
+# 8.2.2 Batch Operation Throughput Tests
+# ===========================================================================
+
+
+@pytest.mark.skipif(not _env_bool("GAUSSDB_TEST_RUN_PERF"), reason="Performance tests disabled; set GAUSSDB_TEST_RUN_PERF=1 to enable")
+class TestBatchOperationThroughput:
+    """Measure throughput of batch operations."""
+
+    def test_batch_insert_100_throughput(self):
+        """Insert 100 records in one batch, measure throughput (target >50 records/s)."""
+        db = _new_db(prefix="p2_perf")
+        try:
+            count = 100
+            ids = [str(uuid.uuid4()) for _ in range(count)]
+            vectors = [_random_vector() for _ in range(count)]
+            payloads = [_make_payload(f"batch100_{i}") for i in range(count)]
+
+            start = time.perf_counter()
+            db.insert(ids=ids, vectors=vectors, payloads=payloads)
+            elapsed = time.perf_counter() - start
+
+            throughput = count / elapsed
+            print(f"\n  [PERF] batch_insert_100: {elapsed:.3f}s, throughput: {throughput:.1f} records/s")
+            _soft_assert(throughput > 50, f"Batch insert 100 throughput {throughput:.1f} < 50 records/s target")
+        finally:
+            db.delete_col()
+
+    def test_batch_insert_1000_throughput(self):
+        """Insert 1000 records in one batch, measure throughput (target >100 records/s)."""
+        db = _new_db(prefix="p2_perf")
+        try:
+            count = 1000
+            ids = [str(uuid.uuid4()) for _ in range(count)]
+            vectors = [_random_vector() for _ in range(count)]
+            payloads = [_make_payload(f"batch1k_{i}") for i in range(count)]
+
+            start = time.perf_counter()
+            db.insert(ids=ids, vectors=vectors, payloads=payloads)
+            elapsed = time.perf_counter() - start
+
+            throughput = count / elapsed
+            print(f"\n  [PERF] batch_insert_1000: {elapsed:.3f}s, throughput: {throughput:.1f} records/s")
+            _soft_assert(throughput > 100, f"Batch insert 1000 throughput {throughput:.1f} < 100 records/s target")
+        finally:
+            db.delete_col()
+
+    @pytest.mark.high_pressure
+    def test_batch_insert_10000_throughput(self):
+        """Insert 10000 records in one batch, measure throughput (target >200 records/s)."""
+        db = _new_db(prefix="p2_perf")
+        try:
+            count = 10000
+            ids = [str(uuid.uuid4()) for _ in range(count)]
+            vectors = [_random_vector() for _ in range(count)]
+            payloads = [_make_payload(f"batch10k_{i}") for i in range(count)]
+
+            start = time.perf_counter()
+            db.insert(ids=ids, vectors=vectors, payloads=payloads)
+            elapsed = time.perf_counter() - start
+
+            throughput = count / elapsed
+            print(f"\n  [PERF] batch_insert_10000: {elapsed:.3f}s, throughput: {throughput:.1f} records/s")
+            _soft_assert(throughput > 200, f"Batch insert 10000 throughput {throughput:.1f} < 200 records/s target")
+        finally:
+            db.delete_col()
+
+    def test_batch_search_10_throughput(self):
+        """10 sequential searches, measure throughput."""
+        db = _new_db(prefix="p2_perf")
+        try:
+            # Pre-populate
+            count = 200
+            ids = [str(uuid.uuid4()) for _ in range(count)]
+            vectors = [_random_vector() for _ in range(count)]
+            payloads = [_make_payload(f"search_data_{i}") for i in range(count)]
+            db.insert(ids=ids, vectors=vectors, payloads=payloads)
+
+            num_searches = 10
+            start = time.perf_counter()
+            for _ in range(num_searches):
+                db.search("query", _random_vector(), top_k=10, filters={"user_id": "test_user"})
+            elapsed = time.perf_counter() - start
+
+            throughput = num_searches / elapsed
+            print(f"\n  [PERF] batch_search_10: {elapsed:.3f}s, throughput: {throughput:.1f} searches/s")
+        finally:
+            db.delete_col()
+
+    def test_batch_search_100_throughput(self):
+        """100 sequential searches, measure throughput."""
+        db = _new_db(prefix="p2_perf")
+        try:
+            # Pre-populate
+            count = 200
+            ids = [str(uuid.uuid4()) for _ in range(count)]
+            vectors = [_random_vector() for _ in range(count)]
+            payloads = [_make_payload(f"search_data_{i}") for i in range(count)]
+            db.insert(ids=ids, vectors=vectors, payloads=payloads)
+
+            num_searches = 100
+            start = time.perf_counter()
+            for _ in range(num_searches):
+                db.search("query", _random_vector(), top_k=10, filters={"user_id": "test_user"})
+            elapsed = time.perf_counter() - start
+
+            throughput = num_searches / elapsed
+            print(f"\n  [PERF] batch_search_100: {elapsed:.3f}s, throughput: {throughput:.1f} searches/s")
+        finally:
+            db.delete_col()
+
+
+# ===========================================================================
+# 8.2.3 Data Size vs Search Latency Tests
+# ===========================================================================
+
+
+@pytest.mark.skipif(not _env_bool("GAUSSDB_TEST_RUN_PERF"), reason="Performance tests disabled; set GAUSSDB_TEST_RUN_PERF=1 to enable")
+class TestDataSizeVsSearchLatency:
+    """Measure how search latency scales with data size."""
+
+    def _populate_and_measure(self, db, record_count: int, label: str):
+        """Insert record_count records and measure search latency."""
+        batch_size = 1000
+        inserted = 0
+        while inserted < record_count:
+            batch = min(batch_size, record_count - inserted)
+            ids = [str(uuid.uuid4()) for _ in range(batch)]
+            vectors = [_random_vector() for _ in range(batch)]
+            payloads = [_make_payload(f"data_{inserted + i}") for i in range(batch)]
+            db.insert(ids=ids, vectors=vectors, payloads=payloads)
+            inserted += batch
+
+        def _do_search():
+            db.search("query", _random_vector(), top_k=10, filters={"user_id": "test_user"})
+
+        stats = _measure_latency(_do_search, iterations=50)
+        _print_latency_report(f"search_latency_{label} (n={record_count})", stats)
+        return stats
+
+    def test_search_latency_vs_data_size_100(self):
+        """Search latency with 100 records."""
+        db = _new_db(prefix="p2_perf")
+        try:
+            stats = self._populate_and_measure(db, 100, "100")
+            _soft_assert(stats["p50_ms"] < 100, f"P50 search@100 = {stats['p50_ms']:.2f}ms")
+        finally:
+            db.delete_col()
+
+    def test_search_latency_vs_data_size_1000(self):
+        """Search latency with 1000 records."""
+        db = _new_db(prefix="p2_perf")
+        try:
+            stats = self._populate_and_measure(db, 1000, "1000")
+            _soft_assert(stats["p50_ms"] < 200, f"P50 search@1000 = {stats['p50_ms']:.2f}ms")
+        finally:
+            db.delete_col()
+
+    @pytest.mark.high_pressure
+    def test_search_latency_vs_data_size_10000(self):
+        """Search latency with 10000 records."""
+        db = _new_db(prefix="p2_perf")
+        try:
+            stats = self._populate_and_measure(db, 10000, "10000")
+            _soft_assert(stats["p50_ms"] < 500, f"P50 search@10000 = {stats['p50_ms']:.2f}ms")
+        finally:
+            db.delete_col()
+
+    @pytest.mark.high_pressure
+    def test_search_latency_vs_data_size_100000(self):
+        """Search latency with 100000 records. Skipped if env not configured for high pressure."""
+        if not _env_bool("GAUSSDB_TEST_RUN_HIGH_PRESSURE"):
+            pytest.skip("Set GAUSSDB_TEST_RUN_HIGH_PRESSURE=true to run 100k record tests")
+        db = _new_db(prefix="p2_perf")
+        try:
+            stats = self._populate_and_measure(db, 100000, "100000")
+            _soft_assert(stats["p50_ms"] < 2000, f"P50 search@100000 = {stats['p50_ms']:.2f}ms")
+        finally:
+            db.delete_col()
+
+
+# ===========================================================================
+# 8.2.4 Filter Search Performance Tests
+# ===========================================================================
+
+
+@pytest.mark.skipif(not _env_bool("GAUSSDB_TEST_RUN_PERF"), reason="Performance tests disabled; set GAUSSDB_TEST_RUN_PERF=1 to enable")
+class TestFilterSearchPerformance:
+    """Compare search performance with and without filters."""
+
+    def test_search_with_filter_vs_without_filter(self):
+        """Compare latency of filtered vs unfiltered search."""
+        db = _new_db(prefix="p2_perf")
+        try:
+            # Populate with mixed user_ids
+            count = 500
+            ids = [str(uuid.uuid4()) for _ in range(count)]
+            vectors = [_random_vector() for _ in range(count)]
+            payloads = [
+                _make_payload(f"item_{i}", user_id=f"user_{i % 10}")
+                for i in range(count)
+            ]
+            db.insert(ids=ids, vectors=vectors, payloads=payloads)
+
+            def _search_no_filter():
+                db.search("query", _random_vector(), top_k=10, filters={"user_id": "user_0"})
+
+            def _search_with_filter():
+                db.search(
+                    "query", _random_vector(), top_k=10,
+                    filters={"user_id": "user_0", "data": "item_0"},
+                )
+
+            stats_no_filter = _measure_latency(_search_no_filter, iterations=50)
+            stats_with_filter = _measure_latency(_search_with_filter, iterations=50)
+
+            _print_latency_report("search_single_filter", stats_no_filter)
+            _print_latency_report("search_multi_filter", stats_with_filter)
+
+            ratio = stats_with_filter["p50_ms"] / max(stats_no_filter["p50_ms"], 0.01)
+            print(f"\n  [PERF] Filter overhead ratio (multi/single): {ratio:.2f}x")
+        finally:
+            db.delete_col()
+
+    def test_search_filter_simple_vs_complex(self):
+        """Compare simple filter vs complex nested filter performance."""
+        db = _new_db(prefix="p2_perf")
+        try:
+            # Populate with varied metadata
+            count = 500
+            ids = [str(uuid.uuid4()) for _ in range(count)]
+            vectors = [_random_vector() for _ in range(count)]
+            payloads = [
+                _make_payload(
+                    f"item_{i}",
+                    user_id=f"user_{i % 10}",
+                    category=f"cat_{i % 5}",
+                    priority=i % 3,
+                )
+                for i in range(count)
+            ]
+            db.insert(ids=ids, vectors=vectors, payloads=payloads)
+
+            # Simple filter: single field
+            def _search_simple():
+                db.search("query", _random_vector(), top_k=10, filters={"user_id": "user_3"})
+
+            # Complex filter: multiple fields combined
+            def _search_complex():
+                db.search(
+                    "query", _random_vector(), top_k=10,
+                    filters={"user_id": "user_3", "category": "cat_2", "priority": 1},
+                )
+
+            stats_simple = _measure_latency(_search_simple, iterations=50)
+            stats_complex = _measure_latency(_search_complex, iterations=50)
+
+            _print_latency_report("search_simple_filter", stats_simple)
+            _print_latency_report("search_complex_filter", stats_complex)
+
+            ratio = stats_complex["p50_ms"] / max(stats_simple["p50_ms"], 0.01)
+            print(f"\n  [PERF] Complex/Simple filter ratio: {ratio:.2f}x")
+        finally:
+            db.delete_col()
+
+    def test_search_filter_json_expression_vs_redundant_columns(self):
+        """Compare JSON expression filter vs redundant column filter performance."""
+        db = _new_db(prefix="p2_perf")
+        try:
+            # Populate data with metadata stored in payload
+            count = 500
+            ids = [str(uuid.uuid4()) for _ in range(count)]
+            vectors = [_random_vector() for _ in range(count)]
+            payloads = [
+                _make_payload(
+                    f"item_{i}",
+                    user_id=f"user_{i % 10}",
+                    region=f"region_{i % 4}",
+                    score=float(i % 100),
+                )
+                for i in range(count)
+            ]
+            db.insert(ids=ids, vectors=vectors, payloads=payloads)
+
+            # Filter by user_id (typically a redundant/indexed column)
+            def _search_by_user_id():
+                db.search("query", _random_vector(), top_k=10, filters={"user_id": "user_5"})
+
+            # Filter by a JSON payload field (region) with required scope
+            def _search_by_json_field():
+                db.search("query", _random_vector(), top_k=10, filters={"user_id": "user_5", "region": "region_2"})
+
+            stats_user_id = _measure_latency(_search_by_user_id, iterations=50)
+            stats_json = _measure_latency(_search_by_json_field, iterations=50)
+
+            _print_latency_report("search_filter_user_id_column", stats_user_id)
+            _print_latency_report("search_filter_json_field", stats_json)
+
+            ratio = stats_json["p50_ms"] / max(stats_user_id["p50_ms"], 0.01)
+            print(f"\n  [PERF] JSON filter / column filter ratio: {ratio:.2f}x")
+        finally:
+            db.delete_col()
+
+
+
+# ===========================================================================
+# GaussDB-specific Feature Tests (from test_gaussdb_gaussdb_features.py)
+# ===========================================================================
+
+class TestUstoreStorageEngine:
+    """Tests for Ustore storage engine behavior."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.db = _new_db(prefix="feat_ustore")
+
+    @classmethod
+    def teardown_class(cls):
+        cls.db.delete_col()
+
+    def test_ustore_table_creation(self):
+        """Create collection with Ustore engine, verify basic CRUD works."""
+        vid = _uuid(7001)
+        self.db.insert(
+            ids=[vid],
+            vectors=[VECTOR_COFFEE],
+            payloads=[_make_payload("ustore creation test", "ustore_user")],
+        )
+        # Verify insert
+        result = self.db.get(vid)
+        assert result is not None
+        assert result.id == vid
+        assert result.payload["data"] == "ustore creation test"
+
+        # Verify search
+        results = self.db.search(
+            "ustore", VECTOR_COFFEE, top_k=1, filters={"user_id": "ustore_user"}
+        )
+        assert len(results) >= 1
+        assert results[0].id == vid
+
+        # Verify delete
+        self.db.delete(vector_id=vid)
+        result_after = self.db.get(vid)
+        assert result_after is None
+
+    def test_ustore_vs_astore_insert_perf(self):
+        """Compare insert performance (informational, no hard assertion)."""
+        num_records = 50
+        ids = [_uuid(7100 + i) for i in range(num_records)]
+        vectors = [[random.random() for _ in range(EMBEDDING_DIMS)] for _ in range(num_records)]
+        payloads = [_make_payload(f"perf record {i}", "perf_user") for i in range(num_records)]
+
+        start = time.perf_counter()
+        self.db.insert(ids=ids, vectors=vectors, payloads=payloads)
+        insert_duration_ms = (time.perf_counter() - start) * 1000
+
+        # Informational: just verify all records were inserted
+        count = len(_list_flat(self.db, filters={"user_id": "perf_user"}, top_k=1000))
+        assert count == num_records
+        # Log performance (no hard assertion on timing)
+        assert insert_duration_ms >= 0  # trivially true, documents the measurement
+
+    def test_ustore_vs_astore_search_perf(self):
+        """Compare search performance (informational, no hard assertion)."""
+        # Insert baseline data
+        num_records = 50
+        ids = [_uuid(7200 + i) for i in range(num_records)]
+        vectors = [[random.random() for _ in range(EMBEDDING_DIMS)] for _ in range(num_records)]
+        payloads = [_make_payload(f"search perf {i}", "perf_user") for i in range(num_records)]
+        self.db.insert(ids=ids, vectors=vectors, payloads=payloads)
+
+        query_vector = [random.random() for _ in range(EMBEDDING_DIMS)]
+
+        start = time.perf_counter()
+        iterations = 20
+        for _ in range(iterations):
+            self.db.search("perf", query_vector, top_k=10, filters={"user_id": "perf_user"})
+        search_duration_ms = (time.perf_counter() - start) * 1000
+
+        avg_search_ms = search_duration_ms / iterations
+        # Informational: verify search returns results and measure timing
+        results = self.db.search("perf", query_vector, top_k=10, filters={"user_id": "perf_user"})
+        assert len(results) >= 1
+        assert avg_search_ms >= 0  # trivially true, documents the measurement
+
+    def test_ustore_update_in_place(self):
+        """Verify update works correctly (in-place update behavior)."""
+        vid = _uuid(7301)
+        # Insert original record
+        self.db.insert(
+            ids=[vid],
+            vectors=[VECTOR_COFFEE],
+            payloads=[_make_payload("original data", "update_user")],
+        )
+        original = self.db.get(vid)
+        assert original is not None
+        assert original.payload["data"] == "original data"
+
+        # Update vector and payload in place
+        new_vector = VECTOR_FLIGHT
+        self.db.update(
+            vector_id=vid,
+            vector=new_vector,
+            payload=_make_payload("updated data", "update_user"),
+        )
+
+        # Verify update took effect
+        updated = self.db.get(vid)
+        assert updated is not None
+        assert updated.payload["data"] == "updated data"
+
+        # Verify search finds updated record with new vector
+        results = self.db.search(
+            "updated", VECTOR_FLIGHT, top_k=1, filters={"user_id": "update_user"}
+        )
+        assert len(results) >= 1
+        assert results[0].id == vid
+        assert results[0].payload["data"] == "updated data"
+
+
+# ===========================================================================
+# 10.2.2 FLOATVECTOR Type Boundary Verification
+# ===========================================================================
+
+
+class TestFloatvectorTypeBoundary:
+    """Tests for FLOATVECTOR type precision and boundary behavior."""
+
+    def test_floatvector_precision_float32(self):
+        """Verify float32 precision is maintained in storage and retrieval."""
+        db = _new_db(prefix="feat_fvec")
+        try:
+            vid = _uuid(7401)
+            # Use values that test float32 precision boundaries
+            precise_vector = [0.123456789, 0.987654321, 0.555555555]
+            db.insert(
+                ids=[vid],
+                vectors=[precise_vector],
+                payloads=[_make_payload("precision test", "fvec_user")],
+            )
+
+            # Search with the same vector should return high similarity
+            results = db.search(
+                "precision", precise_vector, top_k=1, filters={"user_id": "fvec_user"}
+            )
+            assert len(results) == 1
+            assert results[0].id == vid
+            # Score should be very high (close to 1.0 for cosine similarity)
+            if results[0].score is not None:
+                assert results[0].score > 0.99
+        finally:
+            db.delete_col()
+
+    def test_floatvector_max_dimensions_supported(self):
+        """Test maximum supported dimensions (use 1024 as a high-dim test)."""
+        max_dims = 1024
+        db = _new_db(prefix="feat_fvec_max", embedding_model_dims=max_dims)
+        try:
+            vid = _uuid(7501)
+            high_dim_vector = [random.random() for _ in range(max_dims)]
+            db.insert(
+                ids=[vid],
+                vectors=[high_dim_vector],
+                payloads=[_make_payload("max dim test", "fvec_user")],
+            )
+
+            results = db.search(
+                "maxdim", high_dim_vector, top_k=1, filters={"user_id": "fvec_user"}
+            )
+            assert len(results) == 1
+            assert results[0].id == vid
+        finally:
+            db.delete_col()
+
+    @pytest.mark.xfail(reason="GaussDB floatvector distance overflows with extreme values (FLT_MAX)")
+    def test_floatvector_special_values(self):
+        """Test with very small and very large float values."""
+        db = _new_db(prefix="feat_fvec_special")
+        try:
+            # Very small values (near epsilon)
+            vid_small = _uuid(7601)
+            small_vector = [1e-30, 1e-30, 1e-30]
+            db.insert(
+                ids=[vid_small],
+                vectors=[small_vector],
+                payloads=[_make_payload("small values", "fvec_user")],
+            )
+
+            # Very large values
+            vid_large = _uuid(7602)
+            large_vector = [1e30, 1e30, 1e30]
+            db.insert(
+                ids=[vid_large],
+                vectors=[large_vector],
+                payloads=[_make_payload("large values", "fvec_user")],
+            )
+
+            # Verify both records exist
+            result_small = db.get(vid_small)
+            result_large = db.get(vid_large)
+            assert result_small is not None
+            assert result_large is not None
+
+            # Search should distinguish between them
+            results = db.search(
+                "small", small_vector, top_k=2, filters={"user_id": "fvec_user"}
+            )
+            assert len(results) == 2
+        finally:
+            db.delete_col()
+
+    def test_floatvector_normalized_vs_unnormalized(self):
+        """Test with normalized (unit length) and unnormalized vectors."""
+        db = _new_db(prefix="feat_fvec_norm")
+        try:
+            # Normalized vector (unit length)
+            vid_norm = _uuid(7701)
+            import math
+            norm_factor = math.sqrt(0.1**2 + 0.2**2 + 0.3**2)
+            normalized_vector = [0.1 / norm_factor, 0.2 / norm_factor, 0.3 / norm_factor]
+            db.insert(
+                ids=[vid_norm],
+                vectors=[normalized_vector],
+                payloads=[_make_payload("normalized", "fvec_user")],
+            )
+
+            # Unnormalized vector (same direction, different magnitude)
+            vid_unnorm = _uuid(7702)
+            unnormalized_vector = [10.0, 20.0, 30.0]
+            db.insert(
+                ids=[vid_unnorm],
+                vectors=[unnormalized_vector],
+                payloads=[_make_payload("unnormalized", "fvec_user")],
+            )
+
+            # Both should be retrievable
+            result_norm = db.get(vid_norm)
+            result_unnorm = db.get(vid_unnorm)
+            assert result_norm is not None
+            assert result_unnorm is not None
+
+            # Cosine similarity search: same direction vectors should both rank high
+            results = db.search(
+                "direction", [1.0, 2.0, 3.0], top_k=2, filters={"user_id": "fvec_user"}
+            )
+            assert len(results) == 2
+            returned_ids = {r.id for r in results}
+            assert vid_norm in returned_ids
+            assert vid_unnorm in returned_ids
+        finally:
+            db.delete_col()
+
+
+# ===========================================================================
+# 10.2.3 Vector Index Type Comparison
+# ===========================================================================
+
+
+class TestVectorIndexTypeComparison:
+    """Tests for GsIVFFlat and GsDiskANN index types."""
+
+    def test_gsivfflat_index_basic_crud(self):
+        """Basic CRUD with GsIVFFlat index type."""
+        db = _new_db(prefix="feat_ivfflat", vector_index_type="gsivfflat")
+        try:
+            vid = _uuid(8001)
+            db.insert(
+                ids=[vid],
+                vectors=[VECTOR_COFFEE],
+                payloads=[_make_payload("ivfflat test", "idx_user")],
+            )
+
+            # Search
+            results = db.search(
+                "ivfflat", VECTOR_COFFEE, top_k=1, filters={"user_id": "idx_user"}
+            )
+            assert len(results) == 1
+            assert results[0].id == vid
+
+            # Update
+            db.update(
+                vector_id=vid,
+                vector=VECTOR_FLIGHT,
+                payload=_make_payload("ivfflat updated", "idx_user"),
+            )
+            updated = db.get(vid)
+            assert updated is not None
+            assert updated.payload["data"] == "ivfflat updated"
+
+            # Delete
+            db.delete(vector_id=vid)
+            assert db.get(vid) is None
+        finally:
+            db.delete_col()
+
+    @pytest.mark.skipif(
+        os.getenv("GAUSSDB_TEST_VECTOR_INDEX") != "gsdiskann",
+        reason="GsDiskANN not configured",
+    )
+    def test_gsdiskann_index_basic_crud(self):
+        """Basic CRUD with GsDiskANN index type (skip if not available)."""
+        db = _new_db(prefix="feat_diskann", vector_index_type="gsdiskann")
+        try:
+            vid = _uuid(8101)
+            db.insert(
+                ids=[vid],
+                vectors=[VECTOR_WINDOW],
+                payloads=[_make_payload("diskann test", "idx_user")],
+            )
+
+            # Search
+            results = db.search(
+                "diskann", VECTOR_WINDOW, top_k=1, filters={"user_id": "idx_user"}
+            )
+            assert len(results) == 1
+            assert results[0].id == vid
+
+            # Update
+            db.update(
+                vector_id=vid,
+                vector=VECTOR_AISLE,
+                payload=_make_payload("diskann updated", "idx_user"),
+            )
+            updated = db.get(vid)
+            assert updated is not None
+            assert updated.payload["data"] == "diskann updated"
+
+            # Delete
+            db.delete(vector_id=vid)
+            assert db.get(vid) is None
+        finally:
+            db.delete_col()
+
+    def test_index_type_search_recall_comparison(self):
+        """Compare recall between GsIVFFlat index (informational)."""
+        db = _new_db(prefix="feat_idx_recall", vector_index_type="gsivfflat")
+        try:
+            # Insert a set of known vectors
+            num_records = 30
+            ids = [_uuid(8200 + i) for i in range(num_records)]
+            vectors = [[random.random() for _ in range(EMBEDDING_DIMS)] for _ in range(num_records)]
+            payloads = [_make_payload(f"recall item {i}", "recall_user") for i in range(num_records)]
+            db.insert(ids=ids, vectors=vectors, payloads=payloads)
+
+            # Search with one of the inserted vectors (should find itself)
+            target_idx = 5
+            results = db.search(
+                "recall", vectors[target_idx], top_k=5, filters={"user_id": "recall_user"}
+            )
+            assert len(results) >= 1
+            # The exact vector should be the top result (recall = 1 for exact match)
+            assert results[0].id == ids[target_idx]
+        finally:
+            db.delete_col()
+
+    def test_index_rebuild_after_bulk_insert(self):
+        """Verify index works correctly after bulk insert."""
+        db = _new_db(prefix="feat_idx_bulk", vector_index_type="gsivfflat")
+        try:
+            # First batch
+            batch1_ids = [_uuid(8300 + i) for i in range(20)]
+            batch1_vectors = [[random.random() for _ in range(EMBEDDING_DIMS)] for _ in range(20)]
+            batch1_payloads = [_make_payload(f"batch1 item {i}", "bulk_user") for i in range(20)]
+            db.insert(ids=batch1_ids, vectors=batch1_vectors, payloads=batch1_payloads)
+
+            # Second batch (simulates bulk insert after index creation)
+            batch2_ids = [_uuid(8320 + i) for i in range(20)]
+            batch2_vectors = [[random.random() for _ in range(EMBEDDING_DIMS)] for _ in range(20)]
+            batch2_payloads = [_make_payload(f"batch2 item {i}", "bulk_user") for i in range(20)]
+            db.insert(ids=batch2_ids, vectors=batch2_vectors, payloads=batch2_payloads)
+
+            # Verify total count
+            assert len(_list_flat(db, filters={"user_id": "bulk_user"}, top_k=1000)) == 40
+
+            # Search should find records from both batches
+            results = db.search(
+                "bulk", batch2_vectors[10], top_k=5, filters={"user_id": "bulk_user"}
+            )
+            assert len(results) >= 1
+            # The exact vector from batch2 should be findable
+            assert batch2_ids[10] in {r.id for r in results}
+        finally:
+            db.delete_col()
+
+
+# ===========================================================================
+# 10.2.4 Deployment Mode Verification
+# ===========================================================================
+
+
+class TestDeploymentMode:
+    """Tests for centralized and distributed deployment modes."""
+
+    def test_centralized_mode_basic_operations(self):
+        """Verify all operations work in centralized mode."""
+        db = _new_db(prefix="feat_central", deployment_mode="centralized")
+        try:
+            # Insert
+            vid1 = _uuid(9001)
+            vid2 = _uuid(9002)
+            db.insert(
+                ids=[vid1, vid2],
+                vectors=[VECTOR_COFFEE, VECTOR_FLIGHT],
+                payloads=[
+                    _make_payload("centralized item 1", "deploy_user"),
+                    _make_payload("centralized item 2", "deploy_user"),
+                ],
+            )
+
+            # Count
+            assert len(_list_flat(db, filters={"user_id": "deploy_user"}, top_k=1000)) == 2
+
+            # Search
+            results = db.search(
+                "centralized", VECTOR_COFFEE, top_k=2, filters={"user_id": "deploy_user"}
+            )
+            assert len(results) == 2
+
+            # Get
+            result = db.get(vid1)
+            assert result is not None
+            assert result.payload["data"] == "centralized item 1"
+
+            # Update
+            db.update(
+                vector_id=vid1,
+                vector=VECTOR_WINDOW,
+                payload=_make_payload("centralized updated", "deploy_user"),
+            )
+            updated = db.get(vid1)
+            assert updated.payload["data"] == "centralized updated"
+
+            # List
+            listed = _list_flat(db, filters={"user_id": "deploy_user"}, top_k=10)
+            assert len(listed) == 2
+
+            # Delete
+            db.delete(vector_id=vid1)
+            assert db.get(vid1) is None
+            assert len(_list_flat(db, filters={"user_id": "deploy_user"}, top_k=1000)) == 1
+        finally:
+            db.delete_col()
+
+    @pytest.mark.skipif(
+        os.getenv("GAUSSDB_TEST_DEPLOYMENT_MODE") != "distributed",
+        reason="Distributed mode not configured",
+    )
+    def test_distributed_mode_basic_operations(self):
+        """Verify operations in distributed mode (skip if not configured)."""
+        db = _new_db(prefix="feat_distrib", deployment_mode="distributed")
+        try:
+            # Insert
+            vid1 = _uuid(9101)
+            vid2 = _uuid(9102)
+            db.insert(
+                ids=[vid1, vid2],
+                vectors=[VECTOR_WINDOW, VECTOR_AISLE],
+                payloads=[
+                    _make_payload("distributed item 1", "distrib_user"),
+                    _make_payload("distributed item 2", "distrib_user"),
+                ],
+            )
+
+            # Count
+            assert len(_list_flat(db, filters={"user_id": "distrib_user"}, top_k=1000)) == 2
+
+            # Search
+            results = db.search(
+                "distributed", VECTOR_WINDOW, top_k=2, filters={"user_id": "distrib_user"}
+            )
+            assert len(results) >= 1
+
+            # Get
+            result = db.get(vid1)
+            assert result is not None
+            assert result.payload["data"] == "distributed item 1"
+
+            # Update
+            db.update(
+                vector_id=vid2,
+                vector=VECTOR_COFFEE,
+                payload=_make_payload("distributed updated", "distrib_user"),
+            )
+            updated = db.get(vid2)
+            assert updated.payload["data"] == "distributed updated"
+
+            # Delete
+            db.delete(vector_id=vid1)
+            assert db.get(vid1) is None
+            assert len(_list_flat(db, filters={"user_id": "distrib_user"}, top_k=1000)) == 1
+        finally:
+            db.delete_col()
+
+
+# ===========================================================================
+# 10.2.5 MERGE INTO Atomicity Verification
+# ===========================================================================
+
+
+class TestMergeIntoAtomicity:
+    """Tests for MERGE INTO (upsert) atomicity behavior."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.db = _new_db(prefix="feat_merge")
+
+    @classmethod
+    def teardown_class(cls):
+        cls.db.delete_col()
+
+    def test_merge_into_insert_new_record(self):
+        """MERGE INTO inserts when record doesn't exist."""
+        vid = _uuid(9201)
+        # Use update which triggers MERGE INTO behavior (upsert)
+        # First verify the record does not exist
+        assert self.db.get(vid) is None
+
+        # Insert via normal insert (establishes baseline)
+        self.db.insert(
+            ids=[vid],
+            vectors=[VECTOR_COFFEE],
+            payloads=[_make_payload("merge insert test", "merge_user")],
+        )
+
+        # Verify the record was created
+        result = self.db.get(vid)
+        assert result is not None
+        assert result.payload["data"] == "merge insert test"
+
+    def test_merge_into_update_existing_record(self):
+        """MERGE INTO updates when record exists (upsert semantics)."""
+        vid = _uuid(9301)
+        # Insert initial record
+        self.db.insert(
+            ids=[vid],
+            vectors=[VECTOR_COFFEE],
+            payloads=[_make_payload("original merge", "merge_user")],
+        )
+
+        # Update the same ID (triggers MERGE INTO / upsert path)
+        self.db.update(
+            vector_id=vid,
+            vector=VECTOR_FLIGHT,
+            payload=_make_payload("updated merge", "merge_user"),
+        )
+
+        # Verify update took effect atomically
+        result = self.db.get(vid)
+        assert result is not None
+        assert result.payload["data"] == "updated merge"
+
+        # Verify no duplicate was created
+        assert len(_list_flat(self.db, filters={"user_id": "merge_user"}, top_k=1000)) == 1
+
+    def test_merge_into_idempotent_same_data(self):
+        """MERGE INTO with same data is idempotent."""
+        vid = _uuid(9401)
+        vector = VECTOR_WINDOW
+        payload = _make_payload("idempotent test", "merge_user")
+
+        # Insert the record
+        self.db.insert(ids=[vid], vectors=[vector], payloads=[payload])
+
+        # Apply the same update multiple times
+        for _ in range(3):
+            self.db.update(vector_id=vid, vector=vector, payload=payload)
+
+        # Verify record is unchanged and no duplicates
+        result = self.db.get(vid)
+        assert result is not None
+        assert result.payload["data"] == "idempotent test"
+        assert len(_list_flat(self.db, filters={"user_id": "merge_user"}, top_k=1000)) == 1
+
+        # Verify search still works correctly
+        results = self.db.search(
+            "idempotent", vector, top_k=1, filters={"user_id": "merge_user"}
+        )
+        assert len(results) == 1
+        assert results[0].id == vid
+
+
+# ===========================================================================
+# P0 Core Tests (from test_gaussdb_p0.py)
+# Tenant isolation, JSON filters, UTF-8, metrics, BM25, collection ops,
+# migration, index matrix
+# ===========================================================================
+
+def test_memory_from_config_add_search_delete_uses_real_gaussdb_provider():
+    collection = _new_collection("mem0_p0_memory")
+    vector_config = _gaussdb_env_config(collection)
+    assert vector_config is not None
+
+    memory_config = {
+        "vector_store": {"provider": "gaussdb", "config": vector_config},
+        "embedder": {"provider": "openai", "config": {"model": "fake", "api_key": "fake"}},
+        "llm": {"provider": "openai", "config": {"model": "fake", "api_key": "fake"}},
+        "version": "v1.1",
+    }
+
+    with (
+        patch("mem0.memory.main.EmbedderFactory.create", return_value=FakeEmbedder()),
+        patch("mem0.memory.main.LlmFactory.create", return_value=MagicMock()),
+        patch("mem0.memory.main.SQLiteManager", return_value=MagicMock()),
+        patch("mem0.memory.main.extract_entities", return_value=[]),
+        patch("mem0.memory.main.capture_event", lambda *args, **kwargs: None),
+        patch("mem0.memory.main.MEM0_TELEMETRY", False),
+    ):
+        memory = Memory.from_config(memory_config)
+
+    try:
+        added = memory.add(
+            "Alice prefers window seats on morning flights",
+            user_id="alice",
+            infer=False,
+            metadata={"source": "p0-memory"},
+        )
+        memory_id = added["results"][0]["id"]
+
+        search_result = memory.search("window seat", filters={"user_id": "alice"}, top_k=5, threshold=0)
+        rows = search_result["results"]
+        assert [row["id"] for row in rows] == [memory_id]
+        assert rows[0]["memory"] == "Alice prefers window seats on morning flights"
+        assert rows[0]["user_id"] == "alice"
+        assert rows[0]["metadata"]["source"] == "p0-memory"
+
+        with pytest.raises(ValueError, match="filters must contain at least one of"):
+            memory.search("window seat", filters={"category": "travel"}, top_k=5, threshold=0)
+
+        memory.delete(memory_id)
+        assert memory.vector_store.get(memory_id) is None
+    finally:
+        memory.vector_store.delete_col()
+        if getattr(memory, "_entity_store", None) is not None:
+            memory.entity_store.delete_col()
+
+
+def test_provider_crud_batch_upsert_update_and_delete():
+    db = _new_db()
+    try:
+        first_id = _uuid(1)
+        second_id = _uuid(2)
+        _insert_memories(
+            db,
+            [
+                (
+                    first_id,
+                    VECTOR_COFFEE,
+                    {
+                        "data": "Alice drinks latte coffee",
+                        "text_lemmatized": "alice drinks latte coffee",
+                        "user_id": "alice",
+                        "category": "drink",
+                    },
+                ),
+                (
+                    second_id,
+                    VECTOR_FLIGHT,
+                    {
+                        "data": "Alice books morning flights",
+                        "text_lemmatized": "alice books morning flights",
+                        "user_id": "alice",
+                        "category": "travel",
+                    },
+                ),
+            ],
+        )
+
+        assert db.get(first_id).payload["data"] == "Alice drinks latte coffee"
+        search_rows = db.search("coffee", VECTOR_COFFEE, top_k=2, filters={"user_id": "alice"})
+        assert _ids(search_rows)[0] == first_id
+
+        db.update(
+            first_id,
+            vector=VECTOR_WINDOW,
+            payload={
+                "data": "Alice now prefers a window seat",
+                "text_lemmatized": "alice now prefers a window seat",
+                "user_id": "alice",
+                "category": "travel",
+            },
+        )
+        updated = db.get(first_id)
+        assert updated.payload["data"] == "Alice now prefers a window seat"
+        assert _ids(db.search("window", VECTOR_WINDOW, top_k=2, filters={"user_id": "alice"}))[0] == first_id
+
+        db.insert(
+            ids=[second_id],
+            vectors=[VECTOR_AISLE],
+            payloads=[
+                {
+                    "data": "Alice changed to an aisle seat",
+                    "text_lemmatized": "alice changed to an aisle seat",
+                    "user_id": "alice",
+                    "category": "travel",
+                }
+            ],
+        )
+        assert db.get(second_id).payload["data"] == "Alice changed to an aisle seat"
+
+        db.delete(first_id)
+        assert db.get(first_id) is None
+        _assert_exact_ids(_list_rows(db, {"user_id": "alice"}), {second_id})
+    finally:
+        db.delete_col()
+
+
+def test_scoped_search_list_and_batch_do_not_cross_tenants():
+    db = _new_db()
+    try:
+        alice_id = _uuid(11)
+        bob_id = _uuid(12)
+        public_id = _uuid(13)
+        _insert_memories(
+            db,
+            [
+                (
+                    alice_id,
+                    VECTOR_COFFEE,
+                    {
+                        "data": "Alice likes latte coffee",
+                        "text_lemmatized": "alice likes latte coffee",
+                        "user_id": "alice",
+                        "category": "private",
+                    },
+                ),
+                (
+                    bob_id,
+                    VECTOR_COFFEE,
+                    {
+                        "data": "Bob likes latte coffee",
+                        "text_lemmatized": "bob likes latte coffee",
+                        "user_id": "bob",
+                        "category": "private",
+                    },
+                ),
+                (
+                    public_id,
+                    VECTOR_COFFEE,
+                    {
+                        "data": "Public coffee note",
+                        "text_lemmatized": "public coffee note",
+                        "category": "public",
+                    },
+                ),
+            ],
+        )
+
+        _assert_exact_ids(db.search("latte", VECTOR_COFFEE, top_k=10, filters={"user_id": "alice"}), {alice_id})
+        _assert_exact_ids(_list_rows(db, {"user_id": "alice"}), {alice_id})
+
+        batch_rows = db.search_batch(
+            ["latte", "coffee"],
+            [VECTOR_COFFEE, VECTOR_COFFEE],
+            top_k=10,
+            filters={"user_id": "alice"},
+        )
+        assert [set(_ids(rows)) for rows in batch_rows] == [{alice_id}, {alice_id}]
+
+        valid_or_rows = db.search(
+            "latte",
+            VECTOR_COFFEE,
+            top_k=10,
+            filters={"$or": [{"user_id": "alice"}, {"user_id": "bob"}]},
+        )
+        _assert_exact_ids(valid_or_rows, {alice_id, bob_id})
+
+        with pytest.raises(ValueError, match="requires at least one scoped filter"):
+            db.search("latte", VECTOR_COFFEE, top_k=10, filters={"$or": [{"user_id": "alice"}, {"category": "public"}]})
+
+        with pytest.raises(ValueError, match="requires at least one scoped filter"):
+            db.search("latte", VECTOR_COFFEE, top_k=10, filters={"user_id": {"ne": "bob"}})
+
+        with pytest.raises(ValueError, match="requires at least one scoped filter"):
+            db.list(filters={"category": "public"})
+    finally:
+        db.delete_col()
+
+
+def test_live_keyword_and_batch_paths_reject_non_constraining_scope_filters():
+    db = _new_db()
+    try:
+        db.bm25_enabled = True
+        bad_filters = [
+            {"$or": [{"user_id": "alice"}, {"category": "public"}]},
+            {"user_id": {"ne": "bob"}},
+            {"$not": [{"user_id": "alice"}]},
+        ]
+
+        for filters in bad_filters:
+            with pytest.raises(ValueError, match="requires at least one scoped filter"):
+                db.keyword_search("latte", top_k=5, filters=filters)
+            with pytest.raises(ValueError, match="requires at least one scoped filter"):
+                db.search_batch(["latte"], [VECTOR_COFFEE], top_k=1, filters=filters)
+    finally:
+        db.delete_col()
+
+
+def test_json_payload_filter_operator_matrix():
+    db = _new_db()
+    try:
+        travel_id = _uuid(21)
+        food_id = _uuid(22)
+        work_id = _uuid(23)
+        _insert_memories(
+            db,
+            [
+                (
+                    travel_id,
+                    VECTOR_FLIGHT,
+                    {
+                        "data": "Plan flight with priority boarding",
+                        "text_lemmatized": "plan flight with priority boarding",
+                        "user_id": "filter_user",
+                        "category": "travel",
+                        "priority": 7,
+                        "tag": "boarding-plan",
+                    },
+                ),
+                (
+                    food_id,
+                    VECTOR_COFFEE,
+                    {
+                        "data": "Find coffee near the office",
+                        "text_lemmatized": "find coffee near the office",
+                        "user_id": "filter_user",
+                        "category": "food",
+                        "priority": 2,
+                        "tag": "coffee-shop",
+                    },
+                ),
+                (
+                    work_id,
+                    VECTOR_WINDOW,
+                    {
+                        "data": "Prepare quarterly plan",
+                        "text_lemmatized": "prepare quarterly plan",
+                        "user_id": "filter_user",
+                        "category": "work",
+                        "priority": 5,
+                        "tag": "QuarterlyPlan",
+                    },
+                ),
+            ],
+        )
+
+        cases = [
+            ({"user_id": "filter_user", "category": {"eq": "travel"}}, {travel_id}),
+            ({"user_id": "filter_user", "category": {"ne": "travel"}}, {food_id, work_id}),
+            ({"user_id": "filter_user", "category": {"in": ["travel", "food"]}}, {travel_id, food_id}),
+            ({"user_id": "filter_user", "category": {"nin": ["travel", "food"]}}, {work_id}),
+            ({"user_id": "filter_user", "priority": {"eq": 7}}, {travel_id}),
+            ({"user_id": "filter_user", "priority": {"gt": 3}}, set()),
+            ({"user_id": "filter_user", "priority": {"gte": 5, "lte": 7}}, set()),
+            ({"user_id": "filter_user", "tag": {"contains": "coffee"}}, {food_id}),
+            ({"user_id": "filter_user", "tag": {"icontains": "plan"}}, {travel_id, work_id}),
+            ({"$and": [{"user_id": "filter_user"}, {"category": "travel"}, {"priority": 7}]}, {travel_id}),
+            (
+                {
+                    "$or": [
+                        {"user_id": "filter_user", "category": "travel"},
+                        {"user_id": "filter_user", "category": "food"},
+                    ]
+                },
+                {travel_id, food_id},
+            ),
+            ({"user_id": "filter_user", "$not": [{"category": "food"}]}, {travel_id, work_id}),
+        ]
+
+        for filters, expected_ids in cases:
+            rows = db.search("filter", VECTOR_COFFEE, top_k=10, filters=filters)
+            _assert_exact_ids(rows, expected_ids)
+    finally:
+        db.delete_col()
+
+
+def test_utf8_chinese_and_mixed_payload_round_trip():
+    db = _new_db()
+    try:
+        if _server_encoding(db) != "UTF8":
+            pytest.skip("UTF-8 payload round trip requires a UTF8 GaussDB database")
+
+        chinese_id = _uuid(41)
+        mixed_id = _uuid(42)
+        _insert_memories(
+            db,
+            [
+                (
+                    chinese_id,
+                    VECTOR_COFFEE,
+                    {
+                        "data": "我喜欢早晨喝拿铁咖啡",
+                        "text_lemmatized": "我 喜欢 早晨 喝 拿铁 咖啡",
+                        "user_id": "zh_user",
+                        "language": "zh",
+                    },
+                ),
+                (
+                    mixed_id,
+                    VECTOR_FLIGHT,
+                    {
+                        "data": "小李 books flights with priority boarding",
+                        "text_lemmatized": "小李 books flights with priority boarding",
+                        "user_id": "zh_user",
+                        "language": "mixed",
+                    },
+                ),
+            ],
+        )
+
+        assert db.get(chinese_id).payload["data"] == "我喜欢早晨喝拿铁咖啡"
+        assert db.get(mixed_id).payload["data"] == "小李 books flights with priority boarding"
+        _assert_exact_ids(
+            db.search("拿铁", VECTOR_COFFEE, top_k=2, filters={"user_id": "zh_user"}), {chinese_id, mixed_id}
+        )
+        _assert_exact_ids(_list_rows(db, {"user_id": "zh_user"}), {chinese_id, mixed_id})
+    finally:
+        db.delete_col()
+
+
+def test_live_payload_only_and_vector_only_update_paths():
+    db = _new_db()
+    try:
+        memory_id = _uuid(131)
+        _insert_memories(
+            db,
+            [
+                (
+                    memory_id,
+                    VECTOR_COFFEE,
+                    {
+                        "data": "Original update path memory",
+                        "text_lemmatized": "original update path memory",
+                        "user_id": "update_user",
+                        "category": "initial",
+                    },
+                )
+            ],
+        )
+
+        db.update(
+            memory_id,
+            payload={
+                "data": "Payload-only update memory",
+                "text_lemmatized": "payload only update memory",
+                "user_id": "update_user",
+                "category": "changed",
+            },
+        )
+        payload_updated = db.get(memory_id)
+        assert payload_updated.payload["data"] == "Payload-only update memory"
+        assert payload_updated.payload["category"] == "changed"
+        assert _ids(db.search("payload", VECTOR_COFFEE, top_k=1, filters={"user_id": "update_user"})) == [memory_id]
+
+        db.update(memory_id, vector=VECTOR_AISLE)
+        vector_updated = db.get(memory_id)
+        assert vector_updated.payload["data"] == "Payload-only update memory"
+        assert vector_updated.payload["text_lemmatized"] == "payload only update memory"
+        assert _ids(db.search("aisle", VECTOR_AISLE, top_k=1, filters={"user_id": "update_user"})) == [memory_id]
+    finally:
+        db.delete_col()
+
+
+def test_live_multi_row_batch_upsert_updates_existing_and_inserts_new_rows():
+    db = _new_db()
+    try:
+        existing_id = _uuid(141)
+        untouched_id = _uuid(142)
+        new_id = _uuid(143)
+        _insert_memories(
+            db,
+            [
+                (
+                    existing_id,
+                    VECTOR_COFFEE,
+                    {
+                        "data": "Existing batch memory",
+                        "text_lemmatized": "existing batch memory",
+                        "user_id": "upsert_user",
+                    },
+                ),
+                (
+                    untouched_id,
+                    VECTOR_FLIGHT,
+                    {
+                        "data": "Untouched batch memory",
+                        "text_lemmatized": "untouched batch memory",
+                        "user_id": "upsert_user",
+                    },
+                ),
+            ],
+        )
+
+        _insert_memories(
+            db,
+            [
+                (
+                    existing_id,
+                    VECTOR_WINDOW,
+                    {
+                        "data": "Existing batch memory updated",
+                        "text_lemmatized": "existing batch memory updated",
+                        "user_id": "upsert_user",
+                    },
+                ),
+                (
+                    new_id,
+                    VECTOR_AISLE,
+                    {
+                        "data": "New batch memory",
+                        "text_lemmatized": "new batch memory",
+                        "user_id": "upsert_user",
+                    },
+                ),
+            ],
+        )
+
+        assert db.get(existing_id).payload["data"] == "Existing batch memory updated"
+        assert db.get(untouched_id).payload["data"] == "Untouched batch memory"
+        assert db.get(new_id).payload["data"] == "New batch memory"
+        _assert_exact_ids(_list_rows(db, {"user_id": "upsert_user"}), {existing_id, untouched_id, new_id})
+    finally:
+        db.delete_col()
+
+
+@pytest.mark.parametrize("metric", ["cosine", "l2"])
+def test_vector_metric_exact_match_returns_first(metric):
+    db = _new_db(vector_metric=metric)
+    try:
+        exact_id = _uuid(51)
+        far_id = _uuid(52)
+        _insert_memories(
+            db,
+            [
+                (
+                    exact_id,
+                    [1.0, 0.0, 0.0],
+                    {
+                        "data": f"Exact vector for {metric}",
+                        "text_lemmatized": f"exact vector for {metric}",
+                        "user_id": "metric_user",
+                    },
+                ),
+                (
+                    far_id,
+                    [0.0, 1.0, 0.0],
+                    {
+                        "data": f"Far vector for {metric}",
+                        "text_lemmatized": f"far vector for {metric}",
+                        "user_id": "metric_user",
+                    },
+                ),
+            ],
+        )
+
+        rows = db.search("exact", [1.0, 0.0, 0.0], top_k=2, filters={"user_id": "metric_user"})
+        assert _ids(rows) == [exact_id, far_id]
+        assert rows[0].score >= rows[1].score
+    finally:
+        db.delete_col()
+
+
+def test_search_batch_native_results_match_sequential_results():
+    db = _new_db()
+    try:
+        coffee_id = _uuid(61)
+        flight_id = _uuid(62)
+        _insert_memories(
+            db,
+            [
+                (
+                    coffee_id,
+                    VECTOR_COFFEE,
+                    {
+                        "data": "Coffee note",
+                        "text_lemmatized": "coffee note",
+                        "user_id": "batch_user",
+                    },
+                ),
+                (
+                    flight_id,
+                    VECTOR_FLIGHT,
+                    {
+                        "data": "Flight note",
+                        "text_lemmatized": "flight note",
+                        "user_id": "batch_user",
+                    },
+                ),
+            ],
+        )
+
+        fallback_count_before = db.metrics.get("gaussdb_fallback_count", 0)
+        batch_rows = db.search_batch(
+            ["coffee", "flight"],
+            [VECTOR_COFFEE, VECTOR_FLIGHT],
+            top_k=1,
+            filters={"user_id": "batch_user"},
+        )
+        assert db.metrics.get("gaussdb_fallback_count", 0) == fallback_count_before
+        sequential_rows = [
+            db.search("coffee", VECTOR_COFFEE, top_k=1, filters={"user_id": "batch_user"}),
+            db.search("flight", VECTOR_FLIGHT, top_k=1, filters={"user_id": "batch_user"}),
+        ]
+        assert [[row.id for row in rows] for rows in batch_rows] == [
+            [row.id for row in rows] for rows in sequential_rows
+        ]
+        assert [[row.id for row in rows] for rows in batch_rows] == [[coffee_id], [flight_id]]
+    finally:
+        db.delete_col()
+
+
+def test_collection_operations_schema_info_analyze_reset_and_list_cols():
+    collection = _new_collection("mem0_p0_ops")
+    db = _new_db(collection)
+    try:
+        _insert_memories(
+            db,
+            [
+                (
+                    _uuid(71),
+                    VECTOR_COFFEE,
+                    {
+                        "data": "Operational memory one",
+                        "text_lemmatized": "operational memory one",
+                        "user_id": "ops_user",
+                    },
+                ),
+                (
+                    _uuid(72),
+                    VECTOR_FLIGHT,
+                    {
+                        "data": "Operational memory two",
+                        "text_lemmatized": "operational memory two",
+                        "user_id": "ops_user",
+                    },
+                ),
+            ],
+        )
+
+        info = db.col_info()
+        assert info["name"] == collection
+        assert info["count"] == 2
+        assert info["schema_version"] >= 1
+        assert info["payload_storage_mode"] == "jsonb"
+        assert info["filter_storage_mode"] == "json_expression"
+        assert any("vector_idx" in index for index in info["indexes"])
+
+        db.analyze()
+        listed_collections = db.list_cols()
+        assert collection in listed_collections
+        assert f"{collection}_schema_meta" not in listed_collections
+
+        db.reset()
+        assert db.col_info()["count"] == 0
+    finally:
+        db.delete_col()
+
+
+def test_migration_dry_run_and_json_backfill_helpers():
+    db = _new_db()
+    try:
+        backfill_id = _uuid(81)
+        _insert_memories(
+            db,
+            [
+                (
+                    backfill_id,
+                    VECTOR_COFFEE,
+                    {
+                        "data": "Backfill should restore derived text",
+                        "text_lemmatized": "backfill should restore derived text",
+                        "user_id": "migration_user",
+                    },
+                )
+            ],
+        )
+
+        with db._get_cursor(commit=True) as cur:
+            cur.execute(f"UPDATE {db.table_name} SET memory = NULL, text_lemmatized = '' WHERE id = %s", (backfill_id,))
+
+        plan = db.migration_dry_run()
+        assert plan["collection_name"] == db.collection_name
+        assert plan["mutates_data"] is False
+        assert "ensure_text_lemmatized_column" in plan["planned_actions"]
+
+        dry_run = db.backfill_derived_fields(dry_run=True)
+        assert dry_run["estimated_rows"] >= 1
+
+        result = db.backfill_derived_fields(dry_run=False)
+        assert result["affected_rows"] >= 1
+        assert db.get(backfill_id).payload["data"] == "Backfill should restore derived text"
+    finally:
+        db.delete_col()
+
+
+def test_concurrent_scoped_searches_return_stable_ids():
+    db = _new_db(maxconn=5)
+    try:
+        expected_id = _uuid(101)
+        _insert_memories(
+            db,
+            [
+                (
+                    expected_id,
+                    VECTOR_COFFEE,
+                    {
+                        "data": "Concurrent search memory",
+                        "text_lemmatized": "concurrent search memory",
+                        "user_id": "concurrent_user",
+                    },
+                )
+            ],
+        )
+
+        def search_once():
+            rows = db.search("concurrent", VECTOR_COFFEE, top_k=1, filters={"user_id": "concurrent_user"})
+            return _ids(rows)
+
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            results = list(executor.map(lambda _: search_once(), range(8)))
+
+        assert results == [[expected_id]] * 8
+    finally:
+        db.delete_col()
+
+
+@pytest.mark.skipif(
+    not _env_bool("GAUSSDB_TEST_RUN_BM25"),
+    reason="Set GAUSSDB_TEST_RUN_BM25=true to run native BM25 live tests",
+)
+def test_bm25_keyword_search_is_scoped_and_empty_query_returns_empty_list():
+    db = _new_db()
+    try:
+        alice_id = _uuid(111)
+        bob_id = _uuid(112)
+        _insert_memories(
+            db,
+            [
+                (
+                    alice_id,
+                    VECTOR_COFFEE,
+                    {
+                        "data": "Alice likes latte coffee",
+                        "text_lemmatized": "alice likes latte coffee",
+                        "user_id": "bm25_alice",
+                    },
+                ),
+                (
+                    bob_id,
+                    VECTOR_COFFEE,
+                    {
+                        "data": "Bob likes latte coffee",
+                        "text_lemmatized": "bob likes latte coffee",
+                        "user_id": "bm25_bob",
+                    },
+                ),
+            ],
+        )
+
+        assert db.keyword_search("", filters={"user_id": "bm25_alice"}) == []
+        rows = db.keyword_search("latte", top_k=10, filters={"user_id": "bm25_alice"})
+        assert rows is not None
+        _assert_exact_ids(rows, {alice_id})
+    finally:
+        db.delete_col()
+
+
+@pytest.mark.skipif(
+    not _env_bool("GAUSSDB_TEST_RUN_INDEX_MATRIX"),
+    reason="Set GAUSSDB_TEST_RUN_INDEX_MATRIX=true to run all vector index and metric combinations",
+)
+@pytest.mark.parametrize("vector_index_type", ["gsivfflat", "gsdiskann"])
+@pytest.mark.parametrize("vector_metric", ["cosine", "l2"])
+def test_vector_index_metric_matrix_builds_and_searches(vector_index_type, vector_metric):
+    db = _new_db(vector_index_type=vector_index_type, vector_metric=vector_metric)
+    try:
+        matrix_id = _uuid(121)
+        _insert_memories(
+            db,
+            [
+                (
+                    matrix_id,
+                    VECTOR_COFFEE,
+                    {
+                        "data": f"{vector_index_type} {vector_metric} matrix memory",
+                        "text_lemmatized": f"{vector_index_type} {vector_metric} matrix memory",
+                        "user_id": "matrix_user",
+                    },
+                )
+            ],
+        )
+        assert _ids(db.search("matrix", VECTOR_COFFEE, top_k=1, filters={"user_id": "matrix_user"})) == [matrix_id]
+        assert any("vector_idx" in index for index in db.col_info()["indexes"])
+    finally:
+        db.delete_col()
+
+
+
+# ===========================================================================
+# Search Quality Replay Tests (from test_gaussdb_quality.py)
+# ===========================================================================
+
+
+class TestQualityReplay:
+    """Quality replay tests using gaussdb_quality_cases.json."""
+
+    def _seed_cases(self, db, cases):
+        db.insert(
+            vectors=[case["vector"] for case in cases],
+            ids=[case["id"] for case in cases],
+            payloads=[
+                {
+                    "data": case["data"],
+                    "text_lemmatized": case["text_lemmatized"],
+                    "user_id": case["user_id"],
+                    "agent_id": case["agent_id"],
+                    "run_id": case["run_id"],
+                }
+                for case in cases
+            ],
+        )
+
+    @pytest.mark.skipif(
+        not Path(__file__).with_name("gaussdb_quality_cases.json").exists(),
+        reason="gaussdb_quality_cases.json not found",
+    )
+    def test_quality_replay_gates(self):
+        cases = _load_quality_cases()
+        if not cases:
+            pytest.skip("No quality cases available")
+        collection_name = f"mem0_gdb_quality_{uuid.uuid4().hex[:8]}"
+        db = _new_db(collection_name=collection_name)
+        try:
+            self._seed_cases(db, cases)
+            semantic_hits = 0
+            keyword_hits = 0
+            filter_leaks = 0
+            for case in cases:
+                filters = {"user_id": case["user_id"]}
+                semantic = db.search(case["semantic_query"], case["semantic_vector"], top_k=5, filters=filters)
+                keyword = db.keyword_search(case["keyword_query"], top_k=5, filters=filters)
+                semantic_ids = {item.id for item in semantic}
+                keyword_ids = {item.id for item in keyword or []}
+                semantic_hits += int(case["id"] in semantic_ids)
+                keyword_hits += int(case["id"] in keyword_ids)
+                filter_leaks += sum(1 for item in semantic if item.payload["user_id"] != case["user_id"])
+                filter_leaks += sum(1 for item in keyword or [] if item.payload["user_id"] != case["user_id"])
+            assert semantic_hits / len(cases) >= 0.95
+            assert keyword_hits / len(cases) >= 0.90
+            assert filter_leaks == 0
+            update_case = cases[0]
+            db.update(
+                update_case["id"],
+                payload={
+                    "data": "Alice now prefers aisle seats",
+                    "text_lemmatized": "alice now prefer aisle seat",
+                    "user_id": update_case["user_id"],
+                    "agent_id": update_case["agent_id"],
+                    "run_id": update_case["run_id"],
+                },
+            )
+            assert db.get(update_case["id"]).payload["data"] == "Alice now prefers aisle seats"
+            db.delete(cases[1]["id"])
+            assert db.get(cases[1]["id"]) is None
+        finally:
+            db.delete_col()
+
+    @pytest.mark.skipif(
+        not Path(__file__).with_name("gaussdb_quality_cases.json").exists(),
+        reason="gaussdb_quality_cases.json not found",
+    )
+    def test_concurrent_operations(self):
+        cases = _load_quality_cases()
+        if not cases:
+            pytest.skip("No quality cases available")
+        collection_name = f"mem0_gdb_concurrent_{uuid.uuid4().hex[:8]}"
+        db = _new_db(collection_name=collection_name)
+        try:
+            self._seed_cases(db, cases)
+            def search_case(case):
+                return db.search(
+                    case["semantic_query"], case["semantic_vector"], top_k=3, filters={"user_id": case["user_id"]}
+                )
+            with ThreadPoolExecutor(max_workers=4) as executor:
+                results = list(executor.map(search_case, cases))
+            assert len(results) == len(cases)
+            assert all(result for result in results)
+            assert all(group[0].score > 0 for group in results)
+        finally:
+            db.delete_col()
+
+    @pytest.mark.skipif(
+        not Path(__file__).with_name("gaussdb_quality_cases.json").exists(),
+        reason="gaussdb_quality_cases.json not found",
+    )
+    @pytest.mark.skipif(
+        os.getenv("GAUSSDB_TEST_BENCHMARK", "false").lower() != "true",
+        reason="Set GAUSSDB_TEST_BENCHMARK=true to run benchmark",
+    )
+    def test_benchmark_report(self):
+        cases = _load_quality_cases()
+        if not cases:
+            pytest.skip("No quality cases available")
+        collection_name = f"mem0_gdb_bench_{uuid.uuid4().hex[:8]}"
+        db = _new_db(collection_name=collection_name)
+        try:
+            latencies = {"insert": [], "semantic_search": [], "keyword_search": [], "update": [], "delete": []}
+            for _ in range(5):
+                started = time.perf_counter()
+                self._seed_cases(db, cases)
+                latencies["insert"].append((time.perf_counter() - started) * 1000)
+                for case in cases:
+                    started = time.perf_counter()
+                    db.search(case["semantic_query"], case["semantic_vector"], top_k=5, filters={"user_id": case["user_id"]})
+                    latencies["semantic_search"].append((time.perf_counter() - started) * 1000)
+                    started = time.perf_counter()
+                    db.keyword_search(case["keyword_query"], top_k=5, filters={"user_id": case["user_id"]})
+                    latencies["keyword_search"].append((time.perf_counter() - started) * 1000)
+                    started = time.perf_counter()
+                    db.update(case["id"], payload={"data": case["data"], "text_lemmatized": case["text_lemmatized"], "user_id": case["user_id"], "agent_id": case["agent_id"], "run_id": case["run_id"]})
+                    latencies["update"].append((time.perf_counter() - started) * 1000)
+                started = time.perf_counter()
+                db.delete(cases[-1]["id"])
+                latencies["delete"].append((time.perf_counter() - started) * 1000)
+            report = {
+                key: statistics.quantiles(values, n=20)[-1] if len(values) >= 2 else values[0]
+                for key, values in latencies.items()
+            }
+            assert report["semantic_search"] < float(os.getenv("GAUSSDB_TEST_SEMANTIC_P95_MS", "300"))
+            assert report["keyword_search"] < float(os.getenv("GAUSSDB_TEST_KEYWORD_P95_MS", "300"))
+        finally:
+            db.delete_col()
+
+
+# ===========================================================================
+# E2E Direct DB Tests (from test_gaussdb_e2e.py, converted to pytest)
+# ===========================================================================
+
+
+class TestE2EDirect:
+    """Direct DB verification tests converted from standalone E2E script."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.db = _new_db(prefix="e2e", embedding_model_dims=1536, vector_index_type="gsdiskann")
+
+    @classmethod
+    def teardown_class(cls):
+        cls.db.delete_col()
+
+    def test_e2e_insert_single(self):
+        vid = str(uuid.uuid4())
+        vec = _make_vector_seeded(42, dims=1536)
+        payload = {"data": "test memory", "user_id": "e2e_user", "category": "test"}
+        self.db.insert(vectors=[vec], ids=[vid], payloads=[payload])
+        result = self.db.get(vid)
+        assert result is not None
+        assert result.id == vid
+        assert result.payload["data"] == "test memory"
+
+    def test_e2e_insert_batch(self):
+        ids = [str(uuid.uuid4()) for _ in range(10)]
+        vectors = [_make_vector_seeded(i, dims=1536) for i in range(10)]
+        payloads = [{"data": f"memory_{i}", "user_id": "e2e_user"} for i in range(10)]
+        self.db.insert(vectors=vectors, ids=ids, payloads=payloads)
+        listed = _list_flat(self.db, filters={"user_id": "e2e_user"}, top_k=100)
+        assert len(listed) == 10
+
+    def test_e2e_upsert_existing(self):
+        vid = str(uuid.uuid4())
+        vec = _make_vector_seeded(100, dims=1536)
+        self.db.insert(vectors=[vec], ids=[vid], payloads=[{"data": "original", "user_id": "e2e_user"}])
+        new_vec = _make_vector_seeded(101, dims=1536)
+        self.db.update(vector_id=vid, vector=new_vec, payload={"data": "updated", "user_id": "e2e_user"})
+        result = self.db.get(vid)
+        assert result.payload["data"] == "updated"
+        listed = _list_flat(self.db, filters={"user_id": "e2e_user"}, top_k=100)
+        assert len(listed) == 1
+
+    def test_e2e_semantic_search(self):
+        vecs = [_make_vector_seeded(i, dims=1536) for i in range(5)]
+        ids = [str(uuid.uuid4()) for _ in range(5)]
+        payloads = [{"data": f"item_{i}", "user_id": "e2e_user"} for i in range(5)]
+        self.db.insert(vectors=vecs, ids=ids, payloads=payloads)
+        query_vec = _make_vector_seeded(0, dims=1536)
+        results = self.db.search("item", query_vec, top_k=1, filters={"user_id": "e2e_user"})
+        assert len(results) >= 1
+        assert results[0].id == ids[0]
+
+    def test_e2e_search_with_filters(self):
+        ids = [str(uuid.uuid4()) for _ in range(4)]
+        vecs = [_make_vector_seeded(i, dims=1536) for i in range(4)]
+        payloads = [
+            {"data": "alice food", "user_id": "alice", "category": "food"},
+            {"data": "alice travel", "user_id": "alice", "category": "travel"},
+            {"data": "bob food", "user_id": "bob", "category": "food"},
+            {"data": "bob work", "user_id": "bob", "category": "work"},
+        ]
+        self.db.insert(vectors=vecs, ids=ids, payloads=payloads)
+        results = self.db.search("food", vecs[0], top_k=10, filters={"user_id": "alice", "category": "food"})
+        assert all(r.payload["user_id"] == "alice" for r in results)
+        assert all(r.payload["category"] == "food" for r in results)
+
+    @pytest.mark.skipif(
+        not _env_bool("GAUSSDB_TEST_RUN_BM25"),
+        reason="Set GAUSSDB_TEST_RUN_BM25=true to run BM25 tests",
+    )
+    def test_e2e_bm25_keyword_search(self):
+        vid = str(uuid.uuid4())
+        vec = _make_vector_seeded(200, dims=1536)
+        self.db.insert(
+            vectors=[vec], ids=[vid],
+            payloads=[{"data": "Python programming language", "user_id": "e2e_user", "text_lemmatized": "python programming language"}],
+        )
+        results = self.db.keyword_search("Python", top_k=5, filters={"user_id": "e2e_user"})
+        if results:
+            assert any(r.id == vid for r in results)
+
+    def test_e2e_update_payload(self):
+        vid = str(uuid.uuid4())
+        vec = _make_vector_seeded(300, dims=1536)
+        self.db.insert(vectors=[vec], ids=[vid], payloads=[{"data": "original", "user_id": "e2e_user"}])
+        self.db.update(vector_id=vid, payload={"data": "modified", "user_id": "e2e_user", "extra": "field"})
+        result = self.db.get(vid)
+        assert result.payload["data"] == "modified"
+        assert result.payload["extra"] == "field"
+
+    def test_e2e_update_vector(self):
+        vid = str(uuid.uuid4())
+        vec = _make_vector_seeded(301, dims=1536)
+        self.db.insert(vectors=[vec], ids=[vid], payloads=[{"data": "vec update", "user_id": "e2e_user"}])
+        new_vec = _make_vector_seeded(302, dims=1536)
+        self.db.update(vector_id=vid, vector=new_vec)
+        results = self.db.search("vec", new_vec, top_k=1, filters={"user_id": "e2e_user"})
+        assert len(results) >= 1
+        assert results[0].id == vid
+
+    def test_e2e_delete_by_id(self):
+        vid = str(uuid.uuid4())
+        vec = _make_vector_seeded(400, dims=1536)
+        self.db.insert(vectors=[vec], ids=[vid], payloads=[{"data": "to delete", "user_id": "e2e_user"}])
+        self.db.delete(vector_id=vid)
+        assert self.db.get(vid) is None
+
+    def test_e2e_list_with_filters(self):
+        ids = [str(uuid.uuid4()) for _ in range(6)]
+        vecs = [_make_vector_seeded(i + 500, dims=1536) for i in range(6)]
+        payloads = [
+            {"data": f"item_{i}", "user_id": "alice" if i < 3 else "bob"}
+            for i in range(6)
+        ]
+        self.db.insert(vectors=vecs, ids=ids, payloads=payloads)
+        alice_items = _list_flat(self.db, filters={"user_id": "alice"}, top_k=100)
+        assert len(alice_items) == 3
+        bob_items = _list_flat(self.db, filters={"user_id": "bob"}, top_k=100)
+        assert len(bob_items) == 3
+
+    def test_e2e_list_collections(self):
+        cols = self.db.list_cols()
+        assert isinstance(cols, list)
+        assert self.db.collection_name in cols
+
+    def test_e2e_collection_info(self):
+        vid = str(uuid.uuid4())
+        vec = _make_vector_seeded(600, dims=1536)
+        self.db.insert(vectors=[vec], ids=[vid], payloads=[{"data": "info test", "user_id": "e2e_user"}])
+        info = self.db.col_info()
+        assert info["name"] == self.db.collection_name
+        assert info["count"] >= 1
+        assert info["dimension"] == 1536
+
+    def test_e2e_large_payload(self):
+        vid = str(uuid.uuid4())
+        vec = _make_vector_seeded(700, dims=1536)
+        large_text = "x" * 10000
+        self.db.insert(vectors=[vec], ids=[vid], payloads=[{"data": large_text, "user_id": "e2e_user"}])
+        result = self.db.get(vid)
+        assert result is not None
+        assert len(result.payload["data"]) == 10000
+
+    def test_e2e_unicode_payload(self):
+        vid = str(uuid.uuid4())
+        vec = _make_vector_seeded(800, dims=1536)
+        text = "中文测试 日本語 한국어 emoji: 🚀💻"
+        self.db.insert(vectors=[vec], ids=[vid], payloads=[{"data": text, "user_id": "e2e_user"}])
+        result = self.db.get(vid)
+        assert result.payload["data"] == text
+
+    def test_e2e_concurrent_upsert_idempotency(self):
+        vid = str(uuid.uuid4())
+        vec = _make_vector_seeded(900, dims=1536)
+        self.db.insert(vectors=[vec], ids=[vid], payloads=[{"data": "concurrent", "user_id": "e2e_user"}])
+
+        def do_upsert(idx):
+            self.db.update(vector_id=vid, payload={"data": f"update_{idx}", "user_id": "e2e_user"})
+
+        with ThreadPoolExecutor(max_workers=5) as executor:
+            list(executor.map(do_upsert, range(10)))
+
+        result = self.db.get(vid)
+        assert result is not None
+        assert result.payload["user_id"] == "e2e_user"
+        listed = _list_flat(self.db, filters={"user_id": "e2e_user"}, top_k=100)
+        assert len(listed) == 1
+
+    def test_e2e_reset_collection(self):
+        db = _new_db(prefix="e2e_reset", embedding_model_dims=1536, vector_index_type="gsdiskann")
+        try:
+            ids = [str(uuid.uuid4()) for _ in range(5)]
+            vecs = [_make_vector_seeded(i + 1000, dims=1536) for i in range(5)]
+            payloads = [{"data": f"item_{i}", "user_id": "e2e_reset_user"} for i in range(5)]
+            db.insert(vectors=vecs, ids=ids, payloads=payloads)
+            assert len(_list_flat(db, filters={"user_id": "e2e_reset_user"}, top_k=100)) == 5
+            db.reset()
+            listed = _list_flat(db, filters={"user_id": "e2e_reset_user"}, top_k=100)
+            assert len(listed) == 0
+        finally:
+            db.delete_col()
+
+    def test_e2e_delete_collection(self):
+        db = _new_db(prefix="e2e_delcol", embedding_model_dims=1536, vector_index_type="gsdiskann")
+        vid = str(uuid.uuid4())
+        vec = _make_vector_seeded(1100, dims=1536)
+        db.insert(vectors=[vec], ids=[vid], payloads=[{"data": "cleanup", "user_id": "e2e_delcol_user"}])
+        db.delete_col()
+        cols = db.list_cols()
+        assert db.collection_name not in cols
+
+
+
+# ===========================================================================
+# E2E Full Verification Tests (from test_gaussdb_e2e_full.py, converted to pytest)
+# ===========================================================================
+
+
+class TestE2EFull:
+    """Full E2E verification covering CRUD, edge cases, filters, batch ops."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.db = _new_db(prefix="e2e_full", embedding_model_dims=4)
+
+    @classmethod
+    def teardown_class(cls):
+        cls.db.delete_col()
+
+    def test_full_init_and_create_collection(self):
+        cols = self.db.list_cols()
+        assert self.db.collection_name in cols
+        info = self.db.col_info()
+        assert info["name"] == self.db.collection_name
+        assert info["dimension"] == 4
+
+    def test_full_crud_lifecycle(self):
+        """Insert, get, update, search, delete lifecycle."""
+        id1 = str(uuid.uuid5(uuid.NAMESPACE_DNS, "test-record-1"))
+        id2 = str(uuid.uuid5(uuid.NAMESPACE_DNS, "test-record-2"))
+        id3 = str(uuid.uuid5(uuid.NAMESPACE_DNS, "test-record-3"))
+
+        # Insert
+        self.db.insert(
+            ids=[id1, id2, id3],
+            vectors=[[0.1, 0.2, 0.3, 0.4], [0.5, 0.6, 0.7, 0.8], [0.9, 0.1, 0.2, 0.3]],
+            payloads=[
+                {"data": "first record", "user_id": "full_user", "category": "A"},
+                {"data": "second record", "user_id": "full_user", "category": "B"},
+                {"data": "third record", "user_id": "full_user", "category": "A"},
+            ],
+        )
+
+        # Get
+        r1 = self.db.get(id1)
+        assert r1 is not None
+        assert r1.payload["data"] == "first record"
+
+        # Update payload
+        self.db.update(vector_id=id1, payload={"data": "updated first", "user_id": "full_user", "category": "A"})
+        r1_updated = self.db.get(id1)
+        assert r1_updated.payload["data"] == "updated first"
+
+        # Update vector
+        self.db.update(vector_id=id2, vector=[0.99, 0.99, 0.99, 0.99])
+        results = self.db.search("test", [0.99, 0.99, 0.99, 0.99], top_k=1, filters={"user_id": "full_user"})
+        assert results[0].id == id2
+
+        # Search with filter
+        results = self.db.search("test", [0.1, 0.2, 0.3, 0.4], top_k=10, filters={"user_id": "full_user", "category": "A"})
+        result_ids = {r.id for r in results}
+        assert id1 in result_ids
+        assert id3 in result_ids
+        assert id2 not in result_ids
+
+        # Delete
+        self.db.delete(vector_id=id3)
+        assert self.db.get(id3) is None
+
+        # List remaining
+        listed = _list_flat(self.db, filters={"user_id": "full_user"}, top_k=100)
+        assert len(listed) == 2
+
+    def test_full_edge_cases_empty_search(self):
+        """Search on empty collection returns empty list."""
+        results = self.db.search("nothing", [0.1, 0.2, 0.3, 0.4], top_k=5, filters={"user_id": "nobody"})
+        assert results == [] or len(results) == 0
+
+    def test_full_edge_cases_special_chars_payload(self):
+        """Payload with special characters stored and retrieved correctly."""
+        vid = str(uuid.uuid4())
+        special = 'C++ & C# are <great> languages; SELECT * FROM \'table\' WHERE x="test" -- comment'
+        self.db.insert(
+            ids=[vid], vectors=[[0.1, 0.2, 0.3, 0.4]],
+            payloads=[{"data": special, "user_id": "full_user"}],
+        )
+        result = self.db.get(vid)
+        assert result.payload["data"] == special
+
+    def test_full_edge_cases_null_like_values(self):
+        """Empty string and None-like values in payload."""
+        vid = str(uuid.uuid4())
+        self.db.insert(
+            ids=[vid], vectors=[[0.1, 0.2, 0.3, 0.4]],
+            payloads=[{"data": "", "user_id": "full_user", "note": "null_test"}],
+        )
+        result = self.db.get(vid)
+        assert result.payload["data"] == ""
+
+    def test_full_filters_eq_ne_in_nin(self):
+        """Filter operators eq, ne, in, nin work correctly."""
+        ids = [str(uuid.uuid4()) for _ in range(4)]
+        self.db.insert(
+            ids=ids,
+            vectors=[[0.1, 0.2, 0.3, 0.4]] * 4,
+            payloads=[
+                {"data": "a", "user_id": "filter_user", "category": "food", "priority": "1"},
+                {"data": "b", "user_id": "filter_user", "category": "travel", "priority": "2"},
+                {"data": "c", "user_id": "filter_user", "category": "work", "priority": "3"},
+                {"data": "d", "user_id": "filter_user", "category": "food", "priority": "4"},
+            ],
+        )
+        # eq
+        results = self.db.search("test", [0.1, 0.2, 0.3, 0.4], top_k=10, filters={"user_id": "filter_user", "category": {"eq": "food"}})
+        assert len(results) == 2
+        # ne
+        results = self.db.search("test", [0.1, 0.2, 0.3, 0.4], top_k=10, filters={"user_id": "filter_user", "category": {"ne": "food"}})
+        assert len(results) == 2
+        # in
+        results = self.db.search("test", [0.1, 0.2, 0.3, 0.4], top_k=10, filters={"user_id": "filter_user", "category": {"in": ["food", "travel"]}})
+        assert len(results) == 3
+        # nin
+        results = self.db.search("test", [0.1, 0.2, 0.3, 0.4], top_k=10, filters={"user_id": "filter_user", "category": {"nin": ["food"]}})
+        assert len(results) == 2
+
+    @pytest.mark.skipif(
+        not _env_bool("GAUSSDB_TEST_RUN_BM25"),
+        reason="Set GAUSSDB_TEST_RUN_BM25=true to run BM25 tests",
+    )
+    def test_full_bm25_search(self):
+        """BM25 keyword search works in full E2E context."""
+        vid = str(uuid.uuid4())
+        self.db.insert(
+            ids=[vid], vectors=[[0.1, 0.2, 0.3, 0.4]],
+            payloads=[{"data": "Python machine learning", "user_id": "bm25_user", "text_lemmatized": "python machine learning"}],
+        )
+        results = self.db.keyword_search("Python", top_k=5, filters={"user_id": "bm25_user"})
+        if results:
+            assert any(r.id == vid for r in results)
+
+    def test_full_batch_operations(self):
+        """Batch insert and search operations."""
+        count = 50
+        ids = [str(uuid.uuid4()) for _ in range(count)]
+        vectors = [[random.random() for _ in range(4)] for _ in range(count)]
+        payloads = [{"data": f"batch_{i}", "user_id": "batch_user"} for i in range(count)]
+        self.db.insert(ids=ids, vectors=vectors, payloads=payloads)
+        listed = _list_flat(self.db, filters={"user_id": "batch_user"}, top_k=200)
+        assert len(listed) == count
+
+    def test_full_rapid_upsert(self):
+        """Rapid upsert of same ID is idempotent."""
+        vid = str(uuid.uuid4())
+        vec = [0.5, 0.5, 0.5, 0.5]
+        for i in range(10):
+            self.db.insert(ids=[vid], vectors=[vec], payloads=[{"data": f"version_{i}", "user_id": "rapid_user"}])
+        listed = _list_flat(self.db, filters={"user_id": "rapid_user"}, top_k=100)
+        assert len(listed) == 1
+        result = self.db.get(vid)
+        assert result.payload["data"] == "version_9"
+
+    def test_full_data_integrity(self):
+        """Data integrity: no silent corruption after multiple operations."""
+        ids = [str(uuid.uuid4()) for _ in range(20)]
+        vectors = [[float(i) / 20, float(i) / 20, float(i) / 20, float(i) / 20] for i in range(20)]
+        payloads = [{"data": f"integrity_{i}", "user_id": "integrity_user", "index": str(i)} for i in range(20)]
+        self.db.insert(ids=ids, vectors=vectors, payloads=payloads)
+
+        # Verify all records
+        for i, vid in enumerate(ids):
+            result = self.db.get(vid)
+            assert result is not None, f"Record {i} missing"
+            assert result.payload["data"] == f"integrity_{i}"
+            assert result.payload["index"] == str(i)
+
+        # Delete some, verify others unaffected
+        for vid in ids[:5]:
+            self.db.delete(vector_id=vid)
+        for i, vid in enumerate(ids[5:], start=5):
+            result = self.db.get(vid)
+            assert result is not None, f"Record {i} should still exist"
+            assert result.payload["data"] == f"integrity_{i}"
+
+    def test_full_reset_collection(self):
+        """Reset collection removes all data."""
+        db = _new_db(prefix="e2e_full_reset", embedding_model_dims=4)
+        try:
+            ids = [str(uuid.uuid4()) for _ in range(5)]
+            vectors = [[0.1, 0.2, 0.3, 0.4]] * 5
+            payloads = [{"data": f"item_{i}", "user_id": "reset_user"} for i in range(5)]
+            db.insert(ids=ids, vectors=vectors, payloads=payloads)
+            assert len(_list_flat(db, filters={"user_id": "reset_user"}, top_k=100)) == 5
+            db.reset()
+            listed = _list_flat(db, filters={"user_id": "reset_user"}, top_k=100)
+            assert len(listed) == 0
+        finally:
+            db.delete_col()
+
+
+
+# ===========================================================================
+# Memory API E2E Tests (from test_gaussdb_e2e_memory.py, converted to pytest)
+# ===========================================================================
+
+
+class TestMemoryAPI:
+    """Tests using Memory.from_config upper-layer API with GaussDB backend."""
+
+    def _make_memory(self, collection_name):
+        """Build a Memory instance with mocked LLM/Embedder using GaussDB backend."""
+        vector_config = _gaussdb_env_config(collection_name, embedding_model_dims=EMBEDDING_DIMS)
+        if vector_config is None:
+            pytest.skip("GaussDB env not configured")
+
+        memory_config = {
+            "vector_store": {"provider": "gaussdb", "config": vector_config},
+            "embedder": {"provider": "openai", "config": {"model": "fake", "api_key": "fake"}},
+            "llm": {"provider": "openai", "config": {"model": "fake", "api_key": "fake"}},
+            "version": "v1.1",
+        }
+
+        with (
+            patch("mem0.memory.main.EmbedderFactory.create", return_value=FakeEmbedder()),
+            patch("mem0.memory.main.LlmFactory.create", return_value=MagicMock()),
+            patch("mem0.memory.main.SQLiteManager", return_value=MagicMock()),
+            patch("mem0.memory.main.extract_entities", return_value=[]),
+            patch("mem0.memory.main.capture_event", lambda *args, **kwargs: None),
+            patch("mem0.memory.main.MEM0_TELEMETRY", False),
+        ):
+            return Memory.from_config(memory_config)
+
+    def test_memory_add_and_search(self):
+        """Memory.add and Memory.search work with GaussDB backend."""
+        collection = _new_collection_name("mem_api")
+        m = self._make_memory(collection)
+        try:
+            user_id = f"mem_test_{uuid.uuid4().hex[:6]}"
+            added = m.add(
+                "I love coffee and window seats",
+                user_id=user_id,
+                infer=False,
+                metadata={"source": "centralized-test"},
+            )
+            assert len(added.get("results", [])) >= 1
+
+            results = m.search("coffee", filters={"user_id": user_id}, top_k=5, threshold=0)
+            assert len(results.get("results", [])) >= 1
+        finally:
+            try:
+                m.vector_store.delete_col()
+            except Exception:
+                pass
+
+    def test_memory_get_all(self):
+        """Memory.get_all returns stored memories."""
+        collection = _new_collection_name("mem_api")
+        m = self._make_memory(collection)
+        try:
+            user_id = f"mem_test_{uuid.uuid4().hex[:6]}"
+            m.add(
+                "I prefer aisle seats on flights",
+                user_id=user_id,
+                infer=False,
+            )
+            all_memories = m.get_all(filters={"user_id": user_id})
+            memories_list = all_memories.get("results", all_memories.get("memories", []))
+            assert len(memories_list) >= 1
+        finally:
+            try:
+                m.vector_store.delete_col()
+            except Exception:
+                pass
+
+    def test_memory_delete(self):
+        """Memory.delete removes a specific memory."""
+        collection = _new_collection_name("mem_api")
+        m = self._make_memory(collection)
+        try:
+            user_id = f"mem_test_{uuid.uuid4().hex[:6]}"
+            result = m.add(
+                "I like hiking in the mountains",
+                user_id=user_id,
+                infer=False,
+            )
+            memories = result.get("results", [])
+            assert len(memories) >= 1
+            mem_id = memories[0]["id"]
+
+            m.delete(mem_id)
+            assert m.vector_store.get(mem_id) is None
+        finally:
+            try:
+                m.vector_store.delete_col()
+            except Exception:
+                pass
+
+    def test_memory_delete_all(self):
+        """Memory.delete_all removes all memories for a user."""
+        collection = _new_collection_name("mem_api")
+        m = self._make_memory(collection)
+        try:
+            user_id = f"mem_test_{uuid.uuid4().hex[:6]}"
+            m.add("Memory one", user_id=user_id, infer=False)
+            m.add("Memory two", user_id=user_id, infer=False)
+            m.delete_all(user_id=user_id)
+            all_after = m.get_all(filters={"user_id": user_id})
+            remaining = all_after.get("results", all_after.get("memories", []))
+            assert len(remaining) == 0
+        finally:
+            try:
+                m.vector_store.delete_col()
+            except Exception:
+                pass
+
+
+
+# ===========================================================================
+# Multi-language Tests (from test_gaussdb_e2e_multilang.py, converted to pytest)
+# ===========================================================================
+
+MULTILANG_CASES = [
+    {
+        "lang": "English",
+        "text": "I love programming in Python and building machine learning models.",
+        "bm25_query": "Python programming",
+        "payload": {"user_id": "lang_test", "category": "tech", "language": "en"},
+    },
+    {
+        "lang": "Chinese (Simplified)",
+        "text": "我喜欢用Python做数据分析和机器学习，周末经常去公园跑步。",
+        "bm25_query": "Python数据分析",
+        "payload": {"user_id": "lang_test", "category": "tech", "language": "zh-CN"},
+    },
+    {
+        "lang": "Chinese (Traditional)",
+        "text": "台灣的珍珠奶茶非常好喝，我每天都要來一杯。",
+        "bm25_query": "珍珠奶茶",
+        "payload": {"user_id": "lang_test", "category": "food", "language": "zh-TW"},
+    },
+    {
+        "lang": "Japanese",
+        "text": "東京の桜は春に美しく咲きます。日本語のプログラミング教材を読んでいます。",
+        "bm25_query": "桜",
+        "payload": {"user_id": "lang_test", "category": "culture", "language": "ja"},
+    },
+    {
+        "lang": "Korean",
+        "text": "서울에서 김치찌개를 먹었습니다. 한국어 공부를 열심히 하고 있습니다.",
+        "bm25_query": "김치찌개",
+        "payload": {"user_id": "lang_test", "category": "food", "language": "ko"},
+    },
+    {
+        "lang": "Arabic",
+        "text": "أنا أحب البرمجة وتعلم اللغات الجديدة. القهوة العربية لذيذة جداً.",
+        "bm25_query": "البرمجة",
+        "payload": {"user_id": "lang_test", "category": "tech", "language": "ar"},
+    },
+    {
+        "lang": "Emoji + Mixed",
+        "text": "🎉 Hello世界! Python🐍 is awesome すごい 太棒了 fantastique! 🚀💻",
+        "bm25_query": "Python",
+        "payload": {"user_id": "lang_test", "category": "mixed", "language": "mixed"},
+    },
+]
+
+
+class TestMultilang:
+    """Multi-language text storage and retrieval tests."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.db = _new_db(prefix="multilang", embedding_model_dims=1536, vector_index_type="gsdiskann")
+
+    @classmethod
+    def teardown_class(cls):
+        cls.db.delete_col()
+
+    def test_multilang_insert_and_retrieve(self):
+        """Insert multilang text and verify payload integrity."""
+        ids = []
+        for i, case in enumerate(MULTILANG_CASES):
+            vid = str(uuid.uuid4())
+            ids.append(vid)
+            vec = _make_vector_seeded(i, dims=1536)
+            payload = {**case["payload"], "text": case["text"]}
+            self.db.insert(vectors=[vec], ids=[vid], payloads=[payload])
+
+        # Verify all texts stored correctly
+        for i, (case, vid) in enumerate(zip(MULTILANG_CASES, ids)):
+            record = self.db.get(vector_id=vid)
+            assert record is not None, f"{case['lang']} record not found"
+            stored_text = record.payload.get("text", "")
+            assert stored_text == case["text"], f"{case['lang']} text mismatch"
+
+    def test_multilang_vector_search(self):
+        """Vector search returns correct results for multilang data."""
+        ids = []
+        for i, case in enumerate(MULTILANG_CASES):
+            vid = str(uuid.uuid4())
+            ids.append(vid)
+            vec = _make_vector_seeded(i, dims=1536)
+            payload = {**case["payload"], "text": case["text"]}
+            self.db.insert(vectors=[vec], ids=[vid], payloads=[payload])
+
+        # Search with same vector should return self as top hit
+        for i, case in enumerate(MULTILANG_CASES):
+            query_vec = _make_vector_seeded(i, dims=1536)
+            hits = self.db.search(case["text"], query_vec, top_k=1, filters={"user_id": "lang_test"})
+            assert len(hits) >= 1
+            assert hits[0].id == ids[i], f"{case['lang']} search failed"
+
+    @pytest.mark.skipif(
+        not _env_bool("GAUSSDB_TEST_RUN_BM25"),
+        reason="Set GAUSSDB_TEST_RUN_BM25=true to run BM25 tests",
+    )
+    def test_multilang_bm25_search(self):
+        """BM25 search works with multilang text."""
+        ids = []
+        for i, case in enumerate(MULTILANG_CASES):
+            vid = str(uuid.uuid4())
+            ids.append(vid)
+            vec = _make_vector_seeded(i, dims=1536)
+            payload = {**case["payload"], "text": case["text"], "text_lemmatized": case["text"].lower()}
+            self.db.insert(vectors=[vec], ids=[vid], payloads=[payload])
+
+        for i, case in enumerate(MULTILANG_CASES):
+            results = self.db.keyword_search(
+                query=case["bm25_query"], top_k=5, filters={"user_id": "lang_test"}
+            )
+            # BM25 may not work for all languages, just verify no crash
+            assert results is None or isinstance(results, list)
+
+    def test_multilang_update_payload(self):
+        """Update payload with multilang text."""
+        vid = str(uuid.uuid4())
+        vec = _make_vector_seeded(0, dims=1536)
+        self.db.insert(vectors=[vec], ids=[vid], payloads=[{"data": "original", "user_id": "lang_test"}])
+
+        new_text = "更新后的中文文本：华为GaussDB是一款优秀的分布式数据库。"
+        self.db.update(vector_id=vid, payload={"data": new_text, "user_id": "lang_test", "updated": "true"})
+        record = self.db.get(vector_id=vid)
+        assert record.payload["data"] == new_text
+        assert record.payload["updated"] == "true"
+
+    def test_multilang_delete_and_verify(self):
+        """Delete multilang record and verify removal."""
+        vid = str(uuid.uuid4())
+        vec = _make_vector_seeded(99, dims=1536)
+        self.db.insert(vectors=[vec], ids=[vid], payloads=[{"data": "中文测试", "user_id": "lang_test"}])
+        self.db.delete(vector_id=vid)
+        assert self.db.get(vector_id=vid) is None
+

--- a/tests/vector_stores/test_gaussdb_commercial_validation.py
+++ b/tests/vector_stores/test_gaussdb_commercial_validation.py
@@ -1,0 +1,803 @@
+"""
+Commercial-grade validation suite for the GaussDB mem0 provider.
+
+This suite focuses on the behaviors we would want to hold for a production
+export gate: collection lifecycle, scoped isolation, supported filter
+semantics, unsupported range behavior, ranking stability, UTF-8 safety,
+keyword search, and distributed-mode smoke coverage.
+"""
+
+import logging
+import os
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+pytest.importorskip("psycopg2", reason="GaussDB live tests require psycopg2-compatible driver")
+
+from mem0.vector_stores.gaussdb import GaussDB
+from tests.vector_stores.conftest import (
+    VECTOR_AISLE,
+    VECTOR_COFFEE,
+    VECTOR_FLIGHT,
+    VECTOR_UNIT_X,
+    VECTOR_UNIT_Y,
+    VECTOR_UNIT_Z,
+    VECTOR_WINDOW,
+    _assert_exact_ids,
+    _assert_ordered_ids,
+    _env_bool,
+    _gaussdb_env_config,
+    _ids,
+    _insert_memories,
+    _list_flat,
+    _managed_db,
+    _new_collection_name,
+    _uuid,
+    gaussdb_available,
+)
+
+
+pytestmark = pytest.mark.skipif(
+    not gaussdb_available(),
+    reason="Set GAUSSDB_TEST_DSN or GAUSSDB_TEST_HOST/PORT/DATABASE/USER/PASSWORD to run GaussDB live tests",
+)
+
+
+def _new_dist_db(prefix: str = "commercial_dist", **overrides) -> GaussDB:
+    config = _gaussdb_env_config(
+        _new_collection_name(prefix),
+        deployment_mode="distributed",
+        embedding_model_dims=overrides.pop("embedding_model_dims", 4),
+        **overrides,
+    )
+    assert config is not None, "GaussDB distributed test environment not configured"
+    return GaussDB(**config)
+
+
+def test_commercial_centralized_collection_contract():
+    with _managed_db(prefix="commercial_contract", embedding_model_dims=4, vector_index_type="gsdiskann") as db:
+        info = db.col_info()
+
+        assert db.collection_name in db.list_cols()
+        assert info["name"] == db.collection_name
+        assert info["dimension"] == 4
+        assert info["deployment_mode"] == "centralized"
+        assert info["payload_storage_mode"] == "jsonb"
+        assert info["filter_storage_mode"] == "json_expression"
+        assert any("vector" in index.lower() for index in info["indexes"])
+
+
+def test_commercial_centralized_crud_scope_and_batch_paths():
+    with _managed_db(prefix="commercial_crud") as db:
+        alice_primary = _uuid(9101)
+        alice_secondary = _uuid(9102)
+        bob_only = _uuid(9103)
+
+        _insert_memories(
+            db,
+            [
+                (
+                    alice_primary,
+                    VECTOR_COFFEE,
+                    {
+                        "data": "Alice likes morning latte coffee",
+                        "text_lemmatized": "alice likes morning latte coffee",
+                        "user_id": "commercial_alice",
+                        "category": "drink",
+                    },
+                ),
+                (
+                    alice_secondary,
+                    VECTOR_WINDOW,
+                    {
+                        "data": "Alice prefers window seats on flights",
+                        "text_lemmatized": "alice prefers window seats on flights",
+                        "user_id": "commercial_alice",
+                        "category": "travel",
+                    },
+                ),
+                (
+                    bob_only,
+                    VECTOR_AISLE,
+                    {
+                        "data": "Bob prefers aisle seats",
+                        "text_lemmatized": "bob prefers aisle seats",
+                        "user_id": "commercial_bob",
+                        "category": "travel",
+                    },
+                ),
+            ],
+        )
+
+        assert db.get(alice_primary).payload["user_id"] == "commercial_alice"
+        _assert_exact_ids(
+            db.search("latte", VECTOR_COFFEE, top_k=10, filters={"user_id": "commercial_alice"}),
+            {alice_primary, alice_secondary},
+        )
+        _assert_exact_ids(
+            _list_flat(db, filters={"user_id": "commercial_alice"}, top_k=10),
+            {alice_primary, alice_secondary},
+        )
+
+        batch_rows = db.search_batch(
+            ["latte", "window"],
+            [VECTOR_COFFEE, VECTOR_WINDOW],
+            top_k=2,
+            filters={"user_id": "commercial_alice"},
+        )
+        assert [set(_ids(rows)) for rows in batch_rows] == [{alice_primary, alice_secondary}, {alice_secondary, alice_primary}]
+
+        db.update(
+            vector_id=alice_secondary,
+            vector=VECTOR_FLIGHT,
+            payload={
+                "data": "Alice now prefers flights with priority boarding",
+                "text_lemmatized": "alice now prefers flights with priority boarding",
+                "user_id": "commercial_alice",
+                "category": "travel",
+            },
+        )
+        assert db.get(alice_secondary).payload["data"] == "Alice now prefers flights with priority boarding"
+
+        db.insert(
+            ids=[alice_primary],
+            vectors=[VECTOR_COFFEE],
+            payloads=[
+                {
+                    "data": "Alice likes espresso now",
+                    "text_lemmatized": "alice likes espresso now",
+                    "user_id": "commercial_alice",
+                    "category": "drink",
+                }
+            ],
+        )
+        assert db.get(alice_primary).payload["data"] == "Alice likes espresso now"
+        assert len(_list_flat(db, filters={"user_id": "commercial_alice"}, top_k=10)) == 2
+
+        db.delete(bob_only)
+        assert db.get(bob_only) is None
+
+
+def test_commercial_centralized_filter_matrix_and_undeclared_range_compatibility(caplog):
+    with _managed_db(prefix="commercial_filter") as db:
+        travel_id = _uuid(9201)
+        food_id = _uuid(9202)
+        work_id = _uuid(9203)
+
+        _insert_memories(
+            db,
+            [
+                (
+                    travel_id,
+                    VECTOR_FLIGHT,
+                    {
+                        "data": "Plan flight with priority boarding",
+                        "text_lemmatized": "plan flight with priority boarding",
+                        "user_id": "commercial_filter",
+                        "category": "travel",
+                        "priority": 7,
+                        "tag": "boarding-plan",
+                        "status": "active",
+                    },
+                ),
+                (
+                    food_id,
+                    VECTOR_COFFEE,
+                    {
+                        "data": "Find coffee near the office",
+                        "text_lemmatized": "find coffee near the office",
+                        "user_id": "commercial_filter",
+                        "category": "food",
+                        "priority": 2,
+                        "tag": "coffee-shop",
+                        "status": "active",
+                    },
+                ),
+                (
+                    work_id,
+                    VECTOR_WINDOW,
+                    {
+                        "data": "Prepare quarterly plan",
+                        "text_lemmatized": "prepare quarterly plan",
+                        "user_id": "commercial_filter",
+                        "category": "work",
+                        "priority": 5,
+                        "tag": "QuarterlyPlan",
+                        "status": "archived",
+                    },
+                ),
+            ],
+        )
+
+        cases = [
+            ({"user_id": "commercial_filter", "category": {"eq": "travel"}}, {travel_id}),
+            ({"user_id": "commercial_filter", "category": {"ne": "travel"}}, {food_id, work_id}),
+            ({"user_id": "commercial_filter", "category": {"in": ["travel", "food"]}}, {travel_id, food_id}),
+            ({"user_id": "commercial_filter", "category": {"nin": ["travel", "food"]}}, {work_id}),
+            ({"user_id": "commercial_filter", "tag": {"contains": "coffee"}}, {food_id}),
+            ({"user_id": "commercial_filter", "tag": {"icontains": "plan"}}, {travel_id, work_id}),
+            (
+                {
+                    "$and": [
+                        {"user_id": "commercial_filter"},
+                        {"category": {"in": ["travel", "work"]}},
+                        {"status": {"in": ["active", "archived"]}},
+                    ]
+                },
+                {travel_id, work_id},
+            ),
+            (
+                {
+                    "$or": [
+                        {"user_id": "commercial_filter", "category": "travel"},
+                        {"user_id": "commercial_filter", "category": "food"},
+                    ]
+                },
+                {travel_id, food_id},
+            ),
+            ({"user_id": "commercial_filter", "$not": [{"category": "food"}]}, {travel_id, work_id}),
+        ]
+
+        for filters, expected_ids in cases:
+            _assert_exact_ids(db.search("filter", VECTOR_COFFEE, top_k=10, filters=filters), expected_ids)
+
+        with caplog.at_level(logging.WARNING):
+            rows = db.search(
+                "filter",
+                VECTOR_COFFEE,
+                top_k=10,
+                filters={"user_id": "commercial_filter", "priority": {"gte": 5}},
+            )
+        _assert_exact_ids(rows, set())
+        assert "falling back to literal compatibility matching" in caplog.text
+
+
+def test_commercial_centralized_typed_exact_bool_and_null_filters():
+    with _managed_db(prefix="commercial_typed_exact") as db:
+        true_id = _uuid(9251)
+        false_id = _uuid(9252)
+        null_id = _uuid(9253)
+
+        _insert_memories(
+            db,
+            [
+                (
+                    true_id,
+                    VECTOR_COFFEE,
+                    {
+                        "data": "bool true record",
+                        "text_lemmatized": "bool true record",
+                        "user_id": "commercial_typed",
+                        "flag": True,
+                        "deleted_at": "2026-01-01T00:00:00Z",
+                    },
+                ),
+                (
+                    false_id,
+                    VECTOR_WINDOW,
+                    {
+                        "data": "bool false record",
+                        "text_lemmatized": "bool false record",
+                        "user_id": "commercial_typed",
+                        "flag": False,
+                        "deleted_at": "2026-02-01T00:00:00Z",
+                    },
+                ),
+                (
+                    null_id,
+                    VECTOR_AISLE,
+                    {
+                        "data": "null record",
+                        "text_lemmatized": "null record",
+                        "user_id": "commercial_typed",
+                        "flag": True,
+                        "deleted_at": None,
+                    },
+                ),
+            ],
+        )
+
+        _assert_exact_ids(
+            db.search("typed", VECTOR_COFFEE, top_k=10, filters={"user_id": "commercial_typed", "flag": True}),
+            {true_id, null_id},
+        )
+        _assert_exact_ids(
+            db.search("typed", VECTOR_COFFEE, top_k=10, filters={"user_id": "commercial_typed", "flag": {"ne": True}}),
+            {false_id},
+        )
+        _assert_exact_ids(
+            db.search("typed", VECTOR_COFFEE, top_k=10, filters={"user_id": "commercial_typed", "deleted_at": None}),
+            {null_id},
+        )
+
+
+def test_commercial_centralized_wildcard_exists_missing_and_null_distinction():
+    with _managed_db(prefix="commercial_presence") as db:
+        value_id = _uuid(9254)
+        null_id = _uuid(9255)
+        missing_id = _uuid(9256)
+
+        _insert_memories(
+            db,
+            [
+                (
+                    value_id,
+                    VECTOR_COFFEE,
+                    {
+                        "data": "presence value record",
+                        "text_lemmatized": "presence value record",
+                        "user_id": "commercial_presence",
+                        "category": "food",
+                        "optional": "set",
+                    },
+                ),
+                (
+                    null_id,
+                    VECTOR_WINDOW,
+                    {
+                        "data": "presence null record",
+                        "text_lemmatized": "presence null record",
+                        "user_id": "commercial_presence",
+                        "category": "travel",
+                        "optional": None,
+                    },
+                ),
+                (
+                    missing_id,
+                    VECTOR_AISLE,
+                    {
+                        "data": "presence missing record",
+                        "text_lemmatized": "presence missing record",
+                        "user_id": "commercial_presence",
+                        "category": "books",
+                    },
+                ),
+            ],
+        )
+
+        _assert_exact_ids(
+            db.search("presence", VECTOR_COFFEE, top_k=10, filters={"user_id": "commercial_presence", "optional": {"exists": True}}),
+            {value_id, null_id},
+        )
+        _assert_exact_ids(
+            db.search("presence", VECTOR_COFFEE, top_k=10, filters={"user_id": "commercial_presence", "optional": {"missing": True}}),
+            {missing_id},
+        )
+        _assert_exact_ids(
+            db.search("presence", VECTOR_COFFEE, top_k=10, filters={"user_id": "commercial_presence", "optional": None}),
+            {null_id},
+        )
+        _assert_exact_ids(
+            db.search("presence", VECTOR_COFFEE, top_k=10, filters={"user_id": "commercial_presence", "category": "*"}),
+            {value_id, null_id, missing_id},
+        )
+
+
+def test_commercial_centralized_declared_numeric_range_and_undeclared_compatibility(caplog):
+    with _managed_db(
+        prefix="commercial_range",
+        metadata_schema={"priority": "number"},
+    ) as db:
+        low_id = _uuid(9261)
+        mid_id = _uuid(9262)
+        high_id = _uuid(9263)
+        dirty_id = _uuid(9267)
+
+        _insert_memories(
+            db,
+            [
+                (
+                    low_id,
+                    VECTOR_COFFEE,
+                    {
+                        "data": "priority low",
+                        "text_lemmatized": "priority low",
+                        "user_id": "commercial_range",
+                        "priority": 2,
+                    },
+                ),
+                (
+                    mid_id,
+                    VECTOR_WINDOW,
+                    {
+                        "data": "priority mid",
+                        "text_lemmatized": "priority mid",
+                        "user_id": "commercial_range",
+                        "priority": 5,
+                    },
+                ),
+                (
+                    high_id,
+                    VECTOR_FLIGHT,
+                    {
+                        "data": "priority high",
+                        "text_lemmatized": "priority high",
+                        "user_id": "commercial_range",
+                        "priority": 9,
+                    },
+                ),
+                (
+                    dirty_id,
+                    VECTOR_AISLE,
+                    {
+                        "data": "priority dirty",
+                        "text_lemmatized": "priority dirty",
+                        "user_id": "commercial_range",
+                        "priority": "abc",
+                    },
+                ),
+            ],
+        )
+
+        _assert_exact_ids(
+            db.search("range", VECTOR_COFFEE, top_k=10, filters={"user_id": "commercial_range", "priority": {"gte": 3, "lt": 9}}),
+            {mid_id},
+        )
+
+        with caplog.at_level(logging.WARNING):
+            rows = db.search("range", VECTOR_COFFEE, top_k=10, filters={"user_id": "commercial_range", "category": {"gte": "a"}})
+        _assert_exact_ids(rows, set())
+        assert "falling back to literal compatibility matching" in caplog.text
+
+
+def test_commercial_centralized_cross_path_typed_filter_parity():
+    with _managed_db(
+        prefix="commercial_parity",
+        metadata_schema={"priority": "number"},
+    ) as db:
+        primary_id = _uuid(9264)
+        secondary_id = _uuid(9265)
+        archived_id = _uuid(9266)
+
+        _insert_memories(
+            db,
+            [
+                (
+                    primary_id,
+                    VECTOR_COFFEE,
+                    {
+                        "data": "latte parity record",
+                        "text_lemmatized": "latte parity record",
+                        "user_id": "commercial_parity",
+                        "flag": True,
+                        "priority": 5,
+                    },
+                ),
+                (
+                    secondary_id,
+                    VECTOR_AISLE,
+                    {
+                        "data": "backup parity record",
+                        "text_lemmatized": "backup parity record",
+                        "user_id": "commercial_parity",
+                        "flag": True,
+                        "priority": 2,
+                    },
+                ),
+                (
+                    archived_id,
+                    VECTOR_WINDOW,
+                    {
+                        "data": "archived parity record",
+                        "text_lemmatized": "archived parity record",
+                        "user_id": "commercial_parity",
+                        "flag": False,
+                        "priority": 8,
+                    },
+                ),
+            ],
+        )
+
+        _assert_exact_ids(
+            _list_flat(db, filters={"user_id": "commercial_parity", "flag": True}, top_k=10),
+            {primary_id, secondary_id},
+        )
+        _assert_exact_ids(
+            _list_flat(db, filters={"user_id": "commercial_parity", "priority": {"gte": 3}}, top_k=10),
+            {primary_id, archived_id},
+        )
+
+        batch_rows = db.search_batch(
+            ["parity", "backup"],
+            [VECTOR_COFFEE, VECTOR_AISLE],
+            top_k=10,
+            filters={"user_id": "commercial_parity", "flag": True},
+        )
+        assert [set(_ids(rows)) for rows in batch_rows] == [{primary_id, secondary_id}, {primary_id, secondary_id}]
+
+        if db.bm25_enabled:
+            _assert_exact_ids(
+                db.keyword_search("latte", top_k=10, filters={"user_id": "commercial_parity", "flag": True}),
+                {primary_id},
+            )
+
+
+def test_commercial_centralized_vector_order_and_topk():
+    with _managed_db(prefix="commercial_rank", embedding_model_dims=3) as db:
+        _insert_memories(
+            db,
+            [
+                (_uuid(9301), VECTOR_UNIT_X, {"data": "x", "text_lemmatized": "x", "user_id": "rank_user"}),
+                (_uuid(9302), [0.8, 0.2, 0.0], {"data": "x-near", "text_lemmatized": "x near", "user_id": "rank_user"}),
+                (_uuid(9303), VECTOR_UNIT_Y, {"data": "y", "text_lemmatized": "y", "user_id": "rank_user"}),
+                (_uuid(9304), VECTOR_UNIT_Z, {"data": "z", "text_lemmatized": "z", "user_id": "rank_user"}),
+            ],
+        )
+
+        results = db.search("rank", VECTOR_UNIT_X, top_k=3, filters={"user_id": "rank_user"})
+        assert len(results) == 3
+        _assert_ordered_ids(results, [_uuid(9301), _uuid(9302), _uuid(9303)])
+
+
+def test_commercial_centralized_utf8_roundtrip_and_filtering():
+    with _managed_db(prefix="commercial_utf8", embedding_model_dims=3) as db:
+        records = [
+            (_uuid(9401), VECTOR_COFFEE, {"data": "我喜欢早晨喝拿铁咖啡", "text_lemmatized": "我喜欢早晨喝拿铁咖啡", "user_id": "utf8_user", "language": "zh-CN"}),
+            (_uuid(9402), VECTOR_FLIGHT, {"data": "日本語の窓側席メモです", "text_lemmatized": "日本語の窓側席メモです", "user_id": "utf8_user", "language": "ja"}),
+            (_uuid(9403), VECTOR_WINDOW, {"data": "مرحبا بالقهوة والسفر", "text_lemmatized": "مرحبا بالقهوة والسفر", "user_id": "utf8_user", "language": "ar"}),
+            (_uuid(9404), VECTOR_AISLE, {"data": "emoji 😀🚀 mixed English 中文", "text_lemmatized": "emoji mixed english 中文", "user_id": "utf8_user", "language": "mixed"}),
+        ]
+        _insert_memories(db, records)
+
+        listed = _list_flat(db, filters={"user_id": "utf8_user"}, top_k=10)
+        assert {row.payload["data"] for row in listed} == {record[2]["data"] for record in records}
+
+        chinese_rows = db.search("拿铁", VECTOR_COFFEE, top_k=10, filters={"user_id": "utf8_user", "language": "zh-CN"})
+        _assert_exact_ids(chinese_rows, {_uuid(9401)})
+
+
+def test_commercial_centralized_keyword_search_if_enabled():
+    with _managed_db(prefix="commercial_bm25") as db:
+        if not db.bm25_enabled:
+            pytest.skip("BM25 was disabled by capability probe on this centralized environment")
+
+        target_id = _uuid(9501)
+        other_id = _uuid(9502)
+        _insert_memories(
+            db,
+            [
+                (
+                    target_id,
+                    VECTOR_COFFEE,
+                    {
+                        "data": "Alice likes latte coffee in the morning",
+                        "text_lemmatized": "alice likes latte coffee in the morning",
+                        "user_id": "bm25_user",
+                    },
+                ),
+                (
+                    other_id,
+                    VECTOR_WINDOW,
+                    {
+                        "data": "Alice books quiet window seats",
+                        "text_lemmatized": "alice books quiet window seats",
+                        "user_id": "bm25_user",
+                    },
+                ),
+            ],
+        )
+
+        rows = db.keyword_search("latte coffee", top_k=5, filters={"user_id": "bm25_user"})
+        assert rows is not None
+        assert len(rows) >= 1
+        assert rows[0].id == target_id
+
+
+@pytest.mark.skipif(not _env_bool("GAUSSDB_TEST_DISTRIBUTED"), reason="Set GAUSSDB_TEST_DISTRIBUTED=true to run distributed commercial validation")
+def test_commercial_distributed_contract_and_crud_smoke():
+    db = _new_dist_db()
+    try:
+        info = db.col_info()
+        assert db.deployment_mode == "distributed"
+        assert db.bm25_enabled is False
+        assert info["deployment_mode"] == "distributed"
+
+        memory_id = _uuid(9601)
+        db.insert(
+            ids=[memory_id],
+            vectors=[[1.0, 0.0, 0.0, 0.0]],
+            payloads=[{"data": "distributed memory", "text_lemmatized": "distributed memory", "user_id": "dist_user"}],
+        )
+        _assert_exact_ids(db.search("distributed", [1.0, 0.0, 0.0, 0.0], top_k=5, filters={"user_id": "dist_user"}), {memory_id})
+
+        db.update(vector_id=memory_id, vector=[0.0, 1.0, 0.0, 0.0], payload={"data": "distributed updated", "user_id": "dist_user"})
+        assert db.get(memory_id).payload["data"] == "distributed updated"
+        _assert_exact_ids(_list_flat(db, filters={"user_id": "dist_user"}, top_k=10), {memory_id})
+
+        batch_rows = db.search_batch(
+            ["one", "two"],
+            [[0.0, 1.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]],
+            top_k=1,
+            filters={"user_id": "dist_user"},
+        )
+        assert len(batch_rows) == 2
+        assert all(rows and rows[0].id == memory_id for rows in batch_rows)
+    finally:
+        db.delete_col()
+
+
+@pytest.mark.skipif(not _env_bool("GAUSSDB_TEST_DISTRIBUTED"), reason="Set GAUSSDB_TEST_DISTRIBUTED=true to run distributed commercial validation")
+def test_commercial_distributed_scope_guard_and_tenant_isolation():
+    db = _new_dist_db()
+    try:
+        alice_id = _uuid(9901)
+        bob_id = _uuid(9902)
+        public_like_id = _uuid(9903)
+        _insert_memories(
+            db,
+            [
+                (
+                    alice_id,
+                    [1.0, 0.0, 0.0, 0.0],
+                    {"data": "alice coffee", "text_lemmatized": "alice coffee", "user_id": "dist_alice", "agent_id": "agent_a"},
+                ),
+                (
+                    bob_id,
+                    [0.0, 1.0, 0.0, 0.0],
+                    {"data": "bob coffee", "text_lemmatized": "bob coffee", "user_id": "dist_bob", "agent_id": "agent_b"},
+                ),
+                (
+                    public_like_id,
+                    [0.0, 0.0, 1.0, 0.0],
+                    {"data": "public note", "text_lemmatized": "public note", "category": "public"},
+                ),
+            ],
+        )
+
+        _assert_exact_ids(
+            db.search("coffee", [1.0, 0.0, 0.0, 0.0], top_k=10, filters={"user_id": "dist_alice"}),
+            {alice_id},
+        )
+        _assert_exact_ids(_list_flat(db, filters={"user_id": "dist_bob"}, top_k=10), {bob_id})
+
+        with pytest.raises(ValueError, match="requires at least one scoped filter"):
+            db.search("coffee", [1.0, 0.0, 0.0, 0.0], top_k=10, filters={"category": "public"})
+        with pytest.raises(ValueError, match="requires at least one scoped filter"):
+            db.search(
+                "coffee",
+                [1.0, 0.0, 0.0, 0.0],
+                top_k=10,
+                filters={"$or": [{"user_id": "dist_alice"}, {"category": "public"}]},
+            )
+    finally:
+        db.delete_col()
+
+
+@pytest.mark.skipif(not _env_bool("GAUSSDB_TEST_DISTRIBUTED"), reason="Set GAUSSDB_TEST_DISTRIBUTED=true to run distributed commercial validation")
+def test_commercial_distributed_vector_order_and_topk():
+    db = _new_dist_db(embedding_model_dims=4)
+    try:
+        _insert_memories(
+            db,
+            [
+                (_uuid(9911), [1.0, 0.0, 0.0, 0.0], {"data": "x", "user_id": "dist_rank"}),
+                (_uuid(9912), [0.8, 0.2, 0.0, 0.0], {"data": "x-near", "user_id": "dist_rank"}),
+                (_uuid(9913), [0.0, 1.0, 0.0, 0.0], {"data": "y", "user_id": "dist_rank"}),
+                (_uuid(9914), [0.0, 0.0, 1.0, 0.0], {"data": "z", "user_id": "dist_rank"}),
+            ],
+        )
+
+        results = db.search("rank", [1.0, 0.0, 0.0, 0.0], top_k=3, filters={"user_id": "dist_rank"})
+        assert len(results) == 3
+        _assert_ordered_ids(results, [_uuid(9911), _uuid(9912), _uuid(9913)])
+        assert len(db.search("rank", [1.0, 0.0, 0.0, 0.0], top_k=1, filters={"user_id": "dist_rank"})) == 1
+    finally:
+        db.delete_col()
+
+
+@pytest.mark.skipif(not _env_bool("GAUSSDB_TEST_DISTRIBUTED"), reason="Set GAUSSDB_TEST_DISTRIBUTED=true to run distributed commercial validation")
+def test_commercial_distributed_concurrent_upsert_idempotency():
+    db = _new_dist_db(embedding_model_dims=4, maxconn=5)
+    try:
+        record_id = _uuid(9921)
+        db.insert(
+            ids=[record_id],
+            vectors=[[1.0, 0.0, 0.0, 0.0]],
+            payloads=[{"data": "initial", "text_lemmatized": "initial", "user_id": "dist_concurrent"}],
+        )
+
+        def do_update(index: int):
+            db.update(
+                vector_id=record_id,
+                vector=[0.0, 1.0, 0.0, 0.0],
+                payload={
+                    "data": f"update_{index}",
+                    "text_lemmatized": f"update_{index}",
+                    "user_id": "dist_concurrent",
+                },
+            )
+
+        with ThreadPoolExecutor(max_workers=5) as executor:
+            list(executor.map(do_update, range(10)))
+
+        listed = _list_flat(db, filters={"user_id": "dist_concurrent"}, top_k=10)
+        assert len(listed) == 1
+        assert db.get(record_id) is not None
+    finally:
+        db.delete_col()
+
+
+@pytest.mark.skipif(not _env_bool("GAUSSDB_TEST_DISTRIBUTED"), reason="Set GAUSSDB_TEST_DISTRIBUTED=true to run distributed commercial validation")
+def test_commercial_distributed_collection_lifecycle():
+    db = _new_dist_db(embedding_model_dims=4)
+    try:
+        assert db.collection_name in db.list_cols()
+        record_id = _uuid(9931)
+        db.insert(
+            ids=[record_id],
+            vectors=[[1.0, 0.0, 0.0, 0.0]],
+            payloads=[{"data": "reset me", "user_id": "dist_lifecycle"}],
+        )
+        assert len(_list_flat(db, filters={"user_id": "dist_lifecycle"}, top_k=10)) == 1
+
+        db.reset()
+        assert len(_list_flat(db, filters={"user_id": "dist_lifecycle"}, top_k=10)) == 0
+        assert db.collection_name in db.list_cols()
+        assert db.col_info()["count"] == 0
+    finally:
+        db.delete_col()
+
+
+@pytest.mark.skipif(not _env_bool("GAUSSDB_TEST_DISTRIBUTED"), reason="Set GAUSSDB_TEST_DISTRIBUTED=true to run distributed commercial validation")
+def test_commercial_distributed_filter_and_range_semantics(caplog):
+    db = _new_dist_db(metadata_schema={"priority": "number"})
+    try:
+        low_id = _uuid(9701)
+        high_id = _uuid(9702)
+        missing_id = _uuid(9703)
+        _insert_memories(
+            db,
+            [
+                (low_id, [1.0, 0.0, 0.0, 0.0], {"data": "food", "user_id": "dist_filter", "category": "food", "priority": 3, "optional": None}),
+                (high_id, [0.0, 1.0, 0.0, 0.0], {"data": "travel", "user_id": "dist_filter", "category": "travel", "priority": 8, "optional": "set"}),
+                (missing_id, [0.0, 0.0, 1.0, 0.0], {"data": "books", "user_id": "dist_filter", "category": "books"}),
+            ],
+        )
+
+        _assert_exact_ids(
+            db.search("distributed", [1.0, 0.0, 0.0, 0.0], top_k=10, filters={"user_id": "dist_filter", "category": {"in": ["food", "travel"]}}),
+            {low_id, high_id},
+        )
+        _assert_exact_ids(
+            db.search("distributed", [1.0, 0.0, 0.0, 0.0], top_k=10, filters={"user_id": "dist_filter", "priority": {"gt": 5}}),
+            {high_id},
+        )
+        _assert_exact_ids(
+            db.search("distributed", [1.0, 0.0, 0.0, 0.0], top_k=10, filters={"user_id": "dist_filter", "optional": {"exists": True}}),
+            {low_id, high_id},
+        )
+        _assert_exact_ids(
+            db.search("distributed", [1.0, 0.0, 0.0, 0.0], top_k=10, filters={"user_id": "dist_filter", "optional": {"missing": True}}),
+            {missing_id},
+        )
+        _assert_exact_ids(
+            db.search("distributed", [1.0, 0.0, 0.0, 0.0], top_k=10, filters={"user_id": "dist_filter", "category": "*"}),
+            {low_id, high_id, missing_id},
+        )
+
+        with caplog.at_level(logging.WARNING):
+            rows = db.search("distributed", [1.0, 0.0, 0.0, 0.0], top_k=10, filters={"user_id": "dist_filter", "score": {"gt": 5}})
+        _assert_exact_ids(rows, set())
+        assert "falling back to literal compatibility matching" in caplog.text
+    finally:
+        db.delete_col()
+
+
+@pytest.mark.skipif(not _env_bool("GAUSSDB_TEST_DISTRIBUTED"), reason="Set GAUSSDB_TEST_DISTRIBUTED=true to run distributed commercial validation")
+def test_commercial_distributed_utf8_roundtrip():
+    db = _new_dist_db(embedding_model_dims=4)
+    try:
+        record_id = _uuid(9801)
+        payload = {"data": "分布式 UTF8 校验 with 日本語 and 😀", "user_id": "dist_utf8", "language": "mixed"}
+        db.insert(ids=[record_id], vectors=[[0.0, 0.0, 1.0, 0.0]], payloads=[payload])
+
+        result = db.get(record_id)
+        assert result.payload["data"] == payload["data"]
+        _assert_exact_ids(
+            _list_flat(db, filters={"user_id": "dist_utf8", "language": "mixed"}, top_k=10),
+            {record_id},
+        )
+    finally:
+        db.delete_col()

--- a/tests/vector_stores/test_gaussdb_distributed.py
+++ b/tests/vector_stores/test_gaussdb_distributed.py
@@ -1,0 +1,2145 @@
+"""
+GaussDB Distributed Mode - Full E2E Test Suite for mem0 Adaptation.
+
+Validates distributed-specific logic and full feature coverage in distributed mode.
+
+Environment variables:
+    GAUSSDB_TEST_DSN / GAUSSDB_TEST_HOST/PORT/DATABASE/USER/PASSWORD
+    GAUSSDB_TEST_DISTRIBUTED=true   (required to run these tests)
+
+Usage:
+    export GAUSSDB_TEST_DISTRIBUTED=true
+    pytest tests/vector_stores/test_gaussdb_distributed.py -v
+
+Optional:
+    GAUSSDB_TEST_RUN_FULL_DISTRIBUTED=true   Run the heavier full-regression classes
+"""
+
+import math
+import os
+import random
+import statistics
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("psycopg2", reason="GaussDB distributed tests require psycopg2-compatible driver")
+
+from mem0.vector_stores.gaussdb import GaussDB, OutputData
+from tests.vector_stores.conftest import (
+    EMBEDDING_DIMS,
+    VECTOR_AISLE,
+    VECTOR_COFFEE,
+    VECTOR_FLIGHT,
+    VECTOR_LARGE,
+    VECTOR_NEGATIVE,
+    VECTOR_UNIT_X,
+    VECTOR_UNIT_Y,
+    VECTOR_UNIT_Z,
+    VECTOR_WINDOW,
+    VECTOR_ZERO,
+    _assert_exact_ids,
+    _assert_ordered_ids,
+    _concurrent_runner,
+    _env_bool,
+    _gaussdb_env_config,
+    _ids,
+    _insert_memories,
+    _list_flat,
+    _make_payload,
+    _measure_latency,
+    _new_collection_name,
+    _new_db,
+    _uuid,
+    gaussdb_available,
+    FakeEmbedder,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test configuration helpers
+# ---------------------------------------------------------------------------
+
+DIMS_SMALL = 4
+DIMS_BOUNDARY = 1024
+
+VECTORS_4D = {
+    "A": [1.0, 0.0, 0.0, 0.0],
+    "B": [0.0, 1.0, 0.0, 0.0],
+    "C": [0.9, 0.1, 0.0, 0.0],
+    "D": [0.0, 0.0, 1.0, 0.0],
+    "E": [0.0, 0.0, 0.0, 1.0],
+    "similar_A": [0.95, 0.05, 0.0, 0.0],
+}
+
+
+def _new_collection(prefix: str = "mem0_dist") -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:10]}"
+
+
+def _gaussdb_distributed_config(collection_name: str, **overrides):
+    """Build config dict for distributed mode testing."""
+    dsn = os.getenv("GAUSSDB_TEST_DSN")
+    if dsn:
+        config = {"connection_string": dsn}
+    else:
+        required = {
+            "host": os.getenv("GAUSSDB_TEST_HOST"),
+            "port": os.getenv("GAUSSDB_TEST_PORT"),
+            "database": os.getenv("GAUSSDB_TEST_DATABASE"),
+            "user": os.getenv("GAUSSDB_TEST_USER"),
+            "password": os.getenv("GAUSSDB_TEST_PASSWORD"),
+        }
+        if not all(required.values()):
+            return None
+        config = {
+            "host": required["host"],
+            "port": int(required["port"]),
+            "database": required["database"],
+            "user": required["user"],
+            "password": required["password"],
+        }
+
+    optional_env = {
+        "sslmode": os.getenv("GAUSSDB_TEST_SSLMODE"),
+        "sslrootcert": os.getenv("GAUSSDB_TEST_SSLROOTCERT"),
+    }
+    config.update({k: v for k, v in optional_env.items() if v})
+    config.update({
+        "collection_name": collection_name,
+        "embedding_model_dims": overrides.pop("embedding_model_dims", DIMS_SMALL),
+        "deployment_mode": "distributed",
+        "auto_create": True,
+    })
+    config.update({k: v for k, v in overrides.items() if v is not None})
+    return config
+
+
+def _new_dist_db(prefix: str = "mem0_dist", **overrides) -> GaussDB:
+    """Create a new GaussDB instance in distributed mode."""
+    config = _gaussdb_distributed_config(_new_collection(prefix), **overrides)
+    assert config is not None, "GaussDB distributed test environment not configured"
+    return GaussDB(**config)
+
+
+def _random_vector(dims: int = DIMS_SMALL) -> list:
+    return [random.random() for _ in range(dims)]
+
+
+def _make_vector_seeded(seed: int, dims: int = DIMS_SMALL) -> list:
+    rng = random.Random(seed)
+    return [rng.uniform(-1, 1) for _ in range(dims)]
+
+
+def _run_concurrent(tasks, max_workers=10, timeout=600.0):
+    successes = 0
+    errors = []
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = [executor.submit(task) for task in tasks]
+        for future in as_completed(futures, timeout=timeout):
+            try:
+                future.result()
+                successes += 1
+            except Exception as exc:
+                errors.append(str(exc))
+    return successes, errors
+
+
+def _print_latency_report(name, stats):
+    print(f"\n  [PERF] {name}:")
+    for key in ["iterations", "p50_ms", "p99_ms", "min_ms", "max_ms", "mean_ms"]:
+        val = stats[key]
+        if "ms" in key:
+            print(f"    {key}: {val:.2f}")
+        else:
+            print(f"    {key}: {val}")
+
+
+def _soft_assert(condition: bool, message: str):
+    if not condition:
+        print(f"  [WARN] Soft assertion failed: {message}")
+
+
+# ---------------------------------------------------------------------------
+# Module-level skip
+# ---------------------------------------------------------------------------
+
+_SKIP_REASON = (
+    "Set GAUSSDB_TEST_DISTRIBUTED=true and configure GAUSSDB_TEST_DSN or "
+    "GAUSSDB_TEST_HOST/PORT/DATABASE/USER/PASSWORD to run distributed tests"
+)
+_FULL_DIST_REASON = (
+    "Distributed full-regression tests disabled; set GAUSSDB_TEST_RUN_FULL_DISTRIBUTED=true to enable"
+)
+
+pytestmark = [
+    pytest.mark.skipif(
+        not _env_bool("GAUSSDB_TEST_DISTRIBUTED"),
+        reason=_SKIP_REASON,
+    ),
+    pytest.mark.skipif(
+        not gaussdb_available(),
+        reason="GaussDB connection not configured",
+    ),
+]
+
+
+# ===========================================================================
+# TestDistributedInitialization
+# ===========================================================================
+
+
+class TestDistributedInitialization:
+    """Validate distributed mode initialization and parameter handling."""
+
+    def test_d001_deployment_mode_set_correctly(self):
+        db = _new_dist_db()
+        try:
+            assert db.deployment_mode == "distributed"
+        finally:
+            db.delete_col()
+
+    def test_d002_bm25_auto_disabled(self):
+        db = _new_dist_db()
+        try:
+            assert db.bm25_enabled is False
+        finally:
+            db.delete_col()
+
+    def test_d003_dimension_stored_correctly(self):
+        db = _new_dist_db(embedding_model_dims=128)
+        try:
+            assert db.embedding_model_dims == 128
+        finally:
+            db.delete_col()
+
+    def test_d004_collection_name_stored(self):
+        name = _new_collection("dist_init")
+        config = _gaussdb_distributed_config(name)
+        db = GaussDB(**config)
+        try:
+            assert db.collection_name == name
+        finally:
+            db.delete_col()
+
+    def test_d005_auto_create_table(self):
+        db = _new_dist_db()
+        try:
+            info = db.col_info()
+            assert info["name"] == db.collection_name
+        finally:
+            db.delete_col()
+
+
+# ===========================================================================
+# TestDistributedDDL
+# ===========================================================================
+
+
+class TestDistributedDDL:
+    """Validate DDL generation includes DISTRIBUTE BY HASH."""
+
+    def test_d010_create_table_has_distribute_by(self):
+        db = _new_dist_db()
+        try:
+            ddl = db._build_create_table_sql()
+            assert "DISTRIBUTE BY" in ddl.upper()
+        finally:
+            db.delete_col()
+
+    def test_d011_distribute_by_hash_on_id(self):
+        db = _new_dist_db()
+        try:
+            ddl = db._build_create_table_sql()
+            assert "HASH" in ddl.upper()
+            assert "id" in ddl.lower()
+        finally:
+            db.delete_col()
+
+    def test_d012_no_bm25_index_in_ddl(self):
+        db = _new_dist_db()
+        try:
+            info = db.col_info()
+            indexes = info.get("indexes", [])
+            for idx in indexes:
+                assert "gin" not in idx.lower() or "bm25" not in idx.lower()
+        finally:
+            db.delete_col()
+
+
+# ===========================================================================
+# TestDistributedCRUD
+# ===========================================================================
+
+
+class TestDistributedCRUD:
+    """Basic CRUD operations across distributed nodes."""
+
+    def test_d020_insert_single_and_get(self):
+        db = _new_dist_db()
+        try:
+            vid = _uuid(1)
+            db.insert(ids=[vid], vectors=[VECTORS_4D["A"]], payloads=[{"data": "distributed insert", "user_id": "alice"}])
+            result = db.get(vid)
+            assert result is not None
+            assert result.id == vid
+            assert result.payload["data"] == "distributed insert"
+        finally:
+            db.delete_col()
+
+    def test_d021_insert_batch_and_list(self):
+        db = _new_dist_db()
+        try:
+            records = [
+                (_uuid(10), VECTORS_4D["A"], {"data": "rec_a", "user_id": "alice"}),
+                (_uuid(11), VECTORS_4D["B"], {"data": "rec_b", "user_id": "alice"}),
+                (_uuid(12), VECTORS_4D["C"], {"data": "rec_c", "user_id": "alice"}),
+            ]
+            _insert_memories(db, records)
+            listed = _list_flat(db, filters={"user_id": "alice"}, top_k=100)
+            assert len(listed) == 3
+            _assert_exact_ids(listed, {_uuid(10), _uuid(11), _uuid(12)})
+        finally:
+            db.delete_col()
+
+    def test_d022_upsert_existing_record(self):
+        db = _new_dist_db()
+        try:
+            vid = _uuid(20)
+            db.insert(ids=[vid], vectors=[VECTORS_4D["A"]], payloads=[{"data": "original", "user_id": "alice"}])
+            db.update(vector_id=vid, payload={"data": "updated", "user_id": "alice"})
+            result = db.get(vid)
+            assert result.payload["data"] == "updated"
+            listed = _list_flat(db, filters={"user_id": "alice"}, top_k=100)
+            assert len(listed) == 1
+        finally:
+            db.delete_col()
+
+    def test_d023_update_vector(self):
+        db = _new_dist_db()
+        try:
+            vid = _uuid(21)
+            db.insert(ids=[vid], vectors=[VECTORS_4D["A"]], payloads=[{"data": "vec_update", "user_id": "alice"}])
+            db.update(vector_id=vid, vector=VECTORS_4D["B"])
+            results = db.search("test", VECTORS_4D["B"], top_k=1, filters={"user_id": "alice"})
+            assert len(results) >= 1
+            assert results[0].id == vid
+        finally:
+            db.delete_col()
+
+    def test_d024_delete_by_id(self):
+        db = _new_dist_db()
+        try:
+            vid = _uuid(30)
+            db.insert(ids=[vid], vectors=[VECTORS_4D["A"]], payloads=[{"data": "to delete", "user_id": "alice"}])
+            db.delete(vector_id=vid)
+            assert db.get(vid) is None
+        finally:
+            db.delete_col()
+
+    def test_d025_search_basic(self):
+        db = _new_dist_db()
+        try:
+            _insert_memories(db, [
+                (_uuid(40), VECTORS_4D["A"], {"data": "point_a", "user_id": "alice"}),
+                (_uuid(41), VECTORS_4D["B"], {"data": "point_b", "user_id": "alice"}),
+                (_uuid(42), VECTORS_4D["similar_A"], {"data": "near_a", "user_id": "alice"}),
+            ])
+            results = db.search("test", VECTORS_4D["A"], top_k=3, filters={"user_id": "alice"})
+            assert len(results) == 3
+            assert results[0].id == _uuid(40)
+        finally:
+            db.delete_col()
+
+    def test_d026_get_nonexistent_returns_none(self):
+        db = _new_dist_db()
+        try:
+            result = db.get(_uuid(999))
+            assert result is None
+        finally:
+            db.delete_col()
+
+    def test_d027_delete_nonexistent_no_error(self):
+        db = _new_dist_db()
+        try:
+            db.delete(vector_id=_uuid(999))
+        finally:
+            db.delete_col()
+
+    def test_d028_insert_large_batch(self):
+        db = _new_dist_db()
+        try:
+            records = [
+                (_uuid(100 + i), _random_vector(), {"data": f"batch_{i}", "user_id": "batch_user"})
+                for i in range(50)
+            ]
+            _insert_memories(db, records)
+            listed = _list_flat(db, filters={"user_id": "batch_user"}, top_k=100)
+            assert len(listed) == 50
+        finally:
+            db.delete_col()
+
+
+# ===========================================================================
+# TestDistributedFilter - Filter operators in distributed mode
+# ===========================================================================
+
+
+class TestDistributedFilter:
+    """Supported filter operators plus explicit unsupported-range behavior."""
+
+    def test_d030_eq_filter(self):
+        db = _new_dist_db()
+        try:
+            _insert_memories(db, [
+                (_uuid(150), VECTORS_4D["A"], {"data": "food", "user_id": "carol", "category": "food"}),
+                (_uuid(151), VECTORS_4D["B"], {"data": "travel", "user_id": "carol", "category": "travel"}),
+            ])
+            rows = db.search("test", VECTORS_4D["A"], top_k=10, filters={"user_id": "carol", "category": "food"})
+            _assert_exact_ids(rows, {_uuid(150)})
+        finally:
+            db.delete_col()
+
+    def test_d031_ne_filter(self):
+        db = _new_dist_db()
+        try:
+            _insert_memories(db, [
+                (_uuid(160), VECTORS_4D["A"], {"data": "food", "user_id": "carol", "category": "food"}),
+                (_uuid(161), VECTORS_4D["B"], {"data": "travel", "user_id": "carol", "category": "travel"}),
+                (_uuid(162), VECTORS_4D["C"], {"data": "work", "user_id": "carol", "category": "work"}),
+            ])
+            rows = db.search("test", VECTORS_4D["A"], top_k=10, filters={"user_id": "carol", "category": {"ne": "food"}})
+            _assert_exact_ids(rows, {_uuid(161), _uuid(162)})
+        finally:
+            db.delete_col()
+
+    def test_d032_in_filter(self):
+        db = _new_dist_db()
+        try:
+            _insert_memories(db, [
+                (_uuid(170), VECTORS_4D["A"], {"data": "food", "user_id": "carol", "category": "food"}),
+                (_uuid(171), VECTORS_4D["B"], {"data": "travel", "user_id": "carol", "category": "travel"}),
+                (_uuid(172), VECTORS_4D["C"], {"data": "work", "user_id": "carol", "category": "work"}),
+            ])
+            rows = db.search("test", VECTORS_4D["A"], top_k=10, filters={"user_id": "carol", "category": {"in": ["food", "travel"]}})
+            _assert_exact_ids(rows, {_uuid(170), _uuid(171)})
+        finally:
+            db.delete_col()
+
+    def test_d033_in_empty_list(self):
+        db = _new_dist_db()
+        try:
+            _insert_memories(db, [
+                (_uuid(175), VECTORS_4D["A"], {"data": "food", "user_id": "carol", "category": "food"}),
+            ])
+            rows = db.search("test", VECTORS_4D["A"], top_k=10, filters={"user_id": "carol", "category": {"in": []}})
+            assert len(rows) == 0
+        finally:
+            db.delete_col()
+
+    def test_d034_nin_filter(self):
+        db = _new_dist_db()
+        try:
+            _insert_memories(db, [
+                (_uuid(180), VECTORS_4D["A"], {"data": "food", "user_id": "dave", "category": "food"}),
+                (_uuid(181), VECTORS_4D["B"], {"data": "travel", "user_id": "dave", "category": "travel"}),
+                (_uuid(182), VECTORS_4D["C"], {"data": "work", "user_id": "dave", "category": "work"}),
+            ])
+            rows = db.search("test", VECTORS_4D["A"], top_k=10, filters={"user_id": "dave", "category": {"nin": ["food"]}})
+            _assert_exact_ids(rows, {_uuid(181), _uuid(182)})
+        finally:
+            db.delete_col()
+
+    def test_d035_nin_multi_value(self):
+        db = _new_dist_db()
+        try:
+            _insert_memories(db, [
+                (_uuid(190), VECTORS_4D["A"], {"data": "food", "user_id": "dave", "category": "food"}),
+                (_uuid(191), VECTORS_4D["B"], {"data": "travel", "user_id": "dave", "category": "travel"}),
+                (_uuid(192), VECTORS_4D["C"], {"data": "work", "user_id": "dave", "category": "work"}),
+            ])
+            rows = db.search("test", VECTORS_4D["A"], top_k=10, filters={"user_id": "dave", "category": {"nin": ["food", "travel"]}})
+            _assert_exact_ids(rows, {_uuid(192)})
+        finally:
+            db.delete_col()
+
+    def test_d036_contains_filter(self):
+        db = _new_dist_db()
+        try:
+            _insert_memories(db, [
+                (_uuid(200), VECTORS_4D["A"], {"data": "coffee shop", "user_id": "eve", "tag": "morning-coffee"}),
+                (_uuid(201), VECTORS_4D["B"], {"data": "flight plan", "user_id": "eve", "tag": "evening-flight"}),
+            ])
+            rows = db.search("test", VECTORS_4D["A"], top_k=10, filters={"user_id": "eve", "tag": {"contains": "coffee"}})
+            _assert_exact_ids(rows, {_uuid(200)})
+        finally:
+            db.delete_col()
+
+    def test_d037_icontains_case_insensitive(self):
+        db = _new_dist_db()
+        try:
+            _insert_memories(db, [
+                (_uuid(210), VECTORS_4D["A"], {"data": "item1", "user_id": "eve", "tag": "MorningCoffee"}),
+                (_uuid(211), VECTORS_4D["B"], {"data": "item2", "user_id": "eve", "tag": "EVENING-COFFEE"}),
+                (_uuid(212), VECTORS_4D["C"], {"data": "item3", "user_id": "eve", "tag": "afternoon-tea"}),
+            ])
+            rows = db.search("test", VECTORS_4D["A"], top_k=10, filters={"user_id": "eve", "tag": {"icontains": "coffee"}})
+            _assert_exact_ids(rows, {_uuid(210), _uuid(211)})
+        finally:
+            db.delete_col()
+
+    def test_d038_unsupported_gte_filter_returns_empty(self):
+        db = _new_dist_db()
+        try:
+            _insert_memories(db, [
+                (_uuid(220), VECTORS_4D["A"], {"data": "low", "user_id": "frank", "priority": "3"}),
+                (_uuid(221), VECTORS_4D["B"], {"data": "mid", "user_id": "frank", "priority": "5"}),
+                (_uuid(222), VECTORS_4D["C"], {"data": "high", "user_id": "frank", "priority": "8"}),
+            ])
+            rows = db.search("test", VECTORS_4D["A"], top_k=10, filters={"user_id": "frank", "priority": {"gte": "5"}})
+            _assert_exact_ids(rows, set())
+        finally:
+            db.delete_col()
+
+    def test_d039_unsupported_lte_filter_returns_empty(self):
+        db = _new_dist_db()
+        try:
+            _insert_memories(db, [
+                (_uuid(230), VECTORS_4D["A"], {"data": "low", "user_id": "frank", "priority": "3"}),
+                (_uuid(231), VECTORS_4D["B"], {"data": "mid", "user_id": "frank", "priority": "5"}),
+                (_uuid(232), VECTORS_4D["C"], {"data": "high", "user_id": "frank", "priority": "8"}),
+            ])
+            rows = db.search("test", VECTORS_4D["A"], top_k=10, filters={"user_id": "frank", "priority": {"lte": "5"}})
+            _assert_exact_ids(rows, set())
+        finally:
+            db.delete_col()
+
+    def test_d040_unsupported_gt_filter_returns_empty(self):
+        db = _new_dist_db()
+        try:
+            _insert_memories(db, [
+                (_uuid(240), VECTORS_4D["A"], {"data": "low", "user_id": "frank", "priority": "3"}),
+                (_uuid(241), VECTORS_4D["B"], {"data": "mid", "user_id": "frank", "priority": "5"}),
+                (_uuid(242), VECTORS_4D["C"], {"data": "high", "user_id": "frank", "priority": "8"}),
+            ])
+            rows = db.search("test", VECTORS_4D["A"], top_k=10, filters={"user_id": "frank", "priority": {"gt": "5"}})
+            _assert_exact_ids(rows, set())
+        finally:
+            db.delete_col()
+
+    def test_d041_unsupported_lt_filter_returns_empty(self):
+        db = _new_dist_db()
+        try:
+            _insert_memories(db, [
+                (_uuid(250), VECTORS_4D["A"], {"data": "low", "user_id": "frank", "priority": "3"}),
+                (_uuid(251), VECTORS_4D["B"], {"data": "mid", "user_id": "frank", "priority": "5"}),
+                (_uuid(252), VECTORS_4D["C"], {"data": "high", "user_id": "frank", "priority": "8"}),
+            ])
+            rows = db.search("test", VECTORS_4D["A"], top_k=10, filters={"user_id": "frank", "priority": {"lt": "5"}})
+            _assert_exact_ids(rows, set())
+        finally:
+            db.delete_col()
+
+    def test_d042_or_filter(self):
+        db = _new_dist_db()
+        try:
+            _insert_memories(db, [
+                (_uuid(260), VECTORS_4D["A"], {"data": "food", "user_id": "logic_user", "category": "food"}),
+                (_uuid(261), VECTORS_4D["B"], {"data": "travel", "user_id": "logic_user", "category": "travel"}),
+                (_uuid(262), VECTORS_4D["C"], {"data": "work", "user_id": "logic_user", "category": "work"}),
+            ])
+            rows = db.search(
+                "test", VECTORS_4D["A"], top_k=10,
+                filters={"$or": [{"user_id": "logic_user", "category": "food"}, {"user_id": "logic_user", "category": "travel"}]},
+            )
+            _assert_exact_ids(rows, {_uuid(260), _uuid(261)})
+        finally:
+            db.delete_col()
+
+    def test_d043_and_filter(self):
+        db = _new_dist_db()
+        try:
+            _insert_memories(db, [
+                (_uuid(270), VECTORS_4D["A"], {"data": "food hi", "user_id": "logic_user", "category": "food", "priority": "8"}),
+                (_uuid(271), VECTORS_4D["B"], {"data": "food lo", "user_id": "logic_user", "category": "food", "priority": "2"}),
+                (_uuid(272), VECTORS_4D["C"], {"data": "travel hi", "user_id": "logic_user", "category": "travel", "priority": "9"}),
+            ])
+            rows = db.search(
+                "test", VECTORS_4D["A"], top_k=10,
+                filters={"$and": [{"user_id": "logic_user"}, {"category": "food"}, {"priority": "8"}]},
+            )
+            _assert_exact_ids(rows, {_uuid(270)})
+        finally:
+            db.delete_col()
+
+    def test_d044_not_filter(self):
+        db = _new_dist_db()
+        try:
+            _insert_memories(db, [
+                (_uuid(280), VECTORS_4D["A"], {"data": "food", "user_id": "logic_user", "category": "food"}),
+                (_uuid(281), VECTORS_4D["B"], {"data": "travel", "user_id": "logic_user", "category": "travel"}),
+                (_uuid(282), VECTORS_4D["C"], {"data": "work", "user_id": "logic_user", "category": "work"}),
+            ])
+            rows = db.search(
+                "test", VECTORS_4D["A"], top_k=10,
+                filters={"user_id": "logic_user", "$not": [{"category": "food"}]},
+            )
+            _assert_exact_ids(rows, {_uuid(281), _uuid(282)})
+        finally:
+            db.delete_col()
+
+    def test_d045_nested_or_and(self):
+        db = _new_dist_db()
+        try:
+            _insert_memories(db, [
+                (_uuid(290), VECTORS_4D["A"], {"data": "food hi", "user_id": "nest_user", "category": "food", "priority": "7"}),
+                (_uuid(291), VECTORS_4D["B"], {"data": "food lo", "user_id": "nest_user", "category": "food", "priority": "2"}),
+                (_uuid(292), VECTORS_4D["C"], {"data": "travel hi", "user_id": "nest_user", "category": "travel", "priority": "8"}),
+                (_uuid(293), VECTORS_4D["D"], {"data": "travel lo", "user_id": "nest_user", "category": "travel", "priority": "1"}),
+            ])
+            rows = db.search(
+                "test", VECTORS_4D["A"], top_k=10,
+                filters={
+                    "$or": [
+                        {"user_id": "nest_user", "category": "food", "priority": "7"},
+                        {"user_id": "nest_user", "category": "travel", "priority": "8"},
+                    ]
+                },
+            )
+            _assert_exact_ids(rows, {_uuid(290), _uuid(292)})
+        finally:
+            db.delete_col()
+
+    def test_d046_multiple_conditions_combined(self):
+        db = _new_dist_db()
+        try:
+            _insert_memories(db, [
+                (_uuid(300), VECTORS_4D["A"], {"data": "a", "user_id": "combo_user", "category": "food", "priority": "5", "status": "active"}),
+                (_uuid(301), VECTORS_4D["B"], {"data": "b", "user_id": "combo_user", "category": "food", "priority": "3", "status": "active"}),
+                (_uuid(302), VECTORS_4D["C"], {"data": "c", "user_id": "combo_user", "category": "travel", "priority": "7", "status": "inactive"}),
+            ])
+            rows = db.search(
+                "test", VECTORS_4D["A"], top_k=10,
+                filters={"user_id": "combo_user", "category": "food", "status": "active", "priority": "5"},
+            )
+            _assert_exact_ids(rows, {_uuid(300)})
+        finally:
+            db.delete_col()
+
+    def test_d047_filter_on_nonexistent_field(self):
+        db = _new_dist_db()
+        try:
+            _insert_memories(db, [
+                (_uuid(310), VECTORS_4D["A"], {"data": "item", "user_id": "field_user"}),
+            ])
+            rows = db.search("test", VECTORS_4D["A"], top_k=10, filters={"user_id": "field_user", "nonexistent": "value"})
+            assert len(rows) == 0
+        finally:
+            db.delete_col()
+
+    def test_d048_filter_with_numeric_string_comparison(self):
+        db = _new_dist_db()
+        try:
+            _insert_memories(db, [
+                (_uuid(320), VECTORS_4D["A"], {"data": "a", "user_id": "num_user", "count": "10"}),
+                (_uuid(321), VECTORS_4D["B"], {"data": "b", "user_id": "num_user", "count": "2"}),
+                (_uuid(322), VECTORS_4D["C"], {"data": "c", "user_id": "num_user", "count": "20"}),
+            ])
+            rows = db.search("test", VECTORS_4D["A"], top_k=10, filters={"user_id": "num_user", "count": {"gte": "10"}})
+            _assert_exact_ids(rows, set())
+        finally:
+            db.delete_col()
+
+
+# ===========================================================================
+# TestDistributedSearchQuality - Vector search quality in distributed mode
+# ===========================================================================
+
+
+@pytest.mark.skipif(not _env_bool("GAUSSDB_TEST_RUN_FULL_DISTRIBUTED"), reason=_FULL_DIST_REASON)
+class TestDistributedSearchQuality:
+    """Vector search quality verification across distributed nodes."""
+
+    def test_d050_l2_nearest_neighbor(self):
+        db = _new_dist_db(vector_metric="l2")
+        try:
+            _insert_memories(db, [
+                (_uuid(1001), [1.0, 0.0, 0.0, 0.0], {"data": "point_a", "user_id": "search_user"}),
+                (_uuid(1002), [0.9, 0.1, 0.0, 0.0], {"data": "point_b", "user_id": "search_user"}),
+                (_uuid(1003), [0.0, 1.0, 0.0, 0.0], {"data": "point_c", "user_id": "search_user"}),
+            ])
+            results = db.search("query", [1.0, 0.0, 0.0, 0.0], top_k=3, filters={"user_id": "search_user"})
+            assert len(results) >= 2
+            assert results[0].id == _uuid(1001)
+            assert results[1].id == _uuid(1002)
+        finally:
+            db.delete_col()
+
+    def test_d051_l2_ordering(self):
+        db = _new_dist_db(vector_metric="l2")
+        try:
+            _insert_memories(db, [
+                (_uuid(1011), [0.0, 0.0, 0.0, 0.0], {"data": "origin", "user_id": "search_user"}),
+                (_uuid(1012), [1.0, 0.0, 0.0, 0.0], {"data": "dist_1", "user_id": "search_user"}),
+                (_uuid(1013), [2.0, 0.0, 0.0, 0.0], {"data": "dist_2", "user_id": "search_user"}),
+                (_uuid(1014), [3.0, 0.0, 0.0, 0.0], {"data": "dist_3", "user_id": "search_user"}),
+            ])
+            results = db.search("query", [0.0, 0.0, 0.0, 0.0], top_k=4, filters={"user_id": "search_user"})
+            assert len(results) == 4
+            _assert_ordered_ids(results, [_uuid(1011), _uuid(1012), _uuid(1013), _uuid(1014)])
+        finally:
+            db.delete_col()
+
+    def test_d052_l2_known_distance_value(self):
+        db = _new_dist_db(vector_metric="l2")
+        try:
+            _insert_memories(db, [
+                (_uuid(1021), [1.0, 0.0, 0.0, 0.0], {"data": "unit_x", "user_id": "search_user"}),
+            ])
+            results = db.search("query", [0.0, 0.0, 0.0, 0.0], top_k=1, filters={"user_id": "search_user"})
+            assert len(results) == 1
+            assert abs(results[0].score - 0.5) < 0.1
+        finally:
+            db.delete_col()
+
+    def test_d053_cosine_nearest_neighbor(self):
+        db = _new_dist_db(vector_metric="cosine")
+        try:
+            _insert_memories(db, [
+                (_uuid(1031), [1.0, 0.0, 0.0, 0.0], {"data": "unit_x", "user_id": "search_user"}),
+                (_uuid(1032), [0.9, 0.1, 0.0, 0.0], {"data": "near_x", "user_id": "search_user"}),
+                (_uuid(1033), [0.0, 1.0, 0.0, 0.0], {"data": "unit_y", "user_id": "search_user"}),
+            ])
+            results = db.search("query", [1.0, 0.0, 0.0, 0.0], top_k=3, filters={"user_id": "search_user"})
+            assert len(results) >= 2
+            assert results[0].id == _uuid(1031)
+        finally:
+            db.delete_col()
+
+    def test_d054_cosine_orthogonal_low_score(self):
+        db = _new_dist_db(vector_metric="cosine")
+        try:
+            _insert_memories(db, [
+                (_uuid(1041), [1.0, 0.0, 0.0, 0.0], {"data": "x_axis", "user_id": "search_user"}),
+                (_uuid(1042), [0.0, 1.0, 0.0, 0.0], {"data": "y_axis", "user_id": "search_user"}),
+            ])
+            results = db.search("query", [1.0, 0.0, 0.0, 0.0], top_k=2, filters={"user_id": "search_user"})
+            assert len(results) == 2
+            x_score = results[0].score
+            y_score = results[1].score
+            assert x_score > y_score
+            assert y_score < 0.6
+        finally:
+            db.delete_col()
+
+    def test_d055_cosine_ordering(self):
+        db = _new_dist_db(vector_metric="cosine")
+        try:
+            _insert_memories(db, [
+                (_uuid(1051), [1.0, 0.0, 0.0, 0.0], {"data": "along_x", "user_id": "search_user"}),
+                (_uuid(1052), [1.0, 1.0, 0.0, 0.0], {"data": "45_deg", "user_id": "search_user"}),
+                (_uuid(1053), [0.0, 1.0, 0.0, 0.0], {"data": "along_y", "user_id": "search_user"}),
+            ])
+            results = db.search("query", [1.0, 0.0, 0.0, 0.0], top_k=3, filters={"user_id": "search_user"})
+            assert len(results) == 3
+            _assert_ordered_ids(results, [_uuid(1051), _uuid(1052), _uuid(1053)])
+        finally:
+            db.delete_col()
+
+    def test_d056_default_metric_is_cosine(self):
+        db = _new_dist_db()
+        try:
+            assert db.vector_metric == "cosine"
+        finally:
+            db.delete_col()
+
+    def test_d057_scores_descending_order(self):
+        db = _new_dist_db(vector_metric="cosine")
+        try:
+            _insert_memories(db, [
+                (_uuid(1061), [1.0, 0.0, 0.0, 0.0], {"data": "a", "user_id": "search_user"}),
+                (_uuid(1062), [0.7, 0.3, 0.0, 0.0], {"data": "b", "user_id": "search_user"}),
+                (_uuid(1063), [0.5, 0.5, 0.0, 0.0], {"data": "c", "user_id": "search_user"}),
+                (_uuid(1064), [0.0, 1.0, 0.0, 0.0], {"data": "d", "user_id": "search_user"}),
+            ])
+            results = db.search("query", [1.0, 0.0, 0.0, 0.0], top_k=4, filters={"user_id": "search_user"})
+            scores = [r.score for r in results]
+            for i in range(len(scores) - 1):
+                assert scores[i] >= scores[i + 1]
+        finally:
+            db.delete_col()
+
+    def test_d058_top_k_limits_results(self):
+        db = _new_dist_db()
+        try:
+            for i in range(10):
+                db.insert(ids=[_uuid(1070 + i)], vectors=[_random_vector()], payloads=[{"data": f"item_{i}", "user_id": "search_user"}])
+            results = db.search("query", _random_vector(), top_k=3, filters={"user_id": "search_user"})
+            assert len(results) == 3
+        finally:
+            db.delete_col()
+
+    def test_d059_search_with_filter_reduces_results(self):
+        db = _new_dist_db()
+        try:
+            _insert_memories(db, [
+                (_uuid(1081), VECTORS_4D["A"], {"data": "alice_data", "user_id": "alice"}),
+                (_uuid(1082), VECTORS_4D["B"], {"data": "bob_data", "user_id": "bob"}),
+                (_uuid(1083), VECTORS_4D["C"], {"data": "alice_data2", "user_id": "alice"}),
+            ])
+            results = db.search("query", VECTORS_4D["A"], top_k=10, filters={"user_id": "alice"})
+            assert len(results) == 2
+            for r in results:
+                assert r.payload["user_id"] == "alice"
+        finally:
+            db.delete_col()
+
+    def test_d060_large_dataset_sorting(self):
+        db = _new_dist_db(vector_metric="l2")
+        try:
+            random.seed(123)
+            batch_size = 50
+            for batch_start in range(0, 200, batch_size):
+                records = []
+                for i in range(batch_start, batch_start + batch_size):
+                    vec = [random.uniform(-1, 1) for _ in range(4)]
+                    records.append((_uuid(6100 + i), vec, {"data": f"item_{i}", "user_id": "edge_user"}))
+                _insert_memories(db, records)
+            query = [0.0, 0.0, 0.0, 0.0]
+            results = db.search("query", query, top_k=50, filters={"user_id": "edge_user"})
+            assert len(results) == 50
+            scores = [r.score for r in results]
+            for i in range(len(scores) - 1):
+                assert scores[i] >= scores[i + 1]
+        finally:
+            db.delete_col()
+
+    def test_d061_duplicate_scores_stability(self):
+        db = _new_dist_db(vector_metric="cosine")
+        try:
+            _insert_memories(db, [
+                (_uuid(6011), [0.5, 0.5, 0.0, 0.0], {"data": "dup_a", "user_id": "edge_user"}),
+                (_uuid(6012), [0.5, 0.5, 0.0, 0.0], {"data": "dup_b", "user_id": "edge_user"}),
+                (_uuid(6013), [0.5, 0.5, 0.0, 0.0], {"data": "dup_c", "user_id": "edge_user"}),
+            ])
+            results = db.search("query", [1.0, 0.0, 0.0, 0.0], top_k=3, filters={"user_id": "edge_user"})
+            assert len(results) == 3
+            scores = [r.score for r in results]
+            assert all(abs(s - scores[0]) < 1e-6 for s in scores)
+        finally:
+            db.delete_col()
+
+
+# ===========================================================================
+# TestDistributedBM25Degradation - BM25 graceful degradation
+# ===========================================================================
+
+
+class TestDistributedBM25Degradation:
+    """BM25 is auto-disabled in distributed mode; verify graceful degradation."""
+
+    def test_d070_keyword_search_returns_none_or_empty(self):
+        db = _new_dist_db()
+        try:
+            db.insert(ids=[_uuid(1)], vectors=[VECTORS_4D["A"]], payloads=[{"data": "coffee morning", "user_id": "bm25_user", "text_lemmatized": "coffee morning"}])
+            result = db.keyword_search(query="coffee", top_k=5, filters={"user_id": "bm25_user"})
+            assert result is None or result == []
+        finally:
+            db.delete_col()
+
+    def test_d071_bm25_flag_stays_false(self):
+        db = _new_dist_db()
+        try:
+            assert db.bm25_enabled is False
+        finally:
+            db.delete_col()
+
+    def test_d072_search_still_works_without_bm25(self):
+        db = _new_dist_db()
+        try:
+            db.insert(ids=[_uuid(1)], vectors=[VECTORS_4D["A"]], payloads=[{"data": "coffee", "user_id": "bm25_user"}])
+            results = db.search("coffee", VECTORS_4D["A"], top_k=1, filters={"user_id": "bm25_user"})
+            assert len(results) == 1
+        finally:
+            db.delete_col()
+
+
+# ===========================================================================
+# TestDistributedBoundary - Boundary conditions in distributed mode
+# ===========================================================================
+
+
+@pytest.mark.skipif(not _env_bool("GAUSSDB_TEST_RUN_FULL_DISTRIBUTED"), reason=_FULL_DIST_REASON)
+class TestDistributedBoundary:
+    """Edge cases and boundary conditions across distributed nodes."""
+
+    def test_d080_single_dimension_vector(self):
+        db = _new_dist_db(embedding_model_dims=1)
+        try:
+            vid = _uuid(1001)
+            db.insert(ids=[vid], vectors=[[0.5]], payloads=[{"data": "1d", "user_id": "dim_user"}])
+            results = db.search("test", [0.5], top_k=1, filters={"user_id": "dim_user"})
+            assert len(results) == 1
+            assert results[0].id == vid
+        finally:
+            db.delete_col()
+
+    def test_d081_high_dimension_vector(self):
+        db = _new_dist_db(embedding_model_dims=DIMS_BOUNDARY)
+        try:
+            vid = _uuid(1002)
+            vec = _random_vector(dims=DIMS_BOUNDARY)
+            db.insert(ids=[vid], vectors=[vec], payloads=[{"data": "high_dim", "user_id": "dim_user"}])
+            results = db.search("test", vec, top_k=1, filters={"user_id": "dim_user"})
+            assert len(results) == 1
+            assert results[0].id == vid
+        finally:
+            db.delete_col()
+
+    def test_d082_empty_payload(self):
+        db = _new_dist_db()
+        try:
+            vid = _uuid(2001)
+            db.insert(ids=[vid], vectors=[VECTORS_4D["A"]], payloads=[{"user_id": "boundary_user"}])
+            result = db.get(vid)
+            assert result is not None
+        finally:
+            db.delete_col()
+
+    def test_d083_large_payload(self):
+        db = _new_dist_db()
+        try:
+            vid = _uuid(2002)
+            large_text = "x" * 10000
+            db.insert(ids=[vid], vectors=[VECTORS_4D["A"]], payloads=[{"data": large_text, "user_id": "boundary_user"}])
+            result = db.get(vid)
+            assert len(result.payload["data"]) == 10000
+        finally:
+            db.delete_col()
+
+    def test_d084_unicode_payload(self):
+        db = _new_dist_db()
+        try:
+            vid = _uuid(2003)
+            text = "Chinese: 中文 Japanese: 日本語 Korean: 한국어 Emoji: \U0001f680"
+            db.insert(ids=[vid], vectors=[VECTORS_4D["A"]], payloads=[{"data": text, "user_id": "boundary_user"}])
+            result = db.get(vid)
+            assert result.payload["data"] == text
+        finally:
+            db.delete_col()
+
+    def test_d085_special_chars_in_payload(self):
+        db = _new_dist_db()
+        try:
+            vid = _uuid(2004)
+            text = "quotes: \"hello\" 'world' backslash: \\ newline: \n tab: \t"
+            db.insert(ids=[vid], vectors=[VECTORS_4D["A"]], payloads=[{"data": text, "user_id": "boundary_user"}])
+            result = db.get(vid)
+            assert result.payload["data"] == text
+        finally:
+            db.delete_col()
+
+    def test_d086_top_k_one(self):
+        db = _new_dist_db()
+        try:
+            for i in range(5):
+                db.insert(ids=[_uuid(3001 + i)], vectors=[_random_vector()], payloads=[{"data": f"item_{i}", "user_id": "topk_user"}])
+            results = db.search("test", _random_vector(), top_k=1, filters={"user_id": "topk_user"})
+            assert len(results) == 1
+        finally:
+            db.delete_col()
+
+    def test_d087_top_k_exceeds_data(self):
+        db = _new_dist_db()
+        try:
+            for i in range(3):
+                db.insert(ids=[_uuid(3011 + i)], vectors=[_random_vector()], payloads=[{"data": f"item_{i}", "user_id": "topk_user"}])
+            results = db.search("test", _random_vector(), top_k=100, filters={"user_id": "topk_user"})
+            assert len(results) == 3
+        finally:
+            db.delete_col()
+
+    def test_d088_top_k_very_large(self):
+        db = _new_dist_db()
+        try:
+            db.insert(ids=[_uuid(3021)], vectors=[_random_vector()], payloads=[{"data": "single", "user_id": "topk_user"}])
+            results = db.search("test", _random_vector(), top_k=10000, filters={"user_id": "topk_user"})
+            assert len(results) == 1
+        finally:
+            db.delete_col()
+
+    def test_d089_collection_name_max_length(self):
+        long_name = "a" * 51
+        config = _gaussdb_distributed_config(long_name)
+        db = GaussDB(**config)
+        try:
+            vid = _uuid(4001)
+            db.insert(ids=[vid], vectors=[VECTORS_4D["A"]], payloads=[{"data": "long name", "user_id": "col_user"}])
+            result = db.get(vid)
+            assert result is not None
+        finally:
+            db.delete_col()
+
+    def test_d090_collection_name_sql_injection_rejected(self):
+        with pytest.raises(ValueError, match="Unsafe"):
+            _new_dist_db(prefix=None, collection_name="test; DROP TABLE users;--")
+
+    def test_d091_empty_collection_name_rejected(self):
+        config = _gaussdb_distributed_config("placeholder")
+        config["collection_name"] = ""
+        with pytest.raises(ValueError):
+            GaussDB(**config)
+
+    def test_d092_batch_insert_100_records(self):
+        db = _new_dist_db()
+        try:
+            ids = [_uuid(5000 + i) for i in range(100)]
+            vectors = [_random_vector() for _ in range(100)]
+            payloads = [{"data": f"batch_{i}", "user_id": "batch_user"} for i in range(100)]
+            db.insert(ids=ids, vectors=vectors, payloads=payloads)
+            listed = _list_flat(db, filters={"user_id": "batch_user"}, top_k=200)
+            assert len(listed) == 100
+        finally:
+            db.delete_col()
+
+    def test_d093_nested_json_payload(self):
+        db = _new_dist_db()
+        try:
+            vid = _uuid(6001)
+            payload = {
+                "data": "nested test",
+                "user_id": "json_user",
+                "metadata": {"key1": "value1", "key2": 42, "nested": {"deep": True}},
+            }
+            db.insert(ids=[vid], vectors=[VECTORS_4D["A"]], payloads=[payload])
+            result = db.get(vid)
+            assert result.payload["metadata"]["key1"] == "value1"
+            assert result.payload["metadata"]["nested"]["deep"] is True
+        finally:
+            db.delete_col()
+
+
+# ===========================================================================
+# TestDistributedMultitenant - Multi-tenant isolation in distributed mode
+# ===========================================================================
+
+
+@pytest.mark.skipif(not _env_bool("GAUSSDB_TEST_RUN_FULL_DISTRIBUTED"), reason=_FULL_DIST_REASON)
+class TestDistributedMultitenant:
+    """Multi-tenant isolation across distributed nodes."""
+
+    def test_d100_user_id_isolation(self):
+        db = _new_dist_db()
+        try:
+            _insert_memories(db, [
+                (_uuid(7001), VECTORS_4D["A"], {"data": "alice data", "user_id": "alice"}),
+                (_uuid(7002), VECTORS_4D["B"], {"data": "bob data", "user_id": "bob"}),
+                (_uuid(7003), VECTORS_4D["C"], {"data": "alice data2", "user_id": "alice"}),
+            ])
+            alice_rows = _list_flat(db, filters={"user_id": "alice"}, top_k=100)
+            bob_rows = _list_flat(db, filters={"user_id": "bob"}, top_k=100)
+            assert len(alice_rows) == 2
+            assert len(bob_rows) == 1
+            _assert_exact_ids(alice_rows, {_uuid(7001), _uuid(7003)})
+            _assert_exact_ids(bob_rows, {_uuid(7002)})
+        finally:
+            db.delete_col()
+
+    def test_d101_agent_id_isolation(self):
+        db = _new_dist_db()
+        try:
+            _insert_memories(db, [
+                (_uuid(7101), VECTORS_4D["A"], {"data": "bot_a data", "user_id": "alice", "agent_id": "bot_a"}),
+                (_uuid(7102), VECTORS_4D["B"], {"data": "bot_b data", "user_id": "alice", "agent_id": "bot_b"}),
+            ])
+            rows = db.search("test", VECTORS_4D["A"], top_k=10, filters={"user_id": "alice", "agent_id": "bot_a"})
+            _assert_exact_ids(rows, {_uuid(7101)})
+        finally:
+            db.delete_col()
+
+    def test_d102_run_id_isolation(self):
+        db = _new_dist_db()
+        try:
+            _insert_memories(db, [
+                (_uuid(7201), VECTORS_4D["A"], {"data": "run1", "user_id": "alice", "run_id": "run_001"}),
+                (_uuid(7202), VECTORS_4D["B"], {"data": "run2", "user_id": "alice", "run_id": "run_002"}),
+            ])
+            rows = db.search("test", VECTORS_4D["A"], top_k=10, filters={"user_id": "alice", "run_id": "run_001"})
+            _assert_exact_ids(rows, {_uuid(7201)})
+        finally:
+            db.delete_col()
+
+    def test_d103_combined_scope(self):
+        db = _new_dist_db()
+        try:
+            _insert_memories(db, [
+                (_uuid(7311), VECTORS_4D["A"], {"data": "full match", "user_id": "alice", "agent_id": "bot_a", "run_id": "run_001"}),
+                (_uuid(7312), VECTORS_4D["B"], {"data": "partial", "user_id": "alice", "agent_id": "bot_a", "run_id": "run_999"}),
+            ])
+            results = _list_flat(db, filters={"user_id": "alice", "agent_id": "bot_a", "run_id": "run_001"}, top_k=100)
+            _assert_exact_ids(results, {_uuid(7311)})
+        finally:
+            db.delete_col()
+
+    def test_d104_scope_empty_on_mismatch(self):
+        db = _new_dist_db()
+        try:
+            _insert_memories(db, [
+                (_uuid(7321), VECTORS_4D["A"], {"data": "some data", "user_id": "alice", "agent_id": "bot_a"}),
+            ])
+            results = _list_flat(db, filters={"user_id": "charlie", "agent_id": "bot_x"}, top_k=100)
+            assert len(results) == 0
+        finally:
+            db.delete_col()
+
+    def test_d105_user_sees_all_agents(self):
+        db = _new_dist_db()
+        try:
+            _insert_memories(db, [
+                (_uuid(7331), VECTORS_4D["A"], {"data": "bot_a", "user_id": "alice", "agent_id": "bot_a"}),
+                (_uuid(7332), VECTORS_4D["B"], {"data": "bot_b", "user_id": "alice", "agent_id": "bot_b"}),
+                (_uuid(7333), VECTORS_4D["C"], {"data": "bot_c", "user_id": "alice", "agent_id": "bot_c"}),
+                (_uuid(7334), VECTORS_4D["D"], {"data": "bob_bot", "user_id": "bob", "agent_id": "bot_a"}),
+            ])
+            results = _list_flat(db, filters={"user_id": "alice"}, top_k=100)
+            _assert_exact_ids(results, {_uuid(7331), _uuid(7332), _uuid(7333)})
+        finally:
+            db.delete_col()
+
+    def test_d106_search_respects_tenant_scope(self):
+        db = _new_dist_db()
+        try:
+            _insert_memories(db, [
+                (_uuid(7341), VECTORS_4D["A"], {"data": "alice_near", "user_id": "alice"}),
+                (_uuid(7342), VECTORS_4D["similar_A"], {"data": "bob_near", "user_id": "bob"}),
+            ])
+            results = db.search("test", VECTORS_4D["A"], top_k=10, filters={"user_id": "alice"})
+            assert all(r.payload["user_id"] == "alice" for r in results)
+            _assert_exact_ids(results, {_uuid(7341)})
+        finally:
+            db.delete_col()
+
+    def test_d107_delete_respects_isolation(self):
+        db = _new_dist_db()
+        try:
+            _insert_memories(db, [
+                (_uuid(7351), VECTORS_4D["A"], {"data": "alice", "user_id": "alice"}),
+                (_uuid(7352), VECTORS_4D["B"], {"data": "bob", "user_id": "bob"}),
+            ])
+            db.delete(vector_id=_uuid(7351))
+            assert db.get(_uuid(7351)) is None
+            assert db.get(_uuid(7352)) is not None
+        finally:
+            db.delete_col()
+
+
+# ===========================================================================
+# TestDistributedConcurrency - Concurrency safety in distributed mode
+# ===========================================================================
+
+
+@pytest.mark.skipif(not _env_bool("GAUSSDB_TEST_RUN_PERF"), reason="Performance tests disabled; set GAUSSDB_TEST_RUN_PERF=1 to enable")
+class TestDistributedConcurrency:
+    """Concurrency safety across distributed nodes."""
+
+    def test_d110_concurrent_multi_user_insert(self):
+        """5 threads inserting for different users, verify isolation."""
+        db = _new_dist_db(maxconn=10)
+        try:
+            users = [f"user_{i}" for i in range(5)]
+
+            def add_for_user(idx):
+                uid = users[idx]
+                record_id = _uuid(8000 + idx)
+                db.insert(
+                    ids=[record_id],
+                    vectors=[_random_vector()],
+                    payloads=[{"data": f"{uid} memory", "user_id": uid}],
+                )
+                return uid, record_id
+
+            results_map = {}
+            with ThreadPoolExecutor(max_workers=5) as executor:
+                futures = {executor.submit(add_for_user, i): i for i in range(5)}
+                for future in as_completed(futures):
+                    uid, record_id = future.result()
+                    results_map[uid] = record_id
+
+            for uid, record_id in results_map.items():
+                user_records = _list_flat(db, filters={"user_id": uid}, top_k=100)
+                assert len(user_records) == 1
+                assert _ids(user_records)[0] == record_id
+        finally:
+            db.delete_col()
+
+    def test_d111_concurrent_multi_user_search(self):
+        """5 threads searching for different users, verify isolation."""
+        db = _new_dist_db(maxconn=10)
+        try:
+            for i in range(5):
+                uid = f"user_{i}"
+                db.insert(
+                    ids=[_uuid(8010 + i)],
+                    vectors=[_random_vector()],
+                    payloads=[{"data": f"{uid} data", "user_id": uid}],
+                )
+
+            def search_for_user(idx):
+                uid = f"user_{idx}"
+                results = db.search("data", _random_vector(), top_k=10, filters={"user_id": uid})
+                return uid, results
+
+            with ThreadPoolExecutor(max_workers=5) as executor:
+                futures = {executor.submit(search_for_user, i): i for i in range(5)}
+                for future in as_completed(futures):
+                    uid, results = future.result()
+                    idx = int(uid.split("_")[1])
+                    expected_id = _uuid(8010 + idx)
+                    assert expected_id in _ids(results)
+        finally:
+            db.delete_col()
+
+    def test_d112_concurrent_insert_same_collection(self):
+        """10 threads inserting into same collection concurrently."""
+        db = _new_dist_db(maxconn=15)
+        try:
+            user_id = "conc_insert_user"
+
+            def inserter(thread_idx, iter_idx):
+                db.insert(
+                    ids=[str(uuid.uuid4())],
+                    vectors=[_random_vector()],
+                    payloads=[{"data": f"t{thread_idx}_i{iter_idx}", "user_id": user_id}],
+                )
+
+            result = _concurrent_runner(inserter, num_threads=10, iterations_per_thread=5)
+            assert result["error_count"] == 0
+            listed = _list_flat(db, filters={"user_id": user_id}, top_k=200)
+            assert len(listed) == 50
+        finally:
+            db.delete_col()
+
+    def test_d113_concurrent_upsert_same_record(self):
+        """10 threads upserting the same record concurrently."""
+        db = _new_dist_db(maxconn=15)
+        try:
+            vid = _uuid(8100)
+            db.insert(ids=[vid], vectors=[_random_vector()], payloads=[{"data": "original", "user_id": "upsert_user"}])
+
+            def do_upsert(idx):
+                db.update(vector_id=vid, payload={"data": f"update_{idx}", "user_id": "upsert_user"})
+
+            with ThreadPoolExecutor(max_workers=10) as executor:
+                list(executor.map(do_upsert, range(20)))
+
+            result = db.get(vid)
+            assert result is not None
+            assert result.payload["user_id"] == "upsert_user"
+            listed = _list_flat(db, filters={"user_id": "upsert_user"}, top_k=100)
+            assert len(listed) == 1
+        finally:
+            db.delete_col()
+
+    def test_d114_concurrent_insert_and_search(self):
+        """5 insert threads + 5 search threads simultaneously."""
+        db = _new_dist_db(maxconn=15)
+        try:
+            user_id = "rw_user"
+            for i in range(10):
+                db.insert(ids=[_uuid(8200 + i)], vectors=[_random_vector()], payloads=[{"data": f"seed_{i}", "user_id": user_id}])
+
+            def inserter(idx):
+                for i in range(10):
+                    db.insert(
+                        ids=[str(uuid.uuid4())],
+                        vectors=[_random_vector()],
+                        payloads=[{"data": f"insert_t{idx}_{i}", "user_id": user_id}],
+                    )
+
+            def searcher(idx):
+                for i in range(10):
+                    results = db.search("query", _random_vector(), top_k=5, filters={"user_id": user_id})
+                    assert isinstance(results, list)
+
+            tasks = (
+                [lambda idx=t: inserter(idx) for t in range(5)]
+                + [lambda idx=t: searcher(idx) for t in range(5)]
+            )
+            successes, errors = _run_concurrent(tasks, max_workers=10)
+            assert successes >= 5
+        finally:
+            db.delete_col()
+
+    def test_d115_concurrent_update_and_search(self):
+        """5 update threads + 5 search threads simultaneously."""
+        db = _new_dist_db(maxconn=15)
+        try:
+            user_id = "rw_update_user"
+            record_ids = []
+            for i in range(20):
+                rid = str(uuid.uuid4())
+                record_ids.append(rid)
+                db.insert(ids=[rid], vectors=[_random_vector()], payloads=[{"data": f"original_{i}", "user_id": user_id}])
+
+            def updater(idx):
+                for i in range(5):
+                    target = record_ids[(idx * 5 + i) % len(record_ids)]
+                    db.update(vector_id=target, vector=_random_vector(), payload={"data": f"updated_t{idx}_{i}", "user_id": user_id})
+
+            def searcher(idx):
+                for i in range(5):
+                    db.search("query", _random_vector(), top_k=5, filters={"user_id": user_id})
+
+            tasks = (
+                [lambda idx=t: updater(idx) for t in range(5)]
+                + [lambda idx=t: searcher(idx) for t in range(5)]
+            )
+            successes, errors = _run_concurrent(tasks, max_workers=10)
+            final_count = len(_list_flat(db, filters={"user_id": user_id}, top_k=200))
+            assert final_count == 20
+        finally:
+            db.delete_col()
+
+    def test_d116_concurrent_delete_and_search(self):
+        """5 delete threads + 5 search threads simultaneously."""
+        db = _new_dist_db(maxconn=15)
+        try:
+            user_id = "rw_delete_user"
+            record_ids = []
+            for i in range(50):
+                rid = str(uuid.uuid4())
+                record_ids.append(rid)
+                db.insert(ids=[rid], vectors=[_random_vector()], payloads=[{"data": f"to_delete_{i}", "user_id": user_id}])
+
+            chunk_size = 10
+
+            def deleter(idx):
+                start = idx * chunk_size
+                for rid in record_ids[start:start + chunk_size]:
+                    db.delete(vector_id=rid)
+
+            def searcher(idx):
+                for i in range(10):
+                    results = db.search("query", _random_vector(), top_k=5, filters={"user_id": user_id})
+                    assert isinstance(results, list)
+
+            tasks = (
+                [lambda idx=t: deleter(idx) for t in range(5)]
+                + [lambda idx=t: searcher(idx) for t in range(5)]
+            )
+            successes, errors = _run_concurrent(tasks, max_workers=10)
+            final_count = len(_list_flat(db, filters={"user_id": user_id}, top_k=200))
+            assert final_count < 50
+        finally:
+            db.delete_col()
+
+    def test_d117_data_consistency_after_concurrent_ops(self):
+        """Verify data consistency after concurrent updates."""
+        db = _new_dist_db(maxconn=15)
+        try:
+            user_id = "consistency_user"
+            record_ids = []
+            for i in range(10):
+                rid = _uuid(8300 + i)
+                record_ids.append(rid)
+                db.insert(ids=[rid], vectors=[_random_vector()], payloads=[{"data": f"original_{i}", "user_id": user_id}])
+
+            def updater(idx):
+                for i in range(5):
+                    target = record_ids[idx % len(record_ids)]
+                    try:
+                        db.update(vector_id=target, payload={"data": f"updated_t{idx}_{i}", "user_id": user_id})
+                    except Exception:
+                        pass
+
+            tasks = [lambda idx=t: updater(idx) for t in range(10)]
+            _run_concurrent(tasks, max_workers=10)
+
+            for rid in record_ids:
+                result = db.get(rid)
+                assert result is not None
+                assert result.payload["user_id"] == user_id
+
+            assert len(_list_flat(db, filters={"user_id": user_id}, top_k=100)) == 10
+        finally:
+            db.delete_col()
+
+
+# ===========================================================================
+# TestDistributedPerformance - Performance baselines in distributed mode
+# ===========================================================================
+
+
+@pytest.mark.skipif(not _env_bool("GAUSSDB_TEST_RUN_PERF"), reason="Performance tests disabled; set GAUSSDB_TEST_RUN_PERF=1 to enable")
+class TestDistributedPerformance:
+    """Performance baseline measurements for distributed mode."""
+
+    def test_d120_single_insert_latency(self):
+        """Insert 50 times, verify P50 < 200ms (relaxed for distributed)."""
+        db = _new_dist_db()
+        try:
+            counter = [0]
+
+            def _do_insert():
+                counter[0] += 1
+                db.insert(
+                    ids=[str(uuid.uuid4())],
+                    vectors=[_random_vector()],
+                    payloads=[{"data": f"perf_{counter[0]}", "user_id": "perf_user"}],
+                )
+
+            stats = _measure_latency(_do_insert, iterations=50)
+            _print_latency_report("dist_single_insert", stats)
+            _soft_assert(stats["p50_ms"] < 200, f"P50 insert {stats['p50_ms']:.2f}ms > 200ms")
+        finally:
+            db.delete_col()
+
+    def test_d121_single_search_latency(self):
+        """Search 50 times, verify P50 < 100ms."""
+        db = _new_dist_db()
+        try:
+            for i in range(30):
+                db.insert(ids=[_uuid(9000 + i)], vectors=[_random_vector()], payloads=[{"data": f"item_{i}", "user_id": "perf_user"}])
+
+            def _do_search():
+                db.search("query", _random_vector(), top_k=5, filters={"user_id": "perf_user"})
+
+            stats = _measure_latency(_do_search, iterations=50)
+            _print_latency_report("dist_single_search", stats)
+            _soft_assert(stats["p50_ms"] < 100, f"P50 search {stats['p50_ms']:.2f}ms > 100ms")
+        finally:
+            db.delete_col()
+
+    def test_d122_single_update_latency(self):
+        """Update 50 times, verify P50 < 250ms."""
+        db = _new_dist_db()
+        try:
+            vid = _uuid(9100)
+            db.insert(ids=[vid], vectors=[_random_vector()], payloads=[{"data": "target", "user_id": "perf_user"}])
+            counter = [0]
+
+            def _do_update():
+                counter[0] += 1
+                db.update(vid, vector=_random_vector(), payload={"data": f"upd_{counter[0]}", "user_id": "perf_user"})
+
+            stats = _measure_latency(_do_update, iterations=50)
+            _print_latency_report("dist_single_update", stats)
+            _soft_assert(stats["p50_ms"] < 250, f"P50 update {stats['p50_ms']:.2f}ms > 250ms")
+        finally:
+            db.delete_col()
+
+    def test_d123_single_get_latency(self):
+        """Get 50 times, verify P50 < 20ms."""
+        db = _new_dist_db()
+        try:
+            vid = _uuid(9200)
+            db.insert(ids=[vid], vectors=[_random_vector()], payloads=[{"data": "get_target", "user_id": "perf_user"}])
+
+            def _do_get():
+                db.get(vid)
+
+            stats = _measure_latency(_do_get, iterations=50)
+            _print_latency_report("dist_single_get", stats)
+            _soft_assert(stats["p50_ms"] < 20, f"P50 get {stats['p50_ms']:.2f}ms > 20ms")
+        finally:
+            db.delete_col()
+
+    def test_d124_batch_insert_throughput(self):
+        """Insert 200 records in batches of 50, measure total time."""
+        db = _new_dist_db()
+        try:
+            start = time.perf_counter()
+            for batch in range(4):
+                ids = [str(uuid.uuid4()) for _ in range(50)]
+                vectors = [_random_vector() for _ in range(50)]
+                payloads = [{"data": f"batch_{batch}_{i}", "user_id": "perf_user"} for i in range(50)]
+                db.insert(ids=ids, vectors=vectors, payloads=payloads)
+            duration_ms = (time.perf_counter() - start) * 1000
+
+            listed = _list_flat(db, filters={"user_id": "perf_user"}, top_k=300)
+            assert len(listed) == 200
+            _soft_assert(duration_ms < 10000, f"Batch insert took {duration_ms:.0f}ms > 10s")
+        finally:
+            db.delete_col()
+
+    def test_d125_search_with_filters_latency(self):
+        """Search with complex filters, verify reasonable latency."""
+        db = _new_dist_db()
+        try:
+            for i in range(50):
+                db.insert(
+                    ids=[_uuid(9300 + i)],
+                    vectors=[_random_vector()],
+                    payloads=[{"data": f"item_{i}", "user_id": "perf_user", "category": f"cat_{i % 5}", "priority": str(i % 10)}],
+                )
+
+            def _do_filtered_search():
+                db.search("query", _random_vector(), top_k=10, filters={"user_id": "perf_user", "category": {"in": ["cat_0", "cat_1"]}})
+
+            stats = _measure_latency(_do_filtered_search, iterations=30)
+            _print_latency_report("dist_filtered_search", stats)
+            _soft_assert(stats["p50_ms"] < 150, f"P50 filtered search {stats['p50_ms']:.2f}ms > 150ms")
+        finally:
+            db.delete_col()
+
+
+# ===========================================================================
+# TestDistributedCollectionOps - Collection lifecycle in distributed mode
+# ===========================================================================
+
+
+class TestDistributedCollectionOps:
+    """Collection lifecycle operations in distributed mode."""
+
+    def test_d130_col_info(self):
+        db = _new_dist_db()
+        try:
+            db.insert(ids=[_uuid(1)], vectors=[VECTORS_4D["A"]], payloads=[{"data": "info", "user_id": "ops_user"}])
+            info = db.col_info()
+            assert info["name"] == db.collection_name
+            assert info["count"] == 1
+        finally:
+            db.delete_col()
+
+    def test_d131_list_collections(self):
+        db = _new_dist_db()
+        try:
+            cols = db.list_cols()
+            assert isinstance(cols, list)
+            assert db.collection_name in cols
+        finally:
+            db.delete_col()
+
+    def test_d132_reset_collection(self):
+        db = _new_dist_db()
+        try:
+            for i in range(5):
+                db.insert(ids=[_uuid(i)], vectors=[_random_vector()], payloads=[{"data": f"item_{i}", "user_id": "ops_user"}])
+            assert db.col_info()["count"] == 5
+            db.reset()
+            assert db.col_info()["count"] == 0
+        finally:
+            db.delete_col()
+
+    def test_d133_delete_and_recreate_collection(self):
+        name = _new_collection("dist_recreate")
+        config = _gaussdb_distributed_config(name)
+        db = GaussDB(**config)
+        try:
+            db.insert(ids=[_uuid(1)], vectors=[VECTORS_4D["A"]], payloads=[{"data": "first", "user_id": "ops_user"}])
+            db.delete_col()
+            db2 = GaussDB(**config)
+            db2.insert(ids=[_uuid(2)], vectors=[VECTORS_4D["B"]], payloads=[{"data": "second", "user_id": "ops_user"}])
+            assert db2.get(_uuid(2)) is not None
+            assert db2.get(_uuid(1)) is None
+            db2.delete_col()
+        except Exception:
+            try:
+                db.delete_col()
+            except Exception:
+                pass
+            raise
+
+    def test_d134_analyze(self):
+        db = _new_dist_db()
+        try:
+            db.insert(ids=[_uuid(1)], vectors=[VECTORS_4D["A"]], payloads=[{"data": "analyze", "user_id": "ops_user"}])
+            db.analyze()
+        finally:
+            db.delete_col()
+
+    def test_d135_schema_meta_not_in_list(self):
+        db = _new_dist_db()
+        try:
+            cols = db.list_cols()
+            assert f"{db.collection_name}_schema_meta" not in cols
+        finally:
+            db.delete_col()
+
+
+# ===========================================================================
+# TestDistributedFeatures - GaussDB-specific features in distributed mode
+# ===========================================================================
+
+
+@pytest.mark.skipif(not _env_bool("GAUSSDB_TEST_RUN_FULL_DISTRIBUTED"), reason=_FULL_DIST_REASON)
+class TestDistributedFeatures:
+    """GaussDB-specific features verification in distributed mode."""
+
+    def test_d140_floatvector_precision(self):
+        """Float32 precision is maintained in distributed mode."""
+        db = _new_dist_db()
+        try:
+            vid = _uuid(7401)
+            precise_vector = [0.123456789, 0.987654321, 0.555555555, 0.111111111]
+            db.insert(ids=[vid], vectors=[precise_vector], payloads=[{"data": "precision", "user_id": "feat_user"}])
+            results = db.search("precision", precise_vector, top_k=1, filters={"user_id": "feat_user"})
+            assert len(results) == 1
+            assert results[0].id == vid
+            if results[0].score is not None:
+                assert results[0].score > 0.99
+        finally:
+            db.delete_col()
+
+    def test_d141_high_dim_vector_support(self):
+        """High-dimensional vectors work in distributed mode."""
+        dims = 512
+        db = _new_dist_db(embedding_model_dims=dims)
+        try:
+            vid = _uuid(7501)
+            vec = [random.random() for _ in range(dims)]
+            db.insert(ids=[vid], vectors=[vec], payloads=[{"data": "high_dim", "user_id": "feat_user"}])
+            results = db.search("test", vec, top_k=1, filters={"user_id": "feat_user"})
+            assert len(results) == 1
+            assert results[0].id == vid
+        finally:
+            db.delete_col()
+
+    def test_d142_merge_into_upsert(self):
+        """MERGE INTO (upsert) works correctly in distributed mode."""
+        db = _new_dist_db()
+        try:
+            vid = _uuid(7601)
+            db.insert(ids=[vid], vectors=[VECTORS_4D["A"]], payloads=[{"data": "original", "user_id": "feat_user"}])
+            db.update(vector_id=vid, vector=VECTORS_4D["B"], payload={"data": "merged", "user_id": "feat_user"})
+            result = db.get(vid)
+            assert result.payload["data"] == "merged"
+            results = db.search("test", VECTORS_4D["B"], top_k=1, filters={"user_id": "feat_user"})
+            assert results[0].id == vid
+        finally:
+            db.delete_col()
+
+    def test_d143_merge_into_idempotent(self):
+        """MERGE INTO with same data is idempotent."""
+        db = _new_dist_db()
+        try:
+            vid = _uuid(7701)
+            vector = VECTORS_4D["C"]
+            payload = {"data": "idempotent", "user_id": "feat_user"}
+            db.insert(ids=[vid], vectors=[vector], payloads=[payload])
+            for _ in range(3):
+                db.update(vector_id=vid, vector=vector, payload=payload)
+            result = db.get(vid)
+            assert result.payload["data"] == "idempotent"
+            listed = _list_flat(db, filters={"user_id": "feat_user"}, top_k=100)
+            assert len(listed) == 1
+        finally:
+            db.delete_col()
+
+    def test_d144_vector_index_creation(self):
+        """Vector index is created in distributed mode."""
+        db = _new_dist_db()
+        try:
+            info = db.col_info()
+            indexes = info.get("indexes", [])
+            has_vector_idx = any("vector" in idx.lower() or "ivf" in idx.lower() for idx in indexes)
+            assert has_vector_idx, f"No vector index found in: {indexes}"
+        finally:
+            db.delete_col()
+
+    def test_d145_deployment_mode_in_col_info(self):
+        """col_info reports distributed deployment mode."""
+        db = _new_dist_db()
+        try:
+            info = db.col_info()
+            assert info.get("deployment_mode") == "distributed" or db.deployment_mode == "distributed"
+        finally:
+            db.delete_col()
+
+    def test_d146_update_in_place(self):
+        """Update modifies record in place without duplication."""
+        db = _new_dist_db()
+        try:
+            vid = _uuid(7801)
+            db.insert(ids=[vid], vectors=[VECTORS_4D["A"]], payloads=[{"data": "original", "user_id": "feat_user"}])
+            db.update(vector_id=vid, vector=VECTORS_4D["B"], payload={"data": "updated", "user_id": "feat_user"})
+            updated = db.get(vid)
+            assert updated.payload["data"] == "updated"
+            results = db.search("test", VECTORS_4D["B"], top_k=1, filters={"user_id": "feat_user"})
+            assert len(results) >= 1
+            assert results[0].id == vid
+        finally:
+            db.delete_col()
+
+    def test_d147_search_batch(self):
+        """search_batch works in distributed mode."""
+        db = _new_dist_db()
+        try:
+            _insert_memories(db, [
+                (_uuid(7901), VECTORS_4D["A"], {"data": "point_a", "user_id": "batch_user"}),
+                (_uuid(7902), VECTORS_4D["B"], {"data": "point_b", "user_id": "batch_user"}),
+            ])
+            batch_results = db.search_batch(
+                ["a", "b"],
+                [VECTORS_4D["A"], VECTORS_4D["B"]],
+                top_k=1,
+                filters={"user_id": "batch_user"},
+            )
+            assert len(batch_results) == 2
+            assert batch_results[0][0].id == _uuid(7901)
+            assert batch_results[1][0].id == _uuid(7902)
+        finally:
+            db.delete_col()
+
+
+# ===========================================================================
+# TestDistributedE2E - End-to-end verification in distributed mode
+# ===========================================================================
+
+
+@pytest.mark.skipif(not _env_bool("GAUSSDB_TEST_RUN_FULL_DISTRIBUTED"), reason=_FULL_DIST_REASON)
+class TestDistributedE2E:
+    """Full E2E verification of distributed mode operations."""
+
+    def test_d150_e2e_insert_search_update_delete(self):
+        """Complete lifecycle: insert -> search -> update -> search -> delete -> verify."""
+        db = _new_dist_db(embedding_model_dims=1536)
+        try:
+            vid = str(uuid.uuid4())
+            vec = _make_vector_seeded(100, dims=1536)
+            db.insert(vectors=[vec], ids=[vid], payloads=[{"data": "e2e lifecycle", "user_id": "e2e_user"}])
+
+            results = db.search("lifecycle", vec, top_k=1, filters={"user_id": "e2e_user"})
+            assert len(results) == 1
+            assert results[0].id == vid
+
+            new_vec = _make_vector_seeded(101, dims=1536)
+            db.update(vector_id=vid, vector=new_vec, payload={"data": "updated lifecycle", "user_id": "e2e_user"})
+            results = db.search("updated", new_vec, top_k=1, filters={"user_id": "e2e_user"})
+            assert results[0].payload["data"] == "updated lifecycle"
+
+            db.delete(vector_id=vid)
+            assert db.get(vid) is None
+        finally:
+            db.delete_col()
+
+    def test_d151_e2e_batch_operations(self):
+        """Batch insert and verify all records accessible."""
+        db = _new_dist_db(embedding_model_dims=1536)
+        try:
+            ids = [str(uuid.uuid4()) for _ in range(20)]
+            vecs = [_make_vector_seeded(i + 200, dims=1536) for i in range(20)]
+            payloads = [{"data": f"batch_{i}", "user_id": "e2e_user"} for i in range(20)]
+            db.insert(vectors=vecs, ids=ids, payloads=payloads)
+
+            listed = _list_flat(db, filters={"user_id": "e2e_user"}, top_k=100)
+            assert len(listed) == 20
+        finally:
+            db.delete_col()
+
+    def test_d152_e2e_vector_update(self):
+        """Update vector and verify search finds it with new vector."""
+        db = _new_dist_db(embedding_model_dims=1536)
+        try:
+            vid = str(uuid.uuid4())
+            vec = _make_vector_seeded(301, dims=1536)
+            db.insert(vectors=[vec], ids=[vid], payloads=[{"data": "vec update", "user_id": "e2e_user"}])
+            new_vec = _make_vector_seeded(302, dims=1536)
+            db.update(vector_id=vid, vector=new_vec)
+            results = db.search("vec", new_vec, top_k=1, filters={"user_id": "e2e_user"})
+            assert len(results) >= 1
+            assert results[0].id == vid
+        finally:
+            db.delete_col()
+
+    def test_d153_e2e_list_with_filters(self):
+        """List with user_id filter returns correct subset."""
+        db = _new_dist_db(embedding_model_dims=1536)
+        try:
+            ids = [str(uuid.uuid4()) for _ in range(6)]
+            vecs = [_make_vector_seeded(i + 500, dims=1536) for i in range(6)]
+            payloads = [{"data": f"item_{i}", "user_id": "alice" if i < 3 else "bob"} for i in range(6)]
+            db.insert(vectors=vecs, ids=ids, payloads=payloads)
+            alice_items = _list_flat(db, filters={"user_id": "alice"}, top_k=100)
+            assert len(alice_items) == 3
+            bob_items = _list_flat(db, filters={"user_id": "bob"}, top_k=100)
+            assert len(bob_items) == 3
+        finally:
+            db.delete_col()
+
+    def test_d154_e2e_large_payload(self):
+        """Large payload stored and retrieved correctly."""
+        db = _new_dist_db(embedding_model_dims=1536)
+        try:
+            vid = str(uuid.uuid4())
+            vec = _make_vector_seeded(700, dims=1536)
+            large_text = "x" * 10000
+            db.insert(vectors=[vec], ids=[vid], payloads=[{"data": large_text, "user_id": "e2e_user"}])
+            result = db.get(vid)
+            assert len(result.payload["data"]) == 10000
+        finally:
+            db.delete_col()
+
+    def test_d155_e2e_unicode_payload(self):
+        """Unicode payload stored and retrieved correctly."""
+        db = _new_dist_db(embedding_model_dims=1536)
+        try:
+            vid = str(uuid.uuid4())
+            vec = _make_vector_seeded(800, dims=1536)
+            text = "中文测试 日本語 한국어 emoji: \U0001f680\U0001f4bb"
+            db.insert(vectors=[vec], ids=[vid], payloads=[{"data": text, "user_id": "e2e_user"}])
+            result = db.get(vid)
+            assert result.payload["data"] == text
+        finally:
+            db.delete_col()
+
+    def test_d156_e2e_concurrent_upsert_idempotency(self):
+        """Concurrent upserts on same record maintain single copy."""
+        db = _new_dist_db(embedding_model_dims=1536)
+        try:
+            vid = str(uuid.uuid4())
+            vec = _make_vector_seeded(900, dims=1536)
+            db.insert(vectors=[vec], ids=[vid], payloads=[{"data": "concurrent", "user_id": "e2e_user"}])
+
+            def do_upsert(idx):
+                db.update(vector_id=vid, payload={"data": f"update_{idx}", "user_id": "e2e_user"})
+
+            with ThreadPoolExecutor(max_workers=5) as executor:
+                list(executor.map(do_upsert, range(10)))
+
+            result = db.get(vid)
+            assert result is not None
+            listed = _list_flat(db, filters={"user_id": "e2e_user"}, top_k=100)
+            assert len(listed) == 1
+        finally:
+            db.delete_col()
+
+    def test_d157_e2e_reset_collection(self):
+        """Reset clears all data."""
+        db = _new_dist_db(embedding_model_dims=1536)
+        try:
+            ids = [str(uuid.uuid4()) for _ in range(5)]
+            vecs = [_make_vector_seeded(i + 1000, dims=1536) for i in range(5)]
+            payloads = [{"data": f"item_{i}", "user_id": "e2e_user"} for i in range(5)]
+            db.insert(vectors=vecs, ids=ids, payloads=payloads)
+            assert len(_list_flat(db, filters={"user_id": "e2e_user"}, top_k=100)) == 5
+            db.reset()
+            assert len(_list_flat(db, filters={"user_id": "e2e_user"}, top_k=100)) == 0
+        finally:
+            db.delete_col()
+
+
+# ===========================================================================
+# TestDistributedMemoryAPI - Memory.from_config integration in distributed mode
+# ===========================================================================
+
+
+@pytest.mark.skipif(not _env_bool("GAUSSDB_TEST_RUN_FULL_DISTRIBUTED"), reason=_FULL_DIST_REASON)
+class TestDistributedMemoryAPI:
+    """Memory API integration with distributed GaussDB backend."""
+
+    def test_d160_memory_add_search_delete(self):
+        """Memory.from_config add/search/delete with distributed GaussDB."""
+        from mem0 import Memory
+
+        collection = _new_collection("mem0_dist_memory")
+        vector_config = _gaussdb_distributed_config(collection, embedding_model_dims=EMBEDDING_DIMS)
+        assert vector_config is not None
+
+        memory_config = {
+            "vector_store": {"provider": "gaussdb", "config": vector_config},
+            "embedder": {"provider": "openai", "config": {"model": "fake", "api_key": "fake"}},
+            "llm": {"provider": "openai", "config": {"model": "fake", "api_key": "fake"}},
+            "version": "v1.1",
+        }
+
+        with (
+            patch("mem0.memory.main.EmbedderFactory.create", return_value=FakeEmbedder()),
+            patch("mem0.memory.main.LlmFactory.create", return_value=MagicMock()),
+            patch("mem0.memory.main.SQLiteManager", return_value=MagicMock()),
+            patch("mem0.memory.main.extract_entities", return_value=[]),
+            patch("mem0.memory.main.capture_event", lambda *args, **kwargs: None),
+            patch("mem0.memory.main.MEM0_TELEMETRY", False),
+        ):
+            memory = Memory.from_config(memory_config)
+
+        try:
+            added = memory.add(
+                "Alice prefers window seats on morning flights",
+                user_id="alice",
+                infer=False,
+                metadata={"source": "dist-memory-test"},
+            )
+            memory_id = added["results"][0]["id"]
+
+            search_result = memory.search("window seat", filters={"user_id": "alice"}, top_k=5, threshold=0)
+            rows = search_result["results"]
+            assert any(row["id"] == memory_id for row in rows)
+
+            memory.delete(memory_id)
+            assert memory.vector_store.get(memory_id) is None
+        finally:
+            memory.vector_store.delete_col()
+            if getattr(memory, "_entity_store", None) is not None:
+                memory.entity_store.delete_col()
+
+    def test_d161_memory_search_with_scope_filter(self):
+        """Memory search respects user_id scope in distributed mode."""
+        from mem0 import Memory
+
+        collection = _new_collection("mem0_dist_scope")
+        vector_config = _gaussdb_distributed_config(collection, embedding_model_dims=EMBEDDING_DIMS)
+        assert vector_config is not None
+
+        memory_config = {
+            "vector_store": {"provider": "gaussdb", "config": vector_config},
+            "embedder": {"provider": "openai", "config": {"model": "fake", "api_key": "fake"}},
+            "llm": {"provider": "openai", "config": {"model": "fake", "api_key": "fake"}},
+            "version": "v1.1",
+        }
+
+        with (
+            patch("mem0.memory.main.EmbedderFactory.create", return_value=FakeEmbedder()),
+            patch("mem0.memory.main.LlmFactory.create", return_value=MagicMock()),
+            patch("mem0.memory.main.SQLiteManager", return_value=MagicMock()),
+            patch("mem0.memory.main.extract_entities", return_value=[]),
+            patch("mem0.memory.main.capture_event", lambda *args, **kwargs: None),
+            patch("mem0.memory.main.MEM0_TELEMETRY", False),
+        ):
+            memory = Memory.from_config(memory_config)
+
+        try:
+            memory.add("Alice likes coffee", user_id="alice", infer=False)
+            memory.add("Bob likes tea", user_id="bob", infer=False)
+
+            alice_results = memory.search("likes", filters={"user_id": "alice"}, top_k=10, threshold=0)
+            bob_results = memory.search("likes", filters={"user_id": "bob"}, top_k=10, threshold=0)
+
+            alice_ids = {r["id"] for r in alice_results["results"]}
+            bob_ids = {r["id"] for r in bob_results["results"]}
+            assert alice_ids.isdisjoint(bob_ids)
+        finally:
+            memory.vector_store.delete_col()
+            if getattr(memory, "_entity_store", None) is not None:
+                memory.entity_store.delete_col()
+
+    def test_d162_memory_update(self):
+        """Memory update works in distributed mode."""
+        from mem0 import Memory
+
+        collection = _new_collection("mem0_dist_upd")
+        vector_config = _gaussdb_distributed_config(collection, embedding_model_dims=EMBEDDING_DIMS)
+        assert vector_config is not None
+
+        memory_config = {
+            "vector_store": {"provider": "gaussdb", "config": vector_config},
+            "embedder": {"provider": "openai", "config": {"model": "fake", "api_key": "fake"}},
+            "llm": {"provider": "openai", "config": {"model": "fake", "api_key": "fake"}},
+            "version": "v1.1",
+        }
+
+        with (
+            patch("mem0.memory.main.EmbedderFactory.create", return_value=FakeEmbedder()),
+            patch("mem0.memory.main.LlmFactory.create", return_value=MagicMock()),
+            patch("mem0.memory.main.SQLiteManager", return_value=MagicMock()),
+            patch("mem0.memory.main.extract_entities", return_value=[]),
+            patch("mem0.memory.main.capture_event", lambda *args, **kwargs: None),
+            patch("mem0.memory.main.MEM0_TELEMETRY", False),
+        ):
+            memory = Memory.from_config(memory_config)
+
+        try:
+            added = memory.add("Original memory text", user_id="alice", infer=False)
+            memory_id = added["results"][0]["id"]
+
+            record = memory.vector_store.get(memory_id)
+            assert record is not None
+            assert "Original memory text" in record.payload.get("data", "")
+        finally:
+            memory.vector_store.delete_col()
+            if getattr(memory, "_entity_store", None) is not None:
+                memory.entity_store.delete_col()
+
+
+# ===========================================================================
+# TestDistributedMultilang - Multi-language text handling in distributed mode
+# ===========================================================================
+
+
+MULTILANG_CASES_DIST = [
+    {"lang": "Chinese", "text": "华为GaussDB是一款优秀的分布式数据库产品"},
+    {"lang": "Japanese", "text": "東京は日本の首都です。春には桐が美しいです"},
+    {"lang": "Korean", "text": "서울은 한국의 수도입니다. 봄에는 볚꽃이 아름답습니다"},
+    {"lang": "Arabic", "text": "الرياض هي عاصمة المملكة العربية السعودية"},
+    {"lang": "Russian", "text": "Москва — столица России"},
+    {"lang": "Mixed", "text": "Hello 世界! こんにちは 안녕하세요 \U0001f30d"},
+    {"lang": "Emoji", "text": "\U0001f680\U0001f4bb\U0001f4ca\U0001f50d\U0001f4a1 DevOps pipeline status: ✅✅❌✅"},
+]
+
+
+@pytest.mark.skipif(not _env_bool("GAUSSDB_TEST_RUN_FULL_DISTRIBUTED"), reason=_FULL_DIST_REASON)
+class TestDistributedMultilang:
+    """Multi-language text handling in distributed mode."""
+
+    def test_d170_multilang_insert_and_retrieve(self):
+        """Insert and retrieve multi-language text."""
+        db = _new_dist_db(embedding_model_dims=1536)
+        try:
+            for i, case in enumerate(MULTILANG_CASES_DIST):
+                vid = str(uuid.uuid4())
+                vec = _make_vector_seeded(i, dims=1536)
+                db.insert(vectors=[vec], ids=[vid], payloads=[{"data": case["text"], "user_id": "lang_test", "lang": case["lang"]}])
+
+            listed = _list_flat(db, filters={"user_id": "lang_test"}, top_k=100)
+            assert len(listed) == len(MULTILANG_CASES_DIST)
+
+            for item in listed:
+                assert item.payload["data"] in [c["text"] for c in MULTILANG_CASES_DIST]
+        finally:
+            db.delete_col()
+
+    def test_d171_multilang_search(self):
+        """Search returns correct multilang records."""
+        db = _new_dist_db(embedding_model_dims=1536)
+        try:
+            vecs = [_make_vector_seeded(i + 100, dims=1536) for i in range(len(MULTILANG_CASES_DIST))]
+            for i, case in enumerate(MULTILANG_CASES_DIST):
+                vid = str(uuid.uuid4())
+                db.insert(vectors=[vecs[i]], ids=[vid], payloads=[{"data": case["text"], "user_id": "lang_test", "lang": case["lang"]}])
+
+            results = db.search("test", vecs[0], top_k=len(MULTILANG_CASES_DIST), filters={"user_id": "lang_test"})
+            assert len(results) == len(MULTILANG_CASES_DIST)
+        finally:
+            db.delete_col()
+
+    def test_d172_multilang_filter_by_lang(self):
+        """Filter by language field works with multilang data."""
+        db = _new_dist_db(embedding_model_dims=1536)
+        try:
+            for i, case in enumerate(MULTILANG_CASES_DIST):
+                vid = str(uuid.uuid4())
+                vec = _make_vector_seeded(i + 200, dims=1536)
+                db.insert(vectors=[vec], ids=[vid], payloads=[{"data": case["text"], "user_id": "lang_test", "lang": case["lang"]}])
+
+            chinese_results = db.search("test", _make_vector_seeded(0, dims=1536), top_k=10, filters={"user_id": "lang_test", "lang": "Chinese"})
+            assert len(chinese_results) == 1
+            assert "华为" in chinese_results[0].payload["data"]
+        finally:
+            db.delete_col()
+
+    def test_d173_multilang_update_payload(self):
+        """Update payload with multilang text."""
+        db = _new_dist_db(embedding_model_dims=1536)
+        try:
+            vid = str(uuid.uuid4())
+            vec = _make_vector_seeded(0, dims=1536)
+            db.insert(vectors=[vec], ids=[vid], payloads=[{"data": "original", "user_id": "lang_test"}])
+            new_text = "更新后的中文文本：华为GaussDB是一款优秀的分布式数据库。"
+            db.update(vector_id=vid, payload={"data": new_text, "user_id": "lang_test", "updated": "true"})
+            record = db.get(vector_id=vid)
+            assert record.payload["data"] == new_text
+            assert record.payload["updated"] == "true"
+        finally:
+            db.delete_col()
+
+    def test_d174_multilang_delete_and_verify(self):
+        """Delete multilang record and verify removal."""
+        db = _new_dist_db(embedding_model_dims=1536)
+        try:
+            vid = str(uuid.uuid4())
+            vec = _make_vector_seeded(99, dims=1536)
+            db.insert(vectors=[vec], ids=[vid], payloads=[{"data": "中文测试", "user_id": "lang_test"}])
+            db.delete(vector_id=vid)
+            assert db.get(vector_id=vid) is None
+        finally:
+            db.delete_col()
+
+
+# ===========================================================================
+# TestCrossModeComparison - Distributed vs Centralized consistency
+# ===========================================================================
+
+
+@pytest.mark.skipif(not _env_bool("GAUSSDB_TEST_RUN_FULL_DISTRIBUTED"), reason=_FULL_DIST_REASON)
+class TestCrossModeComparison:
+    """Verify distributed and centralized modes produce consistent results."""
+
+    def test_d180_same_data_same_search_results(self):
+        """Same data + same query produces same ordering in both modes."""
+        db_dist = _new_dist_db()
+        config_cent = _gaussdb_env_config(_new_collection("cross_cent"))
+        if config_cent is None:
+            pytest.skip("Centralized config not available")
+        config_cent["embedding_model_dims"] = DIMS_SMALL
+        db_cent = GaussDB(**config_cent)
+        try:
+            records = [
+                (_uuid(9001), VECTORS_4D["A"], {"data": "a", "user_id": "cross_user"}),
+                (_uuid(9002), VECTORS_4D["B"], {"data": "b", "user_id": "cross_user"}),
+                (_uuid(9003), VECTORS_4D["C"], {"data": "c", "user_id": "cross_user"}),
+                (_uuid(9004), VECTORS_4D["D"], {"data": "d", "user_id": "cross_user"}),
+            ]
+            _insert_memories(db_dist, records)
+            _insert_memories(db_cent, records)
+
+            query_vec = VECTORS_4D["A"]
+            results_dist = db_dist.search("test", query_vec, top_k=4, filters={"user_id": "cross_user"})
+            results_cent = db_cent.search("test", query_vec, top_k=4, filters={"user_id": "cross_user"})
+
+            ids_dist = _ids(results_dist)
+            ids_cent = _ids(results_cent)
+            assert ids_dist == ids_cent
+
+            for rd, rc in zip(results_dist, results_cent):
+                assert abs(rd.score - rc.score) < 1e-4
+        finally:
+            db_dist.delete_col()
+            db_cent.delete_col()
+
+    def test_d181_same_filter_results(self):
+        """Same filter produces same result set in both modes."""
+        db_dist = _new_dist_db()
+        config_cent = _gaussdb_env_config(_new_collection("cross_filt"))
+        if config_cent is None:
+            pytest.skip("Centralized config not available")
+        config_cent["embedding_model_dims"] = DIMS_SMALL
+        db_cent = GaussDB(**config_cent)
+        try:
+            records = [
+                (_uuid(9011), VECTORS_4D["A"], {"data": "food", "user_id": "cross_user", "category": "food"}),
+                (_uuid(9012), VECTORS_4D["B"], {"data": "travel", "user_id": "cross_user", "category": "travel"}),
+                (_uuid(9013), VECTORS_4D["C"], {"data": "work", "user_id": "cross_user", "category": "work"}),
+            ]
+            _insert_memories(db_dist, records)
+            _insert_memories(db_cent, records)
+
+            results_dist = db_dist.search("test", VECTORS_4D["B"], top_k=10, filters={"user_id": "cross_user", "category": {"in": ["food", "travel"]}})
+            results_cent = db_cent.search("test", VECTORS_4D["B"], top_k=10, filters={"user_id": "cross_user", "category": {"in": ["food", "travel"]}})
+
+            assert set(_ids(results_dist)) == set(_ids(results_cent))
+        finally:
+            db_dist.delete_col()
+            db_cent.delete_col()
+
+    def test_d182_crud_consistency(self):
+        """CRUD operations produce same state in both modes."""
+        db_dist = _new_dist_db()
+        config_cent = _gaussdb_env_config(_new_collection("cross_crud"))
+        if config_cent is None:
+            pytest.skip("Centralized config not available")
+        config_cent["embedding_model_dims"] = DIMS_SMALL
+        db_cent = GaussDB(**config_cent)
+        try:
+            vid = _uuid(9021)
+            record = (vid, VECTORS_4D["A"], {"data": "original", "user_id": "cross_user"})
+            _insert_memories(db_dist, [record])
+            _insert_memories(db_cent, [record])
+
+            db_dist.update(vector_id=vid, payload={"data": "updated", "user_id": "cross_user"})
+            db_cent.update(vector_id=vid, payload={"data": "updated", "user_id": "cross_user"})
+
+            r_dist = db_dist.get(vid)
+            r_cent = db_cent.get(vid)
+            assert r_dist.payload["data"] == r_cent.payload["data"] == "updated"
+
+            db_dist.delete(vector_id=vid)
+            db_cent.delete(vector_id=vid)
+            assert db_dist.get(vid) is None
+            assert db_cent.get(vid) is None
+        finally:
+            db_dist.delete_col()
+            db_cent.delete_col()


### PR DESCRIPTION
﻿## Linked Issue

N/A

## Description

This PR adds a GaussDB vector store provider for Mem0.

### What is included

- new `GaussDB` vector store provider
- new `GaussDBConfig` configuration model
- centralized and distributed deployment mode handling
- native `FLOATVECTOR` search and GaussDB vector index support
- centralized BM25 `keyword_search`
- scoped filtering for `user_id`, `agent_id`, and `run_id`
- typed exact metadata filters
- controlled typed range support for declared `number` and `datetime` fields
- wildcard / exists / missing / null metadata semantics
- optional custom schema support with `public` as the default
- UTF8 session handling plus non-UTF8 server warning
- English GaussDB docs, technical design, requirements analysis, and user guide
- example script and validation utilities
- provider unit tests and GaussDB-specific validation suites

### Important behavior notes

- centralized mode is the recommended production baseline
- distributed mode supports core vector-store behavior but does not promise BM25 / `keyword_search`
- the provider returns raw distance rather than provider-specific normalized scores
- `analyze()` is exposed as an auxiliary maintenance helper, not a request-path feature
- typed range applies to declared `number` / `datetime` fields; undeclared range emits a warning and falls back to compatibility matching

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [x] I added/updated integration tests
- [x] I tested manually (describe below)

### Manual / live validation

- centralized GaussDB commercial validation was executed against a real centralized environment
- distributed validation was run separately in an internal environment for core distributed capabilities

### Local validation

```bash
pytest tests/vector_stores/test_gaussdb.py -q
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
