### PR TITLE
feat(aws-bedrock): support injectable boto3 client/session for cross-…

### DIFF
--- a/mem0/configs/llms/aws_bedrock.py
+++ b/mem0/configs/llms/aws_bedrock.py
@@ -24,6 +24,8 @@ class AWSBedrockConfig(BaseLlmConfig):
         aws_session_token: Optional[str] = None,
         aws_profile: Optional[str] = None,
         model_kwargs: Optional[Dict[str, Any]] = None,
+        boto3_client: Optional[Any] = None,
+        boto3_session: Optional[Any] = None,
         **kwargs,
     ):
         """
@@ -42,6 +44,16 @@ class AWSBedrockConfig(BaseLlmConfig):
             aws_session_token: AWS session token for temporary credentials
             aws_profile: AWS profile name for credentials
             model_kwargs: Additional model-specific parameters
+            boto3_client: Pre-built ``boto3`` ``bedrock-runtime`` client instance.
+                When provided, it is used directly and ``_test_connection`` is skipped.
+                This is the recommended pattern for cross-account assume-role or IRSA
+                (IAM Roles for Service Accounts on EKS) deployments where overwriting the
+                global ``boto3`` session would break other AWS service calls in the process.
+            boto3_session: Pre-built ``boto3.Session`` instance.  When provided, a
+                ``bedrock-runtime`` client is derived from it via
+                ``session.client("bedrock-runtime")``.  Takes precedence over the
+                individual ``aws_access_key_id`` / ``aws_secret_access_key`` parameters
+                but is ignored when ``boto3_client`` is also supplied.
             **kwargs: Additional arguments passed to base class
         """
         super().__init__(
@@ -59,6 +71,8 @@ class AWSBedrockConfig(BaseLlmConfig):
         self.aws_session_token = aws_session_token
         self.aws_profile = aws_profile
         self.model_kwargs = model_kwargs or {}
+        self.boto3_client = boto3_client
+        self.boto3_session = boto3_session
 
     @property
     def provider(self) -> str:

--- a/mem0/llms/aws_bedrock.py
+++ b/mem0/llms/aws_bedrock.py
@@ -75,12 +75,35 @@ class AWSBedrockLLM(LLMBase):
         self._initialize_provider_settings()
 
     def _initialize_aws_client(self):
-        """Initialize AWS Bedrock client with proper credentials."""
-        try:
-            aws_config = self.config.get_aws_config()
+        """Initialize AWS Bedrock client with proper credentials.
 
-            # Create Bedrock runtime client
-            self.client = boto3.client("bedrock-runtime", **aws_config)
+        Credential precedence:
+
+        1. ``config.boto3_client`` — used as-is; ``_test_connection`` is skipped
+           because the caller is responsible for the client's validity.
+        2. ``config.boto3_session`` — a ``bedrock-runtime`` client is derived via
+           ``session.client("bedrock-runtime")``.  Recommended for cross-account
+           assume-role / IRSA setups.
+        3. Fallback — a new client is created from the AWS config parameters
+           (``aws_access_key_id``, ``aws_region``, etc.).
+        """
+        try:
+            if self.config.boto3_client is not None:
+                # Use the pre-built client directly; skip _test_connection because
+                # the caller is responsible for validating the client's credentials.
+                self.client = self.config.boto3_client
+                self.available_models = []
+                return
+
+            if self.config.boto3_session is not None:
+                # Derive a bedrock-runtime client from the provided session.
+                # This is the recommended pattern for cross-account assume-role and
+                # IRSA deployments where a custom Session already holds the correct
+                # temporary credentials.
+                self.client = self.config.boto3_session.client("bedrock-runtime")
+            else:
+                aws_config = self.config.get_aws_config()
+                self.client = boto3.client("bedrock-runtime", **aws_config)
 
             # Test connection
             self._test_connection()
@@ -104,7 +127,10 @@ class AWSBedrockLLM(LLMBase):
         """Test connection to AWS Bedrock service."""
         try:
             # List available models to test connection
-            bedrock_client = boto3.client("bedrock", **self.config.get_aws_config())
+            if self.config.boto3_session is not None:
+                bedrock_client = self.config.boto3_session.client("bedrock")
+            else:
+                bedrock_client = boto3.client("bedrock", **self.config.get_aws_config())
             response = bedrock_client.list_foundation_models()
             self.available_models = [model["modelId"] for model in response["modelSummaries"]]
 
@@ -648,7 +674,10 @@ class AWSBedrockLLM(LLMBase):
     def list_available_models(self) -> List[Dict[str, Any]]:
         """List all available models in the current region."""
         try:
-            bedrock_client = boto3.client("bedrock", **self.config.get_aws_config())
+            if self.config.boto3_session is not None:
+                bedrock_client = self.config.boto3_session.client("bedrock")
+            else:
+                bedrock_client = boto3.client("bedrock", **self.config.get_aws_config())
             response = bedrock_client.list_foundation_models()
 
             models = []

--- a/tests/llms/test_aws_bedrock.py
+++ b/tests/llms/test_aws_bedrock.py
@@ -452,3 +452,87 @@ class TestParseResponseLegacy:
         response = {"body": body}
         result = llm._parse_response(response, tools=None)
         assert result == "hello from ai21"
+
+
+# ---------------------------------------------------------------------------
+# Injectable boto3 client / session
+# ---------------------------------------------------------------------------
+
+
+class TestInjectableBoto3:
+    """Tests for boto3_client and boto3_session injection into AWSBedrockConfig / AWSBedrockLLM.
+
+    Enterprise deployments (cross-account assume-role, IRSA on EKS) often need to
+    supply a pre-built boto3 client or Session instead of relying on the global
+    boto3 credential chain.  These tests verify the full precedence behaviour.
+    """
+
+    def test_boto3_client_used_directly(self):
+        """When boto3_client is provided it must be stored on self.client without
+        calling boto3.client() and without triggering _test_connection."""
+        pre_built_client = MagicMock()
+
+        with patch("mem0.llms.aws_bedrock.boto3") as mock_b3:
+            config = AWSBedrockConfig(
+                model="anthropic.claude-3-5-sonnet-20240620-v1:0",
+                boto3_client=pre_built_client,
+            )
+            llm = AWSBedrockLLM(config)
+
+        # The pre-built client must be used as-is
+        assert llm.client is pre_built_client
+        # boto3.client() must NOT have been called (injected client bypasses it)
+        mock_b3.client.assert_not_called()
+
+    def test_boto3_client_skips_test_connection(self):
+        """When boto3_client is injected, _test_connection must NOT be called."""
+        pre_built_client = MagicMock()
+
+        with patch("mem0.llms.aws_bedrock.boto3"):
+            with patch.object(AWSBedrockLLM, "_test_connection") as mock_test:
+                config = AWSBedrockConfig(
+                    model="anthropic.claude-3-5-sonnet-20240620-v1:0",
+                    boto3_client=pre_built_client,
+                )
+                AWSBedrockLLM(config)
+
+        mock_test.assert_not_called()
+
+    def test_boto3_session_derives_runtime_client(self):
+        """When boto3_session is provided, bedrock-runtime client must be derived
+        from the session, not created via the top-level boto3.client()."""
+        mock_session = MagicMock()
+        mock_runtime_client = MagicMock()
+        mock_bedrock_client = MagicMock()
+        mock_bedrock_client.list_foundation_models.return_value = {"modelSummaries": []}
+
+        def _session_client(service):
+            if service == "bedrock-runtime":
+                return mock_runtime_client
+            return mock_bedrock_client
+
+        mock_session.client.side_effect = _session_client
+
+        with patch("mem0.llms.aws_bedrock.boto3") as mock_b3:
+            config = AWSBedrockConfig(
+                model="anthropic.claude-3-5-sonnet-20240620-v1:0",
+                boto3_session=mock_session,
+            )
+            llm = AWSBedrockLLM(config)
+
+        # bedrock-runtime client must come from the injected session
+        assert llm.client is mock_runtime_client
+        mock_session.client.assert_any_call("bedrock-runtime")
+        # top-level boto3.client() must NOT have been called for the runtime client
+        for call in mock_b3.client.call_args_list:
+            assert call.args[0] != "bedrock-runtime", (
+                "boto3.client('bedrock-runtime') must not be called when a session is injected"
+            )
+
+    def test_no_injection_falls_back_to_default_boto3(self, mock_boto3):
+        """When neither boto3_client nor boto3_session is set, the existing
+        behaviour (boto3.client called with aws config kwargs) must be preserved."""
+        llm = _make_llm("anthropic.claude-3-5-sonnet-20240620-v1:0", mock_boto3)
+
+        # The client set on llm must be the one returned by the mocked boto3.client
+        assert llm.client is mock_boto3


### PR DESCRIPTION
## Linked Issue

Closes #5682

## Description

`AWSBedrockLLM` always created its own `boto3` client internally, making it
unusable in enterprise environments that require cross-account assume-role or
IRSA (IAM Roles for Service Accounts on EKS) setups where a pre-built client
or `boto3.Session` already holds the correct temporary credentials.

This PR adds two optional params to `AWSBedrockConfig`:

- `boto3_client` — inject a pre-built `bedrock-runtime` client directly; `_test_connection` is skipped (caller is responsible for validity)
- `boto3_session` — inject a `boto3.Session`; client derived via `session.client("bedrock-runtime")`

**Credential precedence:**
1. `boto3_client` — used as-is, no internal boto3 calls made
2. `boto3_session` — client derived from session
3. Existing fallback — fully backward compatible, no behaviour change

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

Added `TestInjectableBoto3` (4 tests) in `tests/llms/test_aws_bedrock.py`:
- pre-built client used directly, `boto3.client()` never called
- `_test_connection` not called when client is injected
- session derives runtime client via `session.client("bedrock-runtime")`
- fallback behaviour preserved when neither param is provided

All 45 tests pass locally.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
