### PR TITLE
feat(server): support MEM0_EMBEDDING_DIMS env var

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -110,24 +110,47 @@ HISTORY_DB_PATH = os.environ.get("HISTORY_DB_PATH", "/app/history/history.db")
 DEFAULT_LLM_MODEL = os.environ.get("MEM0_DEFAULT_LLM_MODEL", "gpt-4.1-nano-2025-04-14")
 DEFAULT_EMBEDDER_MODEL = os.environ.get("MEM0_DEFAULT_EMBEDDER_MODEL", "text-embedding-3-small")
 
+
+def _parse_embedding_dims(raw: Optional[str]) -> Optional[int]:
+    if raw is None or raw == "":
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        logging.warning("MEM0_EMBEDDING_DIMS=%r is not an integer; ignoring.", raw)
+        return None
+    if value <= 0:
+        logging.warning("MEM0_EMBEDDING_DIMS=%d must be positive; ignoring.", value)
+        return None
+    return value
+
+
+EMBEDDING_DIMS = _parse_embedding_dims(os.environ.get("MEM0_EMBEDDING_DIMS"))
+
+_vector_store_config: Dict[str, Any] = {
+    "host": POSTGRES_HOST,
+    "port": int(POSTGRES_PORT),
+    "dbname": POSTGRES_DB,
+    "user": POSTGRES_USER,
+    "password": POSTGRES_PASSWORD,
+    "collection_name": POSTGRES_COLLECTION_NAME,
+}
+_embedder_config: Dict[str, Any] = {"api_key": OPENAI_API_KEY, "model": DEFAULT_EMBEDDER_MODEL}
+if EMBEDDING_DIMS is not None:
+    _vector_store_config["embedding_model_dims"] = EMBEDDING_DIMS
+    _embedder_config["embedding_dims"] = EMBEDDING_DIMS
+
 DEFAULT_CONFIG = {
     "version": "v1.1",
     "vector_store": {
         "provider": "pgvector",
-        "config": {
-            "host": POSTGRES_HOST,
-            "port": int(POSTGRES_PORT),
-            "dbname": POSTGRES_DB,
-            "user": POSTGRES_USER,
-            "password": POSTGRES_PASSWORD,
-            "collection_name": POSTGRES_COLLECTION_NAME,
-        },
+        "config": _vector_store_config,
     },
     "llm": {
         "provider": "openai",
         "config": {"api_key": OPENAI_API_KEY, "temperature": 0.2, "model": DEFAULT_LLM_MODEL},
     },
-    "embedder": {"provider": "openai", "config": {"api_key": OPENAI_API_KEY, "model": DEFAULT_EMBEDDER_MODEL}},
+    "embedder": {"provider": "openai", "config": _embedder_config},
     "history_db_path": HISTORY_DB_PATH,
 }
 


### PR DESCRIPTION
Reads MEM0_EMBEDDING_DIMS at startup and injects it into both the embedder (embedding_dims) and pgvector (embedding_model_dims) sections of DEFAULT_CONFIG so the two stay consistent.

When unset, behavior is unchanged and the library defaults (1536) apply. Non-integer or non-positive values log a warning and fall back to defaults.

Closes none (env-var convenience for self-hosted deployments).

## Linked Issue

Closes #<!-- issue number -->

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe what breaks and the migration path. Delete this section if not applicable. -->

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

<!-- Describe how you tested this, or link to CI results. -->

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] I have updated documentation if needed
