### PR TITLE
fix: relax flaky entity boost parallelism timing threshold

### DIFF
--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -828,7 +828,7 @@ class TestEntityBoostParallelism:
         boosts = mock_memory._compute_entity_boosts(entities, {"user_id": "u1"})
         elapsed = time.perf_counter() - start
 
-        assert elapsed < 0.6, f"searches did not run concurrently (took {elapsed:.2f}s)"
+        assert elapsed < 0.75, f"searches did not run concurrently (took {elapsed:.2f}s)"
         assert concurrent_count["peak"] >= 2, "no overlap observed between entity searches"
         assert len(boosts) == 4
 
@@ -854,6 +854,6 @@ class TestEntityBoostParallelism:
         boosts = await mock_async_memory._compute_entity_boosts_async(entities, {"user_id": "u1"})
         elapsed = time.perf_counter() - start
 
-        assert elapsed < 0.6, f"searches did not run concurrently (took {elapsed:.2f}s)"
+        assert elapsed < 0.75, f"searches did not run concurrently (took {elapsed:.2f}s)"
         assert concurrent_count["peak"] >= 2, "no overlap observed between entity searches"
         assert len(boosts) == 4


### PR DESCRIPTION
## Linked Issue

N/A — flaky CI test fix.

## Description

`TestEntityBoostParallelism::test_sync_searches_run_concurrently` and its async counterpart assert that 4 concurrent entity-store searches (each sleeping 0.2s) complete in under 0.6s. The implementation is correct — `ThreadPoolExecutor` runs the searches in parallel — but on loaded GitHub Actions runners, thread-startup and OS scheduling overhead can push the elapsed time past 0.6s (observed: 0.66s in CI).

The threshold is raised to 0.75s, which:
- Still sits below the 0.8s sequential baseline (`4 × 0.2s`), so a regression to serial execution would still fail the test
- Gives CI runners ~0.15s of overhead budget above the observed failure time

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I tested manually (both timing assertions now use 0.75s; confirmed passing locally)
- [x] No production code changed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally