### PR TITLE
fix(reranker): export all five rerankers from package root

### DIFF
--- a/mem0/reranker/__init__.py
+++ b/mem0/reranker/__init__.py
@@ -4,6 +4,16 @@ Reranker implementations for mem0 search functionality.
 
 from .base import BaseReranker
 from .cohere_reranker import CohereReranker
+from .huggingface_reranker import HuggingFaceReranker
+from .llm_reranker import LLMReranker
 from .sentence_transformer_reranker import SentenceTransformerReranker
+from .zero_entropy_reranker import ZeroEntropyReranker
 
-__all__ = ["BaseReranker", "CohereReranker", "SentenceTransformerReranker"]
+__all__ = [
+    "BaseReranker",
+    "CohereReranker",
+    "HuggingFaceReranker",
+    "LLMReranker",
+    "SentenceTransformerReranker",
+    "ZeroEntropyReranker",
+]

--- a/tests/rerankers/test_reranker_public_exports.py
+++ b/tests/rerankers/test_reranker_public_exports.py
@@ -1,0 +1,41 @@
+"""Regression test pinning the public exports of ``mem0.reranker``.
+
+All five rerankers are first-class providers in ``RerankerFactory``, so all five
+classes must be importable from the package root. A regression once dropped the
+LLM, HuggingFace, and ZeroEntropy rerankers from ``__init__`` while keeping them
+in the factory, so ``from mem0.reranker import LLMReranker`` raised ImportError.
+"""
+
+import mem0.reranker as reranker_pkg
+
+
+def test_all_rerankers_are_importable_from_package_root():
+    from mem0.reranker import (
+        BaseReranker,
+        CohereReranker,
+        HuggingFaceReranker,
+        LLMReranker,
+        SentenceTransformerReranker,
+        ZeroEntropyReranker,
+    )
+
+    assert {
+        BaseReranker,
+        CohereReranker,
+        HuggingFaceReranker,
+        LLMReranker,
+        SentenceTransformerReranker,
+        ZeroEntropyReranker,
+    }
+
+
+def test_all_exported_names_are_present_in_dunder_all():
+    expected = {
+        "BaseReranker",
+        "CohereReranker",
+        "HuggingFaceReranker",
+        "LLMReranker",
+        "SentenceTransformerReranker",
+        "ZeroEntropyReranker",
+    }
+    assert expected <= set(reranker_pkg.__all__)


### PR DESCRIPTION
## Linked Issue

Closes #5656

## Description

`mem0.reranker.__init__` only re-exported 3 of the 5 rerankers. `LLMReranker`, `HuggingFaceReranker`, and `ZeroEntropyReranker` were missing, even though all five are first-class providers in `RerankerFactory`. So `from mem0.reranker import LLMReranker` raised `ImportError` while `from mem0.reranker import CohereReranker` worked.

I added the three missing classes to the imports and `__all__`. Each of those modules already guards its heavy deps (transformers/torch, zeroentropy) with a module-level try/except, so importing them is safe and matches the existing pattern. Added a regression unit test that pins all five being importable from the package root.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed