### PR TITLE
fix(memory): guard entity embed_batch count mismatch in v3 add pipeline

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -993,6 +993,21 @@ class Memory(MemoryBase):
                         except Exception:
                             entity_embeddings.append(None)
 
+                # A misbehaving embedder may return fewer (or more) vectors than
+                # inputs. Normalise to ordered_keys length so the valid-filter
+                # treats missing vectors as failures instead of raising IndexError
+                # (which the outer except would swallow, silently dropping ALL
+                # entity links). Mirrors the count guard in _compute_entity_boosts.
+                if len(entity_embeddings) != len(ordered_keys):
+                    logger.warning(
+                        "embed_batch returned %d vectors for %d entity texts — "
+                        "padding/truncating to avoid dropping entity links",
+                        len(entity_embeddings),
+                        len(ordered_keys),
+                    )
+                    entity_embeddings = list(entity_embeddings[: len(ordered_keys)])
+                    entity_embeddings += [None] * (len(ordered_keys) - len(entity_embeddings))
+
                 # Filter out entities with failed embeddings
                 valid = [(i, k) for i, k in enumerate(ordered_keys) if entity_embeddings[i] is not None]
                 if valid:
@@ -2519,6 +2534,21 @@ class AsyncMemory(MemoryBase):
                             entity_embeddings.append(await asyncio.to_thread(self.embedding_model.embed, t, "add"))
                         except Exception:
                             entity_embeddings.append(None)
+
+                # A misbehaving embedder may return fewer (or more) vectors than
+                # inputs. Normalise to ordered_keys length so the valid-filter
+                # treats missing vectors as failures instead of raising IndexError
+                # (which the outer except would swallow, silently dropping ALL
+                # entity links). Mirrors the count guard in _compute_entity_boosts.
+                if len(entity_embeddings) != len(ordered_keys):
+                    logger.warning(
+                        "embed_batch returned %d vectors for %d entity texts — "
+                        "padding/truncating to avoid dropping entity links",
+                        len(entity_embeddings),
+                        len(ordered_keys),
+                    )
+                    entity_embeddings = list(entity_embeddings[: len(ordered_keys)])
+                    entity_embeddings += [None] * (len(ordered_keys) - len(entity_embeddings))
 
                 valid = [(i, k) for i, k in enumerate(ordered_keys) if entity_embeddings[i] is not None]
                 if valid:

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -993,11 +993,7 @@ class Memory(MemoryBase):
                         except Exception:
                             entity_embeddings.append(None)
 
-                # A misbehaving embedder may return fewer (or more) vectors than
-                # inputs. Normalise to ordered_keys length so the valid-filter
-                # treats missing vectors as failures instead of raising IndexError
-                # (which the outer except would swallow, silently dropping ALL
-                # entity links). Mirrors the count guard in _compute_entity_boosts.
+
                 if len(entity_embeddings) != len(ordered_keys):
                     logger.warning(
                         "embed_batch returned %d vectors for %d entity texts — "
@@ -2535,11 +2531,6 @@ class AsyncMemory(MemoryBase):
                         except Exception:
                             entity_embeddings.append(None)
 
-                # A misbehaving embedder may return fewer (or more) vectors than
-                # inputs. Normalise to ordered_keys length so the valid-filter
-                # treats missing vectors as failures instead of raising IndexError
-                # (which the outer except would swallow, silently dropping ALL
-                # entity links). Mirrors the count guard in _compute_entity_boosts.
                 if len(entity_embeddings) != len(ordered_keys):
                     logger.warning(
                         "embed_batch returned %d vectors for %d entity texts — "

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -857,3 +857,134 @@ class TestEntityBoostParallelism:
         assert elapsed < 0.75, f"searches did not run concurrently (took {elapsed:.2f}s)"
         assert concurrent_count["peak"] >= 2, "no overlap observed between entity searches"
         assert len(boosts) == 4
+
+
+class TestAddPipelineEntityEmbeddingCountGuard:
+    """A misbehaving embedder returning fewer (or more) vectors than entity
+    texts must not silently drop ALL entity links via a swallowed IndexError.
+
+    Before the fix, `entity_embeddings[i]` (indexed by ordered_keys length) raised
+    IndexError on a short return; the outer `except Exception` in the Phase 7
+    entity-linking block swallowed it, so no entity was ever searched/inserted and
+    no error surfaced. The search path (_compute_entity_boosts) already guarded
+    this; the add path did not.
+    """
+
+    @pytest.fixture
+    def mock_memory(self, mocker):
+        mock_llm, _ = _setup_mocks(mocker)
+        memory = Memory()
+        memory.config = mocker.MagicMock()
+        memory.config.custom_instructions = None
+        memory.config.custom_update_memory_prompt = None
+        memory.custom_instructions = None
+        memory.api_version = "v1.1"
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        memory.db.batch_add_history = MagicMock()
+        return memory
+
+    @pytest.fixture
+    def mock_async_memory(self, mocker):
+        mock_llm, _ = _setup_mocks(mocker)
+        memory = AsyncMemory()
+        memory.config = mocker.MagicMock()
+        memory.config.custom_instructions = None
+        memory.config.custom_update_memory_prompt = None
+        memory.custom_instructions = None
+        memory.api_version = "v1.1"
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        memory.db.batch_add_history = MagicMock()
+        return memory
+
+    @staticmethod
+    def _short_entity_embed_batch(texts, memory_action="add"):
+        # Memory-text embeddings are well-behaved; entity embeddings come back short.
+        if memory_action == "add" and any(t in ("Alice", "Bob") for t in texts):
+            return [[0.1] * 10]  # 1 vector for 2 entity texts
+        return [[0.1] * 10 for _ in texts]
+
+    def test_sync_short_entity_embeddings_still_link_valid_entity(self, mock_memory, mocker, caplog):
+        mock_memory.llm.generate_response.return_value = (
+            '{"memory": [{"text": "Alice met Bob"}, {"text": "Bob called Alice"}]}'
+        )
+        mock_memory.embedding_model = Mock()
+        mock_memory.embedding_model.embed_batch = Mock(side_effect=self._short_entity_embed_batch)
+        mock_memory.embedding_model.embed = Mock(return_value=[0.1] * 10)
+
+        mock_memory._entity_store = Mock()
+        mock_memory._entity_store.search_batch = Mock(return_value=[[]])
+        mock_memory._entity_store.insert = Mock()
+        mock_memory._entity_store.update = Mock()
+
+        mocker.patch(
+            "mem0.memory.main.extract_entities_batch",
+            return_value=[
+                [("person", "Alice"), ("person", "Bob")],
+                [("person", "Bob"), ("person", "Alice")],
+            ],
+        )
+        mocker.patch("mem0.memory.main.capture_event")
+
+        with caplog.at_level(logging.WARNING):
+            result = mock_memory._add_to_vector_store(
+                messages=[{"role": "user", "content": "Alice met Bob; Bob called Alice"}],
+                metadata={},
+                filters={"user_id": "u1"},
+                infer=True,
+            )
+
+        # Both memories persist regardless.
+        assert len(result) == 2
+        # The entity block did NOT abort: it searched + inserted the one valid entity
+        # instead of swallowing an IndexError and linking nothing.
+        assert mock_memory._entity_store.search_batch.call_count == 1
+        assert mock_memory._entity_store.insert.call_count == 1
+        assert not any("Batch entity linking failed" in r.message for r in caplog.records), (
+            "entity linking aborted on a swallowed IndexError"
+        )
+        assert any("padding/truncating" in r.message for r in caplog.records), (
+            "expected count-mismatch warning was not emitted"
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_short_entity_embeddings_still_link_valid_entity(self, mock_async_memory, mocker, caplog):
+        mock_async_memory.llm.generate_response.return_value = (
+            '{"memory": [{"text": "Alice met Bob"}, {"text": "Bob called Alice"}]}'
+        )
+        mock_async_memory.embedding_model = Mock()
+        mock_async_memory.embedding_model.embed_batch = Mock(side_effect=self._short_entity_embed_batch)
+        mock_async_memory.embedding_model.embed = Mock(return_value=[0.1] * 10)
+
+        mock_async_memory._entity_store = Mock()
+        mock_async_memory._entity_store.search_batch = Mock(return_value=[[]])
+        mock_async_memory._entity_store.insert = Mock()
+        mock_async_memory._entity_store.update = Mock()
+
+        mocker.patch(
+            "mem0.memory.main.extract_entities_batch",
+            return_value=[
+                [("person", "Alice"), ("person", "Bob")],
+                [("person", "Bob"), ("person", "Alice")],
+            ],
+        )
+        mocker.patch("mem0.memory.main.capture_event")
+
+        with caplog.at_level(logging.WARNING):
+            result = await mock_async_memory._add_to_vector_store(
+                messages=[{"role": "user", "content": "Alice met Bob; Bob called Alice"}],
+                metadata={},
+                effective_filters={"user_id": "u1"},
+                infer=True,
+            )
+
+        assert len(result) == 2
+        assert mock_async_memory._entity_store.search_batch.call_count == 1
+        assert mock_async_memory._entity_store.insert.call_count == 1
+        assert not any("Batch entity linking failed" in r.message for r in caplog.records), (
+            "async entity linking aborted on a swallowed IndexError"
+        )
+        assert any("padding/truncating" in r.message for r in caplog.records), (
+            "expected count-mismatch warning was not emitted"
+        )


### PR DESCRIPTION
## Summary

- Guards against an embedding backend returning a different number of vectors than entity inputs in the V3 `add()` entity-linking phase.
- Without it, a short `embed_batch` return raises `IndexError` that the outer `except` swallows, **silently dropping ALL entity links** for that `add()` call — no error surfaced to the caller.

## Motivation

In `_add_to_vector_store` (Phase 7, both sync and async), unique entity texts are embedded in one batch:

```python
entity_embeddings = self.embedding_model.embed_batch(entity_texts, "add")
...
valid = [(i, k) for i, k in enumerate(ordered_keys) if entity_embeddings[i] is not None]
```

`entity_embeddings[i]` is indexed by `ordered_keys` length. The API contract for `embed_batch` is not enforced — an OpenAI-compatible backend (vLLM, proxies, etc.) or a transient provider hiccup can return **fewer** vectors than inputs. When that happens, `entity_embeddings[i]` raises `IndexError`, which the surrounding `try/except Exception` catches and logs as `"Batch entity linking failed"` — so **every** entity link for the call is lost, not just the missing one, and the `add()` caller sees a normal success response.

The search path already guards this exact case in `_compute_entity_boosts`:

```python
if len(embeddings) != len(entity_texts):
    logger.warning("embed_batch returned %d vectors for %d texts — skipping entity boost")
    return memory_boosts
```

The add path had no equivalent guard. This PR adds one.

## Fix

Before the valid-filter, normalise `entity_embeddings` to `ordered_keys` length — truncate if too long, pad with `None` if too short — in both the sync and async pipelines. Missing vectors then flow through the **existing** per-entity failure handling (`entity_embeddings[i] is not None`) instead of aborting the whole block. A warning mirrors the search-path message.

## Verification

- `python -m pytest tests/memory/test_main.py` — **44 passed**
- `ruff check mem0/memory/main.py tests/memory/test_main.py` — All checks passed
- Added sync + async regression tests (`TestAddPipelineEntityEmbeddingCountGuard`) that **fail without the fix** (`IndexError` → `search_batch.call_count == 0`) and pass with it.

## Real behavior proof

- **Behavior addressed:** 2 extracted memories yield 2 unique entities ("Alice", "Bob"); embedder returns only 1 vector for the 2 entity texts (simulating a deduped/short backend response).
- **Real environment:** Python 3.14, editable install of this branch, `MagicMock`-backed factories.
- **Command:** repro script driving `Memory._add_to_vector_store(infer=True)` with a flaky `embed_batch`.

**BEFORE fix (current `main`):**
```
WARNING Batch entity linking failed: list index out of range
RESULT: memories returned = 2
RESULT: entity_store.insert calls = 0
RESULT: entities inserted = 0
RESULT: search_batch calls = 0
>>> BUG: entity linking aborted before search/insert (IndexError swallowed).
```

**AFTER fix (this branch):**
```
WARNING embed_batch returned 1 vectors for 2 entity texts — padding/truncating to avoid dropping entity links
RESULT: memories returned = 2
RESULT: entity_store.insert calls = 1
RESULT: entities inserted = 1
RESULT: search_batch calls = 1
>>> OK: entity linking proceeded with the valid embeddings.
```

The successfully-embedded entity is now linked instead of all links being discarded.

- **Regression test:** `tests/memory/test_main.py::TestAddPipelineEntityEmbeddingCountGuard` (sync + async); each asserts the new behavior and fails without the fix.
- **What was NOT tested:** behavior against a real remote embedding provider (the count-mismatch is simulated, matching the existing mock-based test suite).

## Notes

- Memory-text embeddings (Phase 3) already map by `text`-keyed dict, so a short return there drops only the affected memory rather than crashing — out of scope here.
- Distinct from #5245 (per-item embed failure / silent memory drop): this is specifically the unguarded **list-index** on the entity batch.
