### PR TITLE
feat(oss): add opt-in parallel entity boost for Python

### DIFF
--- a/mem0/configs/base.py
+++ b/mem0/configs/base.py
@@ -55,6 +55,13 @@ class MemoryConfig(BaseModel):
         description="Custom instructions for fact extraction",
         default=None,
     )
+    parallel_entity_boost: bool = Field(
+        description=(
+            "When true, compute entity-boost embed/search calls concurrently "
+            "during memory search. Defaults to false to preserve sequential behavior."
+        ),
+        default=False,
+    )
 
 
 class AzureConfig(BaseModel):

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -6,6 +6,7 @@ import logging
 import os
 import uuid
 import warnings
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from copy import deepcopy
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
@@ -1461,10 +1462,10 @@ class Memory(MemoryBase):
             return {}
 
         search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
-        memory_boosts = {}
 
-        try:
-            for _, entity_text in deduped:
+        def process_entity(entity_text):
+            entity_boosts = {}
+            try:
                 entity_embedding = self.embedding_model.embed(entity_text, "search")
                 matches = self.entity_store.search(
                     query=entity_text,
@@ -1491,7 +1492,30 @@ class Memory(MemoryBase):
                     for memory_id in linked_memory_ids:
                         if memory_id:
                             memory_key = str(memory_id)
-                            memory_boosts[memory_key] = max(memory_boosts.get(memory_key, 0.0), boost)
+                            entity_boosts[memory_key] = max(entity_boosts.get(memory_key, 0.0), boost)
+            except Exception:
+                # Individual entity boost failed; continue.
+                return {}
+
+            return entity_boosts
+
+        def merge_boosts(target, source):
+            for memory_key, boost in source.items():
+                target[memory_key] = max(target.get(memory_key, 0.0), boost)
+
+        try:
+            memory_boosts = {}
+            if self.config.parallel_entity_boost:
+                with ThreadPoolExecutor(max_workers=min(len(deduped), 8)) as executor:
+                    futures = [
+                        executor.submit(process_entity, entity_text)
+                        for _, entity_text in deduped
+                    ]
+                    for future in as_completed(futures):
+                        merge_boosts(memory_boosts, future.result())
+            else:
+                for _, entity_text in deduped:
+                    merge_boosts(memory_boosts, process_entity(entity_text))
 
         except Exception as e:
             logger.warning(f"Entity boost computation failed: {e}")
@@ -2869,10 +2893,10 @@ class AsyncMemory(MemoryBase):
             return {}
 
         search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
-        memory_boosts = {}
 
-        try:
-            for _, entity_text in deduped:
+        async def process_entity(entity_text):
+            entity_boosts = {}
+            try:
                 entity_embedding = await asyncio.to_thread(self.embedding_model.embed, entity_text, "search")
                 matches = await asyncio.to_thread(
                     self.entity_store.search,
@@ -2899,7 +2923,28 @@ class AsyncMemory(MemoryBase):
                     for memory_id in linked_memory_ids:
                         if memory_id:
                             memory_key = str(memory_id)
-                            memory_boosts[memory_key] = max(memory_boosts.get(memory_key, 0.0), boost)
+                            entity_boosts[memory_key] = max(entity_boosts.get(memory_key, 0.0), boost)
+            except Exception:
+                # Individual entity boost failed; continue.
+                return {}
+
+            return entity_boosts
+
+        def merge_boosts(target, source):
+            for memory_key, boost in source.items():
+                target[memory_key] = max(target.get(memory_key, 0.0), boost)
+
+        try:
+            memory_boosts = {}
+            if self.config.parallel_entity_boost:
+                per_entity_boosts = await asyncio.gather(
+                    *(process_entity(entity_text) for _, entity_text in deduped)
+                )
+                for boosts in per_entity_boosts:
+                    merge_boosts(memory_boosts, boosts)
+            else:
+                for _, entity_text in deduped:
+                    merge_boosts(memory_boosts, await process_entity(entity_text))
 
         except Exception as e:
             logger.warning(f"Entity boost computation failed: {e}")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,10 +1,12 @@
 import os
+import threading
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
 
 from mem0.configs.base import MemoryConfig
-from mem0.memory.main import Memory
+from mem0.memory.main import AsyncMemory, Memory
 
 
 @pytest.fixture(autouse=True)
@@ -115,6 +117,119 @@ def test_search(memory_instance):
     memory_instance.vector_store.search.assert_called_once_with(
         query="test query", vectors=[0.1, 0.2, 0.3], top_k=80, filters={"user_id": "test_user"}
     )
+
+
+def test_parallel_entity_boost_config_defaults_to_sequential():
+    assert MemoryConfig().parallel_entity_boost is False
+    assert MemoryConfig(parallel_entity_boost=True).parallel_entity_boost is True
+
+
+@pytest.mark.asyncio
+async def test_async_parallel_entity_boost_starts_all_entity_workers():
+    memory = object.__new__(AsyncMemory)
+    memory.config = MemoryConfig(parallel_entity_boost=True)
+    memory.embedding_model = _BlockingEmbeddingModel(expected_calls=3)
+    memory._entity_store = _EntityStore()
+
+    result = await memory._compute_entity_boosts_async(
+        [
+            ("PERSON", "Alice"),
+            ("PERSON", "Bob"),
+            ("PERSON", "Casey"),
+        ],
+        {"user_id": "user-1"},
+    )
+
+    assert result == {
+        "memory-Alice": pytest.approx(0.4),
+        "memory-Bob": pytest.approx(0.4),
+        "memory-Casey": pytest.approx(0.4),
+    }
+    assert set(memory.embedding_model.started) == {"Alice", "Bob", "Casey"}
+    assert set(memory._entity_store.queries) == {"Alice", "Bob", "Casey"}
+
+
+@pytest.mark.asyncio
+async def test_async_parallel_entity_boost_matches_sequential_merging():
+    query_entities = [
+        ("PERSON", "Alice"),
+        ("PERSON", "Bob"),
+        ("PERSON", "Alice"),
+    ]
+    sequential_memory = _entity_boost_memory(parallel_entity_boost=False)
+    parallel_memory = _entity_boost_memory(parallel_entity_boost=True)
+
+    sequential = await sequential_memory._compute_entity_boosts_async(
+        query_entities,
+        {"user_id": "user-1"},
+    )
+    parallel = await parallel_memory._compute_entity_boosts_async(
+        query_entities,
+        {"user_id": "user-1"},
+    )
+
+    assert parallel == sequential
+
+
+class _BlockingEmbeddingModel:
+    def __init__(self, expected_calls):
+        self.expected_calls = expected_calls
+        self.started = []
+        self.lock = threading.Lock()
+        self.all_started = threading.Event()
+
+    def embed(self, text, memory_action):
+        assert memory_action == "search"
+        with self.lock:
+            self.started.append(text)
+            if len(self.started) == self.expected_calls:
+                self.all_started.set()
+        assert self.all_started.wait(timeout=2), "entity boost workers did not run concurrently"
+        return [float(len(text))]
+
+
+class _EntityStore:
+    def __init__(self):
+        self.queries = []
+        self.lock = threading.Lock()
+
+    def search(self, *, query, vectors, top_k, filters):
+        assert vectors == [float(len(query))]
+        assert top_k == 500
+        assert filters == {"user_id": "user-1"}
+        with self.lock:
+            self.queries.append(query)
+        return [
+            SimpleNamespace(
+                score=0.8,
+                payload={"linked_memory_ids": [f"memory-{query}"]},
+            )
+        ]
+
+
+def _entity_boost_memory(*, parallel_entity_boost):
+    memory = object.__new__(AsyncMemory)
+    memory.config = MemoryConfig(parallel_entity_boost=parallel_entity_boost)
+    memory.embedding_model = _NonBlockingEmbeddingModel()
+    memory._entity_store = _SharedEntityStore()
+    return memory
+
+
+class _NonBlockingEmbeddingModel:
+    def embed(self, text, memory_action):
+        assert memory_action == "search"
+        return [float(len(text))]
+
+
+class _SharedEntityStore:
+    def search(self, *, query, vectors, top_k, filters):
+        score = 0.9 if query == "Alice" else 0.7
+        return [
+            SimpleNamespace(
+                score=score,
+                payload={"linked_memory_ids": ["shared-memory"]},
+            )
+        ]
 
 
 def test_update(memory_instance):


### PR DESCRIPTION
## Summary

Add an opt-in `parallel_entity_boost` flag to the Python OSS `MemoryConfig`.
When enabled, entity-boost embedding and entity-store lookup work in `Memory.search()` runs concurrently instead of one entity at a time.

This mirrors the shape of the TypeScript SDK change in #5046 while keeping Python's default behavior unchanged.

## Why

Entity boosting currently embeds and searches each extracted query entity sequentially. With remote embedding providers or networked vector stores, that creates one round trip per entity and can dominate search latency for entity-rich queries.

The new flag defaults to `False` for backward compatibility and for users with rate-limited or single-slot embedding backends. Users who know their embedding/vector-store backends can handle overlap can opt in.

## Implementation

- Adds `parallel_entity_boost: bool = False` to `MemoryConfig`.
- Refactors sync entity-boost work into per-entity workers and uses a bounded `ThreadPoolExecutor` when enabled.
- Refactors async entity-boost work into per-entity coroutines and uses `asyncio.gather()` when enabled.
- Merges per-entity boost maps with `max(existing, boost)`, preserving the existing order-independent scoring semantics.
- Keeps per-entity failures non-fatal, matching the prior best-effort behavior.

## Verification

- `/tmp/taia-mem0/.venv/bin/python -m pytest tests/test_main.py -k "parallel_entity_boost" -v`
  - `3 passed`

The added tests cover:

- default config remains sequential;
- async parallel mode starts all entity workers before any one can complete;
- parallel merging matches sequential merging for duplicate/shared linked memories.
