### PR TITLE
feat(memory): add spaCy semantic entity types to entity store (#5440)

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -517,11 +517,18 @@ class Memory(MemoryBase):
                 match = existing[0]
                 payload = match.payload or {}
                 linked_ids = payload.get("linked_memory_ids", [])
+                changed = False
                 if memory_id not in linked_ids:
                     linked_ids.append(memory_id)
                     payload["linked_memory_ids"] = linked_ids
-                    if semantic_type and not payload.get("semantic_type"):
-                        payload["semantic_type"] = semantic_type
+                    changed = True
+                # Back-fill semantic_type independently of the link update so a
+                # re-visited memory_id (re-index/retry) can still upgrade a record
+                # that was first written without a label.
+                if semantic_type and payload.get("semantic_type") is None:
+                    payload["semantic_type"] = semantic_type
+                    changed = True
+                if changed:
                     self.entity_store.update(
                         vector_id=match.id,
                         vector=None,
@@ -978,8 +985,10 @@ class Memory(MemoryBase):
                     key = entity_text.strip().lower()
                     if key in global_entities:
                         global_entities[key][3].add(memory_id)
-                        # Upgrade semantic_type if not yet set
-                        if semantic_type and not global_entities[key][2]:
+                        # Upgrade semantic_type if not yet set. "First non-None
+                        # wins": when memories disagree, the label of whichever
+                        # record is processed first (in `records` order) is kept.
+                        if semantic_type and global_entities[key][2] is None:
                             global_entities[key][2] = semantic_type
                     else:
                         global_entities[key] = [entity_type, entity_text, semantic_type, {memory_id}]
@@ -1039,7 +1048,7 @@ class Memory(MemoryBase):
                             linked = set(payload.get("linked_memory_ids", []))
                             linked |= memory_ids
                             payload["linked_memory_ids"] = sorted(linked)
-                            if semantic_type and not payload.get("semantic_type"):
+                            if semantic_type and payload.get("semantic_type") is None:
                                 payload["semantic_type"] = semantic_type
                             try:
                                 self.entity_store.update(
@@ -2073,11 +2082,18 @@ class AsyncMemory(MemoryBase):
                 match = existing[0]
                 payload = match.payload or {}
                 linked_ids = payload.get("linked_memory_ids", [])
+                changed = False
                 if memory_id not in linked_ids:
                     linked_ids.append(memory_id)
                     payload["linked_memory_ids"] = linked_ids
-                    if semantic_type and not payload.get("semantic_type"):
-                        payload["semantic_type"] = semantic_type
+                    changed = True
+                # Back-fill semantic_type independently of the link update so a
+                # re-visited memory_id (re-index/retry) can still upgrade a record
+                # that was first written without a label.
+                if semantic_type and payload.get("semantic_type") is None:
+                    payload["semantic_type"] = semantic_type
+                    changed = True
+                if changed:
                     await asyncio.to_thread(
                         self.entity_store.update,
                         vector_id=match.id,
@@ -2529,7 +2545,10 @@ class AsyncMemory(MemoryBase):
                     key = entity_text.strip().lower()
                     if key in global_entities:
                         global_entities[key][3].add(memory_id)
-                        if semantic_type and not global_entities[key][2]:
+                        # Upgrade semantic_type if not yet set. "First non-None
+                        # wins": when memories disagree, the label of whichever
+                        # record is processed first (in `records` order) is kept.
+                        if semantic_type and global_entities[key][2] is None:
                             global_entities[key][2] = semantic_type
                     else:
                         global_entities[key] = [entity_type, entity_text, semantic_type, {memory_id}]
@@ -2586,7 +2605,7 @@ class AsyncMemory(MemoryBase):
                             linked = set(payload.get("linked_memory_ids", []))
                             linked |= memory_ids
                             payload["linked_memory_ids"] = sorted(linked)
-                            if semantic_type and not payload.get("semantic_type"):
+                            if semantic_type and payload.get("semantic_type") is None:
                                 payload["semantic_type"] = semantic_type
                             try:
                                 await asyncio.to_thread(

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -499,7 +499,7 @@ class Memory(MemoryBase):
             )
         return self._entity_store
 
-    def _upsert_entity(self, entity_text, entity_type, memory_id, filters):
+    def _upsert_entity(self, entity_text, entity_type, memory_id, filters, semantic_type=None):
         """Upsert an entity into the entity store, linking it to a memory."""
         try:
             entity_embedding = self.embedding_model.embed(entity_text, "add")
@@ -520,6 +520,8 @@ class Memory(MemoryBase):
                 if memory_id not in linked_ids:
                     linked_ids.append(memory_id)
                     payload["linked_memory_ids"] = linked_ids
+                    if semantic_type and not payload.get("semantic_type"):
+                        payload["semantic_type"] = semantic_type
                     self.entity_store.update(
                         vector_id=match.id,
                         vector=None,
@@ -534,6 +536,8 @@ class Memory(MemoryBase):
                     "linked_memory_ids": [memory_id],
                     **{k: v for k, v in search_filters.items()},
                 }
+                if semantic_type:
+                    entity_payload["semantic_type"] = semantic_type
                 self.entity_store.insert(
                     vectors=[entity_embedding],
                     ids=[entity_id],
@@ -608,13 +612,13 @@ class Memory(MemoryBase):
             if not entities:
                 return
             seen = set()
-            for entity_type, entity_text in entities:
+            for entity_type, entity_text, semantic_type in entities:
                 key = entity_text.strip().lower()
                 if not key or key in seen:
                     continue
                 seen.add(key)
                 try:
-                    self._upsert_entity(entity_text, entity_type, memory_id, filters)
+                    self._upsert_entity(entity_text, entity_type, memory_id, filters, semantic_type=semantic_type)
                 except Exception as e:
                     logger.debug(f"Entity link failed for '{entity_text}': {e}")
         except Exception as e:
@@ -967,15 +971,18 @@ class Memory(MemoryBase):
             all_entities = extract_entities_batch(all_texts)
 
             # 7a: Global dedup — collect unique entities across all memories
-            global_entities = {}  # normalized_key -> (entity_type, entity_text, set of memory_ids)
+            global_entities = {}  # normalized_key -> [entity_type, entity_text, semantic_type, set of memory_ids]
             for idx, (memory_id, text, embedding, payload) in enumerate(records):
                 entities = all_entities[idx] if idx < len(all_entities) else []
-                for entity_type, entity_text in entities:
+                for entity_type, entity_text, semantic_type in entities:
                     key = entity_text.strip().lower()
                     if key in global_entities:
-                        global_entities[key][2].add(memory_id)
+                        global_entities[key][3].add(memory_id)
+                        # Upgrade semantic_type if not yet set
+                        if semantic_type and not global_entities[key][2]:
+                            global_entities[key][2] = semantic_type
                     else:
-                        global_entities[key] = [entity_type, entity_text, {memory_id}]
+                        global_entities[key] = [entity_type, entity_text, semantic_type, {memory_id}]
 
             if global_entities:
                 ordered_keys = list(global_entities.keys())
@@ -1022,7 +1029,7 @@ class Memory(MemoryBase):
                     # 7d: Separate into inserts vs updates
                     to_insert_vectors, to_insert_ids, to_insert_payloads = [], [], []
                     for j, key in enumerate(valid_keys):
-                        entity_type, entity_text, memory_ids = global_entities[key]
+                        entity_type, entity_text, semantic_type, memory_ids = global_entities[key]
                         matches = existing_matches[j] if j < len(existing_matches) else []
 
                         if matches and matches[0].score >= 0.95:
@@ -1032,6 +1039,8 @@ class Memory(MemoryBase):
                             linked = set(payload.get("linked_memory_ids", []))
                             linked |= memory_ids
                             payload["linked_memory_ids"] = sorted(linked)
+                            if semantic_type and not payload.get("semantic_type"):
+                                payload["semantic_type"] = semantic_type
                             try:
                                 self.entity_store.update(
                                     vector_id=match.id,
@@ -1042,14 +1051,17 @@ class Memory(MemoryBase):
                                 logger.debug(f"Entity update failed for '{entity_text}': {e}")
                         else:
                             # New entity — collect for batch insert
-                            to_insert_vectors.append(valid_vectors[j])
-                            to_insert_ids.append(str(uuid.uuid4()))
-                            to_insert_payloads.append({
+                            new_payload = {
                                 "data": entity_text,
                                 "entity_type": entity_type,
                                 "linked_memory_ids": sorted(memory_ids),
                                 **search_filters,
-                            })
+                            }
+                            if semantic_type:
+                                new_payload["semantic_type"] = semantic_type
+                            to_insert_vectors.append(valid_vectors[j])
+                            to_insert_ids.append(str(uuid.uuid4()))
+                            to_insert_payloads.append(new_payload)
 
                     # 7e: Single batch insert for all new entities
                     if to_insert_vectors:
@@ -1599,7 +1611,7 @@ class Memory(MemoryBase):
         # Deduplicate entities (max 8)
         seen = set()
         deduped = []
-        for entity_type, entity_text in query_entities[:8]:
+        for entity_type, entity_text, *_ in query_entities[:8]:
             key = entity_text.strip().lower()
             if key and key not in seen:
                 seen.add(key)
@@ -2043,7 +2055,7 @@ class AsyncMemory(MemoryBase):
             )
         return self._entity_store
 
-    async def _upsert_entity_async(self, entity_text, entity_type, memory_id, filters):
+    async def _upsert_entity_async(self, entity_text, entity_type, memory_id, filters, semantic_type=None):
         """Async variant of `_upsert_entity` — per-entity search-then-update-or-insert."""
         try:
             entity_embedding = await asyncio.to_thread(self.embedding_model.embed, entity_text, "add")
@@ -2064,6 +2076,8 @@ class AsyncMemory(MemoryBase):
                 if memory_id not in linked_ids:
                     linked_ids.append(memory_id)
                     payload["linked_memory_ids"] = linked_ids
+                    if semantic_type and not payload.get("semantic_type"):
+                        payload["semantic_type"] = semantic_type
                     await asyncio.to_thread(
                         self.entity_store.update,
                         vector_id=match.id,
@@ -2078,6 +2092,8 @@ class AsyncMemory(MemoryBase):
                     "linked_memory_ids": [memory_id],
                     **{k: v for k, v in search_filters.items()},
                 }
+                if semantic_type:
+                    entity_payload["semantic_type"] = semantic_type
                 await asyncio.to_thread(
                     self.entity_store.insert,
                     vectors=[entity_embedding],
@@ -2160,13 +2176,13 @@ class AsyncMemory(MemoryBase):
             if not entities:
                 return
             seen = set()
-            for entity_type, entity_text in entities:
+            for entity_type, entity_text, semantic_type in entities:
                 key = entity_text.strip().lower()
                 if not key or key in seen:
                     continue
                 seen.add(key)
                 try:
-                    await self._upsert_entity_async(entity_text, entity_type, memory_id, filters)
+                    await self._upsert_entity_async(entity_text, entity_type, memory_id, filters, semantic_type=semantic_type)
                 except Exception as e:
                     logger.debug(f"Entity link failed for '{entity_text}' (async): {e}")
         except Exception as e:
@@ -2506,15 +2522,17 @@ class AsyncMemory(MemoryBase):
             all_entities = await asyncio.to_thread(extract_entities_batch, all_texts)
 
             # 7a: Global dedup
-            global_entities = {}
+            global_entities = {}  # normalized_key -> [entity_type, entity_text, semantic_type, set of memory_ids]
             for idx, (memory_id, text, embedding, payload) in enumerate(records):
                 entities = all_entities[idx] if idx < len(all_entities) else []
-                for entity_type, entity_text in entities:
+                for entity_type, entity_text, semantic_type in entities:
                     key = entity_text.strip().lower()
                     if key in global_entities:
-                        global_entities[key][2].add(memory_id)
+                        global_entities[key][3].add(memory_id)
+                        if semantic_type and not global_entities[key][2]:
+                            global_entities[key][2] = semantic_type
                     else:
-                        global_entities[key] = [entity_type, entity_text, {memory_id}]
+                        global_entities[key] = [entity_type, entity_text, semantic_type, {memory_id}]
 
             if global_entities:
                 ordered_keys = list(global_entities.keys())
@@ -2559,7 +2577,7 @@ class AsyncMemory(MemoryBase):
                     # 7d: Separate into inserts vs updates
                     to_insert_vectors, to_insert_ids, to_insert_payloads = [], [], []
                     for j, key in enumerate(valid_keys):
-                        entity_type, entity_text, memory_ids = global_entities[key]
+                        entity_type, entity_text, semantic_type, memory_ids = global_entities[key]
                         matches = existing_matches[j] if j < len(existing_matches) else []
 
                         if matches and matches[0].score >= 0.95:
@@ -2568,6 +2586,8 @@ class AsyncMemory(MemoryBase):
                             linked = set(payload.get("linked_memory_ids", []))
                             linked |= memory_ids
                             payload["linked_memory_ids"] = sorted(linked)
+                            if semantic_type and not payload.get("semantic_type"):
+                                payload["semantic_type"] = semantic_type
                             try:
                                 await asyncio.to_thread(
                                     self.entity_store.update,
@@ -2578,14 +2598,17 @@ class AsyncMemory(MemoryBase):
                             except Exception as e:
                                 logger.debug(f"Entity update failed for '{entity_text}' (async): {e}")
                         else:
-                            to_insert_vectors.append(valid_vectors[j])
-                            to_insert_ids.append(str(uuid.uuid4()))
-                            to_insert_payloads.append({
+                            new_payload = {
                                 "data": entity_text,
                                 "entity_type": entity_type,
                                 "linked_memory_ids": sorted(memory_ids),
                                 **search_filters,
-                            })
+                            }
+                            if semantic_type:
+                                new_payload["semantic_type"] = semantic_type
+                            to_insert_vectors.append(valid_vectors[j])
+                            to_insert_ids.append(str(uuid.uuid4()))
+                            to_insert_payloads.append(new_payload)
 
                     # 7e: Batch insert new entities
                     if to_insert_vectors:
@@ -3131,7 +3154,7 @@ class AsyncMemory(MemoryBase):
         """Async version of entity boost computation."""
         seen = set()
         deduped = []
-        for entity_type, entity_text in query_entities[:8]:
+        for entity_type, entity_text, *_ in query_entities[:8]:
             key = entity_text.strip().lower()
             if key and key not in seen:
                 seen.add(key)

--- a/mem0/utils/entity_extraction.py
+++ b/mem0/utils/entity_extraction.py
@@ -8,17 +8,22 @@ Extracts four types of entities from text:
 - **Noun fallback**: Single nouns from circumstantial compound patterns
 
 Public API:
-    extract_entities(text: str) -> List[Tuple[str, str]]
+    extract_entities(text: str) -> List[Tuple[str, str, Optional[str]]]
+
+Each tuple is (syntactic_type, entity_text, semantic_type) where:
+    syntactic_type: one of PROPER, QUOTED, COMPOUND, NOUN
+    entity_text: the extracted entity string
+    semantic_type: spaCy NER label (PERSON, ORG, GPE, LOC, PRODUCT, …) or None
 
 Internal:
-    _extract_entities_from_doc(doc) -> List[Tuple[str, str]]
+    _extract_entities_from_doc(doc) -> List[Tuple[str, str, Optional[str]]]
 """
 
 from __future__ import annotations
 
 import logging
 import re
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +87,13 @@ _GENERIC_CAPS = {
 # Markdown/formatting markers to skip during extraction
 _FORMATTING_MARKERS = {"*", "-", "+", "\u2022", "\u2013", "\u2014", "#", "##", "###", "**", "__"}
 
+# spaCy NER labels considered semantically meaningful for entity storage.
+# Excludes numeric/temporal labels (DATE, TIME, MONEY, PERCENT, CARDINAL, ORDINAL, QUANTITY).
+_SEMANTIC_LABELS = frozenset({
+    "PERSON", "ORG", "GPE", "LOC", "PRODUCT", "EVENT",
+    "WORK_OF_ART", "LAW", "LANGUAGE", "FAC", "NORP",
+})
+
 
 def _is_sentence_start(tokens: list, idx: int) -> bool:
     """Check if a token is at the start of a sentence or after formatting."""
@@ -120,7 +132,7 @@ def _has_artifacts(txt: str) -> bool:
     )
 
 
-def extract_entities(text: str) -> List[Tuple[str, str]]:
+def extract_entities(text: str) -> List[Tuple[str, str, Optional[str]]]:
     """Extract named entities, quoted text, and noun compounds from text.
 
     This is the public API that accepts a string. It loads the spaCy model
@@ -130,8 +142,9 @@ def extract_entities(text: str) -> List[Tuple[str, str]]:
         text: Input text to extract entities from.
 
     Returns:
-        Deduplicated list of (entity_type, entity_text) tuples.
-        Entity types: PROPER, QUOTED, COMPOUND, NOUN.
+        Deduplicated list of (syntactic_type, entity_text, semantic_type) tuples.
+        syntactic_type: PROPER, QUOTED, COMPOUND, or NOUN.
+        semantic_type: spaCy NER label (PERSON, ORG, GPE, …) when available, else None.
         Returns empty list if spaCy is unavailable.
     """
     from mem0.utils.spacy_models import get_nlp_full
@@ -144,7 +157,7 @@ def extract_entities(text: str) -> List[Tuple[str, str]]:
     return _extract_entities_from_doc(doc)
 
 
-def extract_entities_batch(texts: List[str], batch_size: int = 32) -> List[List[Tuple[str, str]]]:
+def extract_entities_batch(texts: List[str], batch_size: int = 32) -> List[List[Tuple[str, str, Optional[str]]]]:
     """Extract entities from multiple texts using spaCy's nlp.pipe() for batched NER.
 
     Uses spaCy's efficient batch processing pipeline instead of calling
@@ -156,8 +169,8 @@ def extract_entities_batch(texts: List[str], batch_size: int = 32) -> List[List[
 
     Returns:
         List of entity lists, one per input text. Each entity list contains
-        (entity_type, entity_text) tuples. Returns list of empty lists if
-        spaCy is unavailable.
+        (syntactic_type, entity_text, semantic_type) tuples. Returns list of
+        empty lists if spaCy is unavailable.
     """
     if not texts:
         return []
@@ -174,10 +187,11 @@ def extract_entities_batch(texts: List[str], batch_size: int = 32) -> List[List[
     return results
 
 
-def _extract_entities_from_doc(doc) -> List[Tuple[str, str]]:
+def _extract_entities_from_doc(doc) -> List[Tuple[str, str, Optional[str]]]:
     """Extract entities from a spaCy Doc object.
 
     Ported from platform's shared.core.utils.entity_extraction.extract_entities().
+    Returns 3-tuples of (syntactic_type, entity_text, semantic_type).
     """
     entities: List[Tuple[str, str]] = []
     text = doc.text
@@ -356,8 +370,16 @@ def _extract_entities_from_doc(doc) -> List[Tuple[str, str]]:
     # Word-boundary anchoring avoids dropping distinct entities that only share a
     # leading substring (e.g. "Sam" must survive alongside "Samsung").
     all_lower = [e[1].lower() for e in deduped]
-    return [
+    final = [
         (t, e)
         for t, e in deduped
         if not any(e.lower() != o and re.search(rf"\b{re.escape(e.lower())}\b", o) for o in all_lower)
     ]
+
+    # Build spaCy NER semantic label lookup from doc.ents (e.g. PERSON, ORG, GPE)
+    spacy_ner_map: dict = {}
+    for ent in doc.ents:
+        if ent.label_ in _SEMANTIC_LABELS:
+            spacy_ner_map[ent.text.lower()] = ent.label_
+
+    return [(t, e, spacy_ner_map.get(e.lower())) for t, e in final]

--- a/mem0/utils/entity_extraction.py
+++ b/mem0/utils/entity_extraction.py
@@ -382,4 +382,7 @@ def _extract_entities_from_doc(doc) -> List[Tuple[str, str, Optional[str]]]:
         if ent.label_ in _SEMANTIC_LABELS:
             spacy_ner_map[ent.text.lower()] = ent.label_
 
+    # `entities`/`cleaned`/`final` above are intentionally 2-tuples (syntactic
+    # type, text); the optional semantic_type is joined here from the NER map so
+    # the public return type is List[Tuple[str, str, Optional[str]]].
     return [(t, e, spacy_ner_map.get(e.lower())) for t, e in final]

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1307,3 +1307,159 @@ class TestAsyncDeleteAllEntityRace:
         mock_entity_store.delete.assert_called_once_with(vector_id="entity-alice")
 
         assert mock_vector_store.delete.call_count == 2
+
+
+# ─── Entity store: semantic_type persistence (#5440) ───────────────────────────
+# These cover the storage path that _upsert_entity / _upsert_entity_async take
+# when linking entities to memories: the spaCy NER label (semantic_type) must be
+# written into the entity payload on insert, back-filled on merge only when
+# absent, and never overwrite an existing label.
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+def test_upsert_entity_insert_persists_semantic_type(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    """New entity insert must carry semantic_type into the stored payload."""
+    embedder = MagicMock()
+    embedder.embed.return_value = [0.1, 0.2, 0.3]
+    mock_embedder_factory.return_value = embedder
+    mock_vector_factory.side_effect = [MagicMock(), MagicMock()]
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+    memory = MemoryClass(MemoryConfig())
+
+    entity_store = MagicMock()
+    entity_store.search.return_value = []  # no existing match -> insert path
+    memory._entity_store = entity_store
+
+    memory._upsert_entity("Alice", "PROPER", "mem-1", {"user_id": "u1"}, semantic_type="PERSON")
+
+    entity_store.insert.assert_called_once()
+    payload = entity_store.insert.call_args.kwargs["payloads"][0]
+    assert payload["semantic_type"] == "PERSON"
+    assert payload["data"] == "Alice"
+    assert payload["entity_type"] == "PROPER"
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+def test_upsert_entity_insert_omits_semantic_type_when_none(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    """When no NER label is available, the payload must not carry a semantic_type key."""
+    embedder = MagicMock()
+    embedder.embed.return_value = [0.1, 0.2, 0.3]
+    mock_embedder_factory.return_value = embedder
+    mock_vector_factory.side_effect = [MagicMock(), MagicMock()]
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+    memory = MemoryClass(MemoryConfig())
+
+    entity_store = MagicMock()
+    entity_store.search.return_value = []
+    memory._entity_store = entity_store
+
+    memory._upsert_entity("machine learning", "COMPOUND", "mem-1", {"user_id": "u1"}, semantic_type=None)
+
+    payload = entity_store.insert.call_args.kwargs["payloads"][0]
+    assert "semantic_type" not in payload
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+def test_upsert_entity_merge_backfills_semantic_type_when_absent(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    """Merging into an existing entity without a label must back-fill semantic_type."""
+    embedder = MagicMock()
+    embedder.embed.return_value = [0.1, 0.2, 0.3]
+    mock_embedder_factory.return_value = embedder
+    mock_vector_factory.side_effect = [MagicMock(), MagicMock()]
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+    memory = MemoryClass(MemoryConfig())
+
+    existing = MockVectorMemory("ent-1", {"linked_memory_ids": ["mem-A"]}, score=0.99)
+    entity_store = MagicMock()
+    entity_store.search.return_value = [existing]
+    memory._entity_store = entity_store
+
+    memory._upsert_entity("Alice", "PROPER", "mem-B", {"user_id": "u1"}, semantic_type="PERSON")
+
+    entity_store.update.assert_called_once()
+    payload = entity_store.update.call_args.kwargs["payload"]
+    assert payload["semantic_type"] == "PERSON"
+    assert "mem-B" in payload["linked_memory_ids"]
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+def test_upsert_entity_merge_does_not_overwrite_existing_semantic_type(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    """An existing label must win over a conflicting new one on merge."""
+    embedder = MagicMock()
+    embedder.embed.return_value = [0.1, 0.2, 0.3]
+    mock_embedder_factory.return_value = embedder
+    mock_vector_factory.side_effect = [MagicMock(), MagicMock()]
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+    memory = MemoryClass(MemoryConfig())
+
+    existing = MockVectorMemory(
+        "ent-1", {"linked_memory_ids": ["mem-A"], "semantic_type": "PERSON"}, score=0.99
+    )
+    entity_store = MagicMock()
+    entity_store.search.return_value = [existing]
+    memory._entity_store = entity_store
+
+    memory._upsert_entity("Apple", "PROPER", "mem-B", {"user_id": "u1"}, semantic_type="ORG")
+
+    payload = entity_store.update.call_args.kwargs["payload"]
+    assert payload["semantic_type"] == "PERSON"  # not overwritten with ORG
+
+
+@pytest.mark.asyncio
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+async def test_async_upsert_entity_insert_persists_semantic_type(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    """Async insert path must persist semantic_type just like the sync path."""
+    embedder = MagicMock()
+    embedder.embed.return_value = [0.1, 0.2, 0.3]
+    mock_embedder_factory.return_value = embedder
+    mock_vector_factory.side_effect = [MagicMock(), MagicMock()]
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import AsyncMemory
+    memory = AsyncMemory(MemoryConfig())
+
+    entity_store = MagicMock()
+    entity_store.search.return_value = []
+    memory._entity_store = entity_store
+
+    await memory._upsert_entity_async("Alice", "PROPER", "mem-1", {"user_id": "u1"}, semantic_type="PERSON")
+
+    payload = entity_store.insert.call_args.kwargs["payloads"][0]
+    assert payload["semantic_type"] == "PERSON"

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1463,3 +1463,129 @@ async def test_async_upsert_entity_insert_persists_semantic_type(
 
     payload = entity_store.insert.call_args.kwargs["payloads"][0]
     assert payload["semantic_type"] == "PERSON"
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+def test_upsert_entity_backfills_semantic_type_on_revisited_memory_id(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    """Re-processing an already-linked memory_id must still back-fill a missing label.
+
+    The link-list update and the semantic_type back-fill are independent: when
+    memory_id is already in linked_memory_ids (re-index/retry), the entity can
+    still be upgraded from no-label to a label.
+    """
+    embedder = MagicMock()
+    embedder.embed.return_value = [0.1, 0.2, 0.3]
+    mock_embedder_factory.return_value = embedder
+    mock_vector_factory.side_effect = [MagicMock(), MagicMock()]
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+    memory = MemoryClass(MemoryConfig())
+
+    # mem-A is already linked and the record has no semantic_type yet.
+    existing = MockVectorMemory("ent-1", {"linked_memory_ids": ["mem-A"]}, score=0.99)
+    entity_store = MagicMock()
+    entity_store.search.return_value = [existing]
+    memory._entity_store = entity_store
+
+    memory._upsert_entity("Alice", "PROPER", "mem-A", {"user_id": "u1"}, semantic_type="PERSON")
+
+    entity_store.update.assert_called_once()
+    payload = entity_store.update.call_args.kwargs["payload"]
+    assert payload["semantic_type"] == "PERSON"
+    assert payload["linked_memory_ids"] == ["mem-A"]  # link list unchanged
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+def test_upsert_entity_no_update_when_nothing_changes(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    """A re-visit with an already-linked id and an already-set label must not update."""
+    embedder = MagicMock()
+    embedder.embed.return_value = [0.1, 0.2, 0.3]
+    mock_embedder_factory.return_value = embedder
+    mock_vector_factory.side_effect = [MagicMock(), MagicMock()]
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+    memory = MemoryClass(MemoryConfig())
+
+    existing = MockVectorMemory(
+        "ent-1", {"linked_memory_ids": ["mem-A"], "semantic_type": "PERSON"}, score=0.99
+    )
+    entity_store = MagicMock()
+    entity_store.search.return_value = [existing]
+    memory._entity_store = entity_store
+
+    memory._upsert_entity("Alice", "PROPER", "mem-A", {"user_id": "u1"}, semantic_type="PERSON")
+
+    entity_store.update.assert_not_called()
+
+
+@patch('mem0.memory.main.extract_entities_batch')
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+def test_add_batch_dedup_upgrades_semantic_type_across_memories(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory, mock_extract_batch
+):
+    """Phase 7 dedup: two memories sharing an entity must produce one insert that
+    carries the non-None semantic_type and both memory IDs.
+
+    Exercises the widened global_entities value (semantic_type at index 2, the
+    memory-ID set at index 3) and the None->label upgrade during dedup.
+    """
+    embedder = MagicMock()
+    embedder.embed.return_value = [0.1, 0.2, 0.3]
+    embedder.embed_batch.side_effect = lambda texts, action=None: [[0.1, 0.2, 0.3] for _ in texts]
+    mock_embedder_factory.return_value = embedder
+
+    vector_store = MagicMock()
+    vector_store.search.return_value = []  # no existing memories
+    entity_store = MagicMock()
+    entity_store.search_batch.return_value = [[]]  # the single unique entity has no match
+    # First factory call -> main vector store, second -> entity store
+    mock_vector_factory.side_effect = [vector_store, entity_store]
+
+    llm = MagicMock()
+    llm.generate_response.return_value = json.dumps(
+        {"memory": [{"text": "Alice joined the team"}, {"text": "Alice shipped the release"}]}
+    )
+    mock_llm_factory.return_value = llm
+    mock_sqlite.return_value = MagicMock()
+
+    # memory-1 sees Alice with no label; memory-2 sees Alice as PERSON -> upgrade path
+    mock_extract_batch.return_value = [
+        [("PROPER", "Alice", None)],
+        [("PROPER", "Alice", "PERSON")],
+    ]
+
+    from mem0.memory.main import Memory as MemoryClass
+    memory = MemoryClass(MemoryConfig())
+    memory._entity_store = entity_store
+
+    memory._add_to_vector_store(
+        messages=[{"role": "user", "content": "Alice joined and shipped"}],
+        metadata={},
+        filters={"user_id": "u1"},
+        infer=True,
+    )
+
+    entity_store.insert.assert_called_once()
+    payloads = entity_store.insert.call_args.kwargs["payloads"]
+    assert len(payloads) == 1
+    assert payloads[0]["semantic_type"] == "PERSON"
+    assert payloads[0]["data"] == "Alice"
+    # both source memories linked to the single deduped entity
+    assert len(payloads[0]["linked_memory_ids"]) == 2

--- a/tests/utils/test_entity_extraction.py
+++ b/tests/utils/test_entity_extraction.py
@@ -56,7 +56,7 @@ class TestExtractEntities:
         from mem0.utils.entity_extraction import extract_entities
 
         entities = extract_entities("Google is great. I love working at Google.")
-        google_count = sum(1 for _, t in entities if "Google" in t)
+        google_count = sum(1 for _, t, *_ in entities if "Google" in t)
         assert google_count <= 1, f"Expected dedup, got {entities}"
 
     def test_substring_dedup_respects_word_boundaries(self):
@@ -75,9 +75,28 @@ class TestExtractEntities:
         entities = extract_entities("John Smith lives in New York City")
         for entity in entities:
             assert isinstance(entity, tuple)
-            assert len(entity) == 2
+            assert len(entity) == 3
             assert entity[0] in ("PROPER", "QUOTED", "COMPOUND", "NOUN")
             assert isinstance(entity[1], str)
+            assert entity[2] is None or isinstance(entity[2], str)
+
+    def test_semantic_type_person(self):
+        from mem0.utils.entity_extraction import extract_entities
+
+        entities = extract_entities("My friend Alice works at Google")
+        semantic_types = {e[1]: e[2] for e in entities}
+        # spaCy should label Alice as PERSON and Google as ORG
+        assert any(v == "PERSON" for v in semantic_types.values()), f"Expected PERSON label, got {semantic_types}"
+        assert any(v == "ORG" for v in semantic_types.values()), f"Expected ORG label, got {semantic_types}"
+
+    def test_semantic_type_none_for_compounds(self):
+        from mem0.utils.entity_extraction import extract_entities
+
+        entities = extract_entities("I enjoy machine learning and neural networks")
+        # Compound nouns should have no spaCy NER label
+        for syntactic_type, text, semantic_type in entities:
+            if syntactic_type == "COMPOUND":
+                assert semantic_type is None, f"Compound '{text}' should have no semantic_type"
 
 
 class TestExtractEntitiesBatch:
@@ -107,5 +126,5 @@ class TestExtractEntitiesBatch:
         single = extract_entities(text)
         batch = extract_entities_batch([text])
         assert len(batch) == 1
-        # Both should extract the same entities
-        assert set(t for _, t in single) == set(t for _, t in batch[0])
+        # Both should extract the same entities (text and semantic type)
+        assert set((t, s) for _, t, s in single) == set((t, s) for _, t, s in batch[0])


### PR DESCRIPTION
## Linked Issue

Closes #5440 (Option C — semantic entity types)

## Description

The entity store records only a **syntactic** type for each entity —
`PROPER` / `QUOTED` / `COMPOUND` / `NOUN`, derived from POS heuristics in
`entity_extraction.py`. As #5440 notes, this carries no domain semantics:
"Apple" the company and "Tesla" the company are both just `PROPER`, so there's
no way to group, filter, or disambiguate entities by what they actually are.

spaCy already produces this information via `doc.ents` (`PERSON`, `ORG`, `GPE`,
`PRODUCT`, …) — the code just wasn't using it. This PR implements **Option C**,
the issue's recommended lowest-risk starting point: attach the spaCy NER label
as a `semantic_type` alongside the existing syntactic type.

This is intentionally **purely additive** — it stores the new signal but does
**not** change scoring or merge gating. That keeps it independent of the
sibling disambiguation work in #5438 / PR #5497; the stored `semantic_type` is
a natural future input to a merge gate, but this PR does not couple to it.

### Changes

- `extract_entities()` / `extract_entities_batch()` now return 3-tuples
  `(syntactic_type, entity_text, semantic_type)`. `semantic_type` is the spaCy
  `doc.ents` label when the entity text matches a named-entity span, else
  `None`. Numeric/temporal labels (`DATE`, `MONEY`, `CARDINAL`, …) are excluded
  via a `_SEMANTIC_LABELS` allow-list.
- Entity store payloads gain an optional `semantic_type` field, persisted on
  both insert and merge across all sync + async paths (`_upsert_entity`,
  `_link_entities_for_memory`, Phase 7 batch linking). On merge it is
  back-filled only when absent — never overwriting an existing label.
- `_compute_entity_boosts` unpacks the wider tuple but is otherwise unchanged.

### Backward compatibility

`semantic_type` is optional everywhere. Existing entity records without the
field continue to work unchanged; nothing in retrieval or scoring depends on
its presence.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Breaking Changes

None. The public `extract_entities()` return shape widens from a 2-tuple to a
3-tuple; all in-repo callers are updated. This is an internal utility, not part
of the documented SDK surface.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed

`tests/utils/test_entity_extraction.py` updated for the 3-tuple shape, plus new
cases asserting `PERSON`/`ORG` labels are attached and that `COMPOUND` entities
(not spaCy named entities) get `None`.

```
tests/utils/test_entity_extraction.py ............  12 passed
tests/test_memory.py + tests/memory/ ..............  399 passed
```

(Two `embed_batch.call_count` failures in `test_memory.py` are pre-existing on
`main`, unrelated to this change — confirmed by running them on a clean
checkout.) `ruff check` passes on all changed files.

Manual check:
```python
>>> extract_entities("My friend Alice works at Google")
[('PROPER', 'Alice', 'PERSON'), ('PROPER', 'Google', 'ORG')]
>>> extract_entities("I enjoy machine learning")
[('COMPOUND', 'machine learning', None)]
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed (internal utility; no public docs affected)

## Note for reviewers

#5440 outlines three options. This PR is **Option C only**. Option A
(relationship weights on entity-memory links) and Option B (entity-to-entity
edges) are larger and best handled as separate PRs. I'm happy to follow up on
either, or to wire `semantic_type` into a merge gate if that's preferred
alongside #5497.