### PR TITLE
fix(openmemory): use top_k instead of limit in search_memory vector query

### DIFF
--- a/openmemory/api/app/mcp_server.py
+++ b/openmemory/api/app/mcp_server.py
@@ -177,9 +177,9 @@ async def search_memory(query: str) -> str:
             embeddings = memory_client.embedding_model.embed(query, "search")
 
             hits = memory_client.vector_store.search(
-                query=query, 
-                vectors=embeddings, 
-                limit=10, 
+                query=query,
+                vectors=embeddings,
+                top_k=10,
                 filters=filters,
             )
 

--- a/openmemory/api/tests/test_mcp_server.py
+++ b/openmemory/api/tests/test_mcp_server.py
@@ -394,3 +394,48 @@ class TestRouteRegistration:
     def test_streamable_http_route_is_registered(self, test_app):
         routes = [r.path for r in test_app.routes if hasattr(r, "path")]
         assert "/mcp/{client_name}/http/{user_id}" in routes
+
+
+# ---------------------------------------------------------------------------
+# search_memory — vector store query
+# ---------------------------------------------------------------------------
+
+class TestSearchMemoryVectorStoreCall:
+    """search_memory must query the vector store with the supported `top_k` kwarg.
+
+    The Mem0 vector store interface uses `top_k`, not `limit`. Passing `limit`
+    does not constrain the result count (it is the wrong kwarg), so the requested
+    cap of 10 is not honored.
+    """
+
+    @pytest.mark.asyncio
+    async def test_search_passes_top_k_not_limit(self):
+        from unittest.mock import MagicMock, patch
+
+        from app import mcp_server
+
+        memory_client = MagicMock()
+        memory_client.embedding_model.embed.return_value = [0.1, 0.2, 0.3]
+        memory_client.vector_store.search.return_value = []
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.all.return_value = []
+
+        user = MagicMock()
+        app = MagicMock()
+
+        user_token = user_id_var.set("user-1")
+        client_token = client_name_var.set("app-1")
+        try:
+            with patch.object(mcp_server, "get_memory_client_safe", return_value=memory_client), \
+                 patch.object(mcp_server, "SessionLocal", return_value=db), \
+                 patch.object(mcp_server, "get_user_and_app", return_value=(user, app)):
+                await mcp_server.search_memory("hello world")
+        finally:
+            user_id_var.reset(user_token)
+            client_name_var.reset(client_token)
+
+        memory_client.vector_store.search.assert_called_once()
+        _, kwargs = memory_client.vector_store.search.call_args
+        assert kwargs.get("top_k") == 10
+        assert "limit" not in kwargs


### PR DESCRIPTION
## Linked Issue

Closes #5404

## Description

In `openmemory/api/app/mcp_server.py`, `search_memory()` called the vector store with `limit=10`:

```python
hits = memory_client.vector_store.search(
    query=query,
    vectors=embeddings,
    limit=10,        # ← wrong kwarg
    filters=filters,
)
```

The Mem0 vector store interface uses `top_k`, not `limit` (see `mem0/vector_stores/base.py` — `def search(self, query, vectors, top_k=5, filters=None)` — and every concrete store). Passing `limit` does not constrain the result count to 10, so the intended cap is not honored.

This PR renames the kwarg to `top_k=10`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added `TestSearchMemoryVectorStoreCall::test_search_passes_top_k_not_limit` to `openmemory/api/tests/test_mcp_server.py`, which invokes `search_memory()` with the memory client and DB mocked and asserts the vector store is called with `top_k=10` and no `limit` kwarg. It fails before the fix and passes after.

```
$ pytest tests/test_mcp_server.py -q
22 passed
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (none needed — internal behavior fix)
