### PR TITLE
fix(codex-hooks): refuse install on Windows native with WSL/Git Bash guidance (#5243)

### DIFF
--- a/mem0-plugin/scripts/install_codex_hooks.py
+++ b/mem0-plugin/scripts/install_codex_hooks.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import platform
 import sys
 from pathlib import Path
 
@@ -125,6 +126,19 @@ def main() -> int:
         write_config(config)
         print(f"Removed Mem0 hooks from {HOOKS_FILE}")
         return 0
+
+    # Codex lifecycle hooks register .sh paths directly in ~/.codex/hooks.json.
+    # On native Windows .sh has no default handler, so Codex spawning a hook
+    # triggers "Open With" dialogs (one OpenWith.exe per event). See #5243.
+    if platform.system() == "Windows":
+        print(
+            "Codex lifecycle hooks register .sh scripts directly, which Windows\n"
+            "cannot execute without a bash interpreter on PATH. Re-run this\n"
+            "installer from WSL or Git Bash, or use Mem0 via MCP / Direct tools\n"
+            "without lifecycle hooks. See https://github.com/mem0ai/mem0/issues/5243.",
+            file=sys.stderr,
+        )
+        return 2
 
     if not TEMPLATE_FILE.exists():
         print(f"error: template not found at {TEMPLATE_FILE}", file=sys.stderr)


### PR DESCRIPTION
Fixes #5243.

Codex lifecycle hooks register `.sh` paths directly in `~/.codex/hooks.json`.
On native Windows `.sh` has no default handler, so Codex spawning a hook
triggers an "Open With" dialog (one `OpenWith.exe` per event), making Codex
unusable until hooks are disabled.

This patch makes `install_codex_hooks.py` exit cleanly (code 2) on Windows
native Python with guidance to re-run from WSL or Git Bash, where `bash.exe`
is on PATH. `--uninstall` continues to work so already-installed users can
clean up.

Per the original report, MCP / Direct Mem0 tools are unaffected — only the
lifecycle hooks installer. Cursor and Claude Code hook templates are out of
scope; the reporter only observed this on Codex.

I considered auto-rewriting `command` entries to `bash <path>.sh` on Windows
but didn't go that route — it would need to pick between Git Bash / WSL /
MSYS2 bash with different working-directory semantics, and Codex itself may
add native-Windows hook execution. A future PR can layer auto-wrap once
Codex Windows behavior stabilizes.

## Test

- Windows 11 native Python: install exits with WSL guidance (code 2),
  `~/.codex/hooks.json` untouched.
- Windows 11 native Python: `--uninstall` still strips owned entries.
- Linux / WSL: no behavior change (`platform.system()` early-return only
  fires on Windows).
