### PR TITLE
fix(ts-oss): anchor entity substring dedup to word boundaries (#5646)

### DIFF
--- a/mem0-ts/src/oss/src/utils/entity_extraction.ts
+++ b/mem0-ts/src/oss/src/utils/entity_extraction.ts
@@ -306,6 +306,11 @@ try {
 // Internal helpers
 // ---------------------------------------------------------------------------
 
+/** Escape a string for safe interpolation into a RegExp. */
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 /** Check for formatting artifacts that indicate non-entity text. */
 function hasArtifacts(txt: string): boolean {
   if (txt.includes("**") || txt.includes("__") || txt.includes(":*")) {
@@ -700,16 +705,18 @@ export function extractEntities(text: string): ExtractedEntity[] {
   }
   const bestEntities = Array.from(best.values());
 
-  // Remove entities that are substrings of longer entities
+  // Remove entities that are whole-word substrings of longer entities.
+  // Word-boundary anchoring avoids dropping distinct entities that only share a
+  // leading substring (e.g. "Sam" must survive alongside "Samsung"), while still
+  // dropping whole-word subsets (e.g. "learning" inside "machine learning").
   const allLower = bestEntities.map((e) => e.text.toLowerCase());
-  return bestEntities.filter(
-    (entity) =>
-      !allLower.some(
-        (other) =>
-          entity.text.toLowerCase() !== other &&
-          other.includes(entity.text.toLowerCase()),
-      ),
-  );
+  return bestEntities.filter((entity) => {
+    const lower = entity.text.toLowerCase();
+    const wordBoundary = new RegExp(`\\b${escapeRegExp(lower)}\\b`);
+    return !allLower.some(
+      (other) => lower !== other && wordBoundary.test(other),
+    );
+  });
 }
 
 /**

--- a/mem0-ts/src/oss/tests/entity-extraction.dedup.test.ts
+++ b/mem0-ts/src/oss/tests/entity-extraction.dedup.test.ts
@@ -1,0 +1,36 @@
+import { extractEntities } from "../src/utils/entity_extraction";
+
+/**
+ * Regression tests for issue #5646 — the TypeScript counterpart of the Python
+ * fix in #5630. The final substring-dedup pass used an unanchored
+ * `other.includes(entity.text.toLowerCase())` check, which silently dropped any
+ * entity whose text appeared *anywhere* inside another entity — including as a
+ * mere leading substring (e.g. "Net" inside "Network"). The fix anchors the
+ * containment check to word boundaries so only whole-word subsets are removed.
+ */
+describe("entity_extraction substring dedup respects word boundaries (#5646)", () => {
+  it("keeps distinct entities that only share a leading substring (Net vs Network)", () => {
+    // Both quoted terms are extracted as separate QUOTED entities. "Net" is a
+    // mid-word substring of "Network", not a whole word, so it must survive.
+    // Before the fix the unanchored `includes` check dropped "Net".
+    const entities = extractEntities(
+      'She mentioned "Network". He mentioned "Net".',
+    );
+    const texts = entities.map((e) => e.text);
+
+    expect(texts).toContain("Net");
+    expect(texts).toContain("Network");
+  });
+
+  it("still drops whole-word subsets of longer entities", () => {
+    // "server" appears as a complete word inside the longer entity that carries
+    // "web server", so the standalone "server" should be deduplicated away.
+    const entities = extractEntities(
+      'He likes "server". She runs a "web server".',
+    );
+    const texts = entities.map((e) => e.text.toLowerCase());
+
+    expect(texts.some((t) => t.includes("web server"))).toBe(true);
+    expect(texts).not.toContain("server");
+  });
+});


### PR DESCRIPTION
## Summary

- Anchors the TypeScript graph entity-dedup substring check to word boundaries.
- Distinct entities that only share a leading substring (e.g. `"Net"` / `"Network"`, `"Sam"` / `"Samsung"`) are no longer silently dropped on the write and search paths.

## Motivation

Closes #5646.

The final dedup pass in `mem0-ts/src/oss/src/utils/entity_extraction.ts` removed entities that are substrings of longer entities using an **unanchored** check:

```ts
other.includes(entity.text.toLowerCase())
```

This drops any entity whose text appears *anywhere* inside another entity, including as a mere leading substring. With both `"Sam"` and `"Samsung"` extracted, `"Sam"` is dropped because `"samsung".includes("sam")` is `true` — a silent recall hit on both write and search. This is the TypeScript counterpart of the Python fix in #5630 (tracked here per review on that PR).

## Fix

Anchor the containment check to word boundaries with a `RegExp` (`\b<escaped>\b`), mirroring #5630. A small `escapeRegExp` helper guards quoted entities that may contain regex-special characters. Whole-word subsets (e.g. `"learning"` inside `"machine learning"`) are still removed as before.

```ts
const lower = entity.text.toLowerCase();
const wordBoundary = new RegExp(`\\b${escapeRegExp(lower)}\\b`);
return !allLower.some((other) => lower !== other && wordBoundary.test(other));
```

## Verification

- `npx jest src/oss/tests/entity-extraction.dedup.test.ts` — 2 passed
- `npx jest memory.entity-boost entity-extraction` — 6 passed (no regressions in the entity paths)
- `npx prettier --check` on both changed files — clean
- `tsc --noEmit -p tsconfig.test.json` — no new errors in the changed file (pre-existing errors only in unrelated `src/community/.../langchain/mem0.ts`)

## Real behavior proof

- **Behavior addressed:** `"Net"` was dropped whenever `"Network"` was also extracted (unanchored `includes`).
- **Real environment:** Node `v25.5.0`, jest + ts-jest, on this branch.
- **Command run after the patch:** captured via a temporary test calling `extractEntities('She mentioned "Network". He mentioned "Net".')`.
- **Captured output AFTER fix:**
  ```
  PROOF_INPUT="She mentioned \"Network\". He mentioned \"Net\"."
  PROOF_OUTPUT=["QUOTED:Network","QUOTED:Net"]
  ```
  Before the fix, the same call returns only `["QUOTED:Network"]` — `"Net"` is dropped.
- **Regression test:** `src/oss/tests/entity-extraction.dedup.test.ts` — `keeps distinct entities that only share a leading substring (Net vs Network)` asserts the new shape and **fails without the fix** (verified by reverting the source: the positive case fails with `Received array: ["Network"]`, while the whole-word-subset case still passes).
- **What was NOT tested:** the procedural/graph store wiring above this function is unchanged and out of scope; this targets the pure `extractEntities` dedup step.
