### PR TITLE
fix: use utf-8 for json config files

### DIFF
--- a/mem0/memory/setup.py
+++ b/mem0/memory/setup.py
@@ -23,7 +23,7 @@ def _load_config():
     if not os.path.exists(path):
         return {}
     try:
-        with open(path, "r") as f:
+        with open(path, "r", encoding="utf-8") as f:
             data = json.load(f)
         return data if isinstance(data, dict) else {}
     except Exception as e:
@@ -35,7 +35,7 @@ def _write_config(config):
     """Best-effort write of ~/.mem0/config.json. Never raises."""
     path = _config_path()
     try:
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             json.dump(config, f, indent=4)
     except Exception as e:
         _logger.debug("Failed to write mem0 config %s: %s", path, e)

--- a/mem0/utils/gcp_auth.py
+++ b/mem0/utils/gcp_auth.py
@@ -57,7 +57,7 @@ class GCPAuthenticator:
                 credentials_path, scopes=scopes
             )
             # Extract project_id from the file
-            with open(credentials_path, 'r') as f:
+            with open(credentials_path, "r", encoding="utf-8") as f:
                 cred_data = json.load(f)
                 project_id = cred_data.get("project_id")
 
@@ -69,7 +69,7 @@ class GCPAuthenticator:
                     env_path, scopes=scopes
                 )
                 # Extract project_id from the file
-                with open(env_path, 'r') as f:
+                with open(env_path, "r", encoding="utf-8") as f:
                     cred_data = json.load(f)
                     project_id = cred_data.get("project_id")
 


### PR DESCRIPTION
## Summary
- Add explicit `encoding="utf-8"` when reading GCP service account JSON files
- Add explicit `encoding="utf-8"` for the local `~/.mem0/config.json` read/write helpers

## Problem
These files are JSON/text files, but a few `open()` calls still relied on the platform default encoding. On Windows or other non-UTF-8 locales, that can make config or credential parsing depend on the user's locale instead of the file format.

## Before / After
Before, JSON config files were opened without an explicit encoding.

After, the same reads/writes use UTF-8 explicitly, matching JSON's common/default encoding and avoiding locale-dependent behavior.

## Verification
- `python -m compileall -q mem0\utils\gcp_auth.py mem0\memory\setup.py`
- `git diff --check`