### PR TITLE
fix(memory): salvage truncated extractions + opt-in token-raise retry

### DIFF
--- a/docs/open-source/configuration.mdx
+++ b/docs/open-source/configuration.mdx
@@ -145,6 +145,18 @@ memory = Memory.from_config_file("config.yaml")
   <Accordion title="Reranker depth">
     Limit `top_k` to 10–20 results; sending more adds latency without meaningful gains.
   </Accordion>
+  <Accordion title="Truncated extraction recovery">
+    When the extraction LLM hits its `max_tokens` mid-output, the complete facts it finished writing are always salvaged from the partial response. To also recover the cut-off remainder, set the top-level `recover_truncated_extractions: True` (default `False`):
+
+    ```python
+    config = {
+        "llm": {"provider": "openai", "config": {"model": "gpt-4.1-mini", "max_tokens": 2000}},
+        "recover_truncated_extractions": True,
+    }
+    ```
+
+    On a truncated response this retries extraction once at a raised `max_tokens` (4x, capped at an absolute ceiling of 8192). The retry is skipped when the configured `max_tokens` is already at or above the cap, and it spends the extra tokens only on the truncation path, never on a normal extraction.
+  </Accordion>
 </AccordionGroup>
 
 <Warning>

--- a/mem0/configs/base.py
+++ b/mem0/configs/base.py
@@ -55,6 +55,17 @@ class MemoryConfig(BaseModel):
         description="Custom instructions for fact extraction",
         default=None,
     )
+    recover_truncated_extractions: bool = Field(
+        description=(
+            "When True, if an extraction response is truncated (the model hit "
+            "max_tokens mid-JSON), retry once at a raised max_tokens (4x) to "
+            "recover the cut-off memories. Complete memories are always salvaged "
+            "from a truncated response regardless of this flag; enabling it only "
+            "adds the extra retry call (which costs more tokens and overrides the "
+            "configured max_tokens for that one call)."
+        ),
+        default=False,
+    )
 
 
 class AzureConfig(BaseModel):

--- a/mem0/configs/base.py
+++ b/mem0/configs/base.py
@@ -58,8 +58,10 @@ class MemoryConfig(BaseModel):
     recover_truncated_extractions: bool = Field(
         description=(
             "When True, if an extraction response is truncated (the model hit "
-            "max_tokens mid-JSON), retry once at a raised max_tokens (4x) to "
-            "recover the cut-off memories. Complete memories are always salvaged "
+            "max_tokens mid-JSON), retry once at a raised max_tokens (4x, capped "
+            "at an absolute ceiling of 8192 tokens) to recover the cut-off "
+            "memories. The retry is skipped when the configured max_tokens is "
+            "already at or above the cap. Complete memories are always salvaged "
             "from a truncated response regardless of this flag; enabling it only "
             "adds the extra retry call (which costs more tokens and overrides the "
             "configured max_tokens for that one call)."

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -2570,6 +2570,9 @@ class AsyncMemory(MemoryBase):
                 logger.info("Salvaged %d complete memory item(s) from a malformed extraction response (async)", len(extracted_memories))
             # Layer 2 (opt-in): retry once with a raised max_tokens on truncation.
             if truncated and getattr(self.config, "recover_truncated_extractions", False) is True:
+                # Runs the sync retry on a worker thread. retry_extraction_with_more_tokens
+                # raises and restores llm.config.max_tokens under a lock, so concurrent
+                # retries sharing this llm cannot corrupt the shared config.
                 retried = await asyncio.to_thread(
                     retry_extraction_with_more_tokens, self.llm, system_prompt, user_prompt
                 )

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -94,34 +94,38 @@ def _vector_store_list_rows(listed):
 # Fields that hold runtime auth/connection objects and must be preserved.
 # These are non-serializable objects (e.g. AWSV4SignerAuth, RequestsHttpConnection)
 # needed by clients like OpenSearch — not sensitive strings to redact.
-_RUNTIME_FIELDS = frozenset({
-    "http_auth",
-    "auth",
-    "connection_class",
-    "ssl_context",
-})
+_RUNTIME_FIELDS = frozenset(
+    {
+        "http_auth",
+        "auth",
+        "connection_class",
+        "ssl_context",
+    }
+)
 
 # Fields that are known to contain sensitive secrets and must be redacted.
-_SENSITIVE_FIELDS_EXACT = frozenset({
-    "api_key",
-    "secret_key",
-    "private_key",
-    "access_key",
-    "password",
-    "credentials",
-    "credential",
-    "secret",
-    "token",
-    "access_token",
-    "refresh_token",
-    "auth_token",
-    "session_token",
-    "client_secret",
-    "auth_client_secret",
-    "azure_client_secret",
-    "service_account_json",
-    "aws_session_token",
-})
+_SENSITIVE_FIELDS_EXACT = frozenset(
+    {
+        "api_key",
+        "secret_key",
+        "private_key",
+        "access_key",
+        "password",
+        "credentials",
+        "credential",
+        "secret",
+        "token",
+        "access_token",
+        "refresh_token",
+        "auth_token",
+        "session_token",
+        "client_secret",
+        "auth_client_secret",
+        "azure_client_secret",
+        "service_account_json",
+        "aws_session_token",
+    }
+)
 
 # Suffixes that indicate a field likely holds a secret value.
 _SENSITIVE_SUFFIXES = (
@@ -167,13 +171,9 @@ def _validate_and_trim_entity_id(value: Optional[str], name: str) -> Optional[st
         return None
     trimmed = value.strip()
     if trimmed == "":
-        raise ValueError(
-            f"Invalid {name}: cannot be empty or whitespace-only. Provide a valid identifier."
-        )
+        raise ValueError(f"Invalid {name}: cannot be empty or whitespace-only. Provide a valid identifier.")
     if any(c.isspace() for c in trimmed):
-        raise ValueError(
-            f"Invalid {name}: cannot contain whitespace. Provide a valid identifier without spaces."
-        )
+        raise ValueError(f"Invalid {name}: cannot contain whitespace. Provide a valid identifier without spaces.")
     return trimmed
 
 
@@ -192,16 +192,12 @@ def _validate_search_params(threshold: Optional[float] = None, top_k: Optional[i
         if not isinstance(threshold, (int, float)):
             raise ValueError("threshold must be a valid number")
         if threshold < 0 or threshold > 1:
-            raise ValueError(
-                f"Invalid threshold: {threshold}. Must be between 0 and 1 (inclusive)."
-            )
+            raise ValueError(f"Invalid threshold: {threshold}. Must be between 0 and 1 (inclusive).")
     if top_k is not None:
         if not isinstance(top_k, int) or isinstance(top_k, bool):
             raise ValueError("top_k must be a valid integer")
         if top_k < 0:
-            raise ValueError(
-                f"Invalid top_k: {top_k}. Must be a non-negative integer."
-            )
+            raise ValueError(f"Invalid top_k: {top_k}. Must be a non-negative integer.")
 
 
 def _validate_and_trim_search_query(query: str) -> str:
@@ -354,7 +350,7 @@ def _build_filters_and_metadata(
             message="At least one of 'user_id', 'agent_id', or 'run_id' must be provided.",
             error_code="VALIDATION_001",
             details={"provided_ids": {"user_id": user_id, "agent_id": agent_id, "run_id": run_id}},
-            suggestion="Please provide at least one identifier to scope the memory operation."
+            suggestion="Please provide at least one identifier to scope the memory operation.",
         )
 
     # ---------- optional actor filter ----------
@@ -463,10 +459,7 @@ class Memory(MemoryBase):
         # Initialize reranker if configured
         self.reranker = None
         if config.reranker:
-            self.reranker = RerankerFactory.create(
-                config.reranker.provider,
-                config.reranker.config
-            )
+            self.reranker = RerankerFactory.create(config.reranker.provider, config.reranker.config)
 
         # Entity store is initialized lazily on first use
         self._entity_store = None
@@ -474,24 +467,24 @@ class Memory(MemoryBase):
         if MEM0_TELEMETRY:
             # Create telemetry config manually to avoid deepcopy issues with thread locks
             telemetry_config_dict = {}
-            if hasattr(self.config.vector_store.config, 'model_dump'):
+            if hasattr(self.config.vector_store.config, "model_dump"):
                 # For pydantic models
                 telemetry_config_dict = self.config.vector_store.config.model_dump()
             else:
                 # For other objects, manually copy common attributes
-                for attr in ['host', 'port', 'path', 'api_key', 'index_name', 'dimension', 'metric']:
+                for attr in ["host", "port", "path", "api_key", "index_name", "dimension", "metric"]:
                     if hasattr(self.config.vector_store.config, attr):
                         telemetry_config_dict[attr] = getattr(self.config.vector_store.config, attr)
 
             # Override collection name for telemetry
-            telemetry_config_dict['collection_name'] = "mem0migrations"
+            telemetry_config_dict["collection_name"] = "mem0migrations"
 
             # Set path for file-based vector stores
             telemetry_config = _safe_deepcopy_config(self.config.vector_store.config)
             if self.config.vector_store.provider in ["faiss", "qdrant"]:
                 provider_path = f"migrations_{self.config.vector_store.provider}"
-                telemetry_config_dict['path'] = os.path.join(mem0_dir, provider_path)
-                os.makedirs(telemetry_config_dict['path'], exist_ok=True)
+                telemetry_config_dict["path"] = os.path.join(mem0_dir, provider_path)
+                os.makedirs(telemetry_config_dict["path"], exist_ok=True)
 
             # Create the config object using the same class as the original
             telemetry_config = self.config.vector_store.config.__class__(**telemetry_config_dict)
@@ -520,10 +513,10 @@ class Memory(MemoryBase):
             entity_config = _safe_deepcopy_config(self.config.vector_store.config)
             entity_collection = _entity_collection_name(self.config.vector_store.provider, self.collection_name)
             # Set collection name on the cloned config
-            if hasattr(entity_config, 'collection_name'):
+            if hasattr(entity_config, "collection_name"):
                 entity_config.collection_name = entity_collection
             elif isinstance(entity_config, dict):
-                entity_config['collection_name'] = entity_collection
+                entity_config["collection_name"] = entity_collection
             # For Qdrant, share the existing client to avoid RocksDB lock contention
             # when using embedded mode (path=...). QdrantConfig.client takes precedence
             # over host/port/path.
@@ -532,9 +525,7 @@ class Memory(MemoryBase):
                     entity_config.client = self.vector_store.client
                 elif isinstance(entity_config, dict):
                     entity_config["client"] = self.vector_store.client
-            self._entity_store = VectorStoreFactory.create(
-                self.config.vector_store.provider, entity_config
-            )
+            self._entity_store = VectorStoreFactory.create(self.config.vector_store.provider, entity_config)
         return self._entity_store
 
     @staticmethod
@@ -786,7 +777,7 @@ class Memory(MemoryBase):
                 message=f"Invalid 'memory_type'. Please pass {MemoryType.PROCEDURAL.value} to create procedural memories.",
                 error_code="VALIDATION_002",
                 details={"provided_type": memory_type, "valid_type": MemoryType.PROCEDURAL.value},
-                suggestion=f"Use '{MemoryType.PROCEDURAL.value}' to create procedural memories."
+                suggestion=f"Use '{MemoryType.PROCEDURAL.value}' to create procedural memories.",
             )
 
         if isinstance(messages, str):
@@ -800,7 +791,7 @@ class Memory(MemoryBase):
                 message="messages must be str, dict, or list[dict]",
                 error_code="VALIDATION_003",
                 details={"provided_type": type(messages).__name__, "valid_types": ["str", "dict", "list[dict]"]},
-                suggestion="Convert your input to a string, dictionary, or list of dictionaries."
+                suggestion="Convert your input to a string, dictionary, or list of dictionaries.",
             )
 
         if agent_id is not None and memory_type == MemoryType.PROCEDURAL.value:
@@ -934,7 +925,9 @@ class Memory(MemoryBase):
             # truncated/malformed response instead of dropping them all.
             extracted_memories, truncated = salvage_memory_objects(response)
             if extracted_memories:
-                logger.info("Salvaged %d complete memory item(s) from a malformed extraction response", len(extracted_memories))
+                logger.info(
+                    "Salvaged %d complete memory item(s) from a malformed extraction response", len(extracted_memories)
+                )
             # Layer 2 (opt-in): if the response was truncated, retry once with a
             # raised max_tokens to recover the cut-off remainder.
             if truncated and getattr(self.config, "recover_truncated_extractions", False) is True:
@@ -1128,12 +1121,14 @@ class Memory(MemoryBase):
                             # New entity — collect for batch insert
                             to_insert_vectors.append(valid_vectors[j])
                             to_insert_ids.append(str(uuid.uuid4()))
-                            to_insert_payloads.append({
-                                "data": entity_text,
-                                "entity_type": entity_type,
-                                "linked_memory_ids": sorted(memory_ids),
-                                **search_filters,
-                            })
+                            to_insert_payloads.append(
+                                {
+                                    "data": entity_text,
+                                    "entity_type": entity_type,
+                                    "linked_memory_ids": sorted(memory_ids),
+                                    **search_filters,
+                                }
+                            )
 
                     # 7e: Single batch insert for all new entities
                     if to_insert_vectors:
@@ -1151,10 +1146,7 @@ class Memory(MemoryBase):
         # Phase 8: Save messages + return
         self.db.save_messages(messages, session_scope)
 
-        returned_memories = [
-            {"id": r[0], "memory": r[1], "event": "ADD"}
-            for r in records
-        ]
+        returned_memories = [{"id": r[0], "memory": r[1], "event": "ADD"} for r in records]
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event(
@@ -1190,7 +1182,16 @@ class Memory(MemoryBase):
             "expiration_date",
         ]
 
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
+        core_and_promoted_keys = {
+            "data",
+            "hash",
+            "created_at",
+            "updated_at",
+            "id",
+            "text_lemmatized",
+            "attributed_to",
+            *promoted_payload_keys,
+        }
 
         result_item = MemoryItem(
             id=memory.id,
@@ -1246,23 +1247,16 @@ class Memory(MemoryBase):
         # Validate and trim entity IDs in filters
         effective_filters = dict(filters) if filters else {}
         if "user_id" in effective_filters:
-            effective_filters["user_id"] = _validate_and_trim_entity_id(
-                effective_filters["user_id"], "user_id"
-            )
+            effective_filters["user_id"] = _validate_and_trim_entity_id(effective_filters["user_id"], "user_id")
         if "agent_id" in effective_filters:
-            effective_filters["agent_id"] = _validate_and_trim_entity_id(
-                effective_filters["agent_id"], "agent_id"
-            )
+            effective_filters["agent_id"] = _validate_and_trim_entity_id(effective_filters["agent_id"], "agent_id")
         if "run_id" in effective_filters:
-            effective_filters["run_id"] = _validate_and_trim_entity_id(
-                effective_filters["run_id"], "run_id"
-            )
+            effective_filters["run_id"] = _validate_and_trim_entity_id(effective_filters["run_id"], "run_id")
 
         # Validate filters contains at least one entity ID
         if not any(key in effective_filters for key in ("user_id", "agent_id", "run_id")):
             raise ValueError(
-                "filters must contain at least one of: user_id, agent_id, run_id. "
-                "Example: filters={'user_id': 'u1'}"
+                "filters must contain at least one of: user_id, agent_id, run_id. Example: filters={'user_id': 'u1'}"
             )
 
         limit = top_k
@@ -1307,7 +1301,16 @@ class Memory(MemoryBase):
             "attributed_to",
             "expiration_date",
         ]
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
+        core_and_promoted_keys = {
+            "data",
+            "hash",
+            "created_at",
+            "updated_at",
+            "id",
+            "text_lemmatized",
+            "attributed_to",
+            *promoted_payload_keys,
+        }
 
         formatted_memories = []
         for mem in actual_memories:
@@ -1402,21 +1405,14 @@ class Memory(MemoryBase):
         # Validate and trim entity IDs in filters
         effective_filters = filters.copy() if filters else {}
         if "user_id" in effective_filters:
-            effective_filters["user_id"] = _validate_and_trim_entity_id(
-                effective_filters["user_id"], "user_id"
-            )
+            effective_filters["user_id"] = _validate_and_trim_entity_id(effective_filters["user_id"], "user_id")
         if "agent_id" in effective_filters:
-            effective_filters["agent_id"] = _validate_and_trim_entity_id(
-                effective_filters["agent_id"], "agent_id"
-            )
+            effective_filters["agent_id"] = _validate_and_trim_entity_id(effective_filters["agent_id"], "agent_id")
         if "run_id" in effective_filters:
-            effective_filters["run_id"] = _validate_and_trim_entity_id(
-                effective_filters["run_id"], "run_id"
-            )
+            effective_filters["run_id"] = _validate_and_trim_entity_id(effective_filters["run_id"], "run_id")
         if not any(key in effective_filters for key in ("user_id", "agent_id", "run_id")):
             raise ValueError(
-                "filters must contain at least one of: user_id, agent_id, run_id. "
-                "Example: filters={'user_id': 'u1'}"
+                "filters must contain at least one of: user_id, agent_id, run_id. Example: filters={'user_id': 'u1'}"
             )
 
         limit = top_k
@@ -1429,7 +1425,9 @@ class Memory(MemoryBase):
             for logical_key in ("AND", "OR", "NOT"):
                 effective_filters.pop(logical_key, None)
             for fk in list(effective_filters.keys()):
-                if fk not in ("AND", "OR", "NOT", "user_id", "agent_id", "run_id") and isinstance(effective_filters.get(fk), dict):
+                if fk not in ("AND", "OR", "NOT", "user_id", "agent_id", "run_id") and isinstance(
+                    effective_filters.get(fk), dict
+                ):
                     effective_filters.pop(fk, None)
             effective_filters.update(processed_filters)
 
@@ -1504,9 +1502,16 @@ class Memory(MemoryBase):
             for operator, value in condition.items():
                 # Map platform operators to universal format that can be translated by each vector store
                 operator_map = {
-                    "eq": "eq", "ne": "ne", "gt": "gt", "gte": "gte",
-                    "lt": "lt", "lte": "lte", "in": "in", "nin": "nin",
-                    "contains": "contains", "icontains": "icontains"
+                    "eq": "eq",
+                    "ne": "ne",
+                    "gt": "gt",
+                    "gte": "gte",
+                    "lt": "lt",
+                    "lte": "lte",
+                    "in": "in",
+                    "nin": "nin",
+                    "contains": "contains",
+                    "icontains": "icontains",
                 }
 
                 if operator in operator_map:
@@ -1560,16 +1565,16 @@ class Memory(MemoryBase):
     def _has_advanced_operators(self, filters: Dict[str, Any]) -> bool:
         """
         Check if filters contain advanced operators that need special processing.
-        
+
         Args:
             filters: Dictionary of filters to check
-            
+
         Returns:
             bool: True if advanced operators are detected
         """
         if not isinstance(filters, dict):
             return False
-            
+
         for key, value in filters.items():
             # Check for platform-style logical operators
             if key in ["AND", "OR", "NOT"]:
@@ -1612,8 +1617,8 @@ class Memory(MemoryBase):
         if keyword_results is not None:
             midpoint, steepness = get_bm25_params(query, lemmatized=query_lemmatized)
             for mem in keyword_results:
-                mem_id = str(mem.id) if hasattr(mem, 'id') else str(mem.get('id', ''))
-                raw_score = mem.score if hasattr(mem, 'score') else mem.get('score', 0)
+                mem_id = str(mem.id) if hasattr(mem, "id") else str(mem.get("id", ""))
+                raw_score = mem.score if hasattr(mem, "score") else mem.get("score", 0)
                 if raw_score and raw_score > 0:
                     bm25_scores[mem_id] = normalize_bm25(raw_score, midpoint, steepness)
 
@@ -1655,7 +1660,16 @@ class Memory(MemoryBase):
             "attributed_to",
             "expiration_date",
         ]
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
+        core_and_promoted_keys = {
+            "data",
+            "hash",
+            "created_at",
+            "updated_at",
+            "id",
+            "text_lemmatized",
+            "attributed_to",
+            *promoted_payload_keys,
+        }
 
         original_memories = []
         for scored in scored_results:
@@ -1730,15 +1744,10 @@ class Memory(MemoryBase):
             entity_store = self.entity_store
 
             def _search_entity(entity_text, embedding):
-                return entity_store.search(
-                    query=entity_text, vectors=embedding, top_k=500, filters=search_filters
-                )
+                return entity_store.search(query=entity_text, vectors=embedding, top_k=500, filters=search_filters)
 
             with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
-                futures = {
-                    pool.submit(_search_entity, text, emb): text
-                    for text, emb in zip(entity_texts, embeddings)
-                }
+                futures = {pool.submit(_search_entity, text, emb): text for text, emb in zip(entity_texts, embeddings)}
 
                 for future in concurrent.futures.as_completed(futures):
                     try:
@@ -1748,11 +1757,11 @@ class Memory(MemoryBase):
                         continue
 
                     for match in matches:
-                        similarity = match.score if hasattr(match, 'score') else 0.0
+                        similarity = match.score if hasattr(match, "score") else 0.0
                         if similarity < 0.5:
                             continue
 
-                        payload = match.payload if hasattr(match, 'payload') else {}
+                        payload = match.payload if hasattr(match, "payload") else {}
                         linked_memory_ids = payload.get("linked_memory_ids", [])
                         if not isinstance(linked_memory_ids, list):
                             continue
@@ -2121,10 +2130,7 @@ class AsyncMemory(MemoryBase):
         # Initialize reranker if configured
         self.reranker = None
         if config.reranker:
-            self.reranker = RerankerFactory.create(
-                config.reranker.provider,
-                config.reranker.config
-            )
+            self.reranker = RerankerFactory.create(config.reranker.provider, config.reranker.config)
 
         if MEM0_TELEMETRY:
             telemetry_config = _safe_deepcopy_config(self.config.vector_store.config)
@@ -2133,7 +2139,9 @@ class AsyncMemory(MemoryBase):
                 provider_path = f"migrations_{self.config.vector_store.provider}"
                 telemetry_config.path = os.path.join(mem0_dir, provider_path)
                 os.makedirs(telemetry_config.path, exist_ok=True)
-            self._telemetry_vector_store = VectorStoreFactory.create(self.config.vector_store.provider, telemetry_config)
+            self._telemetry_vector_store = VectorStoreFactory.create(
+                self.config.vector_store.provider, telemetry_config
+            )
 
         if getattr(type(self.vector_store), "keyword_search", None) is VectorStoreBase.keyword_search:
             logger.warning(
@@ -2156,10 +2164,10 @@ class AsyncMemory(MemoryBase):
         if self._entity_store is None:
             entity_config = _safe_deepcopy_config(self.config.vector_store.config)
             entity_collection = _entity_collection_name(self.config.vector_store.provider, self.collection_name)
-            if hasattr(entity_config, 'collection_name'):
+            if hasattr(entity_config, "collection_name"):
                 entity_config.collection_name = entity_collection
             elif isinstance(entity_config, dict):
-                entity_config['collection_name'] = entity_collection
+                entity_config["collection_name"] = entity_collection
             # For Qdrant, share the existing client to avoid RocksDB lock contention
             # when using embedded mode (path=...). QdrantConfig.client takes precedence
             # over host/port/path.
@@ -2168,9 +2176,7 @@ class AsyncMemory(MemoryBase):
                     entity_config.client = self.vector_store.client
                 elif isinstance(entity_config, dict):
                     entity_config["client"] = self.vector_store.client
-            self._entity_store = VectorStoreFactory.create(
-                self.config.vector_store.provider, entity_config
-            )
+            self._entity_store = VectorStoreFactory.create(self.config.vector_store.provider, entity_config)
         return self._entity_store
 
     @staticmethod
@@ -2423,7 +2429,7 @@ class AsyncMemory(MemoryBase):
                 message="messages must be str, dict, or list[dict]",
                 error_code="VALIDATION_003",
                 details={"provided_type": type(messages).__name__, "valid_types": ["str", "dict", "list[dict]"]},
-                suggestion="Convert your input to a string, dictionary, or list of dictionaries."
+                suggestion="Convert your input to a string, dictionary, or list of dictionaries.",
             )
 
         if agent_id is not None and memory_type == MemoryType.PROCEDURAL.value:
@@ -2567,7 +2573,10 @@ class AsyncMemory(MemoryBase):
             # Layer 1 (always): salvage complete memory objects from a truncated response.
             extracted_memories, truncated = salvage_memory_objects(response)
             if extracted_memories:
-                logger.info("Salvaged %d complete memory item(s) from a malformed extraction response (async)", len(extracted_memories))
+                logger.info(
+                    "Salvaged %d complete memory item(s) from a malformed extraction response (async)",
+                    len(extracted_memories),
+                )
             # Layer 2 (opt-in): retry once with a raised max_tokens on truncation.
             if truncated and getattr(self.config, "recover_truncated_extractions", False) is True:
                 # Runs the sync retry on a worker thread. retry_extraction_with_more_tokens
@@ -2672,8 +2681,12 @@ class AsyncMemory(MemoryBase):
             for hr in history_records:
                 try:
                     await asyncio.to_thread(
-                        self.db.add_history, hr["memory_id"], None, hr["new_memory"], "ADD",
-                        created_at=hr.get("created_at")
+                        self.db.add_history,
+                        hr["memory_id"],
+                        None,
+                        hr["new_memory"],
+                        "ADD",
+                        created_at=hr.get("created_at"),
                     )
                 except Exception as e:
                     logger.error(f"Failed to add history for {hr['memory_id']} (async): {e}")
@@ -2761,12 +2774,14 @@ class AsyncMemory(MemoryBase):
                         else:
                             to_insert_vectors.append(valid_vectors[j])
                             to_insert_ids.append(str(uuid.uuid4()))
-                            to_insert_payloads.append({
-                                "data": entity_text,
-                                "entity_type": entity_type,
-                                "linked_memory_ids": sorted(memory_ids),
-                                **search_filters,
-                            })
+                            to_insert_payloads.append(
+                                {
+                                    "data": entity_text,
+                                    "entity_type": entity_type,
+                                    "linked_memory_ids": sorted(memory_ids),
+                                    **search_filters,
+                                }
+                            )
 
                     # 7e: Batch insert new entities
                     if to_insert_vectors:
@@ -2785,10 +2800,7 @@ class AsyncMemory(MemoryBase):
         # Phase 8: Save messages + return
         await asyncio.to_thread(self.db.save_messages, messages, session_scope)
 
-        returned_memories = [
-            {"id": r[0], "memory": r[1], "event": "ADD"}
-            for r in records
-        ]
+        returned_memories = [{"id": r[0], "memory": r[1], "event": "ADD"} for r in records]
 
         keys, encoded_ids = process_telemetry_filters(effective_filters)
         capture_event(
@@ -2824,7 +2836,16 @@ class AsyncMemory(MemoryBase):
             "expiration_date",
         ]
 
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
+        core_and_promoted_keys = {
+            "data",
+            "hash",
+            "created_at",
+            "updated_at",
+            "id",
+            "text_lemmatized",
+            "attributed_to",
+            *promoted_payload_keys,
+        }
 
         result_item = MemoryItem(
             id=memory.id,
@@ -2880,23 +2901,16 @@ class AsyncMemory(MemoryBase):
         # Validate and trim entity IDs in filters
         effective_filters = dict(filters) if filters else {}
         if "user_id" in effective_filters:
-            effective_filters["user_id"] = _validate_and_trim_entity_id(
-                effective_filters["user_id"], "user_id"
-            )
+            effective_filters["user_id"] = _validate_and_trim_entity_id(effective_filters["user_id"], "user_id")
         if "agent_id" in effective_filters:
-            effective_filters["agent_id"] = _validate_and_trim_entity_id(
-                effective_filters["agent_id"], "agent_id"
-            )
+            effective_filters["agent_id"] = _validate_and_trim_entity_id(effective_filters["agent_id"], "agent_id")
         if "run_id" in effective_filters:
-            effective_filters["run_id"] = _validate_and_trim_entity_id(
-                effective_filters["run_id"], "run_id"
-            )
+            effective_filters["run_id"] = _validate_and_trim_entity_id(effective_filters["run_id"], "run_id")
 
         # Validate filters contains at least one entity ID
         if not any(key in effective_filters for key in ("user_id", "agent_id", "run_id")):
             raise ValueError(
-                "filters must contain at least one of: user_id, agent_id, run_id. "
-                "Example: filters={'user_id': 'u1'}"
+                "filters must contain at least one of: user_id, agent_id, run_id. Example: filters={'user_id': 'u1'}"
             )
 
         limit = top_k
@@ -2941,7 +2955,16 @@ class AsyncMemory(MemoryBase):
             "attributed_to",
             "expiration_date",
         ]
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
+        core_and_promoted_keys = {
+            "data",
+            "hash",
+            "created_at",
+            "updated_at",
+            "id",
+            "text_lemmatized",
+            "attributed_to",
+            *promoted_payload_keys,
+        }
 
         formatted_memories = []
         for mem in actual_memories:
@@ -3038,23 +3061,16 @@ class AsyncMemory(MemoryBase):
         # Validate and trim entity IDs in filters
         effective_filters = filters.copy() if filters else {}
         if "user_id" in effective_filters:
-            effective_filters["user_id"] = _validate_and_trim_entity_id(
-                effective_filters["user_id"], "user_id"
-            )
+            effective_filters["user_id"] = _validate_and_trim_entity_id(effective_filters["user_id"], "user_id")
         if "agent_id" in effective_filters:
-            effective_filters["agent_id"] = _validate_and_trim_entity_id(
-                effective_filters["agent_id"], "agent_id"
-            )
+            effective_filters["agent_id"] = _validate_and_trim_entity_id(effective_filters["agent_id"], "agent_id")
         if "run_id" in effective_filters:
-            effective_filters["run_id"] = _validate_and_trim_entity_id(
-                effective_filters["run_id"], "run_id"
-            )
+            effective_filters["run_id"] = _validate_and_trim_entity_id(effective_filters["run_id"], "run_id")
 
         # Validate filters contains at least one entity ID
         if not any(key in effective_filters for key in ("user_id", "agent_id", "run_id")):
             raise ValueError(
-                "filters must contain at least one of: user_id, agent_id, run_id. "
-                "Example: filters={'user_id': 'u1'}"
+                "filters must contain at least one of: user_id, agent_id, run_id. Example: filters={'user_id': 'u1'}"
             )
 
         limit = top_k
@@ -3067,7 +3083,9 @@ class AsyncMemory(MemoryBase):
             for logical_key in ("AND", "OR", "NOT"):
                 effective_filters.pop(logical_key, None)
             for fk in list(effective_filters.keys()):
-                if fk not in ("AND", "OR", "NOT", "user_id", "agent_id", "run_id") and isinstance(effective_filters.get(fk), dict):
+                if fk not in ("AND", "OR", "NOT", "user_id", "agent_id", "run_id") and isinstance(
+                    effective_filters.get(fk), dict
+                ):
                     effective_filters.pop(fk, None)
             effective_filters.update(processed_filters)
 
@@ -3097,9 +3115,7 @@ class AsyncMemory(MemoryBase):
         if rerank and self.reranker and original_memories:
             try:
                 # Run reranking in thread pool to avoid blocking async loop
-                reranked_memories = await asyncio.to_thread(
-                    self.reranker.rerank, query, original_memories, limit
-                )
+                reranked_memories = await asyncio.to_thread(self.reranker.rerank, query, original_memories, limit)
                 original_memories = reranked_memories
             except Exception as e:
                 logger.warning(f"Reranking failed, using original results: {e}")
@@ -3145,9 +3161,16 @@ class AsyncMemory(MemoryBase):
             for operator, value in condition.items():
                 # Map platform operators to universal format that can be translated by each vector store
                 operator_map = {
-                    "eq": "eq", "ne": "ne", "gt": "gt", "gte": "gte",
-                    "lt": "lt", "lte": "lte", "in": "in", "nin": "nin",
-                    "contains": "contains", "icontains": "icontains"
+                    "eq": "eq",
+                    "ne": "ne",
+                    "gt": "gt",
+                    "gte": "gte",
+                    "lt": "lt",
+                    "lte": "lte",
+                    "in": "in",
+                    "nin": "nin",
+                    "contains": "contains",
+                    "icontains": "icontains",
                 }
 
                 if operator in operator_map:
@@ -3252,8 +3275,8 @@ class AsyncMemory(MemoryBase):
         if keyword_results is not None:
             midpoint, steepness = get_bm25_params(query, lemmatized=query_lemmatized)
             for mem in keyword_results:
-                mem_id = str(mem.id) if hasattr(mem, 'id') else str(mem.get('id', ''))
-                raw_score = mem.score if hasattr(mem, 'score') else mem.get('score', 0)
+                mem_id = str(mem.id) if hasattr(mem, "id") else str(mem.get("id", ""))
+                raw_score = mem.score if hasattr(mem, "score") else mem.get("score", 0)
                 if raw_score and raw_score > 0:
                     bm25_scores[mem_id] = normalize_bm25(raw_score, midpoint, steepness)
 
@@ -3295,7 +3318,16 @@ class AsyncMemory(MemoryBase):
             "attributed_to",
             "expiration_date",
         ]
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
+        core_and_promoted_keys = {
+            "data",
+            "hash",
+            "created_at",
+            "updated_at",
+            "id",
+            "text_lemmatized",
+            "attributed_to",
+            *promoted_payload_keys,
+        }
 
         original_memories = []
         for scored in scored_results:
@@ -3379,11 +3411,11 @@ class AsyncMemory(MemoryBase):
                     continue
 
                 for match in matches:
-                    similarity = match.score if hasattr(match, 'score') else 0.0
+                    similarity = match.score if hasattr(match, "score") else 0.0
                     if similarity < 0.5:
                         continue
 
-                    payload = match.payload if hasattr(match, 'payload') else {}
+                    payload = match.payload if hasattr(match, "payload") else {}
                     linked_memory_ids = payload.get("linked_memory_ids", [])
                     if not isinstance(linked_memory_ids, list):
                         continue
@@ -3607,7 +3639,7 @@ class AsyncMemory(MemoryBase):
             else:
                 procedural_memory = await asyncio.to_thread(self.llm.generate_response, messages=parsed_messages)
                 procedural_memory = remove_code_blocks(procedural_memory)
-        
+
         except Exception as e:
             logger.error(f"Error generating procedural memory summary: {e}")
             raise

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -56,6 +56,8 @@ from mem0.memory.utils import (
     parse_vision_messages,
     process_telemetry_filters,
     remove_code_blocks,
+    retry_extraction_with_more_tokens,
+    salvage_memory_objects,
 )
 from mem0.utils.entity_extraction import extract_entities, extract_entities_batch
 from mem0.utils.factory import (
@@ -928,7 +930,17 @@ class Memory(MemoryBase):
                     extracted_memories = json.loads(extracted_json, strict=False).get("memory", [])
         except Exception as e:
             logger.error(f"Error parsing extraction response: {e}")
-            extracted_memories = []
+            # Layer 1 (always): salvage the complete memory objects from a
+            # truncated/malformed response instead of dropping them all.
+            extracted_memories, truncated = salvage_memory_objects(response)
+            if extracted_memories:
+                logger.info("Salvaged %d complete memory item(s) from a malformed extraction response", len(extracted_memories))
+            # Layer 2 (opt-in): if the response was truncated, retry once with a
+            # raised max_tokens to recover the cut-off remainder.
+            if truncated and getattr(self.config, "recover_truncated_extractions", False) is True:
+                retried = retry_extraction_with_more_tokens(self.llm, system_prompt, user_prompt)
+                if len(retried) > len(extracted_memories):
+                    extracted_memories = retried
 
         if not extracted_memories:
             # Save messages even if nothing extracted
@@ -2552,7 +2564,17 @@ class AsyncMemory(MemoryBase):
                     extracted_memories = json.loads(extracted_json, strict=False).get("memory", [])
         except Exception as e:
             logger.error(f"Error parsing extraction response (async): {e}")
-            extracted_memories = []
+            # Layer 1 (always): salvage complete memory objects from a truncated response.
+            extracted_memories, truncated = salvage_memory_objects(response)
+            if extracted_memories:
+                logger.info("Salvaged %d complete memory item(s) from a malformed extraction response (async)", len(extracted_memories))
+            # Layer 2 (opt-in): retry once with a raised max_tokens on truncation.
+            if truncated and getattr(self.config, "recover_truncated_extractions", False) is True:
+                retried = await asyncio.to_thread(
+                    retry_extraction_with_more_tokens, self.llm, system_prompt, user_prompt
+                )
+                if len(retried) > len(extracted_memories):
+                    extracted_memories = retried
 
         if not extracted_memories:
             await asyncio.to_thread(self.db.save_messages, messages, session_scope)

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -2,6 +2,7 @@ import hashlib
 import json
 import logging
 import re
+import threading
 from typing import Any, Dict, List, Tuple
 
 from mem0.configs.prompts import (
@@ -200,6 +201,12 @@ def salvage_memory_objects(text: str) -> Tuple[List[Dict[str, Any]], bool]:
 #: ``max_tokens``. Real-corpus data: truncations recovered at ~4x the base
 #: budget (e.g. 2000 -> 8000); a 2x raise under-shot and re-truncated.
 _RETRY_TOKEN_MULTIPLIER = 4
+# Serializes the raise/restore of the shared llm.config.max_tokens below. The async
+# add() path runs this retry in a worker thread on a single shared llm, so without
+# this lock two concurrent retries could interleave and leave config.max_tokens
+# permanently corrupted. The retry is a rare truncation-only fallback, so serializing
+# it is cheap.
+_RETRY_TOKEN_LOCK = threading.Lock()
 
 
 def retry_extraction_with_more_tokens(llm, system_prompt, user_prompt) -> List[Dict[str, Any]]:
@@ -212,21 +219,37 @@ def retry_extraction_with_more_tokens(llm, system_prompt, user_prompt) -> List[D
     (including a second truncation, where the caller falls back to whatever
     ``salvage_memory_objects`` already kept).
 
-    Skipped when ``max_tokens`` is unset (cannot compute a raise).
+    Skipped when ``max_tokens`` is unset or non-positive (cannot compute a raise).
     """
     current = getattr(getattr(llm, "config", None), "max_tokens", None)
-    if not current:
+    if not current or current <= 0:
         return []
-    raised = current * _RETRY_TOKEN_MULTIPLIER
+    # ``max_tokens`` is not part of the ``generate_response`` signature. Nearly half the
+    # providers accept ``**kwargs`` (so the kwarg reached the API there), but the rest
+    # raise ``TypeError`` on the unexpected kwarg, which the broad except swallowed -
+    # silently recovering nothing on those. Most providers instead read
+    # ``self.config.max_tokens`` at request time, so raise it there for the single retry
+    # call and restore it. Providers that snapshot or bake in max_tokens (LangChain,
+    # Bedrock) or drop it (the OpenAI structured-output provider, reasoning models such as
+    # gpt-5/o1/o3) ignore the raise, and the caller falls back to the already-salvaged
+    # memories. The raise/restore runs under a process-wide lock with the base re-read
+    # inside it, so concurrent retries on a shared llm cannot corrupt the config; the lock
+    # is held across the one retry call and over-serializes across llm instances, which is
+    # acceptable for this rare truncation-only fallback.
     try:
-        response = llm.generate_response(
-            messages=[
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": user_prompt},
-            ],
-            response_format={"type": "json_object"},
-            max_tokens=raised,
-        )
+        with _RETRY_TOKEN_LOCK:
+            base = llm.config.max_tokens
+            try:
+                llm.config.max_tokens = base * _RETRY_TOKEN_MULTIPLIER
+                response = llm.generate_response(
+                    messages=[
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": user_prompt},
+                    ],
+                    response_format={"type": "json_object"},
+                )
+            finally:
+                llm.config.max_tokens = base
         response = remove_code_blocks(response)
         try:
             memories = json.loads(response, strict=False).get("memory", [])

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -1,7 +1,8 @@
 import hashlib
+import json
 import logging
 import re
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 from mem0.configs.prompts import (
     AGENT_MEMORY_EXTRACTION_PROMPT,
@@ -146,6 +147,97 @@ def extract_json(text):
         else:
             json_str = text
     return json_str
+
+
+def salvage_memory_objects(text: str) -> Tuple[List[Dict[str, Any]], bool]:
+    """Recover complete memory objects from a malformed or truncated extraction.
+
+    When the extraction LLM hits ``max_tokens`` mid-output, it returns valid but
+    incomplete JSON (an unterminated ``{"memory": [...]}`` array). ``json.loads``
+    and ``extract_json`` both fail on it, so every fact is dropped - including
+    the ones the model fully wrote before the cut.
+
+    This peels complete objects off the ``memory`` array one at a time with
+    ``json.JSONDecoder.raw_decode`` (stdlib, no new dependency), stopping at the
+    first object that does not fully parse (the cut-off tail). Only fully-closed,
+    self-contained objects are returned; the half-written object is dropped
+    because its content cannot be trusted.
+
+    Returns ``(memories, truncated)`` where ``truncated`` is True when the array
+    did not close cleanly (at least one object was cut off, so the optional
+    token-raise retry could recover more).
+    """
+    if not text:
+        return [], False
+    match = re.search(r'"memory"\s*:\s*\[', text)
+    if not match:
+        return [], False
+
+    decoder = json.JSONDecoder()
+    idx = match.end()
+    n = len(text)
+    memories: List[Dict[str, Any]] = []
+    truncated = True  # assume cut off until we see the closing ']'
+    while idx < n:
+        while idx < n and text[idx] in " \t\r\n,":
+            idx += 1
+        if idx >= n:
+            break
+        if text[idx] == "]":
+            truncated = False  # array closed cleanly; nothing was lost
+            break
+        try:
+            obj, end = decoder.raw_decode(text, idx)
+        except (json.JSONDecodeError, ValueError):
+            break  # incomplete tail object -> stop, leave truncated=True
+        if isinstance(obj, dict):
+            memories.append(obj)
+        idx = end
+    return memories, truncated
+
+
+#: A truncated extraction is retried once at this multiple of the configured
+#: ``max_tokens``. Real-corpus data: truncations recovered at ~4x the base
+#: budget (e.g. 2000 -> 8000); a 2x raise under-shot and re-truncated.
+_RETRY_TOKEN_MULTIPLIER = 4
+
+
+def retry_extraction_with_more_tokens(llm, system_prompt, user_prompt) -> List[Dict[str, Any]]:
+    """Single bounded retry of extraction with a raised ``max_tokens``.
+
+    For the truncation case only: re-runs the same extraction once at
+    ``_RETRY_TOKEN_MULTIPLIER`` times the configured ``max_tokens`` to recover
+    the memories that were cut off. Bounded to one attempt (no retry loop, no
+    unbounded raising). Returns the parsed memory list, or ``[]`` on any failure
+    (including a second truncation, where the caller falls back to whatever
+    ``salvage_memory_objects`` already kept).
+
+    Skipped when ``max_tokens`` is unset (cannot compute a raise).
+    """
+    current = getattr(getattr(llm, "config", None), "max_tokens", None)
+    if not current:
+        return []
+    raised = current * _RETRY_TOKEN_MULTIPLIER
+    try:
+        response = llm.generate_response(
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            response_format={"type": "json_object"},
+            max_tokens=raised,
+        )
+        response = remove_code_blocks(response)
+        try:
+            memories = json.loads(response, strict=False).get("memory", [])
+        except json.JSONDecodeError:
+            memories = json.loads(extract_json(response), strict=False).get("memory", [])
+    except Exception as e:
+        logger.warning("Token-raise extraction retry failed: %s", e)
+        return []
+    if memories:
+        logger.info("Recovered %d memory item(s) via token-raise retry after truncation", len(memories))
+    return memories
 
 
 def get_image_description(image_obj, llm, vision_details):

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -206,12 +206,39 @@ def salvage_memory_objects(text: str) -> Tuple[List[Dict[str, Any]], bool]:
 #: inside common provider output limits.
 _RETRY_TOKEN_MULTIPLIER = 4
 _RETRY_TOKEN_CAP = 8192
-# Serializes the raise/restore of the shared llm.config.max_tokens below. The async
-# add() path runs this retry in a worker thread on a single shared llm, so without
-# this lock two concurrent retries could interleave and leave config.max_tokens
-# permanently corrupted. The retry is a rare truncation-only fallback, so serializing
-# it is cheap.
+# Serializes the raise/restore of a shared llm.config.max_tokens below. The async add()
+# path runs this retry in a worker thread on a single shared llm, so without a lock two
+# concurrent retries could interleave and leave config.max_tokens permanently corrupted.
+# The lock is per-llm-instance (created once and cached on the llm) so retries on
+# different llm instances never serialize against each other; _RETRY_LOCK_INIT guards the
+# lazy creation, and _RETRY_TOKEN_LOCK is a process-wide fallback for an llm that cannot
+# hold the cached attribute. The retry is a rare truncation-only fallback.
+_RETRY_LOCK_INIT = threading.Lock()
 _RETRY_TOKEN_LOCK = threading.Lock()
+
+
+def _retry_lock_for(llm):
+    """Return the per-instance lock that serializes ``llm``'s own token-raise retries.
+
+    Created once and cached on the llm as ``_retry_lock`` (double-checked under
+    ``_RETRY_LOCK_INIT`` so concurrent first-time callers share one lock rather than each
+    minting their own). Isolates each llm instance. The shared-``_RETRY_TOKEN_LOCK`` fallback
+    is purely defensive: every shipped provider instance carries a ``__dict__`` and caches the
+    lock, so the fallback only triggers for an exotic attribute-less llm, where it still keeps
+    the no-corruption guarantee (at the cost of over-serializing).
+    """
+    lock = getattr(llm, "_retry_lock", None)
+    if lock is not None:
+        return lock
+    with _RETRY_LOCK_INIT:
+        lock = getattr(llm, "_retry_lock", None)
+        if lock is None:
+            lock = threading.Lock()
+            try:
+                llm._retry_lock = lock
+            except Exception:
+                return _RETRY_TOKEN_LOCK
+        return lock
 
 
 def retry_extraction_with_more_tokens(llm, system_prompt, user_prompt) -> List[Dict[str, Any]]:
@@ -240,14 +267,14 @@ def retry_extraction_with_more_tokens(llm, system_prompt, user_prompt) -> List[D
     # call and restore it. Providers that snapshot or bake in max_tokens (LangChain,
     # Bedrock) or drop it (the OpenAI structured-output provider, reasoning models such as
     # gpt-5/o1/o3) ignore the raise, and the caller falls back to the already-salvaged
-    # memories. The raise/restore runs under a process-wide lock with the base re-read
-    # inside it, so concurrent retries on a shared llm cannot corrupt the config; the lock
-    # is held across the one retry call and over-serializes across llm instances, which is
-    # acceptable for this rare truncation-only fallback. (Concurrent non-retry calls on the
-    # same llm take no lock and can observe the raised value during the retry window - a
-    # transient output-budget bump on those calls, not corruption; always restored.)
+    # memories. The raise/restore runs under this llm's own lock with the base re-read
+    # inside it, so concurrent retries on a shared llm cannot corrupt the config, while
+    # retries on different llm instances never serialize against each other. The lock is
+    # held across the one retry call. (Concurrent non-retry calls on the same llm take no
+    # lock and can observe the raised value during the retry window - a transient
+    # output-budget bump on those calls, not corruption; always restored.)
     try:
-        with _RETRY_TOKEN_LOCK:
+        with _retry_lock_for(llm):
             base = llm.config.max_tokens
             try:
                 llm.config.max_tokens = min(base * _RETRY_TOKEN_MULTIPLIER, _RETRY_TOKEN_CAP)

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -16,11 +16,11 @@ logger = logging.getLogger(__name__)
 
 def get_fact_retrieval_messages(message, is_agent_memory=False):
     """Get fact retrieval messages based on the memory type.
-    
+
     Args:
         message: The message content to extract facts from
         is_agent_memory: If True, use agent memory extraction prompt, else use user memory extraction prompt
-        
+
     Returns:
         tuple: (system_prompt, user_prompt)
     """
@@ -54,8 +54,7 @@ def ensure_json_instruction(system_prompt, user_prompt):
     combined = (system_prompt + user_prompt).lower()
     if "json" not in combined:
         system_prompt += (
-            "\n\nYou must return your response in valid JSON format "
-            "with a 'facts' key containing an array of strings."
+            "\n\nYou must return your response in valid JSON format with a 'facts' key containing an array of strings."
         )
     return system_prompt, user_prompt
 
@@ -88,6 +87,7 @@ def format_entities(entities):
         formatted_lines.append(simplified)
 
     return "\n".join(formatted_lines)
+
 
 def normalize_facts(raw_facts):
     """Normalize LLM-extracted facts to a list of strings.
@@ -125,9 +125,8 @@ def remove_code_blocks(content: str) -> str:
     """
     pattern = r"^```[a-zA-Z0-9]*\n([\s\S]*?)\n```$"
     match = re.match(pattern, content.strip())
-    match_res=match.group(1).strip() if match else content.strip()
+    match_res = match.group(1).strip() if match else content.strip()
     return re.sub(r"<think>.*?</think>", "", match_res, flags=re.DOTALL).strip()
-
 
 
 def extract_json(text):
@@ -168,7 +167,9 @@ def salvage_memory_objects(text: str) -> Tuple[List[Dict[str, Any]], bool]:
     did not close cleanly (at least one object was cut off, so the optional
     token-raise retry could recover more).
     """
-    if not text:
+    if not text or not isinstance(text, str):
+        # This runs inside the parse-failure except handler; a provider that
+        # returned a non-string must degrade to "nothing salvaged", not raise.
         return [], False
     match = re.search(r'"memory"\s*:\s*\[', text)
     if not match:
@@ -199,8 +200,12 @@ def salvage_memory_objects(text: str) -> Tuple[List[Dict[str, Any]], bool]:
 
 #: A truncated extraction is retried once at this multiple of the configured
 #: ``max_tokens``. Real-corpus data: truncations recovered at ~4x the base
-#: budget (e.g. 2000 -> 8000); a 2x raise under-shot and re-truncated.
+#: budget (e.g. 2000 -> 8000); a 2x raise under-shot and re-truncated. The
+#: absolute cap bounds the retry's cost so a large configured budget cannot
+#: multiply into an arbitrarily expensive call, and keeps the raised value
+#: inside common provider output limits.
 _RETRY_TOKEN_MULTIPLIER = 4
+_RETRY_TOKEN_CAP = 8192
 # Serializes the raise/restore of the shared llm.config.max_tokens below. The async
 # add() path runs this retry in a worker thread on a single shared llm, so without
 # this lock two concurrent retries could interleave and leave config.max_tokens
@@ -219,10 +224,13 @@ def retry_extraction_with_more_tokens(llm, system_prompt, user_prompt) -> List[D
     (including a second truncation, where the caller falls back to whatever
     ``salvage_memory_objects`` already kept).
 
-    Skipped when ``max_tokens`` is unset or non-positive (cannot compute a raise).
+    Skipped when ``max_tokens`` is unset or non-positive (cannot compute a
+    raise) or already at/above ``_RETRY_TOKEN_CAP`` (no meaningful raise left).
     """
     current = getattr(getattr(llm, "config", None), "max_tokens", None)
     if not current or current <= 0:
+        return []
+    if min(current * _RETRY_TOKEN_MULTIPLIER, _RETRY_TOKEN_CAP) <= current:
         return []
     # ``max_tokens`` is not part of the ``generate_response`` signature. Nearly half the
     # providers accept ``**kwargs`` (so the kwarg reached the API there), but the rest
@@ -235,12 +243,14 @@ def retry_extraction_with_more_tokens(llm, system_prompt, user_prompt) -> List[D
     # memories. The raise/restore runs under a process-wide lock with the base re-read
     # inside it, so concurrent retries on a shared llm cannot corrupt the config; the lock
     # is held across the one retry call and over-serializes across llm instances, which is
-    # acceptable for this rare truncation-only fallback.
+    # acceptable for this rare truncation-only fallback. (Concurrent non-retry calls on the
+    # same llm take no lock and can observe the raised value during the retry window - a
+    # transient output-budget bump on those calls, not corruption; always restored.)
     try:
         with _RETRY_TOKEN_LOCK:
             base = llm.config.max_tokens
             try:
-                llm.config.max_tokens = base * _RETRY_TOKEN_MULTIPLIER
+                llm.config.max_tokens = min(base * _RETRY_TOKEN_MULTIPLIER, _RETRY_TOKEN_CAP)
                 response = llm.generate_response(
                     messages=[
                         {"role": "system", "content": system_prompt},
@@ -258,6 +268,11 @@ def retry_extraction_with_more_tokens(llm, system_prompt, user_prompt) -> List[D
     except Exception as e:
         logger.warning("Token-raise extraction retry failed: %s", e)
         return []
+    if not isinstance(memories, list):
+        return []
+    # Same shape discipline as salvage_memory_objects: downstream reads
+    # m.get("text"), so non-dict items must be dropped, not passed through.
+    memories = [m for m in memories if isinstance(m, dict)]
     if memories:
         logger.info("Recovered %d memory item(s) via token-raise retry after truncation", len(memories))
     return memories
@@ -432,4 +447,3 @@ def remove_spaces_from_entities(
         item["destination"] = item["destination"].lower().replace(" ", "_")
         cleaned.append(item)
     return cleaned
-

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -1,3 +1,4 @@
+import ast
 import hashlib
 import json
 import logging
@@ -171,11 +172,14 @@ def salvage_memory_objects(text: str) -> Tuple[List[Dict[str, Any]], bool]:
         # This runs inside the parse-failure except handler; a provider that
         # returned a non-string must degrade to "nothing salvaged", not raise.
         return [], False
-    match = re.search(r'"memory"\s*:\s*\[', text)
+    # Tolerate either quote style on the key: some models emit a Python-repr
+    # dict ({'memory': [...]}) that fails json.loads upstream and lands here.
+    match = re.search(r"""['"]memory['"]\s*:\s*\[""", text)
     if not match:
         return [], False
 
     decoder = json.JSONDecoder()
+    bracket_idx = match.end() - 1  # the '[' that opens the memory array
     idx = match.end()
     n = len(text)
     memories: List[Dict[str, Any]] = []
@@ -195,7 +199,68 @@ def salvage_memory_objects(text: str) -> Tuple[List[Dict[str, Any]], bool]:
         if isinstance(obj, dict):
             memories.append(obj)
         idx = end
+
+    if memories:
+        return memories, truncated
+
+    # The JSON peeler recovered nothing from a response that DID match the
+    # memory key. The usual cause is non-JSON dict syntax (single quotes,
+    # Python repr) that json.raw_decode cannot read. Try a safe literal-eval of
+    # the complete array before giving up - and if even that fails, log loudly
+    # rather than re-create the silent drop this function exists to kill.
+    # (An apostrophe inside a single-quoted value - "it's" - desyncs the
+    # bracket scanner; that degrades to literal_eval failing and the warning
+    # below, never a crash or a silent drop.)
+    close_idx = _find_matching_bracket(text, bracket_idx)
+    if close_idx != -1:
+        try:
+            parsed = ast.literal_eval(text[bracket_idx : close_idx + 1])
+        except Exception:
+            # literal_eval on untrusted model output can raise more than
+            # ValueError/SyntaxError (RecursionError, MemoryError, ...). This
+            # runs inside the parse-failure except handler, whose contract is to
+            # degrade to "nothing salvaged", never to raise out of it - so catch
+            # broadly and fall through to the warning.
+            parsed = None
+        if isinstance(parsed, list):
+            # Parsed cleanly (array closed); return whatever dicts it held - an
+            # empty/dictless array is a legitimately empty extraction, not a drop.
+            return [o for o in parsed if isinstance(o, dict)], False
+    logger.warning(
+        "Extraction response matched a 'memory' array but no complete object could be "
+        "salvaged (non-JSON dict syntax or truncated mid-first-object); not dropping silently."
+    )
     return memories, truncated
+
+
+def _find_matching_bracket(text: str, open_idx: int) -> int:
+    """Index of the ``]`` matching the ``[`` at ``open_idx``, or -1 if unclosed.
+
+    Quote-aware (handles ``'`` and ``"`` strings with backslash escapes) so a
+    bracket inside a string value cannot throw off the depth count.
+    """
+    depth = 0
+    quote = None
+    i = open_idx
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if quote is not None:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == quote:
+                quote = None
+        elif ch in "'\"":
+            quote = ch
+        elif ch == "[":
+            depth += 1
+        elif ch == "]":
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return -1
 
 
 #: A truncated extraction is retried once at this multiple of the configured

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -138,18 +138,65 @@ class TestTruncationRecovery:
     def test_opt_in_retry_recovers_cut_off_remainder(self, mock_memory):
         mock_memory.config.recover_truncated_extractions = True
         mock_memory.llm.config.max_tokens = 1000
-        mock_memory.llm.generate_response.side_effect = [TRUNCATED_EXTRACTION, COMPLETE_EXTRACTION]
+
+        # Record the max_tokens in effect at each call so we can prove the retry raised it
+        # via the shared config, not via a kwarg most providers reject (the original bug).
+        responses = iter([TRUNCATED_EXTRACTION, COMPLETE_EXTRACTION])
+        observed_max_tokens = []
+
+        def fake_generate_response(*args, **kwargs):
+            observed_max_tokens.append(mock_memory.llm.config.max_tokens)
+            return next(responses)
+
+        mock_memory.llm.generate_response.side_effect = fake_generate_response
 
         result = mock_memory._add_to_vector_store(
             messages=[{"role": "user", "content": "test"}], metadata={}, filters={}, infer=True
         )
 
         assert mock_memory.llm.generate_response.call_count == 2  # extraction + token-raise retry
-        # retry ran with a 4x-raised max_tokens (data-driven; see _RETRY_TOKEN_MULTIPLIER)
-        assert mock_memory.llm.generate_response.call_args_list[1].kwargs["max_tokens"] == 4000
+        # The retry raised max_tokens 4x via the shared config (see _RETRY_TOKEN_MULTIPLIER)
+        # and must NOT pass max_tokens as a kwarg; this fails against the old kwarg-based code.
+        assert observed_max_tokens[1] == 4000
+        assert "max_tokens" not in mock_memory.llm.generate_response.call_args_list[1].kwargs
+        assert mock_memory.llm.config.max_tokens == 1000  # restored after the retry
         texts = [m["memory"] for m in result]
         assert "User has a dog named Max" in texts  # the previously cut-off fact
         assert len(result) == 3
+
+    def test_concurrent_retries_do_not_corrupt_shared_config(self):
+        # The retry raises a SHARED llm.config.max_tokens; the async path runs it in a
+        # worker thread, so concurrent retries on one llm must not corrupt it. The lock in
+        # retry_extraction_with_more_tokens serializes the raise/restore. Without the lock
+        # this trips: some retry sees a doubly-raised budget, or the config never restores.
+        import threading
+        import time
+
+        from mem0.memory.utils import _RETRY_TOKEN_MULTIPLIER, retry_extraction_with_more_tokens
+
+        class _FakeConfig:
+            max_tokens = 1000
+
+        class _FakeLLM:
+            def __init__(self):
+                self.config = _FakeConfig()
+                self.seen = []
+
+            def generate_response(self, messages, response_format=None):
+                self.seen.append(self.config.max_tokens)  # what this retry sees while it holds the raise
+                time.sleep(0.001)  # widen the interleaving window
+                return COMPLETE_EXTRACTION
+
+        llm = _FakeLLM()
+        threads = [threading.Thread(target=retry_extraction_with_more_tokens, args=(llm, "sys", "usr")) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        expected = 1000 * _RETRY_TOKEN_MULTIPLIER
+        assert llm.seen == [expected] * 8  # every retry saw exactly base*MULT, never a corrupted budget
+        assert llm.config.max_tokens == 1000  # always restored to the original
 
 
 class TestPromptOverridesCustomInstructions:

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -62,7 +62,9 @@ class TestAddToVectorStoreErrors:
         # Verify — v3 single-pass pipeline makes 1 LLM call, returns [] on parse error
         assert mock_memory.llm.generate_response.call_count == 1
         assert result == []
-        assert any("Error parsing extraction response" in record.message for record in caplog.records), "Expected error message not found in logs"
+        assert any("Error parsing extraction response" in record.message for record in caplog.records), (
+            "Expected error message not found in logs"
+        )
 
     def test_empty_llm_response_memory_actions(self, mock_memory, caplog):
         """Test empty response from LLM during memory actions (v3: single-pass, 1 LLM call)"""
@@ -114,7 +116,9 @@ class TestTruncationRecovery:
         memory.db.get_last_messages = MagicMock(return_value=[])
         memory.db.save_messages = MagicMock()
         memory.db.batch_add_history = MagicMock()
-        memory.embedding_model.embed_batch = MagicMock(side_effect=lambda texts, *a, **k: [[0.1, 0.2, 0.3] for _ in texts])
+        memory.embedding_model.embed_batch = MagicMock(
+            side_effect=lambda texts, *a, **k: [[0.1, 0.2, 0.3] for _ in texts]
+        )
         return memory
 
     def test_salvages_complete_memories_by_default_no_retry(self, mock_memory, caplog):
@@ -172,7 +176,10 @@ class TestTruncationRecovery:
         import threading
         import time
 
-        from mem0.memory.utils import _RETRY_TOKEN_MULTIPLIER, retry_extraction_with_more_tokens
+        from mem0.memory.utils import (
+            _RETRY_TOKEN_MULTIPLIER,
+            retry_extraction_with_more_tokens,
+        )
 
         class _FakeConfig:
             max_tokens = 1000
@@ -188,7 +195,9 @@ class TestTruncationRecovery:
                 return COMPLETE_EXTRACTION
 
         llm = _FakeLLM()
-        threads = [threading.Thread(target=retry_extraction_with_more_tokens, args=(llm, "sys", "usr")) for _ in range(8)]
+        threads = [
+            threading.Thread(target=retry_extraction_with_more_tokens, args=(llm, "sys", "usr")) for _ in range(8)
+        ]
         for t in threads:
             t.start()
         for t in threads:
@@ -197,6 +206,74 @@ class TestTruncationRecovery:
         expected = 1000 * _RETRY_TOKEN_MULTIPLIER
         assert llm.seen == [expected] * 8  # every retry saw exactly base*MULT, never a corrupted budget
         assert llm.config.max_tokens == 1000  # always restored to the original
+
+    def test_retry_budget_is_capped(self):
+        # 4x a large configured budget would be very expensive; the raise is
+        # capped at an absolute ceiling instead of multiplying without bound.
+        from mem0.memory.utils import (
+            _RETRY_TOKEN_CAP,
+            retry_extraction_with_more_tokens,
+        )
+
+        class _FakeConfig:
+            max_tokens = 4000  # 4x = 16000, above the cap
+
+        class _FakeLLM:
+            def __init__(self):
+                self.config = _FakeConfig()
+                self.seen = []
+
+            def generate_response(self, messages, response_format=None):
+                self.seen.append(self.config.max_tokens)
+                return COMPLETE_EXTRACTION
+
+        llm = _FakeLLM()
+        retry_extraction_with_more_tokens(llm, "sys", "usr")
+        assert llm.seen == [_RETRY_TOKEN_CAP]
+        assert llm.config.max_tokens == 4000  # restored
+
+    def test_retry_skipped_when_budget_already_at_cap(self):
+        # A budget already at/above the cap has no meaningful raise left; the
+        # retry is skipped rather than re-spending the same budget.
+        from mem0.memory.utils import (
+            _RETRY_TOKEN_CAP,
+            retry_extraction_with_more_tokens,
+        )
+
+        class _FakeConfig:
+            max_tokens = _RETRY_TOKEN_CAP
+
+        class _FakeLLM:
+            def __init__(self):
+                self.config = _FakeConfig()
+                self.calls = 0
+
+            def generate_response(self, messages, response_format=None):
+                self.calls += 1
+                return COMPLETE_EXTRACTION
+
+        llm = _FakeLLM()
+        assert retry_extraction_with_more_tokens(llm, "sys", "usr") == []
+        assert llm.calls == 0
+
+    def test_retry_drops_non_dict_memory_items(self):
+        # A schema-violating retry response (bare strings in the memory array)
+        # must be filtered, not passed downstream where m.get("text") would
+        # crash add() - same shape discipline as salvage_memory_objects.
+        from mem0.memory.utils import retry_extraction_with_more_tokens
+
+        class _FakeConfig:
+            max_tokens = 1000
+
+        class _FakeLLM:
+            def __init__(self):
+                self.config = _FakeConfig()
+
+            def generate_response(self, messages, response_format=None):
+                return '{"memory": ["bare string fact", {"id": "0", "text": "Real fact"}, 42]}'
+
+        llm = _FakeLLM()
+        assert retry_extraction_with_more_tokens(llm, "sys", "usr") == [{"id": "0", "text": "Real fact"}]
 
 
 class TestPromptOverridesCustomInstructions:
@@ -346,7 +423,9 @@ class TestAsyncAddToVectorStoreErrors:
             )
         assert mock_async_memory.llm.generate_response.call_count == 1
         assert result == []
-        assert any("Error parsing extraction response" in record.message for record in caplog.records), "Expected error message not found in logs"
+        assert any("Error parsing extraction response" in record.message for record in caplog.records), (
+            "Expected error message not found in logs"
+        )
 
     @pytest.mark.asyncio
     async def test_async_empty_llm_response_memory_actions(self, mock_async_memory, caplog, mocker):
@@ -649,6 +728,7 @@ class TestMetadataNotMutated:
         memory = _build_memory_instance(mocker, Memory)
         metadata = {"user_id": "test_user", "tags": ["important", "urgent"], "config": {"key": "val"}}
         import copy
+
         metadata_snapshot = copy.deepcopy(metadata)
 
         memory._create_memory("test data", {"test data": [0.1, 0.2, 0.3]}, metadata=metadata)
@@ -779,7 +859,8 @@ def test_update_preserves_actor_id_when_different_actor_updates(mocker):
     )
 
     memory._update_memory(
-        "mem-id", "Player #1 is a good person",
+        "mem-id",
+        "Player #1 is a good person",
         {"Player #1 is a good person": [0.1, 0.2, 0.3]},
         metadata={"user_id": "team", "actor_id": "Bob"},
     )
@@ -802,7 +883,8 @@ async def test_async_update_preserves_actor_id_when_different_actor_updates(mock
     )
 
     await memory._update_memory(
-        "mem-id", "Player #1 is a good person",
+        "mem-id",
+        "Player #1 is a good person",
         {"Player #1 is a good person": [0.1, 0.2, 0.3]},
         metadata={"user_id": "team", "actor_id": "Bob"},
     )

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -173,6 +173,11 @@ class TestTruncationRecovery:
         # worker thread, so concurrent retries on one llm must not corrupt it. The lock in
         # retry_extraction_with_more_tokens serializes the raise/restore. Without the lock
         # this trips: some retry sees a doubly-raised budget, or the config never restores.
+        # This drives the sync function directly from 8 threads on one shared llm, which is
+        # exactly what concurrent async to_thread(retry_extraction_with_more_tokens) calls do,
+        # so it is the canonical serialization test for both the sync and async paths (the
+        # async _add_to_vector_store tests use a MagicMock llm and so assert recovery, not
+        # serialization).
         import threading
         import time
 
@@ -274,6 +279,97 @@ class TestTruncationRecovery:
 
         llm = _FakeLLM()
         assert retry_extraction_with_more_tokens(llm, "sys", "usr") == [{"id": "0", "text": "Real fact"}]
+
+    def test_retry_lock_is_per_llm_instance(self):
+        # The retry lock is cached on each llm: concurrent retries on ONE llm serialize
+        # (the corruption guard), while retries on DIFFERENT llms never block each other.
+        # A non-caching getattr(llm, "_retry_lock", threading.Lock()) - a fresh lock every
+        # call - serializes nothing and fails the first assert; a single process-wide lock
+        # over-serializes and fails the second.
+        from mem0.memory.utils import _retry_lock_for
+
+        class _FakeLLM:
+            pass
+
+        a, b = _FakeLLM(), _FakeLLM()
+        assert _retry_lock_for(a) is _retry_lock_for(a)  # same llm -> one cached lock, reused
+        assert _retry_lock_for(a) is not _retry_lock_for(b)  # different llms -> isolated locks
+
+
+@pytest.mark.asyncio
+class TestAsyncTruncationRecovery:
+    """Async counterpart of TestTruncationRecovery. The async path drives recovery
+    through AsyncMemory._add_to_vector_store, which dispatches the token-raise retry via
+    asyncio.to_thread(retry_extraction_with_more_tokens, ...). That wiring - the flag
+    check, argument forwarding, and result assignment on a worker thread - is exercised by
+    zero sync tests, so a regression there would be silent."""
+
+    @pytest.fixture
+    def mock_async_memory(self, mocker):
+        _setup_mocks(mocker)
+        mocker.patch("mem0.memory.main.capture_event")
+        mocker.patch("mem0.memory.main.extract_entities_batch", return_value=[[]])
+        memory = AsyncMemory()
+        memory.config = mocker.MagicMock()
+        memory.config.custom_instructions = None
+        memory.config.custom_update_memory_prompt = None
+        memory.custom_instructions = None
+        memory.api_version = "v1.1"
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        memory.db.batch_add_history = MagicMock()
+        memory.embedding_model.embed_batch = MagicMock(
+            side_effect=lambda texts, *a, **k: [[0.1, 0.2, 0.3] for _ in texts]
+        )
+        return memory
+
+    async def test_async_salvages_complete_memories_by_default_no_retry(self, mock_async_memory, caplog):
+        # Default: opt-in retry OFF. The async Layer-1 salvage still recovers the 2 complete ones.
+        mock_async_memory.config.recover_truncated_extractions = False
+        mock_async_memory.llm.generate_response.return_value = TRUNCATED_EXTRACTION
+
+        with caplog.at_level(logging.INFO):
+            result = await mock_async_memory._add_to_vector_store(
+                messages=[{"role": "user", "content": "test"}], metadata={}, effective_filters={}, infer=True
+            )
+
+        assert mock_async_memory.llm.generate_response.call_count == 1  # no retry
+        texts = [m["memory"] for m in result]
+        assert "User likes hiking in the Laurel Highlands" in texts
+        assert "User was promoted to Senior Engineer" in texts
+        # the cut-off memory is dropped, not stored as a partial fact
+        assert not any("dog nam" in t for t in texts)
+        assert any("Salvaged" in r.message for r in caplog.records)
+
+    async def test_async_opt_in_retry_recovers_cut_off_remainder(self, mock_async_memory):
+        mock_async_memory.config.recover_truncated_extractions = True
+        mock_async_memory.llm.config.max_tokens = 1000
+
+        # Record the max_tokens in effect at each call - including the retry call, which runs
+        # on a worker thread - to prove the retry raised it via the shared config rather than
+        # via a kwarg most providers reject (the original bug), through the async dispatch.
+        responses = iter([TRUNCATED_EXTRACTION, COMPLETE_EXTRACTION])
+        observed_max_tokens = []
+
+        def fake_generate_response(*args, **kwargs):
+            observed_max_tokens.append(mock_async_memory.llm.config.max_tokens)
+            return next(responses)
+
+        mock_async_memory.llm.generate_response.side_effect = fake_generate_response
+
+        result = await mock_async_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "test"}], metadata={}, effective_filters={}, infer=True
+        )
+
+        assert mock_async_memory.llm.generate_response.call_count == 2  # extraction + token-raise retry
+        # The retry raised max_tokens 4x via the shared config (see _RETRY_TOKEN_MULTIPLIER) on a
+        # worker thread, and must NOT pass max_tokens as a kwarg; both fail against the old code.
+        assert observed_max_tokens[1] == 4000
+        assert "max_tokens" not in mock_async_memory.llm.generate_response.call_args_list[1].kwargs
+        assert mock_async_memory.llm.config.max_tokens == 1000  # restored after the retry
+        texts = [m["memory"] for m in result]
+        assert "User has a dog named Max" in texts  # the previously cut-off fact
+        assert len(result) == 3
 
 
 class TestPromptOverridesCustomInstructions:

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -80,6 +80,78 @@ class TestAddToVectorStoreErrors:
         assert result == []  # Should return empty list when no memories processed
 
 
+# A response truncated mid-stream: memories 0 and 1 finished; memory 2 was cut
+# off while its text was still being written (model hit max_tokens).
+TRUNCATED_EXTRACTION = (
+    '{"memory": ['
+    '{"id": "0", "text": "User likes hiking in the Laurel Highlands"}, '
+    '{"id": "1", "text": "User was promoted to Senior Engineer"}, '
+    '{"id": "2", "text": "User has a dog nam'
+)
+# The same extraction, complete, as a higher-max_tokens retry would return it.
+COMPLETE_EXTRACTION = (
+    '{"memory": ['
+    '{"id": "0", "text": "User likes hiking in the Laurel Highlands"}, '
+    '{"id": "1", "text": "User was promoted to Senior Engineer"}, '
+    '{"id": "2", "text": "User has a dog named Max"}]}'
+)
+
+
+class TestTruncationRecovery:
+    """Truncated extractions: complete memories are always salvaged (Layer 1);
+    the cut-off remainder is recovered only when the opt-in retry is enabled."""
+
+    @pytest.fixture
+    def mock_memory(self, mocker):
+        _setup_mocks(mocker)
+        mocker.patch("mem0.memory.main.capture_event")
+        mocker.patch("mem0.memory.main.extract_entities_batch", return_value=[[]])
+        memory = Memory()
+        memory.config = mocker.MagicMock()
+        memory.config.custom_instructions = None
+        memory.custom_instructions = None
+        memory.api_version = "v1.1"
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        memory.db.batch_add_history = MagicMock()
+        memory.embedding_model.embed_batch = MagicMock(side_effect=lambda texts, *a, **k: [[0.1, 0.2, 0.3] for _ in texts])
+        return memory
+
+    def test_salvages_complete_memories_by_default_no_retry(self, mock_memory, caplog):
+        # Default: opt-in retry OFF. Salvage still recovers the 2 complete ones.
+        mock_memory.config.recover_truncated_extractions = False
+        mock_memory.llm.generate_response.return_value = TRUNCATED_EXTRACTION
+
+        with caplog.at_level(logging.INFO):
+            result = mock_memory._add_to_vector_store(
+                messages=[{"role": "user", "content": "test"}], metadata={}, filters={}, infer=True
+            )
+
+        assert mock_memory.llm.generate_response.call_count == 1  # no retry
+        texts = [m["memory"] for m in result]
+        assert "User likes hiking in the Laurel Highlands" in texts
+        assert "User was promoted to Senior Engineer" in texts
+        # the cut-off memory is dropped, not stored as a partial fact
+        assert not any("dog nam" in t for t in texts)
+        assert any("Salvaged" in r.message for r in caplog.records)
+
+    def test_opt_in_retry_recovers_cut_off_remainder(self, mock_memory):
+        mock_memory.config.recover_truncated_extractions = True
+        mock_memory.llm.config.max_tokens = 1000
+        mock_memory.llm.generate_response.side_effect = [TRUNCATED_EXTRACTION, COMPLETE_EXTRACTION]
+
+        result = mock_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "test"}], metadata={}, filters={}, infer=True
+        )
+
+        assert mock_memory.llm.generate_response.call_count == 2  # extraction + token-raise retry
+        # retry ran with a 4x-raised max_tokens (data-driven; see _RETRY_TOKEN_MULTIPLIER)
+        assert mock_memory.llm.generate_response.call_args_list[1].kwargs["max_tokens"] == 4000
+        texts = [m["memory"] for m in result]
+        assert "User has a dog named Max" in texts  # the previously cut-off fact
+        assert len(result) == 3
+
+
 class TestPromptOverridesCustomInstructions:
     @pytest.fixture
     def mock_memory(self, mocker):

--- a/tests/test_chatty_llm_parsing.py
+++ b/tests/test_chatty_llm_parsing.py
@@ -9,7 +9,7 @@ import json
 
 import pytest
 
-from mem0.memory.utils import extract_json, remove_code_blocks
+from mem0.memory.utils import extract_json, remove_code_blocks, salvage_memory_objects
 
 
 # --- Test extract_json ---
@@ -230,3 +230,50 @@ I hope this helps!"""
         response = 'Sure! Here are the facts:\n{"facts": ["Name is Alex", "Loves basketball"]}\nHope that helps!'
         result = self._parse_with_fallback(response)
         assert result["facts"] == ["Name is Alex", "Loves basketball"]
+
+
+class TestSalvageTruncatedMemories:
+    """salvage_memory_objects: recover the complete memory objects from a
+    response truncated mid-stream (the model hit max_tokens), dropping only the
+    half-written tail object."""
+
+    def test_recovers_complete_objects_drops_cut_off_tail(self):
+        # Memories 1-4 finished; memory 5 was cut off mid-write.
+        truncated = (
+            '{"memory": ['
+            '{"id": "0", "text": "User likes hiking in the Laurel Highlands"}, '
+            '{"id": "1", "text": "User was promoted to Senior Engineer"}, '
+            '{"id": "2", "text": "User has a wife named Elena"}, '
+            '{"id": "3", "text": "User celebrated at Osteria Francescana"}, '
+            '{"id": "4", "text": "User has a dog nam'
+        )
+        memories, was_truncated = salvage_memory_objects(truncated)
+        assert was_truncated is True
+        assert len(memories) == 4  # the cut-off 5th is dropped
+        assert [m["id"] for m in memories] == ["0", "1", "2", "3"]
+        assert all("nam" not in m["text"] or m["text"].endswith("nam") is False for m in memories)
+        assert "dog nam" not in memories[-1]["text"]
+
+    def test_clean_array_reports_not_truncated(self):
+        # json.loads failed on the whole blob (trailing junk), but the array closed.
+        text = '{"memory": [{"id": "0", "text": "Name is Alex"}]} <<trailing garbage'
+        memories, was_truncated = salvage_memory_objects(text)
+        assert was_truncated is False
+        assert len(memories) == 1
+        assert memories[0]["text"] == "Name is Alex"
+
+    def test_no_memory_array_returns_empty_not_truncated(self):
+        # Content-hijack (prose, no JSON) is not a truncation case.
+        memories, was_truncated = salvage_memory_objects("I need to ask you a few questions first.")
+        assert memories == []
+        assert was_truncated is False
+
+    def test_empty_input(self):
+        assert salvage_memory_objects("") == ([], False)
+
+    def test_truncated_right_after_an_object_before_array_close(self):
+        # Cut after object 1's '}' but before ']' -> object 1 complete, still truncated.
+        text = '{"memory": [{"id": "0", "text": "Name is Alex"}, '
+        memories, was_truncated = salvage_memory_objects(text)
+        assert len(memories) == 1
+        assert was_truncated is True

--- a/tests/test_chatty_llm_parsing.py
+++ b/tests/test_chatty_llm_parsing.py
@@ -11,8 +11,8 @@ import pytest
 
 from mem0.memory.utils import extract_json, remove_code_blocks, salvage_memory_objects
 
-
 # --- Test extract_json ---
+
 
 class TestExtractJson:
     """Tests for extract_json utility."""
@@ -94,6 +94,7 @@ That's the result."""
 
 # --- Test remove_code_blocks ---
 
+
 class TestRemoveCodeBlocks:
     """Tests for remove_code_blocks — verify it does NOT handle chatty text."""
 
@@ -133,6 +134,7 @@ class TestRemoveCodeBlocks:
 
 
 # --- Test the full fallback chain (remove_code_blocks -> extract_json) ---
+
 
 class TestFallbackChain:
     """Tests the actual fallback pattern used in _add_to_vector_store:
@@ -270,6 +272,14 @@ class TestSalvageTruncatedMemories:
 
     def test_empty_input(self):
         assert salvage_memory_objects("") == ([], False)
+
+    def test_non_string_input_degrades_instead_of_raising(self):
+        # salvage runs inside the parse-failure except handler; a provider
+        # returning a non-string (dict, None, list) must degrade to "nothing
+        # salvaged", never raise out of the error handler.
+        assert salvage_memory_objects({"unexpected": "dict"}) == ([], False)
+        assert salvage_memory_objects(None) == ([], False)
+        assert salvage_memory_objects(["a", "list"]) == ([], False)
 
     def test_truncated_right_after_an_object_before_array_close(self):
         # Cut after object 1's '}' but before ']' -> object 1 complete, still truncated.

--- a/tests/test_chatty_llm_parsing.py
+++ b/tests/test_chatty_llm_parsing.py
@@ -287,3 +287,37 @@ class TestSalvageTruncatedMemories:
         memories, was_truncated = salvage_memory_objects(text)
         assert len(memories) == 1
         assert was_truncated is True
+
+    def test_recovers_single_quoted_python_repr_dict(self):
+        # Some models emit a Python-repr dict ({'memory': [...]}) instead of JSON.
+        # json.loads / extract_json both fail on it upstream, so it lands here. The
+        # double-quoted-only peeler would match nothing and SILENTLY drop every
+        # fact - the adjacent silent-drop this function exists to prevent.
+        text = "{'memory': [{'id': '0', 'text': \"User's dog is named Biscuit\"}, {'id': '1', 'text': 'Lives in Pittsburgh'}]}"
+        memories, was_truncated = salvage_memory_objects(text)
+        assert was_truncated is False  # array closed cleanly
+        assert [m["id"] for m in memories] == ["0", "1"]
+        assert memories[0]["text"] == "User's dog is named Biscuit"  # apostrophe inside survives
+
+    def test_single_quoted_but_truncated_is_not_dropped_silently(self, caplog):
+        # Single-quoted AND cut off mid-stream: literal_eval cannot recover (no
+        # closing ']'), so nothing is salvaged - but it must be logged, not dropped
+        # silently. Asserts the loud-warning floor for the unrecoverable case.
+        import logging
+
+        text = "{'memory': [{'id': '0', 'text': 'Lives in Pitt"
+        with caplog.at_level(logging.WARNING):
+            memories, _ = salvage_memory_objects(text)
+        assert memories == []
+        assert any("not dropping silently" in r.message for r in caplog.records)
+
+    def test_bracket_inside_string_does_not_break_recovery(self):
+        # An UNBALANCED ']' inside a memory's text must not be mistaken for the
+        # array close. The text holds a lone ']' with no matching '[', so a naive
+        # non-quote-aware scanner would stop at it and mis-slice; only the
+        # quote-aware matcher walks past it and recovers the object.
+        text = "{'memory': [{'id': '0', 'text': 'rated 9] stars'}]}"
+        memories, was_truncated = salvage_memory_objects(text)
+        assert was_truncated is False
+        assert len(memories) == 1
+        assert memories[0]["text"] == "rated 9] stars"


### PR DESCRIPTION
## Linked Issue

Closes #5428

## Description

When fact extraction produces a long response and the model hits `max_tokens` mid-output, it returns valid-but-incomplete JSON (an unterminated `{"memory": [...]}` array). `json.loads` fails, the `extract_json` fallback also fails (the structure never closes), and the `except` block sets `extracted_memories = []`. **Every fact is silently dropped, including the memories the model fully wrote before the cut.**

This PR recovers them in two layers:

1. **Salvage (always on, no flag, no extra LLM call).** `salvage_memory_objects` peels the complete objects off the truncated `memory` array one at a time with stdlib `json.JSONDecoder.raw_decode` (no new dependency), stopping at the first object that does not fully parse. The half-written tail object is dropped (its content cannot be trusted); every object the model finished is kept.
2. **Token-raise retry (opt-in).** If the response was truncated and `recover_truncated_extractions=True`, retry the extraction once at `4x` the configured `max_tokens` (capped at an absolute ceiling of 8192 tokens, and skipped when the configured budget is already at or above the cap) to recover the cut-off remainder. Off by default because it overrides the configured `max_tokens` and costs an extra call. The `4x` multiple is data-driven: on a real corpus, truncations recovered at ~4x the base budget; a 2x raise under-shot and re-truncated. Bounded to one attempt; salvage stays the floor if the retry also truncates. The raise is applied via the shared `llm.config.max_tokens` under a lock (raised for the one retry call, restored in a `finally`) rather than as a `max_tokens=` kwarg, which about half the provider `generate_response` signatures reject (only those declaring `**kwargs` accept it).

### What changed

- **`mem0/memory/utils.py`** - `salvage_memory_objects(text) -> (memories, truncated)` and `retry_extraction_with_more_tokens(...)`. Neither raises: salvage degrades to `([], False)` even on non-string input (it runs inside the parse-failure except handler), and both filter non-dict items out of the recovered list so a schema-violating model cannot crash the add pipeline downstream.
- **`mem0/memory/main.py`** - both sync and async `_add_to_vector_store` parse-failure `except` blocks now salvage (always) and, when truncated and opted in, retry with a raised budget, instead of returning `[]`.
- **`mem0/configs/base.py`** - new `MemoryConfig.recover_truncated_extractions` flag (default `False`). Salvage runs regardless; the flag only enables the extra retry call.
- **`docs/open-source/configuration.mdx`** - documents the new `recover_truncated_extractions` flag and its 4x / 8192 retry behavior.

This is the truncation half of the same parse-failure path as the content-hijack case in #5425 - see below. It is orthogonal to #5178 (the API-exception path) and to #3918 (Gemini reasoning-token leakage). #3918's title says "Unterminated JSON," which sounds adjacent, but its reported errors land at low char indices from reasoning tokens leaking in near the start, whereas truncation fails at a high index near the end because the output stopped mid-write.

### Companion PR and combined validation

This fix and #5425 were developed and validated together against a real conversation corpus, as one recovery loop that routes by failure type:
- **content-hijack / no JSON at all** (#5425): force a tool call so the model cannot answer with prose.
- **max_tokens truncation** (this PR): salvage the complete memories, and, opt-in, retry at a raised `max_tokens`.

In a controlled before/after on a 57-transcript window, baseline runs (recovery off) left failures unrecovered; with recovery enabled, all 18 otherwise-dropped extractions were recovered, none left silently dropped. Run across the full 670-transcript corpus (about 5,400 extraction calls), the recovery path recovered all 109 otherwise-dropped extractions - each a set of facts the unpatched code discards with only an ERROR log - none left silently dropped. By recovery type: 28 truncations via token-raise (this PR's path), and 81 content-hijack cases via forced tool (the companion PR, #5425).

The two were split into focused PRs for reviewability, but they compose in the same `except` block, so it may be worth looking at both together. (The corpus is private; only aggregate counts are shared. The tests in this PR are synthetic.)

### Updates since opening

Rebased onto current `main`. Two refinements were added since the initial review; flagging them here rather than folding them in silently:

- **Salvage now covers single-quoted output.** The original salvage anchored on the double-quoted `"memory"` key, so a model that emitted a Python-repr dict (`{'memory': [...]}` with single quotes) matched nothing and had every fact dropped - the exact silent-drop on an adjacent class that this function exists to prevent. Detection is now quote-agnostic; a quote-aware bracket scan plus `ast.literal_eval` recovers the complete single-quoted array, and any memory-bearing response it still cannot parse is logged at WARNING instead of dropped silently.
- **The token-raise retry lock is now per-llm-instance** (cached on the llm via double-checked locking) instead of process-wide, so concurrent retries on *different* llm instances no longer serialize against each other; the corruption window on a *shared* llm stays closed. A process-wide lock remains as a defensive fallback.

Both are covered by new tests. Happy to split either into its own PR if you'd prefer to keep this one to the original scope.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A. Salvage only runs on responses that already fail to parse (today those return `[]`), so it strictly recovers data that was being dropped. The retry is opt-in and off by default.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (described below)
- [ ] No tests needed (explain why)

Ran locally (Python 3.13; the 3.10-3.12 matrix runs in CI): all tests in the two touched suites pass (including the new salvage and concurrency tests), ruff lint + format clean on touched files. The salvage test is falsifiable - reverting the `main.py` wiring makes a truncated response return `[]` (facts lost); with the fix the complete memories are recovered.

New tests (all synthetic - no private data):
- `tests/test_chatty_llm_parsing.py::TestSalvageTruncatedMemories` - salvage recovers the complete objects and drops only the cut-off tail; reports `truncated` correctly; no-op when there is no `memory` array.
- `tests/test_chatty_llm_parsing.py::TestSalvageTruncatedMemories` (single-quote cases) - recovery of a single-quoted Python-repr `{'memory': [...]}` response, a `]` inside a string value not breaking the array scan, and the loud-WARNING floor when a single-quoted response is also truncated (nothing salvageable, but not dropped silently).
- `tests/memory/test_main.py::TestTruncationRecovery` - through `_add_to_vector_store`: salvage recovers the complete memories by default (no retry); with the opt-in flag, the token-raise retry recovers the cut-off remainder at a 4x budget applied via the shared config (asserted at call time, with no `max_tokens=` kwarg, and restored after). Also covers the concurrent-retry lock (no shared-config corruption), that the lock is per-llm-instance, the 8192 cap on the raise, and the skip when the budget is already at the cap.

Manual / empirical validation: beyond the synthetic tests, the approach was run against a real conversation corpus (see the combined-validation note above); truncations were recovered via the token-raise path, with none left unrecovered. Corpus is private; aggregate counts only.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (new config flag documented in its Field description; no public API change)



