### PR TITLE
fix(core): union hybrid search candidates and fix threshold gating

### DIFF
--- a/docs/changelog/sdk.mdx
+++ b/docs/changelog/sdk.mdx
@@ -7,6 +7,13 @@ mode: "wide"
 <Tabs>
 <Tab title="Python">
 
+<Update label="2026-06-21" description="Unreleased">
+
+**Bug Fixes:**
+- **Core:** Fix hybrid search dropping keyword-only and entity-rescued memories — union semantic and keyword candidate pools and allow BM25/entity signals to pass the search threshold
+
+</Update>
+
 <Update label="2026-06-17" description="v2.0.7">
 
 **New Features:**

--- a/docs/changelog/sdk.mdx
+++ b/docs/changelog/sdk.mdx
@@ -10,7 +10,7 @@ mode: "wide"
 <Update label="2026-06-21" description="Unreleased">
 
 **Bug Fixes:**
-- **Core:** Fix hybrid search dropping keyword-only and entity-rescued memories — union semantic and keyword candidate pools and allow BM25/entity signals to pass the search threshold
+- **Core:** Fix hybrid search dropping keyword-only and entity-rescued memories — union semantic and keyword candidate pools and allow BM25/entity signals to pass the search threshold ([#5743](https://github.com/mem0ai/mem0/pull/5743))
 
 </Update>
 

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -70,6 +70,8 @@ import {
   normalizeBm25,
   ENTITY_BOOST_WEIGHT,
   ScoredResult,
+  buildHybridCandidateMap,
+  addEntityBoostCandidates,
 } from "../utils/scoring";
 import { getDefaultVectorStoreDbPath } from "../utils/sqlite";
 import { getOrCreateMem0UserId } from "../../../client/config";
@@ -1406,12 +1408,17 @@ export class Memory {
       }
     }
 
-    // Step 7: Build candidate set from semantic results
-    const candidates = semanticResults.map((mem) => ({
-      id: String(mem.id),
-      score: mem.score ?? 0,
-      payload: mem.payload || {},
-    }));
+    // Step 7: Build hybrid candidate pool (semantic ∪ keyword ∪ entity-rescued)
+    const candidatesById = buildHybridCandidateMap(semanticResults, keywordResults);
+    if (Object.keys(entityBoosts).length > 0) {
+      await addEntityBoostCandidates(
+        candidatesById,
+        entityBoosts,
+        threshold ?? 0.1,
+        this.vectorStore,
+      );
+    }
+    const candidates = Array.from(candidatesById.values());
 
     // Step 8: Score and rank
     const scoredResults = scoreAndRank(

--- a/mem0-ts/src/oss/src/utils/scoring.ts
+++ b/mem0-ts/src/oss/src/utils/scoring.ts
@@ -9,6 +9,80 @@
 
 export const ENTITY_BOOST_WEIGHT = 0.5;
 
+export interface HybridCandidate {
+  id: string;
+  score: number;
+  payload: Record<string, any>;
+}
+
+function recordId(mem: { id?: string | number }): string {
+  return String(mem.id ?? "");
+}
+
+function recordPayload(mem: { payload?: Record<string, any> }): Record<string, any> {
+  return mem.payload ?? {};
+}
+
+/**
+ * Merge semantic and keyword hits into one candidate map keyed by memory ID.
+ */
+export function buildHybridCandidateMap(
+  semanticResults: Array<{ id: string | number; score?: number | null; payload?: Record<string, any> }>,
+  keywordResults?: Array<{ id: string | number; score?: number | null; payload?: Record<string, any> }> | null,
+): Map<string, HybridCandidate> {
+  const candidatesById = new Map<string, HybridCandidate>();
+
+  for (const mem of semanticResults ?? []) {
+    const memId = recordId(mem);
+    if (!memId) continue;
+    candidatesById.set(memId, {
+      id: memId,
+      score: mem.score ?? 0,
+      payload: recordPayload(mem),
+    });
+  }
+
+  for (const mem of keywordResults ?? []) {
+    const memId = recordId(mem);
+    if (!memId || candidatesById.has(memId)) continue;
+    candidatesById.set(memId, {
+      id: memId,
+      score: 0,
+      payload: recordPayload(mem),
+    });
+  }
+
+  return candidatesById;
+}
+
+export interface EntityBoostVectorStore {
+  get(
+    id: string,
+  ): Promise<{ payload?: Record<string, any> } | null> | { payload?: Record<string, any> } | null;
+}
+
+/**
+ * Add entity-linked memories missing from the hybrid pool (in-place).
+ */
+export async function addEntityBoostCandidates(
+  candidatesById: Map<string, HybridCandidate>,
+  entityBoosts: Record<string, number>,
+  threshold: number,
+  vectorStore: EntityBoostVectorStore,
+): Promise<void> {
+  for (const [memId, boost] of Object.entries(entityBoosts)) {
+    if (candidatesById.has(memId) || boost < threshold) continue;
+    try {
+      const existing = await vectorStore.get(memId);
+      const payload = existing?.payload ?? {};
+      if (!payload.data) continue;
+      candidatesById.set(memId, { id: memId, score: 0, payload });
+    } catch {
+      // Non-fatal: skip memories we cannot load
+    }
+  }
+}
+
 /**
  * Get BM25 sigmoid parameters based on query length.
  *
@@ -79,8 +153,8 @@ export interface ScoredResult {
  * For each candidate:
  *   combined = (semantic + bm25 + entity_boost) / max_possible
  *
- * Threshold gates the semantic score BEFORE combining -- candidates
- * below the threshold are excluded even if BM25/entity would boost them.
+ * Threshold gates each signal independently — a candidate passes if its
+ * semantic score, BM25 score, or entity boost meets the threshold.
  *
  * The divisor adapts based on which signals are active:
  *   - Semantic only: max_possible = 1.0
@@ -91,7 +165,7 @@ export interface ScoredResult {
  * @param semanticResults - Candidate results with id, score, and payload.
  * @param bm25Scores - Map of memory ID to normalized BM25 score.
  * @param entityBoosts - Map of memory ID to entity boost score.
- * @param threshold - Minimum semantic score to include a candidate.
+ * @param threshold - Minimum score on at least one signal (semantic, BM25, or entity).
  * @param topK - Maximum number of results to return.
  * @param explain - Include scoreDetails in each result when true.
  * @returns Sorted list of scored results, highest score first.
@@ -128,13 +202,17 @@ export function scoreAndRank(
     }
 
     const semanticScore = result.score ?? 0.0;
-    if (semanticScore < threshold) {
-      continue;
-    }
-
     const memIdStr = String(memId);
     const bm25Score = bm25Scores[memIdStr] ?? 0.0;
     const entityBoost = entityBoosts[memIdStr] ?? 0.0;
+
+    if (
+      semanticScore < threshold &&
+      bm25Score < threshold &&
+      entityBoost < threshold
+    ) {
+      continue;
+    }
 
     const rawCombined = semanticScore + bm25Score + entityBoost;
     const combined = Math.min(rawCombined / maxPossible, 1.0);

--- a/mem0-ts/src/oss/src/utils/scoring.ts
+++ b/mem0-ts/src/oss/src/utils/scoring.ts
@@ -56,9 +56,7 @@ export function buildHybridCandidateMap(
 }
 
 export interface EntityBoostVectorStore {
-  get(
-    id: string,
-  ): Promise<{ payload?: Record<string, any> } | null> | { payload?: Record<string, any> } | null;
+  get(id: string): Promise<{ payload?: Record<string, any> } | null>;
 }
 
 /**
@@ -70,17 +68,22 @@ export async function addEntityBoostCandidates(
   threshold: number,
   vectorStore: EntityBoostVectorStore,
 ): Promise<void> {
-  for (const [memId, boost] of Object.entries(entityBoosts)) {
-    if (candidatesById.has(memId) || boost < threshold) continue;
-    try {
-      const existing = await vectorStore.get(memId);
-      const payload = existing?.payload ?? {};
-      if (!payload.data) continue;
-      candidatesById.set(memId, { id: memId, score: 0, payload });
-    } catch {
-      // Non-fatal: skip memories we cannot load
-    }
-  }
+  const entriesToFetch = Object.entries(entityBoosts).filter(
+    ([memId, boost]) => !candidatesById.has(memId) && boost >= threshold,
+  );
+
+  await Promise.all(
+    entriesToFetch.map(async ([memId]) => {
+      try {
+        const existing = await vectorStore.get(memId);
+        const payload = existing?.payload ?? {};
+        if (!payload.data) return;
+        candidatesById.set(memId, { id: memId, score: 0, payload });
+      } catch {
+        // Non-fatal: skip memories we cannot load
+      }
+    }),
+  );
 }
 
 /**

--- a/mem0-ts/src/oss/tests/scoring.test.ts
+++ b/mem0-ts/src/oss/tests/scoring.test.ts
@@ -46,4 +46,11 @@ describe("scoreAndRank", () => {
     expect(details.maxPossibleScore).toBe(1.0);
     expect(details.finalScore).toBe(0.8);
   });
+
+  it("allows BM25 to rescue candidates below semantic threshold", () => {
+    const lowSemantic = [{ id: "a", score: 0.05, payload: { data: "mem a" } }];
+    const scored = scoreAndRank(lowSemantic, { a: 0.95 }, {}, 0.1, 10);
+    expect(scored).toHaveLength(1);
+    expect(scored[0].id).toBe("a");
+  });
 });

--- a/mem0-ts/src/oss/tests/scoring.test.ts
+++ b/mem0-ts/src/oss/tests/scoring.test.ts
@@ -1,6 +1,63 @@
 /// <reference types="jest" />
 
-import { scoreAndRank } from "../src/utils/scoring";
+import {
+  addEntityBoostCandidates,
+  buildHybridCandidateMap,
+  scoreAndRank,
+} from "../src/utils/scoring";
+
+describe("buildHybridCandidateMap", () => {
+  it("merges keyword-only hits with semantic score zero", () => {
+    const semantic = [{ id: "sem-1", score: 0.9, payload: { data: "semantic" } }];
+    const keyword = [
+      { id: "sem-1", score: 8.0, payload: { data: "semantic" } },
+      { id: "kw-only", score: 12.0, payload: { data: "exact match" } },
+    ];
+
+    const candidates = buildHybridCandidateMap(semantic, keyword);
+
+    expect(Array.from(candidates.keys()).sort()).toEqual(["kw-only", "sem-1"]);
+    expect(candidates.get("sem-1")).toEqual({
+      id: "sem-1",
+      score: 0.9,
+      payload: { data: "semantic" },
+    });
+    expect(candidates.get("kw-only")).toEqual({
+      id: "kw-only",
+      score: 0,
+      payload: { data: "exact match" },
+    });
+  });
+});
+
+describe("addEntityBoostCandidates", () => {
+  it("fetches missing entity-linked memories into the candidate map", async () => {
+    const candidates = new Map([
+      ["sem-1", { id: "sem-1", score: 0.8, payload: { data: "x" } }],
+    ]);
+    const vectorStore = {
+      get: jest.fn(async (id: string) =>
+        id === "entity-only"
+          ? { payload: { data: "entity linked", user_id: "u1" } }
+          : null,
+      ),
+    };
+
+    await addEntityBoostCandidates(
+      candidates,
+      { "entity-only": 0.4 },
+      0.1,
+      vectorStore,
+    );
+
+    expect(vectorStore.get).toHaveBeenCalledWith("entity-only");
+    expect(candidates.get("entity-only")).toEqual({
+      id: "entity-only",
+      score: 0,
+      payload: { data: "entity linked", user_id: "u1" },
+    });
+  });
+});
 
 describe("scoreAndRank", () => {
   const results = [

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -67,6 +67,8 @@ from mem0.utils.factory import (
 from mem0.utils.lemmatization import lemmatize_for_bm25
 from mem0.utils.scoring import (
     ENTITY_BOOST_WEIGHT,
+    add_entity_boost_candidates,
+    build_hybrid_candidate_map,
     get_bm25_params,
     normalize_bm25,
     score_and_rank,
@@ -1523,15 +1525,11 @@ class Memory(MemoryBase):
         if query_entities:
             entity_boosts = self._compute_entity_boosts(query_entities, filters)
 
-        # Step 7: Build candidate set from semantic results
-        candidates = []
-        for mem in semantic_results:
-            mem_id = str(mem.id)
-            candidates.append({
-                "id": mem_id,
-                "score": mem.score,
-                "payload": mem.payload if hasattr(mem, 'payload') else {},
-            })
+        # Step 7: Build hybrid candidate pool (semantic ∪ keyword ∪ entity-rescued)
+        candidates_by_id = build_hybrid_candidate_map(semantic_results, keyword_results)
+        if entity_boosts:
+            add_entity_boost_candidates(candidates_by_id, entity_boosts, threshold, self.vector_store)
+        candidates = list(candidates_by_id.values())
 
         # Step 8: Score and rank
         scored_results = score_and_rank(
@@ -3065,15 +3063,17 @@ class AsyncMemory(MemoryBase):
         if query_entities:
             entity_boosts = await self._compute_entity_boosts_async(query_entities, filters)
 
-        # Step 7: Build candidate set from semantic results
-        candidates = []
-        for mem in semantic_results:
-            mem_id = str(mem.id)
-            candidates.append({
-                "id": mem_id,
-                "score": mem.score,
-                "payload": mem.payload if hasattr(mem, 'payload') else {},
-            })
+        # Step 7: Build hybrid candidate pool (semantic ∪ keyword ∪ entity-rescued)
+        candidates_by_id = build_hybrid_candidate_map(semantic_results, keyword_results)
+        if entity_boosts:
+            await asyncio.to_thread(
+                add_entity_boost_candidates,
+                candidates_by_id,
+                entity_boosts,
+                threshold,
+                self.vector_store,
+            )
+        candidates = list(candidates_by_id.values())
 
         # Step 8: Score and rank
         scored_results = score_and_rank(

--- a/mem0/utils/scoring.py
+++ b/mem0/utils/scoring.py
@@ -57,6 +57,77 @@ def normalize_bm25(raw_score: float, midpoint: float, steepness: float) -> float
 ENTITY_BOOST_WEIGHT = 0.5
 
 
+def _record_id(mem: Any) -> str:
+    return str(mem.id) if hasattr(mem, "id") else str(mem.get("id", ""))
+
+
+def _record_payload(mem: Any) -> Dict[str, Any]:
+    if hasattr(mem, "payload"):
+        return mem.payload or {}
+    return mem.get("payload", {}) or {}
+
+
+def build_hybrid_candidate_map(
+    semantic_results: Optional[List[Any]],
+    keyword_results: Optional[List[Any]] = None,
+) -> Dict[str, Dict[str, Any]]:
+    """Merge semantic and keyword hits into one candidate map keyed by memory ID.
+
+    Keyword matches that are absent from the semantic top-k pool are included
+    with semantic_score=0 so BM25 can still rescue exact-match memories.
+    """
+    candidates_by_id: Dict[str, Dict[str, Any]] = {}
+
+    for mem in semantic_results or []:
+        mem_id = _record_id(mem)
+        if not mem_id:
+            continue
+        score = mem.score if hasattr(mem, "score") else mem.get("score", 0)
+        candidates_by_id[mem_id] = {
+            "id": mem_id,
+            "score": score,
+            "payload": _record_payload(mem),
+        }
+
+    for mem in keyword_results or []:
+        mem_id = _record_id(mem)
+        if not mem_id or mem_id in candidates_by_id:
+            continue
+        candidates_by_id[mem_id] = {
+            "id": mem_id,
+            "score": 0.0,
+            "payload": _record_payload(mem),
+        }
+
+    return candidates_by_id
+
+
+def add_entity_boost_candidates(
+    candidates_by_id: Dict[str, Dict[str, Any]],
+    entity_boosts: Dict[str, float],
+    threshold: float,
+    vector_store: Any,
+) -> None:
+    """Add entity-linked memories missing from the hybrid pool (in-place)."""
+    for mem_id, boost in entity_boosts.items():
+        if mem_id in candidates_by_id or boost < threshold:
+            continue
+        try:
+            existing = vector_store.get(vector_id=mem_id)
+        except Exception:
+            continue
+        if existing is None:
+            continue
+        payload = existing.payload if hasattr(existing, "payload") else {}
+        if not payload.get("data"):
+            continue
+        candidates_by_id[mem_id] = {
+            "id": mem_id,
+            "score": 0.0,
+            "payload": payload,
+        }
+
+
 def score_and_rank(
     semantic_results: List[Dict[str, Any]],
     bm25_scores: Dict[str, float],
@@ -71,8 +142,8 @@ def score_and_rank(
         semantic_score is taken from the result's score field.
         combined = (semantic + bm25 + entity_boost) / max_possible
 
-    Threshold gates the semantic score BEFORE combining -- candidates
-    below the threshold are excluded even if BM25/entity would boost them.
+    Threshold gates each signal independently -- a candidate passes if its
+    semantic score, BM25 score, or entity boost meets the threshold.
 
     The divisor adapts based on which signals are active:
         - Semantic only: max_possible = 1.0
@@ -84,7 +155,7 @@ def score_and_rank(
         semantic_results: Candidate memories from vector search.
         bm25_scores: Normalized keyword scores keyed by memory ID.
         entity_boosts: Entity-link boosts keyed by memory ID.
-        threshold: Minimum semantic score required before hybrid scoring.
+        threshold: Minimum score on at least one signal (semantic, BM25, or entity).
         top_k: Maximum number of results to return.
         explain: Include score_details in each result when true.
 
@@ -108,12 +179,12 @@ def score_and_rank(
             continue
 
         semantic_score = result.get("score") or 0.0
-        if semantic_score < threshold:
-            continue
-
         mem_id_str = str(mem_id)
         bm25_score = bm25_scores.get(mem_id_str, 0.0)
         entity_boost = entity_boosts.get(mem_id_str, 0.0)
+
+        if semantic_score < threshold and bm25_score < threshold and entity_boost < threshold:
+            continue
 
         raw_combined = semantic_score + bm25_score + entity_boost
         combined = min(raw_combined / max_possible, 1.0)

--- a/tests/utils/test_scoring.py
+++ b/tests/utils/test_scoring.py
@@ -1,6 +1,8 @@
 import pytest
 
 from mem0.utils.scoring import (
+    add_entity_boost_candidates,
+    build_hybrid_candidate_map,
     get_bm25_params,
     normalize_bm25,
     score_and_rank,
@@ -86,15 +88,27 @@ class TestScoreAndRank:
         expected = (0.8 + 0.6 + 0.3) / 2.5
         assert scored[0]["score"] == pytest.approx(expected)
 
-    def test_threshold_gates_on_semantic(self):
+    def test_threshold_allows_bm25_rescue(self):
         results = [
-            {"id": "a", "score": 0.05, "payload": {"data": "mem a"}},  # Below threshold
+            {"id": "a", "score": 0.05, "payload": {"data": "mem a"}},  # Below semantic threshold
             {"id": "b", "score": 0.5, "payload": {"data": "mem b"}},
         ]
-        bm25 = {"a": 0.99}  # High BM25 shouldn't save it
+        bm25 = {"a": 0.99}  # Strong BM25 should rescue keyword-only hit
         scored = score_and_rank(results, bm25, {}, threshold=0.1, top_k=10)
+        assert len(scored) == 2
+        assert any(item["id"] == "a" for item in scored)
+
+    def test_threshold_allows_entity_rescue(self):
+        results = [{"id": "a", "score": 0.05, "payload": {"data": "mem a"}}]
+        entity = {"a": 0.2}
+        scored = score_and_rank(results, {}, entity, threshold=0.1, top_k=10)
         assert len(scored) == 1
-        assert scored[0]["id"] == "b"
+        assert scored[0]["id"] == "a"
+
+    def test_threshold_excludes_weak_candidates(self):
+        results = [{"id": "a", "score": 0.05, "payload": {"data": "mem a"}}]
+        scored = score_and_rank(results, {"a": 0.05}, {"a": 0.05}, threshold=0.1, top_k=10)
+        assert scored == []
 
     def test_top_k_limit(self):
         results = [{"id": str(i), "score": 0.5, "payload": {}} for i in range(20)]
@@ -159,3 +173,39 @@ class TestScoreAndRank:
 class TestEntityBoostWeight:
     def test_weight_value(self):
         assert ENTITY_BOOST_WEIGHT == 0.5
+
+
+class TestBuildHybridCandidateMap:
+    def test_merges_keyword_only_hits(self):
+        semantic = [type("Mem", (), {"id": "sem-1", "score": 0.9, "payload": {"data": "semantic"}})()]
+        keyword = [
+            type("Mem", (), {"id": "sem-1", "score": 8.0, "payload": {"data": "semantic"}})(),
+            type("Mem", (), {"id": "kw-only", "score": 12.0, "payload": {"data": "exact match"}})(),
+        ]
+        candidates = build_hybrid_candidate_map(semantic, keyword)
+        assert set(candidates.keys()) == {"sem-1", "kw-only"}
+        assert candidates["sem-1"]["score"] == 0.9
+        assert candidates["kw-only"]["score"] == 0.0
+        assert candidates["kw-only"]["payload"]["data"] == "exact match"
+
+    def test_add_entity_boost_candidates_fetches_missing_memory(self):
+        candidates = {"sem-1": {"id": "sem-1", "score": 0.8, "payload": {"data": "x"}}}
+
+        class MockVectorStore:
+            def get(self, vector_id):
+                if vector_id == "entity-only":
+                    return type(
+                        "Rec",
+                        (),
+                        {"payload": {"data": "entity linked", "user_id": "u1"}},
+                    )()
+                return None
+
+        add_entity_boost_candidates(
+            candidates,
+            {"entity-only": 0.4},
+            threshold=0.1,
+            vector_store=MockVectorStore(),
+        )
+        assert "entity-only" in candidates
+        assert candidates["entity-only"]["payload"]["data"] == "entity linked"


### PR DESCRIPTION
## Linked Issue

Closes #5742

## Description

Fixes hybrid search silently dropping keyword-only and entity-rescued memories:

1. **Candidate union** — merge semantic and keyword hits; fetch entity-linked memories missing from the pool via `vector_store.get()`
2. **Threshold gating** — include candidates when semantic, BM25, or entity boost meets threshold (not semantic-only)

Applied to Python sync/async `_search_vector_store()` and TS OSS search path.

## Review follow-ups

- Added TS tests for `buildHybridCandidateMap` and `addEntityBoostCandidates`
- Parallelized entity-rescue fetches in TS with `Promise.all`
- Narrowed `EntityBoostVectorStore.get()` to async-only typing
- Linked changelog entry to #5743

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test Coverage

- [x] I added/updated unit tests

Python: `TestBuildHybridCandidateMap`, updated threshold tests in `tests/utils/test_scoring.py`
TypeScript: helper tests + BM25 rescue test in `scoring.test.ts`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed