### PR TITLE
fix(memory): guard against malformed image_url in parse_vision_messages

### DIFF
--- a/mem0-ts/src/oss/src/utils/memory.ts
+++ b/mem0-ts/src/oss/src/utils/memory.ts
@@ -31,9 +31,11 @@ const parse_vision_messages = async (messages: Message[]) => {
         typeof message.content === "object" &&
         message.content.type === "image_url"
       ) {
-        const description = await get_image_description(
-          message.content.image_url.url,
-        );
+        const imageUrl = message.content.image_url?.url;
+        if (!imageUrl) {
+          throw new Error("image_url content part is missing image_url.url");
+        }
+        const description = await get_image_description(imageUrl);
         new_message.content =
           typeof description === "string"
             ? description

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -206,7 +206,9 @@ def parse_vision_messages(messages, llm=None, vision_details="auto"):
         elif isinstance(content, dict) and content.get("type") == "image_url":
             if llm is None:
                 continue
-            image_url = content["image_url"]["url"]
+            image_url = content.get("image_url", {}).get("url")
+            if not image_url:
+                raise ValueError("image_url content part is missing image_url.url")
             try:
                 description = get_image_description(image_url, llm, vision_details)
                 returned_messages.append({"role": role, "content": description})

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -206,7 +206,8 @@ def parse_vision_messages(messages, llm=None, vision_details="auto"):
         elif isinstance(content, dict) and content.get("type") == "image_url":
             if llm is None:
                 continue
-            image_url = content.get("image_url", {}).get("url")
+            image_url_obj = content.get("image_url")
+            image_url = image_url_obj.get("url") if isinstance(image_url_obj, dict) else None
             if not image_url:
                 raise ValueError("image_url content part is missing image_url.url")
             try:

--- a/tests/memory/test_memory_utils.py
+++ b/tests/memory/test_memory_utils.py
@@ -101,7 +101,16 @@ class TestParseVisionMessages:
         # uncaught KeyError that aborted add(); it should raise a clear ValueError.
         mock_llm = Mock()
         messages = [{"role": "user", "content": {"type": "image_url", "image_url": {}}}]
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"missing image_url\.url"):
+            parse_vision_messages(messages, llm=mock_llm)
+        mock_llm.generate_response.assert_not_called()
+
+    def test_none_image_url_raises_value_error(self):
+        # image_url present but None (or any non-dict) must also raise the clear
+        # ValueError, not an AttributeError from calling .get() on None.
+        mock_llm = Mock()
+        messages = [{"role": "user", "content": {"type": "image_url", "image_url": None}}]
+        with pytest.raises(ValueError, match=r"missing image_url\.url"):
             parse_vision_messages(messages, llm=mock_llm)
         mock_llm.generate_response.assert_not_called()
 

--- a/tests/memory/test_memory_utils.py
+++ b/tests/memory/test_memory_utils.py
@@ -96,6 +96,15 @@ class TestParseVisionMessages:
         result = parse_vision_messages(messages, llm=None)
         assert result == messages
 
+    def test_malformed_image_dict_raises_value_error(self):
+        # A malformed image part (missing the nested url) used to raise an
+        # uncaught KeyError that aborted add(); it should raise a clear ValueError.
+        mock_llm = Mock()
+        messages = [{"role": "user", "content": {"type": "image_url", "image_url": {}}}]
+        with pytest.raises(ValueError):
+            parse_vision_messages(messages, llm=mock_llm)
+        mock_llm.generate_response.assert_not_called()
+
 
 class TestRemoveSpacesFromEntities:
     """


### PR DESCRIPTION
## Linked Issue

Closes #5659

## Description

In `parse_vision_messages`, a single image content part was dereferenced as `content["image_url"]["url"]` outside the surrounding `try`. When an image part is malformed (missing the nested `url`), this raised an uncaught `KeyError` that bubbled all the way up and aborted `add()`, instead of the intended download/validation error path.

The fix reads the URL defensively with `content.get("image_url", {}).get("url")` and raises a clear `ValueError` when it's absent, so callers get an actionable message instead of a `KeyError`.

Added a regression unit test.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed