### PR TITLE
fix(vector_stores): default to HTTP for self-hosted Qdrant with host/port

### DIFF
--- a/mem0/configs/vector_stores/qdrant.py
+++ b/mem0/configs/vector_stores/qdrant.py
@@ -16,6 +16,7 @@ class QdrantConfig(BaseModel):
     path: Optional[str] = Field("/tmp/qdrant", description="Path for local Qdrant database")
     url: Optional[str] = Field(None, description="Full URL for Qdrant server")
     api_key: Optional[str] = Field(None, description="API key for Qdrant server")
+    https: Optional[bool] = Field(None, description="Use HTTPS for connection. Defaults to True when url is provided, False when host/port are used.")
     on_disk: Optional[bool] = Field(False,description="Enables persistent storage. Vectors are kept on disk (True) or in memory (False). Does not delete the local database path.")
 
     @model_validator(mode="before")

--- a/mem0/vector_stores/qdrant.py
+++ b/mem0/vector_stores/qdrant.py
@@ -37,6 +37,7 @@ class Qdrant(VectorStoreBase):
         path: str = None,
         url: str = None,
         api_key: str = None,
+        https: bool = None,
         on_disk: bool = False,
     ):
         """
@@ -51,6 +52,9 @@ class Qdrant(VectorStoreBase):
             path (str, optional): Path for local Qdrant database. Defaults to None.
             url (str, optional): Full URL for Qdrant server. Defaults to None.
             api_key (str, optional): API key for Qdrant server. Defaults to None.
+            https (bool, optional): Use HTTPS for connection. When None, defaults to False
+                for host/port connections and lets qdrant-client decide for url connections.
+                Defaults to None.
             on_disk (bool, optional): Enables persistent storage. Vectors are stored on disk (True) or in memory (False).
                 Does not delete the local database path. Defaults to False.
         """
@@ -66,6 +70,15 @@ class Qdrant(VectorStoreBase):
             if host and port:
                 params["host"] = host
                 params["port"] = port
+                # When using host/port without an explicit url, default to HTTP
+                # to avoid qdrant-client assuming HTTPS when api_key is present.
+                # See: https://github.com/mem0ai/mem0/issues/5378
+                if https is None:
+                    params["https"] = False
+
+            # Allow explicit https override when provided
+            if https is not None and "https" not in params:
+                params["https"] = https
 
             if not params:
                 params["path"] = path

--- a/tests/vector_stores/test_qdrant.py
+++ b/tests/vector_stores/test_qdrant.py
@@ -932,3 +932,80 @@ class TestQdrantDatetimeRangeFilters(unittest.TestCase):
         types = {type(c.range) for c in result.must}
         self.assertIn(DatetimeRange, types)
         self.assertIn(Range, types)
+
+
+class TestQdrantHttpsDefault(unittest.TestCase):
+    """Tests for HTTPS default behavior when using host/port vs url.
+    See: https://github.com/mem0ai/mem0/issues/5378
+    """
+
+    @patch("mem0.vector_stores.qdrant.QdrantClient")
+    def test_host_port_defaults_to_http(self, MockQdrantClient):
+        """When using host+port, https should default to False."""
+        mock_client = MagicMock()
+        MockQdrantClient.return_value = mock_client
+        mock_client.get_collections.return_value = MagicMock(collections=[])
+
+        Qdrant(
+            collection_name="test",
+            embedding_model_dims=128,
+            host="127.0.0.1",
+            port=6333,
+            api_key="test-key",
+        )
+
+        call_kwargs = MockQdrantClient.call_args[1]
+        self.assertEqual(call_kwargs["https"], False)
+
+    @patch("mem0.vector_stores.qdrant.QdrantClient")
+    def test_host_port_explicit_https_true(self, MockQdrantClient):
+        """When https=True is explicitly set, it should be respected."""
+        mock_client = MagicMock()
+        MockQdrantClient.return_value = mock_client
+        mock_client.get_collections.return_value = MagicMock(collections=[])
+
+        Qdrant(
+            collection_name="test",
+            embedding_model_dims=128,
+            host="127.0.0.1",
+            port=6333,
+            api_key="test-key",
+            https=True,
+        )
+
+        call_kwargs = MockQdrantClient.call_args[1]
+        self.assertEqual(call_kwargs["https"], True)
+
+    @patch("mem0.vector_stores.qdrant.QdrantClient")
+    def test_url_does_not_set_https(self, MockQdrantClient):
+        """When using url, https should not be forced (let qdrant-client decide)."""
+        mock_client = MagicMock()
+        MockQdrantClient.return_value = mock_client
+        mock_client.get_collections.return_value = MagicMock(collections=[])
+
+        Qdrant(
+            collection_name="test",
+            embedding_model_dims=128,
+            url="https://my-qdrant.cloud.io",
+            api_key="test-key",
+        )
+
+        call_kwargs = MockQdrantClient.call_args[1]
+        self.assertNotIn("https", call_kwargs)
+
+    @patch("mem0.vector_stores.qdrant.QdrantClient")
+    def test_host_port_no_api_key_defaults_to_http(self, MockQdrantClient):
+        """Even without api_key, host+port should default to HTTP."""
+        mock_client = MagicMock()
+        MockQdrantClient.return_value = mock_client
+        mock_client.get_collections.return_value = MagicMock(collections=[])
+
+        Qdrant(
+            collection_name="test",
+            embedding_model_dims=128,
+            host="127.0.0.1",
+            port=6333,
+        )
+
+        call_kwargs = MockQdrantClient.call_args[1]
+        self.assertEqual(call_kwargs["https"], False)


### PR DESCRIPTION
## Linked Issue

Closes #5378

## Description

When configuring Qdrant with `host` + `port` + `api_key` for a self-hosted HTTP instance, `qdrant-client` treats `api_key` as a signal to use HTTPS, causing `SSL: WRONG_VERSION_NUMBER` errors. The mem0 Qdrant config did not expose an `https` option, so there was no way to override this without switching to the `url` parameter.

## Root Cause

```python
# Current code — passes api_key + host/port to QdrantClient without https flag
params = {}
if api_key:
    params["api_key"] = api_key
if host and port:
    params["host"] = host
    params["port"] = port
# qdrant-client sees api_key → assumes HTTPS → SSL error on HTTP servers
```

## Fix

- Add optional `https` parameter to `QdrantConfig` and `Qdrant.__init__`
- Default `https` to `False` when using `host`/`port` (self-hosted = HTTP)
- Leave `https` unset when using `url` (let `qdrant-client` decide)
- Allow explicit `https=True` override for HTTPS self-hosted setups

| Config | Before | After |
|--------|--------|-------|
| `host+port+api_key` | SSL error | HTTP (works) |
| `host+port+api_key+https=True` | N/A | HTTPS (explicit) |
| `url+api_key` | Works | Works (unchanged) |
| `host+port` (no key) | Works | HTTP (explicit) |

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test Coverage

- [x] I added/updated unit tests

4 new tests in `TestQdrantHttpsDefault`:
- `test_host_port_defaults_to_http` — host+port+api_key → https=False
- `test_host_port_explicit_https_true` — explicit override → https=True
- `test_url_does_not_set_https` — url+api_key → no https param
- `test_host_port_no_api_key_defaults_to_http` — host+port only → https=False

---

*Bug identified and fix generated with [GitWire](https://gitwire.erlab.uk) — self-hosted AI governance for GitHub automation.*