### PR TITLE
fix(vector_stores): drop stray print in Weaviate list_cols

### DIFF
--- a/mem0/vector_stores/weaviate.py
+++ b/mem0/vector_stores/weaviate.py
@@ -342,7 +342,6 @@ class Weaviate(VectorStoreBase):
         """
         collections = self.client.collections.list_all()
         logger.debug(f"collections: {collections}")
-        print(f"collections: {collections}")
         return {"collections": [{"name": col.name} for col in collections]}
 
     def delete_col(self):

--- a/tests/vector_stores/test_weaviate.py
+++ b/tests/vector_stores/test_weaviate.py
@@ -197,6 +197,16 @@ class TestWeaviateDB(unittest.TestCase):
 
         self.client_mock.collections.list_all.assert_called_once()
 
+    def test_list_cols_does_not_print(self):
+        mock_collection = MagicMock()
+        mock_collection.name = "collection1"
+        self.client_mock.collections.list_all.return_value = [mock_collection]
+
+        with patch("builtins.print") as mock_print:
+            self.weaviate_db.list_cols()
+
+        mock_print.assert_not_called()
+
     def test_delete_col(self):
         self.weaviate_db.delete_col()
 


### PR DESCRIPTION
## Linked Issue

Closes #5658

## Description

`Weaviate.list_cols()` calls `print(f"collections: {collections}")` on every invocation, which leaks raw collection objects to stdout for any app using the Weaviate vector store. The line right above it already logs the same thing at debug level (`logger.debug(f"collections: {collections}")`), so the print is a leftover and the debug log keeps the diagnostic. I removed the stray `print` and added a regression unit test.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

`test_list_cols_does_not_print` asserts `builtins.print` is never called by `list_cols()`. It fails before the fix and passes after; the full `tests/vector_stores/test_weaviate.py` suite is green.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed