### PR TITLE
fix(chroma): get() raises IndexError when vector_id not found

### DIFF
--- a/mem0/vector_stores/chroma.py
+++ b/mem0/vector_stores/chroma.py
@@ -198,7 +198,8 @@ class ChromaDB(VectorStoreBase):
             OutputData: Retrieved vector.
         """
         result = self.collection.get(ids=[vector_id])
-        return self._parse_output(result)[0]
+        parsed = self._parse_output(result)
+        return parsed[0] if parsed else None
 
     def list_cols(self) -> List[chromadb.Collection]:
         """


### PR DESCRIPTION
## Summary

- When `vector_id` does not exist in the collection, `_parse_output` returns an empty list
- Indexing `[0]` on that empty list raises `IndexError`
- Return `None` instead, consistent with other vector store implementations (qdrant, pgvector, etc.)

## Test plan

- [x] Verified `_parse_output` returns `[]` for empty results
- [x] Fix returns `None` for not-found, matching the interface contract