### PR TITLE
feat(embeddings): add native embed_batch to OllamaEmbedding

### DIFF
--- a/mem0/embeddings/ollama.py
+++ b/mem0/embeddings/ollama.py
@@ -63,3 +63,25 @@ class OllamaEmbedding(EmbeddingBase):
         if not embeddings:
             raise ValueError(f"Ollama embed() returned no embeddings for model '{self.config.model}'")
         return embeddings[0]
+
+    def embed_batch(self, texts, memory_action: Optional[Literal["add", "search", "update"]] = "add"):
+        """
+        Embed multiple texts in a single Ollama API call.
+
+        The Ollama SDK's embed() accepts a list for `input` and returns one embedding
+        per text in order, so N texts cost a single round-trip instead of N.
+
+        Args:
+            texts (list[str]): The texts to embed.
+            memory_action (optional): The type of embedding to use. Must be one of "add", "search", or "update".
+        Returns:
+            list: A list of embedding vectors, one per input text, in the same order.
+        """
+        response = self.client.embed(model=self.config.model, input=texts)
+        embeddings = response.get("embeddings") or []
+        if len(embeddings) != len(texts):
+            raise ValueError(
+                f"Ollama embed() returned {len(embeddings)} embeddings for {len(texts)} texts "
+                f"using model '{self.config.model}'"
+            )
+        return embeddings

--- a/tests/embeddings/test_ollama_embeddings.py
+++ b/tests/embeddings/test_ollama_embeddings.py
@@ -60,3 +60,28 @@ def test_embed_empty_response_raises(mock_ollama_client):
 
     with pytest.raises(ValueError, match="returned no embeddings"):
         embedder.embed("some text")
+
+
+def test_embed_batch_single_call(mock_ollama_client):
+    """embed_batch should embed all texts in one Ollama call, preserving order."""
+    config = BaseEmbedderConfig(model="nomic-embed-text", embedding_dims=512)
+    embedder = OllamaEmbedding(config)
+
+    mock_ollama_client.embed.return_value = {"embeddings": [[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]}
+
+    texts = ["first", "second", "third"]
+    result = embedder.embed_batch(texts)
+
+    mock_ollama_client.embed.assert_called_once_with(model="nomic-embed-text", input=texts)
+    assert result == [[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]
+
+
+def test_embed_batch_count_mismatch_raises(mock_ollama_client):
+    """A response with fewer embeddings than texts must raise, not silently misalign."""
+    config = BaseEmbedderConfig(model="nomic-embed-text", embedding_dims=512)
+    embedder = OllamaEmbedding(config)
+
+    mock_ollama_client.embed.return_value = {"embeddings": [[0.1, 0.2]]}  # only 1 for 2 texts
+
+    with pytest.raises(ValueError, match="returned 1 embeddings for 2 texts"):
+        embedder.embed_batch(["a", "b"])


### PR DESCRIPTION
## Linked Issue

Closes #5414

## Description

`OllamaEmbedding` did not override `embed_batch()`, so it fell back to the `EmbeddingBase` default, which calls `embed()` once per text — **N HTTP round-trips for N texts**.

The Ollama Python SDK's `client.embed()` already accepts `input: Union[str, Sequence[str]]` and returns one embedding per text **in order**, so a list of texts can be embedded in a single call. This PR adds the override, mirroring the existing `OpenAIEmbedding` / `AzureOpenAIEmbedding` implementations.

`embed_batch` is on hot paths — it is called from 7 sites in `mem0/memory/main.py` (every `add()` and entity-search path, sync and async). With Ollama as the embedder, bulk operations previously made one request per item; they now make one request total.

The base class docstring already calls this out explicitly:
> "Subclasses with native batch APIs (e.g., OpenAI) should override this for better performance."

### Why the length check

Callers in `memory/main.py` verify that `embed_batch` returns exactly one vector per input and skip entity boosting on mismatch:

```python
"embed_batch returned %d vectors for %d texts — skipping entity boost"
```

So the override raises `ValueError` if Ollama returns a vector count that does not match the input, rather than silently misaligning embeddings.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A — purely additive; existing `embed()` behavior is unchanged.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added two tests to `tests/embeddings/test_ollama_embeddings.py`:
- `test_embed_batch_single_call` — verifies all texts are embedded in **one** `client.embed(input=[...])` call, preserving order.
- `test_embed_batch_count_mismatch_raises` — verifies a short response raises `ValueError` instead of silently misaligning.

```
$ pytest tests/embeddings/test_ollama_embeddings.py -v
6 passed
```
Ruff check, ruff format, and isort all pass on the changed files.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (no public API change; none needed)
