### PR TITLE
fix(pgvector): use URL query parameter syntax for sslmode

### DIFF
--- a/mem0/vector_stores/pgvector.py
+++ b/mem0/vector_stores/pgvector.py
@@ -168,18 +168,17 @@ class PGVector(VectorStoreBase):
             self.connection_pool = connection_pool
         elif connection_string:
             if sslmode:
-                # Append sslmode to connection string if provided
+                # Append sslmode as URL query parameter
                 if 'sslmode=' in connection_string:
-                    # Replace existing sslmode
                     import re
-                    connection_string = re.sub(r'sslmode=[^ ]*', f'sslmode={sslmode}', connection_string)
+                    connection_string = re.sub(r'sslmode=[^&\s]*', f'sslmode={sslmode}', connection_string)
                 else:
-                    # Add sslmode to connection string
-                    connection_string = f"{connection_string} sslmode={sslmode}"
+                    sep = '&' if '?' in connection_string else '?'
+                    connection_string = f"{connection_string}{sep}sslmode={sslmode}"
         else:
             connection_string = f"postgresql://{user}:{password}@{host}:{port}/{dbname}"
             if sslmode:
-                connection_string = f"{connection_string} sslmode={sslmode}"
+                connection_string = f"{connection_string}?sslmode={sslmode}"
         
         if self.connection_pool is None:
             if PSYCOPG_VERSION == 3:


### PR DESCRIPTION
## Summary

When configuring pgvector with \sslmode\, the parameter was appended to the connection URI using a space separator instead of standard URL query syntax. This caused psycopg3 and cloud routing endpoints to parse the sslmode suffix as part of the database name.

## Before
\\\
postgresql://user:pass@host:5432/dbname sslmode=require
\\\
Result: \invalid database name: 'dbname sslmode=require'\

## After  
\\\
postgresql://user:pass@host:5432/dbname?sslmode=require
\\\

## Changes
- Replace space separator with \?\ / \&\ URL query parameter syntax
- Handle both \connection_string\ and individual parameter paths
- Preserve existing sslmode replacement via regex

Fixes #5303