### PR TITLE
Fix token limit crash on large message inputs

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -702,6 +702,10 @@ class Memory(MemoryBase):
         session_scope = _build_session_scope(filters)
         last_messages = self.db.get_last_messages(session_scope, limit=10)
         parsed_messages = parse_messages(messages)
+        
+        # Truncate to avoid token limit crash (8192 tokens ≈ 24000 chars)
+        if len(str(parsed_messages)) > 24000:
+            parsed_messages = parsed_messages[-24000:]
 
         # Phase 1: Existing memory retrieval
         search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
@@ -2117,6 +2121,10 @@ class AsyncMemory(MemoryBase):
         session_scope = _build_session_scope(effective_filters)
         last_messages = await asyncio.to_thread(self.db.get_last_messages, session_scope, 10)
         parsed_messages = parse_messages(messages)
+        
+        # Truncate to avoid token limit crash (8192 tokens ≈ 24000 chars)
+        if len(str(parsed_messages)) > 24000:
+            parsed_messages = parsed_messages[-24000:]
 
         # Phase 1: Existing memory retrieval
         search_filters = {k: v for k, v in effective_filters.items() if k in ("user_id", "agent_id", "run_id") and v}


### PR DESCRIPTION
## Problem

When messages are very long, the embedding model can exceed token limits and crash with 	oken limit exceeded errors.

## Root Cause

parse_messages(messages) can return a very large string. When passed to embedding_model.embed(), it may exceed the model's token limit (e.g., 8192 tokens).

## Fix

Add truncation guard after parse_messages():
\\\python
if len(str(parsed_messages)) > 24000:  # ≈8192 tokens
    parsed_messages = parsed_messages[-24000:]
\\\

Applied to both sync and async methods in mem0/memory/main.py.

## Testing

- [ ] Test with messages > 24000 chars
- [ ] Verify truncation preserves recent context
- [ ] Check no regression for normal-sized messages

Fixes #5148.