### PR TITLE
[HANDOFF — DO NOT MERGE] Holistic import: backfill on-disk Claude state into mem0

### DIFF
--- a/docs/superpowers/README.md
+++ b/docs/superpowers/README.md
@@ -1,0 +1,26 @@
+# docs/superpowers/
+
+Handoff documentation for the **Claude state holistic import** feature for `mem0-plugin`.
+
+This work was researched and designed but **never implemented** — the original owner left the company before code was written. The three files below are the complete picture so the next engineer can pick this up cold.
+
+## Reading order
+
+1. **`research/2026-05-19-claude-state-holistic-import-research.md`** — start here. Problem framing, complete Claude Code state inventory, competitive landscape, mem0 `infer` modes deep-dive, chunking research, and the full design decision trail with rationale.
+2. **`specs/2026-05-18-claude-state-holistic-import-design.md`** — what we decided to build (architecture, components, data flow, error handling, testing strategy).
+3. **`plans/2026-05-18-claude-state-holistic-import.md`** — 14-task TDD implementation plan with code in every step.
+
+## Status
+
+| Artifact | Status |
+|---|---|
+| Research doc | complete |
+| Design spec | complete, approved |
+| Implementation plan | complete, never executed |
+| `mem0-plugin/scripts/import_claude_state.py` | not created |
+| Hook block in `on_session_start.sh` | not added |
+| Tests at `tests/plugin_scripts/` | not created |
+
+## The PR this lives in
+
+Opened as a **non-merge handoff PR**. Branch: `feat/claude-state-holistic-import-handoff`. The PR exists so the next engineer can reference the discussion, the spec, and the plan all in one place. Do not merge — close it once implementation is picked up on a fresh branch.

--- a/docs/superpowers/plans/2026-05-18-claude-state-holistic-import.md
+++ b/docs/superpowers/plans/2026-05-18-claude-state-holistic-import.md
@@ -1,0 +1,541 @@
+# Claude State Holistic Import Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+> **Handoff note:** This plan was written as the next-step from the design spec but the implementation was never executed because the original owner left. It remains accurate as a blueprint. Anyone picking this up should treat the tasks as a recommended ordering — the testing steps assume TDD, but the design itself does not require it. If you prefer to implement the script first and add tests after, the dependency order between tasks 2 → 10 (data structures → orchestrator) still holds.
+
+**Goal:** Add a one-shot importer to `mem0-plugin` that backfills the user's existing CLAUDE.md hierarchy, `.claude/rules`, and `~/.claude/projects/*/memory` + `~/.claude/agent-memory/*` content into mem0 as searchable memories.
+
+**Architecture:** One new Python script (`mem0-plugin/scripts/import_claude_state.py`, patterned on the existing `on_pre_compact.py`) + one new conditional block in the existing `on_session_start.sh` hook + one JSON marker file at `~/.mem0/imports/claude-state.json`. The script does discovery → heading-based chunking → tagging → sequential POST to `https://api.mem0.ai/v1/memories/` with per-chunk marker writes for idempotent re-runs. The hook nudges the agent on first run; the agent invokes the script via `Bash`.
+
+**Tech Stack:** Python 3.9+ stdlib only (urllib, json, hashlib, pathlib, re, argparse, logging, dataclasses) — no new dependencies. pytest + `unittest.mock` for tests. Reuses `_identity.py` and the urllib REST pattern from `on_pre_compact.py`.
+
+**Spec:** [`docs/superpowers/specs/2026-05-18-claude-state-holistic-import-design.md`](../specs/2026-05-18-claude-state-holistic-import-design.md)
+
+---
+
+## File map
+
+| Action | Path | Purpose |
+|---|---|---|
+| Create | `mem0-plugin/scripts/import_claude_state.py` | Discovery + chunking + dispatch + marker engine (~350 lines). |
+| Modify | `mem0-plugin/scripts/on_session_start.sh` | Add ~15-line "Holistic import available" block after existing bootstrap output. |
+| Create | `tests/plugin_scripts/__init__.py` | Empty — marks directory as a Python package for pytest discovery. |
+| Create | `tests/plugin_scripts/conftest.py` | Adds `mem0-plugin/scripts/` to `sys.path` so tests can import the script directly. |
+| Create | `tests/plugin_scripts/test_import_claude_state.py` | All unit + integration tests (~600 lines). |
+
+The marker file `~/.mem0/imports/claude-state.json` is created at runtime by the script — not checked in.
+
+---
+
+## Task 1: Scaffold the script and test harness
+
+**Files:**
+- Create: `mem0-plugin/scripts/import_claude_state.py`
+- Create: `tests/plugin_scripts/__init__.py`
+- Create: `tests/plugin_scripts/conftest.py`
+- Create: `tests/plugin_scripts/test_import_claude_state.py`
+
+The goal is to lay down the minimal scaffold so pytest can discover and import the module — every later task adds tests + implementation to these files.
+
+- [ ] **Step 1: Write the smoke test**
+
+Create `tests/plugin_scripts/__init__.py` as an empty file.
+
+Create `tests/plugin_scripts/conftest.py`:
+
+```python
+"""Make the plugin scripts directory importable by tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "mem0-plugin" / "scripts"
+
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+```
+
+Create `tests/plugin_scripts/test_import_claude_state.py`:
+
+```python
+"""Tests for mem0-plugin/scripts/import_claude_state.py."""
+
+from __future__ import annotations
+
+
+def test_module_imports():
+    """Scaffold smoke test: the module loads without error."""
+    import import_claude_state  # noqa: F401
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+`pytest tests/plugin_scripts/test_import_claude_state.py -v`
+Expected: FAIL with `ModuleNotFoundError`.
+
+- [ ] **Step 3: Create the minimal script scaffold**
+
+Create `mem0-plugin/scripts/import_claude_state.py`:
+
+```python
+#!/usr/bin/env python3
+"""Holistic import of on-disk Claude state into mem0.
+
+Backfills CLAUDE.md hierarchy (+ @imports), .claude/rules, and the
+~/.claude/projects/*/memory + ~/.claude/agent-memory/* directories.
+
+Patterned on on_pre_compact.py: urllib-based POSTs, stderr logging,
+_identity.resolve_user_id() for user_id, and an optional
+~/.mem0/hooks.log when MEM0_DEBUG is set.
+
+Invocation:
+  python3 import_claude_state.py [--dry-run] [--reset] [--no-infer]
+                                 [--source TYPE]
+
+Exit codes:
+  0 = success (including dry-run, no-op, partial failures)
+  1 = fatal (missing MEM0_API_KEY, auth failure, unreadable marker)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+log = logging.getLogger("mem0-import-claude-state")
+log.setLevel(logging.DEBUG)
+_handler = logging.StreamHandler(sys.stderr)
+_handler.setFormatter(logging.Formatter("[mem0-import-claude-state] %(message)s"))
+log.addHandler(_handler)
+
+if os.environ.get("MEM0_DEBUG"):
+    _log_dir = os.path.expanduser("~/.mem0")
+    try:
+        os.makedirs(_log_dir, exist_ok=True)
+        _file_handler = logging.FileHandler(os.path.join(_log_dir, "hooks.log"))
+        _file_handler.setFormatter(
+            logging.Formatter("[mem0-import-claude-state] %(asctime)s %(message)s")
+        )
+        log.addHandler(_file_handler)
+    except OSError:
+        pass
+
+
+def main() -> int:
+    """Entry point. Implementations land in later tasks."""
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+```bash
+chmod +x mem0-plugin/scripts/import_claude_state.py
+```
+
+- [ ] **Step 4: Verify the smoke test passes**
+
+`pytest tests/plugin_scripts/test_import_claude_state.py -v`
+Expected: `1 passed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mem0-plugin/scripts/import_claude_state.py tests/plugin_scripts/
+git commit -m "feat(plugin): scaffold import_claude_state.py + test harness"
+```
+
+---
+
+## Task 2: Marker file I/O
+
+**Files:** `mem0-plugin/scripts/import_claude_state.py`, `tests/plugin_scripts/test_import_claude_state.py`
+
+Marker reads must tolerate missing files and corrupted JSON (returning an empty marker so the run continues). Writes are atomic (temp file + rename).
+
+- [ ] **Step 1: Write the failing tests** — see code in spec §5 (Marker I/O) for the schema. Tests: `test_read_marker_missing_returns_empty`, `test_read_marker_corrupted_returns_empty`, `test_write_marker_then_read_roundtrip`, `test_write_marker_is_atomic` (asserts `os.replace` was called with a `.tmp` path).
+
+- [ ] **Step 2: Run tests, verify they fail** — 4 FAILs (AttributeError).
+
+- [ ] **Step 3: Implement** — add to the script (after logging setup, before `main`):
+
+```python
+import json
+import tempfile
+from pathlib import Path
+from typing import Any
+
+MARKER_PATH = Path.home() / ".mem0" / "imports" / "claude-state.json"
+EMPTY_MARKER: dict[str, Any] = {"schema_version": 1, "imports": []}
+
+
+def read_marker(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return dict(EMPTY_MARKER)
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict) or "imports" not in data:
+            log.warning("Marker file at %s has unexpected shape, treating as empty", path)
+            return dict(EMPTY_MARKER)
+        return data
+    except (json.JSONDecodeError, OSError) as e:
+        log.warning("Marker file at %s is corrupted (%s), treating as empty", path, e)
+        return dict(EMPTY_MARKER)
+
+
+def write_marker(path: Path, marker: dict[str, Any]) -> None:
+    """Atomically write the marker file (temp + os.replace)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=path.name + ".",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(marker, f, indent=2, sort_keys=True)
+            f.write("\n")
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+```
+
+- [ ] **Step 4: Verify tests pass** — `pytest ... -k "marker"`. Expected: 4 passed.
+- [ ] **Step 5: Commit** — `feat(plugin): marker file I/O for claude-state import (atomic write, corruption-tolerant read)`
+
+---
+
+## Task 3: Markdown chunker — basic splits
+
+Split at H2 by default. Each chunk gets SHA-256 content hash. Edge cases: no headings (one chunk), only H1 (one chunk with H1 as heading).
+
+Implement `Chunk` dataclass and `chunk_markdown(text) -> list[Chunk]` using `re.MULTILINE` patterns for `^# `, `^## `. Return one chunk per H2 section. Content before the first H2 attaches to the H1 (if any) as a separate chunk. Body always includes the heading line so re-rendering matches the source. `content_hash = sha256(body.strip("\n"))`.
+
+Tests: `test_chunk_markdown_no_headings_returns_one_chunk`, `test_chunk_markdown_only_h1_returns_one_chunk`, `test_chunk_markdown_splits_on_h2`, `test_chunk_markdown_content_hash_deterministic`.
+
+Commit: `feat(plugin): chunk_markdown basic H2 splits + content_hash`.
+
+---
+
+## Task 4: Chunker — descend to H3 on oversize, merge small siblings
+
+Constants: `MAX_CHARS_PER_CHUNK = 2000`, `MIN_CHARS_PER_CHUNK = 200`.
+
+Logic:
+1. Split at H2.
+2. For each section > MAX, re-split at H3 (if any H3s exist; otherwise emit oversized chunk as-is rather than mid-paragraph break).
+3. For adjacent sections where the *first* sibling's stripped body < MIN AND combined size ≤ MAX, merge into the prior chunk. First sibling's heading is preserved.
+
+Tests: `test_chunk_markdown_oversize_h2_descends_to_h3`, `test_chunk_markdown_merges_small_siblings`, `test_chunk_markdown_does_not_merge_below_min_when_already_at_h3`.
+
+Commit: `feat(plugin): chunk_markdown descends to H3 on oversize, merges small siblings`.
+
+---
+
+## Task 5: Chunker — protect code fences from being split
+
+A fenced code block (``` or ~~~) that contains `## ` text must not trigger a split. Add a pre-pass (`_mask_fences`) that walks the text line-by-line tracking open/close fence state and replaces the leading `#` of any heading-like line *inside a fence* with a space (preserving offsets so chunk offsets stay aligned with the original text).
+
+Important invariant: `len(masked) == len(text)`. After splitting on the masked text, slice chunk bodies from the *original* text using the same offsets.
+
+Tests: `test_chunk_markdown_does_not_split_inside_code_fence`, `test_chunk_markdown_handles_nested_fences_with_tilde`.
+
+Commit: `feat(plugin): chunk_markdown protects code-fenced ## from splitting`.
+
+---
+
+## Task 6: Source typing + tagger
+
+Define:
+
+```python
+SOURCE_TYPES = {
+    "claude_md_managed", "claude_md_user", "claude_md_project", "claude_md_import",
+    "claude_local", "rule",
+    "memory_md", "memory_topic",
+    "agent_memory", "agent_memory_topic",
+}
+
+DEFAULT_TYPE_BY_SOURCE = {
+    "claude_md_managed": "convention",
+    "claude_md_user": "convention",
+    "claude_md_project": "convention",
+    "claude_md_import": "convention",
+    "claude_local": "user_preference",
+    "rule": "convention",
+    "memory_md": "task_learning",
+    "memory_topic": "task_learning",
+    "agent_memory": "task_learning",
+    "agent_memory_topic": "task_learning",
+}
+
+@dataclass
+class Source:
+    path: Path
+    source_type: str
+    project_name: str | None = None
+    subagent_name: str | None = None
+```
+
+Keyword regexes (case-insensitive):
+- `_ANTI_PATTERN_RE = \b(bug|fix|debug|never|always|critical)\b`
+- `_DECISION_RE = \b(decision|decided|chose|picked|chosen)\b`
+- `_PREFERENCE_RE = \b(prefer|preference|style)\b`
+
+Override priority (when multiple match): anti_pattern → decision → user_preference → default. Search heading + body, but heading matches are stronger signal in practice.
+
+`tag_chunk(source, chunk)` returns the metadata dict with `source_file`, `source_type`, `section_heading`, `project`, `subagent`, `content_hash`, `type`.
+
+Tests: 8 cases covering each default + each override path. See spec §5 (Tagging) for the full table.
+
+Commit: `feat(plugin): Source dataclass + tag_chunk with keyword type overrides`.
+
+---
+
+## Task 7: `@import` resolver
+
+Implement `resolve_imports(path, *, depth=0, visited=None) -> list[Path]`:
+
+- Regex: `IMPORT_LINE_RE = r"(?<![A-Za-z0-9_])@([^\s,;)]+)"` (matches `@path` not preceded by a word character, so emails don't trigger).
+- `~/` expanded via `os.path.expanduser`.
+- Relative paths resolved relative to the importing file's parent.
+- Cycle detection via shared `visited` set.
+- `MAX_IMPORT_DEPTH = 5`. Log warning on overflow, return `[]`.
+- Missing target → warning log, skip.
+- The starting `path` is NOT in the result; only descendants are.
+
+Tests: relative, absolute, `~/` expansion, cycle detection, depth limit (chain l0→l7 with depth 5 returns up to l5), missing target.
+
+Commit: `feat(plugin): @import resolver with cycle + depth + missing handling`.
+
+---
+
+## Task 8: File discovery
+
+Implement `discover(*, home=None, cwd=None) -> list[Source]`:
+
+1. User-global CLAUDE.md (`~/.claude/CLAUDE.md`)
+2. User-level rules (`~/.claude/rules/**/*.md`)
+3. Project CLAUDE.md chain (walking up from `cwd`, checking both `<dir>/CLAUDE.md` and `<dir>/.claude/CLAUDE.md`)
+4. Project `CLAUDE.local.md`
+5. Project rules (`<cwd>/.claude/rules/**/*.md`)
+6. Per-project auto-memory (`~/.claude/projects/*/memory/*.md`, with `MEMORY.md` tagged `memory_md` and others `memory_topic`)
+7. Subagent memory (`~/.claude/agent-memory/*/*.md`, with `MEMORY.md` tagged `agent_memory` and others `agent_memory_topic`)
+8. Finally, follow `@imports` from every discovered CLAUDE.md / local / rule, adding them as `claude_md_import`
+
+Decode project name from the encoded path (`-Users-alice-mem0-platform` → `mem0-platform`). Use `PROJECT_DIR_DECODE_RE = r"^-Users-[^-]+-(.+)$"` — strips the `-Users-<username>-` prefix.
+
+Use `Path.resolve()` and a `seen_paths` set to dedupe (the same file can be reached by multiple paths via symlinks or hierarchy + import).
+
+Tests: user + project CLAUDE.md, project memory + topic files, agent memory + subagent name, @import pickup, missing-paths → empty list.
+
+Commit: `feat(plugin): discover() enumerates all Claude state surfaces + follows @imports`.
+
+---
+
+## Task 9: HTTP dispatcher with retry
+
+Implement `post_memory(*, content, user_id, metadata, infer, api_key) -> dict | None`:
+
+- POST to `https://api.mem0.ai/v1/memories/` with body `{"messages": [{"role": "user", "content": content}], "user_id": user_id, "metadata": metadata, "infer": infer}`.
+- Header: `Authorization: Token {api_key}`, `Content-Type: application/json`.
+- Timeout: 15 s.
+- 200/201 → return parsed JSON.
+- 401 → raise `AuthError` (defined in this module). Caller stops the whole run.
+- 429 → log, `time.sleep(2)`, retry once. Second 429 → log + return None.
+- Other HTTPError → log + return None.
+- URLError (network) → log + return None.
+
+Tests: success path returns payload, 401 raises AuthError, 429 retries once and succeeds, 500 returns None, URLError returns None, payload-shape test asserts the JSON body + Authorization header are exactly right.
+
+Commit: `feat(plugin): post_memory with 401/429/5xx/network handling + retry`.
+
+---
+
+## Task 10: Upload orchestrator with per-chunk marker writes
+
+Implement `run_import(*, home, cwd, marker_path, user_id, api_key, infer, dry_run, source_filter) -> dict[str, int]`:
+
+Stats dict keys: `planned`, `uploaded`, `skipped`, `failed`, `files`.
+
+Algorithm:
+
+```
+marker = read_marker(marker_path)
+sources = discover(home=home, cwd=cwd)
+if source_filter:
+    sources = [s for s in sources if s.source_type == source_filter]
+stats = {"planned": 0, "uploaded": 0, "skipped": 0, "failed": 0, "files": len(sources)}
+
+for source in sources:
+    text = source.path.read_text()  # skip on OSError
+    if not text.strip(): continue
+    chunks = chunk_markdown(text)
+    already_hashes = {c["content_hash"] for c in marker_entry_for(source.path).get("chunks", [])}
+    for chunk in chunks:
+        stats["planned"] += 1
+        if chunk.content_hash in already_hashes:
+            stats["skipped"] += 1
+            continue
+        if dry_run:
+            continue
+        metadata = tag_chunk(source, chunk)
+        try:
+            resp = post_memory(content=chunk.body, user_id=user_id, metadata=metadata, infer=infer, api_key=api_key)
+        except AuthError:
+            raise  # propagate to main, which prints + exits 1
+        if resp is None:
+            stats["failed"] += 1
+            continue
+        memory_ids = [item.get("id", "") for item in resp.get("results", [])]
+        entry = _get_or_create_file_entry(marker, str(source.path), source.source_type)
+        entry["chunks"].append({"heading": chunk.heading, "content_hash": chunk.content_hash, "memory_ids": memory_ids})
+        marker["last_run_at"] = _now_iso()
+        marker["user_id"] = user_id
+        write_marker(marker_path, marker)  # per-chunk! resume-on-crash safety
+        stats["uploaded"] += 1
+return stats
+```
+
+Tests: every chunk uploaded once, already-imported chunks skipped on re-run, dry-run makes no POSTs and writes no marker, marker grows monotonically per chunk (assert write_marker called with growing chunk counts), partial-failure leaves succeeded chunks marked and fails to be retried on next run.
+
+Commit: `feat(plugin): run_import orchestrator with per-chunk marker writes + skip-by-hash`.
+
+---
+
+## Task 11: CLI argparse + `main`
+
+Flags: `--dry-run`, `--reset`, `--no-infer`, `--source <type>` (choices: `sorted(SOURCE_TYPES)`).
+
+`main(argv=None) -> int`:
+1. Parse args.
+2. Check `MEM0_API_KEY` env. If missing, print to stderr, return 1.
+3. Resolve `user_id` via `from _identity import resolve_user_id`. Fallback to `$USER` if import fails (so tests pass without _identity).
+4. If `--reset`, `MARKER_PATH.unlink(missing_ok=True)`.
+5. Wrap `run_import(...)` in try/except AuthError → print + return 1.
+6. Print human summary (dry-run: "Would upload X chunks from Y files...", real: "Imported X chunks from Y files (skipped Z, failed W).").
+7. Return 0.
+
+Define module-level helpers `_get_home() -> Path.home()` and `_get_cwd() -> Path.cwd()` so tests can monkeypatch them.
+
+Tests: missing API key → return 1, dry-run prints plan + no marker file, `--reset` wipes pre-existing marker, `--no-infer` sets `infer=False` in the post.
+
+Commit: `feat(plugin): import_claude_state CLI with --dry-run / --reset / --no-infer / --source`.
+
+---
+
+## Task 12: End-to-end integration test
+
+One fixture tmp_path with:
+- `~/.claude/CLAUDE.md` containing `@./extra.md`
+- `~/.claude/extra.md` (the @import target)
+- `<cwd>/CLAUDE.local.md`
+- `~/.claude/projects/-Users-alice-myproj/memory/MEMORY.md`
+- `~/.claude/projects/-Users-alice-myproj/memory/graph-details.md`
+- `~/.claude/agent-memory/meta-reviewer/MEMORY.md`
+- `~/.claude/agent-memory/meta-reviewer/feedback_redis.md`
+
+Mock `post_memory`. Call `run_import(...)`. Assert:
+- 7 files discovered
+- `uploaded == len(posted_calls)`
+- All 7 source_types appear in metadata
+- Heading keyword overrides hit where expected (e.g., "We decided" → `decision`, "Critical Rules" / "Bug fix" → `anti_pattern`)
+- Marker has 7 file entries, total chunk count matches `stats["uploaded"]`
+
+Commit: `test(plugin): end-to-end fixture covering every Claude state source type`.
+
+---
+
+## Task 13: Extend `on_session_start.sh` with the nudge block
+
+Add immediately before the trailing `exit 0`:
+
+```bash
+# ── Holistic import nudge ────────────────────────────────────────────────
+# One-time nudge to backfill existing CLAUDE.md / MEMORY.md / agent-memory
+# into mem0. Silent after the marker file appears (i.e., after first run).
+MEM0_IMPORT_MARKER="$HOME/.mem0/imports/claude-state.json"
+if [ ! -f "$MEM0_IMPORT_MARKER" ]; then
+  cat <<EOF
+
+## Holistic import available
+
+On-disk Claude state (CLAUDE.md, ~/.claude/projects/*/memory, ~/.claude/agent-memory)
+has never been imported into mem0. To preview what would be imported, run:
+
+  python3 "\$SCRIPT_DIR/import_claude_state.py" --dry-run
+
+Then drop \`--dry-run\` to import. This nudge disappears after the first
+successful run. Pass \`--reset\` to re-import from scratch.
+EOF
+fi
+```
+
+The `$SCRIPT_DIR` variable is already set near the top of the script via `SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"`.
+
+Manual smoke: pipe a fake startup JSON to the script with and without the marker file present, confirm the new block appears / disappears.
+
+Commit: `feat(plugin): SessionStart hook nudges agent when on-disk Claude state is un-imported`.
+
+---
+
+## Task 14: README + plugin version bump
+
+- Add a "Holistic import" section to `mem0-plugin/README.md` after the existing "tune categories for coding workflows" section. Document the flags.
+- Bump `mem0-plugin/.claude-plugin/plugin.json` version (0.1.3 → 0.2.0 for a feature release).
+- Add a CHANGELOG entry at the top of `mem0-plugin/CHANGELOG.md`.
+
+Commit: `docs(plugin): document holistic import + bump plugin version to 0.2.0`.
+
+---
+
+## Final verification
+
+```bash
+pytest tests/plugin_scripts/ -v          # all tests pass
+ruff check mem0-plugin/scripts/import_claude_state.py  # no lint errors
+git log --oneline -14                    # 14 focused commits, conventionally named
+```
+
+Manual smoke against a real mem0 account:
+```bash
+export MEM0_USER_ID="mem0_import_smoke_$(date +%Y%m%d)"
+python3 mem0-plugin/scripts/import_claude_state.py --dry-run
+python3 mem0-plugin/scripts/import_claude_state.py
+# Verify chunks appear in https://app.mem0.ai/dashboard with the right metadata.
+```
+
+---
+
+## Plan self-review
+
+**Spec coverage:**
+- §4 Architecture → Tasks 1, 10, 11, 13
+- §5 Components: discover (Task 8), resolve_imports (Task 7), chunk_markdown (Tasks 3-5), tag_chunk (Task 6), upload/run_import (Task 10), post_memory (Task 9), marker I/O (Task 2), main (Task 11)
+- §6 Data flow: integration test (Task 12) + manual hook smoke (Task 13)
+- §7 Error handling: AuthError (Task 9, 11), 429 retry (Task 9), 5xx + network skip (Task 9), corrupted marker (Task 2), missing API key (Task 11), partial-failure resume (Task 10), code-fence safety (Task 5), import cycle / depth / missing (Task 7)
+- §8 Testing: every named case implemented
+- §9 File layout: matches exactly
+
+**Type consistency:**
+- `Source` (Task 6) used in Tasks 7, 8, 10. Fields stable.
+- `Chunk` (Task 3) used in Tasks 4, 5, 6, 10. Fields stable.
+- `read_marker` shape matches spec §5.
+- `post_memory` keyword-only args match `run_import` call site.
+- `AuthError` defined Task 9, raised Task 10, caught Task 11.
+- `MARKER_PATH` defined Task 2, monkeypatched Task 11 tests, used Task 11 main.
+
+**Scope:** Single feature, one new script + one hook block + one marker file. No deferred decisions.

--- a/docs/superpowers/research/2026-05-19-claude-state-holistic-import-research.md
+++ b/docs/superpowers/research/2026-05-19-claude-state-holistic-import-research.md
@@ -1,0 +1,501 @@
+# Claude State Holistic Import — Research & Findings
+
+**Date:** 2026-05-19
+**Status:** Handoff document. Original owner left the company; this consolidates everything we learned so the next engineer can pick this up cold.
+**Reads as:** problem statement → discovery → competitive landscape → mem0 platform behavior → design choices → why we settled where we did → recommended next steps.
+
+---
+
+## Table of contents
+
+1. [Why this exists](#1-why-this-exists)
+2. [Complete Claude Code state inventory (on disk)](#2-complete-claude-code-state-inventory-on-disk)
+3. [Current `mem0-plugin` capabilities (what's already there)](#3-current-mem0-plugin-capabilities-whats-already-there)
+4. [Competitive landscape](#4-competitive-landscape)
+5. [`mem0`'s `infer=True` vs `infer=False` deep-dive](#5-mem0s-infertrue-vs-inferfalse-deep-dive)
+6. [Chunking research (2026 benchmarks)](#6-chunking-research-2026-benchmarks)
+7. [The design decision trail — what we considered and why we picked what we picked](#7-the-design-decision-trail--what-we-considered-and-why-we-picked-what-we-picked)
+8. [Open questions / known unknowns](#8-open-questions--known-unknowns)
+9. [Recommended next steps for new owner](#9-recommended-next-steps-for-new-owner)
+10. [Source materials](#10-source-materials)
+
+---
+
+## 1. Why this exists
+
+**The problem in one sentence:** When a user installs `mem0-plugin`, mem0 starts empty even though Claude Code has been quietly accumulating their CLAUDE.md instructions, auto-memory, and subagent learnings on disk for months.
+
+The existing plugin hooks capture *live* state from the moment of install forward:
+- `session_state` (PreCompact + Stop hooks)
+- `compact_summary` (SessionStart-compact hook)
+- Agent-authored `add_memory` calls (the Stop / TaskCompleted nudge rubric)
+
+None of these backfill the user's prior state. A heavy Claude Code user can have 15+ project memories, hundreds of CLAUDE.md rules, and dozens of subagent feedback files that are all invisible to mem0 until they manually re-state every one of them.
+
+**The differentiation play:** No other plugin in the space does this systematically. We confirmed this by surveying claude-mem, Memory Store Plugin, Serena, Cipher, and OpenCode (details in §4). Memory Store Plugin is the closest — it auto-syncs CLAUDE.md continuously — but doesn't do a bulk holistic backfill or touch MEMORY.md. Cloud-backed cross-machine recall of Claude's accumulated knowledge is an open lane.
+
+**The strategic asks this answers:**
+- "I switched machines and Claude doesn't remember the conventions I taught it on my old laptop."
+- "Why does mem0 know nothing about my project even though Claude Code clearly does?"
+- "I'd switch from MEMORY.md to mem0 but I'd lose six months of accumulated learnings."
+
+---
+
+## 2. Complete Claude Code state inventory (on disk)
+
+We crawled the official Claude Code docs (https://code.claude.com/docs/en/memory) and the live filesystem to build this. Anything not listed here was deliberately excluded from scope (transient state, harness internals, secrets).
+
+### User-authored ("how I want Claude to behave")
+
+| Source | Path | Loaded into | Notes |
+|---|---|---|---|
+| Managed policy CLAUDE.md (org-wide) | macOS: `/Library/Application Support/ClaudeCode/CLAUDE.md` <br> Linux/WSL: `/etc/claude-code/CLAUDE.md` <br> Windows: `C:\Program Files\ClaudeCode\CLAUDE.md` | every session | rarely populated; exists in regulated environments |
+| User CLAUDE.md | `~/.claude/CLAUDE.md` | every session | user-global rules across all projects |
+| Project CLAUDE.md | `./CLAUDE.md` or `./.claude/CLAUDE.md` | every session in/under the dir | team-shared via VCS; also picked up walking up parent dirs |
+| `CLAUDE.local.md` | `./CLAUDE.local.md` (gitignored) | every session | personal project-specific overrides |
+| Nested CLAUDE.md | subdirectory CLAUDE.md | loaded on demand when Claude reads files in that subtree | not all loaded at startup |
+| `@imports` | inline `@path/to/file` syntax | follows from any CLAUDE.md | recursive up to 5 hops; relative resolved against importer; non-`.md` extensions allowed |
+| Path-scoped rules | `./.claude/rules/**/*.md` + `~/.claude/rules/*.md` | by path glob, or always if no `paths:` frontmatter | per-language / per-subdir guidance |
+| AGENTS.md cross-tool config | `./AGENTS.md` | not loaded by Claude Code directly | usually imported via `@AGENTS.md` from CLAUDE.md, or symlinked |
+
+### Claude-authored ("what Claude figured out") — Claude Code v2.1.59+, on by default
+
+| Source | Path | Loaded into | Notes |
+|---|---|---|---|
+| Auto-memory index | `~/.claude/projects/<encoded-path>/memory/MEMORY.md` | every session, first 200 lines or 25 KB | one per repo; encoded path = `-Users-<user>-<repo-dir>-...` |
+| Auto-memory topic files | `~/.claude/projects/<encoded-path>/memory/*.md` (other than MEMORY.md) | on demand | Claude moves detail out of MEMORY.md to keep the index short |
+| Subagent auto-memory | `~/.claude/agent-memory/<agent>/MEMORY.md` + topic files | when that subagent runs | per subagent (e.g., `meta-reviewer`, `eks-perf-finops-tuner`) |
+| Custom auto-memory dir | wherever `autoMemoryDirectory` in `~/.claude/settings.json` points | same | only accepted from policy / user / `--settings` flag; not project settings |
+
+### Lower-signal / transient (excluded from scope)
+
+| Source | Path | Why excluded |
+|---|---|---|
+| Shell history | `~/.claude/history.jsonl` (3.8 MB on the original owner's machine) | too noisy; not knowledge |
+| Sessions | `~/.claude/sessions/*.json` | transient working state |
+| Tasks | `~/.claude/tasks/<uuid>/` | task harness internals |
+| Todos | `~/.claude/todos/*/` | transient |
+| File-history | `~/.claude/file-history/*` | binary state |
+| Plans | `~/.claude/plans/` | typically empty; transient |
+| `session-env` | `~/.claude/session-env/` | environment snapshots |
+| `paste-cache` | `~/.claude/paste-cache/` | UX cache |
+| `settings.json` | `~/.claude/settings.json` | config, not memory; secrets risk |
+
+### Already covered by mem0 hooks (don't re-import)
+
+| Captured by | When | metadata.type |
+|---|---|---|
+| `on_pre_compact.py --source=pre-compaction` | PreCompact hook fires | `session_state` |
+| `on_pre_compact.py --source=session-end` | Stop hook (background) | `session_state` |
+| `capture_compact_summary.py` | SessionStart-compact (background) | `compact_summary` |
+| Agent voluntary `add_memory` | Stop / TaskCompleted rubric prompts the agent | `task_learning` / `decision` / `anti_pattern` / `user_preference` |
+
+So mem0 streams *live* state forward but has no eyes on what's already on disk. That's the gap.
+
+### What the original owner's disk actually showed (May 2026)
+
+For grounding — this is one heavy user's footprint:
+
+```
+~/.claude/CLAUDE.md                                  (0 B — empty)
+~/.claude/projects/                                  15 project dirs
+~/.claude/projects/-Users-mragankshekhar-mem0-platform/memory/
+    ├── MEMORY.md                                    (2.4 KB)
+    ├── graph-lambda-details.md                      (2.3 KB)
+    ├── prod_db_topology.md                          (1.7 KB)
+    └── project_team_gabe_departed.md                (1.2 KB)
+~/.claude/agent-memory/meta-reviewer/                19 feedback files (35 KB total)
+~/.claude/agent-memory/eks-perf-finops-tuner/        (also populated)
+```
+
+Sample content from one of the MEMORY.md files (anonymized concept-only):
+```
+## Critical Rules
+- NEVER use raw docker/docker compose commands. Always use `make` targets.
+- NEVER auto-commit. User handles all git commits manually.
+- NEVER touch, clean, delete, or modify prod data/resources. EVER.
+
+## Sandbox E2E Tests
+- `make run_e2e_sandbox` runs E2E tests against local sandbox
+- Django's APPEND_SLASH causes DELETE→GET redirect when URLs lack trailing slashes
+- Categorization pipeline: lambda → SQS → categorization worker → OpenAI → Postgres
+...
+```
+
+This is exactly the kind of content that should be searchable from mem0 cross-machine.
+
+---
+
+## 3. Current `mem0-plugin` capabilities (what's already there)
+
+Read `mem0-plugin/README.md` for the user-facing pitch. The implementation details that matter for the import design:
+
+### Hooks (per `mem0-plugin/hooks/hooks.json`)
+
+| Hook | Script | What it does |
+|---|---|---|
+| `SessionStart` (matcher `startup|resume|compact`) | `on_session_start.sh` | Emits identity line + a context-bootstrap rubric. Branches by `source`. On `compact`, also spawns `capture_compact_summary.py` in background. |
+| `PreToolUse` (matcher `Write|Edit`) | `block_memory_write.sh` | **Blocks writes to `MEMORY.md` and `.claude/memory/*`** — forces all memory operations through mem0 MCP. This is a *strong* opinion: mem0 wants to be the single source of truth, not coexist with native auto-memory. |
+| `PreCompact` | `on_pre_compact.sh` → `on_pre_compact.py --source=pre-compaction` | Captures the transcript tail as a `session_state` memory before context is lost. |
+| `Stop` | `on_stop.sh` → reminder text + `on_pre_compact.py --source=session-end` | Reminds the agent to `add_memory` learnings, then captures session_state as a safety net. |
+| `UserPromptSubmit` | `on_user_prompt.sh` | Injects a "decide whether memory context helps" rubric — the agent decides; the hook never pre-searches. |
+| `TaskCompleted` | `on_task_completed.sh` | Reminder rubric: extract decisions / anti_patterns / conventions / task_learnings via `add_memory`. |
+
+### Cross-client parity
+
+| Hook config | Used by |
+|---|---|
+| `mem0-plugin/hooks/hooks.json` | Claude Code |
+| `mem0-plugin/hooks/cursor-hooks.json` | Cursor (sessionStart, preToolUse, preCompact, stop, beforeSubmitPrompt) |
+| `mem0-plugin/hooks/codex-hooks.json` | Codex (SessionStart startup|resume, UserPromptSubmit, Stop) — installed via `install_codex_hooks.py` because Codex has no plugin auto-wire |
+
+**All three clients call the same bash entry points (`on_session_start.sh`, etc.).** Extending those scripts propagates to every client for free.
+
+### Identity (`scripts/_identity.sh` and `scripts/_identity.py`)
+
+```
+1. $MEM0_USER_ID env var (explicit override)
+2. $USER, else "default"
+```
+
+Note: There was a brief experiment where the user_id was derived from the API key (`6a1597c6 fix(plugin): drop API-key-derived user_id, restore $USER fallback`). That was reverted. The `$USER` fallback is the deliberate convention.
+
+### Reused REST pattern
+
+`on_pre_compact.py` and `capture_compact_summary.py` both:
+- Use stdlib `urllib.request` (no `requests` dependency)
+- POST to `https://api.mem0.ai/v1/memories/`
+- Auth: `Authorization: Token {api_key}` header
+- Log to stderr, plus optional `~/.mem0/hooks.log` when `MEM0_DEBUG=1`
+- Always `sys.exit(0)` so they never break the hook
+- Use `infer=False` (because the content is already structured)
+
+**The import script must follow this exact pattern.**
+
+### Skills
+
+- `mem0-plugin/skills/mem0/SKILL.md` — full SDK guide (Python + TS + framework integrations)
+- `mem0-plugin/skills/mem0-mcp/SKILL.md` — **the metadata vocabulary** the import script must use: `decision`, `anti_pattern`, `user_preference`, `convention`, `task_learning`. Plus the v2 filter syntax (root must be AND/OR/NOT, metadata nested not dotted).
+
+### MCP server
+
+- Remote MCP at `https://mcp.mem0.ai/mcp/`, auth via `Authorization: Token ${MEM0_API_KEY}`
+- 9 tools: `add_memory`, `search_memories`, `get_memories`, `get_memory`, `update_memory`, `delete_memory`, `delete_all_memories`, `delete_entities`, `list_entities`
+
+---
+
+## 4. Competitive landscape
+
+Surveyed May 2026. Each entry: what they do, what they import, gaps.
+
+### claude-mem (`thedotmack/claude-mem`)
+- **Pitch:** "Persistent context across sessions for every agent."
+- **Approach:** Captures tool outputs (1–10 K tokens) live, compresses to ~500-token semantic observations using Claude's Agent SDK. Typed schema: `decision`, `bugfix`, `feature`, `refactor`, `discovery`, `change`. Local SQLite + 3-tier retrieval (index → timeline → full details).
+- **Backfill behavior:** None. Live-capture only.
+- **Differs from us:** local-only; pays LLM cost at every tool call; no cloud sync.
+- **Lesson:** their typed schema and ~500-token observation size validates our heading-based ~50-500-token chunk target as the right granularity for code-context memory.
+
+### Memory Store Plugin (`julep-ai/memory-store-plugin`)
+- **Pitch:** "Tracks dev flow, captures session context, analyzes git, maintains team knowledge across projects."
+- **Approach:** Hook-based continuous sync via SessionStart / PreToolUse / SessionEnd. Reads CLAUDE.md files and **anchor comments** (`<!-- AUTH-FLOW -->`-style markers embedded in code). Internal queue `.memory-queue.jsonl` batched on every user message.
+- **Backfill behavior:** **Closest to ours** — it auto-syncs CLAUDE.md on first run. But it doesn't touch MEMORY.md, agent-memory, or the @import graph.
+- **Differs from us:** continuous sync (not one-shot), no opt-in/opt-out, no LLM extraction.
+- **Lesson:** their continuous-sync model is plausible but more invasive; the one-shot model with explicit consent is the right v1 for us.
+
+### Serena (`oraios/serena`)
+- **Pitch:** "IDE for your agent" — semantic code retrieval and editing at the symbol level.
+- **Approach:** Writes its own `.serena/memories/*.md` for project understanding. Read via `read_memory` MCP tool.
+- **Backfill behavior:** None — creates its own files, doesn't ingest Claude's.
+- **Differs from us:** local file-based memory in a parallel namespace; no semantic search beyond file content.
+
+### Cipher / ByteRover (`campfirein/byterover-cli`, formerly `cipher`)
+- **Pitch:** "Portable memory layer for autonomous coding agents."
+- **Approach:** Dual memory architecture — System 1 (programming concepts, business logic, past interactions) + System 2 (deliberate step-by-step reasoning). Workspace Memory for team sharing. Multi-IDE: Cursor, Windsurf, Claude Desktop, Claude Code, Gemini CLI, Kiro, VS Code, Roo Code, Trae, Amp Code, Warp.
+- **Backfill behavior:** Maps project structure on first connection; detects patterns; saves locally. Not a deliberate CLAUDE.md / MEMORY.md backfill.
+- **Differs from us:** local-first with optional cloud; positions itself as a competitor to mem0 itself, not a complement.
+
+### OpenCode plugin (`kuitos/opencode-claude-memory`)
+- **Pitch:** "OpenCode plugin for Claude Code memory: persistent local Markdown memory shared with Claude Code, zero config, no migration."
+- **Approach:** Stores memory as local Markdown in the same dirs Claude Code already uses. "Auto-dream" periodic background consolidation.
+- **Backfill behavior:** "Zero config, no migration" because it reuses the same files Claude already writes. Functionally not an import — it's a different memory backend.
+- **Differs from us:** doubles down on local; no cloud sync; no programmatic search beyond grep.
+
+### Anthropic native (Claude Code v2.1.59+)
+- **Pitch:** Built into Claude Code itself. Free.
+- **Approach:** Writes `~/.claude/projects/<proj>/memory/MEMORY.md` automatically as Claude works. On by default.
+- **Backfill behavior:** N/A — it IS the local store.
+- **Differs from us:** local only, no cross-machine, no semantic search beyond loading the first 200 lines / 25 KB into context every session.
+
+### The gap, restated
+
+| Capability | claude-mem | Memory Store | Serena | Cipher | OpenCode | Anthropic native | **mem0 + this import** |
+|---|---|---|---|---|---|---|---|
+| Cloud-backed cross-machine memory | ✗ | ✗ | ✗ | optional | ✗ | ✗ | ✓ |
+| Semantic search over accumulated memory | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✓ |
+| Live capture of new state | ✓ | ✓ | partial | ✓ | ✓ | ✓ | ✓ (already shipped) |
+| **One-shot backfill of existing on-disk state** | ✗ | partial (CLAUDE.md only) | ✗ | partial | ✗ | N/A | **✓ (this feature)** |
+| Ingest MEMORY.md auto-memory | ✗ | ✗ | ✗ | ✗ | ✗ | N/A | **✓ (this feature)** |
+| Ingest subagent memory | ✗ | ✗ | ✗ | ✗ | ✗ | N/A | **✓ (this feature)** |
+| Follow `@imports` recursively | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ (loader) | **✓ (this feature)** |
+
+This is the wedge. Nobody else is doing this.
+
+---
+
+## 5. `mem0`'s `infer=True` vs `infer=False` deep-dive
+
+From the source (`mem0/memory/main.py`) and platform docs (https://docs.mem0.ai/platform/features/direct-import).
+
+### `infer=True` (default)
+
+```python
+client.add(messages, user_id=..., metadata=..., infer=True)
+```
+
+- An LLM extracts key facts from `messages`.
+- The LLM decides ADD / UPDATE / DELETE relative to existing memories for the same `user_id`.
+- **Auto-dedup** server-side.
+- Cost: LLM tokens per call (chargeable on hosted platform).
+- Latency: hundreds of ms to a couple of seconds per call.
+- Output: one or many memories per input; the response's `results` array carries IDs + event types.
+
+### `infer=False` (Direct Import)
+
+```python
+client.add(messages, user_id=..., metadata=..., infer=False)
+```
+
+- **Skips the inference pipeline entirely.**
+- Only messages with `role: "user"` are stored. Assistant / system roles are dropped.
+- **No dedup.** Re-sending the same content creates a duplicate.
+- No LLM cost.
+- Sub-100ms typical.
+- Output: one memory per input message.
+
+### When each is right
+
+| Content type | Recommendation | Why |
+|---|---|---|
+| Raw conversation transcripts | `infer=True` | Need atomic fact extraction; lots of noise |
+| Pre-curated structured content | `infer=False` | Already atomic; LLM extraction wastes tokens |
+| Bulk import of pre-existing markdown | **Either, depends on goal** | See decision section |
+| Security guardrails (must store verbatim) | `infer=False` | Wording matters |
+
+### What the existing plugin does
+
+`on_pre_compact.py` and `capture_compact_summary.py` both use `infer=False` because they already produce structured summaries. That's the plugin convention.
+
+For the import: the original design intent was `infer=False` (preserve user wording, lean on heading-based chunks for granularity, use content-hash for idempotency). **The owner pivoted to `infer=True` by default** late in design (see decision §7) because they wanted server-side dedup and search quality over wording preservation. `--no-infer` was kept as an opt-out for power users who want raw fidelity.
+
+---
+
+## 6. Chunking research (2026 benchmarks)
+
+### What we found
+
+- **Recursive 512-token chunking** scored 69% retrieval accuracy in a February 2026 Vecta benchmark across 50 academic papers — winner among basic methods (https://www.firecrawl.dev/blog/best-chunking-strategies-rag).
+- **Document-based chunking** (heading-aware) is the optimal strategy for well-structured markdown — exactly the content we have (https://learn.microsoft.com/en-us/azure/search/search-how-to-semantic-chunking).
+- **Semantic chunking** (embedding-based boundary detection) adds up to 9% recall improvement, but at LLM-call latency and cost (https://weaviate.io/blog/chunking-strategies-for-rag).
+- claude-mem's choice of ~500-token semantic observations validates the same sweet spot from a different angle.
+
+### Why heading-based chunking won for our content
+
+- CLAUDE.md and MEMORY.md are already well-structured markdown with H2/H3 sections.
+- Heading boundaries are *semantic* boundaries (the user wrote them that way).
+- Heading-based chunking is the highest-recall strategy for structured docs at zero LLM cost.
+- The chunks naturally land in the 50–500-token range that matches the Vecta benchmark winner.
+
+### Edge cases the chunker has to handle
+
+1. **Oversized sections** (>2000 chars) — descend to H3 inside that section.
+2. **Tiny sections** (<200 chars) — merge with the next sibling to avoid one-liner memories.
+3. **Code fences containing `## `** — must not be split mid-fence. The implementation masks heading-like lines inside fences with a length-preserving substitution (so chunk offsets stay aligned with the original text).
+
+---
+
+## 7. The design decision trail — what we considered and why we picked what we picked
+
+This section is the journey, not just the destination. Most decisions had three or four credible options; the choice often turned on "what's the minimum viable surface."
+
+### Q1: What's in v1 scope?
+
+| Option | Choice | Why |
+|---|---|---|
+| Instructions only (CLAUDE.md + rules) | rejected | misses the meat of "holistic" — Claude's actual learnings |
+| Instructions + project auto-memory | rejected | misses subagent memory (rich for power users) |
+| **Instructions + ALL auto-memory** | **picked** | the actual "holistic" picture; one heavy user already had 19 meta-reviewer feedback files |
+| Everything including transient state | rejected | history.jsonl / sessions / todos are noise |
+
+### Q2: How does the user trigger the import?
+
+| Option | Choice | Why |
+|---|---|---|
+| Slash command only | rejected | not scriptable; needs an active session |
+| CLI subcommand only | rejected | less discoverable inside Claude Code |
+| Both + auto-prompt on first run | initially chosen | best discoverability |
+| **SessionStart hook nudge + plain Python script (no new CLI subcommand)** | **picked** | the owner's "use existing tools, no new moving parts" pivot. The bash hook does discovery and emits a one-time prompt; the Python script does the work; no Typer subcommand surface needed |
+
+### Q3: Auto-import on install, or always require explicit consent?
+
+| Option | Choice | Why |
+|---|---|---|
+| Fully automatic on plugin install | rejected | uploads user data to cloud without explicit consent — compliance risk |
+| Hook does the import in background | rejected | same consent problem |
+| **Hook detects + nudges; user / agent explicitly invokes the script** | **picked** | consent is explicit per run; hook stays cheap (just `[ -f marker ]`) |
+
+### Q4: How do files become mem0 memories?
+
+| Option | Choice | Why |
+|---|---|---|
+| Raw, one memory per file | rejected | granularity too coarse — 5 KB blobs hurt search |
+| Heading-chunked, `infer=False` (initially recommended) | almost picked | preserves wording, cheap |
+| **Heading-chunked, `infer=True` default + `--no-infer` opt-out** | **picked** | the owner prioritized server-side dedup + search quality over wording preservation. `--no-infer` preserved for raw-fidelity needs |
+| Always LLM-extracted (`infer=True`) without chunking | rejected | mem0's LLM may miss facts in long inputs; chunking improves extraction |
+| Hybrid by file size | rejected | branching logic the user can't predict |
+
+The chunker is heading-based regardless; the toggle is purely whether the chunks get LLM extraction on the server.
+
+### Q5: Identity scoping in mem0
+
+| Option | Choice | Why |
+|---|---|---|
+| **`user_id` only, source info in metadata** | **picked** | matches existing plugin convention; metadata filters give you the same query power |
+| `user_id` + `run_id` per project | rejected | diverges from convention for marginal benefit |
+| `user_id` + `run_id` always | rejected | synthetic run_ids for things that aren't runs |
+
+### Q6: Architecture — how minimal can the surface be?
+
+| Option | Choice | Why |
+|---|---|---|
+| Library + CLI subcommand + hook | rejected | three new things |
+| Library + hook | rejected | still introduces a new top-level package surface |
+| **One new Python script + one new hook block + one marker file** | **picked** | mirrors `on_pre_compact.py` exactly; reuses every existing convention; zero new packages, zero new deps |
+
+### Q7: Dedup model
+
+| Option | Choice | Why |
+|---|---|---|
+| Server-side via `infer=True` only | rejected (alone) | doesn't help client-side: would re-upload everything every run |
+| Content-hash in marker only | rejected (alone) | doesn't help if user runs `--reset` or two machines with same content |
+| **Both: marker for client-side idempotency, `infer=True` for server-side dedup** | **picked** | belt-and-suspenders |
+
+### Q8: Re-prompting after first run
+
+| Option | Choice | Why |
+|---|---|---|
+| Hook nudges every session if any file is newer than marker | rejected | noisy for power users editing CLAUDE.md often |
+| **Hook silent after marker exists; users re-run script manually** | **picked v1** | simple. Staleness re-prompting is a v2 enhancement |
+
+---
+
+## 8. Open questions / known unknowns
+
+These are explicit non-decisions — the new owner gets to make these calls when they pick this up.
+
+1. **Continuous sync** — should v2 add a watcher that re-imports when MEMORY.md changes? Or rely on the existing live-capture (`session_state`) to cover ongoing changes? Open.
+2. **Slash command `/mem0 import`** — convenience wrapper inside Claude Code. The agent can already invoke the Python script via Bash, but a slash command surfaces it in the `/` discovery panel. Cheap to add later.
+3. **Staleness re-prompting** — should the SessionStart hook re-nudge if marker is >N days old or if `find` shows files newer than `last_run_at`? Adds ~50 ms per SessionStart but improves long-term discovery.
+4. **Codex / Cursor parity smoke test** — `codex-hooks.json` and `cursor-hooks.json` already reference the same `on_session_start.sh`. The Python script is client-agnostic. The implementation plan suggests verifying via a smoke run on each client — that wasn't done because implementation never happened.
+5. **Sensitive content scrubbing** — CLAUDE.md often contains internal URLs, sandbox API keys, sometimes secrets. The current design relies on user judgment (same risk profile as the live-capture hooks already in production). A secrets-detection pre-pass would be a good v2.
+6. **Public AGENTRUSH memories interaction** — recent commit `4ca9d13c feat(cli): warn about public AGENTRUSH memories before first add` introduced a confirmation flow for public memories. Imported memories should probably respect that warning if any of the source files end up in a public scope. Out of scope for v1.
+7. **What happens when the user changes machines?** — currently the marker file is per-machine. If a user runs the import on laptop A, then later runs it on laptop B, B will re-upload everything (different marker). mem0's server-side dedup with `infer=True` mostly catches this, but the marker doesn't sync. Probably fine. Worth verifying.
+8. **What about `.claude/skills` and `.claude/agents` directories?** — these contain skill / agent definitions. They're not really "memory" per se but they're context the user has curated. Out of scope for v1 but worth a thought.
+
+---
+
+## 9. Recommended next steps for new owner
+
+If you're picking this up:
+
+1. **Read the spec first.** `docs/superpowers/specs/2026-05-18-claude-state-holistic-import-design.md` — 330 lines, internally consistent, all decisions justified.
+2. **Read the plan.** `docs/superpowers/plans/2026-05-18-claude-state-holistic-import.md` — 14 tasks, TDD-flavored but the test discipline is optional.
+3. **Decide if `infer=True` default is still right.** The owner made the call late in design and the implementation never ran against a real fixture. If the LLM cost on a typical user (15 projects × ~5 files × ~10 chunks each = ~750 chunks → ~750 LLM extractions on the platform side) feels too high, revert to `infer=False` default. The chunker, marker, and dispatcher all work either way — only the default value of one CLI flag changes.
+4. **Start at Task 1 of the plan.** Scaffold the script + test harness. Then go in order — the dependency chain is genuine (chunker depends on Source, dispatcher depends on chunker + tagger, orchestrator depends on dispatcher + marker).
+5. **If you skip the tests** (which is fine — the design isn't TDD-dependent), at minimum write the integration test (Task 12). It's the cheapest insurance against the chunker / tagger / dispatcher mismatching in ways unit tests would catch piecemeal.
+6. **Manual smoke before merging.** Run against a throwaway mem0 account with `MEM0_USER_ID=mem0_import_smoke_$DATE`. Confirm chunks appear in the dashboard with the right `metadata.source_type` and `metadata.type` tags. Verify search filters in `mem0-plugin/skills/mem0-mcp/SKILL.md` actually return what you expect.
+7. **Consider whether to ship this in `0.2.0`** or **bundle into a bigger plugin release**. The plugin already advanced to 0.2.0 on the `feat/claude-code-plugin` branch with Tier 1/2 features. Decide if holistic import fits that release or warrants 0.3.0.
+
+### Quick-start command sequence
+
+```bash
+# Set up
+git checkout main && git pull
+git checkout -b feat/claude-state-holistic-import
+
+# Read the docs
+$EDITOR docs/superpowers/specs/2026-05-18-claude-state-holistic-import-design.md
+$EDITOR docs/superpowers/plans/2026-05-18-claude-state-holistic-import.md
+
+# Implement Task 1: scaffold
+mkdir -p tests/plugin_scripts
+touch tests/plugin_scripts/__init__.py
+# ... follow plan ...
+
+# Run tests as you go
+pytest tests/plugin_scripts/ -v
+
+# Manual smoke
+export MEM0_USER_ID="mem0_import_smoke_$(date +%Y%m%d)"
+python3 mem0-plugin/scripts/import_claude_state.py --dry-run
+
+# Commit per task. PR back to main.
+```
+
+### Estimated effort
+
+| Phase | Estimate |
+|---|---|
+| Read spec + plan + this doc | 1 hour |
+| Tasks 1–11 (script + tests through CLI) | 1–2 days for a Python engineer comfortable with stdlib |
+| Task 12 (integration test) | 2–4 hours |
+| Task 13 (hook block) | 30 minutes |
+| Task 14 (docs + version bump) | 30 minutes |
+| Manual smoke + iteration | 2–4 hours |
+| **Total** | **2–3 working days** |
+
+---
+
+## 10. Source materials
+
+### Anthropic docs
+- [How Claude remembers your project](https://code.claude.com/docs/en/memory) — CLAUDE.md hierarchy, auto-memory, `.claude/rules/`, `@imports`, settings
+- [Claude Code Plugin Marketplace: Complete Guide (2026)](https://www.agensi.io/learn/claude-code-plugin-marketplace-guide)
+- [Discover and install prebuilt plugins through marketplaces](https://code.claude.com/docs/en/discover-plugins)
+- [anthropics/claude-plugins-official](https://github.com/anthropics/claude-plugins-official)
+
+### mem0 docs and source
+- [Direct Import — Mem0](https://docs.mem0.ai/platform/features/direct-import) — `infer=False` semantics
+- [Mem0 Platform docs](https://docs.mem0.ai)
+- `mem0/memory/main.py` — `add()` source, infer kwarg
+- `mem0-plugin/skills/mem0-mcp/SKILL.md` — metadata vocab + v2 filter syntax
+- `mem0-plugin/scripts/on_pre_compact.py` — the pattern reference for the new script
+- `mem0-plugin/scripts/_identity.py` — user_id resolution
+
+### Competitive plugins
+- [claude-mem (thedotmack/claude-mem)](https://github.com/thedotmack/claude-mem)
+- [Claude-Mem Guide — DataCamp](https://www.datacamp.com/tutorial/claude-mem-guide)
+- [Memory Store Plugin (julep-ai/memory-store-plugin)](https://github.com/julep-ai/memory-store-plugin)
+- [Serena (oraios/serena)](https://github.com/oraios/serena)
+- [Cipher / ByteRover CLI (campfirein/byterover-cli)](https://github.com/campfirein/cipher)
+- [OpenCode plugin (kuitos/opencode-claude-memory)](https://github.com/kuitos/opencode-claude-memory)
+- [Hands-on: Build a Memory Layer for Claude Code & Gemini CLI](https://aiengineering.beehiiv.com/p/hands-on-make-coding-agents-10x-smarter-1)
+
+### Chunking research
+- [Best Chunking Strategies for RAG (2026)](https://www.firecrawl.dev/blog/best-chunking-strategies-rag) — Vecta Feb 2026 benchmark
+- [Chunk and Vectorize by Document Layout — Azure AI Search](https://learn.microsoft.com/en-us/azure/search/search-how-to-semantic-chunking)
+- [Chunking Strategies to Improve LLM RAG Pipeline Performance — Weaviate](https://weaviate.io/blog/chunking-strategies-for-rag)
+- [Text Chunking Strategies for RAG: A Comprehensive Guide (March 2026)](https://atlassc.net/2026/03/30/text-chunking-strategies-for-rag)
+- [RAG Chunking Strategies — Latenode](https://latenode.com/blog/ai-frameworks-technical-infrastructure/rag-retrieval-augmented-generation/rag-chunking-strategies-complete-guide-to-document-splitting-for-better-retrieval)
+
+### Related Anthropic features and posts
+- [Auto memory in Claude Code (v2.1.59+) — community context](https://www.shareuhack.com/en/posts/claude-memory-feature-guide-2026)
+- [Import and export your memory from Claude — Help Center](https://support.claude.com/en/articles/12123587-import-and-export-your-memory-from-claude) — note: this is chat memory, not Claude Code memory
+- [Claude Code Memory System Explained — Milvus](https://milvus.io/blog/claude-code-memory-memsearch.md)
+- [The Complete Guide to CLAUDE.md — Bijit Ghosh, Medium](https://medium.com/@bijit211987/the-complete-guide-to-claude-md-memory-rules-loading-and-cross-tool-compression-97cc12ed037b)
+
+### Internal references
+- `docs/superpowers/specs/2026-05-18-claude-state-holistic-import-design.md` — the spec
+- `docs/superpowers/plans/2026-05-18-claude-state-holistic-import.md` — the implementation plan
+- `mem0-plugin/README.md` — current plugin docs
+- `mem0-plugin/CHANGELOG.md` — release history
+- `CLAUDE.md` (this repo's root) — project-level conventions

--- a/docs/superpowers/specs/2026-05-18-claude-state-holistic-import-design.md
+++ b/docs/superpowers/specs/2026-05-18-claude-state-holistic-import-design.md
@@ -1,0 +1,335 @@
+# Claude state holistic import for `mem0-plugin`
+
+**Status:** draft (handoff — not implemented)
+**Date:** 2026-05-18
+**Original owner:** mragank@mem0.ai (leaving company)
+**Scope:** v1 of the holistic-import feature for `mem0-plugin/`
+
+> **Reading order for new owner:**
+> 1. `docs/superpowers/research/2026-05-19-claude-state-holistic-import-research.md` — why, competitive landscape, what we learned
+> 2. **This file (spec)** — what we decided to build and why
+> 3. `docs/superpowers/plans/2026-05-18-claude-state-holistic-import.md` — TDD-style implementation plan (14 tasks)
+
+---
+
+## 1. Problem
+
+When a user installs `mem0-plugin`, mem0 starts empty. Everything Claude has already learned about their projects — every `CLAUDE.md` rule, every `MEMORY.md` auto-memory entry, every subagent's accumulated feedback — sits on local disk, invisible to mem0. The existing hooks only capture *new* state (`session_state`, `compact_summary`, agent `add_memory` calls). They cannot backfill what existed before install.
+
+Competitive plugins either ignore this (claude-mem, Serena live-capture only) or auto-sync `CLAUDE.md` continuously without bulk import (Memory Store Plugin). No one performs a deliberate holistic backfill of Claude's prior state into a cloud memory layer.
+
+This spec defines that backfill.
+
+## 2. Goals
+
+- Backfill into mem0 every piece of on-disk Claude state worth searching against later: `CLAUDE.md` hierarchy (+ `@imports`), `.claude/rules/`, `~/.claude/projects/*/memory/` (auto-memory + topic files), `~/.claude/agent-memory/*/` (subagent memory + topic files).
+- Stay idempotent: re-running adds only new content, never duplicates existing chunks.
+- Add the smallest possible new surface to the plugin (one new Python script + one new block in an existing hook + one marker file).
+- Match existing plugin conventions: `_identity.py` for user resolution, urllib REST calls, stderr-only logging, `~/.mem0/` for state, `MEM0_API_KEY` for auth.
+
+## 3. Non-goals (v1)
+
+- **Continuous sync.** No watcher, no daemon, no per-edit re-import. Re-running the script is the supported way to pick up changes.
+- **Slash command** (`/mem0 import`). Deferred. The CLI script invoked via Bash is enough for v1 since the agent can run it directly.
+- **Cross-machine sync.** Each machine runs its own import. mem0 platform handles cross-machine reads.
+- **Transient state import.** `~/.claude/history.jsonl`, `~/.claude/sessions/`, `~/.claude/todos/`, plan files — out of scope. High noise-to-signal.
+- **Staleness re-prompting.** v1 hook is silent after first successful import. v2 may add a freshness check.
+- **Sensitive content scrubbing.** Out of scope for v1; rely on user judgment (CLAUDE.md often contains internal URLs, API keys — same risk profile as agent-authored `add_memory` calls already in scope today).
+
+## 4. Architecture
+
+### Three deliverables — all minimal
+
+1. **One new Python script:** `mem0-plugin/scripts/import_claude_state.py`. Patterned exactly on existing `on_pre_compact.py`: same logging setup, same urllib REST calls, same `_identity.py` for user resolution, same `exit 0` discipline for hook-invoked paths.
+2. **One new conditional block** in existing `mem0-plugin/scripts/on_session_start.sh`. ~15 lines of bash after the existing identity + bootstrap output. Emits a one-time nudge to the agent if the marker file doesn't exist.
+3. **One marker file:** `~/.mem0/imports/claude-state.json`. Same `~/.mem0/` directory already used for `hooks.log`.
+
+### Invocation
+
+```
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/import_claude_state.py [flags]
+
+Flags:
+  --dry-run           Print plan, don't upload.
+  --reset             Delete marker and re-import everything.
+  --no-infer          Upload chunks raw (infer=False), preserving wording.
+  --source=<type>     Restrict to one source_type (claude_md|memory_md|rule|agent_memory|claude_local).
+```
+
+The agent runs the script via `Bash` when nudged by the hook. Power users run it directly from terminal. No new `mem0` CLI subcommand, no new Typer surface, no new package.
+
+### Reused infrastructure (zero new)
+
+| Need | Reused from |
+|---|---|
+| User identity | `_identity.py` / `_identity.sh` |
+| REST API to mem0 | urllib pattern from `on_pre_compact.py` |
+| Hook plumbing | existing `SessionStart` registration in `hooks.json` |
+| Auth | `MEM0_API_KEY` env (already required) |
+| Storage dir | `~/.mem0/` (already used for `hooks.log`) |
+| Logging style | stderr logger, optional `~/.mem0/hooks.log` when `MEM0_DEBUG=1` |
+
+## 5. Components
+
+All inside `import_claude_state.py`. Flat, top-down, no classes. ~300 lines target.
+
+### Discovery
+
+`discover() -> list[Source]` globs the known paths:
+
+| Path pattern | `source_type` | Notes |
+|---|---|---|
+| `/Library/Application Support/ClaudeCode/CLAUDE.md` (macOS) and platform equivalents | `claude_md_managed` | Org-level; rarely present, but supported. |
+| `~/.claude/CLAUDE.md` | `claude_md_user` | User-global instructions. |
+| `<cwd>/CLAUDE.md`, `<cwd>/.claude/CLAUDE.md`, ancestor `CLAUDE.md` walking up | `claude_md_project` | Project-level. Includes nested CLAUDE.md when discovered via @imports. |
+| `<cwd>/CLAUDE.local.md` | `claude_local` | Personal project-specific. |
+| `<cwd>/.claude/rules/**/*.md`, `~/.claude/rules/*.md` | `rule` | Path-scoped instruction files. |
+| `~/.claude/projects/*/memory/MEMORY.md` | `memory_md` | Per-project auto-memory index. |
+| `~/.claude/projects/*/memory/*.md` (non-MEMORY.md) | `memory_topic` | Topic files. |
+| `~/.claude/agent-memory/*/MEMORY.md` | `agent_memory` | Subagent auto-memory index. |
+| `~/.claude/agent-memory/*/*.md` (non-MEMORY.md) | `agent_memory_topic` | Subagent topic files. |
+
+`Source(path, source_type, project_name?, subagent_name?)` — `project_name` extracted from the encoded path under `~/.claude/projects/`, `subagent_name` from `~/.claude/agent-memory/`.
+
+### `@import` resolution
+
+`resolve_imports(claude_md_path) -> list[Path]`. Follows Claude Code's loader semantics:
+- `@path` syntax inside CLAUDE.md content
+- Relative paths resolve relative to the file containing the import
+- Absolute paths allowed
+- `~/` expanded
+- Max depth 5
+- Cycle detection via a visited set
+- Non-`.md` extensions allowed (Claude Code follows them too)
+
+Discovered imports are merged into the discovery list with `source_type=claude_md_import`.
+
+### Chunking
+
+`chunk_markdown(text) -> list[Chunk]`:
+
+- Split at `## ` (H2) by default.
+- If a chunk exceeds **2000 chars**, descend to `### ` (H3) for that section.
+- If a chunk is under **200 chars**, merge with the next sibling under the same parent heading.
+- Code-fenced blocks (```` ``` ````) are never split mid-fence.
+- If no headings at all, the file is one chunk.
+- Token target: **~50–500 tokens per chunk** (the char heuristics — 200 char min, 2000 char max — map to roughly 50–500 tokens at the standard ~4 chars/token ratio for English prose).
+
+Each `Chunk` carries:
+```python
+@dataclass
+class Chunk:
+    heading: str         # e.g. "## Coding Standards"
+    body: str            # full section body, including the heading line
+    content_hash: str    # sha256(body)
+```
+
+### Tagging
+
+`tag_chunk(source, chunk) -> dict` returns the metadata dict attached to the `add_memory` call:
+
+```python
+{
+    "source_file": "/Users/.../CLAUDE.md",
+    "source_type": "claude_md_project",
+    "section_heading": "Coding Standards",
+    "project": "mem0-platform",     # null if not project-scoped
+    "subagent": null,                # set for agent_memory sources
+    "content_hash": "ab12...",
+    "type": "convention",            # see heuristic below
+}
+```
+
+`type` heuristic (matches the vocabulary in `mem0-plugin/skills/mem0-mcp/SKILL.md`):
+
+| `source_type` | Default `type` | Heading-keyword overrides |
+|---|---|---|
+| `claude_md_*` | `convention` | Headings matching `prefer|preference|style` → `user_preference` |
+| `claude_local` | `user_preference` | — |
+| `rule` | `convention` | — |
+| `memory_md` / `memory_topic` | `task_learning` | `bug|fix|debug` → `anti_pattern`; `decision|chose|picked` → `decision`; `never|always|critical` → `anti_pattern` |
+| `agent_memory*` | `task_learning` | Same heading overrides as `memory_md` |
+
+### Dispatch
+
+`upload(chunks, user_id, infer=True) -> list[UploadResult]`:
+
+- For each chunk in order:
+  - If `content_hash` is already in the marker, skip.
+  - POST `https://api.mem0.ai/v1/memories/` with:
+    ```json
+    {
+      "messages": [{"role": "user", "content": "<chunk.body>"}],
+      "user_id": "<resolved-user-id>",
+      "metadata": { /* tag_chunk output */ },
+      "infer": true
+    }
+    ```
+  - Collect `memory_ids` from the response.
+  - Write the chunk's entry to the marker file immediately (resume-on-crash safety).
+- Sequential. No batching. No parallelism. Matches `on_pre_compact.py`.
+
+### Marker I/O
+
+`read_marker() -> Marker` / `write_marker(Marker)`. JSON at `~/.mem0/imports/claude-state.json`:
+
+```json
+{
+  "schema_version": 1,
+  "user_id": "mragankshekhar",
+  "last_run_at": "2026-05-18T17:55:00Z",
+  "imports": [
+    {
+      "file": "/Users/.../CLAUDE.md",
+      "source_type": "claude_md_user",
+      "imported_at": "2026-05-18T17:55:00Z",
+      "chunks": [
+        {
+          "heading": "Coding Standards",
+          "content_hash": "ab12...",
+          "memory_ids": ["m_xyz"]
+        }
+      ]
+    }
+  ]
+}
+```
+
+Per-chunk writes are atomic via write-temp-then-rename.
+
+### Hook extension
+
+Added to `mem0-plugin/scripts/on_session_start.sh` after the existing identity + bootstrap blocks:
+
+```bash
+# Holistic import nudge — only emit if marker doesn't exist yet
+MARKER="$HOME/.mem0/imports/claude-state.json"
+if [ ! -f "$MARKER" ]; then
+  cat <<'EOF'
+
+## Holistic import available
+
+On-disk Claude state (CLAUDE.md, auto-memory, agent memory) has never been
+imported into mem0. Run:
+
+  python3 ${CLAUDE_PLUGIN_ROOT}/scripts/import_claude_state.py --dry-run
+
+to preview, then drop `--dry-run` to import. The import runs once; this nudge
+goes away after the first successful run.
+EOF
+fi
+```
+
+`${CLAUDE_PLUGIN_ROOT}` is the variable already used by the existing hook scripts to reference the plugin's install path.
+
+## 6. Data flow
+
+### Happy path (first-time user)
+
+```
+1. User installs plugin → restarts Claude Code
+2. SessionStart fires
+   └─ on_session_start.sh:
+      ├─ Identity block (existing)        → "Active user_id: ..."
+      ├─ Bootstrap rubric (existing)      → "Call search_memories first..."
+      └─ NEW: marker absent               → emit holistic-import nudge
+
+3. Agent reads nudge, mentions it to user
+4. User: "preview" → agent runs `python3 ... --dry-run`
+5. Script: discover → chunk → print plan, return 0 (no upload)
+6. Agent shows count, asks for confirmation
+7. User: "go" → agent runs script without --dry-run
+8. Script:
+   for each chunk:
+     - skip if content_hash already in marker (empty on first run)
+     - POST /v1/memories/ with metadata + infer=True
+     - append entry to marker file (atomic temp-and-rename)
+   print "Imported X chunks from Y files, skipped Z duplicates"
+9. Next SessionStart: marker exists → hook stays silent.
+```
+
+### Re-run scenarios
+
+- **User edits a CLAUDE.md, re-runs script** → discover finds the same files; some chunks have unchanged content_hash (skipped via marker), some are new (uploaded). Marker is updated additively.
+- **`--reset`** → marker file is wiped first, then full re-import runs. mem0's `infer=True` server-side dedup catches genuine duplicates.
+- **`--no-infer`** → chunks uploaded with `infer=False`. Marker tracks content_hash, so re-runs remain idempotent client-side. Useful for content where wording must be preserved verbatim.
+- **`--source=<type>`** → restrict discovery + upload to a single `source_type`.
+
+### Concurrency
+
+Sequential POSTs. Matches `on_pre_compact.py`. ~87 chunks (typical user with 15 projects + 2 subagents) completes in under a minute. No batching, no parallelism, no queueing.
+
+## 7. Error handling
+
+The hook block must never break SessionStart. The CLI script can exit non-zero on real failures so users / agents notice.
+
+| Failure | Behavior |
+|---|---|
+| `MEM0_API_KEY` missing | CLI: print *"Set MEM0_API_KEY first — see plugin README"*, exit 1. Hook: existing `[ -z "$MEM0_API_KEY" ] && exit 0` guard short-circuits before the nudge. |
+| Network error / timeout | Log to stderr, skip chunk, continue. Final summary lists failures + *"re-run to retry"*. |
+| 401 / auth error | Stop immediately. Print *"Auth failed — check MEM0_API_KEY"*. Don't keep hammering. |
+| 429 rate limit | Backoff once (sleep 2 s), retry once, then skip-and-continue. |
+| 5xx | Log + skip chunk + continue. |
+| File read error or file disappeared between scan and read | Log warning, skip, continue. |
+| Malformed markdown | Treat whole file as one chunk. Truly unreadable files are skipped + logged. |
+| `@import` cycle or depth > 5 | Detected, logged, first occurrence honored, rest skipped — matches Claude Code's loader. |
+| Marker file JSON corruption | Treat as absent, log warning, continue. Next run rewrites cleanly. |
+| Script killed mid-run | Marker writes per chunk (not per file, not at end) → re-run resumes from the next un-marked chunk. |
+| Hook block tooling missing (`jq`, etc.) | `2>/dev/null || true` wraps the block — never breaks SessionStart. |
+
+## 8. Testing
+
+Three layers, all using existing tooling (pytest + `unittest.mock`).
+
+### Unit tests — `tests/plugin_scripts/test_import_claude_state.py` (new file, new dir under existing `tests/`)
+
+| Function under test | Cases | Approximate count |
+|---|---|---|
+| `chunk_markdown` | no headings, only H1, deeply nested headings, oversized H2 → descends to H3, undersized siblings merged, code fences not split mid-fence | ~10 |
+| `tag_chunk` | every `source_type` → expected default `type`; heading-keyword overrides | ~8 |
+| `resolve_imports` | relative path, absolute path, `~/` expansion, cycle, depth limit, missing target | ~6 |
+| `read_marker` / `write_marker` | roundtrip, corrupted JSON, missing file, schema_version migration | ~4 |
+
+### Integration tests — same file
+
+- End-to-end with `urllib.request.urlopen` mocked. Fixture directory with one fake CLAUDE.md (with one `@import`) + one fake `MEMORY.md` + one fake agent-memory file. Asserts: discover finds 4 files, chunker produces N chunks, dispatcher POSTs N times with correct metadata payloads, marker file written with the expected structure.
+- One test for `--reset` flow (marker wiped, full re-upload).
+- One test for `--no-infer` flow (`infer: false` in payload, content_hash still tracked).
+- One test for partial-failure resume (kill mid-run, re-run, asserts only missing chunks are uploaded).
+
+### Manual smoke
+
+- Documented in the PR description: run against a real mem0 account with `MEM0_USER_ID=mem0_import_smoke_$DATE`. Confirm chunks appear, are searchable, and `metadata.source_type` filters work as advertised in `mem0-plugin/skills/mem0-mcp/SKILL.md`.
+
+### CI
+
+No new workflow. The existing `ci.yml` runs `pytest tests/` — the new test file is picked up automatically. No new dependencies.
+
+## 9. File layout
+
+```
+mem0-plugin/
+  scripts/
+    on_session_start.sh           # extended (one new conditional block)
+    import_claude_state.py        # NEW (~300 lines)
+    _identity.py                  # unchanged, reused
+    _identity.sh                  # unchanged, reused
+    on_pre_compact.py             # unchanged (pattern reference)
+tests/
+  plugin_scripts/                 # NEW directory
+    __init__.py                   # NEW (empty)
+    test_import_claude_state.py   # NEW
+~/.mem0/
+  imports/
+    claude-state.json             # marker, written by the script at runtime
+```
+
+## 10. Open questions
+
+None blocking. Everything below is a deliberate v2 deferral:
+
+- **Continuous sync** — should a future hook watch for changes to `MEMORY.md` and incrementally import? Out of scope for v1.
+- **Slash command `/mem0 import`** — convenience wrapper inside Claude Code. Easy to add later; not needed now since agent can run the script directly.
+- **Staleness re-prompting** — should the SessionStart hook re-nudge if marker is >N days old or if `find` shows files newer than `last_run_at`? Deferred.
+- **Codex / Cursor parity** — `codex-hooks.json` and `cursor-hooks.json` already reference the same `on_session_start.sh` we're modifying, so the nudge propagates to those clients for free. The Python script itself is client-agnostic (uses `${CLAUDE_PLUGIN_ROOT}` env interpolation, falls back to script location). Confirm via a smoke run on each client during implementation.
+- **Sensitive-content scrubbing** — secrets detection in CLAUDE.md before upload. Out of scope; consistent with current plugin treatment of agent-authored memories.


### PR DESCRIPTION
> **⚠️ This PR is a handoff reference, not for merging.** The original owner is leaving the company before implementation could start. This branch lands the full research, spec, and implementation plan so the next engineer can pick this up cold. Close this PR once a new owner opens a real implementation branch.

## Summary

- Researched and designed a one-shot importer that backfills the user's on-disk Claude Code state (CLAUDE.md hierarchy + `@imports`, `.claude/rules`, `~/.claude/projects/*/memory`, `~/.claude/agent-memory`) into mem0 as searchable memories.
- **No code yet.** Three markdown docs only: research, spec, plan.
- Competitive scan showed nobody else does this systematically — Memory Store Plugin syncs CLAUDE.md only; claude-mem / Serena / Cipher / OpenCode / Anthropic native don't backfill at all.

## What this PR contains

```
docs/superpowers/
├── README.md                                                # entry point + reading order
├── research/2026-05-19-claude-state-holistic-import-research.md   # 500 lines — the why, the landscape, the decisions
├── specs/2026-05-18-claude-state-holistic-import-design.md        # 330 lines — what we'd build
└── plans/2026-05-18-claude-state-holistic-import.md               # 540 lines — 14-task TDD implementation plan
```

**Total: 1,403 lines of documentation. Zero lines of executable code.**

## Reading order for whoever picks this up

1. `docs/superpowers/research/...-research.md` — start here. Problem framing, full Claude Code state inventory, competitive landscape (claude-mem, Memory Store, Serena, Cipher, OpenCode, Anthropic native), `mem0` `infer=True` vs `infer=False` deep-dive, 2026 RAG chunking benchmarks, and the full design decision trail with the rationale for every choice.
2. `docs/superpowers/specs/...-design.md` — what we decided to build. Architecture, components, data flow, error handling, testing strategy. All approved, no TBDs.
3. `docs/superpowers/plans/...-import.md` — 14-task TDD implementation plan with code in every step. ~2–3 days of work for a Python engineer comfortable with stdlib.

## Design in one paragraph

One new Python script `mem0-plugin/scripts/import_claude_state.py` (patterned on existing `on_pre_compact.py`) + one new conditional block in `mem0-plugin/scripts/on_session_start.sh` + one marker JSON at `~/.mem0/imports/claude-state.json`. The script does discovery → heading-based markdown chunking (~50–500 tokens) → metadata tagging (`source_type`, `section_heading`, `project`, `subagent`, `content_hash`, `type`) → sequential POST to `https://api.mem0.ai/v1/memories/` with `infer=True` by default and per-chunk marker writes for idempotent re-runs. The hook nudges the agent on first session; the agent invokes the script via Bash; the marker silences the nudge after first success. Reuses every existing convention in the plugin (`_identity.py`, urllib pattern, `${CLAUDE_PLUGIN_ROOT}`, `~/.mem0/` for state).

## Why no code

The owner had to wrap up. Rather than ship a half-finished implementation, this PR consolidates everything that *was* done — the research, the design, the plan — into a single referenceable artifact.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Documentation update (handoff)

## Test Plan

- [x] N/A — no executable code in this PR.
- [ ] Future: when the next owner implements, the plan's Tasks 1–12 cover unit + integration tests. The plan's "Final verification" section documents the manual smoke test against a real mem0 account.

## Checklist

- [x] Self-review performed (every doc cross-references the others; spec self-review section confirms internal consistency)
- [x] No code style violations (markdown only)
- [x] All known design decisions captured with rationale
- [x] Open questions and v2 deferrals explicitly listed in research §8
- [x] Source materials and external references catalogued in research §10
- [x] Recommended next steps and effort estimate in research §9

## Closes

No issue. This is a handoff artifact, not a tracked work item.