### PR TITLE
fix: add real GPT-5 names to reasoning model whitelist

### DIFF
--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -52,7 +52,7 @@ class LLMBase(ABC):
         """
         reasoning_models = {
             "o1", "o1-preview", "o3-mini", "o3",
-            "gpt-5", "gpt-5o", "gpt-5o-mini", "gpt-5o-micro",
+            "gpt-5", "gpt-5-mini", "gpt-5-nano",
         }
 
         model_lower = model.lower()
@@ -62,9 +62,9 @@ class LLMBase(ABC):
         if base_model in reasoning_models:
             return True
 
-        # Match o1/o3 family with prefixes (o1-2024-12-17, o3-2025-04-16)
+        # Match o1/o3 family and gpt-5-mini/nano dated variants
         # but NOT gpt-5.x variants (gpt-5.4-mini supports temperature)
-        if any(base_model.startswith(prefix) for prefix in ["o1-", "o1.", "o3-", "o3."]):
+        if any(base_model.startswith(prefix) for prefix in ["o1-", "o1.", "o3-", "o3.", "gpt-5-mini-", "gpt-5-nano-"]):
             return True
 
         return False

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -317,6 +317,10 @@ def test_is_reasoning_model_classification(mock_openai_client):
     assert llm._is_reasoning_model("o3-mini") is True
     assert llm._is_reasoning_model("o3") is True
     assert llm._is_reasoning_model("gpt-5") is True
+    assert llm._is_reasoning_model("gpt-5-mini") is True
+    assert llm._is_reasoning_model("gpt-5-nano") is True
+    assert llm._is_reasoning_model("gpt-5-mini-2025-08-07") is True
+    assert llm._is_reasoning_model("gpt-5-nano-2025-08-07") is True
     assert llm._is_reasoning_model("o1-preview") is True
     assert llm._is_reasoning_model("o1-2024-12-17") is True
     assert llm._is_reasoning_model("openai/o3-mini") is True


### PR DESCRIPTION
## Linked Issue

Closes #5233 

## Description

`LLMBase._is_reasoning_model` whitelisted model names that don't exist in the OpenAI catalog (`gpt-5o`, `gpt-5o-mini`, `gpt-5o-micro`) while missing the real GPT-5 family names — `gpt-5-mini` and `gpt-5-nano`. Because the set lookup is exact-match and the prefix fallback only covered `o1-`/`o3-`, calls against `gpt-5-mini`/`gpt-5-nano` fell through to the non-reasoning param set and sent the legacy `max_tokens` parameter, which these models reject with HTTP 400 (`'max_tokens' is not supported with this model. Use 'max_completion_tokens'`).

This PR replaces the non-existent names with the real ones and adds prefix matching for dated variants (e.g. `gpt-5-mini 2025-08-07`, which Azure deployments surface). 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test Coverage

- [x] I added/updated unit tests

Extended `test_is_reasoning_model_classification` to assert `gpt-5-mini`, `gpt-5-nano`, and their dated variants classify as reasoning models, while `gpt-5.4-mini` stays non-reasoning.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally