### PR TITLE
fix(ts-oss): preserve custom metadata on Memory.update() (closes #5479)

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -1721,21 +1721,20 @@ export class Memory {
     const embedding =
       existingEmbeddings[data] || (await this.embedder.embed(data));
 
-    const newMetadata = {
+    // Start from the full existing payload so no custom metadata
+    // (category, priority, source, etc.) is lost when the vector store
+    // replaces the whole payload on update. Caller-supplied metadata is
+    // overlaid on top, then the system fields are stamped last so they
+    // always reflect the latest update. Session identifiers carry over
+    // automatically as part of the existing payload.
+    const newMetadata: Record<string, any> = {
+      ...existingMemory.payload,
       ...metadata,
       data,
       hash: createHash("md5").update(data).digest("hex"),
+      textLemmatized: lemmatizeForBm25(data),
       createdAt: existingMemory.payload.createdAt,
       updatedAt: new Date().toISOString(),
-      ...(existingMemory.payload.user_id && {
-        user_id: existingMemory.payload.user_id,
-      }),
-      ...(existingMemory.payload.agent_id && {
-        agent_id: existingMemory.payload.agent_id,
-      }),
-      ...(existingMemory.payload.run_id && {
-        run_id: existingMemory.payload.run_id,
-      }),
     };
 
     await this.vectorStore.update(memoryId, embedding, newMetadata);

--- a/mem0-ts/src/oss/tests/memory.crud.test.ts
+++ b/mem0-ts/src/oss/tests/memory.crud.test.ts
@@ -191,6 +191,27 @@ describe("Memory - update()", () => {
     const after: MemoryItem | null = await memory.get(id);
     expect(after!.hash).not.toBe(before!.hash);
   });
+
+  // Regression test for #5479: a text-only update must not drop custom
+  // metadata stored at add() time (parity with the Python fix in #5179).
+  test("preserves custom metadata on a text-only update", async () => {
+    const addResult: SearchResult = await memory.add("Metadata original", {
+      userId,
+      infer: false,
+      metadata: { category: "work", priority: "high", source: "slack" },
+    });
+    const id = addResult.results[0].id;
+
+    await memory.update(id, "Metadata updated");
+    const after: MemoryItem | null = await memory.get(id);
+
+    expect(after!.memory).toBe("Metadata updated");
+    expect(after!.metadata).toMatchObject({
+      category: "work",
+      priority: "high",
+      source: "slack",
+    });
+  });
 });
 
 // ─── delete() ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- The TypeScript OSS SDK's update path silently dropped custom metadata (`category`, `priority`, `source`, etc.) on a text-only `Memory.update()`.
- This brings the TS SDK to parity with the Python fix in #5179.

## Motivation

Closes #5479 (follow-up to #5160, opened at the maintainer's request in the #5179 review).

`updateMemory()` in `mem0-ts/src/oss/src/memory/index.ts` rebuilt the payload from scratch and hand-copied only the session-identifier fields (`user_id`/`agent_id`/`run_id`) from the existing memory. Because the vector store replaces the **full** payload on update, every other custom metadata field stored at `add()` time was lost. The old code also dropped `textLemmatized` entirely, leaving the BM25 index pointing at the previous text.

## Fix

Mirrors the Python approach in #5179:

1. Start `newMetadata` from a copy of the **full existing payload** so no custom field is lost.
2. Overlay caller-supplied `metadata` on top (intentional metadata updates still apply).
3. Stamp the system fields last so they always reflect the latest update: `data`, `hash`, `textLemmatized` (refreshed from the new text), `createdAt` (preserved), `updatedAt` (now).

Session identifiers carry over automatically as part of the existing payload, so the explicit per-field copies are no longer needed.

## Verification

- `npx jest --config jest.config.js src/oss/tests/memory.crud.test.ts` — **23 passed**, including the new regression test `preserves custom metadata on a text-only update`.
- `npx tsup` — build succeeds (CJS + ESM + DTS).
- `npx prettier --check` on both changed files — clean.

Diff is 2 files, +30/-10.
