### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/docs/components/llms/models/minimax.mdx
+++ b/docs/components/llms/models/minimax.mdx
@@ -18,7 +18,7 @@ config = {
     "llm": {
         "provider": "minimax",
         "config": {
-            "model": "MiniMax-M2.7",  # default model
+            "model": "MiniMax-M3",  # default model
             "temperature": 0.2,
             "max_tokens": 2000,
             "top_p": 1.0

--- a/mem0/llms/minimax.py
+++ b/mem0/llms/minimax.py
@@ -34,7 +34,7 @@ class MiniMaxLLM(LLMBase):
         super().__init__(config)
 
         if not self.config.model:
-            self.config.model = "MiniMax-M2.7"
+            self.config.model = "MiniMax-M3"
 
         api_key = self.config.api_key or os.getenv("MINIMAX_API_KEY")
         base_url = (

--- a/tests/llms/test_minimax.py
+++ b/tests/llms/test_minimax.py
@@ -61,10 +61,10 @@ def test_minimax_llm_config_base_url():
 
 
 def test_minimax_llm_default_model(mock_minimax_client):
-    """Default model is MiniMax-M2.7 when not specified."""
+    """Default model is MiniMax-M3 when not specified."""
     config = MinimaxConfig(temperature=0.7, max_tokens=100, api_key="api_key")
     llm = MiniMaxLLM(config)
-    assert llm.config.model == "MiniMax-M2.7"
+    assert llm.config.model == "MiniMax-M3"
 
 
 def test_minimax_llm_env_api_key():
@@ -192,3 +192,10 @@ def test_factory_creates_minimax_llm(mock_minimax_client):
     llm = LlmFactory.create("minimax", {"model": "MiniMax-M2.7", "api_key": "test-key"})
     assert isinstance(llm, MiniMaxLLM)
     assert llm.config.model == "MiniMax-M2.7"
+
+
+def test_factory_creates_minimax_llm_default_model(mock_minimax_client):
+    """LlmFactory.create with no model returns MiniMaxLLM with MiniMax-M3 default."""
+    llm = LlmFactory.create("minimax", {"api_key": "test-key"})
+    assert isinstance(llm, MiniMaxLLM)
+    assert llm.config.model == "MiniMax-M3"


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to use M3 as the default model.

## Changes
- Set `MiniMax-M3` as the default model in `mem0/llms/minimax.py`
- Keep `MiniMax-M2.7` as a supported alternative (no breaking change for users explicitly selecting M2.7)
- Update the default-model unit test to assert `MiniMax-M3`
- Add a new test verifying the factory default model is `MiniMax-M3`
- Update the usage doc to reflect M3 as the default

## Why
MiniMax-M3 is the latest flagship model, with a 512K context window, up to 128K output, and image input support. Setting M3 as the default gives new users the most capable model out of the box while users on M2.7 continue to work by explicitly setting `model: "MiniMax-M2.7"`.

## Testing
- All 10 unit tests in `tests/llms/test_minimax.py` pass locally
- Default-model assertion updated to `MiniMax-M3`
- Existing M2.7 tests preserved to verify M2.7 still works when explicitly selected