### PR TITLE
mem0-plugin hooks: honor auto_save=false in capture entry points

### DIFF
--- a/mem0-plugin/scripts/on_session_start.sh
+++ b/mem0-plugin/scripts/on_session_start.sh
@@ -189,7 +189,9 @@ elif [ "$SOURCE" = "resume" ]; then
 
 elif [ "$SOURCE" = "compact" ]; then
   echo "Context compacted. Search mem0 for session_state and decision memories to recover context. Run 2 parallel searches."
-  printf '%s' "$INPUT" | python3 "$SCRIPT_DIR/capture_compact_summary.py" 2>/dev/null &
+  if [ "${MEM0_AUTO_SAVE:-true}" != "false" ]; then
+    printf '%s' "$INPUT" | python3 "$SCRIPT_DIR/capture_compact_summary.py" 2>/dev/null &
+  fi
 fi
 
 python3 "$SCRIPT_DIR/telemetry.py" session_start --source="$SOURCE" --memory_count="${MEM0_COUNT:-0}" 2>/dev/null &

--- a/mem0-plugin/scripts/on_stop.sh
+++ b/mem0-plugin/scripts/on_stop.sh
@@ -32,6 +32,11 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 . "$SCRIPT_DIR/_identity.sh" 2>/dev/null || true
 
+# Honor auto_save=false in ~/.mem0/settings.json
+if [ "${MEM0_AUTO_SAVE:-true}" = "false" ]; then
+  exit 0
+fi
+
 if [ -z "${MEM0_API_KEY:-}" ]; then
   exit 0
 fi

--- a/mem0-plugin/scripts/on_user_prompt.sh
+++ b/mem0-plugin/scripts/on_user_prompt.sh
@@ -174,7 +174,7 @@ fi
 # overlapping window ensures the next batch (MSG_COUNT=6) picks up the
 # exchange that was incomplete in the previous batch.
 TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // ""' 2>/dev/null || echo "")
-if [ $((MSG_COUNT % 3)) -eq 0 ] && [ "$MSG_COUNT" -gt 0 ] && [ -n "$TRANSCRIPT_PATH" ]; then
+if [ "${MEM0_AUTO_SAVE:-true}" != "false" ] && [ $((MSG_COUNT % 3)) -eq 0 ] && [ "$MSG_COUNT" -gt 0 ] && [ -n "$TRANSCRIPT_PATH" ]; then
   python3 "$SCRIPT_DIR/auto_capture.py" "$TRANSCRIPT_PATH" 2>/dev/null &
 fi
 


### PR DESCRIPTION
## Summary

Fixes #5449.

The `auto_save` setting in `~/.mem0/settings.json` is loaded into `MEM0_AUTO_SAVE` by `_identity.sh` but no capture script consults it, so `auto_save: false` has no effect. This PR adds a guard at the bash-hook layer so all three current capture paths honor the setting.

- **`on_stop.sh`** — gates the whole script (its sole purpose is capture).
- **`on_user_prompt.sh`** — gates only the `auto_capture.py` invocation; rubric injection / search guidance stays governed by `auto_search`.
- **`on_session_start.sh`** — gates only the `capture_compact_summary.py` invocation; the SessionStart status display still renders.

Gating at the bash layer (rather than inside each Python writer) means any future capture script invoked from these hooks inherits the guard with no further changes.

## Test plan

- [x] `bash -n` passes on all three modified scripts
- [x] Smoke test: with `MEM0_AUTO_SAVE=false`, `on_stop.sh` exits before invoking `capture_session_summary.py`
- [x] Smoke test: with `MEM0_AUTO_SAVE=true` (default), all three scripts proceed past the new guard unchanged
- [x] Applied locally — `auto_save: false` now produces zero `source: stop-hook`, `source: auto_capture`, or `source: compact_summary` rows across multi-turn conversations; explicit `add_memory` calls still work normally
- [x] Rubric injection in `on_user_prompt.sh` and SessionStart status output remain unaffected