### PR TITLE
fix(openmemory): propagate embedder dimension to vector store config

### DIFF
--- a/openmemory/api/.env.example
+++ b/openmemory/api/.env.example
@@ -13,3 +13,6 @@ USER=user
 # EMBEDDER_MODEL=nomic-embed-text
 # EMBEDDER_API_KEY=
 # EMBEDDER_BASE_URL=
+# Set when your embedder produces vectors of a non-default size (vector stores
+# default to 1536). e.g. nomic-embed-text outputs 768-dim vectors.
+# EMBEDDER_EMBEDDING_DIMS=768

--- a/openmemory/api/app/utils/memory.py
+++ b/openmemory/api/app/utils/memory.py
@@ -359,6 +359,16 @@ def get_default_memory_config():
     )
     print(f"Auto-detected embedder provider: {embedder_provider}")
 
+    # Propagate the embedder's vector dimension to the vector store config. Vector
+    # stores default to 1536 (OpenAI's size), so any embedder producing a different
+    # dimension (e.g. Ollama's nomic-embed-text at 768) fails on insert with a
+    # dimension mismatch unless the collection is created with the correct size.
+    embedding_dims = os.environ.get('EMBEDDER_EMBEDDING_DIMS')
+    if embedding_dims:
+        embedding_dims = int(embedding_dims)
+        embedder_config['embedding_dims'] = embedding_dims
+        vector_store_config['embedding_model_dims'] = embedding_dims
+
     return {
         "vector_store": {
             "provider": vector_store_provider,

--- a/openmemory/api/tests/test_memory_config.py
+++ b/openmemory/api/tests/test_memory_config.py
@@ -1,0 +1,38 @@
+"""Tests for memory client configuration building (app.utils.memory)."""
+
+import os
+
+# Set dummy keys before importing modules that may initialize clients
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+from app.utils.memory import get_default_memory_config
+
+
+class TestEmbeddingDimsPropagation:
+    """The embedder's vector dimension must reach the vector store config.
+
+    Without propagation, the vector store keeps its 1536 default (OpenAI size)
+    and any embedder producing a different dimension fails on insert with a
+    dimension mismatch.
+    """
+
+    def test_embedding_dims_propagated_to_vector_store(self, monkeypatch):
+        monkeypatch.setenv("EMBEDDER_PROVIDER", "ollama")
+        monkeypatch.setenv("EMBEDDER_MODEL", "nomic-embed-text-v2-moe")
+        monkeypatch.setenv("EMBEDDER_EMBEDDING_DIMS", "768")
+
+        config = get_default_memory_config()
+
+        assert config["embedder"]["config"]["embedding_dims"] == 768
+        assert config["vector_store"]["config"]["embedding_model_dims"] == 768
+
+    def test_no_dims_env_leaves_vector_store_default(self, monkeypatch):
+        """When EMBEDDER_EMBEDDING_DIMS is unset, no dims are forced (backward compatible)."""
+        monkeypatch.delenv("EMBEDDER_EMBEDDING_DIMS", raising=False)
+        monkeypatch.setenv("EMBEDDER_PROVIDER", "openai")
+        monkeypatch.setenv("EMBEDDER_MODEL", "text-embedding-3-small")
+
+        config = get_default_memory_config()
+
+        assert "embedding_model_dims" not in config["vector_store"]["config"]
+        assert "embedding_dims" not in config["embedder"]["config"]


### PR DESCRIPTION
## Linked Issue

Closes #5405

## Description

`get_default_memory_config()` in `openmemory/api/app/utils/memory.py` resolves the embedder config but never forwards the embedding dimension into the vector store config. Vector stores default `embedding_model_dims` to **1536** (OpenAI's embedding size), so any embedder that produces a different vector size fails immediately on insert with a dimension mismatch.

**Repro:** configure OpenMemory with `EMBEDDER_PROVIDER=ollama` and an embedder like `nomic-embed-text` (768-dim). The Qdrant collection is created at 1536 dims and inserts are rejected.

### Fix

Add an optional `EMBEDDER_EMBEDDING_DIMS` env var and propagate it to **both**:
- the embedder config → `embedding_dims`
- the vector store config → `embedding_model_dims`

```python
embedding_dims = os.environ.get('EMBEDDER_EMBEDDING_DIMS')
if embedding_dims:
    embedding_dims = int(embedding_dims)
    embedder_config['embedding_dims'] = embedding_dims
    vector_store_config['embedding_model_dims'] = embedding_dims
```

When the variable is unset, nothing is injected and behavior is unchanged (the vector store keeps its existing default) — so this is backward compatible.

The new variable is documented in `openmemory/api/.env.example`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A — purely additive and gated on a new opt-in env var.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added `tests/test_memory_config.py`:
- `test_embedding_dims_propagated_to_vector_store` — with `EMBEDDER_EMBEDDING_DIMS=768`, asserts both `embedder.config.embedding_dims` and `vector_store.config.embedding_model_dims` equal 768. Fails before the fix.
- `test_no_dims_env_leaves_vector_store_default` — with the var unset, asserts no dims are injected (backward compatibility).

```
$ pytest tests/ -q
23 passed
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (`.env.example`)
