### PR TITLE
fix(server): upgrade python-dotenv to >=1.2.2 (CVE-2026-28684)

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -2,7 +2,7 @@ fastapi==0.115.8
 uvicorn==0.34.0
 pydantic[email]==2.10.4
 mem0ai>=0.1.48
-python-dotenv==1.0.1
+python-dotenv>=1.2.2,<2.0.0
 psycopg>=3.2.8
 psycopg-pool>=3.2.6,<4.0.0
 


### PR DESCRIPTION
## Linked Issue

N/A — security patch for Vanta/Dependabot alert #762.

## Description

Upgrades `python-dotenv` in `server/requirements.txt` from the pinned `1.0.1` to `>=1.2.2,<2.0.0` to resolve CVE-2026-28684.

## Vulnerability

- **CVE:** CVE-2026-28684
- **Severity:** MEDIUM
- **Affected:** `python-dotenv` < 1.2.2
- **Patched:** 1.2.2
- **Advisory:** https://github.com/advisories/GHSA-gc5v-m9x4-r6x2 (linked via Dependabot alert #762)

## Root cause

`set_key()` and `unset_key()` in python-dotenv follow symbolic links when rewriting `.env` files. A local attacker can craft a symlink to overwrite arbitrary files when a cross-device rename fallback is triggered. Fixed in 1.2.2 by eliminating the symlink-following behaviour in the `rewrite()` context manager.

## Scope

Only `server/requirements.txt` changes. No code changes.

**Note:** A second alert (#760) for `poetry.lock` remains open — it is blocked because `litellm==1.83.7` (the current latest) pins `python-dotenv==1.0.1` exactly as a hard dependency. That alert will be resolved once litellm publishes a version that relaxes this constraint.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] No tests needed — manifest-only change, no code paths altered.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally