### PR TITLE
fix(pinecone): hybrid search crashes when filters is None

### DIFF
--- a/mem0/vector_stores/pinecone.py
+++ b/mem0/vector_stores/pinecone.py
@@ -230,7 +230,7 @@ class PineconeDB(VectorStoreBase):
         if filter_dict:
             query_params["filter"] = filter_dict
 
-        if self.hybrid_search and self.sparse_encoder and "text" in filters:
+        if self.hybrid_search and self.sparse_encoder and filters and "text" in filters:
             query_text = filters.get("text")
             if query_text:
                 sparse_vector = self.sparse_encoder.encode_queries(query_text)


### PR DESCRIPTION
## Summary

- When `hybrid_search=True` and no filters are provided, `"text" in filters` raises `TypeError: argument of type 'NoneType' is not iterable`
- `filters` defaults to `None` but the hybrid search condition checks membership without a null guard
- Added `filters and` before the `"text" in filters` check

## Test plan

- [x] Verified the crash: `"text" in None` raises `TypeError`
- [x] Fix adds null guard consistent with the `filter_dict` check above (line 230)

Closes #5583