### PR TITLE
feat(memory): cluster-aware retrieval to surface stale-fact context a…

### DIFF
--- a/mem0/memory/clustering.py
+++ b/mem0/memory/clustering.py
@@ -1,0 +1,237 @@
+"""
+Cluster-aware retrieval for mem0 search results.
+
+Read-time clustering groups topically related memories that the vector
+store returned for a query (for example, three statements about the
+user's current employer asserted at different times) so that the consumer
+of `search()` can see the whole cluster, with timestamps, instead of just
+the single best semantic match.
+
+The module is intentionally narrow:
+
+* It does **not** mutate or supersede any stored memory. The
+  append-only philosophy of the v3 pipeline is preserved.
+* It does **not** introduce any new vector store schema. Clustering is
+  performed in-memory on whatever the existing `_search_vector_store`
+  call already returns.
+* It has a single public function, `cluster_memories`, that the sync
+  and async search paths call when the user opts in via
+  `expand_clusters=True`.
+
+See issue mem0ai/mem0#4956.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any, Callable, List, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+# Sentinel keys we attach to each result.
+CLUSTER_ID_KEY = "cluster_id"
+CLUSTER_SIZE_KEY = "cluster_size"
+CLUSTER_ROLE_KEY = "cluster_role"
+CLUSTER_ROLE_PRIMARY = "primary"
+CLUSTER_ROLE_SIBLING = "sibling"
+
+# Defaults exposed to callers.
+DEFAULT_CLUSTER_THRESHOLD = 0.85
+DEFAULT_CLUSTER_TOP_K_MULTIPLIER = 3
+DEFAULT_CLUSTER_MAX_SIZE = 5
+
+
+def cosine_similarity(a: Sequence[float], b: Sequence[float]) -> float:
+    """Compute cosine similarity between two equal-length numeric vectors.
+
+    Returns 0.0 if either vector is empty or has zero magnitude.
+    """
+    if not a or not b:
+        return 0.0
+    if len(a) != len(b):
+        # Mismatched dimensions almost certainly indicates a mixed-provider
+        # bug upstream; do not silently coerce.
+        raise ValueError(f"cosine_similarity: vectors have different dimensions ({len(a)} vs {len(b)})")
+
+    dot = 0.0
+    na = 0.0
+    nb = 0.0
+    for x, y in zip(a, b):
+        dot += x * y
+        na += x * x
+        nb += y * y
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    return dot / (math.sqrt(na) * math.sqrt(nb))
+
+
+def _validate_cluster_params(
+    *,
+    threshold: float,
+    top_k_multiplier: int,
+    max_cluster_size: int,
+) -> None:
+    if not (0.0 <= threshold <= 1.0):
+        raise ValueError(f"cluster_threshold must be in [0.0, 1.0]; got {threshold!r}")
+    if top_k_multiplier < 1:
+        raise ValueError(f"cluster_top_k_multiplier must be >= 1; got {top_k_multiplier!r}")
+    if max_cluster_size < 1:
+        raise ValueError(f"cluster_max_size must be >= 1; got {max_cluster_size!r}")
+
+
+def cluster_memories(
+    memories: List[dict],
+    *,
+    embed_batch: Callable[[List[str]], List[Sequence[float]]],
+    top_k: int,
+    threshold: float = DEFAULT_CLUSTER_THRESHOLD,
+    max_cluster_size: int = DEFAULT_CLUSTER_MAX_SIZE,
+    text_key: str = "memory",
+) -> List[dict]:
+    """Group `memories` into clusters by pairwise embedding similarity.
+
+    Inputs are assumed to be already sorted by relevance to the query
+    (highest score first). Output keeps the original ordering but tags
+    each item with cluster metadata and truncates to the top
+    `top_k` *clusters* (not items), including all siblings of those
+    clusters up to `max_cluster_size`.
+
+    The clustering algorithm is greedy single-link with **anchor**
+    comparison: each new item is compared only to the first member of
+    each existing cluster, which is the highest-scoring memory in that
+    cluster because we iterate in score-descending order. This avoids
+    the classic transitive-chaining failure of pure single-link.
+
+    Args:
+        memories: List of result dicts (sorted by score desc) returned
+            from `_search_vector_store`.
+        embed_batch: A callable that takes a list of strings and returns
+            a list of embedding vectors in the same order. Passing it
+            in lets sync and async callers share this function.
+        top_k: Maximum number of clusters to return.
+        threshold: Minimum cosine similarity to anchor for an item to
+            join a cluster. Higher values cluster only near-duplicates;
+            lower values group more loosely.
+        max_cluster_size: Cap on number of members per cluster. Excess
+            members are dropped (they remain stored, just not surfaced
+            for this query).
+        text_key: Key in each memory dict that contains the text to
+            embed.
+
+    Returns:
+        A new list of dicts, each carrying additional keys:
+            - `cluster_id`: stable identifier within this response
+              (e.g., "c0", "c1").
+            - `cluster_size`: total members in the cluster.
+            - `cluster_role`: "primary" for the highest-scoring member,
+              "sibling" for the rest.
+
+        Singleton clusters still get the metadata, with role "primary"
+        and size 1.
+    """
+    _validate_cluster_params(
+        threshold=threshold,
+        top_k_multiplier=1,  # already-fetched here; only validate the others
+        max_cluster_size=max_cluster_size,
+    )
+    if top_k < 1:
+        raise ValueError(f"top_k must be >= 1; got {top_k!r}")
+
+    if not memories:
+        return []
+
+    # If everything we received is a singleton possibility, skip the
+    # embedding round trip entirely.
+    if len(memories) == 1:
+        only = dict(memories[0])
+        only[CLUSTER_ID_KEY] = "c0"
+        only[CLUSTER_SIZE_KEY] = 1
+        only[CLUSTER_ROLE_KEY] = CLUSTER_ROLE_PRIMARY
+        return [only]
+
+    texts = [str(m.get(text_key, "")) for m in memories]
+    try:
+        candidate_embeddings = embed_batch(texts)
+    except Exception as e:  # noqa: BLE001 — broad on purpose; clustering is opt-in
+        logger.warning(
+            "cluster_memories: embedding failed (%s); returning unclustered results",
+            e,
+        )
+        return list(memories)[:top_k]
+
+    if len(candidate_embeddings) != len(memories):
+        logger.warning(
+            "cluster_memories: embed_batch returned %d vectors for %d memories; returning unclustered results",
+            len(candidate_embeddings),
+            len(memories),
+        )
+        return list(memories)[:top_k]
+
+    # Greedy anchor-based clustering. Iterate in input order (which is
+    # score-descending), so the first-added member of each cluster is its
+    # anchor and the highest-scoring member of that cluster.
+    clusters: List[List[int]] = []
+    for i, emb in enumerate(candidate_embeddings):
+        joined = False
+        for cluster in clusters:
+            anchor_emb = candidate_embeddings[cluster[0]]
+            if cosine_similarity(emb, anchor_emb) >= threshold:
+                if len(cluster) < max_cluster_size:
+                    cluster.append(i)
+                # Always mark as joined so we don't open a duplicate
+                # cluster — items past max_cluster_size are simply dropped
+                # from this response's view of that cluster.
+                joined = True
+                break
+        if not joined:
+            clusters.append([i])
+
+    # Keep only the top_k clusters by primary score (already in order).
+    clusters = clusters[:top_k]
+
+    enriched: List[dict] = []
+    for cluster_idx, member_indices in enumerate(clusters):
+        cluster_id = f"c{cluster_idx}"
+        size = len(member_indices)
+        for position, mem_idx in enumerate(member_indices):
+            item = dict(memories[mem_idx])  # shallow copy; safe to mutate
+            item[CLUSTER_ID_KEY] = cluster_id
+            item[CLUSTER_SIZE_KEY] = size
+            item[CLUSTER_ROLE_KEY] = CLUSTER_ROLE_PRIMARY if position == 0 else CLUSTER_ROLE_SIBLING
+            enriched.append(item)
+
+    return enriched
+
+
+def resolve_cluster_kwargs(
+    *,
+    expand_clusters: bool,
+    cluster_threshold: Optional[float],
+    cluster_top_k_multiplier: Optional[int],
+    cluster_max_size: Optional[int],
+) -> dict[str, Any]:
+    """Normalize the cluster knobs passed via Memory.search(**kwargs).
+
+    Returns a dict with concrete values for `threshold`,
+    `top_k_multiplier`, and `max_cluster_size`. Raises `ValueError`
+    early on out-of-range values so callers get a useful traceback.
+    """
+    threshold = DEFAULT_CLUSTER_THRESHOLD if cluster_threshold is None else float(cluster_threshold)
+    top_k_multiplier = (
+        DEFAULT_CLUSTER_TOP_K_MULTIPLIER if cluster_top_k_multiplier is None else int(cluster_top_k_multiplier)
+    )
+    max_cluster_size = DEFAULT_CLUSTER_MAX_SIZE if cluster_max_size is None else int(cluster_max_size)
+
+    if expand_clusters:
+        _validate_cluster_params(
+            threshold=threshold,
+            top_k_multiplier=top_k_multiplier,
+            max_cluster_size=max_cluster_size,
+        )
+
+    return {
+        "threshold": threshold,
+        "top_k_multiplier": top_k_multiplier,
+        "max_cluster_size": max_cluster_size,
+    }

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -22,6 +22,7 @@ from mem0.configs.prompts import (
 )
 from mem0.exceptions import ValidationError as Mem0ValidationError
 from mem0.memory.base import MemoryBase
+from mem0.memory.clustering import cluster_memories, resolve_cluster_kwargs
 from mem0.memory.setup import mem0_dir, setup_config
 from mem0.memory.storage import SQLiteManager
 from mem0.memory.telemetry import MEM0_TELEMETRY, capture_event
@@ -1131,6 +1132,10 @@ class Memory(MemoryBase):
         filters: Optional[Dict[str, Any]] = None,
         threshold: float = 0.1,
         rerank: bool = False,
+        expand_clusters: bool = False,
+        cluster_threshold: Optional[float] = None,
+        cluster_top_k_multiplier: Optional[int] = None,
+        cluster_max_size: Optional[int] = None,
         **kwargs,
     ):
         """
@@ -1139,6 +1144,8 @@ class Memory(MemoryBase):
         Args:
             query (str): Query to search for.
             top_k (int, optional): Maximum number of results to return. Defaults to 20.
+                When `expand_clusters=True`, this is the maximum number of
+                *clusters*; cluster siblings are returned in addition.
             filters (dict): Filter dict containing entity IDs and optional metadata filters.
                 Must contain at least one of: user_id, agent_id, run_id.
                 Example: filters={"user_id": "u1", "agent_id": "a1"}
@@ -1161,10 +1168,32 @@ class Memory(MemoryBase):
                 - {"NOT": [filter1]} - logical NOT
             threshold (float, optional): Minimum score for a memory to be included. Defaults to 0.1.
             rerank (bool, optional): Whether to rerank results. Defaults to False.
+            expand_clusters (bool, optional): Opt-in. When True, related
+                memories returned for the query are grouped into clusters
+                and the full cluster (primary + siblings, including older
+                facts that share an entity/attribute with the primary) is
+                surfaced. Useful for resolving time-sensitive attributes
+                (current employer, address, status, ...) at read time
+                without modifying any stored memory.
+                See `mem0/memory/clustering.py`. Defaults to False.
+            cluster_threshold (float, optional): Cosine similarity required
+                for a candidate to join a cluster's anchor. Only used
+                when `expand_clusters=True`. Default 0.85.
+            cluster_top_k_multiplier (int, optional): How much wider to
+                fetch from the vector store before clustering (final pool
+                size = top_k * multiplier). Only used when
+                `expand_clusters=True`. Default 3.
+            cluster_max_size (int, optional): Cap on cluster size. Older
+                siblings beyond this limit are not surfaced for this query
+                (they remain stored). Only used when
+                `expand_clusters=True`. Default 5.
 
         Returns:
             dict: A dictionary containing the search results under a "results" key.
                   Example for v1.1+: `{"results": [{"id": "...", "memory": "...", "score": 0.8, ...}]}`
