### PR TITLE
fix(pi-agent-plugin): correct repository.url for npm provenance validation

### DIFF
--- a/pi-agent-plugin/package.json
+++ b/pi-agent-plugin/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mem0ai/mem0/pi-agent-plugin",
+    "url": "https://github.com/mem0ai/mem0",
     "directory": "pi-agent-plugin"
   },
   "keywords": [


### PR DESCRIPTION
## Linked Issue

N/A — fixes the npm publish failure in the `pi-agent-v0.1.1` release run (follow-up to #5469 / #5471).

## Description

The `pi-agent-v0.1.1` release publish failed with E422: npm's sigstore provenance validation rejects the package because `repository.url` was `https://github.com/mem0ai/mem0/pi-agent-plugin`, which doesn't match the repo URL in the provenance statement (`https://github.com/mem0ai/mem0`):

```
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@mem0%2fpi-agent-plugin -
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "https://github.com/mem0ai/mem0/pi-agent-plugin",
expected to match "https://github.com/mem0ai/mem0" from provenance
```

This changes `repository.url` to `https://github.com/mem0ai/mem0`, matching the format used by the sibling packages that already publish with provenance (`mem0-ts`, `openclaw`). The monorepo subdirectory remains correctly expressed via the existing `"directory": "pi-agent-plugin"` field.

After merging, the `pi-agent-v0.1.1` tag and release need to be recreated on the new commit so the workflow builds a package.json containing the fix.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [x] No tests needed (explain why)

One-line package metadata fix; the validation happens on npm's side during publish. Format verified against `mem0-ts/package.json` and `openclaw/package.json`, both of which publish successfully with provenance.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (N/A — metadata fix)
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
