### PR TITLE
fix(core): validate and trim entity IDs in delete_all()

### DIFF
--- a/docs/changelog/sdk.mdx
+++ b/docs/changelog/sdk.mdx
@@ -7,6 +7,13 @@ mode: "wide"
 <Tabs>
 <Tab title="Python">
 
+<Update label="2026-06-21" description="Unreleased">
+
+**Bug Fixes:**
+- **Core:** Apply entity ID validation and trimming to `delete_all()` / `deleteAll()` in Python and TypeScript OSS, matching `add()`, `search()`, and `get_all()` ([#4843](https://github.com/mem0ai/mem0/pull/4843))
+
+</Update>
+
 <Update label="2026-06-17" description="v2.0.7">
 
 **New Features:**

--- a/docs/changelog/sdk.mdx
+++ b/docs/changelog/sdk.mdx
@@ -7,13 +7,6 @@ mode: "wide"
 <Tabs>
 <Tab title="Python">
 
-<Update label="2026-06-21" description="Unreleased">
-
-**Bug Fixes:**
-- **Core:** Apply entity ID validation and trimming to `delete_all()` / `deleteAll()` in Python and TypeScript OSS, matching `add()`, `search()`, and `get_all()` ([#4843](https://github.com/mem0ai/mem0/pull/4843))
-
-</Update>
-
 <Update label="2026-06-17" description="v2.0.7">
 
 **New Features:**

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -1532,7 +1532,9 @@ export class Memory {
       has_agent_id: !!config.agentId,
       has_run_id: !!config.runId,
     });
-    const { userId, agentId, runId } = config;
+    const userId = validateAndTrimEntityId(config.userId, "userId");
+    const agentId = validateAndTrimEntityId(config.agentId, "agentId");
+    const runId = validateAndTrimEntityId(config.runId, "runId");
 
     // Convert camelCase entity params to snake_case for filters (matches storage and search/getAll)
     const filters: SearchFilters = {};

--- a/mem0-ts/src/oss/tests/memory.validation.test.ts
+++ b/mem0-ts/src/oss/tests/memory.validation.test.ts
@@ -314,4 +314,27 @@ describe("Memory Input Validation", () => {
       expect(result.results).toBeDefined();
     });
   });
+
+  describe("deleteAll() entity ID validation", () => {
+    it("should throw error when userId is whitespace-only", async () => {
+      await expect(memory.deleteAll({ userId: "   " })).rejects.toThrow(
+        "Invalid userId",
+      );
+    });
+
+    it("should throw error when userId contains internal whitespace", async () => {
+      await expect(memory.deleteAll({ userId: "user 123" })).rejects.toThrow(
+        "Invalid userId: cannot contain whitespace",
+      );
+    });
+
+    it("should trim userId before listing memories", async () => {
+      const listSpy = jest.spyOn(memory["vectorStore"], "list");
+      listSpy.mockResolvedValue([[], null]);
+
+      await memory.deleteAll({ userId: "  alice  " });
+
+      expect(listSpy).toHaveBeenCalledWith({ user_id: "alice" });
+    });
+  });
 });

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1721,6 +1721,10 @@ class Memory(MemoryBase):
             agent_id (str, optional): ID of the agent to delete memories for. Defaults to None.
             run_id (str, optional): ID of the run to delete memories for. Defaults to None.
         """
+        user_id = _validate_and_trim_entity_id(user_id, "user_id")
+        agent_id = _validate_and_trim_entity_id(agent_id, "agent_id")
+        run_id = _validate_and_trim_entity_id(run_id, "run_id")
+
         filters: Dict[str, Any] = {}
         if user_id:
             filters["user_id"] = user_id
@@ -3256,6 +3260,10 @@ class AsyncMemory(MemoryBase):
             agent_id (str, optional): ID of the agent to delete memories for. Defaults to None.
             run_id (str, optional): ID of the run to delete memories for. Defaults to None.
         """
+        user_id = _validate_and_trim_entity_id(user_id, "user_id")
+        agent_id = _validate_and_trim_entity_id(agent_id, "agent_id")
+        run_id = _validate_and_trim_entity_id(run_id, "run_id")
+
         filters = {}
         if user_id:
             filters["user_id"] = user_id

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -286,6 +286,24 @@ class TestEntityIdValidation:
         with pytest.raises(ValueError, match="Invalid user_id.*cannot contain whitespace"):
             memory_instance.add("test message", user_id="user 123")
 
+    def test_delete_all_rejects_whitespace_only_user_id(self, memory_instance):
+        """delete_all should reject whitespace-only user_id."""
+        with pytest.raises(ValueError, match="Invalid user_id.*cannot be empty"):
+            memory_instance.delete_all(user_id="   ")
+
+    def test_delete_all_rejects_internal_whitespace_user_id(self, memory_instance):
+        """delete_all should reject user_id with internal whitespace."""
+        with pytest.raises(ValueError, match="Invalid user_id.*cannot contain whitespace"):
+            memory_instance.delete_all(user_id="user 123")
+
+    def test_delete_all_trims_user_id_before_list(self, memory_instance):
+        """delete_all should trim leading/trailing whitespace on entity IDs."""
+        memory_instance.vector_store.list = Mock(return_value=([], None))
+
+        memory_instance.delete_all(user_id="  alice  ")
+
+        memory_instance.vector_store.list.assert_called_once_with(filters={"user_id": "alice"})
+
 
 class TestSearchParamValidation:
     """Tests for search parameter validation (threshold and top_k)."""


### PR DESCRIPTION
## Linked Issue

Closes #5734

## Description

Completes the entity ID validation rollout from #4843 by applying `_validate_and_trim_entity_id()` / `validateAndTrimEntityId()` to `delete_all()` in:

- Python sync `Memory`
- Python async `AsyncMemory`
- TypeScript OSS `Memory.deleteAll()`

Without this, padded or invalid entity IDs cause silent no-op bulk deletes while returning success.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A — invalid IDs now raise `ValueError`/`Error` consistently with other methods.

## Test Coverage

- [x] I added/updated unit tests

Python: `TestEntityIdValidation` — reject whitespace-only/internal whitespace, trim padded IDs before `list()`.

TypeScript: `deleteAll() entity ID validation` describe block in `memory.validation.test.ts`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed

