### PR TITLE
fix: avoid mutable default arguments

### DIFF
--- a/mem0/configs/embeddings/base.py
+++ b/mem0/configs/embeddings/base.py
@@ -25,7 +25,7 @@ class BaseEmbedderConfig(ABC):
         model_kwargs: Optional[dict] = None,
         huggingface_base_url: Optional[str] = None,
         # AzureOpenAI specific
-        azure_kwargs: Optional[AzureConfig] = {},
+        azure_kwargs: Optional[Union[AzureConfig, Dict]] = None,
         http_client_proxies: Optional[Union[Dict, str]] = None,
         # VertexAI specific
         vertex_credentials_json: Optional[str] = None,
@@ -89,7 +89,10 @@ class BaseEmbedderConfig(ABC):
         self.model_kwargs = model_kwargs or {}
         self.huggingface_base_url = huggingface_base_url
         # AzureOpenAI specific
-        self.azure_kwargs = AzureConfig(**azure_kwargs) or {}
+        if isinstance(azure_kwargs, AzureConfig):
+            self.azure_kwargs = azure_kwargs
+        else:
+            self.azure_kwargs = AzureConfig(**(azure_kwargs or {}))
 
         # VertexAI specific
         self.vertex_credentials_json = vertex_credentials_json

--- a/mem0/proxy/main.py
+++ b/mem0/proxy/main.py
@@ -52,7 +52,7 @@ class Completions:
     def create(
         self,
         model: str,
-        messages: List = [],
+        messages: Optional[List] = None,
         # Mem0 arguments
         user_id: Optional[str] = None,
         agent_id: Optional[str] = None,
@@ -92,6 +92,8 @@ class Completions:
         api_key: Optional[str] = None,
         model_list: Optional[list] = None,  # pass in a list of api_base,keys, etc.
     ):
+        messages = messages or []
+
         if not any([user_id, agent_id, run_id]):
             raise ValueError("One of user_id, agent_id, run_id must be provided")
 

--- a/tests/embeddings/test_azure_openai_embeddings.py
+++ b/tests/embeddings/test_azure_openai_embeddings.py
@@ -52,6 +52,20 @@ def test_embed_text_with_default_headers(default_headers, expected_header):
     assert embedder.client.default_headers.get("Test") == expected_header
 
 
+def test_base_embedder_config_azure_kwargs_default_is_not_shared():
+    first_config = BaseEmbedderConfig()
+    second_config = BaseEmbedderConfig()
+
+    assert first_config.azure_kwargs is not second_config.azure_kwargs
+
+
+def test_base_embedder_config_accepts_azure_config_instance():
+    azure_kwargs = BaseEmbedderConfig().azure_kwargs
+    config = BaseEmbedderConfig(azure_kwargs=azure_kwargs)
+
+    assert config.azure_kwargs is azure_kwargs
+
+
 @pytest.fixture
 def base_embedder_config():
     class DummyAzureKwargs:

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,3 +1,4 @@
+import inspect
 from unittest.mock import Mock, patch
 
 import pytest
@@ -98,3 +99,9 @@ def test_completions_create_with_system_message(mock_memory_client, mock_litellm
     call_args = mock_litellm.completion.call_args[1]
     assert call_args["messages"][0]["role"] == "system"
     assert call_args["messages"][0]["content"] == "You are a helpful assistant."
+
+
+def test_completions_create_messages_default_is_not_mutable():
+    signature = inspect.signature(Completions.create)
+
+    assert signature.parameters["messages"].default is None


### PR DESCRIPTION
## Summary
- replace mutable default `messages=[]` in `Completions.create` with `None`
- replace mutable default `azure_kwargs={}` in `BaseEmbedderConfig` with `None`
- add regression tests for both defaults and preserve AzureConfig instance handling

Fixes #5301

## Test plan
- `uv run --extra test --extra llms --with azure-identity pytest tests/test_proxy.py tests/embeddings/test_azure_openai_embeddings.py -q`
- `uv run --extra test --with ruff ruff check mem0/proxy/main.py mem0/configs/embeddings/base.py tests/test_proxy.py tests/embeddings/test_azure_openai_embeddings.py`
