### PR TITLE
Add quantal vector store provider

### DIFF
--- a/docs/components/vectordbs/dbs/quantal.mdx
+++ b/docs/components/vectordbs/dbs/quantal.mdx
@@ -1,0 +1,55 @@
+---
+title: "Quantal"
+description: "Use quantal as an embedded, quantized vector store in Mem0: no server to run, with graph-routed search and a fraction of the memory of full-precision stores."
+---
+
+[quantal](https://github.com/PaytonWebber/quantal) is an embedded vector index you link into your application, not a server you run. It routes each query through a graph over quantized codes instead of scanning every vector, so search stays fast as memories accumulate, and the index stores compressed data rather than full-precision vectors. Deletes are O(1) tombstones, so removing memories never rebuilds the index.
+
+### Installation
+
+```bash
+pip install quantaldb
+```
+
+Prebuilt wheels cover the common embedding dimensions (256/384/512/768/1024/1536/3072) on Linux, macOS (Apple Silicon), and Windows.
+
+### Usage
+
+```python
+import os
+from mem0 import Memory
+
+os.environ["OPENAI_API_KEY"] = "sk-xx"
+
+config = {
+    "vector_store": {
+        "provider": "quantal",
+        "config": {
+            "collection_name": "test",
+            "path": "/tmp/quantal_memories",
+            "embedding_model_dims": 1536,
+        }
+    }
+}
+
+m = Memory.from_config(config)
+messages = [
+    {"role": "user", "content": "I'm planning to watch a movie tonight. Any recommendations?"},
+    {"role": "assistant", "content": "How about a thriller? They can be quite engaging."},
+    {"role": "user", "content": "I'm not a big fan of thriller movies but I love sci-fi movies."},
+    {"role": "assistant", "content": "Got it! I'll avoid thriller recommendations and suggest sci-fi movies in the future."}
+]
+m.add(messages, user_id="alice", metadata={"category": "movies"})
+```
+
+### Config
+
+Here are the parameters available for configuring quantal:
+
+| Parameter | Description | Default Value |
+| --- | --- | --- |
+| `collection_name` | The name of the collection | `mem0` |
+| `path` | Directory for the index and metadata files | `/tmp/quantal` |
+| `embedding_model_dims` | Dimensions of the embedding model | `1536` |
+
+Vectors are stored normalized and scored by inner product, so similarity is always cosine. Searches with filters (for example `user_id`) restrict scoring to the matching memories up front rather than over-fetching and post-filtering.

--- a/docs/components/vectordbs/overview.mdx
+++ b/docs/components/vectordbs/overview.mdx
@@ -30,6 +30,7 @@ See the list of supported vector databases below.
   <Card title="Vertex AI" href="/components/vectordbs/dbs/vertex_ai"></Card>
   <Card title="Weaviate" href="/components/vectordbs/dbs/weaviate"></Card>
   <Card title="FAISS" href="/components/vectordbs/dbs/faiss"></Card>
+  <Card title="Quantal" href="/components/vectordbs/dbs/quantal"></Card>
   <Card title="LangChain" href="/components/vectordbs/dbs/langchain"></Card>
   <Card title="Amazon S3 Vectors" href="/components/vectordbs/dbs/s3_vectors"></Card>
   <Card title="Databricks" href="/components/vectordbs/dbs/databricks"></Card>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -241,6 +241,7 @@
                               "components/vectordbs/dbs/vertex_ai",
                               "components/vectordbs/dbs/weaviate",
                               "components/vectordbs/dbs/faiss",
+              "components/vectordbs/dbs/quantal",
                               "components/vectordbs/dbs/langchain",
                               "components/vectordbs/dbs/baidu",
                               "components/vectordbs/dbs/cassandra",

--- a/mem0/configs/vector_stores/quantal.py
+++ b/mem0/configs/vector_stores/quantal.py
@@ -1,0 +1,23 @@
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class QuantalConfig(BaseModel):
+    collection_name: str = Field("mem0", description="Default name for the collection")
+    path: Optional[str] = Field(None, description="Directory for the quantal index and metadata files")
+    embedding_model_dims: int = Field(1536, description="Dimension of the embedding vector")
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_extra_fields(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        allowed_fields = set(cls.model_fields.keys())
+        input_fields = set(values.keys())
+        extra_fields = input_fields - allowed_fields
+        if extra_fields:
+            raise ValueError(
+                f"Extra fields not allowed: {', '.join(extra_fields)}. Please input only the following fields: {', '.join(allowed_fields)}"
+            )
+        return values
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -184,6 +184,7 @@ class VectorStoreFactory:
         "supabase": "mem0.vector_stores.supabase.Supabase",
         "weaviate": "mem0.vector_stores.weaviate.Weaviate",
         "faiss": "mem0.vector_stores.faiss.FAISS",
+        "quantal": "mem0.vector_stores.quantal.Quantal",
         "langchain": "mem0.vector_stores.langchain.Langchain",
         "s3_vectors": "mem0.vector_stores.s3_vectors.S3Vectors",
         "baidu": "mem0.vector_stores.baidu.BaiduDB",

--- a/mem0/vector_stores/configs.py
+++ b/mem0/vector_stores/configs.py
@@ -32,6 +32,7 @@ class VectorStoreConfig(BaseModel):
         "supabase": "SupabaseConfig",
         "weaviate": "WeaviateConfig",
         "faiss": "FAISSConfig",
+        "quantal": "QuantalConfig",
         "langchain": "LangchainConfig",
         "s3_vectors": "S3VectorsConfig",
         "turbopuffer": "TurbopufferConfig",

--- a/mem0/vector_stores/quantal.py
+++ b/mem0/vector_stores/quantal.py
@@ -1,0 +1,373 @@
+import json
+import logging
+import os
+import uuid
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import numpy as np
+from pydantic import BaseModel
+
+try:
+    from quantal import Index
+except ImportError:
+    raise ImportError("Could not import quantal python package. Please install it with `pip install quantaldb`.")
+
+from mem0.vector_stores.base import VectorStoreBase
+
+logger = logging.getLogger(__name__)
+
+
+class OutputData(BaseModel):
+    id: Optional[str]  # memory id
+    score: Optional[float]  # similarity score (cosine)
+    payload: Optional[Dict]  # metadata
+
+
+class Quantal(VectorStoreBase):
+    """quantal is an embedded vector index (no server): graph-routed search
+    over quantized codes. Vectors are stored normalized and scored by inner
+    product, i.e. cosine similarity. Deletes are O(1) tombstones, so no
+    index rebuild is needed."""
+
+    def __init__(
+        self,
+        collection_name: str,
+        path: Optional[str] = None,
+        embedding_model_dims: int = 1536,
+    ):
+        """
+        Initialize the quantal vector store.
+
+        Args:
+            collection_name (str): Name of the collection.
+            path (str, optional): Directory for the index and metadata files.
+                Defaults to /tmp/quantal/<collection_name>.
+            embedding_model_dims (int, optional): Dimension of the embedding
+                vector. Defaults to 1536.
+        """
+        self.collection_name = collection_name
+        self.path = path or f"/tmp/quantal/{collection_name}"
+        self.embedding_model_dims = embedding_model_dims
+
+        self.index = None
+        self.docstore = {}  # memory id (str) -> payload dict
+        self.id_map = {}  # memory id (str) -> internal id (int)
+        self.rev_map = {}  # internal id (int) -> memory id (str)
+        self.next_id = 0
+
+        os.makedirs(self.path, exist_ok=True)
+        index_path = f"{self.path}/{collection_name}.tq"
+        meta_path = f"{self.path}/{collection_name}.json"
+        if os.path.exists(index_path) and os.path.exists(meta_path):
+            self._load(index_path, meta_path)
+        else:
+            self.create_col(collection_name)
+
+    def _load(self, index_path: str, meta_path: str):
+        try:
+            self.index = Index.load(index_path)
+            with open(meta_path, "r", encoding="utf-8") as f:
+                meta = json.load(f)
+            self.docstore = meta.get("docstore", {})
+            self.id_map = {k: int(v) for k, v in meta.get("id_map", {}).items()}
+            self.rev_map = {v: k for k, v in self.id_map.items()}
+            self.next_id = int(meta.get("next_id", 0))
+            logger.info(f"Loaded quantal index from {index_path} with {len(self.index)} vectors")
+        except Exception as e:
+            logger.warning(f"Failed to load quantal index: {e}")
+            self.docstore, self.id_map, self.rev_map, self.next_id = {}, {}, {}, 0
+            self.create_col(self.collection_name)
+
+    def _save(self):
+        if not self.path or self.index is None:
+            return
+        try:
+            os.makedirs(self.path, exist_ok=True)
+            self.index.save(f"{self.path}/{self.collection_name}.tq")
+            meta = {
+                "docstore": self.docstore,
+                "id_map": self.id_map,
+                "next_id": self.next_id,
+            }
+            with open(f"{self.path}/{self.collection_name}.json", "w", encoding="utf-8") as f:
+                json.dump(meta, f, indent=2)
+        except Exception as e:
+            logger.warning(f"Failed to save quantal index: {e}")
+
+    def _normalize(self, vectors) -> np.ndarray:
+        vectors = np.ascontiguousarray(vectors, dtype=np.float32)
+        if vectors.ndim == 1:
+            vectors = vectors.reshape(1, -1)
+        norms = np.linalg.norm(vectors, axis=1, keepdims=True)
+        return vectors / np.maximum(norms, 1e-30)
+
+    def _to_output(self, hits) -> List[OutputData]:
+        results = []
+        for internal_id, score in hits:
+            memory_id = self.rev_map.get(int(internal_id))
+            if memory_id is None:
+                continue
+            payload = self.docstore.get(memory_id)
+            if payload is None:
+                continue
+            results.append(OutputData(id=memory_id, score=float(score), payload=payload.copy()))
+        return results
+
+    def _apply_filters(self, payload: Dict, filters: Dict) -> bool:
+        if not filters or not payload:
+            return True
+        for key, value in filters.items():
+            if key not in payload:
+                return False
+            if isinstance(value, list):
+                if payload[key] not in value:
+                    return False
+            elif payload[key] != value:
+                return False
+        return True
+
+    def create_col(self, name: str, distance: str = None):
+        """
+        Create a new collection. quantal scores normalized vectors by inner
+        product, so the distance is always cosine; `distance` is accepted
+        for API compatibility and ignored.
+
+        Args:
+            name (str): Name of the collection.
+            distance (str, optional): Ignored (always cosine).
+
+        Returns:
+            self: The Quantal instance.
+        """
+        self.index = Index(dim=self.embedding_model_dims)
+        self.collection_name = name
+        self._save()
+        return self
+
+    def insert(
+        self,
+        vectors: List[list],
+        payloads: Optional[List[Dict]] = None,
+        ids: Optional[List[str]] = None,
+    ):
+        """
+        Insert vectors into the collection.
+
+        Args:
+            vectors (List[list]): List of vectors to insert.
+            payloads (Optional[List[Dict]], optional): List of payloads corresponding to vectors.
+            ids (Optional[List[str]], optional): List of IDs corresponding to vectors.
+        """
+        if self.index is None:
+            raise ValueError("Collection not initialized. Call create_col first.")
+
+        if ids is None:
+            ids = [str(uuid.uuid4()) for _ in range(len(vectors))]
+        if payloads is None:
+            payloads = [{} for _ in range(len(vectors))]
+        if len(vectors) != len(ids) or len(vectors) != len(payloads):
+            raise ValueError("Vectors, payloads, and IDs must have the same length")
+
+        internal_ids = np.arange(self.next_id, self.next_id + len(vectors), dtype=np.uint64)
+        self.index.add(self._normalize(vectors), ids=internal_ids)
+        for internal_id, memory_id, payload in zip(internal_ids, ids, payloads):
+            self.docstore[memory_id] = payload.copy()
+            self.id_map[memory_id] = int(internal_id)
+            self.rev_map[int(internal_id)] = memory_id
+        self.next_id += len(vectors)
+
+        self._save()
+        logger.info(f"Inserted {len(vectors)} vectors into collection {self.collection_name}")
+
+    def search(
+        self, query: str, vectors: List[list], top_k: int = 5, filters: Optional[Dict] = None
+    ) -> List[OutputData]:
+        """
+        Search for similar vectors. With filters, the search is restricted
+        to the matching ids up front (exact scoring over the allowlist)
+        rather than over-fetching and post-filtering.
+
+        Args:
+            query (str): Query (not used, kept for API compatibility).
+            vectors (List[list]): Query vector.
+            top_k (int, optional): Number of results to return. Defaults to 5.
+            filters (Optional[Dict], optional): Payload filters. Defaults to None.
+
+        Returns:
+            List[OutputData]: Search results.
+        """
+        if self.index is None:
+            raise ValueError("Collection not initialized. Call create_col first.")
+        if len(self.docstore) == 0:
+            return []
+
+        query_vector = self._normalize(vectors)
+
+        if filters:
+            allowlist = [
+                self.id_map[memory_id]
+                for memory_id, payload in self.docstore.items()
+                if memory_id in self.id_map and self._apply_filters(payload, filters)
+            ]
+            if not allowlist:
+                return []
+            hits = self.index.search_filtered(query_vector, allowlist, k=top_k)
+        else:
+            hits = self.index.search(query_vector, k=top_k)
+
+        return self._to_output(hits)
+
+    def delete(self, vector_id: str):
+        """
+        Delete a vector by ID. quantal removes by tombstone in O(1); the
+        index is not rebuilt.
+
+        Args:
+            vector_id (str): ID of the vector to delete.
+        """
+        if self.index is None:
+            raise ValueError("Collection not initialized. Call create_col first.")
+
+        internal_id = self.id_map.pop(vector_id, None)
+        if internal_id is None:
+            logger.warning(f"Vector {vector_id} not found in collection {self.collection_name}")
+            return
+
+        self.index.remove(internal_id)
+        self.rev_map.pop(internal_id, None)
+        self.docstore.pop(vector_id, None)
+        self._save()
+        logger.info(f"Deleted vector {vector_id} from collection {self.collection_name}")
+
+    def update(
+        self,
+        vector_id: str,
+        vector: Optional[List[float]] = None,
+        payload: Optional[Dict] = None,
+    ):
+        """
+        Update a vector and/or its payload.
+
+        Args:
+            vector_id (str): ID of the vector to update.
+            vector (Optional[List[float]], optional): Updated vector.
+            payload (Optional[Dict], optional): Updated payload.
+        """
+        if self.index is None:
+            raise ValueError("Collection not initialized. Call create_col first.")
+        if vector_id not in self.docstore:
+            raise ValueError(f"Vector {vector_id} not found")
+
+        if payload is not None:
+            self.docstore[vector_id] = payload.copy()
+
+        if vector is not None:
+            old_internal = self.id_map[vector_id]
+            self.index.remove(old_internal)
+            self.rev_map.pop(old_internal, None)
+            new_internal = self.next_id
+            self.next_id += 1
+            self.index.add(self._normalize([vector]), ids=np.array([new_internal], dtype=np.uint64))
+            self.id_map[vector_id] = new_internal
+            self.rev_map[new_internal] = vector_id
+
+        self._save()
+        logger.info(f"Updated vector {vector_id} in collection {self.collection_name}")
+
+    def get(self, vector_id: str) -> Optional[OutputData]:
+        """
+        Retrieve a vector's payload by ID.
+
+        Args:
+            vector_id (str): ID of the vector to retrieve.
+
+        Returns:
+            OutputData: Retrieved vector, or None if not found.
+        """
+        if self.index is None:
+            raise ValueError("Collection not initialized. Call create_col first.")
+        if vector_id not in self.docstore:
+            return None
+        return OutputData(id=vector_id, score=None, payload=self.docstore[vector_id].copy())
+
+    def list_cols(self) -> List[str]:
+        """
+        List all collections.
+
+        Returns:
+            List[str]: List of collection names.
+        """
+        if not self.path:
+            return [self.collection_name] if self.index else []
+        try:
+            return [file.stem for file in Path(self.path).glob("*.tq")]
+        except Exception as e:
+            logger.warning(f"Failed to list collections: {e}")
+            return [self.collection_name] if self.index else []
+
+    def delete_col(self):
+        """Delete the collection's files and reset in-memory state."""
+        if self.path:
+            try:
+                for suffix in (".tq", ".json"):
+                    file_path = f"{self.path}/{self.collection_name}{suffix}"
+                    if os.path.exists(file_path):
+                        os.remove(file_path)
+                logger.info(f"Deleted collection {self.collection_name}")
+            except Exception as e:
+                logger.warning(f"Failed to delete collection: {e}")
+
+        if self.index is not None:
+            self.index.close()
+        self.index = None
+        self.docstore = {}
+        self.id_map = {}
+        self.rev_map = {}
+        self.next_id = 0
+
+    def col_info(self) -> Dict:
+        """
+        Get information about the collection.
+
+        Returns:
+            Dict: Collection information.
+        """
+        if self.index is None:
+            return {"name": self.collection_name, "count": 0}
+        return {
+            "name": self.collection_name,
+            "count": len(self.index),
+            "dimension": self.index.dim,
+            "distance": "cosine",
+            "memory_bytes": self.index.memory_bytes,
+        }
+
+    def list(self, filters: Optional[Dict] = None, top_k: int = 100) -> List[OutputData]:
+        """
+        List vectors in the collection.
+
+        Args:
+            filters (Optional[Dict], optional): Payload filters.
+            top_k (int, optional): Maximum number of vectors to return. Defaults to 100.
+
+        Returns:
+            List[OutputData]: List of vectors.
+        """
+        if self.index is None:
+            return []
+
+        results = []
+        for memory_id, payload in self.docstore.items():
+            if filters and not self._apply_filters(payload, filters):
+                continue
+            results.append(OutputData(id=memory_id, score=None, payload=payload.copy()))
+            if len(results) >= top_k:
+                break
+        return [results]
+
+    def reset(self):
+        """Reset the collection by deleting and recreating it."""
+        logger.warning(f"Resetting index {self.collection_name}...")
+        self.delete_col()
+        self.create_col(self.collection_name)

--- a/tests/vector_stores/test_quantal.py
+++ b/tests/vector_stores/test_quantal.py
@@ -1,0 +1,136 @@
+import tempfile
+
+import numpy as np
+import pytest
+
+quantal = pytest.importorskip("quantal", reason="quantaldb not installed (pip install quantaldb)")
+
+from mem0.vector_stores.quantal import Quantal  # noqa: E402
+
+DIMS = 256
+
+
+def _vec(seed: int) -> list:
+    rng = np.random.default_rng(seed)
+    v = rng.standard_normal(DIMS).astype(np.float32)
+    return (v / np.linalg.norm(v)).tolist()
+
+
+@pytest.fixture
+def store():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        store = Quantal(collection_name="test", path=temp_dir, embedding_model_dims=DIMS)
+        yield store
+        store.delete_col()
+
+
+def test_insert_and_search(store):
+    vectors = [_vec(1), _vec(2), _vec(3)]
+    payloads = [{"user_id": "alice"}, {"user_id": "bob"}, {"user_id": "alice"}]
+    ids = ["id1", "id2", "id3"]
+    store.insert(vectors, payloads, ids)
+
+    results = store.search("query", [vectors[1]], top_k=2)
+    assert results[0].id == "id2"
+    assert results[0].payload == {"user_id": "bob"}
+    assert results[0].score == pytest.approx(1.0, abs=0.05)
+
+
+def test_search_with_filters(store):
+    vectors = [_vec(1), _vec(2), _vec(3)]
+    payloads = [{"user_id": "alice"}, {"user_id": "bob"}, {"user_id": "alice"}]
+    store.insert(vectors, payloads, ["id1", "id2", "id3"])
+
+    results = store.search("query", [vectors[1]], top_k=3, filters={"user_id": "alice"})
+    assert {r.id for r in results} == {"id1", "id3"}
+
+    assert store.search("query", [vectors[0]], top_k=3, filters={"user_id": "carol"}) == []
+
+
+def test_search_empty_collection(store):
+    assert store.search("query", [_vec(1)], top_k=5) == []
+
+
+def test_delete(store):
+    store.insert([_vec(1), _vec(2)], [{"a": 1}, {"a": 2}], ["id1", "id2"])
+    store.delete("id1")
+
+    assert store.get("id1") is None
+    results = store.search("query", [_vec(1)], top_k=2)
+    assert [r.id for r in results] == ["id2"]
+
+
+def test_update_payload(store):
+    store.insert([_vec(1)], [{"a": 1}], ["id1"])
+    store.update("id1", payload={"a": 2})
+    assert store.get("id1").payload == {"a": 2}
+
+
+def test_update_vector(store):
+    store.insert([_vec(1), _vec(2)], [{"a": 1}, {"a": 2}], ["id1", "id2"])
+    store.update("id1", vector=_vec(9))
+
+    results = store.search("query", [_vec(9)], top_k=1)
+    assert results[0].id == "id1"
+    assert results[0].payload == {"a": 1}
+
+
+def test_update_missing_raises(store):
+    with pytest.raises(ValueError):
+        store.update("missing", payload={"a": 1})
+
+
+def test_get(store):
+    store.insert([_vec(1)], [{"a": 1}], ["id1"])
+    result = store.get("id1")
+    assert result.id == "id1"
+    assert result.payload == {"a": 1}
+    assert store.get("missing") is None
+
+
+def test_list(store):
+    store.insert([_vec(1), _vec(2)], [{"user_id": "alice"}, {"user_id": "bob"}], ["id1", "id2"])
+
+    [results] = store.list()
+    assert {r.id for r in results} == {"id1", "id2"}
+
+    [results] = store.list(filters={"user_id": "alice"})
+    assert [r.id for r in results] == ["id1"]
+
+
+def test_list_cols_and_col_info(store):
+    store.insert([_vec(1)], [{"a": 1}], ["id1"])
+    assert "test" in store.list_cols()
+
+    info = store.col_info()
+    assert info["name"] == "test"
+    assert info["count"] == 1
+    assert info["dimension"] == DIMS
+    assert info["distance"] == "cosine"
+    assert info["memory_bytes"] > 0
+
+
+def test_persistence_roundtrip():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        store = Quantal(collection_name="test", path=temp_dir, embedding_model_dims=DIMS)
+        store.insert([_vec(1), _vec(2)], [{"a": 1}, {"a": 2}], ["id1", "id2"])
+        store.delete("id2")
+        del store
+
+        reloaded = Quantal(collection_name="test", path=temp_dir, embedding_model_dims=DIMS)
+        assert reloaded.get("id1").payload == {"a": 1}
+        assert reloaded.get("id2") is None
+        results = reloaded.search("query", [_vec(1)], top_k=1)
+        assert results[0].id == "id1"
+
+        # New inserts after a reload must not collide with prior internal ids.
+        reloaded.insert([_vec(3)], [{"a": 3}], ["id3"])
+        assert reloaded.get("id3").payload == {"a": 3}
+        reloaded.delete_col()
+
+
+def test_reset(store):
+    store.insert([_vec(1)], [{"a": 1}], ["id1"])
+    store.reset()
+    assert store.get("id1") is None
+    assert store.col_info()["count"] == 0


### PR DESCRIPTION
## Linked Issue

N/A

## Description

Adds [quantal](https://github.com/PaytonWebber/quantal) as a vector store provider. quantal is an embedded vector index (`pip install quantaldb`): no server to run, graph-routed search over quantized codes, so search stays sub-linear as memories accumulate and the index stores compressed data instead of full-precision vectors.

Provider notes:

- Similarity is always cosine (vectors are stored normalized and scored by inner product).
- Deletes are O(1) tombstones; removing a memory never rebuilds the index.
- Filtered searches (e.g. `user_id`) restrict scoring to the matching ids up front rather than over-fetching and post-filtering.
- Persistence is the index's native `.tq` format plus a JSON sidecar for payloads and id mapping, following the FAISS provider's layout.
- `keyword_search` is not implemented; hybrid retrieval degrades to dense-only per the `VectorStoreBase` contract.

Includes the config class, factory registration, docs page (registered in `docs.json` and the vectordbs overview), and unit tests.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [x] I tested manually (describe below)

`tests/vector_stores/test_quantal.py` covers insert/search, filtered search, delete, update (vector and payload), get, list, collection info, persistence roundtrip (including id-collision safety after reload), and reset; 12 tests, all passing locally against quantaldb 0.1.2. The tests `importorskip` quantal so CI without the package skips them. Also manually verified end-to-end creation through `VectorStoreFactory` and `VectorStoreConfig`.

Disclosure: I am the author of quantal.