### PR TITLE
fix: add explicit encoding="utf-8" to config and credentials file loaders

### DIFF
--- a/mem0/memory/setup.py
+++ b/mem0/memory/setup.py
@@ -23,7 +23,7 @@ def _load_config():
     if not os.path.exists(path):
         return {}
     try:
-        with open(path, "r") as f:
+        with open(path, "r", encoding="utf-8") as f:
             data = json.load(f)
         return data if isinstance(data, dict) else {}
     except Exception as e:
@@ -35,7 +35,7 @@ def _write_config(config):
     """Best-effort write of ~/.mem0/config.json. Never raises."""
     path = _config_path()
     try:
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             json.dump(config, f, indent=4)
     except Exception as e:
         _logger.debug("Failed to write mem0 config %s: %s", path, e)

--- a/mem0/utils/gcp_auth.py
+++ b/mem0/utils/gcp_auth.py
@@ -57,7 +57,7 @@ class GCPAuthenticator:
                 credentials_path, scopes=scopes
             )
             # Extract project_id from the file
-            with open(credentials_path, 'r') as f:
+            with open(credentials_path, 'r', encoding='utf-8') as f:
                 cred_data = json.load(f)
                 project_id = cred_data.get("project_id")
 
@@ -69,7 +69,7 @@ class GCPAuthenticator:
                     env_path, scopes=scopes
                 )
                 # Extract project_id from the file
-                with open(env_path, 'r') as f:
+                with open(env_path, 'r', encoding='utf-8') as f:
                     cred_data = json.load(f)
                     project_id = cred_data.get("project_id")
 


### PR DESCRIPTION
## What

`mem0/utils/gcp_auth.py` and `mem0/memory/setup.py` read/write JSON config files — GCP service-account credentials and `~/.mem0/config.json` respectively — via `open()` in text mode without an explicit `encoding=` argument. Python falls back to `locale.getpreferredencoding()`, which is `cp1252` on Windows and `utf-8` on Linux/macOS.

## Why

Both files can carry non-ASCII content in practice:

- `~/.mem0/config.json` stores a `user_id` that users may set to international names or display strings.
- GCP service-account JSON contains `project_id`, `client_email`, and other fields that — while typically ASCII — are not guaranteed to be ASCII-only and the PEM-encoded private key may include non-ASCII in `description` fields.

On Windows or under a non-utf-8 locale the load can fail with `UnicodeDecodeError` or silently mis-decode bytes. PEP 597 also recommends always specifying `encoding=` for text-mode opens, and Python 3.10+ emits an `EncodingWarning` under `PYTHONWARNDEFAULTENCODING=1`.

## Changes

Added `encoding="utf-8"` to all 4 text-mode `open()` call sites:

- `mem0/utils/gcp_auth.py` — 2 sites loading service-account JSON to extract `project_id`
- `mem0/memory/setup.py` — 2 sites in `_load_config()` and `_write_config()` for `~/.mem0/config.json`

Total: 2 files, +4/-4 lines.

## Testing

Pure keyword-argument addition to existing `open()` calls; no logic touched. Verified both files parse cleanly with `python -m py_compile`. The matching code paths were already round-tripping JSON via `json.load`/`json.dump` which both assume utf-8 — this brings the file opens into agreement with what the JSON layer already expects.