### PR TITLE
fix(memory): parallelize entity boost searches in AsyncMemory.search

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -2871,16 +2871,33 @@ class AsyncMemory(MemoryBase):
         search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
         memory_boosts = {}
 
+        async def _search_entity(entity_text):
+            # Embed + entity-store search for a single entity. Each entity's work
+            # is independent, so these run concurrently via asyncio.gather below.
+            entity_embedding = await asyncio.to_thread(self.embedding_model.embed, entity_text, "search")
+            return await asyncio.to_thread(
+                self.entity_store.search,
+                query=entity_text,
+                vectors=entity_embedding,
+                top_k=500,
+                filters=search_filters,
+            )
+
         try:
-            for _, entity_text in deduped:
-                entity_embedding = await asyncio.to_thread(self.embedding_model.embed, entity_text, "search")
-                matches = await asyncio.to_thread(
-                    self.entity_store.search,
-                    query=entity_text,
-                    vectors=entity_embedding,
-                    top_k=500,
-                    filters=search_filters,
-                )
+            # Run the per-entity embedding/search calls in parallel instead of
+            # sequentially. With a remote embedding provider this turns the
+            # latency from roughly the sum of all calls into roughly the slowest
+            # single call. return_exceptions=True keeps one failed entity from
+            # aborting the others; failures are logged and skipped.
+            results = await asyncio.gather(
+                *(_search_entity(entity_text) for _, entity_text in deduped),
+                return_exceptions=True,
+            )
+
+            for matches in results:
+                if isinstance(matches, Exception):
+                    logger.warning(f"Entity boost search failed for one entity: {matches}")
+                    continue
 
                 for match in matches:
                     similarity = match.score if hasattr(match, 'score') else 0.0

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -1,5 +1,7 @@
 import logging
+import time
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock
 
 import pytest
@@ -663,3 +665,106 @@ async def test_async_update_preserves_actor_id_when_different_actor_updates(mock
     assert stored["actor_id"] == "Alice"
 
 
+
+
+class TestAsyncEntityBoostParallelism:
+    """Regression tests for #5214 — entity boost searches in AsyncMemory run in
+    parallel instead of sequentially, while preserving scoring behaviour."""
+
+    @pytest.fixture
+    def mock_async_memory(self, mocker):
+        _setup_mocks(mocker)
+        memory = AsyncMemory()
+        return memory
+
+    @staticmethod
+    def _match(score, linked_memory_ids):
+        return SimpleNamespace(score=score, payload={"linked_memory_ids": linked_memory_ids})
+
+    @pytest.mark.asyncio
+    async def test_boosts_preserve_scoring(self, mock_async_memory):
+        """Parallelised computation yields the same max-aggregated boosts as the
+        sequential reference math (ENTITY_BOOST_WEIGHT * similarity * weight)."""
+        from mem0.utils.scoring import ENTITY_BOOST_WEIGHT
+
+        mock_async_memory.embedding_model = Mock()
+        mock_async_memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+
+        # Two entities; "mem-1" is linked by both, so its boost must be the max.
+        results_by_query = {
+            "alice": [self._match(0.9, ["mem-1"])],          # single link -> weight 1.0
+            "bob": [self._match(0.6, ["mem-1", "mem-2"])],   # two links -> attenuated
+        }
+
+        def fake_search(query, vectors, top_k, filters):
+            return results_by_query[query]
+
+        mock_async_memory._entity_store = Mock()
+        mock_async_memory._entity_store.search = Mock(side_effect=fake_search)
+
+        boosts = await mock_async_memory._compute_entity_boosts_async(
+            [("person", "alice"), ("person", "bob")],
+            {"user_id": "u1"},
+        )
+
+        # Expected reference math
+        boost_alice = 0.9 * ENTITY_BOOST_WEIGHT * (1.0 / (1.0 + 0.001 * (0 ** 2)))
+        boost_bob = 0.6 * ENTITY_BOOST_WEIGHT * (1.0 / (1.0 + 0.001 * (1 ** 2)))
+        assert boosts["mem-1"] == pytest.approx(max(boost_alice, boost_bob))
+        assert boosts["mem-2"] == pytest.approx(boost_bob)
+        # Below-threshold matches are excluded
+        assert boost_alice > boost_bob  # sanity: alice link wins for mem-1
+
+    @pytest.mark.asyncio
+    async def test_one_entity_failure_does_not_abort_others(self, mock_async_memory, caplog):
+        """A failure embedding/searching a single entity is logged and skipped;
+        remaining entities still contribute boosts (return_exceptions=True)."""
+        mock_async_memory.embedding_model = Mock()
+        mock_async_memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+
+        def fake_search(query, vectors, top_k, filters):
+            if query == "boom":
+                raise RuntimeError("provider timeout")
+            return [self._match(0.8, ["mem-9"])]
+
+        mock_async_memory._entity_store = Mock()
+        mock_async_memory._entity_store.search = Mock(side_effect=fake_search)
+
+        with caplog.at_level(logging.WARNING):
+            boosts = await mock_async_memory._compute_entity_boosts_async(
+                [("person", "boom"), ("person", "ok")],
+                {"user_id": "u1"},
+            )
+
+        assert "mem-9" in boosts  # surviving entity still produced a boost
+        assert any("Entity boost search failed" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_searches_run_concurrently(self, mock_async_memory):
+        """Entity searches overlap in time, proving they are not serialised.
+        Each entity's search sleeps; total wall time must be ~one sleep, not N."""
+        mock_async_memory.embedding_model = Mock()
+        mock_async_memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+
+        concurrent = {"current": 0, "peak": 0}
+
+        def blocking_search(query, vectors, top_k, filters):
+            # asyncio.to_thread runs this in a worker thread; track overlap.
+            concurrent["current"] += 1
+            concurrent["peak"] = max(concurrent["peak"], concurrent["current"])
+            time.sleep(0.2)
+            concurrent["current"] -= 1
+            return [self._match(0.7, [f"mem-{query}"])]
+
+        mock_async_memory._entity_store = Mock()
+        mock_async_memory._entity_store.search = Mock(side_effect=blocking_search)
+
+        entities = [("person", f"e{i}") for i in range(4)]
+        start = time.perf_counter()
+        boosts = await mock_async_memory._compute_entity_boosts_async(entities, {"user_id": "u1"})
+        elapsed = time.perf_counter() - start
+
+        # 4 sequential sleeps would be ~0.8s; parallel should be well under that.
+        assert elapsed < 0.6, f"searches did not run concurrently (took {elapsed:.2f}s)"
+        assert concurrent["peak"] >= 2, "no overlap observed between entity searches"
+        assert len(boosts) == 4


### PR DESCRIPTION
## Summary

- Run the per-entity embedding + entity-store searches in `AsyncMemory._compute_entity_boosts_async` concurrently instead of sequentially.
- Cuts entity-boost latency from roughly the **sum** of all per-entity calls to roughly the **slowest single** call, with no change to scoring behaviour.

## Motivation

Closes #5214.

`AsyncMemory.search()` can become slow when entity boost runs for multiple extracted entities. `_compute_entity_boosts_async()` processed up to 8 deduped entities in a `for` loop, `await`ing each entity's embedding call and entity-store search before starting the next. With a remote embedding provider, wall time is roughly the sum of every per-entity call, which can push otherwise-normal searches into multi-second territory or request timeouts — even though the per-entity work is fully independent.

## Fix

```python
results = await asyncio.gather(
    *(_search_entity(entity_text) for _, entity_text in deduped),
    return_exceptions=True,
)
```

- Each entity's embed + search is wrapped in a small `_search_entity` coroutine and dispatched via `asyncio.gather`, so the independent remote calls overlap.
- `return_exceptions=True` keeps a single failing entity (provider timeout, throttle, transient 5xx) from aborting the others — the failure is logged at `WARNING` and that entity is skipped, matching the previous best-effort behaviour.
- Scoring is **unchanged**: the same `similarity * ENTITY_BOOST_WEIGHT * memory_count_weight` math and `max()` aggregation run over the gathered results. Because `max()` is order-independent, concurrent completion produces identical boosts to the old sequential order.

## Verification

`python3 -m pytest tests/memory/test_main.py` — 37 passed (3 new + 34 existing).

New tests in `tests/memory/test_main.py::TestAsyncEntityBoostParallelism`:
- `test_boosts_preserve_scoring` — output matches the reference scoring math, including the `max()` aggregation when one memory is linked by two entities.
- `test_one_entity_failure_does_not_abort_others` — a raising entity search is logged and skipped while the surviving entity still contributes a boost.
- `test_searches_run_concurrently` — 4 sleeping searches finish in < 0.6 s (vs ~0.8 s sequential) and observed concurrency peak ≥ 2, proving the calls overlap.

Diff is scoped to 2 files (`mem0/memory/main.py`, `tests/memory/test_main.py`); the sync `_compute_entity_boosts` path is intentionally left untouched.
