### PR TITLE
fix(openmemory): align create-memory bootstrap and empty results

### DIFF
--- a/openmemory/api/app/routers/memories.py
+++ b/openmemory/api/app/routers/memories.py
@@ -15,6 +15,7 @@ from app.models import (
     User,
 )
 from app.schemas import MemoryResponse
+from app.utils.db import get_user_and_app
 from app.utils.memory import get_memory_client
 from app.utils.permissions import check_memory_access_permissions
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -223,17 +224,7 @@ async def create_memory(
     request: CreateMemoryRequest,
     db: Session = Depends(get_db)
 ):
-    user = db.query(User).filter(User.user_id == request.user_id).first()
-    if not user:
-        raise HTTPException(status_code=404, detail="User not found")
-    # Get or create app
-    app_obj = db.query(App).filter(App.name == request.app,
-                                   App.owner_id == user.id).first()
-    if not app_obj:
-        app_obj = App(name=request.app, owner_id=user.id)
-        db.add(app_obj)
-        db.commit()
-        db.refresh(app_obj)
+    user, app_obj = get_user_and_app(db, user_id=request.user_id, app_id=request.app)
 
     # Check if app is active
     if not app_obj.is_active:
@@ -318,7 +309,19 @@ async def create_memory(
                 # Return the first memory (for API compatibility)
                 # but all memories are now saved to the database
                 return created_memories[0]
+
+            raise HTTPException(
+                status_code=422,
+                detail="Memory extraction produced no persisted memories"
+            )
+
+        raise HTTPException(
+            status_code=502,
+            detail="Memory backend returned an unexpected response format"
+        )
     except Exception as qdrant_error:
+        if isinstance(qdrant_error, HTTPException):
+            raise qdrant_error
         logging.warning(f"Qdrant operation failed: {qdrant_error}.")
         # Return a json response with the error
         return {

--- a/openmemory/api/tests/test_memories_api.py
+++ b/openmemory/api/tests/test_memories_api.py
@@ -1,0 +1,107 @@
+import os
+from uuid import UUID, uuid4
+
+# Set dummy keys before imports that may initialize providers
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.database import Base, SessionLocal, engine
+from app.models import App, Memory, User
+from app.routers.memories import router as memories_router
+
+
+@pytest.fixture(autouse=True)
+def reset_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture
+def test_app():
+    app = FastAPI()
+    app.include_router(memories_router)
+    return app
+
+
+@pytest_asyncio.fixture
+async def client(test_app):
+    transport = ASGITransport(app=test_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+class DummyMemoryClient:
+    def __init__(self, response):
+        self.response = response
+        self.calls = []
+
+    def add(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        return self.response
+
+
+@pytest.mark.asyncio
+async def test_create_memory_creates_missing_user_and_app(client, monkeypatch):
+    memory_id = str(uuid4())
+    dummy_client = DummyMemoryClient(
+        {
+            "results": [
+                {"id": memory_id, "memory": "René likes self-hosting", "event": "ADD"}
+            ]
+        }
+    )
+    monkeypatch.setattr("app.routers.memories.get_memory_client", lambda: dummy_client)
+
+    response = await client.post(
+        "/api/v1/memories/",
+        json={
+            "user_id": "rene-test-user",
+            "text": "René likes self-hosting",
+            "app": "hermes",
+            "infer": False,
+            "metadata": {"source": "test"},
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["id"] == memory_id
+    assert body["content"] == "René likes self-hosting"
+
+    db = SessionLocal()
+    try:
+        user = db.query(User).filter(User.user_id == "rene-test-user").first()
+        assert user is not None
+
+        app = db.query(App).filter(App.owner_id == user.id, App.name == "hermes").first()
+        assert app is not None
+
+        memory = db.query(Memory).filter(Memory.id == UUID(body["id"])).first()
+        assert memory is not None
+        assert memory.user_id == user.id
+        assert memory.app_id == app.id
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_create_memory_returns_422_when_backend_returns_no_results(client, monkeypatch):
+    monkeypatch.setattr("app.routers.memories.get_memory_client", lambda: DummyMemoryClient({"results": []}))
+
+    response = await client.post(
+        "/api/v1/memories/",
+        json={
+            "user_id": "rene-empty-results",
+            "text": "This may extract to nothing",
+            "app": "hermes",
+        },
+    )
+
+    assert response.status_code == 422, response.text
+    assert response.json() == {"detail": "Memory extraction produced no persisted memories"}


### PR DESCRIPTION
## Bug Description

`POST /api/v1/memories/` handled OpenMemory create requests inconsistently with the MCP path:

- REST returned `404 User not found` for a new `user_id`, while MCP creates the user/app pair via `get_user_and_app()`.
- If `memory_client.add()` returned `{"results": []}`, the endpoint could fall through without returning a response, producing a silent `null`/empty success instead of an explicit error.

Related to #5275.

## Root Cause

The REST create-memory route manually queried `User` and only created the `App`, instead of using the shared OpenMemory user/app bootstrap helper used by MCP.

The response handling also only returned when at least one `ADD` result produced a persisted memory. Empty or unexpected backend responses had no explicit API-level outcome.

## Fix

- Use `get_user_and_app()` in the REST create-memory route so missing users/apps are created consistently with MCP.
- Return `422` when extraction succeeds structurally but produces no persisted memories.
- Return `502` when the backend response shape is unexpected.
- Keep existing error handling for paused apps and backend exceptions.
- Add regression tests for:
  - auto-creating missing user/app on REST create
  - empty backend results no longer returning a silent null response

## How to Verify

1. Run the OpenMemory API tests:
   ```bash
   .venv/bin/python -m pytest openmemory/api/tests/test_memories_api.py -q
   ```
2. POST to `/api/v1/memories/` with a new `user_id` and valid `memory_client.add()` response.
3. Confirm the user/app are created and the memory is returned.
4. Mock `memory_client.add()` to return `{"results": []}` and confirm the endpoint returns `422`.

## Test Plan

- [x] Added regression test for REST user/app auto-create
- [x] Added regression test for empty `results` handling
- [x] Ran `openmemory/api/tests/test_memories_api.py`

Result: `2 passed`

## Risk Assessment

Low — scoped to the OpenMemory REST create-memory route. The change aligns REST behavior with the existing MCP bootstrap path and makes previously ambiguous backend responses explicit.
