### PR TITLE
fix(pgvector): correct connection-string and config validation handling

### DIFF
--- a/mem0/configs/vector_stores/pgvector.py
+++ b/mem0/configs/vector_stores/pgvector.py
@@ -9,8 +9,8 @@ class PGVectorConfig(BaseModel):
     embedding_model_dims: Optional[int] = Field(1536, description="Dimensions of the embedding model")
     user: Optional[str] = Field(None, description="Database user")
     password: Optional[str] = Field(None, description="Database password")
-    host: Optional[str] = Field(None, description="Database host. Default is localhost")
-    port: Optional[int] = Field(None, description="Database port. Default is 1536")
+    host: Optional[str] = Field(None, description="Database host")
+    port: Optional[int] = Field(None, description="Database port (PostgreSQL default is 5432)")
     diskann: Optional[bool] = Field(False, description="Use diskann for approximate nearest neighbors search")
     hnsw: Optional[bool] = Field(True, description="Use hnsw for faster search")
     minconn: Optional[int] = Field(1, description="Minimum number of connections in the pool")
@@ -33,9 +33,9 @@ class PGVectorConfig(BaseModel):
         # Otherwise, validate individual connection parameters
         user, password = values.get("user"), values.get("password")
         host, port = values.get("host"), values.get("port")
-        if not user and not password:
+        if not user or not password:
             raise ValueError("Both 'user' and 'password' must be provided when not using connection_string.")
-        if not host and not port:
+        if not host or not port:
             raise ValueError("Both 'host' and 'port' must be provided when not using connection_string.")
         return values
 

--- a/mem0/vector_stores/pgvector.py
+++ b/mem0/vector_stores/pgvector.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 from contextlib import contextmanager
 from typing import Any, List, Optional
 
@@ -113,6 +114,25 @@ def _build_filter_conditions(filters):
     return conditions, params
 
 
+def _append_sslmode(connection_string: str, sslmode: str) -> str:
+    """Add or replace sslmode in a libpq connection string, respecting its format.
+
+    URI strings (``postgresql://...``) carry parameters in a query string
+    (``?sslmode=...`` / ``&sslmode=...``), while keyword/value DSN strings use
+    space-separated ``sslmode=...``. Mixing the two (e.g. appending a
+    space-separated keyword onto a URI) makes libpq fold it into the dbname and
+    silently drops the SSL setting.
+    """
+    if "sslmode=" in connection_string:
+        return re.sub(r"sslmode=[^ &]*", f"sslmode={sslmode}", connection_string)
+
+    if connection_string.startswith(("postgresql://", "postgres://")):
+        separator = "&" if "?" in connection_string else "?"
+        return f"{connection_string}{separator}sslmode={sslmode}"
+
+    return f"{connection_string} sslmode={sslmode}"
+
+
 class OutputData(BaseModel):
     id: Optional[str]
     score: Optional[float]
@@ -168,18 +188,11 @@ class PGVector(VectorStoreBase):
             self.connection_pool = connection_pool
         elif connection_string:
             if sslmode:
-                # Append sslmode to connection string if provided
-                if 'sslmode=' in connection_string:
-                    # Replace existing sslmode
-                    import re
-                    connection_string = re.sub(r'sslmode=[^ ]*', f'sslmode={sslmode}', connection_string)
-                else:
-                    # Add sslmode to connection string
-                    connection_string = f"{connection_string} sslmode={sslmode}"
+                connection_string = _append_sslmode(connection_string, sslmode)
         else:
             connection_string = f"postgresql://{user}:{password}@{host}:{port}/{dbname}"
             if sslmode:
-                connection_string = f"{connection_string} sslmode={sslmode}"
+                connection_string = _append_sslmode(connection_string, sslmode)
         
         if self.connection_pool is None:
             if PSYCOPG_VERSION == 3:

--- a/tests/vector_stores/test_pgvector.py
+++ b/tests/vector_stores/test_pgvector.py
@@ -2067,7 +2067,7 @@ class TestPGVector(unittest.TestCase):
         self.mock_cursor.fetchall.return_value = []  # No existing collections
         
         connection_string = "postgresql://user:pass@localhost:5432/db"
-        
+
         pgvector = PGVector(
             dbname="test_db",  # Will be overridden by connection_string
             collection_name="test_collection",
@@ -2083,9 +2083,10 @@ class TestPGVector(unittest.TestCase):
             sslmode="require",
             connection_string=connection_string
         )
-        
-        # Verify ConnectionPool was called with the connection string including sslmode
-        expected_conn_string = f"{connection_string} sslmode=require"
+
+        # A URI connection string must carry sslmode in the query string, not as a
+        # space-separated keyword (which libpq would fold into the dbname).
+        expected_conn_string = f"{connection_string}?sslmode=require"
         mock_connection_pool.assert_called_with(
             conninfo=expected_conn_string,
             min_size=1,
@@ -2094,6 +2095,131 @@ class TestPGVector(unittest.TestCase):
         )
         self.assertEqual(pgvector.collection_name, "test_collection")
         self.assertEqual(pgvector.embedding_model_dims, 3)
+
+    @patch('mem0.vector_stores.pgvector.PSYCOPG_VERSION', 3)
+    @patch('mem0.vector_stores.pgvector.ConnectionPool')
+    def test_init_individual_params_with_sslmode_uses_query_string_psycopg3(self, mock_connection_pool):
+        """Individual params + sslmode must build a valid URI (?sslmode=...)."""
+        mock_connection_pool.return_value = self.mock_pool_psycopg
+        self.mock_cursor.fetchall.return_value = []
+
+        PGVector(
+            dbname="test_db",
+            collection_name="test_collection",
+            embedding_model_dims=3,
+            user="test_user",
+            password="test_pass",
+            host="localhost",
+            port=5432,
+            diskann=False,
+            hnsw=False,
+            minconn=1,
+            maxconn=4,
+            sslmode="require",
+        )
+
+        mock_connection_pool.assert_called_once_with(
+            conninfo="postgresql://test_user:test_pass@localhost:5432/test_db?sslmode=require",
+            min_size=1,
+            max_size=4,
+            open=True,
+        )
+
+    @patch('mem0.vector_stores.pgvector.PSYCOPG_VERSION', 3)
+    @patch('mem0.vector_stores.pgvector.ConnectionPool')
+    def test_uri_connection_string_with_existing_query_param_appends_with_ampersand(self, mock_connection_pool):
+        """A URI that already has a query param appends sslmode with '&'."""
+        mock_connection_pool.return_value = self.mock_pool_psycopg
+        self.mock_cursor.fetchall.return_value = []
+
+        connection_string = "postgresql://user:pass@localhost:5432/db?connect_timeout=10"
+
+        PGVector(
+            dbname="test_db",
+            collection_name="test_collection",
+            embedding_model_dims=3,
+            user="test_user",
+            password="test_pass",
+            host="localhost",
+            port=5432,
+            diskann=False,
+            hnsw=False,
+            minconn=1,
+            maxconn=4,
+            sslmode="require",
+            connection_string=connection_string,
+        )
+
+        mock_connection_pool.assert_called_with(
+            conninfo=f"{connection_string}&sslmode=require",
+            min_size=1,
+            max_size=4,
+            open=True,
+        )
+
+    @patch('mem0.vector_stores.pgvector.PSYCOPG_VERSION', 3)
+    @patch('mem0.vector_stores.pgvector.ConnectionPool')
+    def test_keyword_value_dsn_with_sslmode_uses_space_separator(self, mock_connection_pool):
+        """A keyword/value DSN appends sslmode space-separated, not as a query string."""
+        mock_connection_pool.return_value = self.mock_pool_psycopg
+        self.mock_cursor.fetchall.return_value = []
+
+        connection_string = "host=localhost port=5432 dbname=db user=u password=p"
+
+        PGVector(
+            dbname="test_db",
+            collection_name="test_collection",
+            embedding_model_dims=3,
+            user="test_user",
+            password="test_pass",
+            host="localhost",
+            port=5432,
+            diskann=False,
+            hnsw=False,
+            minconn=1,
+            maxconn=4,
+            sslmode="require",
+            connection_string=connection_string,
+        )
+
+        mock_connection_pool.assert_called_with(
+            conninfo=f"{connection_string} sslmode=require",
+            min_size=1,
+            max_size=4,
+            open=True,
+        )
+
+    @patch('mem0.vector_stores.pgvector.PSYCOPG_VERSION', 3)
+    @patch('mem0.vector_stores.pgvector.ConnectionPool')
+    def test_existing_sslmode_in_connection_string_is_replaced(self, mock_connection_pool):
+        """An existing sslmode value is replaced without corrupting other params."""
+        mock_connection_pool.return_value = self.mock_pool_psycopg
+        self.mock_cursor.fetchall.return_value = []
+
+        connection_string = "postgresql://user:pass@localhost:5432/db?sslmode=disable&connect_timeout=10"
+
+        PGVector(
+            dbname="test_db",
+            collection_name="test_collection",
+            embedding_model_dims=3,
+            user="test_user",
+            password="test_pass",
+            host="localhost",
+            port=5432,
+            diskann=False,
+            hnsw=False,
+            minconn=1,
+            maxconn=4,
+            sslmode="require",
+            connection_string=connection_string,
+        )
+
+        mock_connection_pool.assert_called_with(
+            conninfo="postgresql://user:pass@localhost:5432/db?sslmode=require&connect_timeout=10",
+            min_size=1,
+            max_size=4,
+            open=True,
+        )
 
     # Enhanced Test for Index Creation with DiskANN
     @patch('mem0.vector_stores.pgvector.PSYCOPG_VERSION', 3)

--- a/tests/vector_stores/test_pgvector.py
+++ b/tests/vector_stores/test_pgvector.py
@@ -4,6 +4,7 @@ import unittest
 import uuid
 from unittest.mock import MagicMock, patch
 
+from mem0.configs.vector_stores.pgvector import PGVectorConfig
 from mem0.vector_stores.pgvector import PGVector, _build_filter_conditions
 
 
@@ -2534,3 +2535,49 @@ class TestBuildFilterConditions(unittest.TestCase):
     def test_numeric_scalar_becomes_string(self):
         conditions, params = _build_filter_conditions({"priority": 42})
         self.assertEqual(params, ["priority", "42"])
+
+
+class TestPGVectorConfigValidation(unittest.TestCase):
+    """Validation of PGVectorConfig connection-parameter requirements."""
+
+    def _full_params(self, **overrides):
+        params = {
+            "user": "u",
+            "password": "p",
+            "host": "localhost",
+            "port": 5432,
+        }
+        params.update(overrides)
+        return params
+
+    def test_full_individual_params_are_valid(self):
+        config = PGVectorConfig(**self._full_params())
+        self.assertEqual(config.host, "localhost")
+        self.assertEqual(config.port, 5432)
+
+    def test_missing_password_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            PGVectorConfig(**self._full_params(password=None))
+        self.assertIn("'user' and 'password'", str(ctx.exception))
+
+    def test_missing_user_raises(self):
+        with self.assertRaises(ValueError):
+            PGVectorConfig(**self._full_params(user=None))
+
+    def test_missing_port_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            PGVectorConfig(**self._full_params(port=None))
+        self.assertIn("'host' and 'port'", str(ctx.exception))
+
+    def test_missing_host_raises(self):
+        with self.assertRaises(ValueError):
+            PGVectorConfig(**self._full_params(host=None))
+
+    def test_connection_string_skips_individual_param_validation(self):
+        config = PGVectorConfig(connection_string="postgresql://u:p@localhost:5432/db")
+        self.assertEqual(config.connection_string, "postgresql://u:p@localhost:5432/db")
+
+    def test_connection_pool_skips_individual_param_validation(self):
+        sentinel = object()
+        config = PGVectorConfig(connection_pool=sentinel)
+        self.assertIs(config.connection_pool, sentinel)


### PR DESCRIPTION
## Linked Issue

No existing issue. Both bugs are described in full below so they can be triaged from this PR. They are closely related (PostgreSQL connection configuration in the `pgvector` store), hence bundled together.

## Description

### 1. Invalid connection string when `sslmode` is set

In the individual-parameters path, `PGVector.__init__` always builds a **URI** (`postgresql://user:pass@host:port/dbname`) but appended `sslmode` using the **keyword/value DSN** syntax (space-separated):

```
postgresql://user:pass@host:5432/db sslmode=require
```

libpq detects the `postgresql://` prefix and parses the whole thing as a URI, where parameters must live in the query string (`?sslmode=...`). The space-separated ` sslmode=require` is therefore folded into the database name (dbname becomes `db sslmode=require`), which (1) silently drops the SSL setting and (2) typically fails the connection with `database "db sslmode=require" does not exist`. The same applied when a user passed a URI `connection_string` together with `sslmode`.

**Fix:** added a helper `_append_sslmode(connection_string, sslmode)` that attaches `sslmode` according to the connection-string format:
- **URI** (`postgresql://` / `postgres://`): query string — `?sslmode=...`, or `&sslmode=...` if a query string already exists.
- **keyword/value DSN** (`host=... port=...`): space-separated `sslmode=...`.
- **existing `sslmode=`**: replace the value in place without corrupting other query params.

### 2. Connection-parameter validation used `and` instead of `or`

`PGVectorConfig.check_auth_and_connection` validated with:

```python
if not user and not password:
    raise ValueError("Both 'user' and 'password' must be provided ...")
if not host and not port:
    raise ValueError("Both 'host' and 'port' must be provided ...")
```

The messages state both values are required, but `and` only raises when **both** are missing. Supplying only `host` (or only `user`) passed validation and then produced a broken connection string — e.g. a missing port renders as the literal `None` in `postgresql://user:pass@host:None/db`, failing with a confusing error.

**Fix:** switched both checks to `or` so a half-specified pair is rejected up front. Also corrected the `host`/`port` field descriptions, which advertised defaults that are never applied (and a wrong port value of `1536`).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

Configurations that previously passed validation while specifying only one of `user`/`password` or only one of `host`/`port` will now raise at config time instead of failing later with an opaque connection error. This only rejects configs that could never have produced a working connection. Setups that legitimately omit a password (e.g. peer/trust auth) should use `connection_string`.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

In `tests/vector_stores/test_pgvector.py`:
- Corrected `test_connection_string_with_sslmode_psycopg3`, which previously asserted the buggy space-separated form for a URI.
- Added connection-string regression tests: individual params + sslmode → `?sslmode=`; URI with an existing query param → `&sslmode=`; keyword/value DSN → space-separated; existing `sslmode` replaced without corrupting other params.
- Added `TestPGVectorConfigValidation` covering: full params valid; missing user/password/host/port each raise; `connection_string` and `connection_pool` skip individual-param validation.

All 89 tests in `tests/vector_stores/test_pgvector.py` pass; `ruff check` is clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (N/A — internal connection handling)