### PR TITLE
feat: warn when hybrid search silently degrades to semantic-only

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -23,6 +23,7 @@ from mem0.configs.prompts import (
 )
 from mem0.exceptions import ValidationError as Mem0ValidationError
 from mem0.memory.base import MemoryBase
+from mem0.vector_stores.base import VectorStoreBase
 from mem0.memory.setup import mem0_dir, setup_config
 from mem0.memory.storage import SQLiteManager
 from mem0.memory.telemetry import MEM0_TELEMETRY, capture_event
@@ -385,6 +386,15 @@ class Memory(MemoryBase):
             self._telemetry_vector_store = VectorStoreFactory.create(
                 self.config.vector_store.provider, telemetry_config
             )
+        if getattr(type(self.vector_store), "keyword_search", None) is VectorStoreBase.keyword_search:
+            logger.warning(
+                "The '%s' vector store does not support keyword search. "
+                "Hybrid (BM25) scoring will be disabled and search will use "
+                "semantic similarity only. To enable hybrid search, switch to a "
+                "store with keyword_search support (e.g. qdrant, elasticsearch, pgvector).",
+                self.config.vector_store.provider,
+            )
+
         capture_event("mem0.init", self, {"sync_type": "sync"})
 
     @property
@@ -1855,6 +1865,15 @@ class AsyncMemory(MemoryBase):
                 telemetry_config.path = os.path.join(mem0_dir, provider_path)
                 os.makedirs(telemetry_config.path, exist_ok=True)
             self._telemetry_vector_store = VectorStoreFactory.create(self.config.vector_store.provider, telemetry_config)
+
+        if getattr(type(self.vector_store), "keyword_search", None) is VectorStoreBase.keyword_search:
+            logger.warning(
+                "The '%s' vector store does not support keyword search. "
+                "Hybrid (BM25) scoring will be disabled and search will use "
+                "semantic similarity only. To enable hybrid search, switch to a "
+                "store with keyword_search support (e.g. qdrant, elasticsearch, pgvector).",
+                self.config.vector_store.provider,
+            )
 
         capture_event("mem0.init", self, {"sync_type": "async"})
 

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -23,7 +23,6 @@ from mem0.configs.prompts import (
 )
 from mem0.exceptions import ValidationError as Mem0ValidationError
 from mem0.memory.base import MemoryBase
-from mem0.vector_stores.base import VectorStoreBase
 from mem0.memory.setup import mem0_dir, setup_config
 from mem0.memory.storage import SQLiteManager
 from mem0.memory.telemetry import MEM0_TELEMETRY, capture_event
@@ -48,6 +47,7 @@ from mem0.utils.scoring import (
     normalize_bm25,
     score_and_rank,
 )
+from mem0.vector_stores.base import VectorStoreBase
 
 # Suppress SWIG deprecation warnings globally
 warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*SwigPy.*")

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -986,9 +986,20 @@ class TestHybridSearchWarning:
         from mem0.vector_stores.base import VectorStoreBase
         import logging
 
-        mock_store = MagicMock(spec=VectorStoreBase)
-        type(mock_store).keyword_search = VectorStoreBase.keyword_search
-        mock_vs_factory.return_value = mock_store
+        class StoreWithoutKeywordSearch(VectorStoreBase):
+            def create_col(self, *a, **kw): pass
+            def insert(self, *a, **kw): pass
+            def search(self, *a, **kw): return []
+            def delete(self, *a, **kw): pass
+            def update(self, *a, **kw): pass
+            def get(self, *a, **kw): pass
+            def list_cols(self): return []
+            def delete_col(self): pass
+            def col_info(self): return {}
+            def list(self, *a, **kw): return []
+            def reset(self): pass
+
+        mock_vs_factory.return_value = StoreWithoutKeywordSearch()
         mock_emb.return_value = MagicMock()
         mock_llm.return_value = MagicMock()
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -970,3 +970,69 @@ async def test_async_create_memory_stores_text_lemmatized(mock_sqlite, mock_llm_
         "AsyncMemory._create_memory must store text_lemmatized for BM25 keyword search"
     )
     assert payload[0]["text_lemmatized"] != "", "text_lemmatized must not be empty"
+
+
+class TestHybridSearchWarning:
+    """Warn at init when vector store does not support keyword_search."""
+
+    @patch("mem0.memory.telemetry.capture_event")
+    @patch("mem0.memory.main.SQLiteManager")
+    @patch("mem0.utils.factory.LlmFactory.create")
+    @patch("mem0.utils.factory.EmbedderFactory.create")
+    @patch("mem0.utils.factory.VectorStoreFactory.create")
+    def test_warning_for_store_without_keyword_search(
+        self, mock_vs_factory, mock_emb, mock_llm, mock_sqlite, _cap, caplog
+    ):
+        from mem0.vector_stores.base import VectorStoreBase
+        import logging
+
+        mock_store = MagicMock(spec=VectorStoreBase)
+        type(mock_store).keyword_search = VectorStoreBase.keyword_search
+        mock_vs_factory.return_value = mock_store
+        mock_emb.return_value = MagicMock()
+        mock_llm.return_value = MagicMock()
+
+        config = MemoryConfig()
+        config.vector_store.provider = "chroma"
+
+        with caplog.at_level(logging.WARNING, logger="mem0.memory.main"):
+            Memory(config)
+
+        assert any("does not support keyword search" in r.message for r in caplog.records)
+
+    @patch("mem0.memory.telemetry.capture_event")
+    @patch("mem0.memory.main.SQLiteManager")
+    @patch("mem0.utils.factory.LlmFactory.create")
+    @patch("mem0.utils.factory.EmbedderFactory.create")
+    @patch("mem0.utils.factory.VectorStoreFactory.create")
+    def test_no_warning_for_store_with_keyword_search(
+        self, mock_vs_factory, mock_emb, mock_llm, mock_sqlite, _cap, caplog
+    ):
+        from mem0.vector_stores.base import VectorStoreBase
+        import logging
+
+        class StoreWithKeywordSearch(VectorStoreBase):
+            def keyword_search(self, query, top_k=5, filters=None):
+                return []
+            def create_col(self, *a, **kw): pass
+            def insert(self, *a, **kw): pass
+            def search(self, *a, **kw): return []
+            def delete(self, *a, **kw): pass
+            def update(self, *a, **kw): pass
+            def get(self, *a, **kw): pass
+            def list_cols(self): return []
+            def delete_col(self): pass
+            def col_info(self): return {}
+            def list(self, *a, **kw): return []
+            def reset(self): pass
+
+        mock_vs_factory.return_value = StoreWithKeywordSearch()
+        mock_emb.return_value = MagicMock()
+        mock_llm.return_value = MagicMock()
+
+        config = MemoryConfig()
+
+        with caplog.at_level(logging.WARNING, logger="mem0.memory.main"):
+            Memory(config)
+
+        assert not any("does not support keyword search" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

When using a vector store that doesn't implement `keyword_search` (chroma, faiss, cassandra, langchain, etc.), hybrid/BM25 scoring silently falls back to semantic-only search. Users have no way to know this is happening.

This adds a warning at `Memory` and `AsyncMemory` init time so users know their hybrid search config isn't actually doing anything.

**Affected stores** (9 total): chroma, faiss, cassandra, langchain, neptune_analytics, s3_vectors, supabase, turbopuffer, valkey

**Stores with keyword_search support** (15 total): qdrant, elasticsearch, pgvector, pinecone, milvus, redis, weaviate, opensearch, mongodb, azure_ai_search, azure_mysql, baidu, databricks, upstash_vector, vertex_ai_vector_search

## Changes

- Added a `getattr` check in both `Memory.__init__` and `AsyncMemory.__init__` that compares the store's `keyword_search` method against `VectorStoreBase.keyword_search`
- If the method is the inherited no-op, logs a warning with the store name and suggests alternatives
- Added 2 tests covering both the warning and no-warning paths

## Test plan

- [x] `pytest tests/test_memory.py -v -x` - all 43 tests pass
- [x] Verified detection works for all 9 affected stores via method identity check
- [x] Verified no false positives for stores that override keyword_search
- [x] Existing tests unaffected (used `getattr` to handle MagicMock stores)