### PR TITLE
fix: prevent crash in parse_vision_messages when vision is disabled

### DIFF
--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -184,6 +184,8 @@ def parse_vision_messages(messages, llm=None, vision_details="auto"):
                     part["text"] for part in msg["content"]
                     if isinstance(part, dict) and part.get("type") == "text"
                 ]
+                if not text_parts:
+                    continue
                 returned_messages.append({"role": msg["role"], "content": " ".join(text_parts)})
             else:
                 description = get_image_description(msg, llm, vision_details)

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -179,11 +179,18 @@ def parse_vision_messages(messages, llm=None, vision_details="auto"):
 
         # Handle message content
         if isinstance(msg["content"], list):
-            # Multiple image URLs in content
-            description = get_image_description(msg, llm, vision_details)
-            returned_messages.append({"role": msg["role"], "content": description})
+            if llm is None:
+                text_parts = [
+                    part["text"] for part in msg["content"]
+                    if isinstance(part, dict) and part.get("type") == "text"
+                ]
+                returned_messages.append({"role": msg["role"], "content": " ".join(text_parts)})
+            else:
+                description = get_image_description(msg, llm, vision_details)
+                returned_messages.append({"role": msg["role"], "content": description})
         elif isinstance(msg["content"], dict) and msg["content"].get("type") == "image_url":
-            # Single image content
+            if llm is None:
+                continue
             image_url = msg["content"]["image_url"]["url"]
             try:
                 description = get_image_description(image_url, llm, vision_details)

--- a/tests/memory/test_memory_utils.py
+++ b/tests/memory/test_memory_utils.py
@@ -39,6 +39,15 @@ class TestParseVisionMessages:
         assert result[0]["content"] == "A photo of a cat"
         mock_llm.generate_response.assert_called_once()
 
+    def test_image_only_list_without_llm_is_skipped(self):
+        messages = [
+            {"role": "user", "content": [
+                {"type": "image_url", "image_url": {"url": "https://example.com/img.png"}},
+            ]},
+        ]
+        result = parse_vision_messages(messages, llm=None)
+        assert result == []
+
     def test_plain_text_messages_pass_through(self):
         messages = [
             {"role": "system", "content": "You are helpful."},

--- a/tests/memory/test_memory_utils.py
+++ b/tests/memory/test_memory_utils.py
@@ -1,5 +1,51 @@
 import pytest
-from mem0.memory.utils import remove_spaces_from_entities, sanitize_relationship_for_cypher
+from unittest.mock import Mock
+
+from mem0.memory.utils import parse_vision_messages, remove_spaces_from_entities, sanitize_relationship_for_cypher
+
+
+class TestParseVisionMessages:
+    def test_multimodal_list_without_llm_extracts_text(self):
+        messages = [
+            {"role": "user", "content": [
+                {"type": "text", "text": "What is this?"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/img.png"}},
+            ]},
+        ]
+        result = parse_vision_messages(messages, llm=None)
+        assert len(result) == 1
+        assert result[0]["role"] == "user"
+        assert result[0]["content"] == "What is this?"
+
+    def test_image_dict_without_llm_is_skipped(self):
+        messages = [
+            {"role": "user", "content": {"type": "image_url", "image_url": {"url": "https://example.com/img.png"}}},
+            {"role": "user", "content": "hello"},
+        ]
+        result = parse_vision_messages(messages, llm=None)
+        assert len(result) == 1
+        assert result[0]["content"] == "hello"
+
+    def test_multimodal_with_llm_calls_generate_response(self):
+        mock_llm = Mock()
+        mock_llm.generate_response.return_value = "A photo of a cat"
+        messages = [
+            {"role": "user", "content": [
+                {"type": "text", "text": "Describe this"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+            ]},
+        ]
+        result = parse_vision_messages(messages, llm=mock_llm, vision_details="auto")
+        assert result[0]["content"] == "A photo of a cat"
+        mock_llm.generate_response.assert_called_once()
+
+    def test_plain_text_messages_pass_through(self):
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+        ]
+        result = parse_vision_messages(messages, llm=None)
+        assert result == messages
 
 
 class TestRemoveSpacesFromEntities:


### PR DESCRIPTION
## Summary

When `enable_vision` is `False`, `parse_vision_messages()` is called with `llm=None` ([main.py:674](https://github.com/mem0ai/mem0/blob/main/mem0/memory/main.py#L674)). If the input messages contain multimodal content (list format with text + image_url parts), `get_image_description()` tries to call `llm.generate_response()` on `None`, raising `AttributeError: 'NoneType' object has no attribute 'generate_response'`.

This happens when users pass OpenAI-style multimodal messages without enabling vision in their config.

## Fix

When `llm is None`:
- **List content** (text + images): extract text parts and join them, skip image parts
- **Dict image content**: skip the entire message (no text to extract)

This preserves the text content for memory extraction while gracefully handling the missing vision capability.

## Test plan

- [x] `test_multimodal_list_without_llm_extracts_text` — text extracted, images skipped
- [x] `test_image_dict_without_llm_is_skipped` — standalone image messages dropped
- [x] `test_multimodal_with_llm_calls_generate_response` — existing behavior unchanged when LLM provided
- [x] `test_plain_text_messages_pass_through` — regular messages unaffected
- [x] All 12 memory utils tests pass (8 existing + 4 new)