### PR TITLE
fix(gemini): map tool_choice 'required' to ANY and accept **kwargs

### DIFF
--- a/mem0/llms/gemini.py
+++ b/mem0/llms/gemini.py
@@ -140,6 +140,7 @@ class GeminiLLM(LLMBase):
         response_format=None,
         tools: Optional[List[Dict]] = None,
         tool_choice: str = "auto",
+        **kwargs,
     ):
         """
         Generate a response based on the given messages using Gemini.
@@ -148,7 +149,10 @@ class GeminiLLM(LLMBase):
             messages (list): List of message dicts containing 'role' and 'content'.
             response_format (str or object, optional): Format for the response. Defaults to "text".
             tools (list, optional): List of tools that the model can call. Defaults to None.
-            tool_choice (str, optional): Tool choice method. Defaults to "auto".
+            tool_choice (str, optional): Tool choice method, one of "auto", "any",
+                "required", or "none". Defaults to "auto".
+            **kwargs: Additional per-call overrides (e.g. ``max_tokens``, ``temperature``,
+                ``top_p``) that take precedence over the configured defaults.
 
         Returns:
             str: The generated response.
@@ -157,11 +161,12 @@ class GeminiLLM(LLMBase):
         # Extract system instruction and reformat messages
         system_instruction, contents = self._reformat_messages(messages)
 
-        # Prepare generation config
+        # Prepare generation config. Per-call kwargs override the configured
+        # defaults; note Gemini names the token limit `max_output_tokens`.
         config_params = {
-            "temperature": self.config.temperature,
-            "max_output_tokens": self.config.max_tokens,
-            "top_p": self.config.top_p,
+            "temperature": kwargs.get("temperature", self.config.temperature),
+            "max_output_tokens": kwargs.get("max_tokens", self.config.max_tokens),
+            "top_p": kwargs.get("top_p", self.config.top_p),
         }
 
         # Add system instruction to config if present
@@ -178,19 +183,26 @@ class GeminiLLM(LLMBase):
             config_params["tools"] = formatted_tools
 
             if tool_choice:
-                if tool_choice == "auto":
-                    mode = types.FunctionCallingConfigMode.AUTO
-                elif tool_choice == "any":
+                if tool_choice in ("any", "required"):
+                    # Both mean "the model must call a tool" -> Gemini's ANY mode.
                     mode = types.FunctionCallingConfigMode.ANY
-                else:
+                elif tool_choice == "none":
                     mode = types.FunctionCallingConfigMode.NONE
+                else:
+                    # "auto" or any unrecognized value: let the model decide.
+                    mode = types.FunctionCallingConfigMode.AUTO
+
+                # Constrain to the provided tool names only when forcing a call.
+                allowed_function_names = (
+                    [tool["function"]["name"] for tool in tools]
+                    if mode == types.FunctionCallingConfigMode.ANY
+                    else None
+                )
 
                 tool_config = types.ToolConfig(
                     function_calling_config=types.FunctionCallingConfig(
                         mode=mode,
-                        allowed_function_names=(
-                            [tool["function"]["name"] for tool in tools] if tool_choice == "any" else None
-                        ),
+                        allowed_function_names=allowed_function_names,
                     )
                 )
                 config_params["tool_config"] = tool_config

--- a/tests/llms/test_gemini.py
+++ b/tests/llms/test_gemini.py
@@ -187,3 +187,94 @@ def test_parse_response_empty_parts_with_tools(mock_gemini_client: Mock):
 
     result = llm._parse_response(mock_response, tools=[{"function": {"name": "test"}}])
     assert result == {"content": None, "tool_calls": []}
+
+
+# ---------------------------------------------------------------------------
+# tool_choice mapping and per-call kwargs (issue #5430)
+# ---------------------------------------------------------------------------
+
+
+def _add_memory_tool():
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": "add_memory",
+                "description": "Add a memory",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"data": {"type": "string"}},
+                    "required": ["data"],
+                },
+            },
+        }
+    ]
+
+
+def _set_simple_response(mock_client: Mock):
+    """Give the mocked client a minimal, parseable response."""
+    mock_part = Mock(text="ok", function_call=None)
+    mock_content = Mock(parts=[mock_part])
+    mock_candidate = Mock(content=mock_content)
+    mock_client.models.generate_content.return_value = Mock(candidates=[mock_candidate])
+
+
+def _function_calling_config(mock_client: Mock):
+    config_arg = mock_client.models.generate_content.call_args.kwargs["config"]
+    return config_arg.tool_config.function_calling_config
+
+
+@pytest.mark.parametrize("choice", ["any", "required"])
+def test_tool_choice_forces_any_mode(mock_gemini_client: Mock, choice: str):
+    """Both 'any' and 'required' must force a tool call (ANY mode) with names set."""
+    config = BaseLlmConfig(model="gemini-2.0-flash", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = GeminiLLM(config)
+    _set_simple_response(mock_gemini_client)
+
+    llm.generate_response([{"role": "user", "content": "hi"}], tools=_add_memory_tool(), tool_choice=choice)
+
+    fcc = _function_calling_config(mock_gemini_client)
+    assert fcc.mode == types.FunctionCallingConfigMode.ANY
+    assert fcc.allowed_function_names == ["add_memory"]
+
+
+def test_tool_choice_none_disables_calls(mock_gemini_client: Mock):
+    config = BaseLlmConfig(model="gemini-2.0-flash", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = GeminiLLM(config)
+    _set_simple_response(mock_gemini_client)
+
+    llm.generate_response([{"role": "user", "content": "hi"}], tools=_add_memory_tool(), tool_choice="none")
+
+    fcc = _function_calling_config(mock_gemini_client)
+    assert fcc.mode == types.FunctionCallingConfigMode.NONE
+    assert fcc.allowed_function_names is None
+
+
+def test_tool_choice_unknown_defaults_to_auto(mock_gemini_client: Mock):
+    """An unrecognized tool_choice should fall back to AUTO, not silently disable tools."""
+    config = BaseLlmConfig(model="gemini-2.0-flash", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = GeminiLLM(config)
+    _set_simple_response(mock_gemini_client)
+
+    llm.generate_response([{"role": "user", "content": "hi"}], tools=_add_memory_tool(), tool_choice="bogus-value")
+
+    fcc = _function_calling_config(mock_gemini_client)
+    assert fcc.mode == types.FunctionCallingConfigMode.AUTO
+    assert fcc.allowed_function_names is None
+
+
+def test_generate_response_accepts_kwargs_and_overrides_max_tokens(mock_gemini_client: Mock):
+    """Extra kwargs must not raise, and max_tokens must override the configured default."""
+    config = BaseLlmConfig(model="gemini-2.0-flash", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = GeminiLLM(config)
+    _set_simple_response(mock_gemini_client)
+
+    llm.generate_response(
+        [{"role": "user", "content": "hi"}],
+        max_tokens=4096,
+        unsupported_param="ignored",
+    )
+
+    config_arg = mock_gemini_client.models.generate_content.call_args.kwargs["config"]
+    assert config_arg.max_output_tokens == 4096
+    assert config_arg.temperature == 0.7


### PR DESCRIPTION
  ## Linked Issue

  Closes #5430

  ## Description

  Fixes two bugs in `GeminiLLM.generate_response` (`mem0/llms/gemini.py`).

  **1. `tool_choice="required"` silently disabled tool calling.**
  The mode mapping only handled `"auto"` and `"any"`; every other value —
  including the
  standard `"required"` — fell into the `else` branch and became
  `FunctionCallingConfigMode.NONE` ("never call a tool"), the opposite of
  intent.
  `allowed_function_names` was also only set for the literal `"any"`. Now:
  - `"any"` / `"required"` → `ANY` (force a call)
  - `"none"` → `NONE`
  - `"auto"` / unrecognized → `AUTO` (let the model decide, instead of
  silently disabling)
  - `allowed_function_names` is populated whenever the mode is `ANY`.

  **2. `generate_response` didn't accept `**kwargs`.**
  The base `LLMBase.generate_response` defines `**kwargs`, but the Gemini
  override omitted
  it — so passing per-call options (e.g. `max_tokens`) raised `TypeError`,
  and the token
  limit couldn't be overridden per call. It now accepts `**kwargs`, maps
  `max_tokens` →
  Gemini's `max_output_tokens`, allows `temperature`/`top_p` overrides, and
  ignores unknown
  kwargs instead of crashing.

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing
  functionality to change)
  - [ ] Refactor (no functional changes)
  - [ ] Documentation update

  ## Breaking Changes

  N/A

  ## Test Coverage

  - [x] I added/updated unit tests
  - [ ] I added/updated integration tests
  - [ ] I tested manually (describe below)
  - [ ] No tests needed (explain why)

  Added unit tests in `tests/llms/test_gemini.py` (mocked client, no
  network): `"required"` and `"any"` → `ANY` with `allowed_function_names`
  set; `"none"` → `NONE`; unrecognized value → `AUTO`; per-call `max_tokens`
  overrides config and extra kwargs don't raise. All existing Gemini tests
  still pass.

  ## Checklist

  - [x] My code follows the project's style guidelines
  - [x] I have performed a self-review of my code
  - [x] I have added tests that prove my fix/feature works
  - [x] New and existing tests pass locally
  - [ ] I have updated documentation if needed