### PR TITLE
fix(ts-oss): return attributedTo from get/search/getAll

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -1189,7 +1189,13 @@ export class Memory {
       }
     }
 
-    const result = { ...memoryItem, ...filters };
+    const result = {
+      ...memoryItem,
+      ...filters,
+      ...(memory.payload.attributedTo && {
+        attributedTo: memory.payload.attributedTo,
+      }),
+    };
     await this._displayFirstRunNotice("get");
     return result;
   }
@@ -1453,6 +1459,7 @@ export class Memory {
           ...(payload.user_id && { user_id: payload.user_id }),
           ...(payload.agent_id && { agent_id: payload.agent_id }),
           ...(payload.run_id && { run_id: payload.run_id }),
+          ...(payload.attributedTo && { attributedTo: payload.attributedTo }),
           ...(scored.scoreDetails && { score_details: scored.scoreDetails }),
         };
       });
@@ -1687,6 +1694,9 @@ export class Memory {
       ...(mem.payload.user_id && { user_id: mem.payload.user_id }),
       ...(mem.payload.agent_id && { agent_id: mem.payload.agent_id }),
       ...(mem.payload.run_id && { run_id: mem.payload.run_id }),
+      ...(mem.payload.attributedTo && {
+        attributedTo: mem.payload.attributedTo,
+      }),
     }));
 
     const result = { results };

--- a/mem0-ts/src/oss/src/types/index.ts
+++ b/mem0-ts/src/oss/src/types/index.ts
@@ -82,6 +82,7 @@ export interface MemoryItem {
   updatedAt?: string;
   score?: number;
   metadata?: Record<string, any>;
+  attributedTo?: string;
 }
 
 export interface SearchFilters {

--- a/mem0-ts/src/oss/tests/memory.crud.test.ts
+++ b/mem0-ts/src/oss/tests/memory.crud.test.ts
@@ -361,6 +361,45 @@ describe("Memory - search()", () => {
   });
 });
 
+// ─── attributedTo (#5666) ────────────────────────────────
+
+describe("Memory - attributedTo round-trip (#5666)", () => {
+  let memory: Memory;
+  const userId = `attributed_test_${Date.now()}`;
+  let id: string;
+
+  beforeAll(async () => {
+    memory = createMemory();
+    // The mocked LLM tags every extracted fact with attributed_to: "user".
+    const addResult: SearchResult = await memory.add("I love AI", { userId });
+    id = addResult.results[0].id;
+  });
+
+  afterAll(async () => {
+    await memory.reset();
+  });
+
+  test("get() surfaces attributedTo", async () => {
+    const item: MemoryItem | null = await memory.get(id);
+    expect(item!.attributedTo).toBe("user");
+  });
+
+  test("getAll() surfaces attributedTo", async () => {
+    const result: SearchResult = await memory.getAll({
+      filters: { user_id: userId },
+    });
+    expect(result.results[0].attributedTo).toBe("user");
+  });
+
+  test("search() surfaces attributedTo", async () => {
+    const result: SearchResult = await memory.search("AI", {
+      filters: { user_id: userId },
+    });
+    expect(result.results.length).toBeGreaterThan(0);
+    expect(result.results[0].attributedTo).toBe("user");
+  });
+});
+
 // ─── history() ───────────────────────────────────────────
 
 describe("Memory - history()", () => {


### PR DESCRIPTION
## Linked Issue

Closes #5666

## Description

`attributedTo` is written onto the payload on `add()` — the OSS extraction prompt requires an `attributed_to` field per memory (`prompts/index.ts`: "(string, required): Who this memory is about"), set onto the payload at `memory/index.ts:909`. But all three read paths (`get`, `search`, `getAll`) keep `attributedTo` in `excludedKeys` and never spread it onto the top-level result, and `MemoryItem` doesn't declare it. So a caller of the OSS `Memory` class never sees it.

Fix: spread `attributedTo` at each of the three result sites (mirroring `user_id`/`agent_id`/`run_id`), declare `attributedTo?: string` on `MemoryItem`.

TypeScript counterpart of the Python fix in #5629.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test Coverage

- [x] I added/updated unit tests

New tests in `memory.crud.test.ts` (`attributedTo round-trip (#5666)`) add a memory and assert `attributedTo` is returned by `get`, `getAll`, and `search`. Red-green verified: 3 fail without the fix, pass with it; full crud suite 26/26. `pnpm run build` and `prettier --check` pass.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed (N/A — internal behavior fix)
