### PR TITLE
fix: return empty results for blank memory searches

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1212,6 +1212,9 @@ class Memory(MemoryBase):
                     effective_filters.pop(fk, None)
             effective_filters.update(processed_filters)
 
+        if isinstance(query, str) and not query.strip():
+            return {"results": []}
+
         keys, encoded_ids = process_telemetry_filters(effective_filters)
         capture_event(
             "mem0.search",
@@ -2655,6 +2658,9 @@ class AsyncMemory(MemoryBase):
                 if fk not in ("AND", "OR", "NOT", "user_id", "agent_id", "run_id") and isinstance(effective_filters.get(fk), dict):
                     effective_filters.pop(fk, None)
             effective_filters.update(processed_filters)
+
+        if isinstance(query, str) and not query.strip():
+            return {"results": []}
 
         keys, encoded_ids = process_telemetry_filters(effective_filters)
         capture_event(

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -239,6 +239,20 @@ def _assert_utc_timestamp(timestamp: str):
     assert parsed.utcoffset().total_seconds() == 0
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("query", ["", "   "])
+async def test_async_search_returns_empty_results_for_blank_query(mocker, query):
+    memory = _build_memory_instance(mocker, AsyncMemory)
+    memory._search_vector_store = mocker.AsyncMock(
+        side_effect=AssertionError("blank query should not be embedded")
+    )
+
+    result = await memory.search(query, filters={"user_id": "test_user"})
+
+    assert result == {"results": []}
+    memory._search_vector_store.assert_not_called()
+
+
 def test_create_memory_uses_utc_timestamps(mocker):
     memory = _build_memory_instance(mocker, Memory)
     memory._create_memory("new memory", {"new memory": [0.1, 0.2, 0.3]}, metadata={})

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -117,6 +117,16 @@ def test_search(memory_instance):
     )
 
 
+@pytest.mark.parametrize("query", ["", "   "])
+def test_search_returns_empty_results_for_blank_query(memory_instance, query):
+    memory_instance._search_vector_store = Mock(side_effect=AssertionError("blank query should not be embedded"))
+
+    result = memory_instance.search(query, filters={"user_id": "test_user"})
+
+    assert result == {"results": []}
+    memory_instance._search_vector_store.assert_not_called()
+
+
 def test_update(memory_instance):
     memory_instance.embedding_model = Mock()
     memory_instance.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])


### PR DESCRIPTION
## Summary

Fixes #5220.

Blank or whitespace-only `Memory.search()` queries should not be sent to the embedder or vector store. This adds the same guard to the sync and async Python SDK search paths and returns an empty search result instead.

## Tests

- `uv run pytest tests/test_main.py::test_search_returns_empty_results_for_blank_query tests/memory/test_main.py::test_async_search_returns_empty_results_for_blank_query -q`
- `uv run pytest tests/test_main.py -k "search and not server" -q`
- `uvx ruff check mem0/memory/main.py tests/test_main.py tests/memory/test_main.py`
- `git diff --check origin/main -- mem0/memory/main.py tests/test_main.py tests/memory/test_main.py`

Note: `uvx ruff format --check` would reformat unrelated existing lines in these files on current `main`, so I did not apply formatter output to keep this PR focused.