### PR TITLE
fix(oss): resolve vector store dimension from snake_case config keys

### DIFF
--- a/mem0-ts/src/oss/src/config/manager.ts
+++ b/mem0-ts/src/oss/src/config/manager.ts
@@ -63,9 +63,25 @@ export class ConfigManager {
           // probe embedding at startup — this makes *any* embedder work
           // out of the box without the user needing to know or set the
           // dimension manually.
+          //
+          // Honor snake_case keys (embedding_dims / embeddingModelDims) the
+          // same way the embedder config above does — Python SDK / OpenClaw
+          // configs are snake_case, so reading only camelCase here silently
+          // dropped an explicitly-configured dimension and forced a probe.
+          const embedderConf = userConfig.embedder?.config as
+            | Record<string, unknown>
+            | undefined;
+          const vectorStoreConf = userConf as
+            | Record<string, unknown>
+            | undefined;
           const explicitDimension =
-            userConf?.dimension ||
-            userConfig.embedder?.config?.embeddingDims ||
+            (userConf?.dimension as number | undefined) ??
+            (vectorStoreConf?.embeddingModelDims as number | undefined) ??
+            (vectorStoreConf?.embedding_model_dims as number | undefined) ??
+            (userConfig.embedder?.config?.embeddingDims as
+              | number
+              | undefined) ??
+            (embedderConf?.embedding_dims as number | undefined) ??
             undefined;
 
           // Prioritize user-provided client instance

--- a/mem0-ts/src/oss/tests/config-manager.test.ts
+++ b/mem0-ts/src/oss/tests/config-manager.test.ts
@@ -84,6 +84,52 @@ describe("ConfigManager", () => {
 
       expect(config.vectorStore.config.dimension).toBe(768);
     });
+
+    it("should resolve dimension from snake_case embedding_dims on the embedder (issue #5290)", () => {
+      const config = ConfigManager.mergeConfig({
+        embedder: {
+          provider: "openai",
+          // snake_case as written by Python SDK / OpenClaw configs
+          config: { model: "bge-base-zh-v1.5", embedding_dims: 1024 } as any,
+        },
+        vectorStore: { provider: "qdrant", config: { collectionName: "test" } },
+        llm: baseLlm,
+      });
+
+      // Previously the vectorStore dimension fallback only read camelCase
+      // embeddingDims, so a snake_case-only embedder left the dimension
+      // undefined even though the embedder itself was normalized to 1024.
+      expect(config.vectorStore.config.dimension).toBe(1024);
+    });
+
+    it("should resolve dimension from vectorStore embeddingModelDims (issue #5290)", () => {
+      const config = ConfigManager.mergeConfig({
+        embedder: { provider: "openai", config: { apiKey: "test-key" } },
+        vectorStore: {
+          provider: "qdrant",
+          config: { collectionName: "test", embeddingModelDims: 1024 } as any,
+        },
+        llm: baseLlm,
+      });
+
+      expect(config.vectorStore.config.dimension).toBe(1024);
+    });
+
+    it("should prefer explicit vectorStore dimension over snake_case embedder embedding_dims", () => {
+      const config = ConfigManager.mergeConfig({
+        embedder: {
+          provider: "openai",
+          config: { model: "bge-base-zh-v1.5", embedding_dims: 1024 } as any,
+        },
+        vectorStore: {
+          provider: "qdrant",
+          config: { collectionName: "test", dimension: 512 },
+        },
+        llm: baseLlm,
+      });
+
+      expect(config.vectorStore.config.dimension).toBe(512);
+    });
   });
 
   describe("mergeConfig - LLM url passthrough for Ollama", () => {


### PR DESCRIPTION
## Summary

- `ConfigManager.mergeConfig` now resolves the vector store `dimension` from snake_case config keys, not just camelCase.
- A user who configures only `embedding_dims` (snake_case, the Python SDK / OpenClaw convention) no longer silently loses their explicit dimension.

## Motivation

Closes #5290.

The embedder config block in `mergeConfig` already normalizes snake_case `embedding_dims` → `embeddingDims` (see the existing `normalizes embedding_dims to embeddingDims for embedder` test). But two lines later, the vector store dimension fallback read **only** camelCase:

```ts
const explicitDimension =
  userConf?.dimension ||
  userConfig.embedder?.config?.embeddingDims ||
  undefined;
```

So a snake_case-only config produced a correctly-dimensioned **embedder** but an `undefined` **vector store dimension**. The explicitly configured dimension was dropped and a startup probe ran instead — an internal inconsistency (snake_case honored in one place, ignored in the next) that contributes to the dimension-mismatch class of failures against stores like Qdrant.

## Fix

The fallback now also reads:
- snake_case `embedding_dims` from the embedder config, and
- `embeddingModelDims` / `embedding_model_dims` from the vector store config,

mirroring the embedder normalization already present in the same function. Switched `||` → `??` so an explicit value always wins and the precedence is unchanged for all existing (truthy) inputs; dimension is never legitimately `0`, so behavior is identical for every real config.

## Verification

- `npx jest tests/config-manager.test.ts` — **27 passed** (24 existing + 3 new).
- New cases: snake_case `embedding_dims` on embedder → dimension resolved; vectorStore `embeddingModelDims` → resolved; explicit `vectorStore.dimension` still wins over snake_case embedder dims.
- `npx tsc --noEmit` clean for the changed file (the only remaining errors are pre-existing in `src/community/.../langchain/mem0.ts` on `main`, unrelated to this change).
- Diff is 2 files, +62/-2.

## Relationship to #4231

#4231 (open since March) takes a different, broader approach: normalizing snake_case keys to camelCase inside the `Memory` constructor (`memory/index.ts` + `types/index.ts`). This PR is narrower and orthogonal — it makes `ConfigManager.mergeConfig` self-consistent with the snake_case normalization it *already* performs for the embedder, fixing the specific dimension-drop path regardless of whether #4231 lands.
