### PR TITLE
fix(openmemory/mcp): pass top_k kwarg instead of limit to vector_store.search()

### DIFF
--- a/openmemory/api/app/mcp_server.py
+++ b/openmemory/api/app/mcp_server.py
@@ -177,9 +177,9 @@ async def search_memory(query: str) -> str:
             embeddings = memory_client.embedding_model.embed(query, "search")
 
             hits = memory_client.vector_store.search(
-                query=query, 
-                vectors=embeddings, 
-                limit=10, 
+                query=query,
+                vectors=embeddings,
+                top_k=10,
                 filters=filters,
             )
 

--- a/openmemory/api/tests/test_mcp_server.py
+++ b/openmemory/api/tests/test_mcp_server.py
@@ -380,6 +380,54 @@ class TestStreamableHTTPResponses:
 # Route registration
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# search_memory — kwarg regression
+# ---------------------------------------------------------------------------
+
+class TestSearchMemoryKwargs:
+    """Regression: vector_store.search() must be called with top_k, not limit."""
+
+    @pytest.mark.asyncio
+    async def test_search_uses_top_k_not_limit(self):
+        from unittest.mock import MagicMock, patch
+
+        from app.mcp_server import (
+            client_name_var,
+            search_memory,
+            user_id_var,
+        )
+
+        mock_client = MagicMock()
+        mock_client.embedding_model.embed.return_value = [0.1] * 4
+        mock_client.vector_store.search.return_value = []
+
+        mock_user = MagicMock()
+        mock_app = MagicMock()
+        mock_app.id = 1
+
+        with (
+            patch("app.mcp_server.get_memory_client", return_value=mock_client),
+            patch("app.mcp_server.SessionLocal") as mock_session_cls,
+            patch("app.mcp_server.get_user_and_app", return_value=(mock_user, mock_app)),
+            patch("app.mcp_server.check_memory_access_permissions", return_value=True),
+        ):
+            mock_session_cls.return_value.query.return_value.filter.return_value.all.return_value = []
+
+            uid_tok = user_id_var.set("test-user")
+            cn_tok = client_name_var.set("test-client")
+            try:
+                await search_memory("hello world")
+            finally:
+                user_id_var.reset(uid_tok)
+                client_name_var.reset(cn_tok)
+
+        assert mock_client.vector_store.search.called, "vector_store.search was never called"
+        _, kwargs = mock_client.vector_store.search.call_args
+        assert "top_k" in kwargs, "search() must use top_k kwarg"
+        assert "limit" not in kwargs, "search() must not pass limit= (wrong kwarg name)"
+        assert kwargs["top_k"] == 10
+
+
 class TestRouteRegistration:
     """Verify all expected routes are registered in the router."""
 


### PR DESCRIPTION
## Linked Issue

Closes #5404

## Description

`search_memory()` in the MCP server called `vector_store.search()` with
`limit=10`. The vector store interface uses `top_k`, not `limit`, so the
kwarg was silently ignored and the call fell back to the store's internal
default — returning fewer or more results than intended depending on the
backend.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

`openmemory/api/tests/test_mcp_server.py` — `TestSearchMemoryKwargs`:
- `test_search_uses_top_k_not_limit` — mocks the memory client and asserts
  that `vector_store.search()` is called with `top_k=10` and no `limit` kwarg.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed