### PR TITLE
feat(mem0-ts): add prompt to AddMemoryOptions for per-call override

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -522,7 +522,7 @@ export class Memory {
       has_filters: !!config.filters,
       infer: config.infer,
     });
-    const { metadata = {}, filters = {}, infer = true } = config;
+    const { metadata = {}, filters = {}, infer = true, prompt } = config;
 
     // Validate and trim entity IDs
     const userId = validateAndTrimEntityId(config.userId, "userId");
@@ -552,6 +552,7 @@ export class Memory {
       metadata,
       filters,
       infer,
+      prompt,
     );
 
     return {
@@ -564,6 +565,7 @@ export class Memory {
     metadata: Record<string, any>,
     filters: SearchFilters,
     infer: boolean,
+    prompt?: string,
   ): Promise<MemoryItem[]> {
     if (!infer) {
       const returnedMemories: MemoryItem[] = [];
@@ -634,7 +636,7 @@ export class Memory {
       existingMemories,
       newMessages: parsedMessages,
       lastKMessages: lastMessages,
-      customInstructions: this.customInstructions,
+      customInstructions: prompt ?? this.customInstructions,
     });
 
     let response: string;

--- a/mem0-ts/src/oss/src/memory/memory.types.ts
+++ b/mem0-ts/src/oss/src/memory/memory.types.ts
@@ -11,6 +11,8 @@ export interface AddMemoryOptions extends Entity {
   metadata?: Record<string, any>;
   filters?: SearchFilters;
   infer?: boolean;
+  /** Per-call custom instructions override. Replaces the instance-level customInstructions for this call only. */
+  prompt?: string;
 }
 
 export interface SearchMemoryOptions {

--- a/mem0-ts/src/oss/tests/memory.add.test.ts
+++ b/mem0-ts/src/oss/tests/memory.add.test.ts
@@ -175,4 +175,13 @@ describe("Memory - add()", () => {
       expect.objectContaining({ event: "ADD" }),
     );
   });
+
+  test("accepts prompt option and returns results", async () => {
+    const result: SearchResult = await memory.add(
+      "I drink coffee every morning",
+      { userId, prompt: "Only extract beverage preferences." },
+    );
+    expect(Array.isArray(result.results)).toBe(true);
+    expect(result.results.length).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
## Description

The Python SDK `Memory.add()` has a prompt parameter that overrides `customInstructions` for a single call. TypeScript SDK had no equivalent

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added "accepts prompt option and returns results" to memory.add.test.ts. All 596 existing unit tests pass.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
