### PR TITLE
fix(ts-sdk): prevent cross-scope entity linking

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -413,7 +413,11 @@ export class Memory {
             matches = await entityStore.search(entityVec, 1, filters);
           } catch {}
 
-          if (matches.length > 0 && (matches[0].score ?? 0) >= 0.95) {
+          if (
+            matches.length > 0 &&
+            (matches[0].score ?? 0) >= 0.95 &&
+            this.isSameEntityScope(matches[0].payload, filters)
+          ) {
             const match = matches[0];
             const payload = match.payload || {};
             const linked = new Set<string>(
@@ -562,6 +566,30 @@ export class Memory {
       await this._getTelemetryId();
       await displayPerformanceSlowQueryNotice(this, trigger);
     } catch {}
+  }
+
+  private getEntityScope(source: Record<string, any> = {}): SearchFilters {
+    const scope: SearchFilters = {};
+    for (const key of ["user_id", "agent_id", "run_id"] as const) {
+      const value = source[key];
+      if (value) {
+        scope[key] = value;
+      }
+    }
+    return scope;
+  }
+
+  private isSameEntityScope(
+    payload: Record<string, any> = {},
+    filters: SearchFilters,
+  ): boolean {
+    const payloadScope = this.getEntityScope(payload);
+    const filterScope = this.getEntityScope(filters);
+    return (
+      payloadScope.user_id === filterScope.user_id &&
+      payloadScope.agent_id === filterScope.agent_id &&
+      payloadScope.run_id === filterScope.run_id
+    );
   }
 
   private async _getNoticeTelemetryId() {
@@ -1056,7 +1084,11 @@ export class Memory {
               matches = await entityStore.search(entityVec, 1, filters);
             } catch {}
 
-            if (matches.length > 0 && (matches[0].score ?? 0) >= 0.95) {
+            if (
+              matches.length > 0 &&
+              (matches[0].score ?? 0) >= 0.95 &&
+              this.isSameEntityScope(matches[0].payload, filters)
+            ) {
               // Update existing entity
               const match = matches[0];
               const payload = match.payload || {};

--- a/mem0-ts/src/oss/tests/memory.entity-scope.test.ts
+++ b/mem0-ts/src/oss/tests/memory.entity-scope.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Entity linking scope isolation tests.
+ *
+ * Entity-store search filters are provider-dependent, so the merge decision
+ * must verify that the returned entity payload belongs to the current
+ * user/agent/run scope before appending linkedMemoryIds.
+ */
+/// <reference types="jest" />
+import { Memory } from "../src/memory";
+import type { MemoryConfig, VectorStoreResult } from "../src/types";
+
+jest.setTimeout(15000);
+
+jest.mock("../src/embeddings/google", () => ({
+  GoogleEmbedder: jest.fn(),
+}));
+jest.mock("../src/llms/google", () => ({
+  GoogleLLM: jest.fn(),
+}));
+
+jest.mock("../src/llms/openai", () => ({
+  OpenAILLM: jest.fn().mockImplementation(() => ({
+    generateResponse: jest.fn().mockResolvedValue(
+      JSON.stringify({
+        memory: [
+          {
+            id: "0",
+            text: "I met Alice Smith yesterday",
+            attributed_to: "user",
+          },
+        ],
+      }),
+    ),
+  })),
+}));
+
+const mockEmbedding = new Array(1536).fill(0.1);
+jest.mock("../src/embeddings/openai", () => ({
+  OpenAIEmbedder: jest.fn().mockImplementation(() => ({
+    embed: jest.fn().mockResolvedValue(mockEmbedding),
+    embedBatch: jest
+      .fn()
+      .mockImplementation((texts: string[]) =>
+        Promise.resolve(texts.map(() => mockEmbedding)),
+      ),
+    embeddingDims: 1536,
+  })),
+}));
+
+function createMemory(overrides: Partial<MemoryConfig> = {}): Memory {
+  return new Memory({
+    version: "v1.1",
+    embedder: {
+      provider: "openai",
+      config: { apiKey: "test-key", model: "text-embedding-3-small" },
+    },
+    vectorStore: {
+      provider: "memory",
+      config: {
+        collectionName: `test-entity-scope-${Date.now()}-${Math.random()}`,
+        dimension: 1536,
+        dbPath: ":memory:",
+      },
+    },
+    llm: {
+      provider: "openai",
+      config: { apiKey: "test-key", model: "gpt-5-mini" },
+    },
+    historyDbPath: ":memory:",
+    ...overrides,
+  });
+}
+
+function makeEntityMatch(payload: Record<string, any>): VectorStoreResult {
+  return {
+    id: "entity-u1",
+    score: 0.99,
+    payload: {
+      data: "Alice Smith yesterday",
+      entityType: "PROPER",
+      linkedMemoryIds: ["mem-u1"],
+      ...payload,
+    },
+  };
+}
+
+describe("Memory entity linking scope isolation", () => {
+  let memory: Memory;
+
+  beforeEach(() => {
+    memory = createMemory();
+  });
+
+  afterEach(async () => {
+    await memory.reset();
+  });
+
+  it("inserts a new entity instead of merging a single-memory match from another user scope", async () => {
+    const m = memory as any;
+    await m._ensureInitialized();
+
+    const mockEntityStore = {
+      search: jest.fn().mockResolvedValue([makeEntityMatch({ user_id: "u1" })]),
+      update: jest.fn().mockResolvedValue(undefined),
+      insert: jest.fn().mockResolvedValue(undefined),
+      deleteCol: jest.fn().mockResolvedValue(undefined),
+    };
+    m._entityStore = mockEntityStore;
+
+    await m._linkEntitiesForMemory("mem-u2", "I met Alice Smith yesterday", {
+      user_id: "u2",
+    });
+
+    expect(mockEntityStore.update).not.toHaveBeenCalled();
+
+    const insertedPayloads = mockEntityStore.insert.mock.calls.flatMap(
+      (call: any[]) => call[2],
+    );
+    expect(insertedPayloads).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          data: "Alice Smith yesterday",
+          user_id: "u2",
+          linkedMemoryIds: ["mem-u2"],
+        }),
+      ]),
+    );
+  });
+
+  it("inserts a new entity instead of merging a batch add match from another user scope", async () => {
+    const m = memory as any;
+    await m._ensureInitialized();
+
+    const mockEntityStore = {
+      search: jest.fn().mockResolvedValue([makeEntityMatch({ user_id: "u1" })]),
+      update: jest.fn().mockResolvedValue(undefined),
+      insert: jest.fn().mockResolvedValue(undefined),
+      deleteCol: jest.fn().mockResolvedValue(undefined),
+    };
+    m._entityStore = mockEntityStore;
+    m.vectorStore.search = jest.fn().mockResolvedValue([]);
+
+    await memory.add("I met Alice Smith yesterday", { userId: "u2" });
+
+    expect(mockEntityStore.update).not.toHaveBeenCalled();
+
+    const insertedPayloads = mockEntityStore.insert.mock.calls.flatMap(
+      (call: any[]) => call[2],
+    );
+    expect(insertedPayloads).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          data: "Alice Smith yesterday",
+          user_id: "u2",
+        }),
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## Linked Issue

Closes #5597

## Description

This PR prevents the TypeScript OSS entity store from merging entities across `user_id`, `agent_id`, or `run_id` scopes.

The root cause was that both entity-linking paths trusted the vector-store search result once similarity was `>= 0.95`. If a provider returned a high-scoring entity from a different scope, the code appended the new memory ID to that entity's `linkedMemoryIds`, contaminating entity boosts across sessions/users.

The fix extracts the scope fields from the matched entity payload and compares them to the current filters before updating. If the scopes differ, the code inserts a new scoped entity instead.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Validated locally:

- `pnpm jest src/oss/tests/memory.entity-scope.test.ts --runInBand`
- `pnpm jest src/oss/tests/memory.entity-scope.test.ts src/oss/tests/memory.entity-boost.test.ts src/oss/tests/memory.add.test.ts --runInBand`
- `pnpm run build`
- `pnpm run test:unit`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
