### PR TITLE
fix(vector_stores): return None from Redis.get() for missing IDs

### DIFF
--- a/mem0/vector_stores/redis.py
+++ b/mem0/vector_stores/redis.py
@@ -263,7 +263,7 @@ class RedisDB(VectorStoreBase):
 
     def get(self, vector_id):
         result = self.index.fetch(vector_id)
-        if not result:
+        if result is None:
             return None
         payload = {
             "hash": result["hash"],

--- a/mem0/vector_stores/redis.py
+++ b/mem0/vector_stores/redis.py
@@ -263,9 +263,6 @@ class RedisDB(VectorStoreBase):
 
     def get(self, vector_id):
         result = self.index.fetch(vector_id)
-        # redisvl's SearchIndex.fetch() returns None when the id is not found.
-        # Return None (consistent with the other vector stores) instead of
-        # crashing on result["hash"]; Memory relies on get() returning None.
         if not result:
             return None
         payload = {

--- a/mem0/vector_stores/redis.py
+++ b/mem0/vector_stores/redis.py
@@ -263,6 +263,11 @@ class RedisDB(VectorStoreBase):
 
     def get(self, vector_id):
         result = self.index.fetch(vector_id)
+        # redisvl's SearchIndex.fetch() returns None when the id is not found.
+        # Return None (consistent with the other vector stores) instead of
+        # crashing on result["hash"]; Memory relies on get() returning None.
+        if not result:
+            return None
         payload = {
             "hash": result["hash"],
             "data": result["memory"],

--- a/tests/vector_stores/test_redis.py
+++ b/tests/vector_stores/test_redis.py
@@ -113,3 +113,18 @@ def test_list_with_filter_builds_query():
 
     query = mock_index.search.call_args[0][0]
     assert query.query_string() == "@user_id:{alice}"
+
+
+def test_get_returns_none_for_missing_id():
+    """get() must return None for a missing id.
+
+    redisvl's SearchIndex.fetch() returns None when the id is not found, so the
+    old code raised ``TypeError: 'NoneType' object is not subscriptable`` on
+    ``result["hash"]``. Every other vector store returns None for a missing id,
+    and Memory relies on it (``if existing_memory is None``), so get() must too.
+    """
+    db, mock_index = _make_redis_db()
+    mock_index.fetch.return_value = None
+
+    assert db.get("missing_id") is None
+    mock_index.fetch.assert_called_once_with("missing_id")


### PR DESCRIPTION
## Linked Issue

No separate issue — small self-contained bug fix (details below).

## Description

`Redis.get()` raises `TypeError: 'NoneType' object is not subscriptable` when the id does not exist, instead of returning `None`.

redisvl's `SearchIndex.fetch()` returns `None` for a missing id, but `Redis.get()` immediately subscripts the result:

```python
def get(self, vector_id):
    result = self.index.fetch(vector_id)   # None when not found
    payload = {"hash": result["hash"], ...}  # -> TypeError
```

Every other vector store returns `None` for a missing id, and the `Memory` layer relies on that contract — e.g. in `mem0/memory/main.py`:

```python
existing_memory = self.vector_store.get(vector_id=memory_id)
if existing_memory is None:
    ...
```

So `get()` of a non-existent id — and therefore `update()`/`delete()` of a missing memory — crashed with an opaque `TypeError` on Redis instead of being handled. This guards the empty fetch result and returns `None`, consistent with ChromaDB / Milvus / Weaviate / Supabase (#5561, #5562).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

Added `test_get_returns_none_for_missing_id` (mocks `fetch()` returning `None`). Verified red→green: without the guard the test fails with `TypeError: 'NoneType' object is not subscriptable` at `result["hash"]`; with it, the full `test_redis.py` suite (7 tests) passes locally.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
