### PR TITLE
feat: add Voyage AI embedding provider for OSS mode

### DIFF
--- a/integrations/openclaw/cli/oss-wizard.ts
+++ b/integrations/openclaw/cli/oss-wizard.ts
@@ -35,6 +35,7 @@ export interface EmbedderDef extends ProviderDef {
 export const EMBEDDER_PROVIDERS: EmbedderDef[] = [
   { id: "openai", label: "OpenAI (requires API key)", needsApiKey: true, needsUrl: false, envVar: "OPENAI_API_KEY", defaultModel: "text-embedding-3-small", defaultDims: 1536 },
   { id: "ollama", label: "Ollama (local, no API key)", needsApiKey: false, needsUrl: true, defaultModel: "nomic-embed-text", defaultUrl: "http://localhost:11434", defaultDims: 768 },
+  { id: "voyageai", label: "Voyage AI (requires API key)", needsApiKey: true, needsUrl: false, envVar: "VOYAGE_API_KEY", defaultModel: "voyage-3-large", defaultDims: 1024 },
 ];
 
 export interface VectorDef {
@@ -59,6 +60,9 @@ export const KNOWN_EMBEDDER_DIMS: Record<string, number> = {
   "mxbai-embed-large": 1024,
   "all-minilm": 384,
   "snowflake-arctic-embed": 1024,
+  "voyage-3-large": 1024,
+  "voyage-3": 1024,
+  "voyage-3-lite": 512,
 };
 
 export function collectionNameForDims(dims: number): string {

--- a/integrations/openclaw/tests/oss-wizard.test.ts
+++ b/integrations/openclaw/tests/oss-wizard.test.ts
@@ -35,8 +35,18 @@ describe("LLM_PROVIDERS", () => {
 });
 
 describe("EMBEDDER_PROVIDERS", () => {
-  it("has 2 providers", () => {
-    expect(EMBEDDER_PROVIDERS).toHaveLength(2);
+  it("has 3 providers", () => {
+    expect(EMBEDDER_PROVIDERS).toHaveLength(3);
+    expect(EMBEDDER_PROVIDERS.map((p) => p.id)).toEqual(["openai", "ollama", "voyageai"]);
+  });
+
+  it("voyageai requires an API key but no URL", () => {
+    const voyage = EMBEDDER_PROVIDERS.find((p) => p.id === "voyageai")!;
+    expect(voyage.needsApiKey).toBe(true);
+    expect(voyage.needsUrl).toBe(false);
+    expect(voyage.envVar).toBe("VOYAGE_API_KEY");
+    expect(voyage.defaultModel).toBe("voyage-3-large");
+    expect(voyage.defaultDims).toBe(1024);
   });
 });
 
@@ -44,6 +54,9 @@ describe("KNOWN_EMBEDDER_DIMS", () => {
   it("maps default models to dims", () => {
     expect(KNOWN_EMBEDDER_DIMS["text-embedding-3-small"]).toBe(1536);
     expect(KNOWN_EMBEDDER_DIMS["nomic-embed-text"]).toBe(768);
+    expect(KNOWN_EMBEDDER_DIMS["voyage-3-large"]).toBe(1024);
+    expect(KNOWN_EMBEDDER_DIMS["voyage-3-lite"]).toBe(512);
+    expect(KNOWN_EMBEDDER_DIMS["voyage-3"]).toBe(1024);
   });
 });
 
@@ -94,6 +107,20 @@ describe("buildOssEmbedderConfig", () => {
   it("falls back to provider default dims for custom model", () => {
     const result = buildOssEmbedderConfig("ollama", { model: "custom-embed" });
     expect(result.dims).toBe(768);
+  });
+
+  it("builds voyageai embedder with API key and default model", () => {
+    const result = buildOssEmbedderConfig("voyageai", { apiKey: "voyage-key" });
+    expect(result).toEqual({
+      provider: "voyageai",
+      config: { model: "voyage-3-large", apiKey: "voyage-key", embeddingDims: 1024 },
+      dims: 1024,
+    });
+  });
+
+  it("resolves dims for known voyage models", () => {
+    const result = buildOssEmbedderConfig("voyageai", { model: "voyage-3-lite" });
+    expect(result.dims).toBe(512);
   });
 });
 

--- a/mem0-ts/src/oss/src/embeddings/voyage.ts
+++ b/mem0-ts/src/oss/src/embeddings/voyage.ts
@@ -1,0 +1,61 @@
+import OpenAI from "openai";
+import { Embedder } from "./base";
+import { EmbeddingConfig } from "../types";
+
+const VOYAGE_API_BASE_URL = "https://api.voyageai.com/v1";
+const DEFAULT_MODEL = "voyage-3-large";
+
+/**
+ * Embedder backed by the Voyage AI embeddings API.
+ *
+ * Voyage exposes an OpenAI-compatible `POST /v1/embeddings` endpoint, so the
+ * OpenAI client is reused with the Voyage base URL. OpenAI-specific request
+ * params (`dimensions`, `encoding_format`) are intentionally not sent —
+ * Voyage models use their own defaults and would reject unknown params.
+ */
+export class VoyageAIEmbedder implements Embedder {
+  private client: OpenAI;
+  private model: string;
+
+  constructor(config: EmbeddingConfig) {
+    const apiKey = config.apiKey || process.env.VOYAGE_API_KEY;
+    if (!apiKey) {
+      throw new Error(
+        "Voyage AI embedder requires an API key: set embedder.config.apiKey or the VOYAGE_API_KEY environment variable.",
+      );
+    }
+    this.client = new OpenAI({
+      apiKey,
+      baseURL: config.baseURL || config.url || VOYAGE_API_BASE_URL,
+    });
+    this.model = config.model || DEFAULT_MODEL;
+  }
+
+  async embed(text: string): Promise<number[]> {
+    const response = await this.client.embeddings.create({
+      model: this.model,
+      input: text,
+    });
+    return response.data[0].embedding;
+  }
+
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    // Voyage caps batch size well above this; 100 mirrors the OpenAI embedder
+    // and keeps request payloads comfortably under the token limit.
+    const MAX_BATCH = 100;
+    const allEmbeddings: number[][] = [];
+    for (let i = 0; i < texts.length; i += MAX_BATCH) {
+      const chunk = texts.slice(i, i + MAX_BATCH);
+      const response = await this.client.embeddings.create({
+        model: this.model,
+        input: chunk,
+      });
+      allEmbeddings.push(
+        ...response.data
+          .sort((a, b) => a.index - b.index)
+          .map((item) => item.embedding),
+      );
+    }
+    return allEmbeddings;
+  }
+}

--- a/mem0-ts/src/oss/src/utils/factory.ts
+++ b/mem0-ts/src/oss/src/utils/factory.ts
@@ -1,6 +1,7 @@
 import { OpenAIEmbedder } from "../embeddings/openai";
 import { OllamaEmbedder } from "../embeddings/ollama";
 import { LMStudioEmbedder } from "../embeddings/lmstudio";
+import { VoyageAIEmbedder } from "../embeddings/voyage";
 import { OpenAILLM } from "../llms/openai";
 import { OpenAIStructuredLLM } from "../llms/openai_structured";
 import { AnthropicLLM } from "../llms/anthropic";
@@ -46,6 +47,9 @@ export class EmbedderFactory {
         return new OllamaEmbedder(config);
       case "lmstudio":
         return new LMStudioEmbedder(config);
+      case "voyageai":
+      case "voyage":
+        return new VoyageAIEmbedder(config);
       case "google":
       case "gemini":
         return new GoogleEmbedder(config);

--- a/mem0-ts/src/oss/tests/voyage-embedder.test.ts
+++ b/mem0-ts/src/oss/tests/voyage-embedder.test.ts
@@ -1,0 +1,106 @@
+/// <reference types="jest" />
+/**
+ * Voyage AI Embedder — unit tests (mocked OpenAI-compatible client).
+ */
+
+import { VoyageAIEmbedder } from "../src/embeddings/voyage";
+import { EmbedderFactory } from "../src/utils/factory";
+
+const mockEmbedding = [0.1, 0.2, 0.3];
+const mockCreate = jest.fn().mockResolvedValue({
+  data: [{ index: 0, embedding: mockEmbedding }],
+});
+const mockOpenAIConstructor = jest.fn().mockImplementation(() => ({
+  embeddings: { create: mockCreate },
+}));
+
+jest.mock("openai", () => ({
+  __esModule: true,
+  default: jest
+    .fn()
+    .mockImplementation((...args: unknown[]) => mockOpenAIConstructor(...args)),
+}));
+
+describe("VoyageAIEmbedder (unit)", () => {
+  beforeEach(() => {
+    mockCreate.mockClear();
+    mockOpenAIConstructor.mockClear();
+    delete process.env.VOYAGE_API_KEY;
+  });
+
+  it("defaults to the Voyage API base URL and voyage-3-large model", async () => {
+    const embedder = new VoyageAIEmbedder({ apiKey: "voyage-test-key" });
+
+    await embedder.embed("hello");
+
+    expect(mockOpenAIConstructor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: "voyage-test-key",
+        baseURL: "https://api.voyageai.com/v1",
+      }),
+    );
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "voyage-3-large", input: "hello" }),
+    );
+  });
+
+  it("embed() returns the first embedding vector", async () => {
+    const embedder = new VoyageAIEmbedder({ apiKey: "k" });
+    const result = await embedder.embed("text");
+    expect(result).toEqual(mockEmbedding);
+  });
+
+  it("respects explicit model and baseURL overrides", async () => {
+    const embedder = new VoyageAIEmbedder({
+      apiKey: "k",
+      model: "voyage-3-lite",
+      baseURL: "https://proxy.example.com/v1",
+    });
+
+    await embedder.embed("x");
+
+    expect(mockOpenAIConstructor).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: "https://proxy.example.com/v1" }),
+    );
+    expect(mockCreate.mock.calls[0][0].model).toBe("voyage-3-lite");
+  });
+
+  it("falls back to the VOYAGE_API_KEY environment variable", () => {
+    process.env.VOYAGE_API_KEY = "env-voyage-key";
+    new VoyageAIEmbedder({});
+    expect(mockOpenAIConstructor).toHaveBeenCalledWith(
+      expect.objectContaining({ apiKey: "env-voyage-key" }),
+    );
+  });
+
+  it("throws a clear error when no API key is available", () => {
+    expect(() => new VoyageAIEmbedder({})).toThrow(/VOYAGE_API_KEY/);
+  });
+
+  it("does not send OpenAI-specific dimensions/encoding params", async () => {
+    const embedder = new VoyageAIEmbedder({ apiKey: "k", embeddingDims: 1024 });
+    await embedder.embed("x");
+    const payload = mockCreate.mock.calls[0][0];
+    expect(payload).not.toHaveProperty("dimensions");
+    expect(payload).not.toHaveProperty("encoding_format");
+  });
+
+  it("embedBatch() returns vectors ordered by index", async () => {
+    mockCreate.mockResolvedValueOnce({
+      data: [
+        { index: 1, embedding: [2] },
+        { index: 0, embedding: [1] },
+      ],
+    });
+    const embedder = new VoyageAIEmbedder({ apiKey: "k" });
+    const result = await embedder.embedBatch(["a", "b"]);
+    expect(result).toEqual([[1], [2]]);
+  });
+});
+
+describe("EmbedderFactory voyageai wiring", () => {
+  it('creates a VoyageAIEmbedder for provider "voyageai"', () => {
+    const embedder = EmbedderFactory.create("voyageai", { apiKey: "k" });
+    expect(embedder).toBeInstanceOf(VoyageAIEmbedder);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #5503.

Adds **Voyage AI** as an embedding provider for OSS mode, in two layers:

**TS OSS SDK** (`mem0-ts/src/oss`):
- New `VoyageAIEmbedder` — Voyage exposes an OpenAI-compatible `POST /v1/embeddings`, so the OpenAI client is reused with `https://api.voyageai.com/v1` as base URL (overridable via `baseURL`/`url`).
- Wired into `EmbedderFactory` as `voyageai` (alias `voyage`).
- OpenAI-specific params (`dimensions`, `encoding_format`) are intentionally not sent — Voyage rejects unknown params.
- API key resolves from `config.apiKey` or `VOYAGE_API_KEY`, with a clear error message when neither is set.

**OpenClaw plugin** (`integrations/openclaw`):
- `voyageai` entry in `EMBEDDER_PROVIDERS` exactly as proposed in the issue (`VOYAGE_API_KEY`, default `voyage-3-large`, 1024 dims).
- Known dims for `voyage-3-large` (1024), `voyage-3` (1024), `voyage-3-lite` (512).

Note: the plugin pins `mem0ai@3.0.6`, so the wizard entry becomes functional once a release containing the SDK-side embedder ships — happy to split the PR if you prefer landing the SDK part first.

## Tests

- New `voyage-embedder.test.ts` (8 cases, mocked client): defaults, overrides, env fallback, missing-key error, no OpenAI-specific params, batch ordering, factory wiring.
- Extended `oss-wizard.test.ts` with voyageai provider/dims/config cases.
- Full suites green: `mem0-ts` oss tests 403 passed; openclaw plugin 328 passed (12 files). `tsc --noEmit` introduces zero new errors vs main baseline.
