### PR TITLE
fix(cli): keep agent-mode JSON output parseable

### DIFF
--- a/cli/node/src/commands/agent-mode.ts
+++ b/cli/node/src/commands/agent-mode.ts
@@ -5,6 +5,8 @@
 import readline from "node:readline";
 import { colors, printError, printInfo, printSuccess } from "../branding.js";
 import { type Mem0Config, saveConfig } from "../config.js";
+import { formatAgentEnvelope } from "../output.js";
+import { captureNotice, isAgentMode } from "../state.js";
 
 const { brand, dim } = colors;
 
@@ -133,6 +135,22 @@ export async function bootstrapViaBackend(
 	// Adopt the slug-derived user_id as the default scope for memory ops.
 	config.defaults.userId = envelope.default_user_id;
 	saveConfig(config);
+
+	if (isAgentMode()) {
+		captureNotice(envelope.mem0_notice);
+		formatAgentEnvelope({
+			command: "init",
+			data: {
+				api_key_saved: true,
+				agent_mode: true,
+				default_user_id: envelope.default_user_id,
+				agent_caller: agentCaller ?? "",
+				claim_command:
+					envelope.claim_command ?? "mem0 init --email <your-email>",
+			},
+		});
+		return;
+	}
 
 	printSuccess(
 		`Agent Mode active. Default user_id: ${envelope.default_user_id}`,

--- a/cli/node/src/commands/whoami.ts
+++ b/cli/node/src/commands/whoami.ts
@@ -5,6 +5,8 @@
 
 import { colors, printError, printInfo } from "../branding.js";
 import { loadConfig } from "../config.js";
+import { formatAgentEnvelope } from "../output.js";
+import { isAgentMode } from "../state.js";
 
 export async function cmdWhoami(): Promise<void> {
 	const config = loadConfig();
@@ -12,6 +14,13 @@ export async function cmdWhoami(): Promise<void> {
 	if (!sessionId) {
 		printError("No default_user_id found. Run `mem0 init --agent` first.");
 		process.exit(1);
+	}
+	if (isAgentMode()) {
+		formatAgentEnvelope({
+			command: "whoami",
+			data: { default_user_id: sessionId },
+		});
+		return;
 	}
 	console.log(`Your AGENTRUSH identifier:  ${colors.brand(sessionId)}`);
 	printInfo("Find your row at https://mem0.ai/agentrush");

--- a/cli/node/tests/commands.test.ts
+++ b/cli/node/tests/commands.test.ts
@@ -404,6 +404,27 @@ describe("agent mode", () => {
     expect(parsed.data).toBeDefined();
   });
 
+  it("cmdWhoami outputs JSON envelope", async () => {
+    vi.doMock("../src/config.js", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("../src/config.js")>();
+      return {
+        ...actual,
+        loadConfig: () => ({
+          platform: { defaultUserId: "user_test" },
+        }),
+      };
+    });
+    setAgentMode(true);
+
+    const { cmdWhoami } = await import("../src/commands/whoami.js");
+    await cmdWhoami();
+
+    const parsed = JSON.parse(output.trim());
+    expect(parsed.status).toBe("success");
+    expect(parsed.command).toBe("whoami");
+    expect(parsed.data).toEqual({ default_user_id: "user_test" });
+  });
+
   it("cmdEventList outputs JSON envelope", async () => {
     setAgentMode(true);
     const { cmdEventList } = await import("../src/commands/events.js");

--- a/cli/node/tests/init-internals.test.ts
+++ b/cli/node/tests/init-internals.test.ts
@@ -17,6 +17,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { pingKey } from "../src/commands/init.js";
 import { updateClaudeSettings, updateShellRc } from "../src/plugin-sync.js";
+import { setAgentMode } from "../src/state.js";
 
 // ── pingKey ──────────────────────────────────────────────────────────────
 
@@ -55,6 +56,57 @@ describe("pingKey — network vs auth distinction", () => {
 	it("returns true on timeout (prefer reuse)", async () => {
 		globalThis.fetch = vi.fn().mockRejectedValue(new Error("aborted"));
 		await expect(pingKey("k", "http://x")).resolves.toBe(true);
+	});
+});
+
+describe("bootstrapViaBackend", () => {
+	const origFetch = globalThis.fetch;
+	const origLog = console.log;
+
+	afterEach(() => {
+		globalThis.fetch = origFetch;
+		console.log = origLog;
+		setAgentMode(false);
+		vi.restoreAllMocks();
+		vi.resetModules();
+	});
+
+	it("outputs a single JSON envelope in agent mode", async () => {
+		let output = "";
+		console.log = (...args: unknown[]) => {
+			output += `${args.map(String).join(" ")}\n`;
+		};
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => ({
+				api_key: "m0-test",
+				default_user_id: "user_test",
+				org_id: "org_test",
+				project_id: "project_test",
+				claim_command: "mem0 init --email <your-email>",
+				mem0_notice: "Claim me later.",
+			}),
+		} as Response);
+		vi.doMock("../src/config.js", async (importOriginal) => {
+			const actual = await importOriginal<typeof import("../src/config.js")>();
+			return { ...actual, saveConfig: vi.fn() };
+		});
+
+		const { createDefaultConfig } = await import("../src/config.js");
+		const { bootstrapViaBackend } = await import("../src/commands/agent-mode.js");
+		const config = createDefaultConfig();
+		setAgentMode(true);
+
+		await bootstrapViaBackend(config, { agentCaller: "codex" });
+
+		const data = JSON.parse(output);
+		expect(data.status).toBe("success");
+		expect(data.command).toBe("init");
+		expect(data.data.agent_mode).toBe(true);
+		expect(data.data.default_user_id).toBe("user_test");
+		expect(data.mem0_notice).toBe("Claim me later.");
+		expect(output).not.toContain("🔔");
 	});
 });
 

--- a/cli/python/src/mem0_cli/commands/agent_mode_cmd.py
+++ b/cli/python/src/mem0_cli/commands/agent_mode_cmd.py
@@ -124,6 +124,27 @@ def bootstrap_via_backend(
     config.defaults.user_id = envelope["default_user_id"]
     save_config(config)
 
+    from mem0_cli.state import is_agent_mode
+
+    if is_agent_mode():
+        from mem0_cli.output import format_json_envelope
+        from mem0_cli.state import capture_notice
+
+        capture_notice(envelope.get("mem0_notice"))
+
+        format_json_envelope(
+            console,
+            command="init",
+            data={
+                "api_key_saved": True,
+                "agent_mode": True,
+                "default_user_id": envelope["default_user_id"],
+                "agent_caller": agent_caller or "",
+                "claim_command": envelope.get("claim_command", "mem0 init --email <your-email>"),
+            },
+        )
+        return
+
     print_success(console, f"Agent Mode active. Default user_id: {envelope['default_user_id']}")
     notice = envelope.get("mem0_notice")
     if notice:

--- a/cli/python/src/mem0_cli/commands/whoami_cmd.py
+++ b/cli/python/src/mem0_cli/commands/whoami_cmd.py
@@ -21,5 +21,17 @@ def run_whoami() -> None:
             "No default_user_id found. Run `mem0 init --agent` first.",
         )
         raise typer.Exit(1)
+    from mem0_cli.state import is_agent_mode
+
+    if is_agent_mode():
+        from mem0_cli.output import format_json_envelope
+
+        format_json_envelope(
+            console,
+            command="whoami",
+            data={"default_user_id": session_id},
+        )
+        return
+
     console.print(f"Your AGENTRUSH identifier:  [{BRAND_COLOR}]{session_id}[/{BRAND_COLOR}]")
     print_info(console, "Find your row at https://mem0.ai/agentrush")

--- a/cli/python/tests/test_commands.py
+++ b/cli/python/tests/test_commands.py
@@ -1250,6 +1250,27 @@ class TestAgentMode:
         assert data["data"]["deleted"] is True
         assert "duration_ms" in data
 
+    def test_whoami_agent_mode_envelope(self, tmp_path, monkeypatch):
+        from mem0_cli.commands.whoami_cmd import run_whoami
+        from mem0_cli.config import Mem0Config, save_config
+
+        fake_config_file = tmp_path / ".mem0" / "config.json"
+        monkeypatch.setattr("mem0_cli.config.CONFIG_DIR", tmp_path / ".mem0")
+        monkeypatch.setattr("mem0_cli.config.CONFIG_FILE", fake_config_file)
+
+        config = Mem0Config()
+        config.platform.default_user_id = "user_test"
+        save_config(config)
+
+        console, buf = _make_console()
+        with patch("mem0_cli.commands.whoami_cmd.console", console):
+            run_whoami()
+
+        data = json.loads(buf.getvalue())
+        assert data["status"] == "success"
+        assert data["command"] == "whoami"
+        assert data["data"] == {"default_user_id": "user_test"}
+
     # ── event list ───────────────────────────────────────────────────────────
 
     def test_event_list_agent_mode_envelope(self, mock_backend):

--- a/cli/python/tests/test_init_internals.py
+++ b/cli/python/tests/test_init_internals.py
@@ -16,6 +16,7 @@ behavioral assertion here, mirror it on the Node side and vice versa.
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock
 
 import httpx
@@ -204,3 +205,55 @@ def test_bootstrap_403_permission_surfaces_ratelimit(monkeypatch, capsys) -> Non
     combined = captured.out + captured.err
     assert "Daily Agent Mode signup limit reached" in combined
     assert "permission to perform this action" not in combined
+
+
+def test_bootstrap_agent_mode_outputs_single_json_envelope(monkeypatch, capsys, tmp_path) -> None:
+    """Agent-mode bootstrap must not print human notice text beside JSON output."""
+    from mem0_cli.commands.agent_mode_cmd import bootstrap_via_backend
+    from mem0_cli.config import Mem0Config
+    from mem0_cli.state import set_agent_mode
+
+    fake_resp = MagicMock()
+    fake_resp.status_code = 200
+    fake_resp.json = MagicMock(
+        return_value={
+            "api_key": "m0-test",
+            "default_user_id": "user_test",
+            "claim_command": "mem0 init --email <your-email>",
+            "mem0_notice": "Claim me later.",
+        }
+    )
+
+    class _Client:
+        def __init__(self, *a, **kw):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def post(self, *a, **kw):
+            return fake_resp
+
+    monkeypatch.setattr(httpx, "Client", _Client)
+    monkeypatch.setattr("mem0_cli.config.CONFIG_DIR", tmp_path / ".mem0")
+    monkeypatch.setattr("mem0_cli.config.CONFIG_FILE", tmp_path / ".mem0" / "config.json")
+
+    cfg = Mem0Config()
+    cfg.platform.base_url = "https://api.mem0.ai"
+    set_agent_mode(True)
+    try:
+        bootstrap_via_backend(cfg, agent_caller="codex")
+    finally:
+        set_agent_mode(False)
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    data = json.loads(captured.out)
+    assert data["status"] == "success"
+    assert data["command"] == "init"
+    assert data["data"]["agent_mode"] is True
+    assert data["data"]["default_user_id"] == "user_test"
+    assert data["mem0_notice"] == "Claim me later."


### PR DESCRIPTION
## Summary

This fixes agent-mode JSON output for the Python and Node CLIs so human-facing Agent Mode notices are folded into the JSON envelope instead of being printed beside it.

The affected surfaces are successful `init --agent --json` bootstrap and `whoami` in agent mode. Both now return a single parseable envelope, with `mem0_notice` carried as a JSON field when present.

## Why

The CLI already treats `--json` / agent mode as the machine-readable path, and most command envelopes already carry backend notices inside JSON. The bootstrap path printed the claim reminder directly, and `whoami` always printed human text, which makes automation need ad hoc banner stripping.

## Validation

- `cd cli/python && uv run --with-editable . --with pytest pytest tests/test_init_internals.py tests/test_commands.py tests/test_agent_mode.py -q`
- `cd cli/python && uv run --with ruff ruff check src tests/test_init_internals.py tests/test_commands.py tests/test_agent_mode.py`
- `cd cli/node && ./node_modules/.bin/vitest run tests/init-internals.test.ts tests/commands.test.ts tests/agent-mode.test.ts`
- `cd cli/node && ./node_modules/.bin/tsc --noEmit`
- `cd cli/node && ./node_modules/.bin/biome check src/commands/agent-mode.ts src/commands/whoami.ts`