### PR TITLE
chore(mem0-plugin): bump marketplace versions to v0.2.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "mem0",
       "source": "./mem0-plugin",
       "description": "Mem0 memory layer for AI applications. Add persistent memory, personalization, and semantic search to Claude workflows.",
-      "version": "0.1.3"
+      "version": "0.2.1"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "mem0",
       "source": "./mem0-plugin",
       "description": "Mem0 memory layer for AI applications. Add persistent memory, personalization, and semantic search.",
-      "version": "0.1.1"
+      "version": "0.2.1"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Bump `.claude-plugin/marketplace.json` version from `0.1.3` to `0.2.1`
- Bump `.cursor-plugin/marketplace.json` version from `0.1.1` to `0.2.1`
- Aligns marketplace manifests with plugin.json (already at v0.2.1), so users get the latest update via marketplace distribution

## Test plan

- [ ] Verify marketplace install picks up v0.2.1 plugin via `/plugin marketplace add mem0ai/mem0`