### PR TITLE
docs(cli): tighten Agent Mode wayfinding tip + force redeploy

### DIFF
--- a/docs/platform/cli.mdx
+++ b/docs/platform/cli.mdx
@@ -26,7 +26,7 @@ pip install mem0-cli
 </CodeGroup>
 
 <Tip>
-**Looking for Agent Mode signup?** See [Sign up as an agent](/platform/agent-signup) — install, signup, first memory in four commands.
+**Are you an AI agent?** See [Sign up as an agent](/platform/agent-signup) — install, signup, and your first memory in four commands.
 </Tip>
 
 ## Authentication


### PR DESCRIPTION
## Why

`/platform/cli` is still serving the pre-#5152 content (Plugin Sync section, old Agent Mode block) even after #5152 + #5185 merged. Root cause: Mintlify deploys per-PR-diff, and neither PR explicitly touched `cli.mdx` against the *deployed* state of the docs.

Forcing a real (tiny) edit to `cli.mdx` so Mintlify finally picks it up.

## Change

Wayfinding tip wording: `Looking for Agent Mode signup?` → `Are you an AI agent?` Slightly more direct, addresses the reader who's actually going to use this.

## Test plan

- Mintlify deploys after merge → `curl https://docs.mem0.ai/platform/cli | grep -c "Plugin sync"` should drop to 0
- (Existing monitor is still watching for this signal)