### PR TITLE
fix(server): forward explain in REST search

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -448,6 +448,8 @@ def search_memories(search_req: SearchRequest, _auth=Depends(verify_auth)):
             params["top_k"] = search_req.top_k
         if search_req.threshold is not None:
             params["threshold"] = search_req.threshold
+        if search_req.explain is not None:
+            params["explain"] = search_req.explain
         return get_memory_instance().search(query=search_req.query, filters=filters, **params)
     except Exception:
         raise upstream_error()

--- a/tests/test_server_params.py
+++ b/tests/test_server_params.py
@@ -109,6 +109,32 @@ class TestSearchThreshold:
 
 
 # ===========================================================================
+# SearchRequest: explain parameter
+# ===========================================================================
+
+class TestSearchExplain:
+    """Verify that the explain parameter is accepted and forwarded."""
+
+    def test_explain_true_forwarded(self, client, mock_memory):
+        resp = client.post("/search", json={"query": "food", "user_id": "u1", "explain": True})
+        assert resp.status_code == 200
+        _, kwargs = mock_memory.search.call_args
+        assert kwargs["explain"] is True
+
+    def test_explain_false_forwarded(self, client, mock_memory):
+        resp = client.post("/search", json={"query": "food", "user_id": "u1", "explain": False})
+        assert resp.status_code == 200
+        _, kwargs = mock_memory.search.call_args
+        assert kwargs["explain"] is False
+
+    def test_explain_omitted_uses_memory_default(self, client, mock_memory):
+        resp = client.post("/search", json={"query": "food", "user_id": "u1"})
+        assert resp.status_code == 200
+        _, kwargs = mock_memory.search.call_args
+        assert "explain" not in kwargs
+
+
+# ===========================================================================
 # SearchRequest: top_k + threshold together
 # ===========================================================================
 


### PR DESCRIPTION
## Linked Issue

N/A - small REST API correctness fix found while reviewing the existing search request flow.

## Description

The self-hosted REST search schema already accepts `explain`, and the docs show `explain: true` for inspecting score details. The handler currently forwards `top_k` and `threshold`, but drops `explain`, so REST callers cannot receive `score_details` through the server even though the SDK supports it.

This forwards `explain` to `Memory.search()` only when the request includes it. Omitting the field still lets the SDK default apply, so existing responses stay unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Tested locally:

```bash
uv run --no-project --with ruff ruff check server/main.py tests/test_server_params.py
git diff --check
AUTH_DISABLED=true JWT_SECRET=test PYTHONPATH=server uv run --with-editable . --with fastapi --with httpx --with pytest --with pytest-asyncio --with 'python-jose[cryptography]>=3.3,<4.0' --with 'passlib[bcrypt]>=1.7,<2.0' --with 'sqlalchemy>=2.0,<3.0' --with 'pydantic[email]==2.10.4' --with 'psycopg[binary]>=3.2.8' --with slowapi --with python-dotenv pytest tests/test_server_params.py -q
```

Result: `57 passed`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed