### PR TITLE
fix(qdrant): add https option to disable auto-detect for self-hosted instances

### DIFF
--- a/docs/components/vectordbs/dbs/qdrant.mdx
+++ b/docs/components/vectordbs/dbs/qdrant.mdx
@@ -76,6 +76,7 @@ Let's see the available parameters for the `qdrant` config:
 | `path` | Path for the qdrant database | `/tmp/qdrant` |
 | `url` | Full URL for the qdrant server | `None` |
 | `api_key` | API key for the qdrant server | `None` |
+| `https` | Force HTTPS on/off. Defaults to None (auto-detect). Set to `True` for Qdrant Cloud, `False` for self-hosted HTTP instances with API key authentication | `None` |
 | `on_disk` | For enabling persistent storage | `False` |
 </Tab>
 <Tab title="TypeScript">
@@ -91,3 +92,10 @@ Let's see the available parameters for the `qdrant` config:
 | `onDisk` | For enabling persistent storage | `False` |
 </Tab>
 </Tabs>
+
+<Note>
+  If your self-hosted Qdrant server uses plain HTTP with API key authentication,
+  set `https: False` in the Qdrant config to disable HTTPS auto-detection.
+  Without this, the Python `qdrant-client` treats `api_key` as a signal to use HTTPS,
+  which causes SSL errors when connecting to an HTTP endpoint.
+</Note>

--- a/mem0/configs/vector_stores/qdrant.py
+++ b/mem0/configs/vector_stores/qdrant.py
@@ -17,6 +17,7 @@ class QdrantConfig(BaseModel):
     url: Optional[str] = Field(None, description="Full URL for Qdrant server")
     api_key: Optional[str] = Field(None, description="API key for Qdrant server")
     on_disk: Optional[bool] = Field(False,description="Enables persistent storage. Vectors are kept on disk (True) or in memory (False). Does not delete the local database path.")
+    https: Optional[bool] = Field(None, description="Force HTTPS on/off for the Qdrant client. Defaults to None (auto-detect). Set False for self-hosted HTTP servers with API key authentication to avoid HTTPS connection errors.")
 
     @model_validator(mode="before")
     @classmethod

--- a/mem0/vector_stores/qdrant.py
+++ b/mem0/vector_stores/qdrant.py
@@ -38,6 +38,7 @@ class Qdrant(VectorStoreBase):
         url: str = None,
         api_key: str = None,
         on_disk: bool = False,
+        https: bool = None,
     ):
         """
         Initialize the Qdrant vector store.
@@ -53,6 +54,8 @@ class Qdrant(VectorStoreBase):
             api_key (str, optional): API key for Qdrant server. Defaults to None.
             on_disk (bool, optional): Enables persistent storage. Vectors are stored on disk (True) or in memory (False).
                 Does not delete the local database path. Defaults to False.
+            https (bool, optional): Force HTTPS on/off for the Qdrant client. Defaults to None (auto-detect).
+                Set False for self-hosted HTTP servers with API key authentication to avoid HTTPS connection errors.
         """
         if client:
             self.client = client
@@ -61,6 +64,8 @@ class Qdrant(VectorStoreBase):
             params = {}
             if api_key:
                 params["api_key"] = api_key
+            if https is not None:
+                params["https"] = https
             if url:
                 params["url"] = url
             if host and port:

--- a/tests/configs/test_qdrant_config.py
+++ b/tests/configs/test_qdrant_config.py
@@ -1,0 +1,50 @@
+import pytest
+from mem0.configs.vector_stores.qdrant import QdrantConfig
+
+
+def test_qdrant_config_https_default_is_none():
+    """https defaults to None, preserving backward compatibility."""
+    config = QdrantConfig(
+        collection_name="memories",
+        embedding_model_dims=1536,
+        host="localhost",
+        port=6333,
+    )
+    assert config.https is None
+
+
+def test_qdrant_config_https_true():
+    """Explicit https=True forces HTTPS, e.g. for Qdrant Cloud."""
+    config = QdrantConfig(
+        collection_name="memories",
+        embedding_model_dims=1536,
+        host="cloud.qdrant.io",
+        port=6333,
+        https=True,
+    )
+    assert config.https is True
+
+
+def test_qdrant_config_https_false():
+    """Explicit https=False forces HTTP for self-hosted instances with API key."""
+    config = QdrantConfig(
+        collection_name="memories",
+        embedding_model_dims=1536,
+        host="localhost",
+        port=6333,
+        api_key="my-key",
+        https=False,
+    )
+    assert config.https is False
+
+
+def test_qdrant_config_https_none_with_api_key():
+    """When https is None, QdrantClient auto-detects based on api_key presence."""
+    config = QdrantConfig(
+        collection_name="memories",
+        embedding_model_dims=1536,
+        host="localhost",
+        port=6333,
+        api_key="my-key",
+    )
+    assert config.https is None


### PR DESCRIPTION
## Linked Issue

Closes #5378

## Description

Users with self-hosted Qdrant HTTP instances using `api_key` authentication encounter SSL errors because `qdrant-client` auto-detects HTTPS when `api_key` is set.

This PR adds an explicit `https` parameter to both `QdrantConfig` and `Qdrant.__init__` that allows users to force-disable HTTPS for self-hosted HTTP servers.

**Changes:**
- Added `https: Optional[bool]` field to `QdrantConfig` in `mem0/configs/vector_stores/qdrant.py`
- Added `https: bool = None` parameter to `Qdrant.__init__` in `mem0/vector_stores/qdrant.py`
- When `https` is not `None`, it is passed through to `QdrantClient`

Usage example:
```python
config = {
    "vector_store": {
        "provider": "qdrant",
        "config": {
            "host": "localhost",
            "port": 6333,
            "api_key": "your-key",
            "https": False  # force HTTP for self-hosted instance
        }
    }
}
```

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] No tests needed (minimal passthrough change, existing tests cover the vector store initialization)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed