### PR TITLE
Fix/postgres sslmode support

### DIFF
--- a/mem0/vector_stores/pgvector.py
+++ b/mem0/vector_stores/pgvector.py
@@ -172,14 +172,15 @@ class PGVector(VectorStoreBase):
                 if 'sslmode=' in connection_string:
                     # Replace existing sslmode
                     import re
-                    connection_string = re.sub(r'sslmode=[^ ]*', f'sslmode={sslmode}', connection_string)
+                    connection_string = re.sub(r'sslmode=[^ &]*', f'sslmode={sslmode}', connection_string)
                 else:
                     # Add sslmode to connection string
-                    connection_string = f"{connection_string} sslmode={sslmode}"
+                    separator = "&" if "?" in connection_string else "?"
+                    connection_string = f"{connection_string}{separator}sslmode={sslmode}"
         else:
             connection_string = f"postgresql://{user}:{password}@{host}:{port}/{dbname}"
             if sslmode:
-                connection_string = f"{connection_string} sslmode={sslmode}"
+                connection_string = f"{connection_string}?sslmode={sslmode}"
         
         if self.connection_pool is None:
             if PSYCOPG_VERSION == 3:

--- a/server/db.py
+++ b/server/db.py
@@ -10,7 +10,12 @@ def _build_database_url() -> str:
     user = os.environ.get("POSTGRES_USER", "postgres")
     password = os.environ.get("POSTGRES_PASSWORD", "postgres")
     db = os.environ.get("APP_DB_NAME", "mem0_app")
-    return f"postgresql+psycopg://{user}:{password}@{host}:{port}/{db}"
+    sslmode = os.environ.get("POSTGRES_SSLMODE")
+
+    url = f"postgresql+psycopg://{user}:{password}@{host}:{port}/{db}"
+    if sslmode:
+        url += f"?sslmode={sslmode}"
+    return url
 
 
 engine = create_engine(_build_database_url(), pool_pre_ping=True)

--- a/server/main.py
+++ b/server/main.py
@@ -109,6 +109,7 @@ POSTGRES_DB = os.environ.get("POSTGRES_DB", "postgres")
 POSTGRES_USER = os.environ.get("POSTGRES_USER", "postgres")
 POSTGRES_PASSWORD = os.environ.get("POSTGRES_PASSWORD", "postgres")
 POSTGRES_COLLECTION_NAME = os.environ.get("POSTGRES_COLLECTION_NAME", "memories")
+POSTGRES_SSLMODE = os.environ.get("POSTGRES_SSLMODE")
 
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
 HISTORY_DB_PATH = os.environ.get("HISTORY_DB_PATH", "/app/history/history.db")
@@ -126,6 +127,7 @@ DEFAULT_CONFIG = {
             "user": POSTGRES_USER,
             "password": POSTGRES_PASSWORD,
             "collection_name": POSTGRES_COLLECTION_NAME,
+            "sslmode": POSTGRES_SSLMODE,
         },
     },
     "llm": {

--- a/tests/test_server_db.py
+++ b/tests/test_server_db.py
@@ -1,0 +1,45 @@
+import os
+from unittest.mock import patch
+
+from server.db import _build_database_url
+
+
+def test_build_database_url_from_individual_components_with_ssl():
+    """Verify that individual components are parsed and combined correctly with SSL."""
+    env = {
+        "POSTGRES_HOST": "pooled.db.prisma.io",
+        "POSTGRES_PORT": "5432",
+        "POSTGRES_USER": "some_user",
+        "POSTGRES_PASSWORD": "password123",
+        "POSTGRES_SSLMODE": "require",
+    }
+    with patch.dict(os.environ, env, clear=True):
+        url = _build_database_url()
+        assert url == "postgresql+psycopg://some_user:password123@pooled.db.prisma.io:5432/mem0_app?sslmode=require"
+
+
+def test_build_database_url_defaults():
+    """Verify that APP_DB_NAME defaults to 'mem0_app' when not set, and custom value works."""
+    env = {
+        "POSTGRES_HOST": "localhost",
+        "POSTGRES_PORT": "5432",
+        "POSTGRES_USER": "postgres",
+        "POSTGRES_PASSWORD": "password",
+    }
+    with patch.dict(os.environ, env, clear=True):
+        url = _build_database_url()
+        assert url == "postgresql+psycopg://postgres:password@localhost:5432/mem0_app"
+
+    # With APP_DB_NAME custom value
+    env["APP_DB_NAME"] = "override_app_db"
+    with patch.dict(os.environ, env, clear=True):
+        url = _build_database_url()
+        assert url == "postgresql+psycopg://postgres:password@localhost:5432/override_app_db"
+
+
+if __name__ == "__main__":
+    print("Running server DB URL tests...")
+    test_build_database_url_from_individual_components_with_ssl()
+    test_build_database_url_defaults()
+    print("All tests passed successfully!")
+


### PR DESCRIPTION
## Linked Issue

Closes #5303

## Description

- Fixed `server/pgvector.py` syntax issue
- Propagate `server/main.py` sslmode opt
- Add sslmode support in `server/db.py` to include sslmode in conn URI's

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Built and tested pgvector integration with cloud hosted provider that gives an sslmode conn URI.
Added small unit test to verify `db.py`'s conn uri construction.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
