### PR TITLE
fix(azure_openai): avoid AttributeError on multimodal message content

### DIFF
--- a/mem0/llms/azure_openai.py
+++ b/mem0/llms/azure_openai.py
@@ -120,11 +120,13 @@ class AzureOpenAILLM(LLMBase):
             str: The generated response.
         """
 
-        user_prompt = messages[-1]["content"]
-
-        user_prompt = user_prompt.replace("assistant", "ai")
-
-        messages[-1]["content"] = user_prompt
+        # Only the last message's textual content is rewritten. Multimodal
+        # messages carry a list of content parts (e.g. text + image_url), which
+        # has no ``.replace`` method, so guard against non-string content to
+        # avoid an AttributeError on vision/multimodal requests.
+        last_content = messages[-1]["content"]
+        if isinstance(last_content, str):
+            messages[-1]["content"] = last_content.replace("assistant", "ai")
 
         params = self._get_supported_params(messages=messages, **kwargs)
         

--- a/tests/llms/test_azure_openai.py
+++ b/tests/llms/test_azure_openai.py
@@ -91,6 +91,55 @@ def test_generate_response_with_tools(mock_openai_client):
     assert response["tool_calls"][0]["arguments"] == {"data": "Today is a sunny day."}
 
 
+def test_generate_response_with_multimodal_content(mock_openai_client):
+    """A message whose content is a list of parts (multimodal / vision) must not
+    crash. Previously the Azure provider called ``.replace`` on the last
+    message's content unconditionally, raising ``AttributeError: 'list' object
+    has no attribute 'replace'`` for image/multimodal requests."""
+    config = AzureOpenAIConfig(model=MODEL, temperature=TEMPERATURE, max_tokens=MAX_TOKENS, top_p=TOP_P)
+    llm = AzureOpenAILLM(config)
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What is in this image?"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/a.png"}},
+            ],
+        },
+    ]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="A description.", tool_calls=None))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    response = llm.generate_response(messages)
+
+    # List-typed content is forwarded unchanged (no string rewrite applied).
+    sent_messages = mock_openai_client.chat.completions.create.call_args.kwargs["messages"]
+    assert sent_messages[-1]["content"] == [
+        {"type": "text", "text": "What is in this image?"},
+        {"type": "image_url", "image_url": {"url": "https://example.com/a.png"}},
+    ]
+    assert response == "A description."
+
+
+def test_generate_response_rewrites_string_assistant_keyword(mock_openai_client):
+    """String content keeps the existing 'assistant' -> 'ai' rewrite behavior."""
+    config = AzureOpenAIConfig(model=MODEL, temperature=TEMPERATURE, max_tokens=MAX_TOKENS, top_p=TOP_P)
+    llm = AzureOpenAILLM(config)
+    messages = [{"role": "user", "content": "Ask the assistant a question."}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Done.", tool_calls=None))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    sent_messages = mock_openai_client.chat.completions.create.call_args.kwargs["messages"]
+    assert sent_messages[-1]["content"] == "Ask the ai a question."
+
+
 def test_generate_response_with_response_format(mock_openai_client):
     config = AzureOpenAIConfig(model=MODEL, temperature=TEMPERATURE, max_tokens=MAX_TOKENS, top_p=TOP_P)
     llm = AzureOpenAILLM(config)


### PR DESCRIPTION
## Description

`AzureOpenAILLM.generate_response()` rewrites the last message's content with
`str.replace("assistant", "ai")` unconditionally:

```python
user_prompt = messages[-1]["content"]
user_prompt = user_prompt.replace("assistant", "ai")
messages[-1]["content"] = user_prompt
```

When the last message's `content` is a **list of content parts** (the standard
shape for multimodal / vision messages, e.g. `[{"type": "text", ...}, {"type":
"image_url", ...}]`), `.replace` does not exist on `list`, so the call raises:

```
AttributeError: 'list' object has no attribute 'replace'
```

This crashes any `Memory.add()` / `generate_response()` that includes image
content when the LLM provider is `azure_openai`.

### Reproduction

```python
from unittest.mock import Mock, patch
from mem0.configs.llms.azure import AzureOpenAIConfig
from mem0.llms.azure_openai import AzureOpenAILLM

with patch("mem0.llms.azure_openai.AzureOpenAI"):
    llm = AzureOpenAILLM(AzureOpenAIConfig(model="gpt-4.1-nano"))
    llm.generate_response([
        {"role": "user", "content": [
            {"type": "text", "text": "What is in this image?"},
            {"type": "image_url", "image_url": {"url": "https://example.com/a.png"}},
        ]},
    ])
# AttributeError: 'list' object has no attribute 'replace'
```

### Fix

Guard the rewrite so it only runs when the content is a string. List content is
now forwarded unchanged, while the existing string behavior (`assistant` -> `ai`)
is preserved.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test Coverage

- [x] I added/updated unit tests

Added two regression tests in `tests/llms/test_azure_openai.py`:
- `test_generate_response_with_multimodal_content` — fails on `main` with the
  `AttributeError`, passes with the fix; asserts list content is forwarded
  unchanged.
- `test_generate_response_rewrites_string_assistant_keyword` — pins the existing
  string-rewrite behavior so it stays intact.

All tests in `tests/llms/test_azure_openai.py` pass (15 passed). `ruff check` is
clean on the changed files.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally