### PR TITLE
feat: support HTTP self-hosting by making secure cookies conditional

### DIFF
--- a/server/dashboard/.env.example
+++ b/server/dashboard/.env.example
@@ -1,3 +1,6 @@
 NEXT_PUBLIC_API_URL=http://localhost:8888
 API_INTERNAL_URL=http://localhost:8888
 NEXT_PUBLIC_INSTANCE_NAME=Mem0
+
+# Set to false to allow running the dashboard over HTTP without SSL (e.g. self-hosting on local network)
+COOKIE_SECURE=true

--- a/server/dashboard/src/app/api/auth/refresh/route.ts
+++ b/server/dashboard/src/app/api/auth/refresh/route.ts
@@ -4,9 +4,15 @@ import { AUTH_ENDPOINTS } from "@/utils/api-endpoints";
 import { getServerApiUrl } from "@/lib/server-api-url";
 
 const COOKIE_NAME = "mem0_refresh_token";
+const isSecure = process.env.COOKIE_SECURE !== undefined
+  ? process.env.COOKIE_SECURE === "true"
+  : process.env.NEXTAUTH_URL
+    ? process.env.NEXTAUTH_URL.startsWith("https://")
+    : process.env.NODE_ENV === "production";
+
 const COOKIE_OPTIONS = {
   httpOnly: true,
-  secure: process.env.NODE_ENV === "production",
+  secure: isSecure,
   sameSite: "lax" as const,
   path: "/",
   maxAge: 30 * 24 * 60 * 60, // 30 days


### PR DESCRIPTION
### Summary
Currently, the Mem0 dashboard defaults to `secure: true` for the refresh token cookie when running in production mode. This causes an infinite redirect loop when self-hosting the dashboard on a local network IP over plain HTTP (e.g., `http://192.168.1.66:3010`), as modern browsers ignore `Secure` cookies over insecure connections.

Closes #5457

### Changes
- Added `isSecure` logic to `server/dashboard/src/app/api/auth/refresh/route.ts` that detects if `NEXTAUTH_URL` is using HTTPS.
- Added support for a `COOKIE_SECURE` environment variable to explicitly override the security policy.
- Documented `COOKIE_SECURE` in `server/dashboard/.env.example`.
- Default remains `true` for production HTTPS setups, ensuring no security regression for cloud users.

This fix is essential for users deploying Mem0 OSS in local environments without SSL certificates.
