### PR TITLE
fix(mongodb): reset() passes wrong argument to create_col()

### DIFF
--- a/mem0/vector_stores/mongodb.py
+++ b/mem0/vector_stores/mongodb.py
@@ -391,7 +391,7 @@ class MongoDB(VectorStoreBase):
         """Reset the index by deleting and recreating it."""
         logger.warning(f"Resetting index {self.collection_name}...")
         self.delete_col()
-        self.collection = self.create_col(self.collection_name)
+        self.collection = self.create_col()
 
     def __del__(self) -> None:
         """Close the database connection when the object is deleted."""


### PR DESCRIPTION
## Summary

- `reset()` calls `self.create_col(self.collection_name)` but `create_col()` takes no positional arguments
- This always raises `TypeError: create_col() takes 1 positional argument but 2 were given`
- Removed the extra argument since `create_col()` uses `self.collection_name` internally

## Test plan

- [x] Verified `create_col()` signature: `def create_col(self)` at line 50
- [x] Verified `__init__` calls `self.create_col()` with no args (line 48)
- [x] Fix matches the existing call pattern

Closes #5584