### PR TITLE
fix: replace mutable default arguments [] and {} (B006)

### DIFF
--- a/mem0/configs/embeddings/base.py
+++ b/mem0/configs/embeddings/base.py
@@ -25,7 +25,7 @@ class BaseEmbedderConfig(ABC):
         model_kwargs: Optional[dict] = None,
         huggingface_base_url: Optional[str] = None,
         # AzureOpenAI specific
-        azure_kwargs: Optional[AzureConfig] = {},
+        azure_kwargs: Optional[AzureConfig] = None,
         http_client_proxies: Optional[Union[Dict, str]] = None,
         # VertexAI specific
         vertex_credentials_json: Optional[str] = None,
@@ -89,7 +89,7 @@ class BaseEmbedderConfig(ABC):
         self.model_kwargs = model_kwargs or {}
         self.huggingface_base_url = huggingface_base_url
         # AzureOpenAI specific
-        self.azure_kwargs = AzureConfig(**azure_kwargs) or {}
+        self.azure_kwargs = AzureConfig(**(azure_kwargs or {}))
 
         # VertexAI specific
         self.vertex_credentials_json = vertex_credentials_json

--- a/mem0/proxy/main.py
+++ b/mem0/proxy/main.py
@@ -52,7 +52,7 @@ class Completions:
     def create(
         self,
         model: str,
-        messages: List = [],
+        messages: Optional[List] = None,
         # Mem0 arguments
         user_id: Optional[str] = None,
         agent_id: Optional[str] = None,
@@ -92,6 +92,9 @@ class Completions:
         api_key: Optional[str] = None,
         model_list: Optional[list] = None,  # pass in a list of api_base,keys, etc.
     ):
+        if messages is None:
+            messages = []
+
         if not any([user_id, agent_id, run_id]):
             raise ValueError("One of user_id, agent_id, run_id must be provided")
 


### PR DESCRIPTION
## Linked Issue

Closes #5301

## Description

Two classic Python B006 anti-patterns where a single module-level list/dict instance is shared across every call that uses the default value. Any in-place mutation leaks state between call sites.

### `mem0/proxy/main.py` — `Completions.create`

```python
# Before (shared [] across all calls)
def create(self, model: str, messages: List = [], ...):

# After
def create(self, model: str, messages: Optional[List] = None, ...):
    if messages is None:
        messages = []
```

### `mem0/configs/embeddings/base.py` — `BaseEmbedderConfig.__init__`

```python
# Before (shared {} across all instances + type annotation mismatch)
azure_kwargs: Optional[AzureConfig] = {}

# After
azure_kwargs: Optional[AzureConfig] = None
# body:
self.azure_kwargs = AzureConfig(**(azure_kwargs or {}))
```

The `azure_kwargs` change also fixes the type annotation mismatch — the parameter was declared `Optional[AzureConfig]` but defaulted to `{}` (a plain dict). Behaviour is identical: callers that omit `azure_kwargs` still get a default `AzureConfig()`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A — both changes are backward-compatible. Callers passing an explicit value are unaffected.

## Test Coverage

- [x] No tests needed — environment-independent code-quality bug, behaviour is unchanged for callers that pass explicit arguments