### PR TITLE
fix: prevent batch delete from aborting on individual memory failures

### DIFF
--- a/openmemory/api/app/routers/memories.py
+++ b/openmemory/api/app/routers/memories.py
@@ -379,15 +379,27 @@ async def delete_memories(
         )
 
     # Delete from vector store then mark as deleted in database
+    deleted_count = 0
+    failed_ids = []
     for memory_id in request.memory_ids:
         try:
             memory_client.delete(str(memory_id))
         except Exception as delete_error:
             logging.warning(f"Failed to delete memory {memory_id} from vector store: {delete_error}")
 
-        update_memory_state(db, memory_id, MemoryState.deleted, user.id)
+        try:
+            update_memory_state(db, memory_id, MemoryState.deleted, user.id)
+            deleted_count += 1
+        except HTTPException:
+            logging.warning(f"Failed to update memory state for {memory_id}: not found in database")
+            failed_ids.append(str(memory_id))
 
-    return {"message": f"Successfully deleted {len(request.memory_ids)} memories"}
+    if failed_ids:
+        return {
+            "message": f"Deleted {deleted_count} of {len(request.memory_ids)} memories",
+            "failed_ids": failed_ids,
+        }
+    return {"message": f"Successfully deleted {deleted_count} memories"}
 
 
 # Archive memories


### PR DESCRIPTION
## Summary

Fix the `DELETE /` endpoint in the OpenMemory API to handle individual memory deletion failures gracefully instead of aborting the entire batch.

## Problem

The `delete_memories` endpoint iterates over `memory_ids` and calls `update_memory_state()` for each one. However, `update_memory_state()` internally calls `get_memory_or_404()`, which raises `HTTPException(404)` if the memory doesn't exist in the database. This exception is **not caught** inside the loop, so it aborts the entire batch — leaving all subsequent memories without `deleted_at` set.

This commonly occurs when the vector store and PostgreSQL are out of sync (e.g., a memory exists in the vector store but not in the DB, or vice versa).

## Changes

- Wrap each `update_memory_state()` call in try/except to catch per-memory failures
- Track successful deletions and failed IDs
- Return a detailed response: `{"message": "Deleted N of M memories", "failed_ids": [...]}`

## Test plan

- [x] Code review of the fix
- [ ] Test: delete a batch where one ID doesn't exist in DB → others still get deleted
- [ ] Test: delete a batch where all IDs exist → all get deleted, no `failed_ids`

Closes #5066