### PR TITLE
fix(ts-oss): stop Memory.get() leaking session ids into metadata

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -1273,11 +1273,15 @@ export class Memory {
       metadata: {},
     };
 
-    // Add additional metadata
+    // Add additional metadata. Session identifiers are surfaced as
+    // top-level fields below, so exclude them here. The payload stores
+    // them snake_case (user_id/agent_id/run_id) — matching search() and
+    // getAll() — so the exclusion set must use the same casing. (A prior
+    // camelCase set leaked the session ids back into `metadata`.)
     const excludedKeys = new Set([
-      "userId",
-      "agentId",
-      "runId",
+      "user_id",
+      "agent_id",
+      "run_id",
       "hash",
       "data",
       "createdAt",

--- a/mem0-ts/src/oss/tests/memory.crud.test.ts
+++ b/mem0-ts/src/oss/tests/memory.crud.test.ts
@@ -128,6 +128,36 @@ describe("Memory - get()", () => {
     expect(item!.createdAt).toBeDefined();
     expect(new Date(item!.createdAt!).toString()).not.toBe("Invalid Date");
   });
+
+  // Regression: session identifiers must NOT leak into metadata.
+  // They are surfaced as top-level fields; get() previously used a
+  // camelCase exclusion set (userId/agentId/runId) that did not match
+  // the snake_case payload keys, so they leaked into metadata — unlike
+  // search() and getAll(), which use snake_case and excluded them.
+  test("does not leak session identifiers into metadata", async () => {
+    const agentId = `agent_${Date.now()}`;
+    const runId = `run_${Date.now()}`;
+    const addResult: SearchResult = await memory.add("Scope leak test", {
+      userId,
+      agentId,
+      runId,
+      infer: false,
+      metadata: { category: "work" },
+    });
+    const id = addResult.results[0].id;
+    const item: MemoryItem | null = await memory.get(id);
+
+    expect(item!.metadata).not.toHaveProperty("user_id");
+    expect(item!.metadata).not.toHaveProperty("agent_id");
+    expect(item!.metadata).not.toHaveProperty("run_id");
+    // Genuine custom metadata is still surfaced.
+    expect(item!.metadata).toMatchObject({ category: "work" });
+    // Top-level session fields (from the filters spread) stay present.
+    // Without these, a dropped filters spread would still pass metadata-only asserts.
+    expect(item).toHaveProperty("user_id", userId);
+    expect(item).toHaveProperty("agent_id", agentId);
+    expect(item).toHaveProperty("run_id", runId);
+  });
 });
 
 // ─── update() ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `Memory.get()` leaked the session identifiers (`user_id`, `agent_id`, `run_id`) into `MemoryItem.metadata`, even though they are already surfaced as top-level fields on the returned object.
- Brings `get()` in line with `search()` and `getAll()`, which already exclude them correctly.

## Motivation

`get()` builds its metadata-exclusion set with **camelCase** keys:

```ts
const excludedKeys = new Set(["userId", "agentId", "runId", ...]);
```

But the vector-store payload stores session identifiers in **snake_case** (`user_id` / `agent_id` / `run_id`) — set in both `addToVectorStore()` and `createMemory()`. The mismatch means the exclusion never matches, so `get()` copies the session ids into `metadata`.

`search()` (step 9) and `getAll()` already use the snake_case keys in their exclusion sets, so they correctly keep session ids out of `metadata`. Only `get()` was inconsistent — a caller iterating `item.metadata` to enumerate user-supplied fields would unexpectedly find the internal scope keys mixed in.

## Fix

Use the snake_case keys (`user_id` / `agent_id` / `run_id`) in `get()`'s exclusion set so all three read paths agree. Genuine custom metadata is still surfaced unchanged.

## Verification

- Added regression test `does not leak session identifiers into metadata` in `memory.crud.test.ts`.
  - Confirmed **failing before** the fix (metadata contained `user_id`/`agent_id`/`run_id`), **passing after**.
- `npx jest --config jest.config.js src/oss/tests/memory.crud.test.ts` — **23 passed**.
- `npx tsup` — build succeeds (CJS + ESM + DTS).
- `npx prettier --check` on both changed files — clean.

Diff is 2 files, +31/-4.
