### PR TITLE
fix: guard against None score in score_and_rank to prevent TypeError with LangChain vector store

### DIFF
--- a/mem0/utils/scoring.py
+++ b/mem0/utils/scoring.py
@@ -98,7 +98,14 @@ def score_and_rank(
         if mem_id is None:
             continue
 
-        semantic_score = result.get("score", 0.0)
+        # Use explicit None check: dict.get(key, default) only substitutes the
+        # default when the key is *absent*, not when the value is None.
+        # LangChain's similarity_search_by_vector returns Document objects without
+        # scores, so _parse_output sets score=None — causing a TypeError here when
+        # None is compared with the float threshold.
+        # See https://github.com/mem0ai/mem0/issues/5071
+        raw_score = result.get("score")
+        semantic_score = raw_score if raw_score is not None else 0.0
         if semantic_score < threshold:
             continue
 

--- a/tests/utils/test_scoring.py
+++ b/tests/utils/test_scoring.py
@@ -126,6 +126,41 @@ class TestScoreAndRank:
         scored = score_and_rank(results, bm25, entity, threshold=0.1, top_k=10)
         assert scored[0]["score"] <= 1.0
 
+    # ------------------------------------------------------------------
+    # Regression tests for https://github.com/mem0ai/mem0/issues/5071
+    # ------------------------------------------------------------------
+
+    def test_none_score_does_not_raise_typeerror(self):
+        """score=None must be treated as 0.0, not raise TypeError.
+
+        LangChain's similarity_search_by_vector returns Document objects without
+        scores; _parse_output sets score=None.  dict.get("score", 0.0) returns
+        None when the key exists with a None value, so the old code raised
+        TypeError: '<' not supported between NoneType and float.
+        """
+        results = [{"id": "a", "score": None, "payload": {"data": "mem a"}}]
+        # Must not raise — None score is treated as 0.0 (below any positive threshold)
+        scored = score_and_rank(results, {}, {}, threshold=0.1, top_k=10)
+        assert scored == []
+
+    def test_none_score_below_zero_threshold_is_included(self):
+        """score=None treated as 0.0 passes a threshold of 0.0."""
+        results = [{"id": "a", "score": None, "payload": {"data": "mem a"}}]
+        scored = score_and_rank(results, {}, {}, threshold=0.0, top_k=10)
+        assert len(scored) == 1
+        assert scored[0]["id"] == "a"
+
+    def test_mixed_none_and_float_scores(self):
+        """Ensure results with None scores are filtered while valid ones pass."""
+        results = [
+            {"id": "no-score", "score": None, "payload": {}},
+            {"id": "has-score", "score": 0.8, "payload": {}},
+        ]
+        scored = score_and_rank(results, {}, {}, threshold=0.1, top_k=10)
+        ids = [r["id"] for r in scored]
+        assert "has-score" in ids
+        assert "no-score" not in ids
+
 
 class TestEntityBoostWeight:
     def test_weight_value(self):


### PR DESCRIPTION
## Problem

Any `Memory.search()` call using the LangChain vector store crashes with:

```
TypeError: '<' not supported between instances of 'NoneType' and 'float'
```

Fixes #5071

### Root cause

`LangChain`'s `similarity_search_by_vector` returns `List[Document]` (no scores), so `_parse_output` in `langchain.py` sets `score=None` for those results.

In `score_and_rank` (`mem0/utils/scoring.py`):

```python
semantic_score = result.get("score", 0.0)  # returns None — key exists but value is None!
if semantic_score < threshold:              # TypeError: None < float
```

`dict.get(key, default)` substitutes the default only when the key is **absent**, not when the value is `None`.  Since the LangChain path always inserts `"score": None`, the fallback `0.0` is never used.

## Fix

Explicit `None` check before the comparison:

```python
# Before
semantic_score = result.get("score", 0.0)

# After
raw_score = result.get("score")
semantic_score = raw_score if raw_score is not None else 0.0
```

A `None` score is treated as `0.0` — the memory will be filtered out by the threshold or kept if threshold is `<= 0`.

## Tests

Added 3 regression tests to `tests/utils/test_scoring.py`:

| test | what it checks |
|---|---|
| `test_none_score_does_not_raise_typeerror` | `score=None` no longer raises `TypeError` |
| `test_none_score_below_zero_threshold_is_included` | `None` → `0.0`, passes `threshold=0.0` |
| `test_mixed_none_and_float_scores` | valid scores rank through; `None` scores are filtered |

```
pytest tests/utils/test_scoring.py -v
21 passed
```