### PR TITLE
fix(opensearch): return [[]] from list() error path to honor list() contract

### DIFF
--- a/mem0/vector_stores/opensearch.py
+++ b/mem0/vector_stores/opensearch.py
@@ -371,7 +371,7 @@ class OpenSearchDB(VectorStoreBase):
             return [results]  # VectorStore expects tuple/list format
         except Exception as e:
             logger.error(f"Error listing vectors: {e}", exc_info=True)
-            return []
+            return [[]]
 
     def reset(self):
         """Reset the index by deleting and recreating it."""

--- a/tests/vector_stores/test_opensearch.py
+++ b/tests/vector_stores/test_opensearch.py
@@ -247,6 +247,34 @@ class TestOpenSearchDB(unittest.TestCase):
         self.assertEqual(results[0].score, 0.8)
         self.assertEqual(results[0].payload, {"key1": "value1"})
 
+    def test_list_returns_nested_list(self):
+        mock_response = {
+            "hits": {
+                "hits": [
+                    {"_source": {"id": "id1", "payload": {"key1": "value1"}}},
+                ]
+            }
+        }
+        self.client_mock.search.return_value = mock_response
+        result = self.os_db.list(filters={"user_id": "alice"})
+        # Contract is List[List[OutputData]] so callers can do result[0].
+        self.assertIsInstance(result, list)
+        self.assertIsInstance(result[0], list)
+        self.assertEqual(len(result[0]), 1)
+        self.assertEqual(result[0][0].id, "id1")
+
+    @patch("mem0.vector_stores.opensearch.logger")
+    def test_list_error_returns_nested_empty_list(self, mock_logger):
+        """list() error path must return [[]] (not bare []) so callers can do
+        result[0]; e.g. Memory.delete_all() does list(filters=...)[0]."""
+        self.client_mock.search.side_effect = Exception("Listing failed")
+        result = self.os_db.list(filters={"user_id": "alice"})
+        self.assertEqual(result, [[]])
+        self.assertEqual(result[0], [])
+        mock_logger.error.assert_called_once()
+        call_kwargs = mock_logger.error.call_args
+        self.assertTrue(call_kwargs[1].get("exc_info"), "logger.error must be called with exc_info=True")
+
     def test_delete(self):
         mock_search_response = {"hits": {"hits": [{"_id": "doc1", "_source": {"id": "id1"}}]}}
         self.client_mock.search.return_value = mock_search_response


### PR DESCRIPTION
## Summary

- `OpenSearchDB.list()` returned a bare `[]` from its `except` path instead of the wrapped `[[]]`, violating the `List[List[OutputData]]` contract every other vector store follows.
- Fixes `Memory.delete_all()` raising `IndexError` when an OpenSearch list query fails transiently.

## Motivation

Closes #5726.

`OpenSearchDB.list()` returns `[results]` on success but `[]` in its `except` path. Callers rely on the wrapped contract and index the first element:

```python
# mem0/memory/main.py — delete_all()
memories = self.vector_store.list(filters=filters)[0]
```

So when a list query fails (transient connection/cluster error), `delete_all()` raises `IndexError: list index out of range` instead of degrading to "zero memories listed." This is the same `List[List[OutputData]]` contract bug class already recognized for MongoDB (#5691) and Pinecone's `list()` error path (#5701/#5706, which standardized on returning `[[]]`).

## Fix

One line: return `[[]]` from the `except` path (`mem0/vector_stores/opensearch.py`), matching the success path.

## Verification

- `python -m pytest tests/vector_stores/test_opensearch.py` — 22 passed (was 20 + 2 new).
- New `test_list_error_returns_nested_empty_list` asserts the error path returns `[[]]` and `result[0] == []`. It **fails without the fix** (`AssertionError`, got bare `[]`) and passes with it.
- New `test_list_returns_nested_list` confirms the success path stays `List[List[OutputData]]`.

## Real behavior proof

- **Behavior addressed:** `list()` error path returned `[]`, so `list(...)[0]` raised `IndexError`.
- **Real environment:** Python 3.x, repo `.venv` with `opensearch-py`, on current `upstream/main`.
- **Captured output AFTER fix** (client raises during `search`):
  ```
  Exception: boom
  list() on error -> [[]]
  callers do list(...)[0] -> [] (no IndexError)
  ```
- **Captured output BEFORE fix (regression test on unpatched source):**
  ```
  FAILED tests/vector_stores/test_opensearch.py::TestOpenSearchDB::test_list_error_returns_nested_empty_list
  272: AssertionError
  ```
- **What was NOT tested:** no live OpenSearch cluster exercised; the failure is simulated by making the mocked client raise, which is the exact path that previously returned `[]`.
