### PR TITLE
feat(memory): expose opt-in OpenAI usage for OSS add

### DIFF
--- a/mem0/llms/openai.py
+++ b/mem0/llms/openai.py
@@ -30,9 +30,9 @@ class OpenAILLM(LLMBase):
                 top_k=config.top_k,
                 enable_vision=config.enable_vision,
                 vision_details=config.vision_details,
-                reasoning_effort=getattr(config, 'reasoning_effort', None),
+                reasoning_effort=getattr(config, "reasoning_effort", None),
                 http_client_proxies=config.http_client_proxies,
-                is_reasoning_model=getattr(config, 'is_reasoning_model', None),
+                is_reasoning_model=getattr(config, "is_reasoning_model", None),
             )
 
         super().__init__(config)
@@ -71,10 +71,7 @@ class OpenAILLM(LLMBase):
         elif isinstance(usage, dict):
             usage_dict = usage
         elif hasattr(usage, "__dict__"):
-            usage_dict = {
-                key: value for key, value in vars(usage).items()
-                if not key.startswith("_")
-            }
+            usage_dict = {key: value for key, value in vars(usage).items() if not key.startswith("_")}
         else:
             return None
 
@@ -177,10 +174,12 @@ class OpenAILLM(LLMBase):
             self.reset_last_usage()
         params = self._get_supported_params(messages=messages, **kwargs)
 
-        params.update({
-            "model": self.config.model,
-            "messages": messages,
-        })
+        params.update(
+            {
+                "model": self.config.model,
+                "messages": messages,
+            }
+        )
 
         if os.getenv("OPENROUTER_API_KEY"):
             openrouter_params = {}
@@ -197,7 +196,7 @@ class OpenAILLM(LLMBase):
                 openrouter_params["extra_headers"] = extra_headers
 
             params.update(**openrouter_params)
-        
+
         else:
             # Only send OpenAI-specific parameters when the user has explicitly
             # configured them. OpenAI-compatible backends (Gemini, Groq, vLLM, etc.)

--- a/mem0/llms/openai.py
+++ b/mem0/llms/openai.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+from contextvars import ContextVar
 from typing import Any, Dict, List, Optional, Union
 
 from openai import OpenAI
@@ -35,8 +36,14 @@ class OpenAILLM(LLMBase):
             )
 
         super().__init__(config)
-        self._last_usage: Optional[Dict[str, Any]] = None
-        self._capture_usage = False
+        self._last_usage_var: ContextVar[Optional[Dict[str, Any]]] = ContextVar(
+            f"openai_last_usage_{id(self)}",
+            default=None,
+        )
+        self._capture_usage_var: ContextVar[bool] = ContextVar(
+            f"openai_capture_usage_{id(self)}",
+            default=False,
+        )
 
         if not self.config.model:
             self.config.model = "gpt-5-mini"
@@ -74,19 +81,20 @@ class OpenAILLM(LLMBase):
         return usage_dict or None
 
     def reset_last_usage(self) -> None:
-        self._last_usage = None
+        self._last_usage_var.set(None)
 
     def get_last_usage(self) -> Optional[Dict[str, Any]]:
-        if self._last_usage is None:
+        usage = self._last_usage_var.get()
+        if usage is None:
             return None
-        return dict(self._last_usage)
+        return dict(usage)
 
     def start_usage_capture(self) -> None:
         self.reset_last_usage()
-        self._capture_usage = True
+        self._capture_usage_var.set(True)
 
     def stop_usage_capture(self) -> None:
-        self._capture_usage = False
+        self._capture_usage_var.set(False)
 
     def _merge_usage_values(self, current, incoming):
         if isinstance(current, dict) and isinstance(incoming, dict):
@@ -106,12 +114,13 @@ class OpenAILLM(LLMBase):
         return incoming
 
     def _store_usage(self, usage: Optional[Dict[str, Any]]) -> None:
-        if not self._capture_usage:
-            self._last_usage = usage
+        if not self._capture_usage_var.get():
+            self._last_usage_var.set(usage)
             return
 
         if usage:
-            self._last_usage = self._merge_usage_values(self._last_usage or {}, usage)
+            current_usage = self._last_usage_var.get() or {}
+            self._last_usage_var.set(self._merge_usage_values(current_usage, usage))
 
     def _parse_response(self, response, tools):
         """
@@ -164,7 +173,7 @@ class OpenAILLM(LLMBase):
         Returns:
             json: The generated response.
         """
-        if not self._capture_usage:
+        if not self._capture_usage_var.get():
             self.reset_last_usage()
         params = self._get_supported_params(messages=messages, **kwargs)
 

--- a/mem0/llms/openai.py
+++ b/mem0/llms/openai.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from openai import OpenAI
 
@@ -35,6 +35,8 @@ class OpenAILLM(LLMBase):
             )
 
         super().__init__(config)
+        self._last_usage: Optional[Dict[str, Any]] = None
+        self._capture_usage = False
 
         if not self.config.model:
             self.config.model = "gpt-5-mini"
@@ -51,6 +53,65 @@ class OpenAILLM(LLMBase):
             base_url = self.config.openai_base_url or os.getenv("OPENAI_BASE_URL") or "https://api.openai.com/v1"
 
             self.client = OpenAI(api_key=api_key, base_url=base_url)
+
+    def _extract_usage(self, response) -> Optional[Dict[str, Any]]:
+        usage = getattr(response, "usage", None)
+        if usage is None:
+            return None
+
+        if hasattr(usage, "model_dump"):
+            usage_dict = usage.model_dump()
+        elif isinstance(usage, dict):
+            usage_dict = usage
+        elif hasattr(usage, "__dict__"):
+            usage_dict = {
+                key: value for key, value in vars(usage).items()
+                if not key.startswith("_")
+            }
+        else:
+            return None
+
+        return usage_dict or None
+
+    def reset_last_usage(self) -> None:
+        self._last_usage = None
+
+    def get_last_usage(self) -> Optional[Dict[str, Any]]:
+        if self._last_usage is None:
+            return None
+        return dict(self._last_usage)
+
+    def start_usage_capture(self) -> None:
+        self.reset_last_usage()
+        self._capture_usage = True
+
+    def stop_usage_capture(self) -> None:
+        self._capture_usage = False
+
+    def _merge_usage_values(self, current, incoming):
+        if isinstance(current, dict) and isinstance(incoming, dict):
+            merged = dict(current)
+            for key, value in incoming.items():
+                merged[key] = self._merge_usage_values(merged[key], value) if key in merged else value
+            return merged
+
+        if (
+            isinstance(current, (int, float))
+            and not isinstance(current, bool)
+            and isinstance(incoming, (int, float))
+            and not isinstance(incoming, bool)
+        ):
+            return current + incoming
+
+        return incoming
+
+    def _store_usage(self, usage: Optional[Dict[str, Any]]) -> None:
+        if not self._capture_usage:
+            self._last_usage = usage
+            return
+
+        if usage:
+            self._last_usage = self._merge_usage_values(self._last_usage or {}, usage)
 
     def _parse_response(self, response, tools):
         """
@@ -103,8 +164,10 @@ class OpenAILLM(LLMBase):
         Returns:
             json: The generated response.
         """
+        if not self._capture_usage:
+            self.reset_last_usage()
         params = self._get_supported_params(messages=messages, **kwargs)
-        
+
         params.update({
             "model": self.config.model,
             "messages": messages,
@@ -139,6 +202,7 @@ class OpenAILLM(LLMBase):
             params["tools"] = tools
             params["tool_choice"] = tool_choice
         response = self.client.chat.completions.create(**params)
+        self._store_usage(self._extract_usage(response))
         parsed_response = self._parse_response(response, tools)
         if self.config.response_callback:
             try:

--- a/mem0/llms/openai.py
+++ b/mem0/llms/openai.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 from contextvars import ContextVar
+from copy import deepcopy
 from typing import Any, Dict, List, Optional, Union
 
 from openai import OpenAI
@@ -30,9 +31,9 @@ class OpenAILLM(LLMBase):
                 top_k=config.top_k,
                 enable_vision=config.enable_vision,
                 vision_details=config.vision_details,
-                reasoning_effort=getattr(config, "reasoning_effort", None),
+                reasoning_effort=getattr(config, 'reasoning_effort', None),
                 http_client_proxies=config.http_client_proxies,
-                is_reasoning_model=getattr(config, "is_reasoning_model", None),
+                is_reasoning_model=getattr(config, 'is_reasoning_model', None),
             )
 
         super().__init__(config)
@@ -71,7 +72,10 @@ class OpenAILLM(LLMBase):
         elif isinstance(usage, dict):
             usage_dict = usage
         elif hasattr(usage, "__dict__"):
-            usage_dict = {key: value for key, value in vars(usage).items() if not key.startswith("_")}
+            usage_dict = {
+                key: value for key, value in vars(usage).items()
+                if not key.startswith("_")
+            }
         else:
             return None
 
@@ -84,7 +88,7 @@ class OpenAILLM(LLMBase):
         usage = self._last_usage_var.get()
         if usage is None:
             return None
-        return dict(usage)
+        return deepcopy(usage)
 
     def start_usage_capture(self) -> None:
         self.reset_last_usage()
@@ -174,12 +178,10 @@ class OpenAILLM(LLMBase):
             self.reset_last_usage()
         params = self._get_supported_params(messages=messages, **kwargs)
 
-        params.update(
-            {
-                "model": self.config.model,
-                "messages": messages,
-            }
-        )
+        params.update({
+            "model": self.config.model,
+            "messages": messages,
+        })
 
         if os.getenv("OPENROUTER_API_KEY"):
             openrouter_params = {}

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -427,6 +427,48 @@ def _payload_is_expired(payload: Optional[Dict[str, Any]]) -> bool:
         return False
 
 
+def _reset_llm_usage(llm) -> None:
+    reset_usage = getattr(llm, "reset_last_usage", None)
+    if callable(reset_usage):
+        reset_usage()
+
+
+def _start_llm_usage_capture(llm, include_usage: bool) -> None:
+    if not include_usage:
+        return
+
+    start_capture = getattr(llm, "start_usage_capture", None)
+    if callable(start_capture):
+        start_capture()
+        return
+
+    _reset_llm_usage(llm)
+
+
+def _stop_llm_usage_capture(llm, include_usage: bool) -> None:
+    if not include_usage:
+        return
+
+    stop_capture = getattr(llm, "stop_usage_capture", None)
+    if callable(stop_capture):
+        stop_capture()
+
+
+def _attach_usage_if_requested(result: Dict[str, Any], llm, include_usage: bool) -> Dict[str, Any]:
+    if not include_usage:
+        return result
+
+    get_usage = getattr(llm, "get_last_usage", None)
+    if not callable(get_usage):
+        return result
+
+    usage = get_usage()
+    if usage:
+        result["usage"] = usage
+
+    return result
+
+
 setup_config()
 logger = logging.getLogger(__name__)
 
@@ -746,6 +788,7 @@ class Memory(MemoryBase):
         infer: bool = True,
         memory_type: Optional[str] = None,
         prompt: Optional[str] = None,
+        include_usage: bool = False,
     ):
         """
         Create a new memory.
@@ -771,6 +814,8 @@ class Memory(MemoryBase):
                 creating procedural memories (typically requires 'agent_id'). Otherwise, memories
                 are treated as general conversational/factual memories.
             prompt (str, optional): Prompt to use for the memory creation. Defaults to None.
+            include_usage (bool, optional): If True, include provider usage metadata in the
+                returned result when the underlying LLM exposes it. Defaults to False.
 
 
         Returns:
@@ -821,31 +866,37 @@ class Memory(MemoryBase):
                 suggestion="Convert your input to a string, dictionary, or list of dictionaries."
             )
 
-        if agent_id is not None and memory_type == MemoryType.PROCEDURAL.value:
-            results = self._create_procedural_memory(messages, metadata=processed_metadata, prompt=prompt)
-            scale_threshold_notice = detect_scale_threshold_from_add_result(self, results)
+        _start_llm_usage_capture(self.llm, include_usage)
+        try:
+            if agent_id is not None and memory_type == MemoryType.PROCEDURAL.value:
+                results = self._create_procedural_memory(messages, metadata=processed_metadata, prompt=prompt)
+                scale_threshold_notice = detect_scale_threshold_from_add_result(self, results)
+                if temporal_usage_notice:
+                    display_temporal_usage_notice(self, "sync", "add", *temporal_usage_notice)
+                elif scale_threshold_notice:
+                    display_scale_threshold_notice(self, "sync", "add", *scale_threshold_notice)
+                else:
+                    display_first_run_notice(self, "sync", "add")
+                return _attach_usage_if_requested(results, self.llm, include_usage)
+
+            if self.config.llm.config.get("enable_vision"):
+                messages = parse_vision_messages(messages, self.llm, self.config.llm.config.get("vision_details"))
+            else:
+                messages = parse_vision_messages(messages)
+
+            vector_store_result = self._add_to_vector_store(
+                messages, processed_metadata, effective_filters, infer, prompt=prompt
+            )
+            scale_threshold_notice = detect_scale_threshold_from_add_result(self, vector_store_result)
             if temporal_usage_notice:
                 display_temporal_usage_notice(self, "sync", "add", *temporal_usage_notice)
             elif scale_threshold_notice:
                 display_scale_threshold_notice(self, "sync", "add", *scale_threshold_notice)
             else:
                 display_first_run_notice(self, "sync", "add")
-            return results
-
-        if self.config.llm.config.get("enable_vision"):
-            messages = parse_vision_messages(messages, self.llm, self.config.llm.config.get("vision_details"))
-        else:
-            messages = parse_vision_messages(messages)
-
-        vector_store_result = self._add_to_vector_store(messages, processed_metadata, effective_filters, infer, prompt=prompt)
-        scale_threshold_notice = detect_scale_threshold_from_add_result(self, vector_store_result)
-        if temporal_usage_notice:
-            display_temporal_usage_notice(self, "sync", "add", *temporal_usage_notice)
-        elif scale_threshold_notice:
-            display_scale_threshold_notice(self, "sync", "add", *scale_threshold_notice)
-        else:
-            display_first_run_notice(self, "sync", "add")
-        return {"results": vector_store_result}
+            return _attach_usage_if_requested({"results": vector_store_result}, self.llm, include_usage)
+        finally:
+            _stop_llm_usage_capture(self.llm, include_usage)
 
     def _add_to_vector_store(self, messages, metadata, filters, infer, prompt=None):
         if not infer:
@@ -2409,6 +2460,7 @@ class AsyncMemory(MemoryBase):
         infer: bool = True,
         memory_type: Optional[str] = None,
         prompt: Optional[str] = None,
+        include_usage: bool = False,
         llm=None,
     ):
         """
@@ -2427,6 +2479,8 @@ class AsyncMemory(MemoryBase):
             memory_type (str, optional): Type of memory to create. Defaults to None.
                                          Pass "procedural_memory" to create procedural memories.
             prompt (str, optional): Prompt to use for the memory creation. Defaults to None.
+            include_usage (bool, optional): If True, include provider usage metadata in the
+                returned result when the underlying LLM exposes it. Defaults to False.
             llm (BaseChatModel, optional): LLM class to use for generating procedural memories. Defaults to None. Useful when user is using LangChain ChatModel.
         Returns:
             dict: A dictionary containing the result of the memory addition operation.
@@ -2461,33 +2515,40 @@ class AsyncMemory(MemoryBase):
                 suggestion="Convert your input to a string, dictionary, or list of dictionaries."
             )
 
-        if agent_id is not None and memory_type == MemoryType.PROCEDURAL.value:
-            results = await self._create_procedural_memory(
-                messages, metadata=processed_metadata, prompt=prompt, llm=llm
+        active_llm = (llm or self.llm) if agent_id is not None and memory_type == MemoryType.PROCEDURAL.value else self.llm
+        _start_llm_usage_capture(active_llm, include_usage)
+        try:
+            if agent_id is not None and memory_type == MemoryType.PROCEDURAL.value:
+                results = await self._create_procedural_memory(
+                    messages, metadata=processed_metadata, prompt=prompt, llm=llm
+                )
+                scale_threshold_notice = await asyncio.to_thread(detect_scale_threshold_from_add_result, self, results)
+                if temporal_usage_notice:
+                    await display_temporal_usage_notice_async(self, "async", "add", *temporal_usage_notice)
+                elif scale_threshold_notice:
+                    await display_scale_threshold_notice_async(self, "async", "add", *scale_threshold_notice)
+                else:
+                    await display_first_run_notice_async(self, "async", "add")
+                return _attach_usage_if_requested(results, active_llm, include_usage)
+
+            if self.config.llm.config.get("enable_vision"):
+                messages = parse_vision_messages(messages, self.llm, self.config.llm.config.get("vision_details"))
+            else:
+                messages = parse_vision_messages(messages)
+
+            vector_store_result = await self._add_to_vector_store(
+                messages, processed_metadata, effective_filters, infer, prompt=prompt
             )
-            scale_threshold_notice = await asyncio.to_thread(detect_scale_threshold_from_add_result, self, results)
+            scale_threshold_notice = await asyncio.to_thread(detect_scale_threshold_from_add_result, self, vector_store_result)
             if temporal_usage_notice:
                 await display_temporal_usage_notice_async(self, "async", "add", *temporal_usage_notice)
             elif scale_threshold_notice:
                 await display_scale_threshold_notice_async(self, "async", "add", *scale_threshold_notice)
             else:
                 await display_first_run_notice_async(self, "async", "add")
-            return results
-
-        if self.config.llm.config.get("enable_vision"):
-            messages = parse_vision_messages(messages, self.llm, self.config.llm.config.get("vision_details"))
-        else:
-            messages = parse_vision_messages(messages)
-
-        vector_store_result = await self._add_to_vector_store(messages, processed_metadata, effective_filters, infer, prompt=prompt)
-        scale_threshold_notice = await asyncio.to_thread(detect_scale_threshold_from_add_result, self, vector_store_result)
-        if temporal_usage_notice:
-            await display_temporal_usage_notice_async(self, "async", "add", *temporal_usage_notice)
-        elif scale_threshold_notice:
-            await display_scale_threshold_notice_async(self, "async", "add", *scale_threshold_notice)
-        else:
-            await display_first_run_notice_async(self, "async", "add")
-        return {"results": vector_store_result}
+            return _attach_usage_if_requested({"results": vector_store_result}, active_llm, include_usage)
+        finally:
+            _stop_llm_usage_capture(active_llm, include_usage)
 
     async def _add_to_vector_store(
         self,

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -433,6 +433,13 @@ def _reset_llm_usage(llm) -> None:
         reset_usage()
 
 
+def _supports_llm_usage_capture(llm) -> bool:
+    return any(
+        callable(getattr(llm, method, None))
+        for method in ("start_usage_capture", "reset_last_usage")
+    )
+
+
 def _start_llm_usage_capture(llm, include_usage: bool) -> None:
     if not include_usage:
         return
@@ -442,7 +449,8 @@ def _start_llm_usage_capture(llm, include_usage: bool) -> None:
         start_capture()
         return
 
-    _reset_llm_usage(llm)
+    if callable(getattr(llm, "reset_last_usage", None)):
+        _reset_llm_usage(llm)
 
 
 def _stop_llm_usage_capture(llm, include_usage: bool) -> None:
@@ -459,7 +467,7 @@ def _attach_usage_if_requested(result: Dict[str, Any], llm, include_usage: bool)
         return result
 
     get_usage = getattr(llm, "get_last_usage", None)
-    if not callable(get_usage):
+    if not callable(get_usage) or not _supports_llm_usage_capture(llm):
         return result
 
     usage = get_usage()
@@ -481,7 +489,7 @@ def _generate_response_with_optional_usage(llm, include_usage: bool, **kwargs):
         return response, None
 
     get_usage = getattr(llm, "get_last_usage", None)
-    if not callable(get_usage):
+    if not callable(get_usage) or not _supports_llm_usage_capture(llm):
         return response, None
 
     return response, get_usage()

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -93,34 +93,38 @@ def _vector_store_list_rows(listed):
 # Fields that hold runtime auth/connection objects and must be preserved.
 # These are non-serializable objects (e.g. AWSV4SignerAuth, RequestsHttpConnection)
 # needed by clients like OpenSearch — not sensitive strings to redact.
-_RUNTIME_FIELDS = frozenset({
-    "http_auth",
-    "auth",
-    "connection_class",
-    "ssl_context",
-})
+_RUNTIME_FIELDS = frozenset(
+    {
+        "http_auth",
+        "auth",
+        "connection_class",
+        "ssl_context",
+    }
+)
 
 # Fields that are known to contain sensitive secrets and must be redacted.
-_SENSITIVE_FIELDS_EXACT = frozenset({
-    "api_key",
-    "secret_key",
-    "private_key",
-    "access_key",
-    "password",
-    "credentials",
-    "credential",
-    "secret",
-    "token",
-    "access_token",
-    "refresh_token",
-    "auth_token",
-    "session_token",
-    "client_secret",
-    "auth_client_secret",
-    "azure_client_secret",
-    "service_account_json",
-    "aws_session_token",
-})
+_SENSITIVE_FIELDS_EXACT = frozenset(
+    {
+        "api_key",
+        "secret_key",
+        "private_key",
+        "access_key",
+        "password",
+        "credentials",
+        "credential",
+        "secret",
+        "token",
+        "access_token",
+        "refresh_token",
+        "auth_token",
+        "session_token",
+        "client_secret",
+        "auth_client_secret",
+        "azure_client_secret",
+        "service_account_json",
+        "aws_session_token",
+    }
+)
 
 # Suffixes that indicate a field likely holds a secret value.
 _SENSITIVE_SUFFIXES = (
@@ -187,13 +191,9 @@ def _validate_and_trim_entity_id(value: Optional[Any], name: str) -> Optional[st
         value = str(value)
     trimmed = value.strip()
     if trimmed == "":
-        raise ValueError(
-            f"Invalid {name}: cannot be empty or whitespace-only. Provide a valid identifier."
-        )
+        raise ValueError(f"Invalid {name}: cannot be empty or whitespace-only. Provide a valid identifier.")
     if any(c.isspace() for c in trimmed):
-        raise ValueError(
-            f"Invalid {name}: cannot contain whitespace. Provide a valid identifier without spaces."
-        )
+        raise ValueError(f"Invalid {name}: cannot contain whitespace. Provide a valid identifier without spaces.")
     return trimmed
 
 
@@ -212,16 +212,12 @@ def _validate_search_params(threshold: Optional[float] = None, top_k: Optional[i
         if not isinstance(threshold, (int, float)):
             raise ValueError("threshold must be a valid number")
         if threshold < 0 or threshold > 1:
-            raise ValueError(
-                f"Invalid threshold: {threshold}. Must be between 0 and 1 (inclusive)."
-            )
+            raise ValueError(f"Invalid threshold: {threshold}. Must be between 0 and 1 (inclusive).")
     if top_k is not None:
         if not isinstance(top_k, int) or isinstance(top_k, bool):
             raise ValueError("top_k must be a valid integer")
         if top_k < 0:
-            raise ValueError(
-                f"Invalid top_k: {top_k}. Must be a non-negative integer."
-            )
+            raise ValueError(f"Invalid top_k: {top_k}. Must be a non-negative integer.")
 
 
 def _validate_and_trim_search_query(query: str) -> str:
@@ -374,7 +370,7 @@ def _build_filters_and_metadata(
             message="At least one of 'user_id', 'agent_id', or 'run_id' must be provided.",
             error_code="VALIDATION_001",
             details={"provided_ids": {"user_id": user_id, "agent_id": agent_id, "run_id": run_id}},
-            suggestion="Please provide at least one identifier to scope the memory operation."
+            suggestion="Please provide at least one identifier to scope the memory operation.",
         )
 
     # ---------- optional actor filter ----------
@@ -541,10 +537,7 @@ class Memory(MemoryBase):
         # Initialize reranker if configured
         self.reranker = None
         if config.reranker:
-            self.reranker = RerankerFactory.create(
-                config.reranker.provider,
-                config.reranker.config
-            )
+            self.reranker = RerankerFactory.create(config.reranker.provider, config.reranker.config)
 
         # Entity store is initialized lazily on first use
         self._entity_store = None
@@ -552,24 +545,24 @@ class Memory(MemoryBase):
         if MEM0_TELEMETRY:
             # Create telemetry config manually to avoid deepcopy issues with thread locks
             telemetry_config_dict = {}
-            if hasattr(self.config.vector_store.config, 'model_dump'):
+            if hasattr(self.config.vector_store.config, "model_dump"):
                 # For pydantic models
                 telemetry_config_dict = self.config.vector_store.config.model_dump()
             else:
                 # For other objects, manually copy common attributes
-                for attr in ['host', 'port', 'path', 'api_key', 'index_name', 'dimension', 'metric']:
+                for attr in ["host", "port", "path", "api_key", "index_name", "dimension", "metric"]:
                     if hasattr(self.config.vector_store.config, attr):
                         telemetry_config_dict[attr] = getattr(self.config.vector_store.config, attr)
 
             # Override collection name for telemetry
-            telemetry_config_dict['collection_name'] = "mem0migrations"
+            telemetry_config_dict["collection_name"] = "mem0migrations"
 
             # Set path for file-based vector stores
             telemetry_config = _safe_deepcopy_config(self.config.vector_store.config)
             if self.config.vector_store.provider in ["faiss", "qdrant"]:
                 provider_path = f"migrations_{self.config.vector_store.provider}"
-                telemetry_config_dict['path'] = os.path.join(mem0_dir, provider_path)
-                os.makedirs(telemetry_config_dict['path'], exist_ok=True)
+                telemetry_config_dict["path"] = os.path.join(mem0_dir, provider_path)
+                os.makedirs(telemetry_config_dict["path"], exist_ok=True)
 
             # Create the config object using the same class as the original
             telemetry_config = self.config.vector_store.config.__class__(**telemetry_config_dict)
@@ -598,10 +591,10 @@ class Memory(MemoryBase):
             entity_config = _safe_deepcopy_config(self.config.vector_store.config)
             entity_collection = _entity_collection_name(self.config.vector_store.provider, self.collection_name)
             # Set collection name on the cloned config
-            if hasattr(entity_config, 'collection_name'):
+            if hasattr(entity_config, "collection_name"):
                 entity_config.collection_name = entity_collection
             elif isinstance(entity_config, dict):
-                entity_config['collection_name'] = entity_collection
+                entity_config["collection_name"] = entity_collection
             # For Qdrant, share the existing client to avoid RocksDB lock contention
             # when using embedded mode (path=...). QdrantConfig.client takes precedence
             # over host/port/path.
@@ -610,9 +603,7 @@ class Memory(MemoryBase):
                     entity_config.client = self.vector_store.client
                 elif isinstance(entity_config, dict):
                     entity_config["client"] = self.vector_store.client
-            self._entity_store = VectorStoreFactory.create(
-                self.config.vector_store.provider, entity_config
-            )
+            self._entity_store = VectorStoreFactory.create(self.config.vector_store.provider, entity_config)
         return self._entity_store
 
     @staticmethod
@@ -867,7 +858,7 @@ class Memory(MemoryBase):
                 message=f"Invalid 'memory_type'. Please pass {MemoryType.PROCEDURAL.value} to create procedural memories.",
                 error_code="VALIDATION_002",
                 details={"provided_type": memory_type, "valid_type": MemoryType.PROCEDURAL.value},
-                suggestion=f"Use '{MemoryType.PROCEDURAL.value}' to create procedural memories."
+                suggestion=f"Use '{MemoryType.PROCEDURAL.value}' to create procedural memories.",
             )
 
         if isinstance(messages, str):
@@ -881,7 +872,7 @@ class Memory(MemoryBase):
                 message="messages must be str, dict, or list[dict]",
                 error_code="VALIDATION_003",
                 details={"provided_type": type(messages).__name__, "valid_types": ["str", "dict", "list[dict]"]},
-                suggestion="Convert your input to a string, dictionary, or list of dictionaries."
+                suggestion="Convert your input to a string, dictionary, or list of dictionaries.",
             )
 
         active_llm = getattr(self, "llm", None)
@@ -1156,7 +1147,6 @@ class Memory(MemoryBase):
                         except Exception:
                             entity_embeddings.append(None)
 
-
                 if len(entity_embeddings) != len(ordered_keys):
                     logger.warning(
                         "embed_batch returned %d vectors for %d entity texts — "
@@ -1210,12 +1200,14 @@ class Memory(MemoryBase):
                             # New entity — collect for batch insert
                             to_insert_vectors.append(valid_vectors[j])
                             to_insert_ids.append(str(uuid.uuid4()))
-                            to_insert_payloads.append({
-                                "data": entity_text,
-                                "entity_type": entity_type,
-                                "linked_memory_ids": sorted(memory_ids),
-                                **search_filters,
-                            })
+                            to_insert_payloads.append(
+                                {
+                                    "data": entity_text,
+                                    "entity_type": entity_type,
+                                    "linked_memory_ids": sorted(memory_ids),
+                                    **search_filters,
+                                }
+                            )
 
                     # 7e: Single batch insert for all new entities
                     if to_insert_vectors:
@@ -1233,10 +1225,7 @@ class Memory(MemoryBase):
         # Phase 8: Save messages + return
         self.db.save_messages(messages, session_scope)
 
-        returned_memories = [
-            {"id": r[0], "memory": r[1], "event": "ADD"}
-            for r in records
-        ]
+        returned_memories = [{"id": r[0], "memory": r[1], "event": "ADD"} for r in records]
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event(
@@ -1272,7 +1261,16 @@ class Memory(MemoryBase):
             "expiration_date",
         ]
 
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
+        core_and_promoted_keys = {
+            "data",
+            "hash",
+            "created_at",
+            "updated_at",
+            "id",
+            "text_lemmatized",
+            "attributed_to",
+            *promoted_payload_keys,
+        }
 
         result_item = MemoryItem(
             id=memory.id,
@@ -1328,23 +1326,16 @@ class Memory(MemoryBase):
         # Validate and trim entity IDs in filters
         effective_filters = dict(filters) if filters else {}
         if "user_id" in effective_filters:
-            effective_filters["user_id"] = _validate_and_trim_entity_id(
-                effective_filters["user_id"], "user_id"
-            )
+            effective_filters["user_id"] = _validate_and_trim_entity_id(effective_filters["user_id"], "user_id")
         if "agent_id" in effective_filters:
-            effective_filters["agent_id"] = _validate_and_trim_entity_id(
-                effective_filters["agent_id"], "agent_id"
-            )
+            effective_filters["agent_id"] = _validate_and_trim_entity_id(effective_filters["agent_id"], "agent_id")
         if "run_id" in effective_filters:
-            effective_filters["run_id"] = _validate_and_trim_entity_id(
-                effective_filters["run_id"], "run_id"
-            )
+            effective_filters["run_id"] = _validate_and_trim_entity_id(effective_filters["run_id"], "run_id")
 
         # Validate filters contains at least one entity ID
         if not any(key in effective_filters for key in ("user_id", "agent_id", "run_id")):
             raise ValueError(
-                "filters must contain at least one of: user_id, agent_id, run_id. "
-                "Example: filters={'user_id': 'u1'}"
+                "filters must contain at least one of: user_id, agent_id, run_id. Example: filters={'user_id': 'u1'}"
             )
 
         limit = top_k
@@ -1389,7 +1380,16 @@ class Memory(MemoryBase):
             "attributed_to",
             "expiration_date",
         ]
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
+        core_and_promoted_keys = {
+            "data",
+            "hash",
+            "created_at",
+            "updated_at",
+            "id",
+            "text_lemmatized",
+            "attributed_to",
+            *promoted_payload_keys,
+        }
 
         formatted_memories = []
         for mem in actual_memories:
@@ -1484,21 +1484,14 @@ class Memory(MemoryBase):
         # Validate and trim entity IDs in filters
         effective_filters = filters.copy() if filters else {}
         if "user_id" in effective_filters:
-            effective_filters["user_id"] = _validate_and_trim_entity_id(
-                effective_filters["user_id"], "user_id"
-            )
+            effective_filters["user_id"] = _validate_and_trim_entity_id(effective_filters["user_id"], "user_id")
         if "agent_id" in effective_filters:
-            effective_filters["agent_id"] = _validate_and_trim_entity_id(
-                effective_filters["agent_id"], "agent_id"
-            )
+            effective_filters["agent_id"] = _validate_and_trim_entity_id(effective_filters["agent_id"], "agent_id")
         if "run_id" in effective_filters:
-            effective_filters["run_id"] = _validate_and_trim_entity_id(
-                effective_filters["run_id"], "run_id"
-            )
+            effective_filters["run_id"] = _validate_and_trim_entity_id(effective_filters["run_id"], "run_id")
         if not any(key in effective_filters for key in ("user_id", "agent_id", "run_id")):
             raise ValueError(
-                "filters must contain at least one of: user_id, agent_id, run_id. "
-                "Example: filters={'user_id': 'u1'}"
+                "filters must contain at least one of: user_id, agent_id, run_id. Example: filters={'user_id': 'u1'}"
             )
 
         limit = top_k
@@ -1511,7 +1504,9 @@ class Memory(MemoryBase):
             for logical_key in ("AND", "OR", "NOT"):
                 effective_filters.pop(logical_key, None)
             for fk in list(effective_filters.keys()):
-                if fk not in ("AND", "OR", "NOT", "user_id", "agent_id", "run_id") and isinstance(effective_filters.get(fk), dict):
+                if fk not in ("AND", "OR", "NOT", "user_id", "agent_id", "run_id") and isinstance(
+                    effective_filters.get(fk), dict
+                ):
                     effective_filters.pop(fk, None)
             effective_filters.update(processed_filters)
 
@@ -1586,9 +1581,16 @@ class Memory(MemoryBase):
             for operator, value in condition.items():
                 # Map platform operators to universal format that can be translated by each vector store
                 operator_map = {
-                    "eq": "eq", "ne": "ne", "gt": "gt", "gte": "gte",
-                    "lt": "lt", "lte": "lte", "in": "in", "nin": "nin",
-                    "contains": "contains", "icontains": "icontains"
+                    "eq": "eq",
+                    "ne": "ne",
+                    "gt": "gt",
+                    "gte": "gte",
+                    "lt": "lt",
+                    "lte": "lte",
+                    "in": "in",
+                    "nin": "nin",
+                    "contains": "contains",
+                    "icontains": "icontains",
                 }
 
                 if operator in operator_map:
@@ -1642,16 +1644,16 @@ class Memory(MemoryBase):
     def _has_advanced_operators(self, filters: Dict[str, Any]) -> bool:
         """
         Check if filters contain advanced operators that need special processing.
-        
+
         Args:
             filters: Dictionary of filters to check
-            
+
         Returns:
             bool: True if advanced operators are detected
         """
         if not isinstance(filters, dict):
             return False
-            
+
         for key, value in filters.items():
             # Check for platform-style logical operators
             if key in ["AND", "OR", "NOT"]:
@@ -1694,8 +1696,8 @@ class Memory(MemoryBase):
         if keyword_results is not None:
             midpoint, steepness = get_bm25_params(query, lemmatized=query_lemmatized)
             for mem in keyword_results:
-                mem_id = str(mem.id) if hasattr(mem, 'id') else str(mem.get('id', ''))
-                raw_score = mem.score if hasattr(mem, 'score') else mem.get('score', 0)
+                mem_id = str(mem.id) if hasattr(mem, "id") else str(mem.get("id", ""))
+                raw_score = mem.score if hasattr(mem, "score") else mem.get("score", 0)
                 if raw_score and raw_score > 0:
                     bm25_scores[mem_id] = normalize_bm25(raw_score, midpoint, steepness)
 
@@ -1707,15 +1709,17 @@ class Memory(MemoryBase):
         # Step 7: Build candidate set from semantic results
         candidates = []
         for mem in semantic_results:
-            payload = mem.payload if hasattr(mem, 'payload') else {}
+            payload = mem.payload if hasattr(mem, "payload") else {}
             if not show_expired and _payload_is_expired(payload):
                 continue
             mem_id = str(mem.id)
-            candidates.append({
-                "id": mem_id,
-                "score": mem.score,
-                "payload": payload,
-            })
+            candidates.append(
+                {
+                    "id": mem_id,
+                    "score": mem.score,
+                    "payload": payload,
+                }
+            )
 
         # Step 8: Score and rank
         scored_results = score_and_rank(
@@ -1737,7 +1741,16 @@ class Memory(MemoryBase):
             "attributed_to",
             "expiration_date",
         ]
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
+        core_and_promoted_keys = {
+            "data",
+            "hash",
+            "created_at",
+            "updated_at",
+            "id",
+            "text_lemmatized",
+            "attributed_to",
+            *promoted_payload_keys,
+        }
 
         original_memories = []
         for scored in scored_results:
@@ -1812,15 +1825,10 @@ class Memory(MemoryBase):
             entity_store = self.entity_store
 
             def _search_entity(entity_text, embedding):
-                return entity_store.search(
-                    query=entity_text, vectors=embedding, top_k=500, filters=search_filters
-                )
+                return entity_store.search(query=entity_text, vectors=embedding, top_k=500, filters=search_filters)
 
             with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
-                futures = {
-                    pool.submit(_search_entity, text, emb): text
-                    for text, emb in zip(entity_texts, embeddings)
-                }
+                futures = {pool.submit(_search_entity, text, emb): text for text, emb in zip(entity_texts, embeddings)}
 
                 for future in concurrent.futures.as_completed(futures):
                     try:
@@ -1830,11 +1838,11 @@ class Memory(MemoryBase):
                         continue
 
                     for match in matches:
-                        similarity = match.score if hasattr(match, 'score') else 0.0
+                        similarity = match.score if hasattr(match, "score") else 0.0
                         if similarity < 0.5:
                             continue
 
-                        payload = match.payload if hasattr(match, 'payload') else {}
+                        payload = match.payload if hasattr(match, "payload") else {}
                         linked_memory_ids = payload.get("linked_memory_ids", [])
                         if not isinstance(linked_memory_ids, list):
                             continue
@@ -2226,10 +2234,7 @@ class AsyncMemory(MemoryBase):
         # Initialize reranker if configured
         self.reranker = None
         if config.reranker:
-            self.reranker = RerankerFactory.create(
-                config.reranker.provider,
-                config.reranker.config
-            )
+            self.reranker = RerankerFactory.create(config.reranker.provider, config.reranker.config)
 
         if MEM0_TELEMETRY:
             telemetry_config = _safe_deepcopy_config(self.config.vector_store.config)
@@ -2238,7 +2243,9 @@ class AsyncMemory(MemoryBase):
                 provider_path = f"migrations_{self.config.vector_store.provider}"
                 telemetry_config.path = os.path.join(mem0_dir, provider_path)
                 os.makedirs(telemetry_config.path, exist_ok=True)
-            self._telemetry_vector_store = VectorStoreFactory.create(self.config.vector_store.provider, telemetry_config)
+            self._telemetry_vector_store = VectorStoreFactory.create(
+                self.config.vector_store.provider, telemetry_config
+            )
 
         if getattr(type(self.vector_store), "keyword_search", None) is VectorStoreBase.keyword_search:
             logger.warning(
@@ -2261,10 +2268,10 @@ class AsyncMemory(MemoryBase):
         if self._entity_store is None:
             entity_config = _safe_deepcopy_config(self.config.vector_store.config)
             entity_collection = _entity_collection_name(self.config.vector_store.provider, self.collection_name)
-            if hasattr(entity_config, 'collection_name'):
+            if hasattr(entity_config, "collection_name"):
                 entity_config.collection_name = entity_collection
             elif isinstance(entity_config, dict):
-                entity_config['collection_name'] = entity_collection
+                entity_config["collection_name"] = entity_collection
             # For Qdrant, share the existing client to avoid RocksDB lock contention
             # when using embedded mode (path=...). QdrantConfig.client takes precedence
             # over host/port/path.
@@ -2273,9 +2280,7 @@ class AsyncMemory(MemoryBase):
                     entity_config.client = self.vector_store.client
                 elif isinstance(entity_config, dict):
                     entity_config["client"] = self.vector_store.client
-            self._entity_store = VectorStoreFactory.create(
-                self.config.vector_store.provider, entity_config
-            )
+            self._entity_store = VectorStoreFactory.create(self.config.vector_store.provider, entity_config)
         return self._entity_store
 
     @staticmethod
@@ -2306,9 +2311,9 @@ class AsyncMemory(MemoryBase):
         try:
             entity_embedding = await asyncio.to_thread(self.embedding_model.embed, entity_text, "add")
             search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
-            exact_match = (
-                await asyncio.to_thread(self._existing_entities_by_text, search_filters)
-            ).get(self._normalize_entity_text(entity_text))
+            exact_match = (await asyncio.to_thread(self._existing_entities_by_text, search_filters)).get(
+                self._normalize_entity_text(entity_text)
+            )
 
             existing = []
             if exact_match is None:
@@ -2531,11 +2536,13 @@ class AsyncMemory(MemoryBase):
                 message="messages must be str, dict, or list[dict]",
                 error_code="VALIDATION_003",
                 details={"provided_type": type(messages).__name__, "valid_types": ["str", "dict", "list[dict]"]},
-                suggestion="Convert your input to a string, dictionary, or list of dictionaries."
+                suggestion="Convert your input to a string, dictionary, or list of dictionaries.",
             )
 
         default_llm = getattr(self, "llm", None)
-        active_llm = (llm or default_llm) if agent_id is not None and memory_type == MemoryType.PROCEDURAL.value else default_llm
+        active_llm = (
+            (llm or default_llm) if agent_id is not None and memory_type == MemoryType.PROCEDURAL.value else default_llm
+        )
         _start_llm_usage_capture(active_llm, include_usage)
         try:
             if agent_id is not None and memory_type == MemoryType.PROCEDURAL.value:
@@ -2576,7 +2583,9 @@ class AsyncMemory(MemoryBase):
             captured_usage = None
             if isinstance(vector_store_result, tuple) and len(vector_store_result) == 2:
                 vector_store_result, captured_usage = vector_store_result
-            scale_threshold_notice = await asyncio.to_thread(detect_scale_threshold_from_add_result, self, vector_store_result)
+            scale_threshold_notice = await asyncio.to_thread(
+                detect_scale_threshold_from_add_result, self, vector_store_result
+            )
             if temporal_usage_notice:
                 await display_temporal_usage_notice_async(self, "async", "add", *temporal_usage_notice)
             elif scale_threshold_notice:
@@ -2800,8 +2809,12 @@ class AsyncMemory(MemoryBase):
             for hr in history_records:
                 try:
                     await asyncio.to_thread(
-                        self.db.add_history, hr["memory_id"], None, hr["new_memory"], "ADD",
-                        created_at=hr.get("created_at")
+                        self.db.add_history,
+                        hr["memory_id"],
+                        None,
+                        hr["new_memory"],
+                        "ADD",
+                        created_at=hr.get("created_at"),
                     )
                 except Exception as e:
                     logger.error(f"Failed to add history for {hr['memory_id']} (async): {e}")
@@ -2889,12 +2902,14 @@ class AsyncMemory(MemoryBase):
                         else:
                             to_insert_vectors.append(valid_vectors[j])
                             to_insert_ids.append(str(uuid.uuid4()))
-                            to_insert_payloads.append({
-                                "data": entity_text,
-                                "entity_type": entity_type,
-                                "linked_memory_ids": sorted(memory_ids),
-                                **search_filters,
-                            })
+                            to_insert_payloads.append(
+                                {
+                                    "data": entity_text,
+                                    "entity_type": entity_type,
+                                    "linked_memory_ids": sorted(memory_ids),
+                                    **search_filters,
+                                }
+                            )
 
                     # 7e: Batch insert new entities
                     if to_insert_vectors:
@@ -2913,10 +2928,7 @@ class AsyncMemory(MemoryBase):
         # Phase 8: Save messages + return
         await asyncio.to_thread(self.db.save_messages, messages, session_scope)
 
-        returned_memories = [
-            {"id": r[0], "memory": r[1], "event": "ADD"}
-            for r in records
-        ]
+        returned_memories = [{"id": r[0], "memory": r[1], "event": "ADD"} for r in records]
 
         keys, encoded_ids = process_telemetry_filters(effective_filters)
         capture_event(
@@ -2952,7 +2964,16 @@ class AsyncMemory(MemoryBase):
             "expiration_date",
         ]
 
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
+        core_and_promoted_keys = {
+            "data",
+            "hash",
+            "created_at",
+            "updated_at",
+            "id",
+            "text_lemmatized",
+            "attributed_to",
+            *promoted_payload_keys,
+        }
 
         result_item = MemoryItem(
             id=memory.id,
@@ -3008,23 +3029,16 @@ class AsyncMemory(MemoryBase):
         # Validate and trim entity IDs in filters
         effective_filters = dict(filters) if filters else {}
         if "user_id" in effective_filters:
-            effective_filters["user_id"] = _validate_and_trim_entity_id(
-                effective_filters["user_id"], "user_id"
-            )
+            effective_filters["user_id"] = _validate_and_trim_entity_id(effective_filters["user_id"], "user_id")
         if "agent_id" in effective_filters:
-            effective_filters["agent_id"] = _validate_and_trim_entity_id(
-                effective_filters["agent_id"], "agent_id"
-            )
+            effective_filters["agent_id"] = _validate_and_trim_entity_id(effective_filters["agent_id"], "agent_id")
         if "run_id" in effective_filters:
-            effective_filters["run_id"] = _validate_and_trim_entity_id(
-                effective_filters["run_id"], "run_id"
-            )
+            effective_filters["run_id"] = _validate_and_trim_entity_id(effective_filters["run_id"], "run_id")
 
         # Validate filters contains at least one entity ID
         if not any(key in effective_filters for key in ("user_id", "agent_id", "run_id")):
             raise ValueError(
-                "filters must contain at least one of: user_id, agent_id, run_id. "
-                "Example: filters={'user_id': 'u1'}"
+                "filters must contain at least one of: user_id, agent_id, run_id. Example: filters={'user_id': 'u1'}"
             )
 
         limit = top_k
@@ -3069,7 +3083,16 @@ class AsyncMemory(MemoryBase):
             "attributed_to",
             "expiration_date",
         ]
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
+        core_and_promoted_keys = {
+            "data",
+            "hash",
+            "created_at",
+            "updated_at",
+            "id",
+            "text_lemmatized",
+            "attributed_to",
+            *promoted_payload_keys,
+        }
 
         formatted_memories = []
         for mem in actual_memories:
@@ -3151,9 +3174,7 @@ class AsyncMemory(MemoryBase):
                 or if threshold/top_k values are invalid.
         """
         if reference_date is not None:
-            raise ValueError(
-                await get_temporal_feature_error_message_async("async", "search", "reference_date")
-            )
+            raise ValueError(await get_temporal_feature_error_message_async("async", "search", "reference_date"))
 
         # Reject top-level entity params - must use filters instead
         _reject_top_level_entity_params(kwargs, "search")
@@ -3166,23 +3187,16 @@ class AsyncMemory(MemoryBase):
         # Validate and trim entity IDs in filters
         effective_filters = filters.copy() if filters else {}
         if "user_id" in effective_filters:
-            effective_filters["user_id"] = _validate_and_trim_entity_id(
-                effective_filters["user_id"], "user_id"
-            )
+            effective_filters["user_id"] = _validate_and_trim_entity_id(effective_filters["user_id"], "user_id")
         if "agent_id" in effective_filters:
-            effective_filters["agent_id"] = _validate_and_trim_entity_id(
-                effective_filters["agent_id"], "agent_id"
-            )
+            effective_filters["agent_id"] = _validate_and_trim_entity_id(effective_filters["agent_id"], "agent_id")
         if "run_id" in effective_filters:
-            effective_filters["run_id"] = _validate_and_trim_entity_id(
-                effective_filters["run_id"], "run_id"
-            )
+            effective_filters["run_id"] = _validate_and_trim_entity_id(effective_filters["run_id"], "run_id")
 
         # Validate filters contains at least one entity ID
         if not any(key in effective_filters for key in ("user_id", "agent_id", "run_id")):
             raise ValueError(
-                "filters must contain at least one of: user_id, agent_id, run_id. "
-                "Example: filters={'user_id': 'u1'}"
+                "filters must contain at least one of: user_id, agent_id, run_id. Example: filters={'user_id': 'u1'}"
             )
 
         limit = top_k
@@ -3195,7 +3209,9 @@ class AsyncMemory(MemoryBase):
             for logical_key in ("AND", "OR", "NOT"):
                 effective_filters.pop(logical_key, None)
             for fk in list(effective_filters.keys()):
-                if fk not in ("AND", "OR", "NOT", "user_id", "agent_id", "run_id") and isinstance(effective_filters.get(fk), dict):
+                if fk not in ("AND", "OR", "NOT", "user_id", "agent_id", "run_id") and isinstance(
+                    effective_filters.get(fk), dict
+                ):
                     effective_filters.pop(fk, None)
             effective_filters.update(processed_filters)
 
@@ -3225,9 +3241,7 @@ class AsyncMemory(MemoryBase):
         if rerank and self.reranker and original_memories:
             try:
                 # Run reranking in thread pool to avoid blocking async loop
-                reranked_memories = await asyncio.to_thread(
-                    self.reranker.rerank, query, original_memories, limit
-                )
+                reranked_memories = await asyncio.to_thread(self.reranker.rerank, query, original_memories, limit)
                 original_memories = reranked_memories
             except Exception as e:
                 logger.warning(f"Reranking failed, using original results: {e}")
@@ -3273,9 +3287,16 @@ class AsyncMemory(MemoryBase):
             for operator, value in condition.items():
                 # Map platform operators to universal format that can be translated by each vector store
                 operator_map = {
-                    "eq": "eq", "ne": "ne", "gt": "gt", "gte": "gte",
-                    "lt": "lt", "lte": "lte", "in": "in", "nin": "nin",
-                    "contains": "contains", "icontains": "icontains"
+                    "eq": "eq",
+                    "ne": "ne",
+                    "gt": "gt",
+                    "gte": "gte",
+                    "lt": "lt",
+                    "lte": "lte",
+                    "in": "in",
+                    "nin": "nin",
+                    "contains": "contains",
+                    "icontains": "icontains",
                 }
 
                 if operator in operator_map:
@@ -3380,8 +3401,8 @@ class AsyncMemory(MemoryBase):
         if keyword_results is not None:
             midpoint, steepness = get_bm25_params(query, lemmatized=query_lemmatized)
             for mem in keyword_results:
-                mem_id = str(mem.id) if hasattr(mem, 'id') else str(mem.get('id', ''))
-                raw_score = mem.score if hasattr(mem, 'score') else mem.get('score', 0)
+                mem_id = str(mem.id) if hasattr(mem, "id") else str(mem.get("id", ""))
+                raw_score = mem.score if hasattr(mem, "score") else mem.get("score", 0)
                 if raw_score and raw_score > 0:
                     bm25_scores[mem_id] = normalize_bm25(raw_score, midpoint, steepness)
 
@@ -3393,15 +3414,17 @@ class AsyncMemory(MemoryBase):
         # Step 7: Build candidate set from semantic results
         candidates = []
         for mem in semantic_results:
-            payload = mem.payload if hasattr(mem, 'payload') else {}
+            payload = mem.payload if hasattr(mem, "payload") else {}
             if not show_expired and _payload_is_expired(payload):
                 continue
             mem_id = str(mem.id)
-            candidates.append({
-                "id": mem_id,
-                "score": mem.score,
-                "payload": payload,
-            })
+            candidates.append(
+                {
+                    "id": mem_id,
+                    "score": mem.score,
+                    "payload": payload,
+                }
+            )
 
         # Step 8: Score and rank
         scored_results = score_and_rank(
@@ -3423,7 +3446,16 @@ class AsyncMemory(MemoryBase):
             "attributed_to",
             "expiration_date",
         ]
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
+        core_and_promoted_keys = {
+            "data",
+            "hash",
+            "created_at",
+            "updated_at",
+            "id",
+            "text_lemmatized",
+            "attributed_to",
+            *promoted_payload_keys,
+        }
 
         original_memories = []
         for scored in scored_results:
@@ -3507,11 +3539,11 @@ class AsyncMemory(MemoryBase):
                     continue
 
                 for match in matches:
-                    similarity = match.score if hasattr(match, 'score') else 0.0
+                    similarity = match.score if hasattr(match, "score") else 0.0
                     if similarity < 0.5:
                         continue
 
-                    payload = match.payload if hasattr(match, 'payload') else {}
+                    payload = match.payload if hasattr(match, "payload") else {}
                     linked_memory_ids = payload.get("linked_memory_ids", [])
                     if not isinstance(linked_memory_ids, list):
                         continue
@@ -3731,7 +3763,9 @@ class AsyncMemory(MemoryBase):
 
         return memory_id
 
-    async def _create_procedural_memory(self, messages, metadata=None, llm=None, prompt=None, include_usage: bool = False):
+    async def _create_procedural_memory(
+        self, messages, metadata=None, llm=None, prompt=None, include_usage: bool = False
+    ):
         """
         Create a procedural memory asynchronously
 
@@ -3776,7 +3810,7 @@ class AsyncMemory(MemoryBase):
                     messages=parsed_messages,
                 )
                 procedural_memory = remove_code_blocks(procedural_memory)
-        
+
         except Exception as e:
             logger.error(f"Error generating procedural memory summary: {e}")
             raise

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -469,6 +469,24 @@ def _attach_usage_if_requested(result: Dict[str, Any], llm, include_usage: bool)
     return result
 
 
+def _attach_usage(result: Dict[str, Any], usage: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    if usage:
+        result["usage"] = usage
+    return result
+
+
+def _generate_response_with_optional_usage(llm, include_usage: bool, **kwargs):
+    response = llm.generate_response(**kwargs)
+    if not include_usage:
+        return response, None
+
+    get_usage = getattr(llm, "get_last_usage", None)
+    if not callable(get_usage):
+        return response, None
+
+    return response, get_usage()
+
+
 setup_config()
 logger = logging.getLogger(__name__)
 
@@ -2522,8 +2540,15 @@ class AsyncMemory(MemoryBase):
         try:
             if agent_id is not None and memory_type == MemoryType.PROCEDURAL.value:
                 results = await self._create_procedural_memory(
-                    messages, metadata=processed_metadata, prompt=prompt, llm=llm
+                    messages,
+                    metadata=processed_metadata,
+                    prompt=prompt,
+                    llm=llm,
+                    include_usage=include_usage,
                 )
+                captured_usage = None
+                if isinstance(results, tuple) and len(results) == 2:
+                    results, captured_usage = results
                 scale_threshold_notice = await asyncio.to_thread(detect_scale_threshold_from_add_result, self, results)
                 if temporal_usage_notice:
                     await display_temporal_usage_notice_async(self, "async", "add", *temporal_usage_notice)
@@ -2531,6 +2556,8 @@ class AsyncMemory(MemoryBase):
                     await display_scale_threshold_notice_async(self, "async", "add", *scale_threshold_notice)
                 else:
                     await display_first_run_notice_async(self, "async", "add")
+                if captured_usage is not None:
+                    return _attach_usage(results, captured_usage)
                 return _attach_usage_if_requested(results, active_llm, include_usage)
 
             if self.config.llm.config.get("enable_vision"):
@@ -2539,8 +2566,16 @@ class AsyncMemory(MemoryBase):
                 messages = parse_vision_messages(messages)
 
             vector_store_result = await self._add_to_vector_store(
-                messages, processed_metadata, effective_filters, infer, prompt=prompt
+                messages,
+                processed_metadata,
+                effective_filters,
+                infer,
+                prompt=prompt,
+                include_usage=include_usage,
             )
+            captured_usage = None
+            if isinstance(vector_store_result, tuple) and len(vector_store_result) == 2:
+                vector_store_result, captured_usage = vector_store_result
             scale_threshold_notice = await asyncio.to_thread(detect_scale_threshold_from_add_result, self, vector_store_result)
             if temporal_usage_notice:
                 await display_temporal_usage_notice_async(self, "async", "add", *temporal_usage_notice)
@@ -2548,7 +2583,10 @@ class AsyncMemory(MemoryBase):
                 await display_scale_threshold_notice_async(self, "async", "add", *scale_threshold_notice)
             else:
                 await display_first_run_notice_async(self, "async", "add")
-            return _attach_usage_if_requested({"results": vector_store_result}, active_llm, include_usage)
+            result = {"results": vector_store_result}
+            if captured_usage is not None:
+                return _attach_usage(result, captured_usage)
+            return _attach_usage_if_requested(result, active_llm, include_usage)
         finally:
             _stop_llm_usage_capture(active_llm, include_usage)
 
@@ -2559,6 +2597,7 @@ class AsyncMemory(MemoryBase):
         effective_filters: dict,
         infer: bool,
         prompt: Optional[str] = None,
+        include_usage: bool = False,
     ):
         if not infer:
             returned_memories = []
@@ -2637,8 +2676,10 @@ class AsyncMemory(MemoryBase):
         )
 
         try:
-            response = await asyncio.to_thread(
-                self.llm.generate_response,
+            response, captured_usage = await asyncio.to_thread(
+                _generate_response_with_optional_usage,
+                self.llm,
+                include_usage,
                 messages=[
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_prompt},
@@ -2668,7 +2709,7 @@ class AsyncMemory(MemoryBase):
 
         if not extracted_memories:
             await asyncio.to_thread(self.db.save_messages, messages, session_scope)
-            return []
+            return ([], captured_usage) if include_usage else []
 
         # Phase 3: Batch embed all extracted memory texts
         mem_texts = [m.get("text", "") for m in extracted_memories if m.get("text")]
@@ -2720,7 +2761,7 @@ class AsyncMemory(MemoryBase):
 
         if not records:
             await asyncio.to_thread(self.db.save_messages, messages, session_scope)
-            return []
+            return ([], captured_usage) if include_usage else []
 
         # Phase 6: Batch persist
         all_vectors = [r[2] for r in records]
@@ -2883,7 +2924,7 @@ class AsyncMemory(MemoryBase):
             self,
             {"version": self.api_version, "keys": keys, "encoded_ids": encoded_ids, "sync_type": "async"},
         )
-        return returned_memories
+        return (returned_memories, captured_usage) if include_usage else returned_memories
 
     async def get(self, memory_id):
         """
@@ -3690,7 +3731,7 @@ class AsyncMemory(MemoryBase):
 
         return memory_id
 
-    async def _create_procedural_memory(self, messages, metadata=None, llm=None, prompt=None):
+    async def _create_procedural_memory(self, messages, metadata=None, llm=None, prompt=None, include_usage: bool = False):
         """
         Create a procedural memory asynchronously
 
@@ -3726,8 +3767,14 @@ class AsyncMemory(MemoryBase):
                 parsed_messages = convert_to_messages(parsed_messages)
                 response = await asyncio.to_thread(llm.invoke, input=parsed_messages)
                 procedural_memory = remove_code_blocks(response.content)
+                captured_usage = None
             else:
-                procedural_memory = await asyncio.to_thread(self.llm.generate_response, messages=parsed_messages)
+                procedural_memory, captured_usage = await asyncio.to_thread(
+                    _generate_response_with_optional_usage,
+                    self.llm,
+                    include_usage,
+                    messages=parsed_messages,
+                )
                 procedural_memory = remove_code_blocks(procedural_memory)
         
         except Exception as e:
@@ -3744,7 +3791,7 @@ class AsyncMemory(MemoryBase):
 
         result = {"results": [{"id": memory_id, "memory": procedural_memory, "event": "ADD"}]}
 
-        return result
+        return (result, captured_usage) if include_usage else result
 
     async def _update_memory(self, memory_id, data, existing_embeddings, metadata=None):
         logger.info(f"Updating memory with {data=}")

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -866,7 +866,8 @@ class Memory(MemoryBase):
                 suggestion="Convert your input to a string, dictionary, or list of dictionaries."
             )
 
-        _start_llm_usage_capture(self.llm, include_usage)
+        active_llm = getattr(self, "llm", None)
+        _start_llm_usage_capture(active_llm, include_usage)
         try:
             if agent_id is not None and memory_type == MemoryType.PROCEDURAL.value:
                 results = self._create_procedural_memory(messages, metadata=processed_metadata, prompt=prompt)
@@ -877,7 +878,7 @@ class Memory(MemoryBase):
                     display_scale_threshold_notice(self, "sync", "add", *scale_threshold_notice)
                 else:
                     display_first_run_notice(self, "sync", "add")
-                return _attach_usage_if_requested(results, self.llm, include_usage)
+                return _attach_usage_if_requested(results, active_llm, include_usage)
 
             if self.config.llm.config.get("enable_vision"):
                 messages = parse_vision_messages(messages, self.llm, self.config.llm.config.get("vision_details"))
@@ -894,9 +895,9 @@ class Memory(MemoryBase):
                 display_scale_threshold_notice(self, "sync", "add", *scale_threshold_notice)
             else:
                 display_first_run_notice(self, "sync", "add")
-            return _attach_usage_if_requested({"results": vector_store_result}, self.llm, include_usage)
+            return _attach_usage_if_requested({"results": vector_store_result}, active_llm, include_usage)
         finally:
-            _stop_llm_usage_capture(self.llm, include_usage)
+            _stop_llm_usage_capture(active_llm, include_usage)
 
     def _add_to_vector_store(self, messages, metadata, filters, infer, prompt=None):
         if not infer:
@@ -2515,7 +2516,8 @@ class AsyncMemory(MemoryBase):
                 suggestion="Convert your input to a string, dictionary, or list of dictionaries."
             )
 
-        active_llm = (llm or self.llm) if agent_id is not None and memory_type == MemoryType.PROCEDURAL.value else self.llm
+        default_llm = getattr(self, "llm", None)
+        active_llm = (llm or default_llm) if agent_id is not None and memory_type == MemoryType.PROCEDURAL.value else default_llm
         _start_llm_usage_capture(active_llm, include_usage)
         try:
             if agent_id is not None and memory_type == MemoryType.PROCEDURAL.value:

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -93,38 +93,34 @@ def _vector_store_list_rows(listed):
 # Fields that hold runtime auth/connection objects and must be preserved.
 # These are non-serializable objects (e.g. AWSV4SignerAuth, RequestsHttpConnection)
 # needed by clients like OpenSearch — not sensitive strings to redact.
-_RUNTIME_FIELDS = frozenset(
-    {
-        "http_auth",
-        "auth",
-        "connection_class",
-        "ssl_context",
-    }
-)
+_RUNTIME_FIELDS = frozenset({
+    "http_auth",
+    "auth",
+    "connection_class",
+    "ssl_context",
+})
 
 # Fields that are known to contain sensitive secrets and must be redacted.
-_SENSITIVE_FIELDS_EXACT = frozenset(
-    {
-        "api_key",
-        "secret_key",
-        "private_key",
-        "access_key",
-        "password",
-        "credentials",
-        "credential",
-        "secret",
-        "token",
-        "access_token",
-        "refresh_token",
-        "auth_token",
-        "session_token",
-        "client_secret",
-        "auth_client_secret",
-        "azure_client_secret",
-        "service_account_json",
-        "aws_session_token",
-    }
-)
+_SENSITIVE_FIELDS_EXACT = frozenset({
+    "api_key",
+    "secret_key",
+    "private_key",
+    "access_key",
+    "password",
+    "credentials",
+    "credential",
+    "secret",
+    "token",
+    "access_token",
+    "refresh_token",
+    "auth_token",
+    "session_token",
+    "client_secret",
+    "auth_client_secret",
+    "azure_client_secret",
+    "service_account_json",
+    "aws_session_token",
+})
 
 # Suffixes that indicate a field likely holds a secret value.
 _SENSITIVE_SUFFIXES = (
@@ -191,9 +187,13 @@ def _validate_and_trim_entity_id(value: Optional[Any], name: str) -> Optional[st
         value = str(value)
     trimmed = value.strip()
     if trimmed == "":
-        raise ValueError(f"Invalid {name}: cannot be empty or whitespace-only. Provide a valid identifier.")
+        raise ValueError(
+            f"Invalid {name}: cannot be empty or whitespace-only. Provide a valid identifier."
+        )
     if any(c.isspace() for c in trimmed):
-        raise ValueError(f"Invalid {name}: cannot contain whitespace. Provide a valid identifier without spaces.")
+        raise ValueError(
+            f"Invalid {name}: cannot contain whitespace. Provide a valid identifier without spaces."
+        )
     return trimmed
 
 
@@ -212,12 +212,16 @@ def _validate_search_params(threshold: Optional[float] = None, top_k: Optional[i
         if not isinstance(threshold, (int, float)):
             raise ValueError("threshold must be a valid number")
         if threshold < 0 or threshold > 1:
-            raise ValueError(f"Invalid threshold: {threshold}. Must be between 0 and 1 (inclusive).")
+            raise ValueError(
+                f"Invalid threshold: {threshold}. Must be between 0 and 1 (inclusive)."
+            )
     if top_k is not None:
         if not isinstance(top_k, int) or isinstance(top_k, bool):
             raise ValueError("top_k must be a valid integer")
         if top_k < 0:
-            raise ValueError(f"Invalid top_k: {top_k}. Must be a non-negative integer.")
+            raise ValueError(
+                f"Invalid top_k: {top_k}. Must be a non-negative integer."
+            )
 
 
 def _validate_and_trim_search_query(query: str) -> str:
@@ -370,7 +374,7 @@ def _build_filters_and_metadata(
             message="At least one of 'user_id', 'agent_id', or 'run_id' must be provided.",
             error_code="VALIDATION_001",
             details={"provided_ids": {"user_id": user_id, "agent_id": agent_id, "run_id": run_id}},
-            suggestion="Please provide at least one identifier to scope the memory operation.",
+            suggestion="Please provide at least one identifier to scope the memory operation."
         )
 
     # ---------- optional actor filter ----------
@@ -537,7 +541,10 @@ class Memory(MemoryBase):
         # Initialize reranker if configured
         self.reranker = None
         if config.reranker:
-            self.reranker = RerankerFactory.create(config.reranker.provider, config.reranker.config)
+            self.reranker = RerankerFactory.create(
+                config.reranker.provider,
+                config.reranker.config
+            )
 
         # Entity store is initialized lazily on first use
         self._entity_store = None
@@ -545,24 +552,24 @@ class Memory(MemoryBase):
         if MEM0_TELEMETRY:
             # Create telemetry config manually to avoid deepcopy issues with thread locks
             telemetry_config_dict = {}
-            if hasattr(self.config.vector_store.config, "model_dump"):
+            if hasattr(self.config.vector_store.config, 'model_dump'):
                 # For pydantic models
                 telemetry_config_dict = self.config.vector_store.config.model_dump()
             else:
                 # For other objects, manually copy common attributes
-                for attr in ["host", "port", "path", "api_key", "index_name", "dimension", "metric"]:
+                for attr in ['host', 'port', 'path', 'api_key', 'index_name', 'dimension', 'metric']:
                     if hasattr(self.config.vector_store.config, attr):
                         telemetry_config_dict[attr] = getattr(self.config.vector_store.config, attr)
 
             # Override collection name for telemetry
-            telemetry_config_dict["collection_name"] = "mem0migrations"
+            telemetry_config_dict['collection_name'] = "mem0migrations"
 
             # Set path for file-based vector stores
             telemetry_config = _safe_deepcopy_config(self.config.vector_store.config)
             if self.config.vector_store.provider in ["faiss", "qdrant"]:
                 provider_path = f"migrations_{self.config.vector_store.provider}"
-                telemetry_config_dict["path"] = os.path.join(mem0_dir, provider_path)
-                os.makedirs(telemetry_config_dict["path"], exist_ok=True)
+                telemetry_config_dict['path'] = os.path.join(mem0_dir, provider_path)
+                os.makedirs(telemetry_config_dict['path'], exist_ok=True)
 
             # Create the config object using the same class as the original
             telemetry_config = self.config.vector_store.config.__class__(**telemetry_config_dict)
@@ -591,10 +598,10 @@ class Memory(MemoryBase):
             entity_config = _safe_deepcopy_config(self.config.vector_store.config)
             entity_collection = _entity_collection_name(self.config.vector_store.provider, self.collection_name)
             # Set collection name on the cloned config
-            if hasattr(entity_config, "collection_name"):
+            if hasattr(entity_config, 'collection_name'):
                 entity_config.collection_name = entity_collection
             elif isinstance(entity_config, dict):
-                entity_config["collection_name"] = entity_collection
+                entity_config['collection_name'] = entity_collection
             # For Qdrant, share the existing client to avoid RocksDB lock contention
             # when using embedded mode (path=...). QdrantConfig.client takes precedence
             # over host/port/path.
@@ -603,7 +610,9 @@ class Memory(MemoryBase):
                     entity_config.client = self.vector_store.client
                 elif isinstance(entity_config, dict):
                     entity_config["client"] = self.vector_store.client
-            self._entity_store = VectorStoreFactory.create(self.config.vector_store.provider, entity_config)
+            self._entity_store = VectorStoreFactory.create(
+                self.config.vector_store.provider, entity_config
+            )
         return self._entity_store
 
     @staticmethod
@@ -858,7 +867,7 @@ class Memory(MemoryBase):
                 message=f"Invalid 'memory_type'. Please pass {MemoryType.PROCEDURAL.value} to create procedural memories.",
                 error_code="VALIDATION_002",
                 details={"provided_type": memory_type, "valid_type": MemoryType.PROCEDURAL.value},
-                suggestion=f"Use '{MemoryType.PROCEDURAL.value}' to create procedural memories.",
+                suggestion=f"Use '{MemoryType.PROCEDURAL.value}' to create procedural memories."
             )
 
         if isinstance(messages, str):
@@ -872,7 +881,7 @@ class Memory(MemoryBase):
                 message="messages must be str, dict, or list[dict]",
                 error_code="VALIDATION_003",
                 details={"provided_type": type(messages).__name__, "valid_types": ["str", "dict", "list[dict]"]},
-                suggestion="Convert your input to a string, dictionary, or list of dictionaries.",
+                suggestion="Convert your input to a string, dictionary, or list of dictionaries."
             )
 
         active_llm = getattr(self, "llm", None)
@@ -1147,6 +1156,7 @@ class Memory(MemoryBase):
                         except Exception:
                             entity_embeddings.append(None)
 
+
                 if len(entity_embeddings) != len(ordered_keys):
                     logger.warning(
                         "embed_batch returned %d vectors for %d entity texts — "
@@ -1200,14 +1210,12 @@ class Memory(MemoryBase):
                             # New entity — collect for batch insert
                             to_insert_vectors.append(valid_vectors[j])
                             to_insert_ids.append(str(uuid.uuid4()))
-                            to_insert_payloads.append(
-                                {
-                                    "data": entity_text,
-                                    "entity_type": entity_type,
-                                    "linked_memory_ids": sorted(memory_ids),
-                                    **search_filters,
-                                }
-                            )
+                            to_insert_payloads.append({
+                                "data": entity_text,
+                                "entity_type": entity_type,
+                                "linked_memory_ids": sorted(memory_ids),
+                                **search_filters,
+                            })
 
                     # 7e: Single batch insert for all new entities
                     if to_insert_vectors:
@@ -1225,7 +1233,10 @@ class Memory(MemoryBase):
         # Phase 8: Save messages + return
         self.db.save_messages(messages, session_scope)
 
-        returned_memories = [{"id": r[0], "memory": r[1], "event": "ADD"} for r in records]
+        returned_memories = [
+            {"id": r[0], "memory": r[1], "event": "ADD"}
+            for r in records
+        ]
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event(
@@ -1261,16 +1272,7 @@ class Memory(MemoryBase):
             "expiration_date",
         ]
 
-        core_and_promoted_keys = {
-            "data",
-            "hash",
-            "created_at",
-            "updated_at",
-            "id",
-            "text_lemmatized",
-            "attributed_to",
-            *promoted_payload_keys,
-        }
+        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
 
         result_item = MemoryItem(
             id=memory.id,
@@ -1326,16 +1328,23 @@ class Memory(MemoryBase):
         # Validate and trim entity IDs in filters
         effective_filters = dict(filters) if filters else {}
         if "user_id" in effective_filters:
-            effective_filters["user_id"] = _validate_and_trim_entity_id(effective_filters["user_id"], "user_id")
+            effective_filters["user_id"] = _validate_and_trim_entity_id(
+                effective_filters["user_id"], "user_id"
+            )
         if "agent_id" in effective_filters:
-            effective_filters["agent_id"] = _validate_and_trim_entity_id(effective_filters["agent_id"], "agent_id")
+            effective_filters["agent_id"] = _validate_and_trim_entity_id(
+                effective_filters["agent_id"], "agent_id"
+            )
         if "run_id" in effective_filters:
-            effective_filters["run_id"] = _validate_and_trim_entity_id(effective_filters["run_id"], "run_id")
+            effective_filters["run_id"] = _validate_and_trim_entity_id(
+                effective_filters["run_id"], "run_id"
+            )
 
         # Validate filters contains at least one entity ID
         if not any(key in effective_filters for key in ("user_id", "agent_id", "run_id")):
             raise ValueError(
-                "filters must contain at least one of: user_id, agent_id, run_id. Example: filters={'user_id': 'u1'}"
+                "filters must contain at least one of: user_id, agent_id, run_id. "
+                "Example: filters={'user_id': 'u1'}"
             )
 
         limit = top_k
@@ -1380,16 +1389,7 @@ class Memory(MemoryBase):
             "attributed_to",
             "expiration_date",
         ]
-        core_and_promoted_keys = {
-            "data",
-            "hash",
-            "created_at",
-            "updated_at",
-            "id",
-            "text_lemmatized",
-            "attributed_to",
-            *promoted_payload_keys,
-        }
+        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
 
         formatted_memories = []
         for mem in actual_memories:
@@ -1484,14 +1484,21 @@ class Memory(MemoryBase):
         # Validate and trim entity IDs in filters
         effective_filters = filters.copy() if filters else {}
         if "user_id" in effective_filters:
-            effective_filters["user_id"] = _validate_and_trim_entity_id(effective_filters["user_id"], "user_id")
+            effective_filters["user_id"] = _validate_and_trim_entity_id(
+                effective_filters["user_id"], "user_id"
+            )
         if "agent_id" in effective_filters:
-            effective_filters["agent_id"] = _validate_and_trim_entity_id(effective_filters["agent_id"], "agent_id")
+            effective_filters["agent_id"] = _validate_and_trim_entity_id(
+                effective_filters["agent_id"], "agent_id"
+            )
         if "run_id" in effective_filters:
-            effective_filters["run_id"] = _validate_and_trim_entity_id(effective_filters["run_id"], "run_id")
+            effective_filters["run_id"] = _validate_and_trim_entity_id(
+                effective_filters["run_id"], "run_id"
+            )
         if not any(key in effective_filters for key in ("user_id", "agent_id", "run_id")):
             raise ValueError(
-                "filters must contain at least one of: user_id, agent_id, run_id. Example: filters={'user_id': 'u1'}"
+                "filters must contain at least one of: user_id, agent_id, run_id. "
+                "Example: filters={'user_id': 'u1'}"
             )
 
         limit = top_k
@@ -1504,9 +1511,7 @@ class Memory(MemoryBase):
             for logical_key in ("AND", "OR", "NOT"):
                 effective_filters.pop(logical_key, None)
             for fk in list(effective_filters.keys()):
-                if fk not in ("AND", "OR", "NOT", "user_id", "agent_id", "run_id") and isinstance(
-                    effective_filters.get(fk), dict
-                ):
+                if fk not in ("AND", "OR", "NOT", "user_id", "agent_id", "run_id") and isinstance(effective_filters.get(fk), dict):
                     effective_filters.pop(fk, None)
             effective_filters.update(processed_filters)
 
@@ -1581,16 +1586,9 @@ class Memory(MemoryBase):
             for operator, value in condition.items():
                 # Map platform operators to universal format that can be translated by each vector store
                 operator_map = {
-                    "eq": "eq",
-                    "ne": "ne",
-                    "gt": "gt",
-                    "gte": "gte",
-                    "lt": "lt",
-                    "lte": "lte",
-                    "in": "in",
-                    "nin": "nin",
-                    "contains": "contains",
-                    "icontains": "icontains",
+                    "eq": "eq", "ne": "ne", "gt": "gt", "gte": "gte",
+                    "lt": "lt", "lte": "lte", "in": "in", "nin": "nin",
+                    "contains": "contains", "icontains": "icontains"
                 }
 
                 if operator in operator_map:
@@ -1696,8 +1694,8 @@ class Memory(MemoryBase):
         if keyword_results is not None:
             midpoint, steepness = get_bm25_params(query, lemmatized=query_lemmatized)
             for mem in keyword_results:
-                mem_id = str(mem.id) if hasattr(mem, "id") else str(mem.get("id", ""))
-                raw_score = mem.score if hasattr(mem, "score") else mem.get("score", 0)
+                mem_id = str(mem.id) if hasattr(mem, 'id') else str(mem.get('id', ''))
+                raw_score = mem.score if hasattr(mem, 'score') else mem.get('score', 0)
                 if raw_score and raw_score > 0:
                     bm25_scores[mem_id] = normalize_bm25(raw_score, midpoint, steepness)
 
@@ -1709,17 +1707,15 @@ class Memory(MemoryBase):
         # Step 7: Build candidate set from semantic results
         candidates = []
         for mem in semantic_results:
-            payload = mem.payload if hasattr(mem, "payload") else {}
+            payload = mem.payload if hasattr(mem, 'payload') else {}
             if not show_expired and _payload_is_expired(payload):
                 continue
             mem_id = str(mem.id)
-            candidates.append(
-                {
-                    "id": mem_id,
-                    "score": mem.score,
-                    "payload": payload,
-                }
-            )
+            candidates.append({
+                "id": mem_id,
+                "score": mem.score,
+                "payload": payload,
+            })
 
         # Step 8: Score and rank
         scored_results = score_and_rank(
@@ -1741,16 +1737,7 @@ class Memory(MemoryBase):
             "attributed_to",
             "expiration_date",
         ]
-        core_and_promoted_keys = {
-            "data",
-            "hash",
-            "created_at",
-            "updated_at",
-            "id",
-            "text_lemmatized",
-            "attributed_to",
-            *promoted_payload_keys,
-        }
+        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
 
         original_memories = []
         for scored in scored_results:
@@ -1825,10 +1812,15 @@ class Memory(MemoryBase):
             entity_store = self.entity_store
 
             def _search_entity(entity_text, embedding):
-                return entity_store.search(query=entity_text, vectors=embedding, top_k=500, filters=search_filters)
+                return entity_store.search(
+                    query=entity_text, vectors=embedding, top_k=500, filters=search_filters
+                )
 
             with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
-                futures = {pool.submit(_search_entity, text, emb): text for text, emb in zip(entity_texts, embeddings)}
+                futures = {
+                    pool.submit(_search_entity, text, emb): text
+                    for text, emb in zip(entity_texts, embeddings)
+                }
 
                 for future in concurrent.futures.as_completed(futures):
                     try:
@@ -1838,11 +1830,11 @@ class Memory(MemoryBase):
                         continue
 
                     for match in matches:
-                        similarity = match.score if hasattr(match, "score") else 0.0
+                        similarity = match.score if hasattr(match, 'score') else 0.0
                         if similarity < 0.5:
                             continue
 
-                        payload = match.payload if hasattr(match, "payload") else {}
+                        payload = match.payload if hasattr(match, 'payload') else {}
                         linked_memory_ids = payload.get("linked_memory_ids", [])
                         if not isinstance(linked_memory_ids, list):
                             continue
@@ -2234,7 +2226,10 @@ class AsyncMemory(MemoryBase):
         # Initialize reranker if configured
         self.reranker = None
         if config.reranker:
-            self.reranker = RerankerFactory.create(config.reranker.provider, config.reranker.config)
+            self.reranker = RerankerFactory.create(
+                config.reranker.provider,
+                config.reranker.config
+            )
 
         if MEM0_TELEMETRY:
             telemetry_config = _safe_deepcopy_config(self.config.vector_store.config)
@@ -2243,9 +2238,7 @@ class AsyncMemory(MemoryBase):
                 provider_path = f"migrations_{self.config.vector_store.provider}"
                 telemetry_config.path = os.path.join(mem0_dir, provider_path)
                 os.makedirs(telemetry_config.path, exist_ok=True)
-            self._telemetry_vector_store = VectorStoreFactory.create(
-                self.config.vector_store.provider, telemetry_config
-            )
+            self._telemetry_vector_store = VectorStoreFactory.create(self.config.vector_store.provider, telemetry_config)
 
         if getattr(type(self.vector_store), "keyword_search", None) is VectorStoreBase.keyword_search:
             logger.warning(
@@ -2268,10 +2261,10 @@ class AsyncMemory(MemoryBase):
         if self._entity_store is None:
             entity_config = _safe_deepcopy_config(self.config.vector_store.config)
             entity_collection = _entity_collection_name(self.config.vector_store.provider, self.collection_name)
-            if hasattr(entity_config, "collection_name"):
+            if hasattr(entity_config, 'collection_name'):
                 entity_config.collection_name = entity_collection
             elif isinstance(entity_config, dict):
-                entity_config["collection_name"] = entity_collection
+                entity_config['collection_name'] = entity_collection
             # For Qdrant, share the existing client to avoid RocksDB lock contention
             # when using embedded mode (path=...). QdrantConfig.client takes precedence
             # over host/port/path.
@@ -2280,7 +2273,9 @@ class AsyncMemory(MemoryBase):
                     entity_config.client = self.vector_store.client
                 elif isinstance(entity_config, dict):
                     entity_config["client"] = self.vector_store.client
-            self._entity_store = VectorStoreFactory.create(self.config.vector_store.provider, entity_config)
+            self._entity_store = VectorStoreFactory.create(
+                self.config.vector_store.provider, entity_config
+            )
         return self._entity_store
 
     @staticmethod
@@ -2311,9 +2306,9 @@ class AsyncMemory(MemoryBase):
         try:
             entity_embedding = await asyncio.to_thread(self.embedding_model.embed, entity_text, "add")
             search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
-            exact_match = (await asyncio.to_thread(self._existing_entities_by_text, search_filters)).get(
-                self._normalize_entity_text(entity_text)
-            )
+            exact_match = (
+                await asyncio.to_thread(self._existing_entities_by_text, search_filters)
+            ).get(self._normalize_entity_text(entity_text))
 
             existing = []
             if exact_match is None:
@@ -2536,13 +2531,11 @@ class AsyncMemory(MemoryBase):
                 message="messages must be str, dict, or list[dict]",
                 error_code="VALIDATION_003",
                 details={"provided_type": type(messages).__name__, "valid_types": ["str", "dict", "list[dict]"]},
-                suggestion="Convert your input to a string, dictionary, or list of dictionaries.",
+                suggestion="Convert your input to a string, dictionary, or list of dictionaries."
             )
 
         default_llm = getattr(self, "llm", None)
-        active_llm = (
-            (llm or default_llm) if agent_id is not None and memory_type == MemoryType.PROCEDURAL.value else default_llm
-        )
+        active_llm = (llm or default_llm) if agent_id is not None and memory_type == MemoryType.PROCEDURAL.value else default_llm
         _start_llm_usage_capture(active_llm, include_usage)
         try:
             if agent_id is not None and memory_type == MemoryType.PROCEDURAL.value:
@@ -2583,9 +2576,7 @@ class AsyncMemory(MemoryBase):
             captured_usage = None
             if isinstance(vector_store_result, tuple) and len(vector_store_result) == 2:
                 vector_store_result, captured_usage = vector_store_result
-            scale_threshold_notice = await asyncio.to_thread(
-                detect_scale_threshold_from_add_result, self, vector_store_result
-            )
+            scale_threshold_notice = await asyncio.to_thread(detect_scale_threshold_from_add_result, self, vector_store_result)
             if temporal_usage_notice:
                 await display_temporal_usage_notice_async(self, "async", "add", *temporal_usage_notice)
             elif scale_threshold_notice:
@@ -2809,12 +2800,8 @@ class AsyncMemory(MemoryBase):
             for hr in history_records:
                 try:
                     await asyncio.to_thread(
-                        self.db.add_history,
-                        hr["memory_id"],
-                        None,
-                        hr["new_memory"],
-                        "ADD",
-                        created_at=hr.get("created_at"),
+                        self.db.add_history, hr["memory_id"], None, hr["new_memory"], "ADD",
+                        created_at=hr.get("created_at")
                     )
                 except Exception as e:
                     logger.error(f"Failed to add history for {hr['memory_id']} (async): {e}")
@@ -2902,14 +2889,12 @@ class AsyncMemory(MemoryBase):
                         else:
                             to_insert_vectors.append(valid_vectors[j])
                             to_insert_ids.append(str(uuid.uuid4()))
-                            to_insert_payloads.append(
-                                {
-                                    "data": entity_text,
-                                    "entity_type": entity_type,
-                                    "linked_memory_ids": sorted(memory_ids),
-                                    **search_filters,
-                                }
-                            )
+                            to_insert_payloads.append({
+                                "data": entity_text,
+                                "entity_type": entity_type,
+                                "linked_memory_ids": sorted(memory_ids),
+                                **search_filters,
+                            })
 
                     # 7e: Batch insert new entities
                     if to_insert_vectors:
@@ -2928,7 +2913,10 @@ class AsyncMemory(MemoryBase):
         # Phase 8: Save messages + return
         await asyncio.to_thread(self.db.save_messages, messages, session_scope)
 
-        returned_memories = [{"id": r[0], "memory": r[1], "event": "ADD"} for r in records]
+        returned_memories = [
+            {"id": r[0], "memory": r[1], "event": "ADD"}
+            for r in records
+        ]
 
         keys, encoded_ids = process_telemetry_filters(effective_filters)
         capture_event(
@@ -2964,16 +2952,7 @@ class AsyncMemory(MemoryBase):
             "expiration_date",
         ]
 
-        core_and_promoted_keys = {
-            "data",
-            "hash",
-            "created_at",
-            "updated_at",
-            "id",
-            "text_lemmatized",
-            "attributed_to",
-            *promoted_payload_keys,
-        }
+        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
 
         result_item = MemoryItem(
             id=memory.id,
@@ -3029,16 +3008,23 @@ class AsyncMemory(MemoryBase):
         # Validate and trim entity IDs in filters
         effective_filters = dict(filters) if filters else {}
         if "user_id" in effective_filters:
-            effective_filters["user_id"] = _validate_and_trim_entity_id(effective_filters["user_id"], "user_id")
+            effective_filters["user_id"] = _validate_and_trim_entity_id(
+                effective_filters["user_id"], "user_id"
+            )
         if "agent_id" in effective_filters:
-            effective_filters["agent_id"] = _validate_and_trim_entity_id(effective_filters["agent_id"], "agent_id")
+            effective_filters["agent_id"] = _validate_and_trim_entity_id(
+                effective_filters["agent_id"], "agent_id"
+            )
         if "run_id" in effective_filters:
-            effective_filters["run_id"] = _validate_and_trim_entity_id(effective_filters["run_id"], "run_id")
+            effective_filters["run_id"] = _validate_and_trim_entity_id(
+                effective_filters["run_id"], "run_id"
+            )
 
         # Validate filters contains at least one entity ID
         if not any(key in effective_filters for key in ("user_id", "agent_id", "run_id")):
             raise ValueError(
-                "filters must contain at least one of: user_id, agent_id, run_id. Example: filters={'user_id': 'u1'}"
+                "filters must contain at least one of: user_id, agent_id, run_id. "
+                "Example: filters={'user_id': 'u1'}"
             )
 
         limit = top_k
@@ -3083,16 +3069,7 @@ class AsyncMemory(MemoryBase):
             "attributed_to",
             "expiration_date",
         ]
-        core_and_promoted_keys = {
-            "data",
-            "hash",
-            "created_at",
-            "updated_at",
-            "id",
-            "text_lemmatized",
-            "attributed_to",
-            *promoted_payload_keys,
-        }
+        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
 
         formatted_memories = []
         for mem in actual_memories:
@@ -3174,7 +3151,9 @@ class AsyncMemory(MemoryBase):
                 or if threshold/top_k values are invalid.
         """
         if reference_date is not None:
-            raise ValueError(await get_temporal_feature_error_message_async("async", "search", "reference_date"))
+            raise ValueError(
+                await get_temporal_feature_error_message_async("async", "search", "reference_date")
+            )
 
         # Reject top-level entity params - must use filters instead
         _reject_top_level_entity_params(kwargs, "search")
@@ -3187,16 +3166,23 @@ class AsyncMemory(MemoryBase):
         # Validate and trim entity IDs in filters
         effective_filters = filters.copy() if filters else {}
         if "user_id" in effective_filters:
-            effective_filters["user_id"] = _validate_and_trim_entity_id(effective_filters["user_id"], "user_id")
+            effective_filters["user_id"] = _validate_and_trim_entity_id(
+                effective_filters["user_id"], "user_id"
+            )
         if "agent_id" in effective_filters:
-            effective_filters["agent_id"] = _validate_and_trim_entity_id(effective_filters["agent_id"], "agent_id")
+            effective_filters["agent_id"] = _validate_and_trim_entity_id(
+                effective_filters["agent_id"], "agent_id"
+            )
         if "run_id" in effective_filters:
-            effective_filters["run_id"] = _validate_and_trim_entity_id(effective_filters["run_id"], "run_id")
+            effective_filters["run_id"] = _validate_and_trim_entity_id(
+                effective_filters["run_id"], "run_id"
+            )
 
         # Validate filters contains at least one entity ID
         if not any(key in effective_filters for key in ("user_id", "agent_id", "run_id")):
             raise ValueError(
-                "filters must contain at least one of: user_id, agent_id, run_id. Example: filters={'user_id': 'u1'}"
+                "filters must contain at least one of: user_id, agent_id, run_id. "
+                "Example: filters={'user_id': 'u1'}"
             )
 
         limit = top_k
@@ -3209,9 +3195,7 @@ class AsyncMemory(MemoryBase):
             for logical_key in ("AND", "OR", "NOT"):
                 effective_filters.pop(logical_key, None)
             for fk in list(effective_filters.keys()):
-                if fk not in ("AND", "OR", "NOT", "user_id", "agent_id", "run_id") and isinstance(
-                    effective_filters.get(fk), dict
-                ):
+                if fk not in ("AND", "OR", "NOT", "user_id", "agent_id", "run_id") and isinstance(effective_filters.get(fk), dict):
                     effective_filters.pop(fk, None)
             effective_filters.update(processed_filters)
 
@@ -3241,7 +3225,9 @@ class AsyncMemory(MemoryBase):
         if rerank and self.reranker and original_memories:
             try:
                 # Run reranking in thread pool to avoid blocking async loop
-                reranked_memories = await asyncio.to_thread(self.reranker.rerank, query, original_memories, limit)
+                reranked_memories = await asyncio.to_thread(
+                    self.reranker.rerank, query, original_memories, limit
+                )
                 original_memories = reranked_memories
             except Exception as e:
                 logger.warning(f"Reranking failed, using original results: {e}")
@@ -3287,16 +3273,9 @@ class AsyncMemory(MemoryBase):
             for operator, value in condition.items():
                 # Map platform operators to universal format that can be translated by each vector store
                 operator_map = {
-                    "eq": "eq",
-                    "ne": "ne",
-                    "gt": "gt",
-                    "gte": "gte",
-                    "lt": "lt",
-                    "lte": "lte",
-                    "in": "in",
-                    "nin": "nin",
-                    "contains": "contains",
-                    "icontains": "icontains",
+                    "eq": "eq", "ne": "ne", "gt": "gt", "gte": "gte",
+                    "lt": "lt", "lte": "lte", "in": "in", "nin": "nin",
+                    "contains": "contains", "icontains": "icontains"
                 }
 
                 if operator in operator_map:
@@ -3401,8 +3380,8 @@ class AsyncMemory(MemoryBase):
         if keyword_results is not None:
             midpoint, steepness = get_bm25_params(query, lemmatized=query_lemmatized)
             for mem in keyword_results:
-                mem_id = str(mem.id) if hasattr(mem, "id") else str(mem.get("id", ""))
-                raw_score = mem.score if hasattr(mem, "score") else mem.get("score", 0)
+                mem_id = str(mem.id) if hasattr(mem, 'id') else str(mem.get('id', ''))
+                raw_score = mem.score if hasattr(mem, 'score') else mem.get('score', 0)
                 if raw_score and raw_score > 0:
                     bm25_scores[mem_id] = normalize_bm25(raw_score, midpoint, steepness)
 
@@ -3414,17 +3393,15 @@ class AsyncMemory(MemoryBase):
         # Step 7: Build candidate set from semantic results
         candidates = []
         for mem in semantic_results:
-            payload = mem.payload if hasattr(mem, "payload") else {}
+            payload = mem.payload if hasattr(mem, 'payload') else {}
             if not show_expired and _payload_is_expired(payload):
                 continue
             mem_id = str(mem.id)
-            candidates.append(
-                {
-                    "id": mem_id,
-                    "score": mem.score,
-                    "payload": payload,
-                }
-            )
+            candidates.append({
+                "id": mem_id,
+                "score": mem.score,
+                "payload": payload,
+            })
 
         # Step 8: Score and rank
         scored_results = score_and_rank(
@@ -3446,16 +3423,7 @@ class AsyncMemory(MemoryBase):
             "attributed_to",
             "expiration_date",
         ]
-        core_and_promoted_keys = {
-            "data",
-            "hash",
-            "created_at",
-            "updated_at",
-            "id",
-            "text_lemmatized",
-            "attributed_to",
-            *promoted_payload_keys,
-        }
+        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
 
         original_memories = []
         for scored in scored_results:
@@ -3539,11 +3507,11 @@ class AsyncMemory(MemoryBase):
                     continue
 
                 for match in matches:
-                    similarity = match.score if hasattr(match, "score") else 0.0
+                    similarity = match.score if hasattr(match, 'score') else 0.0
                     if similarity < 0.5:
                         continue
 
-                    payload = match.payload if hasattr(match, "payload") else {}
+                    payload = match.payload if hasattr(match, 'payload') else {}
                     linked_memory_ids = payload.get("linked_memory_ids", [])
                     if not isinstance(linked_memory_ids, list):
                         continue
@@ -3763,9 +3731,7 @@ class AsyncMemory(MemoryBase):
 
         return memory_id
 
-    async def _create_procedural_memory(
-        self, messages, metadata=None, llm=None, prompt=None, include_usage: bool = False
-    ):
+    async def _create_procedural_memory(self, messages, metadata=None, llm=None, prompt=None, include_usage: bool = False):
         """
         Create a procedural memory asynchronously
 

--- a/server/main.py
+++ b/server/main.py
@@ -386,7 +386,16 @@ def add_memory(memory_create: MemoryCreate, _auth=Depends(verify_auth)):
 
 
 ALL_MEMORIES_LIMIT = 1000
-_RESERVED_PAYLOAD_KEYS = {"data", "user_id", "agent_id", "run_id", "hash", "created_at", "updated_at", "expiration_date"}
+_RESERVED_PAYLOAD_KEYS = {
+    "data",
+    "user_id",
+    "agent_id",
+    "run_id",
+    "hash",
+    "created_at",
+    "updated_at",
+    "expiration_date",
+}
 
 
 def _serialize_memory(row: Any) -> Dict[str, Any]:

--- a/server/main.py
+++ b/server/main.py
@@ -186,6 +186,10 @@ class MemoryCreate(BaseModel):
     infer: Optional[bool] = Field(None, description="Whether to extract facts from messages. Defaults to True.")
     memory_type: Optional[str] = Field(None, description="Type of memory to store (e.g. 'core').")
     prompt: Optional[str] = Field(None, description="Custom prompt to use for fact extraction.")
+    include_usage: Optional[bool] = Field(
+        None,
+        description="Whether to include provider usage metadata in the response when supported.",
+    )
 
 
 class MemoryUpdate(BaseModel):

--- a/server/main.py
+++ b/server/main.py
@@ -386,16 +386,7 @@ def add_memory(memory_create: MemoryCreate, _auth=Depends(verify_auth)):
 
 
 ALL_MEMORIES_LIMIT = 1000
-_RESERVED_PAYLOAD_KEYS = {
-    "data",
-    "user_id",
-    "agent_id",
-    "run_id",
-    "hash",
-    "created_at",
-    "updated_at",
-    "expiration_date",
-}
+_RESERVED_PAYLOAD_KEYS = {"data", "user_id", "agent_id", "run_id", "hash", "created_at", "updated_at", "expiration_date"}
 
 
 def _serialize_memory(row: Any) -> Dict[str, Any]:

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -1,4 +1,5 @@
 import os
+import threading
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
@@ -491,7 +492,7 @@ def test_generate_response_resets_stale_usage_when_missing(mock_openai_client):
     llm = OpenAILLM(config)
     messages = [{"role": "user", "content": "Hello"}]
 
-    llm._last_usage = {"prompt_tokens": 99}
+    llm._last_usage_var.set({"prompt_tokens": 99})
     mock_response = Mock()
     mock_response.choices = [Mock(message=Mock(content="Response"))]
     mock_response.usage = None
@@ -526,4 +527,67 @@ def test_usage_capture_accumulates_multiple_responses(mock_openai_client):
         "prompt_tokens": 16,
         "completion_tokens": 10,
         "total_tokens": 26,
+    }
+
+
+def test_usage_capture_isolation_across_threads(mock_openai_client):
+    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14")
+    llm = OpenAILLM(config)
+    responses = {
+        "first": SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="First"))],
+            usage=SimpleNamespace(prompt_tokens=11, completion_tokens=7, total_tokens=18),
+        ),
+        "second": SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="Second"))],
+            usage=SimpleNamespace(prompt_tokens=5, completion_tokens=3, total_tokens=8),
+        ),
+    }
+    mock_openai_client.chat.completions.create.side_effect = (
+        lambda **kwargs: responses[kwargs["messages"][0]["content"]]
+    )
+
+    first_generated = threading.Event()
+    second_finished = threading.Event()
+    results = {}
+
+    def run_first_capture():
+        llm.start_usage_capture()
+        try:
+            llm.generate_response([{"role": "user", "content": "first"}])
+            first_generated.set()
+            assert second_finished.wait(timeout=2), "second capture did not finish in time"
+            results["first"] = llm.get_last_usage()
+        finally:
+            llm.stop_usage_capture()
+
+    def run_second_capture():
+        assert first_generated.wait(timeout=2), "first capture did not reach the overlap point"
+        llm.start_usage_capture()
+        try:
+            llm.generate_response([{"role": "user", "content": "second"}])
+            results["second"] = llm.get_last_usage()
+        finally:
+            llm.stop_usage_capture()
+            second_finished.set()
+
+    first_thread = threading.Thread(target=run_first_capture)
+    second_thread = threading.Thread(target=run_second_capture)
+
+    first_thread.start()
+    second_thread.start()
+    first_thread.join(timeout=2)
+    second_thread.join(timeout=2)
+
+    assert not first_thread.is_alive()
+    assert not second_thread.is_alive()
+    assert results["first"] == {
+        "prompt_tokens": 11,
+        "completion_tokens": 7,
+        "total_tokens": 18,
+    }
+    assert results["second"] == {
+        "prompt_tokens": 5,
+        "completion_tokens": 3,
+        "total_tokens": 8,
     }

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -1,4 +1,5 @@
 import os
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import httpx
@@ -464,3 +465,65 @@ def test_openai_llm_preserves_proxies_from_base_config(mock_openai_client):
     llm = OpenAILLM(config)
     assert llm.config.http_client_proxies == "http://proxy.local:8080"
     assert isinstance(llm.config.http_client, httpx.Client)
+
+def test_generate_response_captures_usage(mock_openai_client):
+    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14")
+    llm = OpenAILLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Response"))]
+    mock_response.usage = SimpleNamespace(prompt_tokens=11, completion_tokens=7, total_tokens=18)
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    response = llm.generate_response(messages)
+
+    assert response == "Response"
+    assert llm.get_last_usage() == {
+        "prompt_tokens": 11,
+        "completion_tokens": 7,
+        "total_tokens": 18,
+    }
+
+
+def test_generate_response_resets_stale_usage_when_missing(mock_openai_client):
+    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14")
+    llm = OpenAILLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    llm._last_usage = {"prompt_tokens": 99}
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Response"))]
+    mock_response.usage = None
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    assert llm.get_last_usage() is None
+
+
+def test_usage_capture_accumulates_multiple_responses(mock_openai_client):
+    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14")
+    llm = OpenAILLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    first_response = Mock()
+    first_response.choices = [Mock(message=Mock(content="First"))]
+    first_response.usage = SimpleNamespace(prompt_tokens=11, completion_tokens=7, total_tokens=18)
+    second_response = Mock()
+    second_response.choices = [Mock(message=Mock(content="Second"))]
+    second_response.usage = SimpleNamespace(prompt_tokens=5, completion_tokens=3, total_tokens=8)
+    mock_openai_client.chat.completions.create.side_effect = [first_response, second_response]
+
+    llm.start_usage_capture()
+    try:
+        llm.generate_response(messages)
+        llm.generate_response(messages)
+    finally:
+        llm.stop_usage_capture()
+
+    assert llm.get_last_usage() == {
+        "prompt_tokens": 16,
+        "completion_tokens": 10,
+        "total_tokens": 26,
+    }

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -21,7 +21,9 @@ def mock_openai_client():
 
 def test_openai_llm_base_url():
     # case1: default config: with openai official base url
-    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key")
+    config = OpenAIConfig(
+        model="gpt-4.1-nano-2025-04-14", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key"
+    )
     llm = OpenAILLM(config)
     # Note: openai client will parse the raw base_url into a URL object, which will have a trailing slash
     assert str(llm.client.base_url) == "https://api.openai.com/v1/"
@@ -29,7 +31,9 @@ def test_openai_llm_base_url():
     # case2: with env variable OPENAI_API_BASE
     provider_base_url = "https://api.provider.com/v1"
     os.environ["OPENAI_BASE_URL"] = provider_base_url
-    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key")
+    config = OpenAIConfig(
+        model="gpt-4.1-nano-2025-04-14", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key"
+    )
     llm = OpenAILLM(config)
     # Note: openai client will parse the raw base_url into a URL object, which will have a trailing slash
     assert str(llm.client.base_url) == provider_base_url + "/"
@@ -37,7 +41,12 @@ def test_openai_llm_base_url():
     # case3: with config.openai_base_url
     config_base_url = "https://api.config.com/v1"
     config = OpenAIConfig(
-        model="gpt-4.1-nano-2025-04-14", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key", openai_base_url=config_base_url
+        model="gpt-4.1-nano-2025-04-14",
+        temperature=0.7,
+        max_tokens=100,
+        top_p=1.0,
+        api_key="api_key",
+        openai_base_url=config_base_url,
     )
     llm = OpenAILLM(config)
     # Note: openai client will parse the raw base_url into a URL object, which will have a trailing slash
@@ -101,7 +110,13 @@ def test_generate_response_with_tools(mock_openai_client):
     response = llm.generate_response(messages, tools=tools)
 
     mock_openai_client.chat.completions.create.assert_called_once_with(
-        model="gpt-4.1-nano-2025-04-14", messages=messages, temperature=0.7, max_tokens=100, top_p=1.0, tools=tools, tool_choice="auto"
+        model="gpt-4.1-nano-2025-04-14",
+        messages=messages,
+        temperature=0.7,
+        max_tokens=100,
+        top_p=1.0,
+        tools=tools,
+        tool_choice="auto",
     )
 
     assert response["content"] == "I've added the memory for you."
@@ -113,19 +128,19 @@ def test_generate_response_with_tools(mock_openai_client):
 def test_response_callback_invocation(mock_openai_client):
     # Setup mock callback
     mock_callback = Mock()
-    
+
     config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", response_callback=mock_callback)
     llm = OpenAILLM(config)
     messages = [{"role": "user", "content": "Test callback"}]
-    
+
     # Mock response
     mock_response = Mock()
     mock_response.choices = [Mock(message=Mock(content="Response"))]
     mock_openai_client.chat.completions.create.return_value = mock_response
-    
+
     # Call method
     llm.generate_response(messages)
-    
+
     # Verify callback called with correct arguments
     mock_callback.assert_called_once()
     args = mock_callback.call_args[0]
@@ -138,16 +153,16 @@ def test_no_response_callback(mock_openai_client):
     config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14")
     llm = OpenAILLM(config)
     messages = [{"role": "user", "content": "Test no callback"}]
-    
+
     # Mock response
     mock_response = Mock()
     mock_response.choices = [Mock(message=Mock(content="Response"))]
     mock_openai_client.chat.completions.create.return_value = mock_response
-    
+
     # Should complete without calling any callback
     response = llm.generate_response(messages)
     assert response == "Response"
-    
+
     # Verify no callback is set
     assert llm.config.response_callback is None
 
@@ -156,20 +171,20 @@ def test_callback_exception_handling(mock_openai_client):
     # Callback that raises exception
     def faulty_callback(*args):
         raise ValueError("Callback error")
-    
+
     config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", response_callback=faulty_callback)
     llm = OpenAILLM(config)
     messages = [{"role": "user", "content": "Test exception"}]
-    
+
     # Mock response
     mock_response = Mock()
     mock_response.choices = [Mock(message=Mock(content="Expected response"))]
     mock_openai_client.chat.completions.create.return_value = mock_response
-    
+
     # Should complete without raising
     response = llm.generate_response(messages)
     assert response == "Expected response"
-    
+
     # Verify callback was called (even though it raised an exception)
     assert llm.config.response_callback is faulty_callback
 
@@ -434,10 +449,10 @@ def test_callback_with_tools(mock_openai_client):
                     "properties": {"param1": {"type": "string"}},
                     "required": ["param1"],
                 },
-            }
+            },
         }
     ]
-    
+
     # Mock tool response
     mock_response = Mock()
     mock_message = Mock()
@@ -448,13 +463,13 @@ def test_callback_with_tools(mock_openai_client):
     mock_message.tool_calls = [mock_tool_call]
     mock_response.choices = [Mock(message=mock_message)]
     mock_openai_client.chat.completions.create.return_value = mock_response
-    
+
     llm.generate_response(messages, tools=tools)
-    
+
     # Verify callback called with tool response
     mock_callback.assert_called_once()
     # Check that tool_calls exists in the message
-    assert hasattr(mock_callback.call_args[0][1].choices[0].message, 'tool_calls')
+    assert hasattr(mock_callback.call_args[0][1].choices[0].message, "tool_calls")
 
 
 def test_openai_llm_preserves_proxies_from_base_config(mock_openai_client):
@@ -466,6 +481,7 @@ def test_openai_llm_preserves_proxies_from_base_config(mock_openai_client):
     llm = OpenAILLM(config)
     assert llm.config.http_client_proxies == "http://proxy.local:8080"
     assert isinstance(llm.config.http_client, httpx.Client)
+
 
 def test_generate_response_captures_usage(mock_openai_client):
     config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14")
@@ -543,9 +559,9 @@ def test_usage_capture_isolation_across_threads(mock_openai_client):
             usage=SimpleNamespace(prompt_tokens=5, completion_tokens=3, total_tokens=8),
         ),
     }
-    mock_openai_client.chat.completions.create.side_effect = (
-        lambda **kwargs: responses[kwargs["messages"][0]["content"]]
-    )
+    mock_openai_client.chat.completions.create.side_effect = lambda **kwargs: responses[
+        kwargs["messages"][0]["content"]
+    ]
 
     first_generated = threading.Event()
     second_finished = threading.Event()

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -21,9 +21,7 @@ def mock_openai_client():
 
 def test_openai_llm_base_url():
     # case1: default config: with openai official base url
-    config = OpenAIConfig(
-        model="gpt-4.1-nano-2025-04-14", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key"
-    )
+    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key")
     llm = OpenAILLM(config)
     # Note: openai client will parse the raw base_url into a URL object, which will have a trailing slash
     assert str(llm.client.base_url) == "https://api.openai.com/v1/"
@@ -31,9 +29,7 @@ def test_openai_llm_base_url():
     # case2: with env variable OPENAI_API_BASE
     provider_base_url = "https://api.provider.com/v1"
     os.environ["OPENAI_BASE_URL"] = provider_base_url
-    config = OpenAIConfig(
-        model="gpt-4.1-nano-2025-04-14", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key"
-    )
+    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key")
     llm = OpenAILLM(config)
     # Note: openai client will parse the raw base_url into a URL object, which will have a trailing slash
     assert str(llm.client.base_url) == provider_base_url + "/"
@@ -41,12 +37,7 @@ def test_openai_llm_base_url():
     # case3: with config.openai_base_url
     config_base_url = "https://api.config.com/v1"
     config = OpenAIConfig(
-        model="gpt-4.1-nano-2025-04-14",
-        temperature=0.7,
-        max_tokens=100,
-        top_p=1.0,
-        api_key="api_key",
-        openai_base_url=config_base_url,
+        model="gpt-4.1-nano-2025-04-14", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key", openai_base_url=config_base_url
     )
     llm = OpenAILLM(config)
     # Note: openai client will parse the raw base_url into a URL object, which will have a trailing slash
@@ -110,13 +101,7 @@ def test_generate_response_with_tools(mock_openai_client):
     response = llm.generate_response(messages, tools=tools)
 
     mock_openai_client.chat.completions.create.assert_called_once_with(
-        model="gpt-4.1-nano-2025-04-14",
-        messages=messages,
-        temperature=0.7,
-        max_tokens=100,
-        top_p=1.0,
-        tools=tools,
-        tool_choice="auto",
+        model="gpt-4.1-nano-2025-04-14", messages=messages, temperature=0.7, max_tokens=100, top_p=1.0, tools=tools, tool_choice="auto"
     )
 
     assert response["content"] == "I've added the memory for you."
@@ -449,7 +434,7 @@ def test_callback_with_tools(mock_openai_client):
                     "properties": {"param1": {"type": "string"}},
                     "required": ["param1"],
                 },
-            },
+            }
         }
     ]
 
@@ -469,7 +454,7 @@ def test_callback_with_tools(mock_openai_client):
     # Verify callback called with tool response
     mock_callback.assert_called_once()
     # Check that tool_calls exists in the message
-    assert hasattr(mock_callback.call_args[0][1].choices[0].message, "tool_calls")
+    assert hasattr(mock_callback.call_args[0][1].choices[0].message, 'tool_calls')
 
 
 def test_openai_llm_preserves_proxies_from_base_config(mock_openai_client):
@@ -481,7 +466,6 @@ def test_openai_llm_preserves_proxies_from_base_config(mock_openai_client):
     llm = OpenAILLM(config)
     assert llm.config.http_client_proxies == "http://proxy.local:8080"
     assert isinstance(llm.config.http_client, httpx.Client)
-
 
 def test_generate_response_captures_usage(mock_openai_client):
     config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14")
@@ -501,6 +485,26 @@ def test_generate_response_captures_usage(mock_openai_client):
         "completion_tokens": 7,
         "total_tokens": 18,
     }
+
+
+def test_get_last_usage_returns_isolated_nested_values(mock_openai_client):
+    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14")
+    llm = OpenAILLM(config)
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Response"))]
+    mock_response.usage = {
+        "prompt_tokens": 11,
+        "completion_tokens": 7,
+        "total_tokens": 18,
+        "completion_tokens_details": {"reasoning_tokens": 2},
+    }
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response([{"role": "user", "content": "Test usage copy"}])
+    usage = llm.get_last_usage()
+    usage["completion_tokens_details"]["reasoning_tokens"] = 99
+
+    assert llm.get_last_usage()["completion_tokens_details"]["reasoning_tokens"] == 2
 
 
 def test_generate_response_resets_stale_usage_when_missing(mock_openai_client):
@@ -559,9 +563,9 @@ def test_usage_capture_isolation_across_threads(mock_openai_client):
             usage=SimpleNamespace(prompt_tokens=5, completion_tokens=3, total_tokens=8),
         ),
     }
-    mock_openai_client.chat.completions.create.side_effect = lambda **kwargs: responses[
-        kwargs["messages"][0]["content"]
-    ]
+    mock_openai_client.chat.completions.create.side_effect = (
+        lambda **kwargs: responses[kwargs["messages"][0]["content"]]
+    )
 
     first_generated = threading.Event()
     second_finished = threading.Event()

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -64,9 +64,7 @@ class TestAddToVectorStoreErrors:
         # Verify — v3 single-pass pipeline makes 1 LLM call, returns [] on parse error
         assert mock_memory.llm.generate_response.call_count == 1
         assert result == []
-        assert any("Error parsing extraction response" in record.message for record in caplog.records), (
-            "Expected error message not found in logs"
-        )
+        assert any("Error parsing extraction response" in record.message for record in caplog.records), "Expected error message not found in logs"
 
     def test_empty_llm_response_memory_actions(self, mock_memory, caplog):
         """Test empty response from LLM during memory actions (v3: single-pass, 1 LLM call)"""
@@ -275,9 +273,7 @@ class TestAsyncAddToVectorStoreErrors:
             )
         assert mock_async_memory.llm.generate_response.call_count == 1
         assert result == []
-        assert any("Error parsing extraction response" in record.message for record in caplog.records), (
-            "Expected error message not found in logs"
-        )
+        assert any("Error parsing extraction response" in record.message for record in caplog.records), "Expected error message not found in logs"
 
     @pytest.mark.asyncio
     async def test_async_empty_llm_response_memory_actions(self, mock_async_memory, caplog, mocker):
@@ -655,7 +651,6 @@ class TestMetadataNotMutated:
         memory = _build_memory_instance(mocker, Memory)
         metadata = {"user_id": "test_user", "tags": ["important", "urgent"], "config": {"key": "val"}}
         import copy
-
         metadata_snapshot = copy.deepcopy(metadata)
 
         memory._create_memory("test data", {"test data": [0.1, 0.2, 0.3]}, metadata=metadata)
@@ -1123,6 +1118,21 @@ def test_add_includes_usage_only_when_requested(mocker):
     memory.llm.stop_usage_capture.assert_called_once()
 
 
+def test_add_include_usage_without_capture_api_returns_normal_result(mocker):
+    class LLMWithoutUsageCapture:
+        def get_last_usage(self):
+            return None
+
+    memory = _build_memory_instance(mocker, Memory)
+    memory.config.llm.config = {}
+    memory.llm = LLMWithoutUsageCapture()
+    memory._add_to_vector_store = Mock(return_value=[{"id": "mem-1", "memory": "Likes pizza", "event": "ADD"}])
+
+    result = memory.add("Likes pizza", user_id="alice", include_usage=True)
+
+    assert result == {"results": [{"id": "mem-1", "memory": "Likes pizza", "event": "ADD"}]}
+
+
 @pytest.mark.asyncio
 async def test_async_add_includes_usage_only_when_requested(mocker):
     memory = _build_memory_instance(mocker, AsyncMemory)
@@ -1153,6 +1163,24 @@ async def test_async_add_includes_usage_only_when_requested(mocker):
 
 
 @pytest.mark.asyncio
+async def test_async_add_include_usage_without_capture_api_returns_normal_result(mocker):
+    class LLMWithoutUsageCapture:
+        def get_last_usage(self):
+            return None
+
+    memory = _build_memory_instance(mocker, AsyncMemory)
+    memory.config.llm.config = {}
+    memory.llm = LLMWithoutUsageCapture()
+    memory._add_to_vector_store = mocker.AsyncMock(
+        return_value=[{"id": "mem-1", "memory": "Likes pizza", "event": "ADD"}]
+    )
+
+    result = await memory.add("Likes pizza", user_id="alice", include_usage=True)
+
+    assert result == {"results": [{"id": "mem-1", "memory": "Likes pizza", "event": "ADD"}]}
+
+
+@pytest.mark.asyncio
 async def test_async_add_includes_usage_from_threaded_llm_path(mocker):
     class ContextVarUsageLLM:
         def __init__(self):
@@ -1172,13 +1200,11 @@ async def test_async_add_includes_usage_from_threaded_llm_path(mocker):
 
         def generate_response(self, messages, response_format=None, **kwargs):
             if self._capture.get():
-                self._usage.set(
-                    {
-                        "prompt_tokens": 5,
-                        "completion_tokens": 3,
-                        "total_tokens": 8,
-                    }
-                )
+                self._usage.set({
+                    "prompt_tokens": 5,
+                    "completion_tokens": 3,
+                    "total_tokens": 8,
+                })
             return '{"memory": [{"text": "Likes pizza"}]}'
 
     memory = _build_memory_instance(mocker, AsyncMemory)

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from contextvars import ContextVar
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock
@@ -1144,3 +1145,58 @@ async def test_async_add_includes_usage_only_when_requested(mocker):
     }
     memory.llm.start_usage_capture.assert_called_once()
     memory.llm.stop_usage_capture.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_async_add_includes_usage_from_threaded_llm_path(mocker):
+    class ContextVarUsageLLM:
+        def __init__(self):
+            self._capture = ContextVar("capture", default=False)
+            self._usage = ContextVar("usage", default=None)
+
+        def start_usage_capture(self):
+            self._capture.set(True)
+            self._usage.set(None)
+
+        def stop_usage_capture(self):
+            self._capture.set(False)
+
+        def get_last_usage(self):
+            usage = self._usage.get()
+            return dict(usage) if usage else None
+
+        def generate_response(self, messages, response_format=None, **kwargs):
+            if self._capture.get():
+                self._usage.set({
+                    "prompt_tokens": 5,
+                    "completion_tokens": 3,
+                    "total_tokens": 8,
+                })
+            return '{"memory": [{"text": "Likes pizza"}]}'
+
+    memory = _build_memory_instance(mocker, AsyncMemory)
+    memory.config.llm.config = {}
+    memory.custom_instructions = None
+    memory.llm = ContextVarUsageLLM()
+    memory.embedding_model = Mock()
+    memory.embedding_model.embed.return_value = [0.1, 0.2, 0.3]
+    memory.embedding_model.embed_batch.return_value = [[0.1, 0.2, 0.3]]
+    memory.vector_store.search.return_value = []
+    memory.vector_store.insert = Mock()
+    memory.db.get_last_messages.return_value = []
+    memory.db.save_messages = Mock()
+    memory.db.batch_add_history = Mock()
+    mocker.patch("mem0.memory.main.capture_event")
+    mocker.patch("mem0.memory.main.extract_entities_batch", return_value=[[]])
+    mocker.patch("mem0.memory.main.display_first_run_notice_async", mocker.AsyncMock())
+    mocker.patch("mem0.memory.main.display_temporal_usage_notice_async", mocker.AsyncMock())
+    mocker.patch("mem0.memory.main.display_scale_threshold_notice_async", mocker.AsyncMock())
+
+    result = await memory.add("Likes pizza", user_id="alice", include_usage=True)
+
+    assert result["usage"] == {
+        "prompt_tokens": 5,
+        "completion_tokens": 3,
+        "total_tokens": 8,
+    }
+    assert result["results"][0]["memory"] == "Likes pizza"

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -1089,3 +1089,58 @@ class TestAddPipelineEntityEmbeddingCountGuard:
         assert any("padding/truncating" in r.message for r in caplog.records), (
             "expected count-mismatch warning was not emitted"
         )
+
+
+def test_add_includes_usage_only_when_requested(mocker):
+    memory = _build_memory_instance(mocker, Memory)
+    memory.config.llm.config = {}
+    memory.llm.reset_last_usage = Mock()
+    memory.llm.get_last_usage = Mock(
+        return_value={
+            "prompt_tokens": 11,
+            "completion_tokens": 7,
+            "total_tokens": 18,
+        }
+    )
+    memory._add_to_vector_store = Mock(return_value=[{"id": "mem-1", "memory": "Likes pizza", "event": "ADD"}])
+
+    default_result = memory.add("Likes pizza", user_id="alice")
+    usage_result = memory.add("Likes pizza", user_id="alice", include_usage=True)
+
+    assert "usage" not in default_result
+    assert usage_result["usage"] == {
+        "prompt_tokens": 11,
+        "completion_tokens": 7,
+        "total_tokens": 18,
+    }
+    memory.llm.start_usage_capture.assert_called_once()
+    memory.llm.stop_usage_capture.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_async_add_includes_usage_only_when_requested(mocker):
+    memory = _build_memory_instance(mocker, AsyncMemory)
+    memory.config.llm.config = {}
+    memory.llm.reset_last_usage = Mock()
+    memory.llm.get_last_usage = Mock(
+        return_value={
+            "prompt_tokens": 5,
+            "completion_tokens": 3,
+            "total_tokens": 8,
+        }
+    )
+    memory._add_to_vector_store = mocker.AsyncMock(
+        return_value=[{"id": "mem-1", "memory": "Likes pizza", "event": "ADD"}]
+    )
+
+    default_result = await memory.add("Likes pizza", user_id="alice")
+    usage_result = await memory.add("Likes pizza", user_id="alice", include_usage=True)
+
+    assert "usage" not in default_result
+    assert usage_result["usage"] == {
+        "prompt_tokens": 5,
+        "completion_tokens": 3,
+        "total_tokens": 8,
+    }
+    memory.llm.start_usage_capture.assert_called_once()
+    memory.llm.stop_usage_capture.assert_called_once()

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -64,7 +64,9 @@ class TestAddToVectorStoreErrors:
         # Verify — v3 single-pass pipeline makes 1 LLM call, returns [] on parse error
         assert mock_memory.llm.generate_response.call_count == 1
         assert result == []
-        assert any("Error parsing extraction response" in record.message for record in caplog.records), "Expected error message not found in logs"
+        assert any("Error parsing extraction response" in record.message for record in caplog.records), (
+            "Expected error message not found in logs"
+        )
 
     def test_empty_llm_response_memory_actions(self, mock_memory, caplog):
         """Test empty response from LLM during memory actions (v3: single-pass, 1 LLM call)"""
@@ -273,7 +275,9 @@ class TestAsyncAddToVectorStoreErrors:
             )
         assert mock_async_memory.llm.generate_response.call_count == 1
         assert result == []
-        assert any("Error parsing extraction response" in record.message for record in caplog.records), "Expected error message not found in logs"
+        assert any("Error parsing extraction response" in record.message for record in caplog.records), (
+            "Expected error message not found in logs"
+        )
 
     @pytest.mark.asyncio
     async def test_async_empty_llm_response_memory_actions(self, mock_async_memory, caplog, mocker):
@@ -651,6 +655,7 @@ class TestMetadataNotMutated:
         memory = _build_memory_instance(mocker, Memory)
         metadata = {"user_id": "test_user", "tags": ["important", "urgent"], "config": {"key": "val"}}
         import copy
+
         metadata_snapshot = copy.deepcopy(metadata)
 
         memory._create_memory("test data", {"test data": [0.1, 0.2, 0.3]}, metadata=metadata)
@@ -1167,11 +1172,13 @@ async def test_async_add_includes_usage_from_threaded_llm_path(mocker):
 
         def generate_response(self, messages, response_format=None, **kwargs):
             if self._capture.get():
-                self._usage.set({
-                    "prompt_tokens": 5,
-                    "completion_tokens": 3,
-                    "total_tokens": 8,
-                })
+                self._usage.set(
+                    {
+                        "prompt_tokens": 5,
+                        "completion_tokens": 3,
+                        "total_tokens": 8,
+                    }
+                )
             return '{"memory": [{"text": "Likes pizza"}]}'
 
     memory = _build_memory_instance(mocker, AsyncMemory)

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -1133,6 +1133,21 @@ def test_add_include_usage_without_capture_api_returns_normal_result(mocker):
     assert result == {"results": [{"id": "mem-1", "memory": "Likes pizza", "event": "ADD"}]}
 
 
+def test_add_include_usage_does_not_attach_stale_usage_without_capture_api(mocker):
+    class LLMWithStaleUsage:
+        def get_last_usage(self):
+            return {"prompt_tokens": 99, "completion_tokens": 1, "total_tokens": 100}
+
+    memory = _build_memory_instance(mocker, Memory)
+    memory.config.llm.config = {}
+    memory.llm = LLMWithStaleUsage()
+    memory._add_to_vector_store = Mock(return_value=[{"id": "mem-1", "memory": "Likes pizza", "event": "ADD"}])
+
+    result = memory.add("Likes pizza", user_id="alice", infer=False, include_usage=True)
+
+    assert result == {"results": [{"id": "mem-1", "memory": "Likes pizza", "event": "ADD"}]}
+
+
 @pytest.mark.asyncio
 async def test_async_add_includes_usage_only_when_requested(mocker):
     memory = _build_memory_instance(mocker, AsyncMemory)

--- a/tests/test_server_params.py
+++ b/tests/test_server_params.py
@@ -246,24 +246,53 @@ class TestAddPrompt:
 
 
 # ===========================================================================
+# MemoryCreate: include_usage parameter
+# ===========================================================================
+
+class TestAddIncludeUsage:
+    """Verify that the include_usage parameter is accepted and forwarded."""
+
+    def test_include_usage_true_forwarded(self, client, mock_memory):
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "I like pizza"}],
+            "user_id": "u1",
+            "include_usage": True,
+        })
+        assert resp.status_code == 200
+        _, kwargs = mock_memory.add.call_args
+        assert kwargs["include_usage"] is True
+
+    def test_include_usage_omitted(self, client, mock_memory):
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "hello"}],
+            "user_id": "u1",
+        })
+        assert resp.status_code == 200
+        _, kwargs = mock_memory.add.call_args
+        assert "include_usage" not in kwargs
+
+
+# ===========================================================================
 # MemoryCreate: all new params together
 # ===========================================================================
 
 class TestAddAllNewParams:
 
-    def test_infer_memory_type_and_prompt_together(self, client, mock_memory):
+    def test_infer_memory_type_prompt_and_include_usage_together(self, client, mock_memory):
         resp = client.post("/memories", json={
             "messages": [{"role": "user", "content": "I like pizza"}],
             "user_id": "u1",
             "infer": False,
             "memory_type": "core",
             "prompt": "Custom extraction prompt.",
+            "include_usage": True,
         })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["infer"] is False
         assert kwargs["memory_type"] == "core"
         assert kwargs["prompt"] == "Custom extraction prompt."
+        assert kwargs["include_usage"] is True
 
 
 # ===========================================================================
@@ -384,6 +413,11 @@ class TestOpenAPISchema:
         add_props = schema["components"]["schemas"]["MemoryCreate"]["properties"]
         assert "prompt" in add_props
 
+    def test_add_schema_includes_include_usage(self, client):
+        schema = client.get("/openapi.json").json()
+        add_props = schema["components"]["schemas"]["MemoryCreate"]["properties"]
+        assert "include_usage" in add_props
+
 
 # ===========================================================================
 # Pydantic type validation: invalid types return 422
@@ -475,6 +509,16 @@ class TestExplicitNull:
         _, kwargs = mock_memory.add.call_args
         assert "prompt" not in kwargs
 
+    def test_include_usage_null_uses_memory_default(self, client, mock_memory):
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "test"}],
+            "user_id": "u1",
+            "include_usage": None,
+        })
+        assert resp.status_code == 200
+        _, kwargs = mock_memory.add.call_args
+        assert "include_usage" not in kwargs
+
 
 # ===========================================================================
 # Verify exact call signatures match Memory method params
@@ -507,12 +551,22 @@ class TestCallSignatureMatch:
             "messages": [{"role": "user", "content": "hi"}],
             "user_id": "u1", "agent_id": "a1", "run_id": "r1",
             "metadata": {"k": "v"},
-            "infer": False, "memory_type": "core", "prompt": "custom",
+            "infer": False, "memory_type": "core", "prompt": "custom", "include_usage": True,
         })
         assert resp.status_code == 200
         # The handler passes messages= as a keyword arg, so it appears in kwargs too
         _, kwargs = mock_memory.add.call_args
-        valid_params = {"messages", "user_id", "agent_id", "run_id", "metadata", "infer", "memory_type", "prompt"}
+        valid_params = {
+            "messages",
+            "user_id",
+            "agent_id",
+            "run_id",
+            "metadata",
+            "infer",
+            "memory_type",
+            "prompt",
+            "include_usage",
+        }
         for key in kwargs:
             assert key in valid_params, f"Unexpected kwarg '{key}' forwarded to Memory.add()"
 

--- a/tests/test_server_params.py
+++ b/tests/test_server_params.py
@@ -22,6 +22,7 @@ from fastapi.testclient import TestClient
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def _mock_memory():
     """Patch Memory.from_config so the server imports without a real backend."""
@@ -45,6 +46,7 @@ def _mock_memory():
 def client(_mock_memory):
     """Return a TestClient wired to the server app with mocked Memory."""
     import server.main as server_main
+
     with patch.dict(os.environ, {"ADMIN_API_KEY": ""}):
         importlib.reload(server_main)
     return TestClient(server_main.app)
@@ -58,6 +60,7 @@ def mock_memory(_mock_memory):
 # ===========================================================================
 # SearchRequest: top_k parameter
 # ===========================================================================
+
 
 class TestSearchLimit:
     """Verify that the top_k parameter is accepted and forwarded to Memory.search()."""
@@ -87,6 +90,7 @@ class TestSearchLimit:
 # SearchRequest: threshold parameter
 # ===========================================================================
 
+
 class TestSearchThreshold:
     """Verify that the threshold parameter is accepted and forwarded."""
 
@@ -114,6 +118,7 @@ class TestSearchThreshold:
 # SearchRequest: explain parameter
 # ===========================================================================
 
+
 class TestSearchExplain:
     """Verify that the explain parameter is accepted and forwarded."""
 
@@ -140,12 +145,10 @@ class TestSearchExplain:
 # SearchRequest: top_k + threshold together
 # ===========================================================================
 
-class TestSearchLimitAndThreshold:
 
+class TestSearchLimitAndThreshold:
     def test_both_forwarded(self, client, mock_memory):
-        resp = client.post("/search", json={
-            "query": "food", "user_id": "u1", "top_k": 10, "threshold": 0.5
-        })
+        resp = client.post("/search", json={"query": "food", "user_id": "u1", "top_k": 10, "threshold": 0.5})
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert kwargs["top_k"] == 10
@@ -156,25 +159,32 @@ class TestSearchLimitAndThreshold:
 # MemoryCreate: infer parameter
 # ===========================================================================
 
+
 class TestAddInfer:
     """Verify that the infer parameter is accepted and forwarded to Memory.add()."""
 
     def test_infer_false_forwarded(self, client, mock_memory):
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "Store this exactly"}],
-            "user_id": "u1",
-            "infer": False,
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "Store this exactly"}],
+                "user_id": "u1",
+                "infer": False,
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["infer"] is False
 
     def test_infer_true_forwarded(self, client, mock_memory):
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "I like pizza"}],
-            "user_id": "u1",
-            "infer": True,
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "I like pizza"}],
+                "user_id": "u1",
+                "infer": True,
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["infer"] is True
@@ -182,10 +192,13 @@ class TestAddInfer:
     def test_infer_omitted_uses_memory_default(self, client, mock_memory):
         """When infer is not sent, it should not appear in kwargs,
         allowing Memory.add() to use its own default (True)."""
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "hello"}],
-            "user_id": "u1",
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "hello"}],
+                "user_id": "u1",
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert "infer" not in kwargs
@@ -195,24 +208,31 @@ class TestAddInfer:
 # MemoryCreate: memory_type parameter
 # ===========================================================================
 
+
 class TestAddMemoryType:
     """Verify that the memory_type parameter is accepted and forwarded."""
 
     def test_memory_type_forwarded(self, client, mock_memory):
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "I like pizza"}],
-            "user_id": "u1",
-            "memory_type": "core",
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "I like pizza"}],
+                "user_id": "u1",
+                "memory_type": "core",
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["memory_type"] == "core"
 
     def test_memory_type_omitted(self, client, mock_memory):
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "hello"}],
-            "user_id": "u1",
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "hello"}],
+                "user_id": "u1",
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert "memory_type" not in kwargs
@@ -222,24 +242,31 @@ class TestAddMemoryType:
 # MemoryCreate: prompt parameter
 # ===========================================================================
 
+
 class TestAddPrompt:
     """Verify that the prompt parameter is accepted and forwarded."""
 
     def test_prompt_forwarded(self, client, mock_memory):
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "I like pizza"}],
-            "user_id": "u1",
-            "prompt": "Extract food preferences only.",
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "I like pizza"}],
+                "user_id": "u1",
+                "prompt": "Extract food preferences only.",
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["prompt"] == "Extract food preferences only."
 
     def test_prompt_omitted(self, client, mock_memory):
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "hello"}],
-            "user_id": "u1",
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "hello"}],
+                "user_id": "u1",
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert "prompt" not in kwargs
@@ -249,24 +276,31 @@ class TestAddPrompt:
 # MemoryCreate: include_usage parameter
 # ===========================================================================
 
+
 class TestAddIncludeUsage:
     """Verify that the include_usage parameter is accepted and forwarded."""
 
     def test_include_usage_true_forwarded(self, client, mock_memory):
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "I like pizza"}],
-            "user_id": "u1",
-            "include_usage": True,
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "I like pizza"}],
+                "user_id": "u1",
+                "include_usage": True,
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["include_usage"] is True
 
     def test_include_usage_omitted(self, client, mock_memory):
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "hello"}],
-            "user_id": "u1",
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "hello"}],
+                "user_id": "u1",
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert "include_usage" not in kwargs
@@ -276,17 +310,20 @@ class TestAddIncludeUsage:
 # MemoryCreate: all new params together
 # ===========================================================================
 
-class TestAddAllNewParams:
 
+class TestAddAllNewParams:
     def test_infer_memory_type_prompt_and_include_usage_together(self, client, mock_memory):
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "I like pizza"}],
-            "user_id": "u1",
-            "infer": False,
-            "memory_type": "core",
-            "prompt": "Custom extraction prompt.",
-            "include_usage": True,
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "I like pizza"}],
+                "user_id": "u1",
+                "infer": False,
+                "memory_type": "core",
+                "prompt": "Custom extraction prompt.",
+                "include_usage": True,
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["infer"] is False
@@ -299,24 +336,33 @@ class TestAddAllNewParams:
 # Edge cases: falsy-but-valid values must not be filtered out
 # ===========================================================================
 
+
 class TestFalsyValues:
     """The handler filters with `v is not None`. Falsy values like False, 0,
     0.0, and empty string must still be forwarded."""
 
     def test_infer_false_not_filtered(self, client, mock_memory):
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "test"}],
-            "user_id": "u1",
-            "infer": False,
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "test"}],
+                "user_id": "u1",
+                "infer": False,
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["infer"] is False
 
     def test_threshold_zero_not_filtered(self, client, mock_memory):
-        resp = client.post("/search", json={
-            "query": "food", "user_id": "u1", "threshold": 0.0,
-        })
+        resp = client.post(
+            "/search",
+            json={
+                "query": "food",
+                "user_id": "u1",
+                "threshold": 0.0,
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert kwargs["threshold"] == 0.0
@@ -326,22 +372,30 @@ class TestFalsyValues:
 # Extra/unknown fields are still silently ignored (existing Pydantic behavior)
 # ===========================================================================
 
-class TestUnknownFieldsIgnored:
 
+class TestUnknownFieldsIgnored:
     def test_unknown_search_field_ignored(self, client, mock_memory):
-        resp = client.post("/search", json={
-            "query": "food", "user_id": "u1", "bogus_field": "xyz",
-        })
+        resp = client.post(
+            "/search",
+            json={
+                "query": "food",
+                "user_id": "u1",
+                "bogus_field": "xyz",
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert "bogus_field" not in kwargs
 
     def test_unknown_add_field_ignored(self, client, mock_memory):
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "test"}],
-            "user_id": "u1",
-            "unknown_param": 42,
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "test"}],
+                "user_id": "u1",
+                "unknown_param": 42,
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert "unknown_param" not in kwargs
@@ -351,15 +405,18 @@ class TestUnknownFieldsIgnored:
 # Backward compatibility: existing params still work
 # ===========================================================================
 
-class TestExistingParamsUnchanged:
 
+class TestExistingParamsUnchanged:
     def test_search_filters_still_forwarded(self, client, mock_memory):
-        resp = client.post("/search", json={
-            "query": "food",
-            "user_id": "u1",
-            "agent_id": "a1",
-            "filters": {"category": "food"},
-        })
+        resp = client.post(
+            "/search",
+            json={
+                "query": "food",
+                "user_id": "u1",
+                "agent_id": "a1",
+                "filters": {"category": "food"},
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert kwargs["filters"]["user_id"] == "u1"
@@ -367,12 +424,15 @@ class TestExistingParamsUnchanged:
         assert kwargs["filters"]["category"] == "food"
 
     def test_add_metadata_still_forwarded(self, client, mock_memory):
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "test"}],
-            "user_id": "u1",
-            "agent_id": "a1",
-            "metadata": {"source": "test"},
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "test"}],
+                "user_id": "u1",
+                "agent_id": "a1",
+                "metadata": {"source": "test"},
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["user_id"] == "u1"
@@ -383,6 +443,7 @@ class TestExistingParamsUnchanged:
 # ===========================================================================
 # OpenAPI schema: new fields are documented
 # ===========================================================================
+
 
 class TestOpenAPISchema:
     """Verify the new fields appear in the auto-generated OpenAPI schema."""
@@ -423,53 +484,78 @@ class TestOpenAPISchema:
 # Pydantic type validation: invalid types return 422
 # ===========================================================================
 
+
 class TestTypeValidation:
     """Verify FastAPI/Pydantic rejects invalid types with 422."""
 
     def test_limit_string_rejected(self, client):
-        resp = client.post("/search", json={
-            "query": "food", "user_id": "u1", "top_k": "not_a_number",
-        })
+        resp = client.post(
+            "/search",
+            json={
+                "query": "food",
+                "user_id": "u1",
+                "top_k": "not_a_number",
+            },
+        )
         assert resp.status_code == 422
 
     def test_threshold_string_rejected(self, client):
-        resp = client.post("/search", json={
-            "query": "food", "user_id": "u1", "threshold": "high",
-        })
+        resp = client.post(
+            "/search",
+            json={
+                "query": "food",
+                "user_id": "u1",
+                "threshold": "high",
+            },
+        )
         assert resp.status_code == 422
 
     def test_infer_string_coerced_by_pydantic(self, client, mock_memory):
         """Pydantic v2 coerces truthy strings like 'yes' to True for bool fields."""
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "test"}],
-            "user_id": "u1",
-            "infer": "yes",
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "test"}],
+                "user_id": "u1",
+                "infer": "yes",
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["infer"] is True
 
     def test_infer_invalid_value_rejected(self, client):
         """A value that cannot be coerced to bool should be rejected."""
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "test"}],
-            "user_id": "u1",
-            "infer": [1, 2, 3],
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "test"}],
+                "user_id": "u1",
+                "infer": [1, 2, 3],
+            },
+        )
         assert resp.status_code == 422
 
     def test_limit_float_rejected(self, client):
-        resp = client.post("/search", json={
-            "query": "food", "user_id": "u1", "top_k": 5.7,
-        })
+        resp = client.post(
+            "/search",
+            json={
+                "query": "food",
+                "user_id": "u1",
+                "top_k": 5.7,
+            },
+        )
         assert resp.status_code == 422
 
     def test_memory_type_int_rejected(self, client):
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "test"}],
-            "user_id": "u1",
-            "memory_type": 123,
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "test"}],
+                "user_id": "u1",
+                "memory_type": 123,
+            },
+        )
         assert resp.status_code == 422
 
 
@@ -477,44 +563,59 @@ class TestTypeValidation:
 # Explicit null values: treated as omitted (filtered by `is not None`)
 # ===========================================================================
 
+
 class TestExplicitNull:
     """When a client sends null for an optional field, it should be treated
     as omitted — the Memory class default should be used."""
 
     def test_limit_null_uses_memory_default(self, client, mock_memory):
-        resp = client.post("/search", json={
-            "query": "food", "user_id": "u1", "top_k": None,
-        })
+        resp = client.post(
+            "/search",
+            json={
+                "query": "food",
+                "user_id": "u1",
+                "top_k": None,
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert "top_k" not in kwargs
 
     def test_infer_null_uses_memory_default(self, client, mock_memory):
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "test"}],
-            "user_id": "u1",
-            "infer": None,
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "test"}],
+                "user_id": "u1",
+                "infer": None,
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert "infer" not in kwargs
 
     def test_prompt_null_uses_memory_default(self, client, mock_memory):
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "test"}],
-            "user_id": "u1",
-            "prompt": None,
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "test"}],
+                "user_id": "u1",
+                "prompt": None,
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert "prompt" not in kwargs
 
     def test_include_usage_null_uses_memory_default(self, client, mock_memory):
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "test"}],
-            "user_id": "u1",
-            "include_usage": None,
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "test"}],
+                "user_id": "u1",
+                "include_usage": None,
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert "include_usage" not in kwargs
@@ -524,17 +625,25 @@ class TestExplicitNull:
 # Verify exact call signatures match Memory method params
 # ===========================================================================
 
+
 class TestCallSignatureMatch:
     """Ensure forwarded params exactly match Memory.add() and Memory.search()
     keyword argument names — a typo here would cause a TypeError at runtime."""
 
     def test_search_kwargs_are_valid(self, client, mock_memory):
         """All kwargs forwarded to Memory.search() must be in its signature."""
-        resp = client.post("/search", json={
-            "query": "food", "user_id": "u1", "agent_id": "a1",
-            "run_id": "r1", "filters": {"k": "v"},
-            "top_k": 10, "threshold": 0.5,
-        })
+        resp = client.post(
+            "/search",
+            json={
+                "query": "food",
+                "user_id": "u1",
+                "agent_id": "a1",
+                "run_id": "r1",
+                "filters": {"k": "v"},
+                "top_k": 10,
+                "threshold": 0.5,
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         valid_params = {"query", "top_k", "filters", "threshold", "rerank"}
@@ -547,12 +656,20 @@ class TestCallSignatureMatch:
 
     def test_add_kwargs_are_valid(self, client, mock_memory):
         """All kwargs forwarded to Memory.add() must be in its signature."""
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "hi"}],
-            "user_id": "u1", "agent_id": "a1", "run_id": "r1",
-            "metadata": {"k": "v"},
-            "infer": False, "memory_type": "core", "prompt": "custom", "include_usage": True,
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "hi"}],
+                "user_id": "u1",
+                "agent_id": "a1",
+                "run_id": "r1",
+                "metadata": {"k": "v"},
+                "infer": False,
+                "memory_type": "core",
+                "prompt": "custom",
+                "include_usage": True,
+            },
+        )
         assert resp.status_code == 200
         # The handler passes messages= as a keyword arg, so it appears in kwargs too
         _, kwargs = mock_memory.add.call_args
@@ -572,10 +689,13 @@ class TestCallSignatureMatch:
 
     def test_messages_excluded_from_params_dict(self, client, mock_memory):
         """messages is passed separately via messages= kwarg, not duplicated from model_dump."""
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "hi"}],
-            "user_id": "u1",
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "hi"}],
+                "user_id": "u1",
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         # messages should be present (passed explicitly) and be a list of dicts
@@ -595,6 +715,7 @@ class TestCallSignatureMatch:
 # MemoryUpdate: text and metadata forwarding (fix for #3933)
 # ===========================================================================
 
+
 class TestUpdateMemory:
     """Verify that PUT /memories/{id} extracts text and metadata from the
     request body and forwards them correctly to Memory.update()."""
@@ -606,10 +727,13 @@ class TestUpdateMemory:
         assert kwargs["data"] == "Likes tennis"
 
     def test_metadata_forwarded(self, client, mock_memory):
-        resp = client.put("/memories/mem-1", json={
-            "text": "Likes tennis",
-            "metadata": {"category": "sports"},
-        })
+        resp = client.put(
+            "/memories/mem-1",
+            json={
+                "text": "Likes tennis",
+                "metadata": {"category": "sports"},
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.update.call_args
         assert kwargs["metadata"] == {"category": "sports"}
@@ -654,29 +778,31 @@ class TestUpdateOpenAPISchema:
         update_props = schema["components"]["schemas"]["MemoryUpdate"]["properties"]
         assert "metadata" in update_props
 
+
 # ===========================================================================
 # GetMemories: Entity parameters to filters mapping (fix for #4955)
 # ===========================================================================
+
 
 class TestGetMemories:
     """Verify that GET /memories correctly maps entity parameters to the filters dict."""
 
     def test_get_memories_entity_filters_routing(self, client, mock_memory):
         """
-        Issue #4955: Test that the GET /memories route correctly handles 
+        Issue #4955: Test that the GET /memories route correctly handles
         top-level entity parameters by mapping them to the filters dictionary
         instead of passing them as direct kwargs to get_all()
         """
         # Send a request with a valid top-level entity parameter
         response = client.get("/memories?user_id=test_routing_user")
-        
+
         # 1. Verify the endpoint doesn't crash with a 500 error
         assert response.status_code == 200
-        
+
         # 2. Verify the response is structured correctly
         data = response.json()
         assert isinstance(data, list)
-        
+
         # 3. Verify the core logic: the param was mapped to the filters dict!
         _, kwargs = mock_memory.get_all.call_args
         assert kwargs["filters"] == {"user_id": "test_routing_user"}
@@ -711,6 +837,7 @@ class TestGetMemories:
 # SearchRequest: entity IDs mapped into filters (fix for server 502)
 # ===========================================================================
 
+
 class TestSearchEntityIdMapping:
     """Verify that POST /search maps top-level user_id / agent_id / run_id
     into the filters dict instead of forwarding them as kwargs, which would
@@ -738,19 +865,28 @@ class TestSearchEntityIdMapping:
         assert kwargs["filters"]["run_id"] == "r1"
 
     def test_all_entity_ids_mapped(self, client, mock_memory):
-        resp = client.post("/search", json={
-            "query": "food", "user_id": "u1", "agent_id": "a1", "run_id": "r1",
-        })
+        resp = client.post(
+            "/search",
+            json={
+                "query": "food",
+                "user_id": "u1",
+                "agent_id": "a1",
+                "run_id": "r1",
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert kwargs["filters"] == {"user_id": "u1", "agent_id": "a1", "run_id": "r1"}
 
     def test_entity_ids_merged_with_explicit_filters(self, client, mock_memory):
-        resp = client.post("/search", json={
-            "query": "food",
-            "user_id": "u1",
-            "filters": {"category": "food"},
-        })
+        resp = client.post(
+            "/search",
+            json={
+                "query": "food",
+                "user_id": "u1",
+                "filters": {"category": "food"},
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert kwargs["filters"]["user_id"] == "u1"
@@ -763,10 +899,13 @@ class TestSearchEntityIdMapping:
         assert kwargs["filters"] == {}
 
     def test_only_filters_no_entity_ids(self, client, mock_memory):
-        resp = client.post("/search", json={
-            "query": "food",
-            "filters": {"user_id": "u1", "category": "food"},
-        })
+        resp = client.post(
+            "/search",
+            json={
+                "query": "food",
+                "filters": {"user_id": "u1", "category": "food"},
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert kwargs["filters"]["user_id"] == "u1"
@@ -777,17 +916,13 @@ class TestSearchValidationErrors:
     """Verify that ValueError from Memory.search() returns 400, not 502."""
 
     def test_empty_filters_returns_400(self, client, mock_memory):
-        mock_memory.search.side_effect = ValueError(
-            "filters must contain at least one of: user_id, agent_id, run_id"
-        )
+        mock_memory.search.side_effect = ValueError("filters must contain at least one of: user_id, agent_id, run_id")
         resp = client.post("/search", json={"query": "food", "filters": {}})
         assert resp.status_code == 400
         assert "filters must contain" in resp.json()["detail"]
 
     def test_no_identifiers_returns_400(self, client, mock_memory):
-        mock_memory.search.side_effect = ValueError(
-            "filters must contain at least one of: user_id, agent_id, run_id"
-        )
+        mock_memory.search.side_effect = ValueError("filters must contain at least one of: user_id, agent_id, run_id")
         resp = client.post("/search", json={"query": "food"})
         assert resp.status_code == 400
 
@@ -795,6 +930,7 @@ class TestSearchValidationErrors:
 # ===========================================================================
 # add / update / delete: map core errors to 4xx instead of 502
 # ===========================================================================
+
 
 class TestWriteHandlerErrorMapping:
     """ValueError("... not found") -> 404, other ValueError / Mem0ValidationError
@@ -820,14 +956,22 @@ class TestWriteHandlerErrorMapping:
         mock_memory.add.side_effect = Mem0ValidationError(
             message="messages must be str, dict, or list[dict]", error_code="VALIDATION_003"
         )
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "hi"}], "user_id": "u1",
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "hi"}],
+                "user_id": "u1",
+            },
+        )
         assert resp.status_code == 400
 
     def test_add_real_outage_still_returns_502(self, client, mock_memory):
         mock_memory.add.side_effect = RuntimeError("vector store unreachable")
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "hi"}], "user_id": "u1",
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "hi"}],
+                "user_id": "u1",
+            },
+        )
         assert resp.status_code == 502

--- a/tests/test_server_params.py
+++ b/tests/test_server_params.py
@@ -22,7 +22,6 @@ from fastapi.testclient import TestClient
 # Fixtures
 # ---------------------------------------------------------------------------
 
-
 @pytest.fixture
 def _mock_memory():
     """Patch Memory.from_config so the server imports without a real backend."""
@@ -46,7 +45,6 @@ def _mock_memory():
 def client(_mock_memory):
     """Return a TestClient wired to the server app with mocked Memory."""
     import server.main as server_main
-
     with patch.dict(os.environ, {"ADMIN_API_KEY": ""}):
         importlib.reload(server_main)
     return TestClient(server_main.app)
@@ -60,7 +58,6 @@ def mock_memory(_mock_memory):
 # ===========================================================================
 # SearchRequest: top_k parameter
 # ===========================================================================
-
 
 class TestSearchLimit:
     """Verify that the top_k parameter is accepted and forwarded to Memory.search()."""
@@ -90,7 +87,6 @@ class TestSearchLimit:
 # SearchRequest: threshold parameter
 # ===========================================================================
 
-
 class TestSearchThreshold:
     """Verify that the threshold parameter is accepted and forwarded."""
 
@@ -118,7 +114,6 @@ class TestSearchThreshold:
 # SearchRequest: explain parameter
 # ===========================================================================
 
-
 class TestSearchExplain:
     """Verify that the explain parameter is accepted and forwarded."""
 
@@ -145,10 +140,12 @@ class TestSearchExplain:
 # SearchRequest: top_k + threshold together
 # ===========================================================================
 
-
 class TestSearchLimitAndThreshold:
+
     def test_both_forwarded(self, client, mock_memory):
-        resp = client.post("/search", json={"query": "food", "user_id": "u1", "top_k": 10, "threshold": 0.5})
+        resp = client.post("/search", json={
+            "query": "food", "user_id": "u1", "top_k": 10, "threshold": 0.5
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert kwargs["top_k"] == 10
@@ -159,32 +156,25 @@ class TestSearchLimitAndThreshold:
 # MemoryCreate: infer parameter
 # ===========================================================================
 
-
 class TestAddInfer:
     """Verify that the infer parameter is accepted and forwarded to Memory.add()."""
 
     def test_infer_false_forwarded(self, client, mock_memory):
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "Store this exactly"}],
-                "user_id": "u1",
-                "infer": False,
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "Store this exactly"}],
+            "user_id": "u1",
+            "infer": False,
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["infer"] is False
 
     def test_infer_true_forwarded(self, client, mock_memory):
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "I like pizza"}],
-                "user_id": "u1",
-                "infer": True,
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "I like pizza"}],
+            "user_id": "u1",
+            "infer": True,
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["infer"] is True
@@ -192,13 +182,10 @@ class TestAddInfer:
     def test_infer_omitted_uses_memory_default(self, client, mock_memory):
         """When infer is not sent, it should not appear in kwargs,
         allowing Memory.add() to use its own default (True)."""
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "hello"}],
-                "user_id": "u1",
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "hello"}],
+            "user_id": "u1",
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert "infer" not in kwargs
@@ -208,31 +195,24 @@ class TestAddInfer:
 # MemoryCreate: memory_type parameter
 # ===========================================================================
 
-
 class TestAddMemoryType:
     """Verify that the memory_type parameter is accepted and forwarded."""
 
     def test_memory_type_forwarded(self, client, mock_memory):
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "I like pizza"}],
-                "user_id": "u1",
-                "memory_type": "core",
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "I like pizza"}],
+            "user_id": "u1",
+            "memory_type": "core",
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["memory_type"] == "core"
 
     def test_memory_type_omitted(self, client, mock_memory):
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "hello"}],
-                "user_id": "u1",
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "hello"}],
+            "user_id": "u1",
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert "memory_type" not in kwargs
@@ -242,31 +222,24 @@ class TestAddMemoryType:
 # MemoryCreate: prompt parameter
 # ===========================================================================
 
-
 class TestAddPrompt:
     """Verify that the prompt parameter is accepted and forwarded."""
 
     def test_prompt_forwarded(self, client, mock_memory):
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "I like pizza"}],
-                "user_id": "u1",
-                "prompt": "Extract food preferences only.",
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "I like pizza"}],
+            "user_id": "u1",
+            "prompt": "Extract food preferences only.",
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["prompt"] == "Extract food preferences only."
 
     def test_prompt_omitted(self, client, mock_memory):
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "hello"}],
-                "user_id": "u1",
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "hello"}],
+            "user_id": "u1",
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert "prompt" not in kwargs
@@ -276,54 +249,73 @@ class TestAddPrompt:
 # MemoryCreate: include_usage parameter
 # ===========================================================================
 
-
 class TestAddIncludeUsage:
     """Verify that the include_usage parameter is accepted and forwarded."""
 
     def test_include_usage_true_forwarded(self, client, mock_memory):
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "I like pizza"}],
-                "user_id": "u1",
-                "include_usage": True,
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "I like pizza"}],
+            "user_id": "u1",
+            "include_usage": True,
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["include_usage"] is True
 
+    def test_include_usage_false_forwarded(self, client, mock_memory):
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "I like pizza"}],
+            "user_id": "u1",
+            "include_usage": False,
+        })
+        assert resp.status_code == 200
+        _, kwargs = mock_memory.add.call_args
+        assert kwargs["include_usage"] is False
+
     def test_include_usage_omitted(self, client, mock_memory):
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "hello"}],
-                "user_id": "u1",
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "hello"}],
+            "user_id": "u1",
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert "include_usage" not in kwargs
+
+    def test_usage_is_preserved_in_top_level_response(self, client, mock_memory):
+        mock_memory.add.return_value = {
+            "results": [{"id": "mem-1", "memory": "I like pizza", "event": "ADD"}],
+            "usage": {"prompt_tokens": 4, "completion_tokens": 2, "total_tokens": 6},
+        }
+
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "I like pizza"}],
+            "user_id": "u1",
+            "include_usage": True,
+        })
+
+        assert resp.status_code == 200
+        assert resp.json()["usage"] == {
+            "prompt_tokens": 4,
+            "completion_tokens": 2,
+            "total_tokens": 6,
+        }
 
 
 # ===========================================================================
 # MemoryCreate: all new params together
 # ===========================================================================
 
-
 class TestAddAllNewParams:
+
     def test_infer_memory_type_prompt_and_include_usage_together(self, client, mock_memory):
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "I like pizza"}],
-                "user_id": "u1",
-                "infer": False,
-                "memory_type": "core",
-                "prompt": "Custom extraction prompt.",
-                "include_usage": True,
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "I like pizza"}],
+            "user_id": "u1",
+            "infer": False,
+            "memory_type": "core",
+            "prompt": "Custom extraction prompt.",
+            "include_usage": True,
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["infer"] is False
@@ -336,33 +328,24 @@ class TestAddAllNewParams:
 # Edge cases: falsy-but-valid values must not be filtered out
 # ===========================================================================
 
-
 class TestFalsyValues:
     """The handler filters with `v is not None`. Falsy values like False, 0,
     0.0, and empty string must still be forwarded."""
 
     def test_infer_false_not_filtered(self, client, mock_memory):
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "test"}],
-                "user_id": "u1",
-                "infer": False,
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "test"}],
+            "user_id": "u1",
+            "infer": False,
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["infer"] is False
 
     def test_threshold_zero_not_filtered(self, client, mock_memory):
-        resp = client.post(
-            "/search",
-            json={
-                "query": "food",
-                "user_id": "u1",
-                "threshold": 0.0,
-            },
-        )
+        resp = client.post("/search", json={
+            "query": "food", "user_id": "u1", "threshold": 0.0,
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert kwargs["threshold"] == 0.0
@@ -372,30 +355,22 @@ class TestFalsyValues:
 # Extra/unknown fields are still silently ignored (existing Pydantic behavior)
 # ===========================================================================
 
-
 class TestUnknownFieldsIgnored:
+
     def test_unknown_search_field_ignored(self, client, mock_memory):
-        resp = client.post(
-            "/search",
-            json={
-                "query": "food",
-                "user_id": "u1",
-                "bogus_field": "xyz",
-            },
-        )
+        resp = client.post("/search", json={
+            "query": "food", "user_id": "u1", "bogus_field": "xyz",
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert "bogus_field" not in kwargs
 
     def test_unknown_add_field_ignored(self, client, mock_memory):
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "test"}],
-                "user_id": "u1",
-                "unknown_param": 42,
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "test"}],
+            "user_id": "u1",
+            "unknown_param": 42,
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert "unknown_param" not in kwargs
@@ -405,18 +380,15 @@ class TestUnknownFieldsIgnored:
 # Backward compatibility: existing params still work
 # ===========================================================================
 
-
 class TestExistingParamsUnchanged:
+
     def test_search_filters_still_forwarded(self, client, mock_memory):
-        resp = client.post(
-            "/search",
-            json={
-                "query": "food",
-                "user_id": "u1",
-                "agent_id": "a1",
-                "filters": {"category": "food"},
-            },
-        )
+        resp = client.post("/search", json={
+            "query": "food",
+            "user_id": "u1",
+            "agent_id": "a1",
+            "filters": {"category": "food"},
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert kwargs["filters"]["user_id"] == "u1"
@@ -424,15 +396,12 @@ class TestExistingParamsUnchanged:
         assert kwargs["filters"]["category"] == "food"
 
     def test_add_metadata_still_forwarded(self, client, mock_memory):
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "test"}],
-                "user_id": "u1",
-                "agent_id": "a1",
-                "metadata": {"source": "test"},
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "test"}],
+            "user_id": "u1",
+            "agent_id": "a1",
+            "metadata": {"source": "test"},
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["user_id"] == "u1"
@@ -443,7 +412,6 @@ class TestExistingParamsUnchanged:
 # ===========================================================================
 # OpenAPI schema: new fields are documented
 # ===========================================================================
-
 
 class TestOpenAPISchema:
     """Verify the new fields appear in the auto-generated OpenAPI schema."""
@@ -484,78 +452,53 @@ class TestOpenAPISchema:
 # Pydantic type validation: invalid types return 422
 # ===========================================================================
 
-
 class TestTypeValidation:
     """Verify FastAPI/Pydantic rejects invalid types with 422."""
 
     def test_limit_string_rejected(self, client):
-        resp = client.post(
-            "/search",
-            json={
-                "query": "food",
-                "user_id": "u1",
-                "top_k": "not_a_number",
-            },
-        )
+        resp = client.post("/search", json={
+            "query": "food", "user_id": "u1", "top_k": "not_a_number",
+        })
         assert resp.status_code == 422
 
     def test_threshold_string_rejected(self, client):
-        resp = client.post(
-            "/search",
-            json={
-                "query": "food",
-                "user_id": "u1",
-                "threshold": "high",
-            },
-        )
+        resp = client.post("/search", json={
+            "query": "food", "user_id": "u1", "threshold": "high",
+        })
         assert resp.status_code == 422
 
     def test_infer_string_coerced_by_pydantic(self, client, mock_memory):
         """Pydantic v2 coerces truthy strings like 'yes' to True for bool fields."""
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "test"}],
-                "user_id": "u1",
-                "infer": "yes",
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "test"}],
+            "user_id": "u1",
+            "infer": "yes",
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["infer"] is True
 
     def test_infer_invalid_value_rejected(self, client):
         """A value that cannot be coerced to bool should be rejected."""
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "test"}],
-                "user_id": "u1",
-                "infer": [1, 2, 3],
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "test"}],
+            "user_id": "u1",
+            "infer": [1, 2, 3],
+        })
         assert resp.status_code == 422
 
     def test_limit_float_rejected(self, client):
-        resp = client.post(
-            "/search",
-            json={
-                "query": "food",
-                "user_id": "u1",
-                "top_k": 5.7,
-            },
-        )
+        resp = client.post("/search", json={
+            "query": "food", "user_id": "u1", "top_k": 5.7,
+        })
         assert resp.status_code == 422
 
     def test_memory_type_int_rejected(self, client):
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "test"}],
-                "user_id": "u1",
-                "memory_type": 123,
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "test"}],
+            "user_id": "u1",
+            "memory_type": 123,
+        })
         assert resp.status_code == 422
 
 
@@ -563,59 +506,44 @@ class TestTypeValidation:
 # Explicit null values: treated as omitted (filtered by `is not None`)
 # ===========================================================================
 
-
 class TestExplicitNull:
     """When a client sends null for an optional field, it should be treated
     as omitted — the Memory class default should be used."""
 
     def test_limit_null_uses_memory_default(self, client, mock_memory):
-        resp = client.post(
-            "/search",
-            json={
-                "query": "food",
-                "user_id": "u1",
-                "top_k": None,
-            },
-        )
+        resp = client.post("/search", json={
+            "query": "food", "user_id": "u1", "top_k": None,
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert "top_k" not in kwargs
 
     def test_infer_null_uses_memory_default(self, client, mock_memory):
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "test"}],
-                "user_id": "u1",
-                "infer": None,
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "test"}],
+            "user_id": "u1",
+            "infer": None,
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert "infer" not in kwargs
 
     def test_prompt_null_uses_memory_default(self, client, mock_memory):
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "test"}],
-                "user_id": "u1",
-                "prompt": None,
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "test"}],
+            "user_id": "u1",
+            "prompt": None,
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert "prompt" not in kwargs
 
     def test_include_usage_null_uses_memory_default(self, client, mock_memory):
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "test"}],
-                "user_id": "u1",
-                "include_usage": None,
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "test"}],
+            "user_id": "u1",
+            "include_usage": None,
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert "include_usage" not in kwargs
@@ -625,25 +553,17 @@ class TestExplicitNull:
 # Verify exact call signatures match Memory method params
 # ===========================================================================
 
-
 class TestCallSignatureMatch:
     """Ensure forwarded params exactly match Memory.add() and Memory.search()
     keyword argument names — a typo here would cause a TypeError at runtime."""
 
     def test_search_kwargs_are_valid(self, client, mock_memory):
         """All kwargs forwarded to Memory.search() must be in its signature."""
-        resp = client.post(
-            "/search",
-            json={
-                "query": "food",
-                "user_id": "u1",
-                "agent_id": "a1",
-                "run_id": "r1",
-                "filters": {"k": "v"},
-                "top_k": 10,
-                "threshold": 0.5,
-            },
-        )
+        resp = client.post("/search", json={
+            "query": "food", "user_id": "u1", "agent_id": "a1",
+            "run_id": "r1", "filters": {"k": "v"},
+            "top_k": 10, "threshold": 0.5,
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         valid_params = {"query", "top_k", "filters", "threshold", "rerank"}
@@ -656,20 +576,12 @@ class TestCallSignatureMatch:
 
     def test_add_kwargs_are_valid(self, client, mock_memory):
         """All kwargs forwarded to Memory.add() must be in its signature."""
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "hi"}],
-                "user_id": "u1",
-                "agent_id": "a1",
-                "run_id": "r1",
-                "metadata": {"k": "v"},
-                "infer": False,
-                "memory_type": "core",
-                "prompt": "custom",
-                "include_usage": True,
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "hi"}],
+            "user_id": "u1", "agent_id": "a1", "run_id": "r1",
+            "metadata": {"k": "v"},
+            "infer": False, "memory_type": "core", "prompt": "custom", "include_usage": True,
+        })
         assert resp.status_code == 200
         # The handler passes messages= as a keyword arg, so it appears in kwargs too
         _, kwargs = mock_memory.add.call_args
@@ -689,13 +601,10 @@ class TestCallSignatureMatch:
 
     def test_messages_excluded_from_params_dict(self, client, mock_memory):
         """messages is passed separately via messages= kwarg, not duplicated from model_dump."""
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "hi"}],
-                "user_id": "u1",
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "hi"}],
+            "user_id": "u1",
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         # messages should be present (passed explicitly) and be a list of dicts
@@ -715,7 +624,6 @@ class TestCallSignatureMatch:
 # MemoryUpdate: text and metadata forwarding (fix for #3933)
 # ===========================================================================
 
-
 class TestUpdateMemory:
     """Verify that PUT /memories/{id} extracts text and metadata from the
     request body and forwards them correctly to Memory.update()."""
@@ -727,13 +635,10 @@ class TestUpdateMemory:
         assert kwargs["data"] == "Likes tennis"
 
     def test_metadata_forwarded(self, client, mock_memory):
-        resp = client.put(
-            "/memories/mem-1",
-            json={
-                "text": "Likes tennis",
-                "metadata": {"category": "sports"},
-            },
-        )
+        resp = client.put("/memories/mem-1", json={
+            "text": "Likes tennis",
+            "metadata": {"category": "sports"},
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.update.call_args
         assert kwargs["metadata"] == {"category": "sports"}
@@ -778,11 +683,9 @@ class TestUpdateOpenAPISchema:
         update_props = schema["components"]["schemas"]["MemoryUpdate"]["properties"]
         assert "metadata" in update_props
 
-
 # ===========================================================================
 # GetMemories: Entity parameters to filters mapping (fix for #4955)
 # ===========================================================================
-
 
 class TestGetMemories:
     """Verify that GET /memories correctly maps entity parameters to the filters dict."""
@@ -837,7 +740,6 @@ class TestGetMemories:
 # SearchRequest: entity IDs mapped into filters (fix for server 502)
 # ===========================================================================
 
-
 class TestSearchEntityIdMapping:
     """Verify that POST /search maps top-level user_id / agent_id / run_id
     into the filters dict instead of forwarding them as kwargs, which would
@@ -865,28 +767,19 @@ class TestSearchEntityIdMapping:
         assert kwargs["filters"]["run_id"] == "r1"
 
     def test_all_entity_ids_mapped(self, client, mock_memory):
-        resp = client.post(
-            "/search",
-            json={
-                "query": "food",
-                "user_id": "u1",
-                "agent_id": "a1",
-                "run_id": "r1",
-            },
-        )
+        resp = client.post("/search", json={
+            "query": "food", "user_id": "u1", "agent_id": "a1", "run_id": "r1",
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert kwargs["filters"] == {"user_id": "u1", "agent_id": "a1", "run_id": "r1"}
 
     def test_entity_ids_merged_with_explicit_filters(self, client, mock_memory):
-        resp = client.post(
-            "/search",
-            json={
-                "query": "food",
-                "user_id": "u1",
-                "filters": {"category": "food"},
-            },
-        )
+        resp = client.post("/search", json={
+            "query": "food",
+            "user_id": "u1",
+            "filters": {"category": "food"},
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert kwargs["filters"]["user_id"] == "u1"
@@ -899,13 +792,10 @@ class TestSearchEntityIdMapping:
         assert kwargs["filters"] == {}
 
     def test_only_filters_no_entity_ids(self, client, mock_memory):
-        resp = client.post(
-            "/search",
-            json={
-                "query": "food",
-                "filters": {"user_id": "u1", "category": "food"},
-            },
-        )
+        resp = client.post("/search", json={
+            "query": "food",
+            "filters": {"user_id": "u1", "category": "food"},
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert kwargs["filters"]["user_id"] == "u1"
@@ -916,13 +806,17 @@ class TestSearchValidationErrors:
     """Verify that ValueError from Memory.search() returns 400, not 502."""
 
     def test_empty_filters_returns_400(self, client, mock_memory):
-        mock_memory.search.side_effect = ValueError("filters must contain at least one of: user_id, agent_id, run_id")
+        mock_memory.search.side_effect = ValueError(
+            "filters must contain at least one of: user_id, agent_id, run_id"
+        )
         resp = client.post("/search", json={"query": "food", "filters": {}})
         assert resp.status_code == 400
         assert "filters must contain" in resp.json()["detail"]
 
     def test_no_identifiers_returns_400(self, client, mock_memory):
-        mock_memory.search.side_effect = ValueError("filters must contain at least one of: user_id, agent_id, run_id")
+        mock_memory.search.side_effect = ValueError(
+            "filters must contain at least one of: user_id, agent_id, run_id"
+        )
         resp = client.post("/search", json={"query": "food"})
         assert resp.status_code == 400
 
@@ -930,7 +824,6 @@ class TestSearchValidationErrors:
 # ===========================================================================
 # add / update / delete: map core errors to 4xx instead of 502
 # ===========================================================================
-
 
 class TestWriteHandlerErrorMapping:
     """ValueError("... not found") -> 404, other ValueError / Mem0ValidationError
@@ -956,22 +849,14 @@ class TestWriteHandlerErrorMapping:
         mock_memory.add.side_effect = Mem0ValidationError(
             message="messages must be str, dict, or list[dict]", error_code="VALIDATION_003"
         )
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "hi"}],
-                "user_id": "u1",
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "hi"}], "user_id": "u1",
+        })
         assert resp.status_code == 400
 
     def test_add_real_outage_still_returns_502(self, client, mock_memory):
         mock_memory.add.side_effect = RuntimeError("vector store unreachable")
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "hi"}],
-                "user_id": "u1",
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "hi"}], "user_id": "u1",
+        })
         assert resp.status_code == 502


### PR DESCRIPTION
## Linked Issue

Partially addresses #2820

## Description

Python OSS memory calls can invoke OpenAI and receive token usage in the raw API response, but the SDK currently returns only parsed memory content. This change adds non-breaking, opt-in usage reporting for OpenAI-backed `Memory.add()` and `AsyncMemory.add()` calls, plus the OSS server add route.

`OpenAILLM` keeps the raw usage payload from OpenAI responses. The OSS memory add paths copy accumulated usage into the top-level result only when `include_usage=True`. Calls that do not use OpenAI, do not produce usage, or do not opt in keep the existing response shape.

## Scope

This is limited to OSS add flows that invoke OpenAI during `add()`. Usage from multiple OpenAI calls is accumulated per add operation. Search, get-all, hosted `MemoryClient`, embedding, reranker, and non-OpenAI provider usage remain outside this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually
- [ ] No tests needed

Verification:

- [x] Focused LLM and memory tests: 80 passed
- [x] `ruff check` passed for all six changed files
- [x] `git diff --check` passed
- [ ] Server test execution, blocked during collection because this local environment lacks the optional `telemetry` module
- [ ] `ruff format --check`, current-main formatting differences remain in the six-file diff
- [ ] `make lint` / `make test`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] I have updated documentation if needed
