### PR TITLE
feat(memory): boost negative constraints for recommendation searches

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -41,6 +41,7 @@ from mem0.utils.factory import (
     VectorStoreFactory,
 )
 from mem0.utils.lemmatization import lemmatize_for_bm25
+from mem0.utils.memory_attributes import infer_memory_attributes
 from mem0.utils.scoring import (
     ENTITY_BOOST_WEIGHT,
     get_bm25_params,
@@ -810,6 +811,8 @@ class Memory(MemoryBase):
             mem_metadata["data"] = text
             mem_metadata["text_lemmatized"] = text_lemmatized
             mem_metadata["hash"] = mem_hash
+            for key, value in infer_memory_attributes(text).items():
+                mem_metadata.setdefault(key, value)
             if "created_at" not in mem_metadata:
                 mem_metadata["created_at"] = datetime.now(timezone.utc).isoformat()
             mem_metadata["updated_at"] = mem_metadata["created_at"]
@@ -1400,6 +1403,7 @@ class Memory(MemoryBase):
             threshold=threshold,
             top_k=limit,
             explain=explain,
+            query=query,
         )
 
         # Step 9: Format results
@@ -2251,6 +2255,8 @@ class AsyncMemory(MemoryBase):
             mem_metadata["data"] = text
             mem_metadata["text_lemmatized"] = text_lemmatized
             mem_metadata["hash"] = mem_hash
+            for key, value in infer_memory_attributes(text).items():
+                mem_metadata.setdefault(key, value)
             if "created_at" not in mem_metadata:
                 mem_metadata["created_at"] = datetime.now(timezone.utc).isoformat()
             mem_metadata["updated_at"] = mem_metadata["created_at"]
@@ -2846,6 +2852,7 @@ class AsyncMemory(MemoryBase):
             threshold=threshold,
             top_k=limit,
             explain=explain,
+            query=query,
         )
 
         # Step 9: Format results

--- a/mem0/utils/memory_attributes.py
+++ b/mem0/utils/memory_attributes.py
@@ -1,0 +1,100 @@
+"""Lightweight memory attribute inference for retrieval-time safeguards."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+
+NEGATIVE_CONSTRAINT_BOOST_WEIGHT = 0.35
+
+
+NEGATIVE_CONSTRAINT_PATTERNS = (
+    "do not recommend",
+    "don't recommend",
+    "does not want",
+    "doesn't want",
+    "does not like",
+    "doesn't like",
+    "does not prefer",
+    "doesn't prefer",
+    "does not want to",
+    "doesn't want to",
+    "do not want",
+    "don't want",
+    "should not recommend",
+    "must not recommend",
+    "never recommend",
+    "no longer recommend",
+    "not interested in",
+    "would rather not",
+    "prefers not to",
+    "asked not to",
+    "requests not to",
+    "avoid recommending",
+    "avoids recommending",
+    "dislikes",
+)
+
+
+POSITIVE_PREFERENCE_PATTERNS = (
+    "prefers",
+    "likes",
+    "enjoys",
+    "wants",
+    "prioritizes",
+    "is interested in",
+    "favorite",
+    "favourite",
+)
+
+
+RECOMMENDATION_QUERY_PATTERNS = (
+    "recommend",
+    "suggest",
+    "choose",
+    "which",
+    "best",
+    "rank",
+    "pick",
+    "select",
+    "find a",
+    "find me",
+    "looking for",
+    "where should",
+    "what should",
+)
+
+
+def infer_memory_attributes(memory_text: str) -> Dict[str, str]:
+    """Infer stable, optional attributes from extracted memory text.
+
+    The rules are intentionally conservative. They only tag explicit negative
+    preference or exclusion statements as constraints, leaving ambiguous
+    negations such as "not bothered by noise" as ordinary facts.
+    """
+    text = (memory_text or "").lower()
+
+    if any(pattern in text for pattern in NEGATIVE_CONSTRAINT_PATTERNS):
+        return {"memory_type": "constraint", "polarity": "negative"}
+
+    if any(pattern in text for pattern in POSITIVE_PREFERENCE_PATTERNS):
+        return {"memory_type": "preference", "polarity": "positive"}
+
+    return {"memory_type": "fact", "polarity": "neutral"}
+
+
+def is_recommendation_query(query: str) -> bool:
+    """Return true when a query is likely asking for a choice or recommendation."""
+    text = (query or "").lower()
+    return any(pattern in text for pattern in RECOMMENDATION_QUERY_PATTERNS)
+
+
+def get_constraint_boost(query: str, payload: Dict[str, object]) -> float:
+    """Boost negative constraints only for recommendation or decision queries."""
+    if not is_recommendation_query(query):
+        return 0.0
+
+    if payload.get("memory_type") == "constraint" and payload.get("polarity") == "negative":
+        return NEGATIVE_CONSTRAINT_BOOST_WEIGHT
+
+    return 0.0

--- a/mem0/utils/scoring.py
+++ b/mem0/utils/scoring.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import math
 from typing import Any, Dict, List, Optional
 
+from mem0.utils.memory_attributes import NEGATIVE_CONSTRAINT_BOOST_WEIGHT, get_constraint_boost
+
 
 def get_bm25_params(query: str, *, lemmatized: Optional[str] = None) -> tuple:
     """Get BM25 sigmoid parameters based on query length.
@@ -64,12 +66,13 @@ def score_and_rank(
     threshold: float,
     top_k: int,
     explain: bool = False,
+    query: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """Score candidates additively and return top-k results.
 
     For each candidate:
         semantic_score is taken from the result's score field.
-        combined = (semantic + bm25 + entity_boost) / max_possible
+        combined = (semantic + bm25 + entity_boost + constraint_boost) / max_possible
 
     Threshold gates the semantic score BEFORE combining -- candidates
     below the threshold are excluded even if BM25/entity would boost them.
@@ -79,6 +82,7 @@ def score_and_rank(
         - Semantic + BM25: max_possible = 2.0
         - Semantic + BM25 + entity: max_possible = 2.5
         - Semantic + entity (no BM25): max_possible = 1.5
+        - Negative constraint boost adds 0.35 when active
 
     Args:
         semantic_results: Candidate memories from vector search.
@@ -87,18 +91,28 @@ def score_and_rank(
         threshold: Minimum semantic score required before hybrid scoring.
         top_k: Maximum number of results to return.
         explain: Include score_details in each result when true.
+        query: Original search query, used to boost negative constraints only
+            for recommendation or decision searches.
 
     Returns:
         List of scored result dicts sorted by combined score descending.
     """
     has_bm25 = bool(bm25_scores)
     has_entity = bool(entity_boosts)
+    constraint_boosts = {
+        str(result.get("id")): get_constraint_boost(query or "", result.get("payload") or {})
+        for result in semantic_results
+        if result.get("id") is not None
+    }
+    has_constraint = any(boost > 0 for boost in constraint_boosts.values())
 
     max_possible = 1.0
     if has_bm25:
         max_possible += 1.0
     if has_entity:
         max_possible += ENTITY_BOOST_WEIGHT
+    if has_constraint:
+        max_possible += NEGATIVE_CONSTRAINT_BOOST_WEIGHT
 
     scored: List[Dict[str, Any]] = []
 
@@ -114,8 +128,9 @@ def score_and_rank(
         mem_id_str = str(mem_id)
         bm25_score = bm25_scores.get(mem_id_str, 0.0)
         entity_boost = entity_boosts.get(mem_id_str, 0.0)
+        constraint_boost = constraint_boosts.get(mem_id_str, 0.0)
 
-        raw_combined = semantic_score + bm25_score + entity_boost
+        raw_combined = semantic_score + bm25_score + entity_boost + constraint_boost
         combined = min(raw_combined / max_possible, 1.0)
 
         scored_result = {
@@ -124,7 +139,7 @@ def score_and_rank(
             "payload": result.get("payload"),
         }
         if explain:
-            scored_result["score_details"] = {
+            score_details = {
                 "semantic_score": semantic_score,
                 "bm25_score": bm25_score,
                 "entity_boost": entity_boost,
@@ -133,6 +148,9 @@ def score_and_rank(
                 "final_score": combined,
                 "threshold": threshold,
             }
+            if has_constraint:
+                score_details["constraint_boost"] = constraint_boost
+            scored_result["score_details"] = score_details
         scored.append(scored_result)
 
     scored.sort(key=lambda x: x["score"], reverse=True)

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -117,6 +117,46 @@ class TestPromptOverridesCustomInstructions:
         assert "config-level instructions" in user_prompt
 
 
+class TestMemoryAttributeInference:
+    @pytest.fixture
+    def mock_memory(self, mocker):
+        mock_llm, _ = _setup_mocks(mocker)
+        mock_llm.return_value.generate_response.return_value = (
+            '{"memory": [{"id": "0", "text": '
+            '"User does not want Smash Arena recommended because it is too noisy", '
+            '"attributed_to": "user"}]}'
+        )
+
+        memory = Memory()
+        memory.custom_instructions = None
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        memory.db.batch_add_history = MagicMock()
+        memory.embedding_model.embed.return_value = [0.1, 0.2, 0.3]
+        memory.embedding_model.embed_batch.return_value = [[0.1, 0.2, 0.3]]
+        memory.vector_store.search.return_value = []
+        memory.entity_store.search_batch.return_value = []
+        memory.entity_store.insert = MagicMock()
+        return memory
+
+    def test_add_to_vector_store_stores_negative_constraint_attributes(self, mock_memory, mocker):
+        mocker.patch(
+            "mem0.memory.main.extract_entities_batch",
+            return_value=[[("PROPER", "Smash Arena")]],
+        )
+
+        mock_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "Please do not recommend Smash Arena because it is too noisy."}],
+            metadata={"user_id": "alice"},
+            filters={"user_id": "alice"},
+            infer=True,
+        )
+
+        payload = mock_memory.vector_store.insert.call_args.kwargs["payloads"][0]
+        assert payload["memory_type"] == "constraint"
+        assert payload["polarity"] == "negative"
+
+
 class TestAsyncUpdate:
     @pytest.fixture
     def mock_async_memory(self, mocker):

--- a/tests/utils/test_memory_attributes.py
+++ b/tests/utils/test_memory_attributes.py
@@ -1,0 +1,41 @@
+from mem0.utils.memory_attributes import (
+    NEGATIVE_CONSTRAINT_BOOST_WEIGHT,
+    get_constraint_boost,
+    infer_memory_attributes,
+    is_recommendation_query,
+)
+
+
+class TestInferMemoryAttributes:
+    def test_negative_preference_is_constraint(self):
+        attrs = infer_memory_attributes("User does not want Smash Arena recommended because it is too noisy")
+        assert attrs == {"memory_type": "constraint", "polarity": "negative"}
+
+    def test_positive_preference_is_preference(self):
+        attrs = infer_memory_attributes("User prefers quiet badminton venues with wooden courts")
+        assert attrs == {"memory_type": "preference", "polarity": "positive"}
+
+    def test_plain_fact_is_neutral(self):
+        attrs = infer_memory_attributes("User plays badminton every Saturday morning")
+        assert attrs == {"memory_type": "fact", "polarity": "neutral"}
+
+    def test_ambiguous_negation_is_not_constraint(self):
+        attrs = infer_memory_attributes("User is not bothered by noisy badminton venues")
+        assert attrs == {"memory_type": "fact", "polarity": "neutral"}
+
+
+class TestConstraintBoost:
+    def test_recommendation_query_detected(self):
+        assert is_recommendation_query("Can you recommend a badminton venue?")
+
+    def test_non_recommendation_query_not_detected(self):
+        assert not is_recommendation_query("What sports does the user play?")
+
+    def test_constraint_boost_only_for_recommendation_queries(self):
+        payload = {"memory_type": "constraint", "polarity": "negative"}
+        assert get_constraint_boost("recommend a venue", payload) == NEGATIVE_CONSTRAINT_BOOST_WEIGHT
+        assert get_constraint_boost("what sports does the user play", payload) == 0.0
+
+    def test_constraint_boost_ignores_positive_preferences(self):
+        payload = {"memory_type": "preference", "polarity": "positive"}
+        assert get_constraint_boost("recommend a venue", payload) == 0.0

--- a/tests/utils/test_scoring.py
+++ b/tests/utils/test_scoring.py
@@ -148,6 +148,102 @@ class TestScoreAndRank:
         scored = score_and_rank(results, {}, {}, threshold=0.1, top_k=10)
         assert "score_details" not in scored[0]
 
+    def test_negative_constraint_boost_for_recommendation_query(self):
+        results = [
+            {
+                "id": "preference",
+                "score": 0.8,
+                "payload": {
+                    "data": "User prefers low-priced badminton venues",
+                    "memory_type": "preference",
+                    "polarity": "positive",
+                },
+            },
+            {
+                "id": "constraint",
+                "score": 0.7,
+                "payload": {
+                    "data": "User does not want Smash Arena recommended because it is too noisy",
+                    "memory_type": "constraint",
+                    "polarity": "negative",
+                },
+            },
+        ]
+
+        scored = score_and_rank(
+            results,
+            {},
+            {},
+            threshold=0.1,
+            top_k=10,
+            query="Recommend a badminton venue",
+        )
+
+        assert scored[0]["id"] == "constraint"
+        assert scored[1]["id"] == "preference"
+
+    def test_negative_constraint_not_boosted_for_non_recommendation_query(self):
+        results = [
+            {
+                "id": "preference",
+                "score": 0.8,
+                "payload": {
+                    "data": "User prefers low-priced badminton venues",
+                    "memory_type": "preference",
+                    "polarity": "positive",
+                },
+            },
+            {
+                "id": "constraint",
+                "score": 0.7,
+                "payload": {
+                    "data": "User does not want Smash Arena recommended because it is too noisy",
+                    "memory_type": "constraint",
+                    "polarity": "negative",
+                },
+            },
+        ]
+
+        scored = score_and_rank(
+            results,
+            {},
+            {},
+            threshold=0.1,
+            top_k=10,
+            query="What sports does the user play?",
+        )
+
+        assert scored[0]["id"] == "preference"
+        assert scored[1]["id"] == "constraint"
+
+    def test_constraint_boost_explain_details(self):
+        results = [
+            {
+                "id": "constraint",
+                "score": 0.7,
+                "payload": {
+                    "data": "User does not want Smash Arena recommended because it is too noisy",
+                    "memory_type": "constraint",
+                    "polarity": "negative",
+                },
+            }
+        ]
+
+        scored = score_and_rank(
+            results,
+            {},
+            {},
+            threshold=0.1,
+            top_k=10,
+            explain=True,
+            query="Recommend a badminton venue",
+        )
+
+        details = scored[0]["score_details"]
+        assert details["constraint_boost"] == pytest.approx(0.35)
+        assert details["raw_score"] == pytest.approx(1.05)
+        assert details["max_possible_score"] == pytest.approx(1.35)
+
 
 class TestEntityBoostWeight:
     def test_weight_value(self):


### PR DESCRIPTION
## Linked Issue

N/A

## Description

Adds lightweight support for negative preference memories in recommendation-style searches.

Currently, memories such as "User does not want Smash Arena recommended because it is too noisy" are stored and ranked like ordinary facts. In recommendation or decision workflows, these memories are closer to constraints and should be easier to retrieve alongside positive preferences.

This PR adds a small closed loop:

- infer memory attributes for extracted memories (`memory_type`, `polarity`)
- store those attributes in the memory payload
- boost negative constraints only for recommendation/decision-style search queries
- keep non-recommendation search ranking behavior unchanged
- cover the behavior with unit tests

The implementation is intentionally small and can be extended later with configurable patterns, language-specific detectors, application-level boost tuning, or dedicated evaluation cases for recommendation safety.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Manual testing:
- Ran `.venv/bin/python -m py_compile mem0/utils/memory_attributes.py mem0/utils/scoring.py mem0/memory/main.py tests/utils/test_memory_attributes.py tests/utils/test_scoring.py tests/memory/test_main.py`
- Ran `git diff --check`
- Ran manual Python assertions for memory attribute inference and constraint-aware ranking behavior

Note: I could not run pytest locally because pytest is not installed in this environment.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [x] I have updated documentation if needed