### PR TITLE
fix(bedrock): use dict literal instead of set in AI21 response parse default

### DIFF
--- a/mem0/llms/aws_bedrock.py
+++ b/mem0/llms/aws_bedrock.py
@@ -409,7 +409,7 @@ class AWSBedrockLLM(LLMBase):
             elif self.provider == "cohere":
                 return response_json.get("generations", [{"text": ""}])[0].get("text", "")
             elif self.provider == "ai21":
-                return response_json.get("completions", [{"data", {"text": ""}}])[0].get("data", {}).get("text", "")
+                return response_json.get("completions", [{"data": {"text": ""}}])[0].get("data", {}).get("text", "")
             else:
                 # Generic parsing - try common response fields
                 for field in ["content", "text", "completion", "generation"]:

--- a/tests/llms/test_aws_bedrock.py
+++ b/tests/llms/test_aws_bedrock.py
@@ -424,3 +424,29 @@ class TestMiniMaxProvider:
             assert msg["role"] != "system"
         # user message must be present
         assert kwargs["messages"][0]["role"] == "user"
+
+
+# ---------------------------------------------------------------------------
+# _parse_response — legacy InvokeModel provider-specific parsing
+# ---------------------------------------------------------------------------
+
+class TestParseResponseLegacy:
+    def test_ai21_missing_completions_returns_empty(self, mock_boto3):
+        """When AI21 response lacks 'completions', the fallback default must
+        be a valid dict (not a set literal), returning empty string."""
+        llm = _make_llm("ai21.j2-mid-v1", mock_boto3)
+        import io, json
+        body = io.BytesIO(json.dumps({"not_completions": True}).encode())
+        response = {"body": body}
+        result = llm._parse_response(response, tools=None)
+        assert result == ""
+
+    def test_ai21_normal_response(self, mock_boto3):
+        llm = _make_llm("ai21.j2-mid-v1", mock_boto3)
+        import io, json
+        body = io.BytesIO(json.dumps({
+            "completions": [{"data": {"text": "hello from ai21"}}]
+        }).encode())
+        response = {"body": body}
+        result = llm._parse_response(response, tools=None)
+        assert result == "hello from ai21"

--- a/tests/llms/test_aws_bedrock.py
+++ b/tests/llms/test_aws_bedrock.py
@@ -435,7 +435,8 @@ class TestParseResponseLegacy:
         """When AI21 response lacks 'completions', the fallback default must
         be a valid dict (not a set literal), returning empty string."""
         llm = _make_llm("ai21.j2-mid-v1", mock_boto3)
-        import io, json
+        import io
+        import json
         body = io.BytesIO(json.dumps({"not_completions": True}).encode())
         response = {"body": body}
         result = llm._parse_response(response, tools=None)
@@ -443,7 +444,8 @@ class TestParseResponseLegacy:
 
     def test_ai21_normal_response(self, mock_boto3):
         llm = _make_llm("ai21.j2-mid-v1", mock_boto3)
-        import io, json
+        import io
+        import json
         body = io.BytesIO(json.dumps({
             "completions": [{"data": {"text": "hello from ai21"}}]
         }).encode())


### PR DESCRIPTION
## Summary

- The fallback default for a missing `completions` key in the AI21 Bedrock response parser used `{"data", {"text": ""}}` (a Python **set literal**) instead of `{"data": {"text": ""}}` (a dict)
- When `completions` is absent from the response, this crashes with `TypeError: unhashable type: 'dict'` because you can't put a dict inside a set
- Fix: change the comma to a colon so it's a proper dict literal

## Test plan

- [x] `test_ai21_missing_completions_returns_empty`: verifies fallback returns empty string when `completions` key is absent
- [x] `test_ai21_normal_response`: verifies normal AI21 response parsing still works
- [x] All 41 existing bedrock tests pass