### PR TITLE
fix(vector_stores): point fastembed-missing warning at mem0ai[extras]

### DIFF
--- a/mem0/vector_stores/qdrant.py
+++ b/mem0/vector_stores/qdrant.py
@@ -98,7 +98,10 @@ class Qdrant(VectorStoreBase):
                 self._bm25_encoder = SparseTextEmbedding(model_name="Qdrant/bm25")
                 logger.info("BM25 encoder loaded (fastembed Qdrant/bm25)")
             except ImportError:
-                logger.warning("fastembed not installed — BM25 keyword search disabled. Install with: pip install fastembed")
+                logger.warning(
+                    "fastembed not installed - BM25 keyword search disabled. "
+                    'Install it with: pip install "mem0ai[extras]"'
+                )
                 self._bm25_encoder = False  # sentinel: tried and failed
             except Exception as e:
                 logger.warning(f"Failed to load BM25 encoder: {e}")

--- a/tests/vector_stores/test_qdrant.py
+++ b/tests/vector_stores/test_qdrant.py
@@ -932,3 +932,19 @@ class TestQdrantDatetimeRangeFilters(unittest.TestCase):
         types = {type(c.range) for c in result.must}
         self.assertIn(DatetimeRange, types)
         self.assertIn(Range, types)
+
+    def test_missing_fastembed_warns_with_extras_install_hint(self):
+        """When fastembed is missing, the BM25 warning must point at the mem0 optional group
+        that actually provides it (`mem0ai[extras]`), not the bare `fastembed` package -
+        fastembed is declared under [extras], so that is the discoverable install path."""
+        self.qdrant._bm25_encoder = None
+        # Setting the module to None in sys.modules makes `from fastembed import ...` raise ImportError.
+        with patch.dict("sys.modules", {"fastembed": None}):
+            with self.assertLogs("mem0.vector_stores.qdrant", level="WARNING") as cm:
+                result = self.qdrant._get_bm25_encoder()
+        self.assertIsNone(result)  # encoder unavailable -> None
+        self.assertIs(self.qdrant._bm25_encoder, False)  # sentinel: tried and failed, do not retry
+        joined = "\n".join(cm.output)
+        self.assertIn("mem0ai[extras]", joined)  # points at the right install
+        self.assertNotIn("pip install fastembed", joined)  # not the bare package
+        self.assertNotIn("\u2014", joined)  # no em-dash


### PR DESCRIPTION
## Linked Issue

No separate issue. This is a small follow-on to #5444, which added the store-level warning when hybrid search degrades to semantic-only. It closes the other degradation path: the `fastembed`-missing warning on the Qdrant BM25 keyword encoder.

## Description

When the Qdrant store lazy-loads the BM25 sparse encoder and `fastembed` is not installed, the warning told users to `pip install fastembed`. But `fastembed` is declared under mem0's `extras` optional group, so `pip install "mem0ai[extras]"` is the discoverable, mem0-idiomatic install. This points the warning there, and drops a stray em-dash in the message.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

Added `test_missing_fastembed_warns_with_extras_install_hint` in `tests/vector_stores/test_qdrant.py`: it forces the `fastembed` import to fail (`patch.dict("sys.modules", {"fastembed": None})`) and asserts the warning fires with the `mem0ai[extras]` hint, not the bare `pip install fastembed`. Red-to-green: reverting the message makes it fail at `assertIn("mem0ai[extras]")`. `pytest tests/vector_stores/test_qdrant.py` -> 92 passed.

Note: `qdrant.py` carries some pre-existing `ruff format` drift unrelated to this change; I kept the diff to the warning line only (`ruff check` is clean). Happy to send a separate format-only pass if you prefer.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (no public API change)
