### PR TITLE
fix(ts-oss): skip system messages by role in infer:false add()

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -717,7 +717,7 @@ export class Memory {
     if (!infer) {
       const returnedMemories: MemoryItem[] = [];
       for (const message of messages) {
-        if (message.content === "system") {
+        if (message.role === "system") {
           continue;
         }
         const memoryId = await this.createMemory(

--- a/mem0-ts/src/oss/tests/memory.add.test.ts
+++ b/mem0-ts/src/oss/tests/memory.add.test.ts
@@ -191,4 +191,34 @@ describe("Memory - add()", () => {
       expect.objectContaining({ event: "ADD" }),
     );
   });
+
+  // Regression: infer=false must skip system messages by ROLE, not by content.
+  // See https://github.com/mem0ai/mem0/issues/5676 — comparing message.content
+  // to "system" both (a) stored system prompts as memories and (b) dropped
+  // legitimate user messages whose content happened to equal "system".
+  test("with infer=false skips system messages by role, not content", async () => {
+    const messages = [
+      { role: "system", content: "You are a helpful assistant" },
+      { role: "user", content: "I live in Berlin" },
+    ];
+    const result: SearchResult = await memory.add(messages, {
+      userId,
+      infer: false,
+    });
+    const stored = result.results.map((r) => r.memory);
+    // System prompt must NOT be stored.
+    expect(stored).not.toContain("You are a helpful assistant");
+    // The user message must be stored.
+    expect(stored).toContain("I live in Berlin");
+  });
+
+  test("with infer=false stores a user message whose content is 'system'", async () => {
+    const messages = [{ role: "user", content: "system" }];
+    const result: SearchResult = await memory.add(messages, {
+      userId,
+      infer: false,
+    });
+    // A user message with content === "system" must NOT be skipped.
+    expect(result.results.map((r) => r.memory)).toContain("system");
+  });
 });


### PR DESCRIPTION
## Summary

- In the TS OSS SDK, `add(messages, { infer: false })` decided whether to skip a message by comparing `message.content` to `"system"` instead of `message.role`.
- User-facing impact: legitimate user messages whose content is the literal string `"system"` were silently dropped, and (defensively) system messages were only kept out by an upstream filter rather than this branch itself.

## Motivation

Closes #5676.

`addToVectorStore()`'s `infer: false` branch did:

```ts
if (message.content === "system") { continue; }   // wrong
```

The Python reference skips by role (`mem0/memory/main.py:773` → `if message_dict["role"] == "system": continue`). The content-based check has two failure modes:

1. A `{ role: "user", content: "system" }` message matches `content === "system"` and is **silently dropped**.
2. It relies on `parse_vision_messages` (which already strips `role === "system"` upstream) to keep system prompts out — the branch's own intent (skip system) was expressed against the wrong field.

## Fix

Compare `message.role === "system"`, matching the Python SDK.

```ts
if (message.role === "system") { continue; }
```

## Verification

- `npx jest src/oss/tests/memory.add.test.ts` — 13 passed
- `npx jest src/oss/tests/memory.crud.test.ts src/oss/tests/memory.add.test.ts` — 36 passed
- `npx prettier --check` on both changed files — clean

## Real behavior proof

Two regression tests added to `memory.add.test.ts`:
- `with infer=false skips system messages by role, not content`
- `with infer=false stores a user message whose content is 'system'`

Captured jest output **with the fix** (both pass):

```
✓ with infer=false skips system messages by role, not content (1 ms)
✓ with infer=false stores a user message whose content is 'system' (73 ms)
Tests:       13 passed, 13 total
```

Captured jest output **without the fix** (revert source to `message.content === "system"`):

```
✓ with infer=false skips system messages by role, not content
✕ with infer=false stores a user message whose content is 'system' (1 ms)
Tests:       1 failed, 12 passed, 13 total
```

The `content === "system"` user-message test fails without the fix and passes with it.

## What was NOT tested

The system-prompt-not-stored assertion passes on both source variants because `parse_vision_messages` already strips `role === "system"` before `addToVectorStore`. The fix is still correct (matches Python, removes reliance on an upstream filter for this branch's own intent) and the dropped-user-message case is genuinely live.
