### PR TITLE
fix(openclaw): skip heavy register() side effects on cli-metadata pass (#5371)

### DIFF
--- a/openclaw/index.test.ts
+++ b/openclaw/index.test.ts
@@ -14,6 +14,7 @@ import {
   isGenericAssistantMessage,
   stripNoiseFromContent,
   filterMessagesForExtraction,
+  isCliMetadataPass,
 } from "./index.ts";
 
 // ---------------------------------------------------------------------------
@@ -608,5 +609,29 @@ describe("auto-recall threshold respects cfg.searchThreshold", () => {
   it("threshold 0 returns all results", () => {
     const filtered = applyThresholdFilter(typicalV3Results, 0);
     expect(filtered).toHaveLength(6);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isCliMetadataPass — guards the duplicate register() pass (issue #5371)
+// ---------------------------------------------------------------------------
+describe("isCliMetadataPass", () => {
+  it("returns true on the cli-metadata registration pass", () => {
+    expect(isCliMetadataPass("cli-metadata")).toBe(true);
+  });
+
+  it("returns false on the full registration pass", () => {
+    expect(isCliMetadataPass("full")).toBe(false);
+  });
+
+  it("returns false when registrationMode is undefined (older cores)", () => {
+    expect(isCliMetadataPass(undefined)).toBe(false);
+  });
+
+  it("returns false for unknown/other modes", () => {
+    expect(isCliMetadataPass("")).toBe(false);
+    expect(isCliMetadataPass(null)).toBe(false);
+    expect(isCliMetadataPass("Cli-Metadata")).toBe(false);
+    expect(isCliMetadataPass(0)).toBe(false);
   });
 });

--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -87,6 +87,25 @@ export { createProvider } from "./providers.ts";
 // Helpers
 // ============================================================================
 
+/**
+ * The OpenClaw plugin loader invokes `register()` twice per gateway startup:
+ * once in the main pass (`registrationMode: "full"`) and once in a metadata
+ * pass (`registrationMode: "cli-metadata"`) used only to collect CLI command
+ * metadata for `openclaw mem0 help` and similar commands.
+ *
+ * On the metadata pass we must still register CLI commands, but everything
+ * else (provider/backend construction, memory capability, service, lifecycle
+ * hooks, telemetry, and the "registered" info log) should be skipped so those
+ * side effects only run once. Older cores that do not set `registrationMode`
+ * pass `undefined`, which we treat as a full registration for backwards
+ * compatibility.
+ *
+ * See https://github.com/mem0ai/mem0/issues/5371
+ */
+export function isCliMetadataPass(registrationMode: unknown): boolean {
+  return registrationMode === "cli-metadata";
+}
+
 // ============================================================================
 // Plugin Definition
 // ============================================================================
@@ -107,6 +126,27 @@ const memoryPlugin = definePluginEntry({
       baseUrl: pluginAuth.baseUrl,
     };
     const cfg = mem0ConfigSchema.parse(api.pluginConfig, fileConfig);
+
+    // The core loader calls register() twice: a "full" pass and a
+    // "cli-metadata" pass. The metadata pass only needs the CLI surface so
+    // `openclaw mem0 help` can enumerate commands. Register CLI commands and
+    // return early to avoid constructing a second provider/backend, firing
+    // duplicate telemetry, double-registering the service/capability, and
+    // emitting a duplicate "registered" log line. See issue #5371.
+    if (isCliMetadataPass(api.registrationMode)) {
+      registerCliCommands(
+        api,
+        null as any,
+        null as any,
+        cfg,
+        () => cfg.userId,
+        (id: string) => `${cfg.userId}:agent:${id}`,
+        () => ({ user_id: cfg.userId, top_k: cfg.topK }),
+        () => undefined,
+        () => undefined,
+      );
+      return;
+    }
 
     // Telemetry context bound to this plugin instance's config
     const telemetryCtx = {

--- a/openclaw/openclaw-plugin-sdk.d.ts
+++ b/openclaw/openclaw-plugin-sdk.d.ts
@@ -26,6 +26,15 @@ declare module "openclaw/plugin-sdk" {
 
   export interface OpenClawPluginApi {
     pluginConfig: Record<string, unknown>;
+    /**
+     * Which registration pass the core plugin loader is running.
+     * The loader calls `register()` twice: once with "full" (the real
+     * registration) and once with "cli-metadata" (to collect CLI command
+     * metadata for `openclaw <plugin> help`). Plugins should skip heavy,
+     * non-CLI side effects on the "cli-metadata" pass. Older cores leave
+     * this undefined, which is treated as a full registration.
+     */
+    registrationMode?: "full" | "cli-metadata" | string;
     logger: {
       info(msg: string): void;
       warn(msg: string): void;


### PR DESCRIPTION
## Summary

Fixes #5371. The OpenClaw plugin loader invokes `register()` **twice** per gateway startup:

1. A main pass with `registrationMode: "full"` (the real registration).
2. A second pass with `registrationMode: "cli-metadata"`, used only to collect CLI command metadata for `openclaw mem0 help`.

The mem0 plugin's `register(api)` never checked `api.registrationMode`, so it ran its full side effects on **both** passes:

- emitted the `openclaw-mem0: registered (...)` info log line twice (visible in `openclaw doctor`),
- constructed a second `provider` + `Backend` instance,
- called `api.registerService(...)` and `api.registerMemoryCapability(...)` a second time,
- fired the `openclaw.plugin.registered` telemetry event twice (double-counted).

## Fix

Guard `register()` against the metadata pass. The `cli-metadata` pass still needs the CLI surface, so on that pass we register **only** the CLI commands (mirroring the existing `needsSetup` code path, with `null` backend/provider) and return early. Everything else — provider/backend construction, memory capability, service, lifecycle hooks, telemetry, and the `registered` log line — now runs exactly once on the `"full"` pass.

Cores that don't set `registrationMode` pass `undefined`, which is treated as a full registration, so this is backwards compatible.

This matches the maintainer-suggested fix in the issue.

## Changes

- `openclaw/index.ts`: add exported pure helper `isCliMetadataPass()` and an early-return guard in `register()`.
- `openclaw/openclaw-plugin-sdk.d.ts`: document `registrationMode` on `OpenClawPluginApi`.
- `openclaw/index.test.ts`: unit tests for `isCliMetadataPass` (full / cli-metadata / undefined / unknown modes).

## Testing

- `pnpm test` → **438 tests pass** (15 files), including the 4 new guard tests.
- `pnpm build` → success (ESM + DTS).
- `npx tsc --noEmit` → clean.

Diff is +74 / -0, no behavior change on the `full` pass.
