### PR TITLE
fix(llms): add gpt-5-mini and gpt-5-nano to reasoning whitelist

### DIFF
--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -52,7 +52,7 @@ class LLMBase(ABC):
         """
         reasoning_models = {
             "o1", "o1-preview", "o3-mini", "o3",
-            "gpt-5", "gpt-5o", "gpt-5o-mini", "gpt-5o-micro",
+            "gpt-5", "gpt-5-mini", "gpt-5-nano",
         }
 
         model_lower = model.lower()

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -317,6 +317,10 @@ def test_is_reasoning_model_classification(mock_openai_client):
     assert llm._is_reasoning_model("o3-mini") is True
     assert llm._is_reasoning_model("o3") is True
     assert llm._is_reasoning_model("gpt-5") is True
+    assert llm._is_reasoning_model("gpt-5-mini") is True
+    assert llm._is_reasoning_model("gpt-5-nano") is True
+    assert llm._is_reasoning_model("openai/gpt-5-mini") is True
+    assert llm._is_reasoning_model("azure_openai/gpt-5-nano") is True
     assert llm._is_reasoning_model("o1-preview") is True
     assert llm._is_reasoning_model("o1-2024-12-17") is True
     assert llm._is_reasoning_model("openai/o3-mini") is True


### PR DESCRIPTION
## Linked Issue

Closes #5233

## Description

\`_is_reasoning_model\` in \`mem0/llms/base.py\` whitelists three model names that don't exist in the OpenAI catalog (\`gpt-5o\`, \`gpt-5o-mini\`, \`gpt-5o-micro\`) and misses the real GPT-5 family members — \`gpt-5-mini\` and \`gpt-5-nano\`.

Real \`gpt-5-mini\` / \`gpt-5-nano\` configs therefore fall through to the non-reasoning branch, so \`max_tokens\` reaches the API and \`Memory.add\` fails with:

\`\`\`
HTTP/1.1 400 Bad Request
ERROR LLM extraction failed: Error code: 400 - {'error': {'message': "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.", ...}}
\`\`\`

This fix swaps the bogus names for the real ones. Behaviour for the GPT-5.x family (\`gpt-5.4-mini\` etc.) is unchanged — they still go through the non-reasoning branch as today.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update

## Breaking Changes

N/A. The removed names (\`gpt-5o\`, \`gpt-5o-mini\`, \`gpt-5o-micro\`) aren't real OpenAI models, so no real configuration was relying on them being classified as reasoning models.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually
- [ ] No tests needed

Extended \`test_is_reasoning_model_classification\` in \`tests/llms/test_openai.py\` with four new assertions:

- \`gpt-5-mini\` → True
- \`gpt-5-nano\` → True
- \`openai/gpt-5-mini\` → True (provider-prefixed)
- \`azure_openai/gpt-5-nano\` → True (provider-prefixed)

Existing assertions (\`gpt-5.4-mini\` → False, \`o1\` family, etc.) stay green.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] Documentation updated if needed (no docs touched the bogus names)