### PR TITLE
fix(cli-node): forward --no-infer flag to add

### DIFF
--- a/cli/node/src/commands/memory.ts
+++ b/cli/node/src/commands/memory.ts
@@ -46,7 +46,7 @@ export async function cmdAdd(
 		file?: string;
 		metadata?: string;
 		immutable: boolean;
-		noInfer: boolean;
+		infer?: boolean;
 		expires?: string;
 		categories?: string;
 		output: string;
@@ -136,7 +136,7 @@ export async function cmdAdd(
 				runId: opts.runId,
 				metadata: meta,
 				immutable: opts.immutable,
-				infer: !opts.noInfer,
+				infer: opts.infer !== false,
 				expires: opts.expires,
 				categories: cats,
 			});

--- a/cli/node/tests/commands.test.ts
+++ b/cli/node/tests/commands.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Command } from "commander";
 import { createMockBackend } from "./setup.js";
 import type { Backend } from "../src/backend/base.js";
 import { setAgentMode } from "../src/state.js";
@@ -41,8 +42,6 @@ describe("cmdAdd", () => {
     await cmdAdd(mockBackend, "I prefer dark mode", {
       userId: "alice",
       immutable: false,
-      noInfer: false,
-
       output: "text",
     });
     expect(mockBackend.add).toHaveBeenCalledOnce();
@@ -54,8 +53,6 @@ describe("cmdAdd", () => {
       userId: "alice",
       messages: JSON.stringify([{ role: "user", content: "I love Python" }]),
       immutable: false,
-      noInfer: false,
-
       output: "text",
     });
     expect(mockBackend.add).toHaveBeenCalledOnce();
@@ -66,8 +63,6 @@ describe("cmdAdd", () => {
     await cmdAdd(mockBackend, "test", {
       userId: "alice",
       immutable: false,
-      noInfer: false,
-
       output: "json",
     });
     expect(output).toContain("results");
@@ -78,11 +73,56 @@ describe("cmdAdd", () => {
     await cmdAdd(mockBackend, "test", {
       userId: "alice",
       immutable: false,
-      noInfer: false,
-
       output: "quiet",
     });
     expect(output).not.toContain("dark mode");
+  });
+});
+
+describe("cmdAdd forwards --no-infer (regression for #5261)", () => {
+  it("forwards infer: false when --no-infer is set", async () => {
+    const { cmdAdd } = await import("../src/commands/memory.js");
+    // `infer: false` is the shape Commander produces for `--no-infer`.
+    await cmdAdd(mockBackend, "store me verbatim", {
+      userId: "alice",
+      immutable: false,
+      infer: false,
+      output: "text",
+    });
+    expect(mockBackend.add).toHaveBeenCalledWith(
+      "store me verbatim",
+      undefined,
+      expect.objectContaining({ infer: false }),
+    );
+  });
+
+  it("forwards infer: true by default (flag absent)", async () => {
+    const { cmdAdd } = await import("../src/commands/memory.js");
+    await cmdAdd(mockBackend, "infer me", {
+      userId: "alice",
+      immutable: false,
+      output: "text",
+    });
+    expect(mockBackend.add).toHaveBeenCalledWith(
+      "infer me",
+      undefined,
+      expect.objectContaining({ infer: true }),
+    );
+  });
+
+  it("Commander stores --no-infer as opts.infer, not opts.noInfer", () => {
+    // Pins the assumption the fix relies on: Commander's `--no-X` option
+    // populates the positive camelCase key (`infer`), never `noInfer`.
+    const withFlag = new Command();
+    withFlag.option("--no-infer", "Skip inference, store raw.").action(() => {});
+    withFlag.parse(["--no-infer"], { from: "user" });
+    expect(withFlag.opts().infer).toBe(false);
+    expect(withFlag.opts().noInfer).toBeUndefined();
+
+    const withoutFlag = new Command();
+    withoutFlag.option("--no-infer", "Skip inference, store raw.").action(() => {});
+    withoutFlag.parse([], { from: "user" });
+    expect(withoutFlag.opts().infer).toBe(true);
   });
 });
 
@@ -100,8 +140,6 @@ describe("cmdAdd deduplicates PENDING", () => {
     await cmdAdd(mockBackend, "test", {
       userId: "alice",
       immutable: false,
-      noInfer: false,
-
       output: "text",
     });
     expect(output.match(/Queued/g)?.length).toBe(1);
@@ -113,8 +151,6 @@ describe("cmdAdd deduplicates PENDING", () => {
     await cmdAdd(mockBackend, "test", {
       userId: "alice",
       immutable: false,
-      noInfer: false,
-
       output: "json",
     });
     const data = JSON.parse(output);
@@ -129,8 +165,6 @@ describe("cmdAdd deduplicates PENDING", () => {
     await cmdAdd(mockBackend, "test", {
       userId: "alice",
       immutable: false,
-      noInfer: false,
-
       output: "agent",
     });
     const data = JSON.parse(output);
@@ -315,8 +349,6 @@ describe("agent mode", () => {
     await cmdAdd(mockBackend, "test preference", {
       userId: "alice",
       immutable: false,
-      noInfer: false,
-
       output: "agent",
     });
     const parsed = JSON.parse(output.trim());


### PR DESCRIPTION
## Linked Issue

Closes #5261

## Description

The mem0 Node CLI silently ignored `--no-infer`. A payload that should be stored verbatim was instead run through the inference pipeline (rephrased and split into multiple memories).

**Root cause:** Commander.js stores a `--no-infer` option's value under the positive camelCase key `opts.infer` (boolean, defaults `true`, `false` when the flag is passed), not `opts.noInfer`. `cmdAdd` read `opts.noInfer`, which was always `undefined`, so `infer: !opts.noInfer` was hardcoded to `true`. Confirmed at the wire level: the request body sent no `infer` field at all, so the platform (correctly) ran inference by default.

**Fix:** read `opts.infer` instead, and align the `cmdAdd` opts type.

The Python CLI (Typer binds `--no-infer` to an explicit `no_infer` param) and the platform API are unaffected.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test Coverage

- [x] I added/updated unit tests
- [x] I tested manually (CLI `add` with `--no-infer` now stores 1 verbatim memory; previously split into 6 inferred entries)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed (N/A — behavior now matches docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
