### PR TITLE
fix(xai): factory construction + tool forwarding + tool-call parsing (#5189)

### DIFF
--- a/mem0/configs/llms/xai.py
+++ b/mem0/configs/llms/xai.py
@@ -1,0 +1,56 @@
+from typing import Optional
+
+from mem0.configs.llms.base import BaseLlmConfig
+
+
+class XAIConfig(BaseLlmConfig):
+    """
+    Configuration class for xAI (Grok) specific parameters.
+    Inherits from BaseLlmConfig and adds xAI-specific settings.
+    """
+
+    def __init__(
+        self,
+        # Base parameters
+        model: Optional[str] = None,
+        temperature: float = 0.1,
+        api_key: Optional[str] = None,
+        max_tokens: int = 2000,
+        top_p: float = 0.1,
+        top_k: int = 1,
+        enable_vision: bool = False,
+        vision_details: Optional[str] = "auto",
+        http_client_proxies: Optional[dict] = None,
+        # xAI-specific parameters
+        xai_base_url: Optional[str] = None,
+    ):
+        """
+        Initialize xAI configuration.
+
+        Args:
+            model: xAI model to use, defaults to None
+            temperature: Controls randomness, defaults to 0.1
+            api_key: xAI API key, defaults to None
+            max_tokens: Maximum tokens to generate, defaults to 2000
+            top_p: Nucleus sampling parameter, defaults to 0.1
+            top_k: Top-k sampling parameter, defaults to 1
+            enable_vision: Enable vision capabilities, defaults to False
+            vision_details: Vision detail level, defaults to "auto"
+            http_client_proxies: HTTP client proxy settings, defaults to None
+            xai_base_url: xAI API base URL, defaults to None
+        """
+        # Initialize base parameters
+        super().__init__(
+            model=model,
+            temperature=temperature,
+            api_key=api_key,
+            max_tokens=max_tokens,
+            top_p=top_p,
+            top_k=top_k,
+            enable_vision=enable_vision,
+            vision_details=vision_details,
+            http_client_proxies=http_client_proxies,
+        )
+
+        # xAI-specific parameters
+        self.xai_base_url = xai_base_url

--- a/mem0/llms/xai.py
+++ b/mem0/llms/xai.py
@@ -1,14 +1,36 @@
+import json
 import os
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 from openai import OpenAI
 
 from mem0.configs.llms.base import BaseLlmConfig
+from mem0.configs.llms.xai import XAIConfig
 from mem0.llms.base import LLMBase
+from mem0.memory.utils import extract_json
 
 
 class XAILLM(LLMBase):
-    def __init__(self, config: Optional[BaseLlmConfig] = None):
+    def __init__(self, config: Optional[Union[BaseLlmConfig, XAIConfig, Dict]] = None):
+        # Convert to XAIConfig if needed
+        if config is None:
+            config = XAIConfig()
+        elif isinstance(config, dict):
+            config = XAIConfig(**config)
+        elif isinstance(config, BaseLlmConfig) and not isinstance(config, XAIConfig):
+            # Convert BaseLlmConfig to XAIConfig
+            config = XAIConfig(
+                model=config.model,
+                temperature=config.temperature,
+                api_key=config.api_key,
+                max_tokens=config.max_tokens,
+                top_p=config.top_p,
+                top_k=config.top_k,
+                enable_vision=config.enable_vision,
+                vision_details=config.vision_details,
+                http_client_proxies=config.http_client,
+            )
+
         super().__init__(config)
 
         if not self.config.model:
@@ -18,24 +40,58 @@ class XAILLM(LLMBase):
         base_url = self.config.xai_base_url or os.getenv("XAI_API_BASE") or "https://api.x.ai/v1"
         self.client = OpenAI(api_key=api_key, base_url=base_url)
 
+    def _parse_response(self, response, tools):
+        """
+        Process the response based on whether tools are used or not.
+
+        Args:
+            response: The raw response from API.
+            tools: The list of tools provided in the request.
+
+        Returns:
+            str or dict: The processed response.
+        """
+        if tools:
+            processed_response = {
+                "content": response.choices[0].message.content,
+                "tool_calls": [],
+            }
+
+            if response.choices[0].message.tool_calls:
+                for tool_call in response.choices[0].message.tool_calls:
+                    processed_response["tool_calls"].append(
+                        {
+                            "name": tool_call.function.name,
+                            "arguments": json.loads(extract_json(tool_call.function.arguments)),
+                        }
+                    )
+
+            return processed_response
+        else:
+            return response.choices[0].message.content
+
     def generate_response(
         self,
         messages: List[Dict[str, str]],
         response_format=None,
         tools: Optional[List[Dict]] = None,
         tool_choice: str = "auto",
+        **kwargs,
     ):
         """
-        Generate a response based on the given messages using XAI.
+        Generate a response based on the given messages using xAI (Grok).
 
         Args:
             messages (list): List of message dicts containing 'role' and 'content'.
             response_format (str or object, optional): Format of the response. Defaults to "text".
             tools (list, optional): List of tools that the model can call. Defaults to None.
             tool_choice (str, optional): Tool choice method. Defaults to "auto".
+            **kwargs: Additional xAI-specific parameters.
 
         Returns:
-            str: The generated response.
+            str or dict: The generated response. When tools are provided, returns
+                a dict with "content" and "tool_calls" matching the OpenAI/DeepSeek
+                provider shape; otherwise returns the bare content string.
         """
         params = {
             "model": self.config.model,
@@ -47,6 +103,9 @@ class XAILLM(LLMBase):
 
         if response_format:
             params["response_format"] = response_format
+        if tools:
+            params["tools"] = tools
+            params["tool_choice"] = tool_choice
 
         response = self.client.chat.completions.create(**params)
-        return response.choices[0].message.content
+        return self._parse_response(response, tools)

--- a/tests/llms/test_xai.py
+++ b/tests/llms/test_xai.py
@@ -1,0 +1,166 @@
+import os
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mem0.configs.llms.base import BaseLlmConfig
+from mem0.configs.llms.xai import XAIConfig
+from mem0.llms.xai import XAILLM
+
+
+@pytest.fixture
+def mock_xai_client():
+    with patch("mem0.llms.xai.OpenAI") as mock_openai:
+        mock_client = Mock()
+        mock_openai.return_value = mock_client
+        yield mock_client
+
+
+def _normalize_url(url):
+    """Strip trailing slash for stable URL comparison."""
+    return str(url).rstrip("/")
+
+
+def test_xai_llm_factory_construction_with_base_config():
+    """Regression test for mem0#5189 bug 1: constructing XAILLM via the
+    factory (which passes BaseLlmConfig, not XAIConfig) must not raise
+    AttributeError on the missing xai_base_url attribute."""
+    config = BaseLlmConfig(
+        model="grok-2-latest",
+        temperature=0.7,
+        max_tokens=100,
+        top_p=1.0,
+        api_key="api_key",
+    )
+    # This used to raise: AttributeError: 'BaseLlmConfig' object has no attribute 'xai_base_url'
+    llm = XAILLM(config)
+    assert _normalize_url(llm.client.base_url) == "https://api.x.ai/v1"
+
+
+def test_xai_llm_base_url():
+    # case1: default config with xAI official base url
+    config = BaseLlmConfig(
+        model="grok-2-latest", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key"
+    )
+    llm = XAILLM(config)
+    assert _normalize_url(llm.client.base_url) == "https://api.x.ai/v1"
+
+    # case2: with env variable XAI_API_BASE
+    provider_base_url = "https://api.provider.com/v1/"
+    os.environ["XAI_API_BASE"] = provider_base_url
+    try:
+        config = XAIConfig(
+            model="grok-2-latest", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key"
+        )
+        llm = XAILLM(config)
+        assert _normalize_url(llm.client.base_url) == _normalize_url(provider_base_url)
+    finally:
+        del os.environ["XAI_API_BASE"]
+
+    # case3: with config.xai_base_url (takes precedence over env)
+    config_base_url = "https://api.config.com/v1/"
+    config = XAIConfig(
+        model="grok-2-latest",
+        temperature=0.7,
+        max_tokens=100,
+        top_p=1.0,
+        api_key="api_key",
+        xai_base_url=config_base_url,
+    )
+    llm = XAILLM(config)
+    assert _normalize_url(llm.client.base_url) == _normalize_url(config_base_url)
+
+
+def test_xai_llm_dict_config():
+    """XAILLM should accept a plain dict config (factory passes dicts)."""
+    llm = XAILLM({"model": "grok-2-latest", "api_key": "k"})
+    assert _normalize_url(llm.client.base_url) == "https://api.x.ai/v1"
+    assert llm.config.model == "grok-2-latest"
+
+
+def test_xai_llm_none_config_uses_defaults(monkeypatch):
+    """XAILLM(None) should fall back to XAIConfig defaults."""
+    monkeypatch.setenv("XAI_API_KEY", "test-key")
+    llm = XAILLM(None)
+    assert llm.config.model == "grok-2-latest"
+
+
+def test_generate_response_without_tools(mock_xai_client):
+    config = BaseLlmConfig(
+        model="grok-2-latest", temperature=0.7, max_tokens=100, top_p=1.0
+    )
+    llm = XAILLM(config)
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello."},
+    ]
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Hi there."))]
+    mock_xai_client.chat.completions.create.return_value = mock_response
+
+    response = llm.generate_response(messages)
+    assert response == "Hi there."
+
+    mock_xai_client.chat.completions.create.assert_called_once_with(
+        model="grok-2-latest",
+        messages=messages,
+        temperature=0.7,
+        max_tokens=100,
+        top_p=1.0,
+    )
+
+
+def test_generate_response_with_tools_forwards_them(mock_xai_client):
+    """Regression test for mem0#5189 bug 2: tools and tool_choice must be
+    forwarded to chat.completions.create; previously they were silently
+    dropped on grok."""
+    config = BaseLlmConfig(
+        model="grok-2-latest", temperature=0.7, max_tokens=100, top_p=1.0
+    )
+    llm = XAILLM(config)
+    messages = [{"role": "user", "content": "find X"}]
+    tools = [
+        {
+            "type": "function",
+            "function": {"name": "search", "parameters": {"type": "object", "properties": {}}},
+        }
+    ]
+
+    mock_tool_call = Mock()
+    mock_tool_call.function.name = "search"
+    mock_tool_call.function.arguments = '{"q": "X"}'
+    mock_response = Mock()
+    mock_response.choices = [
+        Mock(message=Mock(content=None, tool_calls=[mock_tool_call]))
+    ]
+    mock_xai_client.chat.completions.create.return_value = mock_response
+
+    response = llm.generate_response(messages, tools=tools)
+
+    # Tools must reach the API
+    call_kwargs = mock_xai_client.chat.completions.create.call_args.kwargs
+    assert "tools" in call_kwargs
+    assert call_kwargs["tools"] == tools
+    assert call_kwargs["tool_choice"] == "auto"
+
+    # Regression for mem0#5189 bug 3: tool_calls must be present in
+    # the parsed response so callers can act on them.
+    assert isinstance(response, dict)
+    assert response["content"] is None
+    assert response["tool_calls"] == [{"name": "search", "arguments": {"q": "X"}}]
+
+
+def test_generate_response_tools_no_tool_calls(mock_xai_client):
+    """When tools are provided but the model replies in plain content,
+    tool_calls should be an empty list (no crash on None tool_calls)."""
+    config = BaseLlmConfig(model="grok-2-latest")
+    llm = XAILLM(config)
+    messages = [{"role": "user", "content": "hi"}]
+    tools = [{"type": "function", "function": {"name": "search", "parameters": {"type": "object"}}}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="plain reply", tool_calls=None))]
+    mock_xai_client.chat.completions.create.return_value = mock_response
+
+    response = llm.generate_response(messages, tools=tools)
+    assert response == {"content": "plain reply", "tool_calls": []}


### PR DESCRIPTION
## What

Three bugs in `mem0/llms/xai.py` — all surfaced together when wiring up Grok and all fixed by mirroring the existing DeepSeek provider shape.

1. **Factory construction raised `AttributeError`**. The constructor read \`self.config.xai_base_url\` unconditionally, but the factory wires xai with plain \`BaseLlmConfig\` (no such attribute). Every user going through \`Memory.from_config\` / \`LlmFactory.create(\"xai\", ...)\` hit \`AttributeError: 'BaseLlmConfig' object has no attribute 'xai_base_url'\` before the env-var fallback could even run.

2. **\`generate_response\` accepted \`tools\` and \`tool_choice\` but never forwarded them** to the OpenAI client, so tool calling silently did nothing on Grok.

3. **No \`_parse_response\` helper**. Even if (2) were fixed, the bare \`message.content\` (which is \`None\` when the model emits tool calls) was returned as-is and the tool-call payload was dropped.

## Change

- Introduce \`mem0/configs/llms/xai.py::XAIConfig\` (mirroring \`DeepSeekConfig\`)
- Accept \`BaseLlmConfig\` / \`XAIConfig\` / \`dict\` / \`None\` in \`XAILLM.__init__\` with consistent normalisation
- Forward \`tools\` + \`tool_choice\` in \`generate_response\`
- Add the same \`_parse_response\` helper DeepSeek uses to produce the \`{\"content\": ..., \"tool_calls\": [...]}\` shape when tools are requested

The doc table at \`docs/components/llms/config.mdx\` already lists \`xai_base_url\` in the master config table, so the docs are already aligned with the intended behaviour. The implementation just never caught up — this PR closes that gap.

## Tests (\`tests/llms/test_xai.py\`)

- factory construction with \`BaseLlmConfig\` no longer raises
- base_url resolution: default / \`XAI_API_BASE\` env / \`config.xai_base_url\` attribute
- dict config and \`None\` config accepted
- \`generate_response\` without tools returns bare content
- \`generate_response\` with tools forwards \`tools\` + \`tool_choice\` and produces the \`{\"content\", \"tool_calls\"}\` dict
- \`tool_calls=None\` on the message becomes \`[]\`

All 7 tests pass locally.

## Disclosure

Hi — I want to be upfront: I work with Claude as a co-processor. I'm 56, came to programming late, and this is genuinely how I learn and contribute. I understand what I'm submitting, but I didn't write it alone. If mem0 prefers human-only contributions, just say so — I'll close without any friction.

Fixes #5189