### PR TITLE
fix(llms/xai): fix factory AttributeError and forward tool calls

### DIFF
--- a/mem0/llms/xai.py
+++ b/mem0/llms/xai.py
@@ -1,3 +1,4 @@
+import json
 import os
 from typing import Dict, List, Optional
 
@@ -5,6 +6,7 @@ from openai import OpenAI
 
 from mem0.configs.llms.base import BaseLlmConfig
 from mem0.llms.base import LLMBase
+from mem0.memory.utils import extract_json
 
 
 class XAILLM(LLMBase):
@@ -15,8 +17,41 @@ class XAILLM(LLMBase):
             self.config.model = "grok-2-latest"
 
         api_key = self.config.api_key or os.getenv("XAI_API_KEY")
-        base_url = self.config.xai_base_url or os.getenv("XAI_API_BASE") or "https://api.x.ai/v1"
+        # The factory wires xai with a plain BaseLlmConfig, which has no
+        # `xai_base_url` attribute. Use getattr so construction works with or
+        # without it instead of raising AttributeError on every call.
+        base_url = getattr(self.config, "xai_base_url", None) or os.getenv("XAI_API_BASE") or "https://api.x.ai/v1"
         self.client = OpenAI(api_key=api_key, base_url=base_url)
+
+    def _parse_response(self, response, tools):
+        """
+        Process the response based on whether tools are used or not.
+
+        Args:
+            response: The raw response from API.
+            tools: The list of tools provided in the request.
+
+        Returns:
+            str or dict: The processed response.
+        """
+        if tools:
+            processed_response = {
+                "content": response.choices[0].message.content,
+                "tool_calls": [],
+            }
+
+            if response.choices[0].message.tool_calls:
+                for tool_call in response.choices[0].message.tool_calls:
+                    processed_response["tool_calls"].append(
+                        {
+                            "name": tool_call.function.name,
+                            "arguments": json.loads(extract_json(tool_call.function.arguments)),
+                        }
+                    )
+
+            return processed_response
+        else:
+            return response.choices[0].message.content
 
     def generate_response(
         self,
@@ -35,7 +70,8 @@ class XAILLM(LLMBase):
             tool_choice (str, optional): Tool choice method. Defaults to "auto".
 
         Returns:
-            str: The generated response.
+            str or dict: The generated response. A dict with ``content`` and
+            ``tool_calls`` when ``tools`` are supplied, otherwise the message string.
         """
         params = {
             "model": self.config.model,
@@ -47,6 +83,9 @@ class XAILLM(LLMBase):
 
         if response_format:
             params["response_format"] = response_format
+        if tools:
+            params["tools"] = tools
+            params["tool_choice"] = tool_choice
 
         response = self.client.chat.completions.create(**params)
-        return response.choices[0].message.content
+        return self._parse_response(response, tools)

--- a/tests/llms/test_xai.py
+++ b/tests/llms/test_xai.py
@@ -1,0 +1,92 @@
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mem0.configs.llms.base import BaseLlmConfig
+from mem0.llms.xai import XAILLM
+from mem0.utils.factory import LlmFactory
+
+
+@pytest.fixture
+def mock_xai_client():
+    with patch("mem0.llms.xai.OpenAI") as mock_openai:
+        mock_client = Mock()
+        mock_openai.return_value = mock_client
+        yield mock_client
+
+
+def test_factory_construction_with_base_config_does_not_raise():
+    """Bug 1 (#5189): the factory wires xai with a plain BaseLlmConfig that has
+    no `xai_base_url` attribute. Construction must not raise AttributeError and
+    must fall back to the default x.ai base URL."""
+    with patch("mem0.llms.xai.OpenAI") as mock_openai:
+        llm = LlmFactory.create("xai", {"model": "grok-2-latest", "api_key": "sk-test"})
+        assert isinstance(llm, XAILLM)
+        # default base url forwarded to the OpenAI-compatible client
+        assert mock_openai.call_args.kwargs["base_url"] == "https://api.x.ai/v1"
+
+
+def test_generate_response_without_tools(mock_xai_client):
+    config = BaseLlmConfig(model="grok-2-latest", temperature=0.7, max_tokens=100, top_p=1.0, api_key="sk-test")
+    llm = XAILLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Hi there"))]
+    mock_xai_client.chat.completions.create.return_value = mock_response
+
+    result = llm.generate_response(messages)
+
+    create_kwargs = mock_xai_client.chat.completions.create.call_args[1]
+    assert "tools" not in create_kwargs
+    assert "tool_choice" not in create_kwargs
+    assert result == "Hi there"
+
+
+def test_generate_response_forwards_tools(mock_xai_client):
+    """Bug 2 (#5189): tools and tool_choice must be forwarded to the client."""
+    config = BaseLlmConfig(model="grok-2-latest", temperature=0.7, max_tokens=100, top_p=1.0, api_key="sk-test")
+    llm = XAILLM(config)
+    messages = [{"role": "user", "content": "Remember I like tennis"}]
+    tools = [{"type": "function", "function": {"name": "add_memory", "parameters": {}}}]
+
+    mock_message = Mock(content=None)
+    mock_message.tool_calls = [
+        Mock(function=Mock(name="add_memory", arguments='{"data": "likes tennis"}'))
+    ]
+    # `name` is special on Mock construction; set it explicitly.
+    mock_message.tool_calls[0].function.name = "add_memory"
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=mock_message)]
+    mock_xai_client.chat.completions.create.return_value = mock_response
+
+    result = llm.generate_response(messages, tools=tools, tool_choice="auto")
+
+    create_kwargs = mock_xai_client.chat.completions.create.call_args[1]
+    assert create_kwargs["tools"] == tools
+    assert create_kwargs["tool_choice"] == "auto"
+
+    # Bug 3 (#5189): tool-call payload must be parsed, not dropped.
+    assert isinstance(result, dict)
+    assert result["content"] is None
+    assert result["tool_calls"] == [{"name": "add_memory", "arguments": {"data": "likes tennis"}}]
+
+
+def test_generate_response_with_tools_but_no_tool_calls(mock_xai_client):
+    """When tools are supplied but the model returns plain content, the parsed
+    response should still be the structured dict with an empty tool_calls list."""
+    config = BaseLlmConfig(model="grok-2-latest", api_key="sk-test")
+    llm = XAILLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+    tools = [{"type": "function", "function": {"name": "noop", "parameters": {}}}]
+
+    mock_message = Mock(content="just text")
+    mock_message.tool_calls = []
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=mock_message)]
+    mock_xai_client.chat.completions.create.return_value = mock_response
+
+    result = llm.generate_response(messages, tools=tools)
+
+    assert result == {"content": "just text", "tool_calls": []}


### PR DESCRIPTION
## Summary

- Fix three bugs in the XAI (Grok) provider, all in `mem0/llms/xai.py`: an `AttributeError` on every factory construction, silently-dropped `tools`/`tool_choice`, and dropped tool-call payloads.
- Minimal, single-file fix that mirrors the existing OpenAI provider's `_parse_response`.

## Motivation

Closes #5189.

1. **AttributeError on construction** — the constructor read `self.config.xai_base_url` unconditionally, but the factory wires xai with a plain `BaseLlmConfig` (`mem0/utils/factory.py:51`), which has no such attribute. So `Memory.from_config(...)` / `LlmFactory.create("xai", ...)` raised `AttributeError` for everyone, even users who never set a base URL.
2. **Tools silently dropped** — `generate_response()` accepted `tools` and `tool_choice` but never forwarded them to the OpenAI-compatible client, so tool calling did nothing on Grok.
3. **Tool-call payload dropped** — there was no `_parse_response` helper, so `message.content` (which is `None` when the model emits tool calls) was returned raw and the structured tool-call payload was lost.

## Fix

- `base_url = getattr(self.config, "xai_base_url", None) or os.getenv("XAI_API_BASE") or "https://api.x.ai/v1"` — works whether or not the config carries `xai_base_url`.
- Forward `tools`/`tool_choice` to `chat.completions.create` when provided.
- Add the same `_parse_response(response, tools)` the OpenAI provider uses (incl. `extract_json` for tool arguments), returning a `{"content", "tool_calls"}` dict when tools are used and the plain string otherwise.

## Verification

`python3 -m pytest tests/llms/test_xai.py` — 4 passed.

New `tests/llms/test_xai.py`:
- `test_factory_construction_with_base_config_does_not_raise` — `LlmFactory.create("xai", ...)` no longer raises and falls back to `https://api.x.ai/v1`.
- `test_generate_response_without_tools` — plain string path, no `tools` sent.
- `test_generate_response_forwards_tools` — `tools`/`tool_choice` forwarded; tool-call payload parsed into `{"name", "arguments"}`.
- `test_generate_response_with_tools_but_no_tool_calls` — structured dict with empty `tool_calls` when the model returns plain content.

## Differential value

#5190 also closes #5189 but takes a heavier approach: it adds a new `XAIConfig` class (`mem0/configs/llms/xai.py`) and rewires the factory (4 files, +344/-19).

This PR is a **minimal, surgical fix to the single `mem0/llms/xai.py` file** (+42/-3 in source). Differences:
- **Mine:** `getattr` fallback keeps the plain `BaseLlmConfig` wiring intact — no new config class, no factory change, lower regression surface. Fixes all three reported bugs.
- **#5190:** introduces `XAIConfig` (enables a typed `xai_base_url` field and vision options) — broader, but larger surface and changes the factory mapping.
- **Recommend:** merge this if the maintainers prefer the minimal fix that closes #5189 without a new config type; otherwise #5190 if a dedicated `XAIConfig` is desired. The two are not complementary (both rewrite `generate_response`), so only one should land.
