### PR TITLE
fix(cli): pass telemetry context via stdin instead of argv

### DIFF
--- a/cli/node/CHANGELOG.md
+++ b/cli/node/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to `@mem0/cli` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.9] — 2026-06-19
+
+### Security
+
+- Telemetry no longer passes the Mem0 API key to its child process via
+  command-line arguments. The context is now sent over stdin, so the key is no
+  longer visible in the process list (`ps`, `/proc/<pid>/cmdline`, Activity
+  Monitor). Fixes #4862.
+
 ## [0.2.8] — 2026-06-01
 
 ### Security

--- a/cli/node/package.json
+++ b/cli/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mem0/cli",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "The official CLI for mem0 — the memory layer for AI agents",
   "type": "module",
   "bin": {

--- a/cli/node/src/telemetry.ts
+++ b/cli/node/src/telemetry.ts
@@ -145,9 +145,6 @@ export function captureEvent(
 			anonDistinctIdToAlias: anonIdToAlias,
 		};
 
-		// Pass the context (which includes the Mem0 API key) over stdin rather
-		// than argv so the secret never appears in the process list (`ps`,
-		// /proc/<pid>/cmdline, Activity Monitor).
 		const child = spawn(process.execPath, [SENDER_SCRIPT], {
 			detached: true,
 			stdio: ["pipe", "ignore", "ignore"],

--- a/cli/node/src/telemetry.ts
+++ b/cli/node/src/telemetry.ts
@@ -145,11 +145,14 @@ export function captureEvent(
 			anonDistinctIdToAlias: anonIdToAlias,
 		};
 
-		const child = spawn(
-			process.execPath,
-			[SENDER_SCRIPT, JSON.stringify(context)],
-			{ detached: true, stdio: "ignore" },
-		);
+		// Pass the context (which includes the Mem0 API key) over stdin rather
+		// than argv so the secret never appears in the process list (`ps`,
+		// /proc/<pid>/cmdline, Activity Monitor).
+		const child = spawn(process.execPath, [SENDER_SCRIPT], {
+			detached: true,
+			stdio: ["pipe", "ignore", "ignore"],
+		});
+		child.stdin?.end(JSON.stringify(context));
 		child.unref();
 	} catch {
 		/* silently swallow */

--- a/cli/node/telemetry-sender.cjs
+++ b/cli/node/telemetry-sender.cjs
@@ -1,7 +1,8 @@
 /**
  * Standalone telemetry sender — runs as a detached child process.
  *
- * Usage: node telemetry-sender.cjs '<json context>'
+ * Usage: node telemetry-sender.cjs   (JSON context is read from stdin; a single
+ * argv argument is still accepted as a legacy fallback)
  *
  * This script is spawned by telemetry.captureEvent() and runs independently
  * of the parent CLI process. It:
@@ -18,6 +19,35 @@
 
 const https = require("https");
 const fs = require("fs");
+
+function loadContext() {
+	return new Promise((resolve, reject) => {
+		// Backward-compat: older parent processes passed the context as argv[2].
+		// The current parent always pipes it via stdin (keeps the API key out of
+		// the process list); this branch can be removed once every shipped parent
+		// uses stdin.
+		if (process.argv[2]) {
+			try {
+				resolve(JSON.parse(process.argv[2]));
+			} catch (err) {
+				reject(err);
+			}
+			return;
+		}
+
+		let data = "";
+		process.stdin.setEncoding("utf8");
+		process.stdin.on("data", (chunk) => (data += chunk));
+		process.stdin.on("end", () => {
+			try {
+				resolve(JSON.parse(data));
+			} catch (err) {
+				reject(err);
+			}
+		});
+		process.stdin.on("error", reject);
+	});
+}
 
 function httpsRequest(url, method, headers, body) {
 	return new Promise((resolve, reject) => {
@@ -108,7 +138,7 @@ async function sendIdentifyEvent(ctx, payload, anonId) {
 }
 
 async function main() {
-	const ctx = JSON.parse(process.argv[2]);
+	const ctx = await loadContext();
 	const payload = ctx.payload;
 
 	if (ctx.needsEmail && ctx.mem0ApiKey) {

--- a/cli/node/telemetry-sender.cjs
+++ b/cli/node/telemetry-sender.cjs
@@ -22,10 +22,6 @@ const fs = require("fs");
 
 function loadContext() {
 	return new Promise((resolve, reject) => {
-		// Backward-compat: older parent processes passed the context as argv[2].
-		// The current parent always pipes it via stdin (keeps the API key out of
-		// the process list); this branch can be removed once every shipped parent
-		// uses stdin.
 		if (process.argv[2]) {
 			try {
 				resolve(JSON.parse(process.argv[2]));

--- a/cli/node/tests/telemetry.test.ts
+++ b/cli/node/tests/telemetry.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockLoadConfig = vi.fn();
+const mockSaveConfig = vi.fn();
+const mockSpawn = vi.fn();
+
+vi.mock("../src/config.js", () => ({
+  CONFIG_FILE: "/tmp/mem0-config.json",
+  loadConfig: mockLoadConfig,
+  saveConfig: mockSaveConfig,
+}));
+
+vi.mock("node:child_process", () => ({
+  spawn: mockSpawn,
+}));
+
+describe("captureEvent", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockLoadConfig.mockReset();
+    mockSaveConfig.mockReset();
+    mockSpawn.mockReset();
+    delete process.env.MEM0_TELEMETRY;
+  });
+
+  it("pipes the telemetry context through stdin instead of argv", async () => {
+    mockLoadConfig.mockReturnValue({
+      platform: {
+        apiKey: "m0-node-secret",
+        baseUrl: "https://api.mem0.ai",
+        userEmail: "",
+      },
+      telemetry: {
+        anonymousId: "cli-anon-node",
+      },
+    });
+
+    const stdin = { end: vi.fn() };
+    const child = { stdin, unref: vi.fn() };
+    mockSpawn.mockReturnValue(child);
+
+    const { captureEvent } = await import("../src/telemetry.js");
+    captureEvent("node_test_event", { case: "stdin-secret" });
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    const [execPath, args, options] = mockSpawn.mock.calls[0];
+    expect(execPath).toBe(process.execPath);
+    expect(args).toHaveLength(1);
+    expect(String(args[0])).toContain("telemetry-sender.cjs");
+    expect(JSON.stringify(args)).not.toContain("m0-node-secret");
+    expect(options).toMatchObject({ detached: true, stdio: ["pipe", "ignore", "ignore"] });
+
+    expect(stdin.end).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(stdin.end.mock.calls[0][0]);
+    expect(payload.mem0ApiKey).toBe("m0-node-secret");
+    expect(payload.payload.event).toBe("node_test_event");
+    expect(child.unref).toHaveBeenCalledTimes(1);
+  });
+});

--- a/cli/python/CHANGELOG.md
+++ b/cli/python/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to `mem0-cli` (Python) are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.8] — 2026-06-19
+
+### Security
+
+- Telemetry no longer passes the Mem0 API key to its child process via
+  command-line arguments. The context is now sent over stdin, so the key is no
+  longer visible in the process list (`ps`, `/proc/<pid>/cmdline`, Activity
+  Monitor). Fixes #4862.
+
+### Fixed
+
+- `__version__` now matches the packaged version (was stale at 0.2.4).
+
 ## [0.2.7] — 2026-05-20
 
 ### Added

--- a/cli/python/pyproject.toml
+++ b/cli/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mem0-cli"
-version = "0.2.7"
+version = "0.2.8"
 description = "The official CLI for mem0 — the memory layer for AI agents"
 readme = "README.md"
 license = "Apache-2.0"

--- a/cli/python/src/mem0_cli/__init__.py
+++ b/cli/python/src/mem0_cli/__init__.py
@@ -1,3 +1,3 @@
 """mem0 CLI — the command-line interface for the mem0 memory layer."""
 
-__version__ = "0.2.4"
+__version__ = "0.2.8"

--- a/cli/python/src/mem0_cli/telemetry.py
+++ b/cli/python/src/mem0_cli/telemetry.py
@@ -137,9 +137,6 @@ def capture_event(
             "anon_distinct_id_to_alias": anon_id_to_alias,
         }
 
-        # Pass the context (which includes the Mem0 API key) over stdin rather
-        # than argv so the secret never appears in the process list (`ps`,
-        # /proc/<pid>/cmdline, Activity Monitor).
         child = subprocess.Popen(
             [sys.executable, "-m", "mem0_cli.telemetry_sender"],
             stdin=subprocess.PIPE,

--- a/cli/python/src/mem0_cli/telemetry.py
+++ b/cli/python/src/mem0_cli/telemetry.py
@@ -137,12 +137,22 @@ def capture_event(
             "anon_distinct_id_to_alias": anon_id_to_alias,
         }
 
-        subprocess.Popen(
-            [sys.executable, "-m", "mem0_cli.telemetry_sender", json.dumps(context)],
+        # Pass the context (which includes the Mem0 API key) over stdin rather
+        # than argv so the secret never appears in the process list (`ps`,
+        # /proc/<pid>/cmdline, Activity Monitor).
+        child = subprocess.Popen(
+            [sys.executable, "-m", "mem0_cli.telemetry_sender"],
+            stdin=subprocess.PIPE,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             start_new_session=True,
             close_fds=True,
+            text=True,
         )
+        if child.stdin:
+            with contextlib.suppress(Exception):
+                child.stdin.write(json.dumps(context))
+            with contextlib.suppress(Exception):
+                child.stdin.close()
     except Exception:
         pass

--- a/cli/python/src/mem0_cli/telemetry_sender.py
+++ b/cli/python/src/mem0_cli/telemetry_sender.py
@@ -22,12 +22,7 @@ import urllib.request
 
 
 def _load_context() -> dict:
-    """Load telemetry context from stdin, falling back to argv for compatibility.
-
-    The current parent pipes the context via stdin; stdin is only read when it
-    is not a TTY. The single-argv branch is a legacy fallback for a pre-stdin
-    parent — parent and child ship together, so it is rarely exercised.
-    """
+    """Load telemetry context from stdin, falling back to argv for compatibility."""
     raw = ""
     if not sys.stdin.isatty():
         raw = sys.stdin.read().strip()

--- a/cli/python/src/mem0_cli/telemetry_sender.py
+++ b/cli/python/src/mem0_cli/telemetry_sender.py
@@ -1,6 +1,7 @@
 """Standalone telemetry sender — runs as a detached subprocess.
 
-Usage: python -m mem0_cli.telemetry_sender '<json context>'
+Usage: python -m mem0_cli.telemetry_sender   (JSON context is read from stdin;
+a single argv argument is still accepted as a legacy fallback)
 
 This module is spawned by telemetry.capture_event() and runs independently
 of the parent CLI process. It:
@@ -20,8 +21,23 @@ import sys
 import urllib.request
 
 
+def _load_context() -> dict:
+    """Load telemetry context from stdin, falling back to argv for compatibility.
+
+    The current parent pipes the context via stdin; stdin is only read when it
+    is not a TTY. The single-argv branch is a legacy fallback for a pre-stdin
+    parent — parent and child ship together, so it is rarely exercised.
+    """
+    raw = ""
+    if not sys.stdin.isatty():
+        raw = sys.stdin.read().strip()
+    if not raw and len(sys.argv) > 1:
+        raw = sys.argv[1]
+    return json.loads(raw)
+
+
 def main() -> None:
-    ctx = json.loads(sys.argv[1])
+    ctx = _load_context()
     payload = ctx["payload"]
 
     if ctx.get("needs_email") and ctx.get("mem0_api_key"):

--- a/cli/python/tests/test_telemetry.py
+++ b/cli/python/tests/test_telemetry.py
@@ -1,0 +1,81 @@
+"""Tests for telemetry subprocess secret handling."""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import sys
+
+from mem0_cli.config import Mem0Config, save_config
+from mem0_cli.telemetry import capture_event
+from mem0_cli.telemetry_sender import _load_context
+
+
+class _CaptureStdin:
+    def __init__(self):
+        self.buffer = ""
+        self.closed = False
+
+    def write(self, value: str) -> None:
+        self.buffer += value
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _DummyProcess:
+    def __init__(self):
+        self.stdin = _CaptureStdin()
+
+
+def test_capture_event_writes_context_to_stdin_not_argv(isolate_config, monkeypatch):
+    config = Mem0Config()
+    config.platform.api_key = "m0-test-secret"
+    config.telemetry.anonymous_id = "cli-anon-test"
+    save_config(config)
+
+    captured: dict[str, object] = {}
+    proc = _DummyProcess()
+
+    def fake_popen(args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return proc
+
+    monkeypatch.setattr("mem0_cli.telemetry.subprocess.Popen", fake_popen)
+
+    capture_event("unit_test_event", {"case": "stdin-secret"})
+
+    argv = captured["args"]
+    assert argv == [sys.executable, "-m", "mem0_cli.telemetry_sender"]
+    assert all("m0-test-secret" not in arg for arg in argv)
+
+    kwargs = captured["kwargs"]
+    assert kwargs["stdin"] == subprocess.PIPE
+    assert kwargs["text"] is True
+
+    ctx = json.loads(proc.stdin.buffer)
+    assert ctx["mem0_api_key"] == "m0-test-secret"
+    assert ctx["payload"]["event"] == "unit_test_event"
+
+    # The pipe must be closed so the detached child receives EOF and can read.
+    assert proc.stdin.closed
+
+
+def test_load_context_reads_from_stdin(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["telemetry_sender"])
+    monkeypatch.setattr("sys.stdin", io.StringIO('{"payload": {"event": "stdin"}}'))
+
+    ctx = _load_context()
+
+    assert ctx["payload"]["event"] == "stdin"
+
+
+def test_load_context_falls_back_to_argv(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["telemetry_sender", '{"payload": {"event": "argv"}}'])
+    monkeypatch.setattr("sys.stdin", io.StringIO(""))
+
+    ctx = _load_context()
+
+    assert ctx["payload"]["event"] == "argv"

--- a/cli/python/tests/test_telemetry.py
+++ b/cli/python/tests/test_telemetry.py
@@ -59,7 +59,6 @@ def test_capture_event_writes_context_to_stdin_not_argv(isolate_config, monkeypa
     assert ctx["mem0_api_key"] == "m0-test-secret"
     assert ctx["payload"]["event"] == "unit_test_event"
 
-    # The pipe must be closed so the detached child receives EOF and can read.
     assert proc.stdin.closed
 
 


### PR DESCRIPTION
## Linked Issue

Closes #4862

## Description

Both CLI telemetry helpers spawned a detached `telemetry_sender` subprocess with the full
telemetry context — **including the live Mem0 API key** (used for the optional `/v1/ping/`
email lookup) — serialized into a JSON **command-line argument**. On Unix-like systems argv is
visible via `ps`, `/proc/<pid>/cmdline`, and Activity Monitor, so the key leaked to any local
observer for the lifetime of the sender process. It is most severe on Linux/CI/shared hosts,
where `/proc/<pid>/cmdline` is readable by any local user.

This PR moves the context out of argv and onto a **stdin pipe** that only the spawned child can
read, for **both** the Python and Node CLIs. Each sender reads its context from stdin and keeps
a single-argv legacy fallback for mixed-version rollout.

> Credit: based on @shaun0927's original implementation in #4865 (co-authored). This PR adds
> the Biome lint fix, a stronger security test assertion, a `close()` regression assertion, and
> explanatory comments — and is authored from the main repo so it can land today.

## Root cause

`cli/python/src/mem0_cli/telemetry.py` placed `context["mem0_api_key"]` into the context and
passed `json.dumps(context)` as a `subprocess.Popen` argv token; `cli/node/src/telemetry.ts`
did the same with `mem0ApiKey` inside `JSON.stringify(context)` passed to `spawn`. Because argv
is visible in the process table, the secret was exposed. Passing the context over stdin keeps
it in the kernel pipe buffer / child read buffer only — no standard process-inspection path can
see it.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

None. The senders keep a single-argv legacy fallback, so a mixed-version parent/child during an
upgrade still works.

## Test Coverage

- [x] I added/updated unit tests
- [x] I tested manually (live `ps` before/after — see below)
- [ ] I added/updated integration tests
- [ ] No tests needed

**Red → green (Python — the security assertion):**

Before the parent fix, the new test fails because the secret is still in argv:

```
tests/test_telemetry.py::test_capture_event_writes_context_to_stdin_not_argv FAILED
    assert argv == [sys.executable, "-m", "mem0_cli.telemetry_sender"]
    Left contains one more item: '{"payload": {...}, "mem0_api_key": "m0-...", ...}'
```

After the fix: `tests/test_telemetry.py ... 3 passed`.
Node, before fix: `expected [ …(2) ] to have a length of 1`; after fix: `1 passed`.
Full suites: **Python 164 passed, Node 116 passed**; Biome + ruff clean.

**Live `ps` (manual):**

- Before (on `main`): `… -m mem0_cli.telemetry_sender {"payload": …, "mem0_api_key": "m0-…SENTINEL…", …}` — key visible in argv.
- After (this branch): `… -m mem0_cli.telemetry_sender` — no JSON payload, no key in argv.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
