### PR TITLE
perf(embeddings): native embed_batch for all providers; fix FastEmbed embed() return type

### DIFF
--- a/mem0/embeddings/aws_bedrock.py
+++ b/mem0/embeddings/aws_bedrock.py
@@ -98,3 +98,32 @@ class AWSBedrockEmbedding(EmbeddingBase):
             list: The embedding vector.
         """
         return self._get_embedding(text)
+
+    def embed_batch(self, texts, memory_action="add"):
+        """Embed multiple texts using AWS Bedrock.
+
+        Cohere models support native batching (up to 96 texts per call).
+        Amazon Titan and other providers only support single-text embedding,
+        so those fall back to sequential calls.
+        """
+        provider = self.config.model.split(".")[0]
+        if provider != "cohere":
+            return [self._get_embedding(text) for text in texts]
+
+        MAX_BATCH = 96
+        all_embeddings = []
+        for i in range(0, len(texts), MAX_BATCH):
+            chunk = texts[i : i + MAX_BATCH]
+            body = json.dumps({"input_type": "search_document", "texts": chunk})
+            try:
+                response = self.client.invoke_model(
+                    body=body,
+                    modelId=self.config.model,
+                    accept="application/json",
+                    contentType="application/json",
+                )
+                response_body = json.loads(response.get("body").read())
+                all_embeddings.extend(response_body.get("embeddings"))
+            except Exception as e:
+                raise ValueError(f"Error getting batch embedding from AWS Bedrock: {e}")
+        return all_embeddings

--- a/mem0/embeddings/fastembed.py
+++ b/mem0/embeddings/fastembed.py
@@ -1,7 +1,7 @@
-from typing import Optional, Literal
+from typing import Literal, Optional
 
-from mem0.embeddings.base import EmbeddingBase
 from mem0.configs.embeddings.base import BaseEmbedderConfig
+from mem0.embeddings.base import EmbeddingBase
 
 try:
     from fastembed import TextEmbedding
@@ -29,4 +29,11 @@ class FastEmbedEmbedding(EmbeddingBase):
         """
         text = text.replace("\n", " ")
         embeddings = list(self.dense_model.embed(text))
-        return embeddings[0]
+        return embeddings[0].tolist()
+
+    def embed_batch(self, texts, memory_action="add"):
+        """
+        Embed multiple texts in a single FastEmbed call.
+        """
+        texts = [text.replace("\n", " ") for text in texts]
+        return [emb.tolist() for emb in self.dense_model.embed(texts)]

--- a/mem0/embeddings/gemini.py
+++ b/mem0/embeddings/gemini.py
@@ -37,3 +37,17 @@ class GoogleGenAIEmbedding(EmbeddingBase):
         response = self.client.models.embed_content(model=self.config.model, contents=text, config=config)
 
         return response.embeddings[0].values
+
+    def embed_batch(self, texts, memory_action="add"):
+        """Embed multiple texts in a single Gemini API call.
+
+        Automatically chunks into batches of 100 to stay within API limits.
+        """
+        MAX_BATCH = 100
+        config = types.EmbedContentConfig(output_dimensionality=self.config.embedding_dims)
+        all_embeddings = []
+        for i in range(0, len(texts), MAX_BATCH):
+            chunk = [t.replace("\n", " ") for t in texts[i : i + MAX_BATCH]]
+            response = self.client.models.embed_content(model=self.config.model, contents=chunk, config=config)
+            all_embeddings.extend(e.values for e in response.embeddings)
+        return all_embeddings

--- a/mem0/embeddings/huggingface.py
+++ b/mem0/embeddings/huggingface.py
@@ -42,3 +42,21 @@ class HuggingFaceEmbedding(EmbeddingBase):
             ).data[0].embedding
         else:
             return self.model.encode(text, convert_to_numpy=True).tolist()
+
+    def embed_batch(self, texts, memory_action="add"):
+        """Embed multiple texts in a single call.
+
+        Automatically chunks into batches of 100 to stay within API limits.
+        """
+        if self.config.huggingface_base_url:
+            MAX_BATCH = 100
+            all_embeddings = []
+            for i in range(0, len(texts), MAX_BATCH):
+                chunk = texts[i : i + MAX_BATCH]
+                response = self.client.embeddings.create(
+                    input=chunk, model=self.config.model, **self.config.model_kwargs
+                )
+                all_embeddings.extend(item.embedding for item in sorted(response.data, key=lambda x: x.index))
+            return all_embeddings
+        else:
+            return self.model.encode(texts, convert_to_numpy=True).tolist()

--- a/mem0/embeddings/langchain.py
+++ b/mem0/embeddings/langchain.py
@@ -33,3 +33,7 @@ class LangchainEmbedding(EmbeddingBase):
         """
 
         return self.langchain_model.embed_query(text)
+
+    def embed_batch(self, texts, memory_action="add"):
+        """Embed multiple texts using LangChain's embed_documents interface."""
+        return self.langchain_model.embed_documents(texts)

--- a/mem0/embeddings/lmstudio.py
+++ b/mem0/embeddings/lmstudio.py
@@ -27,3 +27,17 @@ class LMStudioEmbedding(EmbeddingBase):
         """
         text = text.replace("\n", " ")
         return self.client.embeddings.create(input=[text], model=self.config.model).data[0].embedding
+
+    def embed_batch(self, texts, memory_action="add"):
+        """Embed multiple texts via LM Studio's OpenAI-compatible batch API.
+
+        Chunks into batches of 100 to stay within typical server limits.
+        """
+        MAX_BATCH = 100
+        texts = [text.replace("\n", " ") for text in texts]
+        all_embeddings = []
+        for i in range(0, len(texts), MAX_BATCH):
+            chunk = texts[i : i + MAX_BATCH]
+            response = self.client.embeddings.create(input=chunk, model=self.config.model)
+            all_embeddings.extend(item.embedding for item in sorted(response.data, key=lambda x: x.index))
+        return all_embeddings

--- a/mem0/embeddings/ollama.py
+++ b/mem0/embeddings/ollama.py
@@ -63,3 +63,14 @@ class OllamaEmbedding(EmbeddingBase):
         if not embeddings:
             raise ValueError(f"Ollama embed() returned no embeddings for model '{self.config.model}'")
         return embeddings[0]
+
+    def embed_batch(self, texts, memory_action="add"):
+        """Embed multiple texts in a single Ollama call.
+
+        Ollama's embed() accepts a list and returns one embedding per input.
+        """
+        response = self.client.embed(model=self.config.model, input=texts)
+        embeddings = response.get("embeddings") or []
+        if not embeddings:
+            raise ValueError(f"Ollama embed() returned no embeddings for model '{self.config.model}'")
+        return embeddings

--- a/mem0/embeddings/together.py
+++ b/mem0/embeddings/together.py
@@ -29,3 +29,13 @@ class TogetherEmbedding(EmbeddingBase):
         """
 
         return self.client.embeddings.create(model=self.config.model, input=text).data[0].embedding
+
+    def embed_batch(self, texts, memory_action="add"):
+        """Embed multiple texts in a single Together API call (chunked at 100)."""
+        MAX_BATCH = 100
+        all_embeddings = []
+        for i in range(0, len(texts), MAX_BATCH):
+            chunk = texts[i : i + MAX_BATCH]
+            response = self.client.embeddings.create(model=self.config.model, input=chunk)
+            all_embeddings.extend(item.embedding for item in sorted(response.data, key=lambda x: x.index))
+        return all_embeddings

--- a/mem0/embeddings/vertexai.py
+++ b/mem0/embeddings/vertexai.py
@@ -62,3 +62,21 @@ class VertexAIEmbedding(EmbeddingBase):
         embeddings = self.model.get_embeddings(texts=[text_input], output_dimensionality=self.config.embedding_dims)
 
         return embeddings[0].values
+
+    def embed_batch(self, texts, memory_action="add"):
+        """Embed multiple texts using Vertex AI's native batch support.
+
+        Vertex AI's get_embeddings() accepts up to 250 inputs per call.
+        """
+        MAX_BATCH = 250
+        embedding_type = "SEMANTIC_SIMILARITY"
+        if memory_action in self.embedding_types:
+            embedding_type = self.embedding_types[memory_action]
+
+        all_embeddings = []
+        for i in range(0, len(texts), MAX_BATCH):
+            chunk = texts[i : i + MAX_BATCH]
+            inputs = [TextEmbeddingInput(text=text, task_type=embedding_type) for text in chunk]
+            embeddings = self.model.get_embeddings(texts=inputs, output_dimensionality=self.config.embedding_dims)
+            all_embeddings.extend(e.values for e in embeddings)
+        return all_embeddings

