### PR TITLE
docs(embedders): add documentation page for FastEmbed provider

### DIFF
--- a/docs/components/embedders/models/fastembed.mdx
+++ b/docs/components/embedders/models/fastembed.mdx
@@ -1,0 +1,46 @@
+---
+title: FastEmbed
+description: "Configure FastEmbed as an embedding provider in Mem0 for fast, local embedding generation using the ONNX runtime."
+---
+
+[FastEmbed](https://github.com/qdrant/fastembed) is a lightweight, fast embedding library that runs models in the ONNX runtime — no PyTorch dependency and no external API calls, so embeddings are generated locally.
+
+### Usage
+
+```python
+import os
+from mem0 import Memory
+
+os.environ["OPENAI_API_KEY"] = "your_api_key" # For LLM
+
+config = {
+    "embedder": {
+        "provider": "fastembed",
+        "config": {
+            "model": "thenlper/gte-large"
+        }
+    }
+}
+
+m = Memory.from_config(config)
+messages = [
+    {"role": "user", "content": "I'm planning to watch a movie tonight. Any recommendations?"},
+    {"role": "assistant", "content": "How about thriller movies? They can be quite engaging."},
+    {"role": "user", "content": "I'm not a big fan of thriller movies but I love sci-fi movies."},
+    {"role": "assistant", "content": "Got it! I'll avoid thriller recommendations and suggest sci-fi movies in the future."}
+]
+m.add(messages, user_id="john")
+```
+
+<Note>
+FastEmbed downloads the selected model on first use and caches it locally. The embedding dimension is determined automatically from the model, so `embedding_dims` does not need to be set. See the [FastEmbed supported models list](https://qdrant.github.io/fastembed/examples/Supported_Models/) for available model names.
+</Note>
+
+### Config
+
+Here are the parameters available for configuring the FastEmbed embedder:
+
+| Parameter | Description | Default Value |
+| --- | --- | --- |
+| `model` | The name of the FastEmbed model to use | `thenlper/gte-large` |
+| `embedding_dims` | Dimensions of the embedding model | Inferred from the model |

--- a/docs/components/embedders/overview.mdx
+++ b/docs/components/embedders/overview.mdx
@@ -24,6 +24,7 @@ See the list of supported embedders below.
   <Card title="LM Studio" href="/components/embedders/models/lmstudio"></Card>
   <Card title="Langchain" href="/components/embedders/models/langchain"></Card>
   <Card title="AWS Bedrock" href="/components/embedders/models/aws_bedrock"></Card>
+  <Card title="FastEmbed" href="/components/embedders/models/fastembed"></Card>
 </CardGroup>
 
 ## Usage

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -271,7 +271,8 @@
                               "components/embedders/models/lmstudio",
                               "components/embedders/models/together",
                               "components/embedders/models/langchain",
-                              "components/embedders/models/aws_bedrock"
+                              "components/embedders/models/aws_bedrock",
+                              "components/embedders/models/fastembed"
                             ]
                           }
                         ]

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -458,6 +458,7 @@ Everything below is OSS-only provider configuration. Skip this entire section wh
 - [LM Studio Embeddings](https://docs.mem0.ai/components/embedders/models/lmstudio) [OSS]: Use when embeddings run through LM Studio.
 - [Together Embeddings](https://docs.mem0.ai/components/embedders/models/together) [OSS]: Use when embeddings run on Together.
 - [LangChain Embeddings](https://docs.mem0.ai/components/embedders/models/langchain) [OSS]: Use when embeddings are wrapped behind a LangChain adapter.
+- [FastEmbed Embeddings](https://docs.mem0.ai/components/embedders/models/fastembed) [OSS]: Use for fast local embeddings via the ONNX runtime (no PyTorch, no API calls).
 
 ### Vector Databases [OSS]
 - [Vector Database Overview](https://docs.mem0.ai/components/vectordbs/overview) [OSS]: Use when choosing a vector store.


### PR DESCRIPTION
## Linked Issue

Closes #5163

## Description

The FastEmbed embedding provider (`mem0/embeddings/fastembed.py`) is fully implemented and registered in `mem0/embeddings/configs.py`, but it was the only registered embedding provider without a documentation page. It was also missing from the embedders overview card grid, the `docs.json` navigation, and the `llms.txt` index.

This PR adds the missing documentation:

- **New page** `docs/components/embedders/models/fastembed.mdx` — frontmatter, a usage example, and a config table, following the exact format of the other embedder docs (e.g. `huggingface.mdx`). Defaults (`model = thenlper/gte-large`, auto-inferred `embedding_dims`) match the implementation.
- **overview.mdx** — added a FastEmbed card to the embedders grid.
- **docs.json** — added the page to the embedder models navigation.
- **llms.txt** — added the indexed entry with an `[OSS]` scope tag and a `Use when ...` description.

Verified `docs/llms.txt` is in sync via `python scripts/check-llms-txt-coverage.py` ("in sync with docs/**/*.mdx"), and `docs.json` remains valid JSON.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [x] No tests needed (explain why)

Documentation-only change. Validated the `llms.txt` coverage gate and JSON validity locally.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (docs only)
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
