### PR TITLE
fix(memory): link entities for procedural memory in sync and async paths

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1950,6 +1950,9 @@ class Memory(MemoryBase):
         memory_id = self._create_memory(procedural_memory, {procedural_memory: embeddings}, metadata=metadata)
         capture_event("mem0._create_procedural_memory", self, {"memory_id": memory_id, "sync_type": "sync"})
 
+        session_filters = {k: metadata[k] for k in ("user_id", "agent_id", "run_id") if metadata.get(k)}
+        self._link_entities_for_memory(memory_id, procedural_memory, session_filters)
+
         result = {"results": [{"id": memory_id, "memory": procedural_memory, "event": "ADD"}]}
 
         return result
@@ -3601,6 +3604,9 @@ class AsyncMemory(MemoryBase):
         embeddings = await asyncio.to_thread(self.embedding_model.embed, procedural_memory, memory_action="add")
         memory_id = await self._create_memory(procedural_memory, {procedural_memory: embeddings}, metadata=metadata)
         capture_event("mem0._create_procedural_memory", self, {"memory_id": memory_id, "sync_type": "async"})
+
+        session_filters = {k: metadata[k] for k in ("user_id", "agent_id", "run_id") if metadata.get(k)}
+        await self._link_entities_for_memory(memory_id, procedural_memory, session_filters)
 
         result = {"results": [{"id": memory_id, "memory": procedural_memory, "event": "ADD"}]}
 

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, Mock
 
 import pytest
 
+from mem0.configs.enums import MemoryType
 from mem0.exceptions import LLMError
 from mem0.memory.main import AsyncMemory, Memory
 
@@ -1061,3 +1062,84 @@ class TestAddPipelineEntityEmbeddingCountGuard:
         assert any("padding/truncating" in r.message for r in caplog.records), (
             "expected count-mismatch warning was not emitted"
         )
+class TestProceduralMemoryEntityLinking:
+    """Regression tests for procedural memory entity linking (#5620/#5621).
+
+    Ensures that ``_link_entities_for_memory`` is called after creating a
+    procedural memory, in both the sync (``Memory``) and async (``AsyncMemory``)
+    paths, with correct ``session_filters`` derived from metadata.
+    """
+
+    def test_sync_links_entities_via_add(self, mocker):
+        """Sync ``Memory.add(..., memory_type="procedural_memory")`` must call
+        ``_link_entities_for_memory`` with the correct text and filters."""
+        memory = _build_memory_instance(mocker, Memory)
+
+        mock_link = mocker.patch.object(memory, "_link_entities_for_memory")
+        # Avoid loading spaCy model for lemmatization in unit tests
+        mocker.patch("mem0.memory.main.lemmatize_for_bm25", side_effect=lambda text: text)
+
+        # Stub the LLM so it returns a predictable procedural memory text
+        memory.llm.generate_response.return_value = "The user likes Python programming"
+        # Stub embedding so it returns a fixed vector (avoids live embedder calls)
+        memory.embedding_model.embed.return_value = [0.1, 0.2, 0.3]
+
+        # Suppress telemetry-event logging in test output
+        mocker.patch("mem0.memory.main.capture_event")
+
+        memory.add(
+            messages="I love Python",
+            agent_id="test_agent",
+            user_id="test_user",
+            memory_type=MemoryType.PROCEDURAL.value,
+        )
+
+        # --- assertions ---
+        mock_link.assert_called_once()
+        args = mock_link.call_args[0]  # (memory_id, text, session_filters)
+        assert len(args) == 3
+
+        _memory_id, text, session_filters = args
+        assert text == "The user likes Python programming"
+        assert session_filters == {"user_id": "test_user", "agent_id": "test_agent"}
+        assert isinstance(_memory_id, str)
+
+    @pytest.mark.asyncio
+    async def test_async_links_entities_via_add(self, mocker):
+        """Async ``AsyncMemory.add(..., memory_type="procedural_memory")`` must call
+        ``_link_entities_for_memory`` with the correct text and filters."""
+        # The async path has a lazy import of langchain_core. Provide a fake
+        # module so the import inside _create_procedural_memory succeeds.
+        mocker.patch.dict("sys.modules", {
+            "langchain_core": MagicMock(),
+            "langchain_core.messages": MagicMock(),
+            "langchain_core.messages.utils": MagicMock(),
+        })
+
+        memory = _build_memory_instance(mocker, AsyncMemory)
+
+        mock_link = mocker.patch.object(memory, "_link_entities_for_memory")
+        # Avoid loading spaCy model for lemmatization in unit tests
+        mocker.patch("mem0.memory.main.lemmatize_for_bm25", side_effect=lambda text: text)
+
+        memory.llm.generate_response.return_value = "The agent should check system logs"
+        memory.embedding_model.embed.return_value = [0.1, 0.2, 0.3]
+
+        mocker.patch("mem0.memory.main.capture_event")
+
+        await memory.add(
+            messages="Check system logs for errors",
+            agent_id="test_agent",
+            user_id="test_user",
+            memory_type=MemoryType.PROCEDURAL.value,
+        )
+
+        mock_link.assert_called_once()
+        args = mock_link.call_args[0]
+        assert len(args) == 3
+
+        _memory_id, text, session_filters = args
+        assert text == "The agent should check system logs"
+        assert session_filters == {"user_id": "test_user", "agent_id": "test_agent"}
+        assert isinstance(_memory_id, str)
+


### PR DESCRIPTION
## Linked Issue

Closes #5620

## Description

When creating a procedural memory via `_create_procedural_memory`, the memory was stored but its entities were never linked to the entity store. This meant entity-based retrieval (searching/querying by entity) did not work for procedural memories, even though they contain structured entity information.

In contrast, the regular `add()` method calls `_link_entities_for_memory` after storing memory, which correctly links entities to the entity store.

This fix calls `_link_entities_for_memory` after creating a procedural memory, in both the sync (`Memory`) and async (`AsyncMemory`) paths, matching what `add()` already does for regular memories.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added regression tests in `tests/memory/test_main.py` that verify `_link_entities_for_memory` is called with the correct text and session filters when creating a procedural memory via `add()`. The tests cover both the sync (`TestProceduralMemoryEntityLinking.test_sync_links_entities_via_add`) and async (`TestProceduralMemoryEntityLinking.test_async_links_entities_via_add`) paths, mocking external dependencies (LLM, embeddings, vector store, lemmatization) for a focused unit-level regression check.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed