### PR TITLE
feat: add Solana agent trust + persistent memory example

### DIFF
--- a/examples/solana-agent-trust/README.md
+++ b/examples/solana-agent-trust/README.md
@@ -1,0 +1,76 @@
+# Solana Agent Trust + Persistent Memory
+
+Combines [mem0](https://mem0.ai) persistent memory with the
+[TWZRD Agent Intel](https://intel.twzrd.xyz) MCP server to build an AI
+assistant that **remembers verified Solana agent wallets** across sessions.
+
+## What It Does
+
+- **Trust verification**: Calls the TWZRD MCP server to score a Solana wallet
+  (`score_agent`) and run a preflight check (`preflight_check`)
+- **Memory caching**: Stores trust results in mem0 so repeat checks for the
+  same wallet skip the MCP call entirely
+- **Persistent history**: Builds a local trust database across conversations
+
+## Setup
+
+```bash
+pip install mem0ai mcp openai
+```
+
+```bash
+export MEM0_API_KEY=your_key     # from app.mem0.ai
+export OPENAI_API_KEY=your_key
+```
+
+## Run
+
+```bash
+python solana_agent_trust.py
+```
+
+Then try:
+
+```
+Check wallet D1QkbFJKiPsymJ65RKHhF6DFB8sPMfpBaFBzuHKfJGWi
+```
+
+On the second run, mem0 returns the cached result without hitting the MCP server.
+
+## MCP Server
+
+| Tool | Description | Cost |
+|------|-------------|------|
+| `score_agent` | Trust score 0–1 + x402 payment count | Free |
+| `preflight_check` | APPROVE/REJECT with reasoning | Free |
+| `get_trust_receipt` | Signed on-chain trust receipt | HTTP 402 |
+
+```json
+{
+  "mcpServers": {
+    "twzrd-agent-intel": {
+      "url": "https://intel.twzrd.xyz/mcp"
+    }
+  }
+}
+```
+
+## How It Works
+
+```
+User asks about wallet
+       │
+       ▼
+mem0.search(wallet)  ──── cache hit ──► return cached result
+       │
+   cache miss
+       │
+       ▼
+TWZRD MCP: score_agent + preflight_check
+       │
+       ▼
+mem0.add(result)  ──► stored for next session
+       │
+       ▼
+Return trust decision
+```

--- a/examples/solana-agent-trust/solana_agent_trust.py
+++ b/examples/solana-agent-trust/solana_agent_trust.py
@@ -1,0 +1,141 @@
+"""
+Solana Agent Trust + Persistent Memory: mem0 + TWZRD Agent Intel
+
+This example shows how to combine:
+- mem0: persistent agent memory across conversations
+- TWZRD Agent Intel: on-chain Solana wallet trust verification
+
+Use case: An AI assistant that remembers which agent wallets it has already
+verified, avoiding redundant MCP calls, and builds a local trust history.
+
+Requirements:
+    pip install mem0ai mcp openai
+
+Environment variables:
+    MEM0_API_KEY   - from app.mem0.ai
+    OPENAI_API_KEY - from platform.openai.com
+"""
+
+import asyncio
+import os
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+from mem0 import MemoryClient
+from openai import OpenAI
+
+MCP_URL = "https://intel.twzrd.xyz/mcp"
+TRUST_THRESHOLD = 0.5
+
+mem0_client = MemoryClient(api_key=os.environ["MEM0_API_KEY"])
+openai_client = OpenAI()
+
+
+async def _call_mcp(tool: str, wallet: str) -> str:
+    """Call a TWZRD MCP tool."""
+    async with streamablehttp_client(MCP_URL) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            result = await session.call_tool(tool, {"wallet": wallet})
+            return result.content[0].text
+
+
+def score_wallet(wallet: str) -> dict:
+    """Fetch trust score and preflight result from TWZRD Agent Intel."""
+    score_raw = asyncio.run(_call_mcp("score_agent", wallet))
+    preflight_raw = asyncio.run(_call_mcp("preflight_check", wallet))
+    return {"wallet": wallet, "score": score_raw, "preflight": preflight_raw}
+
+
+def get_cached_trust(wallet: str, user_id: str) -> str | None:
+    """Check mem0 for a previously stored trust result for this wallet."""
+    memories = mem0_client.search(f"trust check {wallet}", user_id=user_id)
+    if memories:
+        return memories[0]["memory"]
+    return None
+
+
+def store_trust_result(wallet: str, result: dict, user_id: str) -> None:
+    """Persist the trust result in mem0 for future sessions."""
+    summary = (
+        f"Wallet {wallet}: score={result['score']}, "
+        f"preflight={result['preflight']}"
+    )
+    mem0_client.add(summary, user_id=user_id)
+
+
+def check_agent_trust(wallet: str, user_id: str = "default") -> dict:
+    """
+    Verify a Solana agent wallet with caching via mem0.
+
+    1. Check mem0 for a cached result (avoids redundant MCP calls).
+    2. If no cache: call TWZRD Agent Intel MCP server.
+    3. Store result in mem0 for future sessions.
+    4. Return trust decision.
+    """
+    # Check memory first
+    cached = get_cached_trust(wallet, user_id)
+    if cached:
+        print(f"[mem0 cache hit] {cached}")
+        return {"wallet": wallet, "cached": True, "result": cached}
+
+    # Live MCP check
+    result = score_wallet(wallet)
+    store_trust_result(wallet, result, user_id)
+    print(f"[MCP check] wallet={wallet} score={result['score']}")
+    return {"wallet": wallet, "cached": False, "result": result}
+
+
+def run_interactive_session(user_id: str = "demo-user"):
+    """Run an interactive chat session with memory-backed trust verification."""
+    history = []
+    system_prompt = (
+        "You are a Solana agent trust verification assistant. "
+        "You have access to mem0 memory and the TWZRD Agent Intel MCP server. "
+        "When users ask about a wallet, check the trust score and preflight result. "
+        "Remember previously checked wallets and cite cached results when available."
+    )
+    print("Solana Agent Trust Assistant (type 'quit' to exit)")
+    print("Try: 'Check wallet D1QkbFJKiPsymJ65RKHhF6DFB8sPMfpBaFBzuHKfJGWi'")
+    print()
+
+    while True:
+        user_input = input("You: ").strip()
+        if user_input.lower() in ("quit", "exit"):
+            break
+
+        # Load relevant memories
+        past_memories = mem0_client.search(user_input, user_id=user_id)
+        memory_context = "\n".join(m["memory"] for m in past_memories[:3])
+
+        # Extract wallet if present (simple heuristic)
+        words = user_input.split()
+        wallet = next(
+            (w for w in words if len(w) >= 32 and w.isalnum()),
+            None
+        )
+
+        if wallet:
+            trust_data = check_agent_trust(wallet, user_id)
+            user_input += f"\n[Trust data: {trust_data}]"
+
+        messages = [
+            {"role": "system", "content": system_prompt + (f"\nRelevant memory:\n{memory_context}" if memory_context else "")},
+            *history,
+            {"role": "user", "content": user_input},
+        ]
+
+        response = openai_client.chat.completions.create(
+            model="gpt-4o-mini", messages=messages
+        )
+        reply = response.choices[0].message.content
+        print(f"\nAssistant: {reply}\n")
+
+        history.extend([
+            {"role": "user", "content": user_input},
+            {"role": "assistant", "content": reply},
+        ])
+        mem0_client.add(f"User asked: {user_input}. Assistant: {reply}", user_id=user_id)
+
+
+if __name__ == "__main__":
+    run_interactive_session()


### PR DESCRIPTION
## Summary

Adds `examples/solana-agent-trust/` — an example combining mem0 persistent memory with the [TWZRD Agent Intel](https://intel.twzrd.xyz) MCP server for Solana agent wallet trust verification.

**What it shows:**
- **Trust verification via MCP**: Calls `score_agent` and `preflight_check` on the TWZRD streamable-HTTP MCP server to get a trust score (0–1) and APPROVE/REJECT decision for any Solana agent wallet
- **mem0 caching**: Stores trust results in mem0 so the same wallet is not re-checked on every session — the assistant retrieves cached results instantly
- **Interactive session**: An OpenAI-backed assistant that loads relevant memories and cites whether results came from cache or live MCP calls

**Use case**: An AI assistant gating paid services (HTTP 402 / x402) behind on-chain agent trust scores, with persistent memory so repeat interactions are fast.

**Files added:**
- `examples/solana-agent-trust/solana_agent_trust.py` — full working example
- `examples/solana-agent-trust/README.md` — setup and usage

**MCP server details:**
- Endpoint: `https://intel.twzrd.xyz/mcp` (streamable-HTTP, no API key)
- Free tools: `score_agent(wallet)`, `preflight_check(wallet)`
- Paid tool: `get_trust_receipt(wallet)` (HTTP 402 / x402)