### PR TITLE
fix(ollama): json format mutates caller's messages list in-place

### DIFF
--- a/mem0/llms/ollama.py
+++ b/mem0/llms/ollama.py
@@ -119,11 +119,12 @@ class OllamaLLM(LLMBase):
         # Handle JSON response format by using Ollama's native format parameter
         if response_format and response_format.get("type") == "json_object":
             params["format"] = "json"
-            # Also add JSON format instruction to the last message as a fallback
+            messages = [dict(m) for m in messages]
             if messages and messages[-1]["role"] == "user":
                 messages[-1]["content"] += "\n\nPlease respond with valid JSON only."
             else:
                 messages.append({"role": "user", "content": "Please respond with valid JSON only."})
+            params["messages"] = messages
 
         # Add options for Ollama (temperature, num_predict, top_p)
         options = {


### PR DESCRIPTION
## Summary

- When `response_format` is `json_object`, the code directly modifies the caller's `messages` list (appending a JSON instruction or modifying the last message content)
- After the call returns, the original `messages` variable is permanently corrupted
- This causes silent data corruption in multi-turn or multi-call scenarios
- Copy the messages list and dicts before mutation

## Test plan

- [x] Verified the mutation: `messages[-1]["content"] +=` modifies the original dict
- [x] Fix creates shallow copies of both list and inner dicts before modification
- [x] Updated `params["messages"]` to use the copied list

Closes #5580