### PR TITLE
perf(qdrant): batch BM25 sparse encoding in insert() into one embed call

### DIFF
--- a/mem0/vector_stores/qdrant.py
+++ b/mem0/vector_stores/qdrant.py
@@ -122,6 +122,29 @@ class Qdrant(VectorStoreBase):
             logger.debug(f"BM25 encoding failed: {e}")
         return None
 
+    def _encode_bm25_batch(self, texts: list[str]) -> list[SparseVector | None]:
+        """Encode multiple texts into BM25 sparse vectors in a single batched call.
+
+        Returns one entry per input text, in order (``None`` where the encoder is
+        unavailable or a vector cannot be produced), so callers can zip the result
+        back to their inputs. fastembed batches the texts internally, so this is a
+        single forward pass instead of one ``embed()`` call per text.
+        """
+        encoder = self._get_bm25_encoder()
+        if encoder is None:
+            return [None] * len(texts)
+        try:
+            results = list(encoder.embed(texts))
+        except Exception as e:
+            logger.debug(f"BM25 batch encoding failed: {e}")
+            return [None] * len(texts)
+        encoded: list[SparseVector | None] = [
+            SparseVector(indices=sparse.indices.tolist(), values=sparse.values.tolist()) for sparse in results
+        ]
+        if len(encoded) < len(texts):
+            encoded.extend([None] * (len(texts) - len(encoded)))
+        return encoded
+
     def create_col(self, vector_size: int, on_disk: bool, distance: Distance = Distance.COSINE):
         """
         Create a new collection with dense vectors and BM25 sparse vectors.
@@ -191,6 +214,24 @@ class Qdrant(VectorStoreBase):
             ids (list, optional): List of IDs corresponding to vectors. Defaults to None.
         """
         logger.info(f"Inserting {len(vectors)} vectors into collection {self.collection_name}")
+        # Precompute BM25 sparse vectors for all text-bearing rows in ONE batched
+        # encode (a single fastembed forward pass) instead of one encoder call per
+        # point. Only rows with text are encoded; the result maps back by index.
+        bm25_by_index: dict[int, SparseVector] = {}
+        if self._has_bm25_slot:
+            texts_to_encode: list[str] = []
+            indices_to_encode: list[int] = []
+            for idx in range(len(vectors)):
+                payload = payloads[idx] if payloads else {}
+                text_for_bm25 = payload.get("text_lemmatized") or payload.get("data", "")
+                if text_for_bm25:
+                    texts_to_encode.append(text_for_bm25)
+                    indices_to_encode.append(idx)
+            if texts_to_encode:
+                for idx, sparse in zip(indices_to_encode, self._encode_bm25_batch(texts_to_encode)):
+                    if sparse is not None:
+                        bm25_by_index[idx] = sparse
+
         points = []
         for idx, vector in enumerate(vectors):
             payload = payloads[idx] if payloads else {}
@@ -198,12 +239,9 @@ class Qdrant(VectorStoreBase):
 
             # Build named vectors: dense + optional BM25 sparse (only if collection has the slot).
             named_vectors = {"": vector}
-            if self._has_bm25_slot:
-                text_for_bm25 = payload.get("text_lemmatized") or payload.get("data", "")
-                if text_for_bm25:
-                    sparse = self._encode_bm25(text_for_bm25)
-                    if sparse is not None:
-                        named_vectors["bm25"] = sparse
+            sparse = bm25_by_index.get(idx)
+            if sparse is not None:
+                named_vectors["bm25"] = sparse
 
             points.append(PointStruct(id=point_id, vector=named_vectors, payload=payload))
 

--- a/tests/vector_stores/test_qdrant.py
+++ b/tests/vector_stores/test_qdrant.py
@@ -86,6 +86,50 @@ class TestQdrant(unittest.TestCase):
 
         self.assertEqual(points[0].payload, payloads[0])
 
+    def test_insert_batch_encodes_bm25_in_a_single_call(self):
+        """BM25 encoding runs in one batched embed() for the whole insert, only for
+        text-bearing rows, and is mapped back to the correct points."""
+        self.qdrant._has_bm25_slot = True
+
+        class _Arr(list):
+            def tolist(self):
+                return list(self)
+
+        class _Sparse:
+            def __init__(self, i):
+                self.indices = _Arr([i])
+                self.values = _Arr([1.0])
+
+        class _Encoder:
+            def __init__(self):
+                self.embed_calls = []
+
+            def embed(self, texts):
+                texts = list(texts)
+                self.embed_calls.append(texts)
+                return iter(_Sparse(i) for i in range(len(texts)))
+
+        encoder = _Encoder()
+        with patch.object(self.qdrant, "_get_bm25_encoder", return_value=encoder):
+            vectors = [[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]
+            payloads = [
+                {"data": "first"},
+                {"key": "no text"},  # no text -> no bm25
+                {"text_lemmatized": "third lemma"},
+            ]
+            ids = [str(uuid.uuid4()) for _ in range(3)]
+            self.qdrant.insert(vectors=vectors, payloads=payloads, ids=ids)
+
+        # The encoder is invoked exactly once, with only the two text-bearing rows.
+        self.assertEqual(len(encoder.embed_calls), 1)
+        self.assertEqual(encoder.embed_calls[0], ["first", "third lemma"])
+
+        points = self.client_mock.upsert.call_args[1]["points"]
+        self.assertEqual(len(points), 3)
+        self.assertIn("bm25", points[0].vector)  # row with "data"
+        self.assertNotIn("bm25", points[1].vector)  # no text
+        self.assertIn("bm25", points[2].vector)  # row with "text_lemmatized"
+
     def test_search(self):
         vectors = [[0.1, 0.2]]
         mock_point = MagicMock(id=str(uuid.uuid4()), score=0.95, payload={"key": "value"})


### PR DESCRIPTION
## Linked Issue

N/A — standalone performance improvement.

## Description

`Qdrant.insert()` encoded the BM25 sparse vector **one text at a time**: for each point it called `_encode_bm25(text)`, which runs `fastembed` `encoder.embed([single_text])`. So inserting `N` text-bearing memories triggered `N` separate model forward passes.

```python
for idx, vector in enumerate(vectors):
    ...
    if self._has_bm25_slot:
        text_for_bm25 = payload.get("text_lemmatized") or payload.get("data", "")
        if text_for_bm25:
            sparse = self._encode_bm25(text_for_bm25)   # one embed() call per point
```

The `upsert` itself was already a single batched call — only the encoding was per-point. Since `add()` typically extracts and inserts several facts at once (and bulk imports insert many), this is real, repeated CPU/inference waste on the write path.

This collects the text-bearing rows and encodes them in **one** `encoder.embed(texts)` call (fastembed batches internally), then maps each sparse vector back to its point by index.

- `_has_bm25_slot` gate, text-presence gate, and `None`-result handling are all **preserved** — the same points get the same sparse vectors.
- The single-text `_encode_bm25` is kept (still used by `search()` and `update()`).

`N` encode calls → **1**.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor (no functional changes) — performance optimization, behavior preserved

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests

`tests/vector_stores/test_qdrant.py` — **92 passed**. Added `test_insert_batch_encodes_bm25_in_a_single_call`: with a fake encoder, asserts `embed()` is called **exactly once** with only the text-bearing rows (in order), and that the resulting `bm25` sparse vector is attached to the right points (and omitted for the text-less row). All existing Qdrant tests unchanged and green. `ruff check` clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed (N/A)
