### PR TITLE
fix: add https config option for Qdrant vector store

### DIFF
--- a/mem0/configs/vector_stores/qdrant.py
+++ b/mem0/configs/vector_stores/qdrant.py
@@ -16,6 +16,7 @@ class QdrantConfig(BaseModel):
     path: Optional[str] = Field("/tmp/qdrant", description="Path for local Qdrant database")
     url: Optional[str] = Field(None, description="Full URL for Qdrant server")
     api_key: Optional[str] = Field(None, description="API key for Qdrant server")
+    https: Optional[bool] = Field(False, description="Whether to use HTTPS for the Qdrant connection. Set to True when connecting to a Qdrant Cloud instance or a self-hosted instance with TLS enabled.")
     on_disk: Optional[bool] = Field(False,description="Enables persistent storage. Vectors are kept on disk (True) or in memory (False). Does not delete the local database path.")
 
     @model_validator(mode="before")

--- a/mem0/vector_stores/qdrant.py
+++ b/mem0/vector_stores/qdrant.py
@@ -37,6 +37,7 @@ class Qdrant(VectorStoreBase):
         path: str = None,
         url: str = None,
         api_key: str = None,
+        https: bool = False,
         on_disk: bool = False,
     ):
         """
@@ -51,6 +52,8 @@ class Qdrant(VectorStoreBase):
             path (str, optional): Path for local Qdrant database. Defaults to None.
             url (str, optional): Full URL for Qdrant server. Defaults to None.
             api_key (str, optional): API key for Qdrant server. Defaults to None.
+            https (bool, optional): Whether to use HTTPS for the connection. Defaults to False.
+                Set to True when connecting to Qdrant Cloud or a self-hosted instance with TLS enabled.
             on_disk (bool, optional): Enables persistent storage. Vectors are stored on disk (True) or in memory (False).
                 Does not delete the local database path. Defaults to False.
         """
@@ -66,6 +69,8 @@ class Qdrant(VectorStoreBase):
             if host and port:
                 params["host"] = host
                 params["port"] = port
+            if https or (host and port and api_key):
+                params["https"] = https
 
             if not params:
                 params["path"] = path


### PR DESCRIPTION
Exposes https boolean to control Qdrant connection protocol.

Fixes #5378