### PR TITLE
fix: expose Qdrant https option

### DIFF
--- a/docs/components/vectordbs/dbs/qdrant.mdx
+++ b/docs/components/vectordbs/dbs/qdrant.mdx
@@ -76,6 +76,7 @@ Let's see the available parameters for the `qdrant` config:
 | `path` | Path for the qdrant database | `/tmp/qdrant` |
 | `url` | Full URL for the qdrant server | `None` |
 | `api_key` | API key for the qdrant server | `None` |
+| `https` | Whether to force HTTPS on or off. `None` lets the client decide; set `False` for plain HTTP Qdrant with API key authentication. | `None` |
 | `on_disk` | For enabling persistent storage | `False` |
 </Tab>
 <Tab title="TypeScript">

--- a/mem0/configs/vector_stores/qdrant.py
+++ b/mem0/configs/vector_stores/qdrant.py
@@ -16,6 +16,10 @@ class QdrantConfig(BaseModel):
     path: Optional[str] = Field("/tmp/qdrant", description="Path for local Qdrant database")
     url: Optional[str] = Field(None, description="Full URL for Qdrant server")
     api_key: Optional[str] = Field(None, description="API key for Qdrant server")
+    https: Optional[bool] = Field(
+        None,
+        description="Whether to force HTTPS on or off. Explicit schemes in url take precedence.",
+    )
     on_disk: Optional[bool] = Field(False,description="Enables persistent storage. Vectors are kept on disk (True) or in memory (False). Does not delete the local database path.")
 
     @model_validator(mode="before")

--- a/mem0/vector_stores/qdrant.py
+++ b/mem0/vector_stores/qdrant.py
@@ -37,6 +37,7 @@ class Qdrant(VectorStoreBase):
         path: str = None,
         url: str = None,
         api_key: str = None,
+        https: bool | None = None,
         on_disk: bool = False,
     ):
         """
@@ -51,6 +52,8 @@ class Qdrant(VectorStoreBase):
             path (str, optional): Path for local Qdrant database. Defaults to None.
             url (str, optional): Full URL for Qdrant server. Defaults to None.
             api_key (str, optional): API key for Qdrant server. Defaults to None.
+            https (bool, optional): Whether to force HTTPS on or off. Explicit schemes in url take precedence.
+                Defaults to None.
             on_disk (bool, optional): Enables persistent storage. Vectors are stored on disk (True) or in memory (False).
                 Does not delete the local database path. Defaults to False.
         """
@@ -66,6 +69,8 @@ class Qdrant(VectorStoreBase):
             if host and port:
                 params["host"] = host
                 params["port"] = port
+            if https is not None:
+                params["https"] = https
 
             if not params:
                 params["path"] = path

--- a/tests/vector_stores/test_qdrant_config.py
+++ b/tests/vector_stores/test_qdrant_config.py
@@ -1,0 +1,37 @@
+from unittest.mock import MagicMock
+
+from mem0.configs.vector_stores.qdrant import QdrantConfig
+from mem0.vector_stores import qdrant as qdrant_module
+
+
+def test_qdrant_config_accepts_explicit_https_false():
+    config = QdrantConfig(
+        host="127.0.0.1",
+        port=6333,
+        api_key="test-key",
+        https=False,
+    )
+
+    assert config.https is False
+
+
+def test_qdrant_passes_explicit_https_to_client(monkeypatch):
+    client_cls = MagicMock()
+    monkeypatch.setattr(qdrant_module, "QdrantClient", client_cls)
+    monkeypatch.setattr(qdrant_module.Qdrant, "create_col", lambda *args, **kwargs: None)
+
+    qdrant_module.Qdrant(
+        collection_name="memories",
+        embedding_model_dims=1536,
+        host="127.0.0.1",
+        port=6333,
+        api_key="test-key",
+        https=False,
+    )
+
+    client_cls.assert_called_once_with(
+        api_key="test-key",
+        host="127.0.0.1",
+        port=6333,
+        https=False,
+    )


### PR DESCRIPTION
## Summary
- add an explicit `https` option to the Qdrant vector-store config
- pass that option through to `QdrantClient`
- document the Python config option for self-hosted HTTP Qdrant with API-key auth
- cover both config parsing and client construction with focused unit tests

Closes #5378

## To verify
- `python -m pytest tests\vector_stores\test_qdrant_config.py -q`
- `python -m py_compile mem0\configs\vector_stores\qdrant.py mem0\vector_stores\qdrant.py tests\vector_stores\test_qdrant_config.py`
- `python -m ruff check mem0\configs\vector_stores\qdrant.py mem0\vector_stores\qdrant.py tests\vector_stores\test_qdrant_config.py`
- `git diff --check`

## Notes
`ruff format --check` would reformat existing unrelated lines in `mem0/vector_stores/qdrant.py`, so I did not run a full-file format pass for this small compatibility fix.