### PR TITLE
fix(vector-stores): index Valkey 'memory' field as TEXT not TAG

### DIFF
--- a/mem0/vector_stores/valkey.py
+++ b/mem0/vector_stores/valkey.py
@@ -21,7 +21,7 @@ DEFAULT_FIELDS = [
     {"name": "agent_id", "type": "tag"},
     {"name": "run_id", "type": "tag"},
     {"name": "user_id", "type": "tag"},
-    {"name": "memory", "type": "tag"},  # Using TAG instead of TEXT for Valkey compatibility
+    {"name": "memory", "type": "text"},  # TEXT for full-text search over memory content (see #5006)
     {"name": "metadata", "type": "tag"},  # Using TAG instead of TEXT for Valkey compatibility
     {"name": "created_at", "type": "numeric"},
     {"name": "updated_at", "type": "numeric"},
@@ -169,7 +169,7 @@ class ValkeyDB(VectorStoreBase):
             "user_id",
             "TAG",
             "memory",
-            "TAG",
+            "TEXT",
             "metadata",
             "TAG",
             "created_at",

--- a/tests/vector_stores/test_valkey.py
+++ b/tests/vector_stores/test_valkey.py
@@ -1020,3 +1020,44 @@ def test_cluster_mode_delete(valkey_db_cluster, mock_valkey_cluster_client):
     """Test that delete works in cluster mode."""
     valkey_db_cluster.delete("id1")
     mock_valkey_cluster_client.delete.assert_called_once_with("mem0:test_cluster:id1")
+
+
+# Schema field-type tests (regression for #5006)
+
+
+def test_default_fields_memory_is_text():
+    """The 'memory' field stores free-form memory text, so it must be indexed as
+    TEXT (full-text searchable, tokenized) rather than TAG.
+
+    Regression test for #5006: TAG only tokenizes on commas, so the entire memory
+    text collapses into a single token, breaking full-text search and bloating the
+    inverted index.
+    """
+    from mem0.vector_stores.valkey import DEFAULT_FIELDS
+
+    memory_field = next(f for f in DEFAULT_FIELDS if f["name"] == "memory")
+    assert memory_field["type"] == "text", (
+        "DEFAULT_FIELDS['memory'] must be 'text' (full-text searchable), not 'tag'"
+    )
+
+
+def test_build_index_schema_indexes_memory_as_text(valkey_db):
+    """The FT.CREATE command emitted by _build_index_schema must declare the
+    'memory' field as TEXT, not TAG.
+
+    Regression test for #5006.
+    """
+    cmd = valkey_db._build_index_schema(
+        collection_name="test_collection",
+        embedding_dims=1536,
+        distance_metric="COSINE",
+        prefix="mem0:test_collection",
+    )
+
+    # Locate the 'memory' field declaration and check the type token that follows it.
+    memory_idx = cmd.index("memory")
+    assert cmd[memory_idx + 1] == "TEXT", (
+        f"'memory' field must be indexed as TEXT, got {cmd[memory_idx + 1]!r}"
+    )
+    # And it must not be declared as TAG.
+    assert ["memory", "TAG"] != cmd[memory_idx : memory_idx + 2]


### PR DESCRIPTION
## Problem

Closes #5006

The Valkey vector store indexes the `memory` field as a **TAG** field. `memory` holds free-form memory content, but Valkey `TAG` fields only tokenize on commas — so the entire memory text collapses into a **single token**. This breaks full-text search over memory content and bloats the inverted index. The inline `"Using TAG instead of TEXT for Valkey compatibility"` comment is stale: `valkey-search` supports `TEXT`.

## Fix

`mem0/vector_stores/valkey.py` — change the `memory` field type from `tag` → `text` in the two places it is declared:

- `DEFAULT_FIELDS` (the `{"name": "memory", ...}` entry)
- `_build_index_schema()` — the `FT.CREATE` argument list

Scoped to `memory` only. The `metadata` field is intentionally left as `TAG` (it stores a JSON blob, not searchable prose). The `memory` field is never used as a `@tag` filter key (filters only reference `user_id` / `agent_id` / `run_id` / `hash`), so this change does not affect existing filter or search behavior.

Diff: **2 files, +43/-2**, no new dependencies.

## Test

Added a **RED-first** schema-assertion test in `tests/vector_stores/test_valkey.py` (unit-level, mocked Valkey client — no live server required):

- `test_default_fields_memory_is_text` — asserts the `DEFAULT_FIELDS` entry for `memory` is `text`.
- `test_build_index_schema_indexes_memory_as_text` — asserts the `FT.CREATE` command emitted by `_build_index_schema(...)` declares `memory` as `TEXT` (and not `TAG`).

Both tests **fail on `main`** (the field is emitted as `TAG`) and **pass after the fix** — proving the fix actually changes the indexed schema, rather than just asserting current behavior.

## Verification

```
# RED on main (before fix):
FAILED tests/vector_stores/test_valkey.py::test_default_fields_memory_is_text
FAILED tests/vector_stores/test_valkey.py::test_build_index_schema_indexes_memory_as_text

# After fix:
tests/vector_stores/test_valkey.py .... 54 passed in 0.55s
```

- Full `tests/vector_stores/test_valkey.py` suite: **54 passed** (52 pre-existing + 2 new), 0 regressions.
- `ruff check` on both touched files: **All checks passed**.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Breaking Changes

None. Existing indices are unaffected on read; new indices created after this change will index `memory` as `TEXT`.

---

🤖 AI-assistance: drafted with Claude (Opus 4.8), reviewed for correctness.
