### PR TITLE
fix: apply pnpm overrides for HIGH severity vulnerabilities

### DIFF
--- a/mem0-ts/package.json
+++ b/mem0-ts/package.json
@@ -137,6 +137,9 @@
     "onlyBuiltDependencies": [
       "esbuild",
       "better-sqlite3"
-    ]
+    ],
+    "overrides": {
+      "langsmith": ">=0.6.0"
+    }
   }
 }

--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -62,7 +62,8 @@
   },
   "pnpm": {
     "overrides": {
-      "protobufjs@<7.5.5": "^7.5.5"
+      "protobufjs@<7.5.5": "^7.5.5",
+      "langsmith": ">=0.6.0"
     }
   }
 }

--- a/openmemory/ui/package.json
+++ b/openmemory/ui/package.json
@@ -79,6 +79,9 @@
     "onlyBuiltDependencies": [
       "@parcel/watcher",
       "sharp"
-    ]
+    ],
+    "overrides": {
+      "immutable": ">=5.1.5"
+    }
   }
 }


### PR DESCRIPTION
## Closing Reason

This PR had CI failures due to `pnpm install` errors when applying the overrides. The "Install dependencies" step failed on Node 20.

**Root Cause:**
The pnpm overrides I added caused dependency resolution failures during `pnpm install`. This needs a different approach - either:
1. More specific override syntax for transitive dependencies
2. Testing locally before pushing
3. Using resolutions instead of overrides

I'll create a corrected PR with proper validation.

**CI Failure Details:**
- Job: `build_ts_sdk (20)`
- Step: "Install dependencies" (failed after 2s)
- Other jobs were cancelled as a result

---
*This PR was automatically closed. A corrected version will be created shortly.*