### PR TITLE
fix: use dash separator for S3 Vectors entity collection name

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -391,7 +391,9 @@ class Memory(MemoryBase):
         """Lazily initialize entity store on first use."""
         if self._entity_store is None:
             entity_config = _safe_deepcopy_config(self.config.vector_store.config)
-            entity_collection = f"{self.collection_name}_entities"
+            # S3 Vectors does not support underscores in collection names
+            sep = "-" if self.config.vector_store.provider == "s3_vectors" else "_"
+            entity_collection = f"{self.collection_name}{sep}entities"
             # Set collection name on the cloned config
             if hasattr(entity_config, 'collection_name'):
                 entity_config.collection_name = entity_collection
@@ -1835,7 +1837,9 @@ class AsyncMemory(MemoryBase):
         """Lazily initialize entity store on first use."""
         if self._entity_store is None:
             entity_config = _safe_deepcopy_config(self.config.vector_store.config)
-            entity_collection = f"{self.collection_name}_entities"
+            # S3 Vectors does not support underscores in collection names
+            sep = "-" if self.config.vector_store.provider == "s3_vectors" else "_"
+            entity_collection = f"{self.collection_name}{sep}entities"
             if hasattr(entity_config, 'collection_name'):
                 entity_config.collection_name = entity_collection
             elif isinstance(entity_config, dict):


### PR DESCRIPTION
## Summary

S3 Vectors does not support underscores in index/collection names. When entity linking is triggered during Memory.add(), the hardcoded _{collection_name}_entities separator causes a ValidationException from the S3 API.

## Changes

- Added provider-aware separator: uses - (dash) for s3_vectors provider, keeps _ (underscore) for all other providers
- Applied to both entity_store property locations in main.py

## Testing

Since I don't have S3 Vectors infrastructure, this was verified by code inspection. The fix is minimal and follows the suggestion in the issue.

Fixes #5361