### PR TITLE
fix(pinecone): map all comparison operators in _create_filter()

### DIFF
--- a/mem0/vector_stores/pinecone.py
+++ b/mem0/vector_stores/pinecone.py
@@ -186,6 +186,17 @@ class PineconeDB(VectorStoreBase):
 
             return result
 
+    OPERATOR_MAP = {
+        "eq": "$eq",
+        "ne": "$ne",
+        "gt": "$gt",
+        "gte": "$gte",
+        "lt": "$lt",
+        "lte": "$lte",
+        "in": "$in",
+        "nin": "$nin",
+    }
+
     def _create_filter(self, filters: Optional[Dict]) -> Dict:
         """
         Create a filter dictionary from the provided filters.
@@ -196,8 +207,15 @@ class PineconeDB(VectorStoreBase):
         pinecone_filter = {}
 
         for key, value in filters.items():
-            if isinstance(value, dict) and "gte" in value and "lte" in value:
-                pinecone_filter[key] = {"$gte": value["gte"], "$lte": value["lte"]}
+            if isinstance(value, dict):
+                condition = {}
+                for op, operand in value.items():
+                    pc_op = self.OPERATOR_MAP.get(op)
+                    if pc_op:
+                        condition[pc_op] = operand
+                    else:
+                        condition[f"${op}"] = operand
+                pinecone_filter[key] = condition
             else:
                 pinecone_filter[key] = {"$eq": value}
 

--- a/tests/vector_stores/test_pinecone.py
+++ b/tests/vector_stores/test_pinecone.py
@@ -196,3 +196,28 @@ def test_list_error_returns_list_not_dict(pinecone_db):
     result = pinecone_db.list(filters={"user_id": "alice"}, top_k=10)
     assert isinstance(result, list)
     assert result == [[]]
+
+
+def test_create_filter_plain_value(pinecone_db):
+    result = pinecone_db._create_filter({"user_id": "alice"})
+    assert result == {"user_id": {"$eq": "alice"}}
+
+
+def test_create_filter_range(pinecone_db):
+    result = pinecone_db._create_filter({"age": {"gte": 18, "lte": 65}})
+    assert result == {"age": {"$gte": 18, "$lte": 65}}
+
+
+def test_create_filter_gt_operator(pinecone_db):
+    result = pinecone_db._create_filter({"score": {"gt": 0.5}})
+    assert result == {"score": {"$gt": 0.5}}
+
+
+def test_create_filter_in_operator(pinecone_db):
+    result = pinecone_db._create_filter({"status": {"in": ["active", "pending"]}})
+    assert result == {"status": {"$in": ["active", "pending"]}}
+
+
+def test_create_filter_ne_operator(pinecone_db):
+    result = pinecone_db._create_filter({"status": {"ne": "deleted"}})
+    assert result == {"status": {"$ne": "deleted"}}


### PR DESCRIPTION
## Summary
- `_create_filter()` only handled the `gte+lte` range case as a special dict path. Any other operator dict (`gt`, `lt`, `ne`, `in`, `nin`, etc.) fell through to the `else` branch and was wrapped as `$eq`, producing invalid Pinecone filters like `{"$eq": {"gt": 5}}` instead of `{"$gt": 5}`.
- Added an `OPERATOR_MAP` that maps all mem0 internal operators (`eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`) to their Pinecone `$`-prefixed equivalents.
- When `value` is a dict, each key is now individually mapped through `OPERATOR_MAP`.

## Test plan
- [x] `test_create_filter_plain_value` -- plain string produces `$eq`
- [x] `test_create_filter_range` -- `gte+lte` dict produces `$gte+$lte`
- [x] `test_create_filter_gt_operator` -- `gt` operator correctly mapped
- [x] `test_create_filter_in_operator` -- `in` operator correctly mapped
- [x] `test_create_filter_ne_operator` -- `ne` operator correctly mapped
- [x] All 20 Pinecone tests pass

Closes #5702