### PR TITLE
feat(server): add information on self-hosted dashboard

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -359,6 +359,8 @@ def add_memory(memory_create: MemoryCreate, _auth=Depends(verify_auth)):
     params = {k: v for k, v in memory_create.model_dump().items() if v is not None and k != "messages"}
     try:
         response = get_memory_instance().add(messages=[m.model_dump() for m in memory_create.messages], **params)
+        if response.get("results"):
+            telemetry.log_dashboard_nudge_once(DASHBOARD_URL)
         return JSONResponse(content=response)
     except Exception:
         raise upstream_error()

--- a/server/scripts/seed.sh
+++ b/server/scripts/seed.sh
@@ -69,6 +69,8 @@ echo "Email:      $EMAIL"
 echo "Password:   $PASSWORD"
 echo "API Key:    $API_KEY"
 echo ""
+echo "Open your dashboard at $DASHBOARD_URL to see and manage your memories in your browser."
+echo ""
 
 if ! grep -qE '^(OPENAI|ANTHROPIC|GOOGLE)_API_KEY=.' .env 2>/dev/null; then
   echo "!! No LLM provider API key set in server/.env."

--- a/server/scripts/seed.sh
+++ b/server/scripts/seed.sh
@@ -64,7 +64,6 @@ fi
 
 echo ""
 echo "=== Ready ==="
-echo "Dashboard:  $DASHBOARD_URL"
 echo "Email:      $EMAIL"
 echo "Password:   $PASSWORD"
 echo "API Key:    $API_KEY"

--- a/server/telemetry.py
+++ b/server/telemetry.py
@@ -29,6 +29,7 @@ STATE_PATH = Path(os.environ.get("MEM0_TELEMETRY_STATE_PATH", "/app/history/tele
 
 _lock = Lock()
 _client: Any = None
+_dashboard_nudge_logged = False
 
 
 def _load_state() -> dict[str, Any]:
@@ -110,3 +111,19 @@ def capture_admin_registered(email: str) -> None:
 
 def capture_onboarding_completed(email: str, use_case: str) -> None:
     _capture_once(email, "onboarding_completed", "onboarding_sent_at", {"use_case": use_case})
+
+
+def log_dashboard_nudge_once(dashboard_url: str) -> None:
+    """Log a hint pointing the operator to the web dashboard the first time a memory
+    is stored. Fires at most once per process (so a restart may re-log it on the next
+    add — harmless for a discovery nudge). LOCAL console log only — sends nothing
+    off-box, so it is intentionally NOT gated by MEM0_TELEMETRY.
+    """
+    global _dashboard_nudge_logged
+    if _dashboard_nudge_logged:
+        return
+    _dashboard_nudge_logged = True
+    logging.info(
+        "First memory stored. Open the dashboard at %s to view and manage your memories.",
+        dashboard_url,
+    )


### PR DESCRIPTION
## Description

Self-hosters often set up the server, grab an API key, and build against the API without ever discovering the bundled web dashboard (some even build their own). This is a discovery gap. Surface the dashboard at the two moments a human is actually looking at the terminal:

- **Setup output** (`seed.sh`): add an explicit "Open your dashboard at … to see and manage your memories" line to the `=== Ready ===` block, instead of listing the URL as a bare credential next to email/password/API key.
- **First memory stored** (`main.py` + `telemetry.py`): log a one-time hint pointing at the dashboard the first time an `add` succeeds. Once per process; local console log only, not gated by `MEM0_TELEMETRY` (it sends nothing off-box).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Test Coverage

- [x] Tested manually (no server test suite exists)
  - Verified the seed line appears in the Ready block via `make bootstrap`.
  - Verified the first `/memories` add logs the nudge once; a second add does not re-log.
  - Confirmed `ruff` passes on the changed files.

## Breaking Changes

N/A