### PR TITLE
fix(antigravity-plugin): remove unnecessary skills symlink from install steps

### DIFF
--- a/docs/integrations/antigravity.mdx
+++ b/docs/integrations/antigravity.mdx
@@ -27,15 +27,11 @@ echo 'export MEM0_API_KEY="m0-your-api-key"' >> ~/.bashrc && source ~/.bashrc
 **Option A — degit** (recommended):
 
 ```bash
-# 1. Install the plugin (MCP server, hooks, scripts)
+# Install the plugin (MCP server, hooks, scripts)
 npx degit mem0ai/mem0/mem0-plugin ~/.gemini/config/plugins/mem0
-
-# 2. Link skills into Gemini CLI's discovery path
-mkdir -p ~/.gemini/skills
-ln -sf ~/.gemini/config/plugins/mem0/skills/* ~/.gemini/skills/
 ```
 
-Step 1 installs the MCP server, lifecycle hooks, and shared scripts. Step 2 links the 16 skills into `~/.gemini/skills/` where Gemini CLI discovers them.
+This installs the MCP server, lifecycle hooks, and shared scripts.
 
 ## What's Included
 

--- a/mem0-plugin/README.md
+++ b/mem0-plugin/README.md
@@ -189,15 +189,11 @@ See [OpenCode integration docs](https://docs.mem0.ai/integrations/opencode) for 
 **Option A — degit** (recommended):
 
 ```bash
-# 1. Install the plugin (MCP server, hooks, scripts)
+# Install the plugin (MCP server, hooks, scripts)
 npx degit mem0ai/mem0/mem0-plugin ~/.gemini/config/plugins/mem0
-
-# 2. Link skills into Gemini CLI's discovery path
-mkdir -p ~/.gemini/skills
-ln -sf ~/.gemini/config/plugins/mem0/skills/* ~/.gemini/skills/
 ```
 
-Step 1 installs the MCP server, lifecycle hooks, and shared scripts. Step 2 links the 16 skills into `~/.gemini/skills/` where Gemini CLI discovers them.
+This installs the MCP server, lifecycle hooks, and shared scripts.
 
 See [Antigravity integration docs](https://docs.mem0.ai/integrations/antigravity) for full details.
 


### PR DESCRIPTION
## Summary

- Removed the `ln -sf ~/.gemini/skills` symlink command from Gemini CLI install steps in both `docs/integrations/antigravity.mdx` and `mem0-plugin/README.md`
- Simplified install instructions to a single `npx degit` command

## Test plan

- [ ] Verify antigravity docs render correctly on Mintlify
- [ ] Confirm README install steps are clear and accurate