### PR TITLE
fix(huggingface): use self.config instead of raw config parameter

### DIFF
--- a/mem0/embeddings/huggingface.py
+++ b/mem0/embeddings/huggingface.py
@@ -16,8 +16,8 @@ class HuggingFaceEmbedding(EmbeddingBase):
     def __init__(self, config: Optional[BaseEmbedderConfig] = None):
         super().__init__(config)
 
-        if config.huggingface_base_url:
-            self.client = OpenAI(base_url=config.huggingface_base_url)
+        if self.config.huggingface_base_url:
+            self.client = OpenAI(base_url=self.config.huggingface_base_url)
             self.config.model = self.config.model or "tei"
         else:
             self.config.model = self.config.model or "multi-qa-MiniLM-L6-cos-v1"


### PR DESCRIPTION
## Summary

- `__init__` accesses `config.huggingface_base_url` on the raw `config` parameter instead of `self.config` (set by `super().__init__()`)
- When `config=None` (the documented default), this raises `AttributeError: 'NoneType' object has no attribute 'huggingface_base_url'`
- Changed to `self.config`, matching every other embedder in the project

## Test plan

- [x] Verified `super().__init__(config)` sets `self.config` (line 17)
- [x] Verified all other embedders use `self.config` after super init
- [x] Fix uses `self.config` consistently for both the check and the `base_url` value

Closes #5581