### PR TITLE
feat(memory): add batch_add, batch_update, batch_delete to Memory and…

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -6,9 +6,10 @@ import logging
 import os
 import uuid
 import warnings
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from copy import deepcopy
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import ValidationError
 
@@ -1583,6 +1584,133 @@ class Memory(MemoryBase):
         capture_event("mem0.history", self, {"memory_id": memory_id, "sync_type": "sync"})
         return self.db.get_history(memory_id)
 
+    def batch_add(
+        self,
+        inputs: List[Dict[str, Any]],
+        *,
+        max_workers: int = 4,
+    ) -> List[Dict[str, Any]]:
+        """
+        Add multiple memories in parallel.
+
+        Args:
+            inputs (list[dict]): List of dicts, each containing keyword arguments
+                accepted by :meth:`add` (``messages`` is required; ``user_id``,
+                ``agent_id``, ``run_id``, ``metadata``, ``infer``, ``memory_type``,
+                ``prompt``, and ``timestamp`` are optional).
+            max_workers (int): Maximum number of threads. Defaults to 4.
+
+        Returns:
+            list[dict]: Results from each :meth:`add` call, in the same order as
+            ``inputs``. On failure, the entry is ``{"error": "<message>"}``.
+
+        Example:
+            >>> results = m.batch_add([
+            ...     {"messages": "Alice likes hiking", "user_id": "alice"},
+            ...     {"messages": "Bob prefers chess", "user_id": "bob"},
+            ... ])
+        """
+        capture_event("mem0.batch_add", self, {"count": len(inputs), "sync_type": "sync"})
+
+        results: List[Optional[Dict[str, Any]]] = [None] * len(inputs)
+
+        def _run(idx: int, kwargs: Dict[str, Any]) -> tuple[int, Dict[str, Any]]:
+            try:
+                return idx, self.add(**kwargs)
+            except Exception as exc:
+                return idx, {"error": str(exc)}
+
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = {executor.submit(_run, i, kw): i for i, kw in enumerate(inputs)}
+            for future in as_completed(futures):
+                idx, result = future.result()
+                results[idx] = result
+
+        return results
+
+    def batch_update(
+        self,
+        updates: List[Dict[str, Any]],
+        *,
+        max_workers: int = 4,
+    ) -> List[Dict[str, Any]]:
+        """
+        Update multiple memories in parallel.
+
+        Args:
+            updates (list[dict]): List of dicts, each with ``memory_id`` (str),
+                ``data`` (str), and optional ``metadata`` (dict).
+            max_workers (int): Maximum number of threads. Defaults to 4.
+
+        Returns:
+            list[dict]: Results from each :meth:`update` call, in the same order
+            as ``updates``. On failure, the entry is ``{"error": "<message>"}``.
+
+        Example:
+            >>> results = m.batch_update([
+            ...     {"memory_id": "abc123", "data": "Alice loves hiking"},
+            ...     {"memory_id": "def456", "data": "Bob prefers Go"},
+            ... ])
+        """
+        capture_event("mem0.batch_update", self, {"count": len(updates), "sync_type": "sync"})
+
+        results: List[Optional[Dict[str, Any]]] = [None] * len(updates)
+
+        def _run(idx: int, kwargs: Dict[str, Any]) -> tuple[int, Dict[str, Any]]:
+            try:
+                memory_id = kwargs["memory_id"]
+                data = kwargs["data"]
+                metadata = kwargs.get("metadata")
+                return idx, self.update(memory_id, data, metadata)
+            except Exception as exc:
+                return idx, {"error": str(exc)}
+
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = {executor.submit(_run, i, kw): i for i, kw in enumerate(updates)}
+            for future in as_completed(futures):
+                idx, result = future.result()
+                results[idx] = result
+
+        return results
+
+    def batch_delete(
+        self,
+        memory_ids: List[str],
+        *,
+        max_workers: int = 4,
+    ) -> List[Dict[str, Any]]:
+        """
+        Delete multiple memories in parallel.
+
+        Args:
+            memory_ids (list[str]): List of memory IDs to delete.
+            max_workers (int): Maximum number of threads. Defaults to 4.
+
+        Returns:
+            list[dict]: Results from each :meth:`delete` call, in the same order
+            as ``memory_ids``. On failure, the entry is ``{"error": "<message>"}``.
+
+        Example:
+            >>> results = m.batch_delete(["abc123", "def456"])
+        """
+        capture_event("mem0.batch_delete", self, {"count": len(memory_ids), "sync_type": "sync"})
+
+        results: List[Optional[Dict[str, Any]]] = [None] * len(memory_ids)
+
+        def _run(idx: int, memory_id: str) -> tuple[int, Dict[str, Any]]:
+            try:
+                return idx, self.delete(memory_id)
+            except Exception as exc:
+                return idx, {"error": str(exc)}
+
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = {executor.submit(_run, i, mid): i for i, mid in enumerate(memory_ids)}
+            for future in as_completed(futures):
+                idx, result = future.result()
+                results[idx] = result
+
+        return results
+
     def _create_memory(self, data, existing_embeddings, metadata=None):
         logger.debug(f"Creating memory with {data=}")
         if data in existing_embeddings:
@@ -2994,6 +3122,97 @@ class AsyncMemory(MemoryBase):
         """
         capture_event("mem0.history", self, {"memory_id": memory_id, "sync_type": "async"})
         return await asyncio.to_thread(self.db.get_history, memory_id)
+
+    async def batch_add(
+        self,
+        inputs: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """
+        Add multiple memories concurrently.
+
+        Args:
+            inputs (list[dict]): List of dicts, each containing keyword arguments
+                accepted by :meth:`add` (``messages`` is required; ``user_id``,
+                ``agent_id``, ``run_id``, ``metadata``, ``infer``, ``memory_type``,
+                ``prompt``, and ``timestamp`` are optional).
+
+        Returns:
+            list[dict]: Results from each :meth:`add` call, in the same order as
+            ``inputs``. On failure, the entry is ``{"error": "<message>"}``.
+
+        Example:
+            >>> results = await m.batch_add([
+            ...     {"messages": "Alice likes hiking", "user_id": "alice"},
+            ...     {"messages": "Bob prefers chess", "user_id": "bob"},
+            ... ])
+        """
+        capture_event("mem0.batch_add", self, {"count": len(inputs), "sync_type": "async"})
+
+        async def _run(kwargs: Dict[str, Any]) -> Dict[str, Any]:
+            try:
+                return await self.add(**kwargs)
+            except Exception as exc:
+                return {"error": str(exc)}
+
+        return list(await asyncio.gather(*[_run(kw) for kw in inputs]))
+
+    async def batch_update(
+        self,
+        updates: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """
+        Update multiple memories concurrently.
+
+        Args:
+            updates (list[dict]): List of dicts, each with ``memory_id`` (str),
+                ``data`` (str), and optional ``metadata`` (dict).
+
+        Returns:
+            list[dict]: Results from each :meth:`update` call, in the same order
+            as ``updates``. On failure, the entry is ``{"error": "<message>"}``.
+
+        Example:
+            >>> results = await m.batch_update([
+            ...     {"memory_id": "abc123", "data": "Alice loves hiking"},
+            ...     {"memory_id": "def456", "data": "Bob prefers Go"},
+            ... ])
+        """
+        capture_event("mem0.batch_update", self, {"count": len(updates), "sync_type": "async"})
+
+        async def _run(kwargs: Dict[str, Any]) -> Dict[str, Any]:
+            try:
+                return await self.update(kwargs["memory_id"], kwargs["data"], kwargs.get("metadata"))
+            except Exception as exc:
+                return {"error": str(exc)}
+
+        return list(await asyncio.gather(*[_run(kw) for kw in updates]))
+
+    async def batch_delete(
+        self,
+        memory_ids: List[str],
+    ) -> List[Dict[str, Any]]:
+        """
+        Delete multiple memories concurrently.
+
+        Args:
+            memory_ids (list[str]): List of memory IDs to delete.
+
+        Returns:
+            list[dict]: Results from each :meth:`delete` call, in the same order
+            as ``memory_ids``. On failure, the entry is ``{"error": "<message>"}``.
+
+        Example:
+            >>> results = await m.batch_delete(["abc123", "def456"])
+        """
+        capture_event("mem0.batch_delete", self, {"count": len(memory_ids), "sync_type": "async"})
+
+        async def _run(memory_id: str) -> Dict[str, Any]:
+            try:
+                return await self.delete(memory_id)
+            except Exception as exc:
+                return {"error": str(exc)}
+
+        return list(await asyncio.gather(*[_run(mid) for mid in memory_ids]))
 
     async def _create_memory(self, data, existing_embeddings, metadata=None):
         logger.debug(f"Creating memory with {data=}")

--- a/tests/test_batch_operations.py
+++ b/tests/test_batch_operations.py
@@ -1,0 +1,306 @@
+"""Tests for Memory.batch_add/batch_update/batch_delete and async equivalents."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mem0 import Memory
+
+
+# ---------------------------------------------------------------------------
+# Memory (sync) — batch_add
+# ---------------------------------------------------------------------------
+
+class TestMemoryBatchAdd:
+    def _make_memory(self):
+        with patch.object(Memory, "__init__", return_value=None):
+            m = Memory()
+            m.add = MagicMock(return_value={"results": [{"id": "1", "memory": "test", "event": "ADD"}]})
+            return m
+
+    def test_returns_results_in_order(self):
+        m = self._make_memory()
+        inputs = [
+            {"messages": "Alice likes hiking", "user_id": "alice"},
+            {"messages": "Bob prefers chess", "user_id": "bob"},
+        ]
+        results = m.batch_add(inputs)
+        assert len(results) == 2
+        assert all("results" in r for r in results)
+
+    def test_propagates_error_as_dict(self):
+        with patch.object(Memory, "__init__", return_value=None):
+            m = Memory()
+            m.add = MagicMock(side_effect=ValueError("bad input"))
+        results = m.batch_add([{"messages": "fail", "user_id": "x"}])
+        assert results[0] == {"error": "bad input"}
+
+    def test_empty_inputs_returns_empty(self):
+        m = self._make_memory()
+        assert m.batch_add([]) == []
+
+    def test_max_workers_respected(self):
+        m = self._make_memory()
+        results = m.batch_add([{"messages": "test", "user_id": "u1"}], max_workers=1)
+        assert len(results) == 1
+
+    def test_partial_failure_does_not_short_circuit(self):
+        call_count = 0
+
+        def _add(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if kwargs.get("user_id") == "bad":
+                raise ValueError("bad user")
+            return {"results": [{"id": str(call_count), "memory": "ok", "event": "ADD"}]}
+
+        with patch.object(Memory, "__init__", return_value=None):
+            m = Memory()
+            m.add = _add
+
+        results = m.batch_add([
+            {"messages": "ok", "user_id": "good"},
+            {"messages": "fail", "user_id": "bad"},
+            {"messages": "ok2", "user_id": "good2"},
+        ])
+        assert len(results) == 3
+        successes = [r for r in results if "results" in r]
+        errors = [r for r in results if "error" in r]
+        assert len(successes) == 2
+        assert len(errors) == 1
+
+
+# ---------------------------------------------------------------------------
+# Memory (sync) — batch_update
+# ---------------------------------------------------------------------------
+
+class TestMemoryBatchUpdate:
+    def _make_memory(self):
+        with patch.object(Memory, "__init__", return_value=None):
+            m = Memory()
+            m.update = MagicMock(return_value={"message": "Memory updated successfully!"})
+            return m
+
+    def test_returns_results_in_order(self):
+        m = self._make_memory()
+        updates = [
+            {"memory_id": "id1", "data": "Alice loves hiking"},
+            {"memory_id": "id2", "data": "Bob prefers Go"},
+        ]
+        results = m.batch_update(updates)
+        assert len(results) == 2
+        assert all(r["message"] == "Memory updated successfully!" for r in results)
+
+    def test_propagates_error_as_dict(self):
+        with patch.object(Memory, "__init__", return_value=None):
+            m = Memory()
+            m.update = MagicMock(side_effect=ValueError("not found"))
+        results = m.batch_update([{"memory_id": "bad", "data": "x"}])
+        assert results[0] == {"error": "not found"}
+
+    def test_empty_inputs_returns_empty(self):
+        m = self._make_memory()
+        assert m.batch_update([]) == []
+
+    def test_optional_metadata_forwarded(self):
+        m = self._make_memory()
+        updates = [{"memory_id": "id1", "data": "new data", "metadata": {"source": "test"}}]
+        results = m.batch_update(updates)
+        m.update.assert_called_once_with("id1", "new data", {"source": "test"})
+        assert results[0]["message"] == "Memory updated successfully!"
+
+    def test_missing_memory_id_raises_error_captured(self):
+        with patch.object(Memory, "__init__", return_value=None):
+            m = Memory()
+            m.update = MagicMock()
+        results = m.batch_update([{"data": "no id here"}])
+        assert "error" in results[0]
+
+
+# ---------------------------------------------------------------------------
+# Memory (sync) — batch_delete
+# ---------------------------------------------------------------------------
+
+class TestMemoryBatchDelete:
+    def _make_memory(self):
+        with patch.object(Memory, "__init__", return_value=None):
+            m = Memory()
+            m.delete = MagicMock(return_value={"message": "Memory deleted successfully!"})
+            return m
+
+    def test_returns_results_in_order(self):
+        m = self._make_memory()
+        results = m.batch_delete(["id1", "id2", "id3"])
+        assert len(results) == 3
+        assert all(r["message"] == "Memory deleted successfully!" for r in results)
+
+    def test_propagates_error_as_dict(self):
+        with patch.object(Memory, "__init__", return_value=None):
+            m = Memory()
+            m.delete = MagicMock(side_effect=ValueError("not found"))
+        results = m.batch_delete(["bad_id"])
+        assert results[0] == {"error": "not found"}
+
+    def test_empty_inputs_returns_empty(self):
+        m = self._make_memory()
+        assert m.batch_delete([]) == []
+
+    def test_each_id_deleted_once(self):
+        m = self._make_memory()
+        m.batch_delete(["id1", "id2"])
+        assert m.delete.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# AsyncMemory — batch_add
+# ---------------------------------------------------------------------------
+
+class TestAsyncMemoryBatchAdd:
+    def _make_memory(self):
+        from mem0.memory.main import AsyncMemory
+        with patch.object(AsyncMemory, "__init__", return_value=None):
+            m = AsyncMemory()
+
+            async def _add(**kwargs):
+                return {"results": [{"id": "1", "memory": "test", "event": "ADD"}]}
+
+            m.add = _add
+            return m
+
+    @pytest.mark.asyncio
+    async def test_returns_results_in_order(self):
+        m = self._make_memory()
+        inputs = [
+            {"messages": "Alice likes hiking", "user_id": "alice"},
+            {"messages": "Bob prefers chess", "user_id": "bob"},
+        ]
+        results = await m.batch_add(inputs)
+        assert len(results) == 2
+        assert all("results" in r for r in results)
+
+    @pytest.mark.asyncio
+    async def test_propagates_error_as_dict(self):
+        from mem0.memory.main import AsyncMemory
+        with patch.object(AsyncMemory, "__init__", return_value=None):
+            m = AsyncMemory()
+
+            async def _add_fail(**kwargs):
+                raise ValueError("bad input")
+
+            m.add = _add_fail
+        results = await m.batch_add([{"messages": "fail", "user_id": "x"}])
+        assert results[0] == {"error": "bad input"}
+
+    @pytest.mark.asyncio
+    async def test_empty_inputs_returns_empty(self):
+        m = self._make_memory()
+        assert await m.batch_add([]) == []
+
+    @pytest.mark.asyncio
+    async def test_partial_failure_does_not_short_circuit(self):
+        from mem0.memory.main import AsyncMemory
+        with patch.object(AsyncMemory, "__init__", return_value=None):
+            m = AsyncMemory()
+
+            async def _add(**kwargs):
+                if kwargs.get("user_id") == "bad":
+                    raise ValueError("bad user")
+                return {"results": [{"id": "1", "memory": "ok", "event": "ADD"}]}
+
+            m.add = _add
+
+        results = await m.batch_add([
+            {"messages": "ok", "user_id": "good"},
+            {"messages": "fail", "user_id": "bad"},
+        ])
+        assert len(results) == 2
+        assert any("results" in r for r in results)
+        assert any("error" in r for r in results)
+
+
+# ---------------------------------------------------------------------------
+# AsyncMemory — batch_update
+# ---------------------------------------------------------------------------
+
+class TestAsyncMemoryBatchUpdate:
+    def _make_memory(self):
+        from mem0.memory.main import AsyncMemory
+        with patch.object(AsyncMemory, "__init__", return_value=None):
+            m = AsyncMemory()
+
+            async def _update(memory_id, data, metadata=None):
+                return {"message": "Memory updated successfully!"}
+
+            m.update = _update
+            return m
+
+    @pytest.mark.asyncio
+    async def test_returns_results_in_order(self):
+        m = self._make_memory()
+        updates = [
+            {"memory_id": "id1", "data": "Alice loves hiking"},
+            {"memory_id": "id2", "data": "Bob prefers Go"},
+        ]
+        results = await m.batch_update(updates)
+        assert len(results) == 2
+        assert all(r["message"] == "Memory updated successfully!" for r in results)
+
+    @pytest.mark.asyncio
+    async def test_propagates_error_as_dict(self):
+        from mem0.memory.main import AsyncMemory
+        with patch.object(AsyncMemory, "__init__", return_value=None):
+            m = AsyncMemory()
+
+            async def _update_fail(memory_id, data, metadata=None):
+                raise ValueError("not found")
+
+            m.update = _update_fail
+        results = await m.batch_update([{"memory_id": "bad", "data": "x"}])
+        assert results[0] == {"error": "not found"}
+
+    @pytest.mark.asyncio
+    async def test_empty_inputs_returns_empty(self):
+        m = self._make_memory()
+        assert await m.batch_update([]) == []
+
+
+# ---------------------------------------------------------------------------
+# AsyncMemory — batch_delete
+# ---------------------------------------------------------------------------
+
+class TestAsyncMemoryBatchDelete:
+    def _make_memory(self):
+        from mem0.memory.main import AsyncMemory
+        with patch.object(AsyncMemory, "__init__", return_value=None):
+            m = AsyncMemory()
+
+            async def _delete(memory_id):
+                return {"message": "Memory deleted successfully!"}
+
+            m.delete = _delete
+            return m
+
+    @pytest.mark.asyncio
+    async def test_returns_results_in_order(self):
+        m = self._make_memory()
+        results = await m.batch_delete(["id1", "id2", "id3"])
+        assert len(results) == 3
+        assert all(r["message"] == "Memory deleted successfully!" for r in results)
+
+    @pytest.mark.asyncio
+    async def test_propagates_error_as_dict(self):
+        from mem0.memory.main import AsyncMemory
+        with patch.object(AsyncMemory, "__init__", return_value=None):
+            m = AsyncMemory()
+
+            async def _delete_fail(memory_id):
+                raise ValueError("not found")
+
+            m.delete = _delete_fail
+        results = await m.batch_delete(["bad_id"])
+        assert results[0] == {"error": "not found"}
+
+    @pytest.mark.asyncio
+    async def test_empty_inputs_returns_empty(self):
+        m = self._make_memory()
+        assert await m.batch_delete([]) == []


### PR DESCRIPTION
## Linked Issue
Closes #3761

## Description
Adds `batch_add`, `batch_update`, and `batch_delete` to both `Memory` (sync) and `AsyncMemory`.

**Memory (sync):** uses `ThreadPoolExecutor` — each call runs in a thread pool, results returned in input order.  
**AsyncMemory:** uses `asyncio.gather` — all coroutines run concurrently.

Both variants:
- Preserve result order matching input order
- Capture per-item errors as `{"error": "..."}` instead of raising — partial failures don't abort the batch
- Accept `max_workers` on sync variants (default 4)

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

## Test Coverage
- [x] Added/updated unit tests — 24 tests across sync + async variants
- [x] Tested manually

## Checklist
- [x] Code follows project style guidelines (ruff passes)
- [x] Self-review performed
- [x] Tests added that prove the feature works
- [x] New and existing tests pass locally
