### PR TITLE
fix(server): add google-genai dependency to requirements.txt

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -10,6 +10,7 @@ psycopg-pool>=3.2.6,<4.0.0
 # here, rebuilding the image, and updating BUNDLED_*_PROVIDERS in main.py.
 anthropic>=0.39,<1.0
 google-generativeai>=0.8,<1.0
+google-genai>=1.0.0,<1.1
 
 # Auth & database (Phase 1)
 sqlalchemy>=2.0,<3.0


### PR DESCRIPTION
## Description

This PR resolves a crash on the self-hosted FastAPI server when saving or using the Google/Gemini LLM Provider.

**Root Cause:**
In an update, core mem0ai SDK migrated from [deprecated google-generativeai](https://docs.mem0.ai/components/llms/models/google_AI) package to the new official `google-genai`  SDK (importing  `from google import genai`). 
However, standalone `server/requirements.txt` used to build self-hosted server's Docker image was not updated. 
This caused an `Internal Server Error`.

**Fix:**
- Added `google-genai>=1.0.0` to `server/requirements.txt`.


## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update


## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Rebuilt the mem0 container via `docker compose -f server/docker-compose.yaml up -d --build mem0`  and verified that the config saves successfully.


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed