### PR TITLE
fix: remove dead _process_config method in Memory and AsyncMemory

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -560,20 +560,11 @@ class Memory(MemoryBase):
     @classmethod
     def from_config(cls, config_dict: Dict[str, Any]):
         try:
-            config = cls._process_config(config_dict)
             config = MemoryConfig(**config_dict)
         except ValidationError as e:
             logger.error(f"Configuration validation error: {e}")
             raise
         return cls(config)
-
-    @staticmethod
-    def _process_config(config_dict: Dict[str, Any]) -> Dict[str, Any]:
-        try:
-            return config_dict
-        except ValidationError as e:
-            logger.error(f"Configuration validation error: {e}")
-            raise
 
     def _should_use_agent_memory_extraction(self, messages, metadata):
         """Determine whether to use agent memory extraction based on the logic:
@@ -2027,20 +2018,11 @@ class AsyncMemory(MemoryBase):
     @classmethod
     def from_config(cls, config_dict: Dict[str, Any]):
         try:
-            config = cls._process_config(config_dict)
             config = MemoryConfig(**config_dict)
         except ValidationError as e:
             logger.error(f"Configuration validation error: {e}")
             raise
         return cls(config)
-
-    @staticmethod
-    def _process_config(config_dict: Dict[str, Any]) -> Dict[str, Any]:
-        try:
-            return config_dict
-        except ValidationError as e:
-            logger.error(f"Configuration validation error: {e}")
-            raise
 
     def _should_use_agent_memory_extraction(self, messages, metadata):
         """Determine whether to use agent memory extraction based on the logic:


### PR DESCRIPTION
## Summary

`_process_config()` is a no-op — it wraps `return config_dict` in a `try/except ValidationError` that can never fire on a bare return statement. Its return value in `from_config()` is also immediately overwritten on the next line:

```python
config = cls._process_config(config_dict)  # returns config_dict unchanged
config = MemoryConfig(**config_dict)        # overwrites the variable
```

This dead code exists in both `Memory` and `AsyncMemory`.

## Fix

Remove `_process_config()` and the unused call in both classes. `from_config()` now directly calls `MemoryConfig(**config_dict)`.

## Test plan

- [x] All 43 existing memory tests pass — no behavior change
- [x] `from_config()` still validates config via `MemoryConfig(**config_dict)` and raises `ValidationError` on bad input