### PR TITLE
Fix Qdrant dimension resolution for OpenClaw OSS configs

### DIFF
--- a/integrations/openclaw/providers.ts
+++ b/integrations/openclaw/providers.ts
@@ -268,6 +268,9 @@ class OSSProvider implements Mem0Provider {
         ec.url = ec.host;
         delete ec.host;
       }
+      if (ec.embedding_dims != null && ec.embeddingDims == null) {
+        ec.embeddingDims = ec.embedding_dims;
+      }
       config.embedder = {
         provider: this.ossConfig.embedder.provider || defaultEmbedder.provider,
         config: { ...defaultEmbedder.config, ...ec },
@@ -294,7 +297,9 @@ class OSSProvider implements Mem0Provider {
       const vs = { ...this.ossConfig.vectorStore } as Record<string, unknown>;
       const vsCfg = (vs.config ?? {}) as Record<string, unknown>;
       // Resolve dims from embedder config if vector store doesn't have them
-      const embedderDims = (config.embedder as any)?.config?.embeddingDims;
+      const embedderConfig = (config.embedder as any)?.config ?? {};
+      const embedderDims =
+        embedderConfig.embeddingDims ?? embedderConfig.embedding_dims;
       if (!vsCfg.dimension && embedderDims) {
         vsCfg.dimension = embedderDims;
       }

--- a/mem0-ts/src/oss/src/vector_stores/qdrant.ts
+++ b/mem0-ts/src/oss/src/vector_stores/qdrant.ts
@@ -98,7 +98,7 @@ export class Qdrant implements VectorStore {
     }
 
     this.collectionName = config.collectionName;
-    this.dimension = config.dimension || 1536; // Default OpenAI dimension
+    this.dimension = config.dimension ?? config.embeddingModelDims ?? 1536; // Default OpenAI dimension
     this.initialize().catch(console.error);
   }
 

--- a/mem0-ts/src/oss/tests/qdrant-url-port.test.ts
+++ b/mem0-ts/src/oss/tests/qdrant-url-port.test.ts
@@ -40,6 +40,39 @@ beforeEach(() => {
 });
 
 describe("Qdrant URL port extraction (qdrant/qdrant-js#59 workaround)", () => {
+  it("uses embeddingModelDims when dimension is omitted", async () => {
+    const createCollection = jest.fn().mockResolvedValue(undefined);
+    (
+      require("@qdrant/js-client-rest").QdrantClient as jest.Mock
+    ).mockImplementation(() => ({
+      createCollection,
+      getCollection: jest.fn().mockResolvedValue({
+        config: { params: { vectors: { size: 1024 } } },
+      }),
+      scroll: jest.fn().mockResolvedValue({ points: [] }),
+      upsert: jest.fn().mockResolvedValue(undefined),
+      retrieve: jest.fn().mockResolvedValue([]),
+      search: jest.fn().mockResolvedValue([]),
+      delete: jest.fn().mockResolvedValue(undefined),
+      deleteCollection: jest.fn().mockResolvedValue(undefined),
+    }));
+
+    const store = new Qdrant({
+      url: "http://qdrant:6333",
+      collectionName: "mem0",
+      embeddingModelDims: 1024,
+    });
+
+    await store.initialize();
+
+    expect(createCollection).toHaveBeenCalledWith(
+      "mem0",
+      expect.objectContaining({
+        vectors: expect.objectContaining({ size: 1024 }),
+      }),
+    );
+  });
+
   it("extracts port from HTTPS URL with explicit port", () => {
     new Qdrant({
       url: "https://my-cluster.us-west-1-0.aws.cloud.qdrant.io:6333",


### PR DESCRIPTION
## Problem

OpenClaw OSS setups with custom embedding providers can fail recall/search with `Bad Request` against Qdrant. The vector store collection may be created with the default 1536-d vector size even when the embedder and Qdrant config specify 1024 dimensions, causing dimension mismatches during search.

Configs that only provide `embedding_dims` (snake_case) were also not normalized before OpenClaw built the OSS Memory config.

## Root cause

`Qdrant` ignored `embeddingModelDims` when `dimension` was omitted and defaulted to 1536. The OpenClaw provider only read camelCase `embeddingDims` when syncing vector-store dimensions from the embedder block.

## Fix

- Resolve Qdrant collection size from `dimension ?? embeddingModelDims ?? 1536`
- Normalize `embedding_dims` → `embeddingDims` in OpenClaw OSS provider config assembly
- Read either casing when syncing vector-store dimensions

## Testing

- Added `uses embeddingModelDims when dimension is omitted`
- `npx jest --runTestsByPath src/oss/tests/qdrant-url-port.test.ts -t "uses embeddingModelDims when dimension is omitted"`

Fixes #5290