### PR TITLE
fix(mem0-ts): use native Ollama batch API in embedBatch

### DIFF
--- a/mem0-ts/src/oss/src/embeddings/ollama.ts
+++ b/mem0-ts/src/oss/src/embeddings/ollama.ts
@@ -42,8 +42,18 @@ export class OllamaEmbedder implements Embedder {
   }
 
   async embedBatch(texts: string[]): Promise<number[][]> {
-    const response = await Promise.all(texts.map((text) => this.embed(text)));
-    return response;
+    await this.ensureModelExists();
+    const inputs = texts.map((t) => (typeof t === "string" ? t : JSON.stringify(t)));
+    const response = await this.ollama.embed({
+      model: this.model,
+      input: inputs,
+    });
+    if (!response.embeddings || response.embeddings.length === 0) {
+      throw new Error(
+        `Ollama embedBatch() returned no embeddings for model '${this.model}'`,
+      );
+    }
+    return response.embeddings;
   }
 
   private static normalizeModelName(name: string): string {

--- a/mem0-ts/src/oss/tests/ollama-embedder.test.ts
+++ b/mem0-ts/src/oss/tests/ollama-embedder.test.ts
@@ -56,15 +56,39 @@ describe("OllamaEmbedder (unit)", () => {
     expect(mockEmbed.mock.calls[0][0].input).toBe("42");
   });
 
-  it("embedBatch() returns vectors for multiple inputs", async () => {
+  it("embedBatch() makes a single API call with all inputs", async () => {
+    mockEmbed.mockResolvedValueOnce({
+      model: "nomic-embed-text:latest",
+      embeddings: [[0.1, 0.2], [0.3, 0.4]],
+    });
+
     const embedder = new OllamaEmbedder({
       model: "nomic-embed-text:latest",
     });
 
     const result = await embedder.embedBatch(["text1", "text2"]);
 
-    expect(mockEmbed).toHaveBeenCalledTimes(2);
-    expect(result).toEqual([mockEmbedding, mockEmbedding]);
+    expect(mockEmbed).toHaveBeenCalledTimes(1);
+    expect(mockEmbed.mock.calls[0][0]).toEqual({
+      model: "nomic-embed-text:latest",
+      input: ["text1", "text2"],
+    });
+    expect(result).toEqual([[0.1, 0.2], [0.3, 0.4]]);
+  });
+
+  it("embedBatch() throws when embeddings array is empty", async () => {
+    mockEmbed.mockResolvedValueOnce({
+      model: "nomic-embed-text:latest",
+      embeddings: [],
+    });
+
+    const embedder = new OllamaEmbedder({
+      model: "nomic-embed-text:latest",
+    });
+
+    await expect(embedder.embedBatch(["text"])).rejects.toThrow(
+      "Ollama embedBatch() returned no embeddings",
+    );
   });
 
   it("ensureModelExists() does not pull when model is already present", async () => {


### PR DESCRIPTION
## Description

`OllamaEmbedder.embedBatch()` was calling `embed()` once per text via `Promise.all()`, resulting in separate calls to the Ollama server.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Updated `ollama-embedder.test.ts`: fixed the batch call count assertion,

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
