### PR TITLE
fix(entity-extraction): degrade gracefully on languages without noun_chunks

### DIFF
--- a/mem0/utils/entity_extraction.py
+++ b/mem0/utils/entity_extraction.py
@@ -588,7 +588,16 @@ def _add_quoted_candidates(text: str, candidates: list[_EntityCandidate]) -> Non
 
 
 def _add_topic_phrase_candidates(doc, candidates: list[_EntityCandidate]) -> None:
-    for chunk in doc.noun_chunks:
+    # spaCy's ``noun_chunks`` syntax iterator is language-specific; zh/ja (and
+    # any language without a SentenceRecognizer) raise ``NotImplementedError``
+    # ([E894]). Materialising the iterator once and swallowing that error
+    # leaves the proper-noun, quoted-text, and verb-head strategies running
+    # instead of aborting the whole extraction pass. See #5285.
+    try:
+        noun_chunks = list(doc.noun_chunks)
+    except NotImplementedError:
+        return
+    for chunk in noun_chunks:
         chunk_tokens = list(chunk)
         split_indices: list[int] = []
         poss_splits: list[int] = []

--- a/tests/utils/test_entity_extraction.py
+++ b/tests/utils/test_entity_extraction.py
@@ -139,3 +139,46 @@ class TestExtractEntitiesBatch:
         assert len(batch) == 1
         # Both should extract the same entities
         assert set(t for _, t in single) == set(t for _, t in batch[0])
+
+
+class _NoNounChunksDoc:
+    """Proxy a real spaCy Doc but make ``noun_chunks`` raise.
+
+    spaCy does not implement the ``noun_chunks`` syntax iterator for every
+    language; ``zh``/``ja`` raise ``NotImplementedError`` ([E894]). This
+    wrapper reproduces that on a real English Doc so the rest of the
+    pipeline runs against genuine tokens — only ``noun_chunks`` raises.
+    """
+
+    def __init__(self, doc):
+        self._doc = doc
+
+    @property
+    def noun_chunks(self):
+        raise NotImplementedError(
+            "[E894] The 'noun_chunks' syntax iterator is not implemented for language 'zh'."
+        )
+
+    def __iter__(self):
+        return iter(self._doc)
+
+    def __getattr__(self, name):
+        return getattr(self._doc, name)
+
+
+class TestUnsupportedLanguage:
+    def test_noun_chunks_not_implemented_does_not_abort_extraction(self):
+        """A language without noun_chunks (#5285) must not crash extraction.
+
+        Asserts only that extraction completes and yields some entities — the
+        proper-noun strategy does not depend on ``noun_chunks`` and keeps
+        working. Asserting specific entity strings would couple the test to
+        spaCy model versions.
+        """
+        import spacy
+
+        from mem0.utils.entity_extraction import _extract_entities_from_doc
+
+        doc = spacy.load("en_core_web_sm")("John Smith works at Google")
+        entities = _extract_entities_from_doc(_NoNounChunksDoc(doc))
+        assert len(entities) > 0, entities


### PR DESCRIPTION
## What

`_extract_entities_from_doc` iterates `doc.noun_chunks`, but spaCy's `noun_chunks` syntax iterator is **not implemented for every language** — `zh`, `ja`, and others raise `NotImplementedError` ([E894]). Because the iteration was unguarded, a single non-English Doc aborted the **entire** `extract_entities` call, discarding even the proper-noun and quoted-text entities already collected before that point.

This guards the `noun_chunks` iteration with `try/except NotImplementedError` and skips just that one strategy for unsupported languages; the proper-noun, quoted-text, and verb-head strategies still run. English behavior is unchanged.

## Repro (from #5285)
```
Batch entity linking failed (async): [E894] The 'noun_chunks' syntax iterator is not implemented for language 'zh'.
```

## Test
`tests/utils/test_entity_extraction.py::TestUnsupportedLanguage` wraps a real English Doc so only `noun_chunks` raises (reproducing zh/ja behavior on genuine tokens), then asserts extraction no longer aborts and still returns proper-noun entities.
- Without the guard → `NotImplementedError` (the reported crash).
- With the guard → 11 passed; `ruff check` clean.

Fixes #5285.