### PR TITLE
fix: delete_all now drains all pages, not just the first batch

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1725,12 +1725,17 @@ class Memory(MemoryBase):
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "sync"})
-        # delete all vector memories and reset the collections
-        memories = self.vector_store.list(filters=filters)[0]
-        for memory in memories:
-            self._delete_memory(memory.id)
 
-        logger.info(f"Deleted {len(memories)} memories")
+        total_deleted = 0
+        while True:
+            memories = self.vector_store.list(filters=filters)[0]
+            if not memories:
+                break
+            for memory in memories:
+                self._delete_memory(memory.id)
+            total_deleted += len(memories)
+
+        logger.info(f"Deleted {total_deleted} memories")
 
         decay_usage_notice = detect_decay_usage_from_delete_all(len(memories))
         if decay_usage_notice:
@@ -3235,15 +3240,18 @@ class AsyncMemory(MemoryBase):
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "async"})
-        memories = await asyncio.to_thread(self.vector_store.list, filters=filters)
 
-        delete_tasks = []
-        for memory in memories[0]:
-            delete_tasks.append(self._delete_memory(memory.id))
+        total_deleted = 0
+        while True:
+            memories = await asyncio.to_thread(self.vector_store.list, filters=filters)
+            batch = memories[0]
+            if not batch:
+                break
+            delete_tasks = [self._delete_memory(memory.id) for memory in batch]
+            await asyncio.gather(*delete_tasks)
+            total_deleted += len(batch)
 
-        await asyncio.gather(*delete_tasks)
-
-        logger.info(f"Deleted {len(memories[0])} memories")
+        logger.info(f"Deleted {total_deleted} memories")
 
         decay_usage_notice = detect_decay_usage_from_delete_all(len(memories[0]))
         if decay_usage_notice:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1056,3 +1056,66 @@ class TestHybridSearchWarning:
             Memory(config)
 
         assert not any("does not support keyword search" in r.message for r in caplog.records)
+
+
+class TestDeleteAllPagination:
+
+    @patch('mem0.utils.factory.EmbedderFactory.create')
+    @patch('mem0.utils.factory.VectorStoreFactory.create')
+    @patch('mem0.utils.factory.LlmFactory.create')
+    @patch('mem0.memory.storage.SQLiteManager')
+    def test_delete_all_drains_multiple_pages(self, mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
+        mock_embedder_factory.return_value = MagicMock()
+        mock_vector_store = MagicMock()
+        mock_vector_factory.return_value = mock_vector_store
+        mock_llm_factory.return_value = MagicMock()
+        mock_sqlite.return_value = MagicMock()
+
+        page1 = [MockVectorMemory(f"mem-{i}", {"data": f"d{i}"}) for i in range(100)]
+        page2 = [MockVectorMemory(f"mem-{i}", {"data": f"d{i}"}) for i in range(100, 150)]
+
+        mock_vector_store.list.side_effect = [
+            (page1, "next"),
+            (page2, "next"),
+            ([], None),
+        ]
+        mock_vector_store.get.return_value = MockVectorMemory("x", {"data": "x", "created_at": "2026-01-01T00:00:00+00:00"})
+
+        config = MemoryConfig()
+        memory = Memory(config)
+
+        memory.delete_all(user_id="test_user")
+
+        assert mock_vector_store.list.call_count == 3
+        assert mock_vector_store.delete.call_count == 150
+
+    @pytest.mark.asyncio
+    @patch('mem0.utils.factory.EmbedderFactory.create')
+    @patch('mem0.utils.factory.VectorStoreFactory.create')
+    @patch('mem0.utils.factory.LlmFactory.create')
+    @patch('mem0.memory.storage.SQLiteManager')
+    async def test_async_delete_all_drains_multiple_pages(self, mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
+        mock_embedder_factory.return_value = MagicMock()
+        mock_vector_store = MagicMock()
+        mock_vector_factory.return_value = mock_vector_store
+        mock_llm_factory.return_value = MagicMock()
+        mock_sqlite.return_value = MagicMock()
+
+        page1 = [MockVectorMemory(f"mem-{i}", {"data": f"d{i}"}) for i in range(100)]
+        page2 = [MockVectorMemory(f"mem-{i}", {"data": f"d{i}"}) for i in range(100, 150)]
+
+        mock_vector_store.list.side_effect = [
+            (page1, "next"),
+            (page2, "next"),
+            ([], None),
+        ]
+        mock_vector_store.get.return_value = MockVectorMemory("x", {"data": "x", "created_at": "2026-01-01T00:00:00+00:00"})
+
+        from mem0.memory.main import AsyncMemory
+        config = MemoryConfig()
+        memory = AsyncMemory(config)
+
+        await memory.delete_all(user_id="test_user")
+
+        assert mock_vector_store.list.call_count == 3
+        assert mock_vector_store.delete.call_count == 150


### PR DESCRIPTION
Closes #4869

### Problem

`delete_all()` calls `vector_store.list(filters=filters)` once, which returns at most `top_k` records (default 100). If a user has more memories than the page size, the extra ones survive the deletion.

### Fix

Wrap the list+delete in a `while` loop that keeps calling `list()` until an empty batch comes back. Since each iteration deletes the returned records, the next call naturally returns the next batch.

Both sync and async paths are fixed.

### Tests

Added 2 tests in `TestDeleteAllPagination`:
- Sync: mock returns 3 pages (100 + 50 + 0), asserts all 150 deleted
- Async: same scenario

All 45 tests pass.