### PR TITLE
fix(chroma): return None instead of {} from _generate_where_clause for empty filters

### DIFF
--- a/mem0/vector_stores/chroma.py
+++ b/mem0/vector_stores/chroma.py
@@ -258,7 +258,7 @@ class ChromaDB(VectorStoreBase):
             dict[str, any]: Properly formatted where clause for ChromaDB.
         """
         if where is None:
-            return {}
+            return None
         
         def convert_condition(key: str, value: any) -> dict:
             """Convert universal filter format to ChromaDB format."""
@@ -352,7 +352,7 @@ class ChromaDB(VectorStoreBase):
         
         # Return appropriate format based on number of conditions
         if len(processed_filters) == 0:
-            return {}
+            return None
         elif len(processed_filters) == 1:
             return processed_filters[0]
         else:

--- a/tests/vector_stores/test_chroma.py
+++ b/tests/vector_stores/test_chroma.py
@@ -244,12 +244,18 @@ def test_generate_where_clause_single_filter():
 
 
 def test_generate_where_clause_no_filters():
-    """Test _generate_where_clause with no filters."""
+    """Test _generate_where_clause with no filters returns None."""
     result = ChromaDB._generate_where_clause(None)
-    assert result == {}
+    assert result is None
 
     result = ChromaDB._generate_where_clause({})
-    assert result == {}
+    assert result is None
+
+
+def test_generate_where_clause_all_wildcards_returns_none():
+    """All-wildcard filters must return None, not {}, to avoid ChromaDB ValueError."""
+    result = ChromaDB._generate_where_clause({"user_id": "*"})
+    assert result is None
 
 
 def test_generate_where_clause_non_string_values():


### PR DESCRIPTION
## Summary
- `_generate_where_clause()` returns `{}` when all filter values are wildcards or when the input is `None`/`{}`. ChromaDB rejects `where={}` with `ValueError("Expected where to have exactly one operator or expression, got 0")`.
- Changed both the `None` input path and the empty-processed-filters path to return `None` instead of `{}`. `None` means "no filter" which ChromaDB handles correctly.

## Test plan
- [x] `test_generate_where_clause_no_filters` updated to assert `is None`
- [x] `test_generate_where_clause_all_wildcards_returns_none` added
- [x] All 25 ChromaDB tests pass

Closes #5712