### PR TITLE
fix: xAI LLM provider — AttributeError, missing tools forwarding, and tool-call parsing

### DIFF
--- a/mem0/llms/xai.py
+++ b/mem0/llms/xai.py
@@ -1,3 +1,4 @@
+import json
 import os
 from typing import Dict, List, Optional
 
@@ -5,6 +6,7 @@ from openai import OpenAI
 
 from mem0.configs.llms.base import BaseLlmConfig
 from mem0.llms.base import LLMBase
+from mem0.memory.utils import extract_json
 
 
 class XAILLM(LLMBase):
@@ -15,8 +17,32 @@ class XAILLM(LLMBase):
             self.config.model = "grok-2-latest"
 
         api_key = self.config.api_key or os.getenv("XAI_API_KEY")
-        base_url = self.config.xai_base_url or os.getenv("XAI_API_BASE") or "https://api.x.ai/v1"
+        base_url = (
+            getattr(self.config, "xai_base_url", None)
+            or os.getenv("XAI_API_BASE")
+            or "https://api.x.ai/v1"
+        )
         self.client = OpenAI(api_key=api_key, base_url=base_url)
+
+    def _parse_response(self, response, tools):
+        if tools:
+            processed_response = {
+                "content": response.choices[0].message.content,
+                "tool_calls": [],
+            }
+
+            if response.choices[0].message.tool_calls:
+                for tool_call in response.choices[0].message.tool_calls:
+                    processed_response["tool_calls"].append(
+                        {
+                            "name": tool_call.function.name,
+                            "arguments": json.loads(extract_json(tool_call.function.arguments)),
+                        }
+                    )
+
+            return processed_response
+        else:
+            return response.choices[0].message.content
 
     def generate_response(
         self,
@@ -35,7 +61,7 @@ class XAILLM(LLMBase):
             tool_choice (str, optional): Tool choice method. Defaults to "auto".
 
         Returns:
-            str: The generated response.
+            str or dict: The generated response.
         """
         params = {
             "model": self.config.model,
@@ -47,6 +73,9 @@ class XAILLM(LLMBase):
 
         if response_format:
             params["response_format"] = response_format
+        if tools:
+            params["tools"] = tools
+            params["tool_choice"] = tool_choice
 
         response = self.client.chat.completions.create(**params)
-        return response.choices[0].message.content
+        return self._parse_response(response, tools)


### PR DESCRIPTION
## Summary

Fixes three bugs in `mem0/llms/xai.py` that prevent Grok/xAI from working correctly with Mem0:

1. **AttributeError on construction** — `self.config.xai_base_url` raises `AttributeError` because `BaseLlmConfig` doesn't have this attribute. Fixed by using `getattr(self.config, "xai_base_url", None)`.

2. **Tools silently dropped** — `generate_response()` accepts `tools` and `tool_choice` but never forwards them to the OpenAI client. Fixed by adding them to `params` when provided.

3. **Tool-call responses dropped** — When the model emits tool calls, `message.content` is `None`, and the tool-call payload was lost because there was no `_parse_response` method. Fixed by adding `_parse_response` following the same pattern used by Groq, OpenAI, and other providers.

## Changes

- `__init__`: Use `getattr` for `xai_base_url`
- `generate_response`: Forward `tools` and `tool_choice` to the API
- New `_parse_response`: Handle tool-call responses correctly
- Added missing imports (`json`, `extract_json`)

## Test plan

- [x] `LlmFactory.create("xai", {"model": "grok-2-latest"})` no longer raises `AttributeError`
- [x] Tools are forwarded to the xAI API
- [x] Tool-call responses are parsed and returned as structured dicts

Fixes #5189