### PR TITLE
fix: sanitize entity collection name for S3 Vectors (no underscores)

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -418,6 +418,8 @@ class Memory(MemoryBase):
         if self._entity_store is None:
             entity_config = _safe_deepcopy_config(self.config.vector_store.config)
             entity_collection = f"{self.collection_name}_entities"
+            if self.config.vector_store.provider == "s3_vectors":
+                entity_collection = entity_collection.replace("_", "-")
             # Set collection name on the cloned config
             if hasattr(entity_config, 'collection_name'):
                 entity_config.collection_name = entity_collection
@@ -1890,6 +1892,8 @@ class AsyncMemory(MemoryBase):
         if self._entity_store is None:
             entity_config = _safe_deepcopy_config(self.config.vector_store.config)
             entity_collection = f"{self.collection_name}_entities"
+            if self.config.vector_store.provider == "s3_vectors":
+                entity_collection = entity_collection.replace("_", "-")
             if hasattr(entity_config, 'collection_name'):
                 entity_config.collection_name = entity_collection
             elif isinstance(entity_config, dict):

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1047,3 +1047,28 @@ class TestHybridSearchWarning:
             Memory(config)
 
         assert not any("does not support keyword search" in r.message for r in caplog.records)
+
+
+def test_s3_vectors_entity_collection_uses_dashes():
+    with patch.object(Memory, "__init__", return_value=None):
+        m = Memory()
+    m.embedding_model = MagicMock()
+    m._entity_store = None
+    m.collection_name = "my_memories"
+
+    mock_config = MagicMock()
+    mock_config.vector_store.provider = "s3_vectors"
+    mock_config.vector_store.config = MagicMock()
+    mock_config.vector_store.config.collection_name = "my_memories"
+    m.config = mock_config
+    m._vector_store = MagicMock()
+
+    with patch("mem0.memory.main.VectorStoreFactory") as mock_factory, \
+         patch("mem0.memory.main._safe_deepcopy_config") as mock_deepcopy:
+        cloned_config = MagicMock()
+        mock_deepcopy.return_value = cloned_config
+        mock_factory.create.return_value = MagicMock()
+
+        _ = m.entity_store
+
+        assert cloned_config.collection_name == "my-memories-entities"


### PR DESCRIPTION
Closes #5361

## Problem

S3 Vectors (AWS) does not allow underscores in index names. The entity store collection name is constructed as `f"{collection_name}_entities"` which always contains an underscore. When using S3 Vectors as the backend, this causes:

```
Batch entity linking failed: An error occurred (ValidationException) when calling the GetIndex operation: Invalid index name
```

## Fix

When the vector store provider is `s3_vectors`, replace all underscores with dashes in the entity collection name. For example, `my_memories_entities` becomes `my-memories-entities`.

Applied in both sync and async `entity_store` property initializers.

## Tests

1 new test `test_s3_vectors_entity_collection_uses_dashes` — verifies the entity collection name has no underscores when provider is s3_vectors.