### PR TITLE
fix(client): check HTTP status before parsing ping response in _validate_api_key

### DIFF
--- a/mem0/client/main.py
+++ b/mem0/client/main.py
@@ -151,9 +151,9 @@ class MemoryClient:
         try:
             params = self._prepare_params()
             response = self.client.get("/v1/ping/", params=params)
-            data = response.json()
-
             response.raise_for_status()
+
+            data = response.json()
 
             if data.get("org_id") and data.get("project_id"):
                 self.org_id = data.get("org_id")
@@ -1044,9 +1044,9 @@ class AsyncMemoryClient:
                 },
                 params=params,
             )
-            data = response.json()
-
             response.raise_for_status()
+
+            data = response.json()
 
             if data.get("org_id") and data.get("project_id"):
                 self.org_id = data.get("org_id")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,8 +1,11 @@
 """Tests for MemoryClient entity parameter rejection."""
 
+import json
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
+import requests
 
 
 @pytest.fixture
@@ -207,3 +210,56 @@ class TestDeleteLinked:
 
         call_args = mock_memory_client.client.delete.call_args
         assert "delete_linked" not in call_args.kwargs.get("params", {})
+
+
+class TestValidateApiKeyHttpError:
+    """_validate_api_key should surface a clear ValueError on a non-JSON HTTP error.
+
+    A 5xx from a CDN/proxy often has an HTML body, so response.json() fails. The
+    HTTP status must be checked before json() so the intended ValueError is raised
+    instead of a confusing JSONDecodeError during client construction.
+    """
+
+    def test_sync_client_non_json_5xx_raises_clear_error(self):
+        # HTML body from a CDN/proxy: json() fails, but raise_for_status() reports the 503.
+        request = httpx.Request("GET", "https://api.mem0.ai/v1/ping/")
+        error_response = httpx.Response(503, text="<html>503 Service Unavailable</html>", request=request)
+        response = MagicMock()
+        response.json.side_effect = json.JSONDecodeError("Expecting value", "<html>", 0)
+        response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Server error", request=request, response=error_response
+        )
+
+        with patch("mem0.client.main.httpx.Client") as mock_httpx:
+            mock_http_client = MagicMock()
+            mock_http_client.get.return_value = response
+            mock_httpx.return_value = mock_http_client
+
+            with patch("mem0.client.main.capture_client_event"):
+                from mem0.client.main import MemoryClient
+
+                with pytest.raises(ValueError) as exc_info:
+                    MemoryClient(api_key="test-api-key")
+
+        # The HTTP status must surface as the intended "Error: ..." ValueError,
+        # not the raw JSONDecodeError from parsing the HTML body.
+        assert not isinstance(exc_info.value, json.JSONDecodeError)
+        assert "Error:" in str(exc_info.value)
+
+    def test_async_client_non_json_5xx_raises_clear_error(self):
+        request = httpx.Request("GET", "https://api.mem0.ai/v1/ping/")
+        error_response = httpx.Response(503, text="<html>503 Service Unavailable</html>", request=request)
+        response = MagicMock()
+        response.json.side_effect = requests.exceptions.JSONDecodeError("Expecting value", "<html>", 0)
+        http_error = requests.exceptions.HTTPError("Server error", response=error_response)
+        response.raise_for_status.side_effect = http_error
+
+        with patch("mem0.client.main.requests.get", return_value=response):
+            with patch("mem0.client.main.capture_client_event"):
+                from mem0.client.main import AsyncMemoryClient
+
+                with pytest.raises(ValueError) as exc_info:
+                    AsyncMemoryClient(api_key="test-api-key")
+
+        assert not isinstance(exc_info.value, requests.exceptions.JSONDecodeError)
+        assert "Error:" in str(exc_info.value)


### PR DESCRIPTION
## Linked Issue

Closes #5660

## Description

`MemoryClient._validate_api_key` (and the same method on `AsyncMemoryClient`) runs during `__init__` and parsed the `/v1/ping/` response body as JSON *before* checking the HTTP status:

```python
data = response.json()
response.raise_for_status()
```

When the ping returns a non-JSON 5xx (for example an HTML error page from a CDN or proxy), `response.json()` raises a `JSONDecodeError` first. That error is not caught by the `except httpx.HTTPStatusError` / `except requests.exceptions.HTTPError` handler, and `_validate_api_key` is not wrapped by `api_error_handler`, so it bubbles up as a confusing `JSONDecodeError` while constructing the client instead of the intended `ValueError`.

The fix calls `response.raise_for_status()` before `response.json()` in both the sync and async paths, so the HTTP status surfaces as the clear `ValueError("Error: ...")` the handler already produces. The happy path is unchanged: on a 2xx, `raise_for_status()` is a no-op and the body is parsed as before.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added a regression test for both the sync and async clients in `tests/test_client.py` that mocks a non-JSON 5xx ping and asserts a clear `ValueError` is raised (not a `JSONDecodeError`). It fails on the old order and passes with the fix.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed