### PR TITLE
fix(xai): AttributeError on factory, tools dropped, add _parse_response

### DIFF
--- a/mem0/llms/xai.py
+++ b/mem0/llms/xai.py
@@ -15,8 +15,27 @@ class XAILLM(LLMBase):
             self.config.model = "grok-2-latest"
 
         api_key = self.config.api_key or os.getenv("XAI_API_KEY")
-        base_url = self.config.xai_base_url or os.getenv("XAI_API_BASE") or "https://api.x.ai/v1"
-        self.client = OpenAI(api_key=api_key, base_url=base_url)
+        xai_base_url = getattr(self.config, 'xai_base_url', None) or os.getenv("XAI_API_BASE") or "https://api.x.ai/v1"
+        self.client = OpenAI(api_key=api_key, base_url=xai_base_url)
+
+    def _parse_response(self, response, tools):
+        """
+        Process the response based on whether tools are used or not.
+
+        Args:
+            response: The raw response from API.
+            tools: The list of tools provided in the request.
+
+        Returns:
+            str or dict: The parsed response.
+        """
+        if tools:
+            processed_response = {
+                "content": response.choices[0].message.content,
+                "tool_calls": response.choices[0].message.tool_calls,
+            }
+            return processed_response
+        return response.choices[0].message.content
 
     def generate_response(
         self,
@@ -48,5 +67,9 @@ class XAILLM(LLMBase):
         if response_format:
             params["response_format"] = response_format
 
+        if tools:
+            params["tools"] = tools
+            params["tool_choice"] = tool_choice
+
         response = self.client.chat.completions.create(**params)
-        return response.choices[0].message.content
+        return self._parse_response(response, tools)


### PR DESCRIPTION
## Summary

Fixes #5189 — three bugs in `mem0/llms/xai.py`:

1. **AttributeError on factory construction** — `__init__` reads `self.config.xai_base_url` unconditionally on `BaseLlmConfig` (no such attribute). Every call to `LlmFactory.create("xai", ...)` crashes.


2. **tools silently dropped** — `generate_response()` accepts `tools`/`tool_choice` but never forwards them to the OpenAI client.


3. **content is None for tool calls** — Missing `_parse_response` helper returns `message.content` (None when model emits tool calls) as-is.


## Changes

- `xai_base_url` access via `getattr(self.config, 'xai_base_url', None)` — safely returns `None` on `BaseLlmConfig`
- `tools` and `tool_choice` forwarded to `client.chat.completions.create()`
- `_parse_response()` added (matches OpenAI LLM implementation)
- Response returned via `self._parse_response(response, tools)`


## Testing

```python
import os
os.environ["XAI_API_KEY"] = "sk-test"
from mem0.utils.factory import LlmFactory
llm = LlmFactory.create("xai", {"model": "grok-2-latest"})
# No AttributeError ✅
```


Closes #5189
