### PR TITLE
fix(claude-code-plugin): remove broken authorizationUrl from MCP config

### DIFF
--- a/mem0-plugin/.mcp.json
+++ b/mem0-plugin/.mcp.json
@@ -5,8 +5,7 @@
       "url": "https://mcp.mem0.ai/mcp/",
       "headers": {
         "Authorization": "Token ${MEM0_API_KEY}"
-      },
-      "authorizationUrl": "https://mcp.mem0.ai/authorize"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Removes the `authorizationUrl` field from `mem0-plugin/.mcp.json`, which is the root cause of the long-standing first-install failure reported in #4876.

## The bug

The plugin's `.mcp.json` currently declares **both** a static `Authorization` header *and* an `authorizationUrl`:

```json
"headers": {
  "Authorization": "Token ${MEM0_API_KEY}"
},
"authorizationUrl": "https://mcp.mem0.ai/authorize"
```

When both are present, Claude Code prefers the OAuth flow and never sends the static header. The OAuth callback succeeds in the browser but Claude Code's MCP client doesn't persist the token in a way the mem0 server accepts on reconnect (`/mcp` reports `Got new credentials, but plugin:mem0:mem0 rejected them on reconnect`). The MCP server stays stuck exposing only the `authenticate`/`complete_authentication` stub tools.

Result: every fresh install on a machine without `MEM0_API_KEY` already in the launching shell env hits this. The maintainers likely don't see it because they already have the env var set from working on the SDK day-to-day — the static header path works first try and the OAuth fallback never fires for them.

Worse, **every OAuth retry burns one of the 5/day API-key creation quota on the free tier**, so a few failed onboarding loops lock new users out of completing setup for 24 hours. Upgrading to a paid tier did not immediately lift the cap in testing today (2026-05-26).

## The fix

Remove the `authorizationUrl` line. Claude Code then uses the already-correct `Authorization: Token ${MEM0_API_KEY}` header directly, no OAuth.

Verified by:
1. Direct `curl -X POST https://mcp.mem0.ai/mcp/ -H \"Authorization: Token \$MEM0_API_KEY\" ...` returns HTTP 200 and the full 11-tool catalog
2. Patching the locally-installed copy of this file and restarting Claude Code surfaces the real tools (`add_memory`, `search_memories`, etc.) on first reconnect — no auth dance

## Setup expectation after this lands

Users only need:

1. `MEM0_API_KEY` set in the env of the process launching Claude Code (shell export, `launchctl setenv` on macOS GUI, or `claude plugin configure mem0`)
2. Restart Claude Code

That's it. No browser tab, no `/mem0:onboard` OAuth step, no chance of getting locked out by the daily key-creation quota.

## Related

- Closes the practical issue described in #4876 (the closed issue identified the root cause cleanly in April but no fix landed — best guess is maintenance capacity rather than disagreement, since the change is mechanical)
- Affects every user without `MEM0_API_KEY` already in their shell env, which is the entire new-user population

## Test plan

- [ ] `MEM0_API_KEY=<valid-key> claude` → real mem0 tools surface on first session, no OAuth prompt
- [ ] No regression for users who already had OAuth working (since OAuth was never actually wiring tokens to the MCP server, removing the URL shouldn't change their state)
- [ ] `/mem0:onboard` skill still works — it can be updated separately to drop its OAuth step

🤖 Generated with [Claude Code](https://claude.com/claude-code)