### PR TITLE
fix(reranker): clamp out-of-range LLM scores instead of mis-parsing them

### DIFF
--- a/mem0/reranker/llm_reranker.py
+++ b/mem0/reranker/llm_reranker.py
@@ -90,14 +90,14 @@ class LLMReranker(BaseReranker):
 
     def _extract_score(self, response_text: str) -> float:
         """Extract numerical score from LLM response."""
-        # Look for decimal numbers between 0.0 and 1.0
-        pattern = r'\b([01](?:\.\d+)?)\b'
-        matches = re.findall(pattern, response_text)
-        
+        # Prefer a decimal, fall back to an integer, then clamp: out-of-range outputs
+        # like "2.0"/"5" become 1.0 instead of being mis-parsed into a stray 0/1 digit.
+        matches = re.findall(r'-?\d+\.\d+', response_text) or re.findall(r'-?\d+', response_text)
+
         if matches:
             score = float(matches[0])
             return min(max(score, 0.0), 1.0)  # Clamp between 0.0 and 1.0
-        
+
         # Fallback: return 0.5 if no valid score found
         return 0.5
     

--- a/tests/rerankers/test_llm_reranker_rerank.py
+++ b/tests/rerankers/test_llm_reranker_rerank.py
@@ -27,6 +27,23 @@ class TestExtractScore:
     def test_clamps_to_1(self, reranker):
         assert reranker._extract_score("1.0") == 1.0
 
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("2.0", 1.0),
+            ("5", 1.0),
+            ("10", 1.0),
+            ("-0.3", 0.0),
+            ("-2", 0.0),
+        ],
+    )
+    def test_out_of_range_scores_are_clamped(self, reranker, text, expected):
+        assert reranker._extract_score(text) == expected
+
+    def test_decimal_score_preferred_over_leading_integer(self, reranker):
+        # A distractor integer before the score must not be picked up.
+        assert reranker._extract_score("Confidence 100%. Relevance: 0.1") == 0.1
+
 
 class TestRerank:
     def test_empty_documents(self, mock_llm):


### PR DESCRIPTION
## Linked Issue

Closes #5655

## Description

`LLMReranker._extract_score` used the regex `\b([01](?:\.\d+)?)\b`, which only matches numbers starting with 0 or 1. When a model emits an out-of-range score for a strong match, this mis-parses it:

- `"2.0"` matches the trailing `0` and returns `0.0`
- `"5"` matches nothing and falls back to `0.5`

So a perfect-match document gets a near-zero score and is ranked last. The existing clamp ran on the already-wrong extracted value, so it didn't help.

The fix extracts the score by preferring a decimal, then falling back to a bare integer, and clamps the result to [0, 1]. `"2.0"`/`"5"` now become `1.0`. Decimals are matched first so a distractor integer before the score (e.g. `"Confidence 100%. Relevance: 0.1"`) isn't picked up. In-range outputs are unchanged.

Added a regression unit test.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed