### PR TITLE
fix: upgrade node docker base images and pin pnpm to resolve sqlite b…

### DIFF
--- a/openmemory/ui/Dockerfile
+++ b/openmemory/ui/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker.io/docker/dockerfile:1
 
 # Base stage for common setup
-FROM node:18-alpine AS base
+FROM node:22-alpine AS base
 
 # Install dependencies for pnpm
 RUN apk add --no-cache libc6-compat curl && \

--- a/server/dashboard/Dockerfile
+++ b/server/dashboard/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS base
+FROM node:22-alpine AS base
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 

--- a/server/dashboard/package.json
+++ b/server/dashboard/package.json
@@ -79,5 +79,12 @@
     "prettier": "^3.5.2",
     "tailwindcss": "^3.3.0",
     "typescript": "^5.6.3"
+  },
+  "packageManager": "pnpm@10.5.2+sha512.da9dc28cd3ff40d0592188235ab25d3202add8a207afbedc682220e4a0029ffbff4562102b9e6e46b4e3f9e8bd53e6d05de48544b0c57d4b0179e22c76d1199b",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "sharp",
+      "unrs-resolver"
+    ]
   }
 }


### PR DESCRIPTION
Build errors

## Linked Issue

Closes #[5291](https://github.com/mem0ai/mem0/issues/5291)

## Description

Upgrade Node.js Docker base images to Node 22 (LTS), pin the  pnpm  version in the self-hosted dashboard.
Resolves build failures using `make bootstrap`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update


## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

**Manual Verification:**
- Verified that  docker compose build mem0-dashboard  builds and compiles successfully to completion.
- Verified that the packages resolve correctly under  pnpm@10.5.2 .

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
