### PR TITLE
docs: add security disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please do not report security vulnerabilities through public GitHub issues.
+
+If you believe you have found a security vulnerability in mem0, please report it privately using one of the following options:
+
+1. GitHub Private Vulnerability Reporting, if enabled for this repository.
+2. Email the maintainers at founders@mem0.ai with the subject line:
+
+   SECURITY: mem0 vulnerability report
+
+Please include the following information when possible:
+
+- Affected component or package
+- Affected version or commit
+- Clear reproduction steps
+- Security impact
+- Suggested fix or mitigation, if available
+
+The maintainers will review the report and follow up through a private channel.
+
+## Public Disclosure
+
+Please avoid sharing technical vulnerability details publicly until the maintainers have reviewed the issue and a fix or mitigation is available.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,10 +6,10 @@ Please do not report security vulnerabilities through public GitHub issues.
 
 If you believe you have found a security vulnerability in mem0, please report it privately using one of the following options:
 
-1. GitHub Private Vulnerability Reporting, if enabled for this repository.
-2. Email the maintainers at founders@mem0.ai with the subject line:
+1. **GitHub Private Vulnerability Reporting** — open a [private security advisory](https://github.com/mem0ai/mem0/security/advisories/new) directly on this repository.
+2. **Email** the maintainers at founders@mem0.ai with the subject line:
 
-   SECURITY: mem0 vulnerability report
+   `SECURITY: mem0 vulnerability report`
 
 Please include the following information when possible:
 
@@ -19,7 +19,7 @@ Please include the following information when possible:
 - Security impact
 - Suggested fix or mitigation, if available
 
-The maintainers will review the report and follow up through a private channel.
+The maintainers will acknowledge receipt within 72 hours and follow up through a private channel.
 
 ## Public Disclosure
 


### PR DESCRIPTION
## Linked Issue

Fixes #5385

## Description

This PR adds a SECURITY.md file to provide clear responsible disclosure instructions for reporting security vulnerabilities privately.

It documents GitHub Private Vulnerability Reporting as the primary reporting channel and provides [[founders@mem0.ai](mailto:founders@mem0.ai)](mailto:founders@mem0.ai) as an email fallback.

## Type of Change

* [x] Documentation update

## Test Coverage

* [x] No tests needed

This is a documentation-only change. No code or application behavior was changed, so automated tests are not required.

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] I have updated documentation if needed

## Additional Notes

This follow-up PR addresses the review feedback from #5461 by:

* Removing the “if enabled” wording
* Linking directly to GitHub Private Vulnerability Reporting
* Adding a 72-hour acknowledgement window
* Adding the missing trailing newline at the end of SECURITY.md