### PR TITLE
fix(vertex): pass required vectors arg in list and similarity search

### DIFF
--- a/mem0/vector_stores/vertex_ai_vector_search.py
+++ b/mem0/vector_stores/vertex_ai_vector_search.py
@@ -487,7 +487,7 @@ class GoogleMatchingEngine(VectorStoreBase):
             # Use a large top_k if none specified
             search_limit = top_k if top_k is not None else 10000
 
-            results = self.search(query=zero_vector, top_k=search_limit, filters=filters)
+            results = self.search(query="", vectors=zero_vector, top_k=search_limit, filters=filters)
 
             logger.debug("Found %d results", len(results))
             return [results]  # Wrap in extra array to match interface
@@ -620,7 +620,7 @@ class GoogleMatchingEngine(VectorStoreBase):
         logger.debug("Filter: %s", filter)
 
         embedding = self.embedder.embed_query(query)
-        results = self.search(query=embedding, top_k=k, filters=filter)
+        results = self.search(query=query, vectors=embedding, top_k=k, filters=filter)
 
         docs_and_scores = [
             (Document(page_content=result.payload.get("text", ""), metadata=result.payload), result.score)

--- a/tests/vector_stores/test_vertex_ai_vector_search.py
+++ b/tests/vector_stores/test_vertex_ai_vector_search.py
@@ -116,6 +116,32 @@ def test_search_vectors(vector_store, mock_vertex_ai):
     assert results[0].payload == {"user_id": "test_user"}
 
 
+def test_list_does_not_raise_type_error(vector_store, mock_vertex_ai):
+    """list() must call search() with the required positional `vectors` arg."""
+    mock_vertex_ai["endpoint"].find_neighbors.return_value = [[]]
+
+    results = vector_store.list(filters={"user_id": "test_user"}, top_k=5)
+
+    mock_vertex_ai["endpoint"].find_neighbors.assert_called_once()
+    queries = mock_vertex_ai["endpoint"].find_neighbors.call_args[1]["queries"]
+    assert queries == [[0.0] * 768]
+    assert results == [[]]
+
+
+def test_similarity_search_with_score_passes_embedding(vector_store, mock_vertex_ai):
+    """similarity_search_with_score() must pass the embedding as `vectors`."""
+    embedding = [0.1, 0.2, 0.3]
+    vector_store.embedder = Mock()
+    vector_store.embedder.embed_query.return_value = embedding
+    mock_vertex_ai["endpoint"].find_neighbors.return_value = [[]]
+
+    vector_store.similarity_search_with_score(query="hello", k=3)
+
+    mock_vertex_ai["endpoint"].find_neighbors.assert_called_once()
+    queries = mock_vertex_ai["endpoint"].find_neighbors.call_args[1]["queries"]
+    assert queries == [embedding]
+
+
 def test_delete(vector_store, mock_vertex_ai):
     """Test deleting vectors"""
     vector_id = "test-id"


### PR DESCRIPTION
## Linked Issue

Closes #5652

## Description

`GoogleMatchingEngine.list()` and `similarity_search_with_score()` both called `self.search(...)` without the required positional `vectors` argument - they passed the embedding through `query=` instead. Since `search(self, query, vectors, top_k=5, filters=None)` makes `vectors` required, every call raised `TypeError: search() missing 1 required positional argument: 'vectors'`. This broke `get_all`/`delete_all` (which route through `list`) and similarity search for the whole Vertex backend.

The fix passes the vector positionally as `vectors`: `list()` uses the zero vector with `query=""`, and `similarity_search_with_score()` passes the embedding as `vectors` while keeping the text as `query`. Added a regression unit test for both paths.

Note: the search vector dimension in `list()` is still hardcoded to 768; making it configurable is a separate follow-up and out of scope here.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
