### PR TITLE
fix(pinecone): translate all metadata filter operators, not only gte+lte ranges

### DIFF
--- a/mem0/vector_stores/pinecone.py
+++ b/mem0/vector_stores/pinecone.py
@@ -195,9 +195,27 @@ class PineconeDB(VectorStoreBase):
 
         pinecone_filter = {}
 
+        # Map the universal operators emitted by Memory._process_metadata_filters
+        # to Pinecone's filter syntax (see the sibling translation in
+        # ChromaDB._generate_where_clause / Qdrant._build_field_condition).
+        operator_map = {
+            "eq": "$eq",
+            "ne": "$ne",
+            "gt": "$gt",
+            "gte": "$gte",
+            "lt": "$lt",
+            "lte": "$lte",
+            "in": "$in",
+            "nin": "$nin",
+        }
+
         for key, value in filters.items():
-            if isinstance(value, dict) and "gte" in value and "lte" in value:
-                pinecone_filter[key] = {"$gte": value["gte"], "$lte": value["lte"]}
+            if isinstance(value, dict):
+                # An operator dict such as {"gte": 5}, {"in": [...]} or a closed
+                # range {"gte": 5, "lte": 10}. Translate every operator (Pinecone
+                # has no substring match, so contains/icontains fall back to
+                # equality, matching the ChromaDB sibling).
+                pinecone_filter[key] = {operator_map.get(op, "$eq"): val for op, val in value.items()}
             else:
                 pinecone_filter[key] = {"$eq": value}
 

--- a/tests/vector_stores/test_pinecone.py
+++ b/tests/vector_stores/test_pinecone.py
@@ -188,3 +188,25 @@ def test_count_with_none_vector_count(pinecone_db):
     count = pinecone_db.count()
     assert count == 0
     pinecone_db.index.describe_index_stats.assert_called_once()
+
+
+def test_create_filter_translates_all_operators(pinecone_db):
+    """Operator dicts must map to Pinecone operators, not be wrapped as a value.
+
+    Regression test: ``_create_filter`` previously only handled a closed
+    ``{"gte": ..., "lte": ...}`` range and wrapped every other operator dict as
+    ``{"$eq": value}`` (e.g. ``{"score": {"gte": 5}}`` -> ``{"score": {"$eq":
+    {"gte": 5}}}``), which matches nothing on Pinecone.
+    """
+    # single-bound ranges
+    assert pinecone_db._create_filter({"score": {"gte": 5}}) == {"score": {"$gte": 5}}
+    assert pinecone_db._create_filter({"age": {"lt": 30}}) == {"age": {"$lt": 30}}
+    # membership
+    assert pinecone_db._create_filter({"category": {"in": ["a", "b"]}}) == {"category": {"$in": ["a", "b"]}}
+    assert pinecone_db._create_filter({"tag": {"nin": ["x"]}}) == {"tag": {"$nin": ["x"]}}
+    # inequality
+    assert pinecone_db._create_filter({"k": {"ne": 1}}) == {"k": {"$ne": 1}}
+    # closed range still works (regression)
+    assert pinecone_db._create_filter({"score": {"gte": 5, "lte": 10}}) == {"score": {"$gte": 5, "$lte": 10}}
+    # scalar equality is unchanged
+    assert pinecone_db._create_filter({"user_id": "alice"}) == {"user_id": {"$eq": "alice"}}


### PR DESCRIPTION
## Description

`PineconeDB._create_filter` only translates a metadata-filter operator dict when it contains **both** `gte` and `lte`:

```python
for key, value in filters.items():
    if isinstance(value, dict) and "gte" in value and "lte" in value:
        pinecone_filter[key] = {"$gte": value["gte"], "$lte": value["lte"]}
    else:
        pinecone_filter[key] = {"$eq": value}   # <-- swallows every other operator
```

Every other operator dict that `Memory._process_metadata_filters` emits — a single-bound range `{"gte": 5}` / `{"lt": 10}`, or `{"in": [...]}`, `{"nin": ...}`, `{"ne": ...}`, `{"eq": ...}` — falls into the `else` branch and is wrapped as the **value** of an `$eq`:

```python
{"score": {"gte": 5}}            -> {"score": {"$eq": {"gte": 5}}}
{"category": {"in": ["a","b"]}}  -> {"category": {"$eq": {"in": ["a","b"]}}}
```

Pinecone then matches nothing, so **advanced metadata filtering silently returns wrong/empty results on Pinecone-backed stores** for any filter other than a closed `gte`+`lte` range. (Basic scalar filters like `{"user_id": "..."}` go through the `else` branch as `{"$eq": value}`, which is correct, so they are unaffected.)

The intended translation is established in the repo's sibling adapters — `ChromaDB._generate_where_clause` and `Qdrant._build_field_condition` both map each operator individually — and the operator set is fixed in `Memory._process_metadata_filters` (`eq, ne, gt, gte, lt, lte, in, nin, ...`).

## Fix

Translate each operator to its Pinecone equivalent (`gte`→`$gte`, `in`→`$in`, …), collecting multiple operators on one key into a single condition (so a closed `{"gte", "lte"}` range still works). `contains`/`icontains` and unknown operators fall back to `$eq`, matching the ChromaDB sibling.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How tested

Added `tests/vector_stores/test_pinecone.py::test_create_filter_translates_all_operators` (pure offline, uses the existing mocked-client fixture):

- **Before:** `_create_filter({"score": {"gte": 5}})` → `{"score": {"$eq": {"gte": 5}}}` (assertion fails).
- **After:** `{"score": {"$gte": 5}}`; also covers `in`/`nin`/`ne`, the closed `gte`+`lte` range (regression), and scalar equality.

`pytest tests/vector_stores/test_pinecone.py` → **16 passed**. `ruff check` / `ruff format --check` clean on both files.