### PR TITLE
fix(docs): fix broken metadata filtering examples

### DIFF
--- a/docs/open-source/features/metadata-filtering.mdx
+++ b/docs/open-source/features/metadata-filtering.mdx
@@ -4,22 +4,7 @@ description: Fine-grained metadata queries for precise OSS memory retrieval.
 icon: "filter"
 ---
 
-Enhanced metadata filtering in Mem0 1.0.0 lets you run complex queries across memory metadata. Combine comparisons, logical operators, and wildcard matches to zero in on the exact memories your agent needs.
-
-<Info>
-  **You’ll use this when…**
-  - Retrieval must respect multiple metadata conditions before returning context.
-  - You need to mix numeric, boolean, and string filters in a single query.
-  - Agents rely on deterministic filtering instead of broad semantic search alone.
-</Info>
-
-<Warning>
-  Enhanced filtering requires Mem0 1.0.0 or later and a vector store that supports the operators you enable. Unsupported operators fall back to simple equality filters.
-</Warning>
-
-<Note>
-  The TypeScript SDK accepts the same filter shape shown here—transpose the dictionaries to objects and reuse the keys unchanged.
-</Note>
+Enhanced metadata filtering in Mem0 lets you run complex queries across memory metadata. Combine comparisons, logical operators, and wildcard matches to zero in on the exact memories your agent needs.
 
 ---
 
@@ -148,8 +133,8 @@ Combine filters with `AND`, `OR`, and `NOT` to express complex decision trees. N
 results = m.search(
     "complex query",
     filters={
+        "user_id": "alice",
         "AND": [
-            {"user_id": "alice"},
             {"category": "work"},
             {"priority": {"gte": 7}},
             {"status": {"ne": "completed"}}
@@ -161,15 +146,11 @@ results = m.search(
 results = m.search(
     "flexible query",
     filters={
-        "AND": [
-            {"user_id": "alice"},
-            {
-                "OR": [
-                    {"category": "urgent"},
-                    {"priority": {"gte": 9}},
-                    {"deadline": {"contains": "today"}}
-                ]
-            }
+        "user_id": "alice",
+        "OR": [
+            {"category": "urgent"},
+            {"priority": {"gte": 9}},
+            {"deadline": {"contains": "today"}}
         ]
     }
 )
@@ -178,14 +159,10 @@ results = m.search(
 results = m.search(
     "exclusion query",
     filters={
-        "AND": [
-            {"user_id": "alice"},
-            {
-                "NOT": [
-                    {"category": "archived"},
-                    {"status": "deleted"}
-                ]
-            }
+        "user_id": "alice",
+        "NOT": [
+            {"category": "archived"},
+            {"status": "deleted"}
         ]
     }
 )
@@ -194,8 +171,8 @@ results = m.search(
 results = m.search(
     "advanced query",
     filters={
+        "user_id": "alice",
         "AND": [
-            {"user_id": "alice"},
             {
                 "OR": [
                     {"category": "work"},
@@ -248,8 +225,8 @@ config = {
 ```python
 # More efficient: Filter on indexed fields first
 good_filters = {
+    "user_id": "alice",
     "AND": [
-        {"user_id": "alice"},
         {"category": "work"},
         {"content": {"contains": "meeting"}}
     ]
@@ -257,9 +234,9 @@ good_filters = {
 
 # Less efficient: Complex operations first
 avoid_filters = {
+    "user_id": "alice",
     "AND": [
-        {"description": {"icontains": "complex text search"}},
-        {"user_id": "alice"}
+        {"description": {"icontains": "complex text search"}}
     ]
 }
 ```
@@ -302,8 +279,8 @@ results = m.search(
 results = m.search(
     "query",
     filters={
+        "user_id": "alice",
         "AND": [
-            {"user_id": "alice"},
             {"category": "work"},
             {"status": {"ne": "archived"}},
             {"priority": {"gte": 5}}
@@ -327,8 +304,8 @@ results = m.search(
 results = m.search(
     "What tasks need attention?",
     filters={
+        "user_id": "project_manager",
         "AND": [
-            {"user_id": "project_manager"},
             {"project": {"in": ["alpha", ""]}},
             {"priority": {"gte": 8}},
             {"status": {"ne": "completed"}},
@@ -354,8 +331,8 @@ results = m.search(
 results = m.search(
     "pending support issues",
     filters={
+        "agent_id": "support_bot",
         "AND": [
-            {"agent_id": "support_bot"},
             {"ticket_status": {"ne": "resolved"}},
             {"priority": {"in": ["high", "critical"]}},
             {"created_date": {"gte": "2024-01-01"}},
@@ -380,8 +357,8 @@ results = m.search(
 results = m.search(
     "recommend content",
     filters={
+        "user_id": "reader123",
         "AND": [
-            {"user_id": "reader123"},
             {
                 "OR": [
                     {"genre": {"in": ["sci-fi", "fantasy"]}},


### PR DESCRIPTION
## Summary

- **Fix 8 broken code examples** in the metadata filtering docs — all logical operator examples (`AND`, `OR`, `NOT`) had `user_id`/`agent_id` nested inside `AND` arrays, which throws `ValueError` at runtime
- **Remove redundant callout boxes** (Info, Warning, Note) from the page header
- **Remove version reference** ("Mem0 1.0.0") from the intro paragraph

## Why

The OSS SDK validates that `user_id`, `agent_id`, or `run_id` exists as a **top-level key** in the filters dict. When these are nested inside `AND`, the validator doesn't find them and raises:

```
ValueError: filters must contain at least one of: user_id, agent_id, run_id
```

Every logical operator example in the docs was broken. Verified by running all examples against the SDK with Qdrant on Docker (Python 3.12, OpenRouter + gpt-4o-mini).

## Test plan

- [x] Tested all 8 original docs examples — all throw `ValueError`
- [x] Tested all fixed examples — all return correct results
- [x] Verified on Qdrant Docker (v1.17.1) + Python 3.12
- [x] Simple filters (comparison, equality, list, text, wildcard) confirmed unaffected