### PR TITLE
fix: preserve custom metadata on Memory.update() for all vector stores

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1668,25 +1668,21 @@ class Memory(MemoryBase):
 
         prev_value = existing_memory.payload.get("data")
 
-        new_metadata = deepcopy(metadata) if metadata is not None else {}
+        # Start from the full existing payload so all custom metadata fields
+        # (e.g. category, priority, source) are preserved by default.
+        # Caller-supplied metadata overrides individual keys; system fields
+        # (data, hash, text_lemmatized, created_at, updated_at) are always
+        # recomputed and take final precedence.
+        new_metadata = {k: v for k, v in existing_memory.payload.items()
+                        if k not in ("data", "hash", "text_lemmatized", "created_at", "updated_at")}
+        if metadata is not None:
+            new_metadata.update(deepcopy(metadata))
 
         new_metadata["data"] = data
         new_metadata["hash"] = hashlib.md5(data.encode()).hexdigest()
         new_metadata["text_lemmatized"] = lemmatize_for_bm25(data)
         new_metadata["created_at"] = existing_memory.payload.get("created_at")
         new_metadata["updated_at"] = datetime.now(timezone.utc).isoformat()
-
-        # Preserve session identifiers from existing memory only if not provided in new metadata
-        if "user_id" not in new_metadata and "user_id" in existing_memory.payload:
-            new_metadata["user_id"] = existing_memory.payload["user_id"]
-        if "agent_id" not in new_metadata and "agent_id" in existing_memory.payload:
-            new_metadata["agent_id"] = existing_memory.payload["agent_id"]
-        if "run_id" not in new_metadata and "run_id" in existing_memory.payload:
-            new_metadata["run_id"] = existing_memory.payload["run_id"]
-        if "actor_id" in existing_memory.payload:
-            new_metadata["actor_id"] = existing_memory.payload["actor_id"]
-        if "role" not in new_metadata and "role" in existing_memory.payload:
-            new_metadata["role"] = existing_memory.payload["role"]
 
         if data in existing_embeddings:
             embeddings = existing_embeddings[data]
@@ -3099,26 +3095,18 @@ class AsyncMemory(MemoryBase):
 
         prev_value = existing_memory.payload.get("data")
 
-        new_metadata = deepcopy(metadata) if metadata is not None else {}
+        # Preserve all existing custom metadata by default; caller metadata
+        # overrides individual keys; system fields are always recomputed.
+        new_metadata = {k: v for k, v in existing_memory.payload.items()
+                        if k not in ("data", "hash", "text_lemmatized", "created_at", "updated_at")}
+        if metadata is not None:
+            new_metadata.update(deepcopy(metadata))
 
         new_metadata["data"] = data
         new_metadata["hash"] = hashlib.md5(data.encode()).hexdigest()
         new_metadata["text_lemmatized"] = lemmatize_for_bm25(data)
         new_metadata["created_at"] = existing_memory.payload.get("created_at")
         new_metadata["updated_at"] = datetime.now(timezone.utc).isoformat()
-
-        # Preserve session identifiers from existing memory only if not provided in new metadata
-        if "user_id" not in new_metadata and "user_id" in existing_memory.payload:
-            new_metadata["user_id"] = existing_memory.payload["user_id"]
-        if "agent_id" not in new_metadata and "agent_id" in existing_memory.payload:
-            new_metadata["agent_id"] = existing_memory.payload["agent_id"]
-        if "run_id" not in new_metadata and "run_id" in existing_memory.payload:
-            new_metadata["run_id"] = existing_memory.payload["run_id"]
-
-        if "actor_id" in existing_memory.payload:
-            new_metadata["actor_id"] = existing_memory.payload["actor_id"]
-        if "role" not in new_metadata and "role" in existing_memory.payload:
-            new_metadata["role"] = existing_memory.payload["role"]
 
         if data in existing_embeddings:
             embeddings = existing_embeddings[data]

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -663,3 +663,95 @@ async def test_async_update_preserves_actor_id_when_different_actor_updates(mock
     assert stored["actor_id"] == "Alice"
 
 
+
+
+# ---------------------------------------------------------------------------
+# Tests for custom-metadata preservation in _update_memory (issue #5160)
+# ---------------------------------------------------------------------------
+
+
+def test_update_memory_preserves_custom_metadata(mocker):
+    """_update_memory must not drop custom metadata fields that were stored
+    during add() when update() is called without a new metadata argument.
+
+    Regression test for issue #5160: the whitelist-only approach kept only
+    user_id/agent_id/run_id/actor_id/role, silently discarding everything else.
+    """
+    memory = _build_memory_instance(mocker, Memory)
+    memory.vector_store.get.return_value = MagicMock(
+        payload={
+            "data": "I love tennis",
+            "user_id": "user_1",
+            "actor_id": "Alice",
+            "category": "hobbies",
+            "priority": "high",
+            "source": "chat",
+            "created_at": "2026-01-01T00:00:00+00:00",
+        }
+    )
+
+    memory._update_memory(
+        "mem-id", "I love tennis and swimming",
+        {"I love tennis and swimming": [0.1, 0.2, 0.3]},
+        metadata=None,
+    )
+
+    stored = memory.vector_store.update.call_args.kwargs["payload"]
+    assert stored["category"] == "hobbies", "category was dropped"
+    assert stored["priority"] == "high", "priority was dropped"
+    assert stored["source"] == "chat", "source was dropped"
+    assert stored["user_id"] == "user_1"
+    assert stored["data"] == "I love tennis and swimming"
+
+
+def test_update_memory_caller_metadata_overrides_existing(mocker):
+    """When update() is called with new metadata, caller values override
+    existing ones but all other custom fields are still preserved."""
+    memory = _build_memory_instance(mocker, Memory)
+    memory.vector_store.get.return_value = MagicMock(
+        payload={
+            "data": "I love tennis",
+            "user_id": "user_1",
+            "category": "hobbies",
+            "priority": "low",
+            "created_at": "2026-01-01T00:00:00+00:00",
+        }
+    )
+
+    memory._update_memory(
+        "mem-id", "I love tennis and swimming",
+        {"I love tennis and swimming": [0.1, 0.2, 0.3]},
+        metadata={"priority": "high", "new_field": "added"},
+    )
+
+    stored = memory.vector_store.update.call_args.kwargs["payload"]
+    assert stored["priority"] == "high", "caller-provided override not applied"
+    assert stored["new_field"] == "added", "new caller field not added"
+    assert stored["category"] == "hobbies", "existing custom field was dropped"
+    assert stored["user_id"] == "user_1"
+
+
+@pytest.mark.asyncio
+async def test_async_update_memory_preserves_custom_metadata(mocker):
+    """Async variant of test_update_memory_preserves_custom_metadata."""
+    memory = _build_memory_instance(mocker, AsyncMemory)
+    memory.vector_store.get.return_value = MagicMock(
+        payload={
+            "data": "I love tennis",
+            "user_id": "user_1",
+            "category": "hobbies",
+            "source": "chat",
+            "created_at": "2026-01-01T00:00:00+00:00",
+        }
+    )
+
+    await memory._update_memory(
+        "mem-id", "I love tennis and swimming",
+        {"I love tennis and swimming": [0.1, 0.2, 0.3]},
+        metadata=None,
+    )
+
+    stored = memory.vector_store.update.call_args.kwargs["payload"]
+    assert stored["category"] == "hobbies", "async: category was dropped"
+    assert stored["source"] == "chat", "async: source was dropped"
+    assert stored["user_id"] == "user_1"


### PR DESCRIPTION
## Summary

- `Memory.update()` / `AsyncMemory.update()` silently drops all custom metadata fields (e.g. `category`, `priority`, `source`, `bucket_id`) that were originally stored with `add()`.
- Only a hard-coded whitelist of 5 session identifiers (`user_id`, `agent_id`, `run_id`, `actor_id`, `role`) is copied back from the existing payload; everything else is lost when `vector_store.update()` replaces the entire stored entry.

Fixes #5160.

## Root cause (`mem0/memory/main.py`)

```python
# Before — empty start, whitelist-only restore
new_metadata = deepcopy(metadata) if metadata is not None else {}
# ... only user_id, agent_id, run_id, actor_id, role copied back
```

`#4495` fixed this for MongoDB only; `#4805` (V3 pipeline rewrite) preserved the same whitelist pattern for all other vector stores (Qdrant, Pinecone, Milvus, PGVector, Supabase, Redis, FAISS, Chroma, Weaviate…).

## Fix

Start from the full existing payload (minus the 5 system fields that are always recomputed), then overlay caller-supplied metadata:

```python
# Preserve all existing custom metadata; caller metadata overrides individual keys;
# system fields are always recomputed.
new_metadata = {k: v for k, v in existing_memory.payload.items()
                if k not in ("data", "hash", "text_lemmatized", "created_at", "updated_at")}
if metadata is not None:
    new_metadata.update(deepcopy(metadata))
```

Applied identically to both `Memory._update_memory()` (sync) and `AsyncMemory._update_memory()` (async).

## Tests

Three new tests in `tests/memory/test_main.py`:

- `test_update_memory_preserves_custom_metadata` — category/priority/source survive a text-only update.
- `test_update_memory_caller_metadata_overrides_existing` — caller metadata overrides specific keys while preserving others.
- `test_async_update_memory_preserves_custom_metadata` — same as the first test but for the async path.

All three fail on unfixed code (fields silently dropped) and pass with the fix.