### PR TITLE
fix(server): accept multimodal message content in REST API (closes #5068)

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -21,7 +21,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, RedirectResponse
 from mem0.exceptions import ValidationError as Mem0ValidationError
 from models import RequestLog, User
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from rate_limit import limiter
 from routers import api_keys as api_keys_router
 from routers import auth as auth_router
@@ -182,9 +182,29 @@ class Message(BaseModel):
         description=(
             "Message content. Either a plain string, a single multimodal part "
             "(e.g. {'type': 'image_url', 'image_url': {'url': '...'}}), or a "
-            "list of such parts."
+            "list of such parts. List text parts must include a 'text' key and "
+            "image parts must include 'image_url.url'."
         ),
     )
+
+    @field_validator("content")
+    @classmethod
+    def _validate_multimodal_parts(cls, v):
+        """Validate multimodal list parts up front so malformed payloads return a
+        clear 422 rather than crashing parse_vision_messages() into a generic
+        500 (e.g. a text part missing its 'text' key)."""
+        if isinstance(v, list):
+            for part in v:
+                if not isinstance(part, dict):
+                    raise ValueError("Each content part must be an object.")
+                part_type = part.get("type")
+                if part_type == "text" and "text" not in part:
+                    raise ValueError("Text content parts must include a 'text' key.")
+                if part_type == "image_url":
+                    image_url = part.get("image_url")
+                    if not isinstance(image_url, dict) or not image_url.get("url"):
+                        raise ValueError("Image content parts must include 'image_url.url'.")
+        return v
 
 
 class MemoryCreate(BaseModel):
@@ -372,14 +392,49 @@ def generate_instructions(req: GenerateInstructionsRequest, _auth=Depends(verify
 
 
 @app.post("/memories", summary="Create memories")
+def _message_has_image_content(message: Dict[str, Any]) -> bool:
+    """True if a message carries multimodal image content (a single image_url
+    part or a list containing one). These shapes are silently dropped by
+    parse_vision_messages() when vision is not configured, so we detect them
+    up front to return an explicit error instead."""
+    content = message.get("content")
+    if isinstance(content, dict):
+        return content.get("type") == "image_url"
+    if isinstance(content, list):
+        return any(
+            isinstance(part, dict) and part.get("type") == "image_url"
+            for part in content
+        )
+    return False
+
+
 def add_memory(memory_create: MemoryCreate, _auth=Depends(verify_auth)):
     """Store new memories."""
     if not any([memory_create.user_id, memory_create.agent_id, memory_create.run_id]):
         raise HTTPException(status_code=400, detail="At least one identifier (user_id, agent_id, run_id) is required.")
 
+    dumped_messages = [m.model_dump() for m in memory_create.messages]
+
+    # Guard against silent data loss: if any message carries image content but
+    # the configured LLM has no vision enabled, parse_vision_messages() drops it
+    # and Memory.add() stores nothing while still returning 200. Reject explicitly.
+    if any(_message_has_image_content(m) for m in dumped_messages):
+        try:
+            vision_enabled = bool(get_memory_instance().config.llm.config.get("enable_vision"))
+        except Exception:
+            vision_enabled = False
+        if not vision_enabled:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "Image content was provided but vision is not enabled. "
+                    "Configure an LLM with enable_vision=True to process image_url content."
+                ),
+            )
+
     params = {k: v for k, v in memory_create.model_dump().items() if v is not None and k != "messages"}
     try:
-        response = get_memory_instance().add(messages=[m.model_dump() for m in memory_create.messages], **params)
+        response = get_memory_instance().add(messages=dumped_messages, **params)
         if response.get("results"):
             telemetry.log_dashboard_nudge_once(DASHBOARD_URL)
         return JSONResponse(content=response)

--- a/server/main.py
+++ b/server/main.py
@@ -391,7 +391,6 @@ def generate_instructions(req: GenerateInstructionsRequest, _auth=Depends(verify
         raise upstream_error()
 
 
-@app.post("/memories", summary="Create memories")
 def _message_has_image_content(message: Dict[str, Any]) -> bool:
     """True if a message carries multimodal image content (a single image_url
     part or a list containing one). These shapes are silently dropped by
@@ -408,6 +407,7 @@ def _message_has_image_content(message: Dict[str, Any]) -> bool:
     return False
 
 
+@app.post("/memories", summary="Create memories")
 def add_memory(memory_create: MemoryCreate, _auth=Depends(verify_auth)):
     """Store new memories."""
     if not any([memory_create.user_id, memory_create.agent_id, memory_create.run_id]):

--- a/server/main.py
+++ b/server/main.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import os
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import telemetry
 from auth import ADMIN_API_KEY, AUTH_DISABLED, JWT_SECRET, require_admin, verify_auth
@@ -173,7 +173,18 @@ app.include_router(requests_router.router)
 
 class Message(BaseModel):
     role: str = Field(..., description="Role of the message (user or assistant).")
-    content: str = Field(..., description="Message content.")
+    # Content accepts either a string (plain text) or structured multimodal
+    # content (single image dict, or list of parts), matching the format
+    # accepted by the underlying Memory.add() and parse_vision_messages().
+    # See: mem0/memory/utils.py:parse_vision_messages.
+    content: Union[str, Dict[str, Any], List[Dict[str, Any]]] = Field(
+        ...,
+        description=(
+            "Message content. Either a plain string, a single multimodal part "
+            "(e.g. {'type': 'image_url', 'image_url': {'url': '...'}}), or a "
+            "list of such parts."
+        ),
+    )
 
 
 class MemoryCreate(BaseModel):

--- a/tests/test_server_params.py
+++ b/tests/test_server_params.py
@@ -798,7 +798,7 @@ class TestMultimodalContent:
         })
         assert resp.status_code == 200, resp.text
         _, kwargs = mock_memory.add.call_args
-        sent_messages = kwargs.get("messages") if "messages" in kwargs else mock_memory.add.call_args[0][0]
+        sent_messages = kwargs["messages"]
         assert isinstance(sent_messages[0]["content"], dict)
         assert sent_messages[0]["content"]["type"] == "image_url"
 
@@ -820,7 +820,7 @@ class TestMultimodalContent:
         })
         assert resp.status_code == 200, resp.text
         _, kwargs = mock_memory.add.call_args
-        sent_messages = kwargs.get("messages") if "messages" in kwargs else mock_memory.add.call_args[0][0]
+        sent_messages = kwargs["messages"]
         assert isinstance(sent_messages[0]["content"], list)
         assert len(sent_messages[0]["content"]) == 2
 
@@ -832,7 +832,7 @@ class TestMultimodalContent:
         })
         assert resp.status_code == 200, resp.text
         _, kwargs = mock_memory.add.call_args
-        sent_messages = kwargs.get("messages") if "messages" in kwargs else mock_memory.add.call_args[0][0]
+        sent_messages = kwargs["messages"]
         assert sent_messages[0]["content"] == "I like pizza"
 
     def test_mixed_text_and_image_messages_accepted(self, client, mock_memory):
@@ -851,7 +851,82 @@ class TestMultimodalContent:
         })
         assert resp.status_code == 200, resp.text
         _, kwargs = mock_memory.add.call_args
-        sent_messages = kwargs.get("messages") if "messages" in kwargs else mock_memory.add.call_args[0][0]
+        sent_messages = kwargs["messages"]
         assert sent_messages[0]["content"] == "Here is the receipt"
         assert isinstance(sent_messages[1]["content"], dict)
 
+
+    def test_image_content_rejected_when_vision_disabled(self, client, mock_memory):
+        """Critical guard for #5068 follow-up: an image_url dict with vision NOT
+        configured must return an explicit 422, not silently drop the content
+        and return 200 with empty results."""
+        mock_memory.config.llm.config.get.return_value = False
+        resp = client.post("/memories", json={
+            "messages": [
+                {
+                    "role": "user",
+                    "content": {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/receipt.jpg"},
+                    },
+                }
+            ],
+            "user_id": "alice",
+        })
+        assert resp.status_code == 422, resp.text
+        assert "vision" in resp.text.lower()
+        mock_memory.add.assert_not_called()
+
+    def test_list_image_content_rejected_when_vision_disabled(self, client, mock_memory):
+        """A list containing an image part is also rejected when vision is off."""
+        mock_memory.config.llm.config.get.return_value = False
+        resp = client.post("/memories", json={
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "What is this?"},
+                        {"type": "image_url", "image_url": {"url": "https://example.com/a.jpg"}},
+                    ],
+                }
+            ],
+            "user_id": "alice",
+        })
+        assert resp.status_code == 422, resp.text
+        mock_memory.add.assert_not_called()
+
+    def test_text_only_list_allowed_when_vision_disabled(self, client, mock_memory):
+        """A list with only text parts carries no image content, so it must
+        still be accepted even when vision is disabled."""
+        mock_memory.config.llm.config.get.return_value = False
+        resp = client.post("/memories", json={
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "I like pizza"}]}
+            ],
+            "user_id": "alice",
+        })
+        assert resp.status_code == 200, resp.text
+        mock_memory.add.assert_called_once()
+
+    def test_malformed_text_part_returns_422_not_500(self, client, mock_memory):
+        """A text part missing its 'text' key must be rejected by the request
+        validator with a clean 422, not crash parse_vision_messages into a 500."""
+        resp = client.post("/memories", json={
+            "messages": [
+                {"role": "user", "content": [{"type": "text"}]}
+            ],
+            "user_id": "alice",
+        })
+        assert resp.status_code == 422, resp.text
+        mock_memory.add.assert_not_called()
+
+    def test_malformed_image_part_returns_422(self, client, mock_memory):
+        """An image_url part missing image_url.url must be rejected with 422."""
+        resp = client.post("/memories", json={
+            "messages": [
+                {"role": "user", "content": [{"type": "image_url"}]}
+            ],
+            "user_id": "alice",
+        })
+        assert resp.status_code == 422, resp.text
+        mock_memory.add.assert_not_called()

--- a/tests/test_server_params.py
+++ b/tests/test_server_params.py
@@ -769,3 +769,89 @@ class TestWriteHandlerErrorMapping:
             "messages": [{"role": "user", "content": "hi"}], "user_id": "u1",
         })
         assert resp.status_code == 502
+
+
+# ===========================================================================
+# MemoryCreate.Message.content: multimodal content (image_url) — issue #5068
+# ===========================================================================
+
+class TestMultimodalContent:
+    """Verify the /memories endpoint accepts multimodal content (e.g. image_url
+    dicts and lists of parts), matching the format supported by Memory.add()
+    via parse_vision_messages(). Previously the Pydantic schema only allowed
+    `str`, which rejected the OpenAI-style multimodal payload with 422 before
+    Memory.add() was ever invoked. Regression guard for issue #5068.
+    """
+
+    def test_image_url_dict_content_accepted(self, client, mock_memory):
+        resp = client.post("/memories", json={
+            "messages": [
+                {
+                    "role": "user",
+                    "content": {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/receipt.jpg"},
+                    },
+                }
+            ],
+            "user_id": "alice",
+        })
+        assert resp.status_code == 200, resp.text
+        _, kwargs = mock_memory.add.call_args
+        sent_messages = kwargs.get("messages") if "messages" in kwargs else mock_memory.add.call_args[0][0]
+        assert isinstance(sent_messages[0]["content"], dict)
+        assert sent_messages[0]["content"]["type"] == "image_url"
+
+    def test_list_of_parts_content_accepted(self, client, mock_memory):
+        resp = client.post("/memories", json={
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "What is in this image?"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "https://example.com/a.jpg"},
+                        },
+                    ],
+                }
+            ],
+            "user_id": "alice",
+        })
+        assert resp.status_code == 200, resp.text
+        _, kwargs = mock_memory.add.call_args
+        sent_messages = kwargs.get("messages") if "messages" in kwargs else mock_memory.add.call_args[0][0]
+        assert isinstance(sent_messages[0]["content"], list)
+        assert len(sent_messages[0]["content"]) == 2
+
+    def test_plain_string_content_still_accepted(self, client, mock_memory):
+        """Backward compatibility: plain string content must still work."""
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "I like pizza"}],
+            "user_id": "alice",
+        })
+        assert resp.status_code == 200, resp.text
+        _, kwargs = mock_memory.add.call_args
+        sent_messages = kwargs.get("messages") if "messages" in kwargs else mock_memory.add.call_args[0][0]
+        assert sent_messages[0]["content"] == "I like pizza"
+
+    def test_mixed_text_and_image_messages_accepted(self, client, mock_memory):
+        resp = client.post("/memories", json={
+            "messages": [
+                {"role": "user", "content": "Here is the receipt"},
+                {
+                    "role": "user",
+                    "content": {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/r.jpg"},
+                    },
+                },
+            ],
+            "user_id": "alice",
+        })
+        assert resp.status_code == 200, resp.text
+        _, kwargs = mock_memory.add.call_args
+        sent_messages = kwargs.get("messages") if "messages" in kwargs else mock_memory.add.call_args[0][0]
+        assert sent_messages[0]["content"] == "Here is the receipt"
+        assert isinstance(sent_messages[1]["content"], dict)
+


### PR DESCRIPTION
Closes #5068

## Problem

Posting a multimodal message (e.g. an `image_url` content dict) to
`POST /memories` on the REST API server returns HTTP 422 before
`Memory.add()` is invoked:

```json
{
  "detail": [
    {
      "type": "string_type",
      "loc": ["body", "messages", 0, "content"],
      "msg": "Input should be a valid string",
      "input": { "type": "image_url", "image_url": { "url": "..." } }
    }
  ]
}
```

This is despite the underlying
`mem0.memory.utils.parse_vision_messages` already accepting both
single-image dict content and list-of-parts content.

## Root cause

In `server/main.py`, the request model declares:

```python
class Message(BaseModel):
    role: str
    content: str   # ← too narrow
```

so Pydantic rejects any non-string content before the request reaches
`Memory.add()`.

## Fix

Widen `Message.content` to the union of shapes the underlying
`Memory.add()` already supports:

```python
content: Union[str, Dict[str, Any], List[Dict[str, Any]]]
```

Plain string content still works unchanged (backward-compatible).
Dict and list content are now forwarded as-is to `Memory.add()`, which
hands them to `parse_vision_messages` for normalization.

## Tests

New `TestMultimodalContent` class in `tests/test_server_params.py`:

- `test_image_url_dict_content_accepted` — single `image_url` dict accepted (the exact payload from issue #5068)
- `test_list_of_parts_content_accepted` — list of text+image parts accepted
- `test_plain_string_content_still_accepted` — regression guard for string content
- `test_mixed_text_and_image_messages_accepted` — mixed-shape conversation works

## Verification

```
$ cd server && AUTH_DISABLED=true python -m pytest ../tests/test_server_params.py -v
58 passed (4 new + 54 existing)
```

Diff: 2 files, +98/-2 lines.
