### PR TITLE
fix(graph): keep distinct entities that share a substring prefix

### DIFF
--- a/mem0/utils/entity_extraction.py
+++ b/mem0/utils/entity_extraction.py
@@ -352,7 +352,7 @@ def _extract_entities_from_doc(doc) -> List[Tuple[str, str]]:
             best[k] = (t, e)
     deduped = list(best.values())
 
-    # Remove entities that are whole-word subsequences of longer entities.
+    # Remove entities that are whole-word substrings of longer entities.
     # Word-boundary anchoring avoids dropping distinct entities that only share a
     # leading substring (e.g. "Sam" must survive alongside "Samsung").
     all_lower = [e[1].lower() for e in deduped]

--- a/mem0/utils/entity_extraction.py
+++ b/mem0/utils/entity_extraction.py
@@ -352,6 +352,12 @@ def _extract_entities_from_doc(doc) -> List[Tuple[str, str]]:
             best[k] = (t, e)
     deduped = list(best.values())
 
-    # Remove entities that are substrings of longer entities
+    # Remove entities that are whole-word subsequences of longer entities.
+    # Word-boundary anchoring avoids dropping distinct entities that only share a
+    # leading substring (e.g. "Sam" must survive alongside "Samsung").
     all_lower = [e[1].lower() for e in deduped]
-    return [(t, e) for t, e in deduped if not any(e.lower() != o and e.lower() in o for o in all_lower)]
+    return [
+        (t, e)
+        for t, e in deduped
+        if not any(e.lower() != o and re.search(rf"\b{re.escape(e.lower())}\b", o) for o in all_lower)
+    ]

--- a/tests/utils/test_entity_extraction.py
+++ b/tests/utils/test_entity_extraction.py
@@ -59,6 +59,16 @@ class TestExtractEntities:
         google_count = sum(1 for _, t in entities if "Google" in t)
         assert google_count <= 1, f"Expected dedup, got {entities}"
 
+    def test_substring_dedup_respects_word_boundaries(self):
+        from mem0.utils.entity_extraction import extract_entities
+
+        # "Sam" is a mid-word substring of "Samsung", not a separate token, so it
+        # must not be dropped as a substring of the longer entity.
+        entities = extract_entities("At Samsung, Sam leads design.")
+        entity_texts = [e[1] for e in entities]
+        assert "Sam" in entity_texts, f"Expected 'Sam' to survive alongside 'Samsung', got {entities}"
+        assert any("Samsung" in t for t in entity_texts), f"Expected 'Samsung', got {entities}"
+
     def test_returns_tuples(self):
         from mem0.utils.entity_extraction import extract_entities
 


### PR DESCRIPTION
## Linked Issue

Closes #5657

## Description

`_extract_entities_from_doc` drops entities that are substrings of longer ones, but the check was unanchored (`e.lower() in o`). That means a shorter entity is removed whenever it appears *anywhere* inside a longer one, including mid-word. So "Sam" gets dropped when "Samsung" is present, and any short proper noun that happens to be a leading substring of a longer entity disappears.

Since both entity linking (`_link_entities_for_memory`) and search boosting (`_compute_entity_boosts`) consume this output, the dropped entity is lost in both paths, costing recall.

The fix anchors the match on word boundaries (`re.search(rf"\b{re.escape(e.lower())}\b", o)`), so only whole-word token subsets are dropped ("learning" still drops out of "machine learning", "Apple" out of "Apple Inc"), while distinct entities that merely share a substring prefix are kept. `re.escape` guards against regex-special characters in entity text.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added `test_substring_dedup_respects_word_boundaries` asserting "Sam" survives alongside "Samsung". It fails on the old unanchored check and passes with the fix.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed