### PR TITLE
fix(memory): avoid extracting assistant echo memories

### DIFF
--- a/mem0/configs/prompts.py
+++ b/mem0/configs/prompts.py
@@ -754,6 +754,24 @@ Observation Date: 2025-08-19
 
 Output: {"memory": []}
 
+## Example 4: Skip Assistant Echoes of User Preferences
+
+Summary: ""
+Recently Extracted: []
+Existing Memories: []
+New Messages:
+[{"role": "user", "content": "For badminton venues, I prefer quiet courts with wooden floors after 8 PM, and please don't recommend Smash Arena because it is too noisy."},
+ {"role": "assistant", "content": "Got it. I will prioritize quiet wooden-floor venues after 8 PM and avoid recommending Smash Arena because it is too noisy."}]
+Observation Date: 2025-04-12
+
+Output:
+{"memory": [
+  {"id": "0", "text": "User prefers quiet badminton venues with wooden floors for play after 8 PM"},
+  {"id": "1", "text": "User does not want Smash Arena recommended for badminton because it is too noisy"}
+]}
+
+The assistant message only confirms and restates the same venue preference and constraint. Extract the preference and constraint from the user's statement, not from the assistant's restatement; do NOT add a duplicate memory such as "Assistant will prioritize quiet wooden-floor venues" because that is an echo, not new information.
+
 ## Example 5: Deduplication — Skip Already Captured
 
 Recently Extracted: ["Marcus was promoted to Senior Engineer at Shopify around August 12, 2025"]

--- a/tests/configs/test_prompts.py
+++ b/tests/configs/test_prompts.py
@@ -1,3 +1,5 @@
+import re
+
 from mem0.configs import prompts
 
 
@@ -49,3 +51,36 @@ def test_get_update_memory_messages_non_empty_memory():
     assert str(memory_data) in result
     # And that the non-empty memory message is present
     assert "current content of my memory" in result
+
+
+def test_additive_prompt_example_numbers_are_sequential():
+    example_numbers = re.findall(r"## Example (\d+):", prompts.ADDITIVE_EXTRACTION_PROMPT)
+    assert example_numbers == [str(i) for i in range(1, len(example_numbers) + 1)]
+
+
+def test_additive_prompt_text_includes_assistant_echo_example():
+    prompt = prompts.ADDITIVE_EXTRACTION_PROMPT
+
+    assert "Example 4: Skip Assistant Echoes of User Preferences" in prompt
+    assert "not from the assistant's restatement" in prompt
+    assert "do NOT add a duplicate memory" in prompt
+    assert "Assistant will prioritize quiet wooden-floor venues" in prompt
+
+
+def test_additive_prompt_builder_includes_user_and_assistant_echo_messages():
+    new_messages = [
+        {
+            "role": "user",
+            "content": "For badminton venues, I prefer quiet courts with wooden floors after 8 PM.",
+        },
+        {
+            "role": "assistant",
+            "content": "Got it. I will prioritize quiet wooden-floor venues after 8 PM.",
+        },
+    ]
+
+    result = prompts.generate_additive_extraction_prompt(new_messages=new_messages)
+
+    assert "## New Messages" in result
+    assert "quiet courts with wooden floors after 8 PM" in result
+    assert "I will prioritize quiet wooden-floor venues after 8 PM" in result


### PR DESCRIPTION
## Linked Issue

N/A

## Description

Adds coverage for an additive extraction edge case where the assistant only restates or confirms a user preference.

In this case, Mem0 should keep the user-stated preference once and avoid creating a second assistant-sourced echo memory. The new example uses a venue preference scenario to make the expected behavior clear, and the tests keep this prompt boundary covered.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Manual testing:
- Ran `python -m py_compile mem0/configs/prompts.py tests/configs/test_prompts.py`
- Ran an equivalent Python assertion check for the new prompt tests using `.venv/bin/python`
- Tried `python -m pytest tests/configs/test_prompts.py` and `.venv/bin/python -m pytest tests/configs/test_prompts.py`, but pytest is not installed in this local environment.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [x] I have updated documentation if needed