### PR TITLE
fix(openmemory): fix search kwarg and embedder dims propagation

### DIFF
--- a/openmemory/api/app/mcp_server.py
+++ b/openmemory/api/app/mcp_server.py
@@ -179,7 +179,7 @@ async def search_memory(query: str) -> str:
             hits = memory_client.vector_store.search(
                 query=query, 
                 vectors=embeddings, 
-                limit=10, 
+                top_k=10, 
                 filters=filters,
             )
 

--- a/openmemory/api/app/utils/memory.py
+++ b/openmemory/api/app/utils/memory.py
@@ -475,6 +475,10 @@ def get_memory_client(custom_instructions: str = None):
         print("Parsing environment variables in final config...")
         config = _parse_environment_variables(config)
 
+        dims = config.get("embedder", {}).get("config", {}).get("embedding_dims")
+        if dims and "vector_store" in config and "config" in config["vector_store"]:
+            config["vector_store"]["config"]["embedding_model_dims"] = dims
+
         # Check if config has changed by comparing hashes
         current_config_hash = _get_config_hash(config)
         


### PR DESCRIPTION
Fixes #5404 by using `top_k` instead of `limit` in `search_memory`, and fixes #5405 by propagating `embedding_dims` to the `vector_store` config so that non-OpenAI embedders don't fail with dimension mismatches.