### PR TITLE
fix(search): short-circuit blank queries before embedding (#5220)

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1176,6 +1176,14 @@ class Memory(MemoryBase):
         # Validate search parameters (before applying defaults)
         _validate_search_params(threshold=threshold, top_k=top_k)
 
+        # Reject blank queries before embedding. Without this guard the
+        # query is passed straight to the embedding model: some providers
+        # (e.g. Ollama) raise on empty input, others silently return a
+        # zero/random vector which then matches every stored memory.
+        # See #5220.
+        if not query or not query.strip():
+            return {"results": []}
+
         # Validate and trim entity IDs in filters
         effective_filters = filters.copy() if filters else {}
         if "user_id" in effective_filters:
@@ -2590,6 +2598,14 @@ class AsyncMemory(MemoryBase):
 
         # Validate search parameters (before applying defaults)
         _validate_search_params(threshold=threshold, top_k=top_k)
+
+        # Reject blank queries before embedding. Without this guard the
+        # query is passed straight to the embedding model: some providers
+        # (e.g. Ollama) raise on empty input, others silently return a
+        # zero/random vector which then matches every stored memory.
+        # See #5220.
+        if not query or not query.strip():
+            return {"results": []}
 
         # Validate and trim entity IDs in filters
         effective_filters = filters.copy() if filters else {}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -348,3 +348,45 @@ class TestSearchParamValidation:
             result = memory_instance.search("test", filters={"user_id": "test"}, top_k=0)
 
         assert "results" in result
+
+
+class TestSearchEmptyQueryValidation:
+    """Tests for Memory.search() blank-query short-circuit (regression #5220)."""
+
+    def test_search_returns_empty_for_empty_string_query(self, memory_instance):
+        """Empty string query should return {"results": []} without embedding."""
+        memory_instance.embedding_model = Mock()
+        memory_instance.embedding_model.embed = Mock(side_effect=AssertionError("embed must not be called"))
+        memory_instance.vector_store.search = Mock(side_effect=AssertionError("search must not be called"))
+
+        result = memory_instance.search("", filters={"user_id": "test_user"})
+
+        assert result == {"results": []}
+        memory_instance.embedding_model.embed.assert_not_called()
+        memory_instance.vector_store.search.assert_not_called()
+
+    def test_search_returns_empty_for_whitespace_only_query(self, memory_instance):
+        """Whitespace-only query should return {"results": []} without embedding."""
+        memory_instance.embedding_model = Mock()
+        memory_instance.embedding_model.embed = Mock(side_effect=AssertionError("embed must not be called"))
+        memory_instance.vector_store.search = Mock(side_effect=AssertionError("search must not be called"))
+
+        result = memory_instance.search("   \t\n  ", filters={"user_id": "test_user"})
+
+        assert result == {"results": []}
+        memory_instance.embedding_model.embed.assert_not_called()
+
+    def test_search_returns_empty_for_none_query(self, memory_instance):
+        """None query should return {"results": []} without embedding."""
+        memory_instance.embedding_model = Mock()
+        memory_instance.embedding_model.embed = Mock(side_effect=AssertionError("embed must not be called"))
+
+        result = memory_instance.search(None, filters={"user_id": "test_user"})
+
+        assert result == {"results": []}
+
+    def test_search_still_validates_threshold_before_blank_check(self, memory_instance):
+        """Invalid threshold should still raise even with empty query
+        (param-level validation precedes blank-query short-circuit)."""
+        with pytest.raises(ValueError, match="Invalid threshold"):
+            memory_instance.search("", filters={"user_id": "test"}, threshold=1.5)


### PR DESCRIPTION
## What

\`Memory.search()\` and \`AsyncMemory.search()\` were passing the query string directly to the embedding model with no validation. Empty strings and whitespace-only strings were treated as valid queries, leading to either a provider-level crash (some embedders raise on empty input, e.g. Ollama) or — worse — a silent zero/random vector that matched every stored memory for the filtered user/agent/run.

## Change

In both \`Memory.search\` and \`AsyncMemory.search\` (\`mem0/memory/main.py\`), add a guard that runs AFTER parameter validation (threshold/top_k) but BEFORE filter normalisation and embedding:

\`\`\`python
if not query or not query.strip():
    return {\"results\": []}
\`\`\`

This matches the issue's expected behaviour: blank queries return the same shape as a valid search that matched nothing.

## Tests

Added \`TestSearchEmptyQueryValidation\` in \`tests/test_main.py\` covering:
- empty string → \`{\"results\": []}\`, no embed call, no vector_store.search call
- whitespace-only (spaces, tabs, newlines) → \`{\"results\": []}\`
- \`None\` query → \`{\"results\": []}\`
- invalid threshold + empty query → still raises (parameter validation runs first)

All 4 tests pass locally.

## Why this ordering

Parameter validation (threshold/top_k) runs **before** the blank-query short-circuit so that an operator passing both an invalid threshold and an empty query still sees the threshold error — i.e. the more specific bug-signal isn't masked by the short-circuit.

Filter validation runs **after** the short-circuit because an empty query is a happy-path edge case (\"return nothing\") — there's no need to require entity filters just to tell the caller \"your query was empty\".

## Disclosure

Hi — I want to be upfront: I work with Claude as a co-processor. I'm 56, came to programming late, and this is genuinely how I learn and contribute. I understand what I'm submitting, but I didn't write it alone. If mem0 prefers human-only contributions, just say so — I'll close without any friction.

Fixes #5220