### PR TITLE
fix(openmemory): three bugs preventing Ollama-backed self-hosted setup from working

### DIFF
--- a/openmemory/api/Dockerfile
+++ b/openmemory/api/Dockerfile
@@ -11,4 +11,4 @@ COPY config.json .
 COPY . .
 
 EXPOSE 8765
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8765"]
+ENTRYPOINT ["sh", "entrypoint.sh"]

--- a/openmemory/api/app/mcp_server.py
+++ b/openmemory/api/app/mcp_server.py
@@ -177,9 +177,9 @@ async def search_memory(query: str) -> str:
             embeddings = memory_client.embedding_model.embed(query, "search")
 
             hits = memory_client.vector_store.search(
-                query=query, 
-                vectors=embeddings, 
-                limit=10, 
+                query=query,
+                vectors=embeddings,
+                top_k=10,
                 filters=filters,
             )
 

--- a/openmemory/api/app/utils/memory.py
+++ b/openmemory/api/app/utils/memory.py
@@ -470,6 +470,14 @@ def get_memory_client(custom_instructions: str = None):
         if config.get("embedder", {}).get("provider") == "ollama":
             config["embedder"] = _fix_ollama_urls(config["embedder"])
 
+        # Propagate embedding_dims to vector store so the collection is created
+        # with the correct dimension instead of QdrantConfig's hardcoded default
+        # of 1536, which causes a dimension-mismatch error at insert time.
+        dims = config.get("embedder", {}).get("config", {}).get("embedding_dims")
+        if dims:
+            config["vector_store"]["config"]["embedding_model_dims"] = dims
+            print(f"Set vector store embedding_model_dims={dims} from embedder config")
+
         # ALWAYS parse environment variables in the final config
         # This ensures that even default config values like "env:OPENAI_API_KEY" get parsed
         print("Parsing environment variables in final config...")

--- a/openmemory/api/entrypoint.sh
+++ b/openmemory/api/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+if [ "${EMBEDDER_PROVIDER:-}" = "ollama" ]; then
+    echo "Warming up Ollama embedding model: ${EMBEDDING_MODEL:-nomic-embed-text-v2-moe}"
+    python3 /usr/src/openmemory/warmup.py
+fi
+
+exec uvicorn main:app --host 0.0.0.0 --port 8765 --workers 1

--- a/openmemory/api/warmup.py
+++ b/openmemory/api/warmup.py
@@ -1,0 +1,28 @@
+"""Pre-load the Ollama embedding model before uvicorn starts."""
+import json
+import os
+import sys
+import time
+import urllib.request
+
+model = os.environ.get("EMBEDDING_MODEL", "nomic-embed-text-v2-moe")
+base_url = os.environ.get("OLLAMA_BASE_URL", "http://host.docker.internal:11434")
+url = f"{base_url}/api/embed"
+payload = json.dumps({"model": model, "input": "warmup", "keep_alive": -1}).encode()
+
+for attempt in range(1, 6):
+    try:
+        req = urllib.request.Request(
+            url, data=payload, headers={"Content-Type": "application/json"}
+        )
+        with urllib.request.urlopen(req, timeout=60) as r:
+            r.read()
+        print(f"Embedding model ready: {model} (keep_alive=-1)")
+        sys.exit(0)
+    except Exception as e:
+        print(f"Attempt {attempt}/5 failed: {e}", file=sys.stderr)
+        if attempt < 5:
+            time.sleep(2)
+
+print("ERROR: could not warm up embedding model after 5 attempts", file=sys.stderr)
+sys.exit(1)


### PR DESCRIPTION
## Linked Issue

No issue yet — discovered while running OpenMemory with a local Ollama embedder.

## Description

Three bugs in the OpenMemory API that together prevent a self-hosted setup from working when using Ollama as the embedder provider.

### 1. Wrong kwarg name in `mcp_server.py` (`search_memory`)

`vector_store.search()` is called with `limit=10`, but the Mem0 `QdrantVectorStore.search()` signature uses `top_k`. The unknown kwarg was silently ignored, so search always returned the provider default result count.

**Fix:** rename `limit=10` → `top_k=10` in `openmemory/api/app/mcp_server.py`.

### 2. Dimension mismatch — embedding_dims not forwarded to vector store

`QdrantConfig` defaults `embedding_model_dims` to 1536 (OpenAI size). `get_memory_client()` never propagated the embedder's actual dimension into the vector store config, so Qdrant collections were always created at 1536 dimensions. Any insert using a model with different dimensions (e.g. `nomic-embed-text-v2-moe` at 768) failed immediately.

**Fix:** after resolving the final embedder config, read `embedding_dims` from it and write it into `vector_store.config["embedding_model_dims"]` before calling `Memory.from_config()`.

### 3. Cold-start timeout on first MCP request (Ollama only)

When Ollama is the embedder, the first request after container start timed out because Ollama was still loading the model from disk.

**Fix:** add `entrypoint.sh` and `warmup.py`. The entrypoint runs the warmup before starting uvicorn when `EMBEDDER_PROVIDER=ollama`; warmup calls `/api/embed` with `keep_alive=-1` to load the model and pin it in memory. Non-Ollama setups are unaffected.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I tested manually — ran the full OpenMemory stack with `EMBEDDER_PROVIDER=ollama` and `EMBEDDER_MODEL=nomic-embed-text-v2-moe`; all three issues were reproducible before the fix and absent after.
- [ ] No automated tests added (the existing test suite does not cover the Ollama + Qdrant integration path)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally