### PR TITLE
Fix xai LLM provider (Fixes #5189)

### DIFF
--- a/mem0/llms/xai.py
+++ b/mem0/llms/xai.py
@@ -15,8 +15,26 @@ class XAILLM(LLMBase):
             self.config.model = "grok-2-latest"
 
         api_key = self.config.api_key or os.getenv("XAI_API_KEY")
-        base_url = self.config.xai_base_url or os.getenv("XAI_API_BASE") or "https://api.x.ai/v1"
+        base_url = getattr(self.config, 'xai_base_url', None) or os.getenv("XAI_API_BASE") or "https://api.x.ai/v1"
         self.client = OpenAI(api_key=api_key, base_url=base_url)
+
+    def _parse_response(self, response):
+        """Parse OpenAI-compatible response, handling tool calls."""
+        message = response.choices[0].message
+        result = {"content": message.content}
+        if message.tool_calls:
+            result["tool_calls"] = [
+                {
+                    "id": tc.id,
+                    "type": tc.type,
+                    "function": {
+                        "name": tc.function.name,
+                        "arguments": tc.function.arguments,
+                    },
+                }
+                for tc in message.tool_calls
+            ]
+        return result
 
     def generate_response(
         self,
@@ -47,6 +65,9 @@ class XAILLM(LLMBase):
 
         if response_format:
             params["response_format"] = response_format
+        if tools:
+            params["tools"] = tools
+            params["tool_choice"] = tool_choice
 
         response = self.client.chat.completions.create(**params)
-        return response.choices[0].message.content
+        return self._parse_response(response)


### PR DESCRIPTION
## Summary

Three issues in `mem0/llms/xai.py` that make the xai provider unusable through the factory or with tool calling.

### Bug 1 (AttributeError on factory use)
Constructor reads `self.config.xai_base_url` unconditionally, but the factory wires xai with plain `BaseLlmConfig` (no such attribute). Every user going through `Memory.from_config(...)` or `LlmFactory.create("xai", ...)` hits `AttributeError`.

**Fix**: Use `getattr(self.config, 'xai_base_url', None)` to safely access the attribute.

### Bug 2 (tools silently dropped)
`generate_response()` accepts `tools` and `tool_choice` but never forwards them to the OpenAI client, so tool calling silently does nothing on Grok.

**Fix**: Add `tools` and `tool_choice` to `params` when provided.

### Bug 3 (no `_parse_response` helper)
There's no `_parse_response` helper, so even if Bug 2 were fixed, `message.content` (which is `None` when the model emits tool calls) gets returned as-is and the tool-call payload is dropped.

**Fix**: Add `_parse_response()` helper to parse tool calls and return `{"content": ..., "tool_calls": [...]}`.

## Steps to Reproduce

### Bug 1 (AttributeError on any factory use):
```python
import os
os.environ["XAI_API_KEY"] = "sk-test"

from mem0.utils.factory import LlmFactory
LlmFactory.create("xai", {"model": "grok-2-latest"})
```

Output:
```
Traceback (most recent call last):
  ...
AttributeError: 'BaseLlmConfig' object has no attribute 'xai_base_url'
```

### Bug 2 (tools dropped):
```python
from mem0.llms.xai import XAILLM
from mem0.configs.llms.base import BaseLlmConfig

llm = XAILLM(BaseLlmConfig(model="grok-2-latest", api_key="k"))
tools = [{"type": "function", "function": {"name": "search", "parameters": {"type": "object", "properties": {}}}}]
result = llm.generate_response(
    [{"role": "user", "content": "find X"}],
    tools=tools
)
print(result)  # "plain text reply" (tools never forwarded)
```

## Expected Behavior

- Constructing XAILLM through the factory (or with `BaseLlmConfig`) should not crash.
- `tools` and `tool_choice` should be forwarded to `chat.completions.create(...)`.
- When tools are requested, the return shape should be `{"content": ..., "tool_calls": [...]}`.

## Actual Behavior

- Factory path raises `AttributeError` before the env-var fallback can run.
- `tools` / `tool_choice` are dropped, model receives plain chat.
- Even if forwarded, the return value would be a bare string (or `None` when the model emitted tool calls), so tool-call data is unrecoverable downstream.

## Environment

- **mem0 version**: 2.0.0 (current main)
- **Python**: 3.13
- **OS**: macOS

## Fix Details

This PR fixes all 3 bugs in `mem0/llms/xai.py`:

1. **Bug 1**: Use `getattr(self.config, 'xai_base_url', None)` instead of `self.config.xai_base_url`
2. **Bug 2**: Forward `tools` and `tool_choice` to `client.chat.completions.create()`
3. **Bug 3**: Add `_parse_response()` helper to parse tool calls

**Testing**:
- [ ] Factory construction no longer crashes
- [ ] `tools` are forwarded to API call
- [ ] Tool calls are properly parsed and returned

Fixes #5189.
