### PR TITLE
fix(memory): include metadata keys in add() scope filters

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -362,6 +362,14 @@ def _build_filters_and_metadata(
             suggestion="Please provide at least one identifier to scope the memory operation."
         )
 
+    # ---------- metadata scope keys ----------
+    # Merge non-entity metadata keys into query filters so add() scopes
+    # Phase 1 retrieval and session partitioning the same way search() does.
+    if input_metadata:
+        for k, v in input_metadata.items():
+            if k not in effective_query_filters and v is not None:
+                effective_query_filters[k] = v
+
     # ---------- optional actor filter ----------
     resolved_actor_id = actor_id or effective_query_filters.get("actor_id")
     if resolved_actor_id:
@@ -371,9 +379,9 @@ def _build_filters_and_metadata(
 
 
 def _build_session_scope(filters):
-    """Build deterministic session scope string from entity IDs."""
+    """Build deterministic session scope string from filter keys."""
     parts = []
-    for key in sorted(["user_id", "agent_id", "run_id"]):
+    for key in sorted(filters.keys()):
         val = filters.get(key)
         if val:
             parts.append(f"{key}={val}")
@@ -879,7 +887,7 @@ class Memory(MemoryBase):
         parsed_messages = parse_messages(messages)
 
         # Phase 1: Existing memory retrieval
-        search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
+        search_filters = {k: v for k, v in filters.items() if v}
         query_embedding = self.embedding_model.embed(parsed_messages, "search")
         existing_results = self.vector_store.search(
             query=parsed_messages,
@@ -2516,7 +2524,7 @@ class AsyncMemory(MemoryBase):
         parsed_messages = parse_messages(messages)
 
         # Phase 1: Existing memory retrieval
-        search_filters = {k: v for k, v in effective_filters.items() if k in ("user_id", "agent_id", "run_id") and v}
+        search_filters = {k: v for k, v in effective_filters.items() if v}
         query_embedding = await asyncio.to_thread(self.embedding_model.embed, parsed_messages, "search")
         existing_results = await asyncio.to_thread(
             self.vector_store.search,

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -302,8 +302,9 @@ def _build_filters_and_metadata(
     1. `base_metadata_template`: Used as a template for metadata when storing new memories.
        It includes all provided session identifier(s) and any `input_metadata`.
     2. `effective_query_filters`: Used for querying existing memories. It includes all
-       provided session identifier(s), any `input_filters`, and a resolved actor
-       identifier for targeted filtering if specified by any actor-related inputs.
+       provided session identifier(s), any `input_filters`, any promoted `input_metadata`
+       keys (for scope isolation), and a resolved actor identifier for targeted filtering
+       if specified by any actor-related inputs.
 
     Actor filtering precedence: explicit `actor_id` arg → `filters["actor_id"]`
     This resolved actor ID is used for querying but is not added to `base_metadata_template`,
@@ -888,6 +889,7 @@ class Memory(MemoryBase):
 
         # Phase 1: Existing memory retrieval
         search_filters = {k: v for k, v in filters.items() if v}
+        entity_search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
         query_embedding = self.embedding_model.embed(parsed_messages, "search")
         existing_results = self.vector_store.search(
             query=parsed_messages,
@@ -1105,7 +1107,7 @@ class Memory(MemoryBase):
                         queries=valid_texts,
                         vectors_list=valid_vectors,
                         top_k=1,
-                        filters=search_filters,
+                        filters=entity_search_filters,
                     )
 
                     # 7d: Separate into inserts vs updates
@@ -1139,7 +1141,7 @@ class Memory(MemoryBase):
                                 "data": entity_text,
                                 "entity_type": entity_type,
                                 "linked_memory_ids": sorted(memory_ids),
-                                **search_filters,
+                                **entity_search_filters,
                             })
 
                     # 7e: Single batch insert for all new entities
@@ -2525,6 +2527,7 @@ class AsyncMemory(MemoryBase):
 
         # Phase 1: Existing memory retrieval
         search_filters = {k: v for k, v in effective_filters.items() if v}
+        entity_search_filters = {k: v for k, v in effective_filters.items() if k in ("user_id", "agent_id", "run_id") and v}
         query_embedding = await asyncio.to_thread(self.embedding_model.embed, parsed_messages, "search")
         existing_results = await asyncio.to_thread(
             self.vector_store.search,
@@ -2739,7 +2742,7 @@ class AsyncMemory(MemoryBase):
                         queries=valid_texts,
                         vectors_list=valid_vectors,
                         top_k=1,
-                        filters=search_filters,
+                        filters=entity_search_filters,
                     )
 
                     # 7d: Separate into inserts vs updates
@@ -2772,7 +2775,7 @@ class AsyncMemory(MemoryBase):
                                 "data": entity_text,
                                 "entity_type": entity_type,
                                 "linked_memory_ids": sorted(memory_ids),
-                                **search_filters,
+                                **entity_search_filters,
                             })
 
                     # 7e: Batch insert new entities

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -331,8 +331,9 @@ def _build_filters_and_metadata(
        scope is set from the entity params only; identity keys in `input_metadata` are
        dropped, so freeform metadata cannot place a memory into an unrequested scope.
     2. `effective_query_filters`: Used for querying existing memories. It includes all
-       provided session identifier(s), any `input_filters`, and a resolved actor
-       identifier for targeted filtering if specified by any actor-related inputs.
+       provided session identifier(s), any `input_filters`, any promoted `input_metadata`
+       keys (for scope isolation), and a resolved actor identifier for targeted filtering
+       if specified by any actor-related inputs.
 
     Actor filtering precedence: explicit `actor_id` arg → `filters["actor_id"]`
     This resolved actor ID is used for querying but is not added to `base_metadata_template`,
@@ -930,6 +931,7 @@ class Memory(MemoryBase):
 
         # Phase 1: Existing memory retrieval
         search_filters = {k: v for k, v in filters.items() if v}
+        entity_search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
         query_embedding = self.embedding_model.embed(parsed_messages, "search")
         existing_results = self.vector_store.search(
             query=parsed_messages,
@@ -1147,7 +1149,7 @@ class Memory(MemoryBase):
                         queries=valid_texts,
                         vectors_list=valid_vectors,
                         top_k=1,
-                        filters=search_filters,
+                        filters=entity_search_filters,
                     )
 
                     # 7d: Separate into inserts vs updates
@@ -1181,7 +1183,7 @@ class Memory(MemoryBase):
                                 "data": entity_text,
                                 "entity_type": entity_type,
                                 "linked_memory_ids": sorted(memory_ids),
-                                **search_filters,
+                                **entity_search_filters,
                             })
 
                     # 7e: Single batch insert for all new entities
@@ -2591,6 +2593,7 @@ class AsyncMemory(MemoryBase):
 
         # Phase 1: Existing memory retrieval
         search_filters = {k: v for k, v in effective_filters.items() if v}
+        entity_search_filters = {k: v for k, v in effective_filters.items() if k in ("user_id", "agent_id", "run_id") and v}
         query_embedding = await asyncio.to_thread(self.embedding_model.embed, parsed_messages, "search")
         existing_results = await asyncio.to_thread(
             self.vector_store.search,
@@ -2805,7 +2808,7 @@ class AsyncMemory(MemoryBase):
                         queries=valid_texts,
                         vectors_list=valid_vectors,
                         top_k=1,
-                        filters=search_filters,
+                        filters=entity_search_filters,
                     )
 
                     # 7d: Separate into inserts vs updates
@@ -2838,7 +2841,7 @@ class AsyncMemory(MemoryBase):
                                 "data": entity_text,
                                 "entity_type": entity_type,
                                 "linked_memory_ids": sorted(memory_ids),
-                                **search_filters,
+                                **entity_search_filters,
                             })
 
                     # 7e: Batch insert new entities

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -396,6 +396,14 @@ def _build_filters_and_metadata(
             suggestion="Please provide at least one identifier to scope the memory operation."
         )
 
+    # ---------- metadata scope keys ----------
+    # Merge non-entity metadata keys into query filters so add() scopes
+    # Phase 1 retrieval and session partitioning the same way search() does.
+    if input_metadata:
+        for k, v in input_metadata.items():
+            if k not in effective_query_filters and v is not None:
+                effective_query_filters[k] = v
+
     # ---------- optional actor filter ----------
     resolved_actor_id = actor_id or effective_query_filters.get("actor_id")
     if resolved_actor_id:
@@ -410,9 +418,9 @@ def _escape_scope_value(val: Any) -> str:
 
 
 def _build_session_scope(filters):
-    """Build deterministic session scope string from entity IDs."""
+    """Build deterministic session scope string from filter keys."""
     parts = []
-    for key in sorted(["user_id", "agent_id", "run_id"]):
+    for key in sorted(filters.keys()):
         val = filters.get(key)
         if val:
             parts.append(f"{key}={_escape_scope_value(val)}")
@@ -921,7 +929,7 @@ class Memory(MemoryBase):
         parsed_messages = parse_messages(messages)
 
         # Phase 1: Existing memory retrieval
-        search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
+        search_filters = {k: v for k, v in filters.items() if v}
         query_embedding = self.embedding_model.embed(parsed_messages, "search")
         existing_results = self.vector_store.search(
             query=parsed_messages,
@@ -2582,7 +2590,7 @@ class AsyncMemory(MemoryBase):
         parsed_messages = parse_messages(messages)
 
         # Phase 1: Existing memory retrieval
-        search_filters = {k: v for k, v in effective_filters.items() if k in ("user_id", "agent_id", "run_id") and v}
+        search_filters = {k: v for k, v in effective_filters.items() if v}
         query_embedding = await asyncio.to_thread(self.embedding_model.embed, parsed_messages, "search")
         existing_results = await asyncio.to_thread(
             self.vector_store.search,

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1667,3 +1667,53 @@ class TestMetadataScopeFilters:
         assert filters_a != filters_b
         assert filters_a["app_id"] == "app-a"
         assert filters_b["app_id"] == "app-b"
+
+    @patch('mem0.utils.factory.EmbedderFactory.create')
+    @patch('mem0.utils.factory.VectorStoreFactory.create')
+    @patch('mem0.utils.factory.LlmFactory.create')
+    @patch('mem0.memory.storage.SQLiteManager')
+    def test_entity_store_uses_scope_filters_not_metadata(self, mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
+        """Entity-store search/insert must use only scope keys, not metadata like app_id."""
+        mock_embedder = MagicMock()
+        mock_embedder.embed.return_value = [0.1] * 1536
+        mock_embedder_factory.return_value = mock_embedder
+
+        mock_llm = MagicMock()
+        mock_llm.generate_response.return_value = '{"facts": [{"text": "prefers dark mode"}]}'
+        mock_llm_factory.return_value = mock_llm
+
+        mock_db = MagicMock()
+        mock_db.get_last_messages.return_value = []
+        mock_sqlite.return_value = mock_db
+
+        mock_vector_store = MagicMock()
+        mock_vector_store.search.return_value = []
+        mock_vector_store.keyword_search.return_value = None
+        mock_vector_factory.return_value = mock_vector_store
+
+        config = MemoryConfig()
+        memory = Memory(config)
+
+        mock_entity_store = MagicMock()
+        mock_entity_store.search_batch.return_value = []
+        memory._entity_store = mock_entity_store
+
+        memory.add(
+            "prefers dark mode",
+            user_id="u1",
+            metadata={"app_id": "app-a"},
+        )
+
+        if mock_entity_store.search_batch.called:
+            entity_filters = mock_entity_store.search_batch.call_args.kwargs.get("filters", {})
+            assert "app_id" not in entity_filters, (
+                f"Entity-store search should not include metadata keys but got: {entity_filters}"
+            )
+            assert entity_filters.get("user_id") == "u1"
+
+        if mock_entity_store.insert.called:
+            payloads = mock_entity_store.insert.call_args.kwargs.get("payloads", [])
+            for p in payloads:
+                assert "app_id" not in p, (
+                    f"Entity-store insert payload should not include metadata keys but got: {p}"
+                )

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1570,3 +1570,100 @@ async def test_async_procedural_memory_default_path_without_langchain(mock_llm_f
 
     assert result["results"][0]["event"] == "ADD"
     memory.llm.generate_response.assert_called_once()
+
+
+class TestMetadataScopeFilters:
+    """Tests for metadata keys flowing into add() scope filters (fixes #5121)."""
+
+    def test_build_filters_includes_metadata_keys(self):
+        from mem0.memory.main import _build_filters_and_metadata
+        meta, filters = _build_filters_and_metadata(
+            user_id="u1",
+            input_metadata={"app_id": "app-a", "tenant": "t1"},
+        )
+        assert filters["user_id"] == "u1"
+        assert filters["app_id"] == "app-a"
+        assert filters["tenant"] == "t1"
+        assert meta["app_id"] == "app-a"
+        assert meta["user_id"] == "u1"
+
+    def test_build_filters_entity_ids_not_overwritten_by_metadata(self):
+        from mem0.memory.main import _build_filters_and_metadata
+        meta, filters = _build_filters_and_metadata(
+            user_id="u1",
+            input_metadata={"user_id": "should-not-override"},
+        )
+        assert filters["user_id"] == "u1"
+
+    def test_build_filters_none_metadata_values_excluded(self):
+        from mem0.memory.main import _build_filters_and_metadata
+        _, filters = _build_filters_and_metadata(
+            user_id="u1",
+            input_metadata={"app_id": None, "tenant": "t1"},
+        )
+        assert "app_id" not in filters
+        assert filters["tenant"] == "t1"
+
+    def test_build_session_scope_includes_metadata_keys(self):
+        from mem0.memory.main import _build_session_scope
+        scope = _build_session_scope({"user_id": "u1", "app_id": "app-a"})
+        assert "app_id=app-a" in scope
+        assert "user_id=u1" in scope
+
+    def test_build_session_scope_deterministic_order(self):
+        from mem0.memory.main import _build_session_scope
+        scope_a = _build_session_scope({"user_id": "u1", "app_id": "app-a"})
+        scope_b = _build_session_scope({"app_id": "app-a", "user_id": "u1"})
+        assert scope_a == scope_b
+        assert scope_a == "app_id=app-a&user_id=u1"
+
+    def test_build_session_scope_separates_apps(self):
+        from mem0.memory.main import _build_session_scope
+        scope_a = _build_session_scope({"user_id": "u1", "app_id": "app-a"})
+        scope_b = _build_session_scope({"user_id": "u1", "app_id": "app-b"})
+        assert scope_a != scope_b
+
+    @patch('mem0.utils.factory.EmbedderFactory.create')
+    @patch('mem0.utils.factory.VectorStoreFactory.create')
+    @patch('mem0.utils.factory.LlmFactory.create')
+    @patch('mem0.memory.storage.SQLiteManager')
+    def test_add_passes_metadata_to_phase1_search(self, mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
+        mock_embedder_factory.return_value = MagicMock()
+        mock_llm = MagicMock()
+        mock_llm.generate_response.return_value = '{"facts": [{"text": "prefers dark mode"}]}'
+        mock_llm_factory.return_value = mock_llm
+        mock_db = MagicMock()
+        mock_db.get_last_messages.return_value = []
+        mock_sqlite.return_value = mock_db
+
+        mock_vector_store = MagicMock()
+        mock_vector_store.search.return_value = []
+        mock_vector_store.keyword_search.return_value = None
+        mock_vector_factory.return_value = mock_vector_store
+
+        config = MemoryConfig()
+        memory = Memory(config)
+
+        memory.add(
+            "prefers dark mode",
+            user_id="u1",
+            metadata={"app_id": "app-a"},
+        )
+
+        search_call = mock_vector_store.search.call_args
+        filters_used = search_call.kwargs.get("filters") or search_call[1].get("filters", {})
+        assert filters_used.get("app_id") == "app-a", (
+            f"Phase 1 search should include metadata app_id but got: {filters_used}"
+        )
+
+    def test_add_effective_filters_include_metadata(self):
+        from mem0.memory.main import _build_filters_and_metadata
+        _, filters_a = _build_filters_and_metadata(
+            user_id="u1", input_metadata={"app_id": "app-a"},
+        )
+        _, filters_b = _build_filters_and_metadata(
+            user_id="u1", input_metadata={"app_id": "app-b"},
+        )
+        assert filters_a != filters_b
+        assert filters_a["app_id"] == "app-a"
+        assert filters_b["app_id"] == "app-b"

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1665,3 +1665,100 @@ def test_sync_procedural_memory_empty_content_raises(
         )
 
     mock_vector_store.insert.assert_not_called()
+
+
+class TestMetadataScopeFilters:
+    """Tests for metadata keys flowing into add() scope filters (fixes #5121)."""
+
+    def test_build_filters_includes_metadata_keys(self):
+        from mem0.memory.main import _build_filters_and_metadata
+        meta, filters = _build_filters_and_metadata(
+            user_id="u1",
+            input_metadata={"app_id": "app-a", "tenant": "t1"},
+        )
+        assert filters["user_id"] == "u1"
+        assert filters["app_id"] == "app-a"
+        assert filters["tenant"] == "t1"
+        assert meta["app_id"] == "app-a"
+        assert meta["user_id"] == "u1"
+
+    def test_build_filters_entity_ids_not_overwritten_by_metadata(self):
+        from mem0.memory.main import _build_filters_and_metadata
+        meta, filters = _build_filters_and_metadata(
+            user_id="u1",
+            input_metadata={"user_id": "should-not-override"},
+        )
+        assert filters["user_id"] == "u1"
+
+    def test_build_filters_none_metadata_values_excluded(self):
+        from mem0.memory.main import _build_filters_and_metadata
+        _, filters = _build_filters_and_metadata(
+            user_id="u1",
+            input_metadata={"app_id": None, "tenant": "t1"},
+        )
+        assert "app_id" not in filters
+        assert filters["tenant"] == "t1"
+
+    def test_build_session_scope_includes_metadata_keys(self):
+        from mem0.memory.main import _build_session_scope
+        scope = _build_session_scope({"user_id": "u1", "app_id": "app-a"})
+        assert "app_id=app-a" in scope
+        assert "user_id=u1" in scope
+
+    def test_build_session_scope_deterministic_order(self):
+        from mem0.memory.main import _build_session_scope
+        scope_a = _build_session_scope({"user_id": "u1", "app_id": "app-a"})
+        scope_b = _build_session_scope({"app_id": "app-a", "user_id": "u1"})
+        assert scope_a == scope_b
+        assert scope_a == "app_id=app-a&user_id=u1"
+
+    def test_build_session_scope_separates_apps(self):
+        from mem0.memory.main import _build_session_scope
+        scope_a = _build_session_scope({"user_id": "u1", "app_id": "app-a"})
+        scope_b = _build_session_scope({"user_id": "u1", "app_id": "app-b"})
+        assert scope_a != scope_b
+
+    @patch('mem0.utils.factory.EmbedderFactory.create')
+    @patch('mem0.utils.factory.VectorStoreFactory.create')
+    @patch('mem0.utils.factory.LlmFactory.create')
+    @patch('mem0.memory.storage.SQLiteManager')
+    def test_add_passes_metadata_to_phase1_search(self, mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
+        mock_embedder_factory.return_value = MagicMock()
+        mock_llm = MagicMock()
+        mock_llm.generate_response.return_value = '{"facts": [{"text": "prefers dark mode"}]}'
+        mock_llm_factory.return_value = mock_llm
+        mock_db = MagicMock()
+        mock_db.get_last_messages.return_value = []
+        mock_sqlite.return_value = mock_db
+
+        mock_vector_store = MagicMock()
+        mock_vector_store.search.return_value = []
+        mock_vector_store.keyword_search.return_value = None
+        mock_vector_factory.return_value = mock_vector_store
+
+        config = MemoryConfig()
+        memory = Memory(config)
+
+        memory.add(
+            "prefers dark mode",
+            user_id="u1",
+            metadata={"app_id": "app-a"},
+        )
+
+        search_call = mock_vector_store.search.call_args
+        filters_used = search_call.kwargs.get("filters") or search_call[1].get("filters", {})
+        assert filters_used.get("app_id") == "app-a", (
+            f"Phase 1 search should include metadata app_id but got: {filters_used}"
+        )
+
+    def test_add_effective_filters_include_metadata(self):
+        from mem0.memory.main import _build_filters_and_metadata
+        _, filters_a = _build_filters_and_metadata(
+            user_id="u1", input_metadata={"app_id": "app-a"},
+        )
+        _, filters_b = _build_filters_and_metadata(
+            user_id="u1", input_metadata={"app_id": "app-b"},
+        )
+        assert filters_a != filters_b
+        assert filters_a["app_id"] == "app-a"
+        assert filters_b["app_id"] == "app-b"

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1762,3 +1762,53 @@ class TestMetadataScopeFilters:
         assert filters_a != filters_b
         assert filters_a["app_id"] == "app-a"
         assert filters_b["app_id"] == "app-b"
+
+    @patch('mem0.utils.factory.EmbedderFactory.create')
+    @patch('mem0.utils.factory.VectorStoreFactory.create')
+    @patch('mem0.utils.factory.LlmFactory.create')
+    @patch('mem0.memory.storage.SQLiteManager')
+    def test_entity_store_uses_scope_filters_not_metadata(self, mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
+        """Entity-store search/insert must use only scope keys, not metadata like app_id."""
+        mock_embedder = MagicMock()
+        mock_embedder.embed.return_value = [0.1] * 1536
+        mock_embedder_factory.return_value = mock_embedder
+
+        mock_llm = MagicMock()
+        mock_llm.generate_response.return_value = '{"facts": [{"text": "prefers dark mode"}]}'
+        mock_llm_factory.return_value = mock_llm
+
+        mock_db = MagicMock()
+        mock_db.get_last_messages.return_value = []
+        mock_sqlite.return_value = mock_db
+
+        mock_vector_store = MagicMock()
+        mock_vector_store.search.return_value = []
+        mock_vector_store.keyword_search.return_value = None
+        mock_vector_factory.return_value = mock_vector_store
+
+        config = MemoryConfig()
+        memory = Memory(config)
+
+        mock_entity_store = MagicMock()
+        mock_entity_store.search_batch.return_value = []
+        memory._entity_store = mock_entity_store
+
+        memory.add(
+            "prefers dark mode",
+            user_id="u1",
+            metadata={"app_id": "app-a"},
+        )
+
+        if mock_entity_store.search_batch.called:
+            entity_filters = mock_entity_store.search_batch.call_args.kwargs.get("filters", {})
+            assert "app_id" not in entity_filters, (
+                f"Entity-store search should not include metadata keys but got: {entity_filters}"
+            )
+            assert entity_filters.get("user_id") == "u1"
+
+        if mock_entity_store.insert.called:
+            payloads = mock_entity_store.insert.call_args.kwargs.get("payloads", [])
+            for p in payloads:
+                assert "app_id" not in p, (
+                    f"Entity-store insert payload should not include metadata keys but got: {p}"
+                )


### PR DESCRIPTION
## Summary

Fixes #5121

`Memory.add()` was building Phase 1 retrieval filters and SQLite session scope using only entity IDs (`user_id`/`agent_id`/`run_id`), while `Memory.search()` passes the full filter dict including metadata keys like `app_id`. This caused cross-context contamination in multi-app deployments where the same `user_id` across different apps would share the Phase 1 candidate pool and conversation history.

**Root cause:** Three layers dropped metadata keys:
1. `_build_filters_and_metadata` never merged `input_metadata` into `effective_query_filters`
2. Phase 1 `search_filters` in `_add_to_vector_store` (sync + async) explicitly whitelisted only entity IDs
3. `_build_session_scope` hardcoded iteration over `["user_id", "agent_id", "run_id"]`

**Fix:**
- Merge non-entity metadata keys into `effective_query_filters` in `_build_filters_and_metadata` (entity IDs are never overwritten)
- Remove the entity-ID-only whitelist from `search_filters` in both sync and async `_add_to_vector_store`
- Change `_build_session_scope` to iterate all filter keys instead of only the three hardcoded entity IDs

**Behavior change:** Existing deployments that never pass metadata see no difference (entity IDs still flow through identically). Deployments passing metadata keys like `app_id` now get proper scope isolation.

## Test plan

- [x] `_build_filters_and_metadata` includes metadata keys in effective_query_filters
- [x] Entity IDs in filters are not overwritten by metadata
- [x] `None`-valued metadata keys are excluded from filters
- [x] `_build_session_scope` includes metadata keys and is deterministic
- [x] Different `app_id` values produce different session scopes
- [x] `Memory.add()` passes metadata to Phase 1 `vector_store.search()`
- [x] All 408 existing memory tests pass (no regressions)