### PR TITLE
fix(llms): skip JSON response_format for Groq compound models

### DIFF
--- a/mem0/llms/groq.py
+++ b/mem0/llms/groq.py
@@ -1,6 +1,7 @@
 import json
+import logging
 import os
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 try:
     from groq import Groq
@@ -10,6 +11,8 @@ except ImportError:
 from mem0.configs.llms.base import BaseLlmConfig
 from mem0.llms.base import LLMBase
 from mem0.memory.utils import extract_json
+
+logger = logging.getLogger(__name__)
 
 
 class GroqLLM(LLMBase):
@@ -21,6 +24,24 @@ class GroqLLM(LLMBase):
 
         api_key = self.config.api_key or os.getenv("GROQ_API_KEY")
         self.client = Groq(api_key=api_key)
+
+    @staticmethod
+    def _supports_json_mode(model: Optional[Union[str, Dict]]) -> bool:
+        """
+        Groq's compound agentic systems (e.g. ``groq/compound``, ``groq/compound-mini``)
+        do not support the JSON ``response_format`` and return empty or non-JSON content
+        when it is requested. See https://console.groq.com/docs/structured-outputs.
+
+        Non-string models (the config allows a dict) are assumed to support JSON mode,
+        preserving prior behavior.
+        """
+        if not isinstance(model, str):
+            return True
+        # Strip provider prefixes (e.g. "groq/compound-mini" -> "compound-mini"),
+        # mirroring the _is_reasoning_model heuristic in LLMBase, so the match
+        # targets the compound family rather than any name containing the substring.
+        base_model = model.lower().rsplit("/", 1)[-1]
+        return not base_model.startswith("compound")
 
     def _parse_response(self, response, tools):
         """
@@ -79,7 +100,17 @@ class GroqLLM(LLMBase):
             "top_p": self.config.top_p,
         }
         if response_format:
-            params["response_format"] = response_format
+            requests_json = isinstance(response_format, dict) and response_format.get("type") in (
+                "json_object",
+                "json_schema",
+            )
+            if requests_json and not self._supports_json_mode(self.config.model):
+                logger.debug(
+                    f"Model '{self.config.model}' does not support JSON response_format; "
+                    "sending the request without it."
+                )
+            else:
+                params["response_format"] = response_format
         if tools:
             params["tools"] = tools
             params["tool_choice"] = tool_choice

--- a/tests/llms/test_groq.py
+++ b/tests/llms/test_groq.py
@@ -84,3 +84,101 @@ def test_generate_response_with_tools(mock_groq_client):
     assert len(response["tool_calls"]) == 1
     assert response["tool_calls"][0]["name"] == "add_memory"
     assert response["tool_calls"][0]["arguments"] == {"data": "Today is a sunny day."}
+
+
+@pytest.mark.parametrize("model", ["groq/compound", "groq/compound-mini"])
+def test_generate_response_skips_json_mode_for_compound_models(mock_groq_client, model):
+    config = BaseLlmConfig(model=model, temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = GroqLLM(config)
+    messages = [{"role": "user", "content": "Hi, I'm Alice and I love hiking."}]
+
+    # Compound models answer JSON-mode requests with empty or non-JSON content;
+    # the mock mirrors that plain-text reply. These tests pin request
+    # construction (response_format omitted), not end-to-end extraction.
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Alice introduced herself and mentioned she loves hiking."))]
+    mock_groq_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages, response_format={"type": "json_object"})
+
+    _, kwargs = mock_groq_client.chat.completions.create.call_args
+    assert "response_format" not in kwargs
+
+
+def test_generate_response_keeps_json_mode_for_standard_model(mock_groq_client):
+    config = BaseLlmConfig(model="llama-3.3-70b-versatile", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = GroqLLM(config)
+    messages = [{"role": "user", "content": "Hi, I'm Alice and I love hiking."}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content='{"memory": ["Name is Alice", "Loves hiking"]}'))]
+    mock_groq_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages, response_format={"type": "json_object"})
+
+    _, kwargs = mock_groq_client.chat.completions.create.call_args
+    assert kwargs["response_format"] == {"type": "json_object"}
+
+
+def test_generate_response_keeps_non_json_response_format_for_compound_model(mock_groq_client):
+    config = BaseLlmConfig(model="groq/compound", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = GroqLLM(config)
+    messages = [{"role": "user", "content": "Hi, I'm Alice and I love hiking."}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Alice loves hiking."))]
+    mock_groq_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages, response_format={"type": "text"})
+
+    _, kwargs = mock_groq_client.chat.completions.create.call_args
+    assert kwargs["response_format"] == {"type": "text"}
+
+
+def test_generate_response_keeps_tools_when_skipping_json_mode(mock_groq_client):
+    config = BaseLlmConfig(model="groq/compound", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = GroqLLM(config)
+    messages = [{"role": "user", "content": "Add a new memory: Today is a sunny day."}]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "add_memory",
+                "description": "Add a memory",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"data": {"type": "string", "description": "Data to add to memory"}},
+                    "required": ["data"],
+                },
+            },
+        }
+    ]
+
+    mock_response = Mock()
+    mock_message = Mock()
+    mock_message.content = "Done."
+    mock_message.tool_calls = None
+    mock_response.choices = [Mock(message=mock_message)]
+    mock_groq_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages, response_format={"type": "json_object"}, tools=tools)
+
+    _, kwargs = mock_groq_client.chat.completions.create.call_args
+    assert "response_format" not in kwargs
+    assert kwargs["tools"] == tools
+    assert kwargs["tool_choice"] == "auto"
+
+
+def test_generate_response_handles_non_string_model(mock_groq_client):
+    config = BaseLlmConfig(model={"name": "custom-model"}, temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = GroqLLM(config)
+    messages = [{"role": "user", "content": "Hi, I'm Alice and I love hiking."}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content='{"memory": []}'))]
+    mock_groq_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages, response_format={"type": "json_object"})
+
+    _, kwargs = mock_groq_client.chat.completions.create.call_args
+    assert kwargs["response_format"] == {"type": "json_object"}


### PR DESCRIPTION
## Linked Issue

Addresses #4054

(Marked "Addresses" rather than "Closes" deliberately: this removes the known failure trigger, but no one has yet live-verified end-to-end extraction on a compound model post-fix - the same verification gap the triage notes flag - and the prose-without-JSON variant can still lose memories until a recovery layer like #5425 lands. Happy to flip to "Closes" if you consider this the issue-closing fix.)

## Description

Using a Groq compound model (`groq/compound`, `groq/compound-mini`) with `memory.add()` silently loses every extracted memory. On older releases this surfaced as the reported `Expecting value: line 1 column 1 (char 0)` parse error; on current main the empty response is caught by the blank-response guard in `_add_to_vector_store` (`mem0/memory/main.py:775`), so there is no longer even an error, just an empty extraction. Either way the memories are gone.

Root cause (confirmed in the triage notes on #4054): `GroqLLM.generate_response()` forwards `response_format={"type": "json_object"}` to the Groq API without checking whether the configured model supports JSON mode. Groq's compound agentic systems are not listed among the models supporting structured outputs (https://console.groq.com/docs/structured-outputs), and the triage on #4054 plus the live validation in #5402 show they return empty or non-JSON content when JSON mode is requested.

This PR revives the approach from #5402 by @Hexecu, which the triage notes on #4054 identify as still needed: gate the `response_format` parameter in `groq.py` for compound-family models. @Hexecu's root-cause analysis, Groq doc references, and live before/after validation in #5402 established that omitting the parameter makes the request succeed (HTTP 200 with content); full credit to them for the approach. Relative to #5402, this version:

- mirrors the name-based heuristic of the repo's `LLMBase._is_reasoning_model`: provider-prefix stripping plus a family prefix match (`compound*` after stripping `groq/`), rather than a bare substring over the whole name, so an unrelated model id merely containing "compound" is not mis-gated. (It does not add that helper's explicit config-override knob; happy to add a `supports_json_mode` config escape hatch if you want the full pattern.);
- skips only JSON-type formats; a `{"type": "text"}` or other `response_format` passes through unchanged. `json_schema` is included in the skip defensively alongside `json_object` since compound systems are not listed as supporting structured outputs at all, though mem0 itself only ever sends `json_object`;
- degrades safely when `config.model` is a non-string (the config type allows `Union[str, Dict]`): non-string models are treated as supporting JSON mode, preserving current behavior;
- leaves `tools` / `tool_choice` untouched when the skip fires;
- logs the skip at debug level so the behavior is diagnosable (happy to bump to `warning` if you prefer louder signal for a capability downgrade).

Complementary to #5425 (recovery via forced tool call on parse failure), and prevention is the right layer for this failure mode: an empty response is absorbed by the blank-response guard on main before any parse error is raised, so no parse-failure recovery (current or future) gets a chance to fire on it, and there is nothing to salvage in an empty string anyway. Per Groq's docs, compound systems orchestrate their own built-in tools (web search, code execution), and we found no documented support for custom tool definitions on them, so a forced-tool retry is not a reliable fallback on these models either (doc inference via #5402; not live-tested in this PR). Skipping the unsupported parameter avoids the failed call entirely.

Note: the TypeScript client has the same unconditional forwarding (`mem0-ts/src/oss/src/llms/groq.ts`); left out of scope here to keep the diff reviewable, happy to follow up with the TS mirror if useful.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A. Standard models keep JSON mode exactly as before (pinned by test); only compound-family model names skip it, and only for JSON-type formats.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added to `tests/llms/test_groq.py` (5 new test functions; the first is parametrized over two models, so 6 new cases and 8 collected total in the file):

- `test_generate_response_skips_json_mode_for_compound_models` (parametrized over `groq/compound` and `groq/compound-mini`): asserts `response_format` is not sent.
- `test_generate_response_keeps_json_mode_for_standard_model`: asserts `response_format` is still sent for `llama-3.3-70b-versatile`, pinning the fix to compound models only.
- `test_generate_response_keeps_non_json_response_format_for_compound_model`: a `{"type": "text"}` format passes through even on compound models, pinning the JSON-only scope.
- `test_generate_response_keeps_tools_when_skipping_json_mode`: `tools` / `tool_choice` are unaffected when the skip fires.
- `test_generate_response_handles_non_string_model`: a dict-valued `config.model` does not crash the gate and keeps current behavior.

Red-to-green, precisely: without the `groq.py` change, the two compound parameterizations and the tools-combination test fail (3 of 8); the standard-model, text-format, and non-string-model tests pass in both states by design, since they pin non-regression. With the change, all 8 pass.

These unit tests prove request construction (which parameters are sent), not live Groq behavior. No live Groq API call was made in this PR; the live before/after on the actual API (empty/non-JSON with the parameter, HTTP 200 with content without it, control model unchanged) is @Hexecu's validation from #5402.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (no public API change)
