### PR TITLE
fix(milvus): guard text field in update() with _has_bm25_schema check

### DIFF
--- a/mem0/vector_stores/milvus.py
+++ b/mem0/vector_stores/milvus.py
@@ -295,10 +295,12 @@ class MilvusDB(VectorStoreBase):
             if payload is None:
                 payload = existing[0].get("metadata")
 
-        text = ""
-        if payload:
-            text = (payload.get("text_lemmatized") or payload.get("data", ""))[:65535]
-        schema = {"id": vector_id, "vectors": vector, "metadata": payload, "text": text}
+        schema = {"id": vector_id, "vectors": vector, "metadata": payload}
+        if self._has_bm25_schema:
+            text = ""
+            if payload:
+                text = (payload.get("text_lemmatized") or payload.get("data", ""))[:65535]
+            schema["text"] = text
         self.client.upsert(collection_name=self.collection_name, data=schema)
 
     def get(self, vector_id) -> Optional[OutputData]:

--- a/tests/vector_stores/test_milvus.py
+++ b/tests/vector_stores/test_milvus.py
@@ -337,10 +337,44 @@ class TestMilvusDB:
         assert '(metadata["active"] == True)' in result
         assert '(metadata["deleted"] == False)' in result
 
+    def test_update_omits_text_field_on_pre_v3_collection(self, mock_milvus_client):
+        """update() must not include 'text' for collections without BM25 schema."""
+        mock_milvus_client.has_collection.return_value = True
+        mock_milvus_client.describe_collection.return_value = {
+            "fields": [
+                {"name": "id"},
+                {"name": "vectors"},
+                {"name": "metadata"},
+            ]
+        }
+        db = MilvusDB(
+            url="http://localhost:19530",
+            token="test_token",
+            collection_name="legacy_collection",
+            embedding_model_dims=1536,
+            metric_type=MetricType.COSINE,
+            db_name="test_db",
+        )
+        assert db._has_bm25_schema is False
+
+        db.update(vector_id="id1", vector=[0.1] * 1536, payload={"data": "hello"})
+
+        upserted = mock_milvus_client.upsert.call_args[1]["data"]
+        assert "text" not in upserted
+
+    def test_update_includes_text_field_on_v3_collection(self, milvus_db, mock_milvus_client):
+        """update() must include 'text' for collections with BM25 schema."""
+        assert milvus_db._has_bm25_schema is True
+
+        milvus_db.update(vector_id="id1", vector=[0.1] * 1536, payload={"data": "hello"})
+
+        upserted = mock_milvus_client.upsert.call_args[1]["data"]
+        assert upserted["text"] == "hello"
+
     def test_collection_already_exists(self, mock_milvus_client):
         """Test that existing collection is not recreated."""
         mock_milvus_client.has_collection.return_value = True
-        
+
         MilvusDB(
             url="http://localhost:19530",
             token="test_token",
@@ -349,7 +383,7 @@ class TestMilvusDB:
             metric_type=MetricType.L2,
             db_name="test_db"
         )
-        
+
         # create_collection should not be called
         mock_milvus_client.create_collection.assert_not_called()
 


### PR DESCRIPTION
## Summary
- `MilvusDB.update()` unconditionally includes a top-level `text` field in the upsert payload. Pre-v3 collections lack the `text`/`sparse` BM25 schema fields, so the upsert is rejected by Milvus.
- `insert()` already correctly guards this with `if self._has_bm25_schema` -- this PR applies the same guard to `update()`.

## Test plan
- [x] `test_update_omits_text_field_on_pre_v3_collection` -- verifies `text` is absent when `_has_bm25_schema` is False
- [x] `test_update_includes_text_field_on_v3_collection` -- verifies `text` is present when `_has_bm25_schema` is True
- [x] All 22 Milvus tests pass

Closes #5700