### PR TITLE
Return empty memory search results for blank queries

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -169,6 +169,10 @@ def _validate_search_params(threshold: Optional[float] = None, top_k: Optional[i
             )
 
 
+def _is_blank_search_query(query: str) -> bool:
+    return isinstance(query, str) and query.strip() == ""
+
+
 def _is_sensitive_field(field_name: str) -> bool:
     """Check if a field should be redacted for telemetry safety.
 
@@ -1200,6 +1204,8 @@ class Memory(MemoryBase):
             )
 
         limit = top_k
+        if _is_blank_search_query(query):
+            return {"results": []}
 
         # Apply enhanced metadata filtering if advanced operators are detected
         if self._has_advanced_operators(effective_filters):
@@ -2644,6 +2650,8 @@ class AsyncMemory(MemoryBase):
             )
 
         limit = top_k
+        if _is_blank_search_query(query):
+            return {"results": []}
 
         # Apply enhanced metadata filtering if advanced operators are detected
         if self._has_advanced_operators(effective_filters):

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -259,6 +259,33 @@ def test_create_memory_sets_updated_at(mocker):
     assert history_kwargs.kwargs["updated_at"] == payload["updated_at"]
 
 
+def test_search_returns_empty_results_for_blank_query(mocker):
+    memory = _build_memory_instance(mocker, Memory)
+    memory.embedding_model.embed.side_effect = AssertionError(
+        "blank query should not be embedded"
+    )
+
+    result = memory.search("   ", filters={"user_id": "test_user"})
+
+    assert result == {"results": []}
+    memory.embedding_model.embed.assert_not_called()
+    memory.vector_store.search.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_search_returns_empty_results_for_blank_query(mocker):
+    memory = _build_memory_instance(mocker, AsyncMemory)
+    memory.embedding_model.embed.side_effect = AssertionError(
+        "blank query should not be embedded"
+    )
+
+    result = await memory.search("", filters={"user_id": "test_user"})
+
+    assert result == {"results": []}
+    memory.embedding_model.embed.assert_not_called()
+    memory.vector_store.search.assert_not_called()
+
+
 def test_create_memory_preserves_existing_created_at(mocker):
     memory = _build_memory_instance(mocker, Memory)
     custom_ts = "2023-05-06T09:19:20+00:00"


### PR DESCRIPTION
## Summary
- short-circuit sync and async Memory.search() for empty or whitespace-only queries
- preserve existing filter and search parameter validation before returning
- add regression coverage that blank queries do not call the embedder or vector store

Fixes #5220

## Tests
- uv run --extra test pytest tests/memory/test_main.py
- uv run --extra test ruff check mem0/memory/main.py tests/memory/test_main.py