### PR TITLE
Fix mutable default arguments (B006)

### DIFF
--- a/mem0/configs/embeddings/base.py
+++ b/mem0/configs/embeddings/base.py
@@ -25,7 +25,7 @@ class BaseEmbedderConfig(ABC):
         model_kwargs: Optional[dict] = None,
         huggingface_base_url: Optional[str] = None,
         # AzureOpenAI specific
-        azure_kwargs: Optional[AzureConfig] = {},
+        azure_kwargs: Optional[AzureConfig] = None,
         http_client_proxies: Optional[Union[Dict, str]] = None,
         # VertexAI specific
         vertex_credentials_json: Optional[str] = None,
@@ -89,7 +89,7 @@ class BaseEmbedderConfig(ABC):
         self.model_kwargs = model_kwargs or {}
         self.huggingface_base_url = huggingface_base_url
         # AzureOpenAI specific
-        self.azure_kwargs = AzureConfig(**azure_kwargs) or {}
+        self.azure_kwargs = AzureConfig(**azure_kwargs) if azure_kwargs else {}
 
         # VertexAI specific
         self.vertex_credentials_json = vertex_credentials_json

--- a/mem0/proxy/main.py
+++ b/mem0/proxy/main.py
@@ -52,7 +52,7 @@ class Completions:
     def create(
         self,
         model: str,
-        messages: List = [],
+        messages: Optional[List] = None,
         # Mem0 arguments
         user_id: Optional[str] = None,
         agent_id: Optional[str] = None,
@@ -92,6 +92,8 @@ class Completions:
         api_key: Optional[str] = None,
         model_list: Optional[list] = None,  # pass in a list of api_base,keys, etc.
     ):
+        if messages is None:
+            messages = []
         if not any([user_id, agent_id, run_id]):
             raise ValueError("One of user_id, agent_id, run_id must be provided")
 


### PR DESCRIPTION
## Summary

Two mutable default arguments flagged by ruff B006 / pylint W0102.

- \Completions.create(messages=[])\ → shared list across calls
- \BaseEmbedderConfig.__init__(azure_kwargs={})\ → shared dict, also type-annotation mismatch (declared Optional but defaulted to {})

## Fix

- \messages: List = []\ → \messages: Optional[List] = None\ + \if messages is None: messages = []\
- \zure_kwargs: Optional[AzureConfig] = {}\ → \zure_kwargs: Optional[AzureConfig] = None\ + \if azure_kwargs else {}\

Fixes #5301.