### PR TITLE
feat(server): support per-memory expiration_date in self-hosted add

### DIFF
--- a/docs/migration/oss-v2-to-v3.mdx
+++ b/docs/migration/oss-v2-to-v3.mdx
@@ -415,7 +415,7 @@ You always get semantic search. Hybrid search features layer on top when availab
 
 ## Removed Parameters Reference
 
-These parameters have been removed across all SDKs. Remove them from your code:
+These parameters were removed from the client SDKs, and from the OSS SDK unless noted below. Remove them from your code where applicable:
 
 ### Python Client SDK — Removed parameters
 
@@ -444,6 +444,8 @@ These parameters have been removed across all SDKs. Remove them from your code:
 **get_all():** `enable_graph` / `enableGraph`
 
 ### Python OSS — Removed/renamed parameters
+
+**add():** `expiration_date` remains supported for per-memory expiry metadata in OSS v3.
 
 **Config:** `custom_fact_extraction_prompt` → renamed to `custom_instructions`
 

--- a/mem0/configs/base.py
+++ b/mem0/configs/base.py
@@ -24,6 +24,7 @@ class MemoryItem(BaseModel):
     score: Optional[float] = Field(None, description="The score associated with the text data")
     created_at: Optional[str] = Field(None, description="The timestamp when the memory was created")
     updated_at: Optional[str] = Field(None, description="The timestamp when the memory was updated")
+    expiration_date: Optional[str] = Field(None, description="The timestamp when the memory expires")
 
 
 class MemoryConfig(BaseModel):

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -659,6 +659,7 @@ class Memory(MemoryBase):
         run_id: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
         timestamp: Optional[Any] = None,
+        expiration_date: Optional[str] = None,
         infer: bool = True,
         memory_type: Optional[str] = None,
         prompt: Optional[str] = None,
@@ -677,6 +678,7 @@ class Memory(MemoryBase):
             run_id (str, optional): ID of the run creating the memory. Defaults to None.
             metadata (dict, optional): Metadata to store with the memory. Defaults to None.
             timestamp (Any, optional): Platform-only temporal parameter. Not supported in OSS.
+            expiration_date (str, optional): ISO timestamp for per-memory expiry metadata. Defaults to None.
             infer (bool, optional): If True (default), an LLM is used to extract key facts from
                 'messages' and decide whether to add, update, or delete related memories.
                 If False, 'messages' are added as raw memories directly.
@@ -709,6 +711,8 @@ class Memory(MemoryBase):
             run_id=run_id,
             input_metadata=metadata,
         )
+        if expiration_date is not None:
+            processed_metadata["expiration_date"] = _normalize_iso_timestamp_to_utc(expiration_date)
 
         if memory_type is not None and memory_type != MemoryType.PROCEDURAL.value:
             raise Mem0ValidationError(
@@ -1093,7 +1097,7 @@ class Memory(MemoryBase):
             "role",
         ]
 
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
+        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "expiration_date", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
 
         result_item = MemoryItem(
             id=memory.id,
@@ -1101,6 +1105,7 @@ class Memory(MemoryBase):
             hash=memory.payload.get("hash"),
             created_at=memory.payload.get("created_at"),
             updated_at=memory.payload.get("updated_at"),
+            expiration_date=memory.payload.get("expiration_date"),
         ).model_dump()
 
         for key in promoted_payload_keys:
@@ -1205,7 +1210,7 @@ class Memory(MemoryBase):
             "actor_id",
             "role",
         ]
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
+        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "expiration_date", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
 
         formatted_memories = []
         for mem in actual_memories:
@@ -1215,6 +1220,7 @@ class Memory(MemoryBase):
                 hash=mem.payload.get("hash"),
                 created_at=mem.payload.get("created_at"),
                 updated_at=mem.payload.get("updated_at"),
+                expiration_date=mem.payload.get("expiration_date"),
             ).model_dump(exclude={"score"})
 
             for key in promoted_payload_keys:
@@ -1540,7 +1546,7 @@ class Memory(MemoryBase):
             "actor_id",
             "role",
         ]
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
+        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "expiration_date", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
 
         original_memories = []
         for scored in scored_results:
@@ -1555,6 +1561,7 @@ class Memory(MemoryBase):
                 hash=payload.get("hash"),
                 created_at=payload.get("created_at"),
                 updated_at=payload.get("updated_at"),
+                expiration_date=payload.get("expiration_date"),
                 score=scored["score"],
             ).model_dump()
 
@@ -1767,6 +1774,8 @@ class Memory(MemoryBase):
         if "created_at" not in new_metadata:
             new_metadata["created_at"] = datetime.now(timezone.utc).isoformat()
         new_metadata["updated_at"] = new_metadata["created_at"]
+        if "expiration_date" in new_metadata:
+            new_metadata["expiration_date"] = _normalize_iso_timestamp_to_utc(new_metadata.get("expiration_date"))
         new_metadata["text_lemmatized"] = lemmatize_for_bm25(data)
 
         self.vector_store.insert(
@@ -1846,6 +1855,10 @@ class Memory(MemoryBase):
         new_metadata["text_lemmatized"] = lemmatize_for_bm25(data)
         new_metadata["created_at"] = existing_memory.payload.get("created_at")
         new_metadata["updated_at"] = datetime.now(timezone.utc).isoformat()
+        if "expiration_date" in new_metadata:
+            new_metadata["expiration_date"] = _normalize_iso_timestamp_to_utc(new_metadata.get("expiration_date"))
+        elif "expiration_date" in existing_memory.payload:
+            new_metadata["expiration_date"] = existing_memory.payload["expiration_date"]
 
         # Preserve session identifiers from existing memory only if not provided in new metadata
         if "user_id" not in new_metadata and "user_id" in existing_memory.payload:
@@ -2185,6 +2198,7 @@ class AsyncMemory(MemoryBase):
         run_id: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
         timestamp: Optional[Any] = None,
+        expiration_date: Optional[str] = None,
         infer: bool = True,
         memory_type: Optional[str] = None,
         prompt: Optional[str] = None,
@@ -2200,6 +2214,7 @@ class AsyncMemory(MemoryBase):
             run_id (str, optional): ID of the run creating the memory. Defaults to None.
             metadata (dict, optional): Metadata to store with the memory. Defaults to None.
             timestamp (Any, optional): Platform-only temporal parameter. Not supported in OSS.
+            expiration_date (str, optional): ISO timestamp for per-memory expiry metadata. Defaults to None.
             infer (bool, optional): Whether to infer the memories. Defaults to True.
             memory_type (str, optional): Type of memory to create. Defaults to None.
                                          Pass "procedural_memory" to create procedural memories.
@@ -2215,6 +2230,8 @@ class AsyncMemory(MemoryBase):
         processed_metadata, effective_filters = _build_filters_and_metadata(
             user_id=user_id, agent_id=agent_id, run_id=run_id, input_metadata=metadata
         )
+        if expiration_date is not None:
+            processed_metadata["expiration_date"] = _normalize_iso_timestamp_to_utc(expiration_date)
 
         if memory_type is not None and memory_type != MemoryType.PROCEDURAL.value:
             raise ValueError(
@@ -2605,7 +2622,7 @@ class AsyncMemory(MemoryBase):
             "role",
         ]
 
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
+        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "expiration_date", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
 
         result_item = MemoryItem(
             id=memory.id,
@@ -2613,6 +2630,7 @@ class AsyncMemory(MemoryBase):
             hash=memory.payload.get("hash"),
             created_at=memory.payload.get("created_at"),
             updated_at=memory.payload.get("updated_at"),
+            expiration_date=memory.payload.get("expiration_date"),
         ).model_dump()
 
         for key in promoted_payload_keys:
@@ -2717,7 +2735,7 @@ class AsyncMemory(MemoryBase):
             "actor_id",
             "role",
         ]
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
+        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "expiration_date", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
 
         formatted_memories = []
         for mem in actual_memories:
@@ -2727,6 +2745,7 @@ class AsyncMemory(MemoryBase):
                 hash=mem.payload.get("hash"),
                 created_at=mem.payload.get("created_at"),
                 updated_at=mem.payload.get("updated_at"),
+                expiration_date=mem.payload.get("expiration_date"),
             ).model_dump(exclude={"score"})
 
             for key in promoted_payload_keys:
@@ -3058,7 +3077,7 @@ class AsyncMemory(MemoryBase):
             "actor_id",
             "role",
         ]
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
+        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "expiration_date", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
 
         original_memories = []
         for scored in scored_results:
@@ -3072,6 +3091,7 @@ class AsyncMemory(MemoryBase):
                 hash=payload.get("hash"),
                 created_at=payload.get("created_at"),
                 updated_at=payload.get("updated_at"),
+                expiration_date=payload.get("expiration_date"),
                 score=scored["score"],
             ).model_dump()
 
@@ -3281,6 +3301,8 @@ class AsyncMemory(MemoryBase):
         if "created_at" not in new_metadata:
             new_metadata["created_at"] = datetime.now(timezone.utc).isoformat()
         new_metadata["updated_at"] = new_metadata["created_at"]
+        if "expiration_date" in new_metadata:
+            new_metadata["expiration_date"] = _normalize_iso_timestamp_to_utc(new_metadata.get("expiration_date"))
         new_metadata["text_lemmatized"] = lemmatize_for_bm25(data)
 
         await asyncio.to_thread(
@@ -3378,6 +3400,10 @@ class AsyncMemory(MemoryBase):
         new_metadata["text_lemmatized"] = lemmatize_for_bm25(data)
         new_metadata["created_at"] = existing_memory.payload.get("created_at")
         new_metadata["updated_at"] = datetime.now(timezone.utc).isoformat()
+        if "expiration_date" in new_metadata:
+            new_metadata["expiration_date"] = _normalize_iso_timestamp_to_utc(new_metadata.get("expiration_date"))
+        elif "expiration_date" in existing_memory.payload:
+            new_metadata["expiration_date"] = existing_memory.payload["expiration_date"]
 
         # Preserve session identifiers from existing memory only if not provided in new metadata
         if "user_id" not in new_metadata and "user_id" in existing_memory.payload:

--- a/server/main.py
+++ b/server/main.py
@@ -181,6 +181,7 @@ class MemoryCreate(BaseModel):
     agent_id: Optional[str] = None
     run_id: Optional[str] = None
     metadata: Optional[Dict[str, Any]] = None
+    expiration_date: Optional[str] = Field(None, description="ISO timestamp when the memory should expire.")
     infer: Optional[bool] = Field(None, description="Whether to extract facts from messages. Defaults to True.")
     memory_type: Optional[str] = Field(None, description="Type of memory to store (e.g. 'core').")
     prompt: Optional[str] = Field(None, description="Custom prompt to use for fact extraction.")
@@ -368,7 +369,16 @@ def add_memory(memory_create: MemoryCreate, _auth=Depends(verify_auth)):
 
 
 ALL_MEMORIES_LIMIT = 1000
-_RESERVED_PAYLOAD_KEYS = {"data", "user_id", "agent_id", "run_id", "hash", "created_at", "updated_at"}
+_RESERVED_PAYLOAD_KEYS = {
+    "data",
+    "user_id",
+    "agent_id",
+    "run_id",
+    "hash",
+    "created_at",
+    "updated_at",
+    "expiration_date",
+}
 
 
 def _serialize_memory(row: Any) -> Dict[str, Any]:
@@ -383,6 +393,7 @@ def _serialize_memory(row: Any) -> Dict[str, Any]:
         "metadata": {k: v for k, v in payload.items() if k not in _RESERVED_PAYLOAD_KEYS},
         "created_at": payload.get("created_at"),
         "updated_at": payload.get("updated_at"),
+        "expiration_date": payload.get("expiration_date"),
     }
 
 

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -8,6 +8,8 @@ import pytest
 
 from mem0.memory.main import AsyncMemory, Memory
 
+EXPIRATION_DATE = "2026-07-15T09:30:00+02:00"
+
 
 def _setup_mocks(mocker):
     """Helper to setup common mocks for both sync and async fixtures"""
@@ -62,7 +64,9 @@ class TestAddToVectorStoreErrors:
         # Verify — v3 single-pass pipeline makes 1 LLM call, returns [] on parse error
         assert mock_memory.llm.generate_response.call_count == 1
         assert result == []
-        assert any("Error parsing extraction response" in record.message for record in caplog.records), "Expected error message not found in logs"
+        assert any("Error parsing extraction response" in record.message for record in caplog.records), (
+            "Expected error message not found in logs"
+        )
 
     def test_empty_llm_response_memory_actions(self, mock_memory, caplog):
         """Test empty response from LLM during memory actions (v3: single-pass, 1 LLM call)"""
@@ -200,7 +204,9 @@ class TestAsyncAddToVectorStoreErrors:
             )
         assert mock_async_memory.llm.generate_response.call_count == 1
         assert result == []
-        assert any("Error parsing extraction response" in record.message for record in caplog.records), "Expected error message not found in logs"
+        assert any("Error parsing extraction response" in record.message for record in caplog.records), (
+            "Expected error message not found in logs"
+        )
 
     @pytest.mark.asyncio
     async def test_async_empty_llm_response_memory_actions(self, mock_async_memory, caplog, mocker):
@@ -268,6 +274,15 @@ def test_create_memory_preserves_existing_created_at(mocker):
     assert payload["updated_at"] == custom_ts
 
 
+def test_add_accepts_expiration_date_and_stores_it(mocker):
+    memory = _build_memory_instance(mocker, Memory)
+    result = memory.add("Temporary memory", user_id="alice", infer=False, expiration_date=EXPIRATION_DATE)
+
+    payload = memory.vector_store.insert.call_args.kwargs["payloads"][0]
+    assert result["results"][0]["event"] == "ADD"
+    assert payload["expiration_date"] == "2026-07-15T07:30:00+00:00"
+
+
 def test_update_memory_uses_utc_timestamps(mocker):
     memory = _build_memory_instance(mocker, Memory)
     memory.vector_store.get.return_value = MagicMock(
@@ -312,6 +327,16 @@ async def test_async_create_memory_preserves_existing_created_at(mocker):
 
 
 @pytest.mark.asyncio
+async def test_async_add_accepts_expiration_date_and_stores_it(mocker):
+    memory = _build_memory_instance(mocker, AsyncMemory)
+    result = await memory.add("Temporary memory", user_id="alice", infer=False, expiration_date=EXPIRATION_DATE)
+
+    payload = memory.vector_store.insert.call_args.kwargs["payloads"][0]
+    assert result["results"][0]["event"] == "ADD"
+    assert payload["expiration_date"] == "2026-07-15T07:30:00+00:00"
+
+
+@pytest.mark.asyncio
 async def test_async_update_memory_uses_utc_timestamps(mocker):
     memory = _build_memory_instance(mocker, AsyncMemory)
     memory.vector_store.get.return_value = MagicMock(
@@ -323,12 +348,64 @@ async def test_async_update_memory_uses_utc_timestamps(mocker):
     assert payload["updated_at"] is not None
 
 
+@pytest.mark.asyncio
+async def test_async_update_preserves_expiration_date(mocker):
+    memory = _build_memory_instance(mocker, AsyncMemory)
+    memory.vector_store.get.return_value = MagicMock(
+        id="mem-1",
+        payload={
+            "data": "old memory",
+            "user_id": "alice",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "expiration_date": "2026-07-15T07:30:00+00:00",
+        },
+    )
+
+    await memory._update_memory("mem-1", "new memory", {"new memory": [0.1, 0.2, 0.3]}, metadata={})
+
+    updated_payload = memory.vector_store.update.call_args.kwargs["payload"]
+    assert updated_payload["expiration_date"] == "2026-07-15T07:30:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_async_get_search_and_get_all_promote_expiration_date(mocker):
+    memory = _build_memory_instance(mocker, AsyncMemory)
+    memory.embedding_model.embed.return_value = [0.1, 0.2, 0.3]
+    memory.vector_store.keyword_search.return_value = []
+
+    payload = {
+        "data": "Likes pizza",
+        "hash": "abc123",
+        "user_id": "alice",
+        "created_at": "2023-05-06T09:19:20+00:00",
+        "updated_at": "2026-03-23T10:00:00+00:00",
+        "expiration_date": "2026-07-15T07:30:00+00:00",
+    }
+    mem_result = MagicMock(id="mem-1", payload=payload, score=0.95)
+    memory.vector_store.get.return_value = mem_result
+    memory.vector_store.search.return_value = [mem_result]
+    memory.vector_store.list.return_value = [[mem_result]]
+
+    get_result = await memory.get("mem-1")
+    search_results = await memory._search_vector_store("pizza", filters={"user_id": "alice"}, limit=10)
+    get_all_results = await memory._get_all_from_vector_store(filters={"user_id": "alice"}, limit=100)
+
+    assert get_result["expiration_date"] == "2026-07-15T07:30:00+00:00"
+    assert search_results[0]["expiration_date"] == "2026-07-15T07:30:00+00:00"
+    assert get_all_results[0]["expiration_date"] == "2026-07-15T07:30:00+00:00"
+    assert not get_result.get("metadata") or "expiration_date" not in get_result["metadata"]
+
+
 def test_create_then_search_and_get_all_return_same_timestamps(mocker):
     """Reproduces issue #3720: created_at must be identical in search() and get_all()."""
     memory = _build_memory_instance(mocker, Memory)
 
     # Step 1: Create a memory — capture the payload stored in the vector store
-    memory._create_memory("Likes pizza", {"Likes pizza": [0.1, 0.2, 0.3]}, metadata={"user_id": "alice"})
+    memory._create_memory(
+        "Likes pizza",
+        {"Likes pizza": [0.1, 0.2, 0.3]},
+        metadata={"user_id": "alice", "expiration_date": EXPIRATION_DATE},
+    )
     stored_payload = memory.vector_store.insert.call_args.kwargs["payloads"][0]
     stored_id = memory.vector_store.insert.call_args.kwargs["ids"][0]
 
@@ -343,12 +420,14 @@ def test_create_then_search_and_get_all_return_same_timestamps(mocker):
     mem_result.payload = stored_payload
     mem_result.score = 0.95
 
+    memory.vector_store.get.return_value = mem_result
     memory.vector_store.search.return_value = [mem_result]
     memory.vector_store.list.return_value = [[mem_result]]
 
     # Step 3: Call search and get_all, compare timestamps
     search_results = memory._search_vector_store("pizza", filters={"user_id": "alice"}, limit=10)
     get_all_results = memory._get_all_from_vector_store(filters={"user_id": "alice"}, limit=100)
+    get_result = memory.get(stored_id)
 
     search_item = search_results[0]
     get_all_item = get_all_results[0]
@@ -366,6 +445,10 @@ def test_create_then_search_and_get_all_return_same_timestamps(mocker):
     assert search_item["updated_at"] is not None
     assert get_all_item["created_at"] is not None
     assert get_all_item["updated_at"] is not None
+    assert search_item["expiration_date"] == "2026-07-15T07:30:00+00:00"
+    assert get_all_item["expiration_date"] == "2026-07-15T07:30:00+00:00"
+    assert get_result["expiration_date"] == "2026-07-15T07:30:00+00:00"
+    assert not get_result.get("metadata") or "expiration_date" not in get_result["metadata"]
 
 
 def test_update_preserves_created_at_and_updates_updated_at(mocker):
@@ -391,6 +474,24 @@ def test_update_preserves_created_at_and_updates_updated_at(mocker):
     # updated_at must be set and different from creation time (or at least present)
     assert updated_payload["updated_at"] is not None
     _assert_utc_timestamp(updated_payload["updated_at"])
+
+
+def test_update_preserves_expiration_date(mocker):
+    memory = _build_memory_instance(mocker, Memory)
+    memory.vector_store.get.return_value = MagicMock(
+        id="mem-1",
+        payload={
+            "data": "old memory",
+            "user_id": "alice",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "expiration_date": "2026-07-15T07:30:00+00:00",
+        },
+    )
+
+    memory._update_memory("mem-1", "new memory", {"new memory": [0.1, 0.2, 0.3]}, metadata={})
+
+    updated_payload = memory.vector_store.update.call_args.kwargs["payload"]
+    assert updated_payload["expiration_date"] == "2026-07-15T07:30:00+00:00"
 
 
 def test_search_and_get_all_consistent_after_update(mocker):
@@ -503,6 +604,7 @@ class TestMetadataNotMutated:
         memory = _build_memory_instance(mocker, Memory)
         metadata = {"user_id": "test_user", "tags": ["important", "urgent"], "config": {"key": "val"}}
         import copy
+
         metadata_snapshot = copy.deepcopy(metadata)
 
         memory._create_memory("test data", {"test data": [0.1, 0.2, 0.3]}, metadata=metadata)
@@ -633,7 +735,8 @@ def test_update_preserves_actor_id_when_different_actor_updates(mocker):
     )
 
     memory._update_memory(
-        "mem-id", "Player #1 is a good person",
+        "mem-id",
+        "Player #1 is a good person",
         {"Player #1 is a good person": [0.1, 0.2, 0.3]},
         metadata={"user_id": "team", "actor_id": "Bob"},
     )
@@ -656,7 +759,8 @@ async def test_async_update_preserves_actor_id_when_different_actor_updates(mock
     )
 
     await memory._update_memory(
-        "mem-id", "Player #1 is a good person",
+        "mem-id",
+        "Player #1 is a good person",
         {"Player #1 is a good person": [0.1, 0.2, 0.3]},
         metadata={"user_id": "team", "actor_id": "Bob"},
     )

--- a/tests/test_server_params.py
+++ b/tests/test_server_params.py
@@ -244,24 +244,53 @@ class TestAddPrompt:
 
 
 # ===========================================================================
+# MemoryCreate: expiration_date parameter
+# ===========================================================================
+
+class TestAddExpirationDate:
+    """Verify that the expiration_date parameter is accepted and forwarded."""
+
+    def test_expiration_date_forwarded(self, client, mock_memory):
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "Remember this until next week"}],
+            "user_id": "u1",
+            "expiration_date": "2026-07-15T09:30:00+02:00",
+        })
+        assert resp.status_code == 200
+        _, kwargs = mock_memory.add.call_args
+        assert kwargs["expiration_date"] == "2026-07-15T09:30:00+02:00"
+
+    def test_expiration_date_omitted(self, client, mock_memory):
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "hello"}],
+            "user_id": "u1",
+        })
+        assert resp.status_code == 200
+        _, kwargs = mock_memory.add.call_args
+        assert "expiration_date" not in kwargs
+
+
+# ===========================================================================
 # MemoryCreate: all new params together
 # ===========================================================================
 
 class TestAddAllNewParams:
 
