### PR TITLE
fix: reject empty/whitespace queries in Memory.search()

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1173,6 +1173,11 @@ class Memory(MemoryBase):
         # Reject top-level entity params - must use filters instead
         _reject_top_level_entity_params(kwargs, "search")
 
+        # Validate query
+        if not isinstance(query, str) or not query.strip():
+            raise ValueError("Query must be a non-empty string. Provide a valid search query.")
+        query = query.strip()
+
         # Validate search parameters (before applying defaults)
         _validate_search_params(threshold=threshold, top_k=top_k)
 
@@ -2587,6 +2592,11 @@ class AsyncMemory(MemoryBase):
         """
         # Reject top-level entity params - must use filters instead
         _reject_top_level_entity_params(kwargs, "search")
+
+        # Validate query
+        if not isinstance(query, str) or not query.strip():
+            raise ValueError("Query must be a non-empty string. Provide a valid search query.")
+        query = query.strip()
 
         # Validate search parameters (before applying defaults)
         _validate_search_params(threshold=threshold, top_k=top_k)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -842,6 +842,30 @@ def test_search_rejects_user_id_kwarg(mock_sqlite, mock_llm_factory, mock_vector
 @patch('mem0.utils.factory.VectorStoreFactory.create')
 @patch('mem0.utils.factory.LlmFactory.create')
 @patch('mem0.memory.storage.SQLiteManager')
+def test_search_rejects_empty_query(mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
+    """search() should reject empty or whitespace-only queries (#5220)."""
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    config = MemoryConfig()
+    memory = Memory(config)
+
+    with pytest.raises(ValueError, match=r"non-empty string"):
+        memory.search("", filters={"user_id": "u1"})
+
+    with pytest.raises(ValueError, match=r"non-empty string"):
+        memory.search("   ", filters={"user_id": "u1"})
+
+    with pytest.raises(ValueError, match=r"non-empty string"):
+        memory.search("\t\n", filters={"user_id": "u1"})
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
 def test_get_all_rejects_user_id_kwarg(mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
     """get_all() should reject user_id as top-level kwarg."""
     mock_embedder_factory.return_value = MagicMock()


### PR DESCRIPTION
## Linked Issue

Closes #5220

## Description

Passing an empty or whitespace-only query to `search()` silently proceeds to call the embedding model and vector store with useless input, wasting API calls and returning low-quality results.

This adds early validation that mirrors the existing `_validate_and_trim_entity_id` pattern: strip the query, raise `ValueError` if it becomes empty. Applied to both `Memory.search()` and `AsyncMemory.search()`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test Coverage

- [x] I added/updated unit tests

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally