### PR TITLE
feat(memory): add recall validation utility

### DIFF
--- a/docs/core-concepts/memory-evaluation.mdx
+++ b/docs/core-concepts/memory-evaluation.mdx
@@ -143,6 +143,26 @@ All benchmarks run on the same production-representative model stack. Scores car
 
 The full evaluation framework is [open-sourced](https://github.com/mem0ai/memory-benchmarks) so anyone can reproduce the numbers independently. It supports both Mem0 Cloud and self-hosted OSS backends.
 
+## Validating Recall Locally
+
+For smaller applications, custom extraction prompts, or CI checks, you can run a lightweight recall validation pass directly against your existing memory store. `MemoryValidator` samples stored memories, searches for each sampled memory through the normal retrieval path, and reports whether the source memory appears in the top results.
+
+```python
+from mem0 import Memory
+from mem0.utils import MemoryValidator
+
+memory = Memory.from_config(config)
+validator = MemoryValidator(memory)
+
+report = validator.validate(user_id="alice", sample_size=20, top_k=5)
+
+print(report.retrieval_rate)
+for failure in report.failures:
+    print(failure.memory_id, failure.query, failure.returned_ids)
+```
+
+By default, the validator uses the stored memory text as the search query. For task-specific checks, pass a `query_builder` that turns each memory into the kind of question your application expects users or agents to ask.
+
 ### Setup
 
 <Tabs>

--- a/mem0/utils/__init__.py
+++ b/mem0/utils/__init__.py
@@ -1,0 +1,3 @@
+from mem0.utils.memory_validator import MemoryValidationFailure, MemoryValidationReport, MemoryValidator
+
+__all__ = ["MemoryValidationFailure", "MemoryValidationReport", "MemoryValidator"]

--- a/mem0/utils/memory_validator.py
+++ b/mem0/utils/memory_validator.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from inspect import Parameter, signature
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional
+
+
+QueryBuilder = Callable[[Mapping[str, Any]], str]
+
+
+@dataclass(frozen=True)
+class MemoryValidationFailure:
+    """A memory that was not found in the top search results for its validation query."""
+
+    memory_id: Optional[str]
+    memory: str
+    query: str
+    returned_ids: List[Optional[str]]
+
+
+@dataclass(frozen=True)
+class MemoryValidationReport:
+    """Retrieval validation summary returned by :class:`MemoryValidator`."""
+
+    checked: int
+    found: int
+    retrieval_rate: float
+    failures: List[MemoryValidationFailure]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+class MemoryValidator:
+    """Validate that stored memories can be recalled through the normal search path.
+
+    The validator is intentionally read-only. It samples memories with ``get_all()``,
+    runs ``search()`` for each generated query, and checks whether the source memory
+    appears in the returned top-k results.
+    """
+
+    def __init__(self, memory: Any):
+        if not hasattr(memory, "get_all") or not hasattr(memory, "search"):
+            raise TypeError("memory must expose get_all() and search() methods")
+        self.memory = memory
+
+    def validate(
+        self,
+        *,
+        filters: Optional[Dict[str, Any]] = None,
+        user_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        run_id: Optional[str] = None,
+        sample_size: int = 20,
+        top_k: int = 5,
+        query_builder: Optional[QueryBuilder] = None,
+        get_all_kwargs: Optional[Dict[str, Any]] = None,
+        search_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> MemoryValidationReport:
+        """Run a recall check for sampled memories.
+
+        Args:
+            filters: Entity and metadata filters to pass to ``get_all`` and ``search``.
+            user_id: Convenience shorthand merged into ``filters``.
+            agent_id: Convenience shorthand merged into ``filters``.
+            run_id: Convenience shorthand merged into ``filters``.
+            sample_size: Number of stored memories to validate.
+            top_k: Number of search results to inspect for each validation query.
+            query_builder: Optional callable that receives a memory dict and returns
+                the query to use. By default the memory text itself is used.
+            get_all_kwargs: Extra keyword arguments for ``get_all``.
+            search_kwargs: Extra keyword arguments for ``search``.
+
+        Returns:
+            MemoryValidationReport with aggregate retrieval rate and failed cases.
+        """
+        if sample_size <= 0:
+            raise ValueError("sample_size must be greater than 0")
+        if top_k <= 0:
+            raise ValueError("top_k must be greater than 0")
+
+        effective_filters = self._build_filters(filters, user_id=user_id, agent_id=agent_id, run_id=run_id)
+        if not effective_filters:
+            raise ValueError("filters, user_id, agent_id, or run_id is required to select memories")
+
+        memories = self._sample_memories(effective_filters, sample_size, get_all_kwargs or {})
+        build_query = query_builder or self._default_query_builder
+
+        checked = 0
+        found = 0
+        failures: List[MemoryValidationFailure] = []
+
+        for memory in memories:
+            memory_text = self._memory_text(memory)
+            if not memory_text:
+                continue
+
+            query = build_query(memory)
+            if not isinstance(query, str) or not query.strip():
+                raise ValueError("query_builder must return a non-empty string")
+
+            checked += 1
+            query = query.strip()
+            source_id = self._memory_id(memory)
+            search_results = self._search(query, effective_filters, top_k, search_kwargs or {})
+            match_found = self._contains_memory(search_results, source_id, memory_text)
+
+            if match_found:
+                found += 1
+            else:
+                failures.append(
+                    MemoryValidationFailure(
+                        memory_id=source_id,
+                        memory=memory_text,
+                        query=query,
+                        returned_ids=[self._memory_id(result) for result in search_results],
+                    )
+                )
+
+        retrieval_rate = found / checked if checked else 0.0
+        return MemoryValidationReport(
+            checked=checked,
+            found=found,
+            retrieval_rate=retrieval_rate,
+            failures=failures,
+        )
+
+    def _sample_memories(
+        self, filters: Dict[str, Any], sample_size: int, get_all_kwargs: Dict[str, Any]
+    ) -> List[Dict[str, Any]]:
+        kwargs = {"filters": filters, **get_all_kwargs}
+
+        if "top_k" not in kwargs and "page_size" not in kwargs:
+            kwargs[self._get_all_limit_param()] = sample_size
+
+        response = self.memory.get_all(**kwargs)
+        memories = self._extract_results(response)
+        return memories[:sample_size]
+
+    def _search(
+        self, query: str, filters: Dict[str, Any], top_k: int, search_kwargs: Dict[str, Any]
+    ) -> List[Dict[str, Any]]:
+        response = self.memory.search(query, filters=filters, top_k=top_k, **search_kwargs)
+        return self._extract_results(response)
+
+    def _get_all_limit_param(self) -> str:
+        try:
+            params = signature(self.memory.get_all).parameters
+        except (TypeError, ValueError):
+            return "top_k"
+
+        if "top_k" in params:
+            return "top_k"
+        if "page_size" in params:
+            return "page_size"
+        if any(param.kind == Parameter.VAR_KEYWORD for param in params.values()):
+            return "page_size"
+        return "top_k"
+
+    @staticmethod
+    def _build_filters(
+        filters: Optional[Dict[str, Any]],
+        *,
+        user_id: Optional[str],
+        agent_id: Optional[str],
+        run_id: Optional[str],
+    ) -> Dict[str, Any]:
+        effective_filters = dict(filters or {})
+        for key, value in (("user_id", user_id), ("agent_id", agent_id), ("run_id", run_id)):
+            if value is not None:
+                effective_filters[key] = value
+        return effective_filters
+
+    @staticmethod
+    def _extract_results(response: Any) -> List[Dict[str, Any]]:
+        if isinstance(response, Mapping):
+            results = response.get("results", [])
+        else:
+            results = response
+
+        if results is None:
+            return []
+        if not isinstance(results, Iterable) or isinstance(results, (str, bytes)):
+            raise TypeError("memory response results must be a list of memory dictionaries")
+
+        normalized = []
+        for item in results:
+            if isinstance(item, Mapping):
+                normalized.append(dict(item))
+        return normalized
+
+    @staticmethod
+    def _memory_id(memory: Mapping[str, Any]) -> Optional[str]:
+        memory_id = memory.get("id") or memory.get("memory_id")
+        return str(memory_id) if memory_id is not None else None
+
+    @staticmethod
+    def _memory_text(memory: Mapping[str, Any]) -> str:
+        for key in ("memory", "text", "data"):
+            value = memory.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return ""
+
+    @staticmethod
+    def _default_query_builder(memory: Mapping[str, Any]) -> str:
+        return MemoryValidator._memory_text(memory)
+
+    def _contains_memory(
+        self,
+        search_results: List[Mapping[str, Any]],
+        source_id: Optional[str],
+        source_text: str,
+    ) -> bool:
+        for result in search_results:
+            result_id = self._memory_id(result)
+            if source_id is not None and result_id == source_id:
+                return True
+            if source_id is None and self._memory_text(result) == source_text:
+                return True
+        return False

--- a/tests/utils/test_memory_validator.py
+++ b/tests/utils/test_memory_validator.py
@@ -1,0 +1,93 @@
+import pytest
+
+from mem0.utils import MemoryValidator
+
+
+class FakeMemory:
+    def __init__(self, memories, search_results_by_query):
+        self.memories = memories
+        self.search_results_by_query = search_results_by_query
+        self.get_all_calls = []
+        self.search_calls = []
+
+    def get_all(self, *, filters=None, top_k=20, **kwargs):
+        self.get_all_calls.append({"filters": filters, "top_k": top_k, **kwargs})
+        return {"results": self.memories}
+
+    def search(self, query, **kwargs):
+        self.search_calls.append((query, kwargs))
+        return {"results": self.search_results_by_query.get(query, [])}
+
+
+class FakeHostedMemory(FakeMemory):
+    def get_all(self, options=None, **kwargs):
+        self.get_all_calls.append(kwargs)
+        return {"results": self.memories}
+
+
+def test_validate_reports_retrieval_rate_and_failures():
+    memory = FakeMemory(
+        memories=[
+            {"id": "mem-1", "memory": "Alice likes hiking."},
+            {"id": "mem-2", "memory": "Bob works in Paris."},
+        ],
+        search_results_by_query={
+            "Alice likes hiking.": [{"id": "mem-1", "memory": "Alice likes hiking."}],
+            "Bob works in Paris.": [{"id": "other", "memory": "Someone lives in Paris."}],
+        },
+    )
+
+    report = MemoryValidator(memory).validate(user_id="alice", sample_size=2, top_k=3)
+
+    assert report.checked == 2
+    assert report.found == 1
+    assert report.retrieval_rate == 0.5
+    assert len(report.failures) == 1
+    assert report.failures[0].memory_id == "mem-2"
+    assert report.failures[0].returned_ids == ["other"]
+    assert memory.get_all_calls[0]["filters"] == {"user_id": "alice"}
+    assert memory.get_all_calls[0]["top_k"] == 2
+    assert memory.search_calls[0][1]["top_k"] == 3
+
+
+def test_validate_supports_custom_query_builder():
+    memory = FakeMemory(
+        memories=[{"id": "mem-1", "memory": "Alice prefers tea.", "metadata": {"topic": "drink"}}],
+        search_results_by_query={"What does Alice prefer to drink?": [{"id": "mem-1", "memory": "Alice prefers tea."}]},
+    )
+
+    report = MemoryValidator(memory).validate(
+        filters={"user_id": "alice"},
+        query_builder=lambda item: "What does Alice prefer to drink?",
+    )
+
+    assert report.checked == 1
+    assert report.found == 1
+    assert report.failures == []
+
+
+def test_validate_uses_page_size_for_hosted_client_shape():
+    memory = FakeHostedMemory(
+        memories=[{"id": "mem-1", "memory": "Alice likes hiking."}],
+        search_results_by_query={"Alice likes hiking.": [{"id": "mem-1", "memory": "Alice likes hiking."}]},
+    )
+
+    MemoryValidator(memory).validate(user_id="alice", sample_size=10)
+
+    assert memory.get_all_calls[0]["page_size"] == 10
+    assert "top_k" not in memory.get_all_calls[0]
+
+
+def test_validate_requires_scope_filter():
+    memory = FakeMemory(memories=[], search_results_by_query={})
+
+    with pytest.raises(ValueError, match="filters, user_id, agent_id, or run_id is required"):
+        MemoryValidator(memory).validate()
+
+
+@pytest.mark.parametrize("sample_size, top_k", [(0, 5), (1, 0)])
+def test_validate_rejects_invalid_limits(sample_size, top_k):
+    memory = FakeMemory(memories=[], search_results_by_query={})
+
+    with pytest.raises(ValueError):
+        MemoryValidator(memory).validate(user_id="alice", sample_size=sample_size, top_k=top_k)


### PR DESCRIPTION
## Linked Issue

Closes #3968

## Description

Adds a small read-only `MemoryValidator` utility for checking whether stored memories are actually retrievable through the normal `search()` path.

The validator samples memories with `get_all()`, builds a validation query for each one, runs `search()`, and reports the retrieval rate plus the memories that did not appear in the returned top-k results. By default it uses the stored memory text as the query, and callers can pass a custom `query_builder` for application-specific recall checks.

This is meant to be useful for CI checks, custom extraction prompt validation, and debugging cases where memories are written successfully but do not surface later during recall. It does not change storage, extraction, or retrieval behavior.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Manual validation:

```bash
python3 -m hatch run dev_py_3_12:pytest tests/utils/test_memory_validator.py -q
python3 -m hatch run dev_py_3_12:ruff check mem0/utils/__init__.py mem0/utils/memory_validator.py tests/utils/test_memory_validator.py
python3 -m hatch run dev_py_3_12:ruff format --check mem0/utils/__init__.py mem0/utils/memory_validator.py tests/utils/test_memory_validator.py
python3 -m hatch run dev_py_3_12:python scripts/check-llms-txt-coverage.py
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
