### PR TITLE
fix: pass metadata timestamp to extraction prompt so relative dates resolve correctly

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -733,6 +733,7 @@ class Memory(MemoryBase):
             new_messages=parsed_messages,
             last_k_messages=last_messages,
             custom_instructions=custom_instr,
+            timestamp=metadata.get("timestamp"),
         )
 
         try:
@@ -2149,6 +2150,7 @@ class AsyncMemory(MemoryBase):
             new_messages=parsed_messages,
             last_k_messages=last_messages,
             custom_instructions=custom_instr,
+            timestamp=metadata.get("timestamp"),
         )
 
         try:


### PR DESCRIPTION
`generate_additive_extraction_prompt` has a `timestamp=` parameter that sets the **Observation Date** in the LLM prompt. The prompt uses this to correctly resolve relative time expressions — "last week", "yesterday", "recently" — against when the conversation actually happened rather than today.

Both the sync and async `_add_to_vector_store` paths have access to `metadata` but neither passes `metadata.get("timestamp")` to the prompt. So if you ingest a historical conversation:

```python
m.add(
    "I went to Paris last week",
    user_id="u1",
    metadata={"timestamp": "2023-05-24T10:00:00+00:00"},
)
```

The extraction prompt says `Observation Date: 2026-05-21` (today) instead of `2023-05-24`, and "last week" resolves to May 2026 — silently producing wrong memory dates.

One-line fix in each path: add `timestamp=metadata.get("timestamp")` to both `generate_additive_extraction_prompt` calls.

Fixes #4963