### PR TITLE
fix(llms): honor forced tool_choice and per-call kwargs in Gemini provider

### DIFF
--- a/mem0/llms/gemini.py
+++ b/mem0/llms/gemini.py
@@ -140,6 +140,7 @@ class GeminiLLM(LLMBase):
         response_format=None,
         tools: Optional[List[Dict]] = None,
         tool_choice: str = "auto",
+        **kwargs,
     ):
         """
         Generate a response based on the given messages using Gemini.
@@ -149,6 +150,9 @@ class GeminiLLM(LLMBase):
             response_format (str or object, optional): Format for the response. Defaults to "text".
             tools (list, optional): List of tools that the model can call. Defaults to None.
             tool_choice (str, optional): Tool choice method. Defaults to "auto".
+            **kwargs: Additional parameters (e.g. ``max_tokens``) that override the
+                configured values for this one call. Accepted for parity with the
+                base ``generate_response`` contract and the other providers.
 
         Returns:
             str: The generated response.
@@ -164,6 +168,10 @@ class GeminiLLM(LLMBase):
             "top_p": self.config.top_p,
         }
 
+        # Per-call overrides take precedence over the configured values.
+        if kwargs.get("max_tokens") is not None:
+            config_params["max_output_tokens"] = kwargs["max_tokens"]
+
         # Add system instruction to config if present
         if system_instruction:
             config_params["system_instruction"] = system_instruction
@@ -178,9 +186,13 @@ class GeminiLLM(LLMBase):
             config_params["tools"] = formatted_tools
 
             if tool_choice:
+                # "any" and "required" both mean "force a tool call" -> Gemini ANY
+                # mode. Previously "required" fell through to NONE, which silently
+                # disabled tool calling for any caller forcing a specific tool.
+                forced = tool_choice in ("any", "required")
                 if tool_choice == "auto":
                     mode = types.FunctionCallingConfigMode.AUTO
-                elif tool_choice == "any":
+                elif forced:
                     mode = types.FunctionCallingConfigMode.ANY
                 else:
                     mode = types.FunctionCallingConfigMode.NONE
@@ -189,7 +201,7 @@ class GeminiLLM(LLMBase):
                     function_calling_config=types.FunctionCallingConfig(
                         mode=mode,
                         allowed_function_names=(
-                            [tool["function"]["name"] for tool in tools] if tool_choice == "any" else None
+                            [tool["function"]["name"] for tool in tools] if forced else None
                         ),
                     )
                 )

--- a/mem0/llms/gemini.py
+++ b/mem0/llms/gemini.py
@@ -169,6 +169,8 @@ class GeminiLLM(LLMBase):
         }
 
         # Per-call overrides take precedence over the configured values.
+        # Accepted kwargs: max_tokens. Anything else is ignored rather than
+        # forwarded, so unsupported OpenAI-style params cannot break the call.
         if kwargs.get("max_tokens") is not None:
             config_params["max_output_tokens"] = kwargs["max_tokens"]
 
@@ -188,11 +190,13 @@ class GeminiLLM(LLMBase):
             if tool_choice:
                 # "any" and "required" both mean "force a tool call" -> Gemini ANY
                 # mode. Previously "required" fell through to NONE, which silently
-                # disabled tool calling for any caller forcing a specific tool.
-                forced = tool_choice in ("any", "required")
+                # disabled tool calling for any caller forcing a tool. They differ on
+                # restriction: "any" forces one of *these* tools (allowed_function_names
+                # set), "required" forces *some* tool with the model free to choose
+                # (allowed_function_names unset), matching LiteLLM's Gemini mapping.
                 if tool_choice == "auto":
                     mode = types.FunctionCallingConfigMode.AUTO
-                elif forced:
+                elif tool_choice in ("any", "required"):
                     mode = types.FunctionCallingConfigMode.ANY
                 else:
                     mode = types.FunctionCallingConfigMode.NONE
@@ -201,7 +205,7 @@ class GeminiLLM(LLMBase):
                     function_calling_config=types.FunctionCallingConfig(
                         mode=mode,
                         allowed_function_names=(
-                            [tool["function"]["name"] for tool in tools] if forced else None
+                            [tool["function"]["name"] for tool in tools] if tool_choice == "any" else None
                         ),
                     )
                 )

--- a/tests/llms/test_gemini.py
+++ b/tests/llms/test_gemini.py
@@ -216,7 +216,8 @@ def _tool_response():
 def test_tool_choice_required_forces_any_mode(mock_gemini_client: Mock):
     """Regression: tool_choice='required' must map to ANY (force a tool), not
     NONE (tools off). Previously 'required' fell through to NONE and silently
-    disabled tool calling."""
+    disabled tool calling. 'required' means the model must call *some* tool of
+    its choosing, so allowed_function_names stays unset (LiteLLM parity)."""
     llm = GeminiLLM(BaseLlmConfig(model="gemini-2.0-flash", max_tokens=100))
     mock_gemini_client.models.generate_content.return_value = _tool_response()
 
@@ -224,10 +225,12 @@ def test_tool_choice_required_forces_any_mode(mock_gemini_client: Mock):
 
     cfg = mock_gemini_client.models.generate_content.call_args.kwargs["config"]
     assert cfg.tool_config.function_calling_config.mode == types.FunctionCallingConfigMode.ANY
-    assert cfg.tool_config.function_calling_config.allowed_function_names == ["save_memories"]
+    assert cfg.tool_config.function_calling_config.allowed_function_names is None
 
 
 def test_tool_choice_any_still_forces(mock_gemini_client: Mock):
+    """'any' restricts the forced call to the provided tools, so
+    allowed_function_names is set."""
     llm = GeminiLLM(BaseLlmConfig(model="gemini-2.0-flash", max_tokens=100))
     mock_gemini_client.models.generate_content.return_value = _tool_response()
 
@@ -235,6 +238,7 @@ def test_tool_choice_any_still_forces(mock_gemini_client: Mock):
 
     cfg = mock_gemini_client.models.generate_content.call_args.kwargs["config"]
     assert cfg.tool_config.function_calling_config.mode == types.FunctionCallingConfigMode.ANY
+    assert cfg.tool_config.function_calling_config.allowed_function_names == ["save_memories"]
 
 
 def test_tool_choice_none_disables_tools(mock_gemini_client: Mock):
@@ -254,9 +258,7 @@ def test_max_tokens_kwarg_overrides_config(mock_gemini_client: Mock):
     mock_part = Mock()
     mock_part.text = "ok"
     mock_part.function_call = None
-    mock_gemini_client.models.generate_content.return_value = Mock(
-        candidates=[Mock(content=Mock(parts=[mock_part]))]
-    )
+    mock_gemini_client.models.generate_content.return_value = Mock(candidates=[Mock(content=Mock(parts=[mock_part]))])
 
     llm.generate_response([{"role": "user", "content": "hi"}], max_tokens=8000)
 

--- a/tests/llms/test_gemini.py
+++ b/tests/llms/test_gemini.py
@@ -187,3 +187,78 @@ def test_parse_response_empty_parts_with_tools(mock_gemini_client: Mock):
 
     result = llm._parse_response(mock_response, tools=[{"function": {"name": "test"}}])
     assert result == {"content": None, "tool_calls": []}
+
+
+# --- Forced tool_choice + per-call kwargs (provider bug fixes) ---
+
+_FORCE_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "save_memories",
+            "description": "Save extracted memories.",
+            "parameters": {"type": "object", "properties": {"memory": {"type": "array"}}, "required": ["memory"]},
+        },
+    }
+]
+
+
+def _tool_response():
+    call = Mock()
+    call.name = "save_memories"
+    call.args = {"memory": []}
+    part = Mock()
+    part.text = None
+    part.function_call = call
+    return Mock(candidates=[Mock(content=Mock(parts=[part]))])
+
+
+def test_tool_choice_required_forces_any_mode(mock_gemini_client: Mock):
+    """Regression: tool_choice='required' must map to ANY (force a tool), not
+    NONE (tools off). Previously 'required' fell through to NONE and silently
+    disabled tool calling."""
+    llm = GeminiLLM(BaseLlmConfig(model="gemini-2.0-flash", max_tokens=100))
+    mock_gemini_client.models.generate_content.return_value = _tool_response()
+
+    llm.generate_response([{"role": "user", "content": "hi"}], tools=_FORCE_TOOLS, tool_choice="required")
+
+    cfg = mock_gemini_client.models.generate_content.call_args.kwargs["config"]
+    assert cfg.tool_config.function_calling_config.mode == types.FunctionCallingConfigMode.ANY
+    assert cfg.tool_config.function_calling_config.allowed_function_names == ["save_memories"]
+
+
+def test_tool_choice_any_still_forces(mock_gemini_client: Mock):
+    llm = GeminiLLM(BaseLlmConfig(model="gemini-2.0-flash", max_tokens=100))
+    mock_gemini_client.models.generate_content.return_value = _tool_response()
+
+    llm.generate_response([{"role": "user", "content": "hi"}], tools=_FORCE_TOOLS, tool_choice="any")
+
+    cfg = mock_gemini_client.models.generate_content.call_args.kwargs["config"]
+    assert cfg.tool_config.function_calling_config.mode == types.FunctionCallingConfigMode.ANY
+
+
+def test_tool_choice_none_disables_tools(mock_gemini_client: Mock):
+    llm = GeminiLLM(BaseLlmConfig(model="gemini-2.0-flash", max_tokens=100))
+    mock_gemini_client.models.generate_content.return_value = _tool_response()
+
+    llm.generate_response([{"role": "user", "content": "hi"}], tools=_FORCE_TOOLS, tool_choice="none")
+
+    cfg = mock_gemini_client.models.generate_content.call_args.kwargs["config"]
+    assert cfg.tool_config.function_calling_config.mode == types.FunctionCallingConfigMode.NONE
+
+
+def test_max_tokens_kwarg_overrides_config(mock_gemini_client: Mock):
+    """generate_response accepts **kwargs (base-class contract); a max_tokens
+    override is applied as max_output_tokens for that one call."""
+    llm = GeminiLLM(BaseLlmConfig(model="gemini-2.0-flash", max_tokens=100))
+    mock_part = Mock()
+    mock_part.text = "ok"
+    mock_part.function_call = None
+    mock_gemini_client.models.generate_content.return_value = Mock(
+        candidates=[Mock(content=Mock(parts=[mock_part]))]
+    )
+
+    llm.generate_response([{"role": "user", "content": "hi"}], max_tokens=8000)
+
+    cfg = mock_gemini_client.models.generate_content.call_args.kwargs["config"]
+    assert cfg.max_output_tokens == 8000


### PR DESCRIPTION
## Linked Issue

Closes #5430

## Description

Two small tool-handling bugs in mem0's Gemini provider (`mem0/llms/gemini.py`), the same shape as #5189 (several small same-file provider bugs filed together):

1. **`tool_choice="required"` silently disabled tool calling.** `generate_response` mapped `"required"` to `FunctionCallingConfigMode.NONE` (tools OFF) instead of `ANY` (force a tool), because only `"auto"` and `"any"` were handled and everything else fell through to `NONE`. So asking Gemini to force a tool produced no tool call.
2. **`generate_response` did not accept `**kwargs`.** The base `LLMBase.generate_response` contract and several providers (OpenAI, Anthropic, AWS Bedrock, among others) accept `**kwargs` for per-call overrides; Gemini omitted it, so passing an extra parameter (e.g. a per-call `max_tokens`) raised `TypeError`.

### What changed

- **`mem0/llms/gemini.py`** - map `"required"` to `ANY` mode. The two forcing values keep their distinct semantics, matching LiteLLM's Gemini mapping: `"any"` forces one of *these* tools (`allowed_function_names` set, as before), `"required"` forces *some* tool with the model free to choose (`allowed_function_names` unset). Also accept `**kwargs` and apply a `max_tokens` override as `max_output_tokens` (only `max_tokens` is recognized; anything else is deliberately ignored rather than forwarded).

This is a prerequisite for forced structured-output use on Gemini - the mechanism #5425 uses for OpenAI and Anthropic today, and the angle raised for the Gemini case in #3918. It does not by itself extend that recovery to Gemini (that would be a separate change opting Gemini into the recovery gate). The bug stands on its own: any caller forcing a tool on Gemini hits it.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A. The only behavior change is for `tool_choice="required"` (previously a silent no-op that disabled tools, now forces a tool as intended) and accepting `**kwargs` (previously a `TypeError`). Existing `"auto"` / `"any"` / `"none"` behavior is unchanged.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

New tests in `tests/llms/test_gemini.py` (mocked client, no real API): `tool_choice="required"` maps to `ANY` with `allowed_function_names=None` (model free to choose), `"any"` still forces with `allowed_function_names` set, `"none"` disables, and a per-call `max_tokens` kwarg overrides `max_output_tokens`. Falsifiable: reverting the mapping fix makes the `required`-forces-`ANY` test fail (it maps to `NONE`), which is the bug.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (no public API change)

