### PR TITLE
fix(embeddings): forward embedding_dims to Titan V2 in AWS Bedrock embedder

### DIFF
--- a/mem0/embeddings/aws_bedrock.py
+++ b/mem0/embeddings/aws_bedrock.py
@@ -70,6 +70,11 @@ class AWSBedrockEmbedding(EmbeddingBase):
         else:
             # Amazon and other providers
             input_body["inputText"] = text
+            # Titan Text Embeddings V2 accepts an optional output dimension
+            # (256/512/1024). Only forward embedding_dims when the user set it,
+            # mirroring the OpenAI embedder's guarded `dimensions` pass-through.
+            if self.config.embedding_dims is not None and "v2" in self.config.model:
+                input_body["dimensions"] = self.config.embedding_dims
 
         body = json.dumps(input_body)
 

--- a/tests/embeddings/test_aws_bedrock_embeddings.py
+++ b/tests/embeddings/test_aws_bedrock_embeddings.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import Mock, patch
 
 import pytest
@@ -58,3 +59,49 @@ def test_no_session_token_passes_none(mock_boto3_client):
 
     _, kwargs = mock_boto3_client.call_args
     assert kwargs["aws_session_token"] is None
+
+
+def _captured_request_body(mock_boto3_client, config):
+    """Run a single embed call and return the JSON body sent to invoke_model."""
+    runtime = mock_boto3_client.return_value
+    response_stream = Mock()
+    response_stream.read.return_value = json.dumps({"embedding": [0.0, 0.1, 0.2]}).encode()
+    runtime.invoke_model.return_value = {"body": response_stream}
+
+    embedder = AWSBedrockEmbedding(config)
+    embedder.embed("hello world")
+
+    _, call_kwargs = runtime.invoke_model.call_args
+    return json.loads(call_kwargs["body"])
+
+
+def test_titan_v2_forwards_embedding_dims_as_dimensions(mock_boto3_client):
+    """Titan Text Embeddings V2 must receive embedding_dims as `dimensions`.
+
+    Titan V2 supports an optional output size (256/512/1024); without forwarding
+    it the model returns its default 1024-d vector and ignores the user's request.
+    """
+    with patch("mem0.embeddings.aws_bedrock.os.environ", {}):
+        config = BaseEmbedderConfig(model="amazon.titan-embed-text-v2:0", embedding_dims=512)
+        body = _captured_request_body(mock_boto3_client, config)
+
+    assert body["dimensions"] == 512
+    assert body["inputText"] == "hello world"
+
+
+def test_titan_v2_without_embedding_dims_omits_dimensions(mock_boto3_client):
+    """When embedding_dims is unset, no `dimensions` key is sent (model default)."""
+    with patch("mem0.embeddings.aws_bedrock.os.environ", {}):
+        config = BaseEmbedderConfig(model="amazon.titan-embed-text-v2:0")
+        body = _captured_request_body(mock_boto3_client, config)
+
+    assert "dimensions" not in body
+
+
+def test_titan_v1_ignores_embedding_dims(mock_boto3_client):
+    """Titan V1 has no configurable output size, so `dimensions` must not be sent."""
+    with patch("mem0.embeddings.aws_bedrock.os.environ", {}):
+        config = BaseEmbedderConfig(model="amazon.titan-embed-text-v1", embedding_dims=512)
+        body = _captured_request_body(mock_boto3_client, config)
+
+    assert "dimensions" not in body


### PR DESCRIPTION
## Linked Issue

Closes #5670

## Description

Thanks for Mem0 and for the consistent embedder design across providers.

The AWS Bedrock embedder never reads `BaseEmbedderConfig.embedding_dims`, so a configured `embedding_dims` (e.g. `512`) was dropped for **Amazon Titan Text Embeddings V2** (`amazon.titan-embed-text-v2:0`). Titan V2 then returns its default 1024-d vector, mismatching a vector store sized for the requested dimensions.

This is framed as filling in an **already-established pattern**: the OpenAI embedder (`mem0/embeddings/openai.py`) already forwards `embedding_dims` to the API and only does so when the user set it (`embedding_dims is not None`). The Bedrock embedder was the one embedder in this family not doing it. Per AWS's Bedrock docs, Titan V2 accepts an optional `dimensions` field (256 / 512 / 1024; default 1024); Titan V1 and Cohere have no such field, so they are left untouched.

The change is one guarded branch in the existing Amazon/`else` path:

```python
input_body["inputText"] = text
if self.config.embedding_dims is not None and "v2" in self.config.model:
    input_body["dimensions"] = self.config.embedding_dims
```

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A — purely additive. The `dimensions` field is sent only for Titan V2 **and** only when `embedding_dims` is explicitly set.

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| Titan **V2** + `embedding_dims=512` | ❌ body `{"inputText": ...}` — `dimensions` missing → model returns default 1024-d | ✅ body `{"inputText": ..., "dimensions": 512}` → model returns 512-d |
| Titan **V2**, `embedding_dims` unset | `{"inputText": ...}` (model default) | ✅ unchanged — `{"inputText": ...}` (no `dimensions`) |
| Titan **V1** (`amazon.titan-embed-text-v1`), `embedding_dims=512` | `{"inputText": ...}` | ✅ unchanged — `{"inputText": ...}` (no `dimensions`; V1 has no such field) |
| Cohere path | unchanged | ✅ unchanged (not touched) |
| `aws_session_token` / region / credentials handling | — | ✅ unchanged |
| Public API / method signatures / return shape | — | ✅ unchanged |

## Test Coverage

- [x] I added/updated unit tests

Added 3 mock-based regression tests (no AWS credentials needed) to `tests/embeddings/test_aws_bedrock_embeddings.py`, alongside the existing session-token tests:

- `test_titan_v2_forwards_embedding_dims_as_dimensions` — V2 + dims → body contains `"dimensions": 512`
- `test_titan_v2_without_embedding_dims_omits_dimensions` — V2, no dims → no `dimensions` key
- `test_titan_v1_ignores_embedding_dims` — V1 + dims → no `dimensions` key

**Red/green proof** (reverting only the source, keeping the new tests):

```
$ git show upstream/main:mem0/embeddings/aws_bedrock.py > mem0/embeddings/aws_bedrock.py
$ pytest tests/embeddings/test_aws_bedrock_embeddings.py
...
>       assert body["dimensions"] == 512
E       KeyError: 'dimensions'
FAILED test_titan_v2_forwards_embedding_dims_as_dimensions
========================= 1 failed, 5 passed =========================
```

With the fix restored, all pass:

```
$ pytest tests/embeddings/test_aws_bedrock_embeddings.py -q
......                                                                   [100%]
6 passed in 0.47s
```

`ruff check`, `ruff format --check`, and `isort --profile black --check-only` are clean on both files.

## Relationship to #5564

Open PR #5564 also touches `mem0/embeddings/aws_bedrock.py` and `tests/embeddings/test_aws_bedrock_embeddings.py`, but it addresses an **orthogonal** concern: the Cohere `input_type` / `memory_action` mapping. This PR only adds a guarded branch in the Titan (`else`) path and **appends** test functions with distinct names — no overlap with #5564's Cohere changes or test functions. Happy to rebase whichever lands first.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed (N/A — no public API/doc change)

---

*This contribution was prepared with the help of an AI agent (Claude Code); a human reviewed the change, the AWS-doc rationale, and the test results before submitting.*
