### PR TITLE
fix: mongodb vector store list() returns nested format

### DIFF
--- a/mem0/vector_stores/mongodb.py
+++ b/mem0/vector_stores/mongodb.py
@@ -382,10 +382,10 @@ class MongoDB(VectorStoreBase):
             cursor = self.collection.find(query).limit(top_k)
             results = [OutputData(id=str(doc["_id"]), score=None, payload=doc.get("payload")) for doc in cursor]
             logger.info(f"Retrieved {len(results)} documents from collection '{self.collection_name}'.")
-            return results
+            return [results]
         except PyMongoError as e:
             logger.error(f"Error listing documents: {e}")
-            return []
+            return [[]]
 
     def reset(self):
         """Reset the index by deleting and recreating it."""

--- a/tests/vector_stores/test_mongodb.py
+++ b/tests/vector_stores/test_mongodb.py
@@ -322,9 +322,10 @@ def test_list(mongo_vector_fixture):
 
     mock_collection.find.assert_called_once_with({})
     mock_cursor.limit.assert_called_once_with(2)
-    assert len(results) == 2
-    assert results[0].id == "id1"
-    assert results[0].payload == {"key": "value1"}
+    assert len(results) == 1
+    assert len(results[0]) == 2
+    assert results[0][0].id == "id1"
+    assert results[0][0].payload == {"key": "value1"}
 
 
 def test_list_with_filters(mongo_vector_fixture):
@@ -351,9 +352,10 @@ def test_list_with_filters(mongo_vector_fixture):
     mock_cursor.limit.assert_called_once_with(2)
     
     assert len(results) == 1
-    assert results[0].payload["user_id"] == "alice"
-    assert results[0].payload["agent_id"] == "agent1"
-    assert results[0].payload["run_id"] == "run1"
+    assert len(results[0]) == 1
+    assert results[0][0].payload["user_id"] == "alice"
+    assert results[0][0].payload["agent_id"] == "agent1"
+    assert results[0][0].payload["run_id"] == "run1"
 
 
 def test_list_with_single_filter(mongo_vector_fixture):
@@ -378,7 +380,8 @@ def test_list_with_single_filter(mongo_vector_fixture):
     mock_cursor.limit.assert_called_once_with(2)
     
     assert len(results) == 1
-    assert results[0].payload["user_id"] == "alice"
+    assert len(results[0]) == 1
+    assert results[0][0].payload["user_id"] == "alice"
 
 
 def test_list_with_no_filters(mongo_vector_fixture):
@@ -397,3 +400,5 @@ def test_list_with_no_filters(mongo_vector_fixture):
     mock_cursor.limit.assert_called_once_with(2)
     
     assert len(results) == 1
+    assert len(results[0]) == 1
+    assert results[0][0].payload["key"] == "value1"


### PR DESCRIPTION
## Problem

The MongoDB vector store's `list()` method returns `List[OutputData]` (flat), while all other vector stores return `List[List[OutputData]]` (nested). This causes `delete_all()` to raise `TypeError` when iterating over the result.

## Root cause

In `mem0/vector_stores/mongodb.py` lines 384-387, the `list()` method returns:
- `return results` (flat list)
- `return []` (flat empty list on error)

Other vector stores wrap results in an extra list:
- Chroma: `return [self._parse_output(results)]`
- Pinecone: `return [results]`
- PGVector: `return [[OutputData(...) for r in results]]`

## Fix

Wrap the MongoDB results in an extra list to match the interface contract:
- Line 385: `return results` → `return [results]`
- Line 388: `return []` → `return [[]]`

## Testing

Updated existing tests in `tests/vector_stores/test_mongodb.py` to verify nested return format. All 18 MongoDB tests pass.

Fixes #5691