### PR TITLE
fix(openmemory): propagate embedding_dims from embedder config to vector store

### DIFF
--- a/openmemory/api/app/utils/memory.py
+++ b/openmemory/api/app/utils/memory.py
@@ -470,6 +470,15 @@ def get_memory_client(custom_instructions: str = None):
         if config.get("embedder", {}).get("provider") == "ollama":
             config["embedder"] = _fix_ollama_urls(config["embedder"])
 
+        # Propagate embedding_dims to the vector store config so the collection
+        # is created with the correct dimension. Many vector store configs default
+        # to 1536 (OpenAI size); using a different embedder without overriding
+        # this causes a dimension-mismatch error at insert time.
+        dims = config.get("embedder", {}).get("config", {}).get("embedding_dims")
+        if dims:
+            config["vector_store"]["config"]["embedding_model_dims"] = dims
+            print(f"Set vector store embedding_model_dims={dims} from embedder config")
+
         # ALWAYS parse environment variables in the final config
         # This ensures that even default config values like "env:OPENAI_API_KEY" get parsed
         print("Parsing environment variables in final config...")

--- a/openmemory/api/tests/test_memory_utils.py
+++ b/openmemory/api/tests/test_memory_utils.py
@@ -1,0 +1,97 @@
+"""Regression tests for embedding_dims propagation in get_memory_client().
+
+Ensures that when the embedder config declares an explicit embedding_dims,
+that value is forwarded to the vector store config as embedding_model_dims.
+Without the fix, QdrantConfig defaults to 1536 regardless of the actual
+embedder output size, causing a dimension-mismatch error at insert time.
+"""
+
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+import copy
+from unittest.mock import MagicMock, patch
+
+
+def _base_config(embedding_dims=None):
+    embedder_cfg = {
+        "model": "text-embedding-3-small",
+        "api_key": "test-key",
+    }
+    if embedding_dims is not None:
+        embedder_cfg["embedding_dims"] = embedding_dims
+
+    return {
+        "vector_store": {
+            "provider": "qdrant",
+            "config": {
+                "collection_name": "openmemory",
+                "host": "localhost",
+                "port": 6333,
+            },
+        },
+        "llm": {
+            "provider": "openai",
+            "config": {
+                "model": "gpt-4o-mini",
+                "api_key": "test-key",
+                "temperature": 0.1,
+                "max_tokens": 2000,
+            },
+        },
+        "embedder": {
+            "provider": "openai",
+            "config": embedder_cfg,
+        },
+        "version": "v1.1",
+    }
+
+
+class TestEmbeddingDimsPropagation:
+    def setup_method(self):
+        from app.utils.memory import reset_memory_client
+        reset_memory_client()
+
+    def _call_with_config(self, config):
+        """Call get_memory_client() and return the config dict passed to Memory.from_config."""
+        captured = {}
+
+        def _fake_from_config(config_dict):
+            captured.update(copy.deepcopy(config_dict))
+            return MagicMock()
+
+        with (
+            patch("app.utils.memory.get_default_memory_config", return_value=config),
+            patch("app.utils.memory.SessionLocal") as mock_session_cls,
+            patch("app.utils.memory.Memory") as mock_mem_cls,
+        ):
+            mock_db = MagicMock()
+            mock_db.query.return_value.filter.return_value.first.return_value = None
+            mock_session_cls.return_value = mock_db
+            mock_mem_cls.from_config.side_effect = _fake_from_config
+
+            from app.utils.memory import get_memory_client
+            get_memory_client()
+
+        return captured
+
+    def test_embedding_dims_propagated_to_vector_store(self):
+        """embedding_dims in embedder config must be forwarded to vector_store config."""
+        captured = self._call_with_config(_base_config(embedding_dims=768))
+        dims = captured.get("vector_store", {}).get("config", {}).get("embedding_model_dims")
+        assert dims == 768, f"Expected embedding_model_dims=768, got {dims}"
+
+    def test_no_embedding_dims_leaves_vector_store_config_unchanged(self):
+        """When embedder config has no embedding_dims, vector_store config must not gain embedding_model_dims."""
+        captured = self._call_with_config(_base_config(embedding_dims=None))
+        vs_config = captured.get("vector_store", {}).get("config", {})
+        assert "embedding_model_dims" not in vs_config, (
+            f"vector_store config should not have embedding_model_dims, got: {vs_config}"
+        )
+
+    def test_embedding_dims_1024_propagated(self):
+        """Verify non-standard dim sizes (e.g. 1024) are forwarded correctly."""
+        captured = self._call_with_config(_base_config(embedding_dims=1024))
+        dims = captured.get("vector_store", {}).get("config", {}).get("embedding_model_dims")
+        assert dims == 1024, f"Expected embedding_model_dims=1024, got {dims}"


### PR DESCRIPTION
## Linked Issue

Closes #5405

## Description

When the embedder config specifies an `embedding_dims` value, that dimension
was not forwarded to the vector store config. Many vector store configs
(Qdrant, Milvus, Elasticsearch, FAISS) default to `embedding_model_dims=1536`
(the OpenAI text-embedding-3-small/large output size). Using a different
embedder — for example Ollama's `nomic-embed-text` at 768 dims — without
overriding this default causes the collection to be created at the wrong size,
and subsequent inserts fail with a dimension-mismatch error.

The fix propagates `embedding_dims` from the embedder config to the vector
store config as `embedding_model_dims` before initializing the Memory client.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

`openmemory/api/tests/test_memory_utils.py` — `TestEmbeddingDimsPropagation`:
- `test_embedding_dims_propagated_to_vector_store` — verifies 768-dim is forwarded
- `test_no_embedding_dims_leaves_vector_store_config_unchanged` — verifies no-op when absent
- `test_embedding_dims_1024_propagated` — verifies non-standard dim sizes work

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed