### PR TITLE
fix(openclaw): handle ERR_UNSUPPORTED_ESM_URL_SCHEME on Windows

### DIFF
--- a/openclaw/providers.ts
+++ b/openclaw/providers.ts
@@ -2,6 +2,8 @@
  * Mem0 provider implementations: Platform (cloud) and OSS (self-hosted).
  */
 
+import { createRequire } from "node:module";
+import { pathToFileURL } from "node:url";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type {
   Mem0Config,
@@ -12,6 +14,62 @@ import type {
   MemoryItem,
   AddResult,
 } from "./types.ts";
+
+// ============================================================================
+// Windows ESM URL helpers
+// ============================================================================
+
+/**
+ * Ensure `p` is a valid URL string that Node's ESM loader accepts.
+ *
+ * When OpenClaw loads a third-party plugin extension via a raw Windows
+ * absolute path (e.g. import("C:\\...\\dist\\index.js")), Node sets
+ * import.meta.url inside the loaded module to that raw path instead of a
+ * proper "file://" URL.  Any subsequent dynamic import("pkg-name") call then
+ * fails with ERR_UNSUPPORTED_ESM_URL_SCHEME because Node cannot use a bare
+ * drive-letter path as the base URL for package resolution.
+ *
+ * This helper detects raw paths (Windows drive-letter paths and POSIX absolute
+ * paths) and converts them to "file://" URLs so that createRequire() can
+ * resolve package specifiers correctly.
+ *
+ * @param p - a string that may be a URL or a raw filesystem path
+ * @returns a valid "file://" URL string, or the input unchanged if it already
+ *   has a URL scheme (file://, node:, data:, …)
+ */
+export function toFileUrl(p: string): string {
+  // Already has a multi-character URL scheme (file://, node:, data:, …).
+  // Single-letter prefixes like "C:" are Windows drive letters, not schemes.
+  if (/^[a-zA-Z]{2,}[a-zA-Z0-9+\-.]*:/.test(p)) return p;
+  // Raw filesystem path (Windows C:\... or C:/... or POSIX /...). Convert to
+  // a file:// URL so Node's ESM loader accepts it as a base URL.
+  // On macOS/Linux the Windows backslash path is normalised by replacing
+  // backslashes before handing it to pathToFileURL (which is POSIX-only).
+  const normalised = p.replace(/\\/g, "/");
+  return pathToFileURL(normalised).href;
+}
+
+/**
+ * Dynamically import a package specifier, falling back to createRequire when
+ * import.meta.url is a raw filesystem path (Windows ESM loader quirk).
+ *
+ * Returns the module namespace object (same shape as a dynamic import()).
+ */
+async function safeImport(specifier: string): Promise<any> {
+  const metaUrl = import.meta.url;
+  // If import.meta.url already has a multi-character URL scheme it is valid.
+  // Single-letter "schemes" like "C:" are Windows drive letters, not URLs.
+  if (/^[a-zA-Z]{2,}[a-zA-Z0-9+\-.]*:/.test(metaUrl)) {
+    return import(specifier);
+  }
+  // import.meta.url is a raw path (Windows raw-path loader). createRequire
+  // needs a "file://" URL or an absolute path; convert so resolution works.
+  const req = createRequire(toFileUrl(metaUrl));
+  const mod = req(specifier);
+  // Wrap in a synthetic ESM namespace: CJS module.exports → default export.
+  // Named exports (if any) are spread alongside default for interop.
+  return { default: mod, ...mod };
+}
 
 // ============================================================================
 // Result Normalizers
@@ -95,7 +153,7 @@ class PlatformProvider implements Mem0Provider {
   }
 
   private async _init(): Promise<void> {
-    const { default: MemoryClient } = await import("mem0ai");
+    const { default: MemoryClient } = await safeImport("mem0ai");
     const opts: {
       apiKey: string;
       host?: string;
@@ -316,7 +374,7 @@ class OSSProvider implements Mem0Provider {
   }
 
   private async _init(): Promise<void> {
-    const mod = await import("mem0ai/oss");
+    const mod = await safeImport("mem0ai/oss");
     const Memory = mod.Memory;
     for (const cls of ["PGVector", "RedisDB", "Qdrant"]) {
       const VectorCls = (mod as any)[cls];
@@ -348,7 +406,7 @@ class OSSProvider implements Mem0Provider {
     if (!this.ossConfig?.disableHistory) {
       try {
         // @ts-ignore — better-sqlite3 is a transitive dep; no types in this package
-        const bs3Mod = await import("better-sqlite3");
+        const bs3Mod = await safeImport("better-sqlite3");
         const BS3 = bs3Mod.default ?? bs3Mod;
         const testDb = new (BS3 as any)(":memory:");
         (testDb as any).close();

--- a/openclaw/skill-loader.ts
+++ b/openclaw/skill-loader.ts
@@ -7,6 +7,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { SkillsConfig, CategoryConfig } from "./types.ts";
 import { readText, exists } from "./fs-safe.ts";
+import { toFileUrl } from "./providers.ts";
 
 // ============================================================================
 // Defaults
@@ -94,9 +95,11 @@ function parseSkillFile(content: string): ParsedSkill {
 function resolveSkillsDir(): string {
   const candidates: string[] = [];
 
-  // Strategy 1: import.meta.url (works in native ESM)
+  // Strategy 1: import.meta.url (works in native ESM and Windows raw-path loaders)
+  // toFileUrl() normalises raw Windows paths (C:\...) to file:// URLs so that
+  // fileURLToPath() can convert them back to the correct filesystem path.
   try {
-    const metaDir = path.dirname(fileURLToPath(import.meta.url));
+    const metaDir = path.dirname(fileURLToPath(toFileUrl(import.meta.url)));
     candidates.push(path.join(metaDir, "skills"));
     candidates.push(path.join(metaDir, "..", "skills"));
   } catch {

--- a/openclaw/tests/windows-esm.test.ts
+++ b/openclaw/tests/windows-esm.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Regression tests for Windows ESM URL scheme fix (#5069).
+ *
+ * On Windows, OpenClaw 5.4 loads plugin extensions via a raw absolute path
+ * (e.g. import("C:\\...\\dist\\index.js")). Node's ESM loader then sets
+ * import.meta.url to the raw path inside the loaded module. Any subsequent
+ * dynamic import("pkg-name") call fails with ERR_UNSUPPORTED_ESM_URL_SCHEME
+ * because Node cannot parse "C:\..." as a base URL for package resolution.
+ *
+ * The fix is to export a `toFileUrl` helper from providers.ts that converts
+ * raw Windows (and POSIX) absolute paths to proper "file://" URLs, so that
+ * createRequire(toFileUrl(import.meta.url)) can resolve package specifiers
+ * correctly regardless of how the host loader set import.meta.url.
+ *
+ * These tests are fully cross-platform: they simulate Windows path strings
+ * without requiring a Windows runtime.
+ */
+import { describe, it, expect } from "vitest";
+import { toFileUrl } from "../providers.ts";
+
+describe("toFileUrl — Windows path normalisation", () => {
+  it("converts a Windows absolute path to a file:// URL", () => {
+    const result = toFileUrl("C:\\Users\\xs\\.openclaw\\npm\\node_modules\\@mem0\\openclaw-mem0\\dist\\index.js");
+    expect(result).toMatch(/^file:\/\/\//);
+    expect(result).toContain("C:/");
+    expect(result).not.toContain("\\");
+  });
+
+  it("converts a Windows path with forward slashes to a file:// URL", () => {
+    const result = toFileUrl("C:/Users/xs/.openclaw/npm/node_modules/@mem0/openclaw-mem0/dist/index.js");
+    expect(result).toMatch(/^file:\/\/\//);
+    expect(result).toContain("C:/");
+  });
+
+  it("returns an already-valid file:// URL unchanged", () => {
+    const url = "file:///C:/Users/xs/.openclaw/npm/node_modules/mem0ai/dist/index.js";
+    expect(toFileUrl(url)).toBe(url);
+  });
+
+  it("converts a POSIX absolute path to a file:// URL", () => {
+    const result = toFileUrl("/home/user/.openclaw/npm/node_modules/@mem0/openclaw-mem0/dist/index.js");
+    expect(result).toMatch(/^file:\/\//);
+  });
+
+  it("returns a file:// POSIX URL unchanged", () => {
+    const url = "file:///home/user/.openclaw/npm/node_modules/mem0ai/dist/index.js";
+    expect(toFileUrl(url)).toBe(url);
+  });
+
+  it("returns a node: URL unchanged", () => {
+    expect(toFileUrl("node:path")).toBe("node:path");
+  });
+});


### PR DESCRIPTION
## Linked Issue

Closes #5069

## Description

On Windows, OpenClaw 5.4 loads third-party plugin extensions via a raw absolute path (e.g. `import("C:\\Users\\...\\dist\\index.js")`). Node sets `import.meta.url` inside the loaded module to that raw path instead of a proper `file://` URL. The first lazy `import("package-name")` call — triggered when autoRecall or autoCapture first runs — then fails with:

```
ERR_UNSUPPORTED_ESM_URL_SCHEME: Only URLs with a scheme in: file, data, and node are supported
by the default ESM loader. On Windows, absolute paths must be valid file:// URLs.
Received protocol 'c:'
```

This is exactly why the reporter sees `recall failed` and `capture failed` in the logs: those hook handlers trigger the lazy `import("mem0ai")` initialization in PlatformProvider or OSSProvider.

**Root cause:** `import.meta.url` is set to `"C:\\...\\dist\\index.js"` (no `file://` scheme). Node uses `import.meta.url` as the base URL for package specifier resolution. A bare drive-letter path is not a valid URL, so resolution fails.

**Fix:** Two additions in `providers.ts`:

1. **`toFileUrl(p)`** — exported, tested: converts a raw Windows or POSIX path to a `file://` URL. Multi-character URL schemes (`file://`, `node:`, `data:`) pass through unchanged. Single-letter prefixes like `C:` are correctly treated as Windows drive letters, not URL schemes.

2. **`safeImport(specifier)`** — internal: wraps each lazy `import()`. If `import.meta.url` has a valid multi-char scheme it calls native `import()` unchanged. Otherwise falls back to `createRequire(toFileUrl(import.meta.url))` so packages (`mem0ai`, `mem0ai/oss`, `better-sqlite3`) resolve from the correct base path.

`skill-loader.ts` `resolveSkillsDir()` also uses `toFileUrl()` so that `fileURLToPath(import.meta.url)` correctly locates the skills directory on Windows.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A. On POSIX or when `import.meta.url` is already a `file://` URL (the normal case), `safeImport` calls native `import()` unchanged. No public API changes.

## Test Coverage

- [x] I added/updated unit tests (`openclaw/tests/windows-esm.test.ts`)

### RED — before fix

```
 FAIL  tests/windows-esm.test.ts (6 tests | 6 failed)
TypeError: toFileUrl is not a function
 ❯ tests/windows-esm.test.ts:23:20
```

### GREEN — after fix

```
 Test Files  1 passed (1)
      Tests  6 passed (6)
   Duration  114ms
```

### Full gate (all openclaw tests)

```
 Test Files  16 passed (16)
      Tests  440 passed (440)
   Duration  490ms
```

`pnpm exec tsc --noEmit` exits 0.

## Honesty notes

- Verified by code tracing and unit tests on macOS. The `toFileUrl` conversion is exercised with literal Windows-style path strings — no Windows runtime needed.
- The `safeImport` fallback branch is not exercised at runtime on macOS (it only fires when `import.meta.url` lacks a URL scheme). Runtime verification on Windows was not performed.
- Issue #5204 ("error when install @mem0/openclaw-mem0") has a different root cause (npm arborist failure during `openclaw plugins install`) and is **not** addressed by this PR.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed