### PR TITLE
fix(openmemory): handle postgres engine args and qdrant host defaults

### DIFF
--- a/openmemory/api/app/database.py
+++ b/openmemory/api/app/database.py
@@ -12,10 +12,14 @@ if not DATABASE_URL:
     raise RuntimeError("DATABASE_URL is not set in environment")
 
 # SQLAlchemy engine & session
-engine = create_engine(
-    DATABASE_URL,
-    connect_args={"check_same_thread": False}  # Needed for SQLite
-)
+# `check_same_thread` is only valid for SQLite. Passing it through to
+# PostgreSQL / psycopg2 raises:
+#   invalid dsn: invalid connection option "check_same_thread"
+engine_kwargs = {}
+if DATABASE_URL.startswith("sqlite"):
+    engine_kwargs["connect_args"] = {"check_same_thread": False}
+
+engine = create_engine(DATABASE_URL, **engine_kwargs)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 # Base class for models

--- a/openmemory/api/app/utils/memory.py
+++ b/openmemory/api/app/utils/memory.py
@@ -227,9 +227,14 @@ def _create_embedder_config(provider, model, api_key, base_url, ollama_base_url,
 def get_default_memory_config():
     """Get default memory client configuration with sensible defaults."""
     # Detect vector store based on environment variables
+    # Default to the common compose service name used by the self-hosted
+    # OpenMemory stack. The previous hardcoded default (`mem0_store`) causes
+    # memory client init to fail with `Name or service not known` in the
+    # standard qdrant-based docker-compose deployment unless users patch the
+    # container manually.
     vector_store_config = {
         "collection_name": "openmemory",
-        "host": "mem0_store",
+        "host": os.environ.get('QDRANT_HOST', 'qdrant'),
     }
     
     # Check for different vector store configurations based on environment variables

--- a/openmemory/api/tests/test_config_defaults.py
+++ b/openmemory/api/tests/test_config_defaults.py
@@ -1,0 +1,65 @@
+import importlib
+import sys
+
+import pytest
+
+
+pytest.importorskip("openai")
+
+
+def test_sqlite_database_uses_check_same_thread(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///./openmemory.db")
+    sys.modules.pop("app.database", None)
+
+    import app.database as database  # noqa: WPS433
+
+    database = importlib.reload(database)
+    assert database.engine.url.drivername == "sqlite"
+
+
+def test_postgres_database_does_not_use_sqlite_connect_args(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv(
+        "DATABASE_URL",
+        "postgresql+psycopg2://user:pass@localhost:5432/openmemory",
+    )
+    sys.modules.pop("app.database", None)
+
+    import app.database as database  # noqa: WPS433
+
+    database = importlib.reload(database)
+    assert database.engine.url.drivername == "postgresql+psycopg2"
+
+
+@pytest.mark.parametrize(
+    ("host", "port", "expected_host", "expected_port"),
+    [
+        ("qdrant", "6333", "qdrant", 6333),
+        (None, None, "qdrant", 6333),
+    ],
+)
+def test_qdrant_default_host_is_compose_service_name(
+    monkeypatch,
+    host,
+    port,
+    expected_host,
+    expected_port,
+):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    if host is None:
+        monkeypatch.delenv("QDRANT_HOST", raising=False)
+    else:
+        monkeypatch.setenv("QDRANT_HOST", host)
+
+    if port is None:
+        monkeypatch.delenv("QDRANT_PORT", raising=False)
+    else:
+        monkeypatch.setenv("QDRANT_PORT", port)
+
+    from app.utils.memory import get_default_memory_config
+
+    config = get_default_memory_config()
+    assert config["vector_store"]["provider"] == "qdrant"
+    assert config["vector_store"]["config"]["host"] == expected_host
+    assert config["vector_store"]["config"]["port"] == expected_port


### PR DESCRIPTION
## Summary
- make  conditional on SQLite only in 
- default OpenMemory qdrant host to  or  instead of hardcoded 
- add regression tests for both behaviors

## Why
This addresses the reproducible self-hosted issues documented in #5275:
- PostgreSQL init failure due to SQLite-only 
- memory client init failure from hardcoded  hostname in standard Docker Compose deployments

## Test Plan
- created targeted tests in 
- ran:
  - ....                                                                     [100%]
4 passed in 0.74s
  - result: 

Closes #5275