### PR TITLE
fix: correct GPT-5 reasoning model names (gpt-5-mini, gpt-5-nano)

### DIFF
--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -52,7 +52,7 @@ class LLMBase(ABC):
         """
         reasoning_models = {
             "o1", "o1-preview", "o3-mini", "o3",
-            "gpt-5", "gpt-5o", "gpt-5o-mini", "gpt-5o-micro",
+            "gpt-5", "gpt-5-mini", "gpt-5-nano",
         }
 
         model_lower = model.lower()
@@ -64,7 +64,7 @@ class LLMBase(ABC):
 
         # Match o1/o3 family with prefixes (o1-2024-12-17, o3-2025-04-16)
         # but NOT gpt-5.x variants (gpt-5.4-mini supports temperature)
-        if any(base_model.startswith(prefix) for prefix in ["o1-", "o1.", "o3-", "o3."]):
+        if any(base_model.startswith(prefix) for prefix in ["o1-", "o1.", "o3-", "o3.", "gpt-5-mini-", "gpt-5-nano-"]):
             return True
 
         return False


### PR DESCRIPTION
## Summary

Fixes #5233 — `_is_reasoning_model` in `mem0/llms/base.py` had the wrong GPT-5 model names in its whitelist:

- **Removed**: `gpt-5o`, `gpt-5o-mini`, `gpt-5o-micro` — these are not real OpenAI model identifiers
- **Added**: `gpt-5-mini`, `gpt-5-nano` — the actual GPT-5 family names

This caused `Memory.add()` calls with `gpt-5-mini` to fail with HTTP 400 `"max_tokens is not supported with this model"` because the model was not recognized as a reasoning model and had `max_tokens` incorrectly forwarded.

## Changes

- Line 55: `"gpt-5", "gpt-5o", "gpt-5o-mini", "gpt-5o-micro"` → `"gpt-5", "gpt-5-mini", "gpt-5-nano"`
- Line 67: Added `"gpt-5-mini-", "gpt-5-nano-"` to prefix list to cover dated variants (e.g. `gpt-5-mini-2025-08-07`)

## Testing

```python
from mem0.llms.base import LLMBase
llm = LLMBase()
assert llm._is_reasoning_model("gpt-5-mini") == True
assert llm._is_reasoning_model("gpt-5-nano") == True
assert llm._is_reasoning_model("gpt-5-mini-2025-08-07") == True  # dated variant
assert llm._is_reasoning_model("gpt-5") == True
assert llm._is_reasoning_model("gpt-4") == False
```


Closes #5233
