### PR TITLE
fix(litellm): function-calling check blocks all calls on non-tool models

### DIFF
--- a/mem0/llms/litellm.py
+++ b/mem0/llms/litellm.py
@@ -67,7 +67,7 @@ class LiteLLM(LLMBase):
         Returns:
             str: The generated response.
         """
-        if not litellm.supports_function_calling(self.config.model):
+        if tools and not litellm.supports_function_calling(self.config.model):
             raise ValueError(f"Model '{self.config.model}' in litellm does not support function calling.")
 
         params = {

--- a/tests/llms/test_litellm.py
+++ b/tests/llms/test_litellm.py
@@ -25,6 +25,22 @@ def test_generate_response_with_unsupported_model(mock_litellm):
         llm.generate_response(messages, tools=tools)
 
 
+def test_generate_response_with_unsupported_model_no_tools(mock_litellm):
+    config = BaseLlmConfig(model="unsupported-model", temperature=0.7, max_tokens=100, top_p=1)
+    llm = litellm.LiteLLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="hi"))]
+    mock_litellm.completion.return_value = mock_response
+    mock_litellm.supports_function_calling.return_value = False
+
+    response = llm.generate_response(messages)
+
+    assert response == "hi"
+    mock_litellm.supports_function_calling.assert_not_called()
+
+
 def test_generate_response_without_tools(mock_litellm):
     config = BaseLlmConfig(model="gpt-4.1-nano-2025-04-14", temperature=0.7, max_tokens=100, top_p=1)
     llm = litellm.LiteLLM(config)

--- a/tests/llms/test_litellm.py
+++ b/tests/llms/test_litellm.py
@@ -19,8 +19,10 @@ def test_generate_response_with_unsupported_model(mock_litellm):
 
     mock_litellm.supports_function_calling.return_value = False
 
+    tools = [{"type": "function", "function": {"name": "test", "parameters": {}}}]
+
     with pytest.raises(ValueError, match="Model 'unsupported-model' in litellm does not support function calling."):
-        llm.generate_response(messages)
+        llm.generate_response(messages, tools=tools)
 
 
 def test_generate_response_without_tools(mock_litellm):


### PR DESCRIPTION
## Summary

- `supports_function_calling()` check runs unconditionally on every `generate_response()` call
- Models that don't support function calling (e.g., base completion models) are blocked from all calls, even plain text generation where no tools are requested
- Only run the check when `tools` are actually provided

## Test plan

- [x] Verified the check is at line 70, before any tool-specific logic
- [x] Fix gates the check on `tools` being truthy, matching the existing pattern at line 82