### PR TITLE
fix(reranker): use sigmoid instead of min-max for HuggingFace scores

### DIFF
--- a/mem0/configs/rerankers/huggingface.py
+++ b/mem0/configs/rerankers/huggingface.py
@@ -14,4 +14,4 @@ class HuggingFaceRerankerConfig(BaseRerankerConfig):
     device: Optional[str] = Field(default=None, description="Device to run the model on ('cpu', 'cuda', etc.)")
     batch_size: int = Field(default=32, description="Batch size for processing documents")
     max_length: int = Field(default=512, description="Maximum length for tokenization")
-    normalize: bool = Field(default=True, description="Whether to normalize scores")
+    normalize: bool = Field(default=True, description="Apply sigmoid to map raw logits to [0, 1] relevance scores")

--- a/mem0/reranker/huggingface_reranker.py
+++ b/mem0/reranker/huggingface_reranker.py
@@ -113,11 +113,9 @@ class HuggingFaceReranker(BaseReranker):
 
                     scores.extend(batch_scores)
 
-            # Normalize scores if requested
+            # Map raw logits to [0, 1] via sigmoid (per-document; preserves ranking)
             if self.config.normalize:
-                scores = np.array(scores)
-                scores = (scores - scores.min()) / (scores.max() - scores.min() + 1e-8)
-                scores = scores.tolist()
+                scores = (1.0 / (1.0 + np.exp(-np.array(scores)))).tolist()
 
             # Combine documents with scores
             doc_score_pairs = list(zip(documents, scores))

--- a/tests/rerankers/test_huggingface_reranker.py
+++ b/tests/rerankers/test_huggingface_reranker.py
@@ -1,0 +1,136 @@
+"""Tests for HuggingFaceReranker score normalization."""
+
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from mem0.configs.rerankers.huggingface import HuggingFaceRerankerConfig
+
+
+def _sigmoid(x):
+    return 1.0 / (1.0 + np.exp(-x))
+
+
+class _FakeTensor:
+    def __init__(self, values):
+        self._values = np.asarray(values, dtype=np.float32)
+
+    @property
+    def ndim(self):
+        return self._values.ndim
+
+    def squeeze(self, dim=-1):
+        return _FakeTensor(self._values.squeeze())
+
+    def cpu(self):
+        return self
+
+    def numpy(self):
+        return self._values
+
+    def tolist(self):
+        return self._values.tolist()
+
+
+@pytest.fixture
+def mock_huggingface_reranker(monkeypatch):
+    """Provide a fake ``transformers`` module so HuggingFaceReranker can be constructed."""
+    fake_torch = ModuleType("torch")
+    fake_torch.cuda = SimpleNamespace(is_available=lambda: False)
+
+    class _NoGrad:
+        def __enter__(self):
+            return None
+
+        def __exit__(self, *args):
+            return False
+
+    fake_torch.no_grad = _NoGrad
+
+    fake_transformers = ModuleType("transformers")
+    fake_transformers.AutoTokenizer = MagicMock()
+    fake_transformers.AutoModelForSequenceClassification = MagicMock()
+
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+
+    import mem0.reranker.huggingface_reranker as hf_reranker
+
+    monkeypatch.setattr(hf_reranker, "torch", fake_torch, raising=False)
+    monkeypatch.setattr(hf_reranker, "TRANSFORMERS_AVAILABLE", True, raising=False)
+    return hf_reranker
+
+
+def _make_reranker(module, logits):
+    """Build a reranker whose model returns the given logits for every batch."""
+    reranker = module.HuggingFaceReranker(
+        HuggingFaceRerankerConfig(model="test-model", device="cpu", batch_size=32, normalize=True)
+    )
+
+    logits_array = np.array(logits, dtype=np.float32)
+    batch_offset = {"value": 0}
+
+    def fake_tokenizer(pairs, **kwargs):
+        batch_size = len(pairs)
+        inputs = {"input_ids": MagicMock(), "attention_mask": MagicMock(), "_batch_size": batch_size}
+        wrapper = MagicMock()
+        wrapper.to.return_value = inputs
+        return wrapper
+
+    def fake_model(**inputs):
+        batch_size = inputs.get("_batch_size", len(logits_array))
+        start = batch_offset["value"]
+        end = start + batch_size
+        batch_logits = logits_array[start:end]
+        batch_offset["value"] = end
+        return SimpleNamespace(logits=_FakeTensor(batch_logits.reshape(-1, 1)))
+
+    reranker.tokenizer = MagicMock(side_effect=fake_tokenizer)
+    reranker.model = MagicMock(side_effect=fake_model)
+    reranker.model.eval = MagicMock()
+    return reranker
+
+
+class TestHuggingFaceRerankerNormalization:
+    def test_single_document_uses_sigmoid_not_zero(self, mock_huggingface_reranker):
+        reranker = _make_reranker(mock_huggingface_reranker, [5.0])
+        docs = [{"memory": "relevant doc"}]
+
+        result = reranker.rerank("query", docs)
+
+        assert len(result) == 1
+        assert result[0]["rerank_score"] == pytest.approx(_sigmoid(5.0), rel=1e-5)
+        assert result[0]["rerank_score"] > 0.5
+
+    def test_tied_scores_use_sigmoid_not_zero(self, mock_huggingface_reranker):
+        reranker = _make_reranker(mock_huggingface_reranker, [3.0, 3.0, 3.0])
+        docs = [{"memory": f"doc{i}"} for i in range(3)]
+
+        result = reranker.rerank("query", docs)
+        expected = _sigmoid(3.0)
+
+        assert all(doc["rerank_score"] == pytest.approx(expected, rel=1e-5) for doc in result)
+        assert all(doc["rerank_score"] > 0.5 for doc in result)
+
+    def test_scores_are_absolute_not_set_relative(self, mock_huggingface_reranker):
+        """Lowest-ranked doc keeps its sigmoid score; it is not forced to 0.0."""
+        reranker = _make_reranker(mock_huggingface_reranker, [8.0, 2.0])
+        docs = [{"memory": "high"}, {"memory": "low"}]
+
+        result = reranker.rerank("query", docs)
+
+        assert result[0]["rerank_score"] == pytest.approx(_sigmoid(8.0), rel=1e-5)
+        assert result[1]["rerank_score"] == pytest.approx(_sigmoid(2.0), rel=1e-5)
+        assert result[1]["rerank_score"] > 0.0
+
+    def test_normalize_false_returns_raw_logits(self, mock_huggingface_reranker):
+        reranker = _make_reranker(mock_huggingface_reranker, [4.5])
+        reranker.config.normalize = False
+        docs = [{"memory": "doc"}]
+
+        result = reranker.rerank("query", docs)
+
+        assert result[0]["rerank_score"] == pytest.approx(4.5)


### PR DESCRIPTION
Min-max normalization forced the lowest-ranked document to 0.0 and collapsed single or tied results to ~0.0. Per-document sigmoid maps logits to [0, 1] without changing ranking order.

## Linked Issue

Closes #<!-- issue number -->

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe what breaks and the migration path. Delete this section if not applicable. -->

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

<!-- Describe how you tested this, or link to CI results. -->

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] I have updated documentation if needed
