### PR TITLE
Fix empty/whitespace query validation in search()

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1170,6 +1170,10 @@ class Memory(MemoryBase):
             ValueError: If filters doesn't contain at least one of user_id, agent_id, run_id,
                 or if threshold/top_k values are invalid.
         """
+        # Reject empty/whitespace queries early
+        if not query or (isinstance(query, str) and query.strip() == ""):
+            return {"results": []}
+
         # Reject top-level entity params - must use filters instead
         _reject_top_level_entity_params(kwargs, "search")
 
@@ -2585,6 +2589,10 @@ class AsyncMemory(MemoryBase):
             ValueError: If filters doesn't contain at least one of user_id, agent_id, run_id,
                 or if threshold/top_k values are invalid.
         """
+        # Reject empty/whitespace queries early
+        if not query or (isinstance(query, str) and query.strip() == ""):
+            return {"results": []}
+
         # Reject top-level entity params - must use filters instead
         _reject_top_level_entity_params(kwargs, "search")
 


### PR DESCRIPTION
## Problem

`Memory.search()` and `AsyncMemory.search()` accept empty/whitespace queries without validation. This causes crashes (some embedders raise ValueError) or unintended memory leaks (all stored memories returned).

## Fix

Add early validation after docstring parse:
```python
if not query or (isinstance(query, str) and query.strip() == ""):
    return {"results": []}
```

Returns empty results for blank queries (same as a valid search matching nothing).

## Testing

- [ ] `m.search("")` returns `{"results": []}`
- [ ] `m.search(" ")` returns `{"results": []}`
- [ ] Normal queries still work
- [ ] Async version also fixed

Fixes #5220.
