### PR TITLE
fix(server): use 127.0.0.1 in dashboard healthcheck to avoid IPv6 localhost resolution

### DIFF
--- a/server/docker-compose.yaml
+++ b/server/docker-compose.yaml
@@ -63,7 +63,7 @@ services:
       mem0:
         condition: service_started
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:3000/api/health"]
       interval: 10s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary

The dashboard container's Docker healthcheck uses `wget http://localhost:3000/api/health`. In containers where `localhost` resolves to IPv6 `[::1]` first, this fails because the dashboard's `next-server` binds IPv4 only (`0.0.0.0:3000`). The healthcheck therefore reports the container as **unhealthy** even though the dashboard is fully functional.

This one-line change points the healthcheck at `127.0.0.1` instead of `localhost`, which always resolves to the IPv4 address `next-server` is listening on.

## Reproduction

```
$ docker inspect <dashboard> --format '{{json .State.Health}}'
  "Output": "wget: can't connect to remote host: Connection refused"

# inside the container:
$ wget --spider http://localhost:3000/    -> Connecting to localhost:3000 ([::1]:3000) -> Connection refused
$ wget --spider http://127.0.0.1:3000/    -> HTTP/1.1 307 Temporary Redirect   (works)

# listener is IPv4-only:
$ netstat -tlnp -> 0.0.0.0:3000  next-server
```

## Diff

```diff
-      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:3000/api/health"]
```

## Relationship to #5379

The same one-line fix is already bundled inside #5379 ("LAN deployment enhancements"). I opened this focused PR deliberately, for two reasons:

1. **Scope / reviewability** — #5379 is a large change (+1025/-50) bundling a health endpoint, retry logic, CORS, configurable URLs and Postgres port-binding changes. This healthcheck bug is independent of all of that and shouldn't have to wait on review of the larger feature set.
2. **Fast, low-risk merge** — a single-line healthcheck correction is trivially verifiable and safe to land on its own. If #5379 merges first, this PR can simply be closed as already-fixed; if this lands first, #5379 can drop the duplicate line on rebase.

No existing issue tracks this specific bug (searched: healthcheck / dashboard unhealthy / localhost ipv6 / wget connection refused) — happy to file one if maintainers prefer an issue first.