### PR TITLE
fix(milvus): wrap scalar vector_id in list for delete()

### DIFF
--- a/mem0/vector_stores/milvus.py
+++ b/mem0/vector_stores/milvus.py
@@ -262,7 +262,7 @@ class MilvusDB(VectorStoreBase):
         Args:
             vector_id (str): ID of the vector to delete.
         """
-        self.client.delete(collection_name=self.collection_name, ids=vector_id)
+        self.client.delete(collection_name=self.collection_name, ids=[vector_id])
 
     def update(self, vector_id=None, vector=None, payload=None):
         """

--- a/tests/vector_stores/test_milvus.py
+++ b/tests/vector_stores/test_milvus.py
@@ -178,7 +178,7 @@ class TestMilvusDB:
         
         mock_milvus_client.delete.assert_called_once_with(
             collection_name="test_collection",
-            ids=vector_id
+            ids=[vector_id]
         )
 
     def test_get(self, milvus_db, mock_milvus_client):


### PR DESCRIPTION
## Summary
- `MilvusDB.delete()` passes the scalar `vector_id` string directly to `client.delete(ids=vector_id)`. The pymilvus client expects `ids` as a list -- passing a scalar string causes either a crash or silent failure depending on the pymilvus version.
- Wraps the ID in a list: `client.delete(ids=[vector_id])`
- Updates the existing test assertion to verify the correct list-wrapped call

## Test plan
- [x] Existing `test_delete` updated to assert `ids=[vector_id]`
- [x] All 20 Milvus tests pass

Closes #5699