### PR TITLE
fix: read llms coverage files as utf-8

### DIFF
--- a/scripts/check-llms-txt-coverage.py
+++ b/scripts/check-llms-txt-coverage.py
@@ -42,7 +42,7 @@ def load_ignore_prefixes() -> list[str]:
     if not IGNORE_FILE.exists():
         return []
     prefixes: list[str] = []
-    for raw in IGNORE_FILE.read_text().splitlines():
+    for raw in IGNORE_FILE.read_text(encoding="utf-8").splitlines():
         line = raw.strip()
         if line and not line.startswith("#"):
             prefixes.append(line)
@@ -105,7 +105,7 @@ def main() -> int:
 
     ignore_prefixes = load_ignore_prefixes()
     all_pages, included_pages = canonical_repo_pages(ignore_prefixes)
-    text = LLMS_TXT.read_text()
+    text = LLMS_TXT.read_text(encoding="utf-8")
     linked = indexed_urls(text)
 
     missing = sorted(included_pages - linked)
@@ -131,7 +131,7 @@ def main() -> int:
     if args.write:
         if missing:
             new_text = append_triage_block(text, missing)
-            LLMS_TXT.write_text(new_text)
+            LLMS_TXT.write_text(new_text, encoding="utf-8")
             print(
                 f"\nAppended {len(missing)} placeholder entries under "
                 f"'{TRIAGE_HEADER}' in docs/llms.txt."


### PR DESCRIPTION
## What changed
- Reads `scripts/llms-txt-ignore.txt` and `docs/llms.txt` with explicit `encoding="utf-8"`.
- Writes updated `docs/llms.txt` with explicit `encoding="utf-8"` when `--write` scaffolds missing entries.

## Problem
The helper currently relies on the platform default encoding for text I/O. On systems where the default encoding is not UTF-8, the docs coverage check can misread docs text or write `docs/llms.txt` with a different encoding than expected.

## Before/after
Before: `read_text()` / `write_text()` used the process default encoding.
After: the docs coverage helper consistently uses UTF-8 for the docs index and ignore file.

## Verification
- `python scripts/check-llms-txt-coverage.py`