### PR TITLE
fix: omit None config values from Gemini GenerateContentConfig

### DIFF
--- a/mem0/llms/gemini.py
+++ b/mem0/llms/gemini.py
@@ -157,12 +157,15 @@ class GeminiLLM(LLMBase):
         # Extract system instruction and reformat messages
         system_instruction, contents = self._reformat_messages(messages)
 
-        # Prepare generation config
-        config_params = {
-            "temperature": self.config.temperature,
-            "max_output_tokens": self.config.max_tokens,
-            "top_p": self.config.top_p,
-        }
+        # Prepare generation config — only include non-None values so the
+        # Gemini SDK uses its own defaults instead of rejecting None.
+        config_params = {}
+        if self.config.temperature is not None:
+            config_params["temperature"] = self.config.temperature
+        if self.config.max_tokens is not None:
+            config_params["max_output_tokens"] = self.config.max_tokens
+        if self.config.top_p is not None:
+            config_params["top_p"] = self.config.top_p
 
         # Add system instruction to config if present
         if system_instruction:

--- a/tests/llms/test_gemini.py
+++ b/tests/llms/test_gemini.py
@@ -190,13 +190,10 @@ def test_parse_response_empty_parts_with_tools(mock_gemini_client: Mock):
 
 
 def test_none_config_values_omitted_from_generation_config(mock_gemini_client: Mock):
-    """When temperature/max_tokens/top_p are None (defaults), they must not
-    appear in the GenerateContentConfig kwargs."""
-    config = BaseLlmConfig(model="gemini-2.0-flash")
+    """When temperature/max_tokens/top_p are None, they must not be passed
+    to GenerateContentConfig (verified via model_fields_set)."""
+    config = BaseLlmConfig(model="gemini-2.0-flash", temperature=None, max_tokens=None, top_p=None)
     llm = GeminiLLM(config)
-    llm.config.temperature = None
-    llm.config.max_tokens = None
-    llm.config.top_p = None
 
     mock_part = Mock(text="ok")
     mock_content = Mock(parts=[mock_part])
@@ -204,12 +201,12 @@ def test_none_config_values_omitted_from_generation_config(mock_gemini_client: M
     mock_response = Mock(candidates=[mock_candidate])
     mock_gemini_client.models.generate_content.return_value = mock_response
 
-    with patch("mem0.llms.gemini.types.GenerateContentConfig", wraps=types.GenerateContentConfig) as mock_cfg:
-        llm.generate_response([{"role": "user", "content": "hi"}])
-        kwargs = mock_cfg.call_args.kwargs
-        assert "temperature" not in kwargs
-        assert "max_output_tokens" not in kwargs
-        assert "top_p" not in kwargs
+    llm.generate_response([{"role": "user", "content": "hi"}])
+
+    config_arg = mock_gemini_client.models.generate_content.call_args.kwargs["config"]
+    assert "temperature" not in config_arg.model_fields_set
+    assert "max_output_tokens" not in config_arg.model_fields_set
+    assert "top_p" not in config_arg.model_fields_set
 
 
 def test_explicit_config_values_passed_to_generation_config(mock_gemini_client: Mock):
@@ -223,9 +220,12 @@ def test_explicit_config_values_passed_to_generation_config(mock_gemini_client: 
     mock_response = Mock(candidates=[mock_candidate])
     mock_gemini_client.models.generate_content.return_value = mock_response
 
-    with patch("mem0.llms.gemini.types.GenerateContentConfig", wraps=types.GenerateContentConfig) as mock_cfg:
-        llm.generate_response([{"role": "user", "content": "hi"}])
-        kwargs = mock_cfg.call_args.kwargs
-        assert kwargs["temperature"] == 0.5
-        assert kwargs["max_output_tokens"] == 200
-        assert kwargs["top_p"] == 0.9
+    llm.generate_response([{"role": "user", "content": "hi"}])
+
+    config_arg = mock_gemini_client.models.generate_content.call_args.kwargs["config"]
+    assert "temperature" in config_arg.model_fields_set
+    assert config_arg.temperature == 0.5
+    assert "max_output_tokens" in config_arg.model_fields_set
+    assert config_arg.max_output_tokens == 200
+    assert "top_p" in config_arg.model_fields_set
+    assert config_arg.top_p == 0.9

--- a/tests/llms/test_gemini.py
+++ b/tests/llms/test_gemini.py
@@ -187,3 +187,47 @@ def test_parse_response_empty_parts_with_tools(mock_gemini_client: Mock):
 
     result = llm._parse_response(mock_response, tools=[{"function": {"name": "test"}}])
     assert result == {"content": None, "tool_calls": []}
+
+
+def test_none_config_values_omitted_from_generation_config(mock_gemini_client: Mock):
+    """When temperature/max_tokens/top_p are None (defaults), they must not
+    appear in the GenerateContentConfig to avoid Gemini API validation errors."""
+    config = BaseLlmConfig(model="gemini-2.0-flash")
+    llm = GeminiLLM(config)
+    llm.config.temperature = None
+    llm.config.max_tokens = None
+    llm.config.top_p = None
+
+    mock_part = Mock(text="ok")
+    mock_content = Mock(parts=[mock_part])
+    mock_candidate = Mock(content=mock_content)
+    mock_response = Mock(candidates=[mock_candidate])
+    mock_gemini_client.models.generate_content.return_value = mock_response
+
+    llm.generate_response([{"role": "user", "content": "hi"}])
+
+    call_args = mock_gemini_client.models.generate_content.call_args
+    config_arg = call_args.kwargs["config"]
+    assert config_arg.temperature is None
+    assert config_arg.max_output_tokens is None
+    assert config_arg.top_p is None
+
+
+def test_explicit_config_values_passed_to_generation_config(mock_gemini_client: Mock):
+    """When temperature/max_tokens/top_p are explicitly set, they must appear."""
+    config = BaseLlmConfig(model="gemini-2.0-flash", temperature=0.5, max_tokens=200, top_p=0.9)
+    llm = GeminiLLM(config)
+
+    mock_part = Mock(text="ok")
+    mock_content = Mock(parts=[mock_part])
+    mock_candidate = Mock(content=mock_content)
+    mock_response = Mock(candidates=[mock_candidate])
+    mock_gemini_client.models.generate_content.return_value = mock_response
+
+    llm.generate_response([{"role": "user", "content": "hi"}])
+
+    call_args = mock_gemini_client.models.generate_content.call_args
+    config_arg = call_args.kwargs["config"]
+    assert config_arg.temperature == 0.5
+    assert config_arg.max_output_tokens == 200
+    assert config_arg.top_p == 0.9

--- a/tests/llms/test_gemini.py
+++ b/tests/llms/test_gemini.py
@@ -191,7 +191,7 @@ def test_parse_response_empty_parts_with_tools(mock_gemini_client: Mock):
 
 def test_none_config_values_omitted_from_generation_config(mock_gemini_client: Mock):
     """When temperature/max_tokens/top_p are None (defaults), they must not
-    appear in the GenerateContentConfig to avoid Gemini API validation errors."""
+    appear in the GenerateContentConfig kwargs."""
     config = BaseLlmConfig(model="gemini-2.0-flash")
     llm = GeminiLLM(config)
     llm.config.temperature = None
@@ -204,13 +204,12 @@ def test_none_config_values_omitted_from_generation_config(mock_gemini_client: M
     mock_response = Mock(candidates=[mock_candidate])
     mock_gemini_client.models.generate_content.return_value = mock_response
 
-    llm.generate_response([{"role": "user", "content": "hi"}])
-
-    call_args = mock_gemini_client.models.generate_content.call_args
-    config_arg = call_args.kwargs["config"]
-    assert config_arg.temperature is None
-    assert config_arg.max_output_tokens is None
-    assert config_arg.top_p is None
+    with patch("mem0.llms.gemini.types.GenerateContentConfig", wraps=types.GenerateContentConfig) as mock_cfg:
+        llm.generate_response([{"role": "user", "content": "hi"}])
+        kwargs = mock_cfg.call_args.kwargs
+        assert "temperature" not in kwargs
+        assert "max_output_tokens" not in kwargs
+        assert "top_p" not in kwargs
 
 
 def test_explicit_config_values_passed_to_generation_config(mock_gemini_client: Mock):
@@ -224,10 +223,9 @@ def test_explicit_config_values_passed_to_generation_config(mock_gemini_client: 
     mock_response = Mock(candidates=[mock_candidate])
     mock_gemini_client.models.generate_content.return_value = mock_response
 
-    llm.generate_response([{"role": "user", "content": "hi"}])
-
-    call_args = mock_gemini_client.models.generate_content.call_args
-    config_arg = call_args.kwargs["config"]
-    assert config_arg.temperature == 0.5
-    assert config_arg.max_output_tokens == 200
-    assert config_arg.top_p == 0.9
+    with patch("mem0.llms.gemini.types.GenerateContentConfig", wraps=types.GenerateContentConfig) as mock_cfg:
+        llm.generate_response([{"role": "user", "content": "hi"}])
+        kwargs = mock_cfg.call_args.kwargs
+        assert kwargs["temperature"] == 0.5
+        assert kwargs["max_output_tokens"] == 200
+        assert kwargs["top_p"] == 0.9


### PR DESCRIPTION
## Summary

- When `temperature`, `max_tokens`, or `top_p` are `None`, they were being passed directly to `GenerateContentConfig`, which can cause Gemini SDK validation errors
- Changed to only include non-`None` values in the config dict so the SDK uses its own defaults
- Added tests verifying `None` values are omitted and explicit values are passed through

## Test plan

- [x] All 10 Gemini LLM tests pass
- [x] Verified `None` config values produce a `GenerateContentConfig` without those fields
- [x] Verified explicit config values are correctly forwarded