### PR TITLE
docs: add Screenpipe memory source example

### DIFF
--- a/docs/cookbooks/integrations/screenpipe-memory-source.mdx
+++ b/docs/cookbooks/integrations/screenpipe-memory-source.mdx
@@ -1,0 +1,112 @@
+---
+title: Screenpipe as a Memory Source
+description: "Sync local Screenpipe OCR and audio transcripts into Mem0 for ambient agent memory."
+---
+
+Screenpipe records local screen context, accessibility text, OCR fallback text, and audio transcripts into a SQLite database on your machine. Mem0 can turn that timeline into searchable long-term memory for agents that need context about what a user saw, heard, or worked on.
+
+This cookbook uses the example script in `examples/screenpipe-memory-source/sync_screenpipe.py` to map Screenpipe rows into Mem0 memories with source metadata.
+
+## When to Use This
+
+Use this pattern when an assistant needs local ambient context, such as:
+
+- recalling what was discussed in a meeting transcript
+- finding which app or document was open during a task
+- giving a coding or research agent context from recent desktop activity
+
+## Prerequisites
+
+Install Mem0 and make sure Screenpipe has already captured some local data:
+
+```bash
+pip install mem0ai
+```
+
+Screenpipe stores local data at `~/.screenpipe/db.sqlite` by default.
+
+## Dry Run the Mapping
+
+Start with a dry run so you can inspect what would be written:
+
+```bash
+python examples/screenpipe-memory-source/sync_screenpipe.py \
+  --user-id alice \
+  --limit 5 \
+  --dry-run
+```
+
+The script reads common Screenpipe tables such as `frames`, `ocr_text`, and `audio_transcriptions`. It preserves metadata including the source table, row id, captured timestamp, app name, window title, URL, device, and speaker when those columns are present.
+
+## Sync to Mem0 Platform
+
+Set your Platform API key and run the sync:
+
+```bash
+export MEM0_API_KEY="m0-your-key"
+
+python examples/screenpipe-memory-source/sync_screenpipe.py \
+  --user-id alice \
+  --limit 50
+```
+
+Each synced memory includes metadata like:
+
+```python
+{
+    "source": "screenpipe",
+    "screenpipe_table": "audio_transcriptions",
+    "screenpipe_row_id": 123,
+    "screenpipe_type": "audio",
+    "captured_at": "2026-06-16T09:05:00+00:00",
+}
+```
+
+## Sync to Mem0 OSS
+
+For self-hosted Mem0, pass a normal OSS config JSON:
+
+```bash
+python examples/screenpipe-memory-source/sync_screenpipe.py \
+  --config mem0-config.json \
+  --user-id alice \
+  --limit 50
+```
+
+By default, the script writes each observation with `infer=False`. This keeps the original OCR or transcript text searchable. If you want Mem0 to extract concise facts from each observation, pass `--infer`.
+
+## Search Later
+
+Use metadata filters to search only Screenpipe-backed memories:
+
+```python
+from mem0 import MemoryClient
+
+client = MemoryClient()
+
+results = client.search(
+    "What did Maya ask me to follow up on?",
+    filters={
+        "user_id": "alice",
+        "source": "screenpipe",
+    },
+)
+```
+
+For OSS:
+
+```python
+from mem0 import Memory
+
+memory = Memory.from_config(config)
+
+results = memory.search(
+    "What did Maya ask me to follow up on?",
+    filters={
+        "user_id": "alice",
+        "source": "screenpipe",
+    },
+)
+```
+
+This keeps the integration small: Screenpipe remains the local capture layer, and Mem0 handles durable search and recall for downstream agents.

--- a/docs/cookbooks/overview.mdx
+++ b/docs/cookbooks/overview.mdx
@@ -152,6 +152,13 @@ Here are some examples of how Mem0 can be integrated into various applications:
     Realtime search with personal context.
   </Card>
   <Card
+    title="Screenpipe as Memory Source"
+    icon="desktop"
+    href="/cookbooks/integrations/screenpipe-memory-source"
+  >
+    Sync local screen and audio context into Mem0.
+  </Card>
+  <Card
     title="Bedrock with Persistent Memory"
     icon="aws"
     href="/cookbooks/integrations/aws-bedrock"

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -322,6 +322,7 @@ If the user is on a pre-current major (Python < 2, TS < 3, or Platform `output_f
 - [Healthcare Google ADK](https://docs.mem0.ai/cookbooks/integrations/healthcare-google-adk) [Both]: Use when the domain is medical and the framework is Google ADK.
 - [AWS Bedrock](https://docs.mem0.ai/cookbooks/integrations/aws-bedrock) [Both]: Use when deploying with AWS managed model services.
 - [Tavily Search](https://docs.mem0.ai/cookbooks/integrations/tavily-search) [Both]: Use when the agent layers web search on memory.
+- [Screenpipe as a Memory Source](https://docs.mem0.ai/cookbooks/integrations/screenpipe-memory-source) [Both]: Use when syncing local Screenpipe OCR or audio transcript data into Mem0 for ambient agent memory.
 
 ### Framework Examples
 - [LlamaIndex React](https://docs.mem0.ai/cookbooks/frameworks/llamaindex-react) [Both]: Use when building a React UI with LlamaIndex and memory.

--- a/examples/screenpipe-memory-source/README.md
+++ b/examples/screenpipe-memory-source/README.md
@@ -1,0 +1,47 @@
+# Screenpipe Memory Source
+
+This example syncs local [Screenpipe](https://screenpi.pe) OCR and audio transcript rows into Mem0.
+
+Screenpipe stores its local timeline in SQLite at `~/.screenpipe/db.sqlite`. The sync script reads common tables such as `frames`, `ocr_text`, and `audio_transcriptions`, converts each row into a Mem0 memory, and preserves useful source metadata for later filtering.
+
+## Install
+
+```bash
+pip install mem0ai
+```
+
+For Mem0 Platform:
+
+```bash
+export MEM0_API_KEY="m0-..."
+```
+
+For Mem0 OSS, prepare a Mem0 config JSON and pass it with `--config`.
+
+## Dry Run
+
+```bash
+python examples/screenpipe-memory-source/sync_screenpipe.py \
+  --user-id alice \
+  --limit 5 \
+  --dry-run
+```
+
+## Sync to Mem0 Platform
+
+```bash
+python examples/screenpipe-memory-source/sync_screenpipe.py \
+  --user-id alice \
+  --limit 50
+```
+
+## Sync to Mem0 OSS
+
+```bash
+python examples/screenpipe-memory-source/sync_screenpipe.py \
+  --config mem0-config.json \
+  --user-id alice \
+  --limit 50
+```
+
+By default, entries are added with `infer=False` so the original screen or transcript observation remains searchable. Pass `--infer` if you want Mem0 to extract concise facts from each observation instead.

--- a/examples/screenpipe-memory-source/sync_screenpipe.py
+++ b/examples/screenpipe-memory-source/sync_screenpipe.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+
+DEFAULT_DB_PATH = Path("~/.screenpipe/db.sqlite").expanduser()
+DEFAULT_TABLES = ("frames", "ocr_text", "audio_transcriptions")
+
+TEXT_COLUMNS = ("accessibility_text", "text", "transcription", "content", "ocr_text")
+TIME_COLUMNS = ("timestamp", "created_at", "captured_at", "recorded_at", "start_time", "datetime")
+APP_COLUMNS = ("app_name", "application_name", "app")
+WINDOW_COLUMNS = ("window_name", "window_title", "title")
+URL_COLUMNS = ("url", "browser_url", "source_url")
+DEVICE_COLUMNS = ("device_name", "device", "audio_device")
+SPEAKER_COLUMNS = ("speaker_name", "speaker", "speaker_id")
+
+
+@dataclass(frozen=True)
+class ScreenpipeEntry:
+    table: str
+    row_id: int
+    text: str
+    captured_at: Optional[str] = None
+    app_name: Optional[str] = None
+    window_name: Optional[str] = None
+    url: Optional[str] = None
+    device_name: Optional[str] = None
+    speaker: Optional[str] = None
+
+    @property
+    def source_type(self) -> str:
+        if self.table == "audio_transcriptions":
+            return "audio"
+        if self.table == "ocr_text":
+            return "ocr"
+        return "screen"
+
+    def to_memory_text(self, *, max_text_chars: int = 4000) -> str:
+        parts = [f"Screenpipe {self.source_type} observation"]
+        if self.captured_at:
+            parts.append(f"captured_at={self.captured_at}")
+        if self.app_name:
+            parts.append(f"app={self.app_name}")
+        if self.window_name:
+            parts.append(f"window={self.window_name}")
+        if self.url:
+            parts.append(f"url={self.url}")
+
+        text = self.text.strip()
+        if len(text) > max_text_chars:
+            text = f"{text[:max_text_chars].rstrip()}..."
+        return f"{' | '.join(parts)}\n\n{text}"
+
+    def to_metadata(self) -> Dict[str, Any]:
+        metadata = {
+            "source": "screenpipe",
+            "screenpipe_table": self.table,
+            "screenpipe_row_id": self.row_id,
+            "screenpipe_type": self.source_type,
+        }
+        optional_values = {
+            "captured_at": self.captured_at,
+            "app_name": self.app_name,
+            "window_name": self.window_name,
+            "url": self.url,
+            "device_name": self.device_name,
+            "speaker": self.speaker,
+        }
+        metadata.update({key: value for key, value in optional_values.items() if value})
+        return metadata
+
+
+def read_screenpipe_entries(
+    db_path: Path,
+    *,
+    tables: Iterable[str] = DEFAULT_TABLES,
+    limit: int = 50,
+    since: Optional[str] = None,
+) -> List[ScreenpipeEntry]:
+    if limit <= 0:
+        raise ValueError("limit must be greater than 0")
+    if not db_path.exists():
+        raise FileNotFoundError(f"Screenpipe database not found: {db_path}")
+
+    since_dt = parse_datetime(since) if since else None
+    entries: List[ScreenpipeEntry] = []
+
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        existing_tables = get_table_names(conn)
+
+        for table in tables:
+            if table not in existing_tables:
+                continue
+
+            columns = get_columns(conn, table)
+            text_column = first_existing(columns, TEXT_COLUMNS)
+            if not text_column:
+                continue
+
+            selected_columns = {
+                "text": text_column,
+                "captured_at": first_existing(columns, TIME_COLUMNS),
+                "app_name": first_existing(columns, APP_COLUMNS),
+                "window_name": first_existing(columns, WINDOW_COLUMNS),
+                "url": first_existing(columns, URL_COLUMNS),
+                "device_name": first_existing(columns, DEVICE_COLUMNS),
+                "speaker": first_existing(columns, SPEAKER_COLUMNS),
+            }
+
+            rows = fetch_rows(conn, table, selected_columns, per_table_limit=max(limit * 2, limit))
+            for row in rows:
+                entry = row_to_entry(table, row, selected_columns)
+                if since_dt and entry.captured_at:
+                    entry_dt = parse_datetime(entry.captured_at)
+                    if entry_dt and entry_dt < since_dt:
+                        continue
+                if entry.text:
+                    entries.append(entry)
+
+    entries.sort(key=lambda item: item.captured_at or "", reverse=True)
+    return entries[:limit]
+
+
+def sync_entries(
+    memory: Any,
+    entries: Iterable[ScreenpipeEntry],
+    *,
+    user_id: str,
+    agent_id: Optional[str] = None,
+    run_id: Optional[str] = None,
+    infer: bool = False,
+    dry_run: bool = False,
+    max_text_chars: int = 4000,
+) -> int:
+    synced = 0
+    for entry in entries:
+        content = entry.to_memory_text(max_text_chars=max_text_chars)
+        metadata = entry.to_metadata()
+
+        if dry_run:
+            print(f"[dry-run] {entry.table}:{entry.row_id} {content[:120]!r}")
+            synced += 1
+            continue
+
+        if memory.__class__.__name__.endswith("MemoryClient"):
+            filters = {"user_id": user_id}
+            if agent_id:
+                filters["agent_id"] = agent_id
+            if run_id:
+                filters["run_id"] = run_id
+            memory.add(content, filters=filters, metadata=metadata, infer=infer)
+        else:
+            memory.add(content, user_id=user_id, agent_id=agent_id, run_id=run_id, metadata=metadata, infer=infer)
+        synced += 1
+
+    return synced
+
+
+def build_memory_client(config_path: Optional[Path]) -> Any:
+    if config_path:
+        from mem0 import Memory
+
+        with config_path.open("r", encoding="utf-8") as file:
+            config = json.load(file)
+        return Memory.from_config(config)
+
+    from mem0 import MemoryClient
+
+    return MemoryClient()
+
+
+def get_table_names(conn: sqlite3.Connection) -> set[str]:
+    rows = conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()
+    return {row["name"] for row in rows}
+
+
+def get_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    rows = conn.execute(f"PRAGMA table_info({quote_identifier(table)})").fetchall()
+    return {row["name"] for row in rows}
+
+
+def first_existing(columns: set[str], candidates: Iterable[str]) -> Optional[str]:
+    for candidate in candidates:
+        if candidate in columns:
+            return candidate
+    return None
+
+
+def fetch_rows(
+    conn: sqlite3.Connection,
+    table: str,
+    selected_columns: Dict[str, Optional[str]],
+    *,
+    per_table_limit: int,
+) -> List[sqlite3.Row]:
+    column_names = ["rowid", *[column for column in selected_columns.values() if column]]
+    seen = set()
+    deduped_columns = []
+    for column in column_names:
+        if column not in seen:
+            seen.add(column)
+            deduped_columns.append(column)
+
+    text_column = selected_columns["text"]
+    order_column = selected_columns.get("captured_at") or "rowid"
+    sql = (
+        f"SELECT {', '.join(quote_identifier(column) for column in deduped_columns)} "
+        f"FROM {quote_identifier(table)} "
+        f"WHERE {quote_identifier(text_column)} IS NOT NULL "
+        f"AND TRIM({quote_identifier(text_column)}) != '' "
+        f"ORDER BY {quote_identifier(order_column)} DESC "
+        "LIMIT ?"
+    )
+    return conn.execute(sql, (per_table_limit,)).fetchall()
+
+
+def row_to_entry(table: str, row: sqlite3.Row, selected_columns: Dict[str, Optional[str]]) -> ScreenpipeEntry:
+    def value(name: str) -> Optional[str]:
+        column = selected_columns.get(name)
+        if not column or column not in row.keys():
+            return None
+        raw_value = row[column]
+        return str(raw_value).strip() if raw_value is not None and str(raw_value).strip() else None
+
+    return ScreenpipeEntry(
+        table=table,
+        row_id=int(row["rowid"]),
+        text=value("text") or "",
+        captured_at=normalize_timestamp(value("captured_at")),
+        app_name=value("app_name"),
+        window_name=value("window_name"),
+        url=value("url"),
+        device_name=value("device_name"),
+        speaker=value("speaker"),
+    )
+
+
+def normalize_timestamp(value: Optional[str]) -> Optional[str]:
+    parsed = parse_datetime(value)
+    return parsed.isoformat() if parsed else value
+
+
+def parse_datetime(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+
+    try:
+        numeric = float(value)
+    except ValueError:
+        numeric = None
+
+    if numeric is not None:
+        if numeric > 1_000_000_000_000:
+            numeric = numeric / 1000
+        return datetime.fromtimestamp(numeric, tz=timezone.utc)
+
+    try:
+        normalized = value.replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(normalized)
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def quote_identifier(identifier: str) -> str:
+    return f'"{identifier.replace(chr(34), chr(34) + chr(34))}"'
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Sync Screenpipe SQLite observations into Mem0.")
+    parser.add_argument("--db", type=Path, default=DEFAULT_DB_PATH, help="Path to Screenpipe db.sqlite.")
+    parser.add_argument("--config", type=Path, help="Mem0 OSS config JSON. Omit to use Mem0 Platform.")
+    parser.add_argument("--user-id", required=True, help="Mem0 user_id to attach to synced memories.")
+    parser.add_argument("--agent-id", help="Optional Mem0 agent_id.")
+    parser.add_argument("--run-id", help="Optional Mem0 run_id.")
+    parser.add_argument("--limit", type=int, default=50, help="Maximum entries to sync.")
+    parser.add_argument("--since", help="Only sync entries captured at or after this ISO timestamp.")
+    parser.add_argument("--infer", action="store_true", help="Let Mem0 infer concise facts from each observation.")
+    parser.add_argument("--dry-run", action="store_true", help="Print entries without writing to Mem0.")
+    parser.add_argument("--max-text-chars", type=int, default=4000, help="Maximum text characters per memory.")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    entries = read_screenpipe_entries(args.db.expanduser(), limit=args.limit, since=args.since)
+    memory = None if args.dry_run else build_memory_client(args.config)
+    synced = sync_entries(
+        memory,
+        entries,
+        user_id=args.user_id,
+        agent_id=args.agent_id,
+        run_id=args.run_id,
+        infer=args.infer,
+        dry_run=args.dry_run,
+        max_text_chars=args.max_text_chars,
+    )
+    print(f"Processed {synced} Screenpipe entries.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/examples/test_screenpipe_memory_source.py
+++ b/tests/examples/test_screenpipe_memory_source.py
@@ -1,0 +1,82 @@
+import importlib.util
+import sqlite3
+import sys
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "examples" / "screenpipe-memory-source" / "sync_screenpipe.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("sync_screenpipe", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_read_screenpipe_entries_maps_sqlite_rows(tmp_path):
+    sync_screenpipe = load_module()
+    db_path = tmp_path / "db.sqlite"
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE frames (
+                timestamp TEXT,
+                accessibility_text TEXT,
+                app_name TEXT,
+                window_name TEXT,
+                url TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE audio_transcriptions (
+                created_at TEXT,
+                transcription TEXT,
+                device_name TEXT,
+                speaker_id INTEGER
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO frames VALUES (?, ?, ?, ?, ?)",
+            ("2026-06-16T09:00:00Z", "Reviewed the launch checklist", "Notes", "Launch Plan", None),
+        )
+        conn.execute(
+            "INSERT INTO audio_transcriptions VALUES (?, ?, ?, ?)",
+            ("2026-06-16T09:05:00Z", "We should follow up with Maya", "MacBook Microphone", 7),
+        )
+
+    entries = sync_screenpipe.read_screenpipe_entries(db_path, limit=10)
+
+    assert [entry.source_type for entry in entries] == ["audio", "screen"]
+    assert entries[0].text == "We should follow up with Maya"
+    assert entries[0].to_metadata()["screenpipe_table"] == "audio_transcriptions"
+    assert entries[1].app_name == "Notes"
+    assert "Reviewed the launch checklist" in entries[1].to_memory_text()
+
+
+def test_sync_entries_passes_source_metadata_to_memory_client():
+    sync_screenpipe = load_module()
+
+    class FakeMemoryClient:
+        def __init__(self):
+            self.calls = []
+
+        def add(self, content, **kwargs):
+            self.calls.append((content, kwargs))
+
+    memory = FakeMemoryClient()
+    entry = sync_screenpipe.ScreenpipeEntry(table="frames", row_id=42, text="Alice opened the roadmap")
+
+    synced = sync_screenpipe.sync_entries(memory, [entry], user_id="alice")
+
+    assert synced == 1
+    content, kwargs = memory.calls[0]
+    assert "Alice opened the roadmap" in content
+    assert kwargs["filters"] == {"user_id": "alice"}
+    assert kwargs["metadata"]["source"] == "screenpipe"
+    assert kwargs["metadata"]["screenpipe_row_id"] == 42


### PR DESCRIPTION
## Linked Issue

Closes #3937

## Description

Adds a concrete Screenpipe-to-Mem0 proof of concept for using local screen and audio history as an ambient memory source.

The new example script reads Screenpipe's local SQLite database, maps common tables such as `frames`, `ocr_text`, and `audio_transcriptions` into Mem0 memories, and preserves source metadata like the Screenpipe table, row id, capture timestamp, app/window context, URL, device, and speaker when those columns are present.

The example supports:

- dry-run inspection before writing anything
- Mem0 Platform via `MemoryClient`
- Mem0 OSS via `Memory.from_config(...)`
- `infer=False` by default to keep the original OCR/transcript observation searchable
- optional `--infer` for users who want Mem0 to extract concise facts from each observation

This keeps Screenpipe as the local capture layer and Mem0 as the durable recall layer, without adding runtime dependencies or changing core SDK behavior.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Manual validation:

```bash
python3 -m hatch run dev_py_3_12:pytest tests/examples/test_screenpipe_memory_source.py -q
python3 -m hatch run dev_py_3_12:ruff check examples/screenpipe-memory-source/sync_screenpipe.py tests/examples/test_screenpipe_memory_source.py
python3 -m hatch run dev_py_3_12:ruff format --check examples/screenpipe-memory-source/sync_screenpipe.py tests/examples/test_screenpipe_memory_source.py
python3 -m hatch run dev_py_3_12:python scripts/check-llms-txt-coverage.py
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
