### PR TITLE
fix: prefer newer memories on scoring ties

### DIFF
--- a/mem0/utils/scoring.py
+++ b/mem0/utils/scoring.py
@@ -10,6 +10,7 @@ Provides:
 from __future__ import annotations
 
 import math
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 
@@ -55,6 +56,27 @@ def normalize_bm25(raw_score: float, midpoint: float, steepness: float) -> float
 
 
 ENTITY_BOOST_WEIGHT = 0.5
+
+
+def _memory_timestamp(payload: Optional[Dict[str, Any]]) -> float:
+    """Return a comparable memory timestamp for deterministic recency tie-breaks."""
+    if not payload:
+        return 0.0
+
+    for timestamp in (payload.get("updated_at"), payload.get("created_at")):
+        if not isinstance(timestamp, str):
+            continue
+
+        try:
+            parsed = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+        except ValueError:
+            continue
+
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.timestamp()
+
+    return 0.0
 
 
 def score_and_rank(
@@ -135,5 +157,5 @@ def score_and_rank(
             }
         scored.append(scored_result)
 
-    scored.sort(key=lambda x: x["score"], reverse=True)
+    scored.sort(key=lambda x: (x["score"], _memory_timestamp(x.get("payload"))), reverse=True)
     return scored[:top_k]

--- a/tests/utils/test_scoring.py
+++ b/tests/utils/test_scoring.py
@@ -155,6 +155,73 @@ class TestScoreAndRank:
         scored = score_and_rank(results, {}, {}, threshold=0.1, top_k=10)
         assert "score_details" not in scored[0]
 
+    def test_newer_memory_wins_equal_score_tie(self):
+        """Time-aware tie-break: equally relevant conflicting memories prefer the latest write."""
+        results = [
+            {
+                "id": "old",
+                "score": 0.8,
+                "payload": {
+                    "data": "User prefers email notifications enabled",
+                    "created_at": "2026-06-01T00:00:00+00:00",
+                },
+            },
+            {
+                "id": "new",
+                "score": 0.8,
+                "payload": {
+                    "data": "User prefers email notifications disabled",
+                    "created_at": "2026-06-10T00:00:00+00:00",
+                },
+            },
+        ]
+
+        scored = score_and_rank(results, {}, {}, threshold=0.1, top_k=10)
+
+        assert [result["id"] for result in scored] == ["new", "old"]
+
+    def test_updated_at_wins_over_created_at_for_equal_score_tie(self):
+        results = [
+            {
+                "id": "created-later",
+                "score": 0.8,
+                "payload": {"created_at": "2026-06-10T00:00:00+00:00"},
+            },
+            {
+                "id": "updated-later",
+                "score": 0.8,
+                "payload": {
+                    "created_at": "2026-06-01T00:00:00+00:00",
+                    "updated_at": "2026-06-11T00:00:00+00:00",
+                },
+            },
+        ]
+
+        scored = score_and_rank(results, {}, {}, threshold=0.1, top_k=10)
+
+        assert [result["id"] for result in scored] == ["updated-later", "created-later"]
+
+    def test_invalid_updated_at_falls_back_to_created_at_for_equal_score_tie(self):
+        results = [
+            {
+                "id": "old",
+                "score": 0.8,
+                "payload": {"created_at": "2026-06-01T00:00:00+00:00"},
+            },
+            {
+                "id": "new-with-bad-update-time",
+                "score": 0.8,
+                "payload": {
+                    "created_at": "2026-06-10T00:00:00+00:00",
+                    "updated_at": "not-a-date",
+                },
+            },
+        ]
+
+        scored = score_and_rank(results, {}, {}, threshold=0.1, top_k=10)
+
+        assert [result["id"] for result in scored] == ["new-with-bad-update-time", "old"]
+
 
 class TestEntityBoostWeight:
     def test_weight_value(self):


### PR DESCRIPTION
## Linked Issue

Related to #5352

## Description

Mem0 OSS hybrid scoring currently sorts only by the combined relevance score. When two memories tie, Qdrant/vector-store return order can leave stale but semantically similar memories ahead of newer conflicting memories.

This PR adds a narrow retrieval-layer tie-break: when scored memories have the same final score, prefer the most recent `updated_at` timestamp, falling back to `created_at`. Malformed or missing timestamps are ignored so old payloads remain compatible.

This does not add broad temporal decay, lifecycle metadata, or CRUD semantics. It is intentionally scoped to a deterministic, backwards-compatible improvement for the time-blind retrieval failure mode discussed in #5352.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Manual/focused verification:

- RED: `uv run --extra test pytest tests/utils/test_scoring.py::TestScoreAndRank::test_newer_memory_wins_equal_score_tie -q` failed before the fix with `['old', 'new']` instead of `['new', 'old']`.
- GREEN: `uv run --extra test pytest tests/utils/test_scoring.py::TestScoreAndRank::test_newer_memory_wins_equal_score_tie -q` passed after the fix.
- Focused suite: `uv run --extra test pytest tests/utils/test_scoring.py -q` -> 24 passed.
- Lint: `uv run --extra dev ruff check mem0/utils/scoring.py tests/utils/test_scoring.py` -> passed.
- Format: `uv run --extra dev ruff format --check mem0/utils/scoring.py tests/utils/test_scoring.py` -> passed.
- Build: `uv run --extra dev --with build python -m build --wheel --outdir /tmp/mem0-build-check` -> built `mem0ai-2.0.5-py3-none-any.whl`.
- Autoreview: local subagent review + Codex review found no blocking findings.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing focused tests pass locally
- [ ] I have updated documentation if needed
