### PR TITLE
fix(ts-sdk): preserve user-defined schema keys in createMemoryExport

### DIFF
--- a/mem0-ts/src/client/mem0.ts
+++ b/mem0-ts/src/client/mem0.ts
@@ -696,7 +696,10 @@ export default class MemoryClient {
       throw new Error("Missing filters or schema");
     }
 
-    const { filters, ...rest } = data;
+    // filters and schema are user-controlled blobs whose keys must reach the
+    // API verbatim; only the remaining SDK params (e.g. exportInstructions)
+    // get camel->snake conversion. See issue #5593.
+    const { filters, schema, ...rest } = data;
     const response = await this._fetchWithErrorHandling(
       `${this.host}/v1/exports/`,
       {
@@ -705,6 +708,7 @@ export default class MemoryClient {
         body: JSON.stringify({
           ...camelToSnakeKeys(rest),
           filters,
+          schema,
         }),
       },
     );

--- a/mem0-ts/src/client/tests/memoryClient.exports.test.ts
+++ b/mem0-ts/src/client/tests/memoryClient.exports.test.ts
@@ -1,0 +1,47 @@
+/**
+ * MemoryClient unit tests — createMemoryExport.
+ * Verifies request construction, not mock response echo.
+ */
+import { MemoryClient } from "../mem0";
+import { TEST_API_KEY } from "./helpers";
+import {
+  setupMockFetch,
+  findFetchCall,
+  getFetchBody,
+  installConsoleSuppression,
+} from "./setup";
+
+installConsoleSuppression();
+
+describe("MemoryClient - createMemoryExport()", () => {
+  test("sends user-defined schema keys verbatim, converts SDK params", async () => {
+    const extra = new Map<string, { status: number; body: unknown }>();
+    extra.set("/v1/exports/", {
+      status: 200,
+      body: { message: "ok", id: "exp_1" },
+    });
+    const mock = setupMockFetch(extra);
+
+    const client = new MemoryClient({ apiKey: TEST_API_KEY });
+    await client.createMemoryExport({
+      // camelCase keys here are user-defined export field names — they must
+      // not be snake_cased on the way out.
+      schema: { messageId: "string", customField: { nestedKey: "number" } },
+      filters: { user_id: "u1" },
+      exportInstructions: "export it",
+    });
+
+    const call = findFetchCall(mock, "/v1/exports/", "POST");
+    expect(call).toBeDefined();
+    const body = getFetchBody(call!);
+
+    // User blobs round-trip verbatim (no camel->snake on their keys).
+    expect(body.schema).toEqual({
+      messageId: "string",
+      customField: { nestedKey: "number" },
+    });
+    expect(body.filters).toEqual({ user_id: "u1" });
+    // SDK param is still snake_cased.
+    expect(body.export_instructions).toBe("export it");
+  });
+});


### PR DESCRIPTION
## Linked Issue

Closes #5593

## Description

`createMemoryExport` destructured only `filters` out of the payload, so the user-controlled `schema` blob stayed in `rest` and `camelToSnakeKeys(rest)` rewrote the user's export field names (e.g. `messageId` → `message_id`). `schema: Record<string, any>` holds user-defined keys, so they must reach the API verbatim.

Fix: destructure `schema` out alongside `filters` and send it verbatim, keeping `camelToSnakeKeys(rest)` so SDK params like `exportInstructions` → `export_instructions` still convert.

Same class as #5055 / #5515; flagged by @kartik-mem0 in the #5515 review.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test Coverage

- [x] I added/updated unit tests

New `tests/memoryClient.exports.test.ts` asserts that camelCase schema keys (incl. nested) round-trip verbatim while `exportInstructions` is still snake_cased. Red-green verified: without the fix the test fails (sends `message_id`); with it, passes. `pnpm run build` and `prettier --check` pass.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed (N/A — internal behavior fix)
