### PR TITLE
fix(ts-sdk): prevent hallucinated memories on empty messages payload …

### DIFF
--- a/mem0-ts/src/client/mem0.ts
+++ b/mem0-ts/src/client/mem0.ts
@@ -253,6 +253,12 @@ export default class MemoryClient {
     messages: Array<Message>,
     options: AddMemoryOptions & Record<string, any> = {},
   ): Promise<Array<Memory>> {
+    
+    // Tightly scoped validation guard to resolve #5465
+    if (!messages || (Array.isArray(messages) && messages.length === 0)) {
+      throw new Error("Can not process an empty messages array payload.")
+    }
+
     if (this.telemetryId === "") await this.ping();
 
     const payload = this._preparePayload(messages, options);

--- a/mem0-ts/src/client/mem0.ts
+++ b/mem0-ts/src/client/mem0.ts
@@ -253,10 +253,9 @@ export default class MemoryClient {
     messages: Array<Message>,
     options: AddMemoryOptions & Record<string, any> = {},
   ): Promise<Array<Memory>> {
-    
     // Tightly scoped validation guard to resolve #5465
     if (!messages || (Array.isArray(messages) && messages.length === 0)) {
-      throw new Error("Can not process an empty messages array payload.")
+      throw new Error("Cannot process an empty messages payload.");
     }
 
     if (this.telemetryId === "") await this.ping();

--- a/mem0-ts/src/client/tests/memoryClient.crud.test.ts
+++ b/mem0-ts/src/client/tests/memoryClient.crud.test.ts
@@ -59,16 +59,16 @@ describe("MemoryClient - add()", () => {
     expect(getFetchBody(call!).user_id).toBe("user_1");
   });
 
-  test("sends empty messages array without crashing", async () => {
-    const extra = new Map<string, { status: number; body: unknown }>();
-    extra.set("/v3/memories/add/", { status: 200, body: [] });
-    const mock = setupMockFetch(extra);
+  test("throws an error when given an empty messages array", async () => {
+    
+    setupMockFetch();
 
     const client = new MemoryClient({ apiKey: TEST_API_KEY });
-    await client.add([], { userId: "u1" });
 
-    const call = findFetchCall(mock, "/v3/memories/add/", "POST");
-    expect(getFetchBody(call!).messages).toEqual([]);
+    //Asserts that the validation guard catches the empty input early
+    await expect(client.add([], {userId: "u1"})).rejects.toThrow(
+      "Cannot process an empty messages payload."
+    )
   });
 });
 

--- a/mem0-ts/src/client/tests/memoryClient.crud.test.ts
+++ b/mem0-ts/src/client/tests/memoryClient.crud.test.ts
@@ -60,15 +60,14 @@ describe("MemoryClient - add()", () => {
   });
 
   test("throws an error when given an empty messages array", async () => {
-    
     setupMockFetch();
 
     const client = new MemoryClient({ apiKey: TEST_API_KEY });
 
     //Asserts that the validation guard catches the empty input early
-    await expect(client.add([], {userId: "u1"})).rejects.toThrow(
-      "Cannot process an empty messages payload."
-    )
+    await expect(client.add([], { userId: "u1" })).rejects.toThrow(
+      "Cannot process an empty messages payload.",
+    );
   });
 });
 


### PR DESCRIPTION

## Linked Issue

Related to #5465

## Description

This PR introduces an explicit, tightly scoped validation guard to the hosted TypeScript SDK client (`MemoryClient.add()`) to catch empty message array payloads (`[]`) early. 

By rejecting empty messages before a payload is prepared, this prevents empty data collections from propagating downstream to the server, avoiding unintended LLM extraction loops and memory data hallucinations. 

As noted during review, while #5465 tracks the OSS execution path, this PR provides distinct defensive hardening for the hosted client path explicitly. Following repository architecture guidelines, this fix strictly addresses the core validation boundary without introducing out-of-scope whitespace trimmers or arbitrary mutations.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Updated the existing test case inside `src/client/tests/memoryClient.crud.test.ts` to assert that it correctly expects an early rejection error. The error string in the source method and the unit test file have been perfectly aligned to match `"Cannot process an empty messages payload."` to ensure the test suite passes cleanly. Verified locally via `npx jest src/client/tests/memoryClient.crud.test.ts`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
