### PR TITLE
fix(llms): preserve reasoning fields in base-to-provider config conversion

### DIFF
--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -1,4 +1,5 @@
 import importlib
+import inspect
 from typing import Dict, Optional, Union
 
 from mem0.configs.embeddings.base import BaseEmbedderConfig
@@ -102,6 +103,14 @@ class LlmFactory:
                     "vision_details": config.vision_details,
                     "http_client_proxies": config.http_client,
                 }
+                # Only forward reasoning fields to provider configs that accept them
+                # (explicitly or via **kwargs); others would raise on unexpected kwargs.
+                params = inspect.signature(config_class).parameters
+                accepts_kwargs = any(p.kind == p.VAR_KEYWORD for p in params.values())
+                if accepts_kwargs or "reasoning_effort" in params:
+                    config_dict["reasoning_effort"] = config.reasoning_effort
+                if accepts_kwargs or "is_reasoning_model" in params:
+                    config_dict["is_reasoning_model"] = config.is_reasoning_model
                 config_dict.update(kwargs)
                 config = config_class(**config_dict)
             else:

--- a/tests/utils/test_factory.py
+++ b/tests/utils/test_factory.py
@@ -1,0 +1,53 @@
+from unittest.mock import Mock, patch
+
+from mem0.configs.llms.anthropic import AnthropicConfig
+from mem0.configs.llms.aws_bedrock import AWSBedrockConfig
+from mem0.configs.llms.base import BaseLlmConfig
+from mem0.configs.llms.openai import OpenAIConfig
+from mem0.utils.factory import LlmFactory
+
+
+def _capture_config(provider_name, config):
+    """Build an LLM via the factory and return the config it was constructed with."""
+    captured = {}
+
+    def fake_llm_class(built_config):
+        captured["config"] = built_config
+        return Mock()
+
+    with patch("mem0.utils.factory.load_class", return_value=fake_llm_class):
+        LlmFactory.create(provider_name, config)
+
+    return captured["config"]
+
+
+def test_base_to_openai_preserves_reasoning_fields():
+    base_config = BaseLlmConfig(model="o3", reasoning_effort="high", is_reasoning_model=True)
+
+    built = _capture_config("openai", base_config)
+
+    assert isinstance(built, OpenAIConfig)
+    assert built.reasoning_effort == "high"
+    assert built.is_reasoning_model is True
+
+
+def test_base_to_kwargs_provider_preserves_reasoning_fields():
+    # AWSBedrockConfig accepts the reasoning fields via **kwargs, so they must survive.
+    base_config = BaseLlmConfig(model="amazon.nova", reasoning_effort="medium", is_reasoning_model=True)
+
+    built = _capture_config("aws_bedrock", base_config)
+
+    assert isinstance(built, AWSBedrockConfig)
+    assert built.reasoning_effort == "medium"
+    assert built.is_reasoning_model is True
+
+
+def test_base_to_provider_without_reasoning_fields_still_builds():
+    # Anthropic config does not accept reasoning_effort/is_reasoning_model;
+    # the conversion must not forward unsupported kwargs to it.
+    base_config = BaseLlmConfig(model="claude-3-5-sonnet-20240620")
+
+    built = _capture_config("anthropic", base_config)
+
+    assert isinstance(built, AnthropicConfig)
+    assert built.model == "claude-3-5-sonnet-20240620"


### PR DESCRIPTION
## Linked Issue

Closes #5647

## Description

When `LlmFactory.create` is given a `BaseLlmConfig` and the target provider uses a provider-specific config (e.g. OpenAI), it rebuilds the config from a `config_dict` that omits `reasoning_effort` and `is_reasoning_model`. So building an OpenAI LLM from `BaseLlmConfig(model="o3", reasoning_effort="high", is_reasoning_model=True)` silently produced a config with both set to `None`, and the reasoning-model behavior was lost.

Root cause: those two fields were simply missing from the `config_dict` in the base-to-provider branch.

The fix forwards both fields, but only to provider configs that actually accept them - either explicitly (OpenAI, Azure) or via `**kwargs` (AWS Bedrock). Configs like Anthropic and Gemini don't declare them, so forwarding unconditionally would raise a `TypeError`; the signature guard avoids that.

Added a regression unit test covering an explicit-field provider (OpenAI), a `**kwargs` provider (Bedrock), and a provider that accepts neither (Anthropic, must still build).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

New `tests/utils/test_factory.py`. The reasoning-preservation tests fail on `main` and pass with the fix; `tests/utils/` and `tests/llms/` are green (209 passed).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed