### PR TITLE
ci(opencode-plugin): add build & publish workflows for @mem0/opencode-plugin

### DIFF
--- a/.github/workflows/opencode-plugin-cd.yml
+++ b/.github/workflows/opencode-plugin-cd.yml
@@ -1,0 +1,44 @@
+name: Publish @mem0/opencode-plugin 📦 to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-n-publish:
+    name: Build and publish @mem0/opencode-plugin 📦 to npm
+    if: startsWith(github.event.release.tag_name, 'opencode-v')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    defaults:
+      run:
+        working-directory: mem0-plugin/.opencode-plugin
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build
+
+      - name: Publish to npm
+        run: |
+          if [ "${{ github.event.release.prerelease }}" = "true" ]; then
+            PREID=$(node -p "require('./package.json').version.split('-')[1].split('.')[0]")
+            npx npm@latest publish --provenance --access public --tag "$PREID"
+          else
+            npx npm@latest publish --provenance --access public
+          fi

--- a/.github/workflows/opencode-plugin-checks.yml
+++ b/.github/workflows/opencode-plugin-checks.yml
@@ -1,0 +1,40 @@
+name: opencode-plugin checks
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'mem0-plugin/.opencode-plugin/**'
+      - '.github/workflows/opencode-plugin-checks.yml'
+  pull_request:
+    paths:
+      - 'mem0-plugin/.opencode-plugin/**'
+      - '.github/workflows/opencode-plugin-checks.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mem0-plugin/.opencode-plugin
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Type check
+        run: bun run type-check
+
+      - name: Build
+        run: bun run build
+
+      - name: Verify dist output exists
+        run: |
+          test -f dist/index.js || (echo "Build output missing: dist/index.js" && exit 1)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -413,6 +413,7 @@ To add a new LLM, embedding, vector store, or reranker provider:
 | Python CLI | `cli-python-ci.yml` | Push to `cli/python/`, PRs, manual | Ruff lint + pytest + hatch build on Python 3.10, 3.11, 3.12 |
 | Node CLI | `cli-node-ci.yml` | Push to `cli/node/`, PRs, manual | Biome lint + tsc + vitest + tsup build on Node 20, 22 |
 | OpenClaw | `openclaw-checks.yml` | Push to `openclaw/`, PRs, manual | tsc + vitest (with Codecov) + tsup build on Node 20, 22 |
+| OpenCode Plugin | `opencode-plugin-checks.yml` | Push to `mem0-plugin/.opencode-plugin/`, PRs, manual | Bun: tsc type-check + build + dist artifact check |
 
 ### CD Workflows (automated publishing)
 
@@ -424,6 +425,7 @@ To add a new LLM, embedding, vector store, or reranker provider:
 | Node CLI | `cli-node-cd.yml` | `cli-node-v*` | npm (`@mem0/cli`) |
 | Vercel AI SDK | `vercel-ai-cd.yml` | `vercel-ai-v*` | npm (`@mem0/vercel-ai-provider`) |
 | OpenClaw | `openclaw-cd.yml` | `openclaw-v*` | npm (`@mem0/openclaw-mem0`) |
+| OpenCode Plugin | `opencode-plugin-cd.yml` | `opencode-v*` | npm (`@mem0/opencode-plugin`) |
 
 - All publishing uses **OIDC trusted publishing** — no tokens or secrets required.
 - First publish of a new npm package must be done manually; OIDC works for subsequent versions.


### PR DESCRIPTION
## Linked Issue

N/A — infra follow-up to the `@mem0/opencode-plugin` package added in #5268–#5273 (same series, no separate tracking issue).

## Description

`@mem0/opencode-plugin` (in `mem0-plugin/.opencode-plugin/`) is currently the **only npm package in the repo without GitHub Actions workflows** — every other npm package (`mem0ai`, `@mem0/cli`, `@mem0/vercel-ai-provider`, `@mem0/openclaw-mem0`) has a CI "checks" workflow plus a CD "publish" workflow. This PR adds the matching pair so the package gets PR-time validation and automated, provenance-signed publishing.

**Key difference from the sibling workflows:** this package builds with **Bun**, not pnpm — its lockfile is `bun.lock` and its `build`/`type-check` scripts run under Bun. So the new workflows use `oven-sh/setup-bun@v2` + `bun install --frozen-lockfile` instead of the pnpm setup. The publish step keeps the established `npx npm@latest publish --provenance --access public` pattern so **OIDC trusted publishing** works identically to the other packages.

### What's added

- **`.github/workflows/opencode-plugin-checks.yml`** (CI) — runs on `workflow_dispatch`, push to `main`, and PRs touching `mem0-plugin/.opencode-plugin/**`. Steps: `bun install --frozen-lockfile` → `bun run type-check` (`tsc --noEmit`) → `bun run build` → verify `dist/index.js` exists.
- **`.github/workflows/opencode-plugin-cd.yml`** (CD) — runs on `release: [published]`, gated by `if: startsWith(github.event.release.tag_name, 'opencode-v')`. Builds with Bun and publishes to npm with provenance via OIDC (`id-token: write`), including the prerelease `--tag` handling used by the other packages.
- **`AGENTS.md`** — adds both workflows to the CI/CD tables (tag prefix `opencode-v*`). `CLAUDE.md` is a symlink to `AGENTS.md`, so it updates automatically.

### Release flow

Publishing a GitHub release tagged `opencode-v<version>` (e.g. `opencode-v0.1.0`) triggers the CD workflow.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Manual verification:
- Both workflow files parse as valid YAML.
- Reproduced the CI job locally: `cd mem0-plugin/.opencode-plugin && bun install --frozen-lockfile && bun run type-check && bun run build && test -f dist/index.js` — all pass, `dist/index.js` (~0.49 MB) is produced.
- CD cannot be exercised from a PR; it only runs when a maintainer publishes a release tagged `opencode-v*`.

> Note (out of scope): `package.json` `types` points to `dist/index.d.ts`, but the build emits `dist/opencode-mem0.d.ts` + `dist/cli.d.ts` (no `index.d.ts`). The CI verify step intentionally checks `dist/index.js` (the real entry). Happy to fix the types path in a follow-up if desired.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)