### PR TITLE
fix(server): make GET /entities resilient to naive timestamps (500 on mixed tz)

### DIFF
--- a/server/routers/entities.py
+++ b/server/routers/entities.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Literal, Optional
 
 from auth import require_admin, verify_auth
@@ -35,9 +35,12 @@ def _parse_timestamp(value: Any) -> Optional[datetime]:
     if not value:
         return None
     try:
-        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        dt = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
     except ValueError:
         return None
+    # Normalize to tz-aware UTC so naive timestamps don't raise when compared
+    # against tz-aware ones in list_entities().
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
 
 
 @router.get("", response_model=list[Entity])


### PR DESCRIPTION
## Problem

`GET /entities` returns **500 Internal Server Error** once an entity owns memories with a mix of timezone-aware and timezone-naive `created_at`/`updated_at` values.

`_parse_timestamp()` returns:

```python
return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
```

For values without a timezone (e.g. `"2026-06-21T00:33:15.976797"`) this yields a **naive** datetime, while `"...+00:00"` values yield **aware** ones. `list_entities()` then compares them:

```python
if created and (bucket["created_at"] is None or created < bucket["created_at"]):
```

Mixing the two raises `TypeError: can't compare offset-naive and offset-aware datetimes`, surfaced as a 500. This happens in practice when an entity accumulates both LLM-extracted memories and `infer=False` writes (their stored timestamp formats differ).

**Traceback (self-hosted server):**
```
File "/app/routers/entities.py", line 59, in list_entities
    if created and (bucket["created_at"] is None or created < bucket["created_at"]):
TypeError: can't compare offset-naive and offset-aware datetimes
```

## Fix

Normalize parsed timestamps to tz-aware UTC in `_parse_timestamp()`, so every comparison in `list_entities()` is between aware datetimes. Minimal, no API change.

## Test plan
- Store memories for one `user_id` such that some payloads have tz-aware and some tz-naive `created_at`; `GET /entities` returned 500 before, returns 200 after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
