### PR TITLE
fix(llms,embeddings): repair HTTP proxy support (httpx>=0.28) and preserve proxies in LlmFactory

### DIFF
--- a/mem0/configs/embeddings/base.py
+++ b/mem0/configs/embeddings/base.py
@@ -2,24 +2,8 @@ import os
 from abc import ABC
 from typing import Dict, Optional, Union
 
-import httpx
-
 from mem0.configs.base import AzureConfig
-
-
-def _build_http_client(http_client_proxies: Optional[Union[Dict, str]]) -> Optional[httpx.Client]:
-    """Build an httpx.Client for the given proxy settings.
-
-    httpx >= 0.28 removed the ``proxies=`` argument: a single proxy is passed as
-    ``proxy=`` and per-scheme proxies via ``mounts=``.
-    """
-    if not http_client_proxies:
-        return None
-    if isinstance(http_client_proxies, dict):
-        return httpx.Client(
-            mounts={scheme: httpx.HTTPTransport(proxy=url) for scheme, url in http_client_proxies.items()}
-        )
-    return httpx.Client(proxy=http_client_proxies)
+from mem0.utils.http import build_http_client
 
 
 class BaseEmbedderConfig(ABC):
@@ -97,7 +81,7 @@ class BaseEmbedderConfig(ABC):
 
         # AzureOpenAI specific
         self.http_client_proxies = http_client_proxies
-        self.http_client = _build_http_client(http_client_proxies)
+        self.http_client = build_http_client(http_client_proxies)
 
         # Ollama specific
         self.ollama_base_url = ollama_base_url
@@ -125,4 +109,3 @@ class BaseEmbedderConfig(ABC):
         self.aws_secret_access_key = aws_secret_access_key
         self.aws_session_token = aws_session_token
         self.aws_region = aws_region or os.environ.get("AWS_REGION") or "us-west-2"
-

--- a/mem0/configs/embeddings/base.py
+++ b/mem0/configs/embeddings/base.py
@@ -7,6 +7,21 @@ import httpx
 from mem0.configs.base import AzureConfig
 
 
+def _build_http_client(http_client_proxies: Optional[Union[Dict, str]]) -> Optional[httpx.Client]:
+    """Build an httpx.Client for the given proxy settings.
+
+    httpx >= 0.28 removed the ``proxies=`` argument: a single proxy is passed as
+    ``proxy=`` and per-scheme proxies via ``mounts=``.
+    """
+    if not http_client_proxies:
+        return None
+    if isinstance(http_client_proxies, dict):
+        return httpx.Client(
+            mounts={scheme: httpx.HTTPTransport(proxy=url) for scheme, url in http_client_proxies.items()}
+        )
+    return httpx.Client(proxy=http_client_proxies)
+
+
 class BaseEmbedderConfig(ABC):
     """
     Config for Embeddings.
@@ -81,7 +96,8 @@ class BaseEmbedderConfig(ABC):
         self.embedding_dims = embedding_dims
 
         # AzureOpenAI specific
-        self.http_client = httpx.Client(proxies=http_client_proxies) if http_client_proxies else None
+        self.http_client_proxies = http_client_proxies
+        self.http_client = _build_http_client(http_client_proxies)
 
         # Ollama specific
         self.ollama_base_url = ollama_base_url

--- a/mem0/configs/llms/base.py
+++ b/mem0/configs/llms/base.py
@@ -1,22 +1,7 @@
 from abc import ABC
 from typing import Dict, Optional, Union
 
-import httpx
-
-
-def _build_http_client(http_client_proxies: Optional[Union[Dict, str]]) -> Optional[httpx.Client]:
-    """Build an httpx.Client for the given proxy settings.
-
-    httpx >= 0.28 removed the ``proxies=`` argument: a single proxy is passed as
-    ``proxy=`` and per-scheme proxies via ``mounts=``.
-    """
-    if not http_client_proxies:
-        return None
-    if isinstance(http_client_proxies, dict):
-        return httpx.Client(
-            mounts={scheme: httpx.HTTPTransport(proxy=url) for scheme, url in http_client_proxies.items()}
-        )
-    return httpx.Client(proxy=http_client_proxies)
+from mem0.utils.http import build_http_client
 
 
 class BaseLlmConfig(ABC):
@@ -89,7 +74,5 @@ class BaseLlmConfig(ABC):
         self.vision_details = vision_details
         self.reasoning_effort = reasoning_effort
         self.is_reasoning_model = is_reasoning_model
-        # Keep the raw proxies value so it survives config conversion (e.g. in
-        # LlmFactory) instead of only the built client.
         self.http_client_proxies = http_client_proxies
-        self.http_client = _build_http_client(http_client_proxies)
+        self.http_client = build_http_client(http_client_proxies)

--- a/mem0/configs/llms/base.py
+++ b/mem0/configs/llms/base.py
@@ -4,6 +4,21 @@ from typing import Dict, Optional, Union
 import httpx
 
 
+def _build_http_client(http_client_proxies: Optional[Union[Dict, str]]) -> Optional[httpx.Client]:
+    """Build an httpx.Client for the given proxy settings.
+
+    httpx >= 0.28 removed the ``proxies=`` argument: a single proxy is passed as
+    ``proxy=`` and per-scheme proxies via ``mounts=``.
+    """
+    if not http_client_proxies:
+        return None
+    if isinstance(http_client_proxies, dict):
+        return httpx.Client(
+            mounts={scheme: httpx.HTTPTransport(proxy=url) for scheme, url in http_client_proxies.items()}
+        )
+    return httpx.Client(proxy=http_client_proxies)
+
+
 class BaseLlmConfig(ABC):
     """
     Base configuration for LLMs with only common parameters.
@@ -74,4 +89,7 @@ class BaseLlmConfig(ABC):
         self.vision_details = vision_details
         self.reasoning_effort = reasoning_effort
         self.is_reasoning_model = is_reasoning_model
-        self.http_client = httpx.Client(proxies=http_client_proxies) if http_client_proxies else None
+        # Keep the raw proxies value so it survives config conversion (e.g. in
+        # LlmFactory) instead of only the built client.
+        self.http_client_proxies = http_client_proxies
+        self.http_client = _build_http_client(http_client_proxies)

--- a/mem0/llms/anthropic.py
+++ b/mem0/llms/anthropic.py
@@ -29,7 +29,7 @@ class AnthropicLLM(LLMBase):
                 top_k=config.top_k,
                 enable_vision=config.enable_vision,
                 vision_details=config.vision_details,
-                http_client_proxies=config.http_client,
+                http_client_proxies=config.http_client_proxies,
             )
 
         super().__init__(config)

--- a/mem0/llms/azure_openai.py
+++ b/mem0/llms/azure_openai.py
@@ -32,7 +32,7 @@ class AzureOpenAILLM(LLMBase):
                 enable_vision=config.enable_vision,
                 vision_details=config.vision_details,
                 reasoning_effort=getattr(config, 'reasoning_effort', None),
-                http_client_proxies=config.http_client,
+                http_client_proxies=config.http_client_proxies,
                 is_reasoning_model=getattr(config, 'is_reasoning_model', None),
             )
 

--- a/mem0/llms/deepseek.py
+++ b/mem0/llms/deepseek.py
@@ -28,7 +28,7 @@ class DeepSeekLLM(LLMBase):
                 top_k=config.top_k,
                 enable_vision=config.enable_vision,
                 vision_details=config.vision_details,
-                http_client_proxies=config.http_client,
+                http_client_proxies=config.http_client_proxies,
             )
 
         super().__init__(config)

--- a/mem0/llms/lmstudio.py
+++ b/mem0/llms/lmstudio.py
@@ -27,7 +27,7 @@ class LMStudioLLM(LLMBase):
                 top_k=config.top_k,
                 enable_vision=config.enable_vision,
                 vision_details=config.vision_details,
-                http_client_proxies=config.http_client,
+                http_client_proxies=config.http_client_proxies,
             )
 
         super().__init__(config)

--- a/mem0/llms/minimax.py
+++ b/mem0/llms/minimax.py
@@ -28,7 +28,7 @@ class MiniMaxLLM(LLMBase):
                 top_k=config.top_k,
                 enable_vision=config.enable_vision,
                 vision_details=config.vision_details,
-                http_client_proxies=config.http_client,
+                http_client_proxies=config.http_client_proxies,
             )
 
         super().__init__(config)

--- a/mem0/llms/ollama.py
+++ b/mem0/llms/ollama.py
@@ -30,7 +30,7 @@ class OllamaLLM(LLMBase):
                 top_k=config.top_k,
                 enable_vision=config.enable_vision,
                 vision_details=config.vision_details,
-                http_client_proxies=config.http_client,
+                http_client_proxies=config.http_client_proxies,
             )
 
         super().__init__(config)

--- a/mem0/llms/openai.py
+++ b/mem0/llms/openai.py
@@ -30,7 +30,7 @@ class OpenAILLM(LLMBase):
                 enable_vision=config.enable_vision,
                 vision_details=config.vision_details,
                 reasoning_effort=getattr(config, 'reasoning_effort', None),
-                http_client_proxies=config.http_client,
+                http_client_proxies=config.http_client_proxies,
                 is_reasoning_model=getattr(config, 'is_reasoning_model', None),
             )
 

--- a/mem0/llms/vllm.py
+++ b/mem0/llms/vllm.py
@@ -28,7 +28,7 @@ class VllmLLM(LLMBase):
                 top_k=config.top_k,
                 enable_vision=config.enable_vision,
                 vision_details=config.vision_details,
-                http_client_proxies=config.http_client,
+                http_client_proxies=config.http_client_proxies,
             )
 
         super().__init__(config)

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -100,7 +100,7 @@ class LlmFactory:
                     "top_k": config.top_k,
                     "enable_vision": config.enable_vision,
                     "vision_details": config.vision_details,
-                    "http_client_proxies": config.http_client,
+                    "http_client_proxies": config.http_client_proxies,
                 }
                 config_dict.update(kwargs)
                 config = config_class(**config_dict)

--- a/mem0/utils/http.py
+++ b/mem0/utils/http.py
@@ -1,0 +1,13 @@
+from typing import Dict, Optional, Union
+
+import httpx
+
+
+def build_http_client(http_client_proxies: Optional[Union[Dict, str]]) -> Optional[httpx.Client]:
+    if not http_client_proxies:
+        return None
+    if isinstance(http_client_proxies, dict):
+        return httpx.Client(
+            mounts={scheme: httpx.HTTPTransport(proxy=url) for scheme, url in http_client_proxies.items()}
+        )
+    return httpx.Client(proxy=http_client_proxies)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "qdrant-client>=1.12.0",
     "pydantic>=2.7.3",
     "openai>=1.90.0",
+    "httpx>=0.28.0",
     "posthog>=7.14.0",
     "pytz>=2024.1",
     "sqlalchemy>=2.0.31",

--- a/tests/llms/test_azure_openai.py
+++ b/tests/llms/test_azure_openai.py
@@ -289,7 +289,9 @@ def test_generate_with_http_proxies(default_headers):
             api_version=None,
             default_headers=default_headers,
         )
-        mock_http_client.assert_called_once_with(proxies="http://testproxy.mem0.net:8000")
+        # httpx >= 0.28 removed the ``proxies=`` argument; a single proxy is now
+        # passed as ``proxy=``. _build_http_client builds the client accordingly.
+        mock_http_client.assert_called_once_with(proxy="http://testproxy.mem0.net:8000")
 
 
 def test_init_with_api_key(monkeypatch):

--- a/tests/llms/test_azure_openai.py
+++ b/tests/llms/test_azure_openai.py
@@ -289,8 +289,6 @@ def test_generate_with_http_proxies(default_headers):
             api_version=None,
             default_headers=default_headers,
         )
-        # httpx >= 0.28 removed the ``proxies=`` argument; a single proxy is now
-        # passed as ``proxy=``. _build_http_client builds the client accordingly.
         mock_http_client.assert_called_once_with(proxy="http://testproxy.mem0.net:8000")
 
 

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -456,10 +456,6 @@ def test_callback_with_tools(mock_openai_client):
 
 
 def test_openai_llm_preserves_proxies_from_base_config(mock_openai_client):
-    # Constructing a provider directly with a BaseLlmConfig (not OpenAIConfig)
-    # must forward the raw proxies value, not the already-built httpx.Client.
-    # The factory path is covered separately; this exercises the direct path
-    # that integration examples and tests/llms/test_openai.py rely on.
     config = BaseLlmConfig(
         model="gpt-4.1-nano-2025-04-14",
         api_key="api_key",

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -1,8 +1,10 @@
 import os
 from unittest.mock import Mock, patch
 
+import httpx
 import pytest
 
+from mem0.configs.llms.base import BaseLlmConfig
 from mem0.configs.llms.openai import OpenAIConfig
 from mem0.llms.openai import OpenAILLM
 
@@ -451,3 +453,18 @@ def test_callback_with_tools(mock_openai_client):
     mock_callback.assert_called_once()
     # Check that tool_calls exists in the message
     assert hasattr(mock_callback.call_args[0][1].choices[0].message, 'tool_calls')
+
+
+def test_openai_llm_preserves_proxies_from_base_config(mock_openai_client):
+    # Constructing a provider directly with a BaseLlmConfig (not OpenAIConfig)
+    # must forward the raw proxies value, not the already-built httpx.Client.
+    # The factory path is covered separately; this exercises the direct path
+    # that integration examples and tests/llms/test_openai.py rely on.
+    config = BaseLlmConfig(
+        model="gpt-4.1-nano-2025-04-14",
+        api_key="api_key",
+        http_client_proxies="http://proxy.local:8080",
+    )
+    llm = OpenAILLM(config)
+    assert llm.config.http_client_proxies == "http://proxy.local:8080"
+    assert isinstance(llm.config.http_client, httpx.Client)

--- a/tests/test_http_client_proxies.py
+++ b/tests/test_http_client_proxies.py
@@ -1,13 +1,3 @@
-"""Regression tests for HTTP proxy support in LLM/embedding configs.
-
-Covers two bugs:
-1. `httpx.Client(proxies=...)` was removed in httpx >= 0.28, so building any
-   config with a proxy raised TypeError.
-2. `LlmFactory` passed the already-built `http_client` where the raw
-   `http_client_proxies` value was expected when converting a BaseLlmConfig to a
-   provider-specific config, silently dropping the user's proxy setting.
-"""
-
 import httpx
 import pytest
 
@@ -20,7 +10,6 @@ from mem0.utils.factory import LlmFactory
 def test_config_with_string_proxy_builds_client(config_cls):
     config = config_cls(http_client_proxies="http://proxy.local:8080")
     assert isinstance(config.http_client, httpx.Client)
-    # The raw value is preserved (not only the built client).
     assert config.http_client_proxies == "http://proxy.local:8080"
 
 
@@ -40,8 +29,6 @@ def test_config_without_proxy_has_no_client(config_cls):
 
 
 def test_llm_factory_preserves_http_client_proxies():
-    # Converting a BaseLlmConfig to a provider config must pass the raw proxies
-    # value through, not the constructed httpx.Client object.
     base = BaseLlmConfig(
         model="gpt-4o-mini",
         api_key="sk-test",

--- a/tests/test_http_client_proxies.py
+++ b/tests/test_http_client_proxies.py
@@ -1,0 +1,52 @@
+"""Regression tests for HTTP proxy support in LLM/embedding configs.
+
+Covers two bugs:
+1. `httpx.Client(proxies=...)` was removed in httpx >= 0.28, so building any
+   config with a proxy raised TypeError.
+2. `LlmFactory` passed the already-built `http_client` where the raw
+   `http_client_proxies` value was expected when converting a BaseLlmConfig to a
+   provider-specific config, silently dropping the user's proxy setting.
+"""
+
+import httpx
+import pytest
+
+from mem0.configs.embeddings.base import BaseEmbedderConfig
+from mem0.configs.llms.base import BaseLlmConfig
+from mem0.utils.factory import LlmFactory
+
+
+@pytest.mark.parametrize("config_cls", [BaseLlmConfig, BaseEmbedderConfig])
+def test_config_with_string_proxy_builds_client(config_cls):
+    config = config_cls(http_client_proxies="http://proxy.local:8080")
+    assert isinstance(config.http_client, httpx.Client)
+    # The raw value is preserved (not only the built client).
+    assert config.http_client_proxies == "http://proxy.local:8080"
+
+
+@pytest.mark.parametrize("config_cls", [BaseLlmConfig, BaseEmbedderConfig])
+def test_config_with_dict_proxy_builds_client(config_cls):
+    proxies = {"http://": "http://p:8080", "https://": "http://p:8080"}
+    config = config_cls(http_client_proxies=proxies)
+    assert isinstance(config.http_client, httpx.Client)
+    assert config.http_client_proxies == proxies
+
+
+@pytest.mark.parametrize("config_cls", [BaseLlmConfig, BaseEmbedderConfig])
+def test_config_without_proxy_has_no_client(config_cls):
+    config = config_cls()
+    assert config.http_client is None
+    assert config.http_client_proxies is None
+
+
+def test_llm_factory_preserves_http_client_proxies():
+    # Converting a BaseLlmConfig to a provider config must pass the raw proxies
+    # value through, not the constructed httpx.Client object.
+    base = BaseLlmConfig(
+        model="gpt-4o-mini",
+        api_key="sk-test",
+        http_client_proxies="http://proxy.local:8080",
+    )
+    llm = LlmFactory.create("openai", base)
+    assert llm.config.http_client_proxies == "http://proxy.local:8080"
+    assert isinstance(llm.config.http_client, httpx.Client)


### PR DESCRIPTION
## Description

HTTP proxy support for LLM and embedding clients is currently broken in two ways:

**1. `httpx.Client(proxies=...)` crashes on httpx >= 0.28.** Both `BaseLlmConfig` and `BaseEmbedderConfig` build their client with:

```python
self.http_client = httpx.Client(proxies=http_client_proxies) if http_client_proxies else None
```

httpx removed the `proxies=` argument in 0.28.0 (a single proxy is now `proxy=`, per-scheme proxies are `mounts=`). `poetry.lock` pins `httpx==0.28.1`, so constructing any config with a proxy raises:

```
TypeError: Client.__init__() got an unexpected keyword argument 'proxies'
```

**2. `LlmFactory` drops the proxy value when converting configs.** When a generic `BaseLlmConfig` is converted to a provider-specific config, the factory passes the already-built client object as the proxies value:

```python
"http_client_proxies": config.http_client,   # an httpx.Client, not the proxies value
```

`BaseLlmConfig` only stored the built client, never the original `http_client_proxies`, so the user's actual proxy setting was lost on conversion.

## Fix

- Build the client in an httpx-0.28-compatible way (`proxy=` for a single proxy URL, `mounts=` for a per-scheme dict), in both `BaseLlmConfig` and `BaseEmbedderConfig`.
- Store the raw `http_client_proxies` value on the config so it survives conversion.
- `LlmFactory` now forwards `config.http_client_proxies` instead of the built client.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test Coverage

- [x] I added/updated unit tests

`tests/test_http_client_proxies.py`: covers building a client from a string proxy and a per-scheme dict, the no-proxy case, and that `LlmFactory` preserves the proxies value when converting a `BaseLlmConfig` to a provider config. All fail before the change and pass after; existing LLM/config tests still pass; `ruff check` is clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally

Closes #5648
