### PR TITLE
Return 400 instead of 502 for invalid /search filters

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -440,6 +440,8 @@ def search_memories(search_req: SearchRequest, _auth=Depends(verify_auth)):
         if search_req.threshold is not None:
             params["threshold"] = search_req.threshold
         return get_memory_instance().search(query=search_req.query, filters=filters, **params)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except Exception:
         raise upstream_error()
 


### PR DESCRIPTION
## Problem

The \/search\ endpoint returns **502 Bad Gateway** when invalid filters are provided, confusing MCP clients and API users who expect a 4xx error for invalid input.

## Root Cause

\search_memories()\ catches all \Exception\ and raises \upstream_error()\, which returns 502. This is inappropriate for \ValueError\ thrown by input validation.

## Fix

Add explicit \ValueError\ catch before the generic \Exception\ handler, returning HTTP 400 with the validation message.

## Example

Before:
\\\json
// Empty filters causing ValueError -> 502
\\\

After:
\\\json
// Empty filters causing ValueError -> 400 with detail message
\\\

Fixes #5367.