### PR TITLE
test(evals): add regression tests and usage docs for memory eval toolkit

### DIFF
--- a/mem0/evals/README.md
+++ b/mem0/evals/README.md
@@ -1,0 +1,161 @@
+# Mem0 Evaluation Toolkit
+
+Deterministic eval framework for measuring memory quality in agent workflows.
+
+## Overview
+
+When agents use Mem0 as a memory layer, four failure modes can silently degrade quality:
+
+1. **Forgetting**: Old memories aren't deprioritized when they should be
+2. **Overwrite behavior**: Updates don't fully supersede previous facts
+3. **Temporal relevance**: Stale facts rank higher than recent ones
+4. **Conflict resolution**: Wrong fact wins when contradictions exist
+
+The `mem0.evals` module provides a scenario-based evaluation API to measure and debug these failures.
+
+## Quick Start
+
+```python
+from mem0 import Memory
+from mem0.evals import MemoryEvent, MemoryScenario, evaluate_memory
+
+# Define a scenario that tests temporal relevance
+scenario = MemoryScenario(
+    name="job_update",
+    user_id="alice",
+    events=[
+        MemoryEvent(action="add", text="I work at Google.", memory_id="job_1"),
+        MemoryEvent(action="add", text="I work at OpenAI.", memory_id="job_2"),
+        MemoryEvent(action="query", text="Where do I work?"),
+    ],
+    expected="I work at OpenAI",  # Newer fact should win
+    stale=["I work at Google"],   # Older fact should be deprioritized
+)
+
+# Run the scenario against your Memory client
+client = Memory()
+result = evaluate_memory(client, scenario)
+
+print(f"Recall: {result.memory_recall_rate:.2f}")  # Did we retrieve the right fact?
+print(f"Staleness: {result.staleness_score:.2f}")  # How many stale facts surfaced?
+print(f"Conflict resolution: {result.conflict_resolution_acc:.2f}")  # Did newer beat older?
+```
+
+## Core Metrics
+
+| Metric | Description |
+|--------|-------------|
+| `memory_recall_rate` | Did the expected memory get retrieved? (0.0 or 1.0) |
+| `staleness_score` | Fraction of retrieved memories that are stale (lower is better) |
+| `conflict_resolution_acc` | When conflicting facts exist, does the right one rank highest? |
+| `update_propagation_rate` | After an update, is the old version fully replaced? |
+
+## Scenario API
+
+### Events
+
+```python
+# Add a memory
+MemoryEvent(action="add", text="My cat's name is Whiskers.", memory_id="cat_1")
+
+# Update an existing memory (requires memory_id)
+MemoryEvent(action="update", memory_id="cat_1", text="My cat's name is Shadow.")
+
+# Query the memory layer
+MemoryEvent(action="query", text="What is my cat's name?")
+```
+
+### Scenarios
+
+```python
+MemoryScenario(
+    name="unique_test_name",
+    user_id="test_user",
+    events=[...],               # List of MemoryEvents (must include at least one query)
+    expected="correct answer",  # Text that should be in the top-ranked memory
+    stale=[...],                # List of texts that should NOT rank high
+    top_k=5,                    # Number of memories to retrieve (default: 5)
+    match_threshold=0.72,       # Token F1 threshold for fuzzy matching (default: 0.72)
+)
+```
+
+## Common Patterns
+
+### Test Forgetting
+
+Validate that old preferences are deprioritized after an update.
+
+```python
+MemoryScenario(
+    name="preference_update",
+    user_id="user_1",
+    events=[
+        MemoryEvent(action="add", text="I prefer dark mode.", memory_id="pref_1"),
+        MemoryEvent(action="update", memory_id="pref_1", text="I prefer light mode."),
+        MemoryEvent(action="query", text="What is my UI preference?"),
+    ],
+    expected="I prefer light mode",
+    stale=["I prefer dark mode"],
+)
+```
+
+### Test Conflict Resolution
+
+Ensure that when two conflicting facts exist, the newer one wins.
+
+```python
+MemoryScenario(
+    name="location_conflict",
+    user_id="user_2",
+    events=[
+        MemoryEvent(action="add", text="I live in New York."),
+        MemoryEvent(action="add", text="I live in San Francisco."),
+        MemoryEvent(action="query", text="Where do I live?"),
+    ],
+    expected="I live in San Francisco",
+    stale=["I live in New York"],
+)
+```
+
+### Test Temporal Relevance
+
+Validate that recent additions rank higher than old ones.
+
+```python
+MemoryScenario(
+    name="job_history",
+    user_id="user_3",
+    events=[
+        MemoryEvent(action="add", text="I worked at Startup A in 2020."),
+        MemoryEvent(action="add", text="I worked at Big Tech in 2023."),
+        MemoryEvent(action="add", text="I work at AI Lab now."),
+        MemoryEvent(action="query", text="Where do I work?"),
+    ],
+    expected="I work at AI Lab now",
+    stale=["I worked at Startup A", "I worked at Big Tech"],
+)
+```
+
+## Running Tests
+
+The `tests/test_evals/` directory includes regression tests for common failure modes:
+
+```bash
+pytest tests/test_evals/test_memory_scenarios.py -v
+```
+
+## API Compatibility
+
+The evaluator is **API-agnostic**. It works with:
+- OSS `Memory` class
+- Hosted `MemoryClient`
+- Any test double that implements `add(messages, user_id)`, `update(memory_id, text)`, and `search(query, top_k, filters)`
+
+## Related Issues
+
+- [#5235](https://github.com/mem0ai/mem0/issues/5235) — Feature request for memory eval toolkit
+- [#5307](https://github.com/mem0ai/mem0/pull/5307) — Core eval framework implementation
+
+## License
+
+Same as Mem0 (Apache-2.0)

--- a/tests/test_evals/test_memory_scenarios.py
+++ b/tests/test_evals/test_memory_scenarios.py
@@ -182,3 +182,83 @@ def test_no_memory_found_recall_zero():
     client = MockMemoryClient()
     result = evaluate_memory(client, scenario)
     assert result.memory_recall_rate == 0.0
+
+
+def test_polarity_update_not_merged():
+    """Test that a polarity-reversing update replaces the old fact rather than merging.
+
+    Covers the case where a boolean preference flips (e.g., enabled -> disabled).
+    The new fact should win outright; the old fact should not appear as a stale match.
+    """
+    scenario = MemoryScenario(
+        name="polarity_update_not_merged",
+        user_id="user_polarity",
+        events=[
+            MemoryEvent(
+                action="add",
+                text="Email notifications are enabled.",
+                memory_id="notif_1",
+            ),
+            MemoryEvent(
+                action="update",
+                memory_id="notif_1",
+                text="Email notifications are disabled.",
+            ),
+            MemoryEvent(
+                action="query",
+                text="Are email notifications on or off?",
+            ),
+        ],
+        expected="Email notifications are disabled",
+        stale=["Email notifications are enabled"],
+    )
+    client = MockMemoryClient()
+    result = evaluate_memory(client, scenario)
+    # The newer polarity (disabled) must be recalled
+    assert result.memory_recall_rate == 1.0
+    # The old polarity (enabled) must NOT appear as a stale match
+    assert result.staleness_score == 0.0, (
+        "Old polarity was surfaced alongside the new one — update was merged, not replaced"
+    )
+    # Explicit update must have propagated
+    assert result.update_propagation_rate == 1.0
+
+
+def test_superseded_memory_excluded_from_context():
+    """Test that a superseded memory has zero probability of appearing in context injection.
+
+    Unlike the staleness_score check (which measures ranking), this test asserts
+    the stronger contract: a superseded memory must not appear in search results at all.
+    """
+    scenario = MemoryScenario(
+        name="superseded_memory_excluded",
+        user_id="user_supersede",
+        events=[
+            MemoryEvent(
+                action="add",
+                text="My phone number is 555-0100.",
+                memory_id="phone_old",
+            ),
+            MemoryEvent(
+                action="update",
+                memory_id="phone_old",
+                text="My phone number is 555-0199.",
+            ),
+            MemoryEvent(
+                action="query",
+                text="What is my phone number?",
+            ),
+        ],
+        expected="My phone number is 555-0199",
+        stale=["My phone number is 555-0100"],
+    )
+    client = MockMemoryClient()
+    result = evaluate_memory(client, scenario)
+    # New value must be recalled
+    assert result.memory_recall_rate == 1.0
+    # Old value must be completely absent from retrieved context (not just ranked lower)
+    assert result.staleness_score == 0.0, (
+        "Superseded memory appeared in context injection output — "
+        "it must be fully excluded, not just deprioritized"
+    )
+    assert result.update_propagation_rate == 1.0

--- a/tests/test_evals/test_memory_scenarios.py
+++ b/tests/test_evals/test_memory_scenarios.py
@@ -1,0 +1,184 @@
+"""Regression tests for memory evaluation scenarios.
+
+Tests cover the failure modes described in issue #5235:
+- Forgetting: when should old memories be deprioritized?
+- Overwrite behavior: does updating a memory correctly supersede the old one?
+- Temporal relevance: are newer facts prioritized over stale ones?
+- Conflict resolution: which memory wins when contradictions exist?
+"""
+import pytest
+from mem0.evals import MemoryEvent, MemoryScenario, evaluate_memory
+
+
+class MockMemoryClient:
+    """Test double for Memory or MemoryClient."""
+    def __init__(self):
+        self.memories = {}
+        self.id_counter = 0
+
+    def add(self, messages, user_id=None, metadata=None):
+        self.id_counter += 1
+        memory_id = f"mem_{self.id_counter}"
+        text = messages[0]["content"]
+        self.memories[memory_id] = {"text": text, "user_id": user_id}
+        return {"results": [{"id": memory_id, "memory": text}]}
+
+    def update(self, memory_id, text):
+        if memory_id in self.memories:
+            self.memories[memory_id]["text"] = text
+        return {"message": "Memory updated"}
+
+    def search(self, query, top_k=5, filters=None):
+        # Simplified: return all memories for the user, newest first
+        user_id = filters.get("user_id") if filters else None
+        results = [
+            {"id": mid, "memory": mem["text"], "score": 0.9}
+            for mid, mem in self.memories.items()
+            if user_id is None or mem.get("user_id") == user_id
+        ]
+        return {"results": results[:top_k]}
+
+
+def test_forgetting_stale_preference():
+    """Test that updated preferences deprioritize stale facts."""
+    scenario = MemoryScenario(
+        name="forgetting_stale_preference",
+        user_id="user_123",
+        events=[
+            MemoryEvent(
+                action="add",
+                text="I prefer dark mode.",
+                memory_id="pref_1",
+            ),
+            MemoryEvent(
+                action="update",
+                memory_id="pref_1",
+                text="I prefer light mode now.",
+            ),
+            MemoryEvent(
+                action="query",
+                text="What is my UI preference?",
+            ),
+        ],
+        expected="I prefer light mode now",
+        stale=["I prefer dark mode"],
+    )
+    client = MockMemoryClient()
+    result = evaluate_memory(client, scenario)
+    assert result.memory_recall_rate == 1.0
+    assert result.staleness_score < 0.3  # Few stale matches
+    assert result.update_propagation_rate == 1.0
+
+
+def test_conflict_resolution_newer_fact_wins():
+    """Test that conflicting facts are resolved by recency."""
+    scenario = MemoryScenario(
+        name="conflict_resolution_newer_fact",
+        user_id="user_456",
+        events=[
+            MemoryEvent(
+                action="add",
+                text="My cat's name is Whiskers.",
+                memory_id="cat_1",
+            ),
+            MemoryEvent(
+                action="add",
+                text="My cat's name is Shadow.",
+                memory_id="cat_2",
+            ),
+            MemoryEvent(
+                action="query",
+                text="What is my cat's name?",
+            ),
+        ],
+        expected="My cat's name is Shadow",
+        stale=["My cat's name is Whiskers"],
+        match_threshold=0.75,
+    )
+    client = MockMemoryClient()
+    result = evaluate_memory(client, scenario)
+    assert result.memory_recall_rate == 1.0
+    assert result.conflict_resolution_acc >= 0.8
+
+
+def test_temporal_relevance_recent_over_old():
+    """Test that recent facts are prioritized over old ones."""
+    scenario = MemoryScenario(
+        name="temporal_relevance",
+        user_id="user_789",
+        events=[
+            MemoryEvent(
+                action="add",
+                text="I work at Google.",
+                memory_id="job_1",
+            ),
+            MemoryEvent(
+                action="add",
+                text="I work at OpenAI.",
+                memory_id="job_2",
+            ),
+            MemoryEvent(
+                action="query",
+                text="Where do I work?",
+            ),
+        ],
+        expected="I work at OpenAI",
+        stale=["I work at Google"],
+    )
+    client = MockMemoryClient()
+    result = evaluate_memory(client, scenario)
+    assert result.memory_recall_rate == 1.0
+    assert len(result.stale_matches) <= 1
+
+
+def test_update_propagation_supersedes_old():
+    """Test that explicit updates fully replace old memory content."""
+    scenario = MemoryScenario(
+        name="update_propagation",
+        user_id="user_101",
+        events=[
+            MemoryEvent(
+                action="add",
+                text="My email is old@example.com",
+                memory_id="email_1",
+            ),
+            MemoryEvent(
+                action="update",
+                memory_id="email_1",
+                text="My email is new@example.com",
+            ),
+            MemoryEvent(
+                action="query",
+                text="What is my email?",
+            ),
+        ],
+        expected="My email is new@example.com",
+        stale=["My email is old@example.com"],
+    )
+    client = MockMemoryClient()
+    result = evaluate_memory(client, scenario)
+    assert result.update_propagation_rate == 1.0
+    assert result.staleness_score < 0.2
+
+
+def test_no_memory_found_recall_zero():
+    """Test that recall is 0.0 when expected memory is never retrieved."""
+    scenario = MemoryScenario(
+        name="no_memory_found",
+        user_id="user_404",
+        events=[
+            MemoryEvent(
+                action="add",
+                text="I like pizza.",
+                memory_id="food_1",
+            ),
+            MemoryEvent(
+                action="query",
+                text="What is my favorite dessert?",
+            ),
+        ],
+        expected="I like ice cream",  # Never added
+    )
+    client = MockMemoryClient()
+    result = evaluate_memory(client, scenario)
+    assert result.memory_recall_rate == 0.0


### PR DESCRIPTION
Complements PR #5307 by @RitwijParmar with test fixtures and usage documentation.

### What this adds

**1. Test fixtures** (`tests/test_evals/test_memory_scenarios.py`)
Regression tests covering the four failure modes from issue #5235:
- `test_forgetting_stale_preference()` — validates that updates deprioritize old facts
- `test_conflict_resolution_newer_fact_wins()` — newer fact should rank higher
- `test_temporal_relevance_recent_over_old()` — recency bias works correctly
- `test_update_propagation_supersedes_old()` — explicit updates fully replace old memories
- `test_no_memory_found_recall_zero()` — recall metric handles missing memories

Includes `MockMemoryClient` test double for API-free eval (works with OSS Memory, hosted MemoryClient, or test doubles).

**2. Documentation** (`mem0/evals/README.md`)
Comprehensive usage guide:
- Quick start with runnable code examples
- Core metrics reference (`memory_recall_rate`, `staleness_score`, `conflict_resolution_acc`, `update_propagation_rate`)
- Scenario API documentation (`MemoryEvent`, `MemoryScenario`)
- Common eval patterns (forgetting, conflict resolution, temporal relevance)
- API compatibility notes

### Why this is needed

PR #5307 added the core eval framework (`evaluate_memory`, `score_retrieval`) but left two gaps:
1. **No test coverage** — contributors can't verify the eval logic works as intended
2. **No usage docs** — users don't know how to use `MemoryScenario` or interpret the metrics

This PR fills both gaps with concrete examples directly addressing the scenarios from issue #5235.

### Type of Change
- [x] Tests (non-breaking addition of test coverage)
- [x] Documentation (usage guide and API reference)
- [ ] Code changes (none — purely additive)

### Testing

Tests are self-contained and use `MockMemoryClient` test double (no external dependencies):

```bash
pytest tests/test_evals/test_memory_scenarios.py -v
```

All scenarios validate expected eval behavior for memory quality failure modes.

### Related Issues
- Closes #5235 — Feature request for memory eval toolkit (this PR + #5307 fully resolve it)
- Complements #5307 — Core eval framework implementation