### PR TITLE
fix: skip malformed cli import items

### DIFF
--- a/cli/python/src/mem0_cli/commands/utils.py
+++ b/cli/python/src/mem0_cli/commands/utils.py
@@ -130,6 +130,10 @@ def cmd_import(
     for item in track(
         data, description=f"[{DIM_COLOR}]Importing memories...[/]", console=err_console
     ):
+        if not isinstance(item, dict):
+            failed += 1
+            continue
+
         content = item.get("memory", item.get("text", item.get("content", "")))
         if not content:
             failed += 1

--- a/cli/python/tests/test_commands.py
+++ b/cli/python/tests/test_commands.py
@@ -758,6 +758,25 @@ class TestImportCommand:
             cmd_import(mock_backend, str(file_path), user_id="alice", agent_id=None)
         assert mock_backend.add.call_count == 2
 
+    def test_import_skips_non_object_items(self, mock_backend, tmp_path):
+        file_path = tmp_path / "import.json"
+        data = [
+            {"memory": "Test memory"},
+            "not an object",
+            123,
+            {},
+        ]
+        file_path.write_text(json.dumps(data))
+        console, _buf = _make_console()
+        err_console, _err_buf = _make_err_console()
+        with (
+            patch("mem0_cli.commands.utils.console", console),
+            patch("mem0_cli.commands.utils.err_console", err_console),
+        ):
+            cmd_import(mock_backend, str(file_path), user_id="alice", agent_id=None)
+
+        mock_backend.add.assert_called_once()
+
     def test_import_invalid_file(self, mock_backend):
         console, _buf = _make_console()
         err_console, _err_buf = _make_err_console()


### PR DESCRIPTION
## Problem

`mem0 import` accepts JSON files that can contain either one memory object or a list of memory objects. When the file contains a list with a non-object entry, the import loop calls `.get()` on that value and crashes with an `AttributeError` instead of treating the row as a failed import item.

## Before / After

Before, an import file such as `[ {"memory": "ok"}, "bad" ]` could abort the command when it reached the string item.

After, non-object entries are counted as failed rows and the command continues importing the valid memory objects in the same file.

## Verification

- `$env:PYTHONPATH=(Join-Path (Get-Location) 'cli\\python\\src')`
- `python -m pytest cli/python/tests/test_commands.py::TestImportCommand`