### PR TITLE
fix(redis): search() and list() crash when filters is None

### DIFF
--- a/mem0/vector_stores/redis.py
+++ b/mem0/vector_stores/redis.py
@@ -142,8 +142,11 @@ class RedisDB(VectorStoreBase):
         self.index.load(data, id_field="memory_id")
 
     def search(self, query: str, vectors: list, top_k: int = 5, filters: dict = None):
-        conditions = [Tag(key) == value for key, value in filters.items() if value is not None]
-        filter = reduce(lambda x, y: x & y, conditions)
+        if filters:
+            conditions = [Tag(key) == value for key, value in filters.items() if value is not None]
+            filter = reduce(lambda x, y: x & y, conditions) if conditions else None
+        else:
+            filter = None
 
         v = VectorQuery(
             vector=np.array(vectors, dtype=np.float32).tobytes(),
@@ -312,8 +315,11 @@ class RedisDB(VectorStoreBase):
         """
         List all recent created memories from the vector store.
         """
-        conditions = [Tag(key) == value for key, value in filters.items() if value is not None]
-        filter = reduce(lambda x, y: x & y, conditions)
+        if filters:
+            conditions = [Tag(key) == value for key, value in filters.items() if value is not None]
+            filter = reduce(lambda x, y: x & y, conditions) if conditions else "*"
+        else:
+            filter = "*"
         query = Query(str(filter)).sort_by("created_at", asc=False)
         if top_k is not None:
             query = Query(str(filter)).sort_by("created_at", asc=False).paging(0, top_k)


### PR DESCRIPTION
## Summary

- `search()` and `list()` in Redis vector store crash with `AttributeError` when called without filters (the default)
- `filters` defaults to `None` but both methods call `filters.items()` without a null check
- Even with an empty dict `{}`, `reduce()` on an empty conditions list raises `TypeError`
- Added null/empty guards to both methods

## Test plan

- [x] Verified the crash path: `filters.items()` on `None` raises `AttributeError`
- [x] Verified `reduce()` on empty list raises `TypeError`
- [x] Fix guards both `None` and empty dict cases

Closes #5586