### PR TITLE
docs: fix capitalization in introduction hero subtitle

### DIFF
--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -12,7 +12,7 @@ mode: "custom"
   </h1>
 
   <p className="max-w-2xl mx-auto text-base text-gray-600 dark:text-zinc-400 leading-relaxed">
-    Universal, Self-improving memory layer for LLM applications.
+    Universal, self-improving memory layer for LLM applications.
   </p>
 
   <a


### PR DESCRIPTION
## Linked Issue

No tracked issue — minor docs polish. Also serves as a follow-up to verify the Mintlify deploy pipeline is healthy after #5230 (whose merge commit triggered an unrelated Mintlify failure due to the deletion of \`embedchain/docs/**\` confusing Mintlify's path resolver; the underlying config is fine).

## Description

The hero subtitle in \`docs/introduction.mdx\` was inconsistently capitalized:

> Universal, **S**elf-improving memory layer for LLM applications.

The page's own frontmatter \`description\` on line 3 already uses sentence case (\"universal, self-improving memory layer\"). This PR aligns the visible subtitle to match.

```diff
- Universal, Self-improving memory layer for LLM applications.
+ Universal, self-improving memory layer for LLM applications.
```

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] No tests needed — one-character docs change.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] No new tests required
- [x] Existing tests pass locally (no code changed)
- [x] Documentation updated (this PR is the doc update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)