### PR TITLE
fix(chroma): wrap scalar vector_id in list for delete()

### DIFF
--- a/mem0/vector_stores/chroma.py
+++ b/mem0/vector_stores/chroma.py
@@ -169,7 +169,7 @@ class ChromaDB(VectorStoreBase):
         Args:
             vector_id (str): ID of the vector to delete.
         """
-        self.collection.delete(ids=vector_id)
+        self.collection.delete(ids=[vector_id])
 
     def update(
         self,

--- a/tests/vector_stores/test_chroma.py
+++ b/tests/vector_stores/test_chroma.py
@@ -122,7 +122,7 @@ def test_delete_vector(chromadb_instance):
 
     chromadb_instance.delete(vector_id=vector_id)
 
-    chromadb_instance.collection.delete.assert_called_once_with(ids=vector_id)
+    chromadb_instance.collection.delete.assert_called_once_with(ids=[vector_id])
 
 
 def test_update_vector(chromadb_instance):


### PR DESCRIPTION
## Summary
- `ChromaDB.delete()` passes the scalar `vector_id` string directly to `collection.delete(ids=vector_id)`. ChromaDB's API expects `ids` to be a list -- when given a bare string, it iterates over the individual characters and matches nothing, so the delete silently does nothing.
- Wraps the ID in a list: `collection.delete(ids=[vector_id])`
- Updates the existing test assertion to verify the correct list-wrapped call

## Test plan
- [x] Existing `test_delete_vector` updated to assert `ids=[vector_id]`
- [x] All 24 ChromaDB tests pass

Closes #5698