### PR TITLE
fix(llms): send max_completion_tokens for the GPT-5 family across providers

### DIFF
--- a/mem0/llms/azure_openai_structured.py
+++ b/mem0/llms/azure_openai_structured.py
@@ -76,9 +76,12 @@ class AzureOpenAIStructuredLLM(LLMBase):
             "model": self.config.model,
             "messages": messages,
             "temperature": self.config.temperature,
-            "max_tokens": self.config.max_tokens,
             "top_p": self.config.top_p,
         }
+        if self._uses_max_completion_tokens(self.config.model):
+            params["max_completion_tokens"] = self.config.max_tokens
+        else:
+            params["max_tokens"] = self.config.max_tokens
         if response_format:
             params["response_format"] = response_format
         if tools:

--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -79,6 +79,25 @@ class LLMBase(ABC):
 
         return False
 
+    def _uses_max_completion_tokens(self, model: str) -> bool:
+        """
+        Check if the model expects ``max_completion_tokens`` instead of ``max_tokens``.
+
+        The whole GPT-5 family (gpt-5.4-mini, gpt-5.4-nano, gpt-5.5, ...) rejects the
+        legacy ``max_tokens`` parameter on the Chat Completions API and requires
+        ``max_completion_tokens``. Older models (gpt-4.x, gpt-3.5, etc.) still accept
+        ``max_tokens``.
+
+        Args:
+            model: The model name to check
+
+        Returns:
+            bool: True if the model requires ``max_completion_tokens``
+        """
+        # Strip provider prefixes (e.g. "openai/gpt-5.4-mini" -> "gpt-5.4-mini")
+        base_model = (model or "").lower().rsplit("/", 1)[-1]
+        return base_model.startswith("gpt-5")
+
     def _get_supported_params(self, **kwargs) -> Dict:
         """
         Get parameters that are supported by the current model.
@@ -141,9 +160,14 @@ class LLMBase(ABC):
         """
         params = {
             "temperature": self.config.temperature,
-            "max_tokens": self.config.max_tokens,
             "top_p": self.config.top_p,
         }
+
+        model = getattr(self.config, "model", "")
+        if self._uses_max_completion_tokens(model):
+            params["max_completion_tokens"] = self.config.max_tokens
+        else:
+            params["max_tokens"] = self.config.max_tokens
 
         # Add provider-specific parameters from kwargs
         params.update(kwargs)

--- a/mem0/llms/litellm.py
+++ b/mem0/llms/litellm.py
@@ -74,9 +74,12 @@ class LiteLLM(LLMBase):
             "model": self.config.model,
             "messages": messages,
             "temperature": self.config.temperature,
-            "max_tokens": self.config.max_tokens,
             "top_p": self.config.top_p,
         }
+        if self._uses_max_completion_tokens(self.config.model):
+            params["max_completion_tokens"] = self.config.max_tokens
+        else:
+            params["max_tokens"] = self.config.max_tokens
         if response_format:
             params["response_format"] = response_format
         if tools:  # TODO: Remove tools if no issues found with new memory addition logic

--- a/tests/llms/test_azure_openai_structured.py
+++ b/tests/llms/test_azure_openai_structured.py
@@ -120,6 +120,44 @@ def test_generate_response_without_tools(mock_azure_openai):
 
 
 @mock.patch("mem0.llms.azure_openai_structured.AzureOpenAI")
+def test_generate_response_gpt5_uses_max_completion_tokens(mock_azure_openai):
+    mock_client = Mock()
+    mock_azure_openai.return_value = mock_client
+
+    config = DummyConfig(model="gpt-5.4-mini", azure_kwargs=DummyAzureKwargs(api_key="real-key"))
+    llm = AzureOpenAIStructuredLLM(config)
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Hi"))]
+    mock_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response([{"role": "user", "content": "Hi"}])
+
+    _, kwargs = mock_client.chat.completions.create.call_args
+    assert kwargs["max_completion_tokens"] == 256
+    assert "max_tokens" not in kwargs
+
+
+@mock.patch("mem0.llms.azure_openai_structured.AzureOpenAI")
+def test_generate_response_legacy_model_uses_max_tokens(mock_azure_openai):
+    mock_client = Mock()
+    mock_azure_openai.return_value = mock_client
+
+    config = DummyConfig(model="gpt-4.1", azure_kwargs=DummyAzureKwargs(api_key="real-key"))
+    llm = AzureOpenAIStructuredLLM(config)
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Hi"))]
+    mock_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response([{"role": "user", "content": "Hi"}])
+
+    _, kwargs = mock_client.chat.completions.create.call_args
+    assert kwargs["max_tokens"] == 256
+    assert "max_completion_tokens" not in kwargs
+
+
+@mock.patch("mem0.llms.azure_openai_structured.AzureOpenAI")
 def test_generate_response_with_tools(mock_azure_openai):
     mock_client = Mock()
     mock_azure_openai.return_value = mock_client

--- a/tests/llms/test_litellm.py
+++ b/tests/llms/test_litellm.py
@@ -44,6 +44,40 @@ def test_generate_response_without_tools(mock_litellm):
     assert response == "I'm doing well, thank you for asking!"
 
 
+def test_generate_response_gpt5_uses_max_completion_tokens(mock_litellm):
+    config = BaseLlmConfig(model="gpt-5.4-mini", temperature=0.7, max_tokens=100, top_p=1)
+    llm = litellm.LiteLLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Hi"))]
+    mock_litellm.completion.return_value = mock_response
+    mock_litellm.supports_function_calling.return_value = True
+
+    llm.generate_response(messages)
+
+    _, kwargs = mock_litellm.completion.call_args
+    assert kwargs["max_completion_tokens"] == 100
+    assert "max_tokens" not in kwargs
+
+
+def test_generate_response_legacy_model_uses_max_tokens(mock_litellm):
+    config = BaseLlmConfig(model="gpt-4.1", temperature=0.7, max_tokens=100, top_p=1)
+    llm = litellm.LiteLLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Hi"))]
+    mock_litellm.completion.return_value = mock_response
+    mock_litellm.supports_function_calling.return_value = True
+
+    llm.generate_response(messages)
+
+    _, kwargs = mock_litellm.completion.call_args
+    assert kwargs["max_tokens"] == 100
+    assert "max_completion_tokens" not in kwargs
+
+
 def test_generate_response_with_tools(mock_litellm):
     config = BaseLlmConfig(model="gpt-4.1-nano-2025-04-14", temperature=0.7, max_tokens=100, top_p=1)
     llm = litellm.LiteLLM(config)

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -375,6 +375,45 @@ def test_is_reasoning_model_override_generates_correct_params(mock_openai_client
     assert "temperature" not in call_kwargs
 
 
+def test_gpt5_uses_max_completion_tokens(mock_openai_client):
+    """gpt-5.x (non-reasoning) must send max_completion_tokens, not max_tokens.
+
+    The GPT-5 family rejects the legacy max_tokens param on Chat Completions and
+    requires max_completion_tokens. Regression test for
+    https://github.com/mem0ai/mem0/issues/5054
+    """
+    config = OpenAIConfig(model="gpt-5.4-mini", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = OpenAILLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="ok"))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    call_kwargs = mock_openai_client.chat.completions.create.call_args[1]
+    assert call_kwargs.get("max_completion_tokens") == 100
+    assert "max_tokens" not in call_kwargs
+
+
+def test_gpt4_uses_max_tokens(mock_openai_client):
+    """Older models (gpt-4.x) keep using max_tokens — guards against regressions."""
+    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = OpenAILLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="ok"))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    call_kwargs = mock_openai_client.chat.completions.create.call_args[1]
+    assert call_kwargs.get("max_tokens") == 100
+    assert "max_completion_tokens" not in call_kwargs
+
+
 def test_callback_with_tools(mock_openai_client):
     mock_callback = Mock()
     config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", response_callback=mock_callback)


### PR DESCRIPTION
## Linked Issue

Closes #5054

## Description

`LLMBase._get_common_params` always emitted `max_tokens`. The GPT-5 family on the **Chat Completions API** (which mem0 uses via `client.chat.completions.create`) rejects the legacy `max_tokens` parameter and requires `max_completion_tokens` instead. So a non-reasoning GPT-5 model such as `gpt-5.4-mini` made every `add()` / `search()` call fail with:

```
openai.BadRequestError: Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.
```

The reasoning GPT-5 models (`gpt-5`, `gpt-5o`, …) were unaffected because `_is_reasoning_model` routes them through `_get_supported_params`, which doesn't send `max_tokens` at all. The gap was only the **non-reasoning** GPT-5 variants that fall through to `_get_common_params`.

This PR adds a small name-based helper `_uses_max_completion_tokens()` on the base class — mirroring the provider-prefix handling already used by `_is_reasoning_model` — and selects the correct key in `_get_common_params`. The match is `gpt-5*` (after stripping any provider prefix), so it covers the whole current and future family (`gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-pro`, `gpt-5.5`, …) rather than a single hardcoded model name. Older models (`gpt-4.x`, `gpt-3.5`, o-series) keep using `max_tokens` exactly as before.

Because the fix lives in `LLMBase`, it covers every provider that inherits the base `_get_common_params` (OpenAI, Azure OpenAI, DeepSeek, vLLM, LM Studio, …). Two providers — `litellm` and `azure_openai_structured` — build their request params by hand instead of going through the base, and both default to `gpt-5-mini`, so they hit the same 400 out of the box; this PR routes their max-token param through the same helper so the whole family is covered. Anthropic is unaffected — it overrides `_get_common_params` itself.

**Scope (intentional):** this targets the Chat Completions path that mem0 actually uses (`max_completion_tokens`). The Responses API uses `max_output_tokens`, but mem0 doesn't call it, so it's left out of scope to keep the change surgical. This also lines up with the OpenAI OpenAPI spec, which marks `max_tokens` as deprecated in favor of `max_completion_tokens`.

For reference, #5073 attempted a fix earlier but was closed unmerged for an unsigned CLA (no technical review), and #5516 (thanks @eldar702) fixes the same bug locally in `openai.py`. This PR handles it once in the base and extends it to the hand-built providers, so the whole GPT-5 family across providers is covered.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

**Unit tests** (both directions, guarding against regression):
- `tests/llms/test_openai.py` — `gpt-5.4-mini` sends `max_completion_tokens` and not `max_tokens`; `gpt-4.1-nano` still sends `max_tokens`.
- `tests/llms/test_litellm.py` and `tests/llms/test_azure_openai_structured.py` — same checks for the two hand-built providers.

Full `tests/llms/` suite passes locally (138 passed, 2 skipped); `ruff check` is clean on the changed files.

**Manual testing** (live, against a real Azure `gpt-5.4-mini` deployment):
- Raw call (bypassing mem0): `max_tokens` → 400 `Unsupported parameter: 'max_tokens' ... Use 'max_completion_tokens' instead.`; `max_completion_tokens` → 200. Confirms the bug at the API level.
- mem0 `AzureOpenAILLM` (base `_get_common_params` path): **without** this fix → 400; **with** it → 200.
- mem0 `AzureOpenAIStructuredLLM` (one of the two hand-built providers extended here) → 200.

I exercised the Azure paths end-to-end because that's the deployment I had access to; OpenAI and LiteLLM share the same code path / helper and are covered by the unit tests above.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
