### PR TITLE
fix: restore xai tool calling config

### DIFF
--- a/mem0/configs/llms/xai.py
+++ b/mem0/configs/llms/xai.py
@@ -1,0 +1,54 @@
+from typing import Optional
+
+from mem0.configs.llms.base import BaseLlmConfig
+
+
+class XAIConfig(BaseLlmConfig):
+    """
+    Configuration class for xAI-specific parameters.
+    Inherits from BaseLlmConfig and adds xAI-specific settings.
+    """
+
+    def __init__(
+        self,
+        # Base parameters
+        model: Optional[str] = None,
+        temperature: float = 0.1,
+        api_key: Optional[str] = None,
+        max_tokens: int = 2000,
+        top_p: float = 0.1,
+        top_k: int = 1,
+        enable_vision: bool = False,
+        vision_details: Optional[str] = "auto",
+        http_client_proxies: Optional[dict] = None,
+        # xAI-specific parameters
+        xai_base_url: Optional[str] = None,
+    ):
+        """
+        Initialize xAI configuration.
+
+        Args:
+            model: xAI model to use, defaults to None
+            temperature: Controls randomness, defaults to 0.1
+            api_key: xAI API key, defaults to None
+            max_tokens: Maximum tokens to generate, defaults to 2000
+            top_p: Nucleus sampling parameter, defaults to 0.1
+            top_k: Top-k sampling parameter, defaults to 1
+            enable_vision: Enable vision capabilities, defaults to False
+            vision_details: Vision detail level, defaults to "auto"
+            http_client_proxies: HTTP client proxy settings, defaults to None
+            xai_base_url: xAI API base URL, defaults to None
+        """
+        super().__init__(
+            model=model,
+            temperature=temperature,
+            api_key=api_key,
+            max_tokens=max_tokens,
+            top_p=top_p,
+            top_k=top_k,
+            enable_vision=enable_vision,
+            vision_details=vision_details,
+            http_client_proxies=http_client_proxies,
+        )
+
+        self.xai_base_url = xai_base_url

--- a/mem0/llms/xai.py
+++ b/mem0/llms/xai.py
@@ -1,14 +1,34 @@
+import json
 import os
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 from openai import OpenAI
 
 from mem0.configs.llms.base import BaseLlmConfig
+from mem0.configs.llms.xai import XAIConfig
 from mem0.llms.base import LLMBase
+from mem0.memory.utils import extract_json
 
 
 class XAILLM(LLMBase):
-    def __init__(self, config: Optional[BaseLlmConfig] = None):
+    def __init__(self, config: Optional[Union[BaseLlmConfig, XAIConfig, Dict]] = None):
+        if config is None:
+            config = XAIConfig()
+        elif isinstance(config, dict):
+            config = XAIConfig(**config)
+        elif isinstance(config, BaseLlmConfig) and not isinstance(config, XAIConfig):
+            config = XAIConfig(
+                model=config.model,
+                temperature=config.temperature,
+                api_key=config.api_key,
+                max_tokens=config.max_tokens,
+                top_p=config.top_p,
+                top_k=config.top_k,
+                enable_vision=config.enable_vision,
+                vision_details=config.vision_details,
+                http_client_proxies=config.http_client,
+            )
+
         super().__init__(config)
 
         if not self.config.model:
@@ -17,6 +37,37 @@ class XAILLM(LLMBase):
         api_key = self.config.api_key or os.getenv("XAI_API_KEY")
         base_url = self.config.xai_base_url or os.getenv("XAI_API_BASE") or "https://api.x.ai/v1"
         self.client = OpenAI(api_key=api_key, base_url=base_url)
+
+    def _parse_response(self, response, tools):
+        """
+        Process the response based on whether tools are used or not.
+
+        Args:
+            response: The raw response from API.
+            tools: The list of tools provided in the request.
+
+        Returns:
+            str or dict: The processed response.
+        """
+        message = response.choices[0].message
+        if tools:
+            processed_response = {
+                "content": message.content,
+                "tool_calls": [],
+            }
+
+            if message.tool_calls:
+                for tool_call in message.tool_calls:
+                    processed_response["tool_calls"].append(
+                        {
+                            "name": tool_call.function.name,
+                            "arguments": json.loads(extract_json(tool_call.function.arguments)),
+                        }
+                    )
+
+            return processed_response
+        else:
+            return message.content
 
     def generate_response(
         self,
@@ -47,6 +98,9 @@ class XAILLM(LLMBase):
 
         if response_format:
             params["response_format"] = response_format
+        if tools:
+            params["tools"] = tools
+            params["tool_choice"] = tool_choice
 
         response = self.client.chat.completions.create(**params)
-        return response.choices[0].message.content
+        return self._parse_response(response, tools)

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -12,6 +12,7 @@ from mem0.configs.llms.lmstudio import LMStudioConfig
 from mem0.configs.llms.ollama import OllamaConfig
 from mem0.configs.llms.openai import OpenAIConfig
 from mem0.configs.llms.vllm import VllmConfig
+from mem0.configs.llms.xai import XAIConfig
 from mem0.configs.rerankers.base import BaseRerankerConfig
 from mem0.configs.rerankers.cohere import CohereRerankerConfig
 from mem0.configs.rerankers.sentence_transformer import SentenceTransformerRerankerConfig
@@ -48,7 +49,7 @@ class LlmFactory:
         "gemini": ("mem0.llms.gemini.GeminiLLM", BaseLlmConfig),
         "deepseek": ("mem0.llms.deepseek.DeepSeekLLM", DeepSeekConfig),
         "minimax": ("mem0.llms.minimax.MiniMaxLLM", MinimaxConfig),
-        "xai": ("mem0.llms.xai.XAILLM", BaseLlmConfig),
+        "xai": ("mem0.llms.xai.XAILLM", XAIConfig),
         "sarvam": ("mem0.llms.sarvam.SarvamLLM", BaseLlmConfig),
         "lmstudio": ("mem0.llms.lmstudio.LMStudioLLM", LMStudioConfig),
         "vllm": ("mem0.llms.vllm.VllmLLM", VllmConfig),
@@ -209,7 +210,6 @@ class VectorStoreFactory:
         return instance
 
 
-
 class RerankerFactory:
     """
     Factory for creating reranker instances with appropriate configurations.
@@ -219,7 +219,10 @@ class RerankerFactory:
     # Provider mappings with their config classes
     provider_to_class = {
         "cohere": ("mem0.reranker.cohere_reranker.CohereReranker", CohereRerankerConfig),
-        "sentence_transformer": ("mem0.reranker.sentence_transformer_reranker.SentenceTransformerReranker", SentenceTransformerRerankerConfig),
+        "sentence_transformer": (
+            "mem0.reranker.sentence_transformer_reranker.SentenceTransformerReranker",
+            SentenceTransformerRerankerConfig,
+        ),
         "zero_entropy": ("mem0.reranker.zero_entropy_reranker.ZeroEntropyReranker", ZeroEntropyRerankerConfig),
         "llm_reranker": ("mem0.reranker.llm_reranker.LLMReranker", LLMRerankerConfig),
         "huggingface": ("mem0.reranker.huggingface_reranker.HuggingFaceReranker", HuggingFaceRerankerConfig),

--- a/tests/llms/test_xai.py
+++ b/tests/llms/test_xai.py
@@ -1,0 +1,164 @@
+import os
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mem0.configs.llms.base import BaseLlmConfig
+from mem0.configs.llms.xai import XAIConfig
+from mem0.llms.xai import XAILLM
+from mem0.utils.factory import LlmFactory
+
+
+@pytest.fixture
+def mock_xai_client():
+    with patch("mem0.llms.xai.OpenAI") as mock_openai:
+        mock_client = Mock()
+        mock_openai.return_value = mock_client
+        yield mock_client
+
+
+def test_xai_llm_default_base_url():
+    config = BaseLlmConfig(model="grok-2-latest", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key")
+    with patch("mem0.llms.xai.OpenAI") as mock_openai:
+        XAILLM(config)
+
+    mock_openai.assert_called_once_with(api_key="api_key", base_url="https://api.x.ai/v1")
+
+
+def test_xai_llm_env_base_url():
+    provider_base_url = "https://api.provider.com/v1/"
+    os.environ["XAI_API_BASE"] = provider_base_url
+    try:
+        config = XAIConfig(model="grok-2-latest", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key")
+        with patch("mem0.llms.xai.OpenAI") as mock_openai:
+            XAILLM(config)
+
+        mock_openai.assert_called_once_with(api_key="api_key", base_url=provider_base_url)
+    finally:
+        os.environ.pop("XAI_API_BASE", None)
+
+
+def test_xai_llm_config_base_url():
+    config_base_url = "https://api.config.com/v1/"
+    config = XAIConfig(
+        model="grok-2-latest",
+        temperature=0.7,
+        max_tokens=100,
+        top_p=1.0,
+        api_key="api_key",
+        xai_base_url=config_base_url,
+    )
+    with patch("mem0.llms.xai.OpenAI") as mock_openai:
+        XAILLM(config)
+
+    mock_openai.assert_called_once_with(api_key="api_key", base_url=config_base_url)
+
+
+def test_factory_creates_xai_llm(mock_xai_client):
+    llm = LlmFactory.create("xai", {"model": "grok-2-latest", "api_key": "test-key"})
+    assert isinstance(llm, XAILLM)
+    assert llm.config.model == "grok-2-latest"
+
+
+def test_factory_accepts_xai_base_url(mock_xai_client):
+    llm = LlmFactory.create(
+        "xai",
+        {"model": "grok-2-latest", "api_key": "test-key", "xai_base_url": "https://custom.x.ai/v1"},
+    )
+
+    assert llm.config.xai_base_url == "https://custom.x.ai/v1"
+    mock_xai_client.chat.completions.create.assert_not_called()
+
+
+def test_generate_response_without_tools(mock_xai_client):
+    config = BaseLlmConfig(model="grok-2-latest", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key")
+    llm = XAILLM(config)
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello, how are you?"},
+    ]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="I'm doing well, thank you for asking!"))]
+    mock_xai_client.chat.completions.create.return_value = mock_response
+
+    response = llm.generate_response(messages)
+
+    mock_xai_client.chat.completions.create.assert_called_once_with(
+        model="grok-2-latest", messages=messages, temperature=0.7, max_tokens=100, top_p=1.0
+    )
+    assert response == "I'm doing well, thank you for asking!"
+
+
+def test_generate_response_with_tools(mock_xai_client):
+    config = BaseLlmConfig(model="grok-2-latest", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key")
+    llm = XAILLM(config)
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Add a new memory: Today is a sunny day."},
+    ]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "add_memory",
+                "description": "Add a memory",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"data": {"type": "string", "description": "Data to add to memory"}},
+                    "required": ["data"],
+                },
+            },
+        }
+    ]
+
+    mock_response = Mock()
+    mock_message = Mock()
+    mock_message.content = None
+
+    mock_tool_call = Mock()
+    mock_tool_call.function.name = "add_memory"
+    mock_tool_call.function.arguments = '{"data": "Today is a sunny day."}'
+
+    mock_message.tool_calls = [mock_tool_call]
+    mock_response.choices = [Mock(message=mock_message)]
+    mock_xai_client.chat.completions.create.return_value = mock_response
+
+    response = llm.generate_response(messages, tools=tools)
+
+    mock_xai_client.chat.completions.create.assert_called_once_with(
+        model="grok-2-latest",
+        messages=messages,
+        temperature=0.7,
+        max_tokens=100,
+        top_p=1.0,
+        tools=tools,
+        tool_choice="auto",
+    )
+
+    assert response["content"] is None
+    assert len(response["tool_calls"]) == 1
+    assert response["tool_calls"][0]["name"] == "add_memory"
+    assert response["tool_calls"][0]["arguments"] == {"data": "Today is a sunny day."}
+
+
+def test_generate_response_with_response_format(mock_xai_client):
+    config = BaseLlmConfig(model="grok-2-latest", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key")
+    llm = XAILLM(config)
+    messages = [{"role": "user", "content": "Return JSON."}]
+    response_format = {"type": "json_object"}
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content='{"key": "value"}'))]
+    mock_xai_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages, response_format=response_format)
+
+    mock_xai_client.chat.completions.create.assert_called_once_with(
+        model="grok-2-latest",
+        messages=messages,
+        temperature=0.7,
+        max_tokens=100,
+        top_p=1.0,
+        response_format={"type": "json_object"},
+    )


### PR DESCRIPTION
Fixes #5189.

## Summary
- add an xAI-specific LLM config so `xai_base_url` can be passed through `LlmFactory.create("xai", ...)` and BaseLlmConfig construction no longer raises `AttributeError`
- normalize dict/BaseLlmConfig inputs in `XAILLM`, matching the DeepSeek/MiniMax provider pattern
- forward `tools` and `tool_choice` to the OpenAI-compatible xAI client and parse returned tool calls into the same `{content, tool_calls}` shape used by OpenAI/DeepSeek
- add focused xAI provider tests for base URL selection, factory construction, response_format, plain text responses, and tool-call parsing

## Validation
- `.venv/bin/python -m pytest tests/llms/test_xai.py -q`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy .venv/bin/python -m pytest tests/llms/test_xai.py tests/llms/test_deepseek.py tests/llms/test_minimax.py -q`
- `.venv/bin/ruff format --check mem0/llms/xai.py mem0/configs/llms/xai.py mem0/utils/factory.py tests/llms/test_xai.py`
- `.venv/bin/ruff check mem0/llms/xai.py mem0/configs/llms/xai.py mem0/utils/factory.py tests/llms/test_xai.py`
- `git diff --check`

AI assistance disclosure: I prepared this PR with help from OpenAI Codex and reviewed/validated the resulting patch locally.