### PR TITLE
fix(openclaw): verify package publish artifacts

### DIFF
--- a/.github/workflows/openclaw-cd.yml
+++ b/.github/workflows/openclaw-cd.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Verify publish package
+        run: pnpm package:check
+
       - name: Publish to npm
         run: |
           if [ "${{ github.event.release.prerelease }}" = "true" ]; then

--- a/.github/workflows/openclaw-checks.yml
+++ b/.github/workflows/openclaw-checks.yml
@@ -94,7 +94,5 @@ jobs:
       - name: Build
         run: cd openclaw && pnpm build
 
-      - name: Verify dist output exists
-        run: |
-          test -f openclaw/dist/index.js || (echo "Build output missing: dist/index.js" && exit 1)
-          test -f openclaw/dist/index.d.ts || (echo "Build output missing: dist/index.d.ts" && exit 1)
+      - name: Verify publish package
+        run: cd openclaw && pnpm package:check

--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -31,6 +31,7 @@
   ],
   "scripts": {
     "build": "tsup",
+    "package:check": "node scripts/verify-package.mjs",
     "test": "vitest run"
   },
   "dependencies": {

--- a/openclaw/scripts/verify-package.mjs
+++ b/openclaw/scripts/verify-package.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+
+const requiredPackageEntries = [
+  "package/dist/index.js",
+  "package/dist/index.d.ts",
+  "package/openclaw.plugin.json",
+  "package/package.json",
+  "package/README.md",
+  "package/skills/memory-triage/SKILL.md",
+];
+
+async function readJson(path) {
+  return JSON.parse(await readFile(path, "utf8"));
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function packPackage(packDir) {
+  const output = execFileSync("pnpm", ["pack", "--pack-destination", packDir], {
+    cwd: root,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+
+  const tarball = output
+    .trim()
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .findLast((line) => line.endsWith(".tgz"));
+
+  assert(tarball, "pnpm pack did not report a .tgz path");
+  return tarball;
+}
+
+function listTarball(tarball) {
+  return execFileSync("tar", ["-tzf", tarball], {
+    cwd: root,
+    encoding: "utf8",
+  })
+    .trim()
+    .split(/\r?\n/)
+    .filter(Boolean);
+}
+
+async function main() {
+  const packageJson = await readJson(join(root, "package.json"));
+  const pluginJson = await readJson(join(root, "openclaw.plugin.json"));
+
+  assert(packageJson.main === "./dist/index.js", "package.json main must point to ./dist/index.js");
+  assert(packageJson.types === "./dist/index.d.ts", "package.json types must point to ./dist/index.d.ts");
+  assert(
+    packageJson.exports?.["."]?.import === "./dist/index.js",
+    "package.json exports[\".\"].import must point to ./dist/index.js",
+  );
+  assert(
+    packageJson.exports?.["."]?.types === "./dist/index.d.ts",
+    "package.json exports[\".\"].types must point to ./dist/index.d.ts",
+  );
+  assert(
+    Array.isArray(packageJson.files) && packageJson.files.includes("dist"),
+    "package.json files must include dist",
+  );
+  assert(
+    Array.isArray(pluginJson.skills) && pluginJson.skills.includes("skills"),
+    "openclaw.plugin.json must publish the skills directory",
+  );
+  assert(
+    Array.isArray(packageJson.openclaw?.extensions)
+      && packageJson.openclaw.extensions.includes("./dist/index.js"),
+    "package.json openclaw.extensions must include ./dist/index.js",
+  );
+
+  const packDir = mkdtempSync(join(tmpdir(), "openclaw-pack-"));
+  try {
+    const tarball = packPackage(packDir);
+    const entries = new Set(listTarball(tarball));
+    const missing = requiredPackageEntries.filter((entry) => !entries.has(entry));
+    assert(
+      missing.length === 0,
+      `packed npm tarball is missing required entries: ${missing.join(", ")}`,
+    );
+  } finally {
+    rmSync(packDir, { recursive: true, force: true });
+  }
+
+  console.log("OpenClaw package manifest and tarball are publish-ready.");
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Linked Issue

  Closes #5106

  ## Description

  This PR adds a publish-time regression check for the OpenClaw package so the npm tarball cannot ship without the compiled runtime artifacts.

  It verifies that package metadata points to `./dist/index.js` / `./dist/index.d.ts`, confirms OpenClaw extension metadata references the compiled
  entrypoint, and checks the actual `pnpm pack` output includes the required runtime files, manifest, README, and skills directory.

  The check now runs in both the OpenClaw CI workflow and the npm publish workflow.

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Refactor (no functional changes)
  - [ ] Documentation update

  ## Breaking Changes

  N/A

  ## Test Coverage

  - [ ] I added/updated unit tests
  - [ ] I added/updated integration tests
  - [x] I tested manually (describe below)
  - [ ] No tests needed (explain why)

  Tested locally:

  - `pnpm package:check`
  - `pnpm build`
  - `pnpm test`
  - `pnpm exec tsc --noEmit`
  - `git diff --check`

  ## Checklist

  - [x] My code follows the project's style guidelines
  - [x] I have performed a self-review of my code
  - [x] I have added tests that prove my fix/feature works
  - [x] New and existing tests pass locally
  - [x] I have updated documentation if needed

