### PR TITLE
fix(vector_stores): pass namespace as top-level kwarg to UpstashVector query_many

### DIFF
--- a/mem0/vector_stores/upstash_vector.py
+++ b/mem0/vector_stores/upstash_vector.py
@@ -132,11 +132,10 @@ class UpstashVector(VectorStoreBase):
                     "top_k": top_k,
                     "filter": filters_str or "",
                     "include_metadata": True,
-                    "namespace": self.collection_name,
                 }
                 for v in vectors
             ]
-            responses = self.client.query_many(queries=queries)
+            responses = self.client.query_many(queries=queries, namespace=self.collection_name)
             # flatten
             response = [res for res_list in responses for res in res_list]
 

--- a/tests/vector_stores/test_upstash_vector.py
+++ b/tests/vector_stores/test_upstash_vector.py
@@ -69,11 +69,11 @@ def test_search_vectors(upstash_instance, mock_index):
             {
                 "vector": vectors[0],
                 "top_k": 2,
-                "namespace": "ns",
                 "include_metadata": True,
                 "filter": 'age = 30 AND name = "John"',
             }
-        ]
+        ],
+        namespace="ns",
     )
 
     assert len(results) == 2
@@ -311,11 +311,11 @@ def test_search_vectors_empty_filters(upstash_instance):
             {
                 "vector": vectors[0],
                 "top_k": 1,
-                "namespace": "ns",
                 "include_metadata": True,
                 "filter": "",
             }
-        ]
+        ],
+        namespace="ns",
     )
 
     assert len(results) == 1
@@ -350,3 +350,46 @@ def test_insert_vectors_no_ids(upstash_instance):
         ],
         namespace="ns",
     )
+
+
+def test_search_vectors_multi_query_namespace_at_top_level(upstash_instance):
+    """Regression test for #4207.
+
+    The Upstash client's `query_many` takes `namespace` as a top-level kwarg
+    and the per-query `QueryRequest` TypedDict has no `namespace` field. If we
+    pass `namespace` inside each query dict it is silently dropped (multi-query
+    branch) or causes `TypeError: got multiple values for keyword argument
+    'namespace'` (single-query branch, where `query_many` internally calls
+    `self.query(**query, namespace=namespace)`). This test locks in that
+    `namespace` is forwarded only at the top level and that multi-query
+    results are flattened across all per-query response lists.
+    """
+    mock_results = [
+        [QueryResult(id="id1", score=0.9, vector=None, metadata={"name": "vector1"}, data=None)],
+        [
+            QueryResult(id="id2", score=0.8, vector=None, metadata={"name": "vector2"}, data=None),
+            QueryResult(id="id3", score=0.7, vector=None, metadata={"name": "vector3"}, data=None),
+        ],
+    ]
+    upstash_instance.client.query_many.return_value = mock_results
+
+    vectors = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+    results = upstash_instance.search(query="hello world", vectors=vectors, top_k=5, filters=None)
+
+    upstash_instance.client.query_many.assert_called_once_with(
+        queries=[
+            {"vector": vectors[0], "top_k": 5, "include_metadata": True, "filter": ""},
+            {"vector": vectors[1], "top_k": 5, "include_metadata": True, "filter": ""},
+        ],
+        namespace="ns",
+    )
+
+    # No per-query dict should carry a `namespace` key.
+    sent_queries = upstash_instance.client.query_many.call_args.kwargs["queries"]
+    for q in sent_queries:
+        assert "namespace" not in q
+
+    # Results must be flattened across both per-query response lists.
+    assert [r.id for r in results] == ["id1", "id2", "id3"]
+    assert results[0].score == 0.9
+    assert results[1].payload == {"name": "vector2"}


### PR DESCRIPTION
## Linked Issue

Closes #4207

## Description

`UpstashVector.search()` was passing `namespace` inside each per-query
dict to `upstash_vector.Index.query_many()`. The Upstash client expects
`namespace` as a **top-level keyword argument**; the `QueryRequest`
TypedDict has no `namespace` field, so the per-query value was silently
dropped and every query routed to the default namespace.

When `len(queries) == 1`, `query_many` internally calls
`self.query(**query, namespace=namespace)` — which raises
`TypeError: got multiple values for keyword argument 'namespace'` because
`namespace` ends up bound twice.

This PR moves `namespace` from each query dict onto `query_many`'s
top-level kwarg, matching the Upstash client signature
([`upstash_vector.core.index_operations.IndexOperations.query_many`](https://github.com/upstash/vector-py/blob/v0.8.0/upstash_vector/core/index_operations.py#L253),
v0.8.0).

```diff
-            queries = [
-                {
-                    "vector": v,
-                    "top_k": top_k,
-                    "filter": filters_str or "",
-                    "include_metadata": True,
-                    "namespace": self.collection_name,
-                }
-                for v in vectors
-            ]
-            responses = self.client.query_many(queries=queries)
+            queries = [
+                {
+                    "vector": v,
+                    "top_k": top_k,
+                    "filter": filters_str or "",
+                    "include_metadata": True,
+                }
+                for v in vectors
+            ]
+            responses = self.client.query_many(queries=queries, namespace=self.collection_name)
```

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A — this fixes the search path so `enable_embeddings=False` users
actually receive results from their configured namespace. Users who never
set a custom `collection_name` saw no visible effect; users who did were
silently returned data from the wrong namespace, or hit a `TypeError` on
single-query search.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Updated `test_search_vectors` and `test_search_vectors_empty_filters` to
assert the new (correct) call shape, and added
`test_search_vectors_multi_query_namespace_at_top_level` as a regression
test that locks in the fix on the multi-query path. The new test was
verified to **fail** on the buggy code and **pass** on the fix.

```
tests/vector_stores/test_upstash_vector.py ............. 19 passed
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (not applicable — internal
      bug fix in vector store call shape, no public API change)
