### PR TITLE
fix(memory): return attributed_to from get/get_all/search

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1091,6 +1091,7 @@ class Memory(MemoryBase):
             "run_id",
             "actor_id",
             "role",
+            "attributed_to",
         ]
 
         core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
@@ -1204,6 +1205,7 @@ class Memory(MemoryBase):
             "run_id",
             "actor_id",
             "role",
+            "attributed_to",
         ]
         core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
 
@@ -1539,6 +1541,7 @@ class Memory(MemoryBase):
             "run_id",
             "actor_id",
             "role",
+            "attributed_to",
         ]
         core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
 
@@ -2597,6 +2600,7 @@ class AsyncMemory(MemoryBase):
             "run_id",
             "actor_id",
             "role",
+            "attributed_to",
         ]
 
         core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
@@ -2710,6 +2714,7 @@ class AsyncMemory(MemoryBase):
             "run_id",
             "actor_id",
             "role",
+            "attributed_to",
         ]
         core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
 
@@ -3051,6 +3056,7 @@ class AsyncMemory(MemoryBase):
             "run_id",
             "actor_id",
             "role",
+            "attributed_to",
         ]
         core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -298,6 +298,91 @@ def test_get_all_handles_flat_list_from_postgres(mock_sqlite, mock_llm_factory, 
 @patch('mem0.utils.factory.VectorStoreFactory.create')
 @patch('mem0.utils.factory.LlmFactory.create')
 @patch('mem0.memory.storage.SQLiteManager')
+def test_read_apis_surface_attributed_to(mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
+    """
+    attributed_to is written to the payload on add (and the extraction prompt marks it
+    required), so get/get_all/search must return it instead of dropping it. It must be a
+    top-level field, not buried inside metadata.
+    """
+    mock_embedder = MagicMock()
+    mock_embedder.embed.return_value = [0.1, 0.2, 0.3]
+    mock_embedder_factory.return_value = mock_embedder
+    mock_vector_store = MagicMock()
+    mock_vector_factory.return_value = mock_vector_store
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+    memory = MemoryClass(MemoryConfig())
+    memory.embedding_model = mock_embedder
+
+    payload = {"data": "User likes Python", "attributed_to": "user", "user_id": "u1"}
+
+    # get
+    mock_vector_store.get.return_value = MockVectorMemory("mem_1", payload)
+    got = memory.get("mem_1")
+    assert got["attributed_to"] == "user"
+    assert "attributed_to" not in (got.get("metadata") or {})
+
+    # get_all
+    mock_vector_store.list.return_value = [MockVectorMemory("mem_1", payload)]
+    listed = memory._get_all_from_vector_store({"user_id": "u1"}, 100)
+    assert listed[0]["attributed_to"] == "user"
+    assert "attributed_to" not in (listed[0].get("metadata") or {})
+
+    # search
+    mock_vector_store.search.return_value = [MockVectorMemory("mem_1", payload, score=0.9)]
+    mock_vector_store.keyword_search.return_value = []
+    searched = memory._search_vector_store("python", {"user_id": "u1"}, 10)
+    assert searched[0]["attributed_to"] == "user"
+    assert "attributed_to" not in (searched[0].get("metadata") or {})
+
+
+@pytest.mark.asyncio
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+async def test_async_read_apis_surface_attributed_to(mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
+    """AsyncMemory get/get_all/search must surface attributed_to, same as the sync path."""
+    mock_embedder = MagicMock()
+    mock_embedder.embed.return_value = [0.1, 0.2, 0.3]
+    mock_embedder_factory.return_value = mock_embedder
+    mock_vector_store = MagicMock()
+    mock_vector_factory.return_value = mock_vector_store
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import AsyncMemory
+    memory = AsyncMemory(MemoryConfig())
+    memory.embedding_model = mock_embedder
+
+    payload = {"data": "User likes Python", "attributed_to": "user", "user_id": "u1"}
+
+    # get
+    mock_vector_store.get.return_value = MockVectorMemory("mem_1", payload)
+    got = await memory.get("mem_1")
+    assert got["attributed_to"] == "user"
+    assert "attributed_to" not in (got.get("metadata") or {})
+
+    # get_all
+    mock_vector_store.list.return_value = [MockVectorMemory("mem_1", payload)]
+    listed = await memory._get_all_from_vector_store({"user_id": "u1"}, 100)
+    assert listed[0]["attributed_to"] == "user"
+    assert "attributed_to" not in (listed[0].get("metadata") or {})
+
+    # search
+    mock_vector_store.search.return_value = [MockVectorMemory("mem_1", payload, score=0.9)]
+    mock_vector_store.keyword_search.return_value = []
+    searched = await memory._search_vector_store("python", {"user_id": "u1"}, 10)
+    assert searched[0]["attributed_to"] == "user"
+    assert "attributed_to" not in (searched[0].get("metadata") or {})
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
 def test_add_infer_with_malformed_llm_facts(mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
     """
     Repro for: 'list' object has no attribute 'replace' on infer=true.


### PR DESCRIPTION
## Linked Issue

Closes #5654

## Description

`attributed_to` is written into the memory payload on `add` (and the extraction prompt marks it required, so it's populated for inferred memories), but none of the read APIs ever return it. The read methods build their result by promoting a fixed set of payload keys (`promoted_payload_keys`) onto the top-level dict; `attributed_to` was listed in `core_and_promoted_keys` (so it's correctly kept out of the `metadata` bucket) but was missing from `promoted_payload_keys`, so it fell through the gap and was silently dropped by `get`, `get_all`, and `search` (sync and async). It was effectively a write-only dead value.

The fix adds `"attributed_to"` to `promoted_payload_keys` at all six read sites (3 sync + 3 async). Promotion stays guarded by `if key in payload`, so memories without the field are unaffected.

Added a regression unit test covering `get`/`get_all`/`search` on both `Memory` and `AsyncMemory`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
