### PR TITLE
Return 400 for search requests without identifiers

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -434,12 +434,19 @@ def search_memories(search_req: SearchRequest, _auth=Depends(verify_auth)):
                 ", ".join(deprecated_keys),
                 ", ".join(f'"{k}": "..."' for k in deprecated_keys),
             )
+        if not any(key in filters for key in ("user_id", "agent_id", "run_id")):
+            raise HTTPException(
+                status_code=400,
+                detail="filters must contain at least one of: user_id, agent_id, run_id",
+            )
         params = {}
         if search_req.top_k is not None:
             params["top_k"] = search_req.top_k
         if search_req.threshold is not None:
             params["threshold"] = search_req.threshold
         return get_memory_instance().search(query=search_req.query, filters=filters, **params)
+    except HTTPException:
+        raise
     except Exception:
         raise upstream_error()
 

--- a/tests/test_server_params.py
+++ b/tests/test_server_params.py
@@ -641,11 +641,11 @@ class TestSearchEntityIdMapping:
         assert kwargs["filters"]["user_id"] == "u1"
         assert kwargs["filters"]["category"] == "food"
 
-    def test_no_entity_ids_no_filters(self, client, mock_memory):
-        resp = client.post("/search", json={"query": "food"})
-        assert resp.status_code == 200
-        _, kwargs = mock_memory.search.call_args
-        assert kwargs["filters"] == {}
+    def test_missing_identifier_returns_400(self, client, mock_memory):
+        resp = client.post("/search", json={"query": "food", "filters": {}, "top_k": 5})
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "filters must contain at least one of: user_id, agent_id, run_id"
+        mock_memory.search.assert_not_called()
 
     def test_only_filters_no_entity_ids(self, client, mock_memory):
         resp = client.post("/search", json={


### PR DESCRIPTION
## Summary

Fixes #5367.

`POST /search` now validates that the request includes at least one memory scope identifier before calling `Memory.search()`. After merging deprecated top-level `user_id`, `agent_id`, and `run_id` values into `filters`, the route returns `400 Bad Request` when none of those identifiers is present instead of letting the backend raise and mapping that client error to a generic upstream `502`.

The route also lets intentional FastAPI `HTTPException`s pass through the broad upstream error wrapper, and the regression test verifies that invalid search requests do not call the memory backend.

## Testing

```bash
AUTH_DISABLED=true PYTHONPATH=server:. uv run --extra test --with-requirements server/requirements.txt --with 'psycopg[binary]' pytest tests/test_server_params.py -q
uv run --extra dev ruff check server/main.py tests/test_server_params.py
uv run --extra dev ruff format --check server/main.py
git diff --check
```
