### PR TITLE
feat(server): add health and readiness endpoints

### DIFF
--- a/docs/open-source/features/rest-api.mdx
+++ b/docs/open-source/features/rest-api.mdx
@@ -31,7 +31,7 @@ The Mem0 REST API server exposes every OSS memory operation over HTTP. Run it al
 
 - **CRUD endpoints:** Create, retrieve, search, update, delete, and reset memories by `user_id`, `agent_id`, or `run_id`.
 - **Authentication:** On by default. Dashboard sessions use JWTs; programmatic clients use per-user `X-API-Key` headers. Legacy `ADMIN_API_KEY` is still supported.
-- **Status health check:** Access base routes to confirm the server is online.
+- **Operational probes:** Use `/api/health` for liveness and `/api/ready` for readiness checks.
 - **OpenAPI explorer:** Visit `/docs` for interactive testing and schema reference.
 
 ---
@@ -126,7 +126,7 @@ docker build -t mem0-api-server .
 
 ## Authentication
 
-Auth is on by default. Protected endpoints require either a JWT (from the dashboard login flow) or an `X-API-Key` header. The `/` redirect, `/docs`, and `/openapi.json` routes stay open so you can reach the OpenAPI explorer.
+Auth is on by default. Protected endpoints require either a JWT (from the dashboard login flow) or an `X-API-Key` header. The `/` redirect, `/docs`, `/openapi.json`, `/api/health`, and `/api/ready` routes stay open so you can reach the OpenAPI explorer and wire container probes.
 
 | Mode | How to send it | When to use it |
 |---|---|---|
@@ -273,6 +273,13 @@ The OSS REST server exposes the following endpoints. None use the `/v1/` prefix.
 | `POST` | `/search` | Search memories |
 | `POST` | `/reset` | Reset all memories |
 
+### Operational endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/health` | Liveness check for the FastAPI process. Open, no auth required |
+| `GET` | `/api/ready` | Readiness check for database and runtime configuration availability. Open, no auth required |
+
 ### Authentication
 
 | Method | Path | Description |
@@ -314,7 +321,7 @@ The `/auth/*`, `/api-keys`, `/requests`, and `/entities` routes are new to the s
 
 ## Verify the feature is working
 
-- Hit the root route and `/docs` to confirm the server is reachable.
+- Hit `/api/health` to confirm the server is reachable and `/api/ready` to confirm dependencies are ready.
 - Run a full cycle: `POST /memories` → `GET /memories/{id}` → `DELETE /memories/{id}`.
 - Watch server logs for import errors or provider misconfigurations during startup.
 - Confirm environment variables (API keys, vector store credentials) load correctly when containers restart.

--- a/server/Makefile
+++ b/server/Makefile
@@ -43,7 +43,8 @@ wait-dashboard:
 bootstrap: up wait-api wait-dashboard seed
 
 health:
-	@echo "API:       $$(curl -s -o /dev/null -w '%{http_code}' "$(API_URL)/docs")"
+	@echo "API live:  $$(curl -s -o /dev/null -w '%{http_code}' "$(API_URL)/api/health")"
+	@echo "API ready: $$(curl -s -o /dev/null -w '%{http_code}' "$(API_URL)/api/ready")"
 	@echo "Dashboard: $$(curl -s -o /dev/null -w '%{http_code}' "$(DASHBOARD_URL)/api/health")"
 	@echo "Postgres:  $$(docker compose exec -T postgres pg_isready -q && echo 'ok' || echo 'down')"
 

--- a/server/main.py
+++ b/server/main.py
@@ -54,7 +54,7 @@ SENSITIVE_CONFIG_KEYS = {
     "secret",
     "token",
 }
-SKIPPED_REQUEST_LOG_PATHS = {"/api/health", "/docs", "/redoc", "/openapi.json"}
+SKIPPED_REQUEST_LOG_PATHS = {"/api/health", "/api/ready", "/docs", "/redoc", "/openapi.json"}
 SKIPPED_REQUEST_LOG_PREFIXES = ("/requests",)
 
 BUNDLED_LLM_PROVIDERS = ("openai", "anthropic", "gemini")
@@ -246,6 +246,30 @@ def _validate_bundled_providers(config: Dict[str, Any]) -> None:
         )
 
 
+def _readiness_response() -> tuple[int, Dict[str, Any]]:
+    checks = {"database": "ok", "configuration": "ok"}
+
+    try:
+        with SessionLocal() as session:
+            session.execute(select(1))
+    except Exception:
+        checks["database"] = "error"
+        logging.exception("Readiness check failed: database unavailable")
+
+    try:
+        get_current_config()
+    except Exception:
+        checks["configuration"] = "error"
+        logging.exception("Readiness check failed: configuration unavailable")
+
+    ready = all(status == "ok" for status in checks.values())
+    return 200 if ready else 503, {
+        "status": "ready" if ready else "not_ready",
+        "service": "mem0-api",
+        "checks": checks,
+    }
+
+
 def _should_log_request(request: Request) -> bool:
     if request.method == "OPTIONS":
         return False
@@ -304,6 +328,17 @@ async def log_requests(request: Request, call_next):
                 round((time.perf_counter() - start) * 1000, 2),
                 getattr(request.state, "auth_type", "none"),
             )
+
+
+@app.get("/api/health", summary="Liveness check", tags=["health"])
+def health_check():
+    return {"status": "ok", "service": "mem0-api"}
+
+
+@app.get("/api/ready", summary="Readiness check", tags=["health"])
+def readiness_check():
+    status_code, payload = _readiness_response()
+    return JSONResponse(status_code=status_code, content=payload)
 
 
 @app.get("/configure", summary="Get current Mem0 configuration")

--- a/tests/test_server_health.py
+++ b/tests/test_server_health.py
@@ -1,0 +1,88 @@
+"""Tests for operational health endpoints exposed by the REST API server."""
+
+import importlib
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("fastapi", reason="fastapi not installed")
+
+from fastapi.testclient import TestClient
+
+
+class _FakeSession:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return None
+
+    def execute(self, _statement):
+        return None
+
+
+@pytest.fixture
+def server_main():
+    mock_memory = MagicMock()
+
+    with patch.dict(
+        os.environ,
+        {"OPENAI_API_KEY": "fake-key", "ADMIN_API_KEY": "", "AUTH_DISABLED": "true"},
+    ):
+        with patch("mem0.Memory.from_config", return_value=mock_memory):
+            import server.main as server_main
+
+            importlib.reload(server_main)
+            yield server_main
+
+
+@pytest.fixture
+def client(server_main):
+    return TestClient(server_main.app)
+
+
+def test_health_returns_liveness_payload(client):
+    resp = client.get("/api/health")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok", "service": "mem0-api"}
+
+
+def test_ready_returns_ready_when_dependencies_are_available(client, server_main):
+    with patch.object(server_main, "SessionLocal", return_value=_FakeSession()):
+        with patch.object(server_main, "get_current_config", return_value={"version": "v1.1"}):
+            resp = client.get("/api/ready")
+
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "status": "ready",
+        "service": "mem0-api",
+        "checks": {"database": "ok", "configuration": "ok"},
+    }
+
+
+def test_ready_returns_503_when_database_is_unavailable(client, server_main):
+    with patch.object(server_main, "SessionLocal", side_effect=RuntimeError("database down")):
+        with patch.object(server_main, "get_current_config", return_value={"version": "v1.1"}):
+            resp = client.get("/api/ready")
+
+    assert resp.status_code == 503
+    assert resp.json() == {
+        "status": "not_ready",
+        "service": "mem0-api",
+        "checks": {"database": "error", "configuration": "ok"},
+    }
+
+
+def test_ready_returns_503_when_configuration_is_unavailable(client, server_main):
+    with patch.object(server_main, "SessionLocal", return_value=_FakeSession()):
+        with patch.object(server_main, "get_current_config", side_effect=RuntimeError("config unavailable")):
+            resp = client.get("/api/ready")
+
+    assert resp.status_code == 503
+    assert resp.json() == {
+        "status": "not_ready",
+        "service": "mem0-api",
+        "checks": {"database": "ok", "configuration": "error"},
+    }


### PR DESCRIPTION
## Linked Issue

N/A - small operational improvement for self-hosted deployments.

## Description

Self-hosted deployments currently tend to use `/docs` or dashboard routes as health proxies. That works for a quick manual check, but it is not ideal for Docker, load balancers, or orchestrators that need stable API-owned probes.

This adds two lightweight unauthenticated endpoints:

- `GET /api/health` for liveness: confirms the FastAPI process is serving requests
- `GET /api/ready` for readiness: checks database access and runtime configuration availability

The probes are excluded from request logging so routine uptime checks do not fill the API request log. `make health` and the REST API docs now reference the new endpoints directly.

Both endpoints return only operational status and do not expose secrets or memory data.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Tested locally:

```bash
uv run --no-project --with ruff ruff check server/main.py tests/test_server_health.py
git diff --check
AUTH_DISABLED=true JWT_SECRET=test PYTHONPATH=server uv run --with-editable . --with fastapi --with httpx --with pytest --with pytest-asyncio --with 'python-jose[cryptography]>=3.3,<4.0' --with 'passlib[bcrypt]>=1.7,<2.0' --with 'sqlalchemy>=2.0,<3.0' --with 'pydantic[email]==2.10.4' --with 'psycopg[binary]>=3.2.8' --with slowapi --with python-dotenv pytest tests/test_server_health.py tests/test_server_params.py -q
```

Result: `58 passed`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed