### PR TITLE
fix: return 400 instead of 502 for invalid search filters

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -451,6 +451,8 @@ def search_memories(search_req: SearchRequest, _auth=Depends(verify_auth)):
         if search_req.explain is not None:
             params["explain"] = search_req.explain
         return get_memory_instance().search(query=search_req.query, filters=filters, **params)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except Exception:
         raise upstream_error()
 

--- a/server/main.py
+++ b/server/main.py
@@ -453,6 +453,8 @@ def search_memories(search_req: SearchRequest, _auth=Depends(verify_auth)):
         return get_memory_instance().search(query=search_req.query, filters=filters, **params)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    except HTTPException:
+        raise
     except Exception:
         raise upstream_error()
 

--- a/tests/test_server_params.py
+++ b/tests/test_server_params.py
@@ -682,3 +682,22 @@ class TestSearchEntityIdMapping:
         _, kwargs = mock_memory.search.call_args
         assert kwargs["filters"]["user_id"] == "u1"
         assert kwargs["filters"]["category"] == "food"
+
+
+class TestSearchValidationErrors:
+    """Verify that ValueError from Memory.search() returns 400, not 502."""
+
+    def test_empty_filters_returns_400(self, client, mock_memory):
+        mock_memory.search.side_effect = ValueError(
+            "filters must contain at least one of: user_id, agent_id, run_id"
+        )
+        resp = client.post("/search", json={"query": "food", "filters": {}})
+        assert resp.status_code == 400
+        assert "filters must contain" in resp.json()["detail"]
+
+    def test_no_identifiers_returns_400(self, client, mock_memory):
+        mock_memory.search.side_effect = ValueError(
+            "filters must contain at least one of: user_id, agent_id, run_id"
+        )
+        resp = client.post("/search", json={"query": "food"})
+        assert resp.status_code == 400


### PR DESCRIPTION
Closes #5367

### Problem

`POST /search` with empty or missing filter identifiers raises `ValueError` from `Memory.search()`. The server's generic `except Exception` catches it and maps it to a 502 upstream error, making it look like an infrastructure failure when it's actually a client input issue.

### Fix

Catch `ValueError` before the catch-all `except Exception` in the `/search` endpoint handler and raise `HTTPException(status_code=400)` with the original validation message.

### Tests

Added 2 tests in `TestSearchValidationErrors`:
- Empty filters returns 400 with validation message
- No identifiers at all returns 400

All existing tests pass.