### PR TITLE
Fix mutable default arguments

### DIFF
--- a/mem0/configs/embeddings/base.py
+++ b/mem0/configs/embeddings/base.py
@@ -1,6 +1,6 @@
 import os
 from abc import ABC
-from typing import Dict, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 import httpx
 
@@ -25,7 +25,7 @@ class BaseEmbedderConfig(ABC):
         model_kwargs: Optional[dict] = None,
         huggingface_base_url: Optional[str] = None,
         # AzureOpenAI specific
-        azure_kwargs: Optional[AzureConfig] = {},
+        azure_kwargs: Optional[Union[AzureConfig, Dict[str, Any]]] = None,
         http_client_proxies: Optional[Union[Dict, str]] = None,
         # VertexAI specific
         vertex_credentials_json: Optional[str] = None,
@@ -89,7 +89,7 @@ class BaseEmbedderConfig(ABC):
         self.model_kwargs = model_kwargs or {}
         self.huggingface_base_url = huggingface_base_url
         # AzureOpenAI specific
-        self.azure_kwargs = AzureConfig(**azure_kwargs) or {}
+        self.azure_kwargs = azure_kwargs if isinstance(azure_kwargs, AzureConfig) else AzureConfig(**(azure_kwargs or {}))
 
         # VertexAI specific
         self.vertex_credentials_json = vertex_credentials_json
@@ -107,4 +107,3 @@ class BaseEmbedderConfig(ABC):
         self.aws_access_key_id = aws_access_key_id
         self.aws_secret_access_key = aws_secret_access_key
         self.aws_region = aws_region or os.environ.get("AWS_REGION") or "us-west-2"
-

--- a/mem0/proxy/main.py
+++ b/mem0/proxy/main.py
@@ -52,7 +52,7 @@ class Completions:
     def create(
         self,
         model: str,
-        messages: List = [],
+        messages: Optional[List] = None,
         # Mem0 arguments
         user_id: Optional[str] = None,
         agent_id: Optional[str] = None,
@@ -100,6 +100,7 @@ class Completions:
                 f"Model '{model}' does not support function calling. Please use a model that supports function calling."
             )
 
+        messages = messages or []
         prepared_messages = self._prepare_messages(messages)
         if prepared_messages[-1]["role"] == "user":
             self._async_add_to_memory(messages, user_id, agent_id, run_id, metadata, filters)

--- a/tests/embeddings/test_azure_openai_embeddings.py
+++ b/tests/embeddings/test_azure_openai_embeddings.py
@@ -31,6 +31,13 @@ def test_embed_text(mock_openai_client):
     assert embedding == [0.1, 0.2, 0.3]
 
 
+def test_base_embedder_config_azure_kwargs_default_is_isolated():
+    first = BaseEmbedderConfig()
+    second = BaseEmbedderConfig()
+
+    assert first.azure_kwargs is not second.azure_kwargs
+
+
 @pytest.mark.parametrize(
     "default_headers, expected_header",
     [(None, None), ({"Test": "test_value"}, "test_value"), ({}, None)],

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,3 +1,4 @@
+import inspect
 from unittest.mock import Mock, patch
 
 import pytest
@@ -58,6 +59,12 @@ def test_mem0_initialization_without_params(mock_openai_embedding_client, mock_o
 def test_chat_initialization(mock_memory_client):
     chat = Chat(mock_memory_client)
     assert isinstance(chat.completions, Completions)
+
+
+def test_completions_create_messages_default_is_not_mutable():
+    signature = inspect.signature(Completions.create)
+
+    assert signature.parameters["messages"].default is None
 
 
 def test_completions_create(mock_memory_client, mock_litellm):


### PR DESCRIPTION
## Summary
- replace mutable default values in Completions.create and BaseEmbedderConfig
- preserve AzureConfig compatibility while creating a fresh default config
- add regression coverage for isolated defaults

## Testing
- python3 -m py_compile mem0/proxy/main.py mem0/configs/embeddings/base.py tests/test_proxy.py tests/embeddings/test_azure_openai_embeddings.py
- Not run: pytest, because this local Python environment is missing pytest and project test dependencies.