### PR TITLE
fix: skip JSON response_format for Groq compound models

### DIFF
--- a/mem0/llms/groq.py
+++ b/mem0/llms/groq.py
@@ -22,6 +22,14 @@ class GroqLLM(LLMBase):
         api_key = self.config.api_key or os.getenv("GROQ_API_KEY")
         self.client = Groq(api_key=api_key)
 
+    @staticmethod
+    def _supports_json_mode(model: str) -> bool:
+        """
+        Groq's compound/agentic models don't support the ``response_format``
+        JSON mode and return empty or non-JSON content when it is requested.
+        """
+        return "compound" not in (model or "").lower()
+
     def _parse_response(self, response, tools):
         """
         Process the response based on whether tools are used or not.
@@ -78,7 +86,7 @@ class GroqLLM(LLMBase):
             "max_tokens": self.config.max_tokens,
             "top_p": self.config.top_p,
         }
-        if response_format:
+        if response_format and self._supports_json_mode(self.config.model):
             params["response_format"] = response_format
         if tools:
             params["tools"] = tools

--- a/tests/llms/test_groq.py
+++ b/tests/llms/test_groq.py
@@ -84,3 +84,33 @@ def test_generate_response_with_tools(mock_groq_client):
     assert len(response["tool_calls"]) == 1
     assert response["tool_calls"][0]["name"] == "add_memory"
     assert response["tool_calls"][0]["arguments"] == {"data": "Today is a sunny day."}
+
+
+def test_generate_response_skips_json_mode_for_compound_model(mock_groq_client):
+    config = BaseLlmConfig(model="groq/compound", temperature=0.1, max_tokens=100, top_p=1.0)
+    llm = GroqLLM(config)
+    messages = [{"role": "user", "content": "hi, i'm zach"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Hi Zach!"))]
+    mock_groq_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages, response_format={"type": "json_object"})
+
+    _, kwargs = mock_groq_client.chat.completions.create.call_args
+    assert "response_format" not in kwargs
+
+
+def test_generate_response_keeps_json_mode_for_standard_model(mock_groq_client):
+    config = BaseLlmConfig(model="llama-3.3-70b-versatile", temperature=0.1, max_tokens=100, top_p=1.0)
+    llm = GroqLLM(config)
+    messages = [{"role": "user", "content": "hi, i'm zach"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content='{"memory": []}'))]
+    mock_groq_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages, response_format={"type": "json_object"})
+
+    _, kwargs = mock_groq_client.chat.completions.create.call_args
+    assert kwargs["response_format"] == {"type": "json_object"}


### PR DESCRIPTION
## Linked Issue

Closes #4054

## Description

Using Groq's `groq/compound` model with `memory.add()` prints `Invalid JSON response: Expecting value: line 1 column 1 (char 0)` and silently drops the extracted memories.

Root cause is in `GroqLLM.generate_response()`: it always forwards `response_format={"type": "json_object"}`. Groq's compound/agentic models (`groq/compound`, `groq/compound-mini`) don't support JSON mode and return empty/non-JSON content when it's requested, which then fails the fact-extraction JSON parse.

This matches @kartik-mem0's note on the issue that the error usually means the model returned a non-JSON response for the extraction prompt.

The fix detects compound models and skips the `response_format` parameter for them, letting the model reply in plain text. The fact-extraction parser in `mem0/memory/main.py` already strips code fences and falls back gracefully, so the response is handled normally. Standard models keep JSON mode unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added `test_generate_response_skips_json_mode_for_compound_model` and `test_generate_response_keeps_json_mode_for_standard_model` to `tests/llms/test_groq.py`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
