### PR TITLE
fix(ts-oss): reject empty/blank messages in Memory.add() to prevent hallucinated memories

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -619,6 +619,25 @@ export class Memory {
         "messages is required and cannot be undefined or null. Provide a string or array of messages.",
       );
     }
+    if (Array.isArray(messages)) {
+      if (messages.length === 0) {
+        throw new Error(
+          "messages array cannot be empty. Provide at least one message with non-empty content.",
+        );
+      }
+      const allBlank = messages.every(
+        (m) => typeof m.content === "string" && m.content.trim() === "",
+      );
+      if (allBlank) {
+        throw new Error(
+          "messages array cannot contain only blank content. Provide at least one message with non-empty content.",
+        );
+      }
+    } else if (messages.trim() === "") {
+      throw new Error(
+        "messages string cannot be empty. Provide non-empty content.",
+      );
+    }
 
     const temporalUsageNotice = detectTemporalUsageFromMetadata(
       config?.metadata,

--- a/mem0-ts/src/oss/tests/memory.validation.test.ts
+++ b/mem0-ts/src/oss/tests/memory.validation.test.ts
@@ -84,6 +84,24 @@ describe("Memory Input Validation", () => {
         memory.add(null, { userId: testUserId }),
       ).rejects.toThrow("messages is required");
     });
+
+    it("should throw error when messages is an empty array", async () => {
+      await expect(memory.add([], { userId: testUserId })).rejects.toThrow(
+        "messages array cannot be empty",
+      );
+    });
+
+    it("should throw error when messages array contains only blank content", async () => {
+      await expect(
+        memory.add([{ role: "user", content: "   " }], { userId: testUserId }),
+      ).rejects.toThrow("messages array cannot contain only blank content");
+    });
+
+    it("should throw error when messages is an empty string", async () => {
+      await expect(memory.add("   ", { userId: testUserId })).rejects.toThrow(
+        "messages string cannot be empty",
+      );
+    });
   });
 
   describe("search() threshold validation", () => {


### PR DESCRIPTION
## Summary

- `Memory.add()` in the TypeScript OSS SDK now rejects empty arrays, empty strings, and blank-only message content.
- Prevents hallucinated "ghost" memories that were being generated from an empty extraction prompt.

## Motivation

Closes #5465.

`Memory.add([])` passed the existing `null`/`undefined` guard but continued into `addToVectorStore()`, where `messages.map(m => m.content).join("\n")` produces an empty string `""`. That empty string was embedded and sent to the LLM for fact extraction, and some LLMs hallucinate facts from an empty prompt — the same root cause as the Python SDK issue #4099.

## Fix

Right after the existing null/undefined check in `add()`, reject:
- empty arrays (`messages.length === 0`)
- arrays whose messages all have blank (whitespace-only) string content
- empty / whitespace-only string input

This mirrors the validation direction of the Python SDK fix referenced in the issue (#4435 / #4593).

## Verification

- `npx jest src/oss/tests/memory.validation.test.ts` — **31 passed** (28 existing + 3 new)
- New cases: empty array, blank-only content array, empty string
- `npx prettier --check` on both changed files — clean

## Notes

- 2 files changed, +37/-0. No behavior change for valid input.
- A maintainer's own PR #5472 targeted this issue but was closed unmerged. This PR keeps the validation logic minimal and does **not** alter the shared test harness config (the prior PR's broad `beforeAll` config changes), so it stays focused on the fix.
