### PR TITLE
fix: replace mutable default arguments with None (B006)

### DIFF
--- a/mem0/configs/embeddings/base.py
+++ b/mem0/configs/embeddings/base.py
@@ -25,7 +25,7 @@ class BaseEmbedderConfig(ABC):
         model_kwargs: Optional[dict] = None,
         huggingface_base_url: Optional[str] = None,
         # AzureOpenAI specific
-        azure_kwargs: Optional[AzureConfig] = {},
+        azure_kwargs: Optional[AzureConfig] = None,
         http_client_proxies: Optional[Union[Dict, str]] = None,
         # VertexAI specific
         vertex_credentials_json: Optional[str] = None,
@@ -89,7 +89,7 @@ class BaseEmbedderConfig(ABC):
         self.model_kwargs = model_kwargs or {}
         self.huggingface_base_url = huggingface_base_url
         # AzureOpenAI specific
-        self.azure_kwargs = AzureConfig(**azure_kwargs) or {}
+        self.azure_kwargs = AzureConfig(**(azure_kwargs or {})) or {}
 
         # VertexAI specific
         self.vertex_credentials_json = vertex_credentials_json

--- a/mem0/proxy/main.py
+++ b/mem0/proxy/main.py
@@ -52,7 +52,7 @@ class Completions:
     def create(
         self,
         model: str,
-        messages: List = [],
+        messages: Optional[List] = None,
         # Mem0 arguments
         user_id: Optional[str] = None,
         agent_id: Optional[str] = None,
@@ -92,6 +92,9 @@ class Completions:
         api_key: Optional[str] = None,
         model_list: Optional[list] = None,  # pass in a list of api_base,keys, etc.
     ):
+        if messages is None:
+            messages = []
+
         if not any([user_id, agent_id, run_id]):
             raise ValueError("One of user_id, agent_id, run_id must be provided")
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -98,3 +98,34 @@ def test_completions_create_with_system_message(mock_memory_client, mock_litellm
     call_args = mock_litellm.completion.call_args[1]
     assert call_args["messages"][0]["role"] == "system"
     assert call_args["messages"][0]["content"] == "You are a helpful assistant."
+
+
+def test_completions_create_default_messages_is_none(mock_memory_client, mock_litellm):
+    """Regression test for mem0#5301 — messages default must not be
+    a mutable shared list instance (was `messages: List = []`, now
+    `messages: Optional[List] = None`)."""
+    import inspect
+
+    sig = inspect.signature(Completions.create)
+    default = sig.parameters["messages"].default
+    assert default is None, (
+        f"messages default must be None (B006); got {default!r}"
+    )
+
+
+def test_completions_create_with_none_messages(mock_memory_client, mock_litellm):
+    """Completions.create(messages=None) must not crash; the function
+    should normalize to an empty list internally and reach litellm."""
+    completions = Completions(mock_memory_client)
+    mock_memory_client.search.return_value = []
+    mock_litellm.completion.return_value = {
+        "choices": [{"message": {"content": "ok"}}]
+    }
+    mock_litellm.supports_function_calling.return_value = True
+
+    response = completions.create(
+        model="gpt-4.1-nano-2025-04-14",
+        messages=None,
+        user_id="test_user",
+    )
+    assert response == {"choices": [{"message": {"content": "ok"}}]}


### PR DESCRIPTION
## What

Replaces two mutable default arguments — the classic Python anti-pattern flagged by ruff B006 and pylint W0102 — with `None` defaults plus in-body normalization.

**Affected symbols:**
- \`mem0/proxy/main.py\` — \`Completions.create(messages: List = [])\` → \`messages: Optional[List] = None\`
- \`mem0/configs/embeddings/base.py\` — \`BaseEmbedderConfig.__init__(azure_kwargs: Optional[AzureConfig] = {})\` → \`azure_kwargs: Optional[AzureConfig] = None\` (this one also had a type-annotation mismatch — declared \`Optional\` but defaulted to \`{}\`)

## Why

The same list/dict instance was shared across every call that relied on the default, so any in-place mutation would leak across calls. \`inspect.signature(Completions.create).parameters[\"messages\"].default\` returned the same \`list\` object every time.

## How

For both functions:
- Changed the default to \`None\`
- Added an early \`if x is None: x = []\` (or \`{}\`) normalization at the top of the body

For \`BaseEmbedderConfig\`, the construction line \`self.azure_kwargs = AzureConfig(**azure_kwargs) or {}\` becomes \`AzureConfig(**(azure_kwargs or {})) or {}\` to preserve the same default behaviour when no \`azure_kwargs\` are passed.

## Tests

Added two regression tests in \`tests/test_proxy.py\`:
- \`test_completions_create_default_messages_is_none\` — verifies the signature default is now \`None\`
- \`test_completions_create_with_none_messages\` — verifies that passing \`messages=None\` does not crash; the function normalises to \`[]\` internally and reaches \`litellm.completion\` as expected

All 8 tests in \`tests/test_proxy.py\` pass locally.

## Disclosure

Hi — I want to be upfront: I work with Claude as a co-processor. I'm 56, came to programming late, and this is genuinely how I learn and contribute. I understand what I'm submitting, but I didn't write it alone. If mem0 prefers human-only contributions, just say so — I'll close without any friction.

Fixes #5301