### PR TITLE
fix(pinecone): return [[]] from list() error path instead of dict

### DIFF
--- a/mem0/vector_stores/pinecone.py
+++ b/mem0/vector_stores/pinecone.py
@@ -391,7 +391,7 @@ class PineconeDB(VectorStoreBase):
             return [results]
         except Exception as e:
             logger.error(f"Error listing vectors: {e}")
-            return {"points": [], "next_page_token": None}
+            return [[]]
 
     def count(self) -> int:
         """

--- a/tests/vector_stores/test_pinecone.py
+++ b/tests/vector_stores/test_pinecone.py
@@ -188,3 +188,11 @@ def test_count_with_none_vector_count(pinecone_db):
     count = pinecone_db.count()
     assert count == 0
     pinecone_db.index.describe_index_stats.assert_called_once()
+
+
+def test_list_error_returns_list_not_dict(pinecone_db):
+    """list() error path must return [[]] so callers can do result[0]."""
+    pinecone_db.index.query.side_effect = Exception("connection error")
+    result = pinecone_db.list(filters={"user_id": "alice"}, top_k=10)
+    assert isinstance(result, list)
+    assert result == [[]]


### PR DESCRIPTION
## Summary
- `PineconeDB.list()` error path returns `{"points": [], "next_page_token": None}` (a dict), while the success path returns `[results]` (a list of lists).
- Callers like `delete_all()` access `result[0]`, which crashes with `KeyError` on the dict return type.
- Changed the error path to return `[[]]` to match the success path's list-of-lists format.

## Test plan
- [x] `test_list_error_returns_list_not_dict` -- verifies error path returns a list, not a dict
- [x] All 16 Pinecone tests pass

Closes #5701