### PR TITLE
feat: add optional FunASR audio transcription helper (#5467)

### DIFF
--- a/docs/cookbooks/frameworks/audio-transcription-funasr.mdx
+++ b/docs/cookbooks/frameworks/audio-transcription-funasr.mdx
@@ -1,0 +1,81 @@
+---
+title: Audio Transcription with FunASR
+description: "Transcribe audio offline with FunASR and store speaker-aware memories."
+---
+
+
+Turn meeting recordings, voice notes, and call logs into long-term memory. Mem0 ships an optional helper that transcribes audio with [FunASR](https://github.com/modelscope/FunASR) and feeds the resulting transcript into the existing `Memory.add()` pipeline. Speaker turns (who said what) are preserved as metadata, so you can recall not just *what* was said but *who* said it.
+
+> FunASR runs locally. No audio leaves your machine, which makes this recipe a good fit for privacy-sensitive transcripts.
+
+## Features
+
+- **Offline Transcription**: FunASR runs on-device with no API calls for the audio step
+- **Speaker Turns as Metadata**: Each utterance is tagged with a stable `speaker_*` label
+- **Existing Memory Path**: The transcript flows straight into `Memory.add()` — no new API to learn
+- **Optional Dependency**: `funasr` and `torch` install only when you opt in
+
+## Installation
+
+The audio stack is an optional extra so the core install stays lean:
+
+```bash
+pip install "mem0ai[audio]"
+```
+
+If you call the helper without `funasr` installed, it raises a clear `ImportError` with this exact install hint.
+
+## How It Works
+
+1. **Load the model**: FunASR's `AutoModel` is imported lazily and built with ASR + VAD + punctuation + speaker models
+2. **Transcribe**: The audio file is decoded into a transcript with per-utterance `sentence_info`
+3. **Extract turns**: Each utterance becomes a `{"speaker", "text", "start", "end"}` turn
+4. **Store**: The transcript text plus speaker turns (as metadata) are written via `Memory.add()`
+
+## Usage
+
+```python
+from mem0 import Memory
+from mem0.utils.audio import transcribe_audio_to_memory
+
+memory = Memory()
+
+result = transcribe_audio_to_memory(
+    "meeting.wav",
+    memory=memory,
+    user_id="alice",
+    metadata={"source": "weekly-standup"},
+)
+
+print(result["transcript"])
+for turn in result["speaker_turns"]:
+    print(f"{turn['speaker']}: {turn['text']}")
+```
+
+The stored memory carries the speaker turns under `metadata["speaker_turns"]` and the original file under `metadata["audio_source"]`, alongside any caller-supplied metadata.
+
+## Customizing the Pipeline
+
+Override any FunASR model, or disable speaker diarization by passing `spk_model=None`:
+
+```python
+transcribe_audio_to_memory(
+    "interview.wav",
+    memory=memory,
+    user_id="bob",
+    model="paraformer-zh",       # ASR model
+    spk_model="cam++",           # speaker model (set None to disable turns)
+    generate_kwargs={"batch_size_s": 300},
+)
+```
+
+---
+
+<CardGroup cols={2}>
+  <Card title="Visual Memory Retrieval" icon="image" href="/cookbooks/frameworks/multimodal-retrieval">
+    Store and recall visual context alongside text conversations.
+  </Card>
+  <Card title="Voice Companion with OpenAI" icon="microphone" href="/cookbooks/companions/voice-companion-openai">
+    Build voice-first companions that remember conversations.
+  </Card>
+</CardGroup>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -382,6 +382,7 @@
                       "cookbooks/frameworks/llamaindex-react",
                       "cookbooks/frameworks/llamaindex-multiagent",
                       "cookbooks/frameworks/multimodal-retrieval",
+                      "cookbooks/frameworks/audio-transcription-funasr",
                       "cookbooks/frameworks/eliza-os-character",
                       "cookbooks/frameworks/gemini-3-with-mem0-mcp"
                     ]

--- a/mem0/utils/audio.py
+++ b/mem0/utils/audio.py
@@ -186,9 +186,11 @@ def transcribe_audio_to_memory(
 
     Note:
         Each call to this function constructs a new ``AutoModel`` instance,
-        which loads model weights from disk. For repeated calls, build the
-        model once outside this function and pass it via ``model_kwargs``
-        or refactor to reuse the ``funasr_model`` object directly.
+        which loads model weights from disk. ``model_kwargs`` is forwarded as
+        constructor arguments to ``AutoModel`` and cannot inject an
+        already-instantiated model, so reusing a model across calls would
+        require a future signature change (e.g. accepting a pre-built
+        ``AutoModel``).
     """
     funasr_model = _load_funasr_model(model, vad_model, punc_model, spk_model, model_kwargs)
 

--- a/mem0/utils/audio.py
+++ b/mem0/utils/audio.py
@@ -1,0 +1,225 @@
+"""Optional FunASR audio transcription helper.
+
+This module turns an audio file into a transcript and feeds that transcript
+into the *existing* :meth:`mem0.Memory.add` path. Speaker turns (who said what)
+are preserved as ``metadata`` rather than as a new first-class ingestion API.
+
+``funasr`` (and its ``torch`` backend) is an **optional** dependency. It is
+imported lazily inside :func:`transcribe_audio_to_memory` so that importing
+``mem0`` never requires the audio stack. If the dependency is missing, a clear
+``ImportError`` with an install hint is raised.
+
+Install the optional extra with::
+
+    pip install "mem0ai[audio]"
+
+Example::
+
+    from mem0 import Memory
+    from mem0.utils.audio import transcribe_audio_to_memory
+
+    memory = Memory()
+    transcribe_audio_to_memory("meeting.wav", memory=memory, user_id="alice")
+"""
+
+from typing import Any, Dict, List, Optional
+
+# Default FunASR pipeline. ``paraformer-zh`` handles ASR while the ``cam++``
+# speaker model + VAD/punctuation models enable speaker-segmented output via
+# the ``sentence_info`` field returned by ``AutoModel.generate``.
+DEFAULT_FUNASR_MODEL = "paraformer-zh"
+DEFAULT_VAD_MODEL = "fsmn-vad"
+DEFAULT_PUNC_MODEL = "ct-punc"
+DEFAULT_SPK_MODEL = "cam++"
+
+
+def _load_funasr_model(
+    model: str,
+    vad_model: Optional[str],
+    punc_model: Optional[str],
+    spk_model: Optional[str],
+    model_kwargs: Optional[Dict[str, Any]],
+):
+    """Lazily import FunASR and build an ``AutoModel`` for transcription.
+
+    Args:
+        model: Name/path of the ASR model.
+        vad_model: Optional voice-activity-detection model name.
+        punc_model: Optional punctuation-restoration model name.
+        spk_model: Optional speaker-diarization model name (enables turns).
+        model_kwargs: Extra keyword arguments forwarded to ``AutoModel``.
+
+    Returns:
+        An instantiated FunASR ``AutoModel``.
+
+    Raises:
+        ImportError: If the optional ``funasr`` dependency is not installed.
+    """
+    try:
+        from funasr import AutoModel
+    except ImportError as exc:
+        raise ImportError(
+            "The 'funasr' library is required for audio transcription but is not "
+            "installed. Install the optional audio extra with: "
+            'pip install "mem0ai[audio]"'
+        ) from exc
+
+    build_kwargs: Dict[str, Any] = {"model": model}
+    if vad_model:
+        build_kwargs["vad_model"] = vad_model
+    if punc_model:
+        build_kwargs["punc_model"] = punc_model
+    if spk_model:
+        build_kwargs["spk_model"] = spk_model
+    if model_kwargs:
+        build_kwargs.update(model_kwargs)
+
+    return AutoModel(**build_kwargs)
+
+
+def _extract_speaker_turns(funasr_result: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Convert a FunASR result into ordered speaker turns.
+
+    FunASR's speaker pipeline returns a list whose first element carries a
+    ``sentence_info`` list, one entry per utterance with a ``spk`` (integer
+    speaker id), ``text``, and ``start``/``end`` timestamps (milliseconds).
+
+    Args:
+        funasr_result: The raw value returned by ``AutoModel.generate``.
+
+    Returns:
+        A list of ``{"speaker", "text", "start", "end"}`` dicts in spoken
+        order. Empty if the result carries no per-sentence speaker info.
+    """
+    if not funasr_result:
+        return []
+
+    first = funasr_result[0]
+    sentence_info = first.get("sentence_info") or []
+
+    turns: List[Dict[str, Any]] = []
+    for sentence in sentence_info:
+        # Speaker id may be absent for single-speaker audio; normalise to a
+        # stable, human-readable label so it round-trips cleanly in metadata.
+        speaker_id = sentence.get("spk", 0)
+        turns.append(
+            {
+                "speaker": f"speaker_{speaker_id}",
+                "text": sentence.get("text", ""),
+                "start": sentence.get("start"),
+                "end": sentence.get("end"),
+            }
+        )
+    return turns
+
+
+def _extract_transcript(funasr_result: List[Dict[str, Any]], speaker_turns: List[Dict[str, Any]]) -> str:
+    """Derive the full transcript text from a FunASR result.
+
+    Prefers the top-level ``text`` field; falls back to joining the per-turn
+    texts so a transcript is still produced when only ``sentence_info`` exists.
+
+    Args:
+        funasr_result: The raw value returned by ``AutoModel.generate``.
+        speaker_turns: The parsed speaker turns (used as a fallback source).
+
+    Returns:
+        The transcript as a single string (possibly empty).
+    """
+    if funasr_result and funasr_result[0].get("text"):
+        return funasr_result[0]["text"]
+    return " ".join(turn["text"] for turn in speaker_turns if turn["text"]).strip()
+
+
+def transcribe_audio_to_memory(
+    audio: str,
+    *,
+    memory: Any,
+    user_id: Optional[str] = None,
+    agent_id: Optional[str] = None,
+    run_id: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+    model: str = DEFAULT_FUNASR_MODEL,
+    vad_model: Optional[str] = DEFAULT_VAD_MODEL,
+    punc_model: Optional[str] = DEFAULT_PUNC_MODEL,
+    spk_model: Optional[str] = DEFAULT_SPK_MODEL,
+    model_kwargs: Optional[Dict[str, Any]] = None,
+    generate_kwargs: Optional[Dict[str, Any]] = None,
+    infer: bool = True,
+) -> Dict[str, Any]:
+    """Transcribe an audio input with FunASR and store it via ``Memory.add``.
+
+    The transcript text is fed into the existing :meth:`Memory.add` path. Speaker
+    turns and the audio source are attached as ``metadata`` so retrieval can
+    reason about who said what without introducing a new ingestion API.
+
+    Args:
+        audio: Path to an audio file (or any input FunASR's ``generate``
+            accepts, e.g. raw bytes or a URL).
+        memory: A synchronous ``mem0.Memory`` instance whose ``add`` method
+            receives the transcript. Injected by the caller so this helper
+            stays decoupled from Memory construction. ``AsyncMemory`` is not
+            supported — its ``add`` is a coroutine and cannot be awaited here.
+        user_id: Optional session identifier forwarded to ``Memory.add``.
+        agent_id: Optional session identifier forwarded to ``Memory.add``.
+        run_id: Optional session identifier forwarded to ``Memory.add``.
+        metadata: Optional caller metadata merged into the result metadata.
+            ``audio_source`` and ``speaker_turns`` are reserved keys — they are
+            always set by this function and will overwrite any caller-supplied
+            values with the same name.
+        model: FunASR ASR model name/path.
+        vad_model: Optional voice-activity-detection model name.
+        punc_model: Optional punctuation-restoration model name.
+        spk_model: Optional speaker-diarization model name; enables speaker
+            turns. Pass ``None`` to disable diarization.
+        model_kwargs: Extra keyword arguments forwarded to ``AutoModel``.
+        generate_kwargs: Extra keyword arguments forwarded to ``model.generate``.
+        infer: Forwarded to ``Memory.add``; controls LLM-based memory extraction.
+
+    Returns:
+        A dict with ``transcript`` (str), ``speaker_turns`` (list) and
+        ``memory_result`` (the value returned by ``Memory.add``).
+
+    Raises:
+        ImportError: If the optional ``funasr`` dependency is not installed.
+        ValueError: If FunASR returns an empty transcript.
+
+    Note:
+        Each call to this function constructs a new ``AutoModel`` instance,
+        which loads model weights from disk. For repeated calls, build the
+        model once outside this function and pass it via ``model_kwargs``
+        or refactor to reuse the ``funasr_model`` object directly.
+    """
+    funasr_model = _load_funasr_model(model, vad_model, punc_model, spk_model, model_kwargs)
+
+    generate_args: Dict[str, Any] = {"input": audio}
+    if generate_kwargs:
+        generate_args.update(generate_kwargs)
+    funasr_result = funasr_model.generate(**generate_args)
+
+    speaker_turns = _extract_speaker_turns(funasr_result)
+    transcript = _extract_transcript(funasr_result, speaker_turns)
+
+    if not transcript.strip():
+        raise ValueError("FunASR produced an empty transcript for the given audio input; nothing was stored in memory.")
+
+    # Reserved metadata keys carry the structured audio context. Caller metadata
+    # is layered first so explicit reserved keys here remain authoritative.
+    combined_metadata: Dict[str, Any] = dict(metadata or {})
+    combined_metadata["audio_source"] = audio
+    combined_metadata["speaker_turns"] = speaker_turns
+
+    memory_result = memory.add(
+        transcript,
+        user_id=user_id,
+        agent_id=agent_id,
+        run_id=run_id,
+        metadata=combined_metadata,
+        infer=infer,
+    )
+
+    return {
+        "transcript": transcript,
+        "speaker_turns": speaker_turns,
+        "memory_result": memory_result,
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,11 @@ dependencies = [
 nlp = [
     "spacy>=3.7.0",
 ]
+audio = [
+    "funasr>=1.1.0",
+    "torch>=2.0.0",
+    "torchaudio>=2.0.0",
+]
 vector-stores = [
     "vecs>=0.4.0",
     "chromadb>=0.4.24",

--- a/tests/utils/test_audio.py
+++ b/tests/utils/test_audio.py
@@ -1,0 +1,137 @@
+"""Tests for the optional FunASR audio transcription helper.
+
+These tests fully mock the FunASR model and the Memory instance so that
+CI never downloads model weights or makes any network call. They exercise
+three things:
+
+1. The helper lazy-imports ``funasr`` and raises a clear, actionable
+   ``ImportError`` (with an install hint) when the package is absent.
+2. Given a (mocked) FunASR result, the helper produces transcript text and
+   preserves speaker turns as ``metadata``.
+3. The transcript text + speaker-turn metadata are passed straight into the
+   existing ``Memory.add()`` path (no new first-class API).
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# A realistic FunASR ``AutoModel.generate()`` return value for a speaker
+# diarization pipeline: a single dict whose ``sentence_info`` carries one
+# entry per utterance with a ``spk`` (speaker id), ``text``, and timestamps.
+FAKE_FUNASR_RESULT = [
+    {
+        "text": "hello there i am alice how are you i am fine thanks bob",
+        "sentence_info": [
+            {"text": "hello there i am alice", "spk": 0, "start": 0, "end": 1500},
+            {"text": "how are you", "spk": 1, "start": 1500, "end": 2200},
+            {"text": "i am fine thanks bob", "spk": 0, "start": 2200, "end": 3800},
+        ],
+    }
+]
+
+
+@pytest.fixture
+def mock_funasr(monkeypatch):
+    """Install a fake ``funasr`` module exposing ``AutoModel``.
+
+    ``AutoModel(...)`` returns a model whose ``.generate(...)`` yields
+    ``FAKE_FUNASR_RESULT`` so no real weights are loaded.
+    """
+    fake_module = MagicMock()
+    fake_model = MagicMock()
+    fake_model.generate.return_value = FAKE_FUNASR_RESULT
+    fake_module.AutoModel.return_value = fake_model
+    monkeypatch.setitem(sys.modules, "funasr", fake_module)
+    return fake_module, fake_model
+
+
+def test_missing_funasr_raises_actionable_import_error(monkeypatch):
+    """When ``funasr`` is not installed, the helper must raise a clear hint."""
+    from mem0.utils.audio import transcribe_audio_to_memory
+
+    # Force the lazy import to fail regardless of the real environment.
+    monkeypatch.setitem(sys.modules, "funasr", None)
+
+    memory = MagicMock()
+    with pytest.raises(ImportError) as exc_info:
+        transcribe_audio_to_memory("/tmp/sample.wav", memory=memory, user_id="alice")
+
+    message = str(exc_info.value)
+    assert "funasr" in message.lower()
+    assert "mem0ai[audio]" in message
+    # The Memory path must never be reached if the dependency is missing.
+    memory.add.assert_not_called()
+
+
+def test_transcribe_produces_text_and_speaker_turn_metadata(mock_funasr):
+    """Helper returns transcript text and structured speaker-turn metadata."""
+    from mem0.utils.audio import transcribe_audio_to_memory
+
+    memory = MagicMock()
+    memory.add.return_value = {"results": []}
+
+    result = transcribe_audio_to_memory("/tmp/sample.wav", memory=memory, user_id="alice")
+
+    # Full transcript text is surfaced to the caller.
+    assert result["transcript"] == FAKE_FUNASR_RESULT[0]["text"]
+
+    # Speaker turns preserve order, speaker id, and per-turn text.
+    turns = result["speaker_turns"]
+    assert turns == [
+        {"speaker": "speaker_0", "text": "hello there i am alice", "start": 0, "end": 1500},
+        {"speaker": "speaker_1", "text": "how are you", "start": 1500, "end": 2200},
+        {"speaker": "speaker_0", "text": "i am fine thanks bob", "start": 2200, "end": 3800},
+    ]
+
+
+def test_transcript_text_and_metadata_passed_to_memory_add(mock_funasr):
+    """The transcript + speaker turns must flow into the existing add() path."""
+    from mem0.utils.audio import transcribe_audio_to_memory
+
+    memory = MagicMock()
+    memory.add.return_value = {"results": [{"id": "1", "memory": "x", "event": "ADD"}]}
+
+    transcribe_audio_to_memory(
+        "/tmp/sample.wav",
+        memory=memory,
+        user_id="alice",
+        metadata={"source": "meeting-2026-06-16"},
+    )
+
+    memory.add.assert_called_once()
+    call = memory.add.call_args
+
+    # Positional transcript text passed as the messages argument.
+    assert call.args[0] == FAKE_FUNASR_RESULT[0]["text"]
+
+    # Session identifier forwarded unchanged.
+    assert call.kwargs["user_id"] == "alice"
+
+    # Speaker turns recorded under metadata; caller metadata is merged, not lost.
+    metadata = call.kwargs["metadata"]
+    assert metadata["source"] == "meeting-2026-06-16"
+    assert metadata["audio_source"] == "/tmp/sample.wav"
+    assert metadata["speaker_turns"] == [
+        {"speaker": "speaker_0", "text": "hello there i am alice", "start": 0, "end": 1500},
+        {"speaker": "speaker_1", "text": "how are you", "start": 1500, "end": 2200},
+        {"speaker": "speaker_0", "text": "i am fine thanks bob", "start": 2200, "end": 3800},
+    ]
+
+
+def test_funasr_model_constructed_and_generate_called(mock_funasr):
+    """AutoModel is constructed via the lazy import and generate() is invoked."""
+    fake_module, fake_model = mock_funasr
+    from mem0.utils.audio import transcribe_audio_to_memory
+
+    memory = MagicMock()
+    memory.add.return_value = {"results": []}
+
+    transcribe_audio_to_memory("/tmp/sample.wav", memory=memory, user_id="alice")
+
+    fake_module.AutoModel.assert_called_once()
+    fake_model.generate.assert_called_once()
+    # The audio path is forwarded to FunASR's generate() input.
+    assert fake_model.generate.call_args.kwargs.get("input") == "/tmp/sample.wav"


### PR DESCRIPTION
Closes #5467

## Summary

- **New `mem0/utils/audio.py`**: adds `transcribe_audio_to_memory(audio, *, memory, user_id, ...)` — a thin helper that transcribes audio via FunASR and feeds the transcript into the existing `Memory.add()` path. No new ingestion API.
- **Speaker turns**: `sentence_info` fields (`spk`, `text`, `start`, `end`) are parsed and stored under `metadata["speaker_turns"]` so retrieval can reason about who said what.
- **Optional dependency only**: `funasr`, `torch`, `torchaudio` are declared as an `[audio]` optional extra and lazy-imported, so `import mem0` never requires the audio stack. An `ImportError` with an actionable install hint is raised if the extra is missing.
- **Empty transcript guard**: raises `ValueError` when FunASR returns an empty transcript.
- **Docs**: new cookbook at `docs/cookbooks/frameworks/audio-transcription-funasr.mdx` covering install, basic usage, and speaker-turn access.

## Design note

This implements the option-1 approach confirmed by @LauraGPT (#5467): an optional helper that feeds FunASR output into the existing `Memory.add` path, with speaker turns as metadata and no changes to the core API surface.

## Test plan

```bash
pip install "mem0ai[audio]"
pytest tests/utils/test_audio.py -v
```

All 4 tests use a fully-mocked FunASR `AutoModel` — CI never downloads model weights. Verified RED (4 failed) → GREEN (4 passed). Neighboring test suite (`tests/`) passes with 0 regressions.