-    def test_infer_memory_type_and_prompt_together(self, client, mock_memory):
+    def test_infer_memory_type_prompt_and_expiration_date_together(self, client, mock_memory):
         resp = client.post("/memories", json={
             "messages": [{"role": "user", "content": "I like pizza"}],
             "user_id": "u1",
             "infer": False,
             "memory_type": "core",
             "prompt": "Custom extraction prompt.",
+            "expiration_date": "2026-07-15T09:30:00+02:00",
         })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["infer"] is False
         assert kwargs["memory_type"] == "core"
         assert kwargs["prompt"] == "Custom extraction prompt."
+        assert kwargs["expiration_date"] == "2026-07-15T09:30:00+02:00"
 
 
 # ===========================================================================
@@ -382,6 +411,11 @@ class TestOpenAPISchema:
         add_props = schema["components"]["schemas"]["MemoryCreate"]["properties"]
         assert "prompt" in add_props
 
+    def test_add_schema_includes_expiration_date(self, client):
+        schema = client.get("/openapi.json").json()
+        add_props = schema["components"]["schemas"]["MemoryCreate"]["properties"]
+        assert "expiration_date" in add_props
+
 
 # ===========================================================================
 # Pydantic type validation: invalid types return 422
@@ -473,6 +507,16 @@ class TestExplicitNull:
         _, kwargs = mock_memory.add.call_args
         assert "prompt" not in kwargs
 
+    def test_expiration_date_null_uses_memory_default(self, client, mock_memory):
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "test"}],
+            "user_id": "u1",
+            "expiration_date": None,
+        })
+        assert resp.status_code == 200
+        _, kwargs = mock_memory.add.call_args
+        assert "expiration_date" not in kwargs
+
 
 # ===========================================================================
 # Verify exact call signatures match Memory method params
@@ -505,12 +549,12 @@ class TestCallSignatureMatch:
             "messages": [{"role": "user", "content": "hi"}],
             "user_id": "u1", "agent_id": "a1", "run_id": "r1",
             "metadata": {"k": "v"},
-            "infer": False, "memory_type": "core", "prompt": "custom",
+            "infer": False, "memory_type": "core", "prompt": "custom", "expiration_date": "2026-07-15T09:30:00+02:00",
         })
         assert resp.status_code == 200
         # The handler passes messages= as a keyword arg, so it appears in kwargs too
         _, kwargs = mock_memory.add.call_args
-        valid_params = {"messages", "user_id", "agent_id", "run_id", "metadata", "infer", "memory_type", "prompt"}
+        valid_params = {"messages", "user_id", "agent_id", "run_id", "metadata", "infer", "memory_type", "prompt", "expiration_date"}
         for key in kwargs:
             assert key in valid_params, f"Unexpected kwarg '{key}' forwarded to Memory.add()"
 


### PR DESCRIPTION

## Linked Issue

Closes #3696

## Description

The self-hosted `/memories` add path currently cannot accept `expiration_date`, even though generated API docs still advertise it and users are trying to send it. This change restores per-memory `expiration_date` support across the REST request model and the OSS `Memory.add()` path, so the field can be stored and read back consistently.

## Root cause

`MemoryCreate` in `server/main.py` does not define `expiration_date`, so the REST server drops the field before forwarding to `Memory.add()`. The OSS `Memory.add()` path also lacks an `expiration_date` parameter and does not promote the field through create, update-preservation, or read responses, so callers cannot persist or retrieve it as a first-class memory attribute.

## Scope

This PR is intentionally limited to per-memory `expiration_date` acceptance, storage, update preservation, and readback in the self-hosted REST + OSS add path.

Related work: open PR #5445 adds global `memory_ttl` configuration plus lazy expiry filtering and cleanup. This slice does not implement automatic expiry filtering, cleanup jobs, or importance-decay behavior.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Verification:
- [x] `hatch run pytest tests/test_server_params.py tests/memory/test_main.py -q` - focused REST and OSS add-path regressions passed
- [x] `hatch run ruff check server/main.py mem0/memory/main.py mem0/configs/base.py tests/test_server_params.py tests/memory/test_main.py` - passed
- [x] `hatch run ruff format --check server/main.py mem0/memory/main.py mem0/configs/base.py tests/test_server_params.py tests/memory/test_main.py` - passed
- [x] `python scripts/check-llms-txt-coverage.py --write` - `docs/llms.txt` already in sync
- [ ] `make lint` - not run locally; required before merge-readiness update
- [ ] `make test` - not run locally; required before merge-readiness update

Manual check:
- [x] Confirmed the self-hosted `/memories` route forwards `expiration_date` to `Memory.add()`
- [x] Confirmed created memories return the same `expiration_date` on `get()`, `get_all()`, and `search()`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [x] I have updated documentation if needed
