### PR TITLE
fix(memory): flatten text-part message content in parse_vision_messages

### DIFF
--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -179,6 +179,15 @@ def parse_vision_messages(messages, llm=None, vision_details="auto"):
 
         # Handle message content
         if isinstance(msg["content"], list):
+            if llm is None:
+                text_parts = [
+                    part.get("text", "")
+                    for part in msg["content"]
+                    if isinstance(part, dict) and part.get("type") == "text" and part.get("text")
+                ]
+                returned_messages.append({"role": msg["role"], "content": "\n".join(text_parts)})
+                continue
+
             # Multiple image URLs in content
             description = get_image_description(msg, llm, vision_details)
             returned_messages.append({"role": msg["role"], "content": description})

--- a/tests/memory/test_memory_utils.py
+++ b/tests/memory/test_memory_utils.py
@@ -1,5 +1,11 @@
+from unittest.mock import Mock
+
 import pytest
-from mem0.memory.utils import remove_spaces_from_entities, sanitize_relationship_for_cypher
+from mem0.memory.utils import (
+    parse_vision_messages,
+    remove_spaces_from_entities,
+    sanitize_relationship_for_cypher,
+)
 
 
 class TestRemoveSpacesFromEntities:
@@ -55,3 +61,38 @@ class TestRemoveSpacesFromEntities:
         f = remove_spaces_from_entities([dict(base)], sanitize_relationship=False)[0]["relationship"]
         assert t == sanitize_relationship_for_cypher("a/b")
         assert f == "a/b"
+
+
+class TestParseVisionMessages:
+    def test_text_array_content_without_llm_does_not_crash(self):
+        """#3646: text-only array content + no llm must flatten, not crash."""
+        messages = [
+            {"role": "user", "content": "你好"},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "For context:"},
+                    {"type": "text", "text": "xxxxxxx"},
+                ],
+            },
+        ]
+        out = parse_vision_messages(messages)
+        assert out[0] == {"role": "user", "content": "你好"}
+        assert isinstance(out[1]["content"], str)
+        assert "For context:" in out[1]["content"]
+        assert "xxxxxxx" in out[1]["content"]
+
+    def test_image_url_in_array_still_uses_vision(self):
+        llm = Mock()
+        llm.generate_response.return_value = "a description of the image"
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "http://example.com/cat.png"}},
+                ],
+            }
+        ]
+        out = parse_vision_messages(messages, llm=llm)
+        llm.generate_response.assert_called_once()
+        assert "a description of the image" in out[0]["content"]


### PR DESCRIPTION
## Linked Issue

Closes #3646

## Description

When `parse_vision_messages` receives messages with list-typed content containing text parts and no LLM is provided (vision disabled), flatten the text parts into a plain string instead of crashing with `AttributeError` from calling `llm.generate_response()`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test Coverage

- [x] I added/updated unit tests
- [x] New and existing tests pass locally (10/10 passed)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally