### PR TITLE
fix(opencode-plugin): add plugin array to bundled opencode.json

### DIFF
--- a/mem0-plugin/.opencode-plugin/opencode.json
+++ b/mem0-plugin/.opencode-plugin/opencode.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
+  "plugin": ["@mem0ai/opencode-plugin"],
   "mcp": {
     "mem0": {
       "type": "remote",


### PR DESCRIPTION
## Linked Issue

N/A — found during config review.

## Description

The bundled `opencode.json` shipped with `@mem0ai/opencode-plugin` only contained the MCP server config. Without the `"plugin"` array, OpenCode won't load the npm package's hooks and skills at startup — users would only get the bare MCP tools, missing auto-search, metadata enforcement, compaction context, and slash commands.

Adds `"plugin": ["@mem0ai/opencode-plugin"]` so the bundled config is complete.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test Coverage

- [x] I tested manually — verified the config is valid JSON and matches the format from [OpenCode plugin docs](https://opencode.ai/docs/plugins/)
- No tests needed for a static JSON config file

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally