### PR TITLE
fix(dashboard): pin pnpm to 10.34.2 so docker build works on node:20-alpine

### DIFF
--- a/server/dashboard/package.json
+++ b/server/dashboard/package.json
@@ -2,6 +2,7 @@
   "name": "mem0-dashboard",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@10.34.2",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Linked Issue

Closes #5291 — same `ERR_UNKNOWN_BUILTIN_MODULE: node:sqlite` failure during `server/dashboard` docker build, same root cause (corepack pulling pnpm 11.x on Node 20).

## Description

`server/dashboard/Dockerfile` builds on `node:20-alpine` and runs:

```dockerfile
corepack enable pnpm && pnpm i
```

without pinning a pnpm version. With no `packageManager` field in `server/dashboard/package.json`, corepack resolves to the **latest pnpm on npm**. Since pnpm 11.5.3 (and the rest of the 11.x line), pnpm requires Node >= 22.13. The build now fails immediately with:

```
warn: This version of pnpm requires at least Node.js v22.13
warn: The current version of Node.js is v20.20.2
Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
```

This breaks the documented `docker-compose up` flow in `server/` (see project `CLAUDE.md` "Server" section) for anyone who runs a fresh build today.

This PR pins pnpm to `10.34.2`, the latest 10.x release:

- Supports Node 18+, so `node:20-alpine` keeps working.
- Lockfile is `lockfileVersion: '9.0'`, fully compatible with pnpm 10.x — no lockfile regen required.
- Smallest possible change; no Dockerfile / Node bump needed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update

## Breaking Changes

None. Pin matches what the existing v9 lockfile was generated against.

## Test Coverage

- [ ] Unit tests
- [ ] Integration tests
- [x] Tested manually

Manual verification on a fresh checkout:

```bash
cd server
docker compose build mem0-dashboard   # fails on main
# apply this patch
docker compose build mem0-dashboard   # succeeds
docker compose up -d mem0-dashboard
curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3000/api/health   # 200
```

- [ ] No tests needed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] Tested manually (build + dashboard health check pass)
- [x] New and existing tests pass locally
- [x] No documentation update needed (CLAUDE.md "Server" instructions already point at `docker-compose up`)
