### PR TITLE
fix(@mem0/community): upgrade @langchain/community to ^1.1.18 (CVE-2026-27795, CVE-2026-26019)

### DIFF
--- a/mem0-ts/src/community/package.json
+++ b/mem0-ts/src/community/package.json
@@ -75,8 +75,8 @@
     "typescript": "5.5.4"
   },
   "dependencies": {
-    "@langchain/community": "^0.3.36",
-    "@langchain/core": "^0.3.42",
+    "@langchain/community": "^1.1.18",
+    "@langchain/core": "^1.1.27",
     "axios": "^1.16.0",
     "mem0ai": "^2.1.8",
     "uuid": "^11.1.1",


### PR DESCRIPTION
## Linked Issue

Closes Dependabot alerts #496, #538, and #760.

## Summary

This PR resolves all three remaining open MEDIUM Dependabot alerts for mem0ai/mem0:

| Alert | Package | CVE | Fix |
|-------|---------|-----|-----|
| #496 | @langchain/community ≤ 1.1.13 | CVE-2026-26019 | Bump to ^1.1.18 in @mem0/community |
| #538 | @langchain/community ≤ 1.1.17 | CVE-2026-27795 | Same |
| #760 | python-dotenv < 1.2.2 | CVE-2026-28684 | Upgrade litellm ≥1.88.1, update poetry.lock |

## Vulnerability Details

### CVE-2026-26019 / CVE-2026-27795 — @langchain/community SSRF

| | |
|--|--|
| **Severity** | MEDIUM |
| **Affected** | `@langchain/community` ≤ 1.1.17 |
| **Patched** | 1.1.18 |
| **Advisories** | GHSA-gf3v-fwqg-4vh7, GHSA-mphv-75cg-56wg |

`RecursiveUrlLoader` had two SSRF bugs — (1) `startsWith`-based URL check allowing subdomain bypasses, and (2) no revalidation of redirects, allowing escalation to cloud metadata endpoints.

`@mem0/community` only uses `BaseChatMemory` and `BaseChatMemoryInput` — **`RecursiveUrlLoader` is not used**. The `./memory/chat_memory` export path and `BaseChatMemory` interface are stable across 0.x → 1.x.

### CVE-2026-28684 — python-dotenv symlink attack

| | |
|--|--|
| **Severity** | MEDIUM |
| **Affected** | `python-dotenv` < 1.2.2 |
| **Patched** | 1.2.2 |
| **Advisory** | GHSA-mf9w-mj56-hr94 |

`set_key()` / `unset_key()` followed symlinks on cross-device renames, allowing arbitrary file overwrite.

**Why it was blocked:** `litellm 1.83.7` hard-pinned `python-dotenv==1.0.1`, preventing poetry from resolving to 1.2.2. `litellm 1.88.1` (released after the previous PR #5489) relaxed this to `python-dotenv>=1.0.0,<2.0`. This PR bumps the litellm constraint in `pyproject.toml` to `>=1.88.1` and patches `poetry.lock` with verified PyPI hashes.

**Note:** `poetry.lock` was patched manually rather than regenerated because `litellm` does not yet support Python 3.14 (the local system Python). The content-hash will need a full `poetry lock` on Python 3.10–3.13 to be refreshed. Poetry is not used in CI so this does not affect builds.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

None. `BaseChatMemory` API is unchanged in 1.x. `litellm 1.88.1` is backward-compatible.

## Test Coverage

- [x] `@mem0/community` — only `package.json` version constraints changed; no TypeScript source changed; CI build jobs pass
- [x] Python SDK — no source changes; `pyproject.toml` and `poetry.lock` updated only
- [x] No tests needed for version-constraint-only changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally