### PR TITLE
feat(mem0-ts): return embedding failures with labels and add a retry mechanism

### DIFF
--- a/mem0-ts/src/common/exceptions.ts
+++ b/mem0-ts/src/common/exceptions.ts
@@ -149,15 +149,33 @@ export const EMBED_ERROR_CODE = {
 export type EmbedErrorCode =
   (typeof EMBED_ERROR_CODE)[keyof typeof EMBED_ERROR_CODE];
 
-/** Raised when the embedding step fails. The TS parallel of Python's EmbeddingError. */
+/**
+ * Raised when one or more texts fail to embed during `add()`. The TypeScript
+ * parallel of Python's `EmbeddingError`.
+ *
+ * Successfully-embedded memories are persisted before this is thrown, so a
+ * caller catching it can retry only the dropped texts via `failedTexts` rather
+ * than re-adding the whole batch.
+ */
 export class EmbeddingError extends MemoryError {
+  /** Texts that failed to embed and were not persisted. */
+  readonly failedTexts: string[];
+  /** Number of memories persisted by the call before this was thrown. */
+  readonly persistedCount: number;
+
   constructor(
     message: string,
     errorCode: string = EMBED_ERROR_CODE.TRANSIENT,
-    options?: MemoryErrorOptions,
+    options: MemoryErrorOptions & {
+      failedTexts?: string[];
+      persistedCount?: number;
+    } = {},
   ) {
-    super(message, errorCode, options);
+    const { failedTexts = [], persistedCount = 0, ...rest } = options;
+    super(message, errorCode, rest);
     this.name = "EmbeddingError";
+    this.failedTexts = failedTexts;
+    this.persistedCount = persistedCount;
   }
 }
 

--- a/mem0-ts/src/common/exceptions.ts
+++ b/mem0-ts/src/common/exceptions.ts
@@ -139,6 +139,28 @@ export class MemoryQuotaExceededError extends MemoryError {
   }
 }
 
+// Stable error codes for embedding failures (parallels the Python SDK).
+export const EMBED_ERROR_CODE = {
+  TRANSIENT: "EMBED_001", // provider blip (429, 5xx, network) — retry may work
+  VALIDATION: "EMBED_002", // bad input/vector (wrong dim, NaN) — retry won't help
+  AUTH: "EMBED_003", // auth/permission — needs operator action
+} as const;
+
+export type EmbedErrorCode =
+  (typeof EMBED_ERROR_CODE)[keyof typeof EMBED_ERROR_CODE];
+
+/** Raised when the embedding step fails. The TS parallel of Python's EmbeddingError. */
+export class EmbeddingError extends MemoryError {
+  constructor(
+    message: string,
+    errorCode: string = EMBED_ERROR_CODE.TRANSIENT,
+    options?: MemoryErrorOptions,
+  ) {
+    super(message, errorCode, options);
+    this.name = "EmbeddingError";
+  }
+}
+
 // ─── HTTP Status → Exception Mapping ─────────────────────
 
 type MemoryErrorConstructor = new (

--- a/mem0-ts/src/oss/src/index.ts
+++ b/mem0-ts/src/oss/src/index.ts
@@ -1,4 +1,10 @@
 export * from "./memory";
+export * from "./memory/errorRetry";
+export {
+  EmbeddingError,
+  EMBED_ERROR_CODE,
+  type EmbedErrorCode,
+} from "../../common/exceptions";
 export * from "./memory/memory.types";
 export * from "./types";
 export * from "./embeddings/base";

--- a/mem0-ts/src/oss/src/memory/errorRetry.ts
+++ b/mem0-ts/src/oss/src/memory/errorRetry.ts
@@ -1,8 +1,11 @@
 // Label-driven, guardrailed handling of embedding failures in add().
 import type { MemoryItem } from "../types";
 
-// Why an embed failed. "internal" = provider returned a poison vector without erroring.
-export type ErrorClass = "provider" | "validation" | "internal";
+// Why an embed failed. Values match the Python error_code vocabulary (#5245).
+export type ErrorClass =
+  | "provider_error"
+  | "validation_error"
+  | "internal_error";
 
 // What the caller should do about it.
 export type Remediation = "retry" | "reconfigure" | "escalate";
@@ -86,12 +89,12 @@ export function makeVectorValidator(seedDim: number | null = null) {
 export function classifyValidation(reason: ValidationReason): Classification {
   switch (reason) {
     case "dimension-mismatch":
-      return { errorClass: "validation", remediation: "reconfigure" };
+      return { errorClass: "validation_error", remediation: "reconfigure" };
     case "non-finite":
     case "empty":
     case "undefined":
       // No usable vector to store, and a retry can't conjure one — escalate.
-      return { errorClass: "internal", remediation: "escalate" };
+      return { errorClass: "internal_error", remediation: "escalate" };
   }
 }
 
@@ -206,12 +209,16 @@ export function classifyEmbedError(err: unknown): Classification {
     switch (true) {
       case status === 429:
       case status >= 500 && status < 600:
-        return { errorClass: "provider", remediation: "retry", retryAfter };
+        return {
+          errorClass: "provider_error",
+          remediation: "retry",
+          retryAfter,
+        };
       case status === 401:
       case status === 403:
-        return { errorClass: "provider", remediation: "escalate" };
+        return { errorClass: "provider_error", remediation: "escalate" };
       case status >= 400 && status < 500:
-        return { errorClass: "validation", remediation: "reconfigure" };
+        return { errorClass: "validation_error", remediation: "reconfigure" };
     }
   }
 
@@ -222,7 +229,7 @@ export function classifyEmbedError(err: unknown): Classification {
     case "ENOTFOUND":
     case "EAI_AGAIN":
     case "EPIPE":
-      return { errorClass: "provider", remediation: "retry", retryAfter };
+      return { errorClass: "provider_error", remediation: "retry", retryAfter };
   }
 
   const msg = (
@@ -233,23 +240,23 @@ export function classifyEmbedError(err: unknown): Classification {
       msg,
     )
   ) {
-    return { errorClass: "provider", remediation: "retry", retryAfter };
+    return { errorClass: "provider_error", remediation: "retry", retryAfter };
   }
   if (/dimension|shape|expected .* got|wrong size/.test(msg)) {
-    return { errorClass: "validation", remediation: "reconfigure" };
+    return { errorClass: "validation_error", remediation: "reconfigure" };
   }
   if (/\bnan\b|infinity|non-?finite/.test(msg)) {
-    return { errorClass: "internal", remediation: "escalate" };
+    return { errorClass: "internal_error", remediation: "escalate" };
   }
   if (/invalid|malformed|empty|length|validation/.test(msg)) {
-    return { errorClass: "validation", remediation: "reconfigure" };
+    return { errorClass: "validation_error", remediation: "reconfigure" };
   }
-  return { errorClass: "provider", remediation: "retry", retryAfter };
+  return { errorClass: "provider_error", remediation: "retry", retryAfter };
 }
 
 // provider/retry: wait any retryAfter, re-embed, re-validate, persist if good.
 export class ProviderRetryStrategy implements RemediationStrategy {
-  readonly errorClass = "provider" as const;
+  readonly errorClass = "provider_error" as const;
   async apply(f: EmbeddingFailure, ctx: RetryContext): Promise<RetryOutcome> {
     if (f.retryAfter && f.retryAfter > 0) await ctx.sleep(f.retryAfter * 1000);
     let vec: number[];
@@ -280,7 +287,7 @@ export class ProviderRetryStrategy implements RemediationStrategy {
 
 // validation/reconfigure: would fail identically on retry, so surface it unchanged.
 export class ValidationReconfigureStrategy implements RemediationStrategy {
-  readonly errorClass = "validation" as const;
+  readonly errorClass = "validation_error" as const;
   async apply(f: EmbeddingFailure): Promise<RetryOutcome> {
     return {
       kind: "stillFailed",
@@ -295,7 +302,7 @@ export class ValidationReconfigureStrategy implements RemediationStrategy {
 // internal/escalate: poison vector returned. Sanitize the preserved vector once
 // and persist if safe; never re-embed, never store a degenerate vector.
 export class InternalEscalateStrategy implements RemediationStrategy {
-  readonly errorClass = "internal" as const;
+  readonly errorClass = "internal_error" as const;
   async apply(f: EmbeddingFailure, ctx: RetryContext): Promise<RetryOutcome> {
     if (!f._vector) {
       return {
@@ -312,8 +319,8 @@ export class InternalEscalateStrategy implements RemediationStrategy {
     }
     const c: Classification =
       s.reason === "dimension-mismatch"
-        ? { errorClass: "validation", remediation: "reconfigure" }
-        : { errorClass: "internal", remediation: "escalate" };
+        ? { errorClass: "validation_error", remediation: "reconfigure" }
+        : { errorClass: "internal_error", remediation: "escalate" };
     return {
       kind: "stillFailed",
       failure: { ...f, ...c, error: s.detail ?? `unsanitizable: ${s.reason}` },
@@ -322,7 +329,7 @@ export class InternalEscalateStrategy implements RemediationStrategy {
 }
 
 export const STRATEGIES: Record<ErrorClass, RemediationStrategy> = {
-  provider: new ProviderRetryStrategy(),
-  validation: new ValidationReconfigureStrategy(),
-  internal: new InternalEscalateStrategy(),
+  provider_error: new ProviderRetryStrategy(),
+  validation_error: new ValidationReconfigureStrategy(),
+  internal_error: new InternalEscalateStrategy(),
 };

--- a/mem0-ts/src/oss/src/memory/errorRetry.ts
+++ b/mem0-ts/src/oss/src/memory/errorRetry.ts
@@ -139,6 +139,9 @@ export function toEmbeddingError(err: unknown): MemoryError {
     retryAfter !== undefined ? { retryAfter } : {};
   const C = EMBED_ERROR_CODE;
 
+  // A thrown error is always provider_error (the call failed, no vector to
+  // inspect); the transient/non-transient split rides remediation. A bad
+  // *returned* vector is the only validation_error, handled by classifyValidation.
   if (Number.isFinite(status)) {
     switch (true) {
       case status === 429:
@@ -149,7 +152,10 @@ export function toEmbeddingError(err: unknown): MemoryError {
       case status === 403:
         return new AuthenticationError(message, C.AUTH);
       case status >= 400 && status < 500:
-        return new ValidationError(message, C.VALIDATION);
+        // Other non-transient 4xx (bad request, quota): provider, not retry-safe.
+        return new EmbeddingError(message, C.AUTH, {
+          debugInfo: { surface: "escalate" },
+        });
     }
   }
 
@@ -163,6 +169,8 @@ export function toEmbeddingError(err: unknown): MemoryError {
       return new NetworkError(message, C.TRANSIENT, { debugInfo });
   }
 
+  // Message is a last resort and only nudges transient-vs-escalate; a thrown
+  // error is never validation_error (R2 — don't read structural words off prose).
   const msg = message.toLowerCase();
   switch (true) {
     case /rate.?limit|too many requests/.test(msg):
@@ -171,14 +179,6 @@ export function toEmbeddingError(err: unknown): MemoryError {
       msg,
     ):
       return new NetworkError(message, C.TRANSIENT, { debugInfo });
-    case /\bnan\b|infinity|non-?finite/.test(msg):
-      return new ValidationError(message, C.VALIDATION, {
-        debugInfo: { surface: "escalate" },
-      });
-    case /dimension|shape|expected .* got|wrong size|invalid|malformed|empty|length|validation/.test(
-      msg,
-    ):
-      return new ValidationError(message, C.VALIDATION);
   }
 
   return new EmbeddingError(message, C.TRANSIENT, { debugInfo });
@@ -228,7 +228,8 @@ export function projectError(err: MemoryError): Classification {
     case err instanceof EmbeddingError:
       return {
         errorClass: "provider_error",
-        remediation: "retry",
+        remediation:
+          err.debugInfo?.surface === "escalate" ? "escalate" : "retry",
         errorCode,
         retryAfter,
       };

--- a/mem0-ts/src/oss/src/memory/errorRetry.ts
+++ b/mem0-ts/src/oss/src/memory/errorRetry.ts
@@ -19,8 +19,6 @@ export interface EmbeddingFailure {
   error: string;
   readonly _payload?: Record<string, any>;
   readonly _memoryId?: string;
-  // The poison vector, kept so retry can sanitize it without re-fetching.
-  readonly _vector?: number[];
 }
 
 // What add() and retryFailed() both return.
@@ -51,7 +49,6 @@ export interface RetryContext {
   persist(f: EmbeddingFailure, vec: number[]): Promise<MemoryItem>;
   sleep(ms: number): Promise<void>;
   embed(text: string): Promise<number[]>;
-  expectedDim(): number | null;
 }
 
 export type RetryOutcome =
@@ -86,6 +83,8 @@ export function makeVectorValidator(seedDim: number | null = null) {
   };
 }
 
+// A structurally-bad vector caught by inspecting the embedder's output is a
+// validation_error regardless of how it's bad; remediation tells them what to do.
 export function classifyValidation(reason: ValidationReason): Classification {
   switch (reason) {
     case "dimension-mismatch":
@@ -93,99 +92,8 @@ export function classifyValidation(reason: ValidationReason): Classification {
     case "non-finite":
     case "empty":
     case "undefined":
-      // No usable vector to store, and a retry can't conjure one — escalate.
-      return { errorClass: "internal_error", remediation: "escalate" };
+      return { errorClass: "validation_error", remediation: "escalate" };
   }
-}
-
-// Keep Inf's "huge" meaning as ±1e19 — float32-safe and safe to square.
-export const POS_INF_SENTINEL = 1e19;
-export const NEG_INF_SENTINEL = -1e19;
-
-// --- Sanitizer ------------------------------------------------------------
-export type SanitizeReason =
-  | "undefined"
-  | "empty"
-  | "dimension-mismatch"
-  | "too-many-non-finite"
-  | "degenerate-zero-norm";
-
-export interface SanitizeResult {
-  ok: boolean;
-  vector?: number[];
-  reason?: SanitizeReason;
-  detail?: string;
-}
-
-const NORM_EPS = 1e-12;
-const MAX_REPAIR_FRACTION = 0.05;
-
-// NaN -> 0, ±Inf -> ±1e19 sentinel. Refuses on wrong dimension, too many repairs,
-// or a zero-norm result a cosine index would silently never return.
-export function sanitizeVector(
-  vec: number[] | undefined | null,
-  expectedDim: number | null,
-): SanitizeResult {
-  if (vec == null || !Array.isArray(vec))
-    return { ok: false, reason: "undefined" };
-  if (vec.length === 0) return { ok: false, reason: "empty" };
-  if (expectedDim !== null && vec.length !== expectedDim) {
-    return {
-      ok: false,
-      reason: "dimension-mismatch",
-      detail: `expected ${expectedDim} dims, got ${vec.length}`,
-    };
-  }
-
-  const out = new Array<number>(vec.length);
-  let repaired = 0;
-  let firstBad = -1;
-  for (let i = 0; i < vec.length; i++) {
-    const x = vec[i];
-    if (typeof x === "number" && Number.isFinite(x)) {
-      out[i] = x;
-      continue;
-    }
-    out[i] =
-      x === Infinity
-        ? POS_INF_SENTINEL
-        : x === -Infinity
-          ? NEG_INF_SENTINEL
-          : 0;
-    repaired++;
-    if (firstBad === -1) firstBad = i;
-  }
-
-  // Norm is measured on the vector we actually store.
-  let sumSq = 0;
-  for (let i = 0; i < out.length; i++) sumSq += out[i] * out[i];
-  const degenerate = Math.sqrt(sumSq) <= NORM_EPS;
-
-  if (repaired === 0) {
-    if (degenerate)
-      return {
-        ok: false,
-        reason: "degenerate-zero-norm",
-        detail: "all-zero vector",
-      };
-    return { ok: true, vector: out };
-  }
-
-  const bad = vec[firstBad] as number;
-  const label = Number.isNaN(bad)
-    ? "NaN"
-    : bad === Infinity
-      ? "Inf"
-      : bad === -Infinity
-        ? "-Inf"
-        : "non-number";
-  const detail = `non-finite: ${label} at index ${firstBad} (${repaired}/${vec.length} components)`;
-
-  if (repaired / vec.length > MAX_REPAIR_FRACTION) {
-    return { ok: false, reason: "too-many-non-finite", detail };
-  }
-  if (degenerate) return { ok: false, reason: "degenerate-zero-norm", detail };
-  return { ok: true, vector: out, detail };
 }
 
 function parseRetryAfter(e: any): number | undefined {
@@ -242,13 +150,14 @@ export function classifyEmbedError(err: unknown): Classification {
   ) {
     return { errorClass: "provider_error", remediation: "retry", retryAfter };
   }
-  if (/dimension|shape|expected .* got|wrong size/.test(msg)) {
-    return { errorClass: "validation_error", remediation: "reconfigure" };
-  }
   if (/\bnan\b|infinity|non-?finite/.test(msg)) {
-    return { errorClass: "internal_error", remediation: "escalate" };
+    return { errorClass: "validation_error", remediation: "escalate" };
   }
-  if (/invalid|malformed|empty|length|validation/.test(msg)) {
+  if (
+    /dimension|shape|expected .* got|wrong size|invalid|malformed|empty|length|validation/.test(
+      msg,
+    )
+  ) {
     return { errorClass: "validation_error", remediation: "reconfigure" };
   }
   return { errorClass: "provider_error", remediation: "retry", retryAfter };
@@ -285,51 +194,26 @@ export class ProviderRetryStrategy implements RemediationStrategy {
   }
 }
 
-// validation/reconfigure: would fail identically on retry, so surface it unchanged.
-export class ValidationReconfigureStrategy implements RemediationStrategy {
+// validation_error: a structurally-bad vector (wrong dim, NaN/Inf, empty).
+// A blind retry would reproduce it, so surface it unchanged for the caller to act on.
+export class ValidationSurfaceStrategy implements RemediationStrategy {
   readonly errorClass = "validation_error" as const;
   async apply(f: EmbeddingFailure): Promise<RetryOutcome> {
-    return {
-      kind: "stillFailed",
-      failure: {
-        ...f,
-        error: `${f.error} — not retried: requires reconfiguration (fix the embedder model or vectorStore dimension).`,
-      },
-    };
+    return { kind: "stillFailed", failure: f };
   }
 }
 
-// internal/escalate: poison vector returned. Sanitize the preserved vector once
-// and persist if safe; never re-embed, never store a degenerate vector.
-export class InternalEscalateStrategy implements RemediationStrategy {
+// internal_error: a mem0-side processing failure (store write, dedup, etc.).
+// Re-embedding won't help, so surface it unchanged.
+export class InternalSurfaceStrategy implements RemediationStrategy {
   readonly errorClass = "internal_error" as const;
-  async apply(f: EmbeddingFailure, ctx: RetryContext): Promise<RetryOutcome> {
-    if (!f._vector) {
-      return {
-        kind: "stillFailed",
-        failure: {
-          ...f,
-          error: `${f.error} — no vector preserved to sanitize`,
-        },
-      };
-    }
-    const s = sanitizeVector(f._vector, ctx.expectedDim());
-    if (s.ok && s.vector) {
-      return { kind: "persisted", item: await ctx.persist(f, s.vector) };
-    }
-    const c: Classification =
-      s.reason === "dimension-mismatch"
-        ? { errorClass: "validation_error", remediation: "reconfigure" }
-        : { errorClass: "internal_error", remediation: "escalate" };
-    return {
-      kind: "stillFailed",
-      failure: { ...f, ...c, error: s.detail ?? `unsanitizable: ${s.reason}` },
-    };
+  async apply(f: EmbeddingFailure): Promise<RetryOutcome> {
+    return { kind: "stillFailed", failure: f };
   }
 }
 
 export const STRATEGIES: Record<ErrorClass, RemediationStrategy> = {
   provider_error: new ProviderRetryStrategy(),
-  validation_error: new ValidationReconfigureStrategy(),
-  internal_error: new InternalEscalateStrategy(),
+  validation_error: new ValidationSurfaceStrategy(),
+  internal_error: new InternalSurfaceStrategy(),
 };

--- a/mem0-ts/src/oss/src/memory/errorRetry.ts
+++ b/mem0-ts/src/oss/src/memory/errorRetry.ts
@@ -1,27 +1,37 @@
 // Label-driven, guardrailed handling of embedding failures in add().
 import type { MemoryItem } from "../types";
+import {
+  MemoryError,
+  RateLimitError,
+  NetworkError,
+  ValidationError,
+  AuthenticationError,
+  MemoryQuotaExceededError,
+  EmbeddingError,
+  EMBED_ERROR_CODE,
+  type EmbedErrorCode,
+} from "../../../common/exceptions";
 
-// Why an embed failed. Values match the Python error_code vocabulary (#5245).
+// Values match the Python error_code vocabulary (#5245).
 export type ErrorClass =
   | "provider_error"
   | "validation_error"
   | "internal_error";
 
-// What the caller should do about it.
 export type Remediation = "retry" | "reconfigure" | "escalate";
 
-// One dropped text. Plain data so it survives a JSON round-trip and can be retried later.
+// One dropped text. Plain data so it survives a JSON round-trip.
 export interface EmbeddingFailure {
   text: string;
   errorClass: ErrorClass;
   remediation: Remediation;
+  errorCode?: EmbedErrorCode;
   retryAfter?: number;
   error: string;
   readonly _payload?: Record<string, any>;
   readonly _memoryId?: string;
 }
 
-// What add() and retryFailed() both return.
 export interface AddResult {
   results: MemoryItem[];
   failed: EmbeddingFailure[];
@@ -30,6 +40,7 @@ export interface AddResult {
 export interface Classification {
   errorClass: ErrorClass;
   remediation: Remediation;
+  errorCode: EmbedErrorCode;
   retryAfter?: number;
 }
 
@@ -83,16 +94,24 @@ export function makeVectorValidator(seedDim: number | null = null) {
   };
 }
 
-// A structurally-bad vector caught by inspecting the embedder's output is a
-// validation_error regardless of how it's bad; remediation tells them what to do.
+// A structurally-bad returned vector is always validation_error; remediation differs.
 export function classifyValidation(reason: ValidationReason): Classification {
+  const errorCode = EMBED_ERROR_CODE.VALIDATION;
   switch (reason) {
     case "dimension-mismatch":
-      return { errorClass: "validation_error", remediation: "reconfigure" };
+      return {
+        errorClass: "validation_error",
+        remediation: "reconfigure",
+        errorCode,
+      };
     case "non-finite":
     case "empty":
     case "undefined":
-      return { errorClass: "validation_error", remediation: "escalate" };
+      return {
+        errorClass: "validation_error",
+        remediation: "escalate",
+        errorCode,
+      };
   }
 }
 
@@ -106,27 +125,31 @@ function parseRetryAfter(e: any): number | undefined {
   return Number.isFinite(n) && n >= 0 ? n : undefined;
 }
 
-// Status-first classifier for a thrown embed() error; message is only a fallback.
-export function classifyEmbedError(err: unknown): Classification {
+// Normalize a thrown embed() value into a typed MemoryError (status-first,
+// then node code, then message as a last resort). Mirrors the client SDK types.
+export function toEmbeddingError(err: unknown): MemoryError {
+  if (err instanceof MemoryError) return err;
+
   const e = err as any;
   const raw = e?.status ?? e?.statusCode ?? e?.response?.status;
   const status = typeof raw === "number" ? raw : Number(raw);
   const retryAfter = parseRetryAfter(e);
+  const message = err instanceof Error ? err.message : String(err ?? "");
+  const debugInfo: Record<string, unknown> =
+    retryAfter !== undefined ? { retryAfter } : {};
+  const C = EMBED_ERROR_CODE;
 
   if (Number.isFinite(status)) {
     switch (true) {
       case status === 429:
+        return new RateLimitError(message, C.TRANSIENT, { debugInfo });
       case status >= 500 && status < 600:
-        return {
-          errorClass: "provider_error",
-          remediation: "retry",
-          retryAfter,
-        };
+        return new NetworkError(message, C.TRANSIENT, { debugInfo });
       case status === 401:
       case status === 403:
-        return { errorClass: "provider_error", remediation: "escalate" };
+        return new AuthenticationError(message, C.AUTH);
       case status >= 400 && status < 500:
-        return { errorClass: "validation_error", remediation: "reconfigure" };
+        return new ValidationError(message, C.VALIDATION);
     }
   }
 
@@ -137,30 +160,89 @@ export function classifyEmbedError(err: unknown): Classification {
     case "ENOTFOUND":
     case "EAI_AGAIN":
     case "EPIPE":
-      return { errorClass: "provider_error", remediation: "retry", retryAfter };
+      return new NetworkError(message, C.TRANSIENT, { debugInfo });
   }
 
-  const msg = (
-    err instanceof Error ? err.message : String(err ?? "")
-  ).toLowerCase();
-  if (
-    /rate.?limit|too many requests|timeout|timed out|socket hang up|temporarily unavailable|50[234]/.test(
+  const msg = message.toLowerCase();
+  switch (true) {
+    case /rate.?limit|too many requests/.test(msg):
+      return new RateLimitError(message, C.TRANSIENT, { debugInfo });
+    case /timeout|timed out|socket hang up|temporarily unavailable|50[234]/.test(
       msg,
-    )
-  ) {
-    return { errorClass: "provider_error", remediation: "retry", retryAfter };
-  }
-  if (/\bnan\b|infinity|non-?finite/.test(msg)) {
-    return { errorClass: "validation_error", remediation: "escalate" };
-  }
-  if (
-    /dimension|shape|expected .* got|wrong size|invalid|malformed|empty|length|validation/.test(
+    ):
+      return new NetworkError(message, C.TRANSIENT, { debugInfo });
+    case /\bnan\b|infinity|non-?finite/.test(msg):
+      return new ValidationError(message, C.VALIDATION, {
+        debugInfo: { surface: "escalate" },
+      });
+    case /dimension|shape|expected .* got|wrong size|invalid|malformed|empty|length|validation/.test(
       msg,
-    )
-  ) {
-    return { errorClass: "validation_error", remediation: "reconfigure" };
+    ):
+      return new ValidationError(message, C.VALIDATION);
   }
-  return { errorClass: "provider_error", remediation: "retry", retryAfter };
+
+  return new EmbeddingError(message, C.TRANSIENT, { debugInfo });
+}
+
+function isEmbedCode(c: string): c is EmbedErrorCode {
+  return (
+    c === EMBED_ERROR_CODE.TRANSIENT ||
+    c === EMBED_ERROR_CODE.VALIDATION ||
+    c === EMBED_ERROR_CODE.AUTH
+  );
+}
+
+// Collapse a typed error to the plain wire Classification. Order: specific first.
+export function projectError(err: MemoryError): Classification {
+  const retryAfter =
+    typeof err.debugInfo?.retryAfter === "number"
+      ? (err.debugInfo.retryAfter as number)
+      : undefined;
+  const errorCode: EmbedErrorCode = isEmbedCode(err.errorCode)
+    ? err.errorCode
+    : EMBED_ERROR_CODE.TRANSIENT;
+
+  switch (true) {
+    case err instanceof RateLimitError:
+    case err instanceof NetworkError:
+      return {
+        errorClass: "provider_error",
+        remediation: "retry",
+        errorCode,
+        retryAfter,
+      };
+    case err instanceof MemoryQuotaExceededError:
+    case err instanceof AuthenticationError:
+      return {
+        errorClass: "provider_error",
+        remediation: "escalate",
+        errorCode,
+      };
+    case err instanceof ValidationError:
+      return {
+        errorClass: "validation_error",
+        remediation:
+          err.debugInfo?.surface === "escalate" ? "escalate" : "reconfigure",
+        errorCode,
+      };
+    case err instanceof EmbeddingError:
+      return {
+        errorClass: "provider_error",
+        remediation: "retry",
+        errorCode,
+        retryAfter,
+      };
+    default:
+      return {
+        errorClass: "internal_error",
+        remediation: "escalate",
+        errorCode: EMBED_ERROR_CODE.TRANSIENT,
+      };
+  }
+}
+
+export function classifyEmbedError(err: unknown): Classification {
+  return projectError(toEmbeddingError(err));
 }
 
 // provider/retry: wait any retryAfter, re-embed, re-validate, persist if good.

--- a/mem0-ts/src/oss/src/memory/errorRetry.ts
+++ b/mem0-ts/src/oss/src/memory/errorRetry.ts
@@ -1,0 +1,328 @@
+// Label-driven, guardrailed handling of embedding failures in add().
+import type { MemoryItem } from "../types";
+
+// Why an embed failed. "internal" = provider returned a poison vector without erroring.
+export type ErrorClass = "provider" | "validation" | "internal";
+
+// What the caller should do about it.
+export type Remediation = "retry" | "reconfigure" | "escalate";
+
+// One dropped text. Plain data so it survives a JSON round-trip and can be retried later.
+export interface EmbeddingFailure {
+  text: string;
+  errorClass: ErrorClass;
+  remediation: Remediation;
+  retryAfter?: number;
+  error: string;
+  readonly _payload?: Record<string, any>;
+  readonly _memoryId?: string;
+  // The poison vector, kept so retry can sanitize it without re-fetching.
+  readonly _vector?: number[];
+}
+
+// What add() and retryFailed() both return.
+export interface AddResult {
+  results: MemoryItem[];
+  failed: EmbeddingFailure[];
+}
+
+export interface Classification {
+  errorClass: ErrorClass;
+  remediation: Remediation;
+  retryAfter?: number;
+}
+
+export type ValidationReason =
+  | "undefined"
+  | "empty"
+  | "non-finite"
+  | "dimension-mismatch";
+
+export interface VectorValidation {
+  ok: boolean;
+  reason?: ValidationReason;
+}
+
+export interface RetryContext {
+  validate(vec: number[] | undefined): VectorValidation;
+  persist(f: EmbeddingFailure, vec: number[]): Promise<MemoryItem>;
+  sleep(ms: number): Promise<void>;
+  embed(text: string): Promise<number[]>;
+  expectedDim(): number | null;
+}
+
+export type RetryOutcome =
+  | { kind: "persisted"; item: MemoryItem }
+  | { kind: "stillFailed"; failure: EmbeddingFailure };
+
+export interface RemediationStrategy {
+  readonly errorClass: ErrorClass;
+  apply(f: EmbeddingFailure, ctx: RetryContext): Promise<RetryOutcome>;
+}
+
+// First-good-vector-wins guardrail, one instance per add()/retry run.
+export function makeVectorValidator(seedDim: number | null = null) {
+  let expectedDim = seedDim;
+  return {
+    validate(vec: number[] | undefined): VectorValidation {
+      if (vec === undefined || vec === null || !Array.isArray(vec)) {
+        return { ok: false, reason: "undefined" };
+      }
+      if (vec.length === 0) return { ok: false, reason: "empty" };
+      for (let i = 0; i < vec.length; i++) {
+        if (typeof vec[i] !== "number" || !Number.isFinite(vec[i])) {
+          return { ok: false, reason: "non-finite" };
+        }
+      }
+      if (expectedDim !== null && vec.length !== expectedDim) {
+        return { ok: false, reason: "dimension-mismatch" };
+      }
+      if (expectedDim === null) expectedDim = vec.length;
+      return { ok: true };
+    },
+  };
+}
+
+export function classifyValidation(reason: ValidationReason): Classification {
+  switch (reason) {
+    case "dimension-mismatch":
+      return { errorClass: "validation", remediation: "reconfigure" };
+    case "non-finite":
+    case "empty":
+    case "undefined":
+      // No usable vector to store, and a retry can't conjure one — escalate.
+      return { errorClass: "internal", remediation: "escalate" };
+  }
+}
+
+// Keep Inf's "huge" meaning as ±1e19 — float32-safe and safe to square.
+export const POS_INF_SENTINEL = 1e19;
+export const NEG_INF_SENTINEL = -1e19;
+
+// --- Sanitizer ------------------------------------------------------------
+export type SanitizeReason =
+  | "undefined"
+  | "empty"
+  | "dimension-mismatch"
+  | "too-many-non-finite"
+  | "degenerate-zero-norm";
+
+export interface SanitizeResult {
+  ok: boolean;
+  vector?: number[];
+  reason?: SanitizeReason;
+  detail?: string;
+}
+
+const NORM_EPS = 1e-12;
+const MAX_REPAIR_FRACTION = 0.05;
+
+// NaN -> 0, ±Inf -> ±1e19 sentinel. Refuses on wrong dimension, too many repairs,
+// or a zero-norm result a cosine index would silently never return.
+export function sanitizeVector(
+  vec: number[] | undefined | null,
+  expectedDim: number | null,
+): SanitizeResult {
+  if (vec == null || !Array.isArray(vec))
+    return { ok: false, reason: "undefined" };
+  if (vec.length === 0) return { ok: false, reason: "empty" };
+  if (expectedDim !== null && vec.length !== expectedDim) {
+    return {
+      ok: false,
+      reason: "dimension-mismatch",
+      detail: `expected ${expectedDim} dims, got ${vec.length}`,
+    };
+  }
+
+  const out = new Array<number>(vec.length);
+  let repaired = 0;
+  let firstBad = -1;
+  for (let i = 0; i < vec.length; i++) {
+    const x = vec[i];
+    if (typeof x === "number" && Number.isFinite(x)) {
+      out[i] = x;
+      continue;
+    }
+    out[i] =
+      x === Infinity
+        ? POS_INF_SENTINEL
+        : x === -Infinity
+          ? NEG_INF_SENTINEL
+          : 0;
+    repaired++;
+    if (firstBad === -1) firstBad = i;
+  }
+
+  // Norm is measured on the vector we actually store.
+  let sumSq = 0;
+  for (let i = 0; i < out.length; i++) sumSq += out[i] * out[i];
+  const degenerate = Math.sqrt(sumSq) <= NORM_EPS;
+
+  if (repaired === 0) {
+    if (degenerate)
+      return {
+        ok: false,
+        reason: "degenerate-zero-norm",
+        detail: "all-zero vector",
+      };
+    return { ok: true, vector: out };
+  }
+
+  const bad = vec[firstBad] as number;
+  const label = Number.isNaN(bad)
+    ? "NaN"
+    : bad === Infinity
+      ? "Inf"
+      : bad === -Infinity
+        ? "-Inf"
+        : "non-number";
+  const detail = `non-finite: ${label} at index ${firstBad} (${repaired}/${vec.length} components)`;
+
+  if (repaired / vec.length > MAX_REPAIR_FRACTION) {
+    return { ok: false, reason: "too-many-non-finite", detail };
+  }
+  if (degenerate) return { ok: false, reason: "degenerate-zero-norm", detail };
+  return { ok: true, vector: out, detail };
+}
+
+function parseRetryAfter(e: any): number | undefined {
+  const h =
+    e?.response?.headers?.["retry-after"] ??
+    e?.headers?.["retry-after"] ??
+    e?.retryAfter;
+  if (h == null) return undefined;
+  const n = Number(h);
+  return Number.isFinite(n) && n >= 0 ? n : undefined;
+}
+
+// Status-first classifier for a thrown embed() error; message is only a fallback.
+export function classifyEmbedError(err: unknown): Classification {
+  const e = err as any;
+  const raw = e?.status ?? e?.statusCode ?? e?.response?.status;
+  const status = typeof raw === "number" ? raw : Number(raw);
+  const retryAfter = parseRetryAfter(e);
+
+  if (Number.isFinite(status)) {
+    switch (true) {
+      case status === 429:
+      case status >= 500 && status < 600:
+        return { errorClass: "provider", remediation: "retry", retryAfter };
+      case status === 401:
+      case status === 403:
+        return { errorClass: "provider", remediation: "escalate" };
+      case status >= 400 && status < 500:
+        return { errorClass: "validation", remediation: "reconfigure" };
+    }
+  }
+
+  const code = typeof e?.code === "string" ? e.code.toUpperCase() : "";
+  switch (code) {
+    case "ECONNRESET":
+    case "ETIMEDOUT":
+    case "ENOTFOUND":
+    case "EAI_AGAIN":
+    case "EPIPE":
+      return { errorClass: "provider", remediation: "retry", retryAfter };
+  }
+
+  const msg = (
+    err instanceof Error ? err.message : String(err ?? "")
+  ).toLowerCase();
+  if (
+    /rate.?limit|too many requests|timeout|timed out|socket hang up|temporarily unavailable|50[234]/.test(
+      msg,
+    )
+  ) {
+    return { errorClass: "provider", remediation: "retry", retryAfter };
+  }
+  if (/dimension|shape|expected .* got|wrong size/.test(msg)) {
+    return { errorClass: "validation", remediation: "reconfigure" };
+  }
+  if (/\bnan\b|infinity|non-?finite/.test(msg)) {
+    return { errorClass: "internal", remediation: "escalate" };
+  }
+  if (/invalid|malformed|empty|length|validation/.test(msg)) {
+    return { errorClass: "validation", remediation: "reconfigure" };
+  }
+  return { errorClass: "provider", remediation: "retry", retryAfter };
+}
+
+// provider/retry: wait any retryAfter, re-embed, re-validate, persist if good.
+export class ProviderRetryStrategy implements RemediationStrategy {
+  readonly errorClass = "provider" as const;
+  async apply(f: EmbeddingFailure, ctx: RetryContext): Promise<RetryOutcome> {
+    if (f.retryAfter && f.retryAfter > 0) await ctx.sleep(f.retryAfter * 1000);
+    let vec: number[];
+    try {
+      vec = await ctx.embed(f.text);
+    } catch (e) {
+      const c = classifyEmbedError(e);
+      return {
+        kind: "stillFailed",
+        failure: {
+          ...f,
+          ...c,
+          error: e instanceof Error ? e.message : String(e),
+        },
+      };
+    }
+    const v = ctx.validate(vec);
+    if (!v.ok) {
+      const c = classifyValidation(v.reason!);
+      return {
+        kind: "stillFailed",
+        failure: { ...f, ...c, error: `re-embed produced ${v.reason} vector` },
+      };
+    }
+    return { kind: "persisted", item: await ctx.persist(f, vec) };
+  }
+}
+
+// validation/reconfigure: would fail identically on retry, so surface it unchanged.
+export class ValidationReconfigureStrategy implements RemediationStrategy {
+  readonly errorClass = "validation" as const;
+  async apply(f: EmbeddingFailure): Promise<RetryOutcome> {
+    return {
+      kind: "stillFailed",
+      failure: {
+        ...f,
+        error: `${f.error} — not retried: requires reconfiguration (fix the embedder model or vectorStore dimension).`,
+      },
+    };
+  }
+}
+
+// internal/escalate: poison vector returned. Sanitize the preserved vector once
+// and persist if safe; never re-embed, never store a degenerate vector.
+export class InternalEscalateStrategy implements RemediationStrategy {
+  readonly errorClass = "internal" as const;
+  async apply(f: EmbeddingFailure, ctx: RetryContext): Promise<RetryOutcome> {
+    if (!f._vector) {
+      return {
+        kind: "stillFailed",
+        failure: {
+          ...f,
+          error: `${f.error} — no vector preserved to sanitize`,
+        },
+      };
+    }
+    const s = sanitizeVector(f._vector, ctx.expectedDim());
+    if (s.ok && s.vector) {
+      return { kind: "persisted", item: await ctx.persist(f, s.vector) };
+    }
+    const c: Classification =
+      s.reason === "dimension-mismatch"
+        ? { errorClass: "validation", remediation: "reconfigure" }
+        : { errorClass: "internal", remediation: "escalate" };
+    return {
+      kind: "stillFailed",
+      failure: { ...f, ...c, error: s.detail ?? `unsanitizable: ${s.reason}` },
+    };
+  }
+}
+
+export const STRATEGIES: Record<ErrorClass, RemediationStrategy> = {
+  provider: new ProviderRetryStrategy(),
+  validation: new ValidationReconfigureStrategy(),
+  internal: new InternalEscalateStrategy(),
+};

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -737,7 +737,7 @@ export class Memory {
     const results: MemoryItem[] = [];
     const stillFailed: EmbeddingFailure[] = [];
     for (const f of failed) {
-      const strategy = STRATEGIES[f.errorClass] ?? STRATEGIES.internal;
+      const strategy = STRATEGIES[f.errorClass] ?? STRATEGIES.internal_error;
       try {
         const out = await strategy.apply(f, ctx);
         if (out.kind === "persisted") results.push(out.item);
@@ -745,7 +745,7 @@ export class Memory {
       } catch (e) {
         stillFailed.push({
           ...f,
-          errorClass: "provider",
+          errorClass: "provider_error",
           remediation: "retry",
           error: e instanceof Error ? e.message : String(e),
         });
@@ -888,7 +888,7 @@ export class Memory {
       for (const t of insertFailedTexts) {
         failed.push({
           text: t,
-          errorClass: "provider",
+          errorClass: "provider_error",
           remediation: "retry",
           error: "vector store insert failed",
           _memoryId: uuidv4(),
@@ -1196,7 +1196,7 @@ export class Memory {
       if (!inserted.has(r.memoryId)) {
         failures.push({
           text: r.text,
-          errorClass: "provider",
+          errorClass: "provider_error",
           remediation: "retry",
           error: "vector store insert failed",
         });

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -706,7 +706,7 @@ export class Memory {
   }
 
   // Retry memories that failed to embed during add(), per their errorClass.
-  // Skips LLM extraction; only embed/sanitize -> validate -> persist runs.
+  // Skips LLM extraction; provider errors re-embed, others surface unchanged.
   async retryFailed(failed: EmbeddingFailure[]): Promise<AddResult> {
     await this._ensureInitialized();
     const guard = makeVectorValidator(this._expectedDim());
@@ -714,7 +714,6 @@ export class Memory {
       embed: (t) => this.embedder.embed(t),
       validate: (v) => guard.validate(v),
       sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
-      expectedDim: () => this._expectedDim(),
       persist: async (f, vec) => {
         const id = f._memoryId ?? uuidv4();
         const payload = f._payload ?? {
@@ -745,8 +744,8 @@ export class Memory {
       } catch (e) {
         stillFailed.push({
           ...f,
-          errorClass: "provider_error",
-          remediation: "retry",
+          errorClass: "internal_error",
+          remediation: "escalate",
           error: e instanceof Error ? e.message : String(e),
         });
       }
@@ -872,7 +871,6 @@ export class Memory {
             remediation: c.remediation,
             error: `embedding validation failed: ${v.reason}`,
             _memoryId: uuidv4(),
-            ...(v.reason === "non-finite" ? { _vector: vec } : {}),
           });
           continue;
         }
@@ -888,8 +886,8 @@ export class Memory {
       for (const t of insertFailedTexts) {
         failed.push({
           text: t,
-          errorClass: "provider_error",
-          remediation: "retry",
+          errorClass: "internal_error",
+          remediation: "escalate",
           error: "vector store insert failed",
           _memoryId: uuidv4(),
         });
@@ -1011,12 +1009,7 @@ export class Memory {
     const embedMap: Record<string, number[]> = {};
     const failures: EmbeddingFailure[] = [];
     const guard = makeVectorValidator(this._expectedDim());
-    const recordFailure = (
-      text: string,
-      c: Classification,
-      errMsg: string,
-      vector?: number[],
-    ) =>
+    const recordFailure = (text: string, c: Classification, errMsg: string) =>
       failures.push({
         text,
         errorClass: c.errorClass,
@@ -1025,7 +1018,6 @@ export class Memory {
         error: errMsg,
         // Stable id so a retry overwrites instead of duplicating.
         _memoryId: uuidv4(),
-        ...(vector !== undefined ? { _vector: vector } : {}),
       });
 
     let batch: number[][] | undefined;
@@ -1045,7 +1037,6 @@ export class Memory {
             memTexts[i],
             classifyValidation(v.reason!),
             `embedding validation failed: ${v.reason}`,
-            batch[i],
           );
       }
     } else {
@@ -1060,10 +1051,8 @@ export class Memory {
               text,
               classifyValidation(v.reason!),
               `embedding validation failed: ${v.reason}`,
-              vec,
             );
         } catch (e) {
-          // A thrown error has no vector to preserve.
           recordFailure(
             text,
             classifyEmbedError(e),
@@ -1191,14 +1180,15 @@ export class Memory {
       }
     }
 
-    // Inserts that failed are not silent: report them as retryable failures.
+    // Inserts that failed are not silent: report them so the caller knows.
     for (const r of records) {
       if (!inserted.has(r.memoryId)) {
         failures.push({
           text: r.text,
-          errorClass: "provider_error",
-          remediation: "retry",
+          errorClass: "internal_error",
+          remediation: "escalate",
           error: "vector store insert failed",
+          _memoryId: r.memoryId,
         });
       }
     }

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -856,6 +856,7 @@ export class Memory {
             text,
             errorClass: c.errorClass,
             remediation: c.remediation,
+            errorCode: c.errorCode,
             retryAfter: c.retryAfter,
             error: e instanceof Error ? e.message : String(e),
             _memoryId: uuidv4(),
@@ -869,6 +870,7 @@ export class Memory {
             text,
             errorClass: c.errorClass,
             remediation: c.remediation,
+            errorCode: c.errorCode,
             error: `embedding validation failed: ${v.reason}`,
             _memoryId: uuidv4(),
           });
@@ -1014,6 +1016,7 @@ export class Memory {
         text,
         errorClass: c.errorClass,
         remediation: c.remediation,
+        errorCode: c.errorCode,
         retryAfter: c.retryAfter,
         error: errMsg,
         // Stable id so a retry overwrites instead of duplicating.

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -26,6 +26,16 @@ import {
   generateAdditiveExtractionPrompt,
 } from "../prompts";
 import { DummyHistoryManager } from "../storage/DummyHistoryManager";
+import {
+  AddResult,
+  EmbeddingFailure,
+  Classification,
+  RetryContext,
+  STRATEGIES,
+  makeVectorValidator,
+  classifyValidation,
+  classifyEmbedError,
+} from "./errorRetry";
 import { Embedder } from "../embeddings/base";
 import { LLM } from "../llms/base";
 import { VectorStore } from "../vector_stores/base";
@@ -216,6 +226,10 @@ export class Memory {
       try {
         const probe = await this.embedder.embed("dimension probe");
         this.config.vectorStore.config.dimension = probe.length;
+        // Cloud stores (pgvector/redis/azure) read embeddingModelDims, not dimension.
+        if (this.config.vectorStore.config.embeddingModelDims == null) {
+          this.config.vectorStore.config.embeddingModelDims = probe.length;
+        }
       } catch (error: any) {
         throw new Error(
           `Failed to auto-detect embedding dimension from provider '${this.config.embedder.provider}': ${error.message}. ` +
@@ -656,12 +670,13 @@ export class Memory {
     const final_parsedMessages = await parse_vision_messages(parsedMessages);
 
     // Add to vector store
-    const vectorStoreResult = await this.addToVectorStore(
+    const addResult = await this.addToVectorStore(
       final_parsedMessages,
       metadata,
       filters,
       infer,
     );
+    const vectorStoreResult = addResult.results;
 
     if (temporalUsageNotice) {
       await this._displayTemporalUsageNotice({
@@ -686,6 +701,132 @@ export class Memory {
 
     return {
       results: vectorStoreResult,
+      ...(addResult.failed.length > 0 ? { failed: addResult.failed } : {}),
+    };
+  }
+
+  // Retry memories that failed to embed during add(), per their errorClass.
+  // Skips LLM extraction; only embed/sanitize -> validate -> persist runs.
+  async retryFailed(failed: EmbeddingFailure[]): Promise<AddResult> {
+    await this._ensureInitialized();
+    const guard = makeVectorValidator(this._expectedDim());
+    const ctx: RetryContext = {
+      embed: (t) => this.embedder.embed(t),
+      validate: (v) => guard.validate(v),
+      sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+      expectedDim: () => this._expectedDim(),
+      persist: async (f, vec) => {
+        const id = f._memoryId ?? uuidv4();
+        const payload = f._payload ?? {
+          data: f.text,
+          textLemmatized: lemmatizeForBm25(f.text),
+          hash: createHash("md5").update(f.text).digest("hex"),
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        };
+        const { persisted } = await this.persistRecords([
+          { memoryId: id, text: f.text, embedding: vec, payload },
+        ]);
+        if (persisted.length === 0) {
+          throw new Error("vector store insert failed");
+        }
+        return persisted[0];
+      },
+    };
+
+    const results: MemoryItem[] = [];
+    const stillFailed: EmbeddingFailure[] = [];
+    for (const f of failed) {
+      const strategy = STRATEGIES[f.errorClass] ?? STRATEGIES.internal;
+      try {
+        const out = await strategy.apply(f, ctx);
+        if (out.kind === "persisted") results.push(out.item);
+        else stillFailed.push(out.failure);
+      } catch (e) {
+        stillFailed.push({
+          ...f,
+          errorClass: "provider",
+          remediation: "retry",
+          error: e instanceof Error ? e.message : String(e),
+        });
+      }
+    }
+    return { results, failed: stillFailed };
+  }
+
+  // The configured embedding dimension, from either config field a store may use.
+  private _expectedDim(): number | null {
+    const c = this.config.vectorStore?.config as any;
+    return c?.dimension ?? c?.embeddingModelDims ?? null;
+  }
+
+  /**
+   * Persist a batch of memory records: vector-store insert (with per-item
+   * fallback) plus a history entry each. Shared by addToVectorStore() and
+   * retryFailed() so a retried memory is stored identically to a fresh one.
+   */
+  private async persistRecords(
+    records: Array<{
+      memoryId: string;
+      text: string;
+      embedding: number[];
+      payload: Record<string, any>;
+    }>,
+  ): Promise<{
+    persisted: MemoryItem[];
+    insertFailedTexts: string[];
+  }> {
+    if (records.length === 0) return { persisted: [], insertFailedTexts: [] };
+
+    const inserted = new Set<string>();
+    const allVectors = records.map((r) => r.embedding);
+    const allIds = records.map((r) => r.memoryId);
+    const allPayloads = records.map((r) => r.payload);
+
+    try {
+      await this.vectorStore.insert(allVectors, allIds, allPayloads);
+      for (const id of allIds) inserted.add(id);
+    } catch {
+      for (let i = 0; i < allIds.length; i++) {
+        try {
+          await this.vectorStore.insert(
+            [allVectors[i]],
+            [allIds[i]],
+            [allPayloads[i]],
+          );
+          inserted.add(allIds[i]);
+        } catch (e) {
+          console.error(`Failed to insert memory ${allIds[i]}: ${e}`);
+        }
+      }
+    }
+
+    const persistedRecords = records.filter((r) => inserted.has(r.memoryId));
+    const insertFailedTexts = records
+      .filter((r) => !inserted.has(r.memoryId))
+      .map((r) => r.text);
+
+    for (const r of persistedRecords) {
+      try {
+        await this.db.addHistory(
+          r.memoryId,
+          null,
+          r.text,
+          "ADD",
+          r.payload.createdAt as string | undefined,
+        );
+      } catch (e) {
+        console.error(`Failed to add history for ${r.memoryId}: ${e}`);
+      }
+    }
+
+    return {
+      persisted: persistedRecords.map((r) => ({
+        id: r.memoryId,
+        memory: r.text,
+        metadata: { event: "ADD" },
+      })),
+      insertFailedTexts,
     };
   }
 
@@ -694,25 +835,66 @@ export class Memory {
     metadata: Record<string, any>,
     filters: SearchFilters,
     infer: boolean,
-  ): Promise<MemoryItem[]> {
+  ): Promise<AddResult> {
     if (!infer) {
-      const returnedMemories: MemoryItem[] = [];
+      const guard = makeVectorValidator(this._expectedDim());
+      const failed: EmbeddingFailure[] = [];
+      const records: Array<{
+        memoryId: string;
+        text: string;
+        embedding: number[];
+        payload: Record<string, any>;
+      }> = [];
       for (const message of messages) {
-        if (message.content === "system") {
+        if (message.content === "system") continue;
+        const text = message.content as string;
+        let vec: number[];
+        try {
+          vec = await this.embedder.embed(text);
+        } catch (e) {
+          const c = classifyEmbedError(e);
+          failed.push({
+            text,
+            errorClass: c.errorClass,
+            remediation: c.remediation,
+            retryAfter: c.retryAfter,
+            error: e instanceof Error ? e.message : String(e),
+            _memoryId: uuidv4(),
+          });
           continue;
         }
-        const memoryId = await this.createMemory(
-          message.content as string,
-          {},
-          metadata,
-        );
-        returnedMemories.push({
-          id: memoryId,
-          memory: message.content as string,
-          metadata: { event: "ADD" },
+        const v = guard.validate(vec);
+        if (!v.ok) {
+          const c = classifyValidation(v.reason!);
+          failed.push({
+            text,
+            errorClass: c.errorClass,
+            remediation: c.remediation,
+            error: `embedding validation failed: ${v.reason}`,
+            _memoryId: uuidv4(),
+            ...(v.reason === "non-finite" ? { _vector: vec } : {}),
+          });
+          continue;
+        }
+        records.push({
+          memoryId: uuidv4(),
+          text,
+          embedding: vec,
+          payload: { ...metadata, data: text },
         });
       }
-      return returnedMemories;
+      const { persisted, insertFailedTexts } =
+        await this.persistRecords(records);
+      for (const t of insertFailedTexts) {
+        failed.push({
+          text: t,
+          errorClass: "provider",
+          remediation: "retry",
+          error: "vector store insert failed",
+          _memoryId: uuidv4(),
+        });
+      }
+      return { results: persisted, failed };
     }
 
     // === V3 PHASED BATCH PIPELINE ===
@@ -778,7 +960,7 @@ export class Memory {
       )) as string;
     } catch (e) {
       console.error("LLM extraction failed:", e);
-      return [];
+      return { results: [], failed: [] };
     }
 
     // Parse response
@@ -819,26 +1001,74 @@ export class Memory {
           );
         } catch {}
       }
-      return [];
+      return { results: [], failed: [] };
     }
 
     // Phase 3: Batch embed all extracted memory texts
     const memTexts = extractedMemories
       .map((m) => m.text ?? "")
       .filter((t) => t.length > 0);
-    let embedMap: Record<string, number[]> = {};
+    const embedMap: Record<string, number[]> = {};
+    const failures: EmbeddingFailure[] = [];
+    const guard = makeVectorValidator(this._expectedDim());
+    const recordFailure = (
+      text: string,
+      c: Classification,
+      errMsg: string,
+      vector?: number[],
+    ) =>
+      failures.push({
+        text,
+        errorClass: c.errorClass,
+        remediation: c.remediation,
+        retryAfter: c.retryAfter,
+        error: errMsg,
+        // Stable id so a retry overwrites instead of duplicating.
+        _memoryId: uuidv4(),
+        ...(vector !== undefined ? { _vector: vector } : {}),
+      });
+
+    let batch: number[][] | undefined;
     try {
-      const memEmbeddingsList = await this.embedder.embedBatch(memTexts);
-      for (let i = 0; i < memTexts.length; i++) {
-        embedMap[memTexts[i]] = memEmbeddingsList[i];
-      }
+      batch = await this.embedder.embedBatch(memTexts);
     } catch {
-      // Fallback: embed individually
+      batch = undefined; // whole-batch failure — fall back to per-item
+    }
+
+    if (batch) {
+      // Common path: validate every returned vector before trusting it.
+      for (let i = 0; i < memTexts.length; i++) {
+        const v = guard.validate(batch[i]);
+        if (v.ok) embedMap[memTexts[i]] = batch[i];
+        else
+          recordFailure(
+            memTexts[i],
+            classifyValidation(v.reason!),
+            `embedding validation failed: ${v.reason}`,
+            batch[i],
+          );
+      }
+    } else {
+      // Fallback: embed individually, still validated by the same guard.
       for (const text of memTexts) {
         try {
-          embedMap[text] = await this.embedder.embed(text);
+          const vec = await this.embedder.embed(text);
+          const v = guard.validate(vec);
+          if (v.ok) embedMap[text] = vec;
+          else
+            recordFailure(
+              text,
+              classifyValidation(v.reason!),
+              `embedding validation failed: ${v.reason}`,
+              vec,
+            );
         } catch (e) {
-          console.warn(`Failed to embed memory text: ${e}`);
+          // A thrown error has no vector to preserve.
+          recordFailure(
+            text,
+            classifyEmbedError(e),
+            e instanceof Error ? e.message : String(e),
+          );
         }
       }
     }
@@ -895,6 +1125,32 @@ export class Memory {
       });
     }
 
+    // Carry first-pass payloads onto the failures so retryFailed() can persist
+    // them without re-running extraction.
+    if (failures.length > 0) {
+      const byText = new Map(extractedMemories.map((m) => [m.text, m]));
+      for (const f of failures) {
+        const mem = byText.get(f.text);
+        if (!mem) continue;
+        const memHash = createHash("md5").update(f.text).digest("hex");
+        const now = new Date().toISOString();
+        const payload: Record<string, any> = {
+          ...metadata,
+          data: f.text,
+          textLemmatized: lemmatizeForBm25(f.text),
+          hash: memHash,
+          createdAt: now,
+          updatedAt: now,
+        };
+        if (mem.attributed_to) payload.attributedTo = mem.attributed_to;
+        if (filters.user_id) payload.user_id = filters.user_id;
+        if (filters.agent_id) payload.agent_id = filters.agent_id;
+        if (filters.run_id) payload.run_id = filters.run_id;
+        // Keep the stable _memoryId from recordFailure; only attach the payload.
+        (f as any)._payload = payload;
+      }
+    }
+
     if (records.length === 0) {
       if (typeof this.db.saveMessages === "function") {
         try {
@@ -907,16 +1163,18 @@ export class Memory {
           );
         } catch {}
       }
-      return [];
+      return { results: [], failed: failures };
     }
 
     // Phase 6: Batch persist
     const allVectors = records.map((r) => r.embedding);
     const allIds = records.map((r) => r.memoryId);
     const allPayloads = records.map((r) => r.payload);
+    const inserted = new Set<string>();
 
     try {
       await this.vectorStore.insert(allVectors, allIds, allPayloads);
+      for (const id of allIds) inserted.add(id);
     } catch {
       // Fallback: insert one by one
       for (let i = 0; i < allIds.length; i++) {
@@ -926,9 +1184,22 @@ export class Memory {
             [allIds[i]],
             [allPayloads[i]],
           );
+          inserted.add(allIds[i]);
         } catch (e) {
           console.error(`Failed to insert memory ${allIds[i]}: ${e}`);
         }
+      }
+    }
+
+    // Inserts that failed are not silent: report them as retryable failures.
+    for (const r of records) {
+      if (!inserted.has(r.memoryId)) {
+        failures.push({
+          text: r.text,
+          errorClass: "provider",
+          remediation: "retry",
+          error: "vector store insert failed",
+        });
       }
     }
 
@@ -1116,11 +1387,15 @@ export class Memory {
       } catch {}
     }
 
-    return records.map((r) => ({
-      id: r.memoryId,
-      memory: r.text,
-      metadata: { event: "ADD" },
-    }));
+    const results = records
+      .filter((r) => inserted.has(r.memoryId))
+      .map((r) => ({
+        id: r.memoryId,
+        memory: r.text,
+        metadata: { event: "ADD" },
+      }));
+
+    return { results, failed: failures };
   }
 
   async get(memoryId: string): Promise<MemoryItem | null> {

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -36,6 +36,7 @@ import {
   classifyValidation,
   classifyEmbedError,
 } from "./errorRetry";
+import { EmbeddingError, EMBED_ERROR_CODE } from "../../../common/exceptions";
 import { Embedder } from "../embeddings/base";
 import { LLM } from "../llms/base";
 import { VectorStore } from "../vector_stores/base";
@@ -645,7 +646,12 @@ export class Memory {
       has_filters: !!config.filters,
       infer: config.infer,
     });
-    const { metadata = {}, filters = {}, infer = true } = config;
+    const {
+      metadata = {},
+      filters = {},
+      infer = true,
+      raiseOnPartialFailure = false,
+    } = config;
 
     // Validate and trim entity IDs
     const userId = validateAndTrimEntityId(config.userId, "userId");
@@ -697,6 +703,22 @@ export class Memory {
       } else {
         await this._displayFirstRunNotice("add");
       }
+    }
+
+    // Opt-in strict mode: the good memories are already persisted above; now
+    // raise so callers who prefer exceptions (and Python parity) get one.
+    if (raiseOnPartialFailure && addResult.failed.length > 0) {
+      throw new EmbeddingError(
+        `Failed to embed ${addResult.failed.length} of ${
+          addResult.failed.length + vectorStoreResult.length
+        } memory text(s); ${vectorStoreResult.length} persisted.`,
+        EMBED_ERROR_CODE.TRANSIENT,
+        {
+          failedTexts: addResult.failed.map((f) => f.text),
+          persistedCount: vectorStoreResult.length,
+          details: { failed: addResult.failed },
+        },
+      );
     }
 
     return {

--- a/mem0-ts/src/oss/src/memory/memory.types.ts
+++ b/mem0-ts/src/oss/src/memory/memory.types.ts
@@ -12,6 +12,10 @@ export interface AddMemoryOptions extends Entity {
   filters?: SearchFilters;
   infer?: boolean;
   timestamp?: number | string | Date | null;
+  // When true, add() throws an EmbeddingError after persisting the good
+  // memories if any failed to embed. Default false: failures come back on
+  // the returned `failed[]` instead.
+  raiseOnPartialFailure?: boolean;
 }
 
 export interface SearchMemoryOptions {

--- a/mem0-ts/src/oss/src/tests/embedding-retry.test.ts
+++ b/mem0-ts/src/oss/src/tests/embedding-retry.test.ts
@@ -22,6 +22,7 @@ import {
   NetworkError,
   ValidationError,
   AuthenticationError,
+  EmbeddingError,
 } from "../../../common/exceptions";
 
 const DIM = 1536;
@@ -190,6 +191,48 @@ describe("add() returns { results, failed } with labels", () => {
     const res = await m.add([A, B, C].join(". "), { userId: "u6" });
     expect(res.results).toHaveLength(3);
     expect(res.failed).toBeUndefined();
+  });
+});
+
+describe("raiseOnPartialFailure: opt-in strict mode (preserve-then-raise)", () => {
+  it("raises EmbeddingError with failedTexts/persistedCount, good ones still persisted", async () => {
+    const rules = new Map<string, Rule>([[B, { throwStatus: 503 }]]);
+    const { m } = await ready(rules, [A, B, C]);
+
+    let err: EmbeddingError | undefined;
+    try {
+      await m.add([A, B, C].join(". "), {
+        userId: "rp1",
+        raiseOnPartialFailure: true,
+      });
+    } catch (e) {
+      err = e as EmbeddingError;
+    }
+
+    expect(err).toBeInstanceOf(EmbeddingError);
+    expect(err!.failedTexts).toEqual([B]);
+    expect(err!.persistedCount).toBe(2);
+
+    // Preserve-then-raise: the good ones are in the store despite the throw.
+    const all = await m.getAll({ filters: { user_id: "rp1" } });
+    expect(all.results.map((r) => r.memory).sort()).toEqual([A, C].sort());
+  });
+
+  it("default (flag off) returns { results, failed } and does not throw", async () => {
+    const rules = new Map<string, Rule>([[B, { throwStatus: 503 }]]);
+    const { m } = await ready(rules, [A, B]);
+    const res = await m.add([A, B].join(". "), { userId: "rp2" });
+    expect(res.results).toHaveLength(1);
+    expect(res.failed).toHaveLength(1);
+  });
+
+  it("flag on but nothing fails: does not throw", async () => {
+    const { m } = await ready(new Map(), [A, B]);
+    const res = await m.add([A, B].join(". "), {
+      userId: "rp3",
+      raiseOnPartialFailure: true,
+    });
+    expect(res.results).toHaveLength(2);
   });
 });
 

--- a/mem0-ts/src/oss/src/tests/embedding-retry.test.ts
+++ b/mem0-ts/src/oss/src/tests/embedding-retry.test.ts
@@ -13,8 +13,16 @@ import {
   classifyEmbedError,
   classifyValidation,
   makeVectorValidator,
+  toEmbeddingError,
+  projectError,
   EmbeddingFailure,
 } from "../memory/errorRetry";
+import {
+  RateLimitError,
+  NetworkError,
+  ValidationError,
+  AuthenticationError,
+} from "../../../common/exceptions";
 
 const DIM = 1536;
 
@@ -249,6 +257,7 @@ describe("memory.retryFailed() is label-driven", () => {
     const rehydrated: EmbeddingFailure[] = JSON.parse(
       JSON.stringify(res.failed),
     );
+    expect(rehydrated[0].errorCode).toBe(res.failed![0].errorCode);
     rules.delete(B);
     const retry = await m.retryFailed(rehydrated);
     expect(retry.results.map((r) => r.memory)).toContain(B);
@@ -350,18 +359,65 @@ describe("classifier and validator units", () => {
     expect(classifyValidation("non-finite")).toEqual({
       errorClass: "validation_error",
       remediation: "escalate",
+      errorCode: "EMBED_002",
     });
     expect(classifyValidation("empty")).toEqual({
       errorClass: "validation_error",
       remediation: "escalate",
+      errorCode: "EMBED_002",
     });
     expect(classifyValidation("undefined")).toEqual({
       errorClass: "validation_error",
       remediation: "escalate",
+      errorCode: "EMBED_002",
     });
     expect(classifyValidation("dimension-mismatch")).toEqual({
       errorClass: "validation_error",
       remediation: "reconfigure",
+      errorCode: "EMBED_002",
     });
+  });
+});
+
+describe("typed-exception parity (Python error_code shape)", () => {
+  it("maps raw errors to typed instances (toEmbeddingError)", () => {
+    expect(toEmbeddingError({ status: 429 })).toBeInstanceOf(RateLimitError);
+    expect(toEmbeddingError({ status: 503 })).toBeInstanceOf(NetworkError);
+    expect(toEmbeddingError({ status: 401 })).toBeInstanceOf(
+      AuthenticationError,
+    );
+    const typed = new RateLimitError("limit", "EMBED_001");
+    expect(toEmbeddingError(typed)).toBe(typed); // already typed, passed through
+  });
+
+  it("projects typed instances onto the wire Classification", () => {
+    expect(projectError(new RateLimitError("x", "EMBED_001"))).toMatchObject({
+      errorClass: "provider_error",
+      remediation: "retry",
+      errorCode: "EMBED_001",
+    });
+    expect(projectError(new NetworkError("x", "EMBED_001"))).toMatchObject({
+      errorClass: "provider_error",
+      remediation: "retry",
+    });
+    expect(
+      projectError(new AuthenticationError("x", "EMBED_003")),
+    ).toMatchObject({
+      errorClass: "provider_error",
+      remediation: "escalate",
+      errorCode: "EMBED_003",
+    });
+    expect(projectError(new ValidationError("x", "EMBED_002"))).toMatchObject({
+      errorClass: "validation_error",
+      remediation: "reconfigure",
+      errorCode: "EMBED_002",
+    });
+  });
+
+  it("a classified provider failure carries errorCode on failed[]", async () => {
+    const rules = new Map<string, Rule>([[B, { throwStatus: 503 }]]);
+    const { m } = await ready(rules, [A, B]);
+    const res = await m.add([A, B].join(". "), { userId: "ec" });
+    expect(res.failed![0].errorCode).toBe("EMBED_001");
   });
 });

--- a/mem0-ts/src/oss/src/tests/embedding-retry.test.ts
+++ b/mem0-ts/src/oss/src/tests/embedding-retry.test.ts
@@ -129,7 +129,7 @@ describe("add() returns { results, failed } with labels", () => {
     expect(res.failed).toHaveLength(1);
     expect(res.failed![0]).toMatchObject({
       text: B,
-      errorClass: "internal",
+      errorClass: "internal_error",
       remediation: "escalate",
     });
     const all = await m.getAll({ filters: { user_id: "u1" } });
@@ -143,7 +143,7 @@ describe("add() returns { results, failed } with labels", () => {
     const res = await m.add([A, B].join(". "), { userId: "u2" });
     expect(res.failed![0]).toMatchObject({
       text: B,
-      errorClass: "provider",
+      errorClass: "provider_error",
       remediation: "retry",
     });
     expect(res.results).toHaveLength(1);
@@ -155,7 +155,7 @@ describe("add() returns { results, failed } with labels", () => {
     const res = await m.add([A, B].join(". "), { userId: "u3" });
     expect(res.failed![0]).toMatchObject({
       text: B,
-      errorClass: "validation",
+      errorClass: "validation_error",
       remediation: "reconfigure",
     });
   });
@@ -193,7 +193,7 @@ describe("memory.retryFailed() is label-driven", () => {
     const { m, embedder } = await ready(rules, [A, B]);
 
     const res = await m.add([A, B].join(". "), { userId: "u7" });
-    expect(res.failed![0].errorClass).toBe("provider");
+    expect(res.failed![0].errorClass).toBe("provider_error");
 
     // Provider recovers: B now embeds cleanly.
     rules.delete(B);
@@ -227,7 +227,7 @@ describe("memory.retryFailed() is label-driven", () => {
     const { m, embedder } = await ready(rules, [A, B]);
 
     const res = await m.add([A, B].join(". "), { userId: "u9" });
-    expect(res.failed![0]).toMatchObject({ errorClass: "internal" });
+    expect(res.failed![0]).toMatchObject({ errorClass: "internal_error" });
     const before = embedder.embedCalls;
 
     const retry = await m.retryFailed(res.failed!);
@@ -278,8 +278,8 @@ describe("hardening: insert failures, dedup, infer:false, short batch", () => {
     const res = await m.add([A, B].join(". "), { userId: "c1" });
     expect(res.results).toHaveLength(0);
     expect(res.failed!.map((f) => f.errorClass)).toEqual([
-      "provider",
-      "provider",
+      "provider_error",
+      "provider_error",
     ]);
   });
 
@@ -329,7 +329,7 @@ describe("classifier and validator units", () => {
     const err: any = new Error("invalid dimension nan");
     err.status = 503;
     expect(classifyEmbedError(err)).toMatchObject({
-      errorClass: "provider",
+      errorClass: "provider_error",
       remediation: "retry",
     });
   });
@@ -339,7 +339,7 @@ describe("classifier and validator units", () => {
     err.status = 429;
     err.retryAfter = 30;
     expect(classifyEmbedError(err)).toMatchObject({
-      errorClass: "provider",
+      errorClass: "provider_error",
       retryAfter: 30,
     });
   });

--- a/mem0-ts/src/oss/src/tests/embedding-retry.test.ts
+++ b/mem0-ts/src/oss/src/tests/embedding-retry.test.ts
@@ -340,6 +340,24 @@ describe("classifier and validator units", () => {
     });
   });
 
+  // A thrown error is always provider_error; the retry decision rides remediation.
+  it.each([
+    [503, "retry", false],
+    [502, "retry", false],
+    [429, "retry", true],
+    [401, "escalate", false],
+    [403, "escalate", false],
+    [400, "escalate", false],
+  ])("status %i -> provider_error/%s", (status, remediation, hasRetryAfter) => {
+    const err: any = new Error("provider call failed");
+    err.status = status;
+    if (status === 429) err.retryAfter = 30;
+    const c = classifyEmbedError(err);
+    expect(c.errorClass).toBe("provider_error");
+    expect(c.remediation).toBe(remediation);
+    expect(c.retryAfter !== undefined).toBe(hasRetryAfter);
+  });
+
   it("validator rejects empty, NaN, wrong-dim, undefined; accepts clean", () => {
     const g = makeVectorValidator(3);
     expect(g.validate([0.1, 0.2, 0.3]).ok).toBe(true);

--- a/mem0-ts/src/oss/src/tests/embedding-retry.test.ts
+++ b/mem0-ts/src/oss/src/tests/embedding-retry.test.ts
@@ -11,15 +11,14 @@ import path from "path";
 import { Memory } from "../memory";
 import {
   classifyEmbedError,
+  classifyValidation,
   makeVectorValidator,
-  sanitizeVector,
   EmbeddingFailure,
 } from "../memory/errorRetry";
 
 const DIM = 1536;
 
-// A distinct, dense-ish vector per text. Several non-zero components (not a
-// single one-hot) so that zeroing one NaN slot still leaves a healthy L2 norm.
+// A distinct vector per text.
 function vectorFor(text: string): number[] {
   let h = 0;
   for (const c of text) h = (h * 31 + c.charCodeAt(0)) | 0;
@@ -51,7 +50,7 @@ afterAll(() => {
 //   "dim"             -> returns a wrong-length vector (no throw)
 //   "empty"           -> returns []
 //   otherwise         -> a clean one-hot vector
-type Rule = "ok" | "nan" | "allnan" | "dim" | "empty" | { throwStatus: number };
+type Rule = "ok" | "nan" | "dim" | "empty" | { throwStatus: number };
 class RuleEmbedder {
   public embedCalls = 0;
   constructor(private rules: Map<string, Rule>) {}
@@ -67,7 +66,6 @@ class RuleEmbedder {
       throw err;
     }
     if (r === "nan") return vectorFor(text).map((x, i) => (i === 0 ? NaN : x));
-    if (r === "allnan") return new Array(DIM).fill(NaN);
     if (r === "dim") return new Array(DIM - 2).fill(0.1);
     if (r === "empty") return [];
     return vectorFor(text);
@@ -119,7 +117,7 @@ async function ready(rules: Map<string, Rule>, facts: string[]) {
 jest.setTimeout(30000);
 
 describe("add() returns { results, failed } with labels", () => {
-  it("flagship: good saved, NaN reported as internal/escalate, not persisted", async () => {
+  it("flagship: good saved, NaN reported as validation_error/escalate, not persisted", async () => {
     const rules = new Map<string, Rule>([[B, "nan"]]);
     const { m } = await ready(rules, [A, B, C]);
 
@@ -129,7 +127,7 @@ describe("add() returns { results, failed } with labels", () => {
     expect(res.failed).toHaveLength(1);
     expect(res.failed![0]).toMatchObject({
       text: B,
-      errorClass: "internal_error",
+      errorClass: "validation_error",
       remediation: "escalate",
     });
     const all = await m.getAll({ filters: { user_id: "u1" } });
@@ -205,11 +203,15 @@ describe("memory.retryFailed() is label-driven", () => {
     expect(all.results.map((r) => r.memory).sort()).toEqual([A, B].sort());
   });
 
-  it("refuses to blindly re-embed a reconfigure failure (no embed call)", async () => {
+  it("does not re-embed a validation failure (wrong dim), surfaces it instead", async () => {
     const rules = new Map<string, Rule>([[B, "dim"]]);
     const { m, embedder } = await ready(rules, [A, B]);
 
     const res = await m.add([A, B].join(". "), { userId: "u8" });
+    expect(res.failed![0]).toMatchObject({
+      errorClass: "validation_error",
+      remediation: "reconfigure",
+    });
     const before = embedder.embedCalls;
 
     const retry = await m.retryFailed(res.failed!);
@@ -217,40 +219,25 @@ describe("memory.retryFailed() is label-driven", () => {
     expect(embedder.embedCalls).toBe(before); // never re-embedded
     expect(retry.results).toHaveLength(0);
     expect(retry.failed).toHaveLength(1);
-    expect(retry.failed[0].error).toMatch(/reconfigur/i);
   });
 
-  it("sanitizes a localized-NaN vector and SAVES it without re-embedding", async () => {
-    // One NaN component in 1536 — localized poison. Retry coerces NaN->0
-    // (intent lives in the text, untouched) and persists, no wasted re-embed.
+  it("a NaN failure is surfaced on retry and never persisted (no sanitize)", async () => {
     const rules = new Map<string, Rule>([[B, "nan"]]);
     const { m, embedder } = await ready(rules, [A, B]);
 
     const res = await m.add([A, B].join(". "), { userId: "u9" });
-    expect(res.failed![0]).toMatchObject({ errorClass: "internal_error" });
+    expect(res.failed![0]).toMatchObject({
+      errorClass: "validation_error",
+      remediation: "escalate",
+    });
     const before = embedder.embedCalls;
 
     const retry = await m.retryFailed(res.failed!);
 
-    expect(embedder.embedCalls).toBe(before); // sanitized the preserved vector, no re-embed
-    expect(retry.results.map((r) => r.memory)).toContain(B);
-    expect(retry.failed).toHaveLength(0);
-    const all = await m.getAll({ filters: { user_id: "u9" } });
-    expect(all.results.map((r) => r.memory).sort()).toEqual([A, B].sort());
-  });
-
-  it("refuses to save a fully-degenerate (all-NaN) vector", async () => {
-    // Whole vector NaN -> sanitizing gives a zero-norm vector a cosine index
-    // would silently never return, so it must stay failed, not be stored.
-    const rules = new Map<string, Rule>([[B, "allnan"]]);
-    const { m } = await ready(rules, [A, B]);
-
-    const res = await m.add([A, B].join(". "), { userId: "u9b" });
-    const retry = await m.retryFailed(res.failed!);
-
+    expect(embedder.embedCalls).toBe(before); // no re-embed, no sanitize
     expect(retry.results).toHaveLength(0);
     expect(retry.failed).toHaveLength(1);
-    const all = await m.getAll({ filters: { user_id: "u9b" } });
+    const all = await m.getAll({ filters: { user_id: "u9" } });
     expect(all.results.map((r) => r.memory)).not.toContain(B);
   });
 
@@ -278,8 +265,8 @@ describe("hardening: insert failures, dedup, infer:false, short batch", () => {
     const res = await m.add([A, B].join(". "), { userId: "c1" });
     expect(res.results).toHaveLength(0);
     expect(res.failed!.map((f) => f.errorClass)).toEqual([
-      "provider_error",
-      "provider_error",
+      "internal_error",
+      "internal_error",
     ]);
   });
 
@@ -358,57 +345,23 @@ describe("classifier and validator units", () => {
     expect(g.validate([1, 2, 3, 4]).ok).toBe(true); // sets bar to 4
     expect(g.validate([1, 2, 3]).reason).toBe("dimension-mismatch");
   });
-});
 
-describe("sanitizeVector repairs only what is safe to store", () => {
-  it("coerces a localized NaN to 0 and keeps a healthy norm", () => {
-    const v = new Array(100).fill(0.5);
-    v[1] = NaN; // 1% poison, under the 5% threshold
-    const s = sanitizeVector(v, 100);
-    expect(s.ok).toBe(true);
-    expect(s.vector![1]).toBe(0);
-  });
-
-  it("keeps Inf as 'huge' (±1e19), float32- and square-safe, never zero", () => {
-    const v = new Array(100).fill(0.5);
-    v[10] = Infinity;
-    v[20] = -Infinity;
-    const s = sanitizeVector(v, 100);
-    expect(s.ok).toBe(true);
-    expect(s.vector!.every((x) => Number.isFinite(x))).toBe(true);
-    expect(s.vector![10]).toBe(1e19);
-    expect(s.vector![20]).toBe(-1e19);
-    // The sentinel must survive float32 storage and squaring (the MAX_VALUE bug).
-    expect(Number.isFinite(new Float32Array([s.vector![10]])[0])).toBe(true);
-    expect(Number.isFinite(new Float32Array([s.vector![10] ** 2])[0])).toBe(
-      true,
-    );
-  });
-
-  it("refuses an all-NaN vector (degenerate zero norm)", () => {
-    const s = sanitizeVector([NaN, NaN, NaN, NaN], 4);
-    expect(s.ok).toBe(false);
-    // >5% repaired trips the heavy-damage guard first; either way it refuses.
-    expect(["too-many-non-finite", "degenerate-zero-norm"]).toContain(s.reason);
-  });
-
-  it("refuses a wrong-dimension vector (cannot fabricate axes)", () => {
-    const s = sanitizeVector([0.5, 0.5], 4);
-    expect(s.ok).toBe(false);
-    expect(s.reason).toBe("dimension-mismatch");
-  });
-
-  it("refuses when too many components are non-finite (>5%)", () => {
-    const v = new Array(100).fill(0.5);
-    for (let i = 0; i < 10; i++) v[i] = NaN; // 10% poison
-    const s = sanitizeVector(v, 100);
-    expect(s.ok).toBe(false);
-    expect(s.reason).toBe("too-many-non-finite");
-  });
-
-  it("passes a clean vector through unchanged", () => {
-    const s = sanitizeVector([0.1, 0.2, 0.3], 3);
-    expect(s.ok).toBe(true);
-    expect(s.vector).toEqual([0.1, 0.2, 0.3]);
+  it("classifyValidation: same class (validation_error), remediation on the orthogonal axis", () => {
+    expect(classifyValidation("non-finite")).toEqual({
+      errorClass: "validation_error",
+      remediation: "escalate",
+    });
+    expect(classifyValidation("empty")).toEqual({
+      errorClass: "validation_error",
+      remediation: "escalate",
+    });
+    expect(classifyValidation("undefined")).toEqual({
+      errorClass: "validation_error",
+      remediation: "escalate",
+    });
+    expect(classifyValidation("dimension-mismatch")).toEqual({
+      errorClass: "validation_error",
+      remediation: "reconfigure",
+    });
   });
 });

--- a/mem0-ts/src/oss/src/tests/embedding-retry.test.ts
+++ b/mem0-ts/src/oss/src/tests/embedding-retry.test.ts
@@ -1,0 +1,414 @@
+/**
+ * Tests for label-driven, guardrailed embedding failures + retry in add().
+ *
+ * add() returns { results, failed[] }: good memories persist, failures carry a
+ * label (errorClass / remediation / retryAfter). memory.retryFailed() retries
+ * them per label, and the guardrail (NaN/Inf/dim) gates persistence every time.
+ */
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { Memory } from "../memory";
+import {
+  classifyEmbedError,
+  makeVectorValidator,
+  sanitizeVector,
+  EmbeddingFailure,
+} from "../memory/errorRetry";
+
+const DIM = 1536;
+
+// A distinct, dense-ish vector per text. Several non-zero components (not a
+// single one-hot) so that zeroing one NaN slot still leaves a healthy L2 norm.
+function vectorFor(text: string): number[] {
+  let h = 0;
+  for (const c of text) h = (h * 31 + c.charCodeAt(0)) | 0;
+  const v = new Array(DIM).fill(0.01);
+  for (let k = 0; k < 5; k++) v[Math.abs(h + k * 97) % DIM] = 0.5;
+  return v;
+}
+
+const tmpDbs: string[] = [];
+function freshDbPath(): string {
+  const p = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), "mem0-retry-")),
+    "store.db",
+  );
+  tmpDbs.push(p);
+  return p;
+}
+afterAll(() => {
+  for (const p of tmpDbs) {
+    try {
+      fs.rmSync(path.dirname(p), { recursive: true, force: true });
+    } catch {}
+  }
+});
+
+// Embedder driven by per-text rules so each scenario is deterministic.
+//   "throw:<status>"  -> embed() throws { status }
+//   "nan"             -> returns a vector with a NaN element (no throw)
+//   "dim"             -> returns a wrong-length vector (no throw)
+//   "empty"           -> returns []
+//   otherwise         -> a clean one-hot vector
+type Rule = "ok" | "nan" | "allnan" | "dim" | "empty" | { throwStatus: number };
+class RuleEmbedder {
+  public embedCalls = 0;
+  constructor(private rules: Map<string, Rule>) {}
+  private rule(text: string): Rule {
+    return this.rules.get(text) ?? "ok";
+  }
+  async embed(text: string): Promise<number[]> {
+    this.embedCalls++;
+    const r = this.rule(text);
+    if (typeof r === "object") {
+      const err: any = new Error(`provider ${r.throwStatus}`);
+      err.status = r.throwStatus;
+      throw err;
+    }
+    if (r === "nan") return vectorFor(text).map((x, i) => (i === 0 ? NaN : x));
+    if (r === "allnan") return new Array(DIM).fill(NaN);
+    if (r === "dim") return new Array(DIM - 2).fill(0.1);
+    if (r === "empty") return [];
+    return vectorFor(text);
+  }
+  // Always force the per-item path so per-text rules apply cleanly.
+  async embedBatch(_texts: string[]): Promise<number[][]> {
+    throw new Error("batch unavailable");
+  }
+}
+
+function buildMemory(rules: Map<string, Rule>) {
+  const m = new Memory({
+    disableHistory: true,
+    vectorStore: {
+      provider: "memory",
+      config: { dimension: DIM, dbPath: freshDbPath() },
+    },
+    embedder: { provider: "openai", config: { apiKey: "x" } },
+    llm: { provider: "openai", config: { apiKey: "x" } },
+  } as any);
+  return { m, embedder: new RuleEmbedder(rules) };
+}
+
+const A = "Alice likes Python";
+const B = "Bob lives in Lyon";
+const C = "Carol ships fast";
+
+function stubLLM(facts: string[]) {
+  return {
+    async generateResponse(): Promise<string> {
+      return JSON.stringify({
+        memory: facts.map((text, i) => ({ id: String(i), text })),
+      });
+    },
+    async generateChat() {
+      return { content: "", role: "assistant" };
+    },
+  };
+}
+
+async function ready(rules: Map<string, Rule>, facts: string[]) {
+  const { m, embedder } = buildMemory(rules);
+  (m as any).embedder = embedder;
+  (m as any).llm = stubLLM(facts);
+  await (m as any)._ensureInitialized();
+  return { m, embedder };
+}
+
+jest.setTimeout(30000);
+
+describe("add() returns { results, failed } with labels", () => {
+  it("flagship: good saved, NaN reported as internal/escalate, not persisted", async () => {
+    const rules = new Map<string, Rule>([[B, "nan"]]);
+    const { m } = await ready(rules, [A, B, C]);
+
+    const res = await m.add([A, B, C].join(". "), { userId: "u1" });
+
+    expect(res.results.map((r) => r.memory).sort()).toEqual([A, C].sort());
+    expect(res.failed).toHaveLength(1);
+    expect(res.failed![0]).toMatchObject({
+      text: B,
+      errorClass: "internal",
+      remediation: "escalate",
+    });
+    const all = await m.getAll({ filters: { user_id: "u1" } });
+    expect(all.results.map((r) => r.memory)).not.toContain(B);
+  });
+
+  it("provider 503 is labelled provider/retry and not persisted", async () => {
+    const rules = new Map<string, Rule>([[B, { throwStatus: 503 }]]);
+    const { m } = await ready(rules, [A, B]);
+
+    const res = await m.add([A, B].join(". "), { userId: "u2" });
+    expect(res.failed![0]).toMatchObject({
+      text: B,
+      errorClass: "provider",
+      remediation: "retry",
+    });
+    expect(res.results).toHaveLength(1);
+  });
+
+  it("wrong dimension is labelled validation/reconfigure", async () => {
+    const rules = new Map<string, Rule>([[B, "dim"]]);
+    const { m } = await ready(rules, [A, B]);
+    const res = await m.add([A, B].join(". "), { userId: "u3" });
+    expect(res.failed![0]).toMatchObject({
+      text: B,
+      errorClass: "validation",
+      remediation: "reconfigure",
+    });
+  });
+
+  it("empty vector is caught (not vacuously valid)", async () => {
+    const rules = new Map<string, Rule>([[B, "empty"]]);
+    const { m } = await ready(rules, [A, B]);
+    const res = await m.add([A, B].join(". "), { userId: "u4" });
+    expect(res.failed!.map((f) => f.text)).toContain(B);
+    expect(res.results).toHaveLength(1);
+  });
+
+  it("all-fail returns { results: [], failed } without throwing", async () => {
+    const rules = new Map<string, Rule>([
+      [A, "nan"],
+      [B, "nan"],
+    ]);
+    const { m } = await ready(rules, [A, B]);
+    const res = await m.add([A, B].join(". "), { userId: "u5" });
+    expect(res.results).toHaveLength(0);
+    expect(res.failed).toHaveLength(2);
+  });
+
+  it("happy path: all good, no failed field", async () => {
+    const { m } = await ready(new Map(), [A, B, C]);
+    const res = await m.add([A, B, C].join(". "), { userId: "u6" });
+    expect(res.results).toHaveLength(3);
+    expect(res.failed).toBeUndefined();
+  });
+});
+
+describe("memory.retryFailed() is label-driven", () => {
+  it("retries a provider failure once the provider recovers, and persists it", async () => {
+    const rules = new Map<string, Rule>([[B, { throwStatus: 503 }]]);
+    const { m, embedder } = await ready(rules, [A, B]);
+
+    const res = await m.add([A, B].join(". "), { userId: "u7" });
+    expect(res.failed![0].errorClass).toBe("provider");
+
+    // Provider recovers: B now embeds cleanly.
+    rules.delete(B);
+    const retry = await m.retryFailed(res.failed!);
+
+    expect(retry.results.map((r) => r.memory)).toContain(B);
+    expect(retry.failed).toHaveLength(0);
+    const all = await m.getAll({ filters: { user_id: "u7" } });
+    expect(all.results.map((r) => r.memory).sort()).toEqual([A, B].sort());
+  });
+
+  it("refuses to blindly re-embed a reconfigure failure (no embed call)", async () => {
+    const rules = new Map<string, Rule>([[B, "dim"]]);
+    const { m, embedder } = await ready(rules, [A, B]);
+
+    const res = await m.add([A, B].join(". "), { userId: "u8" });
+    const before = embedder.embedCalls;
+
+    const retry = await m.retryFailed(res.failed!);
+
+    expect(embedder.embedCalls).toBe(before); // never re-embedded
+    expect(retry.results).toHaveLength(0);
+    expect(retry.failed).toHaveLength(1);
+    expect(retry.failed[0].error).toMatch(/reconfigur/i);
+  });
+
+  it("sanitizes a localized-NaN vector and SAVES it without re-embedding", async () => {
+    // One NaN component in 1536 — localized poison. Retry coerces NaN->0
+    // (intent lives in the text, untouched) and persists, no wasted re-embed.
+    const rules = new Map<string, Rule>([[B, "nan"]]);
+    const { m, embedder } = await ready(rules, [A, B]);
+
+    const res = await m.add([A, B].join(". "), { userId: "u9" });
+    expect(res.failed![0]).toMatchObject({ errorClass: "internal" });
+    const before = embedder.embedCalls;
+
+    const retry = await m.retryFailed(res.failed!);
+
+    expect(embedder.embedCalls).toBe(before); // sanitized the preserved vector, no re-embed
+    expect(retry.results.map((r) => r.memory)).toContain(B);
+    expect(retry.failed).toHaveLength(0);
+    const all = await m.getAll({ filters: { user_id: "u9" } });
+    expect(all.results.map((r) => r.memory).sort()).toEqual([A, B].sort());
+  });
+
+  it("refuses to save a fully-degenerate (all-NaN) vector", async () => {
+    // Whole vector NaN -> sanitizing gives a zero-norm vector a cosine index
+    // would silently never return, so it must stay failed, not be stored.
+    const rules = new Map<string, Rule>([[B, "allnan"]]);
+    const { m } = await ready(rules, [A, B]);
+
+    const res = await m.add([A, B].join(". "), { userId: "u9b" });
+    const retry = await m.retryFailed(res.failed!);
+
+    expect(retry.results).toHaveLength(0);
+    expect(retry.failed).toHaveLength(1);
+    const all = await m.getAll({ filters: { user_id: "u9b" } });
+    expect(all.results.map((r) => r.memory)).not.toContain(B);
+  });
+
+  it("survives a JSON round-trip (plain data, no closures)", async () => {
+    const rules = new Map<string, Rule>([[B, { throwStatus: 503 }]]);
+    const { m } = await ready(rules, [A, B]);
+    const res = await m.add([A, B].join(". "), { userId: "u10" });
+
+    const rehydrated: EmbeddingFailure[] = JSON.parse(
+      JSON.stringify(res.failed),
+    );
+    rules.delete(B);
+    const retry = await m.retryFailed(rehydrated);
+    expect(retry.results.map((r) => r.memory)).toContain(B);
+  });
+});
+
+describe("hardening: insert failures, dedup, infer:false, short batch", () => {
+  it("C1: a vector-store insert failure is surfaced, not reported as success", async () => {
+    const { m } = await ready(new Map(), [A, B]);
+    // Make the store reject every insert after init.
+    (m as any).vectorStore.insert = async () => {
+      throw new Error("store down");
+    };
+    const res = await m.add([A, B].join(". "), { userId: "c1" });
+    expect(res.results).toHaveLength(0);
+    expect(res.failed!.map((f) => f.errorClass)).toEqual([
+      "provider",
+      "provider",
+    ]);
+  });
+
+  it("C2: retrying the same failure twice does not duplicate the memory", async () => {
+    const rules = new Map<string, Rule>([[B, { throwStatus: 503 }]]);
+    const { m } = await ready(rules, [A, B]);
+    const res = await m.add([A, B].join(". "), { userId: "c2" });
+
+    rules.delete(B);
+    await m.retryFailed(res.failed!);
+    await m.retryFailed(res.failed!); // second retry should be a no-op
+
+    const all = await m.getAll({ filters: { user_id: "c2" } });
+    const bobs = all.results.filter((r) => r.memory === B);
+    expect(bobs).toHaveLength(1);
+  });
+
+  it("H1: infer:false captures embed failures instead of throwing", async () => {
+    const rules = new Map<string, Rule>([["bad text", { throwStatus: 503 }]]);
+    const { m } = await ready(rules, []);
+    const res = await m.add(
+      [
+        { role: "user", content: "good text" },
+        { role: "user", content: "bad text" },
+      ],
+      { userId: "h1", infer: false },
+    );
+    expect(res.results.map((r) => r.memory)).toEqual(["good text"]);
+    expect(res.failed!.map((f) => f.text)).toEqual(["bad text"]);
+  });
+
+  it("H4: a short embedBatch return reports the missing tail as a failure (not silently dropped)", async () => {
+    const { m } = await ready(new Map(), [A, B, C]);
+    // embedBatch returns one fewer vector than texts.
+    (m as any).embedder.embedBatch = async (texts: string[]) =>
+      texts.slice(0, texts.length - 1).map(() => new Array(DIM).fill(0.1));
+
+    const res = await m.add([A, B, C].join(". "), { userId: "h4" });
+    // The tail text has no vector, so it is surfaced as a failure, never dropped.
+    expect(res.failed!.length).toBeGreaterThan(0);
+    expect(res.results.length).toBeLessThan(3);
+  });
+});
+
+describe("classifier and validator units", () => {
+  it("classifies by status, not a misleading message", () => {
+    const err: any = new Error("invalid dimension nan");
+    err.status = 503;
+    expect(classifyEmbedError(err)).toMatchObject({
+      errorClass: "provider",
+      remediation: "retry",
+    });
+  });
+
+  it("parses retryAfter on 429", () => {
+    const err: any = new Error("rate limited");
+    err.status = 429;
+    err.retryAfter = 30;
+    expect(classifyEmbedError(err)).toMatchObject({
+      errorClass: "provider",
+      retryAfter: 30,
+    });
+  });
+
+  it("validator rejects empty, NaN, wrong-dim, undefined; accepts clean", () => {
+    const g = makeVectorValidator(3);
+    expect(g.validate([0.1, 0.2, 0.3]).ok).toBe(true);
+    expect(g.validate([]).reason).toBe("empty");
+    expect(g.validate([0.1, NaN, 0.3]).reason).toBe("non-finite");
+    expect(g.validate([0.1, 0.2]).reason).toBe("dimension-mismatch");
+    expect(g.validate(undefined).reason).toBe("undefined");
+  });
+
+  it("first-vector-wins when no seed dim", () => {
+    const g = makeVectorValidator(null);
+    expect(g.validate([1, 2, 3, 4]).ok).toBe(true); // sets bar to 4
+    expect(g.validate([1, 2, 3]).reason).toBe("dimension-mismatch");
+  });
+});
+
+describe("sanitizeVector repairs only what is safe to store", () => {
+  it("coerces a localized NaN to 0 and keeps a healthy norm", () => {
+    const v = new Array(100).fill(0.5);
+    v[1] = NaN; // 1% poison, under the 5% threshold
+    const s = sanitizeVector(v, 100);
+    expect(s.ok).toBe(true);
+    expect(s.vector![1]).toBe(0);
+  });
+
+  it("keeps Inf as 'huge' (±1e19), float32- and square-safe, never zero", () => {
+    const v = new Array(100).fill(0.5);
+    v[10] = Infinity;
+    v[20] = -Infinity;
+    const s = sanitizeVector(v, 100);
+    expect(s.ok).toBe(true);
+    expect(s.vector!.every((x) => Number.isFinite(x))).toBe(true);
+    expect(s.vector![10]).toBe(1e19);
+    expect(s.vector![20]).toBe(-1e19);
+    // The sentinel must survive float32 storage and squaring (the MAX_VALUE bug).
+    expect(Number.isFinite(new Float32Array([s.vector![10]])[0])).toBe(true);
+    expect(Number.isFinite(new Float32Array([s.vector![10] ** 2])[0])).toBe(
+      true,
+    );
+  });
+
+  it("refuses an all-NaN vector (degenerate zero norm)", () => {
+    const s = sanitizeVector([NaN, NaN, NaN, NaN], 4);
+    expect(s.ok).toBe(false);
+    // >5% repaired trips the heavy-damage guard first; either way it refuses.
+    expect(["too-many-non-finite", "degenerate-zero-norm"]).toContain(s.reason);
+  });
+
+  it("refuses a wrong-dimension vector (cannot fabricate axes)", () => {
+    const s = sanitizeVector([0.5, 0.5], 4);
+    expect(s.ok).toBe(false);
+    expect(s.reason).toBe("dimension-mismatch");
+  });
+
+  it("refuses when too many components are non-finite (>5%)", () => {
+    const v = new Array(100).fill(0.5);
+    for (let i = 0; i < 10; i++) v[i] = NaN; // 10% poison
+    const s = sanitizeVector(v, 100);
+    expect(s.ok).toBe(false);
+    expect(s.reason).toBe("too-many-non-finite");
+  });
+
+  it("passes a clean vector through unchanged", () => {
+    const s = sanitizeVector([0.1, 0.2, 0.3], 3);
+    expect(s.ok).toBe(true);
+    expect(s.vector).toEqual([0.1, 0.2, 0.3]);
+  });
+});

--- a/mem0-ts/src/oss/src/types/index.ts
+++ b/mem0-ts/src/oss/src/types/index.ts
@@ -90,6 +90,8 @@ export interface SearchFilters {
 
 export interface SearchResult {
   results: MemoryItem[];
+  // Present on add() when some memories failed to embed (see EmbeddingFailure).
+  failed?: import("../memory/errorRetry").EmbeddingFailure[];
 }
 
 export interface VectorStoreResult {


### PR DESCRIPTION
## Linked Issue

Relates to #5509 (and the taxonomy talked about in #5245 / #5249)

## Description

This is a follow up to my other PR for #5509. That one just surfaces the failure. This one finishes the idea: it shows you what failed, why, and lets you retry it.

So what happens now. When you call add and some memories fail to embed, add no longer drops them quietly. It returns { results, failed }. results are the ones that saved. failed are the ones that did not, and each one carries a label:

- errorClass: provider, validation, or internal
- remediation: retry, reconfigure, or escalate
- retryAfter when the provider gave one

Before saving, every vector is checked (NaN, Inf, empty, wrong dimension). A bad vector is never stored. And if the vector store insert itself fails, that memory is reported in failed instead of being returned as if it saved.

Then there is a real retry, not just a label:

```ts
const { results, failed } = await memory.add(messages, { userId });
if (failed.length) {
  const retry = await memory.retryFailed(failed);
}
```

retryFailed reads each label and does the right thing:
- provider: re-embed (waits retryAfter), validate, save
- reconfigure: does not blindly retry, it would fail the same way, so it surfaces it for you to fix config
- internal (a returned NaN/Inf vector): sanitize the vector (NaN to 0, Inf to a finite sentinel) and save only if the result is still searchable, else keep it failed

The infinity part is the interesting bit. A vector store can not hold Infinity, and if you store it as the max float it comes back as Infinity again in float32 and breaks the math. So we keep its meaning as a finite sentinel that survives float32 and squaring, and the real word infinity is preserved in the text anyway.

Each failure gets a stable id when it is first flagged, so retrying the same one just overwrites instead of making a duplicate. No extra lookups, no dedup scan.

## Why return instead of raise

The earlier idea was to raise an error on failure. I went with return instead, for two reasons. You can not both raise and hand back the failed list, the raise stops everything. And raising is all or nothing, so a small blip looks like the whole add failed even when most memories saved. Returning keeps the good ones and still gives you the labels to act on.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Breaking Changes

add() used to return { results }. It now also returns failed when some memories fail to embed. Existing code that reads results keeps working. Code that wants the failures or the retry can use the new fields.

## Test Coverage

- [x] I added/updated unit tests
- [x] I tested manually (ran it many times with a flaky embedder: provider errors, NaN, Inf, wrong dimension, empty, insert failure, infer:false, retry, double-retry)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
