### PR TITLE
fix(core): port delete_all hardening from async to sync Memory

### DIFF
--- a/docs/changelog/sdk.mdx
+++ b/docs/changelog/sdk.mdx
@@ -7,6 +7,13 @@ mode: "wide"
 <Tabs>
 <Tab title="Python">
 
+<Update label="2026-06-21" description="Unreleased">
+
+**Bug Fixes:**
+- **Core:** Fix sync `delete_all` aborting on first error and orphaning entity records — port partial-failure handling and bulk entity-store cleanup from async ([#5529](https://github.com/mem0ai/mem0/pull/5529))
+
+</Update>
+
 <Update label="2026-06-17" description="v2.0.7">
 
 **New Features:**

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1762,7 +1762,7 @@ class Memory(MemoryBase):
         for memory in memories:
             try:
                 self._delete_memory(memory.id, skip_entity_cleanup=True)
-            except BaseException as e:
+            except Exception as e:
                 errors.append(e)
                 logger.warning("Delete error: %s", e)
 

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -597,6 +597,27 @@ class Memory(MemoryBase):
         except Exception as e:
             logger.warning(f"Entity store cleanup failed for memory_id={memory_id}: {e}")
 
+    def _bulk_clear_entity_store(self, filters):
+        """Delete all entity records matching the given scope filters.
+
+        Used by delete_all to avoid the race condition that occurs when
+        sequential _delete_memory calls each try to read-modify-write
+        the same entity rows' linked_memory_ids lists.
+        """
+        if self._entity_store is None:
+            return
+        search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
+        try:
+            listed = self.entity_store.list(filters=search_filters, top_k=10000)
+            rows = listed[0] if isinstance(listed, (list, tuple)) and listed and isinstance(listed[0], list) else listed
+            for row in rows or []:
+                try:
+                    self.entity_store.delete(vector_id=row.id)
+                except Exception as e:
+                    logger.debug(f"Bulk entity delete failed for id={row.id}: {e}")
+        except Exception as e:
+            logger.warning(f"Bulk entity store cleanup failed: {e}")
+
     def _link_entities_for_memory(self, memory_id, text, filters):
         """Extract entities from `text` and link them to `memory_id` in the
         entity store, scoped to `filters`. Simpler single-memory variant of
@@ -1736,12 +1757,23 @@ class Memory(MemoryBase):
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "sync"})
-        # delete all vector memories and reset the collections
         memories = self.vector_store.list(filters=filters)[0]
+        errors = []
         for memory in memories:
-            self._delete_memory(memory.id)
+            try:
+                self._delete_memory(memory.id, skip_entity_cleanup=True)
+            except BaseException as e:
+                errors.append(e)
+                logger.warning("Delete error: %s", e)
 
-        logger.info(f"Deleted {len(memories)} memories")
+        if self._entity_store is not None:
+            self._bulk_clear_entity_store(filters)
+
+        if errors:
+            logger.warning("Failed to delete %d out of %d memories", len(errors), len(memories))
+
+        deleted_count = len(memories) - len(errors)
+        logger.info(f"Deleted {deleted_count} memories")
 
         decay_usage_notice = detect_decay_usage_from_delete_all(len(memories))
         if decay_usage_notice:
@@ -1895,7 +1927,7 @@ class Memory(MemoryBase):
 
         return memory_id
 
-    def _delete_memory(self, memory_id, existing_memory=None):
+    def _delete_memory(self, memory_id, existing_memory=None, skip_entity_cleanup=False):
         logger.info(f"Deleting memory with {memory_id=}")
         if existing_memory is None:
             existing_memory = self.vector_store.get(vector_id=memory_id)
@@ -1921,7 +1953,8 @@ class Memory(MemoryBase):
 
         # Entity-store cleanup: strip this memory's id from any entity records
         # that linked to it. Non-fatal — the helper swallows errors.
-        self._remove_memory_from_entity_store(memory_id, session_filters)
+        if not skip_entity_cleanup:
+            self._remove_memory_from_entity_store(memory_id, session_filters)
 
         return memory_id
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -181,6 +181,8 @@ def test_delete_all(memory_instance):
     result = memory_instance.delete_all(user_id="test_user")
 
     assert memory_instance._delete_memory.call_count == 2
+    for call in memory_instance._delete_memory.call_args_list:
+        assert call.kwargs.get("skip_entity_cleanup") is True
     # Ensure the collection is NOT dropped — only matched memories should be removed
     memory_instance.vector_store.reset.assert_not_called()
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -814,6 +814,52 @@ async def test_async_delete_all_continues_on_partial_failure(mock_sqlite, mock_l
 @patch('mem0.utils.factory.EmbedderFactory.create')
 @patch('mem0.utils.factory.VectorStoreFactory.create')
 @patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.main.SQLiteManager')
+def test_sync_delete_all_continues_on_partial_failure(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    """sync delete_all must not abort when a single memory fails to delete."""
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_store = MagicMock()
+    mock_vector_factory.return_value = mock_vector_store
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory
+    config = MemoryConfig()
+    memory = Memory(config)
+
+    mem1 = MagicMock()
+    mem1.id = "mem-1"
+    mem1.payload = {"data": "one", "created_at": "2024-01-01T00:00:00+00:00", "actor_id": None, "role": None}
+    mem2 = MagicMock()
+    mem2.id = "mem-2"
+    mem2.payload = {"data": "two", "created_at": "2024-01-01T00:00:00+00:00", "actor_id": None, "role": None}
+    mem3 = MagicMock()
+    mem3.id = "mem-3"
+    mem3.payload = {"data": "three", "created_at": "2024-01-01T00:00:00+00:00", "actor_id": None, "role": None}
+
+    mock_vector_store.list.return_value = ([mem1, mem2, mem3],)
+
+    def _get_side_effect(vector_id):
+        if vector_id == "mem-2":
+            raise RuntimeError("simulated store failure")
+        return {
+            "mem-1": mem1,
+            "mem-3": mem3,
+        }.get(vector_id)
+
+    mock_vector_store.get.side_effect = _get_side_effect
+
+    result = memory.delete_all(user_id="test-user")
+
+    assert result == {"message": "Memories deleted successfully!"}
+    assert mock_vector_store.delete.call_count == 2
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
 @patch('mem0.memory.storage.SQLiteManager')
 class TestProcessMetadataFiltersMerge:
     """Regression tests for issue #3952: multiple operators on the same key must be merged."""
@@ -1303,6 +1349,58 @@ class TestAsyncDeleteAllEntityRace:
         memory._entity_store = mock_entity_store
 
         await memory.delete_all(user_id="alice")
+
+        mock_entity_store.delete.assert_called_once_with(vector_id="entity-alice")
+
+        assert mock_vector_store.delete.call_count == 2
+
+
+class TestSyncDeleteAllEntityRace:
+    """Tests for sync delete_all entity store race condition fix."""
+
+    @patch('mem0.utils.factory.EmbedderFactory.create')
+    @patch('mem0.utils.factory.VectorStoreFactory.create')
+    @patch('mem0.utils.factory.LlmFactory.create')
+    @patch('mem0.memory.main.SQLiteManager')
+    def test_sync_delete_all_bulk_clears_entity_store(
+        self, mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+    ):
+        """
+        Verify that sync delete_all bulk-clears entity records after
+        memory deletes complete, preventing read-modify-write races and
+        entity orphaning on partial failures.
+        """
+        mock_embedder_factory.return_value = MagicMock()
+        mock_llm_factory.return_value = MagicMock()
+        mock_sqlite.return_value = MagicMock()
+
+        mock_vector_store = MagicMock()
+        mem_a = MagicMock()
+        mem_a.id = "mem-a"
+        mem_a.payload = {"data": "Alice likes Python", "user_id": "alice"}
+        mem_b = MagicMock()
+        mem_b.id = "mem-b"
+        mem_b.payload = {"data": "Alice works at Acme", "user_id": "alice"}
+        mock_vector_store.list.return_value = ([mem_a, mem_b],)
+        mock_vector_store.get.side_effect = lambda vector_id: {"mem-a": mem_a, "mem-b": mem_b}[vector_id]
+        mock_vector_factory.return_value = mock_vector_store
+
+        mock_entity_store = MagicMock()
+        entity_row = MagicMock()
+        entity_row.id = "entity-alice"
+        entity_row.payload = {
+            "data": "alice",
+            "user_id": "alice",
+            "linked_memory_ids": ["mem-a", "mem-b"],
+        }
+        mock_entity_store.list.return_value = ([entity_row],)
+
+        from mem0.memory.main import Memory
+        config = MemoryConfig()
+        memory = Memory(config)
+        memory._entity_store = mock_entity_store
+
+        memory.delete_all(user_id="alice")
 
         mock_entity_store.delete.assert_called_once_with(vector_id="entity-alice")
 


### PR DESCRIPTION
## Linked Issue

Closes #5696

## Description

Ports two `delete_all()` hardening fixes from `AsyncMemory` (#5529) to sync `Memory`:

1. **Partial failure tolerance** — continue deleting remaining memories when one fails; log warnings instead of aborting mid-operation
2. **Bulk entity-store cleanup** — skip per-delete entity RMW during bulk delete; bulk-clear scoped entity records at the end to prevent orphaning and race conditions

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added:
- `test_sync_delete_all_continues_on_partial_failure`
- `TestSyncDeleteAllEntityRace.test_sync_delete_all_bulk_clears_entity_store`

Updated `test_delete_all` to assert `skip_entity_cleanup=True` is passed during bulk delete.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed