### PR TITLE
chore(pi-agent-plugin): bump version to 0.1.1

### DIFF
--- a/pi-agent-plugin/CHANGELOG.md
+++ b/pi-agent-plugin/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.1.1 (2026-06-10)
+
+Maintenance release — no functional changes.
+
+### Chores
+
+- Version bump to validate the new release pipeline (`pi-agent-plugin-checks.yml` / `pi-agent-plugin-cd.yml`)
+
 ## 0.1.0 (2026-06-09)
 
 Initial release of `@mem0/pi-agent-plugin` — persistent semantic memory for Pi Agent.

--- a/pi-agent-plugin/package.json
+++ b/pi-agent-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mem0/pi-agent-plugin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "Mem0 memory extension for Pi Agent persistent, scoped, semantic memory across sessions and projects",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Linked Issue

N/A — maintenance version bump to validate the release pipeline added in #5469.

## Description

Bumps `@mem0/pi-agent-plugin` from 0.1.0 to 0.1.1 and adds the corresponding CHANGELOG entry. No functional changes — this exists to exercise the new CI (`pi-agent-plugin-checks.yml`) and CD (`pi-agent-plugin-cd.yml`) workflows end-to-end once #5469 lands: merge this, publish a GitHub release tagged `pi-agent-v0.1.1`, and confirm the OIDC npm publish goes through.

Depends on #5469 (the workflows must be merged first for the release tag to do anything).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [x] No tests needed (explain why)

Version metadata and CHANGELOG only — no code changes. Existing suite still passes locally (77 tests / 10 files).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (N/A — version bump only)
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
