### PR TITLE
feat(memory): add search hit lifecycle callback

### DIFF
--- a/docs/open-source/configuration.mdx
+++ b/docs/open-source/configuration.mdx
@@ -147,6 +147,28 @@ memory = Memory.from_config_file("config.yaml")
   </Accordion>
 </AccordionGroup>
 
+## Track search hits
+
+Self-hosted deployments can attach an optional `on_search_hit` callback to the Python OSS config. Mem0 calls it once for each ranked memory returned by `search()`, after reranking and filtering. This lets lifecycle plugins update access counters, last-access timestamps, or retention metadata without changing every vector store backend.
+
+```python
+from mem0 import Memory
+
+
+def track_access(memory):
+    # Example: update access_count / last_accessed_at in your metadata layer.
+    print(f"accessed memory {memory['id']}")
+
+
+memory = Memory.from_config({
+    "on_search_hit": track_access,
+})
+```
+
+<Note>
+  Callback errors are logged and do not fail the search request. Use the callback for lightweight bookkeeping, then run expensive cleanup or decay jobs outside the search path.
+</Note>
+
 <Warning>
   Mixing managed and self-hosted components? Make sure every outbound provider call happens through a secure network path. Managed rerankers often require outbound internet even if your vector store is on-prem.
 </Warning>

--- a/mem0/configs/base.py
+++ b/mem0/configs/base.py
@@ -1,7 +1,7 @@
 import os
 from typing import Any, Dict, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from mem0.configs.rerankers.config import RerankerConfig
 from mem0.embeddings.configs import EmbedderConfig
@@ -55,6 +55,18 @@ class MemoryConfig(BaseModel):
         description="Custom instructions for fact extraction",
         default=None,
     )
+    on_search_hit: Optional[Any] = Field(
+        description="Optional callback invoked for each ranked search result.",
+        default=None,
+        exclude=True,
+    )
+
+    @field_validator("on_search_hit")
+    @classmethod
+    def validate_on_search_hit(cls, value):
+        if value is not None and not callable(value):
+            raise ValueError("on_search_hit must be callable")
+        return value
 
 
 class AzureConfig(BaseModel):

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -10,6 +10,7 @@ import uuid
 import warnings
 from copy import deepcopy
 from datetime import datetime, timezone
+from inspect import isawaitable
 from typing import Any, Dict, Optional
 
 from pydantic import ValidationError
@@ -1353,6 +1354,8 @@ class Memory(MemoryBase):
             except Exception as e:
                 logger.warning(f"Reranking failed, using original results: {e}")
 
+        self._notify_search_hits(original_memories)
+
         if temporal_usage_notice:
             display_temporal_usage_notice(self, "sync", "search", *temporal_usage_notice)
         elif scale_threshold_notice:
@@ -1573,6 +1576,17 @@ class Memory(MemoryBase):
             original_memories.append(memory_item_dict)
 
         return original_memories
+
+    def _notify_search_hits(self, memories):
+        callback = self.config.on_search_hit
+        if callback is None:
+            return
+
+        for memory in memories:
+            try:
+                callback(memory)
+            except Exception as e:
+                logger.warning(f"Search hit callback failed for memory_id={memory.get('id')}: {e}")
 
     def _compute_entity_boosts(self, query_entities, filters):
         """Compute per-memory entity boosts from entity store search.
@@ -2872,6 +2886,8 @@ class AsyncMemory(MemoryBase):
             except Exception as e:
                 logger.warning(f"Reranking failed, using original results: {e}")
 
+        await self._notify_search_hits(original_memories)
+
         if temporal_usage_notice:
             await display_temporal_usage_notice_async(self, "async", "search", *temporal_usage_notice)
         elif scale_threshold_notice:
@@ -3090,6 +3106,19 @@ class AsyncMemory(MemoryBase):
             original_memories.append(memory_item_dict)
 
         return original_memories
+
+    async def _notify_search_hits(self, memories):
+        callback = self.config.on_search_hit
+        if callback is None:
+            return
+
+        for memory in memories:
+            try:
+                result = await asyncio.to_thread(callback, memory)
+                if isawaitable(result):
+                    await result
+            except Exception as e:
+                logger.warning(f"Search hit callback failed for memory_id={memory.get('id')}: {e}")
 
     async def _compute_entity_boosts_async(self, query_entities, filters):
         """Async version of entity boost computation."""

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from mem0.configs.base import MemoryConfig
-from mem0.memory.main import Memory
+from mem0.memory.main import AsyncMemory, Memory
 
 
 @pytest.fixture(autouse=True)
@@ -52,6 +52,23 @@ def memory_custom_instance():
         return Memory(config)
 
 
+@pytest.fixture
+def async_memory_instance():
+    with (
+        patch("mem0.utils.factory.EmbedderFactory") as mock_embedder,
+        patch("mem0.memory.main.VectorStoreFactory") as mock_vector_store,
+        patch("mem0.utils.factory.LlmFactory") as mock_llm,
+        patch("mem0.memory.telemetry.capture_event"),
+    ):
+        mock_embedder.create.return_value = Mock()
+        mock_vector_store.create.return_value = Mock()
+        mock_vector_store.create.return_value.search.return_value = []
+        mock_llm.create.return_value = Mock()
+
+        config = MemoryConfig(version="v1.1")
+        return AsyncMemory(config)
+
+
 def test_add(memory_instance):
     memory_instance._add_to_vector_store = Mock(return_value=[{"memory": "Test memory", "event": "ADD"}])
 
@@ -61,7 +78,11 @@ def test_add(memory_instance):
     assert result["results"] == [{"memory": "Test memory", "event": "ADD"}]
 
     memory_instance._add_to_vector_store.assert_called_once_with(
-        [{"role": "user", "content": "Test message"}], {"user_id": "test_user"}, {"user_id": "test_user"}, True, prompt=None
+        [{"role": "user", "content": "Test message"}],
+        {"user_id": "test_user"},
+        {"user_id": "test_user"},
+        True,
+        prompt=None,
     )
 
 
@@ -99,8 +120,10 @@ def test_search(memory_instance):
     memory_instance.vector_store.keyword_search = Mock(return_value=None)  # No BM25
     memory_instance.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
 
-    with patch("mem0.memory.main.lemmatize_for_bm25", return_value="test query"), \
-         patch("mem0.memory.main.extract_entities", return_value=[]):
+    with (
+        patch("mem0.memory.main.lemmatize_for_bm25", return_value="test query"),
+        patch("mem0.memory.main.extract_entities", return_value=[]),
+    ):
         result = memory_instance.search("test query", filters={"user_id": "test_user"})
 
     assert "results" in result
@@ -115,6 +138,72 @@ def test_search(memory_instance):
     memory_instance.vector_store.search.assert_called_once_with(
         query="test query", vectors=[0.1, 0.2, 0.3], top_k=80, filters={"user_id": "test_user"}
     )
+
+
+def test_search_invokes_on_search_hit_callback_for_ranked_results(memory_instance):
+    mock_memories = [
+        Mock(id="1", payload={"data": "Memory 1", "user_id": "test_user"}, score=0.9),
+        Mock(id="2", payload={"data": "Memory 2", "user_id": "test_user"}, score=0.8),
+    ]
+    memory_instance.vector_store.search = Mock(return_value=mock_memories)
+    memory_instance.vector_store.keyword_search = Mock(return_value=None)
+    memory_instance.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+    memory_instance.reranker = Mock()
+    memory_instance.reranker.rerank = Mock(side_effect=lambda query, memories, limit: memories[:1])
+    on_search_hit = Mock()
+    memory_instance.config.on_search_hit = on_search_hit
+
+    with (
+        patch("mem0.memory.main.lemmatize_for_bm25", return_value="test query"),
+        patch("mem0.memory.main.extract_entities", return_value=[]),
+    ):
+        result = memory_instance.search("test query", filters={"user_id": "test_user"}, rerank=True)
+
+    assert len(result["results"]) == 1
+    assert on_search_hit.call_count == 1
+    on_search_hit.assert_any_call(result["results"][0])
+
+
+@pytest.mark.asyncio
+async def test_async_search_invokes_async_on_search_hit_callback(async_memory_instance):
+    mock_memories = [
+        Mock(id="1", payload={"data": "Memory 1", "user_id": "test_user"}, score=0.9),
+        Mock(id="2", payload={"data": "Memory 2", "user_id": "test_user"}, score=0.8),
+    ]
+    async_memory_instance.vector_store.search = Mock(return_value=mock_memories)
+    async_memory_instance.vector_store.keyword_search = Mock(return_value=None)
+    async_memory_instance.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+    async_memory_instance.reranker = Mock()
+    async_memory_instance.reranker.rerank = Mock(side_effect=lambda query, memories, limit: memories[:1])
+    seen = []
+
+    async def on_search_hit(memory):
+        seen.append(memory)
+
+    async_memory_instance.config.on_search_hit = on_search_hit
+
+    with (
+        patch("mem0.memory.main.lemmatize_for_bm25", return_value="test query"),
+        patch("mem0.memory.main.extract_entities", return_value=[]),
+    ):
+        result = await async_memory_instance.search("test query", filters={"user_id": "test_user"}, rerank=True)
+
+    assert seen == result["results"]
+
+
+def test_on_search_hit_keeps_memory_config_serializable():
+    def on_search_hit(memory):
+        return None
+
+    config = MemoryConfig(on_search_hit=on_search_hit)
+
+    assert MemoryConfig.model_json_schema()
+    assert "on_search_hit" not in config.model_dump(exclude={"vector_store", "llm", "embedder", "reranker"})
+
+
+def test_on_search_hit_must_be_callable():
+    with pytest.raises(ValueError, match="on_search_hit must be callable"):
+        MemoryConfig(on_search_hit="not-callable")
 
 
 def test_update(memory_instance):
@@ -307,8 +396,10 @@ class TestSearchParamValidation:
         memory_instance.vector_store.keyword_search = Mock(return_value=None)
         memory_instance.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
 
-        with patch("mem0.memory.main.lemmatize_for_bm25", return_value="test"), \
-             patch("mem0.memory.main.extract_entities", return_value=[]):
+        with (
+            patch("mem0.memory.main.lemmatize_for_bm25", return_value="test"),
+            patch("mem0.memory.main.extract_entities", return_value=[]),
+        ):
             memory_instance.search("  test  ", filters={"user_id": "test"})
 
         memory_instance.embedding_model.embed.assert_called_once_with("test", "search")
@@ -340,8 +431,10 @@ class TestSearchParamValidation:
         memory_instance.vector_store.keyword_search = Mock(return_value=None)
         memory_instance.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
 
-        with patch("mem0.memory.main.lemmatize_for_bm25", return_value="test"), \
-             patch("mem0.memory.main.extract_entities", return_value=[]):
+        with (
+            patch("mem0.memory.main.lemmatize_for_bm25", return_value="test"),
+            patch("mem0.memory.main.extract_entities", return_value=[]),
+        ):
             result = memory_instance.search("test", filters={"user_id": "test"}, threshold=0)
 
         assert "results" in result
@@ -353,8 +446,10 @@ class TestSearchParamValidation:
         memory_instance.vector_store.keyword_search = Mock(return_value=None)
         memory_instance.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
 
-        with patch("mem0.memory.main.lemmatize_for_bm25", return_value="test"), \
-             patch("mem0.memory.main.extract_entities", return_value=[]):
+        with (
+            patch("mem0.memory.main.lemmatize_for_bm25", return_value="test"),
+            patch("mem0.memory.main.extract_entities", return_value=[]),
+        ):
             result = memory_instance.search("test", filters={"user_id": "test"}, threshold=1.0)
 
         assert "results" in result
@@ -366,8 +461,10 @@ class TestSearchParamValidation:
         memory_instance.vector_store.keyword_search = Mock(return_value=None)
         memory_instance.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
 
-        with patch("mem0.memory.main.lemmatize_for_bm25", return_value="test"), \
-             patch("mem0.memory.main.extract_entities", return_value=[]):
+        with (
+            patch("mem0.memory.main.lemmatize_for_bm25", return_value="test"),
+            patch("mem0.memory.main.extract_entities", return_value=[]),
+        ):
             result = memory_instance.search("test", filters={"user_id": "test"}, top_k=0)
 
         assert "results" in result


### PR DESCRIPTION
## Linked Issue

Refs #5330

## Description

Adds an OSS `on_search_hit` callback on `MemoryConfig` and invokes it once for each ranked result returned by sync and async `search()` after filtering/reranking. This gives lifecycle plugins a native hook to update access counters, last-access timestamps, or retention metadata without coupling cleanup logic to every vector store backend.

Callback failures are logged and do not fail the search request.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Manual verification:

```bash
.venv/bin/python -m pytest tests/test_main.py -q
.venv/bin/ruff check mem0/configs/base.py mem0/memory/main.py tests/test_main.py
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing focused tests pass locally
- [x] I have updated documentation if needed
