### PR TITLE
fix(pgvector): use URI query params for sslmode instead of space separator

### DIFF
--- a/mem0/vector_stores/pgvector.py
+++ b/mem0/vector_stores/pgvector.py
@@ -168,18 +168,23 @@ class PGVector(VectorStoreBase):
             self.connection_pool = connection_pool
         elif connection_string:
             if sslmode:
-                # Append sslmode to connection string if provided
+                is_uri = connection_string.startswith(("postgresql://", "postgres://"))
                 if 'sslmode=' in connection_string:
-                    # Replace existing sslmode
                     import re
-                    connection_string = re.sub(r'sslmode=[^ ]*', f'sslmode={sslmode}', connection_string)
+                    if is_uri:
+                        connection_string = re.sub(r'sslmode=[^&\s]*', f'sslmode={sslmode}', connection_string)
+                    else:
+                        connection_string = re.sub(r'sslmode=[^ ]*', f'sslmode={sslmode}', connection_string)
                 else:
-                    # Add sslmode to connection string
-                    connection_string = f"{connection_string} sslmode={sslmode}"
+                    if is_uri:
+                        sep = '&' if '?' in connection_string else '?'
+                        connection_string = f"{connection_string}{sep}sslmode={sslmode}"
+                    else:
+                        connection_string = f"{connection_string} sslmode={sslmode}"
         else:
             connection_string = f"postgresql://{user}:{password}@{host}:{port}/{dbname}"
             if sslmode:
-                connection_string = f"{connection_string} sslmode={sslmode}"
+                connection_string = f"{connection_string}?sslmode={sslmode}"
         
         if self.connection_pool is None:
             if PSYCOPG_VERSION == 3:

--- a/tests/vector_stores/test_pgvector.py
+++ b/tests/vector_stores/test_pgvector.py
@@ -2084,8 +2084,8 @@ class TestPGVector(unittest.TestCase):
             connection_string=connection_string
         )
         
-        # Verify ConnectionPool was called with the connection string including sslmode
-        expected_conn_string = f"{connection_string} sslmode=require"
+        # Verify ConnectionPool was called with proper URI query param format
+        expected_conn_string = f"{connection_string}?sslmode=require"
         mock_connection_pool.assert_called_with(
             conninfo=expected_conn_string,
             min_size=1,
@@ -2094,6 +2094,71 @@ class TestPGVector(unittest.TestCase):
         )
         self.assertEqual(pgvector.collection_name, "test_collection")
         self.assertEqual(pgvector.embedding_model_dims, 3)
+
+    @patch('mem0.vector_stores.pgvector.PSYCOPG_VERSION', 3)
+    @patch('mem0.vector_stores.pgvector.ConnectionPool')
+    def test_individual_params_with_sslmode_psycopg3(self, mock_connection_pool):
+        """Test that sslmode is appended as a URI query param when built from individual params."""
+        mock_pool = MagicMock()
+        mock_connection_pool.return_value = mock_pool
+        self.mock_cursor.fetchall.return_value = []
+
+        PGVector(
+            dbname="test_db",
+            collection_name="test_collection",
+            embedding_model_dims=3,
+            user="test_user",
+            password="test_pass",
+            host="localhost",
+            port=5432,
+            diskann=False,
+            hnsw=False,
+            minconn=1,
+            maxconn=4,
+            sslmode="require",
+        )
+
+        expected_conn_string = "postgresql://test_user:test_pass@localhost:5432/test_db?sslmode=require"
+        mock_connection_pool.assert_called_with(
+            conninfo=expected_conn_string,
+            min_size=1,
+            max_size=4,
+            open=True
+        )
+
+    @patch('mem0.vector_stores.pgvector.PSYCOPG_VERSION', 3)
+    @patch('mem0.vector_stores.pgvector.ConnectionPool')
+    def test_connection_string_uri_with_existing_query_params_and_sslmode(self, mock_connection_pool):
+        """Test sslmode appended with & when URI already contains query params."""
+        mock_pool = MagicMock()
+        mock_connection_pool.return_value = mock_pool
+        self.mock_cursor.fetchall.return_value = []
+
+        connection_string = "postgresql://user:pass@localhost:5432/db?connect_timeout=10"
+
+        PGVector(
+            dbname="test_db",
+            collection_name="test_collection",
+            embedding_model_dims=3,
+            user="test_user",
+            password="test_pass",
+            host="localhost",
+            port=5432,
+            diskann=False,
+            hnsw=False,
+            minconn=1,
+            maxconn=4,
+            sslmode="require",
+            connection_string=connection_string,
+        )
+
+        expected_conn_string = f"{connection_string}&sslmode=require"
+        mock_connection_pool.assert_called_with(
+            conninfo=expected_conn_string,
+            min_size=1,
+            max_size=4,
+            open=True
+        )
 
     # Enhanced Test for Index Creation with DiskANN
     @patch('mem0.vector_stores.pgvector.PSYCOPG_VERSION', 3)


### PR DESCRIPTION
## Linked Issue

Closes #5303

## Description

When building or extending a `postgresql://` connection URI, `sslmode` was being appended with a bare space:

```
postgresql://user:pass@host:5432/db sslmode=require   ← broken
```

Drivers like psycopg3 and psycopg2 parse everything after the space as part of the database name, causing the connection to fail with an error like:

```
Failed to select your database ('postgres sslmode=require'): invalid database name
```

The fix appends `sslmode` as a proper URI query parameter:
- `?sslmode=require` when no query params exist yet
- `&sslmode=require` when the URI already has other query params (e.g. `?connect_timeout=10`)

For libpq key=value format strings (non-URI), the existing space-separated format is preserved — it is valid in that context.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

Three test cases updated/added in `tests/vector_stores/test_pgvector.py`:
1. **Updated** `test_connection_string_with_sslmode_psycopg3` — corrected expected value from `" sslmode=require"` to `"?sslmode=require"`
2. **Added** `test_individual_params_with_sslmode_psycopg3` — verifies `?sslmode=` is used when the URI is built from individual host/user/pass/dbname params
3. **Added** `test_connection_string_uri_with_existing_query_params_and_sslmode` — verifies `&sslmode=` is used when the URI already contains other query parameters

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed