### PR TITLE
fix(server): register v1/v2/v3 route aliases so OSS server accepts Python client SDK paths

### DIFF
--- a/server/auth.py
+++ b/server/auth.py
@@ -146,7 +146,7 @@ async def verify_auth(
     credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
     x_api_key: str | None = Depends(api_key_header),
 ) -> User | None:
-    """Authenticate via JWT, X-API-Key, or legacy ADMIN_API_KEY. Returns User or None.
+    """Authenticate via JWT, X-API-Key, Token <key>, or legacy ADMIN_API_KEY. Returns User or None.
 
     A short-lived session is opened only on the branches that query the DB, so no
     pooled connection is held for the lifetime of the (possibly long-running) request.
@@ -164,13 +164,26 @@ async def verify_auth(
         with SessionLocal() as db:
             return _resolve_user_from_api_key(x_api_key, db)
 
+    if not AUTH_DISABLED:
+        # SDK compat: Python/TS clients send "Authorization: Token <key>"
+        auth_header = request.headers.get("authorization", "")
+        if auth_header.lower().startswith("token "):
+            token_key = auth_header[6:].strip()
+            if token_key:
+                if ADMIN_API_KEY and secrets.compare_digest(token_key, ADMIN_API_KEY):
+                    _mark_auth_type(request, "admin_api_key")
+                    return None
+                _mark_auth_type(request, "api_key")
+                with SessionLocal() as db:
+                    return _resolve_user_from_api_key(token_key, db)
+
     if AUTH_DISABLED:
         _mark_auth_type(request, "disabled")
         return None
 
     raise HTTPException(
         status_code=401,
-        detail="Authentication required. Provide a Bearer token or X-API-Key header.",
+        detail="Authentication required. Provide a Bearer token, X-API-Key, or Token header.",
         headers={"WWW-Authenticate": "Bearer"},
     )
 

--- a/server/auth.py
+++ b/server/auth.py
@@ -151,7 +151,7 @@ async def verify_auth(
     A short-lived session is opened only on the branches that query the DB, so no
     pooled connection is held for the lifetime of the (possibly long-running) request.
     """
-    if credentials is not None:
+    if credentials is not None and credentials.scheme.lower() == "bearer":
         _mark_auth_type(request, "bearer")
         with SessionLocal() as db:
             return _resolve_user_from_jwt(credentials.credentials, db)
@@ -204,7 +204,12 @@ async def require_auth(
 
 
 _BOOTSTRAP_ADMIN = User(
-    id=uuid.UUID(int=0), name="admin_api_key", email="", password_hash="", role="admin", created_at=datetime.min.replace(tzinfo=timezone.utc),
+    id=uuid.UUID(int=0),
+    name="admin_api_key",
+    email="",
+    password_hash="",
+    role="admin",
+    created_at=datetime.min.replace(tzinfo=timezone.utc),
 )
 
 

--- a/server/main.py
+++ b/server/main.py
@@ -27,6 +27,7 @@ from routers import api_keys as api_keys_router
 from routers import auth as auth_router
 from routers import entities as entities_router
 from routers import requests as requests_router
+from routers.entities import EntityType, delete_entity, list_entities
 from schemas import MessageResponse
 from server_state import (
     get_current_config,
@@ -169,6 +170,21 @@ app.include_router(auth_router.router)
 app.include_router(api_keys_router.router)
 app.include_router(entities_router.router)
 app.include_router(requests_router.router)
+
+
+# Entity route aliases: registered on app rather than router to avoid prefix collision
+
+
+@app.get("/v1/entities/", include_in_schema=False)
+def v1_list_entities(_auth=Depends(verify_auth)):
+    """List entities (SDK compatibility alias)."""
+    return list_entities(_auth=_auth)
+
+
+@app.delete("/v2/entities/{entity_type}/{entity_id}/", include_in_schema=False)
+def v2_delete_entity(entity_type: EntityType, entity_id: str, _auth=Depends(require_admin)):
+    """Delete entity (SDK compatibility alias)."""
+    return delete_entity(entity_type=entity_type, entity_id=entity_id, _auth=_auth)
 
 
 class Message(BaseModel):
@@ -363,6 +379,26 @@ def generate_instructions(req: GenerateInstructionsRequest, _auth=Depends(verify
         raise upstream_error()
 
 
+@app.get("/v1/ping/", include_in_schema=False)
+def ping(_auth=Depends(verify_auth)):
+    """Health check for SDK compatibility."""
+    return {"status": "ok"}
+
+
+@app.post("/v3/memories/", include_in_schema=False)
+async def v3_memories_dispatch(request: Request, _auth=Depends(verify_auth)):
+    """Route POST /v3/memories/ to add or get_all based on body content."""
+    body = await request.json()
+    if "messages" in body:
+        memory_create = MemoryCreate(**body)
+        return add_memory(memory_create, _auth=_auth)
+    user_id = body.get("user_id")
+    run_id = body.get("run_id")
+    agent_id = body.get("agent_id")
+    return get_all_memories(request, user_id=user_id, run_id=run_id, agent_id=agent_id, _auth=_auth)
+
+
+@app.post("/v3/memories/add/", include_in_schema=False)
 @app.post("/memories", summary="Create memories")
 def add_memory(memory_create: MemoryCreate, _auth=Depends(verify_auth)):
     """Store new memories."""
@@ -407,6 +443,7 @@ def _list_all_memories(limit: int = ALL_MEMORIES_LIMIT) -> Dict[str, Any]:
     return {"results": [_serialize_memory(row) for row in rows]}
 
 
+@app.get("/v1/memories/", include_in_schema=False)
 @app.get("/memories", summary="Get memories")
 def get_all_memories(
     request: Request,
@@ -439,6 +476,7 @@ def get_all_memories(
         raise upstream_error()
 
 
+@app.get("/v1/memories/{memory_id}/", include_in_schema=False)
 @app.get("/memories/{memory_id}", summary="Get a memory")
 def get_memory(memory_id: str, _auth=Depends(verify_auth)):
     """Retrieve a specific memory by ID."""
@@ -448,6 +486,7 @@ def get_memory(memory_id: str, _auth=Depends(verify_auth)):
         raise upstream_error()
 
 
+@app.post("/v3/memories/search/", include_in_schema=False)
 @app.post("/search", summary="Search memories")
 def search_memories(search_req: SearchRequest, _auth=Depends(verify_auth)):
     """Search for memories based on a query."""
@@ -483,6 +522,7 @@ def search_memories(search_req: SearchRequest, _auth=Depends(verify_auth)):
         raise upstream_error()
 
 
+@app.put("/v1/memories/{memory_id}/", include_in_schema=False)
 @app.put("/memories/{memory_id}", summary="Update a memory")
 def update_memory(memory_id: str, updated_memory: MemoryUpdate, _auth=Depends(verify_auth)):
     """Update an existing memory."""
@@ -502,6 +542,7 @@ def update_memory(memory_id: str, updated_memory: MemoryUpdate, _auth=Depends(ve
         raise upstream_error()
 
 
+@app.get("/v1/memories/{memory_id}/history/", include_in_schema=False)
 @app.get("/memories/{memory_id}/history", summary="Get memory history")
 def memory_history(memory_id: str, _auth=Depends(verify_auth)):
     """Retrieve memory history."""
@@ -511,6 +552,7 @@ def memory_history(memory_id: str, _auth=Depends(verify_auth)):
         raise upstream_error()
 
 
+@app.delete("/v1/memories/{memory_id}/", include_in_schema=False)
 @app.delete("/memories/{memory_id}", summary="Delete a memory", response_model=MessageResponse)
 def delete_memory(memory_id: str, _auth=Depends(verify_auth)):
     """Delete a specific memory by ID."""
@@ -523,6 +565,7 @@ def delete_memory(memory_id: str, _auth=Depends(verify_auth)):
         raise upstream_error()
 
 
+@app.delete("/v1/memories/", include_in_schema=False)
 @app.delete("/memories", summary="Delete all memories", response_model=MessageResponse)
 def delete_all_memories(
     user_id: Optional[str] = None,
@@ -543,6 +586,7 @@ def delete_all_memories(
         raise upstream_error()
 
 
+@app.post("/v1/reset/", include_in_schema=False)
 @app.post("/reset", summary="Reset all memories")
 def reset_memory(_auth=Depends(require_admin)):
     """Completely reset stored memories. Requires admin role."""

--- a/server/main.py
+++ b/server/main.py
@@ -1,7 +1,9 @@
+import ast
 import asyncio
 import logging
 import os
 import time
+from collections.abc import Mapping
 from typing import Any, Dict, List, Optional
 
 import telemetry
@@ -21,7 +23,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, RedirectResponse
 from mem0.exceptions import ValidationError as Mem0ValidationError
 from models import RequestLog, User
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from rate_limit import limiter
 from routers import api_keys as api_keys_router
 from routers import auth as auth_router
@@ -172,16 +174,25 @@ app.include_router(entities_router.router)
 app.include_router(requests_router.router)
 
 
-# Entity route aliases: registered on app rather than router to avoid prefix collision
+# Entity compatibility adapters: registered on app rather than router to avoid prefix collision
 
 
-@app.get("/v1/entities/", include_in_schema=False)
+class EntityListResponse(BaseModel):
+    count: int
+    next: Optional[str] = None
+    previous: Optional[str] = None
+    results: List[Dict[str, Any]]
+
+
+@app.get("/v1/entities/", response_model=EntityListResponse, include_in_schema=False)
 def v1_list_entities(_auth=Depends(verify_auth)):
-    """List entities (SDK compatibility alias)."""
-    return list_entities(_auth=_auth)
+    """List entities in the envelope consumed by the Python client."""
+    entities = list_entities(_auth=_auth)
+    results = [entity.model_dump() | {"name": entity.id} for entity in entities]
+    return {"count": len(results), "next": None, "previous": None, "results": results}
 
 
-@app.delete("/v2/entities/{entity_type}/{entity_id}/", include_in_schema=False)
+@app.delete("/v2/entities/{entity_type}/{entity_id}/", response_model=MessageResponse, include_in_schema=False)
 def v2_delete_entity(entity_type: EntityType, entity_id: str, _auth=Depends(require_admin)):
     """Delete entity (SDK compatibility alias)."""
     return delete_entity(entity_type=entity_type, entity_id=entity_id, _auth=_auth)
@@ -224,6 +235,122 @@ class SearchRequest(BaseModel):
 
 class GenerateInstructionsRequest(BaseModel):
     use_case: str = Field(..., description="Description of what the user will use Mem0 for.")
+
+
+ALL_MEMORIES_LIMIT = 1000
+IDENTITY_KEYS = ("user_id", "agent_id", "run_id")
+DELETE_ALL_FILTERS_MAX_LENGTH = 8192
+
+
+class CompatibilityModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class CompatibilityMessage(CompatibilityModel):
+    role: str
+    content: str
+
+
+class V3AddRequest(CompatibilityModel):
+    messages: List[CompatibilityMessage]
+    filters: Optional[Dict[str, Any]] = None
+    user_id: Optional[str] = None
+    agent_id: Optional[str] = None
+    run_id: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+    infer: Optional[bool] = None
+    expiration_date: Optional[str] = None
+    custom_instructions: Optional[str] = None
+
+
+class V3GetAllRequest(CompatibilityModel):
+    filters: Optional[Dict[str, Any]] = None
+    user_id: Optional[str] = None
+    agent_id: Optional[str] = None
+    run_id: Optional[str] = None
+    top_k: Optional[int] = Field(None, ge=0, le=ALL_MEMORIES_LIMIT)
+    show_expired: Optional[bool] = None
+
+
+class V3SearchRequest(CompatibilityModel):
+    query: str
+    filters: Optional[Dict[str, Any]] = None
+    top_k: Optional[int] = Field(None, ge=0, le=ALL_MEMORIES_LIMIT)
+    threshold: Optional[float] = None
+    rerank: Optional[bool] = None
+    show_expired: Optional[bool] = None
+
+
+class V1UpdateRequest(CompatibilityModel):
+    text: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+    expiration_date: Optional[str] = None
+
+
+def _validation_error(detail: str) -> HTTPException:
+    return HTTPException(status_code=422, detail=detail)
+
+
+def _normalize_identity(*sources: Mapping[str, Any] | None) -> Dict[str, str]:
+    normalized: Dict[str, str] = {}
+    for source in sources:
+        if source is None:
+            continue
+        if not isinstance(source, Mapping):
+            raise _validation_error("identity filters must be an object")
+        for key, value in source.items():
+            if key not in IDENTITY_KEYS:
+                raise _validation_error(f"Unsupported identity filter: {key}")
+            if not isinstance(value, str) or not value.strip():
+                raise _validation_error(f"{key} must be a non-empty string")
+            if key in normalized and normalized[key] != value:
+                raise _validation_error(f"Conflicting values for {key}")
+            normalized[key] = value
+    if not normalized:
+        raise _validation_error("At least one identifier (user_id, agent_id, or run_id) is required.")
+    return normalized
+
+
+def _normalize_filters(
+    filters: Optional[Dict[str, Any]],
+    *top_level_identity: Mapping[str, Any] | None,
+    identity_only: bool = False,
+    allow_no_identity: bool = False,
+) -> Dict[str, Any]:
+    if filters is not None and not isinstance(filters, Mapping):
+        raise _validation_error("filters must be an object")
+    filters = dict(filters or {})
+    filter_identity = {key: filters[key] for key in IDENTITY_KEYS if key in filters}
+    identity_sources = [
+        source for source in [filter_identity, *top_level_identity] if source
+    ]
+    extra_filters = {key: value for key, value in filters.items() if key not in IDENTITY_KEYS}
+    if "app_id" in extra_filters:
+        raise _validation_error("app_id is not supported by the OSS server")
+    if not identity_sources:
+        if allow_no_identity and not extra_filters:
+            return {}
+        raise _validation_error("At least one identifier (user_id, agent_id, or run_id) is required.")
+    normalized_identity = _normalize_identity(*identity_sources)
+    if identity_only and extra_filters:
+        unsupported = next(iter(extra_filters))
+        raise _validation_error(f"Unsupported filter: {unsupported}")
+    return extra_filters | normalized_identity
+
+
+def _parse_delete_all_filters(value: str) -> Mapping[str, Any]:
+    if len(value) > DELETE_ALL_FILTERS_MAX_LENGTH:
+        raise _validation_error("filters exceeds the 8192-character limit")
+    try:
+        parsed = __import__("json").loads(value)
+    except (TypeError, ValueError):
+        try:
+            parsed = ast.literal_eval(value)
+        except (SyntaxError, ValueError, TypeError):
+            raise _validation_error("filters must be a JSON or Python mapping")
+    if not isinstance(parsed, Mapping):
+        raise _validation_error("filters must be a mapping")
+    return parsed
 
 
 def _client_error(exc: Exception) -> HTTPException:
@@ -385,20 +512,24 @@ def ping(_auth=Depends(verify_auth)):
     return {"status": "ok"}
 
 
-@app.post("/v3/memories/", include_in_schema=False)
-async def v3_memories_dispatch(request: Request, _auth=Depends(verify_auth)):
-    """Route POST /v3/memories/ to add or get_all based on body content."""
-    body = await request.json()
-    if "messages" in body:
-        memory_create = MemoryCreate(**body)
-        return add_memory(memory_create, _auth=_auth)
-    user_id = body.get("user_id")
-    run_id = body.get("run_id")
-    agent_id = body.get("agent_id")
-    return get_all_memories(request, user_id=user_id, run_id=run_id, agent_id=agent_id, _auth=_auth)
-
-
 @app.post("/v3/memories/add/", include_in_schema=False)
+def v3_add_memory(payload: V3AddRequest, _auth=Depends(verify_auth)):
+    identity = _normalize_filters(
+        payload.filters,
+        {key: getattr(payload, key) for key in IDENTITY_KEYS if key in payload.model_fields_set},
+        identity_only=True,
+    )
+    memory_create = MemoryCreate(
+        messages=[message.model_dump() for message in payload.messages],
+        metadata=payload.metadata,
+        infer=payload.infer,
+        expiration_date=payload.expiration_date,
+        prompt=payload.custom_instructions,
+        **identity,
+    )
+    return add_memory(memory_create, _auth=_auth)
+
+
 @app.post("/memories", summary="Create memories")
 def add_memory(memory_create: MemoryCreate, _auth=Depends(verify_auth)):
     """Store new memories."""
@@ -417,8 +548,16 @@ def add_memory(memory_create: MemoryCreate, _auth=Depends(verify_auth)):
         raise upstream_error()
 
 
-ALL_MEMORIES_LIMIT = 1000
-_RESERVED_PAYLOAD_KEYS = {"data", "user_id", "agent_id", "run_id", "hash", "created_at", "updated_at", "expiration_date"}
+_RESERVED_PAYLOAD_KEYS = {
+    "data",
+    "user_id",
+    "agent_id",
+    "run_id",
+    "hash",
+    "created_at",
+    "updated_at",
+    "expiration_date",
+}
 
 
 def _serialize_memory(row: Any) -> Dict[str, Any]:
@@ -443,7 +582,55 @@ def _list_all_memories(limit: int = ALL_MEMORIES_LIMIT) -> Dict[str, Any]:
     return {"results": [_serialize_memory(row) for row in rows]}
 
 
-@app.get("/v1/memories/", include_in_schema=False)
+def _get_all_memories(
+    request: Request,
+    user_id: Optional[str] = None,
+    run_id: Optional[str] = None,
+    agent_id: Optional[str] = None,
+    filters: Optional[Dict[str, Any]] = None,
+    top_k: Optional[int] = None,
+    show_expired: bool = False,
+    _auth=None,
+):
+    try:
+        combined_filters = dict(filters or {})
+        combined_filters.update(
+            {k: v for k, v in {"user_id": user_id, "run_id": run_id, "agent_id": agent_id}.items() if v}
+        )
+        if not combined_filters:
+            auth_type = getattr(request.state, "auth_type", "none")
+            if _auth is not None and _auth.role != "admin" and auth_type not in {"admin_api_key", "disabled"}:
+                raise HTTPException(status_code=403, detail="Admin role required to list all memories.")
+            return _list_all_memories(limit=top_k if top_k is not None else ALL_MEMORIES_LIMIT)
+        params = {"filters": combined_filters}
+        if top_k is not None:
+            params["top_k"] = top_k
+        params["show_expired"] = show_expired
+        return get_memory_instance().get_all(**params)
+    except HTTPException:
+        raise
+    except Exception:
+        raise upstream_error()
+
+
+@app.post("/v3/memories/", include_in_schema=False)
+def v3_get_all_memories(payload: V3GetAllRequest, request: Request, _auth=Depends(verify_auth)):
+    if request.query_params:
+        raise _validation_error("pagination and query parameters are not supported")
+    filters = _normalize_filters(
+        payload.filters,
+        {key: getattr(payload, key) for key in IDENTITY_KEYS if key in payload.model_fields_set},
+        allow_no_identity=True,
+    )
+    return _get_all_memories(
+        request,
+        filters=filters or None,
+        top_k=payload.top_k,
+        show_expired=payload.show_expired if payload.show_expired is not None else False,
+        _auth=_auth,
+    )
+
+
 @app.get("/memories", summary="Get memories")
 def get_all_memories(
     request: Request,
@@ -455,28 +642,17 @@ def get_all_memories(
     _auth=Depends(verify_auth),
 ):
     """Retrieve stored memories. Lists all memories when no identifier is provided (admin only)."""
-    try:
-        if not any([user_id, run_id, agent_id]):
-            auth_type = getattr(request.state, "auth_type", "none")
-            if _auth is not None and _auth.role != "admin" and auth_type not in {"admin_api_key", "disabled"}:
-                raise HTTPException(status_code=403, detail="Admin role required to list all memories.")
-            # Admin all-memory listing is intentionally raw; scoped get_all below applies expiry visibility.
-            return _list_all_memories(limit=top_k if top_k is not None else ALL_MEMORIES_LIMIT)
-        filters = {
-            k: v for k, v in {"user_id": user_id, "run_id": run_id, "agent_id": agent_id}.items() if v
-        }
-        params = {"filters": filters}
-        if top_k is not None:
-            params["top_k"] = top_k
-        params["show_expired"] = show_expired
-        return get_memory_instance().get_all(**params)
-    except HTTPException:
-        raise
-    except Exception:
-        raise upstream_error()
+    return _get_all_memories(
+        request,
+        user_id=user_id,
+        run_id=run_id,
+        agent_id=agent_id,
+        top_k=top_k,
+        show_expired=show_expired,
+        _auth=_auth,
+    )
 
 
-@app.get("/v1/memories/{memory_id}/", include_in_schema=False)
 @app.get("/memories/{memory_id}", summary="Get a memory")
 def get_memory(memory_id: str, _auth=Depends(verify_auth)):
     """Retrieve a specific memory by ID."""
@@ -486,34 +662,28 @@ def get_memory(memory_id: str, _auth=Depends(verify_auth)):
         raise upstream_error()
 
 
-@app.post("/v3/memories/search/", include_in_schema=False)
-@app.post("/search", summary="Search memories")
-def search_memories(search_req: SearchRequest, _auth=Depends(verify_auth)):
-    """Search for memories based on a query."""
+def _execute_search(
+    query: str,
+    filters: Dict[str, Any],
+    top_k: Optional[int] = None,
+    threshold: Optional[float] = None,
+    explain: Optional[bool] = None,
+    show_expired: Optional[bool] = None,
+    rerank: Optional[bool] = None,
+):
     try:
-        filters = search_req.filters or {}
-        deprecated_keys = []
-        for entity_key in ("user_id", "agent_id", "run_id"):
-            entity_val = getattr(search_req, entity_key, None)
-            if entity_val:
-                filters[entity_key] = entity_val
-                deprecated_keys.append(entity_key)
-        if deprecated_keys:
-            logging.warning(
-                "Top-level %s in /search is deprecated. Use filters={%s} instead.",
-                ", ".join(deprecated_keys),
-                ", ".join(f'"{k}": "..."' for k in deprecated_keys),
-            )
         params = {}
-        if search_req.top_k is not None:
-            params["top_k"] = search_req.top_k
-        if search_req.threshold is not None:
-            params["threshold"] = search_req.threshold
-        if search_req.explain is not None:
-            params["explain"] = search_req.explain
-        if search_req.show_expired is not None:
-            params["show_expired"] = search_req.show_expired
-        return get_memory_instance().search(query=search_req.query, filters=filters, **params)
+        if top_k is not None:
+            params["top_k"] = top_k
+        if threshold is not None:
+            params["threshold"] = threshold
+        if explain is not None:
+            params["explain"] = explain
+        if show_expired is not None:
+            params["show_expired"] = show_expired
+        if rerank is not None:
+            params["rerank"] = rerank
+        return get_memory_instance().search(query=query, filters=dict(filters), **params)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except HTTPException:
@@ -522,12 +692,54 @@ def search_memories(search_req: SearchRequest, _auth=Depends(verify_auth)):
         raise upstream_error()
 
 
-@app.put("/v1/memories/{memory_id}/", include_in_schema=False)
+@app.post("/v3/memories/search/", include_in_schema=False)
+def v3_search_memories(search_req: V3SearchRequest, _auth=Depends(verify_auth)):
+    filters = _normalize_filters(search_req.filters, allow_no_identity=True)
+    return _execute_search(
+        search_req.query,
+        filters,
+        top_k=search_req.top_k,
+        threshold=search_req.threshold,
+        rerank=search_req.rerank,
+        show_expired=search_req.show_expired,
+    )
+
+
+@app.post("/search", summary="Search memories")
+def search_memories(search_req: SearchRequest, _auth=Depends(verify_auth)):
+    """Search for memories based on a query."""
+    filters = dict(search_req.filters or {})
+    deprecated_keys = []
+    for entity_key in ("user_id", "agent_id", "run_id"):
+        entity_val = getattr(search_req, entity_key, None)
+        if entity_val:
+            filters[entity_key] = entity_val
+            deprecated_keys.append(entity_key)
+    if deprecated_keys:
+        logging.warning(
+            "Top-level %s in /search is deprecated. Use filters={%s} instead.",
+            ", ".join(deprecated_keys),
+            ", ".join(f'"{k}": "..."' for k in deprecated_keys),
+        )
+    return _execute_search(
+        search_req.query,
+        filters,
+        top_k=search_req.top_k,
+        threshold=search_req.threshold,
+        explain=search_req.explain,
+        show_expired=search_req.show_expired,
+    )
+
+
 @app.put("/memories/{memory_id}", summary="Update a memory")
 def update_memory(memory_id: str, updated_memory: MemoryUpdate, _auth=Depends(verify_auth)):
     """Update an existing memory."""
     try:
-        fields_set = getattr(updated_memory, "model_fields_set", getattr(updated_memory, "__fields_set__", set()))
+        fields_set = (
+            updated_memory.model_fields_set
+            if hasattr(updated_memory, "model_fields_set")
+            else getattr(updated_memory, "__fields_set__", set())
+        )
         params = {"memory_id": memory_id}
         if "text" in fields_set:
             params["data"] = updated_memory.text
@@ -542,7 +754,14 @@ def update_memory(memory_id: str, updated_memory: MemoryUpdate, _auth=Depends(ve
         raise upstream_error()
 
 
-@app.get("/v1/memories/{memory_id}/history/", include_in_schema=False)
+@app.put("/v1/memories/{memory_id:path}/", include_in_schema=False)
+def v1_update_memory(memory_id: str, payload: V1UpdateRequest, _auth=Depends(verify_auth)):
+    if not payload.model_fields_set:
+        raise _validation_error("At least one update field is required")
+    updated_memory = MemoryUpdate.model_validate(payload.model_dump(exclude_unset=True))
+    return update_memory(memory_id, updated_memory, _auth=_auth)
+
+
 @app.get("/memories/{memory_id}/history", summary="Get memory history")
 def memory_history(memory_id: str, _auth=Depends(verify_auth)):
     """Retrieve memory history."""
@@ -552,7 +771,6 @@ def memory_history(memory_id: str, _auth=Depends(verify_auth)):
         raise upstream_error()
 
 
-@app.delete("/v1/memories/{memory_id}/", include_in_schema=False)
 @app.delete("/memories/{memory_id}", summary="Delete a memory", response_model=MessageResponse)
 def delete_memory(memory_id: str, _auth=Depends(verify_auth)):
     """Delete a specific memory by ID."""
@@ -565,7 +783,27 @@ def delete_memory(memory_id: str, _auth=Depends(verify_auth)):
         raise upstream_error()
 
 
-@app.delete("/v1/memories/", include_in_schema=False)
+@app.get("/v1/memories/{memory_id:path}/history/", include_in_schema=False)
+def v1_memory_history(memory_id: str, _auth=Depends(verify_auth)):
+    return memory_history(memory_id, _auth=_auth)
+
+
+@app.get("/v1/memories/{memory_id:path}/", include_in_schema=False)
+def v1_get_memory(memory_id: str, _auth=Depends(verify_auth)):
+    return get_memory(memory_id, _auth=_auth)
+
+
+@app.delete("/v1/memories/{memory_id:path}/", include_in_schema=False, response_model=MessageResponse)
+def v1_delete_memory(
+    memory_id: str,
+    delete_linked: Optional[bool] = Query(None),
+    _auth=Depends(verify_auth),
+):
+    if delete_linked is True:
+        raise _validation_error("delete_linked=true is not supported by the OSS server")
+    return delete_memory(memory_id, _auth=_auth)
+
+
 @app.delete("/memories", summary="Delete all memories", response_model=MessageResponse)
 def delete_all_memories(
     user_id: Optional[str] = None,
@@ -577,16 +815,36 @@ def delete_all_memories(
     if not any([user_id, run_id, agent_id]):
         raise HTTPException(status_code=400, detail="At least one identifier is required.")
     try:
-        params = {
-            k: v for k, v in {"user_id": user_id, "run_id": run_id, "agent_id": agent_id}.items() if v
-        }
+        params = {k: v for k, v in {"user_id": user_id, "run_id": run_id, "agent_id": agent_id}.items() if v}
         get_memory_instance().delete_all(**params)
         return MessageResponse(message="All relevant memories deleted")
     except Exception:
         raise upstream_error()
 
 
-@app.post("/v1/reset/", include_in_schema=False)
+@app.delete("/v1/memories/", include_in_schema=False, response_model=MessageResponse)
+def v1_delete_all_memories(
+    request: Request,
+    filters: Optional[str] = Query(None),
+    user_id: Optional[str] = Query(None),
+    agent_id: Optional[str] = Query(None),
+    run_id: Optional[str] = Query(None),
+    _auth=Depends(require_admin),
+):
+    allowed = {"filters", "user_id", "agent_id", "run_id"}
+    unsupported = [key for key in request.query_params if key not in allowed]
+    if unsupported:
+        raise _validation_error(f"Unsupported delete-all query parameter: {unsupported[0]}")
+    parsed_filters = _parse_delete_all_filters(filters) if filters is not None else None
+    top_level = {
+        key: value
+        for key, value in {"user_id": user_id, "agent_id": agent_id, "run_id": run_id}.items()
+        if value is not None
+    }
+    identity = _normalize_identity(*(source for source in (parsed_filters, top_level) if source is not None))
+    return delete_all_memories(_auth=_auth, **identity)
+
+
 @app.post("/reset", summary="Reset all memories")
 def reset_memory(_auth=Depends(require_admin)):
     """Completely reset stored memories. Requires admin role."""

--- a/tests/test_server_params.py
+++ b/tests/test_server_params.py
@@ -22,9 +22,16 @@ from fastapi.testclient import TestClient
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def _mock_memory():
     """Patch Memory.from_config so the server imports without a real backend."""
+    import sys
+
+    server_path = os.path.join(os.path.dirname(__file__), "..", "server")
+    if server_path not in sys.path:
+        sys.path.insert(0, server_path)
+
     mock_instance = MagicMock()
     mock_instance.add.return_value = {"results": [{"id": "mem-1", "event": "ADD", "memory": "test"}]}
     mock_instance.search.return_value = [{"id": "mem-1", "memory": "test", "score": 0.9}]
@@ -36,7 +43,8 @@ def _mock_memory():
     mock_instance.delete_all.return_value = {"message": "Memories deleted"}
     mock_instance.reset.return_value = None
 
-    with patch.dict(os.environ, {"OPENAI_API_KEY": "fake-key", "ADMIN_API_KEY": ""}):
+    env = {"OPENAI_API_KEY": "fake-key", "ADMIN_API_KEY": "", "AUTH_DISABLED": "true"}
+    with patch.dict(os.environ, env):
         with patch("mem0.Memory.from_config", return_value=mock_instance):
             yield mock_instance
 
@@ -44,10 +52,22 @@ def _mock_memory():
 @pytest.fixture
 def client(_mock_memory):
     """Return a TestClient wired to the server app with mocked Memory."""
+    import server.auth as server_auth
     import server.main as server_main
-    with patch.dict(os.environ, {"ADMIN_API_KEY": ""}):
+
+    env = {"ADMIN_API_KEY": "", "AUTH_DISABLED": "true"}
+    with patch.dict(os.environ, env):
+        importlib.reload(server_auth)
         importlib.reload(server_main)
-    return TestClient(server_main.app)
+
+    from db import get_db
+
+    mock_db = MagicMock()
+    mock_db.scalar.return_value = None
+    server_main.app.dependency_overrides[get_db] = lambda: mock_db
+    with patch.object(server_main, "SessionLocal", return_value=mock_db):
+        yield TestClient(server_main.app)
+    server_main.app.dependency_overrides.clear()
 
 
 @pytest.fixture
@@ -58,6 +78,7 @@ def mock_memory(_mock_memory):
 # ===========================================================================
 # SearchRequest: top_k parameter
 # ===========================================================================
+
 
 class TestSearchLimit:
     """Verify that the top_k parameter is accepted and forwarded to Memory.search()."""
@@ -87,6 +108,7 @@ class TestSearchLimit:
 # SearchRequest: threshold parameter
 # ===========================================================================
 
+
 class TestSearchThreshold:
     """Verify that the threshold parameter is accepted and forwarded."""
 
@@ -114,6 +136,7 @@ class TestSearchThreshold:
 # SearchRequest: explain parameter
 # ===========================================================================
 
+
 class TestSearchExplain:
     """Verify that the explain parameter is accepted and forwarded."""
 
@@ -140,12 +163,10 @@ class TestSearchExplain:
 # SearchRequest: top_k + threshold together
 # ===========================================================================
 
-class TestSearchLimitAndThreshold:
 
+class TestSearchLimitAndThreshold:
     def test_both_forwarded(self, client, mock_memory):
-        resp = client.post("/search", json={
-            "query": "food", "user_id": "u1", "top_k": 10, "threshold": 0.5
-        })
+        resp = client.post("/search", json={"query": "food", "user_id": "u1", "top_k": 10, "threshold": 0.5})
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert kwargs["top_k"] == 10
@@ -156,25 +177,32 @@ class TestSearchLimitAndThreshold:
 # MemoryCreate: infer parameter
 # ===========================================================================
 
+
 class TestAddInfer:
     """Verify that the infer parameter is accepted and forwarded to Memory.add()."""
 
     def test_infer_false_forwarded(self, client, mock_memory):
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "Store this exactly"}],
-            "user_id": "u1",
-            "infer": False,
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "Store this exactly"}],
+                "user_id": "u1",
+                "infer": False,
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["infer"] is False
 
     def test_infer_true_forwarded(self, client, mock_memory):
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "I like pizza"}],
-            "user_id": "u1",
-            "infer": True,
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "I like pizza"}],
+                "user_id": "u1",
+                "infer": True,
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["infer"] is True
@@ -182,10 +210,13 @@ class TestAddInfer:
     def test_infer_omitted_uses_memory_default(self, client, mock_memory):
         """When infer is not sent, it should not appear in kwargs,
         allowing Memory.add() to use its own default (True)."""
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "hello"}],
-            "user_id": "u1",
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "hello"}],
+                "user_id": "u1",
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert "infer" not in kwargs
@@ -195,24 +226,31 @@ class TestAddInfer:
 # MemoryCreate: memory_type parameter
 # ===========================================================================
 
+
 class TestAddMemoryType:
     """Verify that the memory_type parameter is accepted and forwarded."""
 
     def test_memory_type_forwarded(self, client, mock_memory):
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "I like pizza"}],
-            "user_id": "u1",
-            "memory_type": "core",
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "I like pizza"}],
+                "user_id": "u1",
+                "memory_type": "core",
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["memory_type"] == "core"
 
     def test_memory_type_omitted(self, client, mock_memory):
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "hello"}],
-            "user_id": "u1",
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "hello"}],
+                "user_id": "u1",
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert "memory_type" not in kwargs
@@ -222,24 +260,31 @@ class TestAddMemoryType:
 # MemoryCreate: prompt parameter
 # ===========================================================================
 
+
 class TestAddPrompt:
     """Verify that the prompt parameter is accepted and forwarded."""
 
     def test_prompt_forwarded(self, client, mock_memory):
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "I like pizza"}],
-            "user_id": "u1",
-            "prompt": "Extract food preferences only.",
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "I like pizza"}],
+                "user_id": "u1",
+                "prompt": "Extract food preferences only.",
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["prompt"] == "Extract food preferences only."
 
     def test_prompt_omitted(self, client, mock_memory):
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "hello"}],
-            "user_id": "u1",
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "hello"}],
+                "user_id": "u1",
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert "prompt" not in kwargs
@@ -249,16 +294,19 @@ class TestAddPrompt:
 # MemoryCreate: all new params together
 # ===========================================================================
 
-class TestAddAllNewParams:
 
+class TestAddAllNewParams:
     def test_infer_memory_type_and_prompt_together(self, client, mock_memory):
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "I like pizza"}],
-            "user_id": "u1",
-            "infer": False,
-            "memory_type": "core",
-            "prompt": "Custom extraction prompt.",
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "I like pizza"}],
+                "user_id": "u1",
+                "infer": False,
+                "memory_type": "core",
+                "prompt": "Custom extraction prompt.",
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["infer"] is False
@@ -270,24 +318,33 @@ class TestAddAllNewParams:
 # Edge cases: falsy-but-valid values must not be filtered out
 # ===========================================================================
 
+
 class TestFalsyValues:
     """The handler filters with `v is not None`. Falsy values like False, 0,
     0.0, and empty string must still be forwarded."""
 
     def test_infer_false_not_filtered(self, client, mock_memory):
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "test"}],
-            "user_id": "u1",
-            "infer": False,
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "test"}],
+                "user_id": "u1",
+                "infer": False,
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["infer"] is False
 
     def test_threshold_zero_not_filtered(self, client, mock_memory):
-        resp = client.post("/search", json={
-            "query": "food", "user_id": "u1", "threshold": 0.0,
-        })
+        resp = client.post(
+            "/search",
+            json={
+                "query": "food",
+                "user_id": "u1",
+                "threshold": 0.0,
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert kwargs["threshold"] == 0.0
@@ -297,22 +354,30 @@ class TestFalsyValues:
 # Extra/unknown fields are still silently ignored (existing Pydantic behavior)
 # ===========================================================================
 
-class TestUnknownFieldsIgnored:
 
+class TestUnknownFieldsIgnored:
     def test_unknown_search_field_ignored(self, client, mock_memory):
-        resp = client.post("/search", json={
-            "query": "food", "user_id": "u1", "bogus_field": "xyz",
-        })
+        resp = client.post(
+            "/search",
+            json={
+                "query": "food",
+                "user_id": "u1",
+                "bogus_field": "xyz",
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert "bogus_field" not in kwargs
 
     def test_unknown_add_field_ignored(self, client, mock_memory):
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "test"}],
-            "user_id": "u1",
-            "unknown_param": 42,
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "test"}],
+                "user_id": "u1",
+                "unknown_param": 42,
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert "unknown_param" not in kwargs
@@ -322,15 +387,18 @@ class TestUnknownFieldsIgnored:
 # Backward compatibility: existing params still work
 # ===========================================================================
 
-class TestExistingParamsUnchanged:
 
+class TestExistingParamsUnchanged:
     def test_search_filters_still_forwarded(self, client, mock_memory):
-        resp = client.post("/search", json={
-            "query": "food",
-            "user_id": "u1",
-            "agent_id": "a1",
-            "filters": {"category": "food"},
-        })
+        resp = client.post(
+            "/search",
+            json={
+                "query": "food",
+                "user_id": "u1",
+                "agent_id": "a1",
+                "filters": {"category": "food"},
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert kwargs["filters"]["user_id"] == "u1"
@@ -338,12 +406,15 @@ class TestExistingParamsUnchanged:
         assert kwargs["filters"]["category"] == "food"
 
     def test_add_metadata_still_forwarded(self, client, mock_memory):
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "test"}],
-            "user_id": "u1",
-            "agent_id": "a1",
-            "metadata": {"source": "test"},
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "test"}],
+                "user_id": "u1",
+                "agent_id": "a1",
+                "metadata": {"source": "test"},
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["user_id"] == "u1"
@@ -354,6 +425,7 @@ class TestExistingParamsUnchanged:
 # ===========================================================================
 # OpenAPI schema: new fields are documented
 # ===========================================================================
+
 
 class TestOpenAPISchema:
     """Verify the new fields appear in the auto-generated OpenAPI schema."""
@@ -389,53 +461,78 @@ class TestOpenAPISchema:
 # Pydantic type validation: invalid types return 422
 # ===========================================================================
 
+
 class TestTypeValidation:
     """Verify FastAPI/Pydantic rejects invalid types with 422."""
 
     def test_limit_string_rejected(self, client):
-        resp = client.post("/search", json={
-            "query": "food", "user_id": "u1", "top_k": "not_a_number",
-        })
+        resp = client.post(
+            "/search",
+            json={
+                "query": "food",
+                "user_id": "u1",
+                "top_k": "not_a_number",
+            },
+        )
         assert resp.status_code == 422
 
     def test_threshold_string_rejected(self, client):
-        resp = client.post("/search", json={
-            "query": "food", "user_id": "u1", "threshold": "high",
-        })
+        resp = client.post(
+            "/search",
+            json={
+                "query": "food",
+                "user_id": "u1",
+                "threshold": "high",
+            },
+        )
         assert resp.status_code == 422
 
     def test_infer_string_coerced_by_pydantic(self, client, mock_memory):
         """Pydantic v2 coerces truthy strings like 'yes' to True for bool fields."""
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "test"}],
-            "user_id": "u1",
-            "infer": "yes",
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "test"}],
+                "user_id": "u1",
+                "infer": "yes",
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["infer"] is True
 
     def test_infer_invalid_value_rejected(self, client):
         """A value that cannot be coerced to bool should be rejected."""
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "test"}],
-            "user_id": "u1",
-            "infer": [1, 2, 3],
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "test"}],
+                "user_id": "u1",
+                "infer": [1, 2, 3],
+            },
+        )
         assert resp.status_code == 422
 
     def test_limit_float_rejected(self, client):
-        resp = client.post("/search", json={
-            "query": "food", "user_id": "u1", "top_k": 5.7,
-        })
+        resp = client.post(
+            "/search",
+            json={
+                "query": "food",
+                "user_id": "u1",
+                "top_k": 5.7,
+            },
+        )
         assert resp.status_code == 422
 
     def test_memory_type_int_rejected(self, client):
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "test"}],
-            "user_id": "u1",
-            "memory_type": 123,
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "test"}],
+                "user_id": "u1",
+                "memory_type": 123,
+            },
+        )
         assert resp.status_code == 422
 
 
@@ -443,34 +540,46 @@ class TestTypeValidation:
 # Explicit null values: treated as omitted (filtered by `is not None`)
 # ===========================================================================
 
+
 class TestExplicitNull:
     """When a client sends null for an optional field, it should be treated
     as omitted — the Memory class default should be used."""
 
     def test_limit_null_uses_memory_default(self, client, mock_memory):
-        resp = client.post("/search", json={
-            "query": "food", "user_id": "u1", "top_k": None,
-        })
+        resp = client.post(
+            "/search",
+            json={
+                "query": "food",
+                "user_id": "u1",
+                "top_k": None,
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert "top_k" not in kwargs
 
     def test_infer_null_uses_memory_default(self, client, mock_memory):
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "test"}],
-            "user_id": "u1",
-            "infer": None,
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "test"}],
+                "user_id": "u1",
+                "infer": None,
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert "infer" not in kwargs
 
     def test_prompt_null_uses_memory_default(self, client, mock_memory):
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "test"}],
-            "user_id": "u1",
-            "prompt": None,
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "test"}],
+                "user_id": "u1",
+                "prompt": None,
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert "prompt" not in kwargs
@@ -480,17 +589,25 @@ class TestExplicitNull:
 # Verify exact call signatures match Memory method params
 # ===========================================================================
 
+
 class TestCallSignatureMatch:
     """Ensure forwarded params exactly match Memory.add() and Memory.search()
     keyword argument names — a typo here would cause a TypeError at runtime."""
 
     def test_search_kwargs_are_valid(self, client, mock_memory):
         """All kwargs forwarded to Memory.search() must be in its signature."""
-        resp = client.post("/search", json={
-            "query": "food", "user_id": "u1", "agent_id": "a1",
-            "run_id": "r1", "filters": {"k": "v"},
-            "top_k": 10, "threshold": 0.5,
-        })
+        resp = client.post(
+            "/search",
+            json={
+                "query": "food",
+                "user_id": "u1",
+                "agent_id": "a1",
+                "run_id": "r1",
+                "filters": {"k": "v"},
+                "top_k": 10,
+                "threshold": 0.5,
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         valid_params = {"query", "top_k", "filters", "threshold", "rerank"}
@@ -503,12 +620,19 @@ class TestCallSignatureMatch:
 
     def test_add_kwargs_are_valid(self, client, mock_memory):
         """All kwargs forwarded to Memory.add() must be in its signature."""
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "hi"}],
-            "user_id": "u1", "agent_id": "a1", "run_id": "r1",
-            "metadata": {"k": "v"},
-            "infer": False, "memory_type": "core", "prompt": "custom",
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "hi"}],
+                "user_id": "u1",
+                "agent_id": "a1",
+                "run_id": "r1",
+                "metadata": {"k": "v"},
+                "infer": False,
+                "memory_type": "core",
+                "prompt": "custom",
+            },
+        )
         assert resp.status_code == 200
         # The handler passes messages= as a keyword arg, so it appears in kwargs too
         _, kwargs = mock_memory.add.call_args
@@ -518,10 +642,13 @@ class TestCallSignatureMatch:
 
     def test_messages_excluded_from_params_dict(self, client, mock_memory):
         """messages is passed separately via messages= kwarg, not duplicated from model_dump."""
-        resp = client.post("/memories", json={
-            "messages": [{"role": "user", "content": "hi"}],
-            "user_id": "u1",
-        })
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "hi"}],
+                "user_id": "u1",
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         # messages should be present (passed explicitly) and be a list of dicts
@@ -541,6 +668,7 @@ class TestCallSignatureMatch:
 # MemoryUpdate: text and metadata forwarding (fix for #3933)
 # ===========================================================================
 
+
 class TestUpdateMemory:
     """Verify that PUT /memories/{id} extracts text and metadata from the
     request body and forwards them correctly to Memory.update()."""
@@ -552,10 +680,13 @@ class TestUpdateMemory:
         assert kwargs["data"] == "Likes tennis"
 
     def test_metadata_forwarded(self, client, mock_memory):
-        resp = client.put("/memories/mem-1", json={
-            "text": "Likes tennis",
-            "metadata": {"category": "sports"},
-        })
+        resp = client.put(
+            "/memories/mem-1",
+            json={
+                "text": "Likes tennis",
+                "metadata": {"category": "sports"},
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.update.call_args
         assert kwargs["metadata"] == {"category": "sports"}
@@ -600,29 +731,31 @@ class TestUpdateOpenAPISchema:
         update_props = schema["components"]["schemas"]["MemoryUpdate"]["properties"]
         assert "metadata" in update_props
 
+
 # ===========================================================================
 # GetMemories: Entity parameters to filters mapping (fix for #4955)
 # ===========================================================================
+
 
 class TestGetMemories:
     """Verify that GET /memories correctly maps entity parameters to the filters dict."""
 
     def test_get_memories_entity_filters_routing(self, client, mock_memory):
         """
-        Issue #4955: Test that the GET /memories route correctly handles 
+        Issue #4955: Test that the GET /memories route correctly handles
         top-level entity parameters by mapping them to the filters dictionary
         instead of passing them as direct kwargs to get_all()
         """
         # Send a request with a valid top-level entity parameter
         response = client.get("/memories?user_id=test_routing_user")
-        
+
         # 1. Verify the endpoint doesn't crash with a 500 error
         assert response.status_code == 200
-        
+
         # 2. Verify the response is structured correctly
         data = response.json()
         assert isinstance(data, list)
-        
+
         # 3. Verify the core logic: the param was mapped to the filters dict!
         _, kwargs = mock_memory.get_all.call_args
         assert kwargs["filters"] == {"user_id": "test_routing_user"}
@@ -657,6 +790,7 @@ class TestGetMemories:
 # SearchRequest: entity IDs mapped into filters (fix for server 502)
 # ===========================================================================
 
+
 class TestSearchEntityIdMapping:
     """Verify that POST /search maps top-level user_id / agent_id / run_id
     into the filters dict instead of forwarding them as kwargs, which would
@@ -684,19 +818,28 @@ class TestSearchEntityIdMapping:
         assert kwargs["filters"]["run_id"] == "r1"
 
     def test_all_entity_ids_mapped(self, client, mock_memory):
-        resp = client.post("/search", json={
-            "query": "food", "user_id": "u1", "agent_id": "a1", "run_id": "r1",
-        })
+        resp = client.post(
+            "/search",
+            json={
+                "query": "food",
+                "user_id": "u1",
+                "agent_id": "a1",
+                "run_id": "r1",
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert kwargs["filters"] == {"user_id": "u1", "agent_id": "a1", "run_id": "r1"}
 
     def test_entity_ids_merged_with_explicit_filters(self, client, mock_memory):
-        resp = client.post("/search", json={
-            "query": "food",
-            "user_id": "u1",
-            "filters": {"category": "food"},
-        })
+        resp = client.post(
+            "/search",
+            json={
+                "query": "food",
+                "user_id": "u1",
+                "filters": {"category": "food"},
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert kwargs["filters"]["user_id"] == "u1"
@@ -709,10 +852,13 @@ class TestSearchEntityIdMapping:
         assert kwargs["filters"] == {}
 
     def test_only_filters_no_entity_ids(self, client, mock_memory):
-        resp = client.post("/search", json={
-            "query": "food",
-            "filters": {"user_id": "u1", "category": "food"},
-        })
+        resp = client.post(
+            "/search",
+            json={
+                "query": "food",
+                "filters": {"user_id": "u1", "category": "food"},
+            },
+        )
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert kwargs["filters"]["user_id"] == "u1"
@@ -723,17 +869,13 @@ class TestSearchValidationErrors:
     """Verify that ValueError from Memory.search() returns 400, not 502."""
 
     def test_empty_filters_returns_400(self, client, mock_memory):
-        mock_memory.search.side_effect = ValueError(
-            "filters must contain at least one of: user_id, agent_id, run_id"
-        )
+        mock_memory.search.side_effect = ValueError("filters must contain at least one of: user_id, agent_id, run_id")
         resp = client.post("/search", json={"query": "food", "filters": {}})
         assert resp.status_code == 400
         assert "filters must contain" in resp.json()["detail"]
 
     def test_no_identifiers_returns_400(self, client, mock_memory):
-        mock_memory.search.side_effect = ValueError(
-            "filters must contain at least one of: user_id, agent_id, run_id"
-        )
+        mock_memory.search.side_effect = ValueError("filters must contain at least one of: user_id, agent_id, run_id")
         resp = client.post("/search", json={"query": "food"})
         assert resp.status_code == 400
 

--- a/tests/test_server_params.py
+++ b/tests/test_server_params.py
@@ -15,6 +15,7 @@ import pytest
 from mem0.exceptions import ValidationError as Mem0ValidationError
 
 pytest.importorskip("fastapi", reason="fastapi not installed")
+pytest.importorskip("telemetry", reason="telemetry not installed")
 
 from fastapi.testclient import TestClient
 
@@ -22,16 +23,9 @@ from fastapi.testclient import TestClient
 # Fixtures
 # ---------------------------------------------------------------------------
 
-
 @pytest.fixture
 def _mock_memory():
     """Patch Memory.from_config so the server imports without a real backend."""
-    import sys
-
-    server_path = os.path.join(os.path.dirname(__file__), "..", "server")
-    if server_path not in sys.path:
-        sys.path.insert(0, server_path)
-
     mock_instance = MagicMock()
     mock_instance.add.return_value = {"results": [{"id": "mem-1", "event": "ADD", "memory": "test"}]}
     mock_instance.search.return_value = [{"id": "mem-1", "memory": "test", "score": 0.9}]
@@ -43,8 +37,7 @@ def _mock_memory():
     mock_instance.delete_all.return_value = {"message": "Memories deleted"}
     mock_instance.reset.return_value = None
 
-    env = {"OPENAI_API_KEY": "fake-key", "ADMIN_API_KEY": "", "AUTH_DISABLED": "true"}
-    with patch.dict(os.environ, env):
+    with patch.dict(os.environ, {"OPENAI_API_KEY": "fake-key", "ADMIN_API_KEY": ""}):
         with patch("mem0.Memory.from_config", return_value=mock_instance):
             yield mock_instance
 
@@ -52,22 +45,10 @@ def _mock_memory():
 @pytest.fixture
 def client(_mock_memory):
     """Return a TestClient wired to the server app with mocked Memory."""
-    import server.auth as server_auth
     import server.main as server_main
-
-    env = {"ADMIN_API_KEY": "", "AUTH_DISABLED": "true"}
-    with patch.dict(os.environ, env):
-        importlib.reload(server_auth)
+    with patch.dict(os.environ, {"ADMIN_API_KEY": ""}):
         importlib.reload(server_main)
-
-    from db import get_db
-
-    mock_db = MagicMock()
-    mock_db.scalar.return_value = None
-    server_main.app.dependency_overrides[get_db] = lambda: mock_db
-    with patch.object(server_main, "SessionLocal", return_value=mock_db):
-        yield TestClient(server_main.app)
-    server_main.app.dependency_overrides.clear()
+    return TestClient(server_main.app)
 
 
 @pytest.fixture
@@ -78,7 +59,6 @@ def mock_memory(_mock_memory):
 # ===========================================================================
 # SearchRequest: top_k parameter
 # ===========================================================================
-
 
 class TestSearchLimit:
     """Verify that the top_k parameter is accepted and forwarded to Memory.search()."""
@@ -108,7 +88,6 @@ class TestSearchLimit:
 # SearchRequest: threshold parameter
 # ===========================================================================
 
-
 class TestSearchThreshold:
     """Verify that the threshold parameter is accepted and forwarded."""
 
@@ -136,7 +115,6 @@ class TestSearchThreshold:
 # SearchRequest: explain parameter
 # ===========================================================================
 
-
 class TestSearchExplain:
     """Verify that the explain parameter is accepted and forwarded."""
 
@@ -163,10 +141,12 @@ class TestSearchExplain:
 # SearchRequest: top_k + threshold together
 # ===========================================================================
 
-
 class TestSearchLimitAndThreshold:
+
     def test_both_forwarded(self, client, mock_memory):
-        resp = client.post("/search", json={"query": "food", "user_id": "u1", "top_k": 10, "threshold": 0.5})
+        resp = client.post("/search", json={
+            "query": "food", "user_id": "u1", "top_k": 10, "threshold": 0.5
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert kwargs["top_k"] == 10
@@ -177,32 +157,25 @@ class TestSearchLimitAndThreshold:
 # MemoryCreate: infer parameter
 # ===========================================================================
 
-
 class TestAddInfer:
     """Verify that the infer parameter is accepted and forwarded to Memory.add()."""
 
     def test_infer_false_forwarded(self, client, mock_memory):
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "Store this exactly"}],
-                "user_id": "u1",
-                "infer": False,
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "Store this exactly"}],
+            "user_id": "u1",
+            "infer": False,
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["infer"] is False
 
     def test_infer_true_forwarded(self, client, mock_memory):
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "I like pizza"}],
-                "user_id": "u1",
-                "infer": True,
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "I like pizza"}],
+            "user_id": "u1",
+            "infer": True,
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["infer"] is True
@@ -210,13 +183,10 @@ class TestAddInfer:
     def test_infer_omitted_uses_memory_default(self, client, mock_memory):
         """When infer is not sent, it should not appear in kwargs,
         allowing Memory.add() to use its own default (True)."""
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "hello"}],
-                "user_id": "u1",
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "hello"}],
+            "user_id": "u1",
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert "infer" not in kwargs
@@ -226,31 +196,24 @@ class TestAddInfer:
 # MemoryCreate: memory_type parameter
 # ===========================================================================
 
-
 class TestAddMemoryType:
     """Verify that the memory_type parameter is accepted and forwarded."""
 
     def test_memory_type_forwarded(self, client, mock_memory):
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "I like pizza"}],
-                "user_id": "u1",
-                "memory_type": "core",
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "I like pizza"}],
+            "user_id": "u1",
+            "memory_type": "core",
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["memory_type"] == "core"
 
     def test_memory_type_omitted(self, client, mock_memory):
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "hello"}],
-                "user_id": "u1",
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "hello"}],
+            "user_id": "u1",
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert "memory_type" not in kwargs
@@ -260,31 +223,24 @@ class TestAddMemoryType:
 # MemoryCreate: prompt parameter
 # ===========================================================================
 
-
 class TestAddPrompt:
     """Verify that the prompt parameter is accepted and forwarded."""
 
     def test_prompt_forwarded(self, client, mock_memory):
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "I like pizza"}],
-                "user_id": "u1",
-                "prompt": "Extract food preferences only.",
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "I like pizza"}],
+            "user_id": "u1",
+            "prompt": "Extract food preferences only.",
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["prompt"] == "Extract food preferences only."
 
     def test_prompt_omitted(self, client, mock_memory):
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "hello"}],
-                "user_id": "u1",
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "hello"}],
+            "user_id": "u1",
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert "prompt" not in kwargs
@@ -294,19 +250,16 @@ class TestAddPrompt:
 # MemoryCreate: all new params together
 # ===========================================================================
 
-
 class TestAddAllNewParams:
+
     def test_infer_memory_type_and_prompt_together(self, client, mock_memory):
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "I like pizza"}],
-                "user_id": "u1",
-                "infer": False,
-                "memory_type": "core",
-                "prompt": "Custom extraction prompt.",
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "I like pizza"}],
+            "user_id": "u1",
+            "infer": False,
+            "memory_type": "core",
+            "prompt": "Custom extraction prompt.",
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["infer"] is False
@@ -318,33 +271,24 @@ class TestAddAllNewParams:
 # Edge cases: falsy-but-valid values must not be filtered out
 # ===========================================================================
 
-
 class TestFalsyValues:
     """The handler filters with `v is not None`. Falsy values like False, 0,
     0.0, and empty string must still be forwarded."""
 
     def test_infer_false_not_filtered(self, client, mock_memory):
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "test"}],
-                "user_id": "u1",
-                "infer": False,
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "test"}],
+            "user_id": "u1",
+            "infer": False,
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["infer"] is False
 
     def test_threshold_zero_not_filtered(self, client, mock_memory):
-        resp = client.post(
-            "/search",
-            json={
-                "query": "food",
-                "user_id": "u1",
-                "threshold": 0.0,
-            },
-        )
+        resp = client.post("/search", json={
+            "query": "food", "user_id": "u1", "threshold": 0.0,
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert kwargs["threshold"] == 0.0
@@ -354,30 +298,22 @@ class TestFalsyValues:
 # Extra/unknown fields are still silently ignored (existing Pydantic behavior)
 # ===========================================================================
 
-
 class TestUnknownFieldsIgnored:
+
     def test_unknown_search_field_ignored(self, client, mock_memory):
-        resp = client.post(
-            "/search",
-            json={
-                "query": "food",
-                "user_id": "u1",
-                "bogus_field": "xyz",
-            },
-        )
+        resp = client.post("/search", json={
+            "query": "food", "user_id": "u1", "bogus_field": "xyz",
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert "bogus_field" not in kwargs
 
     def test_unknown_add_field_ignored(self, client, mock_memory):
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "test"}],
-                "user_id": "u1",
-                "unknown_param": 42,
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "test"}],
+            "user_id": "u1",
+            "unknown_param": 42,
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert "unknown_param" not in kwargs
@@ -387,18 +323,15 @@ class TestUnknownFieldsIgnored:
 # Backward compatibility: existing params still work
 # ===========================================================================
 
-
 class TestExistingParamsUnchanged:
+
     def test_search_filters_still_forwarded(self, client, mock_memory):
-        resp = client.post(
-            "/search",
-            json={
-                "query": "food",
-                "user_id": "u1",
-                "agent_id": "a1",
-                "filters": {"category": "food"},
-            },
-        )
+        resp = client.post("/search", json={
+            "query": "food",
+            "user_id": "u1",
+            "agent_id": "a1",
+            "filters": {"category": "food"},
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert kwargs["filters"]["user_id"] == "u1"
@@ -406,15 +339,12 @@ class TestExistingParamsUnchanged:
         assert kwargs["filters"]["category"] == "food"
 
     def test_add_metadata_still_forwarded(self, client, mock_memory):
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "test"}],
-                "user_id": "u1",
-                "agent_id": "a1",
-                "metadata": {"source": "test"},
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "test"}],
+            "user_id": "u1",
+            "agent_id": "a1",
+            "metadata": {"source": "test"},
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["user_id"] == "u1"
@@ -425,7 +355,6 @@ class TestExistingParamsUnchanged:
 # ===========================================================================
 # OpenAPI schema: new fields are documented
 # ===========================================================================
-
 
 class TestOpenAPISchema:
     """Verify the new fields appear in the auto-generated OpenAPI schema."""
@@ -461,78 +390,53 @@ class TestOpenAPISchema:
 # Pydantic type validation: invalid types return 422
 # ===========================================================================
 
-
 class TestTypeValidation:
     """Verify FastAPI/Pydantic rejects invalid types with 422."""
 
     def test_limit_string_rejected(self, client):
-        resp = client.post(
-            "/search",
-            json={
-                "query": "food",
-                "user_id": "u1",
-                "top_k": "not_a_number",
-            },
-        )
+        resp = client.post("/search", json={
+            "query": "food", "user_id": "u1", "top_k": "not_a_number",
+        })
         assert resp.status_code == 422
 
     def test_threshold_string_rejected(self, client):
-        resp = client.post(
-            "/search",
-            json={
-                "query": "food",
-                "user_id": "u1",
-                "threshold": "high",
-            },
-        )
+        resp = client.post("/search", json={
+            "query": "food", "user_id": "u1", "threshold": "high",
+        })
         assert resp.status_code == 422
 
     def test_infer_string_coerced_by_pydantic(self, client, mock_memory):
         """Pydantic v2 coerces truthy strings like 'yes' to True for bool fields."""
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "test"}],
-                "user_id": "u1",
-                "infer": "yes",
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "test"}],
+            "user_id": "u1",
+            "infer": "yes",
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert kwargs["infer"] is True
 
     def test_infer_invalid_value_rejected(self, client):
         """A value that cannot be coerced to bool should be rejected."""
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "test"}],
-                "user_id": "u1",
-                "infer": [1, 2, 3],
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "test"}],
+            "user_id": "u1",
+            "infer": [1, 2, 3],
+        })
         assert resp.status_code == 422
 
     def test_limit_float_rejected(self, client):
-        resp = client.post(
-            "/search",
-            json={
-                "query": "food",
-                "user_id": "u1",
-                "top_k": 5.7,
-            },
-        )
+        resp = client.post("/search", json={
+            "query": "food", "user_id": "u1", "top_k": 5.7,
+        })
         assert resp.status_code == 422
 
     def test_memory_type_int_rejected(self, client):
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "test"}],
-                "user_id": "u1",
-                "memory_type": 123,
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "test"}],
+            "user_id": "u1",
+            "memory_type": 123,
+        })
         assert resp.status_code == 422
 
 
@@ -540,46 +444,34 @@ class TestTypeValidation:
 # Explicit null values: treated as omitted (filtered by `is not None`)
 # ===========================================================================
 
-
 class TestExplicitNull:
     """When a client sends null for an optional field, it should be treated
     as omitted — the Memory class default should be used."""
 
     def test_limit_null_uses_memory_default(self, client, mock_memory):
-        resp = client.post(
-            "/search",
-            json={
-                "query": "food",
-                "user_id": "u1",
-                "top_k": None,
-            },
-        )
+        resp = client.post("/search", json={
+            "query": "food", "user_id": "u1", "top_k": None,
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert "top_k" not in kwargs
 
     def test_infer_null_uses_memory_default(self, client, mock_memory):
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "test"}],
-                "user_id": "u1",
-                "infer": None,
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "test"}],
+            "user_id": "u1",
+            "infer": None,
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert "infer" not in kwargs
 
     def test_prompt_null_uses_memory_default(self, client, mock_memory):
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "test"}],
-                "user_id": "u1",
-                "prompt": None,
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "test"}],
+            "user_id": "u1",
+            "prompt": None,
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         assert "prompt" not in kwargs
@@ -589,25 +481,17 @@ class TestExplicitNull:
 # Verify exact call signatures match Memory method params
 # ===========================================================================
 
-
 class TestCallSignatureMatch:
     """Ensure forwarded params exactly match Memory.add() and Memory.search()
     keyword argument names — a typo here would cause a TypeError at runtime."""
 
     def test_search_kwargs_are_valid(self, client, mock_memory):
         """All kwargs forwarded to Memory.search() must be in its signature."""
-        resp = client.post(
-            "/search",
-            json={
-                "query": "food",
-                "user_id": "u1",
-                "agent_id": "a1",
-                "run_id": "r1",
-                "filters": {"k": "v"},
-                "top_k": 10,
-                "threshold": 0.5,
-            },
-        )
+        resp = client.post("/search", json={
+            "query": "food", "user_id": "u1", "agent_id": "a1",
+            "run_id": "r1", "filters": {"k": "v"},
+            "top_k": 10, "threshold": 0.5,
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         valid_params = {"query", "top_k", "filters", "threshold", "rerank"}
@@ -620,19 +504,12 @@ class TestCallSignatureMatch:
 
     def test_add_kwargs_are_valid(self, client, mock_memory):
         """All kwargs forwarded to Memory.add() must be in its signature."""
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "hi"}],
-                "user_id": "u1",
-                "agent_id": "a1",
-                "run_id": "r1",
-                "metadata": {"k": "v"},
-                "infer": False,
-                "memory_type": "core",
-                "prompt": "custom",
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "hi"}],
+            "user_id": "u1", "agent_id": "a1", "run_id": "r1",
+            "metadata": {"k": "v"},
+            "infer": False, "memory_type": "core", "prompt": "custom",
+        })
         assert resp.status_code == 200
         # The handler passes messages= as a keyword arg, so it appears in kwargs too
         _, kwargs = mock_memory.add.call_args
@@ -642,13 +519,10 @@ class TestCallSignatureMatch:
 
     def test_messages_excluded_from_params_dict(self, client, mock_memory):
         """messages is passed separately via messages= kwarg, not duplicated from model_dump."""
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "hi"}],
-                "user_id": "u1",
-            },
-        )
+        resp = client.post("/memories", json={
+            "messages": [{"role": "user", "content": "hi"}],
+            "user_id": "u1",
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.add.call_args
         # messages should be present (passed explicitly) and be a list of dicts
@@ -668,7 +542,6 @@ class TestCallSignatureMatch:
 # MemoryUpdate: text and metadata forwarding (fix for #3933)
 # ===========================================================================
 
-
 class TestUpdateMemory:
     """Verify that PUT /memories/{id} extracts text and metadata from the
     request body and forwards them correctly to Memory.update()."""
@@ -680,13 +553,10 @@ class TestUpdateMemory:
         assert kwargs["data"] == "Likes tennis"
 
     def test_metadata_forwarded(self, client, mock_memory):
-        resp = client.put(
-            "/memories/mem-1",
-            json={
-                "text": "Likes tennis",
-                "metadata": {"category": "sports"},
-            },
-        )
+        resp = client.put("/memories/mem-1", json={
+            "text": "Likes tennis",
+            "metadata": {"category": "sports"},
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.update.call_args
         assert kwargs["metadata"] == {"category": "sports"}
@@ -731,11 +601,9 @@ class TestUpdateOpenAPISchema:
         update_props = schema["components"]["schemas"]["MemoryUpdate"]["properties"]
         assert "metadata" in update_props
 
-
 # ===========================================================================
 # GetMemories: Entity parameters to filters mapping (fix for #4955)
 # ===========================================================================
-
 
 class TestGetMemories:
     """Verify that GET /memories correctly maps entity parameters to the filters dict."""
@@ -790,7 +658,6 @@ class TestGetMemories:
 # SearchRequest: entity IDs mapped into filters (fix for server 502)
 # ===========================================================================
 
-
 class TestSearchEntityIdMapping:
     """Verify that POST /search maps top-level user_id / agent_id / run_id
     into the filters dict instead of forwarding them as kwargs, which would
@@ -818,28 +685,19 @@ class TestSearchEntityIdMapping:
         assert kwargs["filters"]["run_id"] == "r1"
 
     def test_all_entity_ids_mapped(self, client, mock_memory):
-        resp = client.post(
-            "/search",
-            json={
-                "query": "food",
-                "user_id": "u1",
-                "agent_id": "a1",
-                "run_id": "r1",
-            },
-        )
+        resp = client.post("/search", json={
+            "query": "food", "user_id": "u1", "agent_id": "a1", "run_id": "r1",
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert kwargs["filters"] == {"user_id": "u1", "agent_id": "a1", "run_id": "r1"}
 
     def test_entity_ids_merged_with_explicit_filters(self, client, mock_memory):
-        resp = client.post(
-            "/search",
-            json={
-                "query": "food",
-                "user_id": "u1",
-                "filters": {"category": "food"},
-            },
-        )
+        resp = client.post("/search", json={
+            "query": "food",
+            "user_id": "u1",
+            "filters": {"category": "food"},
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert kwargs["filters"]["user_id"] == "u1"
@@ -852,13 +710,10 @@ class TestSearchEntityIdMapping:
         assert kwargs["filters"] == {}
 
     def test_only_filters_no_entity_ids(self, client, mock_memory):
-        resp = client.post(
-            "/search",
-            json={
-                "query": "food",
-                "filters": {"user_id": "u1", "category": "food"},
-            },
-        )
+        resp = client.post("/search", json={
+            "query": "food",
+            "filters": {"user_id": "u1", "category": "food"},
+        })
         assert resp.status_code == 200
         _, kwargs = mock_memory.search.call_args
         assert kwargs["filters"]["user_id"] == "u1"
@@ -869,13 +724,17 @@ class TestSearchValidationErrors:
     """Verify that ValueError from Memory.search() returns 400, not 502."""
 
     def test_empty_filters_returns_400(self, client, mock_memory):
-        mock_memory.search.side_effect = ValueError("filters must contain at least one of: user_id, agent_id, run_id")
+        mock_memory.search.side_effect = ValueError(
+            "filters must contain at least one of: user_id, agent_id, run_id"
+        )
         resp = client.post("/search", json={"query": "food", "filters": {}})
         assert resp.status_code == 400
         assert "filters must contain" in resp.json()["detail"]
 
     def test_no_identifiers_returns_400(self, client, mock_memory):
-        mock_memory.search.side_effect = ValueError("filters must contain at least one of: user_id, agent_id, run_id")
+        mock_memory.search.side_effect = ValueError(
+            "filters must contain at least one of: user_id, agent_id, run_id"
+        )
         resp = client.post("/search", json={"query": "food"})
         assert resp.status_code == 400
 

--- a/tests/test_server_route_aliases.py
+++ b/tests/test_server_route_aliases.py
@@ -334,3 +334,64 @@ class TestV2EntitiesDeleteAlias:
         resp = client.delete("/entities/user/user-1")
         assert resp.status_code == 200
         assert mock_memory.delete_all.called
+
+
+# ===========================================================================
+# Authorization: Token <key> scheme (SDK compatibility)
+# ===========================================================================
+
+
+@pytest.fixture
+def auth_client(_mock_memory):
+    """TestClient with auth enabled and a known ADMIN_API_KEY."""
+    # main.py imports bare 'auth', not 'server.auth', so reload the bare module
+    import auth as auth_mod
+    import server.main as server_main
+
+    env = {
+        "ADMIN_API_KEY": "test-admin-key-for-token-auth",
+        "AUTH_DISABLED": "false",
+        "JWT_SECRET": "test-jwt-secret-for-token-auth-tests",
+    }
+    with patch.dict(os.environ, env):
+        importlib.reload(auth_mod)
+        importlib.reload(server_main)
+
+    from db import get_db
+
+    mock_db = MagicMock()
+    mock_db.scalar.return_value = None
+    mock_db.execute.return_value.scalars.return_value.all.return_value = []
+    server_main.app.dependency_overrides[get_db] = lambda: mock_db
+    with patch.object(server_main, "SessionLocal", return_value=mock_db):
+        yield TestClient(server_main.app)
+    server_main.app.dependency_overrides.clear()
+
+
+class TestTokenAuthScheme:
+    """Verify that 'Authorization: Token <key>' is accepted, matching SDK behavior."""
+
+    def test_token_scheme_with_admin_key_returns_200(self, auth_client):
+        resp = auth_client.get("/v1/ping/", headers={"Authorization": "Token test-admin-key-for-token-auth"})
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
+
+    def test_token_scheme_with_wrong_key_returns_401(self, auth_client):
+        resp = auth_client.get("/v1/ping/", headers={"Authorization": "Token wrong-key"})
+        assert resp.status_code == 401
+
+    def test_no_auth_returns_401_when_auth_enabled(self, auth_client):
+        resp = auth_client.get("/v1/ping/")
+        assert resp.status_code == 401
+
+    def test_x_api_key_still_works_with_auth_enabled(self, auth_client):
+        resp = auth_client.get("/v1/ping/", headers={"X-API-Key": "test-admin-key-for-token-auth"})
+        assert resp.status_code == 200
+
+    def test_token_scheme_on_versioned_alias(self, auth_client, _mock_memory):
+        resp = auth_client.post(
+            "/v3/memories/search/",
+            json={"query": "food", "user_id": "u1"},
+            headers={"Authorization": "Token test-admin-key-for-token-auth"},
+        )
+        assert resp.status_code == 200

--- a/tests/test_server_route_aliases.py
+++ b/tests/test_server_route_aliases.py
@@ -1,0 +1,336 @@
+"""Tests for REST API route aliases (versioned paths for SDK compatibility).
+
+Verifies that the versioned route aliases (/v1/, /v2/, /v3/) registered on the
+server respond with HTTP 200 and call the underlying Memory methods correctly,
+matching the behavior of the base routes without the version prefix.
+"""
+
+import importlib
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("fastapi", reason="fastapi not installed")
+
+from fastapi.testclient import TestClient
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _mock_memory():
+    """Patch Memory.from_config so the server imports without a real backend."""
+    # Add server directory to path so imports work
+    server_path = os.path.join(os.path.dirname(__file__), "..", "server")
+    if server_path not in sys.path:
+        sys.path.insert(0, server_path)
+
+    mock_instance = MagicMock()
+    mock_instance.add.return_value = {"results": [{"id": "mem-1", "event": "ADD", "memory": "test"}]}
+    mock_instance.search.return_value = [{"id": "mem-1", "memory": "test", "score": 0.9}]
+    mock_instance.get.return_value = {"id": "mem-1", "memory": "test memory"}
+    mock_instance.get_all.return_value = [{"id": "mem-1", "memory": "test memory"}]
+    mock_instance.update.return_value = {"message": "Memory updated"}
+    mock_instance.history.return_value = [{"id": "mem-1", "old_memory": "a", "new_memory": "b"}]
+    mock_instance.delete.return_value = None
+    mock_instance.delete_all.return_value = {"message": "Memories deleted"}
+    mock_instance.reset.return_value = None
+
+    env = {"OPENAI_API_KEY": "fake-key", "ADMIN_API_KEY": "", "AUTH_DISABLED": "true"}
+    with patch.dict(os.environ, env):
+        with patch("mem0.Memory.from_config", return_value=mock_instance):
+            yield mock_instance
+
+
+@pytest.fixture
+def client(_mock_memory):
+    """Return a TestClient wired to the server app with mocked Memory."""
+    import server.auth as server_auth
+    import server.main as server_main
+
+    env = {"ADMIN_API_KEY": "", "AUTH_DISABLED": "true"}
+    with patch.dict(os.environ, env):
+        importlib.reload(server_auth)
+        importlib.reload(server_main)
+
+    from db import get_db
+
+    mock_db = MagicMock()
+    mock_db.scalar.return_value = None
+    server_main.app.dependency_overrides[get_db] = lambda: mock_db
+    with patch.object(server_main, "SessionLocal", return_value=mock_db):
+        yield TestClient(server_main.app)
+    server_main.app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def mock_memory(_mock_memory):
+    return _mock_memory
+
+
+# ===========================================================================
+# /v1/ping/ alias
+# ===========================================================================
+
+
+class TestV1PingAlias:
+    """Verify that GET /v1/ping/ responds with 200."""
+
+    def test_v1_ping_returns_200(self, client):
+        resp = client.get("/v1/ping/")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
+
+
+# ===========================================================================
+# /v3/memories/add/ and /v3/memories/ aliases
+# ===========================================================================
+
+
+class TestV3MemoriesAddAlias:
+    """Verify that POST /v3/memories/add/ calls add_memory."""
+
+    def test_v3_memories_add_calls_add_memory(self, client, mock_memory):
+        resp = client.post(
+            "/v3/memories/add/",
+            json={
+                "messages": [{"role": "user", "content": "test"}],
+                "user_id": "u1",
+            },
+        )
+        assert resp.status_code == 200
+        assert mock_memory.add.called
+
+    def test_v3_memories_with_messages_calls_add(self, client, mock_memory):
+        resp = client.post(
+            "/v3/memories/",
+            json={
+                "messages": [{"role": "user", "content": "test"}],
+                "user_id": "u1",
+            },
+        )
+        assert resp.status_code == 200
+        assert mock_memory.add.called
+
+    def test_v3_memories_without_messages_calls_get_all(self, client, mock_memory):
+        resp = client.post("/v3/memories/", json={"user_id": "u1"})
+        assert resp.status_code == 200
+        mock_memory.get_all.assert_called_once()
+
+    def test_base_memories_still_works(self, client, mock_memory):
+        resp = client.post(
+            "/memories",
+            json={
+                "messages": [{"role": "user", "content": "test"}],
+                "user_id": "u1",
+            },
+        )
+        assert resp.status_code == 200
+        assert mock_memory.add.called
+
+
+# ===========================================================================
+# /v1/memories/ alias (get_all)
+# ===========================================================================
+
+
+class TestV1MemoriesListAlias:
+    """Verify that GET /v1/memories/ calls get_all_memories."""
+
+    def test_v1_memories_list_calls_get_all(self, client, mock_memory):
+        resp = client.get("/v1/memories/?user_id=u1")
+        assert resp.status_code == 200
+        assert mock_memory.get_all.called
+
+    def test_base_memories_list_still_works(self, client, mock_memory):
+        resp = client.get("/memories?user_id=u1")
+        assert resp.status_code == 200
+        assert mock_memory.get_all.called
+
+
+# ===========================================================================
+# /v1/memories/{id}/ alias (get)
+# ===========================================================================
+
+
+class TestV1MemoriesGetAlias:
+    """Verify that GET /v1/memories/{memory_id}/ calls get_memory."""
+
+    def test_v1_memories_get_calls_memory_get(self, client, mock_memory):
+        resp = client.get("/v1/memories/mem-1/")
+        assert resp.status_code == 200
+        assert mock_memory.get.called
+
+    def test_base_memories_get_still_works(self, client, mock_memory):
+        resp = client.get("/memories/mem-1")
+        assert resp.status_code == 200
+        assert mock_memory.get.called
+
+
+# ===========================================================================
+# /v3/memories/search/ alias
+# ===========================================================================
+
+
+class TestV3MemoriesSearchAlias:
+    """Verify that POST /v3/memories/search/ calls search_memories."""
+
+    def test_v3_memories_search_calls_search(self, client, mock_memory):
+        resp = client.post(
+            "/v3/memories/search/",
+            json={"query": "food", "user_id": "u1"},
+        )
+        assert resp.status_code == 200
+        assert mock_memory.search.called
+
+    def test_base_search_still_works(self, client, mock_memory):
+        resp = client.post(
+            "/search",
+            json={"query": "food", "user_id": "u1"},
+        )
+        assert resp.status_code == 200
+        assert mock_memory.search.called
+
+
+# ===========================================================================
+# /v1/memories/{id}/ PUT alias (update)
+# ===========================================================================
+
+
+class TestV1MemoriesUpdateAlias:
+    """Verify that PUT /v1/memories/{memory_id}/ calls update_memory."""
+
+    def test_v1_memories_update_calls_update(self, client, mock_memory):
+        resp = client.put(
+            "/v1/memories/mem-1/",
+            json={"text": "Updated text"},
+        )
+        assert resp.status_code == 200
+        assert mock_memory.update.called
+
+    def test_base_memories_update_still_works(self, client, mock_memory):
+        resp = client.put(
+            "/memories/mem-1",
+            json={"text": "Updated text"},
+        )
+        assert resp.status_code == 200
+        assert mock_memory.update.called
+
+
+# ===========================================================================
+# /v1/memories/{id}/history/ alias
+# ===========================================================================
+
+
+class TestV1MemoriesHistoryAlias:
+    """Verify that GET /v1/memories/{memory_id}/history/ calls memory_history."""
+
+    def test_v1_memories_history_calls_history(self, client, mock_memory):
+        resp = client.get("/v1/memories/mem-1/history/")
+        assert resp.status_code == 200
+        assert mock_memory.history.called
+
+    def test_base_memories_history_still_works(self, client, mock_memory):
+        resp = client.get("/memories/mem-1/history")
+        assert resp.status_code == 200
+        assert mock_memory.history.called
+
+
+# ===========================================================================
+# /v1/memories/{id}/ DELETE alias
+# ===========================================================================
+
+
+class TestV1MemoriesDeleteAlias:
+    """Verify that DELETE /v1/memories/{memory_id}/ calls delete_memory."""
+
+    def test_v1_memories_delete_calls_delete(self, client, mock_memory):
+        resp = client.delete("/v1/memories/mem-1/")
+        assert resp.status_code == 200
+        assert mock_memory.delete.called
+
+    def test_base_memories_delete_still_works(self, client, mock_memory):
+        resp = client.delete("/memories/mem-1")
+        assert resp.status_code == 200
+        assert mock_memory.delete.called
+
+
+# ===========================================================================
+# /v1/memories/ DELETE alias (delete_all)
+# ===========================================================================
+
+
+class TestV1MemoriesDeleteAllAlias:
+    """Verify that DELETE /v1/memories/ calls delete_all_memories."""
+
+    def test_v1_memories_delete_all_calls_delete_all(self, client, mock_memory):
+        resp = client.delete("/v1/memories/?user_id=u1")
+        assert resp.status_code == 200
+        assert mock_memory.delete_all.called
+
+    def test_base_memories_delete_all_still_works(self, client, mock_memory):
+        resp = client.delete("/memories?user_id=u1")
+        assert resp.status_code == 200
+        assert mock_memory.delete_all.called
+
+
+# ===========================================================================
+# /v1/reset/ alias
+# ===========================================================================
+
+
+class TestV1ResetAlias:
+    """Verify that POST /v1/reset/ calls reset_memory."""
+
+    def test_v1_reset_calls_reset(self, client, mock_memory):
+        resp = client.post("/v1/reset/")
+        assert resp.status_code == 200
+        assert mock_memory.reset.called
+
+    def test_base_reset_still_works(self, client, mock_memory):
+        resp = client.post("/reset")
+        assert resp.status_code == 200
+        assert mock_memory.reset.called
+
+
+# ===========================================================================
+# /v1/entities/ alias
+# ===========================================================================
+
+
+class TestV1EntitiesListAlias:
+    """Verify that GET /v1/entities/ calls list_entities."""
+
+    def test_v1_entities_list(self, client, mock_memory):
+        # Mock the vector_store.list() method since list_entities calls it
+        mock_memory.vector_store.list.return_value = [[], []]
+        resp = client.get("/v1/entities/")
+        assert resp.status_code == 200
+
+    def test_base_entities_list_still_works(self, client, mock_memory):
+        mock_memory.vector_store.list.return_value = [[], []]
+        resp = client.get("/entities")
+        assert resp.status_code == 200
+
+
+# ===========================================================================
+# /v2/entities/{type}/{id}/ alias
+# ===========================================================================
+
+
+class TestV2EntitiesDeleteAlias:
+    """Verify that DELETE /v2/entities/{entity_type}/{entity_id}/ calls delete_entity."""
+
+    def test_v2_entities_delete(self, client, mock_memory):
+        resp = client.delete("/v2/entities/user/user-1/")
+        assert resp.status_code == 200
+        assert mock_memory.delete_all.called
+
+    def test_base_entities_delete_still_works(self, client, mock_memory):
+        resp = client.delete("/entities/user/user-1")
+        assert resp.status_code == 200
+        assert mock_memory.delete_all.called

--- a/tests/test_server_route_aliases.py
+++ b/tests/test_server_route_aliases.py
@@ -85,6 +85,11 @@ class TestV1PingAlias:
         assert resp.status_code == 200
         assert resp.json() == {"status": "ok"}
 
+    def test_token_header_bypassed_when_auth_disabled(self, client):
+        resp = client.get("/v1/ping/", headers={"Authorization": "Token any-dummy-key"})
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
+
 
 # ===========================================================================
 # /v3/memories/add/ and /v3/memories/ aliases

--- a/tests/test_server_route_aliases.py
+++ b/tests/test_server_route_aliases.py
@@ -388,6 +388,10 @@ class TestTokenAuthScheme:
         resp = auth_client.get("/v1/ping/", headers={"X-API-Key": "test-admin-key-for-token-auth"})
         assert resp.status_code == 200
 
+    def test_empty_token_value_returns_401(self, auth_client):
+        resp = auth_client.get("/v1/ping/", headers={"Authorization": "Token "})
+        assert resp.status_code == 401
+
     def test_token_scheme_on_versioned_alias(self, auth_client, _mock_memory):
         resp = auth_client.post(
             "/v3/memories/search/",

--- a/tests/test_server_route_aliases.py
+++ b/tests/test_server_route_aliases.py
@@ -7,6 +7,9 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+pytest.importorskip("fastapi", reason="fastapi not installed")
+
 from fastapi.testclient import TestClient
 
 from mem0.client.main import AsyncMemoryClient, MemoryClient

--- a/tests/test_server_route_aliases.py
+++ b/tests/test_server_route_aliases.py
@@ -1,406 +1,418 @@
-"""Tests for REST API route aliases (versioned paths for SDK compatibility).
-
-Verifies that the versioned route aliases (/v1/, /v2/, /v3/) registered on the
-server respond with HTTP 200 and call the underlying Memory methods correctly,
-matching the behavior of the base routes without the version prefix.
-"""
+"""Production-composed proof for the Python-client compatibility routes."""
 
 import importlib
 import os
 import sys
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
-
-pytest.importorskip("fastapi", reason="fastapi not installed")
-
 from fastapi.testclient import TestClient
 
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
+from mem0.client.main import AsyncMemoryClient, MemoryClient
 
 
 @pytest.fixture
 def _mock_memory():
-    """Patch Memory.from_config so the server imports without a real backend."""
-    # Add server directory to path so imports work
     server_path = os.path.join(os.path.dirname(__file__), "..", "server")
     if server_path not in sys.path:
         sys.path.insert(0, server_path)
 
-    mock_instance = MagicMock()
-    mock_instance.add.return_value = {"results": [{"id": "mem-1", "event": "ADD", "memory": "test"}]}
-    mock_instance.search.return_value = [{"id": "mem-1", "memory": "test", "score": 0.9}]
-    mock_instance.get.return_value = {"id": "mem-1", "memory": "test memory"}
-    mock_instance.get_all.return_value = [{"id": "mem-1", "memory": "test memory"}]
-    mock_instance.update.return_value = {"message": "Memory updated"}
-    mock_instance.history.return_value = [{"id": "mem-1", "old_memory": "a", "new_memory": "b"}]
-    mock_instance.delete.return_value = None
-    mock_instance.delete_all.return_value = {"message": "Memories deleted"}
-    mock_instance.reset.return_value = None
+    memory = MagicMock()
+    memory.add.return_value = {"results": [{"id": "mem-1", "event": "ADD", "memory": "stored"}]}
+    memory.get_all.return_value = {"results": [{"id": "mem-1", "memory": "stored"}]}
+    memory.search.return_value = {"results": [{"id": "mem-1", "memory": "stored", "score": 0.9}]}
+    memory.get.return_value = {"id": "mem-1", "memory": "stored"}
+    memory.update.return_value = {"message": "Memory updated"}
+    memory.history.return_value = [{"id": "mem-1", "event": "ADD"}]
+    memory.delete.return_value = {"message": "Memory deleted successfully!"}
+    memory.delete_all.return_value = {"message": "All relevant memories deleted"}
+    memory.vector_store.list.return_value = [
+        SimpleNamespace(
+            id="mem-1",
+            payload={"user_id": "u1", "created_at": "2026-01-01T00:00:00+00:00"},
+        )
+    ]
 
-    env = {"OPENAI_API_KEY": "fake-key", "ADMIN_API_KEY": "", "AUTH_DISABLED": "true"}
-    with patch.dict(os.environ, env):
-        with patch("mem0.Memory.from_config", return_value=mock_instance):
-            yield mock_instance
+    with patch.dict(os.environ, {"OPENAI_API_KEY": "fake-key", "ADMIN_API_KEY": "", "AUTH_DISABLED": "true"}):
+        with patch("mem0.Memory.from_config", return_value=memory):
+            yield memory
 
 
 @pytest.fixture
 def client(_mock_memory):
-    """Return a TestClient wired to the server app with mocked Memory."""
-    import server.auth as server_auth
-    import server.main as server_main
-
-    env = {"ADMIN_API_KEY": "", "AUTH_DISABLED": "true"}
-    with patch.dict(os.environ, env):
-        importlib.reload(server_auth)
-        importlib.reload(server_main)
-
-    from db import get_db
-
-    mock_db = MagicMock()
-    mock_db.scalar.return_value = None
-    server_main.app.dependency_overrides[get_db] = lambda: mock_db
-    with patch.object(server_main, "SessionLocal", return_value=mock_db):
-        yield TestClient(server_main.app)
-    server_main.app.dependency_overrides.clear()
-
-
-@pytest.fixture
-def mock_memory(_mock_memory):
-    return _mock_memory
-
-
-# ===========================================================================
-# /v1/ping/ alias
-# ===========================================================================
-
-
-class TestV1PingAlias:
-    """Verify that GET /v1/ping/ responds with 200."""
-
-    def test_v1_ping_returns_200(self, client):
-        resp = client.get("/v1/ping/")
-        assert resp.status_code == 200
-        assert resp.json() == {"status": "ok"}
-
-    def test_token_header_bypassed_when_auth_disabled(self, client):
-        resp = client.get("/v1/ping/", headers={"Authorization": "Token any-dummy-key"})
-        assert resp.status_code == 200
-        assert resp.json() == {"status": "ok"}
-
-
-# ===========================================================================
-# /v3/memories/add/ and /v3/memories/ aliases
-# ===========================================================================
-
-
-class TestV3MemoriesAddAlias:
-    """Verify that POST /v3/memories/add/ calls add_memory."""
-
-    def test_v3_memories_add_calls_add_memory(self, client, mock_memory):
-        resp = client.post(
-            "/v3/memories/add/",
-            json={
-                "messages": [{"role": "user", "content": "test"}],
-                "user_id": "u1",
-            },
-        )
-        assert resp.status_code == 200
-        assert mock_memory.add.called
-
-    def test_v3_memories_with_messages_calls_add(self, client, mock_memory):
-        resp = client.post(
-            "/v3/memories/",
-            json={
-                "messages": [{"role": "user", "content": "test"}],
-                "user_id": "u1",
-            },
-        )
-        assert resp.status_code == 200
-        assert mock_memory.add.called
-
-    def test_v3_memories_without_messages_calls_get_all(self, client, mock_memory):
-        resp = client.post("/v3/memories/", json={"user_id": "u1"})
-        assert resp.status_code == 200
-        mock_memory.get_all.assert_called_once()
-
-    def test_base_memories_still_works(self, client, mock_memory):
-        resp = client.post(
-            "/memories",
-            json={
-                "messages": [{"role": "user", "content": "test"}],
-                "user_id": "u1",
-            },
-        )
-        assert resp.status_code == 200
-        assert mock_memory.add.called
-
-
-# ===========================================================================
-# /v1/memories/ alias (get_all)
-# ===========================================================================
-
-
-class TestV1MemoriesListAlias:
-    """Verify that GET /v1/memories/ calls get_all_memories."""
-
-    def test_v1_memories_list_calls_get_all(self, client, mock_memory):
-        resp = client.get("/v1/memories/?user_id=u1")
-        assert resp.status_code == 200
-        assert mock_memory.get_all.called
-
-    def test_base_memories_list_still_works(self, client, mock_memory):
-        resp = client.get("/memories?user_id=u1")
-        assert resp.status_code == 200
-        assert mock_memory.get_all.called
-
-
-# ===========================================================================
-# /v1/memories/{id}/ alias (get)
-# ===========================================================================
-
-
-class TestV1MemoriesGetAlias:
-    """Verify that GET /v1/memories/{memory_id}/ calls get_memory."""
-
-    def test_v1_memories_get_calls_memory_get(self, client, mock_memory):
-        resp = client.get("/v1/memories/mem-1/")
-        assert resp.status_code == 200
-        assert mock_memory.get.called
-
-    def test_base_memories_get_still_works(self, client, mock_memory):
-        resp = client.get("/memories/mem-1")
-        assert resp.status_code == 200
-        assert mock_memory.get.called
-
-
-# ===========================================================================
-# /v3/memories/search/ alias
-# ===========================================================================
-
-
-class TestV3MemoriesSearchAlias:
-    """Verify that POST /v3/memories/search/ calls search_memories."""
-
-    def test_v3_memories_search_calls_search(self, client, mock_memory):
-        resp = client.post(
-            "/v3/memories/search/",
-            json={"query": "food", "user_id": "u1"},
-        )
-        assert resp.status_code == 200
-        assert mock_memory.search.called
-
-    def test_base_search_still_works(self, client, mock_memory):
-        resp = client.post(
-            "/search",
-            json={"query": "food", "user_id": "u1"},
-        )
-        assert resp.status_code == 200
-        assert mock_memory.search.called
-
-
-# ===========================================================================
-# /v1/memories/{id}/ PUT alias (update)
-# ===========================================================================
-
-
-class TestV1MemoriesUpdateAlias:
-    """Verify that PUT /v1/memories/{memory_id}/ calls update_memory."""
-
-    def test_v1_memories_update_calls_update(self, client, mock_memory):
-        resp = client.put(
-            "/v1/memories/mem-1/",
-            json={"text": "Updated text"},
-        )
-        assert resp.status_code == 200
-        assert mock_memory.update.called
-
-    def test_base_memories_update_still_works(self, client, mock_memory):
-        resp = client.put(
-            "/memories/mem-1",
-            json={"text": "Updated text"},
-        )
-        assert resp.status_code == 200
-        assert mock_memory.update.called
-
-
-# ===========================================================================
-# /v1/memories/{id}/history/ alias
-# ===========================================================================
-
-
-class TestV1MemoriesHistoryAlias:
-    """Verify that GET /v1/memories/{memory_id}/history/ calls memory_history."""
-
-    def test_v1_memories_history_calls_history(self, client, mock_memory):
-        resp = client.get("/v1/memories/mem-1/history/")
-        assert resp.status_code == 200
-        assert mock_memory.history.called
-
-    def test_base_memories_history_still_works(self, client, mock_memory):
-        resp = client.get("/memories/mem-1/history")
-        assert resp.status_code == 200
-        assert mock_memory.history.called
-
-
-# ===========================================================================
-# /v1/memories/{id}/ DELETE alias
-# ===========================================================================
-
-
-class TestV1MemoriesDeleteAlias:
-    """Verify that DELETE /v1/memories/{memory_id}/ calls delete_memory."""
-
-    def test_v1_memories_delete_calls_delete(self, client, mock_memory):
-        resp = client.delete("/v1/memories/mem-1/")
-        assert resp.status_code == 200
-        assert mock_memory.delete.called
-
-    def test_base_memories_delete_still_works(self, client, mock_memory):
-        resp = client.delete("/memories/mem-1")
-        assert resp.status_code == 200
-        assert mock_memory.delete.called
-
-
-# ===========================================================================
-# /v1/memories/ DELETE alias (delete_all)
-# ===========================================================================
-
-
-class TestV1MemoriesDeleteAllAlias:
-    """Verify that DELETE /v1/memories/ calls delete_all_memories."""
-
-    def test_v1_memories_delete_all_calls_delete_all(self, client, mock_memory):
-        resp = client.delete("/v1/memories/?user_id=u1")
-        assert resp.status_code == 200
-        assert mock_memory.delete_all.called
-
-    def test_base_memories_delete_all_still_works(self, client, mock_memory):
-        resp = client.delete("/memories?user_id=u1")
-        assert resp.status_code == 200
-        assert mock_memory.delete_all.called
-
-
-# ===========================================================================
-# /v1/reset/ alias
-# ===========================================================================
-
-
-class TestV1ResetAlias:
-    """Verify that POST /v1/reset/ calls reset_memory."""
-
-    def test_v1_reset_calls_reset(self, client, mock_memory):
-        resp = client.post("/v1/reset/")
-        assert resp.status_code == 200
-        assert mock_memory.reset.called
-
-    def test_base_reset_still_works(self, client, mock_memory):
-        resp = client.post("/reset")
-        assert resp.status_code == 200
-        assert mock_memory.reset.called
-
-
-# ===========================================================================
-# /v1/entities/ alias
-# ===========================================================================
-
-
-class TestV1EntitiesListAlias:
-    """Verify that GET /v1/entities/ calls list_entities."""
-
-    def test_v1_entities_list(self, client, mock_memory):
-        # Mock the vector_store.list() method since list_entities calls it
-        mock_memory.vector_store.list.return_value = [[], []]
-        resp = client.get("/v1/entities/")
-        assert resp.status_code == 200
-
-    def test_base_entities_list_still_works(self, client, mock_memory):
-        mock_memory.vector_store.list.return_value = [[], []]
-        resp = client.get("/entities")
-        assert resp.status_code == 200
-
-
-# ===========================================================================
-# /v2/entities/{type}/{id}/ alias
-# ===========================================================================
-
-
-class TestV2EntitiesDeleteAlias:
-    """Verify that DELETE /v2/entities/{entity_type}/{entity_id}/ calls delete_entity."""
-
-    def test_v2_entities_delete(self, client, mock_memory):
-        resp = client.delete("/v2/entities/user/user-1/")
-        assert resp.status_code == 200
-        assert mock_memory.delete_all.called
-
-    def test_base_entities_delete_still_works(self, client, mock_memory):
-        resp = client.delete("/entities/user/user-1")
-        assert resp.status_code == 200
-        assert mock_memory.delete_all.called
-
-
-# ===========================================================================
-# Authorization: Token <key> scheme (SDK compatibility)
-# ===========================================================================
+    import auth as auth_module
+    import server.main as server_module
+
+    with patch.dict(os.environ, {"ADMIN_API_KEY": "", "AUTH_DISABLED": "true"}):
+        importlib.reload(auth_module)
+        importlib.reload(server_module)
+    db = MagicMock()
+    db.scalar.return_value = None
+    session = MagicMock()
+    session.__enter__.return_value = db
+    session.__exit__.return_value = None
+    with (
+        patch.object(auth_module, "SessionLocal", return_value=session) as session_factory,
+        patch.object(server_module, "SessionLocal", return_value=MagicMock()),
+    ):
+        test_client = TestClient(server_module.app)
+        test_client.auth_session = session_factory
+        yield test_client
 
 
 @pytest.fixture
 def auth_client(_mock_memory):
-    """TestClient with auth enabled and a known ADMIN_API_KEY."""
-    # main.py imports bare 'auth', not 'server.auth', so reload the bare module
-    import auth as auth_mod
-    import server.main as server_main
+    import auth as auth_module
+    import server.main as server_module
 
-    env = {
-        "ADMIN_API_KEY": "test-admin-key-for-token-auth",
-        "AUTH_DISABLED": "false",
-        "JWT_SECRET": "test-jwt-secret-for-token-auth-tests",
+    with patch.dict(
+        os.environ,
+        {
+            "ADMIN_API_KEY": "test-admin-key-for-token-auth",
+            "AUTH_DISABLED": "false",
+            "JWT_SECRET": "test-jwt-secret-for-token-auth-tests",
+        },
+    ):
+        importlib.reload(auth_module)
+        importlib.reload(server_module)
+
+    db = MagicMock()
+    session = MagicMock()
+    session.__enter__.return_value = db
+    session.__exit__.return_value = None
+    with (
+        patch.object(auth_module, "SessionLocal", return_value=session) as session_factory,
+        patch.object(server_module, "SessionLocal", return_value=db),
+    ):
+        yield TestClient(server_module.app), auth_module, session, session_factory
+
+
+def _sdk(client):
+    with patch("mem0.client.main.Project"):
+        return MemoryClient(api_key="test-client-key", host="http://localhost:8000", client=client)
+
+
+def test_custom_host_reproduction_and_real_add(client, _mock_memory):
+    sdk = _sdk(client)
+
+    result = sdk.add(
+        [{"role": "user", "content": "Store this"}],
+        filters={"user_id": "u1"},
+        metadata={"source": "test"},
+        infer=False,
+        custom_instructions="Extract preferences only.",
+    )
+
+    assert result["results"][0]["id"] == "mem-1"
+    kwargs = _mock_memory.add.call_args.kwargs
+    assert kwargs["user_id"] == "u1"
+    assert kwargs["metadata"] == {"source": "test"}
+    assert kwargs["infer"] is False
+    assert kwargs["prompt"] == "Extract preferences only."
+    assert "filters" not in kwargs
+
+
+def test_real_client_get_all_preserves_nested_filters_and_false_zero(client, _mock_memory):
+    sdk = _sdk(client)
+
+    sdk.get_all(filters={"user_id": "u1"}, top_k=0, show_expired=False)
+
+    kwargs = _mock_memory.get_all.call_args.kwargs
+    assert kwargs == {"filters": {"user_id": "u1"}, "top_k": 0, "show_expired": False}
+    _mock_memory.add.assert_not_called()
+
+
+def test_real_client_get_all_without_filters_lists_all(client, _mock_memory):
+    sdk = _sdk(client)
+
+    result = sdk.get_all()
+
+    assert result["results"][0]["id"] == "mem-1"
+    _mock_memory.vector_store.list.assert_called_once()
+
+
+def test_real_client_search_without_filters_forwards_query(client, _mock_memory):
+    sdk = _sdk(client)
+
+    sdk.search("food")
+
+    assert _mock_memory.search.call_args.kwargs == {"query": "food", "filters": {}}
+
+
+def test_real_client_search_preserves_supported_options(client, _mock_memory):
+    sdk = _sdk(client)
+
+    sdk.search(
+        "food",
+        filters={"user_id": "u1", "category": "food"},
+        top_k=0,
+        threshold=0,
+        rerank=False,
+        show_expired=False,
+    )
+
+    args, kwargs = _mock_memory.search.call_args
+    assert args == ()
+    assert kwargs == {
+        "query": "food",
+        "filters": {"user_id": "u1", "category": "food"},
+        "top_k": 0,
+        "threshold": 0,
+        "rerank": False,
+        "show_expired": False,
     }
-    with patch.dict(os.environ, env):
-        importlib.reload(auth_mod)
-        importlib.reload(server_main)
-
-    from db import get_db
-
-    mock_db = MagicMock()
-    mock_db.scalar.return_value = None
-    mock_db.execute.return_value.scalars.return_value.all.return_value = []
-    server_main.app.dependency_overrides[get_db] = lambda: mock_db
-    with patch.object(server_main, "SessionLocal", return_value=mock_db):
-        yield TestClient(server_main.app)
-    server_main.app.dependency_overrides.clear()
 
 
-class TestTokenAuthScheme:
-    """Verify that 'Authorization: Token <key>' is accepted, matching SDK behavior."""
+def test_real_client_update_delete_and_encoded_id(client, _mock_memory):
+    sdk = _sdk(client)
 
-    def test_token_scheme_with_admin_key_returns_200(self, auth_client):
-        resp = auth_client.get("/v1/ping/", headers={"Authorization": "Token test-admin-key-for-token-auth"})
-        assert resp.status_code == 200
-        assert resp.json() == {"status": "ok"}
+    sdk.update("mem/1", text="updated", metadata={"source": "test"}, expiration_date=None)
+    sdk.delete("mem/1", delete_linked=False)
 
-    def test_token_scheme_with_wrong_key_returns_401(self, auth_client):
-        resp = auth_client.get("/v1/ping/", headers={"Authorization": "Token wrong-key"})
-        assert resp.status_code == 401
+    assert _mock_memory.update.call_args.kwargs == {
+        "memory_id": "mem/1",
+        "data": "updated",
+        "metadata": {"source": "test"},
+        "expiration_date": None,
+    }
+    assert _mock_memory.delete.call_args.kwargs == {"memory_id": "mem/1"}
 
-    def test_no_auth_returns_401_when_auth_enabled(self, auth_client):
-        resp = auth_client.get("/v1/ping/")
-        assert resp.status_code == 401
 
-    def test_x_api_key_still_works_with_auth_enabled(self, auth_client):
-        resp = auth_client.get("/v1/ping/", headers={"X-API-Key": "test-admin-key-for-token-auth"})
-        assert resp.status_code == 200
+def test_real_client_get_and_history_use_decoded_memory_id(client, _mock_memory):
+    sdk = _sdk(client)
 
-    def test_empty_token_value_returns_401(self, auth_client):
-        resp = auth_client.get("/v1/ping/", headers={"Authorization": "Token "})
-        assert resp.status_code == 401
+    sdk.get("mem/1")
+    sdk.history("mem/1")
 
-    def test_token_scheme_on_versioned_alias(self, auth_client, _mock_memory):
-        resp = auth_client.post(
-            "/v3/memories/search/",
-            json={"query": "food", "user_id": "u1"},
-            headers={"Authorization": "Token test-admin-key-for-token-auth"},
-        )
-        assert resp.status_code == 200
+    assert _mock_memory.get.call_args.args == ("mem/1",)
+    assert _mock_memory.history.call_args.kwargs == {"memory_id": "mem/1"}
+
+
+def test_real_client_delete_all_decodes_serialized_filters(client, _mock_memory):
+    sdk = _sdk(client)
+
+    sdk.delete_all(filters={"user_id": "u1"})
+
+    assert _mock_memory.delete_all.call_args.kwargs == {"user_id": "u1"}
+
+
+def test_real_client_users_and_no_id_delete_users(client, _mock_memory):
+    sdk = _sdk(client)
+
+    users = sdk.users()
+    assert users == {
+        "count": 1,
+        "next": None,
+        "previous": None,
+        "results": [
+            {
+                "id": "u1",
+                "type": "user",
+                "total_memories": 1,
+                "created_at": "2026-01-01T00:00:00Z",
+                "updated_at": "2026-01-01T00:00:00Z",
+                "name": "u1",
+            }
+        ],
+    }
+    sdk.delete_users()
+    assert _mock_memory.delete_all.call_args.kwargs == {"user_id": "u1"}
+
+
+@pytest.mark.parametrize(
+    ("path", "payload"),
+    [
+        ("/v3/memories/add/", {"messages": [{"role": "user", "content": "x"}], "filters": {"app_id": "a"}}),
+        ("/v3/memories/add/", {"messages": [{"role": "user", "content": "x"}], "custom_categories": []}),
+        ("/v3/memories/add/", {"messages": [{"role": "user", "content": "x"}], "structured_data_schema": {}}),
+        ("/v3/memories/add/", {"messages": [{"role": "user", "content": "x"}], "timestamp": 1}),
+        ("/v3/memories/search/", {"query": "x", "filters": {"user_id": "u1"}, "metadata": {"x": 1}}),
+        ("/v3/memories/search/", {"query": "x", "filters": {"user_id": "u1"}, "fields": []}),
+        ("/v3/memories/search/", {"query": "x", "filters": {"user_id": "u1"}, "categories": []}),
+        ("/v3/memories/search/", {"query": "x", "filters": {"user_id": "u1"}, "unknown": 1}),
+        ("/v3/memories/", {"messages": [{"role": "user", "content": "x"}]}),
+        ("/v3/memories/", {"filters": {"user_id": "u1"}, "page": 1}),
+        ("/v3/memories/", {"filters": {"user_id": "u1"}, "start_date": "2026-01-01"}),
+        ("/v3/memories/", {"filters": {"user_id": "u1"}, "categories": []}),
+        ("/v3/memories/", {"filters": {"user_id": "u1"}, "unknown": 1}),
+    ],
+)
+def test_unsupported_versioned_fields_return_422_before_side_effects(client, _mock_memory, path, payload):
+    before = (_mock_memory.add.call_count, _mock_memory.search.call_count, _mock_memory.get_all.call_count)
+
+    response = client.post(path, json=payload)
+
+    assert response.status_code == 422
+    assert (_mock_memory.add.call_count, _mock_memory.search.call_count, _mock_memory.get_all.call_count) == before
+
+
+@pytest.mark.parametrize("payload", [{"timestamp": 1}, {"delete_linked": True}])
+def test_update_and_delete_unsupported_values_are_rejected(client, _mock_memory, payload):
+    if "timestamp" in payload:
+        response = client.put("/v1/memories/mem-1/", json=payload)
+        assert response.status_code == 422
+        _mock_memory.update.assert_not_called()
+    else:
+        response = client.delete("/v1/memories/mem-1/", params=payload)
+        assert response.status_code == 422
+        _mock_memory.delete.assert_not_called()
+
+
+def test_update_empty_body_is_rejected_before_mutation(client, _mock_memory):
+    response = client.put("/v1/memories/mem-1/", json={})
+
+    assert response.status_code == 422
+    _mock_memory.update.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"filters": "[]"},
+        {"filters": "not-a-mapping"},
+        {"filters": '{"app_id": "a"}'},
+        {"filters": '{"user_id": ""}'},
+        {"filters": '{"user_id": "u1", "agent_id": "a1"}', "user_id": "u2"},
+        {"app_id": "a"},
+    ],
+)
+def test_delete_all_invalid_filters_are_rejected(client, _mock_memory, params):
+    response = client.delete("/v1/memories/", params=params)
+
+    assert response.status_code == 422
+    _mock_memory.delete_all.assert_not_called()
+
+
+def test_delete_all_filter_length_boundary(client, _mock_memory):
+    prefix = "{'user_id': '"
+    suffix = "'}"
+    valid = prefix + "u" * (8192 - len(prefix) - len(suffix)) + suffix
+    response = client.delete("/v1/memories/", params={"filters": valid})
+    assert response.status_code == 200
+    assert _mock_memory.delete_all.call_args.kwargs["user_id"] == "u" * (8192 - len(prefix) - len(suffix))
+
+    _mock_memory.delete_all.reset_mock()
+    response = client.delete("/v1/memories/", params={"filters": valid + " "})
+    assert response.status_code == 422
+    _mock_memory.delete_all.assert_not_called()
+
+
+def test_entity_app_deletion_is_rejected_before_mutation(client, _mock_memory):
+    response = client.delete("/v2/entities/app/app-1/")
+
+    assert response.status_code == 422
+    _mock_memory.delete_all.assert_not_called()
+
+
+def test_versioned_routes_are_hidden_and_unversioned_routes_remain(client):
+    paths = client.get("/openapi.json").json()["paths"]
+
+    assert "/memories" in paths
+    assert "/search" in paths
+    assert "/entities" in paths
+    assert "/v1/ping/" not in paths
+    assert "/v3/memories/" not in paths
+    assert "/v3/memories/add/" not in paths
+    assert "/v3/memories/search/" not in paths
+    assert "/v1/memories/" not in paths
+    assert "/v1/memories/{memory_id}/" not in paths
+    assert "/v1/reset/" not in paths
+    assert "/v1/entities/" not in paths
+    assert "/v2/entities/{entity_type}/{entity_id}/" not in paths
+
+
+def test_async_serializer_preserves_mirrored_request_values():
+    client = object.__new__(AsyncMemoryClient)
+
+    assert client._prepare_payload(
+        [{"role": "user", "content": "x"}], {"filters": {"user_id": "u1"}, "infer": False}
+    ) == {"messages": [{"role": "user", "content": "x"}], "filters": {"user_id": "u1"}, "infer": False}
+    assert client._prepare_params({"filters": {"user_id": "u1"}}) == {"filters": {"user_id": "u1"}}
+
+
+def test_token_admin_and_empty_token_precedence(auth_client):
+    client, _auth_module, session, session_factory = auth_client
+
+    response = client.get("/v1/ping/", headers={"Authorization": "Token test-admin-key-for-token-auth"})
+    assert response.status_code == 200
+    session_factory.assert_not_called()
+
+    response = client.get("/v1/ping/", headers={"Authorization": "Token "})
+    assert response.status_code == 401
+    session_factory.assert_not_called()
+
+
+def test_invalid_token_and_missing_auth_are_rejected(auth_client):
+    client, _auth_module, session, session_factory = auth_client
+
+    response = client.get("/v1/ping/", headers={"Authorization": "Token wrong-key"})
+    assert response.status_code == 401
+    assert session.__exit__.called
+
+    session.reset_mock()
+    session_factory.reset_mock()
+    response = client.get("/v1/ping/")
+    assert response.status_code == 401
+    session_factory.assert_not_called()
+
+
+def test_valid_non_admin_token_uses_real_key_resolution(auth_client):
+    client, auth_module, session, session_factory = auth_client
+    db = session.__enter__.return_value
+    candidate = SimpleNamespace(key_hash="stored-hash", created_by="user-id")
+    db.execute.return_value.scalars.return_value.all.return_value = [candidate]
+    db.get.return_value = SimpleNamespace(role="user")
+
+    with patch.object(auth_module, "verify_api_key_hash", return_value=True) as verify_hash:
+        response = client.get("/v1/ping/", headers={"Authorization": "Token valid-user-key"})
+
+    assert response.status_code == 200
+    verify_hash.assert_called_once_with("valid-user-key", "stored-hash")
+    session_factory.assert_called_once_with()
+    session.__exit__.assert_called_once_with(None, None, None)
+
+
+def test_bearer_and_x_api_key_schemes_remain_supported(auth_client):
+    client, auth_module, session, session_factory = auth_client
+
+    response = client.get("/v1/ping/", headers={"X-API-Key": "test-admin-key-for-token-auth"})
+    assert response.status_code == 200
+    session_factory.assert_not_called()
+
+    session.reset_mock()
+    session_factory.reset_mock()
+    session.__enter__.return_value.get.return_value = SimpleNamespace(role="user")
+    token = auth_module.create_access_token("user-id", "user")
+    response = client.get("/v1/ping/", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 200
+    session_factory.assert_called_once_with()
+    session.__exit__.assert_called_once_with(None, None, None)
+
+
+def test_disabled_auth_ignores_token_without_opening_session(client):
+    response = client.get("/v1/ping/", headers={"Authorization": "Token any-dummy-key"})
+
+    assert response.status_code == 200
+    client.auth_session.assert_not_called()
+
+
+def test_valid_non_admin_token_closes_session_before_handler(auth_client):
+    client, auth_module, session, session_factory = auth_client
+    with patch.object(auth_module, "_resolve_user_from_api_key", return_value=SimpleNamespace(role="user")):
+        response = client.get("/v1/ping/", headers={"Authorization": "Token valid-user-key"})
+
+    assert response.status_code == 200
+    session_factory.assert_called_once_with()
+    session.__enter__.assert_called_once_with()
+    session.__exit__.assert_called_once_with(None, None, None)
+
+
+def test_auth_schemes_keep_precedence(auth_client):
+    client, _auth_module, session, session_factory = auth_client
+    response = client.get(
+        "/v1/ping/",
+        headers={"Authorization": "Token wrong-key", "X-API-Key": "test-admin-key-for-token-auth"},
+    )
+    assert response.status_code == 200
+    session_factory.assert_not_called()


### PR DESCRIPTION
## Linked Issue

Closes #4777

## Description

`MemoryClient` and `AsyncMemoryClient` use versioned paths such as `/v1/ping/`, `/v3/memories/add/`, and `/v3/memories/search/`, while the self-hosted OSS server historically registered only the unversioned handlers. This makes the Python SDK fail against a custom host during client initialization.

The server now exposes the client-facing versioned paths within the existing four-file scope and accepts `Authorization: Token <api_key>` through the current authentication ownership. The implementation uses explicit typed adapters where the versioned request or response contract differs from the unversioned handler, preserving filters, falsey values, delete-all decoding, entity response envelopes, and current auth/session behavior.

## Scope

- `server/main.py` and `server/auth.py` contain the route adapters and Token authentication support.
- `tests/test_server_route_aliases.py` covers the Python client contracts, validation, filtering, entity responses, delete-all behavior, auth precedence, and session closure.
- `tests/test_server_params.py` keeps existing parameter forwarding coverage aligned with current server initialization.

The Python SDK, TypeScript SDK, hosted API, OpenAPI output, and existing unversioned handler contracts remain unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update

## Breaking Changes

N/A. The versioned routes are hidden compatibility paths, and existing unversioned routes remain available.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually with mocked Memory and the Python client
- [ ] No tests needed

Verification:

- [x] `tests/test_server_route_aliases.py`: 42 passed, 0 skipped
- [ ] `tests/test_server_params.py`, skipped during collection because this local environment lacks the optional `telemetry` module
- [x] `ruff check` passed for all four changed files
- [x] `git diff --check` passed
- [ ] `make test`, bounded locally by missing optional dependencies

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing focused tests pass locally
- [ ] I have updated documentation if needed
