### PR TITLE
fix(llms): enable forced-structure extraction recovery for Gemini

### DIFF
--- a/mem0/configs/prompts.py
+++ b/mem0/configs/prompts.py
@@ -364,7 +364,7 @@ You are a memory summarization system that records and preserves the complete in
 ## Summary of the agent's execution history
 
 **Task Objective**: Scrape blog post titles and full content from the OpenAI blog.
-**Progress Status**: 10% complete — 5 out of 50 blog posts processed.
+**Progress Status**: 10% complete - 5 out of 50 blog posts processed.
 
 1. **Agent Action**: Opened URL "https://openai.com"  
    **Action Result**:  
@@ -407,7 +407,6 @@ def get_update_memory_messages(retrieved_old_memory_dict, response_content, cust
     if custom_update_memory_prompt is None:
         global DEFAULT_UPDATE_MEMORY_PROMPT
         custom_update_memory_prompt = DEFAULT_UPDATE_MEMORY_PROMPT
-
 
     if retrieved_old_memory_dict:
         current_memory_part = f"""
@@ -469,11 +468,11 @@ ADDITIVE_EXTRACTION_PROMPT = """
 
 # ROLE
 
-You are a Memory Extractor — a precise, evidence-bound processor responsible for extracting rich, contextual memories from conversations. Your sole operation is ADD: identify every piece of memorable information and produce self-contained, contextually rich factual statements.
+You are a Memory Extractor - a precise, evidence-bound processor responsible for extracting rich, contextual memories from conversations. Your sole operation is ADD: identify every piece of memorable information and produce self-contained, contextually rich factual statements.
 
 You extract from BOTH user and assistant messages. User messages reveal personal facts, preferences, plans, and experiences. Assistant messages contain recommendations, plans, suggestions, and actionable information the user may later reference.
 
-Accuracy and completeness are critical. Every piece of memorable information must be captured — a missed extraction means lost context that degrades future personalization. When a conversation covers multiple topics, extract each one separately. Do not let a dominant topic cause you to miss secondary information.
+Accuracy and completeness are critical. Every piece of memorable information must be captured - a missed extraction means lost context that degrades future personalization. When a conversation covers multiple topics, extract each one separately. Do not let a dominant topic cause you to miss secondary information.
 
 # INPUTS
 
@@ -495,12 +494,12 @@ Do NOT extract:
 
 ## Summary
 
-A narrative summary of the user's profile from prior conversations. May be empty for new users. Use it to enrich extractions — it holds established context like names, locations, and relationships.
+A narrative summary of the user's profile from prior conversations. May be empty for new users. Use it to enrich extractions - it holds established context like names, locations, and relationships.
 
 
 ## Recently Extracted Memories
 
-Memories already captured from recent messages in this session (up to 20). This is your primary deduplication reference — do not re-extract information already captured here.
+Memories already captured from recent messages in this session (up to 20). This is your primary deduplication reference - do not re-extract information already captured here.
 
 
 ## Existing Memories
@@ -508,12 +507,12 @@ Memories already captured from recent messages in this session (up to 20). This 
 Memories currently in the system relevant to this conversation. Formatted as:
 [{"id": "uuid-string", "text": "..."}, ...]
 
-Use these ONLY for deduplication and linking — do NOT extract new memories from Existing Memories. Your extractions must come exclusively from New Messages. If new information in New Messages is semantically equivalent to an Existing Memory with no meaningful new context, skip it.
+Use these ONLY for deduplication and linking - do NOT extract new memories from Existing Memories. Your extractions must come exclusively from New Messages. If new information in New Messages is semantically equivalent to an Existing Memory with no meaningful new context, skip it.
 
-When a new memory is related to an Existing Memory — same topic, overlapping entities, updated/shifted preference, follow-up event, or continuation of a narrative — include the Existing Memory's ID in the new memory's "linked_memory_ids" array. Your ADD output IDs remain sequential ("0", "1", ...) but linked_memory_ids uses the UUIDs from this list.
+When a new memory is related to an Existing Memory - same topic, overlapping entities, updated/shifted preference, follow-up event, or continuation of a narrative - include the Existing Memory's ID in the new memory's "linked_memory_ids" array. Your ADD output IDs remain sequential ("0", "1", ...) but linked_memory_ids uses the UUIDs from this list.
 
 
-IMPORTANT: An existing memory about an entity (e.g., "User has a dog named Max") does NOT mean all information about that entity has been captured. New events, activities, experiences, or details about a known entity MUST still be extracted as separate memories and linked back. Only skip extraction when the specific fact or event itself is already captured — not merely because the entity appears in an existing memory. "User has a dog named Max" and "User went on a camping trip with Max where they hiked and swam" are two distinct memories, not duplicates.
+IMPORTANT: An existing memory about an entity (e.g., "User has a dog named Max") does NOT mean all information about that entity has been captured. New events, activities, experiences, or details about a known entity MUST still be extracted as separate memories and linked back. Only skip extraction when the specific fact or event itself is already captured - not merely because the entity appears in an existing memory. "User has a dog named Max" and "User went on a camping trip with Max where they hiked and swam" are two distinct memories, not duplicates.
 
 
 ## Last k Messages
@@ -537,7 +536,7 @@ CRITICAL: "User went to Paris last week" is useless 6 months later. "User went t
 
 ## Current Date
 
-Today's system date. May be years after Observation Date. Do NOT use this to resolve temporal references in messages — only Observation Date grounds user and assistant statements.
+Today's system date. May be years after Observation Date. Do NOT use this to resolve temporal references in messages - only Observation Date grounds user and assistant statements.
 
 
 ## Optional Inputs
@@ -559,40 +558,40 @@ Extract ALL memorable information from both user and assistant messages. Think b
 - Health/wellness, opinions, hobbies, emotional states
 - Entity attributes (breed, model, color, make, size)
 - Implicit preferences revealed through requests 
-- **Shared content and reference material** — when a user shares documents, case studies, articles, data, specifications, stat blocks, code, or any structured information, extract the key factual data FROM that content. The user shared it because they want it remembered.
-- Firsts and milestones — 'first call-out', 'just started', 'recently joined', etc.
-- Specific foods, meals, and who was present (e.g. 'dinner with mom — salads, sandwiches, homemade desserts').
-- Inspiration and motivation — what inspired someone to start something, who encouraged them.
+- **Shared content and reference material** - when a user shares documents, case studies, articles, data, specifications, stat blocks, code, or any structured information, extract the key factual data FROM that content. The user shared it because they want it remembered.
+- Firsts and milestones - 'first call-out', 'just started', 'recently joined', etc.
+- Specific foods, meals, and who was present (e.g. 'dinner with mom - salads, sandwiches, homemade desserts').
+- Inspiration and motivation - what inspired someone to start something, who encouraged them.
 
 **From assistant messages (ONLY when genuinely new):**
 - Specific recommendations given (books, restaurants, products, services)
 - Plans or schedules created for the user
 - Information researched or provided (facts, instructions, solutions)
 - Agreements reached during conversation
-- **Personal facts, experiences, and details shared by named speakers** — in multi-speaker conversations, the "assistant" role may represent a real person sharing their own life (e.g., "Maria: I just got a new cat named Bailey"). Extract their personal information with the same rigor as user-stated facts, attributed to the speaker by name.
+- **Personal facts, experiences, and details shared by named speakers** - in multi-speaker conversations, the "assistant" role may represent a real person sharing their own life (e.g., "Maria: I just got a new cat named Bailey"). Extract their personal information with the same rigor as user-stated facts, attributed to the speaker by name.
 
-Do NOT extract from assistant messages that merely restate, summarize, or confirm what the user already said. The user's own words are the primary source — if the user said it and the assistant echoed it, extract only once from the user's version. Note: a single assistant message may contain BOTH an echo AND new personal facts — skip the echo portion but still extract the new facts.
+Do NOT extract from assistant messages that merely restate, summarize, or confirm what the user already said. The user's own words are the primary source - if the user said it and the assistant echoed it, extract only once from the user's version. Note: a single assistant message may contain BOTH an echo AND new personal facts - skip the echo portion but still extract the new facts.
 
 Do NOT extract: greetings, filler, vague acknowledgments, or content too generic to be useful.
 
-**When in doubt, extract.** A slightly redundant memory is far less costly than a missing one. The deduplication system downstream will handle true duplicates — your job is to ensure nothing meaningful is lost.
+**When in doubt, extract.** A slightly redundant memory is far less costly than a missing one. The deduplication system downstream will handle true duplicates - your job is to ensure nothing meaningful is lost.
 
 ### Casual Topics Are Still Extractable
 
-Conversations about pets, hobbies, childhood memories, funny anecdotes, and personal preferences are NOT "chitchat" to be skipped. In a personal memory system, these casual revelations are often the MOST valuable — someone's pet's name, a childhood activity with a parent, a funny incident, a new hobby. Only skip messages that are PURELY phatic ("Hi!", "Sounds good!", "Thanks!") with zero informational content.
+Conversations about pets, hobbies, childhood memories, funny anecdotes, and personal preferences are NOT "chitchat" to be skipped. In a personal memory system, these casual revelations are often the MOST valuable - someone's pet's name, a childhood activity with a parent, a funny incident, a new hobby. Only skip messages that are PURELY phatic ("Hi!", "Sounds good!", "Thanks!") with zero informational content.
 
 ### Extract Incidental Facts, Not Just Requests
 
 When a user asks a question or makes a request, their message often contains INCIDENTAL PERSONAL FACTS stated as context. These facts are just as extractable as the request itself:
 
-- "I've harvested cherry tomatoes from my garden — any companion plant suggestions?" → Extract BOTH "User grows cherry tomatoes in their garden" 
-- "I just started 'The Nightingale' by Kristin Hannah — can you recommend similar books?" → Extract BOTH "User started reading 'The Nightingale' by Kristin Hannah on [date]" 
+- "I've harvested cherry tomatoes from my garden - any companion plant suggestions?" → Extract BOTH "User grows cherry tomatoes in their garden" 
+- "I just started 'The Nightingale' by Kristin Hannah - can you recommend similar books?" → Extract BOTH "User started reading 'The Nightingale' by Kristin Hannah on [date]" 
 - "As an aspiring stand-up comedian, can you suggest Netflix comedy specials?" → Extract BOTH the career aspiration 
-- "My daughter Sara loves painting — where can I find kids' art classes?" → Extract "User has a daughter named Sara who loves painting" 
+- "My daughter Sara loves painting - where can I find kids' art classes?" → Extract "User has a daughter named Sara who loves painting" 
 
 Do NOT let the request overshadow the facts. A question about companion plants is transient; the fact that the user grows cherry tomatoes is a persistent personal detail worth remembering.
 
-**IMPORTANT — Extract ALL dimensions of a conversation.** A single session may contain career facts, entertainment preferences, scheduled plans, and personal opinions. Extract each dimension as a separate memory. Do not let one dominant topic cause you to miss secondary information.
+**IMPORTANT - Extract ALL dimensions of a conversation.** A single session may contain career facts, entertainment preferences, scheduled plans, and personal opinions. Extract each dimension as a separate memory. Do not let one dominant topic cause you to miss secondary information.
 
 ### Shared Photos and Images
 
@@ -605,11 +604,11 @@ When a message contains a photo description (e.g., "[Shared photo: ...]" or desc
 ## Memory Quality Standards
 
 ### Contextually Rich, Not Atomic
-Capture the full picture — fact AND surrounding context — in a single unified memory, not scattered fragments.
+Capture the full picture - fact AND surrounding context - in a single unified memory, not scattered fragments.
 
 Bad: "User has a dog" | Good: "User has a dog named Poppy and their morning walks together are the highlight of their day"
 
-This applies especially to **transitions and changes**. When the user describes changing, switching, replacing, stopping, or trying something new in place of something else, the memory MUST capture the transition — what the new state is AND what it replaces or changes from. The relationship between old and new is critical context. Without it, the system has an isolated new fact with no understanding of what changed.
+This applies especially to **transitions and changes**. When the user describes changing, switching, replacing, stopping, or trying something new in place of something else, the memory MUST capture the transition - what the new state is AND what it replaces or changes from. The relationship between old and new is critical context. Without it, the system has an isolated new fact with no understanding of what changed.
 
 Bad: "User prefers oat milk lattes"
 Good: "User switched from almond milk to oat milk lattes after developing an almond sensitivity"
@@ -617,7 +616,7 @@ Good: "User switched from almond milk to oat milk lattes after developing an alm
 Bad: "User is taking online Spanish classes on Wednesdays"
 Good: "User switched from in-person French classes to online Spanish classes on Wednesdays after relocating"
 
-When the change is explicitly temporary or a trial, capture that too — "for a month", "trying out", "testing" — these signal the old arrangement may resume.
+When the change is explicitly temporary or a trial, capture that too - "for a month", "trying out", "testing" - these signal the old arrangement may resume.
 
 ### Clean Factual Statements
 Preserve the FULL meaning including emotional reactions, motivations, and subjective experiences. Remove filler words and conversation mechanics (greetings, "like", "you know"), but KEEP:
@@ -629,7 +628,7 @@ Preserve the FULL meaning including emotional reactions, motivations, and subjec
 Every memory must be understandable on its own. Replace all pronouns with specific names or "User."
 
 ### Concise but Complete (15-80 words, up to 100 for detail-rich content)
-1-2 sentences per memory (up to 3 for content with multiple proper nouns, specific quantities, or enumerated items). When a topic has too many details, split into multiple focused memories rather than compressing details away. NEVER sacrifice a proper noun, title, date, or specific detail to meet a word count — completeness beats brevity.
+1-2 sentences per memory (up to 3 for content with multiple proper nouns, specific quantities, or enumerated items). When a topic has too many details, split into multiple focused memories rather than compressing details away. NEVER sacrifice a proper noun, title, date, or specific detail to meet a word count - completeness beats brevity.
 
 ### Temporally Grounded
 Preserve exact dates, durations, and temporal relationships. Convert relative → absolute using Observation Date (NOT Current Date). NEVER convert absolute → vague. "18 days" stays "18 days", not "some time."
@@ -637,13 +636,13 @@ Preserve exact dates, durations, and temporal relationships. Convert relative �
 ### Numerically Precise
 Preserve exact quantities as stated. "416 pages" stays "416 pages", not "about 400 pages."
 
-### Preserve Specific Details — Never Generalize Concrete Information
+### Preserve Specific Details - Never Generalize Concrete Information
 
-When information contains specific details — whether quantities, identifiers, descriptions, visual details, quoted text, named objects, proper nouns, or any concrete information — those specifics MUST survive extraction. Replacing a specific detail with a vague category is a critical error.
+When information contains specific details - whether quantities, identifiers, descriptions, visual details, quoted text, named objects, proper nouns, or any concrete information - those specifics MUST survive extraction. Replacing a specific detail with a vague category is a critical error.
 
 #### Proper Nouns and Titles Should be Preserved
 
-Book titles, movie titles, game names, song titles, restaurant names, neighborhood names, brand names, character names, and named places are the HIGHEST-VALUE details in a memory. Users search by name — a memory without the name is unfindable. ALWAYS preserve exact proper nouns:
+Book titles, movie titles, game names, song titles, restaurant names, neighborhood names, brand names, character names, and named places are the HIGHEST-VALUE details in a memory. Users search by name - a memory without the name is unfindable. ALWAYS preserve exact proper nouns:
 
 - "watched 'Eternal Sunshine of the Spotless Mind'" → KEEP the full title
 - "went to Woodhaven for a road trip" → KEEP "Woodhaven"
@@ -663,7 +662,7 @@ Never generalize specific qualifiers. The qualifier is almost always the detail 
 - "scored 3 goals in the semifinal" → KEEP "3 goals in the semifinal", NOT "scored several goals"
 - "walks her dogs multiple times a day" → KEEP "multiple times a day", NOT "regularly" or "daily"
 
-If the input is specific, the memory must be equally specific. The concrete details are precisely what distinguishes a useful memory from a useless one. NEVER replace a specific noun, number, title, or description with a vague category or paraphrase — this destroys the information the user actually shared.
+If the input is specific, the memory must be equally specific. The concrete details are precisely what distinguishes a useful memory from a useless one. NEVER replace a specific noun, number, title, or description with a vague category or paraphrase - this destroys the information the user actually shared.
 
 ### Meaning-Preserving
 Capture the EXACT meaning of what was said. Read carefully:
@@ -679,14 +678,14 @@ Misinterpreting the user's words is worse than not extracting at all.
 - **No Fabrication**: Every detail must trace to the inputs. If you can't point to where it came from, don't include it.
 - **No Implicit Attribute Inference**: Don't infer gender, age, ethnicity, etc. from names or context. Only record explicitly stated attributes.
 - **Correct Attribution**: Distinguish user-stated facts from assistant-provided information. Frame assistant content appropriately.
-- **No Echo Extraction**: When an assistant message restates, summarizes, or confirms information the user already provided in the same conversation, do NOT extract it again from the assistant's message. Only extract from assistant messages when they contribute genuinely NEW information not already present in the user's messages — specific recommendations, newly created plans or schedules, researched facts, or solutions the assistant provided that the user did not state themselves. If the user says "I want daily check-ins at 7:30 AM" and the assistant responds "I've set up daily check-ins at 7:30 AM", that is already captured from the user's message — do not extract a second memory from the assistant's echo.
-- **No Within-Response Duplication**: Each piece of information must appear exactly ONCE in your output, regardless of how many messages mention it. Before finalizing your output, review your extractions and remove any that are semantically equivalent to another extraction in the same response. Two memories about the same fact phrased differently are redundant — keep the richer one and drop the other.
+- **No Echo Extraction**: When an assistant message restates, summarizes, or confirms information the user already provided in the same conversation, do NOT extract it again from the assistant's message. Only extract from assistant messages when they contribute genuinely NEW information not already present in the user's messages - specific recommendations, newly created plans or schedules, researched facts, or solutions the assistant provided that the user did not state themselves. If the user says "I want daily check-ins at 7:30 AM" and the assistant responds "I've set up daily check-ins at 7:30 AM", that is already captured from the user's message - do not extract a second memory from the assistant's echo.
+- **No Within-Response Duplication**: Each piece of information must appear exactly ONCE in your output, regardless of how many messages mention it. Before finalizing your output, review your extractions and remove any that are semantically equivalent to another extraction in the same response. Two memories about the same fact phrased differently are redundant - keep the richer one and drop the other.
 - **No Meta-Extraction**: Extract the CONTENT of what was shared, not a description of the user's action. When a user shares a document, data, or reference material, extract the actual facts FROM that material.
   - WRONG: "User asked for the introductory paragraph to be shortened" / "User shared a case summary for optimization"
   - RIGHT: "The Bajimaya v Reward Homes case involved construction starting in 2014, contract signed in 2015, with completion due by October 2015" / "The tribunal found Reward Homes breached its contract through poor workmanship, waterproofing defects, and non-compliance with the Building Code of Australia"
   - WRONG: "Assistant created a D&D adventure with enemies"
   - RIGHT: "The Lost Temple of the Djinn adventure includes 4 Mummies (AC 11, 45 HP), 2 Construct Guardians (AC 17, 110 HP), and 6 Skeletal Warriors (AC 12, 22 HP)"
-- **No Detail Contamination from Context**: When extracting from New Messages, do NOT import or merge details from Existing Memories or Recent Memories into the new extraction UNLESS the new message explicitly references those details. If the New Message says "I had a great meal" and an Existing Memory says "User's favorite restaurant is Olive Garden," do NOT produce "User had a great meal at Olive Garden" — the new message never mentioned the restaurant. Each extraction must be faithful to its source message only.
+- **No Detail Contamination from Context**: When extracting from New Messages, do NOT import or merge details from Existing Memories or Recent Memories into the new extraction UNLESS the new message explicitly references those details. If the New Message says "I had a great meal" and an Existing Memory says "User's favorite restaurant is Olive Garden," do NOT produce "User had a great meal at Olive Garden" - the new message never mentioned the restaurant. Each extraction must be faithful to its source message only.
 
 
 ## Memory Linking
@@ -698,7 +697,7 @@ When extracting a new memory, check if it relates to any Existing Memory. Add re
 - **Continuation**: Follow-up event or next step in a previously captured narrative
 - **Contradiction**: New information that conflicts with an existing memory
 
-Do NOT link memories that merely share a vague theme. Links should be specific and meaningful — the linked memories should be about the same specific entity, event, or topic. If no existing memories are related, omit linked_memory_ids or pass an empty array.
+Do NOT link memories that merely share a vague theme. Links should be specific and meaningful - the linked memories should be about the same specific entity, event, or topic. If no existing memories are related, omit linked_memory_ids or pass an empty array.
 
 
 # EXAMPLES
@@ -721,7 +720,7 @@ Output:
   {"id": "2", "text": "Marcus and his wife Elena are expecting their first baby in March 2026"}
 ]}
 
-Three distinct topics — career, relationship/dining, family milestone — each get their own memory with full context.
+Three distinct topics - career, relationship/dining, family milestone - each get their own memory with full context.
 
 
 ## Example 2: Extracting from Assistant Recommendations
@@ -754,7 +753,7 @@ Observation Date: 2025-08-19
 
 Output: {"memory": []}
 
-## Example 5: Deduplication — Skip Already Captured
+## Example 5: Deduplication - Skip Already Captured
 
 Recently Extracted: ["Marcus was promoted to Senior Engineer at Shopify around August 12, 2025"]
 Existing Memories: [{"id": "0", "text": "Marcus was promoted to Senior Engineer at Shopify around August 12, 2025"}]
@@ -765,7 +764,7 @@ Observation Date: 2025-08-19
 Output: {"memory": []}
 
 
-## Example 6: Extract ALL Dimensions — Don't Miss Secondary Info
+## Example 6: Extract ALL Dimensions - Don't Miss Secondary Info
 
 Summary: "User is an aspiring actor."
 Recently Extracted: []
@@ -797,16 +796,16 @@ Current Date: 2026-02-18
 Output:
 {"memory": [{"id": "0", "text": "User listened to the Ready Player One audiobook around early January 2022 and enjoyed the pop culture references"}]}
 
-"Recently" is grounded to the Observation Date (January 2022), NOT Current Date (February 2026). The Hitchhiker's Guide memory already exists — not re-extracted.
+"Recently" is grounded to the Observation Date (January 2022), NOT Current Date (February 2026). The Hitchhiker's Guide memory already exists - not re-extracted.
 
 
-## Example 8: Document / Reference Material — Extract Content, Not Actions
+## Example 8: Document / Reference Material - Extract Content, Not Actions
 
 Summary: ""
 Recently Extracted: []
 Existing Memories: []
 New Messages:
-[{"role": "user", "content": "I want you to remember this case. If you understand, just say acknowledged. Bajimaya v Reward Homes Pty Ltd [2021] NSWCATAP 297 — The construction began in 2014, contract signed in 2015 with completion due by October 2015. The plaintiff received keys in December 2016 and found defects including incomplete works, poor workmanship, and non-compliance with the building code. The tribunal found the builder breached contract."},
+[{"role": "user", "content": "I want you to remember this case. If you understand, just say acknowledged. Bajimaya v Reward Homes Pty Ltd [2021] NSWCATAP 297 - The construction began in 2014, contract signed in 2015 with completion due by October 2015. The plaintiff received keys in December 2016 and found defects including incomplete works, poor workmanship, and non-compliance with the building code. The tribunal found the builder breached contract."},
  {"role": "assistant", "content": "Acknowledged."}]
 Observation Date: 2024-03-10
 
@@ -817,7 +816,7 @@ Output:
   {"id": "2", "text": "The tribunal found Reward Homes Pty Ltd breached its contract with Mr. Bajimaya by failing to complete work in a proper and workmanlike manner and failing to comply with plans, specifications, and the Building Code."}
 ]}
 
-The user shared reference material to be remembered. Extract the actual factual content — dates, parties, findings — NOT "User shared a case summary" or "User asked to remember a case."
+The user shared reference material to be remembered. Extract the actual factual content - dates, parties, findings - NOT "User shared a case summary" or "User asked to remember a case."
 
 
 ## Example 9: Structured Data with Counts and Specifics
@@ -840,13 +839,13 @@ Output:
 Every count (4 Mummies, 2 Construct Guardians, 6 Skeletal Warriors) and every specific value (AC, HP, DCs, trait names) is preserved. Dropping the counts or stat values would destroy the most queryable information.
 
 
-## Example 10: Memory Linking — Connecting Related Memories
+## Example 10: Memory Linking - Connecting Related Memories
 
 Summary: ""
 Recently Extracted: []
 Existing Memories: [{"id": "a1b2c3d4-5678-9abc-def0-111111111111", "text": "User has a dog named Poppy, a golden retriever"}, {"id": "b2c3d4e5-6789-abcd-ef01-222222222222", "text": "User works as a Senior Engineer at Shopify"}]
 New Messages:
-[{"role": "user", "content": "Poppy had her vet checkup yesterday — she's healthy but needs to lose a few pounds. Also, I'm switching teams at work next month to the payments platform."}]
+[{"role": "user", "content": "Poppy had her vet checkup yesterday - she's healthy but needs to lose a few pounds. Also, I'm switching teams at work next month to the payments platform."}]
 Observation Date: 2025-03-15
 
 Output:
@@ -855,10 +854,10 @@ Output:
   {"id": "1", "text": "User is switching teams at Shopify to the payments platform in April 2025", "linked_memory_ids": ["b2c3d4e5-6789-abcd-ef01-222222222222"]}
 ]}
 
-Both new memories link to related existing memories — the vet checkup links to the existing Poppy memory, and the team switch links to the existing Shopify memory. This enables the system to build a graph of related memories.
+Both new memories link to related existing memories - the vet checkup links to the existing Poppy memory, and the team switch links to the existing Shopify memory. This enables the system to build a graph of related memories.
 
 
-## Example 11: Long Multi-Topic Conversation — Don't Stop After First Topic
+## Example 11: Long Multi-Topic Conversation - Don't Stop After First Topic
 
 Summary: ""
 Recently Extracted: []
@@ -868,7 +867,7 @@ New Messages:
  {"role": "assistant", "content": "Congratulations! How's he settling in?"},
  {"role": "user", "content": "Great! Oh, and I also started pottery classes on Tuesdays. Made a mug with my daughter's face on it."},
  {"role": "assistant", "content": "Fun! Sounds like a lot going on."},
- {"role": "user", "content": "Yeah — my sister just moved to Portland too. I'm happy but honestly a bit overwhelmed. My boss gave me a promotion to team lead last week as well."}]
+ {"role": "user", "content": "Yeah - my sister just moved to Portland too. I'm happy but honestly a bit overwhelmed. My boss gave me a promotion to team lead last week as well."}]
 Observation Date: 2025-03-10
 
 Output:
@@ -880,18 +879,18 @@ Output:
   {"id": "4", "text": "User was promoted to team lead around March 3, 2025, and feels happy but overwhelmed about all the recent changes"}
 ]}
 
-FIVE topics across 5 messages — each one extracted separately. Do not stop after the first topic (the puppy). The pottery mug detail, the sister's move, and the emotional reaction to the promotion are all distinct, extractable facts.
+FIVE topics across 5 messages - each one extracted separately. Do not stop after the first topic (the puppy). The pottery mug detail, the sister's move, and the emotional reaction to the promotion are all distinct, extractable facts.
 
 
-## Example 12: Multi-Speaker Conversation — Extract From ALL Speakers
+## Example 12: Multi-Speaker Conversation - Extract From ALL Speakers
 
 Summary: "John has a dog named Max."
 Recently Extracted: []
 Existing Memories: [{"id": "a1b2c3d4-0000-0000-0000-111111111111", "text": "John has a dog named Max"}]
 New Messages:
 [{"role": "user", "content": "John: Max and I had a blast on our camping trip last summer. We hiked, swam, and made great memories. It was a really peaceful experience."},
- {"role": "assistant", "content": "Maria: That sounds amazing! I actually just got a new cat named Bailey last week — she's been such a joy already. Camping with pets is so soul-nourishing."},
- {"role": "user", "content": "John: Congrats on Bailey! Here's a picture of my family too — that was from a trip we took for my daughter Sara's birthday last fall."}]
+ {"role": "assistant", "content": "Maria: That sounds amazing! I actually just got a new cat named Bailey last week - she's been such a joy already. Camping with pets is so soul-nourishing."},
+ {"role": "user", "content": "John: Congrats on Bailey! Here's a picture of my family too - that was from a trip we took for my daughter Sara's birthday last fall."}]
 Observation Date: 2023-08-11
 
 Output:
@@ -901,18 +900,18 @@ Output:
   {"id": "2", "text": "John has a daughter named Sara and the family took a trip for her birthday in fall 2022"}
 ]}
 
-Three key lessons: (1) The existing memory "John has a dog named Max" does NOT mean all Max-related information is captured — the camping trip is a new event with specific activities (hiking, swimming) and must be extracted and linked. (2) Maria is a named speaker in the "assistant" role but shares a genuine personal fact (new cat Bailey) — this MUST be extracted with the same rigor as user facts. Her echo ("that sounds amazing", "camping is soul-nourishing") is correctly skipped, but her personal fact is not. (3) Sara's name and the birthday trip are separate factual details that each deserve their own extraction.
+Three key lessons: (1) The existing memory "John has a dog named Max" does NOT mean all Max-related information is captured - the camping trip is a new event with specific activities (hiking, swimming) and must be extracted and linked. (2) Maria is a named speaker in the "assistant" role but shares a genuine personal fact (new cat Bailey) - this MUST be extracted with the same rigor as user facts. Her echo ("that sounds amazing", "camping is soul-nourishing") is correctly skipped, but her personal fact is not. (3) Sara's name and the birthday trip are separate factual details that each deserve their own extraction.
 
 
 # CRITICAL: Exhaustive Extraction Checklist
 
-Before producing output, mentally scan the ENTIRE conversation — every single message — and verify:
+Before producing output, mentally scan the ENTIRE conversation - every single message - and verify:
 1. Have you extracted at least one memory from every distinct topic or subject change in the conversation?
 2. Have you extracted facts from messages in the MIDDLE and END of the conversation, not just the beginning?
-3. For conversations with 10+ messages, you should typically extract 5-15 memories. If you have fewer than 3, re-read the conversation — you are almost certainly missing information.
+3. For conversations with 10+ messages, you should typically extract 5-15 memories. If you have fewer than 3, re-read the conversation - you are almost certainly missing information.
 4. Re-read each user message individually: does EVERY specific fact, preference, experience, or event mentioned in that message have a corresponding extraction? If a single message mentions two distinct facts (e.g., an allergy AND a hobby), both must be captured.
 
-A common failure mode is "first topic dominance" — the extractor captures the first major topic thoroughly, then treats subsequent topics as filler. This is WRONG. Every topic mentioned deserves extraction if it contains memorable facts. If a chunk has 8 messages covering 4 different topics, you MUST produce memories for all 4 topics — not just the first or most prominent one.
+A common failure mode is "first topic dominance" - the extractor captures the first major topic thoroughly, then treats subsequent topics as filler. This is WRONG. Every topic mentioned deserves extraction if it contains memorable facts. If a chunk has 8 messages covering 4 different topics, you MUST produce memories for all 4 topics - not just the first or most prominent one.
 
 
 # OUTPUT FORMAT
@@ -958,7 +957,7 @@ The attributed_to field should still reflect the original source: "user" for fac
 
 
 # ---------------------------------------------------------------------------
-# V3 Prompt Builder — constructs the user-side prompt for additive extraction
+# V3 Prompt Builder - constructs the user-side prompt for additive extraction
 # Ported from platform/backend/shared/core/utils/prompt_builder.py
 # ---------------------------------------------------------------------------
 
@@ -1048,7 +1047,7 @@ def generate_additive_extraction_prompt(
         sections.append(
             "## Language Requirement\n"
             "CRITICAL: Respond in the SAME LANGUAGE and SCRIPT as the input messages.\n"
-            "1. Match the language of the user's messages exactly — if they write in Korean, extract in Korean; Japanese in Japanese; etc.\n"
+            "1. Match the language of the user's messages exactly - if they write in Korean, extract in Korean; Japanese in Japanese; etc.\n"
             "2. Preserve the exact script/alphabet of the input.\n"
             "3. Do NOT translate or transliterate into English unless the input is already in English.\n"
             "4. Maintain all quality standards (contextual richness, temporal grounding, etc.) regardless of language.\n"
@@ -1068,11 +1067,15 @@ def generate_additive_extraction_prompt(
 # "Expecting value: line 1 column 1 (char 0)" parse failure). Forcing a tool
 # call constrains the model to the schema, so it cannot answer with prose.
 #
-# Defined in OpenAI function-calling format — the format mem0 providers expect
+# Defined in OpenAI function-calling format - the format mem0 providers expect
 # and convert from internally (see e.g. AnthropicLLM / AWSBedrockLLM). Mirrors
 # the ADDITIVE_EXTRACTION_PROMPT output shape: {"memory": [{"id", "text", ...}]}.
 # The "text" field name is load-bearing: the add() pipeline reads m.get("text")
 # (mem0/memory/main.py). Renaming it here silently drops every recovered memory.
+# "attributed_to" is also consumed (main.py promotes it into the memory's
+# metadata); "id" and "linked_memory_ids" mirror the prompt's output shape for
+# model familiarity and are harmlessly ignored downstream. Only "text" is
+# required - the others are optional, including "id".
 MEMORY_EXTRACTION_TOOL = {
     "type": "function",
     "function": {
@@ -1092,7 +1095,7 @@ MEMORY_EXTRACTION_TOOL = {
                         "properties": {
                             "id": {
                                 "type": "string",
-                                "description": "Sequential id for this memory ('0', '1', ...).",
+                                "description": "Optional sequential id for this memory ('0', '1', ...).",
                             },
                             "text": {
                                 "type": "string",

--- a/mem0/configs/prompts.py
+++ b/mem0/configs/prompts.py
@@ -1060,3 +1060,59 @@ def generate_additive_extraction_prompt(
 
     sections.append("# Output:")
     return "\n\n".join(sections)
+
+
+# Forced structured-output tool used to recover extraction when the LLM returns
+# free prose with no JSON object (e.g. the model role-plays / continues the
+# transcript instead of extracting facts, producing the classic
+# "Expecting value: line 1 column 1 (char 0)" parse failure). Forcing a tool
+# call constrains the model to the schema, so it cannot answer with prose.
+#
+# Defined in OpenAI function-calling format — the format mem0 providers expect
+# and convert from internally (see e.g. AnthropicLLM / AWSBedrockLLM). Mirrors
+# the ADDITIVE_EXTRACTION_PROMPT output shape: {"memory": [{"id", "text", ...}]}.
+# The "text" field name is load-bearing: the add() pipeline reads m.get("text")
+# (mem0/memory/main.py). Renaming it here silently drops every recovered memory.
+MEMORY_EXTRACTION_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "save_memories",
+        "description": (
+            "Save the memorable facts extracted from the conversation. "
+            "Call this with every distinct fact worth remembering."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "memory": {
+                    "type": "array",
+                    "description": "The list of extracted memories. Empty if nothing is memorable.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "description": "Sequential id for this memory ('0', '1', ...).",
+                            },
+                            "text": {
+                                "type": "string",
+                                "description": "The self-contained, contextually rich memory statement.",
+                            },
+                            "attributed_to": {
+                                "type": "string",
+                                "description": "Optional speaker name the memory is attributed to.",
+                            },
+                            "linked_memory_ids": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": "Optional ids of related existing memories.",
+                            },
+                        },
+                        "required": ["text"],
+                    },
+                }
+            },
+            "required": ["memory"],
+        },
+    },
+}

--- a/mem0/llms/anthropic.py
+++ b/mem0/llms/anthropic.py
@@ -117,10 +117,11 @@ class AnthropicLLM(LLMBase):
     def _parse_response(response, tools):
         """Process the Anthropic response based on whether tools were used.
 
-        With tools, returns the same shape as the OpenAI provider —
-        ``{"content": <text>, "tool_calls": [{"name", "arguments"}]}`` — reading
+        With tools, returns the same shape as the OpenAI provider -
+        ``{"content": <text>, "tool_calls": [{"name", "arguments"}]}`` - reading
         the JSON out of each ``tool_use`` block's ``.input`` (the SDK already
-        parses it to a dict). Without tools, returns the assistant text.
+        parses it to a dict). Without tools, returns the assistant text, or ""
+        when the response carries no content blocks (e.g. blocked/refused).
         """
         if tools:
             processed_response = {"content": None, "tool_calls": []}
@@ -129,12 +130,10 @@ class AnthropicLLM(LLMBase):
                 if block_type == "text":
                     processed_response["content"] = block.text
                 elif block_type == "tool_use":
-                    processed_response["tool_calls"].append(
-                        {"name": block.name, "arguments": block.input}
-                    )
+                    processed_response["tool_calls"].append({"name": block.name, "arguments": block.input})
             return processed_response
 
-        return response.content[0].text
+        return response.content[0].text if response.content else ""
 
     def generate_response(
         self,

--- a/mem0/llms/anthropic.py
+++ b/mem0/llms/anthropic.py
@@ -12,6 +12,8 @@ from mem0.llms.base import LLMBase
 
 
 class AnthropicLLM(LLMBase):
+    supports_tool_calls = True
+
     def __init__(self, config: Optional[Union[BaseLlmConfig, AnthropicConfig, Dict]] = None):
         # Convert to AnthropicConfig if needed
         if config is None:
@@ -65,6 +67,75 @@ class AnthropicLLM(LLMBase):
         params.update(kwargs)
         return params
 
+    @staticmethod
+    def _convert_tools(tools: List[Dict]) -> List[Dict]:
+        """Convert OpenAI function-calling tool schemas to Anthropic's format.
+
+        mem0 defines tools in OpenAI format ({"type": "function", "function":
+        {"name", "description", "parameters"}}); Anthropic expects flat tools
+        with an ``input_schema``. Tools already in Anthropic format (carrying
+        ``input_schema``) are passed through unchanged.
+        """
+        converted = []
+        for tool in tools:
+            if "input_schema" in tool:
+                converted.append(tool)
+                continue
+            function = tool.get("function", tool)
+            converted.append(
+                {
+                    "name": function.get("name"),
+                    "description": function.get("description", ""),
+                    "input_schema": function.get("parameters", {"type": "object", "properties": {}}),
+                }
+            )
+        return converted
+
+    @staticmethod
+    def _convert_tool_choice(tool_choice):
+        """Map the cross-provider ``tool_choice`` value to Anthropic's format.
+
+        Anthropic expects a dict ({"type": "auto" | "any" | "none" | "tool"}).
+        Accepts the OpenAI-style strings used across mem0 ("auto", "required",
+        "none") and a bare tool name to force a specific tool; an already-formed
+        dict is passed through.
+        """
+        if isinstance(tool_choice, dict):
+            return tool_choice
+        mapping = {
+            "auto": {"type": "auto"},
+            "required": {"type": "any"},
+            "any": {"type": "any"},
+            "none": {"type": "none"},
+        }
+        if tool_choice in mapping:
+            return mapping[tool_choice]
+        # Anything else is treated as a specific tool name to force.
+        return {"type": "tool", "name": tool_choice}
+
+    @staticmethod
+    def _parse_response(response, tools):
+        """Process the Anthropic response based on whether tools were used.
+
+        With tools, returns the same shape as the OpenAI provider —
+        ``{"content": <text>, "tool_calls": [{"name", "arguments"}]}`` — reading
+        the JSON out of each ``tool_use`` block's ``.input`` (the SDK already
+        parses it to a dict). Without tools, returns the assistant text.
+        """
+        if tools:
+            processed_response = {"content": None, "tool_calls": []}
+            for block in response.content:
+                block_type = getattr(block, "type", None)
+                if block_type == "text":
+                    processed_response["content"] = block.text
+                elif block_type == "tool_use":
+                    processed_response["tool_calls"].append(
+                        {"name": block.name, "arguments": block.input}
+                    )
+            return processed_response
+
+        return response.content[0].text
+
     def generate_response(
         self,
         messages: List[Dict[str, str]],
@@ -84,7 +155,8 @@ class AnthropicLLM(LLMBase):
             **kwargs: Additional Anthropic-specific parameters.
 
         Returns:
-            str: The generated response.
+            str or dict: The assistant text, or, when ``tools`` are supplied, a
+            ``{"content", "tool_calls"}`` dict matching the other providers.
         """
         # Separate system message from other messages
         system_message = ""
@@ -104,9 +176,9 @@ class AnthropicLLM(LLMBase):
             }
         )
 
-        if tools:  # TODO: Remove tools if no issues found with new memory addition logic
-            params["tools"] = tools
-            params["tool_choice"] = tool_choice
+        if tools:
+            params["tools"] = self._convert_tools(tools)
+            params["tool_choice"] = self._convert_tool_choice(tool_choice)
 
         response = self.client.messages.create(**params)
-        return response.content[0].text
+        return self._parse_response(response, tools)

--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -10,6 +10,12 @@ class LLMBase(ABC):
     Handles common functionality and delegates provider-specific logic to subclasses.
     """
 
+    #: Whether this provider can recover extraction via a forced tool call —
+    #: i.e. it honors ``tools`` / ``tool_choice`` and returns the standard
+    #: ``{"tool_calls": [{"name", "arguments"}]}`` dict. Providers that support
+    #: forced structured output opt in by overriding this to ``True``.
+    supports_tool_calls: bool = False
+
     def __init__(self, config: Optional[Union[BaseLlmConfig, Dict]] = None):
         """Initialize a base LLM class
 

--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -10,10 +10,14 @@ class LLMBase(ABC):
     Handles common functionality and delegates provider-specific logic to subclasses.
     """
 
-    #: Whether this provider can recover extraction via a forced tool call —
+    #: Whether this provider can recover extraction via a forced tool call -
     #: i.e. it honors ``tools`` / ``tool_choice`` and returns the standard
     #: ``{"tool_calls": [{"name", "arguments"}]}`` dict. Providers that support
-    #: forced structured output opt in by overriding this to ``True``.
+    #: forced structured output opt in by overriding this to ``True``. The
+    #: opt-in is deliberately narrow to start: other OpenAI-compatible
+    #: providers (e.g. Azure OpenAI, Groq, LiteLLM, DeepSeek) likely qualify
+    #: and can flip this flag once their forced-tool_choice behavior is
+    #: verified against a real endpoint.
     supports_tool_calls: bool = False
 
     def __init__(self, config: Optional[Union[BaseLlmConfig, Dict]] = None):
@@ -67,8 +71,14 @@ class LLMBase(ABC):
             return explicit
 
         reasoning_models = {
-            "o1", "o1-preview", "o3-mini", "o3",
-            "gpt-5", "gpt-5o", "gpt-5o-mini", "gpt-5o-micro",
+            "o1",
+            "o1-preview",
+            "o3-mini",
+            "o3",
+            "gpt-5",
+            "gpt-5o",
+            "gpt-5o-mini",
+            "gpt-5o-micro",
         }
 
         model_lower = model.lower()
@@ -89,18 +99,18 @@ class LLMBase(ABC):
         """
         Get parameters that are supported by the current model.
         Filters out unsupported parameters for reasoning models and GPT-5 series.
-        
+
         Args:
             **kwargs: Additional parameters to include
-            
+
         Returns:
             Dict: Filtered parameters dictionary
         """
-        model = getattr(self.config, 'model', '')
-        
+        model = getattr(self.config, "model", "")
+
         if self._is_reasoning_model(model):
             supported_params = {}
-            
+
             if "messages" in kwargs:
                 supported_params["messages"] = kwargs["messages"]
             if "response_format" in kwargs:
@@ -111,7 +121,7 @@ class LLMBase(ABC):
                 supported_params["tool_choice"] = kwargs["tool_choice"]
 
             # Add reasoning_effort if configured
-            reasoning_effort = getattr(self.config, 'reasoning_effort', None)
+            reasoning_effort = getattr(self.config, "reasoning_effort", None)
             if reasoning_effort:
                 supported_params["reasoning_effort"] = reasoning_effort
 

--- a/mem0/llms/gemini.py
+++ b/mem0/llms/gemini.py
@@ -140,6 +140,7 @@ class GeminiLLM(LLMBase):
         response_format=None,
         tools: Optional[List[Dict]] = None,
         tool_choice: str = "auto",
+        **kwargs,
     ):
         """
         Generate a response based on the given messages using Gemini.
@@ -149,6 +150,9 @@ class GeminiLLM(LLMBase):
             response_format (str or object, optional): Format for the response. Defaults to "text".
             tools (list, optional): List of tools that the model can call. Defaults to None.
             tool_choice (str, optional): Tool choice method. Defaults to "auto".
+            **kwargs: Additional parameters (e.g. ``max_tokens``) that override the
+                configured values for this one call. Accepted for parity with the
+                base ``generate_response`` contract and the other providers.
 
         Returns:
             str: The generated response.
@@ -164,6 +168,10 @@ class GeminiLLM(LLMBase):
             "top_p": self.config.top_p,
         }
 
+        # Per-call overrides take precedence over the configured values.
+        if kwargs.get("max_tokens") is not None:
+            config_params["max_output_tokens"] = kwargs["max_tokens"]
+
         # Add system instruction to config if present
         if system_instruction:
             config_params["system_instruction"] = system_instruction
@@ -178,9 +186,13 @@ class GeminiLLM(LLMBase):
             config_params["tools"] = formatted_tools
 
             if tool_choice:
+                # "any" and "required" both mean "force a tool call" -> Gemini ANY
+                # mode. Previously "required" fell through to NONE, which silently
+                # disabled tool calling for any caller forcing a specific tool.
+                forced = tool_choice in ("any", "required")
                 if tool_choice == "auto":
                     mode = types.FunctionCallingConfigMode.AUTO
-                elif tool_choice == "any":
+                elif forced:
                     mode = types.FunctionCallingConfigMode.ANY
                 else:
                     mode = types.FunctionCallingConfigMode.NONE
@@ -189,7 +201,7 @@ class GeminiLLM(LLMBase):
                     function_calling_config=types.FunctionCallingConfig(
                         mode=mode,
                         allowed_function_names=(
-                            [tool["function"]["name"] for tool in tools] if tool_choice == "any" else None
+                            [tool["function"]["name"] for tool in tools] if forced else None
                         ),
                     )
                 )

--- a/mem0/llms/gemini.py
+++ b/mem0/llms/gemini.py
@@ -169,6 +169,8 @@ class GeminiLLM(LLMBase):
         }
 
         # Per-call overrides take precedence over the configured values.
+        # Accepted kwargs: max_tokens. Anything else is ignored rather than
+        # forwarded, so unsupported OpenAI-style params cannot break the call.
         if kwargs.get("max_tokens") is not None:
             config_params["max_output_tokens"] = kwargs["max_tokens"]
 
@@ -188,11 +190,13 @@ class GeminiLLM(LLMBase):
             if tool_choice:
                 # "any" and "required" both mean "force a tool call" -> Gemini ANY
                 # mode. Previously "required" fell through to NONE, which silently
-                # disabled tool calling for any caller forcing a specific tool.
-                forced = tool_choice in ("any", "required")
+                # disabled tool calling for any caller forcing a tool. They differ on
+                # restriction: "any" forces one of *these* tools (allowed_function_names
+                # set), "required" forces *some* tool with the model free to choose
+                # (allowed_function_names unset), matching LiteLLM's Gemini mapping.
                 if tool_choice == "auto":
                     mode = types.FunctionCallingConfigMode.AUTO
-                elif forced:
+                elif tool_choice in ("any", "required"):
                     mode = types.FunctionCallingConfigMode.ANY
                 else:
                     mode = types.FunctionCallingConfigMode.NONE
@@ -201,7 +205,7 @@ class GeminiLLM(LLMBase):
                     function_calling_config=types.FunctionCallingConfig(
                         mode=mode,
                         allowed_function_names=(
-                            [tool["function"]["name"] for tool in tools] if forced else None
+                            [tool["function"]["name"] for tool in tools] if tool_choice == "any" else None
                         ),
                     )
                 )

--- a/mem0/llms/gemini.py
+++ b/mem0/llms/gemini.py
@@ -12,6 +12,13 @@ from mem0.llms.base import LLMBase
 
 
 class GeminiLLM(LLMBase):
+    # Gemini honors a forced tool_choice and returns the standard
+    # {"content", "tool_calls"} dict, so the forced-structure extraction
+    # recovery can use it. Forcing a tool call also keeps Gemini's reasoning
+    # tokens out of the response, which is what corrupts the JSON in the
+    # leakage case (see issue #3918).
+    supports_tool_calls = True
+
     def __init__(self, config: Optional[BaseLlmConfig] = None):
         super().__init__(config)
 

--- a/mem0/llms/openai.py
+++ b/mem0/llms/openai.py
@@ -31,9 +31,9 @@ class OpenAILLM(LLMBase):
                 top_k=config.top_k,
                 enable_vision=config.enable_vision,
                 vision_details=config.vision_details,
-                reasoning_effort=getattr(config, 'reasoning_effort', None),
+                reasoning_effort=getattr(config, "reasoning_effort", None),
                 http_client_proxies=config.http_client,
-                is_reasoning_model=getattr(config, 'is_reasoning_model', None),
+                is_reasoning_model=getattr(config, "is_reasoning_model", None),
             )
 
         super().__init__(config)
@@ -106,11 +106,13 @@ class OpenAILLM(LLMBase):
             json: The generated response.
         """
         params = self._get_supported_params(messages=messages, **kwargs)
-        
-        params.update({
-            "model": self.config.model,
-            "messages": messages,
-        })
+
+        params.update(
+            {
+                "model": self.config.model,
+                "messages": messages,
+            }
+        )
 
         if os.getenv("OPENROUTER_API_KEY"):
             openrouter_params = {}
@@ -127,7 +129,7 @@ class OpenAILLM(LLMBase):
                 openrouter_params["extra_headers"] = extra_headers
 
             params.update(**openrouter_params)
-        
+
         else:
             # Only send OpenAI-specific parameters when the user has explicitly
             # configured them. OpenAI-compatible backends (Gemini, Groq, vLLM, etc.)

--- a/mem0/llms/openai.py
+++ b/mem0/llms/openai.py
@@ -12,6 +12,8 @@ from mem0.memory.utils import extract_json
 
 
 class OpenAILLM(LLMBase):
+    supports_tool_calls = True
+
     def __init__(self, config: Optional[Union[BaseLlmConfig, OpenAIConfig, Dict]] = None):
         # Convert to OpenAIConfig if needed
         if config is None:
@@ -135,7 +137,7 @@ class OpenAILLM(LLMBase):
 
         if response_format:
             params["response_format"] = response_format
-        if tools:  # TODO: Remove tools if no issues found with new memory addition logic
+        if tools:
             params["tools"] = tools
             params["tool_choice"] = tool_choice
         response = self.client.chat.completions.create(**params)

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -60,34 +60,38 @@ logger = logging.getLogger(__name__)
 # Fields that hold runtime auth/connection objects and must be preserved.
 # These are non-serializable objects (e.g. AWSV4SignerAuth, RequestsHttpConnection)
 # needed by clients like OpenSearch — not sensitive strings to redact.
-_RUNTIME_FIELDS = frozenset({
-    "http_auth",
-    "auth",
-    "connection_class",
-    "ssl_context",
-})
+_RUNTIME_FIELDS = frozenset(
+    {
+        "http_auth",
+        "auth",
+        "connection_class",
+        "ssl_context",
+    }
+)
 
 # Fields that are known to contain sensitive secrets and must be redacted.
-_SENSITIVE_FIELDS_EXACT = frozenset({
-    "api_key",
-    "secret_key",
-    "private_key",
-    "access_key",
-    "password",
-    "credentials",
-    "credential",
-    "secret",
-    "token",
-    "access_token",
-    "refresh_token",
-    "auth_token",
-    "session_token",
-    "client_secret",
-    "auth_client_secret",
-    "azure_client_secret",
-    "service_account_json",
-    "aws_session_token",
-})
+_SENSITIVE_FIELDS_EXACT = frozenset(
+    {
+        "api_key",
+        "secret_key",
+        "private_key",
+        "access_key",
+        "password",
+        "credentials",
+        "credential",
+        "secret",
+        "token",
+        "access_token",
+        "refresh_token",
+        "auth_token",
+        "session_token",
+        "client_secret",
+        "auth_client_secret",
+        "azure_client_secret",
+        "service_account_json",
+        "aws_session_token",
+    }
+)
 
 # Suffixes that indicate a field likely holds a secret value.
 _SENSITIVE_SUFFIXES = (
@@ -133,13 +137,9 @@ def _validate_and_trim_entity_id(value: Optional[str], name: str) -> Optional[st
         return None
     trimmed = value.strip()
     if trimmed == "":
-        raise ValueError(
-            f"Invalid {name}: cannot be empty or whitespace-only. Provide a valid identifier."
-        )
+        raise ValueError(f"Invalid {name}: cannot be empty or whitespace-only. Provide a valid identifier.")
     if any(c.isspace() for c in trimmed):
-        raise ValueError(
-            f"Invalid {name}: cannot contain whitespace. Provide a valid identifier without spaces."
-        )
+        raise ValueError(f"Invalid {name}: cannot contain whitespace. Provide a valid identifier without spaces.")
     return trimmed
 
 
@@ -158,16 +158,12 @@ def _validate_search_params(threshold: Optional[float] = None, top_k: Optional[i
         if not isinstance(threshold, (int, float)):
             raise ValueError("threshold must be a valid number")
         if threshold < 0 or threshold > 1:
-            raise ValueError(
-                f"Invalid threshold: {threshold}. Must be between 0 and 1 (inclusive)."
-            )
+            raise ValueError(f"Invalid threshold: {threshold}. Must be between 0 and 1 (inclusive).")
     if top_k is not None:
         if not isinstance(top_k, int) or isinstance(top_k, bool):
             raise ValueError("top_k must be a valid integer")
         if top_k < 0:
-            raise ValueError(
-                f"Invalid top_k: {top_k}. Must be a non-negative integer."
-            )
+            raise ValueError(f"Invalid top_k: {top_k}. Must be a non-negative integer.")
 
 
 def _is_sensitive_field(field_name: str) -> bool:
@@ -305,7 +301,7 @@ def _build_filters_and_metadata(
             message="At least one of 'user_id', 'agent_id', or 'run_id' must be provided.",
             error_code="VALIDATION_001",
             details={"provided_ids": {"user_id": user_id, "agent_id": agent_id, "run_id": run_id}},
-            suggestion="Please provide at least one identifier to scope the memory operation."
+            suggestion="Please provide at least one identifier to scope the memory operation.",
         )
 
     # ---------- optional actor filter ----------
@@ -351,10 +347,7 @@ class Memory(MemoryBase):
         # Initialize reranker if configured
         self.reranker = None
         if config.reranker:
-            self.reranker = RerankerFactory.create(
-                config.reranker.provider,
-                config.reranker.config
-            )
+            self.reranker = RerankerFactory.create(config.reranker.provider, config.reranker.config)
 
         # Entity store is initialized lazily on first use
         self._entity_store = None
@@ -362,24 +355,24 @@ class Memory(MemoryBase):
         if MEM0_TELEMETRY:
             # Create telemetry config manually to avoid deepcopy issues with thread locks
             telemetry_config_dict = {}
-            if hasattr(self.config.vector_store.config, 'model_dump'):
+            if hasattr(self.config.vector_store.config, "model_dump"):
                 # For pydantic models
                 telemetry_config_dict = self.config.vector_store.config.model_dump()
             else:
                 # For other objects, manually copy common attributes
-                for attr in ['host', 'port', 'path', 'api_key', 'index_name', 'dimension', 'metric']:
+                for attr in ["host", "port", "path", "api_key", "index_name", "dimension", "metric"]:
                     if hasattr(self.config.vector_store.config, attr):
                         telemetry_config_dict[attr] = getattr(self.config.vector_store.config, attr)
 
             # Override collection name for telemetry
-            telemetry_config_dict['collection_name'] = "mem0migrations"
+            telemetry_config_dict["collection_name"] = "mem0migrations"
 
             # Set path for file-based vector stores
             telemetry_config = _safe_deepcopy_config(self.config.vector_store.config)
             if self.config.vector_store.provider in ["faiss", "qdrant"]:
                 provider_path = f"migrations_{self.config.vector_store.provider}"
-                telemetry_config_dict['path'] = os.path.join(mem0_dir, provider_path)
-                os.makedirs(telemetry_config_dict['path'], exist_ok=True)
+                telemetry_config_dict["path"] = os.path.join(mem0_dir, provider_path)
+                os.makedirs(telemetry_config_dict["path"], exist_ok=True)
 
             # Create the config object using the same class as the original
             telemetry_config = self.config.vector_store.config.__class__(**telemetry_config_dict)
@@ -395,10 +388,10 @@ class Memory(MemoryBase):
             entity_config = _safe_deepcopy_config(self.config.vector_store.config)
             entity_collection = f"{self.collection_name}_entities"
             # Set collection name on the cloned config
-            if hasattr(entity_config, 'collection_name'):
+            if hasattr(entity_config, "collection_name"):
                 entity_config.collection_name = entity_collection
             elif isinstance(entity_config, dict):
-                entity_config['collection_name'] = entity_collection
+                entity_config["collection_name"] = entity_collection
             # For Qdrant, share the existing client to avoid RocksDB lock contention
             # when using embedded mode (path=...). QdrantConfig.client takes precedence
             # over host/port/path.
@@ -407,9 +400,7 @@ class Memory(MemoryBase):
                     entity_config.client = self.vector_store.client
                 elif isinstance(entity_config, dict):
                     entity_config["client"] = self.vector_store.client
-            self._entity_store = VectorStoreFactory.create(
-                self.config.vector_store.provider, entity_config
-            )
+            self._entity_store = VectorStoreFactory.create(self.config.vector_store.provider, entity_config)
         return self._entity_store
 
     def _upsert_entity(self, entity_text, entity_type, memory_id, filters):
@@ -632,7 +623,7 @@ class Memory(MemoryBase):
                 message=f"Invalid 'memory_type'. Please pass {MemoryType.PROCEDURAL.value} to create procedural memories.",
                 error_code="VALIDATION_002",
                 details={"provided_type": memory_type, "valid_type": MemoryType.PROCEDURAL.value},
-                suggestion=f"Use '{MemoryType.PROCEDURAL.value}' to create procedural memories."
+                suggestion=f"Use '{MemoryType.PROCEDURAL.value}' to create procedural memories.",
             )
 
         if isinstance(messages, str):
@@ -646,7 +637,7 @@ class Memory(MemoryBase):
                 message="messages must be str, dict, or list[dict]",
                 error_code="VALIDATION_003",
                 details={"provided_type": type(messages).__name__, "valid_types": ["str", "dict", "list[dict]"]},
-                suggestion="Convert your input to a string, dictionary, or list of dictionaries."
+                suggestion="Convert your input to a string, dictionary, or list of dictionaries.",
             )
 
         if agent_id is not None and memory_type == MemoryType.PROCEDURAL.value:
@@ -658,7 +649,9 @@ class Memory(MemoryBase):
         else:
             messages = parse_vision_messages(messages)
 
-        vector_store_result = self._add_to_vector_store(messages, processed_metadata, effective_filters, infer, prompt=prompt)
+        vector_store_result = self._add_to_vector_store(
+            messages, processed_metadata, effective_filters, infer, prompt=prompt
+        )
         return {"results": vector_store_result}
 
     def _add_to_vector_store(self, messages, metadata, filters, infer, prompt=None):
@@ -762,10 +755,19 @@ class Memory(MemoryBase):
                     extracted_memories = json.loads(extracted_json, strict=False).get("memory", [])
         except Exception as e:
             logger.error(f"Error parsing extraction response: {e}")
-            # The response had no parseable JSON (e.g. the model returned prose /
-            # continued the transcript instead of extracting). Recover via a
-            # forced tool call where supported, else fall back to [].
-            extracted_memories = recover_extraction_via_tools(self.llm, system_prompt, user_prompt)
+            if "{" in str(response):
+                # JSON was emitted but did not parse (e.g. truncated by
+                # max_tokens). A forced tool call cannot fix a token budget, so
+                # do not spend extra LLM calls here. (Hijack prose that merely
+                # contains a brace also lands here and keeps the current
+                # behavior - a deliberate fail-safe: never pay for recovery
+                # when JSON may have been emitted.)
+                extracted_memories = []
+            else:
+                # No JSON at all: the model answered with prose (content
+                # hijack). Recover via a forced tool call where supported, else
+                # fall back to [].
+                extracted_memories = recover_extraction_via_tools(self.llm, system_prompt, user_prompt)
 
         if not extracted_memories:
             # Save messages even if nothing extracted
@@ -939,12 +941,14 @@ class Memory(MemoryBase):
                             # New entity — collect for batch insert
                             to_insert_vectors.append(valid_vectors[j])
                             to_insert_ids.append(str(uuid.uuid4()))
-                            to_insert_payloads.append({
-                                "data": entity_text,
-                                "entity_type": entity_type,
-                                "linked_memory_ids": sorted(memory_ids),
-                                **search_filters,
-                            })
+                            to_insert_payloads.append(
+                                {
+                                    "data": entity_text,
+                                    "entity_type": entity_type,
+                                    "linked_memory_ids": sorted(memory_ids),
+                                    **search_filters,
+                                }
+                            )
 
                     # 7e: Single batch insert for all new entities
                     if to_insert_vectors:
@@ -962,10 +966,7 @@ class Memory(MemoryBase):
         # Phase 8: Save messages + return
         self.db.save_messages(messages, session_scope)
 
-        returned_memories = [
-            {"id": r[0], "memory": r[1], "event": "ADD"}
-            for r in records
-        ]
+        returned_memories = [{"id": r[0], "memory": r[1], "event": "ADD"} for r in records]
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event(
@@ -998,7 +999,16 @@ class Memory(MemoryBase):
             "role",
         ]
 
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
+        core_and_promoted_keys = {
+            "data",
+            "hash",
+            "created_at",
+            "updated_at",
+            "id",
+            "text_lemmatized",
+            "attributed_to",
+            *promoted_payload_keys,
+        }
 
         result_item = MemoryItem(
             id=memory.id,
@@ -1051,23 +1061,16 @@ class Memory(MemoryBase):
         # Validate and trim entity IDs in filters
         effective_filters = dict(filters) if filters else {}
         if "user_id" in effective_filters:
-            effective_filters["user_id"] = _validate_and_trim_entity_id(
-                effective_filters["user_id"], "user_id"
-            )
+            effective_filters["user_id"] = _validate_and_trim_entity_id(effective_filters["user_id"], "user_id")
         if "agent_id" in effective_filters:
-            effective_filters["agent_id"] = _validate_and_trim_entity_id(
-                effective_filters["agent_id"], "agent_id"
-            )
+            effective_filters["agent_id"] = _validate_and_trim_entity_id(effective_filters["agent_id"], "agent_id")
         if "run_id" in effective_filters:
-            effective_filters["run_id"] = _validate_and_trim_entity_id(
-                effective_filters["run_id"], "run_id"
-            )
+            effective_filters["run_id"] = _validate_and_trim_entity_id(effective_filters["run_id"], "run_id")
 
         # Validate filters contains at least one entity ID
         if not any(key in effective_filters for key in ("user_id", "agent_id", "run_id")):
             raise ValueError(
-                "filters must contain at least one of: user_id, agent_id, run_id. "
-                "Example: filters={'user_id': 'u1'}"
+                "filters must contain at least one of: user_id, agent_id, run_id. Example: filters={'user_id': 'u1'}"
             )
 
         limit = top_k
@@ -1104,7 +1107,16 @@ class Memory(MemoryBase):
             "actor_id",
             "role",
         ]
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
+        core_and_promoted_keys = {
+            "data",
+            "hash",
+            "created_at",
+            "updated_at",
+            "id",
+            "text_lemmatized",
+            "attributed_to",
+            *promoted_payload_keys,
+        }
 
         formatted_memories = []
         for mem in actual_memories:
@@ -1186,21 +1198,14 @@ class Memory(MemoryBase):
         # Validate and trim entity IDs in filters
         effective_filters = filters.copy() if filters else {}
         if "user_id" in effective_filters:
-            effective_filters["user_id"] = _validate_and_trim_entity_id(
-                effective_filters["user_id"], "user_id"
-            )
+            effective_filters["user_id"] = _validate_and_trim_entity_id(effective_filters["user_id"], "user_id")
         if "agent_id" in effective_filters:
-            effective_filters["agent_id"] = _validate_and_trim_entity_id(
-                effective_filters["agent_id"], "agent_id"
-            )
+            effective_filters["agent_id"] = _validate_and_trim_entity_id(effective_filters["agent_id"], "agent_id")
         if "run_id" in effective_filters:
-            effective_filters["run_id"] = _validate_and_trim_entity_id(
-                effective_filters["run_id"], "run_id"
-            )
+            effective_filters["run_id"] = _validate_and_trim_entity_id(effective_filters["run_id"], "run_id")
         if not any(key in effective_filters for key in ("user_id", "agent_id", "run_id")):
             raise ValueError(
-                "filters must contain at least one of: user_id, agent_id, run_id. "
-                "Example: filters={'user_id': 'u1'}"
+                "filters must contain at least one of: user_id, agent_id, run_id. Example: filters={'user_id': 'u1'}"
             )
 
         limit = top_k
@@ -1212,7 +1217,9 @@ class Memory(MemoryBase):
             for logical_key in ("AND", "OR", "NOT"):
                 effective_filters.pop(logical_key, None)
             for fk in list(effective_filters.keys()):
-                if fk not in ("AND", "OR", "NOT", "user_id", "agent_id", "run_id") and isinstance(effective_filters.get(fk), dict):
+                if fk not in ("AND", "OR", "NOT", "user_id", "agent_id", "run_id") and isinstance(
+                    effective_filters.get(fk), dict
+                ):
                     effective_filters.pop(fk, None)
             effective_filters.update(processed_filters)
 
@@ -1268,9 +1275,16 @@ class Memory(MemoryBase):
             for operator, value in condition.items():
                 # Map platform operators to universal format that can be translated by each vector store
                 operator_map = {
-                    "eq": "eq", "ne": "ne", "gt": "gt", "gte": "gte",
-                    "lt": "lt", "lte": "lte", "in": "in", "nin": "nin",
-                    "contains": "contains", "icontains": "icontains"
+                    "eq": "eq",
+                    "ne": "ne",
+                    "gt": "gt",
+                    "gte": "gte",
+                    "lt": "lt",
+                    "lte": "lte",
+                    "in": "in",
+                    "nin": "nin",
+                    "contains": "contains",
+                    "icontains": "icontains",
                 }
 
                 if operator in operator_map:
@@ -1324,16 +1338,16 @@ class Memory(MemoryBase):
     def _has_advanced_operators(self, filters: Dict[str, Any]) -> bool:
         """
         Check if filters contain advanced operators that need special processing.
-        
+
         Args:
             filters: Dictionary of filters to check
-            
+
         Returns:
             bool: True if advanced operators are detected
         """
         if not isinstance(filters, dict):
             return False
-            
+
         for key, value in filters.items():
             # Check for platform-style logical operators
             if key in ["AND", "OR", "NOT"]:
@@ -1376,8 +1390,8 @@ class Memory(MemoryBase):
         if keyword_results is not None:
             midpoint, steepness = get_bm25_params(query, lemmatized=query_lemmatized)
             for mem in keyword_results:
-                mem_id = str(mem.id) if hasattr(mem, 'id') else str(mem.get('id', ''))
-                raw_score = mem.score if hasattr(mem, 'score') else mem.get('score', 0)
+                mem_id = str(mem.id) if hasattr(mem, "id") else str(mem.get("id", ""))
+                raw_score = mem.score if hasattr(mem, "score") else mem.get("score", 0)
                 if raw_score and raw_score > 0:
                     bm25_scores[mem_id] = normalize_bm25(raw_score, midpoint, steepness)
 
@@ -1390,11 +1404,13 @@ class Memory(MemoryBase):
         candidates = []
         for mem in semantic_results:
             mem_id = str(mem.id)
-            candidates.append({
-                "id": mem_id,
-                "score": mem.score,
-                "payload": mem.payload if hasattr(mem, 'payload') else {},
-            })
+            candidates.append(
+                {
+                    "id": mem_id,
+                    "score": mem.score,
+                    "payload": mem.payload if hasattr(mem, "payload") else {},
+                }
+            )
 
         # Step 8: Score and rank
         scored_results = score_and_rank(
@@ -1414,7 +1430,16 @@ class Memory(MemoryBase):
             "actor_id",
             "role",
         ]
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
+        core_and_promoted_keys = {
+            "data",
+            "hash",
+            "created_at",
+            "updated_at",
+            "id",
+            "text_lemmatized",
+            "attributed_to",
+            *promoted_payload_keys,
+        }
 
         original_memories = []
         for scored in scored_results:
@@ -1489,15 +1514,10 @@ class Memory(MemoryBase):
             entity_store = self.entity_store
 
             def _search_entity(entity_text, embedding):
-                return entity_store.search(
-                    query=entity_text, vectors=embedding, top_k=500, filters=search_filters
-                )
+                return entity_store.search(query=entity_text, vectors=embedding, top_k=500, filters=search_filters)
 
             with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
-                futures = {
-                    pool.submit(_search_entity, text, emb): text
-                    for text, emb in zip(entity_texts, embeddings)
-                }
+                futures = {pool.submit(_search_entity, text, emb): text for text, emb in zip(entity_texts, embeddings)}
 
                 for future in concurrent.futures.as_completed(futures):
                     try:
@@ -1507,11 +1527,11 @@ class Memory(MemoryBase):
                         continue
 
                     for match in matches:
-                        similarity = match.score if hasattr(match, 'score') else 0.0
+                        similarity = match.score if hasattr(match, "score") else 0.0
                         if similarity < 0.5:
                             continue
 
-                        payload = match.payload if hasattr(match, 'payload') else {}
+                        payload = match.payload if hasattr(match, "payload") else {}
                         linked_memory_ids = payload.get("linked_memory_ids", [])
                         if not isinstance(linked_memory_ids, list):
                             continue
@@ -1846,10 +1866,7 @@ class AsyncMemory(MemoryBase):
         # Initialize reranker if configured
         self.reranker = None
         if config.reranker:
-            self.reranker = RerankerFactory.create(
-                config.reranker.provider,
-                config.reranker.config
-            )
+            self.reranker = RerankerFactory.create(config.reranker.provider, config.reranker.config)
 
         if MEM0_TELEMETRY:
             telemetry_config = _safe_deepcopy_config(self.config.vector_store.config)
@@ -1858,7 +1875,9 @@ class AsyncMemory(MemoryBase):
                 provider_path = f"migrations_{self.config.vector_store.provider}"
                 telemetry_config.path = os.path.join(mem0_dir, provider_path)
                 os.makedirs(telemetry_config.path, exist_ok=True)
-            self._telemetry_vector_store = VectorStoreFactory.create(self.config.vector_store.provider, telemetry_config)
+            self._telemetry_vector_store = VectorStoreFactory.create(
+                self.config.vector_store.provider, telemetry_config
+            )
 
         capture_event("mem0.init", self, {"sync_type": "async"})
 
@@ -1868,10 +1887,10 @@ class AsyncMemory(MemoryBase):
         if self._entity_store is None:
             entity_config = _safe_deepcopy_config(self.config.vector_store.config)
             entity_collection = f"{self.collection_name}_entities"
-            if hasattr(entity_config, 'collection_name'):
+            if hasattr(entity_config, "collection_name"):
                 entity_config.collection_name = entity_collection
             elif isinstance(entity_config, dict):
-                entity_config['collection_name'] = entity_collection
+                entity_config["collection_name"] = entity_collection
             # For Qdrant, share the existing client to avoid RocksDB lock contention
             # when using embedded mode (path=...). QdrantConfig.client takes precedence
             # over host/port/path.
@@ -1880,9 +1899,7 @@ class AsyncMemory(MemoryBase):
                     entity_config.client = self.vector_store.client
                 elif isinstance(entity_config, dict):
                     entity_config["client"] = self.vector_store.client
-            self._entity_store = VectorStoreFactory.create(
-                self.config.vector_store.provider, entity_config
-            )
+            self._entity_store = VectorStoreFactory.create(self.config.vector_store.provider, entity_config)
         return self._entity_store
 
     async def _upsert_entity_async(self, entity_text, entity_type, memory_id, filters):
@@ -2082,7 +2099,7 @@ class AsyncMemory(MemoryBase):
                 message="messages must be str, dict, or list[dict]",
                 error_code="VALIDATION_003",
                 details={"provided_type": type(messages).__name__, "valid_types": ["str", "dict", "list[dict]"]},
-                suggestion="Convert your input to a string, dictionary, or list of dictionaries."
+                suggestion="Convert your input to a string, dictionary, or list of dictionaries.",
             )
 
         if agent_id is not None and memory_type == MemoryType.PROCEDURAL.value:
@@ -2096,7 +2113,9 @@ class AsyncMemory(MemoryBase):
         else:
             messages = parse_vision_messages(messages)
 
-        vector_store_result = await self._add_to_vector_store(messages, processed_metadata, effective_filters, infer, prompt=prompt)
+        vector_store_result = await self._add_to_vector_store(
+            messages, processed_metadata, effective_filters, infer, prompt=prompt
+        )
         return {"results": vector_store_result}
 
     async def _add_to_vector_store(
@@ -2209,10 +2228,16 @@ class AsyncMemory(MemoryBase):
                     extracted_memories = json.loads(extracted_json, strict=False).get("memory", [])
         except Exception as e:
             logger.error(f"Error parsing extraction response (async): {e}")
-            # Recover via a forced tool call where supported, else fall back to [].
-            extracted_memories = await asyncio.to_thread(
-                recover_extraction_via_tools, self.llm, system_prompt, user_prompt
-            )
+            if "{" in str(response):
+                # JSON was emitted but did not parse (e.g. truncated by
+                # max_tokens) - not recoverable via a forced tool call.
+                extracted_memories = []
+            else:
+                # No JSON at all (content hijack): recover via a forced tool
+                # call where supported, else fall back to [].
+                extracted_memories = await asyncio.to_thread(
+                    recover_extraction_via_tools, self.llm, system_prompt, user_prompt
+                )
 
         if not extracted_memories:
             await asyncio.to_thread(self.db.save_messages, messages, session_scope)
@@ -2307,8 +2332,12 @@ class AsyncMemory(MemoryBase):
             for hr in history_records:
                 try:
                     await asyncio.to_thread(
-                        self.db.add_history, hr["memory_id"], None, hr["new_memory"], "ADD",
-                        created_at=hr.get("created_at")
+                        self.db.add_history,
+                        hr["memory_id"],
+                        None,
+                        hr["new_memory"],
+                        "ADD",
+                        created_at=hr.get("created_at"),
                     )
                 except Exception as e:
                     logger.error(f"Failed to add history for {hr['memory_id']} (async): {e}")
@@ -2383,12 +2412,14 @@ class AsyncMemory(MemoryBase):
                         else:
                             to_insert_vectors.append(valid_vectors[j])
                             to_insert_ids.append(str(uuid.uuid4()))
-                            to_insert_payloads.append({
-                                "data": entity_text,
-                                "entity_type": entity_type,
-                                "linked_memory_ids": sorted(memory_ids),
-                                **search_filters,
-                            })
+                            to_insert_payloads.append(
+                                {
+                                    "data": entity_text,
+                                    "entity_type": entity_type,
+                                    "linked_memory_ids": sorted(memory_ids),
+                                    **search_filters,
+                                }
+                            )
 
                     # 7e: Batch insert new entities
                     if to_insert_vectors:
@@ -2407,10 +2438,7 @@ class AsyncMemory(MemoryBase):
         # Phase 8: Save messages + return
         await asyncio.to_thread(self.db.save_messages, messages, session_scope)
 
-        returned_memories = [
-            {"id": r[0], "memory": r[1], "event": "ADD"}
-            for r in records
-        ]
+        returned_memories = [{"id": r[0], "memory": r[1], "event": "ADD"} for r in records]
 
         keys, encoded_ids = process_telemetry_filters(effective_filters)
         capture_event(
@@ -2443,7 +2471,16 @@ class AsyncMemory(MemoryBase):
             "role",
         ]
 
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
+        core_and_promoted_keys = {
+            "data",
+            "hash",
+            "created_at",
+            "updated_at",
+            "id",
+            "text_lemmatized",
+            "attributed_to",
+            *promoted_payload_keys,
+        }
 
         result_item = MemoryItem(
             id=memory.id,
@@ -2496,23 +2533,16 @@ class AsyncMemory(MemoryBase):
         # Validate and trim entity IDs in filters
         effective_filters = dict(filters) if filters else {}
         if "user_id" in effective_filters:
-            effective_filters["user_id"] = _validate_and_trim_entity_id(
-                effective_filters["user_id"], "user_id"
-            )
+            effective_filters["user_id"] = _validate_and_trim_entity_id(effective_filters["user_id"], "user_id")
         if "agent_id" in effective_filters:
-            effective_filters["agent_id"] = _validate_and_trim_entity_id(
-                effective_filters["agent_id"], "agent_id"
-            )
+            effective_filters["agent_id"] = _validate_and_trim_entity_id(effective_filters["agent_id"], "agent_id")
         if "run_id" in effective_filters:
-            effective_filters["run_id"] = _validate_and_trim_entity_id(
-                effective_filters["run_id"], "run_id"
-            )
+            effective_filters["run_id"] = _validate_and_trim_entity_id(effective_filters["run_id"], "run_id")
 
         # Validate filters contains at least one entity ID
         if not any(key in effective_filters for key in ("user_id", "agent_id", "run_id")):
             raise ValueError(
-                "filters must contain at least one of: user_id, agent_id, run_id. "
-                "Example: filters={'user_id': 'u1'}"
+                "filters must contain at least one of: user_id, agent_id, run_id. Example: filters={'user_id': 'u1'}"
             )
 
         limit = top_k
@@ -2549,7 +2579,16 @@ class AsyncMemory(MemoryBase):
             "actor_id",
             "role",
         ]
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
+        core_and_promoted_keys = {
+            "data",
+            "hash",
+            "created_at",
+            "updated_at",
+            "id",
+            "text_lemmatized",
+            "attributed_to",
+            *promoted_payload_keys,
+        }
 
         formatted_memories = []
         for mem in actual_memories:
@@ -2631,23 +2670,16 @@ class AsyncMemory(MemoryBase):
         # Validate and trim entity IDs in filters
         effective_filters = filters.copy() if filters else {}
         if "user_id" in effective_filters:
-            effective_filters["user_id"] = _validate_and_trim_entity_id(
-                effective_filters["user_id"], "user_id"
-            )
+            effective_filters["user_id"] = _validate_and_trim_entity_id(effective_filters["user_id"], "user_id")
         if "agent_id" in effective_filters:
-            effective_filters["agent_id"] = _validate_and_trim_entity_id(
-                effective_filters["agent_id"], "agent_id"
-            )
+            effective_filters["agent_id"] = _validate_and_trim_entity_id(effective_filters["agent_id"], "agent_id")
         if "run_id" in effective_filters:
-            effective_filters["run_id"] = _validate_and_trim_entity_id(
-                effective_filters["run_id"], "run_id"
-            )
+            effective_filters["run_id"] = _validate_and_trim_entity_id(effective_filters["run_id"], "run_id")
 
         # Validate filters contains at least one entity ID
         if not any(key in effective_filters for key in ("user_id", "agent_id", "run_id")):
             raise ValueError(
-                "filters must contain at least one of: user_id, agent_id, run_id. "
-                "Example: filters={'user_id': 'u1'}"
+                "filters must contain at least one of: user_id, agent_id, run_id. Example: filters={'user_id': 'u1'}"
             )
 
         limit = top_k
@@ -2659,7 +2691,9 @@ class AsyncMemory(MemoryBase):
             for logical_key in ("AND", "OR", "NOT"):
                 effective_filters.pop(logical_key, None)
             for fk in list(effective_filters.keys()):
-                if fk not in ("AND", "OR", "NOT", "user_id", "agent_id", "run_id") and isinstance(effective_filters.get(fk), dict):
+                if fk not in ("AND", "OR", "NOT", "user_id", "agent_id", "run_id") and isinstance(
+                    effective_filters.get(fk), dict
+                ):
                     effective_filters.pop(fk, None)
             effective_filters.update(processed_filters)
 
@@ -2685,9 +2719,7 @@ class AsyncMemory(MemoryBase):
         if rerank and self.reranker and original_memories:
             try:
                 # Run reranking in thread pool to avoid blocking async loop
-                reranked_memories = await asyncio.to_thread(
-                    self.reranker.rerank, query, original_memories, limit
-                )
+                reranked_memories = await asyncio.to_thread(self.reranker.rerank, query, original_memories, limit)
                 original_memories = reranked_memories
             except Exception as e:
                 logger.warning(f"Reranking failed, using original results: {e}")
@@ -2718,9 +2750,16 @@ class AsyncMemory(MemoryBase):
             for operator, value in condition.items():
                 # Map platform operators to universal format that can be translated by each vector store
                 operator_map = {
-                    "eq": "eq", "ne": "ne", "gt": "gt", "gte": "gte",
-                    "lt": "lt", "lte": "lte", "in": "in", "nin": "nin",
-                    "contains": "contains", "icontains": "icontains"
+                    "eq": "eq",
+                    "ne": "ne",
+                    "gt": "gt",
+                    "gte": "gte",
+                    "lt": "lt",
+                    "lte": "lte",
+                    "in": "in",
+                    "nin": "nin",
+                    "contains": "contains",
+                    "icontains": "icontains",
                 }
 
                 if operator in operator_map:
@@ -2825,8 +2864,8 @@ class AsyncMemory(MemoryBase):
         if keyword_results is not None:
             midpoint, steepness = get_bm25_params(query, lemmatized=query_lemmatized)
             for mem in keyword_results:
-                mem_id = str(mem.id) if hasattr(mem, 'id') else str(mem.get('id', ''))
-                raw_score = mem.score if hasattr(mem, 'score') else mem.get('score', 0)
+                mem_id = str(mem.id) if hasattr(mem, "id") else str(mem.get("id", ""))
+                raw_score = mem.score if hasattr(mem, "score") else mem.get("score", 0)
                 if raw_score and raw_score > 0:
                     bm25_scores[mem_id] = normalize_bm25(raw_score, midpoint, steepness)
 
@@ -2839,11 +2878,13 @@ class AsyncMemory(MemoryBase):
         candidates = []
         for mem in semantic_results:
             mem_id = str(mem.id)
-            candidates.append({
-                "id": mem_id,
-                "score": mem.score,
-                "payload": mem.payload if hasattr(mem, 'payload') else {},
-            })
+            candidates.append(
+                {
+                    "id": mem_id,
+                    "score": mem.score,
+                    "payload": mem.payload if hasattr(mem, "payload") else {},
+                }
+            )
 
         # Step 8: Score and rank
         scored_results = score_and_rank(
@@ -2863,7 +2904,16 @@ class AsyncMemory(MemoryBase):
             "actor_id",
             "role",
         ]
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
+        core_and_promoted_keys = {
+            "data",
+            "hash",
+            "created_at",
+            "updated_at",
+            "id",
+            "text_lemmatized",
+            "attributed_to",
+            *promoted_payload_keys,
+        }
 
         original_memories = []
         for scored in scored_results:
@@ -2947,11 +2997,11 @@ class AsyncMemory(MemoryBase):
                     continue
 
                 for match in matches:
-                    similarity = match.score if hasattr(match, 'score') else 0.0
+                    similarity = match.score if hasattr(match, "score") else 0.0
                     if similarity < 0.5:
                         continue
 
-                    payload = match.payload if hasattr(match, 'payload') else {}
+                    payload = match.payload if hasattr(match, "payload") else {}
                     linked_memory_ids = payload.get("linked_memory_ids", [])
                     if not isinstance(linked_memory_ids, list):
                         continue
@@ -3132,7 +3182,7 @@ class AsyncMemory(MemoryBase):
             else:
                 procedural_memory = await asyncio.to_thread(self.llm.generate_response, messages=parsed_messages)
                 procedural_memory = remove_code_blocks(procedural_memory)
-        
+
         except Exception as e:
             logger.error(f"Error generating procedural memory summary: {e}")
             raise

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -31,6 +31,7 @@ from mem0.memory.utils import (
     parse_messages,
     parse_vision_messages,
     process_telemetry_filters,
+    recover_extraction_via_tools,
     remove_code_blocks,
 )
 from mem0.utils.entity_extraction import extract_entities, extract_entities_batch
@@ -761,7 +762,10 @@ class Memory(MemoryBase):
                     extracted_memories = json.loads(extracted_json, strict=False).get("memory", [])
         except Exception as e:
             logger.error(f"Error parsing extraction response: {e}")
-            extracted_memories = []
+            # The response had no parseable JSON (e.g. the model returned prose /
+            # continued the transcript instead of extracting). Recover via a
+            # forced tool call where supported, else fall back to [].
+            extracted_memories = recover_extraction_via_tools(self.llm, system_prompt, user_prompt)
 
         if not extracted_memories:
             # Save messages even if nothing extracted
@@ -2205,7 +2209,10 @@ class AsyncMemory(MemoryBase):
                     extracted_memories = json.loads(extracted_json, strict=False).get("memory", [])
         except Exception as e:
             logger.error(f"Error parsing extraction response (async): {e}")
-            extracted_memories = []
+            # Recover via a forced tool call where supported, else fall back to [].
+            extracted_memories = await asyncio.to_thread(
+                recover_extraction_via_tools, self.llm, system_prompt, user_prompt
+            )
 
         if not extracted_memories:
             await asyncio.to_thread(self.db.save_messages, messages, session_scope)

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -2,7 +2,7 @@ import hashlib
 import json
 import logging
 import re
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from mem0.configs.prompts import (
     AGENT_MEMORY_EXTRACTION_PROMPT,
@@ -16,11 +16,11 @@ logger = logging.getLogger(__name__)
 
 def get_fact_retrieval_messages(message, is_agent_memory=False):
     """Get fact retrieval messages based on the memory type.
-    
+
     Args:
         message: The message content to extract facts from
         is_agent_memory: If True, use agent memory extraction prompt, else use user memory extraction prompt
-        
+
     Returns:
         tuple: (system_prompt, user_prompt)
     """
@@ -54,8 +54,7 @@ def ensure_json_instruction(system_prompt, user_prompt):
     combined = (system_prompt + user_prompt).lower()
     if "json" not in combined:
         system_prompt += (
-            "\n\nYou must return your response in valid JSON format "
-            "with a 'facts' key containing an array of strings."
+            "\n\nYou must return your response in valid JSON format with a 'facts' key containing an array of strings."
         )
     return system_prompt, user_prompt
 
@@ -82,6 +81,7 @@ def format_entities(entities):
         formatted_lines.append(simplified)
 
     return "\n".join(formatted_lines)
+
 
 def normalize_facts(raw_facts):
     """Normalize LLM-extracted facts to a list of strings.
@@ -119,9 +119,8 @@ def remove_code_blocks(content: str) -> str:
     """
     pattern = r"^```[a-zA-Z0-9]*\n([\s\S]*?)\n```$"
     match = re.match(pattern, content.strip())
-    match_res=match.group(1).strip() if match else content.strip()
+    match_res = match.group(1).strip() if match else content.strip()
     return re.sub(r"<think>.*?</think>", "", match_res, flags=re.DOTALL).strip()
-
 
 
 def extract_json(text):
@@ -164,16 +163,23 @@ def llm_supports_tool_calls(llm) -> bool:
     return getattr(llm, "supports_tool_calls", False) is True
 
 
-def parse_tool_calls_for_memory(response) -> List[Dict[str, Any]]:
+def parse_tool_calls_for_memory(response) -> Optional[List[Dict[str, Any]]]:
     """Pull the ``memory`` list out of a provider's tool-call response.
 
     Providers return ``{"content": ..., "tool_calls": [{"name", "arguments"}]}``
     (or a bare ``{"tool_calls": [...]}``) when a tool is invoked. ``arguments``
-    is normally a dict but some providers hand back a JSON string. Returns the
-    first tool call's ``memory`` array, or ``[]`` if none is present.
+    is normally a dict but some providers hand back a JSON string. Merges the
+    ``memory`` arrays across ALL tool calls (a model may answer a forced call
+    with several parallel invocations, one per fact) and drops non-dict items
+    (downstream reads ``m.get("text")``, so a bare string would crash the add
+    pipeline). Returns the merged list (which may legitimately be empty), or
+    ``None`` when no tool call carried a parseable ``memory`` list at all -
+    callers use that distinction to tell "valid empty extraction" from
+    "truncated/unusable tool output".
     """
     if not isinstance(response, dict):
-        return []
+        return None
+    collected: Optional[List[Dict[str, Any]]] = None
     for call in response.get("tool_calls") or []:
         if not isinstance(call, dict):
             continue
@@ -186,21 +192,29 @@ def parse_tool_calls_for_memory(response) -> List[Dict[str, Any]]:
         if isinstance(arguments, dict):
             memory = arguments.get("memory")
             if isinstance(memory, list):
-                return memory
-    return []
+                if collected is None:
+                    collected = []
+                collected.extend(m for m in memory if isinstance(m, dict))
+    return collected
 
 
 # A forced tool call whose own structured output hits ``max_tokens`` is retried
-# at this multiple of the configured ``max_tokens``. Real-corpus data: tool-call
-# truncations recovered at ~4x the base budget; a 2x raise under-shot.
+# once at this multiple of the configured ``max_tokens``. The 4x figure comes
+# from observed tool-call truncations on a real conversation corpus, where a 2x
+# raise still under-shot. The absolute cap bounds the retry's cost so a large
+# configured budget cannot multiply into an arbitrarily expensive call, and
+# keeps the raised value inside common provider output limits.
 _TOOL_RETRY_TOKEN_MULTIPLIER = 4
+_TOOL_RETRY_TOKEN_CAP = 8192
 
 
-def _forced_tool_extraction(llm, system_prompt, user_prompt, max_tokens=None) -> List[Dict[str, Any]]:
-    """Run one forced tool call and return its parsed memory list, or ``[]``.
+def _forced_tool_extraction(llm, system_prompt, user_prompt, max_tokens=None) -> Optional[List[Dict[str, Any]]]:
+    """Run one forced tool call and return its parsed memory list.
 
-    ``max_tokens`` overrides the provider's configured budget for this one call
-    (used by the truncation retry). Never raises.
+    Returns ``None`` when the call failed or produced no parseable tool call
+    (see ``parse_tool_calls_for_memory``). ``max_tokens`` overrides the
+    provider's configured budget for this one call (used by the truncation
+    retry). Never raises.
     """
     kwargs = {
         "messages": [
@@ -219,7 +233,7 @@ def _forced_tool_extraction(llm, system_prompt, user_prompt, max_tokens=None) ->
         return parse_tool_calls_for_memory(llm.generate_response(**kwargs))
     except Exception as e:
         logger.warning("Tool-based extraction recovery failed: %s", e)
-        return []
+        return None
 
 
 def recover_extraction_via_tools(llm, system_prompt, user_prompt) -> List[Dict[str, Any]]:
@@ -231,10 +245,22 @@ def recover_extraction_via_tools(llm, system_prompt, user_prompt) -> List[Dict[s
     ``save_memories`` schema: the model cannot answer a forced tool call with
     free prose, so the content-hijack that caused the drop cannot recur.
 
-    If the forced tool call yields nothing, its own structured output may have
-    been truncated (``max_tokens`` reached mid-call). In that case it retries
-    once at a raised ``max_tokens`` **staying in tool mode** - reverting to free
-    text would reintroduce the content-hijack the tool call exists to prevent.
+    If no tool call could be parsed at all, the forced call's own structured
+    output may have been truncated (``max_tokens`` reached mid-call). In that
+    case it retries once at a raised ``max_tokens`` **staying in tool mode** -
+    reverting to free text would reintroduce the content-hijack the tool call
+    exists to prevent. A tool call that parsed cleanly to an empty ``memory``
+    list is a valid "nothing memorable" result and is returned as-is, with no
+    retry spend. (Providers that drop the ``max_tokens`` override - e.g. the
+    reasoning models whose params layer strips it - re-run at the same budget;
+    the retry then harmlessly no-ops back to ``[]``.)
+
+    The recovery reuses the original extraction's ``system_prompt`` and
+    ``user_prompt`` (existing memories, recent messages, dates) so the
+    recovered extraction sees exactly the context the failed one did - same
+    fidelity, and therefore roughly the same cost as the original call. That
+    cost is only paid on the rare parse-failure path, never on healthy
+    extractions.
 
     Gated to providers that declare ``supports_tool_calls``; any failure (an
     unsupported provider, an API error, or an unparseable response) falls back
@@ -247,20 +273,23 @@ def recover_extraction_via_tools(llm, system_prompt, user_prompt) -> List[Dict[s
     if memories:
         logger.info("Recovered %d memory item(s) via forced tool call after parse failure", len(memories))
         return memories
+    if memories is not None:
+        # The tool call parsed cleanly to an empty list: the conversation had
+        # nothing memorable. That is a valid result, not a truncation - do not
+        # spend another LLM call retrying it.
+        return []
 
-    # Empty result: the forced tool call may have truncated. Retry once at a
-    # raised budget, still forcing the tool.
+    # No parseable tool call: the forced call's own output may have truncated.
+    # Retry once at a raised (and capped) budget, still forcing the tool.
     current = getattr(getattr(llm, "config", None), "max_tokens", None)
-    if current:
-        retried = _forced_tool_extraction(
-            llm, system_prompt, user_prompt, max_tokens=current * _TOOL_RETRY_TOKEN_MULTIPLIER
-        )
-        if retried:
-            logger.info(
-                "Recovered %d memory item(s) via forced tool call after a raised-token retry", len(retried)
-            )
-            return retried
-    return memories
+    if isinstance(current, int) and current > 0:
+        raised = min(current * _TOOL_RETRY_TOKEN_MULTIPLIER, _TOOL_RETRY_TOKEN_CAP)
+        if raised > current:
+            retried = _forced_tool_extraction(llm, system_prompt, user_prompt, max_tokens=raised)
+            if retried:
+                logger.info("Recovered %d memory item(s) via forced tool call after a raised-token retry", len(retried))
+                return retried
+    return []
 
 
 def get_image_description(image_obj, llm, vision_details):
@@ -413,4 +442,3 @@ def remove_spaces_from_entities(
         item["destination"] = item["destination"].lower().replace(" ", "_")
         cleaned.append(item)
     return cleaned
-

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -1,4 +1,5 @@
 import hashlib
+import json
 import logging
 import re
 from typing import Any, Dict, List
@@ -6,6 +7,7 @@ from typing import Any, Dict, List
 from mem0.configs.prompts import (
     AGENT_MEMORY_EXTRACTION_PROMPT,
     FACT_RETRIEVAL_PROMPT,
+    MEMORY_EXTRACTION_TOOL,
     USER_MEMORY_EXTRACTION_PROMPT,
 )
 
@@ -140,6 +142,125 @@ def extract_json(text):
         else:
             json_str = text
     return json_str
+
+
+def llm_supports_tool_calls(llm) -> bool:
+    """Whether this LLM provider can recover extraction via a forced tool call.
+
+    The recovery path (``recover_extraction_via_tools``) only works on providers
+    that (a) accept ``tools`` / ``tool_choice`` and (b) return the standard
+    ``{"tool_calls": [{"name", "arguments"}]}`` dict when a tool is called.
+    Providers opt in explicitly by setting the class attribute
+    ``supports_tool_calls = True``. This is intentionally distinct from
+    AWSBedrockLLM's pre-existing ``supports_tools`` (whether the underlying
+    Bedrock model family accepts tools at all): this flag specifically asserts
+    "honors a forced ``tool_choice`` and returns the standard tool_calls dict",
+    which is what the recovery path needs.
+
+    The ``is True`` check is deliberate: it requires a real boolean opt-in and
+    will not be tripped by the auto-populated attributes of a ``MagicMock`` in
+    tests or by partially-wired providers.
+    """
+    return getattr(llm, "supports_tool_calls", False) is True
+
+
+def parse_tool_calls_for_memory(response) -> List[Dict[str, Any]]:
+    """Pull the ``memory`` list out of a provider's tool-call response.
+
+    Providers return ``{"content": ..., "tool_calls": [{"name", "arguments"}]}``
+    (or a bare ``{"tool_calls": [...]}``) when a tool is invoked. ``arguments``
+    is normally a dict but some providers hand back a JSON string. Returns the
+    first tool call's ``memory`` array, or ``[]`` if none is present.
+    """
+    if not isinstance(response, dict):
+        return []
+    for call in response.get("tool_calls") or []:
+        if not isinstance(call, dict):
+            continue
+        arguments = call.get("arguments")
+        if isinstance(arguments, str):
+            try:
+                arguments = json.loads(arguments)
+            except (json.JSONDecodeError, ValueError):
+                continue
+        if isinstance(arguments, dict):
+            memory = arguments.get("memory")
+            if isinstance(memory, list):
+                return memory
+    return []
+
+
+# A forced tool call whose own structured output hits ``max_tokens`` is retried
+# at this multiple of the configured ``max_tokens``. Real-corpus data: tool-call
+# truncations recovered at ~4x the base budget; a 2x raise under-shot.
+_TOOL_RETRY_TOKEN_MULTIPLIER = 4
+
+
+def _forced_tool_extraction(llm, system_prompt, user_prompt, max_tokens=None) -> List[Dict[str, Any]]:
+    """Run one forced tool call and return its parsed memory list, or ``[]``.
+
+    ``max_tokens`` overrides the provider's configured budget for this one call
+    (used by the truncation retry). Never raises.
+    """
+    kwargs = {
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+        # No response_format: the forced tool call supersedes it, and OpenAI
+        # rejects response_format={"type": "json_object"} combined with a forced
+        # tool_choice.
+        "tools": [MEMORY_EXTRACTION_TOOL],
+        "tool_choice": "required",
+    }
+    if max_tokens:
+        kwargs["max_tokens"] = max_tokens
+    try:
+        return parse_tool_calls_for_memory(llm.generate_response(**kwargs))
+    except Exception as e:
+        logger.warning("Tool-based extraction recovery failed: %s", e)
+        return []
+
+
+def recover_extraction_via_tools(llm, system_prompt, user_prompt) -> List[Dict[str, Any]]:
+    """Recover dropped memories after a parse failure using forced tool use.
+
+    When the extraction LLM returns prose with no JSON object, the standard
+    parse path raises ``json.JSONDecodeError`` and the memories are silently
+    lost. This retries the same extraction with a forced ``tool_choice`` on the
+    ``save_memories`` schema: the model cannot answer a forced tool call with
+    free prose, so the content-hijack that caused the drop cannot recur.
+
+    If the forced tool call yields nothing, its own structured output may have
+    been truncated (``max_tokens`` reached mid-call). In that case it retries
+    once at a raised ``max_tokens`` **staying in tool mode** - reverting to free
+    text would reintroduce the content-hijack the tool call exists to prevent.
+
+    Gated to providers that declare ``supports_tool_calls``; any failure (an
+    unsupported provider, an API error, or an unparseable response) falls back
+    to the current behavior by returning ``[]`` - recovery never raises.
+    """
+    if not llm_supports_tool_calls(llm):
+        return []
+
+    memories = _forced_tool_extraction(llm, system_prompt, user_prompt)
+    if memories:
+        logger.info("Recovered %d memory item(s) via forced tool call after parse failure", len(memories))
+        return memories
+
+    # Empty result: the forced tool call may have truncated. Retry once at a
+    # raised budget, still forcing the tool.
+    current = getattr(getattr(llm, "config", None), "max_tokens", None)
+    if current:
+        retried = _forced_tool_extraction(
+            llm, system_prompt, user_prompt, max_tokens=current * _TOOL_RETRY_TOKEN_MULTIPLIER
+        )
+        if retried:
+            logger.info(
+                "Recovered %d memory item(s) via forced tool call after a raised-token retry", len(retried)
+            )
+            return retried
+    return memories
 
 
 def get_image_description(image_obj, llm, vision_details):

--- a/tests/llms/test_anthropic.py
+++ b/tests/llms/test_anthropic.py
@@ -150,9 +150,7 @@ def test_openai_format_tools_converted_to_anthropic_schema(mock_anthropic_client
         content=[_tool_use_block("save_memories", {"memory": []})]
     )
 
-    llm.generate_response(
-        [{"role": "user", "content": "Hi"}], tools=[OPENAI_FORMAT_TOOL], tool_choice="required"
-    )
+    llm.generate_response([{"role": "user", "content": "Hi"}], tools=[OPENAI_FORMAT_TOOL], tool_choice="required")
 
     call_kwargs = mock_anthropic_client.messages.create.call_args[1]
     sent_tool = call_kwargs["tools"][0]
@@ -168,9 +166,7 @@ def test_tool_use_block_parsed_into_tool_calls_dict(mock_anthropic_client):
     config = AnthropicConfig(model="claude-3-5-sonnet-20240620", api_key="test-key")
     llm = AnthropicLLM(config)
     payload = {"memory": [{"id": "0", "text": "Likes hiking"}]}
-    mock_anthropic_client.messages.create.return_value = Mock(
-        content=[_tool_use_block("save_memories", payload)]
-    )
+    mock_anthropic_client.messages.create.return_value = Mock(content=[_tool_use_block("save_memories", payload)])
 
     result = llm.generate_response(
         [{"role": "user", "content": "Hi"}], tools=[OPENAI_FORMAT_TOOL], tool_choice="required"
@@ -193,7 +189,7 @@ def test_tool_choice_auto_maps_to_dict(mock_anthropic_client):
 
 def test_tool_requested_but_text_returned_yields_no_tool_calls(mock_anthropic_client):
     """If the model returns only text despite a forced tool, tool_calls is empty
-    (graceful — the recovery degrades to [] rather than raising)."""
+    (graceful - the recovery degrades to [] rather than raising)."""
     config = AnthropicConfig(model="claude-3-5-sonnet-20240620", api_key="test-key")
     llm = AnthropicLLM(config)
     text_block = Mock()
@@ -224,9 +220,7 @@ def test_already_anthropic_format_tool_passed_through(mock_anthropic_client):
 def test_tool_missing_parameters_gets_empty_object_schema(mock_anthropic_client):
     config = AnthropicConfig(model="claude-3-5-sonnet-20240620", api_key="test-key")
     llm = AnthropicLLM(config)
-    mock_anthropic_client.messages.create.return_value = Mock(
-        content=[_tool_use_block("noop", {})]
-    )
+    mock_anthropic_client.messages.create.return_value = Mock(content=[_tool_use_block("noop", {})])
     tool = {"type": "function", "function": {"name": "noop", "description": "d"}}
 
     llm.generate_response([{"role": "user", "content": "Hi"}], tools=[tool], tool_choice="required")
@@ -243,12 +237,21 @@ def test_parse_response_output_feeds_recovery_parser(mock_anthropic_client):
     config = AnthropicConfig(model="claude-3-5-sonnet-20240620", api_key="test-key")
     llm = AnthropicLLM(config)
     payload = {"memory": [{"id": "0", "text": "Likes hiking"}]}
-    mock_anthropic_client.messages.create.return_value = Mock(
-        content=[_tool_use_block("save_memories", payload)]
-    )
+    mock_anthropic_client.messages.create.return_value = Mock(content=[_tool_use_block("save_memories", payload)])
 
     response = llm.generate_response(
         [{"role": "user", "content": "Hi"}], tools=[OPENAI_FORMAT_TOOL], tool_choice="required"
     )
 
     assert parse_tool_calls_for_memory(response) == [{"id": "0", "text": "Likes hiking"}]
+
+
+def test_no_tools_path_empty_content_returns_empty_string(mock_anthropic_client):
+    """An empty content list (e.g. a blocked/refused response) must not raise
+    IndexError on the no-tools path; it degrades to an empty string."""
+    config = AnthropicConfig(model="claude-3-5-sonnet-20240620", api_key="test-key")
+    llm = AnthropicLLM(config)
+
+    mock_anthropic_client.messages.create.return_value = Mock(content=[])
+
+    assert llm.generate_response([{"role": "user", "content": "Hi"}]) == ""

--- a/tests/llms/test_anthropic.py
+++ b/tests/llms/test_anthropic.py
@@ -98,3 +98,157 @@ def test_base_config_conversion_does_not_send_both(mock_anthropic_client):
     call_kwargs = mock_anthropic_client.messages.create.call_args[1]
     assert "temperature" in call_kwargs
     assert "top_p" not in call_kwargs
+
+
+# --- Tool / forced structured output handling ---
+
+OPENAI_FORMAT_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "save_memories",
+        "description": "Save extracted memories.",
+        "parameters": {
+            "type": "object",
+            "properties": {"memory": {"type": "array", "items": {"type": "object"}}},
+            "required": ["memory"],
+        },
+    },
+}
+
+
+def _tool_use_block(name, payload):
+    block = Mock()
+    block.type = "tool_use"
+    block.name = name
+    block.input = payload
+    return block
+
+
+def test_declares_tool_call_support():
+    assert AnthropicLLM.supports_tool_calls is True
+
+
+def test_no_tools_path_returns_text(mock_anthropic_client):
+    """Without tools, behavior is unchanged: the assistant text is returned."""
+    config = AnthropicConfig(model="claude-3-5-sonnet-20240620", api_key="test-key")
+    llm = AnthropicLLM(config)
+
+    text_block = Mock()
+    text_block.type = "text"
+    text_block.text = "Hello!"
+    mock_anthropic_client.messages.create.return_value = Mock(content=[text_block])
+
+    assert llm.generate_response([{"role": "user", "content": "Hi"}]) == "Hello!"
+    assert "tools" not in mock_anthropic_client.messages.create.call_args[1]
+
+
+def test_openai_format_tools_converted_to_anthropic_schema(mock_anthropic_client):
+    """OpenAI function-format tools are converted to Anthropic's input_schema."""
+    config = AnthropicConfig(model="claude-3-5-sonnet-20240620", api_key="test-key")
+    llm = AnthropicLLM(config)
+    mock_anthropic_client.messages.create.return_value = Mock(
+        content=[_tool_use_block("save_memories", {"memory": []})]
+    )
+
+    llm.generate_response(
+        [{"role": "user", "content": "Hi"}], tools=[OPENAI_FORMAT_TOOL], tool_choice="required"
+    )
+
+    call_kwargs = mock_anthropic_client.messages.create.call_args[1]
+    sent_tool = call_kwargs["tools"][0]
+    assert sent_tool["name"] == "save_memories"
+    assert "input_schema" in sent_tool and "function" not in sent_tool
+    assert sent_tool["input_schema"]["required"] == ["memory"]
+    # "required" maps to Anthropic's {"type": "any"}.
+    assert call_kwargs["tool_choice"] == {"type": "any"}
+
+
+def test_tool_use_block_parsed_into_tool_calls_dict(mock_anthropic_client):
+    """A tool_use block is returned as {"content", "tool_calls"} like other providers."""
+    config = AnthropicConfig(model="claude-3-5-sonnet-20240620", api_key="test-key")
+    llm = AnthropicLLM(config)
+    payload = {"memory": [{"id": "0", "text": "Likes hiking"}]}
+    mock_anthropic_client.messages.create.return_value = Mock(
+        content=[_tool_use_block("save_memories", payload)]
+    )
+
+    result = llm.generate_response(
+        [{"role": "user", "content": "Hi"}], tools=[OPENAI_FORMAT_TOOL], tool_choice="required"
+    )
+
+    assert result["tool_calls"] == [{"name": "save_memories", "arguments": payload}]
+
+
+def test_tool_choice_auto_maps_to_dict(mock_anthropic_client):
+    config = AnthropicConfig(model="claude-3-5-sonnet-20240620", api_key="test-key")
+    llm = AnthropicLLM(config)
+    mock_anthropic_client.messages.create.return_value = Mock(
+        content=[_tool_use_block("save_memories", {"memory": []})]
+    )
+
+    llm.generate_response([{"role": "user", "content": "Hi"}], tools=[OPENAI_FORMAT_TOOL])
+
+    assert mock_anthropic_client.messages.create.call_args[1]["tool_choice"] == {"type": "auto"}
+
+
+def test_tool_requested_but_text_returned_yields_no_tool_calls(mock_anthropic_client):
+    """If the model returns only text despite a forced tool, tool_calls is empty
+    (graceful — the recovery degrades to [] rather than raising)."""
+    config = AnthropicConfig(model="claude-3-5-sonnet-20240620", api_key="test-key")
+    llm = AnthropicLLM(config)
+    text_block = Mock()
+    text_block.type = "text"
+    text_block.text = "I'd rather just chat."
+    mock_anthropic_client.messages.create.return_value = Mock(content=[text_block])
+
+    result = llm.generate_response(
+        [{"role": "user", "content": "Hi"}], tools=[OPENAI_FORMAT_TOOL], tool_choice="required"
+    )
+
+    assert result == {"content": "I'd rather just chat.", "tool_calls": []}
+
+
+def test_already_anthropic_format_tool_passed_through(mock_anthropic_client):
+    config = AnthropicConfig(model="claude-3-5-sonnet-20240620", api_key="test-key")
+    llm = AnthropicLLM(config)
+    mock_anthropic_client.messages.create.return_value = Mock(
+        content=[_tool_use_block("save_memories", {"memory": []})]
+    )
+    native_tool = {"name": "save_memories", "description": "d", "input_schema": {"type": "object"}}
+
+    llm.generate_response([{"role": "user", "content": "Hi"}], tools=[native_tool], tool_choice="required")
+
+    assert mock_anthropic_client.messages.create.call_args[1]["tools"][0] == native_tool
+
+
+def test_tool_missing_parameters_gets_empty_object_schema(mock_anthropic_client):
+    config = AnthropicConfig(model="claude-3-5-sonnet-20240620", api_key="test-key")
+    llm = AnthropicLLM(config)
+    mock_anthropic_client.messages.create.return_value = Mock(
+        content=[_tool_use_block("noop", {})]
+    )
+    tool = {"type": "function", "function": {"name": "noop", "description": "d"}}
+
+    llm.generate_response([{"role": "user", "content": "Hi"}], tools=[tool], tool_choice="required")
+
+    sent_tool = mock_anthropic_client.messages.create.call_args[1]["tools"][0]
+    assert sent_tool["input_schema"] == {"type": "object", "properties": {}}
+
+
+def test_parse_response_output_feeds_recovery_parser(mock_anthropic_client):
+    """Seam test: AnthropicLLM's tool response shape is byte-compatible with the
+    recovery parser that consumes it (parse_tool_calls_for_memory)."""
+    from mem0.memory.utils import parse_tool_calls_for_memory
+
+    config = AnthropicConfig(model="claude-3-5-sonnet-20240620", api_key="test-key")
+    llm = AnthropicLLM(config)
+    payload = {"memory": [{"id": "0", "text": "Likes hiking"}]}
+    mock_anthropic_client.messages.create.return_value = Mock(
+        content=[_tool_use_block("save_memories", payload)]
+    )
+
+    response = llm.generate_response(
+        [{"role": "user", "content": "Hi"}], tools=[OPENAI_FORMAT_TOOL], tool_choice="required"
+    )
+
+    assert parse_tool_calls_for_memory(response) == [{"id": "0", "text": "Likes hiking"}]

--- a/tests/llms/test_gemini.py
+++ b/tests/llms/test_gemini.py
@@ -288,9 +288,7 @@ def test_forced_structure_recovery_works_end_to_end_on_gemini(mock_gemini_client
     part = Mock()
     part.text = None
     part.function_call = call
-    mock_gemini_client.models.generate_content.return_value = Mock(
-        candidates=[Mock(content=Mock(parts=[part]))]
-    )
+    mock_gemini_client.models.generate_content.return_value = Mock(candidates=[Mock(content=Mock(parts=[part]))])
 
     recovered = recover_extraction_via_tools(llm, "system prompt", "user prompt")
 

--- a/tests/llms/test_gemini.py
+++ b/tests/llms/test_gemini.py
@@ -216,7 +216,8 @@ def _tool_response():
 def test_tool_choice_required_forces_any_mode(mock_gemini_client: Mock):
     """Regression: tool_choice='required' must map to ANY (force a tool), not
     NONE (tools off). Previously 'required' fell through to NONE and silently
-    disabled tool calling."""
+    disabled tool calling. 'required' means the model must call *some* tool of
+    its choosing, so allowed_function_names stays unset (LiteLLM parity)."""
     llm = GeminiLLM(BaseLlmConfig(model="gemini-2.0-flash", max_tokens=100))
     mock_gemini_client.models.generate_content.return_value = _tool_response()
 
@@ -224,10 +225,12 @@ def test_tool_choice_required_forces_any_mode(mock_gemini_client: Mock):
 
     cfg = mock_gemini_client.models.generate_content.call_args.kwargs["config"]
     assert cfg.tool_config.function_calling_config.mode == types.FunctionCallingConfigMode.ANY
-    assert cfg.tool_config.function_calling_config.allowed_function_names == ["save_memories"]
+    assert cfg.tool_config.function_calling_config.allowed_function_names is None
 
 
 def test_tool_choice_any_still_forces(mock_gemini_client: Mock):
+    """'any' restricts the forced call to the provided tools, so
+    allowed_function_names is set."""
     llm = GeminiLLM(BaseLlmConfig(model="gemini-2.0-flash", max_tokens=100))
     mock_gemini_client.models.generate_content.return_value = _tool_response()
 
@@ -235,6 +238,7 @@ def test_tool_choice_any_still_forces(mock_gemini_client: Mock):
 
     cfg = mock_gemini_client.models.generate_content.call_args.kwargs["config"]
     assert cfg.tool_config.function_calling_config.mode == types.FunctionCallingConfigMode.ANY
+    assert cfg.tool_config.function_calling_config.allowed_function_names == ["save_memories"]
 
 
 def test_tool_choice_none_disables_tools(mock_gemini_client: Mock):
@@ -254,9 +258,7 @@ def test_max_tokens_kwarg_overrides_config(mock_gemini_client: Mock):
     mock_part = Mock()
     mock_part.text = "ok"
     mock_part.function_call = None
-    mock_gemini_client.models.generate_content.return_value = Mock(
-        candidates=[Mock(content=Mock(parts=[mock_part]))]
-    )
+    mock_gemini_client.models.generate_content.return_value = Mock(candidates=[Mock(content=Mock(parts=[mock_part]))])
 
     llm.generate_response([{"role": "user", "content": "hi"}], max_tokens=8000)
 

--- a/tests/llms/test_gemini.py
+++ b/tests/llms/test_gemini.py
@@ -187,3 +187,78 @@ def test_parse_response_empty_parts_with_tools(mock_gemini_client: Mock):
 
     result = llm._parse_response(mock_response, tools=[{"function": {"name": "test"}}])
     assert result == {"content": None, "tool_calls": []}
+
+
+# --- Forced tool_choice + per-call kwargs (provider bug fixes) ---
+
+_FORCE_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "save_memories",
+            "description": "Save extracted memories.",
+            "parameters": {"type": "object", "properties": {"memory": {"type": "array"}}, "required": ["memory"]},
+        },
+    }
+]
+
+
+def _tool_response():
+    call = Mock()
+    call.name = "save_memories"
+    call.args = {"memory": []}
+    part = Mock()
+    part.text = None
+    part.function_call = call
+    return Mock(candidates=[Mock(content=Mock(parts=[part]))])
+
+
+def test_tool_choice_required_forces_any_mode(mock_gemini_client: Mock):
+    """Regression: tool_choice='required' must map to ANY (force a tool), not
+    NONE (tools off). Previously 'required' fell through to NONE and silently
+    disabled tool calling."""
+    llm = GeminiLLM(BaseLlmConfig(model="gemini-2.0-flash", max_tokens=100))
+    mock_gemini_client.models.generate_content.return_value = _tool_response()
+
+    llm.generate_response([{"role": "user", "content": "hi"}], tools=_FORCE_TOOLS, tool_choice="required")
+
+    cfg = mock_gemini_client.models.generate_content.call_args.kwargs["config"]
+    assert cfg.tool_config.function_calling_config.mode == types.FunctionCallingConfigMode.ANY
+    assert cfg.tool_config.function_calling_config.allowed_function_names == ["save_memories"]
+
+
+def test_tool_choice_any_still_forces(mock_gemini_client: Mock):
+    llm = GeminiLLM(BaseLlmConfig(model="gemini-2.0-flash", max_tokens=100))
+    mock_gemini_client.models.generate_content.return_value = _tool_response()
+
+    llm.generate_response([{"role": "user", "content": "hi"}], tools=_FORCE_TOOLS, tool_choice="any")
+
+    cfg = mock_gemini_client.models.generate_content.call_args.kwargs["config"]
+    assert cfg.tool_config.function_calling_config.mode == types.FunctionCallingConfigMode.ANY
+
+
+def test_tool_choice_none_disables_tools(mock_gemini_client: Mock):
+    llm = GeminiLLM(BaseLlmConfig(model="gemini-2.0-flash", max_tokens=100))
+    mock_gemini_client.models.generate_content.return_value = _tool_response()
+
+    llm.generate_response([{"role": "user", "content": "hi"}], tools=_FORCE_TOOLS, tool_choice="none")
+
+    cfg = mock_gemini_client.models.generate_content.call_args.kwargs["config"]
+    assert cfg.tool_config.function_calling_config.mode == types.FunctionCallingConfigMode.NONE
+
+
+def test_max_tokens_kwarg_overrides_config(mock_gemini_client: Mock):
+    """generate_response accepts **kwargs (base-class contract); a max_tokens
+    override is applied as max_output_tokens for that one call."""
+    llm = GeminiLLM(BaseLlmConfig(model="gemini-2.0-flash", max_tokens=100))
+    mock_part = Mock()
+    mock_part.text = "ok"
+    mock_part.function_call = None
+    mock_gemini_client.models.generate_content.return_value = Mock(
+        candidates=[Mock(content=Mock(parts=[mock_part]))]
+    )
+
+    llm.generate_response([{"role": "user", "content": "hi"}], max_tokens=8000)
+
+    cfg = mock_gemini_client.models.generate_content.call_args.kwargs["config"]
+    assert cfg.max_output_tokens == 8000

--- a/tests/llms/test_gemini.py
+++ b/tests/llms/test_gemini.py
@@ -262,3 +262,37 @@ def test_max_tokens_kwarg_overrides_config(mock_gemini_client: Mock):
 
     cfg = mock_gemini_client.models.generate_content.call_args.kwargs["config"]
     assert cfg.max_output_tokens == 8000
+
+
+# --- Forced-structure extraction recovery enablement (issue #3918) ---
+
+
+def test_gemini_declares_tool_call_support():
+    """Gemini opts into the forced-structure extraction recovery."""
+    assert GeminiLLM.supports_tool_calls is True
+
+
+def test_forced_structure_recovery_works_end_to_end_on_gemini(mock_gemini_client: Mock):
+    """A parse failure is recovered via a forced tool call on Gemini. Exercises
+    the recovery path + the forced tool_choice mapping + supports_tool_calls
+    together: the model returns a structured tool call (so leaked reasoning
+    tokens cannot corrupt the JSON), and the memories are recovered."""
+    from mem0.memory.utils import recover_extraction_via_tools
+
+    llm = GeminiLLM(BaseLlmConfig(model="gemini-2.0-flash", max_tokens=2000))
+    call = Mock()
+    call.name = "save_memories"
+    call.args = {"memory": [{"id": "0", "text": "User adopted a dog named Max"}]}
+    part = Mock()
+    part.text = None
+    part.function_call = call
+    mock_gemini_client.models.generate_content.return_value = Mock(
+        candidates=[Mock(content=Mock(parts=[part]))]
+    )
+
+    recovered = recover_extraction_via_tools(llm, "system prompt", "user prompt")
+
+    assert recovered == [{"id": "0", "text": "User adopted a dog named Max"}]
+    # recovery forced a tool call (ANY mode), not free text
+    cfg = mock_gemini_client.models.generate_content.call_args.kwargs["config"]
+    assert cfg.tool_config.function_calling_config.mode == types.FunctionCallingConfigMode.ANY

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -62,7 +62,9 @@ class TestAddToVectorStoreErrors:
         # Verify — v3 single-pass pipeline makes 1 LLM call, returns [] on parse error
         assert mock_memory.llm.generate_response.call_count == 1
         assert result == []
-        assert any("Error parsing extraction response" in record.message for record in caplog.records), "Expected error message not found in logs"
+        assert any("Error parsing extraction response" in record.message for record in caplog.records), (
+            "Expected error message not found in logs"
+        )
 
     def test_empty_llm_response_memory_actions(self, mock_memory, caplog):
         """Test empty response from LLM during memory actions (v3: single-pass, 1 LLM call)"""
@@ -116,7 +118,9 @@ class TestParseFailureRecovery:
         memory.db.get_last_messages = MagicMock(return_value=[])
         memory.db.save_messages = MagicMock()
         memory.db.batch_add_history = MagicMock()
-        memory.embedding_model.embed_batch = MagicMock(side_effect=lambda texts, *a, **k: [[0.1, 0.2, 0.3] for _ in texts])
+        memory.embedding_model.embed_batch = MagicMock(
+            side_effect=lambda texts, *a, **k: [[0.1, 0.2, 0.3] for _ in texts]
+        )
         return memory
 
     def test_recovers_dropped_memories_when_provider_supports_tools(self, mock_memory, caplog):
@@ -154,6 +158,38 @@ class TestParseFailureRecovery:
         assert mock_memory.llm.generate_response.call_count == 1
         assert result == []
         assert any("Error parsing extraction response" in r.message for r in caplog.records)
+
+    def test_truncated_json_does_not_trigger_tool_recovery(self, mock_memory):
+        # A response that contained JSON but failed to parse (e.g. max_tokens
+        # cut it off mid-object) is a token-budget problem, not a content
+        # hijack. The forced-tool recovery must not fire - otherwise every
+        # under-budgeted extraction silently pays for extra LLM calls.
+        mock_memory.llm.supports_tool_calls = True
+        mock_memory.llm.generate_response.return_value = '{"memory": [{"id": "0", "text": "User likes hik'
+
+        result = mock_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "test"}], metadata={}, filters={}, infer=True
+        )
+
+        assert mock_memory.llm.generate_response.call_count == 1
+        assert result == []
+
+    def test_hijack_prose_containing_a_brace_keeps_current_behavior(self, mock_memory):
+        # Pins the deliberate fail-safe edge of the '{' gate: hijack prose that
+        # merely contains a brace (e.g. an echoed code snippet) is treated as
+        # "JSON may have been emitted" and keeps the current no-recovery
+        # behavior rather than paying for a recovery call.
+        mock_memory.llm.supports_tool_calls = True
+        mock_memory.llm.generate_response.return_value = (
+            "Sure! Here is a config you could use: server { listen 80; } - let me know if it works."
+        )
+
+        result = mock_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "test"}], metadata={}, filters={}, infer=True
+        )
+
+        assert mock_memory.llm.generate_response.call_count == 1
+        assert result == []
 
 
 class TestPromptOverridesCustomInstructions:
@@ -276,7 +312,9 @@ class TestAsyncAddToVectorStoreErrors:
             )
         assert mock_async_memory.llm.generate_response.call_count == 1
         assert result == []
-        assert any("Error parsing extraction response" in record.message for record in caplog.records), "Expected error message not found in logs"
+        assert any("Error parsing extraction response" in record.message for record in caplog.records), (
+            "Expected error message not found in logs"
+        )
 
     @pytest.mark.asyncio
     async def test_async_empty_llm_response_memory_actions(self, mock_async_memory, caplog, mocker):
@@ -313,7 +351,9 @@ class TestAsyncParseFailureRecovery:
         memory.db.get_last_messages = MagicMock(return_value=[])
         memory.db.save_messages = MagicMock()
         memory.db.batch_add_history = MagicMock()
-        memory.embedding_model.embed_batch = MagicMock(side_effect=lambda texts, *a, **k: [[0.1, 0.2, 0.3] for _ in texts])
+        memory.embedding_model.embed_batch = MagicMock(
+            side_effect=lambda texts, *a, **k: [[0.1, 0.2, 0.3] for _ in texts]
+        )
         return memory
 
     @pytest.mark.asyncio
@@ -347,6 +387,20 @@ class TestAsyncParseFailureRecovery:
         assert mock_async_memory.llm.generate_response.call_count == 1
         assert result == []
         assert any("Error parsing extraction response (async)" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_async_truncated_json_does_not_trigger_tool_recovery(self, mock_async_memory):
+        # Async counterpart: truncated JSON (token budget) must not fire the
+        # forced-tool recovery.
+        mock_async_memory.llm.supports_tool_calls = True
+        mock_async_memory.llm.generate_response.return_value = '{"memory": [{"id": "0", "text": "User likes hik'
+
+        result = await mock_async_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "test"}], metadata={}, effective_filters={}, infer=True
+        )
+
+        assert mock_async_memory.llm.generate_response.call_count == 1
+        assert result == []
 
 
 def _build_memory_instance(mocker, memory_cls):
@@ -633,6 +687,7 @@ class TestMetadataNotMutated:
         memory = _build_memory_instance(mocker, Memory)
         metadata = {"user_id": "test_user", "tags": ["important", "urgent"], "config": {"key": "val"}}
         import copy
+
         metadata_snapshot = copy.deepcopy(metadata)
 
         memory._create_memory("test data", {"test data": [0.1, 0.2, 0.3]}, metadata=metadata)
@@ -763,7 +818,8 @@ def test_update_preserves_actor_id_when_different_actor_updates(mocker):
     )
 
     memory._update_memory(
-        "mem-id", "Player #1 is a good person",
+        "mem-id",
+        "Player #1 is a good person",
         {"Player #1 is a good person": [0.1, 0.2, 0.3]},
         metadata={"user_id": "team", "actor_id": "Bob"},
     )
@@ -786,7 +842,8 @@ async def test_async_update_preserves_actor_id_when_different_actor_updates(mock
     )
 
     await memory._update_memory(
-        "mem-id", "Player #1 is a good person",
+        "mem-id",
+        "Player #1 is a good person",
         {"Player #1 is a good person": [0.1, 0.2, 0.3]},
         metadata={"user_id": "team", "actor_id": "Bob"},
     )

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -80,6 +80,82 @@ class TestAddToVectorStoreErrors:
         assert result == []  # Should return empty list when no memories processed
 
 
+# A synthetic content-hijack response: the model continued / role-played the
+# conversation instead of extracting facts, so there is no JSON object anywhere.
+# This reproduces the "Expecting value: line 1 column 1 (char 0)" parse failure
+# without using any private conversation data.
+HIJACK_PROSE = (
+    "PLAN: I'll help you organize that. Before I start, a few questions: "
+    "1) What is the deadline? 2) Who is the audience? Let me know and we'll begin."
+)
+
+
+def _tool_call_response(text):
+    """Provider response shape when a forced tool call succeeds (OpenAI/Anthropic)."""
+    return {
+        "content": None,
+        "tool_calls": [{"name": "save_memories", "arguments": {"memory": [{"id": "0", "text": text}]}}],
+    }
+
+
+class TestParseFailureRecovery:
+    """A parse failure (prose, no JSON) is recovered via a forced tool call on
+    capable providers, and silently dropped (current behavior) otherwise."""
+
+    @pytest.fixture
+    def mock_memory(self, mocker):
+        mock_llm, _ = _setup_mocks(mocker)
+        mocker.patch("mem0.memory.main.capture_event")
+        mocker.patch("mem0.memory.main.extract_entities_batch", return_value=[[]])
+
+        memory = Memory()
+        memory.config = mocker.MagicMock()
+        memory.config.custom_instructions = None
+        memory.custom_instructions = None
+        memory.api_version = "v1.1"
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        memory.db.batch_add_history = MagicMock()
+        memory.embedding_model.embed_batch = MagicMock(side_effect=lambda texts, *a, **k: [[0.1, 0.2, 0.3] for _ in texts])
+        return memory
+
+    def test_recovers_dropped_memories_when_provider_supports_tools(self, mock_memory, caplog):
+        recovered_text = "User was promoted to Senior Engineer at Shopify"
+        mock_memory.llm.supports_tool_calls = True
+        mock_memory.llm.generate_response.side_effect = [
+            HIJACK_PROSE,  # extraction: hijacked, no JSON -> parse failure
+            _tool_call_response(recovered_text),  # forced-tool recovery
+        ]
+
+        with caplog.at_level(logging.INFO):
+            result = mock_memory._add_to_vector_store(
+                messages=[{"role": "user", "content": "test"}], metadata={}, filters={}, infer=True
+            )
+
+        # Two calls: the hijacked extraction, then the forced-tool recovery.
+        assert mock_memory.llm.generate_response.call_count == 2
+        recovery_kwargs = mock_memory.llm.generate_response.call_args_list[1].kwargs
+        assert recovery_kwargs["tool_choice"] == "required"
+        assert recovery_kwargs["tools"][0]["function"]["name"] == "save_memories"
+        # The dropped fact is recovered instead of silently lost.
+        assert any(m["memory"] == recovered_text for m in result)
+        assert any("Recovered" in r.message for r in caplog.records)
+
+    def test_silently_drops_when_provider_does_not_support_tools(self, mock_memory, caplog):
+        # No supports_tool_calls opt-in -> current behavior: one call, empty result.
+        mock_memory.llm.supports_tool_calls = False
+        mock_memory.llm.generate_response.return_value = HIJACK_PROSE
+
+        with caplog.at_level(logging.ERROR):
+            result = mock_memory._add_to_vector_store(
+                messages=[{"role": "user", "content": "test"}], metadata={}, filters={}, infer=True
+            )
+
+        assert mock_memory.llm.generate_response.call_count == 1
+        assert result == []
+        assert any("Error parsing extraction response" in r.message for r in caplog.records)
+
+
 class TestPromptOverridesCustomInstructions:
     @pytest.fixture
     def mock_memory(self, mocker):
@@ -217,6 +293,60 @@ class TestAsyncAddToVectorStoreErrors:
 
         assert result == []
         assert mock_async_memory.llm.generate_response.call_count == 1
+
+
+@pytest.mark.asyncio
+class TestAsyncParseFailureRecovery:
+    """Async counterpart of TestParseFailureRecovery."""
+
+    @pytest.fixture
+    def mock_async_memory(self, mocker):
+        mock_llm, _ = _setup_mocks(mocker)
+        mocker.patch("mem0.memory.main.capture_event")
+        mocker.patch("mem0.memory.main.extract_entities_batch", return_value=[[]])
+
+        memory = AsyncMemory()
+        memory.config = mocker.MagicMock()
+        memory.config.custom_instructions = None
+        memory.custom_instructions = None
+        memory.api_version = "v1.1"
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        memory.db.batch_add_history = MagicMock()
+        memory.embedding_model.embed_batch = MagicMock(side_effect=lambda texts, *a, **k: [[0.1, 0.2, 0.3] for _ in texts])
+        return memory
+
+    @pytest.mark.asyncio
+    async def test_async_recovers_dropped_memories(self, mock_async_memory, caplog):
+        recovered_text = "User adopted a dog named Poppy"
+        mock_async_memory.llm.supports_tool_calls = True
+        mock_async_memory.llm.generate_response.side_effect = [
+            HIJACK_PROSE,
+            _tool_call_response(recovered_text),
+        ]
+
+        with caplog.at_level(logging.INFO):
+            result = await mock_async_memory._add_to_vector_store(
+                messages=[{"role": "user", "content": "test"}], metadata={}, effective_filters={}, infer=True
+            )
+
+        assert mock_async_memory.llm.generate_response.call_count == 2
+        assert any(m["memory"] == recovered_text for m in result)
+        assert any("Recovered" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_async_silently_drops_when_provider_does_not_support_tools(self, mock_async_memory, caplog):
+        mock_async_memory.llm.supports_tool_calls = False
+        mock_async_memory.llm.generate_response.return_value = HIJACK_PROSE
+
+        with caplog.at_level(logging.ERROR):
+            result = await mock_async_memory._add_to_vector_store(
+                messages=[{"role": "user", "content": "test"}], metadata={}, effective_filters={}, infer=True
+            )
+
+        assert mock_async_memory.llm.generate_response.call_count == 1
+        assert result == []
+        assert any("Error parsing extraction response (async)" in r.message for r in caplog.records)
 
 
 def _build_memory_instance(mocker, memory_cls):

--- a/tests/test_chatty_llm_parsing.py
+++ b/tests/test_chatty_llm_parsing.py
@@ -6,10 +6,9 @@ conversational text, markdown code blocks, or both.
 """
 
 import json
+from unittest.mock import MagicMock
 
 import pytest
-
-from unittest.mock import MagicMock
 
 from mem0.memory.utils import (
     extract_json,
@@ -19,8 +18,8 @@ from mem0.memory.utils import (
     remove_code_blocks,
 )
 
-
 # --- Test extract_json ---
+
 
 class TestExtractJson:
     """Tests for extract_json utility."""
@@ -102,6 +101,7 @@ That's the result."""
 
 # --- Test remove_code_blocks ---
 
+
 class TestRemoveCodeBlocks:
     """Tests for remove_code_blocks — verify it does NOT handle chatty text."""
 
@@ -141,6 +141,7 @@ class TestRemoveCodeBlocks:
 
 
 # --- Test the full fallback chain (remove_code_blocks -> extract_json) ---
+
 
 class TestFallbackChain:
     """Tests the actual fallback pattern used in _add_to_vector_store:
@@ -242,7 +243,7 @@ I hope this helps!"""
 
 class TestToolCallRecovery:
     """The forced-tool-call recovery used when no JSON could be parsed at all
-    (full content-hijack — the case extract_json structurally cannot fix)."""
+    (full content-hijack - the case extract_json structurally cannot fix)."""
 
     def test_parse_tool_calls_extracts_memory_from_dict_arguments(self):
         response = {
@@ -255,10 +256,45 @@ class TestToolCallRecovery:
         response = {"tool_calls": [{"name": "save_memories", "arguments": '{"memory": [{"text": "Has a cat"}]}'}]}
         assert parse_tool_calls_for_memory(response) == [{"text": "Has a cat"}]
 
-    def test_parse_tool_calls_returns_empty_for_plain_string(self):
-        # A provider that ignored the tool and returned prose recovers nothing.
-        assert parse_tool_calls_for_memory("just some prose") == []
-        assert parse_tool_calls_for_memory({"tool_calls": []}) == []
+    def test_parse_tool_calls_returns_none_when_no_tool_call_parses(self):
+        # A provider that ignored the tool and returned prose, or returned no
+        # usable tool call, yields None - "could not parse", distinct from a
+        # successfully parsed empty memory list.
+        assert parse_tool_calls_for_memory("just some prose") is None
+        assert parse_tool_calls_for_memory({"tool_calls": []}) is None
+
+    def test_parse_tool_calls_distinguishes_valid_empty_from_unparseable(self):
+        # {"memory": []} parsed cleanly is a real (empty) result, not a failure.
+        parsed_empty = {"tool_calls": [{"name": "save_memories", "arguments": {"memory": []}}]}
+        assert parse_tool_calls_for_memory(parsed_empty) == []
+        # Truncated stringified arguments cannot parse -> None.
+        truncated = {"tool_calls": [{"name": "save_memories", "arguments": '{"memory": [{"text": "cut of'}]}
+        assert parse_tool_calls_for_memory(truncated) is None
+
+    def test_parse_tool_calls_merges_parallel_tool_calls(self):
+        # The tool description invites one call per fact; a model answering a
+        # forced call with parallel invocations must not lose facts beyond the
+        # first call (and a leading empty call must not mask later facts).
+        response = {
+            "tool_calls": [
+                {"name": "save_memories", "arguments": {"memory": []}},
+                {"name": "save_memories", "arguments": {"memory": [{"text": "Likes hiking"}]}},
+                {"name": "save_memories", "arguments": {"memory": [{"text": "Has a cat"}]}},
+            ]
+        }
+        assert parse_tool_calls_for_memory(response) == [{"text": "Likes hiking"}, {"text": "Has a cat"}]
+
+    def test_parse_tool_calls_drops_non_dict_memory_items(self):
+        # A schema-violating model can emit bare strings in the memory array.
+        # Downstream reads m.get("text"), so non-dict items must be filtered
+        # out here rather than crash add() - the recovery path must never make
+        # things worse than the silent drop it replaces.
+        response = {
+            "tool_calls": [
+                {"name": "save_memories", "arguments": {"memory": ["bare string", {"text": "Has a cat"}, 42]}}
+            ]
+        }
+        assert parse_tool_calls_for_memory(response) == [{"text": "Has a cat"}]
 
     def test_gate_requires_explicit_true(self):
         # A MagicMock auto-populates attributes; the gate must not be tripped by one.
@@ -291,18 +327,20 @@ class TestToolCallRecovery:
         llm.generate_response.side_effect = RuntimeError("provider exploded")
         assert recover_extraction_via_tools(llm, "sys", "user") == []
 
-    def test_recover_returns_empty_when_nothing_memorable(self):
-        # A forced tool call with an empty memory array round-trips to [] —
-        # the model is not compelled to invent a fact to satisfy the call.
+    def test_recover_returns_empty_when_nothing_memorable_without_retrying(self):
+        # A forced tool call with an empty memory array round-trips to [] -
+        # the model is not compelled to invent a fact to satisfy the call. A
+        # valid empty list is NOT treated as truncation: no token-raise retry,
+        # exactly one LLM call.
         llm = MagicMock()
         llm.supports_tool_calls = True
-        llm.generate_response.return_value = {
-            "tool_calls": [{"name": "save_memories", "arguments": {"memory": []}}]
-        }
+        llm.config.max_tokens = 2000
+        llm.generate_response.return_value = {"tool_calls": [{"name": "save_memories", "arguments": {"memory": []}}]}
         assert recover_extraction_via_tools(llm, "sys", "user") == []
+        assert llm.generate_response.call_count == 1
 
     def test_recover_is_graceful_when_tool_calls_malformed(self):
-        # A provider returning a non-dict tool_call must not raise — the
+        # A provider returning a non-dict tool_call must not raise - the
         # "recovery never raises" guarantee.
         llm = MagicMock()
         llm.supports_tool_calls = True
@@ -333,6 +371,34 @@ class TestToolCallRecovery:
         llm = MagicMock()
         llm.supports_tool_calls = True
         llm.config.max_tokens = None
-        llm.generate_response.return_value = {"tool_calls": [{"name": "save_memories", "arguments": {"memory": []}}]}
+        llm.generate_response.return_value = {"tool_calls": [{"name": "save_memories", "arguments": "truncat"}]}
+        assert recover_extraction_via_tools(llm, "sys", "user") == []
+        assert llm.generate_response.call_count == 1
+
+    def test_token_raise_retry_is_capped(self):
+        # 4x a large configured budget would be very expensive; the retry is
+        # capped at an absolute ceiling (8192) instead.
+        llm = MagicMock()
+        llm.supports_tool_calls = True
+        llm.config.max_tokens = 4000  # 4x = 16000, above the cap
+        llm.generate_response.side_effect = [
+            {"tool_calls": [{"name": "save_memories", "arguments": '{"memory": [{"text": "cut of'}]},
+            {"tool_calls": [{"name": "save_memories", "arguments": {"memory": [{"text": "Recovered"}]}}]},
+        ]
+        result = recover_extraction_via_tools(llm, "sys", "user")
+        assert result == [{"text": "Recovered"}]
+        retry_kwargs = llm.generate_response.call_args_list[1].kwargs
+        assert retry_kwargs["max_tokens"] == 8192
+
+    def test_no_token_raise_retry_when_budget_already_at_cap(self):
+        # If the configured budget is already at/above the cap there is no
+        # meaningful raise to attempt; skip the retry rather than re-spend the
+        # same budget.
+        llm = MagicMock()
+        llm.supports_tool_calls = True
+        llm.config.max_tokens = 8192
+        llm.generate_response.return_value = {
+            "tool_calls": [{"name": "save_memories", "arguments": '{"memory": [{"text": "cut of'}]
+        }
         assert recover_extraction_via_tools(llm, "sys", "user") == []
         assert llm.generate_response.call_count == 1

--- a/tests/test_chatty_llm_parsing.py
+++ b/tests/test_chatty_llm_parsing.py
@@ -9,7 +9,15 @@ import json
 
 import pytest
 
-from mem0.memory.utils import extract_json, remove_code_blocks
+from unittest.mock import MagicMock
+
+from mem0.memory.utils import (
+    extract_json,
+    llm_supports_tool_calls,
+    parse_tool_calls_for_memory,
+    recover_extraction_via_tools,
+    remove_code_blocks,
+)
 
 
 # --- Test extract_json ---
@@ -230,3 +238,101 @@ I hope this helps!"""
         response = 'Sure! Here are the facts:\n{"facts": ["Name is Alex", "Loves basketball"]}\nHope that helps!'
         result = self._parse_with_fallback(response)
         assert result["facts"] == ["Name is Alex", "Loves basketball"]
+
+
+class TestToolCallRecovery:
+    """The forced-tool-call recovery used when no JSON could be parsed at all
+    (full content-hijack — the case extract_json structurally cannot fix)."""
+
+    def test_parse_tool_calls_extracts_memory_from_dict_arguments(self):
+        response = {
+            "content": None,
+            "tool_calls": [{"name": "save_memories", "arguments": {"memory": [{"text": "Likes hiking"}]}}],
+        }
+        assert parse_tool_calls_for_memory(response) == [{"text": "Likes hiking"}]
+
+    def test_parse_tool_calls_handles_stringified_arguments(self):
+        response = {"tool_calls": [{"name": "save_memories", "arguments": '{"memory": [{"text": "Has a cat"}]}'}]}
+        assert parse_tool_calls_for_memory(response) == [{"text": "Has a cat"}]
+
+    def test_parse_tool_calls_returns_empty_for_plain_string(self):
+        # A provider that ignored the tool and returned prose recovers nothing.
+        assert parse_tool_calls_for_memory("just some prose") == []
+        assert parse_tool_calls_for_memory({"tool_calls": []}) == []
+
+    def test_gate_requires_explicit_true(self):
+        # A MagicMock auto-populates attributes; the gate must not be tripped by one.
+        assert llm_supports_tool_calls(MagicMock()) is False
+        capable = MagicMock()
+        capable.supports_tool_calls = True
+        assert llm_supports_tool_calls(capable) is True
+
+    def test_recover_skips_uncapable_provider_without_calling_llm(self):
+        llm = MagicMock()
+        llm.supports_tool_calls = False
+        assert recover_extraction_via_tools(llm, "sys", "user") == []
+        llm.generate_response.assert_not_called()
+
+    def test_recover_forces_tool_choice_and_returns_memory(self):
+        llm = MagicMock()
+        llm.supports_tool_calls = True
+        llm.generate_response.return_value = {
+            "tool_calls": [{"name": "save_memories", "arguments": {"memory": [{"text": "Born in Pittsburgh"}]}}]
+        }
+        result = recover_extraction_via_tools(llm, "sys", "user")
+        assert result == [{"text": "Born in Pittsburgh"}]
+        call_kwargs = llm.generate_response.call_args.kwargs
+        assert call_kwargs["tool_choice"] == "required"
+        assert call_kwargs["tools"][0]["function"]["name"] == "save_memories"
+
+    def test_recover_is_graceful_when_llm_raises(self):
+        llm = MagicMock()
+        llm.supports_tool_calls = True
+        llm.generate_response.side_effect = RuntimeError("provider exploded")
+        assert recover_extraction_via_tools(llm, "sys", "user") == []
+
+    def test_recover_returns_empty_when_nothing_memorable(self):
+        # A forced tool call with an empty memory array round-trips to [] —
+        # the model is not compelled to invent a fact to satisfy the call.
+        llm = MagicMock()
+        llm.supports_tool_calls = True
+        llm.generate_response.return_value = {
+            "tool_calls": [{"name": "save_memories", "arguments": {"memory": []}}]
+        }
+        assert recover_extraction_via_tools(llm, "sys", "user") == []
+
+    def test_recover_is_graceful_when_tool_calls_malformed(self):
+        # A provider returning a non-dict tool_call must not raise — the
+        # "recovery never raises" guarantee.
+        llm = MagicMock()
+        llm.supports_tool_calls = True
+        llm.generate_response.return_value = {"tool_calls": ["not-a-dict", None]}
+        assert recover_extraction_via_tools(llm, "sys", "user") == []
+
+    def test_tool_call_truncation_retries_at_raised_tokens_staying_in_tool_mode(self):
+        # The forced tool call itself truncates (its arguments are a cut-off JSON
+        # string -> no memory parses). Recovery retries the tool call once at a
+        # raised max_tokens, still forcing the tool (not reverting to free text).
+        llm = MagicMock()
+        llm.supports_tool_calls = True
+        llm.config.max_tokens = 2000
+        llm.generate_response.side_effect = [
+            {"tool_calls": [{"name": "save_memories", "arguments": '{"memory": [{"text": "User likes hik'}]},
+            {"tool_calls": [{"name": "save_memories", "arguments": {"memory": [{"text": "User likes hiking"}]}}]},
+        ]
+        result = recover_extraction_via_tools(llm, "sys", "user")
+        assert result == [{"text": "User likes hiking"}]
+        assert llm.generate_response.call_count == 2
+        # the retry is still a forced tool call, at 4x the configured budget
+        retry_kwargs = llm.generate_response.call_args_list[1].kwargs
+        assert retry_kwargs["tool_choice"] == "required"
+        assert retry_kwargs["max_tokens"] == 8000
+
+    def test_no_token_raise_retry_when_max_tokens_unset(self):
+        # If max_tokens is unset there is nothing to raise; do not spuriously retry.
+        llm = MagicMock()
+        llm.supports_tool_calls = True
+        llm.config.max_tokens = None
+        llm.generate_response.return_value = {"tool_calls": [{"name": "save_memories", "arguments": {"memory": []}}]}
+        assert recover_extraction_via_tools(llm, "sys", "user") == []
+        assert llm.generate_response.call_count == 1


### PR DESCRIPTION
> **DRAFT - please do not merge yet.** This PR is **stacked on #5425 and #5431**, so its diff currently *includes* their changes. The **net-new change here is one line** - `GeminiLLM.supports_tool_calls = True` - plus a test. Once #5425 and #5431 merge, I will rebase so the diff shows only that delta. Opening as a draft to make the forced-structure direction for #3918 concrete and reviewable; deferring to your call on direction.

## Linked Issue

Addresses #3918

## Description

#3918 is the case where Gemini leaks reasoning ("thinking") tokens into the JSON output, malforming it so extraction's `json.loads` fails and the facts are silently dropped. This PR addresses it by **prevention rather than repair**: enabling the forced-structure extraction recovery for Gemini.

When extraction fails to parse, the recovery (from #5425) retries with a forced `tool_choice` on a `save_memories` schema. A forced tool call constrains the model to emit structured arguments, so reasoning tokens **cannot leak into the response to corrupt it** in the first place. This complements the json-repair approaches in flight on #3918 (#4662 / #4548 / #5176), which clean up malformed output after the fact - prevention where the provider supports it, repair as the fallback.

The change itself is one line: `GeminiLLM.supports_tool_calls = True`. mem0's Gemini provider already returns the standard `{"content", "tool_calls"}` dict and (with #5431) honors a forced `tool_choice`, so opting Gemini into the recovery gate is all that is needed.

### Stacking / dependencies

- **#5425** - the forced-structure recovery path (`recover_extraction_via_tools`) this reuses.
- **#5431** - fixes Gemini's `tool_choice="required"` mapping (it previously mapped to `NONE`, silently disabling the forced tool call). Without it, the recovery would not actually force a tool on Gemini.

Both must merge first. This PR's only new code is the opt-in flag plus a test; everything else in the diff belongs to those two PRs and will drop out on rebase.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A. The flag only opts Gemini into the existing parse-failure recovery; the normal (successful-parse) path is unchanged.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

New tests in `tests/llms/test_gemini.py` (mocked client, no real API): Gemini declares `supports_tool_calls`, and an end-to-end test where a forced tool call on Gemini recovers the memories through the recovery path (asserting the call was forced via `ANY` mode). Falsifiable: with the flag off, the recovery gate closes and the same test recovers nothing (`[]`).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (no public API change)
