### PR TITLE
fix(openclaw): skip runtime setup during metadata registration

### DIFF
--- a/integrations/openclaw/index.test.ts
+++ b/integrations/openclaw/index.test.ts
@@ -2,8 +2,8 @@
  * Regression tests for per-agent memory isolation helpers and
  * message filtering logic.
  */
-import { describe, it, expect } from "vitest";
-import {
+import { describe, it, expect, vi } from "vitest";
+import memoryPlugin, {
   extractAgentId,
   effectiveUserId,
   agentUserId,
@@ -15,6 +15,47 @@ import {
   stripNoiseFromContent,
   filterMessagesForExtraction,
 } from "./index.ts";
+
+function createPluginApi(registrationMode?: string) {
+  return {
+    pluginConfig: {
+      mode: "platform",
+      apiKey: "test-api-key",
+      userId: "alice",
+    },
+    registrationMode,
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+    resolvePath: vi.fn((p: string) => p),
+    registerTool: vi.fn(),
+    on: vi.fn(),
+    registerCli: vi.fn(),
+    registerCommand: vi.fn(),
+    registerService: vi.fn(),
+    registerMemoryCapability: vi.fn(),
+  };
+}
+
+describe("plugin registration modes", () => {
+  it("keeps cli-metadata registration free of runtime side effects", () => {
+    const api = createPluginApi("cli-metadata");
+
+    memoryPlugin.register(api as any);
+
+    expect(api.registerCli).toHaveBeenCalledTimes(1);
+    expect(api.registerService).not.toHaveBeenCalled();
+    expect(api.registerMemoryCapability).not.toHaveBeenCalled();
+    expect(api.registerTool).not.toHaveBeenCalled();
+    expect(api.on).not.toHaveBeenCalled();
+    expect(api.logger.info).not.toHaveBeenCalledWith(
+      expect.stringContaining("openclaw-mem0: registered"),
+    );
+  });
+});
 
 // ---------------------------------------------------------------------------
 // extractAgentId

--- a/integrations/openclaw/index.ts
+++ b/integrations/openclaw/index.ts
@@ -107,6 +107,7 @@ const memoryPlugin = definePluginEntry({
       baseUrl: pluginAuth.baseUrl,
     };
     const cfg = mem0ConfigSchema.parse(api.pluginConfig, fileConfig);
+    const isMetadataRegistration = api.registrationMode === "cli-metadata";
 
     // Telemetry context bound to this plugin instance's config
     const telemetryCtx = {
@@ -121,6 +122,21 @@ const memoryPlugin = definePluginEntry({
         /* silently swallow */
       }
     };
+
+    if (isMetadataRegistration) {
+      registerCliCommands(
+        api,
+        null as any,
+        null as any,
+        cfg,
+        () => cfg.userId,
+        (id: string) => `${cfg.userId}:agent:${id}`,
+        () => ({ user_id: cfg.userId, top_k: cfg.topK }),
+        () => undefined,
+        (cmd: string) => _captureEvent(`openclaw.cli.${cmd}`, { command: cmd }),
+      );
+      return;
+    }
 
     if (cfg.needsSetup) {
       api.logger.warn(

--- a/integrations/openclaw/openclaw-plugin-sdk.d.ts
+++ b/integrations/openclaw/openclaw-plugin-sdk.d.ts
@@ -26,6 +26,7 @@ declare module "openclaw/plugin-sdk" {
 
   export interface OpenClawPluginApi {
     pluginConfig: Record<string, unknown>;
+    registrationMode?: "full" | "cli-metadata" | string;
     logger: {
       info(msg: string): void;
       warn(msg: string): void;


### PR DESCRIPTION
Fixes #5371.

## Summary

- treat OpenClaw `registrationMode: "cli-metadata"` as a CLI-only registration pass
- skip provider/backend creation, tool and hook registration, service registration, memory capability registration, and the `openclaw.plugin.registered` telemetry/log side effects during that pass
- keep the normal full registration path unchanged
- add a regression test for the metadata registration path

## Why

OpenClaw can call a plugin's `register()` twice: once for the real gateway runtime and once for CLI metadata discovery. The mem0 plugin was doing the full runtime setup on both passes, so `openclaw doctor` could show duplicate `openclaw-mem0: registered` lines and telemetry could count the same plugin startup twice.

The metadata pass only needs the CLI command surface. Registering CLI commands with null backend/provider dependencies matches the existing setup flow and avoids runtime side effects.

## Validation

- `pnpm install`
- `pnpm exec vitest run index.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm run build`
- `git diff --check`
