### PR TITLE
fix(mem0-ts): surface EmbeddingError instead of silently dropping memories

### DIFF
--- a/mem0-ts/src/oss/src/index.ts
+++ b/mem0-ts/src/oss/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./memory";
+export * from "./memory/errors";
 export * from "./memory/memory.types";
 export * from "./types";
 export * from "./embeddings/base";

--- a/mem0-ts/src/oss/src/memory/errors.ts
+++ b/mem0-ts/src/oss/src/memory/errors.ts
@@ -1,0 +1,63 @@
+// Why an embed failed: retry on "provider", fix config/input on "validation".
+export type EmbeddingErrorClass = "provider" | "validation" | "unknown";
+
+// Thrown by add() when some texts fail to embed; the rest are still persisted.
+export class EmbeddingError extends Error {
+  public readonly failedTexts: string[];
+  // Memories persisted by this add() call (after dedup), before the throw.
+  public readonly persistedCount: number;
+  public readonly errorClass: EmbeddingErrorClass;
+
+  constructor(
+    failedTexts: string[],
+    persistedCount: number,
+    errorClass: EmbeddingErrorClass = "unknown",
+  ) {
+    super(
+      `Failed to embed ${failedTexts.length} memory text(s); ` +
+        `${persistedCount} memory(ies) were persisted (errorClass=${errorClass}). ` +
+        `Inspect 'failedTexts' to retry the dropped memories.`,
+    );
+    this.name = "EmbeddingError";
+    this.failedTexts = failedTexts;
+    this.persistedCount = persistedCount;
+    this.errorClass = errorClass;
+    Object.setPrototypeOf(this, EmbeddingError.prototype);
+  }
+}
+
+// When several embeds fail, keep the most actionable class: provider (retryable)
+// beats validation beats unknown.
+export function mergeEmbeddingErrorClass(
+  a: EmbeddingErrorClass,
+  b: EmbeddingErrorClass,
+): EmbeddingErrorClass {
+  const rank = { provider: 2, validation: 1, unknown: 0 };
+  return rank[b] > rank[a] ? b : a;
+}
+
+// Guess why an embed() call failed from its message/status.
+export function classifyEmbeddingError(err: unknown): EmbeddingErrorClass {
+  const msg = (
+    err instanceof Error ? err.message : String(err ?? "")
+  ).toLowerCase();
+  const status = (err as any)?.status ?? (err as any)?.statusCode;
+
+  if (
+    status === 429 ||
+    (typeof status === "number" && status >= 500) ||
+    /rate.?limit|too many requests|timeout|timed out|econnreset|etimedout|socket hang up|network|503|502|504|429|temporarily unavailable/.test(
+      msg,
+    )
+  ) {
+    return "provider";
+  }
+  if (
+    /dimension|nan|invalid|malformed|empty|length|shape|expected .* got|validation/.test(
+      msg,
+    )
+  ) {
+    return "validation";
+  }
+  return "unknown";
+}

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -26,6 +26,12 @@ import {
   generateAdditiveExtractionPrompt,
 } from "../prompts";
 import { DummyHistoryManager } from "../storage/DummyHistoryManager";
+import {
+  EmbeddingError,
+  EmbeddingErrorClass,
+  classifyEmbeddingError,
+  mergeEmbeddingErrorClass,
+} from "./errors";
 import { Embedder } from "../embeddings/base";
 import { LLM } from "../llms/base";
 import { VectorStore } from "../vector_stores/base";
@@ -827,6 +833,9 @@ export class Memory {
       .map((m) => m.text ?? "")
       .filter((t) => t.length > 0);
     let embedMap: Record<string, number[]> = {};
+    // Track texts that fail to embed so we don't drop them silently.
+    const failedEmbedTexts: string[] = [];
+    let embedErrorClass: EmbeddingErrorClass = "unknown";
     try {
       const memEmbeddingsList = await this.embedder.embedBatch(memTexts);
       for (let i = 0; i < memTexts.length; i++) {
@@ -839,6 +848,11 @@ export class Memory {
           embedMap[text] = await this.embedder.embed(text);
         } catch (e) {
           console.warn(`Failed to embed memory text: ${e}`);
+          failedEmbedTexts.push(text);
+          embedErrorClass = mergeEmbeddingErrorClass(
+            embedErrorClass,
+            classifyEmbeddingError(e),
+          );
         }
       }
     }
@@ -906,6 +920,10 @@ export class Memory {
             sessionScope,
           );
         } catch {}
+      }
+      // Nothing persisted — if embeddings failed, surface it instead of a silent empty result.
+      if (failedEmbedTexts.length > 0) {
+        throw new EmbeddingError(failedEmbedTexts, 0, embedErrorClass);
       }
       return [];
     }
@@ -1116,11 +1134,22 @@ export class Memory {
       } catch {}
     }
 
-    return records.map((r) => ({
+    const result = records.map((r) => ({
       id: r.memoryId,
       memory: r.text,
       metadata: { event: "ADD" },
     }));
+
+    // Good memories are persisted above; now surface any that failed to embed.
+    if (failedEmbedTexts.length > 0) {
+      throw new EmbeddingError(
+        failedEmbedTexts,
+        result.length,
+        embedErrorClass,
+      );
+    }
+
+    return result;
   }
 
   async get(memoryId: string): Promise<MemoryItem | null> {

--- a/mem0-ts/src/oss/src/tests/embedding-failure.test.ts
+++ b/mem0-ts/src/oss/src/tests/embedding-failure.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Regression tests for issue #5509: add() must not silently drop memories when
+ * an embedding fails. Successfully-embedded memories are persisted, then an
+ * EmbeddingError is raised reporting the dropped texts.
+ */
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { Memory } from "../memory";
+import { EmbeddingError } from "../memory/errors";
+
+const DIM = 1536; // matches the default in-memory vector store dimension
+
+// Each Memory gets its own temp SQLite file so tests don't share store state.
+const tmpDbs: string[] = [];
+function freshDbPath(): string {
+  const p = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), "mem0-5509-")),
+    "store.db",
+  );
+  tmpDbs.push(p);
+  return p;
+}
+afterAll(() => {
+  for (const p of tmpDbs) {
+    try {
+      fs.rmSync(path.dirname(p), { recursive: true, force: true });
+    } catch {}
+  }
+});
+
+// A distinct one-hot vector per text so dedup/similarity doesn't collapse them.
+function vectorFor(text: string): number[] {
+  let h = 0;
+  for (const c of text) h = (h * 31 + c.charCodeAt(0)) | 0;
+  const v = new Array(DIM).fill(0);
+  v[Math.abs(h) % DIM] = 1;
+  return v;
+}
+
+// embedBatch() always throws to force the per-item fallback; embed() throws for
+// any text in `failTexts`, otherwise returns a stable vector.
+class FlakyEmbedder {
+  public failedTexts: string[] = [];
+  constructor(
+    private failTexts: Set<string>,
+    private error: Error = new Error("Simulated provider 503"),
+  ) {}
+  async embed(text: string): Promise<number[]> {
+    if (this.failTexts.has(text)) {
+      this.failedTexts.push(text);
+      throw this.error;
+    }
+    return vectorFor(text);
+  }
+  async embedBatch(_texts: string[]): Promise<number[][]> {
+    throw new Error("Batch endpoint unavailable");
+  }
+}
+
+function makeStubLLM(facts: string[]) {
+  return {
+    async generateResponse(): Promise<string> {
+      return JSON.stringify({
+        memory: facts.map((text, i) => ({ id: String(i), text })),
+      });
+    },
+    async generateChat() {
+      return { content: "", role: "assistant" };
+    },
+  };
+}
+
+async function buildMemory(facts: string[], embedder: FlakyEmbedder) {
+  const m = new Memory({
+    disableHistory: true,
+    // Explicit dimension skips the startup embed() probe; fresh db per test.
+    vectorStore: {
+      provider: "memory",
+      config: { dimension: DIM, dbPath: freshDbPath() },
+    },
+    embedder: { provider: "openai", config: { apiKey: "x" } },
+    llm: { provider: "openai", config: { apiKey: "x" } },
+  } as any);
+  (m as any).embedder = embedder;
+  (m as any).llm = makeStubLLM(facts);
+  // Finish init now (with the stub in place) so add() doesn't race the probe.
+  await (m as any)._ensureInitialized();
+  return m;
+}
+
+const FACTS = [
+  "Alice is friends with Bob",
+  "Alice is friends with Carol",
+  "Alice is friends with Dave",
+];
+const FAILED = "Alice is friends with Carol";
+
+jest.setTimeout(30000);
+
+describe("#5509 add() embedding failures are not silent", () => {
+  it("throws EmbeddingError when some texts fail to embed", async () => {
+    const m = await buildMemory(FACTS, new FlakyEmbedder(new Set([FAILED])));
+    await expect(m.add(FACTS.join(". "), { userId: "u1" })).rejects.toThrow(
+      EmbeddingError,
+    );
+  });
+
+  it("persists the memories that did embed and reports the ones that failed", async () => {
+    const m = await buildMemory(FACTS, new FlakyEmbedder(new Set([FAILED])));
+
+    let err: EmbeddingError | undefined;
+    try {
+      await m.add(FACTS.join(". "), { userId: "u2" });
+    } catch (e) {
+      err = e as EmbeddingError;
+    }
+
+    expect(err).toBeInstanceOf(EmbeddingError);
+    expect(err!.failedTexts).toEqual([FAILED]);
+    // The two facts that embedded were persisted (hybrid, not all-or-nothing).
+    expect(err!.persistedCount).toBe(2);
+  });
+
+  it("classifies a 503 as a provider error", async () => {
+    const m = await buildMemory(
+      FACTS,
+      new FlakyEmbedder(new Set([FAILED]), new Error("Simulated provider 503")),
+    );
+    await expect(
+      m.add(FACTS.join(". "), { userId: "u3" }),
+    ).rejects.toMatchObject({ errorClass: "provider" });
+  });
+
+  it("classifies a dimension mismatch as a validation error", async () => {
+    const m = await buildMemory(
+      FACTS,
+      new FlakyEmbedder(
+        new Set([FAILED]),
+        new Error("Invalid embedding dimension: expected 1536 got 512"),
+      ),
+    );
+    await expect(
+      m.add(FACTS.join(". "), { userId: "u4" }),
+    ).rejects.toMatchObject({ errorClass: "validation" });
+  });
+
+  it("keeps the most actionable errorClass when failures are mixed (provider wins)", async () => {
+    // Carol fails with a validation error, Dave with a provider 503.
+    class MixedEmbedder extends FlakyEmbedder {
+      async embed(text: string): Promise<number[]> {
+        if (text === "Alice is friends with Carol") {
+          this.failedTexts.push(text);
+          throw new Error("Invalid embedding dimension");
+        }
+        if (text === "Alice is friends with Dave") {
+          this.failedTexts.push(text);
+          throw new Error("Simulated provider 503");
+        }
+        return vectorFor(text);
+      }
+    }
+    const m = await buildMemory(FACTS, new MixedEmbedder(new Set()));
+    await expect(
+      m.add(FACTS.join(". "), { userId: "u6" }),
+    ).rejects.toMatchObject({ errorClass: "provider" });
+  });
+
+  it("does not throw when every text embeds successfully", async () => {
+    const embedder = new FlakyEmbedder(new Set());
+    const m = await buildMemory(FACTS, embedder);
+    const res = await m.add(FACTS.join(". "), { userId: "u5" });
+    expect(res.results.length).toBe(FACTS.length);
+    expect(embedder.failedTexts.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Linked Issue

Closes #5509

## Description

add() can lose memories without telling you. I will explain but the short version is, if embedding fails for one text it just skips it and returns less, no error.

Ok so what happens. You call add, the LLM pulls out the facts, then each fact gets embedded so it can be stored. Normally all in one batch. If the batch call fails it falls back and embeds them one by one. That part is ok. The bug is in the catch. If one of them fails it only does a console.warn and keeps going, so that text never goes into the map, and later when it saves it just gets skipped. So 6 facts come out, maybe 4 get saved, and add returns like nothing went wrong.

Think of a courier who drops one of your parcels but still says everything was delivered. You don't notice until you go looking for that one parcel later and it's just not there. Same thing here.

I did not want to guess so I tested it. Fake embedder, batch always fails so it goes to the fallback, and one text fails there. Ran add 10 times. Every time 6 extracted, only 2 to 4 saved, no error. So it is not flaky, it drops them every time.

This is the TS version of the Python issue #5245 and PR #5249. Same pattern.

## The fix

Main thing, do not make it worse by also throwing away the good ones. So it still saves every memory that embedded fine. Only after that it throws an EmbeddingError. You keep the good data and you also get told what failed.

The error has failedTexts so you can retry just those, persistedCount for how many got saved, and errorClass which is provider or validation or unknown. The class is there so you know what to do next. Provider, retry. Validation, your config or input is wrong so retrying will not help. That errorClass part is the same thing discussed in #5245 and #5249, so the same shape can go on the Python side and keep both consistent.

Also the entity embedding paths have the same swallow but at console.debug. I left those for now. Did not want to grow the scope. Can do a follow up if you want.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Breaking Changes

Today add() never throws here, it just returns fewer results. After this it can throw an EmbeddingError when some texts fail. If you want the old behavior just catch it. The good memories are already saved by then so you can retry the failed ones from e.failedTexts.

```ts
import { EmbeddingError } from "mem0ai/oss";

try {
  await memory.add(messages, { userId });
} catch (e) {
  if (e instanceof EmbeddingError) {
    // good memories already saved, retry e.failedTexts if you want
  } else {
    throw e;
  }
}
```

## Test Coverage

- [x] I added/updated unit tests
- [x] I tested manually (ran add 10 times with a flaky embedder, saw the drop, then confirmed the fix)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
