### PR TITLE
fix: add entity_type merge gate to prevent same-name entity conflation

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -595,20 +595,26 @@ class Memory(MemoryBase):
 
             semantic_match = existing[0] if existing and existing[0].score >= 0.95 else None
             match = exact_match or semantic_match
+            matched = False
             if match:
-                # Update existing entity's linked_memory_ids
                 payload = match.payload or {}
-                linked_ids = payload.get("linked_memory_ids", [])
-                if memory_id not in linked_ids:
-                    linked_ids.append(memory_id)
-                    payload["linked_memory_ids"] = linked_ids
-                    self.entity_store.update(
-                        vector_id=match.id,
-                        vector=None,
-                        payload=payload,
-                    )
-            else:
-                # Create new entity
+                if entity_type and payload.get("entity_type") and payload["entity_type"] != entity_type:
+                    pass
+                else:
+                    matched = True
+                    linked_ids = payload.get("linked_memory_ids", [])
+                    if memory_id not in linked_ids:
+                        linked_ids.append(memory_id)
+                        payload["linked_memory_ids"] = linked_ids
+                        if entity_type and not payload.get("entity_type"):
+                            payload["entity_type"] = entity_type
+                        self.entity_store.update(
+                            vector_id=match.id,
+                            vector=None,
+                            payload=payload,
+                        )
+
+            if not matched:
                 entity_id = str(uuid.uuid4())
                 entity_payload = {
                     "data": entity_text,
@@ -2237,19 +2243,27 @@ class AsyncMemory(MemoryBase):
 
             semantic_match = existing[0] if existing and existing[0].score >= 0.95 else None
             match = exact_match or semantic_match
+            matched = False
             if match:
                 payload = match.payload or {}
-                linked_ids = payload.get("linked_memory_ids", [])
-                if memory_id not in linked_ids:
-                    linked_ids.append(memory_id)
-                    payload["linked_memory_ids"] = linked_ids
-                    await asyncio.to_thread(
-                        self.entity_store.update,
-                        vector_id=match.id,
-                        vector=None,
-                        payload=payload,
-                    )
-            else:
+                if entity_type and payload.get("entity_type") and payload["entity_type"] != entity_type:
+                    pass
+                else:
+                    matched = True
+                    linked_ids = payload.get("linked_memory_ids", [])
+                    if memory_id not in linked_ids:
+                        linked_ids.append(memory_id)
+                        payload["linked_memory_ids"] = linked_ids
+                        if entity_type and not payload.get("entity_type"):
+                            payload["entity_type"] = entity_type
+                        await asyncio.to_thread(
+                            self.entity_store.update,
+                            vector_id=match.id,
+                            vector=None,
+                            payload=payload,
+                        )
+
+            if not matched:
                 entity_id = str(uuid.uuid4())
                 entity_payload = {
                     "data": entity_text,

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1132,7 +1132,7 @@ class Memory(MemoryBase):
                             payload = match.payload or {}
                             existing_type = payload.get("entity_type")
                             if entity_type and existing_type and existing_type != entity_type:
-                                matched = False
+                                pass
                             else:
                                 matched = True
                                 linked = set(payload.get("linked_memory_ids", []))
@@ -2780,7 +2780,7 @@ class AsyncMemory(MemoryBase):
                             payload = match.payload or {}
                             existing_type = payload.get("entity_type")
                             if entity_type and existing_type and existing_type != entity_type:
-                                matched = False
+                                pass
                             else:
                                 matched = True
                                 linked = set(payload.get("linked_memory_ids", []))

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -599,7 +599,14 @@ class Memory(MemoryBase):
             if match:
                 payload = match.payload or {}
                 if entity_type and payload.get("entity_type") and payload["entity_type"] != entity_type:
-                    pass
+                    logger.warning(
+                        "Skipping merge for entity %r: stored entity_type %r != new "
+                        "entity_type %r. A duplicate entity will be created instead of "
+                        "merging (this can happen after an entity_type vocabulary change).",
+                        entity_text,
+                        payload.get("entity_type"),
+                        entity_type,
+                    )
                 else:
                     matched = True
                     linked_ids = payload.get("linked_memory_ids", [])
@@ -1132,7 +1139,14 @@ class Memory(MemoryBase):
                             payload = match.payload or {}
                             existing_type = payload.get("entity_type")
                             if entity_type and existing_type and existing_type != entity_type:
-                                pass
+                                logger.warning(
+                                    "Skipping merge for entity %r: stored entity_type %r != new "
+                                    "entity_type %r. A duplicate entity will be created instead of "
+                                    "merging (this can happen after an entity_type vocabulary change).",
+                                    entity_text,
+                                    existing_type,
+                                    entity_type,
+                                )
                             else:
                                 matched = True
                                 linked = set(payload.get("linked_memory_ids", []))
@@ -2255,7 +2269,14 @@ class AsyncMemory(MemoryBase):
             if match:
                 payload = match.payload or {}
                 if entity_type and payload.get("entity_type") and payload["entity_type"] != entity_type:
-                    pass
+                    logger.warning(
+                        "Skipping merge for entity %r: stored entity_type %r != new "
+                        "entity_type %r. A duplicate entity will be created instead of "
+                        "merging (this can happen after an entity_type vocabulary change).",
+                        entity_text,
+                        payload.get("entity_type"),
+                        entity_type,
+                    )
                 else:
                     matched = True
                     linked_ids = payload.get("linked_memory_ids", [])
@@ -2780,7 +2801,14 @@ class AsyncMemory(MemoryBase):
                             payload = match.payload or {}
                             existing_type = payload.get("entity_type")
                             if entity_type and existing_type and existing_type != entity_type:
-                                pass
+                                logger.warning(
+                                    "Skipping merge for entity %r: stored entity_type %r != new "
+                                    "entity_type %r. A duplicate entity will be created instead of "
+                                    "merging (this can happen after an entity_type vocabulary change).",
+                                    entity_text,
+                                    existing_type,
+                                    entity_type,
+                                )
                             else:
                                 matched = True
                                 linked = set(payload.get("linked_memory_ids", []))

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1127,21 +1127,29 @@ class Memory(MemoryBase):
 
                         semantic_match = matches[0] if matches and matches[0].score >= 0.95 else None
                         match = exact_match or semantic_match
+                        matched = False
                         if match:
-                            # Update existing entity
                             payload = match.payload or {}
-                            linked = set(payload.get("linked_memory_ids", []))
-                            linked |= memory_ids
-                            payload["linked_memory_ids"] = sorted(linked)
-                            try:
-                                self.entity_store.update(
-                                    vector_id=match.id,
-                                    vector=None,
-                                    payload=payload,
-                                )
-                            except Exception as e:
-                                logger.debug(f"Entity update failed for '{entity_text}': {e}")
-                        else:
+                            existing_type = payload.get("entity_type")
+                            if entity_type and existing_type and existing_type != entity_type:
+                                matched = False
+                            else:
+                                matched = True
+                                linked = set(payload.get("linked_memory_ids", []))
+                                linked |= memory_ids
+                                payload["linked_memory_ids"] = sorted(linked)
+                                if not existing_type and entity_type:
+                                    payload["entity_type"] = entity_type
+                                try:
+                                    self.entity_store.update(
+                                        vector_id=match.id,
+                                        vector=None,
+                                        payload=payload,
+                                    )
+                                except Exception as e:
+                                    logger.debug(f"Entity update failed for '{entity_text}': {e}")
+
+                        if not matched:
                             # New entity — collect for batch insert
                             to_insert_vectors.append(valid_vectors[j])
                             to_insert_ids.append(str(uuid.uuid4()))
@@ -2767,21 +2775,30 @@ class AsyncMemory(MemoryBase):
 
                         semantic_match = matches[0] if matches and matches[0].score >= 0.95 else None
                         match = exact_match or semantic_match
+                        matched = False
                         if match:
                             payload = match.payload or {}
-                            linked = set(payload.get("linked_memory_ids", []))
-                            linked |= memory_ids
-                            payload["linked_memory_ids"] = sorted(linked)
-                            try:
-                                await asyncio.to_thread(
-                                    self.entity_store.update,
-                                    vector_id=match.id,
-                                    vector=None,
-                                    payload=payload,
-                                )
-                            except Exception as e:
-                                logger.debug(f"Entity update failed for '{entity_text}' (async): {e}")
-                        else:
+                            existing_type = payload.get("entity_type")
+                            if entity_type and existing_type and existing_type != entity_type:
+                                matched = False
+                            else:
+                                matched = True
+                                linked = set(payload.get("linked_memory_ids", []))
+                                linked |= memory_ids
+                                payload["linked_memory_ids"] = sorted(linked)
+                                if not existing_type and entity_type:
+                                    payload["entity_type"] = entity_type
+                                try:
+                                    await asyncio.to_thread(
+                                        self.entity_store.update,
+                                        vector_id=match.id,
+                                        vector=None,
+                                        payload=payload,
+                                    )
+                                except Exception as e:
+                                    logger.debug(f"Entity update failed for '{entity_text}' (async): {e}")
+
+                        if not matched:
                             to_insert_vectors.append(valid_vectors[j])
                             to_insert_ids.append(str(uuid.uuid4()))
                             to_insert_payloads.append({

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1157,21 +1157,29 @@ class Memory(MemoryBase):
 
                         semantic_match = matches[0] if matches and matches[0].score >= 0.95 else None
                         match = exact_match or semantic_match
+                        matched = False
                         if match:
-                            # Update existing entity
                             payload = match.payload or {}
-                            linked = set(payload.get("linked_memory_ids", []))
-                            linked |= memory_ids
-                            payload["linked_memory_ids"] = sorted(linked)
-                            try:
-                                self.entity_store.update(
-                                    vector_id=match.id,
-                                    vector=None,
-                                    payload=payload,
-                                )
-                            except Exception as e:
-                                logger.debug(f"Entity update failed for '{entity_text}': {e}")
-                        else:
+                            existing_type = payload.get("entity_type")
+                            if entity_type and existing_type and existing_type != entity_type:
+                                matched = False
+                            else:
+                                matched = True
+                                linked = set(payload.get("linked_memory_ids", []))
+                                linked |= memory_ids
+                                payload["linked_memory_ids"] = sorted(linked)
+                                if not existing_type and entity_type:
+                                    payload["entity_type"] = entity_type
+                                try:
+                                    self.entity_store.update(
+                                        vector_id=match.id,
+                                        vector=None,
+                                        payload=payload,
+                                    )
+                                except Exception as e:
+                                    logger.debug(f"Entity update failed for '{entity_text}': {e}")
+
+                        if not matched:
                             # New entity — collect for batch insert
                             to_insert_vectors.append(valid_vectors[j])
                             to_insert_ids.append(str(uuid.uuid4()))
@@ -2823,21 +2831,30 @@ class AsyncMemory(MemoryBase):
 
                         semantic_match = matches[0] if matches and matches[0].score >= 0.95 else None
                         match = exact_match or semantic_match
+                        matched = False
                         if match:
                             payload = match.payload or {}
-                            linked = set(payload.get("linked_memory_ids", []))
-                            linked |= memory_ids
-                            payload["linked_memory_ids"] = sorted(linked)
-                            try:
-                                await asyncio.to_thread(
-                                    self.entity_store.update,
-                                    vector_id=match.id,
-                                    vector=None,
-                                    payload=payload,
-                                )
-                            except Exception as e:
-                                logger.debug(f"Entity update failed for '{entity_text}' (async): {e}")
-                        else:
+                            existing_type = payload.get("entity_type")
+                            if entity_type and existing_type and existing_type != entity_type:
+                                matched = False
+                            else:
+                                matched = True
+                                linked = set(payload.get("linked_memory_ids", []))
+                                linked |= memory_ids
+                                payload["linked_memory_ids"] = sorted(linked)
+                                if not existing_type and entity_type:
+                                    payload["entity_type"] = entity_type
+                                try:
+                                    await asyncio.to_thread(
+                                        self.entity_store.update,
+                                        vector_id=match.id,
+                                        vector=None,
+                                        payload=payload,
+                                    )
+                                except Exception as e:
+                                    logger.debug(f"Entity update failed for '{entity_text}' (async): {e}")
+
+                        if not matched:
                             to_insert_vectors.append(valid_vectors[j])
                             to_insert_ids.append(str(uuid.uuid4()))
                             to_insert_payloads.append({

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -620,20 +620,26 @@ class Memory(MemoryBase):
 
             semantic_match = existing[0] if existing and existing[0].score >= 0.95 else None
             match = exact_match or semantic_match
+            matched = False
             if match:
-                # Update existing entity's linked_memory_ids
                 payload = match.payload or {}
-                linked_ids = payload.get("linked_memory_ids", [])
-                if memory_id not in linked_ids:
-                    linked_ids.append(memory_id)
-                    payload["linked_memory_ids"] = linked_ids
-                    self.entity_store.update(
-                        vector_id=match.id,
-                        vector=None,
-                        payload=payload,
-                    )
-            else:
-                # Create new entity
+                if entity_type and payload.get("entity_type") and payload["entity_type"] != entity_type:
+                    pass
+                else:
+                    matched = True
+                    linked_ids = payload.get("linked_memory_ids", [])
+                    if memory_id not in linked_ids:
+                        linked_ids.append(memory_id)
+                        payload["linked_memory_ids"] = linked_ids
+                        if entity_type and not payload.get("entity_type"):
+                            payload["entity_type"] = entity_type
+                        self.entity_store.update(
+                            vector_id=match.id,
+                            vector=None,
+                            payload=payload,
+                        )
+
+            if not matched:
                 entity_id = str(uuid.uuid4())
                 entity_payload = {
                     "data": entity_text,
@@ -2287,19 +2293,27 @@ class AsyncMemory(MemoryBase):
 
             semantic_match = existing[0] if existing and existing[0].score >= 0.95 else None
             match = exact_match or semantic_match
+            matched = False
             if match:
                 payload = match.payload or {}
-                linked_ids = payload.get("linked_memory_ids", [])
-                if memory_id not in linked_ids:
-                    linked_ids.append(memory_id)
-                    payload["linked_memory_ids"] = linked_ids
-                    await asyncio.to_thread(
-                        self.entity_store.update,
-                        vector_id=match.id,
-                        vector=None,
-                        payload=payload,
-                    )
-            else:
+                if entity_type and payload.get("entity_type") and payload["entity_type"] != entity_type:
+                    pass
+                else:
+                    matched = True
+                    linked_ids = payload.get("linked_memory_ids", [])
+                    if memory_id not in linked_ids:
+                        linked_ids.append(memory_id)
+                        payload["linked_memory_ids"] = linked_ids
+                        if entity_type and not payload.get("entity_type"):
+                            payload["entity_type"] = entity_type
+                        await asyncio.to_thread(
+                            self.entity_store.update,
+                            vector_id=match.id,
+                            vector=None,
+                            payload=payload,
+                        )
+
+            if not matched:
                 entity_id = str(uuid.uuid4())
                 entity_payload = {
                     "data": entity_text,

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1162,7 +1162,7 @@ class Memory(MemoryBase):
                             payload = match.payload or {}
                             existing_type = payload.get("entity_type")
                             if entity_type and existing_type and existing_type != entity_type:
-                                matched = False
+                                pass
                             else:
                                 matched = True
                                 linked = set(payload.get("linked_memory_ids", []))
@@ -2836,7 +2836,7 @@ class AsyncMemory(MemoryBase):
                             payload = match.payload or {}
                             existing_type = payload.get("entity_type")
                             if entity_type and existing_type and existing_type != entity_type:
-                                matched = False
+                                pass
                             else:
                                 matched = True
                                 linked = set(payload.get("linked_memory_ids", []))

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -624,7 +624,14 @@ class Memory(MemoryBase):
             if match:
                 payload = match.payload or {}
                 if entity_type and payload.get("entity_type") and payload["entity_type"] != entity_type:
-                    pass
+                    logger.warning(
+                        "Skipping merge for entity %r: stored entity_type %r != new "
+                        "entity_type %r. A duplicate entity will be created instead of "
+                        "merging (this can happen after an entity_type vocabulary change).",
+                        entity_text,
+                        payload.get("entity_type"),
+                        entity_type,
+                    )
                 else:
                     matched = True
                     linked_ids = payload.get("linked_memory_ids", [])
@@ -1162,7 +1169,14 @@ class Memory(MemoryBase):
                             payload = match.payload or {}
                             existing_type = payload.get("entity_type")
                             if entity_type and existing_type and existing_type != entity_type:
-                                pass
+                                logger.warning(
+                                    "Skipping merge for entity %r: stored entity_type %r != new "
+                                    "entity_type %r. A duplicate entity will be created instead of "
+                                    "merging (this can happen after an entity_type vocabulary change).",
+                                    entity_text,
+                                    existing_type,
+                                    entity_type,
+                                )
                             else:
                                 matched = True
                                 linked = set(payload.get("linked_memory_ids", []))
@@ -2305,7 +2319,14 @@ class AsyncMemory(MemoryBase):
             if match:
                 payload = match.payload or {}
                 if entity_type and payload.get("entity_type") and payload["entity_type"] != entity_type:
-                    pass
+                    logger.warning(
+                        "Skipping merge for entity %r: stored entity_type %r != new "
+                        "entity_type %r. A duplicate entity will be created instead of "
+                        "merging (this can happen after an entity_type vocabulary change).",
+                        entity_text,
+                        payload.get("entity_type"),
+                        entity_type,
+                    )
                 else:
                     matched = True
                     linked_ids = payload.get("linked_memory_ids", [])
@@ -2836,7 +2857,14 @@ class AsyncMemory(MemoryBase):
                             payload = match.payload or {}
                             existing_type = payload.get("entity_type")
                             if entity_type and existing_type and existing_type != entity_type:
-                                pass
+                                logger.warning(
+                                    "Skipping merge for entity %r: stored entity_type %r != new "
+                                    "entity_type %r. A duplicate entity will be created instead of "
+                                    "merging (this can happen after an entity_type vocabulary change).",
+                                    entity_text,
+                                    existing_type,
+                                    entity_type,
+                                )
                             else:
                                 matched = True
                                 linked = set(payload.get("linked_memory_ids", []))

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1700,6 +1700,64 @@ class TestEntityTypeMergeGate:
         assert inserted_payload["entity_type"] == "NOUN"
 
     @pytest.mark.asyncio
+    @patch("mem0.memory.main.extract_entities_batch")
+    @patch("mem0.memory.telemetry.capture_event")
+    @patch("mem0.memory.main.SQLiteManager")
+    @patch("mem0.utils.factory.LlmFactory.create")
+    @patch("mem0.utils.factory.EmbedderFactory.create")
+    @patch("mem0.utils.factory.VectorStoreFactory.create")
+    async def test_async_phase7d_different_type_inserts_instead_of_update(
+        self, mock_vs, mock_emb, mock_llm, mock_sqlite, _cap, mock_extract
+    ):
+        """Async Phase 7d (AsyncMemory._add_to_vector_store) must not merge
+        entities with different entity_type."""
+        from mem0.memory.main import AsyncMemory
+
+        mock_embedder = MagicMock()
+        mock_embedder.embed.return_value = [0.1, 0.2, 0.3]
+        mock_embedder.embed_batch.return_value = [[0.1, 0.2, 0.3]]
+        mock_emb.return_value = mock_embedder
+
+        mock_vector_store = MagicMock()
+        mock_vector_store.search.return_value = []
+        mock_vs.return_value = mock_vector_store
+
+        mock_llm_inst = MagicMock()
+        mock_llm_inst.generate_response.return_value = json.dumps({
+            "memory": [{"text": "Python is a snake", "event": "ADD"}]
+        })
+        mock_llm.return_value = mock_llm_inst
+        mock_sqlite.return_value = MagicMock()
+
+        mock_extract.return_value = [
+            [("NOUN", "python")]
+        ]
+
+        config = MemoryConfig()
+        m = AsyncMemory(config)
+        entity_store = MagicMock()
+        entity_store.search_batch.return_value = [
+            [MockVectorMemory(
+                "entity-1",
+                {"data": "python", "entity_type": "PROPER", "linked_memory_ids": ["mem-A"]},
+                score=0.99,
+            )]
+        ]
+        m._entity_store = entity_store
+
+        await m._add_to_vector_store(
+            messages=[{"role": "user", "content": "Python is a snake"}],
+            metadata={"user_id": "u1"},
+            effective_filters={"user_id": "u1"},
+            infer=True,
+        )
+
+        entity_store.update.assert_not_called()
+        entity_store.insert.assert_called_once()
+        inserted_payload = entity_store.insert.call_args.kwargs["payloads"][0]
+        assert inserted_payload["entity_type"] == "NOUN"
+
+    @pytest.mark.asyncio
     async def test_async_upsert_entity_different_type_creates_new(self):
         """_upsert_entity_async must not merge entities with different entity_type."""
         from mem0.memory.main import AsyncMemory

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1644,3 +1644,57 @@ class TestEntityTypeMergeGate:
 
         m._entity_store.update.assert_called_once()
         m._entity_store.insert.assert_not_called()
+
+    @patch("mem0.memory.main.extract_entities_batch")
+    @patch("mem0.memory.telemetry.capture_event")
+    @patch("mem0.memory.main.SQLiteManager")
+    @patch("mem0.utils.factory.LlmFactory.create")
+    @patch("mem0.utils.factory.EmbedderFactory.create")
+    @patch("mem0.utils.factory.VectorStoreFactory.create")
+    def test_phase7d_different_type_inserts_instead_of_update(
+        self, mock_vs, mock_emb, mock_llm, mock_sqlite, _cap, mock_extract
+    ):
+        """Phase 7d in _add_to_vector_store must not merge entities with different entity_type."""
+        mock_embedder = MagicMock()
+        mock_embedder.embed.return_value = [0.1, 0.2, 0.3]
+        mock_embedder.embed_batch.return_value = [[0.1, 0.2, 0.3]]
+        mock_emb.return_value = mock_embedder
+
+        mock_vector_store = MagicMock()
+        mock_vector_store.search.return_value = []
+        mock_vs.return_value = mock_vector_store
+
+        mock_llm_inst = MagicMock()
+        mock_llm_inst.generate_response.return_value = json.dumps({
+            "memory": [{"text": "Python is a snake", "event": "ADD"}]
+        })
+        mock_llm.return_value = mock_llm_inst
+        mock_sqlite.return_value = MagicMock()
+
+        mock_extract.return_value = [
+            [("NOUN", "python")]
+        ]
+
+        config = MemoryConfig()
+        m = Memory(config)
+        entity_store = MagicMock()
+        entity_store.search_batch.return_value = [
+            [MockVectorMemory(
+                "entity-1",
+                {"data": "python", "entity_type": "PROPER", "linked_memory_ids": ["mem-A"]},
+                score=0.99,
+            )]
+        ]
+        m._entity_store = entity_store
+
+        m._add_to_vector_store(
+            messages=[{"role": "user", "content": "Python is a snake"}],
+            metadata={"user_id": "u1"},
+            filters={"user_id": "u1"},
+            infer=True,
+        )
+
+        entity_store.update.assert_not_called()
+        entity_store.insert.assert_called_once()
+        inserted_payload = entity_store.insert.call_args.kwargs["payloads"][0]
+        assert inserted_payload["entity_type"] == "NOUN"

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1611,7 +1611,7 @@ class TestEntityTypeMergeGate:
 
         m._entity_store.update.assert_not_called()
         m._entity_store.insert.assert_called_once()
-        inserted_payload = m._entity_store.insert.call_args[1]["payloads"][0]
+        inserted_payload = m._entity_store.insert.call_args.kwargs["payloads"][0]
         assert inserted_payload["entity_type"] == "animal"
 
     def test_no_type_on_existing_still_merges(self):
@@ -1627,7 +1627,7 @@ class TestEntityTypeMergeGate:
         m._upsert_entity("python", "language", "mem-B", {})
 
         m._entity_store.update.assert_called_once()
-        updated_payload = m._entity_store.update.call_args[1]["payload"]
+        updated_payload = m._entity_store.update.call_args.kwargs["payload"]
         assert updated_payload["entity_type"] == "language"
 
     def test_no_type_on_new_still_merges(self):
@@ -1697,4 +1697,31 @@ class TestEntityTypeMergeGate:
         entity_store.update.assert_not_called()
         entity_store.insert.assert_called_once()
         inserted_payload = entity_store.insert.call_args.kwargs["payloads"][0]
+        assert inserted_payload["entity_type"] == "NOUN"
+
+    @pytest.mark.asyncio
+    async def test_async_upsert_entity_different_type_creates_new(self):
+        """_upsert_entity_async must not merge entities with different entity_type."""
+        from mem0.memory.main import AsyncMemory
+
+        with patch.object(AsyncMemory, "__init__", return_value=None):
+            m = AsyncMemory()
+        m.embedding_model = MagicMock()
+        m.embedding_model.embed = MagicMock(return_value=[0.1, 0.2, 0.3])
+        m._entity_store = MagicMock()
+
+        existing = MockVectorMemory(
+            "entity-1",
+            {"data": "python", "entity_type": "PROPER", "linked_memory_ids": ["mem-A"]},
+            score=0.99,
+        )
+        m._entity_store.search = MagicMock(return_value=[existing])
+        m._entity_store.update = MagicMock()
+        m._entity_store.insert = MagicMock()
+
+        await m._upsert_entity_async("python", "NOUN", "mem-B", {})
+
+        m._entity_store.update.assert_not_called()
+        m._entity_store.insert.assert_called_once()
+        inserted_payload = m._entity_store.insert.call_args.kwargs["payloads"][0]
         assert inserted_payload["entity_type"] == "NOUN"

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1570,3 +1570,77 @@ async def test_async_procedural_memory_default_path_without_langchain(mock_llm_f
 
     assert result["results"][0]["event"] == "ADD"
     memory.llm.generate_response.assert_called_once()
+
+
+class TestEntityTypeMergeGate:
+    """Verify _upsert_entity refuses to merge entities with different entity_type."""
+
+    def _make_memory(self):
+        with patch.object(Memory, "__init__", return_value=None):
+            m = Memory()
+        m.embedding_model = MagicMock()
+        m.embedding_model.embed = MagicMock(return_value=[0.1, 0.2, 0.3])
+        m._entity_store = MagicMock()
+        m._existing_entities_by_text = MagicMock(return_value={})
+        return m
+
+    def test_same_type_merges(self):
+        m = self._make_memory()
+        existing = MockVectorMemory(
+            "entity-1",
+            {"data": "python", "entity_type": "language", "linked_memory_ids": ["mem-A"]},
+            score=0.99,
+        )
+        m._entity_store.search = MagicMock(return_value=[existing])
+
+        m._upsert_entity("python", "language", "mem-B", {})
+
+        m._entity_store.update.assert_called_once()
+        m._entity_store.insert.assert_not_called()
+
+    def test_different_type_creates_new(self):
+        m = self._make_memory()
+        existing = MockVectorMemory(
+            "entity-1",
+            {"data": "python", "entity_type": "language", "linked_memory_ids": ["mem-A"]},
+            score=0.99,
+        )
+        m._entity_store.search = MagicMock(return_value=[existing])
+
+        m._upsert_entity("python", "animal", "mem-B", {})
+
+        m._entity_store.update.assert_not_called()
+        m._entity_store.insert.assert_called_once()
+        inserted_payload = m._entity_store.insert.call_args[1]["payloads"][0]
+        assert inserted_payload["entity_type"] == "animal"
+
+    def test_no_type_on_existing_still_merges(self):
+        """When existing entity has no entity_type, merge is allowed (backward compat)."""
+        m = self._make_memory()
+        existing = MockVectorMemory(
+            "entity-1",
+            {"data": "python", "linked_memory_ids": ["mem-A"]},
+            score=0.99,
+        )
+        m._entity_store.search = MagicMock(return_value=[existing])
+
+        m._upsert_entity("python", "language", "mem-B", {})
+
+        m._entity_store.update.assert_called_once()
+        updated_payload = m._entity_store.update.call_args[1]["payload"]
+        assert updated_payload["entity_type"] == "language"
+
+    def test_no_type_on_new_still_merges(self):
+        """When new entity has no entity_type, merge is allowed."""
+        m = self._make_memory()
+        existing = MockVectorMemory(
+            "entity-1",
+            {"data": "python", "entity_type": "language", "linked_memory_ids": ["mem-A"]},
+            score=0.99,
+        )
+        m._entity_store.search = MagicMock(return_value=[existing])
+
+        m._upsert_entity("python", None, "mem-B", {})
+
+        m._entity_store.update.assert_called_once()
+        m._entity_store.insert.assert_not_called()

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1739,3 +1739,57 @@ class TestEntityTypeMergeGate:
 
         m._entity_store.update.assert_called_once()
         m._entity_store.insert.assert_not_called()
+
+    @patch("mem0.memory.main.extract_entities_batch")
+    @patch("mem0.memory.telemetry.capture_event")
+    @patch("mem0.memory.main.SQLiteManager")
+    @patch("mem0.utils.factory.LlmFactory.create")
+    @patch("mem0.utils.factory.EmbedderFactory.create")
+    @patch("mem0.utils.factory.VectorStoreFactory.create")
+    def test_phase7d_different_type_inserts_instead_of_update(
+        self, mock_vs, mock_emb, mock_llm, mock_sqlite, _cap, mock_extract
+    ):
+        """Phase 7d in _add_to_vector_store must not merge entities with different entity_type."""
+        mock_embedder = MagicMock()
+        mock_embedder.embed.return_value = [0.1, 0.2, 0.3]
+        mock_embedder.embed_batch.return_value = [[0.1, 0.2, 0.3]]
+        mock_emb.return_value = mock_embedder
+
+        mock_vector_store = MagicMock()
+        mock_vector_store.search.return_value = []
+        mock_vs.return_value = mock_vector_store
+
+        mock_llm_inst = MagicMock()
+        mock_llm_inst.generate_response.return_value = json.dumps({
+            "memory": [{"text": "Python is a snake", "event": "ADD"}]
+        })
+        mock_llm.return_value = mock_llm_inst
+        mock_sqlite.return_value = MagicMock()
+
+        mock_extract.return_value = [
+            [("NOUN", "python")]
+        ]
+
+        config = MemoryConfig()
+        m = Memory(config)
+        entity_store = MagicMock()
+        entity_store.search_batch.return_value = [
+            [MockVectorMemory(
+                "entity-1",
+                {"data": "python", "entity_type": "PROPER", "linked_memory_ids": ["mem-A"]},
+                score=0.99,
+            )]
+        ]
+        m._entity_store = entity_store
+
+        m._add_to_vector_store(
+            messages=[{"role": "user", "content": "Python is a snake"}],
+            metadata={"user_id": "u1"},
+            filters={"user_id": "u1"},
+            infer=True,
+        )
+
+        entity_store.update.assert_not_called()
+        entity_store.insert.assert_called_once()
+        inserted_payload = entity_store.insert.call_args.kwargs["payloads"][0]
+        assert inserted_payload["entity_type"] == "NOUN"

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1795,6 +1795,64 @@ class TestEntityTypeMergeGate:
         assert inserted_payload["entity_type"] == "NOUN"
 
     @pytest.mark.asyncio
+    @patch("mem0.memory.main.extract_entities_batch")
+    @patch("mem0.memory.telemetry.capture_event")
+    @patch("mem0.memory.main.SQLiteManager")
+    @patch("mem0.utils.factory.LlmFactory.create")
+    @patch("mem0.utils.factory.EmbedderFactory.create")
+    @patch("mem0.utils.factory.VectorStoreFactory.create")
+    async def test_async_phase7d_different_type_inserts_instead_of_update(
+        self, mock_vs, mock_emb, mock_llm, mock_sqlite, _cap, mock_extract
+    ):
+        """Async Phase 7d (AsyncMemory._add_to_vector_store) must not merge
+        entities with different entity_type."""
+        from mem0.memory.main import AsyncMemory
+
+        mock_embedder = MagicMock()
+        mock_embedder.embed.return_value = [0.1, 0.2, 0.3]
+        mock_embedder.embed_batch.return_value = [[0.1, 0.2, 0.3]]
+        mock_emb.return_value = mock_embedder
+
+        mock_vector_store = MagicMock()
+        mock_vector_store.search.return_value = []
+        mock_vs.return_value = mock_vector_store
+
+        mock_llm_inst = MagicMock()
+        mock_llm_inst.generate_response.return_value = json.dumps({
+            "memory": [{"text": "Python is a snake", "event": "ADD"}]
+        })
+        mock_llm.return_value = mock_llm_inst
+        mock_sqlite.return_value = MagicMock()
+
+        mock_extract.return_value = [
+            [("NOUN", "python")]
+        ]
+
+        config = MemoryConfig()
+        m = AsyncMemory(config)
+        entity_store = MagicMock()
+        entity_store.search_batch.return_value = [
+            [MockVectorMemory(
+                "entity-1",
+                {"data": "python", "entity_type": "PROPER", "linked_memory_ids": ["mem-A"]},
+                score=0.99,
+            )]
+        ]
+        m._entity_store = entity_store
+
+        await m._add_to_vector_store(
+            messages=[{"role": "user", "content": "Python is a snake"}],
+            metadata={"user_id": "u1"},
+            effective_filters={"user_id": "u1"},
+            infer=True,
+        )
+
+        entity_store.update.assert_not_called()
+        entity_store.insert.assert_called_once()
+        inserted_payload = entity_store.insert.call_args.kwargs["payloads"][0]
+        assert inserted_payload["entity_type"] == "NOUN"
+
+    @pytest.mark.asyncio
     async def test_async_upsert_entity_different_type_creates_new(self):
         """_upsert_entity_async must not merge entities with different entity_type."""
         from mem0.memory.main import AsyncMemory

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1706,7 +1706,7 @@ class TestEntityTypeMergeGate:
 
         m._entity_store.update.assert_not_called()
         m._entity_store.insert.assert_called_once()
-        inserted_payload = m._entity_store.insert.call_args[1]["payloads"][0]
+        inserted_payload = m._entity_store.insert.call_args.kwargs["payloads"][0]
         assert inserted_payload["entity_type"] == "animal"
 
     def test_no_type_on_existing_still_merges(self):
@@ -1722,7 +1722,7 @@ class TestEntityTypeMergeGate:
         m._upsert_entity("python", "language", "mem-B", {})
 
         m._entity_store.update.assert_called_once()
-        updated_payload = m._entity_store.update.call_args[1]["payload"]
+        updated_payload = m._entity_store.update.call_args.kwargs["payload"]
         assert updated_payload["entity_type"] == "language"
 
     def test_no_type_on_new_still_merges(self):
@@ -1792,4 +1792,31 @@ class TestEntityTypeMergeGate:
         entity_store.update.assert_not_called()
         entity_store.insert.assert_called_once()
         inserted_payload = entity_store.insert.call_args.kwargs["payloads"][0]
+        assert inserted_payload["entity_type"] == "NOUN"
+
+    @pytest.mark.asyncio
+    async def test_async_upsert_entity_different_type_creates_new(self):
+        """_upsert_entity_async must not merge entities with different entity_type."""
+        from mem0.memory.main import AsyncMemory
+
+        with patch.object(AsyncMemory, "__init__", return_value=None):
+            m = AsyncMemory()
+        m.embedding_model = MagicMock()
+        m.embedding_model.embed = MagicMock(return_value=[0.1, 0.2, 0.3])
+        m._entity_store = MagicMock()
+
+        existing = MockVectorMemory(
+            "entity-1",
+            {"data": "python", "entity_type": "PROPER", "linked_memory_ids": ["mem-A"]},
+            score=0.99,
+        )
+        m._entity_store.search = MagicMock(return_value=[existing])
+        m._entity_store.update = MagicMock()
+        m._entity_store.insert = MagicMock()
+
+        await m._upsert_entity_async("python", "NOUN", "mem-B", {})
+
+        m._entity_store.update.assert_not_called()
+        m._entity_store.insert.assert_called_once()
+        inserted_payload = m._entity_store.insert.call_args.kwargs["payloads"][0]
         assert inserted_payload["entity_type"] == "NOUN"

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1665,3 +1665,77 @@ def test_sync_procedural_memory_empty_content_raises(
         )
 
     mock_vector_store.insert.assert_not_called()
+
+
+class TestEntityTypeMergeGate:
+    """Verify _upsert_entity refuses to merge entities with different entity_type."""
+
+    def _make_memory(self):
+        with patch.object(Memory, "__init__", return_value=None):
+            m = Memory()
+        m.embedding_model = MagicMock()
+        m.embedding_model.embed = MagicMock(return_value=[0.1, 0.2, 0.3])
+        m._entity_store = MagicMock()
+        m._existing_entities_by_text = MagicMock(return_value={})
+        return m
+
+    def test_same_type_merges(self):
+        m = self._make_memory()
+        existing = MockVectorMemory(
+            "entity-1",
+            {"data": "python", "entity_type": "language", "linked_memory_ids": ["mem-A"]},
+            score=0.99,
+        )
+        m._entity_store.search = MagicMock(return_value=[existing])
+
+        m._upsert_entity("python", "language", "mem-B", {})
+
+        m._entity_store.update.assert_called_once()
+        m._entity_store.insert.assert_not_called()
+
+    def test_different_type_creates_new(self):
+        m = self._make_memory()
+        existing = MockVectorMemory(
+            "entity-1",
+            {"data": "python", "entity_type": "language", "linked_memory_ids": ["mem-A"]},
+            score=0.99,
+        )
+        m._entity_store.search = MagicMock(return_value=[existing])
+
+        m._upsert_entity("python", "animal", "mem-B", {})
+
+        m._entity_store.update.assert_not_called()
+        m._entity_store.insert.assert_called_once()
+        inserted_payload = m._entity_store.insert.call_args[1]["payloads"][0]
+        assert inserted_payload["entity_type"] == "animal"
+
+    def test_no_type_on_existing_still_merges(self):
+        """When existing entity has no entity_type, merge is allowed (backward compat)."""
+        m = self._make_memory()
+        existing = MockVectorMemory(
+            "entity-1",
+            {"data": "python", "linked_memory_ids": ["mem-A"]},
+            score=0.99,
+        )
+        m._entity_store.search = MagicMock(return_value=[existing])
+
+        m._upsert_entity("python", "language", "mem-B", {})
+
+        m._entity_store.update.assert_called_once()
+        updated_payload = m._entity_store.update.call_args[1]["payload"]
+        assert updated_payload["entity_type"] == "language"
+
+    def test_no_type_on_new_still_merges(self):
+        """When new entity has no entity_type, merge is allowed."""
+        m = self._make_memory()
+        existing = MockVectorMemory(
+            "entity-1",
+            {"data": "python", "entity_type": "language", "linked_memory_ids": ["mem-A"]},
+            score=0.99,
+        )
+        m._entity_store.search = MagicMock(return_value=[existing])
+
+        m._upsert_entity("python", None, "mem-B", {})
+
+        m._entity_store.update.assert_called_once()
+        m._entity_store.insert.assert_not_called()


### PR DESCRIPTION
Closes #5438

## Problem

`_upsert_entity` and the Phase 7d batch path in `_add_to_vector_store` merge entities based solely on a 0.95 vector similarity threshold. Same-name entities with different roles get incorrectly merged, accumulating unrelated `linked_memory_ids` and degrading search quality.

## Scope

This PR adds a **cross-POS-category gate** -- it prevents merging when the syntactic `entity_type` values differ (e.g. PROPER vs NOUN, QUOTED vs COMPOUND). The four possible values come from `entity_extraction.py`: `PROPER`, `QUOTED`, `COMPOUND`, `NOUN`.

**What this catches:** a NOUN entity "python" (the snake) merging with a PROPER entity "Python" (a title/name). Different POS categories signal different usage contexts.

**What this does NOT catch:** same-POS polysemes like "Python" (the language) and "Python" (the snake), since both are classified as PROPER. Disambiguating those requires the `semantic_type` field from #5573, which is out of scope here.

## Fix

All four entity merge paths are now protected:
- `_upsert_entity` (sync)
- `_upsert_entity_async`
- `_add_to_vector_store` Phase 7d (sync)
- `_add_to_vector_store` Phase 7d (async)

Logic at each site:
- If both entities have `entity_type` set **and they differ**, skip the merge and insert a new entity
- If either side has no `entity_type`, merge is allowed (backward compat)
- When merging, backfill `entity_type` on the existing entity if it was missing

## Tests

6 tests in `TestEntityTypeMergeGate`:
- `test_same_type_merges` -- same entity_type, merge proceeds
- `test_different_type_creates_new` -- different entity_type, new entity created
- `test_no_type_on_existing_still_merges` -- existing lacks type, merge + backfill
- `test_no_type_on_new_still_merges` -- new entity lacks type, merge allowed
- `test_phase7d_different_type_inserts_instead_of_update` -- Phase 7d batch path with type mismatch
- `test_async_upsert_entity_different_type_creates_new` -- async path coverage

## Composition with #5573

PR #5573 changes `extract_entities` to return 3-tuples with `semantic_type`. If it merges first, this PR will need a rebase to update the unpacking loops. The natural resolution is combining both gates (`entity_type` + `semantic_type`) into a single predicate.