### PR TITLE
fix: support configurable spaCy model via MEM0_SPACY_MODEL env var

### DIFF
--- a/mem0/utils/spacy_models.py
+++ b/mem0/utils/spacy_models.py
@@ -7,15 +7,32 @@ each loading their own copy from disk.
 """
 
 import logging
+import os
 import threading
 
 logger = logging.getLogger(__name__)
+
+# 语言代码 → spaCy 模型名映射
+SPACY_MODEL_MAP: dict[str, str] = {
+    "en": "en_core_web_sm",
+    "zh": "zh_core_web_sm",
+}
 
 _nlp_full = None
 _nlp_lemma = None
 _load_failed_full = False
 _load_failed_lemma = False
 _lock = threading.Lock()
+
+
+def _get_model_name() -> str:
+    """从环境变量获取 spaCy 模型名。
+
+    支持语言代码（查 SPACY_MODEL_MAP）或完整模型名。
+    默认返回 en_core_web_sm。
+    """
+    val = os.environ.get("MEM0_SPACY_MODEL", "en_core_web_sm")
+    return SPACY_MODEL_MAP.get(val, val)
 
 
 def _ensure_model_available():

--- a/mem0/utils/spacy_models.py
+++ b/mem0/utils/spacy_models.py
@@ -18,10 +18,9 @@ SPACY_MODEL_MAP: dict[str, str] = {
     "zh": "zh_core_web_sm",
 }
 
-_nlp_full = None
-_nlp_lemma = None
-_load_failed_full = False
-_load_failed_lemma = False
+_nlp_full_cache: dict[str, object] = {}
+_nlp_lemma_cache: dict[str, object] = {}
+_load_failed: set[str] = set()
 _lock = threading.Lock()
 
 
@@ -35,8 +34,8 @@ def _get_model_name() -> str:
     return SPACY_MODEL_MAP.get(val, val)
 
 
-def _ensure_model_available():
-    """Download en_core_web_sm if spaCy is installed but model is missing."""
+def _ensure_model_available(model_name: str):
+    """检查并下载指定 spaCy 模型（如缺失）。"""
     try:
         import spacy
     except ImportError:
@@ -44,65 +43,81 @@ def _ensure_model_available():
             "spaCy is not installed. Install it with: pip install mem0ai[nlp]"
         )
 
-    if not spacy.util.is_package("en_core_web_sm"):
-        logger.info("Downloading spaCy model en_core_web_sm...")
+    if not spacy.util.is_package(model_name):
+        logger.info("Downloading spaCy model %s...", model_name)
         try:
             from spacy.cli import download
 
-            download("en_core_web_sm")
-            logger.info("spaCy model en_core_web_sm downloaded successfully")
-        except Exception as e:
+            download(model_name)
+            logger.info("spaCy model %s downloaded successfully", model_name)
+        except (Exception, SystemExit) as e:
             raise RuntimeError(
-                f"Failed to download spaCy model en_core_web_sm: {e}. "
-                "Please install manually: python -m spacy download en_core_web_sm"
+                f"Failed to download spaCy model {model_name}: {e}. "
+                f"Please install manually: python -m spacy download {model_name}"
             ) from e
 
 
 def get_nlp_full():
-    """Return spaCy model with all pipelines (NER, tagger, etc.) for entity extraction."""
-    global _nlp_full, _load_failed_full
-    if _load_failed_full:
+    """返回 spaCy 完整模型（NER、tagger 等），用于实体提取。"""
+    model_name = _get_model_name()
+    global _nlp_full_cache, _load_failed
+
+    if model_name in _load_failed:
         return None
-    if _nlp_full is not None:
-        return _nlp_full
+    cached = _nlp_full_cache.get(model_name)
+    if cached is not None:
+        return cached
+
     with _lock:
-        if _nlp_full is not None:
-            return _nlp_full
-        if _load_failed_full:
+        if model_name in _load_failed:
             return None
+        cached = _nlp_full_cache.get(model_name)
+        if cached is not None:
+            return cached
+
         try:
-            _ensure_model_available()
+            _ensure_model_available(model_name)
             import spacy
 
-            _nlp_full = spacy.load("en_core_web_sm")
-            logger.info("spaCy full model loaded")
+            _nlp_full_cache[model_name] = spacy.load(model_name)
+            logger.info("spaCy full model loaded: %s", model_name)
         except Exception as e:
-            logger.warning(f"Failed to load spaCy full model: {e}")
-            _load_failed_full = True
+            logger.warning("Failed to load spaCy full model %s: %s", model_name, e)
+            _load_failed.add(model_name)
             return None
-    return _nlp_full
+
+    return _nlp_full_cache[model_name]
 
 
 def get_nlp_lemma():
-    """Return spaCy model with only lemmatizer for BM25 text processing."""
-    global _nlp_lemma, _load_failed_lemma
-    if _load_failed_lemma:
+    """返回 spaCy 模型（仅 lemmatizer），用于 BM25 文本处理。"""
+    model_name = _get_model_name()
+    global _nlp_lemma_cache, _load_failed
+
+    if model_name in _load_failed:
         return None
-    if _nlp_lemma is not None:
-        return _nlp_lemma
+    cached = _nlp_lemma_cache.get(model_name)
+    if cached is not None:
+        return cached
+
     with _lock:
-        if _nlp_lemma is not None:
-            return _nlp_lemma
-        if _load_failed_lemma:
+        if model_name in _load_failed:
             return None
+        cached = _nlp_lemma_cache.get(model_name)
+        if cached is not None:
+            return cached
+
         try:
-            _ensure_model_available()
+            _ensure_model_available(model_name)
             import spacy
 
-            _nlp_lemma = spacy.load("en_core_web_sm", disable=["ner", "parser"])
-            logger.info("spaCy lemma model loaded")
+            _nlp_lemma_cache[model_name] = spacy.load(
+                model_name, disable=["ner", "parser"]
+            )
+            logger.info("spaCy lemma model loaded: %s", model_name)
         except Exception as e:
-            logger.warning(f"Failed to load spaCy lemma model: {e}")
-            _load_failed_lemma = True
+            logger.warning("Failed to load spaCy lemma model %s: %s", model_name, e)
+            _load_failed.add(model_name)
             return None
-    return _nlp_lemma
+
+    return _nlp_lemma_cache[model_name]

--- a/mem0/utils/spacy_models.py
+++ b/mem0/utils/spacy_models.py
@@ -62,18 +62,18 @@ def get_nlp_full():
     model_name = _get_model_name()
     global _nlp_full_cache, _load_failed
 
-    if model_name in _load_failed:
-        return None
     cached = _nlp_full_cache.get(model_name)
     if cached is not None:
         return cached
+    if model_name in _load_failed:
+        return None
 
     with _lock:
-        if model_name in _load_failed:
-            return None
         cached = _nlp_full_cache.get(model_name)
         if cached is not None:
             return cached
+        if model_name in _load_failed:
+            return None
 
         try:
             _ensure_model_available(model_name)
@@ -94,18 +94,18 @@ def get_nlp_lemma():
     model_name = _get_model_name()
     global _nlp_lemma_cache, _load_failed
 
-    if model_name in _load_failed:
-        return None
     cached = _nlp_lemma_cache.get(model_name)
     if cached is not None:
         return cached
+    if model_name in _load_failed:
+        return None
 
     with _lock:
-        if model_name in _load_failed:
-            return None
         cached = _nlp_lemma_cache.get(model_name)
         if cached is not None:
             return cached
+        if model_name in _load_failed:
+            return None
 
         try:
             _ensure_model_available(model_name)

--- a/tests/utils/test_spacy_models.py
+++ b/tests/utils/test_spacy_models.py
@@ -75,6 +75,18 @@ class TestSpacyModelCache:
         # lemma 模型禁用了 NER 和 parser，是不同的管道配置
         assert nlp_full is not nlp_lemma
 
+    def test_full_and_lemma_cache_independent(self):
+        from mem0.utils.spacy_models import get_nlp_full, get_nlp_lemma
+
+        nlp_full = get_nlp_full()
+        nlp_lemma = get_nlp_lemma()
+        # 不同的管道配置，应该是不同的对象
+        assert nlp_full is not nlp_lemma
+        # Full 应该有 ner/parser 管道
+        assert nlp_full.has_pipe("ner")
+        # Lemma 应该没有 ner/parser 管道
+        assert not nlp_lemma.has_pipe("ner")
+
 
 class TestSpacyModelFailure:
     """无效模型降级测试（不需要 spaCy 模型）。"""
@@ -86,4 +98,12 @@ class TestSpacyModelFailure:
 
         result = get_nlp_full()
         # 模型加载失败时应返回 None，不抛异常
+        assert result is None
+
+    def test_invalid_model_returns_none_for_lemma(self, monkeypatch):
+        monkeypatch.setenv("MEM0_SPACY_MODEL", "nonexistent_model_xyz")
+
+        from mem0.utils.spacy_models import get_nlp_lemma
+
+        result = get_nlp_lemma()
         assert result is None

--- a/tests/utils/test_spacy_models.py
+++ b/tests/utils/test_spacy_models.py
@@ -1,0 +1,89 @@
+"""Tests for shared spaCy model loader."""
+
+import pytest
+
+
+class TestGetModelName:
+    """_get_model_name() 模型名解析测试（纯逻辑，不需要 spaCy）。
+
+    _get_model_name() 在函数体内读取 os.environ，monkeypatch.setenv 直接生效。
+    """
+
+    def test_default_is_en_core_web_sm(self, monkeypatch):
+        monkeypatch.delenv("MEM0_SPACY_MODEL", raising=False)
+
+        from mem0.utils.spacy_models import _get_model_name
+
+        assert _get_model_name() == "en_core_web_sm"
+
+    def test_language_code_zh_maps_to_zh_core_web_sm(self, monkeypatch):
+        monkeypatch.setenv("MEM0_SPACY_MODEL", "zh")
+
+        from mem0.utils.spacy_models import _get_model_name
+
+        assert _get_model_name() == "zh_core_web_sm"
+
+    def test_full_model_name_passthrough(self, monkeypatch):
+        monkeypatch.setenv("MEM0_SPACY_MODEL", "ja_core_news_sm")
+
+        from mem0.utils.spacy_models import _get_model_name
+
+        assert _get_model_name() == "ja_core_news_sm"
+
+    def test_unknown_language_code_passthrough(self, monkeypatch):
+        monkeypatch.setenv("MEM0_SPACY_MODEL", "xx")
+
+        from mem0.utils.spacy_models import _get_model_name
+
+        assert _get_model_name() == "xx"
+
+
+class TestSpacyModelCache:
+    """get_nlp_full / get_nlp_lemma 缓存行为测试（需要 spaCy en_core_web_sm）。"""
+
+    @pytest.fixture(autouse=True)
+    def _ensure_spacy_and_default_env(self, monkeypatch):
+        monkeypatch.delenv("MEM0_SPACY_MODEL", raising=False)
+        try:
+            import spacy
+            spacy.load("en_core_web_sm")
+        except Exception:
+            pytest.skip("spaCy en_core_web_sm model not available")
+
+    def test_get_nlp_full_returns_model(self):
+        from mem0.utils.spacy_models import get_nlp_full
+
+        assert get_nlp_full() is not None
+
+    def test_get_nlp_lemma_returns_model(self):
+        from mem0.utils.spacy_models import get_nlp_lemma
+
+        assert get_nlp_lemma() is not None
+
+    def test_same_instance_on_repeated_calls(self):
+        from mem0.utils.spacy_models import get_nlp_full
+
+        nlp1 = get_nlp_full()
+        nlp2 = get_nlp_full()
+        assert nlp1 is nlp2
+
+    def test_full_and_lemma_are_different_models(self):
+        from mem0.utils.spacy_models import get_nlp_full, get_nlp_lemma
+
+        nlp_full = get_nlp_full()
+        nlp_lemma = get_nlp_lemma()
+        # lemma 模型禁用了 NER 和 parser，是不同的管道配置
+        assert nlp_full is not nlp_lemma
+
+
+class TestSpacyModelFailure:
+    """无效模型降级测试（不需要 spaCy 模型）。"""
+
+    def test_invalid_model_returns_none(self, monkeypatch):
+        monkeypatch.setenv("MEM0_SPACY_MODEL", "nonexistent_model_xyz")
+
+        from mem0.utils.spacy_models import get_nlp_full
+
+        result = get_nlp_full()
+        # 模型加载失败时应返回 None，不抛异常
+        assert result is None


### PR DESCRIPTION
## Summary

- 通过环境变量 `MEM0_SPACY_MODEL` 支持切换 spaCy 语言模型，解决硬编码 `en_core_web_sm` 的问题
- 支持语言代码映射（如 `MEM0_SPACY_MODEL=zh` → `zh_core_web_sm`）和完整模型名直传（如 `ja_core_news_sm`）
- 缓存从单变量改为按模型名索引的字典，不同模型独立缓存
- 调用方零改动，完全向后兼容（默认行为不变）

## Test Plan

- [x] 新增 11 个单元测试，覆盖模型名解析、缓存行为、降级处理
- [x] 已有 17 个工具层测试全部通过（零回归）
- [x] 验证调用方 `lemmatize_for_bm25()` 和 `extract_entities()` 功能正常
- [x] 验证 `MEM0_SPACY_MODEL=zh` 映射为 `zh_core_web_sm`

Fixes #5285

🤖 Generated with [Claude Code](https://claude.com/claude-code)