### PR TITLE
fix: return 400 for invalid search filters

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -430,7 +430,7 @@ def get_memory(memory_id: str, _auth=Depends(verify_auth)):
 def search_memories(search_req: SearchRequest, _auth=Depends(verify_auth)):
     """Search for memories based on a query."""
     try:
-        filters = search_req.filters or {}
+        filters = dict(search_req.filters or {})
         deprecated_keys = []
         for entity_key in ("user_id", "agent_id", "run_id"):
             entity_val = getattr(search_req, entity_key, None)
@@ -443,12 +443,22 @@ def search_memories(search_req: SearchRequest, _auth=Depends(verify_auth)):
                 ", ".join(deprecated_keys),
                 ", ".join(f'"{k}": "..."' for k in deprecated_keys),
             )
+        if not any(key in filters for key in ("user_id", "agent_id", "run_id")):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "filters must contain at least one of: user_id, agent_id, run_id. "
+                    "Example: filters={'user_id': 'u1'}"
+                ),
+            )
         params = {}
         if search_req.top_k is not None:
             params["top_k"] = search_req.top_k
         if search_req.threshold is not None:
             params["threshold"] = search_req.threshold
         return get_memory_instance().search(query=search_req.query, filters=filters, **params)
+    except HTTPException:
+        raise
     except Exception:
         raise upstream_error()
 

--- a/tests/test_server_params.py
+++ b/tests/test_server_params.py
@@ -641,11 +641,11 @@ class TestSearchEntityIdMapping:
         assert kwargs["filters"]["user_id"] == "u1"
         assert kwargs["filters"]["category"] == "food"
 
-    def test_no_entity_ids_no_filters(self, client, mock_memory):
+    def test_no_entity_ids_no_filters_returns_400(self, client, mock_memory):
         resp = client.post("/search", json={"query": "food"})
-        assert resp.status_code == 200
-        _, kwargs = mock_memory.search.call_args
-        assert kwargs["filters"] == {}
+        assert resp.status_code == 400
+        assert "filters must contain at least one of" in resp.json()["detail"]
+        mock_memory.search.assert_not_called()
 
     def test_only_filters_no_entity_ids(self, client, mock_memory):
         resp = client.post("/search", json={

--- a/tests/test_server_search_validation.py
+++ b/tests/test_server_search_validation.py
@@ -1,0 +1,58 @@
+import importlib
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("fastapi", reason="fastapi not installed")
+
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def mock_memory():
+    mock_instance = MagicMock()
+    mock_instance.search.return_value = [{"id": "mem-1", "memory": "test", "score": 0.9}]
+
+    with patch.dict(
+        os.environ,
+        {"OPENAI_API_KEY": "fake-key", "ADMIN_API_KEY": "", "AUTH_DISABLED": "true"},
+    ):
+        with patch("mem0.Memory.from_config", return_value=mock_instance):
+            yield mock_instance
+
+
+@pytest.fixture
+def client(mock_memory):
+    import auth
+    import server.main as server_main
+
+    with patch.dict(
+        os.environ,
+        {"OPENAI_API_KEY": "fake-key", "ADMIN_API_KEY": "", "AUTH_DISABLED": "true"},
+    ):
+        importlib.reload(auth)
+        importlib.reload(server_main)
+    return TestClient(server_main.app)
+
+
+def test_search_without_identifier_filters_returns_400(client, mock_memory):
+    resp = client.post("/search", json={"query": "food"})
+
+    assert resp.status_code == 400
+    assert "filters must contain at least one of" in resp.json()["detail"]
+    mock_memory.search.assert_not_called()
+
+
+def test_search_with_metadata_only_filters_returns_400(client, mock_memory):
+    resp = client.post(
+        "/search",
+        json={
+            "query": "food",
+            "filters": {"category": "food"},
+        },
+    )
+
+    assert resp.status_code == 400
+    assert "filters must contain at least one of" in resp.json()["detail"]
+    mock_memory.search.assert_not_called()


### PR DESCRIPTION
## Linked Issue

Closes #5367

## Description

POST `/search` currently lets requests without `user_id`, `agent_id`, or `run_id` reach `Memory.search()`. The SDK correctly raises a local `ValueError` for that invalid input, but the server catches it as a generic upstream failure and returns 502.

This PR validates the required identifier filters in the REST handler before calling `Memory.search()`, so invalid search requests return 400 with the same clear validation message. It also copies the filters dict before merging deprecated top-level identifiers to avoid mutating the request model data.

AI-assisted contribution; I self-reviewed the diff and validated it locally.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Local validation:

```console
AUTH_DISABLED=true PYTHONPATH=.:server /Users/fengjikui/Documents/dev-coding/codex_build/oss_contrib/mem0/.venv/bin/python -m pytest tests/test_server_search_validation.py tests/test_server_params.py -q
# 56 passed

/Users/fengjikui/Documents/dev-coding/codex_build/oss_contrib/mem0/.venv/bin/python -m ruff check server/main.py tests/test_server_params.py tests/test_server_search_validation.py
/Users/fengjikui/Documents/dev-coding/codex_build/oss_contrib/mem0/.venv/bin/python -m ruff format --check server/main.py tests/test_server_search_validation.py
/Users/fengjikui/Documents/dev-coding/codex_build/oss_contrib/mem0/.venv/bin/python -m py_compile server/main.py tests/test_server_params.py tests/test_server_search_validation.py
git diff --check
```

`tests/test_server_params.py` is not included in the targeted ruff format check because the pre-existing file would be reformatted wholesale; this PR keeps its diff minimal.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
