### PR TITLE
fix(ts-oss): tolerate trailing commas in LLM JSON extraction

### DIFF
--- a/mem0-ts/src/oss/src/prompts/index.ts
+++ b/mem0-ts/src/oss/src/prompts/index.ts
@@ -881,6 +881,92 @@ export function removeCodeBlocks(text: string): string {
 }
 
 /**
+ * Removes trailing commas that appear immediately before a closing `}` or `]`.
+ *
+ * Trailing commas are invalid JSON but are an extremely common defect in LLM
+ * output (especially OpenRouter-proxied and weaker/local models), e.g.
+ * `{"memory": [{"text": "a"},]}`. The scan is string-aware: it tracks string
+ * boundaries and escapes so commas, braces, and brackets that appear *inside*
+ * string values are never touched.
+ *
+ * @param json - A candidate JSON string
+ * @returns The same string with offending trailing commas removed
+ */
+function stripTrailingCommas(json: string): string {
+  let result = "";
+  let inString = false;
+  let escapeNext = false;
+
+  for (let i = 0; i < json.length; i++) {
+    const char = json[i];
+
+    if (escapeNext) {
+      result += char;
+      escapeNext = false;
+      continue;
+    }
+
+    if (char === "\\") {
+      result += char;
+      escapeNext = true;
+      continue;
+    }
+
+    if (char === '"') {
+      inString = !inString;
+      result += char;
+      continue;
+    }
+
+    if (!inString && char === ",") {
+      // Look ahead past whitespace for the next significant character.
+      let j = i + 1;
+      while (j < json.length && /\s/.test(json[j])) j++;
+      if (j < json.length && (json[j] === "}" || json[j] === "]")) {
+        // Drop this trailing comma (skip it, keep the whitespace).
+        continue;
+      }
+    }
+
+    result += char;
+  }
+
+  return result;
+}
+
+/**
+ * Validates a candidate JSON string, tolerating common LLM malformations.
+ *
+ * Returns a parseable JSON string when the candidate is valid as-is, or can be
+ * made valid by removing trailing commas. Returns `null` when the candidate is
+ * not recoverable. When the candidate is already valid it is returned byte-for-
+ * byte unchanged, so callers relying on exact output are unaffected.
+ *
+ * @param candidate - A substring that may be JSON
+ * @returns A parseable JSON string, or `null` if unrecoverable
+ */
+function validateOrRepairJson(candidate: string): string | null {
+  try {
+    JSON.parse(candidate);
+    return candidate;
+  } catch {
+    // Fall through to trailing-comma repair.
+  }
+
+  const repaired = stripTrailingCommas(candidate);
+  if (repaired !== candidate) {
+    try {
+      JSON.parse(repaired);
+      return repaired;
+    } catch {
+      // Not recoverable.
+    }
+  }
+
+  return null;
+}
+
+/**
  * Extracts a JSON object from text that may be wrapped in explanation text.
  *
  * Some LLMs (especially local models like Ollama/LM Studio, or OpenRouter)
@@ -892,6 +978,7 @@ export function removeCodeBlocks(text: string): string {
  * 1. Strips known noise tokens from OpenRouter and other providers
  * 2. Removes code fences and <think> blocks
  * 3. Tries to find a valid JSON object by testing each `{` as a starting point
+ *    (tolerating trailing commas, a common LLM defect)
  * 4. Falls back to first/last brace matching if validation isn't possible
  *
  * @param text - The raw LLM response text
@@ -951,13 +1038,12 @@ export function extractJson(text: string): string {
         depth--;
         if (depth === 0) {
           const candidate = trimmed.substring(start, i + 1);
-          try {
-            JSON.parse(candidate);
-            return candidate; // Valid JSON found
-          } catch {
-            // Not valid JSON, try next starting brace
-            break;
+          const valid = validateOrRepairJson(candidate);
+          if (valid !== null) {
+            return valid; // Valid JSON found (possibly trailing-comma repaired)
           }
+          // Not valid JSON, try next starting brace
+          break;
         }
       }
     }
@@ -969,12 +1055,11 @@ export function extractJson(text: string): string {
   const lastBrace = trimmed.lastIndexOf("}");
   if (firstBrace !== -1 && lastBrace > firstBrace) {
     const candidate = trimmed.substring(firstBrace, lastBrace + 1);
-    try {
-      JSON.parse(candidate);
-      return candidate;
-    } catch {
-      // Not valid JSON, continue to array extraction
+    const valid = validateOrRepairJson(candidate);
+    if (valid !== null) {
+      return valid;
     }
+    // Not valid JSON, continue to array extraction
   }
 
   // Step 5: Try to locate a JSON array by testing each `[` as potential start
@@ -1013,12 +1098,11 @@ export function extractJson(text: string): string {
         depth--;
         if (depth === 0) {
           const candidate = trimmed.substring(start, i + 1);
-          try {
-            JSON.parse(candidate);
-            return candidate;
-          } catch {
-            break;
+          const valid = validateOrRepairJson(candidate);
+          if (valid !== null) {
+            return valid;
           }
+          break;
         }
       }
     }
@@ -1029,12 +1113,11 @@ export function extractJson(text: string): string {
   const lastBracket = trimmed.lastIndexOf("]");
   if (firstBracket !== -1 && lastBracket > firstBracket) {
     const candidate = trimmed.substring(firstBracket, lastBracket + 1);
-    try {
-      JSON.parse(candidate);
-      return candidate;
-    } catch {
-      // Not valid JSON
+    const valid = validateOrRepairJson(candidate);
+    if (valid !== null) {
+      return valid;
     }
+    // Not valid JSON
   }
 
   // No valid JSON found — return as-is and let the caller handle the error

--- a/mem0-ts/src/oss/tests/extract-json.test.ts
+++ b/mem0-ts/src/oss/tests/extract-json.test.ts
@@ -229,4 +229,75 @@ That's all I found.`;
     const result = extractJson(input);
     expect(JSON.parse(result)).toEqual(["fact1", "fact2"]);
   });
+
+  // Issue #4737: trailing commas are invalid JSON but extremely common in
+  // OpenRouter-proxied / weaker / local model output. Without tolerance the
+  // extraction silently fails closed and memories are skipped.
+  describe("trailing comma tolerance (issue #4737)", () => {
+    it("recovers an object with a trailing comma before the closing brace", () => {
+      const input = '{"facts": ["a"],}';
+      const result = extractJson(input);
+      expect(JSON.parse(result)).toEqual({ facts: ["a"] });
+    });
+
+    it("recovers an array with a trailing comma before the closing bracket", () => {
+      const input = '{"memory": [{"text": "a"},]}';
+      const result = extractJson(input);
+      expect(JSON.parse(result)).toEqual({ memory: [{ text: "a" }] });
+    });
+
+    it("recovers a trailing comma inside a nested object", () => {
+      const input = '{"memory": [{"id": "0", "text": "a",}]}';
+      const result = extractJson(input);
+      expect(JSON.parse(result)).toEqual({
+        memory: [{ id: "0", text: "a" }],
+      });
+    });
+
+    it("recovers multiple trailing commas across nesting levels", () => {
+      const input =
+        '{"memory": [{"id": "0", "text": "a",}, {"id": "1", "text": "b",},],}';
+      const result = extractJson(input);
+      expect(JSON.parse(result)).toEqual({
+        memory: [
+          { id: "0", text: "a" },
+          { id: "1", text: "b" },
+        ],
+      });
+    });
+
+    it("recovers a trailing comma in a wrapped/chatty response", () => {
+      const input =
+        "Here are the extracted memories:\n" +
+        '{"memory": [{"text": "User likes pizza"},]}\n' +
+        "Let me know if you need more.";
+      const result = extractJson(input);
+      expect(JSON.parse(result)).toEqual({
+        memory: [{ text: "User likes pizza" }],
+      });
+    });
+
+    it("recovers a bare top-level array with a trailing comma", () => {
+      const input = 'The results are: ["fact1", "fact2",]';
+      const result = extractJson(input);
+      expect(JSON.parse(result)).toEqual(["fact1", "fact2"]);
+    });
+
+    it("does NOT strip commas that appear inside string values", () => {
+      const input = '{"facts": ["a, b, and c"],}';
+      const result = extractJson(input);
+      expect(JSON.parse(result)).toEqual({ facts: ["a, b, and c"] });
+    });
+
+    it("does NOT mistake a brace inside a string for a trailing-comma boundary", () => {
+      const input = '{"facts": ["weird },] value"],}';
+      const result = extractJson(input);
+      expect(JSON.parse(result)).toEqual({ facts: ["weird },] value"] });
+    });
+
+    it("leaves already-valid JSON byte-for-byte unchanged", () => {
+      const input = '{"facts": ["hello", "world"]}';
+      expect(extractJson(input)).toBe('{"facts": ["hello", "world"]}');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- `extractJson()` now tolerates **trailing commas** in LLM JSON output (an extremely common defect from OpenRouter-proxied and weaker/local models).
- Fixes the "Failed to parse memory actions / facts from LLM response" failures where memories were silently skipped.

## Motivation

Closes #4737.

When the OSS pipeline runs through OpenRouter (or Ollama/LM Studio), the LLM frequently returns otherwise-correct JSON with a trailing comma, e.g.:

```
{"memory": [{"text": "User likes pizza"},]}
```

This is invalid JSON. `extractJson()` validated every candidate substring with `JSON.parse` and rejected anything that didn't parse as-is, so these responses fell through to the "no valid JSON found" path. The caller then logged `Failed to parse memory actions from LLM response` / `Failed to parse facts from LLM response` and dropped the extraction — exactly the intermittent auto-capture failures reported in #4737.

## Root cause

The four candidate-validation sites in `extractJson` (object scan, object first/last-brace fallback, array scan, array first/last-bracket fallback) each only accepted a substring when `JSON.parse` succeeded. A trailing comma always throws, so a single stray comma rejected the entire (otherwise valid) payload.

## Fix

- New string-aware `stripTrailingCommas()` helper. It tracks string and escape state, so commas / braces / brackets that appear **inside string values** are never touched.
- New `validateOrRepairJson()` that first tries the candidate as-is and, only on failure, retries after stripping trailing commas. Returns `null` when unrecoverable.
- All four validation sites now route through `validateOrRepairJson()`.
- **Already-valid JSON is returned byte-for-byte unchanged**, so existing exact-match behavior is fully preserved.

Scope: `mem0-ts/src/oss/src/prompts/index.ts` (+ tests). 2 files.

## Verification

- `npx jest extract-json` — **39 passed** (30 existing + 9 new).
- `npx jest oss` — **588 passed** (no regressions).
- `npx prettier --check` — clean.

New tests cover: object/array/nested/multiple trailing commas, wrapped/chatty responses, bare top-level arrays, and negative cases proving commas/braces **inside string values** are preserved.

## Real behavior proof

Captured from a real run of the patched `extractJson()` (via `jest` on this branch) against OpenRouter-style payloads that fail on `main`:

```
INPUT : "Here are the memories:\n{\"memory\": [{\"id\":\"0\",\"text\":\"User likes pizza\"},]}\nDone."
OUTPUT: {"memory": [{"id":"0","text":"User likes pizza"}]}
PARSED: {"memory":[{"id":"0","text":"User likes pizza"}]}
---
INPUT : "{\"facts\": [\"Name is John\", \"Lives in Tokyo\",]}"
OUTPUT: {"facts": ["Name is John", "Lives in Tokyo"]}
PARSED: {"facts":["Name is John","Lives in Tokyo"]}
```

On `main`, both `JSON.parse` calls throw and the extraction is dropped; with this fix they parse cleanly.

Regression test: `mem0-ts/src/oss/tests/extract-json.test.ts` → `trailing comma tolerance (issue #4737)`; these assertions fail without the fix and pass with it.

## What was NOT changed

- Did not alter the cloud/managed SDK paths or the Python pipeline — this is scoped to the TS OSS `extractJson` consumed by the V3 add pipeline and the Azure AI Search vector store.
- Did not relax any other JSON tolerance (single quotes, unquoted keys, etc.) — trailing commas are the documented #4737 symptom; broader repair is intentionally out of scope.
