### PR TITLE
fix(memory): recover silently-dropped extractions via forced tool call

### DIFF
--- a/mem0/configs/prompts.py
+++ b/mem0/configs/prompts.py
@@ -1060,3 +1060,63 @@ def generate_additive_extraction_prompt(
 
     sections.append("# Output:")
     return "\n\n".join(sections)
+
+
+# Forced structured-output tool used to recover extraction when the LLM returns
+# free prose with no JSON object (e.g. the model role-plays / continues the
+# transcript instead of extracting facts, producing the classic
+# "Expecting value: line 1 column 1 (char 0)" parse failure). Forcing a tool
+# call constrains the model to the schema, so it cannot answer with prose.
+#
+# Defined in OpenAI function-calling format - the format mem0 providers expect
+# and convert from internally (see e.g. AnthropicLLM / AWSBedrockLLM). Mirrors
+# the ADDITIVE_EXTRACTION_PROMPT output shape: {"memory": [{"id", "text", ...}]}.
+# The "text" field name is contractual: the add() pipeline reads m.get("text")
+# (mem0/memory/main.py), so renaming it here silently drops every recovered memory.
+# "attributed_to" is also consumed (main.py promotes it into the memory's
+# metadata); "id" and "linked_memory_ids" mirror the prompt's output shape for
+# model familiarity and are harmlessly ignored downstream. Only "text" is
+# required - the others are optional, including "id".
+MEMORY_EXTRACTION_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "save_memories",
+        "description": (
+            "Save the memorable facts extracted from the conversation. "
+            "Call this with every distinct fact worth remembering."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "memory": {
+                    "type": "array",
+                    "description": "The list of extracted memories. Empty if nothing is memorable.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "description": "Optional sequential id for this memory ('0', '1', ...).",
+                            },
+                            "text": {
+                                "type": "string",
+                                "description": "The self-contained, contextually rich memory statement.",
+                            },
+                            "attributed_to": {
+                                "type": "string",
+                                "description": "Optional speaker name the memory is attributed to.",
+                            },
+                            "linked_memory_ids": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": "Optional ids of related existing memories.",
+                            },
+                        },
+                        "required": ["text"],
+                    },
+                }
+            },
+            "required": ["memory"],
+        },
+    },
+}

--- a/mem0/llms/anthropic.py
+++ b/mem0/llms/anthropic.py
@@ -12,6 +12,8 @@ from mem0.llms.base import LLMBase
 
 
 class AnthropicLLM(LLMBase):
+    supports_tool_calls = True
+
     def __init__(self, config: Optional[Union[BaseLlmConfig, AnthropicConfig, Dict]] = None):
         # Convert to AnthropicConfig if needed
         if config is None:
@@ -69,6 +71,74 @@ class AnthropicLLM(LLMBase):
         params.update(kwargs)
         return params
 
+    @staticmethod
+    def _convert_tools(tools: List[Dict]) -> List[Dict]:
+        """Convert OpenAI function-calling tool schemas to Anthropic's format.
+
+        mem0 defines tools in OpenAI format ({"type": "function", "function":
+        {"name", "description", "parameters"}}); Anthropic expects flat tools
+        with an ``input_schema``. Tools already in Anthropic format (carrying
+        ``input_schema``) are passed through unchanged.
+        """
+        converted = []
+        for tool in tools:
+            if "input_schema" in tool:
+                converted.append(tool)
+                continue
+            function = tool.get("function", tool)
+            converted.append(
+                {
+                    "name": function.get("name"),
+                    "description": function.get("description", ""),
+                    "input_schema": function.get("parameters", {"type": "object", "properties": {}}),
+                }
+            )
+        return converted
+
+    @staticmethod
+    def _convert_tool_choice(tool_choice):
+        """Map the cross-provider ``tool_choice`` value to Anthropic's format.
+
+        Anthropic expects a dict ({"type": "auto" | "any" | "none" | "tool"}).
+        Accepts the OpenAI-style strings used across mem0 ("auto", "required",
+        "none") and a bare tool name to force a specific tool; an already-formed
+        dict is passed through.
+        """
+        if isinstance(tool_choice, dict):
+            return tool_choice
+        mapping = {
+            "auto": {"type": "auto"},
+            "required": {"type": "any"},
+            "any": {"type": "any"},
+            "none": {"type": "none"},
+        }
+        if tool_choice in mapping:
+            return mapping[tool_choice]
+        # Anything else is treated as a specific tool name to force.
+        return {"type": "tool", "name": tool_choice}
+
+    @staticmethod
+    def _parse_response(response, tools):
+        """Process the Anthropic response based on whether tools were used.
+
+        With tools, returns the same shape as the OpenAI provider -
+        ``{"content": <text>, "tool_calls": [{"name", "arguments"}]}`` - reading
+        the JSON out of each ``tool_use`` block's ``.input`` (the SDK already
+        parses it to a dict). Without tools, returns the assistant text, or ""
+        when the response carries no content blocks (e.g. blocked/refused).
+        """
+        if tools:
+            processed_response = {"content": None, "tool_calls": []}
+            for block in response.content:
+                block_type = getattr(block, "type", None)
+                if block_type == "text":
+                    processed_response["content"] = block.text
+                elif block_type == "tool_use":
+                    processed_response["tool_calls"].append({"name": block.name, "arguments": block.input})
+            return processed_response
+
+        return response.content[0].text if response.content else ""
+
     def generate_response(
         self,
         messages: List[Dict[str, str]],
@@ -88,7 +158,8 @@ class AnthropicLLM(LLMBase):
             **kwargs: Additional Anthropic-specific parameters.
 
         Returns:
-            str: The generated response.
+            str or dict: The assistant text, or, when ``tools`` are supplied, a
+            ``{"content", "tool_calls"}`` dict matching the other providers.
         """
         # Separate system message from other messages
         system_message = ""
@@ -108,22 +179,9 @@ class AnthropicLLM(LLMBase):
             }
         )
 
-        if tools:  # TODO: Remove tools if no issues found with new memory addition logic
-            params["tools"] = tools
-            params["tool_choice"] = {"type": tool_choice}
+        if tools:
+            params["tools"] = self._convert_tools(tools)
+            params["tool_choice"] = self._convert_tool_choice(tool_choice)
 
         response = self.client.messages.create(**params)
         return self._parse_response(response, tools)
-
-    def _parse_response(self, response, tools):
-        if tools:
-            result = {"content": None, "tool_calls": []}
-            for block in response.content:
-                if block.type == "text":
-                    result["content"] = block.text
-                elif block.type == "tool_use":
-                    result["tool_calls"].append(
-                        {"name": block.name, "arguments": block.input}
-                    )
-            return result
-        return response.content[0].text

--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -10,6 +10,16 @@ class LLMBase(ABC):
     Handles common functionality and delegates provider-specific logic to subclasses.
     """
 
+    #: Whether this provider can recover extraction via a forced tool call -
+    #: i.e. it honors ``tools`` / ``tool_choice`` and returns the standard
+    #: ``{"tool_calls": [{"name", "arguments"}]}`` dict. Providers that support
+    #: forced structured output opt in by overriding this to ``True``. The
+    #: opt-in is deliberately narrow to start: other OpenAI-compatible
+    #: providers (e.g. Azure OpenAI, Groq, LiteLLM, DeepSeek) likely qualify
+    #: and can flip this flag once their forced-tool_choice behavior is
+    #: verified against a real endpoint.
+    supports_tool_calls: bool = False
+
     def __init__(self, config: Optional[Union[BaseLlmConfig, Dict]] = None):
         """Initialize a base LLM class
 

--- a/mem0/llms/groq.py
+++ b/mem0/llms/groq.py
@@ -25,6 +25,18 @@ class GroqLLM(LLMBase):
         api_key = self.config.api_key or os.getenv("GROQ_API_KEY")
         self.client = Groq(api_key=api_key)
 
+    @property
+    def supports_tool_calls(self) -> bool:
+        # Groq is #4054's provider. Forced-tool_choice recovery needs a model
+        # that honors tool calling; the compound agentic systems that reject
+        # JSON response_format (_supports_json_mode) reject tool calling too, so
+        # reuse that gate and opt in every other Groq model. Verified against the
+        # live Groq API: llama-3.3-70b-versatile and openai/gpt-oss-20b recover
+        # via a forced tool call, while compound-beta returns "tool calling is
+        # not supported". A weaker model that fails to emit a valid call surfaces
+        # a caught error and falls back to the current behavior, never a crash.
+        return self._supports_json_mode(self.config.model)
+
     @staticmethod
     def _supports_json_mode(model: Optional[Union[str, Dict]]) -> bool:
         """

--- a/mem0/llms/openai.py
+++ b/mem0/llms/openai.py
@@ -12,6 +12,8 @@ from mem0.memory.utils import extract_json
 
 
 class OpenAILLM(LLMBase):
+    supports_tool_calls = True
+
     def __init__(self, config: Optional[Union[BaseLlmConfig, OpenAIConfig, Dict]] = None):
         # Convert to OpenAIConfig if needed
         if config is None:

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -55,6 +55,7 @@ from mem0.memory.utils import (
     parse_messages,
     parse_vision_messages,
     process_telemetry_filters,
+    recover_extraction_via_tools,
     remove_code_blocks,
 )
 from mem0.utils.entity_extraction import extract_entities, extract_entities_batch
@@ -928,7 +929,19 @@ class Memory(MemoryBase):
                     extracted_memories = json.loads(extracted_json, strict=False).get("memory", [])
         except Exception as e:
             logger.error(f"Error parsing extraction response: {e}")
-            extracted_memories = []
+            if "{" in str(response):
+                # JSON was emitted but did not parse (e.g. truncated by
+                # max_tokens). A forced tool call cannot fix a token budget, so
+                # do not spend extra LLM calls here. (Hijack prose that merely
+                # contains a brace also lands here and keeps the current
+                # behavior - a deliberate fail-safe: never pay for recovery
+                # when JSON may have been emitted.)
+                extracted_memories = []
+            else:
+                # No JSON at all: the model answered with prose (content
+                # hijack). Recover via a forced tool call where supported, else
+                # fall back to [].
+                extracted_memories = recover_extraction_via_tools(self.llm, system_prompt, user_prompt)
 
         if not extracted_memories:
             # Save messages even if nothing extracted
@@ -2552,7 +2565,16 @@ class AsyncMemory(MemoryBase):
                     extracted_memories = json.loads(extracted_json, strict=False).get("memory", [])
         except Exception as e:
             logger.error(f"Error parsing extraction response (async): {e}")
-            extracted_memories = []
+            if "{" in str(response):
+                # JSON was emitted but did not parse (e.g. truncated by
+                # max_tokens) - not recoverable via a forced tool call.
+                extracted_memories = []
+            else:
+                # No JSON at all (content hijack): recover via a forced tool
+                # call where supported, else fall back to [].
+                extracted_memories = await asyncio.to_thread(
+                    recover_extraction_via_tools, self.llm, system_prompt, user_prompt
+                )
 
         if not extracted_memories:
             await asyncio.to_thread(self.db.save_messages, messages, session_scope)

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -1,11 +1,13 @@
 import hashlib
+import json
 import logging
 import re
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from mem0.configs.prompts import (
     AGENT_MEMORY_EXTRACTION_PROMPT,
     FACT_RETRIEVAL_PROMPT,
+    MEMORY_EXTRACTION_TOOL,
     USER_MEMORY_EXTRACTION_PROMPT,
 )
 
@@ -146,6 +148,155 @@ def extract_json(text):
         else:
             json_str = text
     return json_str
+
+
+def llm_supports_tool_calls(llm) -> bool:
+    """Whether this LLM provider can recover extraction via a forced tool call.
+
+    The recovery path (``recover_extraction_via_tools``) only works on providers
+    that (a) accept ``tools`` / ``tool_choice`` and (b) return the standard
+    ``{"tool_calls": [{"name", "arguments"}]}`` dict when a tool is called.
+    Providers opt in explicitly by setting the class attribute
+    ``supports_tool_calls = True``. This is intentionally distinct from
+    AWSBedrockLLM's pre-existing ``supports_tools`` (whether the underlying
+    Bedrock model family accepts tools at all): this flag specifically asserts
+    "honors a forced ``tool_choice`` and returns the standard tool_calls dict",
+    which is what the recovery path needs.
+
+    The ``is True`` check is deliberate: it requires a real boolean opt-in and
+    will not be tripped by the auto-populated attributes of a ``MagicMock`` in
+    tests or by partially-wired providers.
+    """
+    return getattr(llm, "supports_tool_calls", False) is True
+
+
+def parse_tool_calls_for_memory(response) -> Optional[List[Dict[str, Any]]]:
+    """Pull the ``memory`` list out of a provider's tool-call response.
+
+    Providers return ``{"content": ..., "tool_calls": [{"name", "arguments"}]}``
+    (or a bare ``{"tool_calls": [...]}``) when a tool is invoked. ``arguments``
+    is normally a dict but some providers hand back a JSON string. Merges the
+    ``memory`` arrays across ALL tool calls (a model may answer a forced call
+    with several parallel invocations, one per fact) and drops non-dict items
+    (downstream reads ``m.get("text")``, so a bare string would crash the add
+    pipeline). Returns the merged list (which may legitimately be empty), or
+    ``None`` when no tool call carried a parseable ``memory`` list at all -
+    callers use that distinction to tell "valid empty extraction" from
+    "truncated/unusable tool output".
+    """
+    if not isinstance(response, dict):
+        return None
+    collected: Optional[List[Dict[str, Any]]] = None
+    for call in response.get("tool_calls") or []:
+        if not isinstance(call, dict):
+            continue
+        arguments = call.get("arguments")
+        if isinstance(arguments, str):
+            try:
+                arguments = json.loads(arguments)
+            except (json.JSONDecodeError, ValueError):
+                continue
+        if isinstance(arguments, dict):
+            memory = arguments.get("memory")
+            if isinstance(memory, list):
+                if collected is None:
+                    collected = []
+                collected.extend(m for m in memory if isinstance(m, dict))
+    return collected
+
+
+# A forced tool call whose own structured output hits ``max_tokens`` is retried
+# once at this multiple of the configured ``max_tokens``. The 4x figure comes
+# from observed tool-call truncations on a real conversation corpus, where a 2x
+# raise still under-shot. The absolute cap bounds the retry's cost so a large
+# configured budget cannot multiply into an arbitrarily expensive call, and
+# keeps the raised value inside common provider output limits.
+_TOOL_RETRY_TOKEN_MULTIPLIER = 4
+_TOOL_RETRY_TOKEN_CAP = 8192
+
+
+def _forced_tool_extraction(llm, system_prompt, user_prompt, max_tokens=None) -> Optional[List[Dict[str, Any]]]:
+    """Run one forced tool call and return its parsed memory list.
+
+    Returns ``None`` when the call failed or produced no parseable tool call
+    (see ``parse_tool_calls_for_memory``). ``max_tokens`` overrides the
+    provider's configured budget for this one call (used by the truncation
+    retry). Never raises.
+    """
+    kwargs = {
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+        # No response_format: the forced tool call supersedes it, and OpenAI
+        # rejects response_format={"type": "json_object"} combined with a forced
+        # tool_choice.
+        "tools": [MEMORY_EXTRACTION_TOOL],
+        "tool_choice": "required",
+    }
+    if max_tokens:
+        kwargs["max_tokens"] = max_tokens
+    try:
+        return parse_tool_calls_for_memory(llm.generate_response(**kwargs))
+    except Exception as e:
+        logger.warning("Tool-based extraction recovery failed: %s", e)
+        return None
+
+
+def recover_extraction_via_tools(llm, system_prompt, user_prompt) -> List[Dict[str, Any]]:
+    """Recover dropped memories after a parse failure using forced tool use.
+
+    When the extraction LLM returns prose with no JSON object, the standard
+    parse path raises ``json.JSONDecodeError`` and the memories are silently
+    lost. This retries the same extraction with a forced ``tool_choice`` on the
+    ``save_memories`` schema: the model cannot answer a forced tool call with
+    free prose, so the content-hijack that caused the drop cannot recur.
+
+    If no tool call could be parsed at all, the forced call's own structured
+    output may have been truncated (``max_tokens`` reached mid-call). In that
+    case it retries once at a raised ``max_tokens`` **staying in tool mode** -
+    reverting to free text would reintroduce the content-hijack the tool call
+    exists to prevent. A tool call that parsed cleanly to an empty ``memory``
+    list is a valid "nothing memorable" result and is returned as-is, with no
+    retry spend. (Providers that drop the ``max_tokens`` override - e.g. the
+    reasoning models whose params layer strips it - re-run at the same budget;
+    the retry then harmlessly no-ops back to ``[]``.)
+
+    The recovery reuses the original extraction's ``system_prompt`` and
+    ``user_prompt`` (existing memories, recent messages, dates) so the
+    recovered extraction sees exactly the context the failed one did - same
+    fidelity, and therefore roughly the same cost as the original call. That
+    cost is only paid on the rare parse-failure path, never on healthy
+    extractions.
+
+    Gated to providers that declare ``supports_tool_calls``; any failure (an
+    unsupported provider, an API error, or an unparseable response) falls back
+    to the current behavior by returning ``[]`` - recovery never raises.
+    """
+    if not llm_supports_tool_calls(llm):
+        return []
+
+    memories = _forced_tool_extraction(llm, system_prompt, user_prompt)
+    if memories:
+        logger.info("Recovered %d memory item(s) via forced tool call after parse failure", len(memories))
+        return memories
+    if memories is not None:
+        # The tool call parsed cleanly to an empty list: the conversation had
+        # nothing memorable. That is a valid result, not a truncation - do not
+        # spend another LLM call retrying it.
+        return []
+
+    # No parseable tool call: the forced call's own output may have truncated.
+    # Retry once at a raised (and capped) budget, still forcing the tool.
+    current = getattr(getattr(llm, "config", None), "max_tokens", None)
+    if isinstance(current, int) and current > 0:
+        raised = min(current * _TOOL_RETRY_TOKEN_MULTIPLIER, _TOOL_RETRY_TOKEN_CAP)
+        if raised > current:
+            retried = _forced_tool_extraction(llm, system_prompt, user_prompt, max_tokens=raised)
+            if retried:
+                logger.info("Recovered %d memory item(s) via forced tool call after a raised-token retry", len(retried))
+                return retried
+    return []
 
 
 def get_image_description(image_obj, llm, vision_details):

--- a/tests/llms/test_anthropic.py
+++ b/tests/llms/test_anthropic.py
@@ -131,3 +131,160 @@ def test_base_config_conversion_does_not_send_both(mock_anthropic_client):
     call_kwargs = mock_anthropic_client.messages.create.call_args[1]
     assert "temperature" in call_kwargs
     assert "top_p" not in call_kwargs
+
+
+# --- Tool / forced structured output handling ---
+
+OPENAI_FORMAT_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "save_memories",
+        "description": "Save extracted memories.",
+        "parameters": {
+            "type": "object",
+            "properties": {"memory": {"type": "array", "items": {"type": "object"}}},
+            "required": ["memory"],
+        },
+    },
+}
+
+
+def _tool_use_block(name, payload):
+    block = Mock()
+    block.type = "tool_use"
+    block.name = name
+    block.input = payload
+    return block
+
+
+def test_declares_tool_call_support():
+    assert AnthropicLLM.supports_tool_calls is True
+
+
+def test_no_tools_path_returns_text(mock_anthropic_client):
+    """Without tools, behavior is unchanged: the assistant text is returned."""
+    config = AnthropicConfig(model="claude-3-5-sonnet-20240620", api_key="test-key")
+    llm = AnthropicLLM(config)
+
+    text_block = Mock()
+    text_block.type = "text"
+    text_block.text = "Hello!"
+    mock_anthropic_client.messages.create.return_value = Mock(content=[text_block])
+
+    assert llm.generate_response([{"role": "user", "content": "Hi"}]) == "Hello!"
+    assert "tools" not in mock_anthropic_client.messages.create.call_args[1]
+
+
+def test_openai_format_tools_converted_to_anthropic_schema(mock_anthropic_client):
+    """OpenAI function-format tools are converted to Anthropic's input_schema."""
+    config = AnthropicConfig(model="claude-3-5-sonnet-20240620", api_key="test-key")
+    llm = AnthropicLLM(config)
+    mock_anthropic_client.messages.create.return_value = Mock(
+        content=[_tool_use_block("save_memories", {"memory": []})]
+    )
+
+    llm.generate_response([{"role": "user", "content": "Hi"}], tools=[OPENAI_FORMAT_TOOL], tool_choice="required")
+
+    call_kwargs = mock_anthropic_client.messages.create.call_args[1]
+    sent_tool = call_kwargs["tools"][0]
+    assert sent_tool["name"] == "save_memories"
+    assert "input_schema" in sent_tool and "function" not in sent_tool
+    assert sent_tool["input_schema"]["required"] == ["memory"]
+    # "required" maps to Anthropic's {"type": "any"}.
+    assert call_kwargs["tool_choice"] == {"type": "any"}
+
+
+def test_tool_use_block_parsed_into_tool_calls_dict(mock_anthropic_client):
+    """A tool_use block is returned as {"content", "tool_calls"} like other providers."""
+    config = AnthropicConfig(model="claude-3-5-sonnet-20240620", api_key="test-key")
+    llm = AnthropicLLM(config)
+    payload = {"memory": [{"id": "0", "text": "Likes hiking"}]}
+    mock_anthropic_client.messages.create.return_value = Mock(content=[_tool_use_block("save_memories", payload)])
+
+    result = llm.generate_response(
+        [{"role": "user", "content": "Hi"}], tools=[OPENAI_FORMAT_TOOL], tool_choice="required"
+    )
+
+    assert result["tool_calls"] == [{"name": "save_memories", "arguments": payload}]
+
+
+def test_tool_choice_auto_maps_to_dict(mock_anthropic_client):
+    config = AnthropicConfig(model="claude-3-5-sonnet-20240620", api_key="test-key")
+    llm = AnthropicLLM(config)
+    mock_anthropic_client.messages.create.return_value = Mock(
+        content=[_tool_use_block("save_memories", {"memory": []})]
+    )
+
+    llm.generate_response([{"role": "user", "content": "Hi"}], tools=[OPENAI_FORMAT_TOOL])
+
+    assert mock_anthropic_client.messages.create.call_args[1]["tool_choice"] == {"type": "auto"}
+
+
+def test_tool_requested_but_text_returned_yields_no_tool_calls(mock_anthropic_client):
+    """If the model returns only text despite a forced tool, tool_calls is empty
+    (graceful - the recovery degrades to [] rather than raising)."""
+    config = AnthropicConfig(model="claude-3-5-sonnet-20240620", api_key="test-key")
+    llm = AnthropicLLM(config)
+    text_block = Mock()
+    text_block.type = "text"
+    text_block.text = "I'd rather just chat."
+    mock_anthropic_client.messages.create.return_value = Mock(content=[text_block])
+
+    result = llm.generate_response(
+        [{"role": "user", "content": "Hi"}], tools=[OPENAI_FORMAT_TOOL], tool_choice="required"
+    )
+
+    assert result == {"content": "I'd rather just chat.", "tool_calls": []}
+
+
+def test_already_anthropic_format_tool_passed_through(mock_anthropic_client):
+    config = AnthropicConfig(model="claude-3-5-sonnet-20240620", api_key="test-key")
+    llm = AnthropicLLM(config)
+    mock_anthropic_client.messages.create.return_value = Mock(
+        content=[_tool_use_block("save_memories", {"memory": []})]
+    )
+    native_tool = {"name": "save_memories", "description": "d", "input_schema": {"type": "object"}}
+
+    llm.generate_response([{"role": "user", "content": "Hi"}], tools=[native_tool], tool_choice="required")
+
+    assert mock_anthropic_client.messages.create.call_args[1]["tools"][0] == native_tool
+
+
+def test_tool_missing_parameters_gets_empty_object_schema(mock_anthropic_client):
+    config = AnthropicConfig(model="claude-3-5-sonnet-20240620", api_key="test-key")
+    llm = AnthropicLLM(config)
+    mock_anthropic_client.messages.create.return_value = Mock(content=[_tool_use_block("noop", {})])
+    tool = {"type": "function", "function": {"name": "noop", "description": "d"}}
+
+    llm.generate_response([{"role": "user", "content": "Hi"}], tools=[tool], tool_choice="required")
+
+    sent_tool = mock_anthropic_client.messages.create.call_args[1]["tools"][0]
+    assert sent_tool["input_schema"] == {"type": "object", "properties": {}}
+
+
+def test_parse_response_output_feeds_recovery_parser(mock_anthropic_client):
+    """Seam test: AnthropicLLM's tool response shape is byte-compatible with the
+    recovery parser that consumes it (parse_tool_calls_for_memory)."""
+    from mem0.memory.utils import parse_tool_calls_for_memory
+
+    config = AnthropicConfig(model="claude-3-5-sonnet-20240620", api_key="test-key")
+    llm = AnthropicLLM(config)
+    payload = {"memory": [{"id": "0", "text": "Likes hiking"}]}
+    mock_anthropic_client.messages.create.return_value = Mock(content=[_tool_use_block("save_memories", payload)])
+
+    response = llm.generate_response(
+        [{"role": "user", "content": "Hi"}], tools=[OPENAI_FORMAT_TOOL], tool_choice="required"
+    )
+
+    assert parse_tool_calls_for_memory(response) == [{"id": "0", "text": "Likes hiking"}]
+
+
+def test_no_tools_path_empty_content_returns_empty_string(mock_anthropic_client):
+    """An empty content list (e.g. a blocked/refused response) must not raise
+    IndexError on the no-tools path; it degrades to an empty string."""
+    config = AnthropicConfig(model="claude-3-5-sonnet-20240620", api_key="test-key")
+    llm = AnthropicLLM(config)
+
+    mock_anthropic_client.messages.create.return_value = Mock(content=[])
+
+    assert llm.generate_response([{"role": "user", "content": "Hi"}]) == ""

--- a/tests/llms/test_groq.py
+++ b/tests/llms/test_groq.py
@@ -182,3 +182,23 @@ def test_generate_response_handles_non_string_model(mock_groq_client):
 
     _, kwargs = mock_groq_client.chat.completions.create.call_args
     assert kwargs["response_format"] == {"type": "json_object"}
+
+
+@pytest.mark.parametrize(
+    "model,expected",
+    [
+        ("llama-3.3-70b-versatile", True),
+        ("openai/gpt-oss-20b", True),
+        ("llama3-70b-8192", True),
+        ("groq/compound", False),
+        ("compound-beta", False),
+        ("groq/compound-mini", False),
+    ],
+)
+def test_supports_tool_calls_excludes_compound_models(mock_groq_client, model, expected):
+    # Forced-tool_choice recovery must be enabled for tool-capable Groq models
+    # (#4054's provider) but NOT for the compound agentic systems, which reject
+    # tool calling the same way they reject JSON response_format.
+    config = BaseLlmConfig(model=model, temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = GroqLLM(config)
+    assert llm.supports_tool_calls is expected

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -62,7 +62,9 @@ class TestAddToVectorStoreErrors:
         # Verify — v3 single-pass pipeline makes 1 LLM call, returns [] on parse error
         assert mock_memory.llm.generate_response.call_count == 1
         assert result == []
-        assert any("Error parsing extraction response" in record.message for record in caplog.records), "Expected error message not found in logs"
+        assert any("Error parsing extraction response" in record.message for record in caplog.records), (
+            "Expected error message not found in logs"
+        )
 
     def test_empty_llm_response_memory_actions(self, mock_memory, caplog):
         """Test empty response from LLM during memory actions (v3: single-pass, 1 LLM call)"""
@@ -78,6 +80,116 @@ class TestAddToVectorStoreErrors:
         # Verify — v3 only makes 1 LLM call (no separate merge step)
         assert mock_memory.llm.generate_response.call_count == 1
         assert result == []  # Should return empty list when no memories processed
+
+
+# A synthetic content-hijack response: the model continued / role-played the
+# conversation instead of extracting facts, so there is no JSON object anywhere.
+# This reproduces the "Expecting value: line 1 column 1 (char 0)" parse failure
+# without using any private conversation data.
+HIJACK_PROSE = (
+    "PLAN: I'll help you organize that. Before I start, a few questions: "
+    "1) What is the deadline? 2) Who is the audience? Let me know and we'll begin."
+)
+
+
+def _tool_call_response(text):
+    """Provider response shape when a forced tool call succeeds (OpenAI/Anthropic)."""
+    return {
+        "content": None,
+        "tool_calls": [{"name": "save_memories", "arguments": {"memory": [{"id": "0", "text": text}]}}],
+    }
+
+
+class TestParseFailureRecovery:
+    """A parse failure (prose, no JSON) is recovered via a forced tool call on
+    capable providers, and silently dropped (current behavior) otherwise."""
+
+    @pytest.fixture
+    def mock_memory(self, mocker):
+        mock_llm, _ = _setup_mocks(mocker)
+        mocker.patch("mem0.memory.main.capture_event")
+        mocker.patch("mem0.memory.main.extract_entities_batch", return_value=[[]])
+
+        memory = Memory()
+        memory.config = mocker.MagicMock()
+        memory.config.custom_instructions = None
+        memory.custom_instructions = None
+        memory.api_version = "v1.1"
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        memory.db.batch_add_history = MagicMock()
+        memory.embedding_model.embed_batch = MagicMock(
+            side_effect=lambda texts, *a, **k: [[0.1, 0.2, 0.3] for _ in texts]
+        )
+        return memory
+
+    def test_recovers_dropped_memories_when_provider_supports_tools(self, mock_memory, caplog):
+        recovered_text = "User was promoted to Senior Engineer at Shopify"
+        mock_memory.llm.supports_tool_calls = True
+        mock_memory.llm.generate_response.side_effect = [
+            HIJACK_PROSE,  # extraction: hijacked, no JSON -> parse failure
+            _tool_call_response(recovered_text),  # forced-tool recovery
+        ]
+
+        with caplog.at_level(logging.INFO):
+            result = mock_memory._add_to_vector_store(
+                messages=[{"role": "user", "content": "test"}], metadata={}, filters={}, infer=True
+            )
+
+        # Two calls: the hijacked extraction, then the forced-tool recovery.
+        assert mock_memory.llm.generate_response.call_count == 2
+        recovery_kwargs = mock_memory.llm.generate_response.call_args_list[1].kwargs
+        assert recovery_kwargs["tool_choice"] == "required"
+        assert recovery_kwargs["tools"][0]["function"]["name"] == "save_memories"
+        # The dropped fact is recovered instead of silently lost.
+        assert any(m["memory"] == recovered_text for m in result)
+        assert any("Recovered" in r.message for r in caplog.records)
+
+    def test_silently_drops_when_provider_does_not_support_tools(self, mock_memory, caplog):
+        # No supports_tool_calls opt-in -> current behavior: one call, empty result.
+        mock_memory.llm.supports_tool_calls = False
+        mock_memory.llm.generate_response.return_value = HIJACK_PROSE
+
+        with caplog.at_level(logging.ERROR):
+            result = mock_memory._add_to_vector_store(
+                messages=[{"role": "user", "content": "test"}], metadata={}, filters={}, infer=True
+            )
+
+        assert mock_memory.llm.generate_response.call_count == 1
+        assert result == []
+        assert any("Error parsing extraction response" in r.message for r in caplog.records)
+
+    def test_truncated_json_does_not_trigger_tool_recovery(self, mock_memory):
+        # A response that contained JSON but failed to parse (e.g. max_tokens
+        # cut it off mid-object) is a token-budget problem, not a content
+        # hijack. The forced-tool recovery must not fire - otherwise every
+        # under-budgeted extraction silently pays for extra LLM calls.
+        mock_memory.llm.supports_tool_calls = True
+        mock_memory.llm.generate_response.return_value = '{"memory": [{"id": "0", "text": "User likes hik'
+
+        result = mock_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "test"}], metadata={}, filters={}, infer=True
+        )
+
+        assert mock_memory.llm.generate_response.call_count == 1
+        assert result == []
+
+    def test_hijack_prose_containing_a_brace_keeps_current_behavior(self, mock_memory):
+        # Pins the deliberate fail-safe edge of the '{' gate: hijack prose that
+        # merely contains a brace (e.g. an echoed code snippet) is treated as
+        # "JSON may have been emitted" and keeps the current no-recovery
+        # behavior rather than paying for a recovery call.
+        mock_memory.llm.supports_tool_calls = True
+        mock_memory.llm.generate_response.return_value = (
+            "Sure! Here is a config you could use: server { listen 80; } - let me know if it works."
+        )
+
+        result = mock_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "test"}], metadata={}, filters={}, infer=True
+        )
+
+        assert mock_memory.llm.generate_response.call_count == 1
+        assert result == []
 
 
 class TestPromptOverridesCustomInstructions:
@@ -227,7 +339,9 @@ class TestAsyncAddToVectorStoreErrors:
             )
         assert mock_async_memory.llm.generate_response.call_count == 1
         assert result == []
-        assert any("Error parsing extraction response" in record.message for record in caplog.records), "Expected error message not found in logs"
+        assert any("Error parsing extraction response" in record.message for record in caplog.records), (
+            "Expected error message not found in logs"
+        )
 
     @pytest.mark.asyncio
     async def test_async_empty_llm_response_memory_actions(self, mock_async_memory, caplog, mocker):
@@ -244,6 +358,76 @@ class TestAsyncAddToVectorStoreErrors:
 
         assert result == []
         assert mock_async_memory.llm.generate_response.call_count == 1
+
+
+@pytest.mark.asyncio
+class TestAsyncParseFailureRecovery:
+    """Async counterpart of TestParseFailureRecovery."""
+
+    @pytest.fixture
+    def mock_async_memory(self, mocker):
+        mock_llm, _ = _setup_mocks(mocker)
+        mocker.patch("mem0.memory.main.capture_event")
+        mocker.patch("mem0.memory.main.extract_entities_batch", return_value=[[]])
+
+        memory = AsyncMemory()
+        memory.config = mocker.MagicMock()
+        memory.config.custom_instructions = None
+        memory.custom_instructions = None
+        memory.api_version = "v1.1"
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        memory.db.batch_add_history = MagicMock()
+        memory.embedding_model.embed_batch = MagicMock(
+            side_effect=lambda texts, *a, **k: [[0.1, 0.2, 0.3] for _ in texts]
+        )
+        return memory
+
+    @pytest.mark.asyncio
+    async def test_async_recovers_dropped_memories(self, mock_async_memory, caplog):
+        recovered_text = "User adopted a dog named Poppy"
+        mock_async_memory.llm.supports_tool_calls = True
+        mock_async_memory.llm.generate_response.side_effect = [
+            HIJACK_PROSE,
+            _tool_call_response(recovered_text),
+        ]
+
+        with caplog.at_level(logging.INFO):
+            result = await mock_async_memory._add_to_vector_store(
+                messages=[{"role": "user", "content": "test"}], metadata={}, effective_filters={}, infer=True
+            )
+
+        assert mock_async_memory.llm.generate_response.call_count == 2
+        assert any(m["memory"] == recovered_text for m in result)
+        assert any("Recovered" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_async_silently_drops_when_provider_does_not_support_tools(self, mock_async_memory, caplog):
+        mock_async_memory.llm.supports_tool_calls = False
+        mock_async_memory.llm.generate_response.return_value = HIJACK_PROSE
+
+        with caplog.at_level(logging.ERROR):
+            result = await mock_async_memory._add_to_vector_store(
+                messages=[{"role": "user", "content": "test"}], metadata={}, effective_filters={}, infer=True
+            )
+
+        assert mock_async_memory.llm.generate_response.call_count == 1
+        assert result == []
+        assert any("Error parsing extraction response (async)" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_async_truncated_json_does_not_trigger_tool_recovery(self, mock_async_memory):
+        # Async counterpart: truncated JSON (token budget) must not fire the
+        # forced-tool recovery.
+        mock_async_memory.llm.supports_tool_calls = True
+        mock_async_memory.llm.generate_response.return_value = '{"memory": [{"id": "0", "text": "User likes hik'
+
+        result = await mock_async_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "test"}], metadata={}, effective_filters={}, infer=True
+        )
+
+        assert mock_async_memory.llm.generate_response.call_count == 1
+        assert result == []
 
 
 def _build_memory_instance(mocker, memory_cls):
@@ -530,6 +714,7 @@ class TestMetadataNotMutated:
         memory = _build_memory_instance(mocker, Memory)
         metadata = {"user_id": "test_user", "tags": ["important", "urgent"], "config": {"key": "val"}}
         import copy
+
         metadata_snapshot = copy.deepcopy(metadata)
 
         memory._create_memory("test data", {"test data": [0.1, 0.2, 0.3]}, metadata=metadata)
@@ -660,7 +845,8 @@ def test_update_preserves_actor_id_when_different_actor_updates(mocker):
     )
 
     memory._update_memory(
-        "mem-id", "Player #1 is a good person",
+        "mem-id",
+        "Player #1 is a good person",
         {"Player #1 is a good person": [0.1, 0.2, 0.3]},
         metadata={"user_id": "team", "actor_id": "Bob"},
     )
@@ -683,7 +869,8 @@ async def test_async_update_preserves_actor_id_when_different_actor_updates(mock
     )
 
     await memory._update_memory(
-        "mem-id", "Player #1 is a good person",
+        "mem-id",
+        "Player #1 is a good person",
         {"Player #1 is a good person": [0.1, 0.2, 0.3]},
         metadata={"user_id": "team", "actor_id": "Bob"},
     )

--- a/tests/test_chatty_llm_parsing.py
+++ b/tests/test_chatty_llm_parsing.py
@@ -6,13 +6,20 @@ conversational text, markdown code blocks, or both.
 """
 
 import json
+from unittest.mock import MagicMock
 
 import pytest
 
-from mem0.memory.utils import extract_json, remove_code_blocks
-
+from mem0.memory.utils import (
+    extract_json,
+    llm_supports_tool_calls,
+    parse_tool_calls_for_memory,
+    recover_extraction_via_tools,
+    remove_code_blocks,
+)
 
 # --- Test extract_json ---
+
 
 class TestExtractJson:
     """Tests for extract_json utility."""
@@ -94,6 +101,7 @@ That's the result."""
 
 # --- Test remove_code_blocks ---
 
+
 class TestRemoveCodeBlocks:
     """Tests for remove_code_blocks — verify it does NOT handle chatty text."""
 
@@ -133,6 +141,7 @@ class TestRemoveCodeBlocks:
 
 
 # --- Test the full fallback chain (remove_code_blocks -> extract_json) ---
+
 
 class TestFallbackChain:
     """Tests the actual fallback pattern used in _add_to_vector_store:
@@ -230,3 +239,166 @@ I hope this helps!"""
         response = 'Sure! Here are the facts:\n{"facts": ["Name is Alex", "Loves basketball"]}\nHope that helps!'
         result = self._parse_with_fallback(response)
         assert result["facts"] == ["Name is Alex", "Loves basketball"]
+
+
+class TestToolCallRecovery:
+    """The forced-tool-call recovery used when no JSON could be parsed at all
+    (full content-hijack - the case extract_json structurally cannot fix)."""
+
+    def test_parse_tool_calls_extracts_memory_from_dict_arguments(self):
+        response = {
+            "content": None,
+            "tool_calls": [{"name": "save_memories", "arguments": {"memory": [{"text": "Likes hiking"}]}}],
+        }
+        assert parse_tool_calls_for_memory(response) == [{"text": "Likes hiking"}]
+
+    def test_parse_tool_calls_handles_stringified_arguments(self):
+        response = {"tool_calls": [{"name": "save_memories", "arguments": '{"memory": [{"text": "Has a cat"}]}'}]}
+        assert parse_tool_calls_for_memory(response) == [{"text": "Has a cat"}]
+
+    def test_parse_tool_calls_returns_none_when_no_tool_call_parses(self):
+        # A provider that ignored the tool and returned prose, or returned no
+        # usable tool call, yields None - "could not parse", distinct from a
+        # successfully parsed empty memory list.
+        assert parse_tool_calls_for_memory("just some prose") is None
+        assert parse_tool_calls_for_memory({"tool_calls": []}) is None
+
+    def test_parse_tool_calls_distinguishes_valid_empty_from_unparseable(self):
+        # {"memory": []} parsed cleanly is a real (empty) result, not a failure.
+        parsed_empty = {"tool_calls": [{"name": "save_memories", "arguments": {"memory": []}}]}
+        assert parse_tool_calls_for_memory(parsed_empty) == []
+        # Truncated stringified arguments cannot parse -> None.
+        truncated = {"tool_calls": [{"name": "save_memories", "arguments": '{"memory": [{"text": "cut of'}]}
+        assert parse_tool_calls_for_memory(truncated) is None
+
+    def test_parse_tool_calls_merges_parallel_tool_calls(self):
+        # The tool description invites one call per fact; a model answering a
+        # forced call with parallel invocations must not lose facts beyond the
+        # first call (and a leading empty call must not mask later facts).
+        response = {
+            "tool_calls": [
+                {"name": "save_memories", "arguments": {"memory": []}},
+                {"name": "save_memories", "arguments": {"memory": [{"text": "Likes hiking"}]}},
+                {"name": "save_memories", "arguments": {"memory": [{"text": "Has a cat"}]}},
+            ]
+        }
+        assert parse_tool_calls_for_memory(response) == [{"text": "Likes hiking"}, {"text": "Has a cat"}]
+
+    def test_parse_tool_calls_drops_non_dict_memory_items(self):
+        # A schema-violating model can emit bare strings in the memory array.
+        # Downstream reads m.get("text"), so non-dict items must be filtered
+        # out here rather than crash add() - the recovery path must never make
+        # things worse than the silent drop it replaces.
+        response = {
+            "tool_calls": [
+                {"name": "save_memories", "arguments": {"memory": ["bare string", {"text": "Has a cat"}, 42]}}
+            ]
+        }
+        assert parse_tool_calls_for_memory(response) == [{"text": "Has a cat"}]
+
+    def test_gate_requires_explicit_true(self):
+        # A MagicMock auto-populates attributes; the gate must not be tripped by one.
+        assert llm_supports_tool_calls(MagicMock()) is False
+        capable = MagicMock()
+        capable.supports_tool_calls = True
+        assert llm_supports_tool_calls(capable) is True
+
+    def test_recover_skips_uncapable_provider_without_calling_llm(self):
+        llm = MagicMock()
+        llm.supports_tool_calls = False
+        assert recover_extraction_via_tools(llm, "sys", "user") == []
+        llm.generate_response.assert_not_called()
+
+    def test_recover_forces_tool_choice_and_returns_memory(self):
+        llm = MagicMock()
+        llm.supports_tool_calls = True
+        llm.generate_response.return_value = {
+            "tool_calls": [{"name": "save_memories", "arguments": {"memory": [{"text": "Born in Pittsburgh"}]}}]
+        }
+        result = recover_extraction_via_tools(llm, "sys", "user")
+        assert result == [{"text": "Born in Pittsburgh"}]
+        call_kwargs = llm.generate_response.call_args.kwargs
+        assert call_kwargs["tool_choice"] == "required"
+        assert call_kwargs["tools"][0]["function"]["name"] == "save_memories"
+
+    def test_recover_is_graceful_when_llm_raises(self):
+        llm = MagicMock()
+        llm.supports_tool_calls = True
+        llm.generate_response.side_effect = RuntimeError("provider exploded")
+        assert recover_extraction_via_tools(llm, "sys", "user") == []
+
+    def test_recover_returns_empty_when_nothing_memorable_without_retrying(self):
+        # A forced tool call with an empty memory array round-trips to [] -
+        # the model is not compelled to invent a fact to satisfy the call. A
+        # valid empty list is NOT treated as truncation: no token-raise retry,
+        # exactly one LLM call.
+        llm = MagicMock()
+        llm.supports_tool_calls = True
+        llm.config.max_tokens = 2000
+        llm.generate_response.return_value = {"tool_calls": [{"name": "save_memories", "arguments": {"memory": []}}]}
+        assert recover_extraction_via_tools(llm, "sys", "user") == []
+        assert llm.generate_response.call_count == 1
+
+    def test_recover_is_graceful_when_tool_calls_malformed(self):
+        # A provider returning a non-dict tool_call must not raise - the
+        # "recovery never raises" guarantee.
+        llm = MagicMock()
+        llm.supports_tool_calls = True
+        llm.generate_response.return_value = {"tool_calls": ["not-a-dict", None]}
+        assert recover_extraction_via_tools(llm, "sys", "user") == []
+
+    def test_tool_call_truncation_retries_at_raised_tokens_staying_in_tool_mode(self):
+        # The forced tool call itself truncates (its arguments are a cut-off JSON
+        # string -> no memory parses). Recovery retries the tool call once at a
+        # raised max_tokens, still forcing the tool (not reverting to free text).
+        llm = MagicMock()
+        llm.supports_tool_calls = True
+        llm.config.max_tokens = 2000
+        llm.generate_response.side_effect = [
+            {"tool_calls": [{"name": "save_memories", "arguments": '{"memory": [{"text": "User likes hik'}]},
+            {"tool_calls": [{"name": "save_memories", "arguments": {"memory": [{"text": "User likes hiking"}]}}]},
+        ]
+        result = recover_extraction_via_tools(llm, "sys", "user")
+        assert result == [{"text": "User likes hiking"}]
+        assert llm.generate_response.call_count == 2
+        # the retry is still a forced tool call, at 4x the configured budget
+        retry_kwargs = llm.generate_response.call_args_list[1].kwargs
+        assert retry_kwargs["tool_choice"] == "required"
+        assert retry_kwargs["max_tokens"] == 8000
+
+    def test_no_token_raise_retry_when_max_tokens_unset(self):
+        # If max_tokens is unset there is nothing to raise; do not spuriously retry.
+        llm = MagicMock()
+        llm.supports_tool_calls = True
+        llm.config.max_tokens = None
+        llm.generate_response.return_value = {"tool_calls": [{"name": "save_memories", "arguments": "truncat"}]}
+        assert recover_extraction_via_tools(llm, "sys", "user") == []
+        assert llm.generate_response.call_count == 1
+
+    def test_token_raise_retry_is_capped(self):
+        # 4x a large configured budget would be very expensive; the retry is
+        # capped at an absolute ceiling (8192) instead.
+        llm = MagicMock()
+        llm.supports_tool_calls = True
+        llm.config.max_tokens = 4000  # 4x = 16000, above the cap
+        llm.generate_response.side_effect = [
+            {"tool_calls": [{"name": "save_memories", "arguments": '{"memory": [{"text": "cut of'}]},
+            {"tool_calls": [{"name": "save_memories", "arguments": {"memory": [{"text": "Recovered"}]}}]},
+        ]
+        result = recover_extraction_via_tools(llm, "sys", "user")
+        assert result == [{"text": "Recovered"}]
+        retry_kwargs = llm.generate_response.call_args_list[1].kwargs
+        assert retry_kwargs["max_tokens"] == 8192
+
+    def test_no_token_raise_retry_when_budget_already_at_cap(self):
+        # If the configured budget is already at/above the cap there is no
+        # meaningful raise to attempt; skip the retry rather than re-spend the
+        # same budget.
+        llm = MagicMock()
+        llm.supports_tool_calls = True
+        llm.config.max_tokens = 8192
+        llm.generate_response.return_value = {
+            "tool_calls": [{"name": "save_memories", "arguments": '{"memory": [{"text": "cut of'}]
+        }
+        assert recover_extraction_via_tools(llm, "sys", "user") == []
+        assert llm.generate_response.call_count == 1


### PR DESCRIPTION
## Linked Issue

Addresses #4054

(Framed as a complementary *recovery* option for the maintainers to weigh, not a replacement for the graceful-fail work already in flight on that issue. Happy to retarget as "Closes" if the team wants this as the resolution.)

## Description

When fact extraction runs against a cheaper or local model on instruction-dense / agentic transcripts, the model sometimes continues or role-plays the conversation instead of extracting facts, returning **prose with no JSON object at all**. The parser then raises `Expecting value: line 1 column 1 (char 0)`, the `except` block sets `extracted_memories = []`, and the facts are **silently dropped** (only an ERROR log). This is the failure in #4054.

The existing `extract_json` fallback cannot recover this case: with no `{` anywhere in the response, `text.find("{")` returns `-1` and `json.loads` raises at char 0. `extract_json` handles prose that *wraps* a JSON object; it cannot recover JSON that was never emitted.

This PR adds a **recovery** step on that parse failure: retry the same extraction with **forced structured output** (`tool_choice="required"`) on a `save_memories` schema. A model cannot answer a forced tool call with free prose, so the content-hijack that produced no JSON cannot recur in the same form. The recovery is gated to providers that support it and degrades gracefully to the current behavior (return `[]`) everywhere else.

Cost note: this adds **one extra LLM call, only on the parse-failure path** (never on the happy path) - occasionally two, in the rare case where the forced call's own structured output also truncates and the single bounded retry fires. That path was previously a guaranteed data loss, so the tradeoff is "one retry to recover otherwise-dropped facts." If you'd prefer it behind a config flag (default on or off), I'm happy to add one - flagged it here rather than presuming.

### What changed

- **`mem0/memory/main.py`** - in both the sync and async `_add_to_vector_store` parse-failure `except` blocks, call `recover_extraction_via_tools(...)` instead of giving up with `[]` - but only when the failed response contains no `{` at all (the content-hijack signature). Truncated JSON (a token-budget problem a forced tool call cannot fix) keeps the current behavior, so under-budgeted configs pay zero extra LLM calls. Behavior is unchanged on success and unchanged for providers that don't opt in.
- **`mem0/memory/utils.py`** - `recover_extraction_via_tools()` (the gated retry), `parse_tool_calls_for_memory()` (pull the `memory` arrays out of a tool-call response, merging across parallel tool calls, tolerating dict or JSON-string arguments, and dropping non-dict items a schema-violating model might emit; returns `None` when nothing parsed, distinct from a valid empty list), and `llm_supports_tool_calls()` (the capability gate). Recovery never raises - any failure returns `[]`. If the forced tool call's own structured output truncates (no tool call parsed at all - a successfully parsed empty `memory` list is a valid result and is never retried), it retries once at a raised `max_tokens`, capped at an absolute ceiling of 8192 tokens and **staying in tool mode** - reverting to free text would reintroduce the hijack the tool call exists to prevent.
- **`mem0/configs/prompts.py`** - `MEMORY_EXTRACTION_TOOL`, the forced-output schema in OpenAI function-calling format (the format mem0 providers already convert from internally), mirroring the `{"memory": [{"text", ...}]}` shape of `ADDITIVE_EXTRACTION_PROMPT`.
- **`mem0/llms/base.py`** - `supports_tool_calls = False` class attribute (the opt-in gate). This is deliberately separate from `AWSBedrockLLM.supports_tools` (which asks whether the Bedrock model family accepts tools at all); this flag asserts the stronger "honors a forced `tool_choice` and returns the standard `{"tool_calls": [...]}` dict." If you'd rather consolidate the two into one capability surface, I'm glad to - flagging the overlap rather than quietly adding a near-duplicate.
- **`mem0/llms/openai.py`** - opt in (`supports_tool_calls = True`); the provider already returns the `{"tool_calls": [...]}` dict.
- **`mem0/llms/anthropic.py`** - opt in, and fix the tools path so a forced call actually works. `_parse_response` on `main` already reads `tool_use` blocks into the `{"content", "tool_calls"}` shape, but the request side sent OpenAI-format tools straight through (Anthropic expects a flat `input_schema`) and mapped `tool_choice` as `{"type": tool_choice}`, so `"required"` became the invalid `{"type": "required"}` (Anthropic uses `{"type": "any"}`). This adds the OpenAI-to-Anthropic tool-schema conversion and the correct `tool_choice` mapping, and guards the no-tools `response.content[0].text` against an empty content list.
- **`mem0/llms/groq.py`** - opt in via a model-aware `supports_tool_calls` property. Groq is #4054's provider; its compound agentic models reject tool calling (the same family that rejects JSON `response_format`, per the existing `_supports_json_mode` gate), so they are excluded and every other Groq model is enabled. Verified against the live Groq API (see Provider scope).

### Provider scope

Recovery is enabled for **OpenAI, Anthropic, and Groq** - the providers whose forced-`tool_choice` behavior I could verify. OpenAI and Anthropic are exercised in the synthetic unit tests. Groq (#4054's provider) I verified against the live API: `llama-3.3-70b-versatile` and `openai/gpt-oss-20b` recover the dropped facts via a forced tool call, while `compound-beta` returns "tool calling is not supported" - so the Groq opt-in is a model-aware property that excludes the compound family (mirroring the existing JSON-mode gate) rather than a blanket class flag. Verified end-to-end through mem0's own `GroqLLM` -> `recover_extraction_via_tools`, not just the raw API.

Other providers (the rest of the OpenAI-compatible family, and Bedrock for the Anthropic/Cohere/Amazon families) appear to return a compatible `tool_calls` dict and could likely opt in the same way, but I haven't verified each one's forced-`tool_choice` behavior, so I left them off rather than claim coverage I don't have. Happy to extend per your direction. (Note: Bedrock already has its own `supports_tools` attribute, so wiring it in would mean reconciling the two - see above.)

This is orthogonal to #5178 (which surfaces the *API-exception* path). It is the content-hijack half of the same parse-failure path that the truncation case (#3918-adjacent) also lives in - see below.

### Companion PR and combined validation

This fix and a companion PR (#5429) for the other parse-failure mode were developed and validated together against a real conversation corpus, as one recovery loop that routes by failure type:
- **content-hijack / no JSON at all** (this PR): force a tool call so the model cannot answer with prose.
- **max_tokens truncation** (#5429): salvage the complete memories from the cut-off JSON, and, opt-in, retry at a raised `max_tokens`.

In a controlled before/after on a 57-transcript window, baseline runs (recovery off) left failures unrecovered; with recovery enabled, all 18 otherwise-dropped extractions were recovered, none left silently dropped. Run across the full 670-transcript corpus (about 5,400 extraction calls), the recovery path recovered all 109 otherwise-dropped extractions - each a set of facts the unpatched code discards with only an ERROR log - none left silently dropped. By recovery type: 81 via forced tool call (74 directly, plus 7 compound cases this PR now handles, where the forced tool call's own output truncated and was recovered by retrying at a raised budget rather than reverting to free text), and 28 truncations via token-raise.

The two were split into focused PRs for reviewability, but they compose in the same `except` block, so it may be worth looking at both together. (The corpus is private; only aggregate counts are shared. The tests in this PR are synthetic.)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

No internal callers are affected, and the tools-path return shape is unchanged (`main` already returns `{"content", "tool_calls"}` when `tools` are passed; this PR does not change that). The behavioral change is that a forced `tool_choice` request to Anthropic now succeeds: previously the OpenAI-format tools and the `{"type": "required"}` mapping were rejected by the Anthropic API, so no caller passing `tools` could get a tool call back. The only other change is a hardening on the no-tools path - an empty content list (e.g. a blocked response) now returns `""` instead of raising `IndexError`.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (described below)
- [ ] No tests needed (explain why)

Ran locally (Python 3.13; the 3.10-3.12 matrix runs in CI): the new and touched tests pass, with all four touched suites green, `ruff check` + `ruff format --check` clean on the touched files. The recovery test is falsifiable - reverting the `main.py` wiring makes it fail (memory dropped, one LLM call); with the fix it passes (recovered, two calls). So it catches the bug rather than illustrating it.

Manual / empirical validation: beyond the synthetic unit tests, the recovery approach was run against a real conversation corpus in a controlled before/after. Two baseline runs without recovery permanently lost a set of facts to this exact parse failure (dropped, never recovered); with forced structured-output recovery enabled, the 6 prose-instead-of-JSON cases in that 57-transcript window were recovered rather than lost (the full-corpus numbers are in the combined-validation section above). (Truncation-class drops, where the model emits incomplete JSON after hitting `max_tokens`, are a separate case tracked in #5428 and fixed in the companion PR #5429, out of scope here. The corpus is private; only aggregate counts are shared.)

New tests (all synthetic - no private data):

- `tests/memory/test_main.py::TestParseFailureRecovery` and `TestAsyncParseFailureRecovery` (sync + async) - drive a synthetic content-hijack response (prose, no JSON) through `_add_to_vector_store` and assert the dropped memory is **recovered** on a capable provider (two LLM calls: hijacked extraction, then forced-tool recovery) and **still silently dropped** when the provider does not opt in (the current behavior, asserted explicitly in both sync and async).
- `tests/test_chatty_llm_parsing.py::TestToolCallRecovery` - unit tests for `parse_tool_calls_for_memory` (dict and JSON-string arguments), the capability gate (`is True`, not tripped by a `MagicMock`), the skip-when-uncapable path, the forced `tool_choice`, an **empty `memory` array round-tripping to `[]`** (the model is not compelled to invent a fact), and graceful `[]` when the provider raises or returns a malformed `tool_calls` entry (the never-raises guarantee).
- `tests/llms/test_anthropic.py` - OpenAI-format → Anthropic `input_schema` conversion, already-Anthropic-format passthrough, missing-`parameters` default, `tool_choice` mapping (`required` → `{"type": "any"}`, `auto` → `{"type": "auto"}`), `tool_use` block parsing, the tool-requested-but-text-returned graceful case, that the no-tools path still returns text unchanged, and a **seam test** asserting `AnthropicLLM`'s tool-response shape is consumed correctly by `parse_tool_calls_for_memory`.
- `tests/llms/test_groq.py` - the model-aware `supports_tool_calls` gate opts in tool-capable Groq models (`llama-3.3-70b-versatile`, `openai/gpt-oss-20b`) and excludes the compound family (`groq/compound`, `compound-beta`, `groq/compound-mini`).

Synthetic repro (the case that is currently dropped):

```python
# Extraction returns prose with no JSON object -> currently silently dropped.
mock.llm.generate_response.return_value = (
    "PLAN: I'll help you organize that. Before I start, a few questions: "
    "1) What is the deadline? 2) Who is the audience? Let me know and we'll begin."
)
# Without this PR: add() returns [], no exception, ERROR-level log only.
# With this PR (capable provider): the facts are recovered via a forced tool call.
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (no public API change)



