### PR TITLE
fix(ts-oss): raise EmbeddingError on partial embed failure instead of dropping memories

### DIFF
--- a/mem0-ts/src/client/index.ts
+++ b/mem0-ts/src/client/index.ts
@@ -42,7 +42,11 @@ export {
   NetworkError,
   ConfigurationError,
   MemoryQuotaExceededError,
+  EmbeddingError,
   createExceptionFromResponse,
 } from "../common/exceptions";
 
-export type { MemoryErrorOptions } from "../common/exceptions";
+export type {
+  MemoryErrorOptions,
+  EmbeddingErrorClass,
+} from "../common/exceptions";

--- a/mem0-ts/src/common/exceptions.ts
+++ b/mem0-ts/src/common/exceptions.ts
@@ -139,6 +139,65 @@ export class MemoryQuotaExceededError extends MemoryError {
   }
 }
 
+/**
+ * Coarse failure category for OSS Memory.add() embedding failures.
+ * Assigned at the point of detection (not parsed from the message).
+ * - provider: embed() / embedBatch() threw
+ * - validation: vector returned non-finite or wrong-dimension
+ * - internal: catch-all
+ */
+export type EmbeddingErrorClass = "provider" | "validation" | "internal";
+
+/**
+ * Raised when embedding one or more memory texts fails during OSS Memory.add(),
+ * which would otherwise cause those memories to be silently dropped.
+ * Mirrors the Python SDK EmbeddingError (see #5245 / #5509).
+ *
+ * Successful memories are persisted before this is thrown (preserve-then-raise).
+ * Callers can retry only `failedTexts`; `persistedCount` is the number actually
+ * committed via vector-store insert (not merely attempted).
+ */
+export class EmbeddingError extends MemoryError {
+  /** Texts whose embeddings failed and were therefore not persisted. */
+  readonly failedTexts: string[];
+  /** Number of memories that embedded and were actually inserted. */
+  readonly persistedCount: number;
+  /** Coarse failure category collapsed as validation > provider > internal. */
+  readonly errorClass: EmbeddingErrorClass;
+
+  constructor(
+    message: string,
+    opts: {
+      failedTexts?: string[];
+      persistedCount?: number;
+      errorClass?: EmbeddingErrorClass;
+      suggestion?: string;
+      details?: Record<string, unknown>;
+      debugInfo?: Record<string, unknown>;
+    } = {},
+  ) {
+    const failedTexts = opts.failedTexts ?? [];
+    const persistedCount = opts.persistedCount ?? 0;
+    const errorClass = opts.errorClass ?? "internal";
+    super(message, "EMBED_001", {
+      suggestion:
+        opts.suggestion ??
+        "Retry only the failed texts; successful memories were already persisted",
+      details: {
+        ...(opts.details ?? {}),
+        failedTexts,
+        persistedCount,
+        errorClass,
+      },
+      debugInfo: opts.debugInfo,
+    });
+    this.name = "EmbeddingError";
+    this.failedTexts = failedTexts;
+    this.persistedCount = persistedCount;
+    this.errorClass = errorClass;
+  }
+}
+
 // ─── HTTP Status → Exception Mapping ─────────────────────
 
 type MemoryErrorConstructor = new (

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -1,6 +1,10 @@
 import { v4 as uuidv4 } from "uuid";
 import { createHash } from "crypto";
 import {
+  EmbeddingError,
+  type EmbeddingErrorClass,
+} from "../../../common/exceptions";
+import {
   MemoryConfig,
   MemoryConfigSchema,
   MemoryItem,
@@ -79,6 +83,9 @@ import { getDefaultVectorStoreDbPath } from "../utils/sqlite";
 import { logger } from "../utils/logger";
 import { normalizeExpirationDate, payloadIsExpired } from "../utils/expiration";
 import { getOrCreateMem0UserId } from "../../../client/config";
+
+export { EmbeddingError } from "../../../common/exceptions";
+export type { EmbeddingErrorClass } from "../../../common/exceptions";
 
 export class LLMError extends Error {
   readonly cause?: unknown;
@@ -943,21 +950,72 @@ export class Memory {
       .map((m) => m.text ?? "")
       .filter((t) => t.length > 0);
     let embedMap: Record<string, number[]> = {};
+    // Collected across the fallback path; surfaced AFTER successful memories are
+    // persisted (preserve-then-raise), so one failed item never discards the
+    // good ones. Classified at the point of detection, not from the message.
+    const embedFailures: { text: string; errorClass: EmbeddingErrorClass }[] =
+      [];
+    // A returned vector can be "successful" yet unusable: non-finite values
+    // (NaN/Infinity) or the wrong dimension. These don't throw today and get
+    // persisted as corrupt vectors (the more dangerous half of #5509). Validate
+    // at the point of return and record a `validation` failure instead.
+    const expectedDims = this.config.vectorStore.config.dimension;
+    const isValidVector = (v: number[] | undefined): boolean => {
+      if (!Array.isArray(v) || v.length === 0) return false;
+      if (typeof expectedDims === "number" && v.length !== expectedDims)
+        return false;
+      return v.every((n) => Number.isFinite(n));
+    };
+    const acceptEmbedding = (text: string, vector: number[] | undefined) => {
+      if (isValidVector(vector)) {
+        embedMap[text] = vector as number[];
+      } else {
+        console.warn(
+          `Embedding for memory text failed validation (non-finite or wrong ` +
+            `dimension); not persisting: ${JSON.stringify(text.slice(0, 80))}`,
+        );
+        embedFailures.push({ text, errorClass: "validation" });
+      }
+    };
+
     try {
       const memEmbeddingsList = await this.embedder.embedBatch(memTexts, "add");
       for (let i = 0; i < memTexts.length; i++) {
-        embedMap[memTexts[i]] = memEmbeddingsList[i];
+        acceptEmbedding(memTexts[i], memEmbeddingsList[i]);
       }
     } catch {
       // Fallback: embed individually
       for (const text of memTexts) {
         try {
-          embedMap[text] = await this.embedder.embed(text, "add");
+          acceptEmbedding(text, await this.embedder.embed(text, "add"));
         } catch (e) {
+          // The embed call threw -> provider-class failure.
           console.warn(`Failed to embed memory text: ${e}`);
+          embedFailures.push({ text, errorClass: "provider" });
         }
       }
     }
+
+    // Preserve-then-raise helper: call AFTER successful memories are persisted.
+    // Raises an EmbeddingError carrying the failed texts, how many were
+    // actually inserted, and a collapsed error class (validation > provider > internal).
+    const raiseIfEmbedFailures = (persistedCount: number): void => {
+      if (embedFailures.length === 0) return;
+      const failedTexts = embedFailures.map((f) => f.text);
+      const errorClass: EmbeddingErrorClass = embedFailures.some(
+        (f) => f.errorClass === "validation",
+      )
+        ? "validation"
+        : embedFailures.some((f) => f.errorClass === "provider")
+          ? "provider"
+          : "internal";
+      throw new EmbeddingError(
+        `Failed to embed ${failedTexts.length} of ${memTexts.length} memory ` +
+          `text(s); ${persistedCount} persisted, ${failedTexts.length} not ` +
+          `persisted. Failed: ${JSON.stringify(failedTexts)}`,
+        { failedTexts, persistedCount, errorClass },
+      );
+    };
 
     // Phase 4-5: CPU processing + hash dedup
     const existingHashes = new Set<string>();
@@ -1023,6 +1081,9 @@ export class Memory {
           );
         } catch {}
       }
+      // Nothing persisted — but if that's because embeds failed, surface it
+      // rather than returning a misleading empty success.
+      raiseIfEmbedFailures(0);
       return [];
     }
 
@@ -1031,8 +1092,12 @@ export class Memory {
     const allIds = records.map((r) => r.memoryId);
     const allPayloads = records.map((r) => r.payload);
 
+    // Track actual inserts so persistedCount does not over-report when the
+    // per-item fallback swallows individual insert errors.
+    let persistedCount = 0;
     try {
       await this.vectorStore.insert(allVectors, allIds, allPayloads);
+      persistedCount = allIds.length;
     } catch {
       // Fallback: insert one by one
       for (let i = 0; i < allIds.length; i++) {
@@ -1042,6 +1107,7 @@ export class Memory {
             [allIds[i]],
             [allPayloads[i]],
           );
+          persistedCount += 1;
         } catch (e) {
           console.error(`Failed to insert memory ${allIds[i]}: ${e}`);
         }
@@ -1243,11 +1309,20 @@ export class Memory {
       } catch {}
     }
 
-    return records.map((r) => ({
+    const result = records.map((r) => ({
       id: r.memoryId,
       memory: r.text,
       metadata: { event: "ADD" },
     }));
+
+    // Preserve-then-raise: everything embeddable has now been persisted above.
+    // If any memory text failed to embed, surface it so the caller can retry
+    // only the failed items — without having discarded the good ones.
+    // Use the actual insert count (not records.length) so a partial insert
+    // fallback cannot over-report.
+    raiseIfEmbedFailures(persistedCount);
+
+    return result;
   }
 
   async get(memoryId: string): Promise<MemoryItem | null> {

--- a/mem0-ts/src/oss/tests/memory.embed-failure.test.ts
+++ b/mem0-ts/src/oss/tests/memory.embed-failure.test.ts
@@ -1,0 +1,127 @@
+/**
+ * OSS Memory unit test — add() surfaces embedding failures instead of
+ * silently dropping the affected memories, while PRESERVING the ones that
+ * embedded successfully (preserve-then-raise).
+ *
+ * Regression test for #5509 (TS counterpart of the Python fix #5249 / #5245):
+ *  - when an embed fails, the extracted fact must not be silently discarded at
+ *    `warn`/`debug` level;
+ *  - successful memories are still persisted before the error is raised;
+ *  - the raised EmbeddingError carries failedTexts / persistedCount / errorClass
+ *    so the caller can retry only the failed items;
+ *  - a returned NON-FINITE / wrong-dimension vector is treated as a
+ *    `validation` failure and is NOT persisted (the dangerous half of #5509).
+ */
+/// <reference types="jest" />
+import { Memory, EmbeddingError } from "../src/memory";
+import type { MemoryConfig } from "../src/types";
+
+jest.setTimeout(15000);
+
+// Mock Google modules to prevent @google/genai crash in CI
+jest.mock("../src/embeddings/google", () => ({
+  GoogleEmbedder: jest.fn(),
+}));
+jest.mock("../src/llms/google", () => ({
+  GoogleLLM: jest.fn(),
+}));
+
+const mockEmbedding = new Array(1536).fill(0.1);
+
+function createMemory(overrides: Partial<MemoryConfig> = {}): Memory {
+  return new Memory({
+    version: "v1.1",
+    embedder: {
+      provider: "openai",
+      config: { apiKey: "test-key", model: "text-embedding-3-small" },
+    },
+    vectorStore: {
+      provider: "memory",
+      config: {
+        collectionName: `test-embed-fail-${Date.now()}`,
+        dimension: 1536,
+        dbPath: ":memory:",
+      },
+    },
+    llm: {
+      provider: "openai",
+      config: { apiKey: "test-key", model: "gpt-4o-mini" },
+    },
+    historyDbPath: ":memory:",
+    ...overrides,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Suite 1: every memory-text embed fails -> raise, nothing persisted
+// ---------------------------------------------------------------------------
+jest.mock("../src/llms/openai", () => ({
+  OpenAILLM: jest.fn().mockImplementation(() => ({
+    generateResponse: jest.fn().mockResolvedValue(
+      JSON.stringify({
+        memory: [{ id: "0", text: "test memory fact", attributed_to: "user" }],
+      }),
+    ),
+  })),
+}));
+
+// Embedder where the batch path always throws (forcing the per-item fallback),
+// and the per-item embed() throws ONLY for the extracted memory fact text.
+jest.mock("../src/embeddings/openai", () => ({
+  OpenAIEmbedder: jest.fn().mockImplementation(() => ({
+    embed: jest.fn().mockImplementation((input: unknown) => {
+      const text = Array.isArray(input) ? input.join(" ") : String(input);
+      if (text.includes("test memory fact")) {
+        return Promise.reject(new Error("embed boom"));
+      }
+      return Promise.resolve(mockEmbedding);
+    }),
+    embedBatch: jest.fn().mockRejectedValue(new Error("embedBatch boom")),
+    embeddingDims: 1536,
+  })),
+}));
+
+describe("Memory - add() embedding failure handling (#5509)", () => {
+  let memory: Memory;
+  const userId = `embed_fail_${Date.now()}`;
+
+  beforeAll(async () => {
+    memory = createMemory();
+  });
+
+  afterAll(async () => {
+    try {
+      await memory.reset();
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  test("throws EmbeddingError when all fallback embeds fail", async () => {
+    await expect(
+      memory.add("I am a software engineer", { userId }),
+    ).rejects.toBeInstanceOf(EmbeddingError);
+  });
+
+  test("error message reports the dropped memory text", async () => {
+    await expect(
+      memory.add("I enjoy hiking in the mountains", { userId }),
+    ).rejects.toThrow(/Failed to embed \d+ of \d+ memory text/);
+  });
+
+  test("EmbeddingError carries failedTexts, persistedCount, and provider errorClass", async () => {
+    try {
+      await memory.add("Another fact to drop", { userId });
+      throw new Error("expected add() to throw EmbeddingError");
+    } catch (e) {
+      expect(e).toBeInstanceOf(EmbeddingError);
+      const err = e as EmbeddingError;
+      expect(err.errorClass).toBe("provider");
+      expect(err.failedTexts.length).toBeGreaterThan(0);
+      // all facts failed in this suite -> nothing persisted
+      expect(err.persistedCount).toBe(0);
+      // SDK-wide MemoryError shape
+      expect(err.errorCode).toBe("EMBED_001");
+    }
+  });
+});

--- a/mem0-ts/src/oss/tests/memory.embed-partial.test.ts
+++ b/mem0-ts/src/oss/tests/memory.embed-partial.test.ts
@@ -1,0 +1,142 @@
+/**
+ * OSS Memory unit test — preserve-then-raise + validation classification (#5509).
+ *
+ * Two extracted facts. One embeds fine, one fails. add() must:
+ *  - PERSIST the successful memory (not throw it away), then
+ *  - raise EmbeddingError carrying failedTexts (the failed one only),
+ *    persistedCount === 1, and the right errorClass.
+ *
+ * Also covers the validation half: a returned NON-FINITE vector (NaN) is not
+ * persisted and is classified `validation`, which outranks `provider`.
+ */
+/// <reference types="jest" />
+import { Memory, EmbeddingError } from "../src/memory";
+import type { MemoryConfig } from "../src/types";
+
+jest.setTimeout(15000);
+
+jest.mock("../src/embeddings/google", () => ({
+  GoogleEmbedder: jest.fn(),
+}));
+jest.mock("../src/llms/google", () => ({
+  GoogleLLM: jest.fn(),
+}));
+
+const GOOD = "I live in Tennessee";
+const BAD = "I work in regenerative agriculture";
+const NAN = "this one returns a NaN vector";
+
+const okVec = new Array(8).fill(0.1);
+
+// LLM extracts three facts: one good, one whose embed throws, one whose embed
+// returns a NaN vector.
+jest.mock("../src/llms/openai", () => ({
+  OpenAILLM: jest.fn().mockImplementation(() => ({
+    generateResponse: jest.fn().mockResolvedValue(
+      JSON.stringify({
+        memory: [
+          { id: "0", text: "I live in Tennessee", attributed_to: "user" },
+          {
+            id: "1",
+            text: "I work in regenerative agriculture",
+            attributed_to: "user",
+          },
+          {
+            id: "2",
+            text: "this one returns a NaN vector",
+            attributed_to: "user",
+          },
+        ],
+      }),
+    ),
+  })),
+}));
+
+// Batch always throws -> force per-item fallback. Per item:
+//  - GOOD  -> valid 8-dim vector
+//  - BAD   -> throws (provider-class)
+//  - NAN   -> returns a vector containing NaN (validation-class)
+//  - any other text (probe/query/entity) -> valid vector
+jest.mock("../src/embeddings/openai", () => ({
+  OpenAIEmbedder: jest.fn().mockImplementation(() => ({
+    embed: jest.fn().mockImplementation((input: unknown) => {
+      const text = Array.isArray(input) ? input.join(" ") : String(input);
+      if (text.includes("regenerative agriculture")) {
+        return Promise.reject(new Error("provider 503"));
+      }
+      if (text.includes("NaN vector")) {
+        return Promise.resolve([0.1, 0.2, NaN, 0.4, 0.5, 0.6, 0.7, 0.8]);
+      }
+      return Promise.resolve(okVec);
+    }),
+    embedBatch: jest.fn().mockRejectedValue(new Error("batch unavailable")),
+    embeddingDims: 8,
+  })),
+}));
+
+function createMemory(overrides: Partial<MemoryConfig> = {}): Memory {
+  return new Memory({
+    version: "v1.1",
+    embedder: {
+      provider: "openai",
+      config: { apiKey: "test-key", model: "text-embedding-3-small" },
+    },
+    vectorStore: {
+      provider: "memory",
+      config: {
+        collectionName: `test-embed-partial-${Date.now()}`,
+        dimension: 8,
+        dbPath: ":memory:",
+      },
+    },
+    llm: {
+      provider: "openai",
+      config: { apiKey: "test-key", model: "gpt-4o-mini" },
+    },
+    historyDbPath: ":memory:",
+    ...overrides,
+  });
+}
+
+describe("Memory - add() preserve-then-raise + validation (#5509)", () => {
+  let memory: Memory;
+  const userId = `embed_partial_${Date.now()}`;
+
+  beforeAll(async () => {
+    memory = createMemory();
+  });
+
+  afterAll(async () => {
+    try {
+      await memory.reset();
+    } catch {
+      // ignore
+    }
+  });
+
+  test("persists the good memory, raises with only the failed ones, validation outranks provider", async () => {
+    let err: EmbeddingError | null = null;
+    try {
+      await memory.add("tell me about myself", { userId });
+    } catch (e) {
+      err = e as EmbeddingError;
+    }
+
+    expect(err).toBeInstanceOf(EmbeddingError);
+    // one good fact persisted, two failed (provider + validation)
+    expect(err!.persistedCount).toBe(1);
+    expect(err!.failedTexts).toEqual(expect.arrayContaining([BAD, NAN]));
+    expect(err!.failedTexts).not.toContain(GOOD);
+    // validation is the more dangerous half and must win the collapse
+    expect(err!.errorClass).toBe("validation");
+    expect(err!.errorCode).toBe("EMBED_001");
+
+    // The good memory really was written, despite the raise.
+    const all = await memory.getAll({ filters: { user_id: userId } });
+    const memories = Array.isArray(all) ? all : ((all as any).results ?? []);
+    const texts = memories.map((m: any) => m.memory);
+    expect(texts).toContain(GOOD);
+    // the NaN vector must NOT have been persisted
+    expect(texts).not.toContain(NAN);
+  });
+});


### PR DESCRIPTION
## Summary

- `Memory.add()` now raises an `EmbeddingError` when one or more extracted memories cannot be embedded, instead of silently dropping them.
- New `EmbeddingError` class is exported so callers can catch it explicitly.

## Motivation

Closes #5509 — the TypeScript counterpart of the Python SDK fix #5249 (issue #5245), filed at @kartik-mem0's request in the #5249 review.

In `Memory.add()` Phase 3 (`mem0-ts/src/oss/src/memory/index.ts`), the batch embed has a per-item fallback:

```typescript
} catch {
  for (const text of memTexts) {
    try {
      embedMap[text] = await this.embedder.embed(text);
    } catch (e) {
      console.warn(`Failed to embed memory text: ${e}`); // swallowed
    }
  }
}
```

When an individual `embed()` fails, `text` is never added to `embedMap`. The downstream materialization loop (`if (!text || !(text in embedMap)) continue;`) then skips it, so the extracted memory is silently discarded while the caller still receives a success result with missing memories.

## Fix

Collect the texts that fail the per-item fallback; if any remain unembedded, throw a new `EmbeddingError` naming the dropped texts. This mirrors the Python `EmbeddingError` added in #5249. The error is exported for callers to catch.

No behavior change when embedding succeeds (batch path or fully-successful fallback).

## Verification

- `npx jest src/oss/tests/memory.embed-failure.test.ts` — **2 passed** (new regression tests: throws `EmbeddingError`; message reports dropped text)
- `npx jest memory.add + memory.validation` — **38 passed** (no regression)
- `npx prettier --check` on both changed files — clean

## Notes

- 2 files changed, +129/-0. Independent of #5545 (different issue/branch).
- Test isolates the failure to the Phase-3 memory-text embed path (query/probe/entity embeds still succeed), matching the real-world partial-failure scenario.
