### PR TITLE
fix(weaviate): pass embedding dims in reset() so it does not crash

### DIFF
--- a/mem0/vector_stores/weaviate.py
+++ b/mem0/vector_stores/weaviate.py
@@ -389,4 +389,4 @@ class Weaviate(VectorStoreBase):
         """Reset the index by deleting and recreating it."""
         logger.warning(f"Resetting index {self.collection_name}...")
         self.delete_col()
-        self.create_col()
+        self.create_col(self.embedding_model_dims)

--- a/tests/vector_stores/test_weaviate.py
+++ b/tests/vector_stores/test_weaviate.py
@@ -202,6 +202,14 @@ class TestWeaviateDB(unittest.TestCase):
 
         self.client_mock.collections.delete.assert_called_once_with("test_collection")
 
+    def test_reset(self):
+        self.client_mock.collections.exists.return_value = False
+
+        self.weaviate_db.reset()
+
+        self.client_mock.collections.delete.assert_called_once_with("test_collection")
+        self.client_mock.collections.create.assert_called_once()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Bug

`Weaviate.reset()` calls `self.create_col()` with no arguments:

```python
def reset(self):
    """Reset the index by deleting and recreating it."""
    logger.warning(f"Resetting index {self.collection_name}...")
    self.delete_col()
    self.create_col()
```

But `create_col` requires `vector_size`:

```python
def create_col(self, vector_size, distance="cosine"):
```

So every `reset()` on the Weaviate backend raises:

```
TypeError: Weaviate.create_col() missing 1 required positional argument: 'vector_size'
```

This makes `Memory.reset()` unusable whenever Weaviate is the vector store. The other adapters store the dimension at init and pass it back into `create_col` from `reset()` (qdrant: `self.create_col(self.embedding_model_dims, self.on_disk)`, pinecone: `self.create_col(self.embedding_model_dims, self.metric)`, milvus likewise) — Weaviate was the one that dropped it.

### Fix

Pass `self.embedding_model_dims` (already stored in `__init__`) into `create_col`, matching the other adapters. One-line change.

### Test

Added `test_reset` to `tests/vector_stores/test_weaviate.py`. It drives the real `reset()` and asserts the collection is deleted and recreated.

- Before the fix it fails with the `TypeError` above.
- After the fix the file passes (10 passed).
