### PR TITLE
fix(llms): keep configured token limit for reasoning models

### DIFF
--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -123,6 +123,9 @@ class LLMBase(ABC):
             if "tool_choice" in kwargs:
                 supported_params["tool_choice"] = kwargs["tool_choice"]
 
+            # Reasoning / o-series / gpt-5 use max_completion_tokens, never legacy max_tokens.
+            supported_params["max_completion_tokens"] = self.config.max_tokens
+
             # Add reasoning_effort if configured
             reasoning_effort = getattr(self.config, 'reasoning_effort', None)
             if reasoning_effort:

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -221,6 +221,27 @@ def test_non_reasoning_model_ignores_reasoning_effort(mock_openai_client):
     assert "reasoning_effort" not in call_kwargs[1]
 
 
+def test_reasoning_model_sends_max_completion_tokens(mock_openai_client):
+    """Reasoning models must forward the configured token cap as max_completion_tokens.
+
+    The reasoning branch previously dropped the cap entirely, so o-series/gpt-5 calls
+    ran with no limit. Reasoning models use max_completion_tokens, never legacy max_tokens.
+    """
+    config = OpenAIConfig(model="o3-mini", max_tokens=100)
+    llm = OpenAILLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Response"))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    call_kwargs = mock_openai_client.chat.completions.create.call_args[1]
+    assert call_kwargs.get("max_completion_tokens") == 100
+    assert "max_tokens" not in call_kwargs
+
+
 def test_reasoning_effort_config_values():
     """Test that reasoning_effort can be set to all valid values."""
     for effort in ["low", "medium", "high"]:


### PR DESCRIPTION
## Linked Issue

Closes #5653

## Description

In `LLMBase._get_supported_params`, the reasoning-model branch (o1/o3/gpt-5) builds the request dict but never sets a token-limit key, so a configured `max_tokens` was silently dropped for those models. Non-reasoning models already forward the cap via `_get_common_params`, so the limit only vanished for reasoning models, across every provider that uses this shared helper (OpenAI, Azure OpenAI, DeepSeek, xAI, etc.).

The fix sets `max_completion_tokens` from `self.config.max_tokens` in the reasoning branch. Reasoning/o-series/gpt-5 models use `max_completion_tokens` and reject the legacy `max_tokens`, so this is the correct key.

Added a regression unit test.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

`test_reasoning_model_sends_max_completion_tokens` fails before the fix (no token key sent) and passes after. Full `tests/llms/test_openai.py` passes (21/21).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