--- a/tests/embeddings/test_aws_bedrock_embeddings.py
+++ b/tests/embeddings/test_aws_bedrock_embeddings.py
@@ -1,0 +1,90 @@
+import json
+from io import BytesIO
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mem0.configs.embeddings.base import BaseEmbedderConfig
+from mem0.embeddings.aws_bedrock import AWSBedrockEmbedding
+
+
+@pytest.fixture
+def mock_boto3_client():
+    with patch("mem0.embeddings.aws_bedrock.boto3") as mock_boto3:
+        mock_client = Mock()
+        mock_boto3.client.return_value = mock_client
+        yield mock_client
+
+
+def make_bedrock_response(body_dict):
+    body_bytes = json.dumps(body_dict).encode()
+    mock_response = Mock()
+    mock_response.get.return_value = BytesIO(body_bytes)
+    return mock_response
+
+
+def test_embed_amazon_titan(mock_boto3_client):
+    config = BaseEmbedderConfig(model="amazon.titan-embed-text-v1", aws_region="us-east-1")
+    embedder = AWSBedrockEmbedding(config)
+
+    mock_boto3_client.invoke_model.return_value = make_bedrock_response({"embedding": [0.1, 0.2, 0.3]})
+
+    result = embedder.embed("hello world")
+
+    assert result == [0.1, 0.2, 0.3]
+
+
+def test_embed_batch_cohere_single_call(mock_boto3_client):
+    config = BaseEmbedderConfig(model="cohere.embed-english-v3", aws_region="us-east-1")
+    embedder = AWSBedrockEmbedding(config)
+
+    mock_boto3_client.invoke_model.return_value = make_bedrock_response(
+        {"embeddings": [[0.1, 0.2], [0.3, 0.4]]}
+    )
+
+    result = embedder.embed_batch(["first", "second"])
+
+    mock_boto3_client.invoke_model.assert_called_once()
+    call_body = json.loads(mock_boto3_client.invoke_model.call_args.kwargs["body"])
+    assert call_body["texts"] == ["first", "second"]
+    assert result == [[0.1, 0.2], [0.3, 0.4]]
+
+
+def test_embed_batch_cohere_chunks_at_96(mock_boto3_client):
+    config = BaseEmbedderConfig(model="cohere.embed-english-v3", aws_region="us-east-1")
+    embedder = AWSBedrockEmbedding(config)
+
+    mock_boto3_client.invoke_model.side_effect = [
+        make_bedrock_response({"embeddings": [[float(i)] for i in range(96)]}),
+        make_bedrock_response({"embeddings": [[float(i)] for i in range(4)]}),
+    ]
+
+    result = embedder.embed_batch([f"text {i}" for i in range(100)])
+
+    assert mock_boto3_client.invoke_model.call_count == 2
+    assert len(result) == 100
+
+
+def test_embed_batch_titan_falls_back_to_serial(mock_boto3_client):
+    config = BaseEmbedderConfig(model="amazon.titan-embed-text-v1", aws_region="us-east-1")
+    embedder = AWSBedrockEmbedding(config)
+
+    mock_boto3_client.invoke_model.side_effect = [
+        make_bedrock_response({"embedding": [0.1, 0.2]}),
+        make_bedrock_response({"embedding": [0.3, 0.4]}),
+    ]
+
+    result = embedder.embed_batch(["first", "second"])
+
+    assert mock_boto3_client.invoke_model.call_count == 2
+    assert result == [[0.1, 0.2], [0.3, 0.4]]
+
+
+def test_embed_batch_cohere_raises_on_api_error(mock_boto3_client):
+    config = BaseEmbedderConfig(model="cohere.embed-english-v3", aws_region="us-east-1")
+    embedder = AWSBedrockEmbedding(config)
+
+    mock_boto3_client.invoke_model.side_effect = Exception("throttled")
+
+    with pytest.raises(ValueError, match="Error getting batch embedding from AWS Bedrock"):
+        embedder.embed_batch(["text"])

--- a/tests/embeddings/test_fastembed_embeddings.py
+++ b/tests/embeddings/test_fastembed_embeddings.py
@@ -1,7 +1,8 @@
 from unittest.mock import Mock, patch
 
-import pytest
 import numpy as np
+import pytest
+
 from mem0.configs.embeddings.base import BaseEmbedderConfig
 
 try:
@@ -29,18 +30,51 @@ def test_embed_with_jina_model(mock_fastembed_client):
     embedding = embedder.embed(text)
     
     mock_fastembed_client.embed.assert_called_once_with(text)
-    assert list(embedding) == [0.1, 0.2, 0.3, 0.4, 0.5]
+    assert embedding == [0.1, 0.2, 0.3, 0.4, 0.5]
 
 
 def test_embed_removes_newlines(mock_fastembed_client):
     config = BaseEmbedderConfig(model="jinaai/jina-embeddings-v2-base-en", embedding_dims=768)
     embedder = FastEmbedEmbedding(config)
-    
+
     mock_embedding = np.array([0.7, 0.8, 0.9])
     mock_fastembed_client.embed.return_value = iter([mock_embedding])
-    
+
     text_with_newlines = "Hello\nworld"
     embedding = embedder.embed(text_with_newlines)
-    
+
     mock_fastembed_client.embed.assert_called_once_with("Hello world")
-    assert list(embedding) == [0.7, 0.8, 0.9]
+    assert embedding == [0.7, 0.8, 0.9]
+
+
+def test_embed_batch(mock_fastembed_client):
+    config = BaseEmbedderConfig(model="jinaai/jina-embeddings-v2-base-en", embedding_dims=768)
+    embedder = FastEmbedEmbedding(config)
+
+    mock_fastembed_client.embed.return_value = iter([np.array([0.1, 0.2]), np.array([0.3, 0.4])])
+
+    texts = ["first text", "second text"]
+    result = embedder.embed_batch(texts)
+
+    mock_fastembed_client.embed.assert_called_once_with(["first text", "second text"])
+    assert result == [[0.1, 0.2], [0.3, 0.4]]
+
+
+def test_embed_batch_single_call(mock_fastembed_client):
+    config = BaseEmbedderConfig(model="jinaai/jina-embeddings-v2-base-en", embedding_dims=768)
+    embedder = FastEmbedEmbedding(config)
+
+    mock_fastembed_client.embed.return_value = iter([np.array([0.1] * 768)] * 50)
+    embedder.embed_batch([f"text {i}" for i in range(50)])
+
+    assert mock_fastembed_client.embed.call_count == 1
+
+
+def test_embed_batch_strips_newlines(mock_fastembed_client):
+    config = BaseEmbedderConfig(model="jinaai/jina-embeddings-v2-base-en", embedding_dims=768)
+    embedder = FastEmbedEmbedding(config)
+
+    mock_fastembed_client.embed.return_value = iter([np.array([0.5, 0.6])])
+    embedder.embed_batch(["hello\nworld"])
+
+    mock_fastembed_client.embed.assert_called_once_with(["hello world"])

--- a/tests/embeddings/test_gemini_emeddings.py
+++ b/tests/embeddings/test_gemini_emeddings.py
@@ -58,3 +58,47 @@ def test_config_initialization(config):
     assert embedder.config.api_key == "dummy_api_key"
     assert embedder.config.model == "test_model"
     assert embedder.config.embedding_dims == 786
+
+
+def test_embed_batch(mock_genai, config):
+    def make_embedding(values):
+        return type("Embedding", (), {"values": values})()
+
+    mock_genai.return_value = type(
+        "Response", (), {"embeddings": [make_embedding([0.1, 0.2]), make_embedding([0.3, 0.4])]}
+    )()
+
+    embedder = GoogleGenAIEmbedding(config)
+    result = embedder.embed_batch(["hello world", "foo bar"])
+
+    assert result == [[0.1, 0.2], [0.3, 0.4]]
+    mock_genai.assert_called_once_with(model="test_model", contents=["hello world", "foo bar"], config=ANY)
+
+
+def test_embed_batch_chunks_at_100(mock_genai, config):
+    def make_embedding(values):
+        return type("Embedding", (), {"values": values})()
+
+    mock_genai.return_value = type(
+        "Response", (), {"embeddings": [make_embedding([0.1]) for _ in range(100)]}
+    )()
+
+    embedder = GoogleGenAIEmbedding(config)
+    embedder.embed_batch([f"text {i}" for i in range(150)])
+
+    assert mock_genai.call_count == 2
+
+
+def test_embed_batch_strips_newlines(mock_genai, config):
+    def make_embedding(values):
+        return type("Embedding", (), {"values": values})()
+
+    mock_genai.return_value = type(
+        "Response", (), {"embeddings": [make_embedding([0.1, 0.2])]}
+    )()
+
+    embedder = GoogleGenAIEmbedding(config)
+    embedder.embed_batch(["hello\nworld"])
+
+    call_contents = mock_genai.call_args.kwargs["contents"]
+    assert call_contents == ["hello world"]

--- a/tests/embeddings/test_huggingface_embeddings.py
+++ b/tests/embeddings/test_huggingface_embeddings.py
@@ -72,6 +72,54 @@ def test_embed_with_custom_embedding_dims(mock_sentence_transformer):
     assert result == [1.0, 1.1, 1.2]
 
 
+def test_embed_batch_local(mock_sentence_transformer):
+    config = BaseEmbedderConfig()
+    embedder = HuggingFaceEmbedding(config)
+
+    mock_sentence_transformer.encode.return_value = np.array([[0.1, 0.2], [0.3, 0.4]])
+
+    texts = ["text one", "text two"]
+    result = embedder.embed_batch(texts)
+
+    mock_sentence_transformer.encode.assert_called_once_with(texts, convert_to_numpy=True)
+    assert result == [[0.1, 0.2], [0.3, 0.4]]
+
+
+def test_embed_batch_local_single_call(mock_sentence_transformer):
+    config = BaseEmbedderConfig()
+    embedder = HuggingFaceEmbedding(config)
+
+    mock_sentence_transformer.encode.return_value = np.array([[0.1] * 384] * 10)
+    embedder.embed_batch([f"text {i}" for i in range(10)])
+
+    assert mock_sentence_transformer.encode.call_count == 1
+
+
+def test_embed_batch_base_url():
+    config = BaseEmbedderConfig(huggingface_base_url="http://localhost:8080", model="tei-model")
+    with patch("mem0.embeddings.huggingface.OpenAI") as mock_openai:
+        mock_client = Mock()
+        mock_openai.return_value = mock_client
+
+        def make_item(idx, emb):
+            item = Mock()
+            item.index = idx
+            item.embedding = emb
+            return item
+
+        mock_response = Mock()
+        mock_response.data = [make_item(0, [0.1, 0.2]), make_item(1, [0.3, 0.4])]
+        mock_client.embeddings.create.return_value = mock_response
+
+        embedder = HuggingFaceEmbedding(config)
+        result = embedder.embed_batch(["first", "second"])
+
+        mock_client.embeddings.create.assert_called_once_with(
+            input=["first", "second"], model="tei-model"
+        )
+        assert result == [[0.1, 0.2], [0.3, 0.4]]
+
+
 def test_embed_with_huggingface_base_url():
     config = BaseEmbedderConfig(
         huggingface_base_url="http://localhost:8080",

--- a/tests/embeddings/test_langchain_embeddings.py
+++ b/tests/embeddings/test_langchain_embeddings.py
@@ -1,0 +1,69 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mem0.configs.embeddings.base import BaseEmbedderConfig
+
+try:
+    from mem0.embeddings.langchain import LangchainEmbedding
+except ImportError:
+    pytest.skip("langchain not installed", allow_module_level=True)
+
+
+def make_langchain_embedder():
+    mock_lc_model = Mock()
+    config = BaseEmbedderConfig(model=mock_lc_model)
+    with patch("mem0.embeddings.langchain.Embeddings", Mock):
+        embedder = LangchainEmbedding(config)
+    return embedder, mock_lc_model
+
+
+def test_embed_calls_embed_query():
+    embedder, mock_lc_model = make_langchain_embedder()
+    mock_lc_model.embed_query.return_value = [0.1, 0.2, 0.3]
+
+    result = embedder.embed("hello world")
+
+    mock_lc_model.embed_query.assert_called_once_with("hello world")
+    assert result == [0.1, 0.2, 0.3]
+
+
+def test_embed_batch_calls_embed_documents():
+    embedder, mock_lc_model = make_langchain_embedder()
+    mock_lc_model.embed_documents.return_value = [[0.1, 0.2], [0.3, 0.4]]
+
+    result = embedder.embed_batch(["first", "second"])
+
+    mock_lc_model.embed_documents.assert_called_once_with(["first", "second"])
+    assert result == [[0.1, 0.2], [0.3, 0.4]]
+
+
+def test_embed_batch_single_api_call():
+    embedder, mock_lc_model = make_langchain_embedder()
+    mock_lc_model.embed_documents.return_value = [[float(i)] for i in range(50)]
+
+    embedder.embed_batch([f"text {i}" for i in range(50)])
+
+    assert mock_lc_model.embed_documents.call_count == 1
+
+
+def test_embed_batch_memory_action_ignored():
+    """LangChain's embed_documents has no concept of memory_action — it should be accepted but not forwarded."""
+    embedder, mock_lc_model = make_langchain_embedder()
+    mock_lc_model.embed_documents.return_value = [[0.5, 0.6]]
+
+    embedder.embed_batch(["query text"], memory_action="search")
+
+    mock_lc_model.embed_documents.assert_called_once_with(["query text"])
+
+
+def test_init_requires_model():
+    config = BaseEmbedderConfig(model=None)
+    with pytest.raises(ValueError, match="`model` parameter is required"):
+        LangchainEmbedding(config)
+
+
+def test_init_requires_embeddings_instance():
+    config = BaseEmbedderConfig(model="not-an-embeddings-instance")
+    with pytest.raises(ValueError, match="`model` must be an instance of Embeddings"):
+        LangchainEmbedding(config)

--- a/tests/embeddings/test_lm_studio_embeddings.py
+++ b/tests/embeddings/test_lm_studio_embeddings.py
@@ -27,3 +27,63 @@ def test_embed_text(mock_lm_studio_client):
     )
 
     assert embedding == [0.1, 0.2, 0.3, 0.4, 0.5]
+
+
+def test_embed_batch(mock_lm_studio_client):
+    config = BaseEmbedderConfig(model="nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.f16.gguf", embedding_dims=512)
+    embedder = LMStudioEmbedding(config)
+
+    def make_item(idx, emb):
+        item = Mock()
+        item.index = idx
+        item.embedding = emb
+        return item
+
+    mock_lm_studio_client.embeddings.create.return_value = Mock(
+        data=[make_item(0, [0.1, 0.2]), make_item(1, [0.3, 0.4])]
+    )
+
+    result = embedder.embed_batch(["first text", "second text"])
+
+    mock_lm_studio_client.embeddings.create.assert_called_once_with(
+        input=["first text", "second text"],
+        model="nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.f16.gguf",
+    )
+    assert result == [[0.1, 0.2], [0.3, 0.4]]
+
+
+def test_embed_batch_chunks_at_100(mock_lm_studio_client):
+    config = BaseEmbedderConfig(model="nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.f16.gguf", embedding_dims=512)
+    embedder = LMStudioEmbedding(config)
+
+    def make_item(idx):
+        item = Mock()
+        item.index = idx
+        item.embedding = [float(idx)]
+        return item
+
+    mock_lm_studio_client.embeddings.create.side_effect = [
+        Mock(data=[make_item(i) for i in range(100)]),
+        Mock(data=[make_item(0)]),
+    ]
+
+    embedder.embed_batch([f"text {i}" for i in range(101)])
+
+    assert mock_lm_studio_client.embeddings.create.call_count == 2
+
+
+def test_embed_batch_strips_newlines(mock_lm_studio_client):
+    config = BaseEmbedderConfig(model="nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.f16.gguf", embedding_dims=512)
+    embedder = LMStudioEmbedding(config)
+
+    item = Mock()
+    item.index = 0
+    item.embedding = [0.9]
+    mock_lm_studio_client.embeddings.create.return_value = Mock(data=[item])
+
+    embedder.embed_batch(["hello\nworld"])
+
+    mock_lm_studio_client.embeddings.create.assert_called_once_with(
+        input=["hello world"],
+        model="nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.f16.gguf",
+    )

--- a/tests/embeddings/test_ollama_embeddings.py
+++ b/tests/embeddings/test_ollama_embeddings.py
@@ -60,3 +60,36 @@ def test_embed_empty_response_raises(mock_ollama_client):
 
     with pytest.raises(ValueError, match="returned no embeddings"):
         embedder.embed("some text")
+
+
+def test_embed_batch(mock_ollama_client):
+    config = BaseEmbedderConfig(model="nomic-embed-text", embedding_dims=512)
+    embedder = OllamaEmbedding(config)
+
+    mock_ollama_client.embed.return_value = {"embeddings": [[0.1, 0.2], [0.3, 0.4]]}
+
+    texts = ["first text", "second text"]
+    embeddings = embedder.embed_batch(texts)
+
+    mock_ollama_client.embed.assert_called_once_with(model="nomic-embed-text", input=texts)
+    assert embeddings == [[0.1, 0.2], [0.3, 0.4]]
+
+
+def test_embed_batch_single_api_call(mock_ollama_client):
+    config = BaseEmbedderConfig(model="nomic-embed-text", embedding_dims=512)
+    embedder = OllamaEmbedding(config)
+
+    mock_ollama_client.embed.return_value = {"embeddings": [[0.1] * 512] * 5}
+    embedder.embed_batch(["t1", "t2", "t3", "t4", "t5"])
+
+    assert mock_ollama_client.embed.call_count == 1
+
+
+def test_embed_batch_empty_response_raises(mock_ollama_client):
+    config = BaseEmbedderConfig(model="nomic-embed-text", embedding_dims=512)
+    embedder = OllamaEmbedding(config)
+
+    mock_ollama_client.embed.return_value = {"embeddings": []}
+
+    with pytest.raises(ValueError, match="returned no embeddings"):
+        embedder.embed_batch(["text"])

--- a/tests/embeddings/test_together_embeddings.py
+++ b/tests/embeddings/test_together_embeddings.py
@@ -1,0 +1,94 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mem0.configs.embeddings.base import BaseEmbedderConfig
+from mem0.embeddings.together import TogetherEmbedding
+
+
+@pytest.fixture
+def mock_together_client():
+    with patch("mem0.embeddings.together.Together") as mock_together:
+        mock_client = Mock()
+        mock_together.return_value = mock_client
+        yield mock_client
+
+
+@pytest.fixture
+def embedder(mock_together_client):
+    config = BaseEmbedderConfig(
+        model="togethercomputer/m2-bert-80M-8k-retrieval",
+        api_key="test-key",
+        embedding_dims=768,
+    )
+    return TogetherEmbedding(config)
+
+
+def _make_response(embeddings: list):
+    """Build a mock Together embeddings response."""
+    items = []
+    for idx, emb in enumerate(embeddings):
+        item = Mock()
+        item.index = idx
+        item.embedding = emb
+        items.append(item)
+    response = Mock()
+    response.data = items
+    return response
+
+
+def test_embed(embedder, mock_together_client):
+    mock_together_client.embeddings.create.return_value = _make_response([[0.1, 0.2, 0.3]])
+
+    result = embedder.embed("hello world")
+
+    mock_together_client.embeddings.create.assert_called_once_with(
+        model="togethercomputer/m2-bert-80M-8k-retrieval", input="hello world"
+    )
+    assert result == [0.1, 0.2, 0.3]
+
+
+def test_embed_batch(embedder, mock_together_client):
+    mock_together_client.embeddings.create.return_value = _make_response([[0.1, 0.2], [0.3, 0.4]])
+
+    texts = ["first text", "second text"]
+    result = embedder.embed_batch(texts)
+
+    mock_together_client.embeddings.create.assert_called_once_with(
+        model="togethercomputer/m2-bert-80M-8k-retrieval", input=texts
+    )
+    assert result == [[0.1, 0.2], [0.3, 0.4]]
+
+
+def test_embed_batch_single_api_call(embedder, mock_together_client):
+    mock_together_client.embeddings.create.return_value = _make_response([[0.1] * 768] * 50)
+
+    embedder.embed_batch([f"text {i}" for i in range(50)])
+
+    assert mock_together_client.embeddings.create.call_count == 1
+
+
+def test_embed_batch_chunks_at_100(embedder, mock_together_client):
+    mock_together_client.embeddings.create.return_value = _make_response([[0.1] * 768] * 100)
+
+    embedder.embed_batch([f"text {i}" for i in range(150)])
+
+    assert mock_together_client.embeddings.create.call_count == 2
+
+
+def test_embed_batch_preserves_order(embedder, mock_together_client):
+    """Results should be sorted by index, not by API return order."""
+    item0 = Mock()
+    item0.index = 0
+    item0.embedding = [0.1, 0.2]
+    item1 = Mock()
+    item1.index = 1
+    item1.embedding = [0.3, 0.4]
+
+    response = Mock()
+    response.data = [item1, item0]  # intentionally reversed
+    mock_together_client.embeddings.create.return_value = response
+
+    result = embedder.embed_batch(["first", "second"])
+
+    assert result == [[0.1, 0.2], [0.3, 0.4]]

--- a/tests/embeddings/test_vertexai_embeddings.py
+++ b/tests/embeddings/test_vertexai_embeddings.py
@@ -159,3 +159,57 @@ def test_invalid_memory_action(mock_text_embedding_model, mock_config):
 
     with pytest.raises(ValueError):
         embedder.embed("Hello world", memory_action="invalid_action")
+
+
+@patch("mem0.embeddings.vertexai.TextEmbeddingInput")
+@patch("mem0.embeddings.vertexai.TextEmbeddingModel")
+def test_embed_batch(mock_text_embedding_model, mock_text_embedding_input, mock_config):
+    mock_config.return_value.model = "gemini-embedding-001"
+    mock_config.return_value.embedding_dims = 256
+
+    config = mock_config()
+    embedder = VertexAIEmbedding(config)
+
+    mock_embeddings = [Mock(values=[0.1, 0.2]), Mock(values=[0.3, 0.4])]
+    mock_text_embedding_model.from_pretrained.return_value.get_embeddings.return_value = mock_embeddings
+
+    result = embedder.embed_batch(["first text", "second text"])
+
+    mock_text_embedding_model.from_pretrained.return_value.get_embeddings.assert_called_once()
+    assert result == [[0.1, 0.2], [0.3, 0.4]]
+
+
+@patch("mem0.embeddings.vertexai.TextEmbeddingInput")
+@patch("mem0.embeddings.vertexai.TextEmbeddingModel")
+def test_embed_batch_uses_memory_action_embedding_type(mock_text_embedding_model, mock_text_embedding_input, mock_config):
+    mock_config.return_value.model = "gemini-embedding-001"
+    mock_config.return_value.embedding_dims = 256
+    mock_config.return_value.memory_search_embedding_type = "RETRIEVAL_QUERY"
+
+    config = mock_config()
+    embedder = VertexAIEmbedding(config)
+
+    mock_text_embedding_model.from_pretrained.return_value.get_embeddings.return_value = [Mock(values=[0.5, 0.6])]
+
+    embedder.embed_batch(["query text"], memory_action="search")
+
+    mock_text_embedding_input.assert_called_once_with(text="query text", task_type="RETRIEVAL_QUERY")
+
+
+@patch("mem0.embeddings.vertexai.TextEmbeddingInput")
+@patch("mem0.embeddings.vertexai.TextEmbeddingModel")
+def test_embed_batch_chunks_at_250(mock_text_embedding_model, mock_text_embedding_input, mock_config):
+    mock_config.return_value.model = "gemini-embedding-001"
+    mock_config.return_value.embedding_dims = 256
+
+    config = mock_config()
+    embedder = VertexAIEmbedding(config)
+
+    mock_text_embedding_model.from_pretrained.return_value.get_embeddings.side_effect = [
+        [Mock(values=[float(i)]) for i in range(250)],
+        [Mock(values=[float(i)]) for i in range(10)],
+    ]
+
+    embedder.embed_batch([f"text {i}" for i in range(260)])
+
+    assert mock_text_embedding_model.from_pretrained.return_value.get_embeddings.call_count == 2


### PR DESCRIPTION
## Description

Add native `embed_batch()` to all embeddings providers that support batch APIs. Previously, every provider without an explicit override fell back to the base class which calls `embed()` sequentially — one API call per text. This PR completes coverage across all providers and fixes a pre-existing bug in FastEmbed.

**Providers with native batch added:**
- **HuggingFace** — TEI/base_url mode via OpenAI-compatible batch API; local SentenceTransformer via `encode([...])`
- **Together** — OpenAI-compatible batch API, chunked at 100
- **Ollama** — native `input=[...]` batch support
- **Gemini** — `embed_content` with 100-item chunks
- **VertexAI** — `get_embeddings(texts=[...])`, chunked at 250 (gemini-embedding-001 limit)
- **FastEmbed** — `TextEmbedding.embed([...])` accepts a list natively, single inference pass
- **LMStudio** — OpenAI-compatible batch API, chunked at 100
- **LangChain** — delegates to `embed_documents()`, unlocking whatever batch support the underlying provider has
- **AWS Bedrock** — Cohere models support native `"texts": [...]` batching (chunked at 96); Titan and other providers fall back to sequential since they have no batch API

**Bug fix — FastEmbed `embed()` return type:**
`embed()` was returning a raw numpy array instead of `list[float]`, inconsistent with every other provider and the base class contract. Fixed by adding `.tolist()`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added 34 new unit tests across. All 73 embedding tests pass locally.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed (no public API changes, internal optimization only)
