### PR TITLE
fix(oss-ts): preserve message roles in extraction input so assistant facts aren't attributed to the user

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -601,7 +601,13 @@ export class Memory {
         // getLastMessages not supported — proceed without context
       }
     }
-    const parsedMessages = messages.map((m) => m.content).join("\n");
+    // Preserve role on the messages being extracted so the prompt's role-aware
+    // logic and the required `attributed_to` output have the speaker to work
+    // with. Matches the Python oss `parse_messages` helper (`role: content`);
+    // without this, assistant statements get attributed to the user.
+    const parsedMessages = messages
+      .map((m) => `${m.role}: ${m.content}`)
+      .join("\n");
 
     // Phase 1: Existing memory retrieval
     const queryEmbedding = await this.embedder.embed(parsedMessages);

--- a/mem0-ts/src/oss/tests/memory.add.test.ts
+++ b/mem0-ts/src/oss/tests/memory.add.test.ts
@@ -126,6 +126,22 @@ describe("Memory - add()", () => {
     expect(result.results.length).toBeGreaterThan(0);
   });
 
+  test("preserves message roles in the extraction prompt (## New Messages)", async () => {
+    // The OpenAI LLM mock echoes the `## New Messages` section of the prompt back
+    // as the extracted text, so the stored memory reveals what the LLM received.
+    // Roles must survive into that section, otherwise the prompt's role-aware
+    // logic and required `attributed_to` output have no speaker to attribute to
+    // and assistant statements get stored as user facts.
+    const messages = [
+      { role: "user", content: "I want to sleep earlier." },
+      { role: "assistant", content: "Aim for 00:30 sleep / 08:30 wake." },
+    ];
+    const result: SearchResult = await memory.add(messages, { userId });
+    const seen = result.results.map((r) => r.memory).join("\n");
+    expect(seen).toContain("user: I want to sleep earlier.");
+    expect(seen).toContain("assistant: Aim for 00:30 sleep / 08:30 wake.");
+  });
+
   test("works with agentId instead of userId", async () => {
     const result: SearchResult = await memory.add("test", {
       agentId: "agent_1",


### PR DESCRIPTION
## Linked Issue

Closes #5642

## Description

In the TypeScript oss build, the fact-extraction step dropped message `role`s before building the extraction prompt:

```ts
// mem0-ts/src/oss/src/memory/index.ts
const parsedMessages = messages.map((m) => m.content).join("\n"); // roles lost
```

That string is passed to `generateAdditiveExtractionPrompt` as the `## New Messages` section. But the additive extraction prompt is role-aware and its output schema **requires** an `attributed_to: "user" | "assistant"` field. With roles stripped, the LLM cannot tell who said what, so assistant statements (recommendations / plans it proposed) get attributed to and stored as **user** facts. (Note the `## Last k Messages` context section *does* keep roles via `formatConversationHistory`, so only the messages actually being extracted lose attribution.)

The Python oss build does not have this bug — `parse_messages()` in `mem0/memory/utils.py` preserves roles as `role: content`. This PR brings the TS path in line:

```ts
const parsedMessages = messages
  .map((m) => `${m.role}: ${m.content}`)
  .join("\n");
```

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added a regression test in `mem0-ts/src/oss/tests/memory.add.test.ts` ("preserves message roles in the extraction prompt") asserting roles survive into the `## New Messages` prompt section. It **fails on `main`** and passes with this change. Full TS unit suite passes locally (`jest --config jest.config.js`: 634 passed).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed (N/A — no doc-facing behavior change)
