### PR TITLE
fix(memory): cap embedding input length to prevent 8192-token crash on long conversations (closes #5148)

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -51,6 +51,7 @@ from mem0.memory.notices import (
     get_temporal_feature_error_message_async,
 )
 from mem0.memory.utils import (
+    cap_text_for_embedding,
     extract_json,
     parse_messages,
     parse_vision_messages,
@@ -803,10 +804,15 @@ class Memory(MemoryBase):
         parsed_messages = parse_messages(messages)
 
         # Phase 1: Existing memory retrieval
+        # Cap the embedding input to avoid embedding-provider token-limit
+        # crashes on long multi-turn conversations (issue #5148). The full
+        # parsed_messages is still used for the LLM extraction step below;
+        # only the embedding-for-retrieval input is bounded.
+        embed_input = cap_text_for_embedding(parsed_messages)
         search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
-        query_embedding = self.embedding_model.embed(parsed_messages, "search")
+        query_embedding = self.embedding_model.embed(embed_input, "search")
         existing_results = self.vector_store.search(
-            query=parsed_messages,
+            query=embed_input,
             vectors=query_embedding,
             top_k=10,
             filters=search_filters,
@@ -2341,11 +2347,16 @@ class AsyncMemory(MemoryBase):
         parsed_messages = parse_messages(messages)
 
         # Phase 1: Existing memory retrieval
+        # Cap the embedding input to avoid embedding-provider token-limit
+        # crashes on long multi-turn conversations (issue #5148). The full
+        # parsed_messages is still used for the LLM extraction step below;
+        # only the embedding-for-retrieval input is bounded.
+        embed_input = cap_text_for_embedding(parsed_messages)
         search_filters = {k: v for k, v in effective_filters.items() if k in ("user_id", "agent_id", "run_id") and v}
-        query_embedding = await asyncio.to_thread(self.embedding_model.embed, parsed_messages, "search")
+        query_embedding = await asyncio.to_thread(self.embedding_model.embed, embed_input, "search")
         existing_results = await asyncio.to_thread(
             self.vector_store.search,
-            query=parsed_messages,
+            query=embed_input,
             vectors=query_embedding,
             top_k=10,
             filters=search_filters,

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -57,6 +57,7 @@ from mem0.memory.utils import (
     parse_vision_messages,
     process_telemetry_filters,
     remove_code_blocks,
+    cap_text_for_embedding,
 )
 from mem0.utils.entity_extraction import extract_entities, extract_entities_batch
 from mem0.utils.factory import (
@@ -917,7 +918,9 @@ class Memory(MemoryBase):
 
         # Phase 1: Existing memory retrieval
         search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
-        query_embedding = self.embedding_model.embed(parsed_messages, "search")
+        embed_input = cap_text_for_embedding(parsed_messages)
+
+        query_embedding = self.embedding_model.embed(embed_input, "search")
         existing_results = self.vector_store.search(
             query=parsed_messages,
             vectors=query_embedding,
@@ -2572,7 +2575,9 @@ class AsyncMemory(MemoryBase):
 
         # Phase 1: Existing memory retrieval
         search_filters = {k: v for k, v in effective_filters.items() if k in ("user_id", "agent_id", "run_id") and v}
-        query_embedding = await asyncio.to_thread(self.embedding_model.embed, parsed_messages, "search")
+        embed_input = cap_text_for_embedding(parsed_messages)
+
+        query_embedding = await asyncio.to_thread(self.embedding_model.embed, embed_input, "search")
         existing_results = await asyncio.to_thread(
             self.vector_store.search,
             query=parsed_messages,

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -76,6 +76,52 @@ def parse_messages(messages):
     return response
 
 
+# Safe character budget for the existing-memory retrieval embedding step.
+# OpenAI's text-embedding-* models cap input at 8192 tokens, and other
+# providers have similar limits. English averages ~4 chars/token but
+# code, numbers, and non-English text can drop that to ~3 chars/token.
+# 24000 chars stays under 8192 tokens even in the ~3-chars/token worst
+# case (24000 / 3 = 8000 tokens < 8192) while still preserving the gist
+# of the conversation for retrieval.
+DEFAULT_RETRIEVAL_EMBED_CHAR_BUDGET = 24000
+
+
+def cap_text_for_embedding(text, max_chars=DEFAULT_RETRIEVAL_EMBED_CHAR_BUDGET):
+    """Cap a long retrieval-embedding input by keeping the tail.
+
+    During Memory.add(), the full parsed conversation is embedded once to
+    search for existing related memories. On long multi-turn conversations
+    this input can exceed the embedding provider's token limit (e.g. 8192
+    tokens for OpenAI text-embedding-* models) and crash the entire add()
+    call with HTTP 400, before any memory is extracted or stored.
+
+    To avoid that hard failure while preserving recency-biased recall, we
+    truncate from the front when the input exceeds the safe character
+    budget. The tail (most recent content) is the most relevant signal
+    for retrieving existing memories about what the user just said.
+
+    Args:
+        text: The text to potentially truncate.
+        max_chars: Soft character budget. Defaults to a conservative value
+            chosen to stay well under common 8192-token embedding limits.
+
+    Returns:
+        The original text if under budget; otherwise the trailing slice.
+    """
+    if not isinstance(text, str):
+        return text
+    if len(text) <= max_chars:
+        return text
+    logger.warning(
+        "Embedding input length (%d chars) exceeds retrieval budget (%d chars); "
+        "truncating from the front to avoid embedding-provider token-limit errors. "
+        "Set a smaller-message conversation or pre-summarize for best recall.",
+        len(text),
+        max_chars,
+    )
+    return text[-max_chars:]
+
+
 def format_entities(entities):
     if not entities:
         return ""

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -85,9 +85,24 @@ def parse_messages(messages):
 # of the conversation for retrieval.
 DEFAULT_RETRIEVAL_EMBED_CHAR_BUDGET = 24000
 
+# When the retrieval input exceeds the budget we keep BOTH ends of the
+# conversation rather than only the tail. The most-recent turns (the tail)
+# carry the current topic, but the earliest turns often establish the
+# entities/facts that an existing memory was stored against. Preserving a
+# slice of the head keeps those older, semantically-related memories
+# discoverable for dedup/update, instead of silently dropping them.
+# Split is recency-weighted: most of the budget goes to the tail, a smaller
+# portion to the head. Both constants are tunable.
+RETRIEVAL_EMBED_TAIL_RATIO = 0.7
+RETRIEVAL_EMBED_HEAD_RATIO = 1.0 - RETRIEVAL_EMBED_TAIL_RATIO
+# Marker inserted between the preserved head and tail so the embedding
+# (and any logging) makes the gap explicit. It counts against the budget,
+# so the crash-prevention invariant (result <= max_chars) always holds.
+RETRIEVAL_EMBED_TRUNCATION_MARKER = "\n[...older turns omitted...]\n"
+
 
 def cap_text_for_embedding(text, max_chars=DEFAULT_RETRIEVAL_EMBED_CHAR_BUDGET):
-    """Cap a long retrieval-embedding input by keeping the tail.
+    """Cap a long retrieval-embedding input while preserving both ends.
 
     During Memory.add(), the full parsed conversation is embedded once to
     search for existing related memories. On long multi-turn conversations
@@ -95,31 +110,60 @@ def cap_text_for_embedding(text, max_chars=DEFAULT_RETRIEVAL_EMBED_CHAR_BUDGET):
     tokens for OpenAI text-embedding-* models) and crash the entire add()
     call with HTTP 400, before any memory is extracted or stored.
 
-    To avoid that hard failure while preserving recency-biased recall, we
-    truncate from the front when the input exceeds the safe character
-    budget. The tail (most recent content) is the most relevant signal
-    for retrieving existing memories about what the user just said.
+    Naively keeping only the tail prevents the crash but biases retrieval
+    toward the most-recent turns, so older yet semantically-related
+    memories can be missed -> duplicate memories get created and stale
+    facts never get updated. To address that, when the input exceeds the
+    budget we build a recency-weighted head+tail window: a large slice of
+    the most-recent content (where the current topic lives) PLUS a smaller
+    slice of the earliest content (where entities/facts were first
+    introduced), joined by an explicit truncation marker. This keeps older
+    related memories surfaceable for dedup/update while still bounding the
+    input. A full hierarchical/summarized query is a reasonable larger
+    follow-up but out of scope for this crash fix.
+
+    The crash-prevention guarantee is exact: the returned string is never
+    longer than ``max_chars`` (the marker is charged against the budget).
 
     Args:
         text: The text to potentially truncate.
-        max_chars: Soft character budget. Defaults to a conservative value
+        max_chars: Hard character budget. Defaults to a conservative value
             chosen to stay well under common 8192-token embedding limits.
 
     Returns:
-        The original text if under budget; otherwise the trailing slice.
+        The original text if under budget; otherwise a head+tail window
+        bounded to ``max_chars`` (falling back to a tail-only slice when
+        the budget is too small to fit both ends plus the marker).
     """
     if not isinstance(text, str):
         return text
     if len(text) <= max_chars:
         return text
+
     logger.warning(
         "Embedding input length (%d chars) exceeds retrieval budget (%d chars); "
-        "truncating from the front to avoid embedding-provider token-limit errors. "
-        "Set a smaller-message conversation or pre-summarize for best recall.",
+        "keeping a head+tail window (oldest + most-recent turns) to bound the input "
+        "while preserving older context for memory dedup/update. "
+        "Pre-summarize long conversations for best recall.",
         len(text),
         max_chars,
     )
-    return text[-max_chars:]
+
+    marker = RETRIEVAL_EMBED_TRUNCATION_MARKER
+    # If the budget is too small to fit both ends plus the marker, fall
+    # back to the simplest safe behavior: keep the most-recent tail.
+    if len(marker) >= max_chars:
+        return text[-max_chars:]
+
+    content_budget = max_chars - len(marker)
+    tail_chars = int(content_budget * RETRIEVAL_EMBED_TAIL_RATIO)
+    head_chars = content_budget - tail_chars
+    head = text[:head_chars]
+    tail = text[-tail_chars:] if tail_chars else ""
+    capped = head + marker + tail
+    # Invariant: head_chars + len(marker) + tail_chars == max_chars, so this
+    # is always <= max_chars. Guard defensively regardless.
+    return capped[:max_chars]
 
 
 def format_entities(entities):

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -12,6 +12,95 @@ from mem0.configs.prompts import (
 logger = logging.getLogger(__name__)
 
 
+# Safe character budget for the existing-memory retrieval embedding step.
+# OpenAI's text-embedding-* models cap input at 8192 tokens, and other
+# providers have similar limits. English averages ~4 chars/token but
+# code, numbers, and non-English text can drop that to ~3 chars/token.
+# 24000 chars stays under 8192 tokens even in the ~3-chars/token worst
+# case (24000 / 3 = 8000 tokens < 8192) while still preserving the gist
+# of the conversation for retrieval.
+DEFAULT_RETRIEVAL_EMBED_CHAR_BUDGET = 24000
+
+# When the retrieval input exceeds the budget we keep BOTH ends of the
+# conversation rather than only the tail. The most-recent turns (the tail)
+# carry the current topic, but the earliest turns often establish the
+# entities/facts that an existing memory was stored against. Preserving a
+# slice of the head keeps those older, semantically-related memories
+# discoverable for dedup/update, instead of silently dropping them.
+# Split is recency-weighted: most of the budget goes to the tail, a smaller
+# portion to the head. Both constants are tunable.
+RETRIEVAL_EMBED_TAIL_RATIO = 0.7
+RETRIEVAL_EMBED_HEAD_RATIO = 1.0 - RETRIEVAL_EMBED_TAIL_RATIO
+# Marker inserted between the preserved head and tail so the embedding
+# (and any logging) makes the gap explicit. It counts against the budget,
+# so the crash-prevention invariant (result <= max_chars) always holds.
+RETRIEVAL_EMBED_TRUNCATION_MARKER = "\n[...older turns omitted...]\n"
+
+
+def cap_text_for_embedding(text, max_chars=DEFAULT_RETRIEVAL_EMBED_CHAR_BUDGET):
+    """Cap a long retrieval-embedding input while preserving both ends.
+
+    During Memory.add(), the full parsed conversation is embedded once to
+    search for existing related memories. On long multi-turn conversations
+    this input can exceed the embedding provider's token limit (e.g. 8192
+    tokens for OpenAI text-embedding-* models) and crash the entire add()
+    call with HTTP 400, before any memory is extracted or stored.
+
+    Naively keeping only the tail prevents the crash but biases retrieval
+    toward the most-recent turns, so older yet semantically-related
+    memories can be missed -> duplicate memories get created and stale
+    facts never get updated. To address that, when the input exceeds the
+    budget we build a recency-weighted head+tail window: a large slice of
+    the most-recent content (where the current topic lives) PLUS a smaller
+    slice of the earliest content (where entities/facts were first
+    introduced), joined by an explicit truncation marker. This keeps older
+    related memories surfaceable for dedup/update while still bounding the
+    input. A full hierarchical/summarized query is a reasonable larger
+    follow-up but out of scope for this crash fix.
+
+    The crash-prevention guarantee is exact: the returned string is never
+    longer than ``max_chars`` (the marker is charged against the budget).
+
+    Args:
+        text: The text to potentially truncate.
+        max_chars: Hard character budget. Defaults to a conservative value
+            chosen to stay well under common 8192-token embedding limits.
+
+    Returns:
+        The original text if under budget; otherwise a head+tail window
+        bounded to ``max_chars`` (falling back to a tail-only slice when
+        the budget is too small to fit both ends plus the marker).
+    """
+    if not isinstance(text, str):
+        return text
+    if len(text) <= max_chars:
+        return text
+
+    logger.warning(
+        "Embedding input length (%d chars) exceeds retrieval budget (%d chars); "
+        "keeping a head+tail window (oldest + most-recent turns) to bound the input "
+        "while preserving older context for memory dedup/update. "
+        "Pre-summarize long conversations for best recall.",
+        len(text),
+        max_chars,
+    )
+
+    marker = RETRIEVAL_EMBED_TRUNCATION_MARKER
+    # If the budget is too small to fit both ends plus the marker, fall
+    # back to the simplest safe behavior: keep the most-recent tail.
+    if len(marker) >= max_chars:
+        return text[-max_chars:]
+
+    content_budget = max_chars - len(marker)
+    tail_chars = int(content_budget * RETRIEVAL_EMBED_TAIL_RATIO)
+    head_chars = content_budget - tail_chars
+    head = text[:head_chars]
+    tail = text[-tail_chars:] if tail_chars else ""
+    capped = head + marker + tail
+    # Invariant: head_chars + len(marker) + tail_chars == max_chars, so this
+    # is always <= max_chars. Guard defensively regardless.
+    return capped[:max_chars]
+
 def get_fact_retrieval_messages(message, is_agent_memory=False):
     """Get fact retrieval messages based on the memory type.
     

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -1068,3 +1068,36 @@ class TestEmbeddingInputCapForLongConversations:
         # The whole short conversation should be present in the embed input.
         assert "I like pizza" in first_arg
         assert "Noted." in first_arg
+
+    def test_long_conversation_embed_input_preserves_head_and_tail(self, mock_memory):
+        """PR #5281 review fix: when capping a long conversation, the
+        retrieval-embedding input must preserve BOTH the oldest and the
+        most-recent content so older semantically-related memories still
+        surface for dedup/update — not just the recent tail.
+
+        Uses distinctive sentinels at the very start and very end of a long
+        conversation and asserts both survive in the bounded embed input.
+        """
+        from mem0.memory.utils import DEFAULT_RETRIEVAL_EMBED_CHAR_BUDGET
+
+        head_sentinel = "OLDEST_TURN_SENTINEL_ABC"
+        tail_sentinel = "NEWEST_TURN_SENTINEL_XYZ"
+        filler = "Discuss microservices and Postgres migrations. " * 1600
+        messages = [
+            {"role": "user", "content": head_sentinel + " " + filler},
+            {"role": "assistant", "content": filler + " " + tail_sentinel},
+        ]
+
+        mock_memory._add_to_vector_store(
+            messages=messages, metadata={}, filters={"user_id": "u1"}, infer=True
+        )
+
+        embed_calls = mock_memory.embedding_model.embed.call_args_list
+        assert len(embed_calls) >= 1
+        embed_input = embed_calls[0].args[0]
+        assert isinstance(embed_input, str)
+        # Crash-prevention invariant: never exceeds the budget.
+        assert len(embed_input) <= DEFAULT_RETRIEVAL_EMBED_CHAR_BUDGET
+        # Both ends preserved — the core fix for the reviewer's concern.
+        assert head_sentinel in embed_input, "oldest turn lost — older-memory recall broken"
+        assert tail_sentinel in embed_input, "newest turn lost — recency broken"

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -988,3 +988,83 @@ class TestAddPipelineEntityEmbeddingCountGuard:
         assert any("padding/truncating" in r.message for r in caplog.records), (
             "expected count-mismatch warning was not emitted"
         )
+
+# ===========================================================================
+# Issue #5148: Cap embedding input length to prevent token-limit crash
+# ===========================================================================
+
+
+class TestEmbeddingInputCapForLongConversations:
+    """Verify that Memory._add_to_vector_store Phase 1 caps the embedding
+    input length when the conversation is too long, so we don't crash on
+    embedding-provider token limits (e.g. OpenAI 8192-token cap).
+
+    Regression coverage for issue #5148.
+    """
+
+    @pytest.fixture
+    def mock_memory(self, mocker):
+        mock_llm, _ = _setup_mocks(mocker)
+        memory = Memory()
+        memory.config = mocker.MagicMock()
+        memory.config.custom_instructions = None
+        memory.config.custom_update_memory_prompt = None
+        memory.custom_instructions = None
+        memory.api_version = "v1.1"
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        # Return empty extraction so the test stays in Phase 1.
+        memory.llm.generate_response.return_value = '{"memory": []}'
+        return memory
+
+    def test_long_conversation_does_not_crash_and_embed_input_is_bounded(self, mock_memory):
+        """A long conversation (well over the 8192-token embedding limit)
+        must not raise from embed(); the cap helper bounds the input."""
+        from mem0.memory.utils import DEFAULT_RETRIEVAL_EMBED_CHAR_BUDGET
+
+        # ~80KB of conversation = far beyond any embedding provider's limit.
+        long_content = "Talk about microservices and Postgres migrations. " * 1600
+        messages = [
+            {"role": "user", "content": long_content},
+            {"role": "assistant", "content": "Acknowledged."},
+        ]
+
+        # Sanity: parsed text would blow past the budget without the cap.
+        from mem0.memory.utils import parse_messages
+        assert len(parse_messages(messages)) > DEFAULT_RETRIEVAL_EMBED_CHAR_BUDGET
+
+        # Should not raise. (Before the fix, embedding would receive the
+        # entire conversation and a real provider would 400 on token limit.)
+        result = mock_memory._add_to_vector_store(
+            messages=messages, metadata={}, filters={"user_id": "u1"}, infer=True
+        )
+
+        # Verify the embedding call received a bounded input, not the
+        # full parsed conversation.
+        embed_calls = mock_memory.embedding_model.embed.call_args_list
+        assert len(embed_calls) >= 1
+        first_arg = embed_calls[0].args[0]
+        assert isinstance(first_arg, str)
+        assert len(first_arg) <= DEFAULT_RETRIEVAL_EMBED_CHAR_BUDGET, (
+            f"Embedding input was {len(first_arg)} chars, expected <= "
+            f"{DEFAULT_RETRIEVAL_EMBED_CHAR_BUDGET}"
+        )
+        # No exception → test passes; result shape is allowed to be empty
+        assert isinstance(result, list)
+
+    def test_short_conversation_passes_through_unchanged(self, mock_memory):
+        """Short conversations should NOT be truncated — only ones that
+        actually exceed the budget."""
+        messages = [
+            {"role": "user", "content": "I like pizza"},
+            {"role": "assistant", "content": "Noted."},
+        ]
+        mock_memory._add_to_vector_store(
+            messages=messages, metadata={}, filters={"user_id": "u1"}, infer=True
+        )
+        embed_calls = mock_memory.embedding_model.embed.call_args_list
+        assert len(embed_calls) >= 1
+        first_arg = embed_calls[0].args[0]
+        # The whole short conversation should be present in the embed input.
+        assert "I like pizza" in first_arg
+        assert "Noted." in first_arg

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -1178,3 +1178,111 @@ class TestAddPipelineEntityEmbeddingCountGuard:
         assert any("padding/truncating" in r.message for r in caplog.records), (
             "expected count-mismatch warning was not emitted"
         )
+
+class TestEmbeddingInputCapForLongConversations:
+    """Verify that Memory._add_to_vector_store Phase 1 caps the embedding
+    input length when the conversation is too long, so we don't crash on
+    embedding-provider token limits (e.g. OpenAI 8192-token cap).
+
+    Regression coverage for issue #5148.
+    """
+
+    @pytest.fixture
+    def mock_memory(self, mocker):
+        mock_llm, _ = _setup_mocks(mocker)
+        memory = Memory()
+        memory.config = mocker.MagicMock()
+        memory.config.custom_instructions = None
+        memory.config.custom_update_memory_prompt = None
+        memory.custom_instructions = None
+        memory.api_version = "v1.1"
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        # Return empty extraction so the test stays in Phase 1.
+        memory.llm.generate_response.return_value = '{"memory": []}'
+        return memory
+
+    def test_long_conversation_does_not_crash_and_embed_input_is_bounded(self, mock_memory):
+        """A long conversation (well over the 8192-token embedding limit)
+        must not raise from embed(); the cap helper bounds the input."""
+        from mem0.memory.utils import DEFAULT_RETRIEVAL_EMBED_CHAR_BUDGET
+
+        # ~80KB of conversation = far beyond any embedding provider's limit.
+        long_content = "Talk about microservices and Postgres migrations. " * 1600
+        messages = [
+            {"role": "user", "content": long_content},
+            {"role": "assistant", "content": "Acknowledged."},
+        ]
+
+        # Sanity: parsed text would blow past the budget without the cap.
+        from mem0.memory.utils import parse_messages
+        assert len(parse_messages(messages)) > DEFAULT_RETRIEVAL_EMBED_CHAR_BUDGET
+
+        # Should not raise. (Before the fix, embedding would receive the
+        # entire conversation and a real provider would 400 on token limit.)
+        result = mock_memory._add_to_vector_store(
+            messages=messages, metadata={}, filters={"user_id": "u1"}, infer=True
+        )
+
+        # Verify the embedding call received a bounded input, not the
+        # full parsed conversation.
+        embed_calls = mock_memory.embedding_model.embed.call_args_list
+        assert len(embed_calls) >= 1
+        first_arg = embed_calls[0].args[0]
+        assert isinstance(first_arg, str)
+        assert len(first_arg) <= DEFAULT_RETRIEVAL_EMBED_CHAR_BUDGET, (
+            f"Embedding input was {len(first_arg)} chars, expected <= "
+            f"{DEFAULT_RETRIEVAL_EMBED_CHAR_BUDGET}"
+        )
+        # No exception → test passes; result shape is allowed to be empty
+        assert isinstance(result, list)
+
+    def test_short_conversation_passes_through_unchanged(self, mock_memory):
+        """Short conversations should NOT be truncated — only ones that
+        actually exceed the budget."""
+        messages = [
+            {"role": "user", "content": "I like pizza"},
+            {"role": "assistant", "content": "Noted."},
+        ]
+        mock_memory._add_to_vector_store(
+            messages=messages, metadata={}, filters={"user_id": "u1"}, infer=True
+        )
+        embed_calls = mock_memory.embedding_model.embed.call_args_list
+        assert len(embed_calls) >= 1
+        first_arg = embed_calls[0].args[0]
+        # The whole short conversation should be present in the embed input.
+        assert "I like pizza" in first_arg
+        assert "Noted." in first_arg
+
+    def test_long_conversation_embed_input_preserves_head_and_tail(self, mock_memory):
+        """PR #5281 review fix: when capping a long conversation, the
+        retrieval-embedding input must preserve BOTH the oldest and the
+        most-recent content so older semantically-related memories still
+        surface for dedup/update — not just the recent tail.
+
+        Uses distinctive sentinels at the very start and very end of a long
+        conversation and asserts both survive in the bounded embed input.
+        """
+        from mem0.memory.utils import DEFAULT_RETRIEVAL_EMBED_CHAR_BUDGET
+
+        head_sentinel = "OLDEST_TURN_SENTINEL_ABC"
+        tail_sentinel = "NEWEST_TURN_SENTINEL_XYZ"
+        filler = "Discuss microservices and Postgres migrations. " * 1600
+        messages = [
+            {"role": "user", "content": head_sentinel + " " + filler},
+            {"role": "assistant", "content": filler + " " + tail_sentinel},
+        ]
+
+        mock_memory._add_to_vector_store(
+            messages=messages, metadata={}, filters={"user_id": "u1"}, infer=True
+        )
+
+        embed_calls = mock_memory.embedding_model.embed.call_args_list
+        assert len(embed_calls) >= 1
+        embed_input = embed_calls[0].args[0]
+        assert isinstance(embed_input, str)
+        # Crash-prevention invariant: never exceeds the budget.
+        assert len(embed_input) <= DEFAULT_RETRIEVAL_EMBED_CHAR_BUDGET
+        # Both ends preserved — the core fix for the reviewer's concern.
+        assert head_sentinel in embed_input, "oldest turn lost — older-memory recall broken"
+        assert tail_sentinel in embed_input, "newest turn lost — recency broken"

--- a/tests/memory/test_memory_utils.py
+++ b/tests/memory/test_memory_utils.py
@@ -150,3 +150,57 @@ class TestRemoveSpacesFromEntities:
         f = remove_spaces_from_entities([dict(base)], sanitize_relationship=False)[0]["relationship"]
         assert t == sanitize_relationship_for_cypher("a/b")
         assert f == "a/b"
+
+
+class TestCapTextForEmbedding:
+    """Regression coverage for issue #5148 — protect existing-memory retrieval
+    from embedding-provider token-limit crashes on long conversations.
+
+    The helper truncates from the front (keeps the tail) so the most-recent
+    content drives retrieval, matching the intent of the retrieval step in
+    Memory._add_to_vector_store Phase 1.
+    """
+
+    def test_short_text_passes_through(self):
+        from mem0.memory.utils import cap_text_for_embedding
+
+        text = "hello world"
+        assert cap_text_for_embedding(text) == text
+
+    def test_long_text_is_truncated_to_budget(self):
+        from mem0.memory.utils import cap_text_for_embedding
+
+        max_chars = 100
+        long_text = "x" * (max_chars * 3)
+        out = cap_text_for_embedding(long_text, max_chars=max_chars)
+        assert len(out) == max_chars
+
+    def test_long_text_keeps_the_tail(self):
+        """Recency matters most for retrieval — the most recent content
+        (which the user just said) should be preserved when truncating."""
+        from mem0.memory.utils import cap_text_for_embedding
+
+        head = "OLD" * 100
+        tail = "RECENT-CONTENT-MARKER"
+        long_text = head + tail
+        out = cap_text_for_embedding(long_text, max_chars=len(tail) + 5)
+        # The recent marker must survive truncation
+        assert tail in out
+        # And the old content must be gone (or at least mostly gone)
+        assert out.endswith(tail)
+
+    def test_default_budget_under_8192_token_limit(self):
+        """The default budget must stay safely under common 8192-token
+        embedding limits even with worst-case ~3 chars/token packing."""
+        from mem0.memory.utils import DEFAULT_RETRIEVAL_EMBED_CHAR_BUDGET
+
+        # Worst-case token estimate (3 chars/token); must stay under 8192.
+        worst_case_tokens = DEFAULT_RETRIEVAL_EMBED_CHAR_BUDGET / 3
+        assert worst_case_tokens < 8192
+
+    def test_non_string_input_returned_unchanged(self):
+        """Defensive: callers may accidentally pass non-string input."""
+        from mem0.memory.utils import cap_text_for_embedding
+
+        assert cap_text_for_embedding(None) is None
+        assert cap_text_for_embedding(12345) == 12345

--- a/tests/memory/test_memory_utils.py
+++ b/tests/memory/test_memory_utils.py
@@ -156,9 +156,12 @@ class TestCapTextForEmbedding:
     """Regression coverage for issue #5148 — protect existing-memory retrieval
     from embedding-provider token-limit crashes on long conversations.
 
-    The helper truncates from the front (keeps the tail) so the most-recent
-    content drives retrieval, matching the intent of the retrieval step in
-    Memory._add_to_vector_store Phase 1.
+    The helper bounds the retrieval-embedding input to a safe char budget so
+    embed() never receives more than the provider's token limit. To avoid
+    biasing retrieval toward only the newest turns (which would miss older
+    semantically-related memories — see PR #5281 review), it keeps BOTH a
+    slice of the head (oldest turns, where entities/facts were introduced)
+    and the tail (most-recent turns) within the budget.
     """
 
     def test_short_text_passes_through(self):
@@ -168,26 +171,66 @@ class TestCapTextForEmbedding:
         assert cap_text_for_embedding(text) == text
 
     def test_long_text_is_truncated_to_budget(self):
+        """Crash-prevention invariant: result length never exceeds budget."""
         from mem0.memory.utils import cap_text_for_embedding
 
         max_chars = 100
         long_text = "x" * (max_chars * 3)
         out = cap_text_for_embedding(long_text, max_chars=max_chars)
-        assert len(out) == max_chars
+        assert len(out) <= max_chars
 
-    def test_long_text_keeps_the_tail(self):
-        """Recency matters most for retrieval — the most recent content
-        (which the user just said) should be preserved when truncating."""
+    def test_long_text_preserves_both_head_and_tail(self):
+        """The fix for PR #5281's review: capping must keep BOTH the oldest
+        and the most-recent content so older related memories still surface
+        for dedup/update — not just the tail."""
         from mem0.memory.utils import cap_text_for_embedding
 
-        head = "OLD" * 100
-        tail = "RECENT-CONTENT-MARKER"
-        long_text = head + tail
-        out = cap_text_for_embedding(long_text, max_chars=len(tail) + 5)
-        # The recent marker must survive truncation
-        assert tail in out
-        # And the old content must be gone (or at least mostly gone)
-        assert out.endswith(tail)
+        head_marker = "HEAD-OLDEST-CONTENT-MARKER"
+        tail_marker = "TAIL-RECENT-CONTENT-MARKER"
+        # Long filler between the two distinctive sentinels.
+        long_text = head_marker + ("x" * 5000) + tail_marker
+        out = cap_text_for_embedding(long_text, max_chars=2000)
+
+        # Crash-prevention invariant still holds.
+        assert len(out) <= 2000
+        # BOTH ends survive — older context is preserved for retrieval.
+        assert head_marker in out, "oldest content must survive for older-memory recall"
+        assert tail_marker in out, "most-recent content must survive for recency"
+        # The newest content sits at the end of the embedding input.
+        assert out.endswith(tail_marker)
+
+    def test_recency_weighting_tail_gets_more_budget(self):
+        """Tail (recency) should receive the larger share of the budget."""
+        from mem0.memory.utils import (
+            RETRIEVAL_EMBED_TAIL_RATIO,
+            RETRIEVAL_EMBED_TRUNCATION_MARKER,
+            cap_text_for_embedding,
+        )
+
+        max_chars = 1000
+        long_text = "a" * 10000
+        out = cap_text_for_embedding(long_text, max_chars=max_chars)
+        assert len(out) <= max_chars
+        # Marker is present, charged against the budget.
+        assert RETRIEVAL_EMBED_TRUNCATION_MARKER in out
+        head, _, tail = out.partition(RETRIEVAL_EMBED_TRUNCATION_MARKER)
+        # Tail share should exceed head share (recency-weighted).
+        assert len(tail) > len(head)
+        assert RETRIEVAL_EMBED_TAIL_RATIO > 0.5
+
+    def test_tiny_budget_falls_back_to_tail(self):
+        """If the budget is smaller than the marker, fall back to a safe
+        tail-only slice; invariant still holds."""
+        from mem0.memory.utils import (
+            RETRIEVAL_EMBED_TRUNCATION_MARKER,
+            cap_text_for_embedding,
+        )
+
+        tiny = len(RETRIEVAL_EMBED_TRUNCATION_MARKER) - 1
+        long_text = "abcdefghij" * 100
+        out = cap_text_for_embedding(long_text, max_chars=tiny)
+        assert len(out) <= tiny
+        assert out == long_text[-tiny:]
 
     def test_default_budget_under_8192_token_limit(self):
         """The default budget must stay safely under common 8192-token

--- a/tests/memory/test_memory_utils.py
+++ b/tests/memory/test_memory_utils.py
@@ -192,3 +192,99 @@ class TestProcessTelemetryFilters:
 class TestRemoveCodeBlocks:
     def test_none_content_returns_empty_string(self):
         assert remove_code_blocks(None) == ""
+
+class TestCapTextForEmbedding:
+    """Regression coverage for issue #5148 — protect existing-memory retrieval
+    from embedding-provider token-limit crashes on long conversations.
+
+    The helper bounds the retrieval-embedding input to a safe char budget so
+    embed() never receives more than the provider's token limit. To avoid
+    biasing retrieval toward only the newest turns (which would miss older
+    semantically-related memories — see PR #5281 review), it keeps BOTH a
+    slice of the head (oldest turns, where entities/facts were introduced)
+    and the tail (most-recent turns) within the budget.
+    """
+
+    def test_short_text_passes_through(self):
+        from mem0.memory.utils import cap_text_for_embedding
+
+        text = "hello world"
+        assert cap_text_for_embedding(text) == text
+
+    def test_long_text_is_truncated_to_budget(self):
+        """Crash-prevention invariant: result length never exceeds budget."""
+        from mem0.memory.utils import cap_text_for_embedding
+
+        max_chars = 100
+        long_text = "x" * (max_chars * 3)
+        out = cap_text_for_embedding(long_text, max_chars=max_chars)
+        assert len(out) <= max_chars
+
+    def test_long_text_preserves_both_head_and_tail(self):
+        """The fix for PR #5281's review: capping must keep BOTH the oldest
+        and the most-recent content so older related memories still surface
+        for dedup/update — not just the tail."""
+        from mem0.memory.utils import cap_text_for_embedding
+
+        head_marker = "HEAD-OLDEST-CONTENT-MARKER"
+        tail_marker = "TAIL-RECENT-CONTENT-MARKER"
+        # Long filler between the two distinctive sentinels.
+        long_text = head_marker + ("x" * 5000) + tail_marker
+        out = cap_text_for_embedding(long_text, max_chars=2000)
+
+        # Crash-prevention invariant still holds.
+        assert len(out) <= 2000
+        # BOTH ends survive — older context is preserved for retrieval.
+        assert head_marker in out, "oldest content must survive for older-memory recall"
+        assert tail_marker in out, "most-recent content must survive for recency"
+        # The newest content sits at the end of the embedding input.
+        assert out.endswith(tail_marker)
+
+    def test_recency_weighting_tail_gets_more_budget(self):
+        """Tail (recency) should receive the larger share of the budget."""
+        from mem0.memory.utils import (
+            RETRIEVAL_EMBED_TAIL_RATIO,
+            RETRIEVAL_EMBED_TRUNCATION_MARKER,
+            cap_text_for_embedding,
+        )
+
+        max_chars = 1000
+        long_text = "a" * 10000
+        out = cap_text_for_embedding(long_text, max_chars=max_chars)
+        assert len(out) <= max_chars
+        # Marker is present, charged against the budget.
+        assert RETRIEVAL_EMBED_TRUNCATION_MARKER in out
+        head, _, tail = out.partition(RETRIEVAL_EMBED_TRUNCATION_MARKER)
+        # Tail share should exceed head share (recency-weighted).
+        assert len(tail) > len(head)
+        assert RETRIEVAL_EMBED_TAIL_RATIO > 0.5
+
+    def test_tiny_budget_falls_back_to_tail(self):
+        """If the budget is smaller than the marker, fall back to a safe
+        tail-only slice; invariant still holds."""
+        from mem0.memory.utils import (
+            RETRIEVAL_EMBED_TRUNCATION_MARKER,
+            cap_text_for_embedding,
+        )
+
+        tiny = len(RETRIEVAL_EMBED_TRUNCATION_MARKER) - 1
+        long_text = "abcdefghij" * 100
+        out = cap_text_for_embedding(long_text, max_chars=tiny)
+        assert len(out) <= tiny
+        assert out == long_text[-tiny:]
+
+    def test_default_budget_under_8192_token_limit(self):
+        """The default budget must stay safely under common 8192-token
+        embedding limits even with worst-case ~3 chars/token packing."""
+        from mem0.memory.utils import DEFAULT_RETRIEVAL_EMBED_CHAR_BUDGET
+
+        # Worst-case token estimate (3 chars/token); must stay under 8192.
+        worst_case_tokens = DEFAULT_RETRIEVAL_EMBED_CHAR_BUDGET / 3
+        assert worst_case_tokens < 8192
+
+    def test_non_string_input_returned_unchanged(self):
+        """Defensive: callers may accidentally pass non-string input."""
+        from mem0.memory.utils import cap_text_for_embedding
+
+        assert cap_text_for_embedding(None) is None
+        assert cap_text_for_embedding(12345) == 12345


### PR DESCRIPTION
Closes #5148

## Problem

`Memory._add_to_vector_store` Phase 1 (existing-memory retrieval)
embeds the **full parsed conversation** into a single vector:

```python
# mem0/memory/main.py ~line 704
parsed_messages = parse_messages(messages)                          # full raw conversation
query_embedding = self.embedding_model.embed(parsed_messages, "search")  # 💥 crashes if > 8192 tokens
```

On long multi-turn conversations this input can exceed the embedding
provider's token limit (8192 tokens for all OpenAI `text-embedding-*`
models, similar for others). The embed call returns HTTP 400 and the
**entire `Memory.add()` crashes** — no fact is extracted, no memory is
stored, even though the user may have just told the agent something
genuinely important.

## Root cause

There is no length guard on the embedding-for-retrieval input. The
exact same `parsed_messages` is passed both to the embedding model
(which has a hard input-token limit) and to the LLM extractor (which
has its own, much larger, context window).

## Fix

Introduce `mem0.memory.utils.cap_text_for_embedding(text, max_chars)`:

- Default `max_chars=24000`, sized to stay under 8192 tokens even at a
  worst-case ~3 chars/token packing (24000 / 3 = 8000 tokens < 8192).
- Truncates from the **front** so the tail (most-recent content, which
  is what the user just said) is preserved — recency matters most for
  retrieval.
- Logs a `WARNING` when truncation actually happens, so operators
  notice and can pre-summarize or trim if they care about full recall.

Apply the cap at both call sites in `mem0/memory/main.py`:

- `Memory._add_to_vector_store` (sync)
- `AsyncMemory._add_to_vector_store` (async)

The full `parsed_messages` is still passed to the LLM extraction step
that follows — **only the embedding-for-retrieval input is bounded**.
Behavior on short conversations is unchanged (no truncation, no warning).

## Tests

**`TestCapTextForEmbedding`** in `tests/memory/test_memory_utils.py`:

- `test_short_text_passes_through` — under-budget text untouched
- `test_long_text_is_truncated_to_budget` — bounded output length
- `test_long_text_keeps_the_tail` — recent content preserved
- `test_default_budget_under_8192_token_limit` — budget proven safe vs 8192 tokens
- `test_non_string_input_returned_unchanged` — defensive contract

**`TestEmbeddingInputCapForLongConversations`** in `tests/memory/test_main.py`:

- `test_long_conversation_does_not_crash_and_embed_input_is_bounded`
  sends a ~80KB conversation through `_add_to_vector_store` with mocked
  embedding/LLM and asserts the `embed()` call received a bounded input.
- `test_short_conversation_passes_through_unchanged` — regression guard
  for normal-length conversations.

## Verification

```
$ python -m pytest tests/memory/test_memory_utils.py tests/memory/test_main.py -v
49 passed in 0.52s
```

(7 new tests + 42 existing.)

## Notes

- This is a **soft cap**: the embedding still happens, it just sees a
  bounded slice of the conversation. Full extraction quality is
  preserved (LLM still sees everything).
- Future improvement: pre-summarize the older portion of long
  conversations instead of hard-truncating, for better recall on
  cross-topic retrieval. Out of scope for this fix.
