### PR TITLE
fix(faiss): return [[]] for uninitialized index to honor list() contract

### DIFF
--- a/mem0/vector_stores/faiss.py
+++ b/mem0/vector_stores/faiss.py
@@ -603,7 +603,7 @@ class FAISS(VectorStoreBase):
             List[OutputData]: List of vectors.
         """
         if self.index is None:
-            return []
+            return [[]]
 
         results = []
         count = 0

--- a/tests/vector_stores/test_faiss.py
+++ b/tests/vector_stores/test_faiss.py
@@ -285,6 +285,20 @@ def test_list(faiss_instance):
         assert result.payload["category"] == "A"
 
 
+def test_list_uninitialized_index_returns_nested_list(faiss_instance):
+    # Regression for the List[List[OutputData]] contract: callers (e.g.
+    # Memory.delete_all) do `vector_store.list(filters=...)[0]`, so an
+    # uninitialized index must return [[]] (one level deep) and NOT a bare
+    # [], which would make result[0] raise IndexError on an empty store.
+    faiss_instance.index = None
+
+    results = faiss_instance.list()
+
+    assert results == [[]]
+    # The contract callers rely on: result[0] is the (empty) memory list.
+    assert results[0] == []
+
+
 def test_col_info(faiss_instance, mock_faiss_index):
     # Mock index attributes
     mock_faiss_index.ntotal = 5


### PR DESCRIPTION
## Summary

- `FAISS.list()` returned a bare `[]` for an uninitialized index instead of the wrapped `[[]]`, violating the `List[List[OutputData]]` contract every other vector store follows.
- Fixes `Memory.delete_all()` raising `IndexError` on a fresh/empty FAISS-backed store.

## Motivation

Closes #5724.

`FAISS.list()` returns `[results]` on its normal path but `[]` when `self.index is None`. Callers rely on the wrapped contract and index the first element:

```python
# mem0/memory/main.py — delete_all()
memories = self.vector_store.list(filters=filters)[0]
```

So on a not-yet-initialized FAISS store, `delete_all()` raises `IndexError: list index out of range` instead of cleanly deleting zero memories. This is the same `List[List[OutputData]]` contract bug class already recognized for MongoDB (#5691) and Pinecone's `list()` error path (#5701/#5706, which standardized on returning `[[]]`).

## Fix

One line: return `[[]]` on the uninitialized-index path (`mem0/vector_stores/faiss.py`), matching the wrapped contract.

## Verification

- `python -m pytest tests/vector_stores/test_faiss.py` — 31 passed (was 30 + 1 new).
- New regression test `test_list_uninitialized_index_returns_nested_list` asserts `list()` returns `[[]]` and `result[0] == []`. It **fails without the fix** (`AssertionError`, got bare `[]`) and passes with it.

## Real behavior proof

- **Behavior addressed:** `list()` on `index is None` returned `[]`, so `list(...)[0]` raised `IndexError`.
- **Real environment:** Python 3.x, repo `.venv` with `faiss-cpu`, on current `upstream/main`.
- **Captured output AFTER fix:**
  ```
  list() on uninitialized index -> [[]]
  callers do list(...)[0] -> [] (no IndexError)
  ```
- **Captured output BEFORE fix (regression test on unpatched source):**
  ```
  FAILED tests/vector_stores/test_faiss.py::test_list_uninitialized_index_returns_nested_list
  297: AssertionError
  ```
- **What was NOT tested:** no live FAISS-on-disk reload path exercised; the test sets `index = None` directly, which is the exact condition before `create_col`/load.
