### PR TITLE
fix: return empty results for empty/whitespace search query

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1176,6 +1176,9 @@ class Memory(MemoryBase):
         # Validate search parameters (before applying defaults)
         _validate_search_params(threshold=threshold, top_k=top_k)
 
+        if not isinstance(query, str) or not query.strip():
+            return {"results": []}
+
         # Validate and trim entity IDs in filters
         effective_filters = filters.copy() if filters else {}
         if "user_id" in effective_filters:
@@ -2590,6 +2593,9 @@ class AsyncMemory(MemoryBase):
 
         # Validate search parameters (before applying defaults)
         _validate_search_params(threshold=threshold, top_k=top_k)
+
+        if not isinstance(query, str) or not query.strip():
+            return {"results": []}
 
         # Validate and trim entity IDs in filters
         effective_filters = filters.copy() if filters else {}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -348,3 +348,31 @@ class TestSearchParamValidation:
             result = memory_instance.search("test", filters={"user_id": "test"}, top_k=0)
 
         assert "results" in result
+
+
+class TestEmptySearchQueryValidation:
+    """Tests for empty and whitespace query handling in search()."""
+
+    def test_search_empty_string_returns_empty(self, memory_instance):
+        result = memory_instance.search("", filters={"user_id": "test_user"})
+        assert result == {"results": []}
+
+    def test_search_whitespace_only_returns_empty(self, memory_instance):
+        result = memory_instance.search("   ", filters={"user_id": "test_user"})
+        assert result == {"results": []}
+
+    def test_search_tab_only_returns_empty(self, memory_instance):
+        result = memory_instance.search("\t\n", filters={"user_id": "test_user"})
+        assert result == {"results": []}
+
+    def test_search_accepts_valid_query(self, memory_instance):
+        mock_memories = []
+        memory_instance.vector_store.search = Mock(return_value=mock_memories)
+        memory_instance.vector_store.keyword_search = Mock(return_value=None)
+        memory_instance.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+
+        with patch("mem0.memory.main.lemmatize_for_bm25", return_value="hello"), \
+             patch("mem0.memory.main.extract_entities", return_value=[]):
+            result = memory_instance.search("hello", filters={"user_id": "test_user"})
+
+        assert "results" in result


### PR DESCRIPTION
## Linked Issue

Closes #5220 

## Description

Memory.search() had no input validation on the query string. Empty strings and whitespace-only queries were passed directly to the embedding model. Depending on the provider, this caused either a crash (ValueError from Ollama) or all stored memories being silently returned. This PR adds an early-return guard in both the sync Memory and async AsyncMemory search() methods that returns {"results": []} for blank queries, consistent with a valid search that matched nothing.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)


## Test Coverage

- [x] I added/updated unit tests

<!-- Describe how you tested this, or link to CI results. -->

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
