### PR TITLE
fix(weaviate): reset() crashes with missing vector_size argument

### DIFF
--- a/mem0/vector_stores/weaviate.py
+++ b/mem0/vector_stores/weaviate.py
@@ -389,4 +389,4 @@ class Weaviate(VectorStoreBase):
         """Reset the index by deleting and recreating it."""
         logger.warning(f"Resetting index {self.collection_name}...")
         self.delete_col()
-        self.create_col()
+        self.create_col(self.embedding_model_dims)


### PR DESCRIPTION
## Summary

- `reset()` calls `self.create_col()` without the required `vector_size` positional argument
- This always raises `TypeError: create_col() missing 1 required positional argument: 'vector_size'`
- Pass `self.embedding_model_dims` to match the initial `__init__` call

## Test plan

- [x] Verified `create_col()` signature requires `vector_size` (line 119)
- [x] Verified `self.embedding_model_dims` is set in `__init__` (line 83)
- [x] Fix passes the stored dims, matching the pattern used at init (line 84)

Closes #5585