### PR TITLE
fix(notices): derive scale counts for Redis and search backends

### DIFF
--- a/mem0/memory/notices.py
+++ b/mem0/memory/notices.py
@@ -1419,6 +1419,12 @@ def _get_provider_memory_count(memory_instance) -> Optional[int]:
         col_info = getattr(vector_store, "col_info", None)
         if callable(col_info):
             collection_name = getattr(vector_store, "collection_name", None)
+            if collection_name is None:
+                schema = getattr(vector_store, "schema", None)
+                if isinstance(schema, dict):
+                    index = schema.get("index")
+                    if isinstance(index, dict):
+                        collection_name = index.get("name")
             if collection_name is not None:
                 try:
                     info = col_info(collection_name)

--- a/mem0/memory/notices.py
+++ b/mem0/memory/notices.py
@@ -1418,7 +1418,18 @@ def _get_provider_memory_count(memory_instance) -> Optional[int]:
     try:
         col_info = getattr(vector_store, "col_info", None)
         if callable(col_info):
-            return _extract_count(col_info())
+            info = col_info()
+            value = _extract_count(info)
+            if value is not None:
+                return value
+
+            client = getattr(vector_store, "client", None)
+            collection_name = getattr(vector_store, "collection_name", None)
+            client_count = (
+                getattr(client, "count", None) if client is not None and collection_name is not None else None
+            )
+            if callable(client_count):
+                return _extract_count(client_count(index=collection_name))
     except Exception:
         return None
 
@@ -1430,7 +1441,7 @@ def _extract_count(info: Any) -> Optional[int]:
         return None
 
     if isinstance(info, dict):
-        for key in ("count", "points_count", "vectors_count", "indexed_vectors_count"):
+        for key in ("count", "points_count", "vectors_count", "indexed_vectors_count", "num_docs"):
             value = _coerce_nonnegative_int(info.get(key), None)
             if value is not None:
                 return value
@@ -1445,7 +1456,7 @@ def _extract_count(info: Any) -> Optional[int]:
         except Exception:
             return None
 
-    for attr in ("count", "points_count", "vectors_count", "indexed_vectors_count"):
+    for attr in ("count", "points_count", "vectors_count", "indexed_vectors_count", "num_docs"):
         value = _coerce_nonnegative_int(getattr(info, attr, None), None)
         if value is not None:
             return value

--- a/mem0/memory/notices.py
+++ b/mem0/memory/notices.py
@@ -1418,13 +1418,19 @@ def _get_provider_memory_count(memory_instance) -> Optional[int]:
     try:
         col_info = getattr(vector_store, "col_info", None)
         if callable(col_info):
-            info = col_info()
+            collection_name = getattr(vector_store, "collection_name", None)
+            if collection_name is not None:
+                try:
+                    info = col_info(collection_name)
+                except TypeError:
+                    info = col_info()
+            else:
+                info = col_info()
             value = _extract_count(info)
             if value is not None:
                 return value
 
             client = getattr(vector_store, "client", None)
-            collection_name = getattr(vector_store, "collection_name", None)
             client_count = (
                 getattr(client, "count", None) if client is not None and collection_name is not None else None
             )

--- a/tests/memory/test_notices.py
+++ b/tests/memory/test_notices.py
@@ -1404,10 +1404,14 @@ def test_scale_threshold_provider_count_helpers_are_safe():
             return {"count": 2300}
 
     class RedisInfoStore:
+        def __init__(self):
+            self.collection_name = "test_collection"
+
         def count(self):
             raise RuntimeError("count unavailable")
 
-        def col_info(self):
+        def col_info(self, name):
+            assert name == self.collection_name
             return {"index_name": "test_collection", "num_docs": 2300}
 
     class SearchMetadataStore:
@@ -1419,7 +1423,8 @@ def test_scale_threshold_provider_count_helpers_are_safe():
         def count(self):
             raise RuntimeError("count unavailable")
 
-        def col_info(self):
+        def col_info(self, name):
+            assert name == self.collection_name
             return {"test_collection": {"settings": {"index": {}}}}
 
     memory = MagicMock()

--- a/tests/memory/test_notices.py
+++ b/tests/memory/test_notices.py
@@ -1403,6 +1403,25 @@ def test_scale_threshold_provider_count_helpers_are_safe():
         def col_info(self):
             return {"count": 2300}
 
+    class RedisInfoStore:
+        def count(self):
+            raise RuntimeError("count unavailable")
+
+        def col_info(self):
+            return {"index_name": "test_collection", "num_docs": 2300}
+
+    class SearchMetadataStore:
+        def __init__(self):
+            self.collection_name = "test_collection"
+            self.client = MagicMock()
+            self.client.count.return_value = {"count": 2400}
+
+        def count(self):
+            raise RuntimeError("count unavailable")
+
+        def col_info(self):
+            return {"test_collection": {"settings": {"index": {}}}}
+
     memory = MagicMock()
     memory.vector_store = CountStore()
     assert notices._get_provider_memory_count(memory) == 2100
@@ -1410,7 +1429,15 @@ def test_scale_threshold_provider_count_helpers_are_safe():
     memory.vector_store = FallbackStore()
     assert notices._get_provider_memory_count(memory) == 2300
 
-    assert notices._extract_count({"points_count": 2400}) == 2400
+    memory.vector_store = RedisInfoStore()
+    assert notices._get_provider_memory_count(memory) == 2300
+
+    search_store = SearchMetadataStore()
+    memory.vector_store = search_store
+    assert notices._get_provider_memory_count(memory) == 2400
+    search_store.client.count.assert_called_once_with(index="test_collection")
+
+    assert notices._extract_count({"points_count": 2500}) == 2500
     assert notices._extract_count(Info()) == 2200
     assert notices._extract_count({"count": -1}) is None
 

--- a/tests/memory/test_notices.py
+++ b/tests/memory/test_notices.py
@@ -1405,13 +1405,13 @@ def test_scale_threshold_provider_count_helpers_are_safe():
 
     class RedisInfoStore:
         def __init__(self):
-            self.collection_name = "test_collection"
+            self.schema = {"index": {"name": "test_collection"}}
 
         def count(self):
             raise RuntimeError("count unavailable")
 
         def col_info(self, name):
-            assert name == self.collection_name
+            assert name == self.schema["index"]["name"]
             return {"index_name": "test_collection", "num_docs": 2300}
 
     class SearchMetadataStore:


### PR DESCRIPTION
## Linked Issue

Closes #5678

## Summary

Scale-threshold notices could not derive collection sizes for Redis, Valkey, Elasticsearch, or OpenSearch once the helper fell through the direct `vector_store.count()` path. This change keeps the existing fast path, teaches the notices count parser to read `num_docs` payloads, reuses the Redis schema index name when `collection_name` is not exposed, and adds a notices-local fallback for Elasticsearch and OpenSearch when `col_info()` only returns index metadata.

## Root cause

`_get_provider_memory_count()` stopped after `col_info()` and immediately returned `_extract_count(col_info())`. That worked for providers with top-level `count`-style fields, but Redis and Valkey expose collection size as `num_docs`, Redis keeps its index name under `schema["index"]["name"]` instead of `collection_name`, and the Elasticsearch and OpenSearch providers currently return `client.indices.get(...)` metadata that does not include any recognized count field. As a result, the scale warning could stay silent even when the collection was already above the threshold.

## Fix

- widen `_extract_count()` to recognize `num_docs` in both dict and attribute form
- keep the existing `vector_store.count()` fast path and the existing `col_info()` attempt
- resolve the collection name from either `vector_store.collection_name` or the Redis-style `vector_store.schema["index"]["name"]` shape before calling `col_info(name)`
- if `col_info()` succeeds but does not yield a count, fall back locally to `vector_store.client.count(index=vector_store.collection_name)` when that client API is available
- keep all non-negative coercion and field parsing inside `_extract_count()`

## Scope

This PR stays inside `mem0/memory/notices.py` and `tests/memory/test_notices.py`. It does not change any provider implementation under `mem0/vector_stores/`, and it remains complementary to `#5608`, which addresses the `col_info()` interface mismatch without changing notices-side count extraction.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Test Coverage

- [x] Added or updated unit tests
- [ ] Added or updated integration tests
- [ ] Tested manually
- [ ] No tests needed

Focused local validation:

- `hatch run pytest tests/memory/test_notices.py -q`
- `hatch run ruff check mem0/memory/notices.py tests/memory/test_notices.py`
- `hatch run python -m py_compile mem0/memory/notices.py tests/memory/test_notices.py`

Additional local status:

- `hatch run ruff format --check mem0/memory/notices.py tests/memory/test_notices.py` still reports both files would be reformatted locally; that formatting cleanup is left out of this bugfix to keep the change focused
- the repo-config full-suite commands `make lint` and `make test` could not be run in this environment because `make` is not installed locally

## Breaking Changes

N/A

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review performed
- [x] Added tests that prove the fix works
- [ ] New and existing tests pass locally
- [ ] Documentation updated if needed
