### PR TITLE
fix: prevent cross-scope entity linking in _upsert_entity

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -512,21 +512,26 @@ class Memory(MemoryBase):
                 filters=search_filters,
             )
 
+            matched = False
             if existing and existing[0].score >= 0.95:
-                # Update existing entity's linked_memory_ids
                 match = existing[0]
                 payload = match.payload or {}
-                linked_ids = payload.get("linked_memory_ids", [])
-                if memory_id not in linked_ids:
-                    linked_ids.append(memory_id)
-                    payload["linked_memory_ids"] = linked_ids
-                    self.entity_store.update(
-                        vector_id=match.id,
-                        vector=None,
-                        payload=payload,
-                    )
-            else:
-                # Create new entity
+                scope_match = all(
+                    payload.get(k) == v for k, v in search_filters.items()
+                )
+                if scope_match:
+                    matched = True
+                    linked_ids = payload.get("linked_memory_ids", [])
+                    if memory_id not in linked_ids:
+                        linked_ids.append(memory_id)
+                        payload["linked_memory_ids"] = linked_ids
+                        self.entity_store.update(
+                            vector_id=match.id,
+                            vector=None,
+                            payload=payload,
+                        )
+
+            if not matched:
                 entity_id = str(uuid.uuid4())
                 entity_payload = {
                     "data": entity_text,
@@ -2052,20 +2057,27 @@ class AsyncMemory(MemoryBase):
                 filters=search_filters,
             )
 
+            matched = False
             if existing and existing[0].score >= 0.95:
                 match = existing[0]
                 payload = match.payload or {}
-                linked_ids = payload.get("linked_memory_ids", [])
-                if memory_id not in linked_ids:
-                    linked_ids.append(memory_id)
-                    payload["linked_memory_ids"] = linked_ids
-                    await asyncio.to_thread(
-                        self.entity_store.update,
-                        vector_id=match.id,
-                        vector=None,
-                        payload=payload,
-                    )
-            else:
+                scope_match = all(
+                    payload.get(k) == v for k, v in search_filters.items()
+                )
+                if scope_match:
+                    matched = True
+                    linked_ids = payload.get("linked_memory_ids", [])
+                    if memory_id not in linked_ids:
+                        linked_ids.append(memory_id)
+                        payload["linked_memory_ids"] = linked_ids
+                        await asyncio.to_thread(
+                            self.entity_store.update,
+                            vector_id=match.id,
+                            vector=None,
+                            payload=payload,
+                        )
+
+            if not matched:
                 entity_id = str(uuid.uuid4())
                 entity_payload = {
                     "data": entity_text,

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1056,3 +1056,62 @@ class TestHybridSearchWarning:
             Memory(config)
 
         assert not any("does not support keyword search" in r.message for r in caplog.records)
+
+
+class TestEntityScopeGuard:
+    """Verify _upsert_entity refuses to merge entities across different scopes."""
+
+    def _make_memory(self):
+        with patch.object(Memory, "__init__", return_value=None):
+            m = Memory()
+        m.embedding_model = MagicMock()
+        m.embedding_model.embed = MagicMock(return_value=[0.1, 0.2, 0.3])
+        m._entity_store = MagicMock()
+        return m
+
+    def test_same_scope_merges(self):
+        m = self._make_memory()
+        existing = MockVectorMemory(
+            "entity-1",
+            {"data": "apple", "entity_type": "food", "linked_memory_ids": ["mem-A"], "user_id": "alice"},
+            score=0.99,
+        )
+        m.entity_store.search = MagicMock(return_value=[existing])
+
+        m._upsert_entity("apple", "food", "mem-B", {"user_id": "alice"})
+
+        m.entity_store.update.assert_called_once()
+        m.entity_store.insert.assert_not_called()
+        updated_payload = m.entity_store.update.call_args[1]["payload"]
+        assert "mem-B" in updated_payload["linked_memory_ids"]
+
+    def test_different_scope_creates_new(self):
+        m = self._make_memory()
+        existing = MockVectorMemory(
+            "entity-1",
+            {"data": "apple", "entity_type": "food", "linked_memory_ids": ["mem-A"], "user_id": "alice"},
+            score=0.99,
+        )
+        m.entity_store.search = MagicMock(return_value=[existing])
+
+        m._upsert_entity("apple", "food", "mem-B", {"user_id": "bob"})
+
+        m.entity_store.update.assert_not_called()
+        m.entity_store.insert.assert_called_once()
+        inserted_payload = m.entity_store.insert.call_args[1]["payloads"][0]
+        assert inserted_payload["user_id"] == "bob"
+        assert "mem-B" in inserted_payload["linked_memory_ids"]
+
+    def test_missing_scope_in_payload_creates_new(self):
+        m = self._make_memory()
+        existing = MockVectorMemory(
+            "entity-1",
+            {"data": "apple", "entity_type": "food", "linked_memory_ids": ["mem-A"]},
+            score=0.99,
+        )
+        m.entity_store.search = MagicMock(return_value=[existing])
+
+        m._upsert_entity("apple", "food", "mem-B", {"user_id": "alice"})
+
+        m.entity_store.update.assert_not_called()
+        m.entity_store.insert.assert_called_once()


### PR DESCRIPTION
Closes #5439

## Problem

`_upsert_entity` uses scoped filters when **searching** for existing entities, but does not verify the matched entity's payload scope before merging. When two users mention the same entity (e.g. "Apple"), user B's `memory_id` gets appended to user A's entity record — leaking cross-scope linked memory IDs.

This causes:
- **Cross-user memory linking** — entity records contain `linked_memory_ids` from multiple users
- **Leaked influence in search** — `_compute_entity_boosts` uses the full unscoped count, so one user's data subtly affects another's ranking

## Fix

Added a scope-match guard in both sync `_upsert_entity` and async `_upsert_entity_async`: after finding a high-similarity entity match (>= 0.95), verify that the matched entity's `user_id`/`agent_id`/`run_id` in the payload match the current `search_filters`. If they don't match, create a new scoped entity instead of merging.

## Tests

3 new tests in `TestEntityScopeGuard`:
- `test_same_scope_merges` — same user, entity merges correctly
- `test_different_scope_creates_new` — different user_id, new entity created
- `test_missing_scope_in_payload_creates_new` — entity missing scope fields, treated as mismatch