### PR TITLE
fix(mongodb): wrap list() return in outer list to match interface contract

### DIFF
--- a/mem0/vector_stores/mongodb.py
+++ b/mem0/vector_stores/mongodb.py
@@ -382,10 +382,10 @@ class MongoDB(VectorStoreBase):
             cursor = self.collection.find(query).limit(top_k)
             results = [OutputData(id=str(doc["_id"]), score=None, payload=doc.get("payload")) for doc in cursor]
             logger.info(f"Retrieved {len(results)} documents from collection '{self.collection_name}'.")
-            return results
+            return [results]
         except PyMongoError as e:
             logger.error(f"Error listing documents: {e}")
-            return []
+            return [[]]
 
     def reset(self):
         """Reset the index by deleting and recreating it."""

--- a/tests/vector_stores/test_mongodb.py
+++ b/tests/vector_stores/test_mongodb.py
@@ -322,9 +322,10 @@ def test_list(mongo_vector_fixture):
 
     mock_collection.find.assert_called_once_with({})
     mock_cursor.limit.assert_called_once_with(2)
-    assert len(results) == 2
-    assert results[0].id == "id1"
-    assert results[0].payload == {"key": "value1"}
+    assert len(results) == 1
+    assert len(results[0]) == 2
+    assert results[0][0].id == "id1"
+    assert results[0][0].payload == {"key": "value1"}
 
 
 def test_list_with_filters(mongo_vector_fixture):
@@ -338,7 +339,7 @@ def test_list_with_filters(mongo_vector_fixture):
 
     filters = {"user_id": "alice", "agent_id": "agent1", "run_id": "run1"}
     results = mongo_vector.list(filters=filters, top_k=2)
-    
+
     # Verify that the find method was called with the correct query
     expected_query = {
         "$and": [
@@ -349,11 +350,12 @@ def test_list_with_filters(mongo_vector_fixture):
     }
     mock_collection.find.assert_called_once_with(expected_query)
     mock_cursor.limit.assert_called_once_with(2)
-    
+
     assert len(results) == 1
-    assert results[0].payload["user_id"] == "alice"
-    assert results[0].payload["agent_id"] == "agent1"
-    assert results[0].payload["run_id"] == "run1"
+    assert len(results[0]) == 1
+    assert results[0][0].payload["user_id"] == "alice"
+    assert results[0][0].payload["agent_id"] == "agent1"
+    assert results[0][0].payload["run_id"] == "run1"
 
 
 def test_list_with_single_filter(mongo_vector_fixture):
@@ -367,7 +369,7 @@ def test_list_with_single_filter(mongo_vector_fixture):
 
     filters = {"user_id": "alice"}
     results = mongo_vector.list(filters=filters, top_k=2)
-    
+
     # Verify that the find method was called with the correct query
     expected_query = {
         "$and": [
@@ -376,9 +378,10 @@ def test_list_with_single_filter(mongo_vector_fixture):
     }
     mock_collection.find.assert_called_once_with(expected_query)
     mock_cursor.limit.assert_called_once_with(2)
-    
+
     assert len(results) == 1
-    assert results[0].payload["user_id"] == "alice"
+    assert len(results[0]) == 1
+    assert results[0][0].payload["user_id"] == "alice"
 
 
 def test_list_with_no_filters(mongo_vector_fixture):
@@ -391,9 +394,10 @@ def test_list_with_no_filters(mongo_vector_fixture):
     ]
 
     results = mongo_vector.list(filters=None, top_k=2)
-    
+
     # Verify that the find method was called with empty query
     mock_collection.find.assert_called_once_with({})
     mock_cursor.limit.assert_called_once_with(2)
-    
+
     assert len(results) == 1
+    assert len(results[0]) == 1


### PR DESCRIPTION
## Summary

- `MongoDB.list()` returned a flat list of `OutputData` objects instead of wrapping in an outer list like every other vector store implementation
- This breaks `Memory.delete_all()` and `AsyncMemory.delete_all()` which index with `[0]` expecting the inner list -- MongoDB users only get the first memory deleted instead of all matching
- Error path also returned `[]` instead of `[[]]`

## Changes

- `mem0/vector_stores/mongodb.py`: `return results` -> `return [results]`, `return []` -> `return [[]]`
- Updated test assertions to validate the nested return format

## Test plan

- [x] All 18 existing MongoDB vector store tests pass with updated assertions
- [x] `ruff check` clean

Fixes #5691