+                  When `expand_clusters=True`, each result dict also includes:
+                  `cluster_id` (str), `cluster_size` (int), and
+                  `cluster_role` ("primary" | "sibling").
 
         Raises:
             ValueError: If filters doesn't contain at least one of user_id, agent_id, run_id,
@@ -1175,6 +1204,14 @@ class Memory(MemoryBase):
 
         # Validate search parameters (before applying defaults)
         _validate_search_params(threshold=threshold, top_k=top_k)
+
+        # Validate cluster params up-front (only when expand_clusters=True).
+        cluster_kwargs = resolve_cluster_kwargs(
+            expand_clusters=expand_clusters,
+            cluster_threshold=cluster_threshold,
+            cluster_top_k_multiplier=cluster_top_k_multiplier,
+            cluster_max_size=cluster_max_size,
+        )
 
         # Validate and trim entity IDs in filters
         effective_filters = filters.copy() if filters else {}
@@ -1197,6 +1234,10 @@ class Memory(MemoryBase):
             )
 
         limit = top_k
+        # When expanding clusters, over-fetch from the vector store so we
+        # have a pool wide enough to surface siblings.
+        if expand_clusters:
+            limit = top_k * cluster_kwargs["top_k_multiplier"]
 
         # Apply enhanced metadata filtering if advanced operators are detected
         if self._has_advanced_operators(effective_filters):
@@ -1221,6 +1262,7 @@ class Memory(MemoryBase):
                 "sync_type": "sync",
                 "threshold": threshold,
                 "advanced_filters": bool(filters and self._has_advanced_operators(filters)),
+                "expand_clusters": expand_clusters,
             },
         )
 
@@ -1233,6 +1275,16 @@ class Memory(MemoryBase):
                 original_memories = reranked_memories
             except Exception as e:
                 logger.warning(f"Reranking failed, using original results: {e}")
+
+        # Apply cluster expansion last so it sees the final ranking.
+        if expand_clusters and original_memories:
+            original_memories = cluster_memories(
+                original_memories,
+                embed_batch=lambda texts: self.embedding_model.embed_batch(texts, "search"),
+                top_k=top_k,
+                threshold=cluster_kwargs["threshold"],
+                max_cluster_size=cluster_kwargs["max_cluster_size"],
+            )
 
         return {"results": original_memories}
 
@@ -2546,6 +2598,10 @@ class AsyncMemory(MemoryBase):
         filters: Optional[Dict[str, Any]] = None,
         threshold: float = 0.1,
         rerank: bool = False,
+        expand_clusters: bool = False,
+        cluster_threshold: Optional[float] = None,
+        cluster_top_k_multiplier: Optional[int] = None,
+        cluster_max_size: Optional[int] = None,
         **kwargs,
     ):
         """
@@ -2554,6 +2610,8 @@ class AsyncMemory(MemoryBase):
         Args:
             query (str): Query to search for.
             top_k (int, optional): Maximum number of results to return. Defaults to 20.
+                When `expand_clusters=True`, this is the maximum number of
+                *clusters*; cluster siblings are returned in addition.
             filters (dict): Filter dict containing entity IDs and optional metadata filters.
                 Must contain at least one of: user_id, agent_id, run_id.
                 Example: filters={"user_id": "u1", "agent_id": "a1"}
@@ -2576,10 +2634,25 @@ class AsyncMemory(MemoryBase):
                 - {"NOT": [filter1]} - logical NOT
             threshold (float, optional): Minimum score for a memory to be included. Defaults to 0.1.
             rerank (bool, optional): Whether to rerank results. Defaults to False.
+            expand_clusters (bool, optional): Opt-in. When True, related
+                memories returned for the query are grouped into clusters
+                and the full cluster (primary + siblings) is surfaced.
+                See the sync `Memory.search` docstring for full semantics.
+                Defaults to False.
+            cluster_threshold (float, optional): Cosine similarity required
+                for a candidate to join a cluster's anchor. Default 0.85.
+            cluster_top_k_multiplier (int, optional): Vector-store
+                over-fetch multiplier (final pool = top_k * multiplier).
+                Default 3.
+            cluster_max_size (int, optional): Cap on cluster size.
+                Default 5.
 
         Returns:
             dict: A dictionary containing the search results under a "results" key.
                   Example for v1.1+: `{"results": [{"id": "...", "memory": "...", "score": 0.8, ...}]}`
+                  When `expand_clusters=True`, each result dict also includes:
+                  `cluster_id` (str), `cluster_size` (int), and
+                  `cluster_role` ("primary" | "sibling").
 
         Raises:
             ValueError: If filters doesn't contain at least one of user_id, agent_id, run_id,
@@ -2590,6 +2663,14 @@ class AsyncMemory(MemoryBase):
 
         # Validate search parameters (before applying defaults)
         _validate_search_params(threshold=threshold, top_k=top_k)
+
+        # Validate cluster params up-front (only when expand_clusters=True).
+        cluster_kwargs = resolve_cluster_kwargs(
+            expand_clusters=expand_clusters,
+            cluster_threshold=cluster_threshold,
+            cluster_top_k_multiplier=cluster_top_k_multiplier,
+            cluster_max_size=cluster_max_size,
+        )
 
         # Validate and trim entity IDs in filters
         effective_filters = filters.copy() if filters else {}
@@ -2614,6 +2695,9 @@ class AsyncMemory(MemoryBase):
             )
 
         limit = top_k
+        # Over-fetch when expanding clusters.
+        if expand_clusters:
+            limit = top_k * cluster_kwargs["top_k_multiplier"]
 
         # Apply enhanced metadata filtering if advanced operators are detected
         if self._has_advanced_operators(effective_filters):
@@ -2638,6 +2722,7 @@ class AsyncMemory(MemoryBase):
                 "sync_type": "async",
                 "threshold": threshold,
                 "advanced_filters": bool(filters and self._has_advanced_operators(filters)),
+                "expand_clusters": expand_clusters,
             },
         )
 
@@ -2653,6 +2738,21 @@ class AsyncMemory(MemoryBase):
                 original_memories = reranked_memories
             except Exception as e:
                 logger.warning(f"Reranking failed, using original results: {e}")
+
+        # Apply cluster expansion last. The embedding model's `embed_batch`
+        # is synchronous; run it in a thread to avoid blocking the loop.
+        if expand_clusters and original_memories:
+            def _embed_batch(texts):
+                return self.embedding_model.embed_batch(texts, "search")
+
+            original_memories = await asyncio.to_thread(
+                cluster_memories,
+                original_memories,
+                embed_batch=_embed_batch,
+                top_k=top_k,
+                threshold=cluster_kwargs["threshold"],
+                max_cluster_size=cluster_kwargs["max_cluster_size"],
+            )
 
         return {"results": original_memories}
 

--- a/tests/memory/test_clustering.py
+++ b/tests/memory/test_clustering.py
@@ -1,0 +1,445 @@
+"""Tests for cluster-aware retrieval (mem0ai/mem0#4956).
+
+These tests are designed to run with **no external API keys**:
+all embeddings and vector store interactions are mocked.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from mem0.memory.clustering import (
+    CLUSTER_ID_KEY,
+    CLUSTER_ROLE_KEY,
+    CLUSTER_ROLE_PRIMARY,
+    CLUSTER_ROLE_SIBLING,
+    CLUSTER_SIZE_KEY,
+    DEFAULT_CLUSTER_MAX_SIZE,
+    DEFAULT_CLUSTER_THRESHOLD,
+    DEFAULT_CLUSTER_TOP_K_MULTIPLIER,
+    cluster_memories,
+    cosine_similarity,
+    resolve_cluster_kwargs,
+)
+from mem0.memory.main import AsyncMemory, Memory
+
+# ---------------------------------------------------------------------------
+# cosine_similarity
+# ---------------------------------------------------------------------------
+
+
+class TestCosineSimilarity:
+    def test_identical_vectors(self):
+        assert cosine_similarity([1.0, 2.0, 3.0], [1.0, 2.0, 3.0]) == pytest.approx(1.0)
+
+    def test_orthogonal_vectors(self):
+        assert cosine_similarity([1.0, 0.0], [0.0, 1.0]) == pytest.approx(0.0)
+
+    def test_anti_parallel_vectors(self):
+        assert cosine_similarity([1.0, 0.0], [-1.0, 0.0]) == pytest.approx(-1.0)
+
+    def test_empty_vectors_return_zero(self):
+        assert cosine_similarity([], []) == 0.0
+        assert cosine_similarity([1.0], []) == 0.0
+
+    def test_zero_magnitude_returns_zero(self):
+        assert cosine_similarity([0.0, 0.0], [1.0, 1.0]) == 0.0
+
+    def test_mismatched_dims_raises(self):
+        with pytest.raises(ValueError, match="different dimensions"):
+            cosine_similarity([1.0, 2.0], [1.0, 2.0, 3.0])
+
+
+# ---------------------------------------------------------------------------
+# resolve_cluster_kwargs
+# ---------------------------------------------------------------------------
+
+
+class TestResolveClusterKwargs:
+    def test_defaults_when_expansion_off(self):
+        # Defaults are returned even when expansion is off; validation skipped.
+        result = resolve_cluster_kwargs(
+            expand_clusters=False,
+            cluster_threshold=None,
+            cluster_top_k_multiplier=None,
+            cluster_max_size=None,
+        )
+        assert result["threshold"] == DEFAULT_CLUSTER_THRESHOLD
+        assert result["top_k_multiplier"] == DEFAULT_CLUSTER_TOP_K_MULTIPLIER
+        assert result["max_cluster_size"] == DEFAULT_CLUSTER_MAX_SIZE
+
+    def test_user_values_override_defaults(self):
+        result = resolve_cluster_kwargs(
+            expand_clusters=True,
+            cluster_threshold=0.7,
+            cluster_top_k_multiplier=4,
+            cluster_max_size=10,
+        )
+        assert result["threshold"] == 0.7
+        assert result["top_k_multiplier"] == 4
+        assert result["max_cluster_size"] == 10
+
+    def test_invalid_threshold_raises_only_when_enabled(self):
+        # Bad value silently passed through when expansion is off.
+        resolve_cluster_kwargs(
+            expand_clusters=False,
+            cluster_threshold=2.0,
+            cluster_top_k_multiplier=None,
+            cluster_max_size=None,
+        )
+        # But raises when enabled.
+        with pytest.raises(ValueError, match="cluster_threshold"):
+            resolve_cluster_kwargs(
+                expand_clusters=True,
+                cluster_threshold=2.0,
+                cluster_top_k_multiplier=None,
+                cluster_max_size=None,
+            )
+
+    def test_invalid_multiplier_raises(self):
+        with pytest.raises(ValueError, match="cluster_top_k_multiplier"):
+            resolve_cluster_kwargs(
+                expand_clusters=True,
+                cluster_threshold=None,
+                cluster_top_k_multiplier=0,
+                cluster_max_size=None,
+            )
+
+    def test_invalid_max_size_raises(self):
+        with pytest.raises(ValueError, match="cluster_max_size"):
+            resolve_cluster_kwargs(
+                expand_clusters=True,
+                cluster_threshold=None,
+                cluster_top_k_multiplier=None,
+                cluster_max_size=0,
+            )
+
+
+# ---------------------------------------------------------------------------
+# cluster_memories
+# ---------------------------------------------------------------------------
+
+
+def _mk(memory_text: str, score: float, **extra) -> dict:
+    """Build a memory result dict matching what _search_vector_store returns."""
+    return {"id": memory_text, "memory": memory_text, "score": score, **extra}
+
+
+def _stub_embed_batch(text_to_vec: dict[str, list[float]]):
+    """Return a callable that emits the configured vector for each text."""
+
+    def _impl(texts):
+        return [text_to_vec[t] for t in texts]
+
+    return _impl
+
+
+class TestClusterMemories:
+    def test_empty_input_returns_empty(self):
+        result = cluster_memories(
+            [],
+            embed_batch=lambda _texts: [],
+            top_k=10,
+            threshold=0.85,
+        )
+        assert result == []
+
+    def test_singleton_input_is_tagged_primary(self):
+        memories = [_mk("only one", 0.9, created_at="2026-05-22")]
+        result = cluster_memories(
+            memories,
+            embed_batch=lambda _texts: [],  # not called
+            top_k=10,
+            threshold=0.85,
+        )
+        assert len(result) == 1
+        assert result[0][CLUSTER_ID_KEY] == "c0"
+        assert result[0][CLUSTER_SIZE_KEY] == 1
+        assert result[0][CLUSTER_ROLE_KEY] == CLUSTER_ROLE_PRIMARY
+        # Original fields preserved.
+        assert result[0]["memory"] == "only one"
+        assert result[0]["score"] == 0.9
+        assert result[0]["created_at"] == "2026-05-22"
+
+    def test_two_similar_items_form_one_cluster(self):
+        # Both vectors are parallel -> cosine 1.0 -> always cluster together.
+        memories = [
+            _mk("I work at Company B", 0.92, created_at="2026-05-22"),
+            _mk("I work at Company A", 0.89, created_at="2026-02-15"),
+        ]
+        vecs = {
+            "I work at Company B": [1.0, 0.0, 0.0],
+            "I work at Company A": [1.0, 0.0, 0.0],
+        }
+        result = cluster_memories(
+            memories,
+            embed_batch=_stub_embed_batch(vecs),
+            top_k=10,
+            threshold=0.85,
+        )
+        assert len(result) == 2
+        assert {r[CLUSTER_ID_KEY] for r in result} == {"c0"}
+        assert result[0][CLUSTER_ROLE_KEY] == CLUSTER_ROLE_PRIMARY
+        assert result[1][CLUSTER_ROLE_KEY] == CLUSTER_ROLE_SIBLING
+        # Cluster ordering matches input ordering (= score-desc).
+        assert result[0]["memory"] == "I work at Company B"
+        assert result[1]["memory"] == "I work at Company A"
+
+    def test_dissimilar_items_form_separate_clusters(self):
+        memories = [
+            _mk("I work at B", 0.92),
+            _mk("I live in NY", 0.62),
+        ]
+        vecs = {
+            "I work at B": [1.0, 0.0],
+            "I live in NY": [0.0, 1.0],  # orthogonal -> not clustered
+        }
+        result = cluster_memories(
+            memories,
+            embed_batch=_stub_embed_batch(vecs),
+            top_k=10,
+            threshold=0.85,
+        )
+        assert len(result) == 2
+        assert result[0][CLUSTER_ID_KEY] == "c0"
+        assert result[1][CLUSTER_ID_KEY] == "c1"
+        # Each is its own primary.
+        assert result[0][CLUSTER_ROLE_KEY] == CLUSTER_ROLE_PRIMARY
+        assert result[1][CLUSTER_ROLE_KEY] == CLUSTER_ROLE_PRIMARY
+        assert result[0][CLUSTER_SIZE_KEY] == 1
+        assert result[1][CLUSTER_SIZE_KEY] == 1
+
+    def test_max_cluster_size_truncates_siblings(self):
+        # Four identical-embedding items; cap to 2.
+        memories = [_mk(f"item-{i}", 0.9 - 0.01 * i) for i in range(4)]
+        vecs = {f"item-{i}": [1.0, 0.0] for i in range(4)}
+        result = cluster_memories(
+            memories,
+            embed_batch=_stub_embed_batch(vecs),
+            top_k=10,
+            threshold=0.85,
+            max_cluster_size=2,
+        )
+        # 4 items, all want to join the same cluster, capped to 2.
+        cluster_0_members = [r for r in result if r[CLUSTER_ID_KEY] == "c0"]
+        assert len(cluster_0_members) == 2
+        # First two highest-scoring members win; rest are dropped silently.
+        assert {r["memory"] for r in cluster_0_members} == {"item-0", "item-1"}
+
+    def test_top_k_caps_number_of_clusters(self):
+        # Three orthogonal clusters; ask for only 2.
+        memories = [
+            _mk("A", 0.9),
+            _mk("B", 0.85),
+            _mk("C", 0.80),
+        ]
+        vecs = {
+            "A": [1.0, 0.0, 0.0],
+            "B": [0.0, 1.0, 0.0],
+            "C": [0.0, 0.0, 1.0],
+        }
+        result = cluster_memories(
+            memories,
+            embed_batch=_stub_embed_batch(vecs),
+            top_k=2,
+            threshold=0.85,
+        )
+        cluster_ids = {r[CLUSTER_ID_KEY] for r in result}
+        assert cluster_ids == {"c0", "c1"}
+        # C (lowest score) is dropped because we asked for 2 clusters.
+        assert all(r["memory"] != "C" for r in result)
+
+    def test_invalid_top_k_raises(self):
+        with pytest.raises(ValueError, match="top_k"):
+            cluster_memories(
+                [_mk("a", 0.9)],
+                embed_batch=lambda _t: [[1.0]],
+                top_k=0,
+            )
+
+    def test_embed_batch_failure_returns_unclustered(self, caplog):
+        memories = [_mk("a", 0.9), _mk("b", 0.85)]
+
+        def boom(_texts):
+            raise RuntimeError("embedding API down")
+
+        result = cluster_memories(memories, embed_batch=boom, top_k=10)
+        # Falls back to passing through (truncated to top_k) without tags.
+        assert len(result) == 2
+        assert CLUSTER_ID_KEY not in result[0]
+
+    def test_embed_batch_length_mismatch_returns_unclustered(self):
+        memories = [_mk("a", 0.9), _mk("b", 0.85)]
+        # Returns only one vector for two inputs — corrupted upstream.
+        result = cluster_memories(
+            memories,
+            embed_batch=lambda _texts: [[1.0, 0.0]],
+            top_k=10,
+        )
+        assert len(result) == 2
+        assert CLUSTER_ID_KEY not in result[0]
+
+    def test_anchor_based_avoids_transitive_chaining(self):
+        # A close to B (sim 0.9), B close to C (sim 0.9), but A not close to C.
+        # Pure single-link would put A, B, C in one cluster (transitive).
+        # Anchor-based: only compare to first member (A). C is far from A,
+        # so C gets its own cluster.
+        import math
+
+        # Construct three vectors:
+        #   A = (1, 0)
+        #   B = (cos(20deg), sin(20deg))    -> A·B ≈ 0.94
+        #   C = (cos(50deg), sin(50deg))    -> A·C ≈ 0.64, but B·C ≈ 0.94
+        a = [1.0, 0.0]
+        b = [math.cos(math.radians(20)), math.sin(math.radians(20))]
+        c = [math.cos(math.radians(50)), math.sin(math.radians(50))]
+        memories = [_mk("A", 0.95), _mk("B", 0.90), _mk("C", 0.85)]
+        result = cluster_memories(
+            memories,
+            embed_batch=_stub_embed_batch({"A": a, "B": b, "C": c}),
+            top_k=10,
+            threshold=0.85,
+        )
+        # A and B end up in the same cluster (anchor A, sim 0.94 >= 0.85).
+        # C does NOT join A's cluster (anchor sim 0.64 < 0.85).
+        cluster_map = {r["memory"]: r[CLUSTER_ID_KEY] for r in result}
+        assert cluster_map["A"] == cluster_map["B"]
+        assert cluster_map["C"] != cluster_map["A"]
+
+
+# ---------------------------------------------------------------------------
+# Memory.search end-to-end (mocked embedding + vector store)
+# ---------------------------------------------------------------------------
+
+
+def _make_memory(mocker, search_results):
+    """Construct a `Memory` instance with the vector store / embedder mocked.
+
+    `search_results` is the list of dicts that `_search_vector_store` will
+    return. The embedder's `embed_batch` is stubbed to emit identical
+    vectors for all texts (forces them into one cluster).
+    """
+    mocker.patch("mem0.utils.factory.EmbedderFactory.create", mocker.MagicMock())
+    mocker.patch(
+        "mem0.utils.factory.VectorStoreFactory.create",
+        side_effect=[mocker.MagicMock(), mocker.MagicMock()],
+    )
+    mocker.patch("mem0.utils.factory.LlmFactory.create", mocker.MagicMock())
+    mocker.patch("mem0.memory.storage.SQLiteManager", mocker.MagicMock())
+
+    memory = Memory()
+    memory.api_version = "v1.1"
+    memory._search_vector_store = MagicMock(return_value=search_results)
+    memory.embedding_model = MagicMock()
+    memory.embedding_model.embed_batch = MagicMock(side_effect=lambda texts, _action: [[1.0, 0.0] for _ in texts])
+    memory.reranker = None
+    return memory
+
+
+class TestMemorySearchClusterExpansion:
+    def test_off_by_default_returns_unmodified_results(self, mocker):
+        results = [
+            {"id": "1", "memory": "I work at A", "score": 0.9},
+            {"id": "2", "memory": "I work at B", "score": 0.85},
+        ]
+        memory = _make_memory(mocker, results)
+
+        out = memory.search("where do I work?", filters={"user_id": "u1"})
+
+        assert out["results"] == results
+        # No cluster metadata added.
+        assert CLUSTER_ID_KEY not in out["results"][0]
+        # Embedder.embed_batch should NOT have been called.
+        memory.embedding_model.embed_batch.assert_not_called()
+
+    def test_expand_clusters_adds_metadata(self, mocker):
+        results = [
+            {"id": "1", "memory": "I work at B", "score": 0.92, "created_at": "today"},
+            {"id": "2", "memory": "I work at A", "score": 0.89, "created_at": "old"},
+        ]
+        memory = _make_memory(mocker, results)
+
+        out = memory.search(
+            "where do I work?",
+            filters={"user_id": "u1"},
+            expand_clusters=True,
+        )
+
+        assert len(out["results"]) == 2
+        for r in out["results"]:
+            assert CLUSTER_ID_KEY in r
+            assert CLUSTER_SIZE_KEY in r
+            assert CLUSTER_ROLE_KEY in r
+        # Both went into the same cluster (mock vectors identical).
+        assert out["results"][0][CLUSTER_ID_KEY] == out["results"][1][CLUSTER_ID_KEY]
+        # Highest-score memory is the primary; older one is sibling.
+        assert out["results"][0][CLUSTER_ROLE_KEY] == CLUSTER_ROLE_PRIMARY
+        assert out["results"][1][CLUSTER_ROLE_KEY] == CLUSTER_ROLE_SIBLING
+
+    def test_expand_clusters_over_fetches_from_vector_store(self, mocker):
+        results = [{"id": str(i), "memory": f"m-{i}", "score": 0.9 - 0.01 * i} for i in range(5)]
+        memory = _make_memory(mocker, results)
+
+        memory.search(
+            "q",
+            filters={"user_id": "u1"},
+            top_k=2,
+            expand_clusters=True,
+            cluster_top_k_multiplier=4,
+        )
+
+        # _search_vector_store should have been called with limit = 2 * 4 = 8.
+        # call_args.args = (query, filters, limit, threshold)
+        call_args = memory._search_vector_store.call_args
+        assert call_args.args[2] == 8
+
+    def test_invalid_cluster_threshold_raises(self, mocker):
+        memory = _make_memory(mocker, [])
+        with pytest.raises(ValueError, match="cluster_threshold"):
+            memory.search(
+                "q",
+                filters={"user_id": "u1"},
+                expand_clusters=True,
+                cluster_threshold=1.5,
+            )
+
+
+@pytest.mark.asyncio
+class TestAsyncMemorySearchClusterExpansion:
+    async def test_async_expand_clusters_adds_metadata(self, mocker):
+        mocker.patch("mem0.utils.factory.EmbedderFactory.create", mocker.MagicMock())
+        mocker.patch(
+            "mem0.utils.factory.VectorStoreFactory.create",
+            side_effect=[mocker.MagicMock(), mocker.MagicMock()],
+        )
+        mocker.patch("mem0.utils.factory.LlmFactory.create", mocker.MagicMock())
+        mocker.patch("mem0.memory.storage.SQLiteManager", mocker.MagicMock())
+
+        memory = AsyncMemory()
+        memory.api_version = "v1.1"
+
+        results = [
+            {"id": "1", "memory": "I work at B", "score": 0.92},
+            {"id": "2", "memory": "I work at A", "score": 0.89},
+        ]
+
+        async def _fake_search(*_args, **_kwargs):
+            return results
+
+        memory._search_vector_store = _fake_search
+        memory.embedding_model = MagicMock()
+        memory.embedding_model.embed_batch = MagicMock(side_effect=lambda texts, _action: [[1.0, 0.0] for _ in texts])
+        memory.reranker = None
+
+        out = await memory.search(
+            "where do I work?",
+            filters={"user_id": "u1"},
+            expand_clusters=True,
+        )
+
+        assert len(out["results"]) == 2
+        # Both clustered together (identical mock vectors).
+        cluster_ids = {r[CLUSTER_ID_KEY] for r in out["results"]}
+        assert len(cluster_ids) == 1
+        roles = [r[CLUSTER_ROLE_KEY] for r in out["results"]]
+        assert roles == [CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_SIBLING]


### PR DESCRIPTION
## Linked Issue

Closes #4956 (I am the original reporter of this issue.)

## Description

The v3 ADD-only extraction pipeline lets contradictory facts about the same attribute (current employer, address, status, …) accumulate over time. At search-time, pure semantic similarity does not know that two memories describe the same thing at different points in time, so the consumer LLM can hand back a stale fact as the answer.

This PR adds an opt-in `expand_clusters=True` mode to `Memory.search()` / `AsyncMemory.search()` that groups topically-related results into clusters via in-memory pairwise cosine similarity over the existing embedder, and surfaces the whole cluster (primary + siblings, with `created_at`) so the consumer can apply its own temporal-resolution policy.

As the reporter of #4956, I want to be explicit about how this fits next to the existing write-time supersession proposals (PR #4969, PR #5218): this change is **complementary**, not competing. Those PRs detect contradictions at write time and flip an `is_active` / `is_superseded` flag on the older memory. This PR addresses the second half of the issue I raised — *"retrieval scoring signals don't incorporate recency"* — at the read layer. It does not mutate any stored memory, introduces no new vector-store schema, and defaults to `False`. Either path can ship independently; both can also ship together.

### Live demo with `gemini-embedding-001`

A user has asserted three different employers over six months plus two stable unrelated facts. Query: `"Where does the user work?"`. Real cosine scores (script in `demo_4956.py`):

```
Raw vector-store ranking (top 5):
  - score=0.695  age=2026-02-22  'I now work at Beta Industries.'     ← 3 months old
  - score=0.682  age=2025-11-24  'I work at Acme Corp...'              ← 6 months old
  - score=0.610  age=2026-04-23  'I live in New York City.'            ← irrelevant
  - score=0.583  age=2026-05-21  'I just joined Gamma Labs this week.' ← CURRENT
  - score=0.488  age=2026-03-24  'My favorite cuisine is Vietnamese pho.'
```

The user's actual current employer (**Gamma Labs**, 2 days old) ranks **#4** — below an irrelevant NYC fact and below both stale employer claims. Terser current phrasing scores lower than richer older phrasing.

**Today (no cluster expansion):**

```
search(top_k=1)
  → 'I now work at Beta Industries.'   (3-month-old stale fact)
```

The downstream LLM answers "Beta". Wrong.

**With this PR:**

```
search(top_k=1, expand_clusters=True)
  → 'I now work at Beta Industries.'              [c0 primary size=3]
  → 'I work at Acme Corp as a backend engineer.'  [c0 sibling size=3]
  → 'I just joined Gamma Labs this week.'         [c0 sibling size=3]
```

The downstream LLM sees the full employer history with `created_at` timestamps and answers "Gamma Labs" (most recent), correctly. Nothing was stored or mutated — pure read-side enrichment.

### Why anchor-based clustering doesn't promote irrelevant-recent items

A common worry about retrieval-time recency tricks is that an unrelated-but-recent memory gets pushed to the top. Anchor-based greedy clustering avoids this because each candidate is compared only to the highest-scoring member of each existing cluster:

```
Pairwise Gemini cosines:
          Beta   Acme   NYC    Gamma  pho
   Beta:  1.00   0.73   0.60   0.73   0.52
   Acme:  0.73   1.00   0.62   0.60   0.56
   NYC:   0.60   0.62   1.00   0.55   0.56
   Gamma: 0.73   0.60   0.55   1.00   0.53
   pho:   0.52   0.56   0.56   0.53   1.00
```

With `threshold=0.65`, `sim(NYC, Beta-anchor) = 0.60 < 0.65` so NYC opens its **own** cluster — it never gets into the employer cluster despite scoring higher than Gamma against the query. Cross-cluster ranking is unchanged.

### Design

- **Pure append-only.** No stored memory is mutated (no `is_active` / `is_superseded` flags).
- **Opt-in.** `expand_clusters` defaults to `False`; all existing callers see no behavior change.
- **No new vector-store schema.** Clustering uses the existing embedder's `embed_batch` at search time. Works with all supported vector stores unchanged.
- **Anchor-based greedy clustering** to avoid the transitive-chaining failure of pure single-link (verified by a dedicated test).
- **Non-fatal.** If `embed_batch` raises or returns the wrong number of vectors, original (unclustered) results pass through with a warning.

Knobs (all optional):

| Param | Default | Purpose |
|---|---|---|
| `expand_clusters` | `False` | Opt-in flag |
| `cluster_threshold` | `0.85` | Cosine sim required to join a cluster's anchor |
| `cluster_top_k_multiplier` | `3` | Over-fetch factor before clustering |
| `cluster_max_size` | `5` | Cap on cluster members per response |

The demo above uses `threshold=0.65` because `gemini-embedding-001` paraphrase pairs sit around 0.7. The conservative `0.85` default is tuned for OpenAI `text-embedding-3-*` and similar high-discrimination embedders.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A — `expand_clusters` defaults to `False`, so existing callers see no behavior change.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

26 new unit tests in `tests/memory/test_clustering.py`, fully mocked, no external API keys needed. Coverage:

- `cosine_similarity` correctness (identical, orthogonal, anti-parallel, empty, zero-norm, mismatched-dim raises)
- `cluster_memories` empty / singleton / multi-cluster / max-size / top-k cap
- Anchor-based clustering verifiably avoids transitive chaining
- Graceful fallback on embedder failure and length mismatch
- `Memory.search` opt-out (default behavior unchanged) and opt-in (returns cluster metadata)
- Over-fetch multiplier is applied at the vector-store call site
- Invalid cluster params raise early
- `AsyncMemory.search` parity

Manual: `demo_4956.py` with real `gemini-embedding-001` — output reproduced verbatim above. All 201 pre-existing `tests/memory/` tests continue to pass.

## Checklist

- [x] My code follows the project's style guidelines (`ruff check`, `ruff format`, `isort --profile black` all clean on touched files)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove the feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed (happy to add a `docs/open-source/` page if reviewers want)
