### PR TITLE
ci: add CI and CD workflows for pi-agent-plugin

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,7 +7,9 @@ on:
 jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
-    if: startsWith(github.event.release.tag_name, 'v')
+    # Pure SDK version tags only (v1.2.3) — excludes package-prefixed tags
+    # like vercel-ai-v* that also start with 'v'
+    if: startsWith(github.event.release.tag_name, 'v') && !contains(github.event.release.tag_name, '-v')
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -39,7 +41,7 @@ jobs:
       #     packages_dir: dist/
 
       - name: Publish distribution 📦 to PyPI
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-v')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages_dir: dist/

--- a/.github/workflows/pi-agent-plugin-cd.yml
+++ b/.github/workflows/pi-agent-plugin-cd.yml
@@ -1,0 +1,46 @@
+name: Publish @mem0/pi-agent-plugin 📦 to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-n-publish:
+    name: Build and publish @mem0/pi-agent-plugin 📦 to npm
+    if: startsWith(github.event.release.tag_name, 'pi-agent-v')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    defaults:
+      run:
+        working-directory: pi-agent-plugin
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
+          cache-dependency-path: pi-agent-plugin/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Publish to npm
+        run: |
+          if [ "${{ github.event.release.prerelease }}" = "true" ]; then
+            PREID=$(node -p "require('./package.json').version.split('-')[1].split('.')[0]")
+            npx npm@latest publish --provenance --access public --tag "$PREID"
+          else
+            npx npm@latest publish --provenance --access public
+          fi

--- a/.github/workflows/pi-agent-plugin-checks.yml
+++ b/.github/workflows/pi-agent-plugin-checks.yml
@@ -1,0 +1,93 @@
+name: pi-agent-plugin checks
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'pi-agent-plugin/**'
+      - '.github/workflows/pi-agent-plugin-checks.yml'
+  pull_request:
+    paths:
+      - 'pi-agent-plugin/**'
+      - '.github/workflows/pi-agent-plugin-checks.yml'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+          cache-dependency-path: pi-agent-plugin/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: cd pi-agent-plugin && pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: cd pi-agent-plugin && pnpm exec tsc --noEmit
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+          cache-dependency-path: pi-agent-plugin/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: cd pi-agent-plugin && pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: cd pi-agent-plugin && pnpm exec vitest run
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+          cache-dependency-path: pi-agent-plugin/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: cd pi-agent-plugin && pnpm install --frozen-lockfile
+
+      - name: Build
+        run: cd pi-agent-plugin && pnpm build
+
+      - name: Verify dist output exists
+        run: |
+          test -f pi-agent-plugin/dist/index.js || (echo "Build output missing: dist/index.js" && exit 1)
+          test -f pi-agent-plugin/dist/index.d.ts || (echo "Build output missing: dist/index.d.ts" && exit 1)
+          test -f pi-agent-plugin/dist/entry.js || (echo "Build output missing: dist/entry.js" && exit 1)
+          test -f pi-agent-plugin/dist/entry.d.ts || (echo "Build output missing: dist/entry.d.ts" && exit 1)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -414,6 +414,7 @@ To add a new LLM, embedding, vector store, or reranker provider:
 | Node CLI | `cli-node-ci.yml` | Push to `cli/node/`, PRs, manual | Biome lint + tsc + vitest + tsup build on Node 20, 22 |
 | OpenClaw | `openclaw-checks.yml` | Push to `openclaw/`, PRs, manual | tsc + vitest (with Codecov) + tsup build on Node 20, 22 |
 | OpenCode Plugin | `opencode-plugin-checks.yml` | Push to `mem0-plugin/.opencode-plugin/`, PRs, manual | Bun: tsc type-check + build + dist artifact check |
+| Pi Agent Plugin | `pi-agent-plugin-checks.yml` | Push to `pi-agent-plugin/`, PRs, manual | tsc + vitest + tsup build (dist artifact check) on Node 20, 22 |
 
 ### CD Workflows (automated publishing)
 
@@ -426,6 +427,7 @@ To add a new LLM, embedding, vector store, or reranker provider:
 | Vercel AI SDK | `vercel-ai-cd.yml` | `vercel-ai-v*` | npm (`@mem0/vercel-ai-provider`) |
 | OpenClaw | `openclaw-cd.yml` | `openclaw-v*` | npm (`@mem0/openclaw-mem0`) |
 | OpenCode Plugin | `opencode-plugin-cd.yml` | `opencode-v*` | npm (`@mem0/opencode-plugin`) |
+| Pi Agent Plugin | `pi-agent-plugin-cd.yml` | `pi-agent-v*` | npm (`@mem0/pi-agent-plugin`) |
 
 - All publishing uses **OIDC trusted publishing** — no tokens or secrets required.
 - First publish of a new npm package must be done manually; OIDC works for subsequent versions.


### PR DESCRIPTION
## Linked Issue

N/A — infra addition for the recently added `pi-agent-plugin/` package, which currently has no CI or release automation, plus a fix for a tag-prefix collision in the existing Python CD workflow. (Happy to open a tracking issue if preferred.)

## Description

Adds GitHub Actions workflows for `pi-agent-plugin/` (`@mem0/pi-agent-plugin`), following the established patterns of the other npm packages in the monorepo:

- **`pi-agent-plugin-checks.yml`** (CI) — modeled on `openclaw-checks.yml`. Runs on pushes to `main` and PRs touching `pi-agent-plugin/`, plus manual dispatch:
  - `lint`: `tsc --noEmit` type check (Node 20)
  - `test`: `vitest run` on a Node 20/22 matrix
  - `build`: `pnpm build` (tsup) + verification that all four dist artifacts exist (`index.js`, `index.d.ts`, `entry.js`, `entry.d.ts`)
- **`pi-agent-plugin-cd.yml`** (CD) — modeled on `openclaw-cd.yml`. Publishes to npm via OIDC trusted publishing (`--provenance`, no tokens) on GitHub releases tagged `pi-agent-v*`. Prereleases publish under their preid dist-tag instead of `latest`.
- **`AGENTS.md`** — added both workflows to the CI/CD tables.

### Fix: Python CD fires on `vercel-ai-v*` tags

While auditing tag prefixes for collisions, found that `cd.yml` (Python SDK → PyPI) gates on `startsWith(tag_name, 'v')`, which also matches `vercel-ai-v*` tags — the existing `vercel-ai-v2.0.6` release would have triggered an unintended PyPI publish attempt of the Python SDK. The job condition now additionally requires `!contains(tag_name, '-v')`, which blocks `vercel-ai-v*` (and any future `<package>-v*` prefix that starts with `v`) while still matching all historical Python tags (`v1.2.3` style, no hyphens) and prerelease tags like `v2.1.0-beta.1`. The step-level `github.ref` guard was tightened the same way.

Verified no other collisions exist among the 8 tag prefixes (checked every prefix as a prefix of every other, e.g. `cli-v` vs `cli-node-v` diverge at the fifth character; `pi-agent-v*` matches nothing else and nothing else matches it).

Deliberate deviations from the openclaw CI: no `--coverage`/Codecov steps, since the package doesn't have `@vitest/coverage-v8` in its devDependencies; the dist check also covers the second tsup entry point (`entry.*`).

Note: the npm trusted publisher for `@mem0/pi-agent-plugin` must be configured (repo + `pi-agent-plugin-cd.yml`) before the first tagged release; the package is already published at 0.1.0 so OIDC publishing works for subsequent versions.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Manual verification: ran every command the workflows execute locally in `pi-agent-plugin/` — `pnpm install --frozen-lockfile`, `pnpm exec tsc --noEmit` (passes), `pnpm exec vitest run` (77 tests / 10 files, all pass), and `pnpm build` (all four dist artifacts produced). All workflow files validated as well-formed YAML. The `cd.yml` guard was checked against the full historical tag list: every `v*` tag in repo history is `v<digit>...` except `vercel-ai-v2.0.6`, which the new condition correctly excludes.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (N/A — workflow files; verified manually as described above)
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
