### PR TITLE
fix: preserve empty Azure AI Search update values

### DIFF
--- a/mem0/vector_stores/azure_ai_search.py
+++ b/mem0/vector_stores/azure_ai_search.py
@@ -298,9 +298,9 @@ class AzureAISearch(VectorStoreBase):
             payload (Dict, optional): Updated payload.
         """
         document = {"id": vector_id}
-        if vector:
+        if vector is not None:
             document["vector"] = vector
-        if payload:
+        if payload is not None:
             json_payload = json.dumps(payload)
             document["payload"] = json_payload
             for field in ["user_id", "run_id", "agent_id"]:

--- a/tests/vector_stores/test_azure_ai_search.py
+++ b/tests/vector_stores/test_azure_ai_search.py
@@ -511,6 +511,30 @@ def test_insert_with_http_error(azure_ai_search_instance):
     assert "Azure service error" in str(exc_info.value)
 
 
+def test_update_allows_empty_payload(azure_ai_search_instance):
+    """Test updating with an empty payload explicitly clears stored payload data."""
+    instance, mock_search_client, _ = azure_ai_search_instance
+
+    mock_search_client.merge_or_upload_documents.return_value = [{"status": True, "id": "doc1", "status_code": 200}]
+
+    instance.update("doc1", payload={})
+
+    mock_search_client.merge_or_upload_documents.assert_called_once_with(
+        documents=[{"id": "doc1", "payload": "{}", "user_id": None, "run_id": None, "agent_id": None}]
+    )
+
+
+def test_update_allows_empty_vector(azure_ai_search_instance):
+    """Test updating with an empty vector still sends the vector field to Azure."""
+    instance, mock_search_client, _ = azure_ai_search_instance
+
+    mock_search_client.merge_or_upload_documents.return_value = [{"status": True, "id": "doc1", "status_code": 200}]
+
+    instance.update("doc1", vector=[])
+
+    mock_search_client.merge_or_upload_documents.assert_called_once_with(documents=[{"id": "doc1", "vector": []}])
+
+
 # --- Tests for search method ---
 
 


### PR DESCRIPTION
## Summary
- Use explicit `is not None` checks in Azure AI Search updates so provided empty vectors or payloads are not skipped.
- Add regression tests for empty payload and empty vector updates.

## Testing
- `MEM0_DIR=.tmp-mem0 D:\anaconda3\envs\yolov12\python.exe -m pytest tests\vector_stores\test_azure_ai_search.py`
- `D:\anaconda3\envs\yolov12\python.exe -m ruff check mem0\vector_stores\azure_ai_search.py tests\vector_stores\test_azure_ai_search.py`
- `D:\anaconda3\envs\yolov12\python.exe -m ruff format --check mem0\vector_stores\azure_ai_search.py tests\vector_stores\test_azure_ai_search.py`
- `git diff --check`
