### PR TITLE
fix: persist telemetry state as utf-8

### DIFF
--- a/server/telemetry.py
+++ b/server/telemetry.py
@@ -35,7 +35,7 @@ def _load_state() -> dict[str, Any]:
     if not STATE_PATH.exists():
         return {}
     try:
-        return json.loads(STATE_PATH.read_text())
+        return json.loads(STATE_PATH.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return {}
 
@@ -43,7 +43,7 @@ def _load_state() -> dict[str, Any]:
 def _save_state(state: dict[str, Any]) -> None:
     try:
         STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
-        STATE_PATH.write_text(json.dumps(state))
+        STATE_PATH.write_text(json.dumps(state), encoding="utf-8")
     except OSError:
         logging.exception("telemetry: failed to persist state")
 

--- a/tests/test_server_telemetry.py
+++ b/tests/test_server_telemetry.py
@@ -1,0 +1,19 @@
+import json
+import sys
+from types import SimpleNamespace
+
+
+sys.modules.setdefault("mem0", SimpleNamespace(__version__="test"))
+
+from server import telemetry  # noqa: E402
+
+
+def test_telemetry_state_round_trips_non_ascii(tmp_path, monkeypatch):
+    state_path = tmp_path / "telemetry.json"
+    monkeypatch.setattr(telemetry, "STATE_PATH", state_path)
+    state = {"install_id": "abc", "use_case": "Olá, 世界"}
+
+    telemetry._save_state(state)
+
+    assert json.loads(state_path.read_text(encoding="utf-8")) == state
+    assert telemetry._load_state() == state


### PR DESCRIPTION
## What changed
- Read and write the server telemetry state file with explicit `encoding="utf-8"`.
- Added a focused test that round-trips non-ASCII telemetry state through `_save_state()` and `_load_state()`.

## Problem
The telemetry state file stores JSON text but currently relies on the platform default encoding. On non-UTF-8 systems, state containing non-ASCII operator input, such as onboarding use-case text, can be decoded or written inconsistently.

## Before/after
Before: `STATE_PATH.read_text()` and `STATE_PATH.write_text(...)` used the process default encoding.
After: telemetry state JSON is consistently read and written as UTF-8.

## Verification
- `python -m pytest tests/test_server_telemetry.py`