### PR TITLE
fix(memory): return empty results for blank search queries

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1176,6 +1176,12 @@ class Memory(MemoryBase):
         # Reject top-level entity params - must use filters instead
         _reject_top_level_entity_params(kwargs, "search")
 
+        # A blank query has no meaningful embedding: some providers raise on empty
+        # input, others return a vector that matches everything (an unintended
+        # memory leak). Short-circuit to no results.
+        if not query or not query.strip():
+            return {"results": []}
+
         # Validate search parameters (before applying defaults)
         _validate_search_params(threshold=threshold, top_k=top_k)
 
@@ -2617,6 +2623,12 @@ class AsyncMemory(MemoryBase):
         """
         # Reject top-level entity params - must use filters instead
         _reject_top_level_entity_params(kwargs, "search")
+
+        # A blank query has no meaningful embedding: some providers raise on empty
+        # input, others return a vector that matches everything (an unintended
+        # memory leak). Short-circuit to no results.
+        if not query or not query.strip():
+            return {"results": []}
 
         # Validate search parameters (before applying defaults)
         _validate_search_params(threshold=threshold, top_k=top_k)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -117,6 +117,49 @@ def test_search(memory_instance):
     )
 
 
+@pytest.mark.parametrize("blank_query", ["", "   ", "\n\t "])
+def test_search_blank_query_returns_empty_without_embedding(memory_instance, blank_query):
+    """Empty/whitespace queries must short-circuit to no results.
+
+    Without validation, a blank query is embedded — some providers raise, others
+    return a vector that matches all stored memories (an unintended memory leak).
+    """
+    memory_instance.embedding_model.embed = Mock()
+    memory_instance.vector_store.search = Mock()
+
+    result = memory_instance.search(blank_query, filters={"user_id": "test_user"})
+
+    assert result == {"results": []}
+    memory_instance.embedding_model.embed.assert_not_called()
+    memory_instance.vector_store.search.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_search_blank_query_returns_empty_without_embedding():
+    """Async search must short-circuit blank queries, same as the sync path."""
+    with (
+        patch("mem0.utils.factory.EmbedderFactory") as mock_embedder,
+        patch("mem0.memory.main.VectorStoreFactory") as mock_vector_store,
+        patch("mem0.utils.factory.LlmFactory") as mock_llm,
+        patch("mem0.memory.telemetry.capture_event"),
+    ):
+        mock_embedder.create.return_value = Mock()
+        mock_vector_store.create.return_value = Mock()
+        mock_llm.create.return_value = Mock()
+
+        from mem0.memory.main import AsyncMemory
+
+        memory = AsyncMemory(MemoryConfig(version="v1.1"))
+        memory.embedding_model.embed = Mock()
+        memory.vector_store.search = Mock()
+
+        result = await memory.search("   ", filters={"user_id": "test_user"})
+
+        assert result == {"results": []}
+        memory.embedding_model.embed.assert_not_called()
+        memory.vector_store.search.assert_not_called()
+
+
 def test_update(memory_instance):
     memory_instance.embedding_model = Mock()
     memory_instance.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])


### PR DESCRIPTION
## Linked Issue

Closes #5220

## Description

`Memory.search()` performed no validation on the query string before passing it to the embedding model. Empty (`""`) and whitespace-only (`"   "`) queries were treated as valid, leading to provider-dependent behavior:

- some embedders (e.g. Ollama) **raise a ValueError** on empty input;
- others **return a vector that matches everything**, so *all* of a user's stored memories are returned — an unintended memory leak.

### Fix

Short-circuit blank queries to `{"results": []}` at the top of both the sync and async `search()` paths, before any embedding or vector store call:

```python
if not query or not query.strip():
    return {"results": []}
```

This returns the same shape as a valid search that matched nothing, and avoids the wasted embedding/vector-store round-trip entirely.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A — blank queries previously crashed or leaked; they now return `{"results": []}`.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added to `tests/test_main.py`:
- `test_search_blank_query_returns_empty_without_embedding` — parametrized over `""`, `"   "`, `"\n\t "`; asserts `{"results": []}` and that neither the embedding model nor the vector store is called.
- `test_async_search_blank_query_returns_empty_without_embedding` — same guarantee on the `AsyncMemory` path.

```
$ pytest tests/test_main.py tests/test_memory.py -q
70 passed
```
`ruff check` passes on both changed files.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (internal behavior fix — none needed)
