### PR TITLE
fix: compute score_and_rank divisor per candidate instead of globally

### DIFF
--- a/mem0/utils/scoring.py
+++ b/mem0/utils/scoring.py
@@ -74,7 +74,8 @@ def score_and_rank(
     Threshold gates the semantic score BEFORE combining -- candidates
     below the threshold are excluded even if BM25/entity would boost them.
 
-    The divisor adapts based on which signals are active:
+    The divisor adapts per candidate based on which signals that
+    candidate actually received:
         - Semantic only: max_possible = 1.0
         - Semantic + BM25: max_possible = 2.0
         - Semantic + BM25 + entity: max_possible = 2.5
@@ -91,15 +92,6 @@ def score_and_rank(
     Returns:
         List of scored result dicts sorted by combined score descending.
     """
-    has_bm25 = bool(bm25_scores)
-    has_entity = bool(entity_boosts)
-
-    max_possible = 1.0
-    if has_bm25:
-        max_possible += 1.0
-    if has_entity:
-        max_possible += ENTITY_BOOST_WEIGHT
-
     scored: List[Dict[str, Any]] = []
 
     for result in semantic_results:
@@ -114,6 +106,12 @@ def score_and_rank(
         mem_id_str = str(mem_id)
         bm25_score = bm25_scores.get(mem_id_str, 0.0)
         entity_boost = entity_boosts.get(mem_id_str, 0.0)
+
+        max_possible = 1.0
+        if bm25_score > 0.0:
+            max_possible += 1.0
+        if entity_boost > 0.0:
+            max_possible += ENTITY_BOOST_WEIGHT
 
         raw_combined = semantic_score + bm25_score + entity_boost
         combined = min(raw_combined / max_possible, 1.0)

--- a/tests/utils/test_scoring.py
+++ b/tests/utils/test_scoring.py
@@ -149,6 +149,45 @@ class TestScoreAndRank:
         assert "score_details" not in scored[0]
 
 
+    def test_per_candidate_divisor_no_penalty_for_missing_bm25(self):
+        results = [
+            {"id": "a", "score": 0.9, "payload": {"data": "mem a"}},
+            {"id": "b", "score": 0.7, "payload": {"data": "mem b"}},
+        ]
+        bm25 = {"b": 0.8}
+        scored = score_and_rank(results, bm25, {}, threshold=0.1, top_k=10)
+        # "a" has no BM25 hit -> max_possible=1.0 -> score=0.9
+        # "b" has BM25 hit -> max_possible=2.0 -> score=(0.7+0.8)/2.0=0.75
+        assert scored[0]["id"] == "a"
+        assert scored[0]["score"] == pytest.approx(0.9)
+        assert scored[1]["id"] == "b"
+        assert scored[1]["score"] == pytest.approx(0.75)
+
+    def test_per_candidate_divisor_entity_only_one_candidate(self):
+        results = [
+            {"id": "a", "score": 0.8, "payload": {"data": "mem a"}},
+            {"id": "b", "score": 0.7, "payload": {"data": "mem b"}},
+        ]
+        entity = {"a": 0.4}
+        scored = score_and_rank(results, {}, entity, threshold=0.1, top_k=10)
+        # "a": (0.8+0.4)/1.5=0.8
+        # "b": 0.7/1.0=0.7
+        assert scored[0]["id"] == "a"
+        assert scored[0]["score"] == pytest.approx(0.8)
+        assert scored[1]["id"] == "b"
+        assert scored[1]["score"] == pytest.approx(0.7)
+
+    def test_per_candidate_divisor_explain_shows_candidate_max(self):
+        results = [
+            {"id": "a", "score": 0.9, "payload": {"data": "mem a"}},
+            {"id": "b", "score": 0.7, "payload": {"data": "mem b"}},
+        ]
+        bm25 = {"b": 0.6}
+        scored = score_and_rank(results, bm25, {}, threshold=0.1, top_k=10, explain=True)
+        assert scored[0]["score_details"]["max_possible_score"] == 1.0
+        assert scored[1]["score_details"]["max_possible_score"] == 2.0
+
+
 class TestEntityBoostWeight:
     def test_weight_value(self):
         assert ENTITY_BOOST_WEIGHT == 0.5


### PR DESCRIPTION
## Summary

`score_and_rank` computes a `max_possible` divisor based on whether **any** candidate in the result set has BM25 or entity scores, then applies that divisor to **all** candidates. This systematically penalizes memories that matched only on semantic similarity when other memories happened to have keyword hits.

**Example:** A memory with `semantic_score=0.9` and no BM25 match gets normalized to `0.9 / 2.0 = 0.45` simply because a different memory in the same result set had a BM25 score. The memory's final score is halved through no fault of its own.

## Fix

Move `max_possible` computation inside the per-candidate loop so each memory's divisor reflects only the signals **it** actually received:

- Semantic only → `max_possible = 1.0`
- Semantic + BM25 → `max_possible = 2.0`
- Semantic + entity → `max_possible = 1.5`
- All three → `max_possible = 2.5`

This ensures a purely semantic match is never penalized by another candidate's keyword or entity hit.

## Test plan

- [x] Added `test_per_candidate_divisor_no_penalty_for_missing_bm25` — verifies semantic-only candidate keeps full score when another has BM25
- [x] Added `test_per_candidate_divisor_entity_only_one_candidate` — verifies entity boost only affects the candidate that has it
- [x] Added `test_per_candidate_divisor_explain_shows_candidate_max` — verifies `score_details.max_possible_score` reflects per-candidate value
- [x] All 23 scoring tests pass (20 existing + 3 new)