### PR TITLE
fix(ts-sdk): preserve customCategories names through key conversion

### DIFF
--- a/mem0-ts/src/client/mem0.types.ts
+++ b/mem0-ts/src/client/mem0.types.ts
@@ -169,7 +169,9 @@ export interface PaginatedMemories {
 
 export interface ProjectResponse {
   customInstructions?: string;
-  customCategories?: string[];
+  // The API returns category objects (`[{ "<name>": "<description>" }]`),
+  // not bare strings (see issue #5738).
+  customCategories?: custom_categories[];
   [key: string]: any;
 }
 

--- a/mem0-ts/src/client/tests/utils.test.ts
+++ b/mem0-ts/src/client/tests/utils.test.ts
@@ -99,4 +99,50 @@ describe("camelToSnakeKeys / snakeToCamelKeys", () => {
       });
     });
   });
+
+  describe("user-controlled customCategories names (issue #5738)", () => {
+    it("converts the outer key but leaves multi-word category names on write", () => {
+      expect(
+        camelToSnakeKeys({
+          customCategories: [
+            { work_life_balance: "desc" },
+            { AIResearch: "desc" },
+          ],
+        }),
+      ).toEqual({
+        // outer SDK key is snake_cased, user-defined category names are not
+        custom_categories: [
+          { work_life_balance: "desc" },
+          { AIResearch: "desc" },
+        ],
+      });
+    });
+
+    it("converts the outer key but leaves category names verbatim on read", () => {
+      expect(
+        snakeToCamelKeys({
+          custom_categories: [
+            { work_life_balance: "desc" },
+            { AIResearch: "desc" },
+          ],
+        }),
+      ).toEqual({
+        customCategories: [
+          { work_life_balance: "desc" },
+          { AIResearch: "desc" },
+        ],
+      });
+    });
+
+    it("round-trips category names losslessly (write then read)", () => {
+      const customCategories = [
+        { work_life_balance: "balance between work and life" },
+        { AIResearch: "artificial intelligence research" },
+      ];
+      const roundTripped = snakeToCamelKeys(
+        camelToSnakeKeys({ customCategories }),
+      );
+      expect(roundTripped.customCategories).toEqual(customCategories);
+    });
+  });
 });

--- a/mem0-ts/src/client/utils.ts
+++ b/mem0-ts/src/client/utils.ts
@@ -29,6 +29,11 @@ const OPAQUE_VALUE_KEYS = new Set([
   "metadata",
   "structuredDataSchema",
   "structured_data_schema",
+  // Custom-category names are user-controlled keys (`[{ "<name>": "<desc>" }]`).
+  // Listed in both casings so they round-trip verbatim in both directions
+  // (see issue #5738; same class as `metadata`/`structuredDataSchema`).
+  "customCategories",
+  "custom_categories",
 ]);
 
 /**


### PR DESCRIPTION
## Summary

- `customCategories` is now treated as an opaque-value key, so user-defined category names round-trip verbatim through the camel/snake key conversion.
- Corrected `ProjectResponse.customCategories` type to match what the API actually returns.

## Motivation

Closes #5738.

Custom-category names are user-controlled keys (`[{ "<name>": "<description>" }]`), but `customCategories` was missing from `OPAQUE_VALUE_KEYS` in `mem0-ts/src/client/utils.ts`. The recursive key conversion therefore rewrote category names on the write paths (`add` → `_preparePayload` → `camelToSnakeKeys`, `updateProject`) and the read path (`getProject` → `snakeToCamelKeys`):

| You set | Stored on platform | Read back |
|---|---|---|
| `cooking` | `cooking` | `cooking` ✅ |
| `workLifeBalance` | `work_life_balance` | `workLifeBalance` ⚠️ stored name differs |
| `work_life_balance` | `work_life_balance` | `workLifeBalance` ❌ read ≠ stored |
| `AIResearch` | `_a_i_research` | `AIResearch` ❌ corrupted on backend |

This is the same class of bug already fixed for `metadata` (#5515) and `structuredDataSchema` (#5594).

## Fix

- Add `customCategories` and `custom_categories` to `OPAQUE_VALUE_KEYS` (both casings, exactly like `structuredDataSchema`) so the values under that key are left untouched in both directions. The outer SDK key itself is still converted; only the user-defined category names inside are preserved.
- Correct `ProjectResponse.customCategories` from `string[]` to `custom_categories[]` (`mem0.types.ts`) to match the `Array<Record<string,string>>` the API returns.

Single-word names (the docs examples `cooking`, `fitness`) were already unaffected and remain so.

## Verification

- Added 3 regression tests in `mem0-ts/src/client/tests/utils.test.ts` (write, read, lossless round-trip), covering `work_life_balance` and the previously-corrupted `AIResearch`.
- All 3 **fail without the fix and pass with it**.
- `npx jest src/client/tests/utils.test.ts` → **11 passed**.
- `npx prettier --check` clean; `tsc --noEmit` reports 0 errors in the changed source files.

### Captured test output (after fix)

```
PASS src/client/tests/utils.test.ts
  camelToSnakeKeys / snakeToCamelKeys
    user-controlled customCategories names (issue #5738)
      ✓ converts the outer key but leaves multi-word category names on write
      ✓ converts the outer key but leaves category names verbatim on read
      ✓ round-trips category names losslessly (write then read)
Tests:       11 passed, 11 total
```

### Without the source fix (regression tests catch it)

```
    user-controlled customCategories names (issue #5738)
      ✕ converts the outer key but leaves multi-word category names on write
      ✕ converts the outer key but leaves category names verbatim on read
      ✕ round-trips category names losslessly (write then read)
Tests:       3 failed, 8 passed, 11 total
```
