### PR TITLE
fix(cli-python): import Exit from typer instead of click in tests

### DIFF
--- a/cli/python/tests/test_commands.py
+++ b/cli/python/tests/test_commands.py
@@ -8,8 +8,8 @@ from io import StringIO
 from unittest.mock import patch
 
 import pytest
-from click.exceptions import Exit as ClickExit
 from rich.console import Console
+from typer import Exit as TyperExit
 
 from mem0_cli.commands.config_cmd import (
     cmd_config_get,
@@ -181,7 +181,7 @@ class TestAddCommand:
             patch("mem0_cli.commands.memory.console", console),
             patch("mem0_cli.commands.memory.err_console", err_console),
             patch("mem0_cli.commands.memory._stdin_is_piped", return_value=False),
-            pytest.raises((SystemExit, ClickExit)),
+            pytest.raises((SystemExit, TyperExit)),
         ):
             cmd_add(
                 mock_backend,
@@ -206,7 +206,7 @@ class TestAddCommand:
         with (
             patch("mem0_cli.commands.memory.console", console),
             patch("mem0_cli.commands.memory.err_console", err_console),
-            pytest.raises((SystemExit, ClickExit)),
+            pytest.raises((SystemExit, TyperExit)),
         ):
             cmd_add(
                 mock_backend,
@@ -764,7 +764,7 @@ class TestImportCommand:
         with (
             patch("mem0_cli.commands.utils.console", console),
             patch("mem0_cli.commands.utils.err_console", err_console),
-            pytest.raises((SystemExit, ClickExit)),
+            pytest.raises((SystemExit, TyperExit)),
         ):
             cmd_import(mock_backend, "/nonexistent/file.json", user_id=None, agent_id=None)
 
@@ -801,7 +801,7 @@ class TestEntitiesListCommand:
         with (
             patch("mem0_cli.commands.entities.console", console),
             patch("mem0_cli.commands.entities.err_console", err_console),
-            pytest.raises((SystemExit, ClickExit)),
+            pytest.raises((SystemExit, TyperExit)),
         ):
             cmd_entities_list(mock_backend, "invalid", output="table")
 
@@ -944,7 +944,7 @@ class TestEntitiesDeleteCommand:
         with (
             patch("mem0_cli.commands.entities.console", console),
             patch("mem0_cli.commands.entities.err_console", err_console),
-            pytest.raises((SystemExit, ClickExit)),
+            pytest.raises((SystemExit, TyperExit)),
         ):
             cmd_entities_delete(
                 mock_backend,
@@ -1308,7 +1308,7 @@ class TestAgentMode:
             patch("mem0_cli.commands.memory.console", console),
             patch("mem0_cli.commands.memory.err_console", err_console),
             patch("sys.stdout", captured_stdout),
-            pytest.raises((SystemExit, ClickExit)),
+            pytest.raises((SystemExit, TyperExit)),
         ):
             cmd_get(mock_backend, "bad-id", output="text")
 


### PR DESCRIPTION
## Linked Issue

N/A — fixes the `Python CLI / test` failure surfaced by the CI Gate run on #5476 (https://github.com/mem0ai/mem0/actions/runs/27293136169).

## Description

`cli/python` tests fail at collection with `ModuleNotFoundError: No module named 'click'`. Root cause: **typer ≥ 0.26 vendored click** (its dependencies are now `annotated-doc`, `rich`, `shellingham` — no `click`), so a fresh `pip install -e ".[dev]"` no longer installs the standalone `click` package. The test file imported `from click.exceptions import Exit as ClickExit`, which is broken on two counts under new typer: the module is missing, and even with `click` installed it would be a *different class* than the vendored `typer.Exit` the CLI actually raises — so `pytest.raises((SystemExit, ClickExit))` would silently stop catching the right exception.

Fix: import `Exit` from `typer` (`from typer import Exit as TyperExit`), which is correct on both old typer (where `typer.Exit` *is* click's `Exit`) and new typer (vendored). The CLI source already uses `typer.Exit` everywhere — only the test file needed the change.

This is a pre-existing breakage on `main` (resolver drift), not caused by the CI Gate PR — the gate surfaced it because the Python CLI pipeline hadn't run recently.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Reproduced the CI failure locally with a fresh venv (`pip install -e ".[dev]"` resolves typer 0.26.7, `import click` fails). With the fix: all **161 tests pass** and `ruff check .` is clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
