### PR TITLE
fix(llms): send max_completion_tokens for gpt-5.x OpenAI models

### DIFF
--- a/mem0/llms/openai.py
+++ b/mem0/llms/openai.py
@@ -82,6 +82,28 @@ class OpenAILLM(LLMBase):
         else:
             return response.choices[0].message.content
 
+    @staticmethod
+    def _requires_max_completion_tokens(model: str) -> bool:
+        """Whether the OpenAI Chat Completions API requires ``max_completion_tokens``.
+
+        The gpt-5 family rejects the legacy ``max_tokens`` parameter with a 400
+        ("Unsupported parameter: 'max_tokens' ... Use 'max_completion_tokens'
+        instead."). These models are NOT classified as reasoning models (so they
+        still accept ``temperature``/``top_p`` and never hit the param-stripping
+        path), which is exactly why the token cap reaches the request and must be
+        renamed here. See https://github.com/mem0ai/mem0/issues/5054
+
+        Args:
+            model: The configured model name (provider prefixes are tolerated).
+
+        Returns:
+            bool: True if ``max_tokens`` must be sent as ``max_completion_tokens``.
+        """
+        if not model:
+            return False
+        base_model = model.lower().rsplit("/", 1)[-1]
+        return base_model == "gpt-5" or base_model.startswith(("gpt-5-", "gpt-5."))
+
     def generate_response(
         self,
         messages: List[Dict[str, str]],
@@ -104,11 +126,16 @@ class OpenAILLM(LLMBase):
             json: The generated response.
         """
         params = self._get_supported_params(messages=messages, **kwargs)
-        
+
         params.update({
             "model": self.config.model,
             "messages": messages,
         })
+
+        # gpt-5.x chat models reject the legacy `max_tokens` and require
+        # `max_completion_tokens`; rename in place to avoid a 400 (issue #5054).
+        if "max_tokens" in params and self._requires_max_completion_tokens(self.config.model):
+            params["max_completion_tokens"] = params.pop("max_tokens")
 
         if os.getenv("OPENROUTER_API_KEY"):
             openrouter_params = {}

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -375,6 +375,58 @@ def test_is_reasoning_model_override_generates_correct_params(mock_openai_client
     assert "temperature" not in call_kwargs
 
 
+def test_gpt5_non_reasoning_uses_max_completion_tokens(mock_openai_client):
+    """gpt-5.x chat models reject `max_tokens` and require `max_completion_tokens`.
+
+    gpt-5.4-mini is correctly NOT classified as a reasoning model (see #4738/#4746),
+    so it flows through the common-params path and would otherwise be sent
+    `max_tokens`, which the OpenAI Chat Completions API rejects with a 400:
+    "Unsupported parameter: 'max_tokens' is not supported with this model.
+    Use 'max_completion_tokens' instead." This breaks every add()/search() call
+    for users on gpt-5.x models. Regression test for
+    https://github.com/mem0ai/mem0/issues/5054
+    """
+    config = OpenAIConfig(model="gpt-5.4-mini", temperature=0.1, max_tokens=123)
+    llm = OpenAILLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Response"))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    call_kwargs = mock_openai_client.chat.completions.create.call_args[1]
+    # The token cap must be sent under the new key, carrying the configured value...
+    assert call_kwargs.get("max_completion_tokens") == 123
+    # ...and the legacy key must NOT be sent (it triggers the 400).
+    assert "max_tokens" not in call_kwargs
+    # gpt-5.x chat models still support temperature/top_p, so those remain.
+    assert call_kwargs.get("temperature") == 0.1
+
+
+def test_standard_model_still_uses_max_tokens(mock_openai_client):
+    """Non-gpt-5 OpenAI models (e.g. gpt-4.1) must keep `max_tokens` unchanged.
+
+    Guards against the #5054 fix over-reaching and renaming the param for models
+    that still accept `max_tokens`. Companion to
+    test_gpt5_non_reasoning_uses_max_completion_tokens.
+    """
+    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", temperature=0.1, max_tokens=123)
+    llm = OpenAILLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Response"))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    call_kwargs = mock_openai_client.chat.completions.create.call_args[1]
+    assert call_kwargs.get("max_tokens") == 123
+    assert "max_completion_tokens" not in call_kwargs
+
+
 def test_callback_with_tools(mock_openai_client):
     mock_callback = Mock()
     config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", response_callback=mock_callback)


### PR DESCRIPTION
## Summary
Closes #5054. OpenAI's gpt-5.x chat models (e.g. `gpt-5.4-mini`) reject the legacy `max_tokens` parameter and require `max_completion_tokens`. Because these models are correctly classified as **non**-reasoning, the parameter wasn't being renamed, so requests fail with an HTTP 400.

## Fix
Add `_requires_max_completion_tokens(model)` (matches `gpt-5`, `gpt-5-*`, `gpt-5.*` after stripping any provider prefix) and rename `max_tokens` → `max_completion_tokens` in `generate_response` only for those models. gpt-4.x and reasoning-model paths are unchanged.

## Tests
RED-first: a gpt-5.4-mini request now sends `max_completion_tokens` (was `max_tokens`); a gpt-4.1 companion test guards against over-reach. `tests/llms/test_openai.py`: 20 passed.

(Returning contributor — prior merged PR #5443.)

*AI-assisted contribution.*
