### PR TITLE
fix: guard openclaw register() against duplicate cli-metadata invocation

### DIFF
--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -108,6 +108,26 @@ const memoryPlugin = definePluginEntry({
     };
     const cfg = mem0ConfigSchema.parse(api.pluginConfig, fileConfig);
 
+    // OpenClaw's plugin loader calls register() twice: once with
+    // registrationMode "full" and once with "cli-metadata". Only
+    // CLI commands need to be available in the metadata pass —
+    // skip all heavy side effects (provider init, hooks, tools,
+    // service registration, telemetry).
+    if ((api as any).registrationMode === "cli-metadata") {
+      registerCliCommands(
+        api,
+        null as any,
+        null as any,
+        cfg,
+        () => cfg.userId,
+        (id: string) => `${cfg.userId}:agent:${id}`,
+        () => ({ user_id: cfg.userId, top_k: cfg.topK }),
+        () => undefined,
+        () => {},
+      );
+      return;
+    }
+
     // Telemetry context bound to this plugin instance's config
     const telemetryCtx = {
       apiKey: cfg.apiKey,


### PR DESCRIPTION
Closes #5371

## Problem

OpenClaw's plugin loader calls `register()` twice per plugin startup:
1. `registrationMode: "full"` — full initialization
2. `registrationMode: "cli-metadata"` — only needs CLI command metadata

The mem0 plugin's `register()` doesn't check the mode, so every side effect runs twice: provider/backend creation, service registration, tool registration, hook registration, and telemetry events.

## Fix

Added an early-return guard at the top of `register()`: when `api.registrationMode === "cli-metadata"`, only register CLI commands (which is all the metadata pass needs) and return immediately — skipping provider init, backend creation, tools, hooks, service registration, and telemetry.

This matches the pattern already used in the `needsSetup` early-return path (which also only registers CLI).