### PR TITLE
fix(server): return 404 not 500 for malformed api key id on revoke

### DIFF
--- a/server/routers/api_keys.py
+++ b/server/routers/api_keys.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -77,7 +78,11 @@ def create_key(body: CreateKeyRequest, user: User = Depends(require_auth), db: S
 
 @router.delete("/{key_id}", response_model=MessageResponse)
 def revoke_key(key_id: str, user: User = Depends(require_auth), db: Session = Depends(get_db)):
-    api_key = db.get(APIKey, key_id)
+    try:
+        key_uuid = uuid.UUID(key_id)
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=404, detail="API key not found.")
+    api_key = db.get(APIKey, key_uuid)
     if api_key is None or api_key.created_by != user.id:
         raise HTTPException(status_code=404, detail="API key not found.")
     if api_key.revoked_at is not None:

--- a/tests/test_api_keys_router.py
+++ b/tests/test_api_keys_router.py
@@ -1,0 +1,69 @@
+"""Tests for the api-keys router.
+
+revoke_key takes the key_id straight from the URL path and passes it to
+db.get(APIKey, key_id). The id column is a Postgres uuid, so a malformed
+(non-UUID) key_id makes psycopg raise a DataError at bind time -- which
+surfaces as a 500 -- before the None -> 404 check is ever reached. A missing
+key should always be a 404, whether or not the id is a valid UUID.
+"""
+
+import os
+import sys
+import uuid
+
+import pytest
+
+pytest.importorskip("fastapi", reason="fastapi not installed")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from sqlalchemy.exc import DataError  # noqa: E402
+
+# server/ modules use bare imports (from auth import ...), so the server
+# directory itself must be importable, mirroring how it runs in Docker.
+_SERVER_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "server")
+if _SERVER_DIR not in sys.path:
+    sys.path.insert(0, _SERVER_DIR)
+
+from auth import require_auth  # noqa: E402
+from db import get_db  # noqa: E402
+from models import User  # noqa: E402
+from routers import api_keys as api_keys_router  # noqa: E402
+
+
+class _RaisingSession:
+    """Stands in for a SQLAlchemy session whose uuid column rejects bad input.
+
+    Postgres raises DataError when a non-UUID string is bound to a uuid
+    column; we reproduce that here without needing a live database. A valid
+    UUID that maps to no row yields None, the same as a real lookup miss.
+    """
+
+    def get(self, _model, ident, *_args, **_kwargs):
+        try:
+            uuid.UUID(str(ident))
+        except ValueError as exc:
+            raise DataError("invalid input syntax for type uuid", None, exc) from exc
+        return None
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    app.include_router(api_keys_router.router)
+
+    fake_user = User(id=uuid.uuid4(), name="t", email="t@e.com", password_hash="x", role="admin")
+    app.dependency_overrides[require_auth] = lambda: fake_user
+    app.dependency_overrides[get_db] = lambda: _RaisingSession()
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_revoke_malformed_key_id_returns_404(client):
+    resp = client.delete("/api-keys/not-a-uuid")
+    assert resp.status_code == 404
+
+
+def test_revoke_missing_valid_uuid_returns_404(client):
+    resp = client.delete(f"/api-keys/{uuid.uuid4()}")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Linked Issue

Self-found; no existing issue. The bug is small and self-contained, so I'm explaining it here per the template rather than opening a separate issue.

## Description

`DELETE /api-keys/{key_id}` returned a 500 when `key_id` wasn't a valid UUID. `revoke_key` passed the raw path string straight to `db.get(APIKey, key_id)`, and since `api_keys.id` is a Postgres `uuid` column, psycopg raises a `DataError` while binding the value -- before the existing `None -> 404` check ever runs. So a typo'd or garbage key id surfaced as a server error instead of a clean 404.

The fix parses `key_id` as a UUID first and raises 404 on failure, mirroring the guard already used in `auth.consume_refresh_jti`. A valid-but-missing id still returns 404 as before.

Added a regression unit test.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

`tests/test_api_keys_router.py` mounts the api-keys router and overrides the DB session to reproduce the Postgres uuid rejection. The malformed-id test fails (500) without the fix and passes (404) with it; a valid-but-missing id stays 404.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
