### PR TITLE
fix(reranker): log reranking failures instead of swallowing them silently

### DIFF
--- a/mem0/reranker/cohere_reranker.py
+++ b/mem0/reranker/cohere_reranker.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from typing import List, Dict, Any
 
@@ -8,6 +9,8 @@ try:
     COHERE_AVAILABLE = True
 except ImportError:
     COHERE_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
 
 
 class CohereReranker(BaseReranker):
@@ -78,8 +81,9 @@ class CohereReranker(BaseReranker):
                 
             return reranked_docs
 
-        except Exception:
+        except Exception as e:
             # Fallback to original order if reranking fails
+            logger.warning("Cohere reranking failed, falling back to original order: %s", e)
             for doc in documents:
                 doc['rerank_score'] = 0.0
             final_top_k = top_k or self.config.top_k

--- a/mem0/reranker/huggingface_reranker.py
+++ b/mem0/reranker/huggingface_reranker.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List, Dict, Any, Union
 import numpy as np
 
@@ -11,6 +12,8 @@ try:
     TRANSFORMERS_AVAILABLE = True
 except ImportError:
     TRANSFORMERS_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
 
 
 class HuggingFaceReranker(BaseReranker):
@@ -139,8 +142,9 @@ class HuggingFaceReranker(BaseReranker):
 
             return reranked_docs
 
-        except Exception:
+        except Exception as e:
             # Fallback to original order if reranking fails
+            logger.warning("HuggingFace reranking failed, falling back to original order: %s", e)
             for doc in documents:
                 doc['rerank_score'] = 0.0
             final_top_k = top_k or self.config.top_k

--- a/mem0/reranker/llm_reranker.py
+++ b/mem0/reranker/llm_reranker.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from typing import Any, Dict, List, Union
 
@@ -5,6 +6,8 @@ from mem0.configs.rerankers.base import BaseRerankerConfig
 from mem0.configs.rerankers.llm import LLMRerankerConfig
 from mem0.reranker.base import BaseReranker
 from mem0.utils.factory import LlmFactory
+
+logger = logging.getLogger(__name__)
 
 
 class LLMReranker(BaseReranker):
@@ -151,8 +154,9 @@ class LLMReranker(BaseReranker):
                 scored_doc['rerank_score'] = score
                 scored_docs.append(scored_doc)
 
-            except Exception:
+            except Exception as e:
                 # Fallback: assign neutral score if scoring fails
+                logger.warning("LLM reranking failed for a document, assigning neutral score: %s", e)
                 scored_doc = doc.copy()
                 scored_doc['rerank_score'] = 0.5
                 scored_docs.append(scored_doc)

--- a/mem0/reranker/sentence_transformer_reranker.py
+++ b/mem0/reranker/sentence_transformer_reranker.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List, Dict, Any, Union
 import numpy as np
 
@@ -10,6 +11,8 @@ try:
     SENTENCE_TRANSFORMERS_AVAILABLE = True
 except ImportError:
     SENTENCE_TRANSFORMERS_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
 
 
 class SentenceTransformerReranker(BaseReranker):
@@ -102,8 +105,9 @@ class SentenceTransformerReranker(BaseReranker):
                 
             return reranked_docs
 
-        except Exception:
+        except Exception as e:
             # Fallback to original order if reranking fails
+            logger.warning("SentenceTransformer reranking failed, falling back to original order: %s", e)
             for doc in documents:
                 doc['rerank_score'] = 0.0
             final_top_k = top_k or self.config.top_k

--- a/mem0/reranker/zero_entropy_reranker.py
+++ b/mem0/reranker/zero_entropy_reranker.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from typing import List, Dict, Any
 
@@ -8,6 +9,8 @@ try:
     ZERO_ENTROPY_AVAILABLE = True
 except ImportError:
     ZERO_ENTROPY_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
 
 
 class ZeroEntropyReranker(BaseReranker):
@@ -89,8 +92,9 @@ class ZeroEntropyReranker(BaseReranker):
                 
             return reranked_docs
 
-        except Exception:
+        except Exception as e:
             # Fallback to original order if reranking fails
+            logger.warning("Zero Entropy reranking failed, falling back to original order: %s", e)
             for doc in documents:
                 doc['rerank_score'] = 0.0
             final_top_k = top_k or self.config.top_k

--- a/tests/rerankers/test_reranker_failure_logging.py
+++ b/tests/rerankers/test_reranker_failure_logging.py
@@ -1,0 +1,32 @@
+"""Reranker failures must be logged, not silently swallowed.
+
+Uses the LLMReranker because it is constructible without heavy ML deps (the
+``mock_llm`` fixture stubs the LLM factory). The fix under test is shared by all
+reranker providers: the ``except`` fallback now emits a ``logger.warning`` before
+degrading to the original order / a neutral score.
+"""
+
+import logging
+
+from mem0.reranker.llm_reranker import LLMReranker
+
+
+class TestRerankerFailureLogging:
+    def test_llm_failure_is_logged_and_falls_back(self, mock_llm, caplog):
+        _factory, llm_instance = mock_llm
+        llm_instance.generate_response.side_effect = RuntimeError("upstream 500")
+
+        reranker = LLMReranker({"provider": "openai"})
+        docs = [{"memory": "alpha"}, {"memory": "beta"}]
+
+        with caplog.at_level(logging.WARNING, logger="mem0.reranker.llm_reranker"):
+            result = reranker.rerank("q", docs)
+
+        # Graceful degradation preserved: every doc still comes back, scored neutral.
+        assert len(result) == 2
+        assert all(d["rerank_score"] == 0.5 for d in result)
+
+        # The failure is no longer silent.
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings, "expected a warning to be logged on reranking failure"
+        assert "upstream 500" in caplog.text


### PR DESCRIPTION
## Linked Issue

Closes #5716

## Description

Every reranker provider wrapped its scoring in a bare `except Exception:` that **silently** degraded to the original order with `rerank_score = 0.0` (or a neutral `0.5` for the LLM reranker), with no logging. A real, fixable misconfiguration — a wrong/renamed API parameter, an auth error, a network failure, an SDK version mismatch — therefore produced unranked results that looked successful, with no way for an operator to discover the cause.

This PR captures the exception and emits a `logger.warning` in each fallback path before degrading. Graceful degradation is otherwise unchanged — results are still returned.

Affected files:
- `mem0/reranker/cohere_reranker.py`
- `mem0/reranker/huggingface_reranker.py`
- `mem0/reranker/sentence_transformer_reranker.py`
- `mem0/reranker/zero_entropy_reranker.py`
- `mem0/reranker/llm_reranker.py`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A — behavior is unchanged except that a `WARNING` is now logged when reranking fails.

## Test Coverage

- [x] I added/updated unit tests

Added `tests/rerankers/test_reranker_failure_logging.py`, which forces the LLM reranker's backend to raise and asserts (a) the warning is logged and (b) the neutral fallback is still applied. Full reranker suite: 46 passed. `ruff check` passes on changed files.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (internal utility; no public docs affected)
