### PR TITLE
fix: AsyncMemory.reset() does not reset entity store

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -3482,6 +3482,13 @@ class AsyncMemory(MemoryBase):
             self.config.vector_store.provider, self.config.vector_store.config
         )
 
+        if self._entity_store is not None:
+            try:
+                await asyncio.to_thread(self._entity_store.reset)
+            except Exception as e:
+                logger.warning(f"Failed to reset entity store: {e}")
+            self._entity_store = None
+
         capture_event("mem0.reset", self, {"sync_type": "async"})
         await display_first_run_notice_async(self, "async", "reset")
 


### PR DESCRIPTION
## Summary

- Sync `Memory.reset()` resets and nullifies `_entity_store` (lines 1821-1826), but `AsyncMemory.reset()` has no corresponding cleanup
- After an async reset, `_entity_store` still holds references to the old (deleted) collection
- Entity boosts computed during subsequent searches use stale entity data, returning incorrect results
- Added the same entity store reset block to `AsyncMemory.reset()`, wrapped in `asyncio.to_thread()`

## Test plan

- [x] Verified sync `Memory.reset()` has entity store cleanup (lines 1821-1826)
- [x] Verified `AsyncMemory.reset()` was missing this block
- [x] Fix matches the sync pattern with async thread delegation

Closes #5582