### PR TITLE
feat(vector-stores): add Azure Cosmos DB NoSQL vector store provider

### DIFF
--- a/docs/components/vectordbs/dbs/azure_cosmos_nosql.mdx
+++ b/docs/components/vectordbs/dbs/azure_cosmos_nosql.mdx
@@ -1,0 +1,83 @@
+---
+title: Azure Cosmos DB NoSQL
+description: "Use Azure Cosmos DB for NoSQL as a vector store in Mem0, storing embeddings alongside your data with native vector indexing."
+---
+
+[Azure Cosmos DB for NoSQL](https://learn.microsoft.com/azure/cosmos-db/nosql/) is a globally distributed, fully managed NoSQL database service. Its native [vector search](https://learn.microsoft.com/azure/cosmos-db/nosql/vector-search) support lets you store embeddings directly inside your documents — alongside other data — with efficient vector indexing (including DiskANN), autoscaling, low latency, and high availability.
+
+<Note> Vector search must be enabled on your Cosmos DB account before use. Enable the **Vector Search for NoSQL API** feature in the Azure portal under *Settings → Features*, or via the Azure CLI. </Note>
+
+<Note> Ensure the `embedding_model_dims` in your config matches your chosen embedding model's dimensions. For example, OpenAI's text-embedding-3-small uses 1536 dimensions. </Note>
+
+## Usage
+
+```python
+import os
+from mem0 import Memory
+
+os.environ["OPENAI_API_KEY"] = "sk-xx"   # This key is used for embedding purpose
+
+config = {
+    "vector_store": {
+        "provider": "azure_cosmos_nosql",
+        "config": {
+            "endpoint": "https://<your-account>.documents.azure.com:443/",
+            "api_key": "<your-account-key>",
+            "database_name": "mem0db",
+            "collection_name": "mem0",
+            "embedding_model_dims": 1536
+        }
+    }
+}
+
+m = Memory.from_config(config)
+messages = [
+    {"role": "user", "content": "I'm planning to watch a movie tonight. Any recommendations?"},
+    {"role": "assistant", "content": "How about thriller movies? They can be quite engaging."},
+    {"role": "user", "content": "I'm not a big fan of thriller movies but I love sci-fi movies."},
+    {"role": "assistant", "content": "Got it! I'll avoid thriller recommendations and suggest sci-fi movies in the future."}
+]
+m.add(messages, user_id="alice", metadata={"category": "movies"})
+```
+
+## Using a connection string
+
+```python
+config = {
+    "vector_store": {
+        "provider": "azure_cosmos_nosql",
+        "config": {
+            "connection_string": "AccountEndpoint=https://<your-account>.documents.azure.com:443/;AccountKey=<key>;",
+            "collection_name": "mem0",
+            "embedding_model_dims": 1536
+        }
+    }
+}
+```
+
+Credentials can also be supplied via environment variables instead of config fields: `AZURE_COSMOS_CONNECTION_STRING`, or `AZURE_COSMOS_ENDPOINT` + `AZURE_COSMOS_KEY`.
+
+## Configuration Parameters
+
+| Parameter | Description | Default Value | Options |
+| --- | --- | --- | --- |
+| `collection_name` | Name of the container that stores memories | `mem0` | Any valid container name |
+| `database_name` | Name of the database | `mem0db` | Any valid database name |
+| `embedding_model_dims` | Dimensions of the embedding model | `1536` | Any integer value |
+| `client` | Existing `azure.cosmos.CosmosClient` instance | `None` | Any `CosmosClient` |
+| `endpoint` | Cosmos DB account endpoint URL | `None` | Falls back to `AZURE_COSMOS_ENDPOINT` |
+| `api_key` | Cosmos DB account key | `None` | Falls back to `AZURE_COSMOS_KEY` |
+| `connection_string` | Cosmos DB connection string | `None` | Falls back to `AZURE_COSMOS_CONNECTION_STRING` |
+| `metric` | Distance function for vector similarity | `cosine` | `cosine`, `dotproduct`, `euclidean` |
+| `index_type` | Vector index type | `diskANN` | `flat`, `quantizedFlat`, `diskANN` |
+
+## Notes on Configuration Options
+
+- **index_type**:
+  - `diskANN` (default): approximate-nearest-neighbor index that scales to high-dimensional embeddings with low latency and cost.
+  - `quantizedFlat`: exact search over quantized vectors — good accuracy/cost balance for mid-sized collections.
+  - `flat`: exact search over raw vectors; Cosmos DB caps `flat` indexes at 505 dimensions, so it is unsuitable for most modern embedding models (e.g. 1536-dim OpenAI embeddings).
+
+- **Scores**: Mem0 normalizes Cosmos DB's `VectorDistance()` results into similarity scores where higher is better — cosine similarity is clamped to `[0, 1]`, and euclidean distance is converted via `1 / (1 + distance)`.
+
+- **Document layout**: each memory is stored as a document `{"id": ..., "vector": [...], "payload": {...}}` with `/id` as the partition key, and the `/vector` path excluded from the regular index.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -230,6 +230,7 @@
                               "components/vectordbs/dbs/pinecone",
                               "components/vectordbs/dbs/mongodb",
                               "components/vectordbs/dbs/azure",
+                              "components/vectordbs/dbs/azure_cosmos_nosql",
                               "components/vectordbs/dbs/azure_mysql",
                               "components/vectordbs/dbs/redis",
                               "components/vectordbs/dbs/valkey",

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -470,6 +470,7 @@ Everything below is OSS-only provider configuration. Skip this entire section wh
 - [Pinecone](https://docs.mem0.ai/components/vectordbs/dbs/pinecone) [OSS]: Use when the user is on Pinecone managed.
 - [MongoDB](https://docs.mem0.ai/components/vectordbs/dbs/mongodb) [OSS]: Use when Mongo Atlas Vector Search is the backing store.
 - [Azure AI Search](https://docs.mem0.ai/components/vectordbs/dbs/azure) [OSS]: Use when the user is on Azure AI Search.
+- [Azure Cosmos DB NoSQL](https://docs.mem0.ai/components/vectordbs/dbs/azure_cosmos_nosql) [OSS]: Use when embeddings should live in Azure Cosmos DB for NoSQL documents.
 - [Azure MySQL](https://docs.mem0.ai/components/vectordbs/dbs/azure_mysql) [OSS]: Use when vector search runs on Azure Database for MySQL.
 - [Redis](https://docs.mem0.ai/components/vectordbs/dbs/redis) [OSS]: Use when Redis Stack is the backing store.
 - [Valkey](https://docs.mem0.ai/components/vectordbs/dbs/valkey) [OSS]: Use when the user is on Valkey (Redis fork).

--- a/mem0/configs/vector_stores/azure_cosmos_nosql.py
+++ b/mem0/configs/vector_stores/azure_cosmos_nosql.py
@@ -1,0 +1,57 @@
+import os
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class AzureCosmosNoSQLConfig(BaseModel):
+    """Configuration for Azure Cosmos DB for NoSQL vector database."""
+
+    collection_name: str = Field("mem0", description="Name of the container")
+    database_name: str = Field("mem0db", description="Name of the database")
+    embedding_model_dims: int = Field(1536, description="Dimensions of the embedding model")
+    client: Optional[Any] = Field(None, description="Existing `azure.cosmos.CosmosClient` instance")
+    endpoint: Optional[str] = Field(None, description="Azure Cosmos DB account endpoint URL")
+    api_key: Optional[str] = Field(None, description="Azure Cosmos DB account key")
+    connection_string: Optional[str] = Field(None, description="Azure Cosmos DB connection string")
+    metric: str = Field("cosine", description="Distance function: 'cosine', 'dotproduct' or 'euclidean'")
+    index_type: str = Field("diskANN", description="Vector index type: 'flat', 'quantizedFlat' or 'diskANN'")
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_credentials(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        client = values.get("client")
+        connection_string = values.get("connection_string") or os.environ.get("AZURE_COSMOS_CONNECTION_STRING")
+        endpoint = values.get("endpoint") or os.environ.get("AZURE_COSMOS_ENDPOINT")
+        api_key = values.get("api_key") or os.environ.get("AZURE_COSMOS_KEY")
+        if not client and not connection_string and not (endpoint and api_key):
+            raise ValueError(
+                "Provide one of: 'client', 'connection_string', or 'endpoint' + 'api_key' "
+                "(or set AZURE_COSMOS_CONNECTION_STRING, or AZURE_COSMOS_ENDPOINT + AZURE_COSMOS_KEY)."
+            )
+        return values
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_metric_and_index_type(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        metric = values.get("metric", "cosine")
+        if metric not in ("cosine", "dotproduct", "euclidean"):
+            raise ValueError(f"Invalid metric '{metric}'. Must be one of: 'cosine', 'dotproduct', 'euclidean'.")
+        index_type = values.get("index_type", "diskANN")
+        if index_type not in ("flat", "quantizedFlat", "diskANN"):
+            raise ValueError(f"Invalid index_type '{index_type}'. Must be one of: 'flat', 'quantizedFlat', 'diskANN'.")
+        return values
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_extra_fields(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        allowed_fields = set(cls.model_fields.keys())
+        input_fields = set(values.keys())
+        extra_fields = input_fields - allowed_fields
+        if extra_fields:
+            raise ValueError(
+                f"Extra fields not allowed: {', '.join(extra_fields)}. Please input only the following fields: {', '.join(allowed_fields)}"
+            )
+        return values
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -173,6 +173,7 @@ class VectorStoreFactory:
         "milvus": "mem0.vector_stores.milvus.MilvusDB",
         "upstash_vector": "mem0.vector_stores.upstash_vector.UpstashVector",
         "azure_ai_search": "mem0.vector_stores.azure_ai_search.AzureAISearch",
+        "azure_cosmos_nosql": "mem0.vector_stores.azure_cosmos_nosql.AzureCosmosNoSQL",
         "azure_mysql": "mem0.vector_stores.azure_mysql.AzureMySQL",
         "pinecone": "mem0.vector_stores.pinecone.PineconeDB",
         "mongodb": "mem0.vector_stores.mongodb.MongoDB",

--- a/mem0/vector_stores/azure_cosmos_nosql.py
+++ b/mem0/vector_stores/azure_cosmos_nosql.py
@@ -1,0 +1,327 @@
+import logging
+import os
+import re
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from pydantic import BaseModel
+
+try:
+    from azure.cosmos import CosmosClient, PartitionKey
+    from azure.cosmos.exceptions import CosmosResourceNotFoundError
+except ImportError:
+    raise ImportError("Azure Cosmos DB requires extra dependencies. Install with `pip install azure-cosmos`") from None
+
+from mem0.vector_stores.base import VectorStoreBase
+
+logger = logging.getLogger(__name__)
+
+VALID_FILTER_KEY = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+class OutputData(BaseModel):
+    id: Optional[str]  # memory id
+    score: Optional[float]  # similarity score (higher = more similar)
+    payload: Optional[Dict]  # metadata
+
+
+class AzureCosmosNoSQL(VectorStoreBase):
+    def __init__(
+        self,
+        collection_name: str,
+        database_name: str,
+        embedding_model_dims: int,
+        client: Optional["CosmosClient"] = None,
+        endpoint: Optional[str] = None,
+        api_key: Optional[str] = None,
+        connection_string: Optional[str] = None,
+        metric: str = "cosine",
+        index_type: str = "diskANN",
+    ):
+        """
+        Initialize the Azure Cosmos DB for NoSQL vector store.
+
+        Args:
+            collection_name (str): Name of the container.
+            database_name (str): Name of the database.
+            embedding_model_dims (int): Dimensions of the embedding model.
+            client (CosmosClient, optional): Existing Cosmos client instance. Defaults to None.
+            endpoint (str, optional): Cosmos DB account endpoint URL. Defaults to None.
+            api_key (str, optional): Cosmos DB account key. Defaults to None.
+            connection_string (str, optional): Cosmos DB connection string. Defaults to None.
+            metric (str, optional): Distance function ('cosine', 'dotproduct', 'euclidean'). Defaults to "cosine".
+            index_type (str, optional): Vector index type ('flat', 'quantizedFlat', 'diskANN'). Defaults to "diskANN".
+        """
+        if client:
+            self.client = client
+        else:
+            connection_string = connection_string or os.environ.get("AZURE_COSMOS_CONNECTION_STRING")
+            if connection_string:
+                self.client = CosmosClient.from_connection_string(connection_string)
+            else:
+                endpoint = endpoint or os.environ.get("AZURE_COSMOS_ENDPOINT")
+                api_key = api_key or os.environ.get("AZURE_COSMOS_KEY")
+                if not endpoint or not api_key:
+                    raise ValueError(
+                        "Azure Cosmos DB credentials must be provided: either a 'client', a "
+                        "'connection_string', or 'endpoint' + 'api_key' (also settable via the "
+                        "AZURE_COSMOS_CONNECTION_STRING or AZURE_COSMOS_ENDPOINT/AZURE_COSMOS_KEY "
+                        "environment variables)."
+                    )
+                self.client = CosmosClient(url=endpoint, credential=api_key)
+
+        self.collection_name = collection_name
+        self.database_name = database_name
+        self.embedding_model_dims = embedding_model_dims
+        self.metric = metric
+        self.index_type = index_type
+
+        self.create_col(embedding_model_dims, metric)
+
+    def create_col(self, vector_size: int, metric: str = "cosine"):
+        """
+        Create the database and container with a vector embedding/indexing policy.
+
+        Args:
+            vector_size (int): Size of the vectors to be stored.
+            metric (str, optional): Distance function for vector similarity. Defaults to "cosine".
+        """
+        self.database = self.client.create_database_if_not_exists(id=self.database_name)
+
+        vector_embedding_policy = {
+            "vectorEmbeddings": [
+                {
+                    "path": "/vector",
+                    "dataType": "float32",
+                    "distanceFunction": metric,
+                    "dimensions": vector_size,
+                }
+            ]
+        }
+        indexing_policy = {
+            "indexingMode": "consistent",
+            "includedPaths": [{"path": "/*"}],
+            "excludedPaths": [{"path": '/"_etag"/?'}, {"path": "/vector/*"}],
+            "vectorIndexes": [{"path": "/vector", "type": self.index_type}],
+        }
+
+        self.container = self.database.create_container_if_not_exists(
+            id=self.collection_name,
+            partition_key=PartitionKey(path="/id"),
+            indexing_policy=indexing_policy,
+            vector_embedding_policy=vector_embedding_policy,
+        )
+
+    def insert(
+        self,
+        vectors: List[List[float]],
+        payloads: Optional[List[Dict]] = None,
+        ids: Optional[List[Union[str, int]]] = None,
+    ):
+        """
+        Insert vectors into the container.
+
+        Args:
+            vectors (list): List of vectors to insert.
+            payloads (list, optional): List of payloads corresponding to vectors. Defaults to None.
+            ids (list, optional): List of IDs corresponding to vectors. Defaults to None.
+        """
+        logger.info(f"Inserting {len(vectors)} vectors into container {self.collection_name}")
+        for idx, vector in enumerate(vectors):
+            item_id = str(ids[idx]) if ids is not None else str(idx)
+            payload = payloads[idx] if payloads else {}
+            self.container.upsert_item({"id": item_id, "vector": vector, "payload": payload})
+
+    def _to_similarity(self, value: float) -> float:
+        """Convert a VectorDistance() result into a similarity score (higher = better)."""
+        if value is None:
+            return None
+        if self.metric == "euclidean":
+            # Euclidean is a distance (lower = better): map [0, inf) -> (0, 1].
+            return 1.0 / (1.0 + value)
+        if self.metric == "cosine":
+            # Cosmos returns cosine similarity in [-1, 1]: clamp to [0, 1].
+            return max(0.0, min(1.0, value))
+        # dotproduct: already higher = better.
+        return value
+
+    def _build_where(self, filters: Optional[Dict]) -> Tuple[str, List[Dict[str, Any]]]:
+        """Build a parameterized WHERE clause from mem0 filters."""
+        if not filters:
+            return "", []
+
+        clauses = []
+        parameters = []
+        for idx, (key, value) in enumerate(filters.items()):
+            if not VALID_FILTER_KEY.match(key):
+                raise ValueError(f"Invalid filter key: {key!r}")
+            field = f'c.payload["{key}"]'
+            if isinstance(value, dict) and ("gte" in value or "lte" in value):
+                if "gte" in value:
+                    clauses.append(f"{field} >= @p{idx}_gte")
+                    parameters.append({"name": f"@p{idx}_gte", "value": value["gte"]})
+                if "lte" in value:
+                    clauses.append(f"{field} <= @p{idx}_lte")
+                    parameters.append({"name": f"@p{idx}_lte", "value": value["lte"]})
+            else:
+                clauses.append(f"{field} = @p{idx}")
+                parameters.append({"name": f"@p{idx}", "value": value})
+
+        return " WHERE " + " AND ".join(clauses), parameters
+
+    def search(
+        self, query: str, vectors: List[float], top_k: int = 5, filters: Optional[Dict] = None
+    ) -> List[OutputData]:
+        """
+        Search for similar vectors using VectorDistance().
+
+        Args:
+            query (str): Query text (unused; similarity is computed from `vectors`).
+            vectors (list): Query vector.
+            top_k (int, optional): Number of results to return. Defaults to 5.
+            filters (dict, optional): Filters to apply to the search. Defaults to None.
+
+        Returns:
+            list: Search results.
+        """
+        where_clause, parameters = self._build_where(filters)
+        # Pass the distance function explicitly instead of relying on the container's
+        # embedding policy default. self.metric is validated against a fixed enum.
+        distance_expr = f"VectorDistance(c.vector, @embedding, false, {{'distanceFunction': '{self.metric}', 'dataType': 'float32'}})"
+        sql = (
+            f"SELECT TOP @top_k c.id, c.payload, {distance_expr} AS distance "
+            f"FROM c{where_clause} ORDER BY {distance_expr}"
+        )
+        parameters.extend(
+            [
+                {"name": "@top_k", "value": top_k},
+                {"name": "@embedding", "value": vectors},
+            ]
+        )
+
+        items = self.container.query_items(query=sql, parameters=parameters, enable_cross_partition_query=True)
+        return [
+            OutputData(
+                id=item.get("id"),
+                score=self._to_similarity(item.get("distance")),
+                payload=item.get("payload"),
+            )
+            for item in items
+        ]
+
+    def delete(self, vector_id: Union[str, int]):
+        """
+        Delete a vector by ID.
+
+        Args:
+            vector_id (Union[str, int]): ID of the vector to delete.
+        """
+        try:
+            self.container.delete_item(item=str(vector_id), partition_key=str(vector_id))
+        except CosmosResourceNotFoundError:
+            logger.warning(f"Vector {vector_id} not found in container {self.collection_name}")
+
+    def update(self, vector_id: Union[str, int], vector: Optional[List[float]] = None, payload: Optional[Dict] = None):
+        """
+        Update a vector and its payload.
+
+        Args:
+            vector_id (Union[str, int]): ID of the vector to update.
+            vector (list, optional): Updated vector. Defaults to None.
+            payload (dict, optional): Updated payload. Defaults to None.
+        """
+        try:
+            item = self.container.read_item(item=str(vector_id), partition_key=str(vector_id))
+        except CosmosResourceNotFoundError:
+            logger.warning(f"Vector {vector_id} not found in container {self.collection_name}")
+            return
+
+        if vector is not None:
+            item["vector"] = vector
+        if payload is not None:
+            item["payload"] = payload
+
+        self.container.upsert_item(item)
+
+    def get(self, vector_id: Union[str, int]) -> Optional[OutputData]:
+        """
+        Retrieve a vector by ID.
+
+        Args:
+            vector_id (Union[str, int]): ID of the vector to retrieve.
+
+        Returns:
+            OutputData: Retrieved vector or None if not found.
+        """
+        try:
+            item = self.container.read_item(item=str(vector_id), partition_key=str(vector_id))
+        except CosmosResourceNotFoundError:
+            return None
+        return OutputData(id=item.get("id"), score=None, payload=item.get("payload"))
+
+    def list_cols(self) -> List[str]:
+        """
+        List all containers in the database.
+
+        Returns:
+            list: List of container names.
+        """
+        return [container["id"] for container in self.database.list_containers()]
+
+    def delete_col(self):
+        """Delete the container."""
+        try:
+            self.database.delete_container(self.collection_name)
+            logger.info(f"Container {self.collection_name} deleted successfully")
+        except CosmosResourceNotFoundError:
+            logger.warning(f"Container {self.collection_name} not found")
+
+    def col_info(self) -> Dict:
+        """
+        Get information about the container.
+
+        Returns:
+            dict: Container properties.
+        """
+        return self.container.read()
+
+    def list(self, filters: Optional[Dict] = None, top_k: int = 100) -> List[List[OutputData]]:
+        """
+        List vectors in the container with optional filtering.
+
+        Args:
+            filters (dict, optional): Filters to apply to the list. Defaults to None.
+            top_k (int, optional): Number of vectors to return. Defaults to 100.
+
+        Returns:
+            list: A single-element list containing the list of results.
+        """
+        where_clause, parameters = self._build_where(filters)
+        top_clause = ""
+        if top_k is not None:
+            top_clause = "TOP @top_k "
+            parameters.append({"name": "@top_k", "value": top_k})
+        sql = f"SELECT {top_clause}c.id, c.payload FROM c{where_clause}"
+
+        items = self.container.query_items(query=sql, parameters=parameters, enable_cross_partition_query=True)
+        results = [OutputData(id=item.get("id"), score=None, payload=item.get("payload")) for item in items]
+        return [results]
+
+    def count(self) -> int:
+        """
+        Count the number of vectors in the container.
+
+        Returns:
+            int: Total number of vectors.
+        """
+        items = list(
+            self.container.query_items(query="SELECT VALUE COUNT(1) FROM c", enable_cross_partition_query=True)
+        )
+        return items[0] if items else 0
+
+    def reset(self):
+        """
+        Reset the container by deleting and recreating it.
+        """
+        logger.warning(f"Resetting container {self.collection_name}...")
+        self.delete_col()
+        self.create_col(self.embedding_model_dims, self.metric)

--- a/mem0/vector_stores/configs.py
+++ b/mem0/vector_stores/configs.py
@@ -22,6 +22,7 @@ class VectorStoreConfig(BaseModel):
         "neptune": "NeptuneAnalyticsConfig",
         "upstash_vector": "UpstashVectorConfig",
         "azure_ai_search": "AzureAISearchConfig",
+        "azure_cosmos_nosql": "AzureCosmosNoSQLConfig",
         "azure_mysql": "AzureMySQLConfig",
         "redis": "RedisDBConfig",
         "valkey": "ValkeyConfig",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ vector_stores = [
     "faiss-cpu>=1.7.4",
     "upstash-vector>=0.6.0",
     "azure-search-documents>=11.4.0b8",
+    "azure-cosmos>=4.7.0",
     "psycopg>=3.2.8",
     "psycopg-pool>=3.2.6,<4.0.0",
     "pymongo>=4.13.2",

--- a/tests/vector_stores/test_azure_cosmos_nosql.py
+++ b/tests/vector_stores/test_azure_cosmos_nosql.py
@@ -1,0 +1,261 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from azure.cosmos.exceptions import CosmosResourceNotFoundError
+
+from mem0.vector_stores.azure_cosmos_nosql import AzureCosmosNoSQL
+
+
+@pytest.fixture
+def mock_cosmos_client():
+    client = MagicMock()
+    database = MagicMock()
+    container = MagicMock()
+    client.create_database_if_not_exists.return_value = database
+    database.create_container_if_not_exists.return_value = container
+    return client
+
+
+@pytest.fixture
+def cosmos_db(mock_cosmos_client):
+    return AzureCosmosNoSQL(
+        collection_name="mem0",
+        database_name="mem0db",
+        embedding_model_dims=128,
+        client=mock_cosmos_client,
+        metric="cosine",
+        index_type="diskANN",
+    )
+
+
+def test_init_requires_credentials(monkeypatch):
+    monkeypatch.delenv("AZURE_COSMOS_CONNECTION_STRING", raising=False)
+    monkeypatch.delenv("AZURE_COSMOS_ENDPOINT", raising=False)
+    monkeypatch.delenv("AZURE_COSMOS_KEY", raising=False)
+    with pytest.raises(ValueError, match="credentials"):
+        AzureCosmosNoSQL(
+            collection_name="mem0",
+            database_name="mem0db",
+            embedding_model_dims=128,
+        )
+
+
+def test_init_with_connection_string(monkeypatch):
+    monkeypatch.delenv("AZURE_COSMOS_CONNECTION_STRING", raising=False)
+    with patch("mem0.vector_stores.azure_cosmos_nosql.CosmosClient") as mock_client_cls:
+        AzureCosmosNoSQL(
+            collection_name="mem0",
+            database_name="mem0db",
+            embedding_model_dims=128,
+            connection_string="AccountEndpoint=https://x.documents.azure.com:443/;AccountKey=abc==;",
+        )
+        mock_client_cls.from_connection_string.assert_called_once()
+
+
+def test_init_with_endpoint_and_key(monkeypatch):
+    monkeypatch.delenv("AZURE_COSMOS_CONNECTION_STRING", raising=False)
+    with patch("mem0.vector_stores.azure_cosmos_nosql.CosmosClient") as mock_client_cls:
+        AzureCosmosNoSQL(
+            collection_name="mem0",
+            database_name="mem0db",
+            embedding_model_dims=128,
+            endpoint="https://x.documents.azure.com:443/",
+            api_key="fake_key",
+        )
+        mock_client_cls.assert_called_once_with(url="https://x.documents.azure.com:443/", credential="fake_key")
+
+
+def test_create_col_policies(cosmos_db, mock_cosmos_client):
+    mock_cosmos_client.create_database_if_not_exists.assert_called_with(id="mem0db")
+    database = mock_cosmos_client.create_database_if_not_exists.return_value
+    _, kwargs = database.create_container_if_not_exists.call_args
+
+    assert kwargs["id"] == "mem0"
+    embedding = kwargs["vector_embedding_policy"]["vectorEmbeddings"][0]
+    assert embedding["path"] == "/vector"
+    assert embedding["dimensions"] == 128
+    assert embedding["distanceFunction"] == "cosine"
+    vector_index = kwargs["indexing_policy"]["vectorIndexes"][0]
+    assert vector_index == {"path": "/vector", "type": "diskANN"}
+    assert {"path": "/vector/*"} in kwargs["indexing_policy"]["excludedPaths"]
+
+
+def test_insert_vectors(cosmos_db):
+    vectors = [[0.1] * 128, [0.2] * 128]
+    payloads = [{"name": "vector1"}, {"name": "vector2"}]
+    ids = ["id1", "id2"]
+
+    cosmos_db.insert(vectors, payloads, ids)
+
+    assert cosmos_db.container.upsert_item.call_count == 2
+    cosmos_db.container.upsert_item.assert_any_call(
+        {"id": "id1", "vector": [0.1] * 128, "payload": {"name": "vector1"}}
+    )
+    cosmos_db.container.upsert_item.assert_any_call(
+        {"id": "id2", "vector": [0.2] * 128, "payload": {"name": "vector2"}}
+    )
+
+
+def test_search_returns_similarity_scores(cosmos_db):
+    cosmos_db.container.query_items.return_value = [
+        {"id": "id1", "payload": {"name": "vector1"}, "distance": 0.9},
+        {"id": "id2", "payload": {"name": "vector2"}, "distance": -0.2},
+    ]
+
+    results = cosmos_db.search("test query", [0.1] * 128, top_k=2)
+
+    _, kwargs = cosmos_db.container.query_items.call_args
+    assert "VectorDistance(c.vector, @embedding, false, {'distanceFunction': 'cosine'" in kwargs["query"]
+    assert "ORDER BY VectorDistance" in kwargs["query"]
+    assert {"name": "@top_k", "value": 2} in kwargs["parameters"]
+    assert {"name": "@embedding", "value": [0.1] * 128} in kwargs["parameters"]
+
+    assert len(results) == 2
+    assert results[0].id == "id1"
+    assert results[0].score == 0.9  # cosine similarity passed through
+    assert results[0].payload == {"name": "vector1"}
+    assert results[1].score == 0.0  # negative cosine similarity clamped to 0
+
+
+def test_search_euclidean_distance_conversion(mock_cosmos_client):
+    db = AzureCosmosNoSQL(
+        collection_name="mem0",
+        database_name="mem0db",
+        embedding_model_dims=128,
+        client=mock_cosmos_client,
+        metric="euclidean",
+    )
+    db.container.query_items.return_value = [{"id": "id1", "payload": {}, "distance": 1.0}]
+
+    results = db.search("test query", [0.1] * 128, top_k=1)
+
+    _, kwargs = db.container.query_items.call_args
+    assert "{'distanceFunction': 'euclidean'" in kwargs["query"]
+    assert results[0].score == 0.5  # 1 / (1 + 1.0)
+
+
+def test_search_with_filters(cosmos_db):
+    cosmos_db.container.query_items.return_value = []
+
+    cosmos_db.search("test query", [0.1] * 128, top_k=5, filters={"user_id": "alice", "agent_id": "bot"})
+
+    _, kwargs = cosmos_db.container.query_items.call_args
+    assert 'WHERE c.payload["user_id"] = @p0 AND c.payload["agent_id"] = @p1' in kwargs["query"]
+    assert {"name": "@p0", "value": "alice"} in kwargs["parameters"]
+    assert {"name": "@p1", "value": "bot"} in kwargs["parameters"]
+
+
+def test_search_with_range_filter(cosmos_db):
+    cosmos_db.container.query_items.return_value = []
+
+    cosmos_db.search("test query", [0.1] * 128, top_k=5, filters={"created_at": {"gte": 1, "lte": 2}})
+
+    _, kwargs = cosmos_db.container.query_items.call_args
+    assert 'c.payload["created_at"] >= @p0_gte AND c.payload["created_at"] <= @p0_lte' in kwargs["query"]
+    assert {"name": "@p0_gte", "value": 1} in kwargs["parameters"]
+    assert {"name": "@p0_lte", "value": 2} in kwargs["parameters"]
+
+
+def test_search_rejects_invalid_filter_key(cosmos_db):
+    with pytest.raises(ValueError, match="Invalid filter key"):
+        cosmos_db.search("test query", [0.1] * 128, filters={'bad"] = 1 OR 1=1 --': "x"})
+
+
+def test_get_vector_found(cosmos_db):
+    cosmos_db.container.read_item.return_value = {"id": "id1", "vector": [0.1] * 128, "payload": {"name": "vector1"}}
+
+    result = cosmos_db.get("id1")
+
+    cosmos_db.container.read_item.assert_called_with(item="id1", partition_key="id1")
+    assert result.id == "id1"
+    assert result.payload == {"name": "vector1"}
+
+
+def test_get_vector_not_found(cosmos_db):
+    cosmos_db.container.read_item.side_effect = CosmosResourceNotFoundError()
+
+    result = cosmos_db.get("missing")
+
+    assert result is None
+
+
+def test_update_vector_and_payload(cosmos_db):
+    cosmos_db.container.read_item.return_value = {"id": "id1", "vector": [0.1] * 128, "payload": {"name": "old"}}
+
+    cosmos_db.update("id1", vector=[0.5] * 128, payload={"name": "new"})
+
+    cosmos_db.container.upsert_item.assert_called_with({"id": "id1", "vector": [0.5] * 128, "payload": {"name": "new"}})
+
+
+def test_update_payload_only_keeps_vector(cosmos_db):
+    cosmos_db.container.read_item.return_value = {"id": "id1", "vector": [0.1] * 128, "payload": {"name": "old"}}
+
+    cosmos_db.update("id1", payload={"name": "new"})
+
+    cosmos_db.container.upsert_item.assert_called_with({"id": "id1", "vector": [0.1] * 128, "payload": {"name": "new"}})
+
+
+def test_update_missing_vector_is_noop(cosmos_db):
+    cosmos_db.container.read_item.side_effect = CosmosResourceNotFoundError()
+
+    cosmos_db.update("missing", payload={"name": "new"})
+
+    cosmos_db.container.upsert_item.assert_not_called()
+
+
+def test_delete_vector(cosmos_db):
+    cosmos_db.delete("id1")
+
+    cosmos_db.container.delete_item.assert_called_with(item="id1", partition_key="id1")
+
+
+def test_delete_vector_not_found_does_not_raise(cosmos_db):
+    cosmos_db.container.delete_item.side_effect = CosmosResourceNotFoundError()
+
+    cosmos_db.delete("missing")
+
+
+def test_list_with_filters(cosmos_db):
+    cosmos_db.container.query_items.return_value = [{"id": "id1", "payload": {"name": "vector1"}}]
+
+    results = cosmos_db.list(filters={"user_id": "alice"}, top_k=10)
+
+    _, kwargs = cosmos_db.container.query_items.call_args
+    assert kwargs["query"].startswith("SELECT TOP @top_k c.id, c.payload FROM c WHERE")
+    assert "VectorDistance" not in kwargs["query"]
+    assert len(results) == 1
+    assert results[0][0].id == "id1"
+
+
+def test_list_cols(cosmos_db):
+    cosmos_db.database.list_containers.return_value = [{"id": "mem0"}, {"id": "other"}]
+
+    assert cosmos_db.list_cols() == ["mem0", "other"]
+
+
+def test_delete_col(cosmos_db):
+    cosmos_db.delete_col()
+
+    cosmos_db.database.delete_container.assert_called_with("mem0")
+
+
+def test_col_info(cosmos_db):
+    cosmos_db.col_info()
+
+    cosmos_db.container.read.assert_called_once()
+
+
+def test_count(cosmos_db):
+    cosmos_db.container.query_items.return_value = iter([42])
+
+    assert cosmos_db.count() == 42
+
+
+def test_reset(cosmos_db, mock_cosmos_client):
+    database = mock_cosmos_client.create_database_if_not_exists.return_value
+    database.create_container_if_not_exists.reset_mock()
+
+    cosmos_db.reset()
+
+    database.delete_container.assert_called_with("mem0")
+    database.create_container_if_not_exists.assert_called_once()


### PR DESCRIPTION
## Linked Issue

Closes #3297

## Description

This PR adds Azure Cosmos DB for NoSQL as a vector store provider (`azure_cosmos_nosql`).

Memories are stored as regular Cosmos documents with the embedding in a `/vector` field, so vectors live alongside the payload data as the issue describes. The container is created with a vector embedding policy and a vector index (defaults to `diskANN`, since the `flat` index is capped at 505 dimensions which doesn't fit common embedding models like text-embedding-3-small at 1536). Search uses parameterized `VectorDistance()` queries.

A few implementation notes:

- Auth works three ways: pass an existing `CosmosClient`, a connection string, or endpoint + key. Env vars `AZURE_COSMOS_CONNECTION_STRING` or `AZURE_COSMOS_ENDPOINT`/`AZURE_COSMOS_KEY` also work. I kept Entra ID / `DefaultAzureCredential` out of this PR to keep it small, happy to add it as a follow-up if there's interest.
- Scores follow the base class contract (higher = more similar): cosine gets clamped to [0, 1] and euclidean distance is converted with `1 / (1 + d)`. I pass the distance function explicitly in the query instead of relying on the container policy default, after running into a case where the two can disagree (details under testing).
- Filter values are bound as query parameters and filter keys are validated against an identifier regex, so user-supplied filters can't inject into the SQL.
- `azure-cosmos>=4.7.0` goes in the `vector_stores` optional group, core dependencies untouched.
- Followed the existing provider pattern throughout (config in `mem0/configs/vector_stores/`, registered in the config registry and `VectorStoreFactory`).

Docs: added `docs/components/vectordbs/dbs/azure_cosmos_nosql.mdx`, the `docs.json` nav entry, and the `llms.txt` line (coverage script passes).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added 23 unit tests with a mocked Cosmos client (same approach as the other vector store test suites) covering credential validation, container creation with the vector policy, insert, search (score conversion for cosine and euclidean, equality and range filters, rejection of malformed filter keys), get/update/delete, list, list_cols, delete_col, col_info, count and reset.

I also tested manually against the official Cosmos DB emulator (`mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview` in Docker): full CRUD plus live `VectorDistance()` searches, checking that result ordering and scores match hand-computed values for both cosine and euclidean. That run is actually what caught the policy-default issue mentioned above — the emulator ignored the euclidean policy and computed cosine, which silently inverted the rankings. Passing the distance function explicitly in the query fixes it regardless of backend behavior.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
