### PR TITLE
fix(oss): include entity_type in Phase 7a batch entity dedup key

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -1017,7 +1017,7 @@ export class Memory {
         const memoryId = records[idx].memoryId;
         const entities = idx < allEntities.length ? allEntities[idx] : [];
         for (const entity of entities) {
-          const key = entity.text.trim().toLowerCase();
+          const key = `${entity.type.trim().toLowerCase()}:${entity.text.trim().toLowerCase()}`;
           if (key in globalEntities) {
             globalEntities[key].memoryIds.add(memoryId);
           } else {

--- a/mem0-ts/src/oss/tests/memory.entity-dedup.test.ts
+++ b/mem0-ts/src/oss/tests/memory.entity-dedup.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Phase 7a entity dedup tests — same-name entities with different types must not merge.
+ * Related to mem0ai/mem0#5587.
+ */
+/// <reference types="jest" />
+import { Memory } from "../src/memory";
+
+jest.setTimeout(15000);
+
+jest.mock("../src/embeddings/google", () => ({
+  GoogleEmbedder: jest.fn(),
+}));
+jest.mock("../src/llms/google", () => ({
+  GoogleLLM: jest.fn(),
+}));
+
+jest.mock("../src/llms/openai", () => ({
+  OpenAILLM: jest.fn().mockImplementation(() => ({
+    generateResponse: jest.fn().mockResolvedValue(
+      JSON.stringify({
+        memory: [
+          { text: "Python is a language" },
+          { text: "Python is a snake" },
+        ],
+      }),
+    ),
+  })),
+}));
+
+const mockEmbedding = new Array(1536).fill(0.1);
+jest.mock("../src/embeddings/openai", () => ({
+  OpenAIEmbedder: jest.fn().mockImplementation(() => ({
+    embed: jest.fn().mockResolvedValue(mockEmbedding),
+    embedBatch: jest
+      .fn()
+      .mockImplementation((texts: string[]) =>
+        Promise.resolve(texts.map(() => mockEmbedding)),
+      ),
+    embeddingDims: 1536,
+  })),
+}));
+
+jest.mock("../src/utils/entity_extraction", () => ({
+  extractEntitiesBatch: jest.fn().mockReturnValue([
+    [{ type: "PROPER", text: "Python" }],
+    [{ type: "NOUN", text: "Python" }],
+  ]),
+  extractEntities: jest.fn().mockReturnValue([]),
+}));
+
+function createMemory(): Memory {
+  return new Memory({
+    version: "v1.1",
+    embedder: {
+      provider: "openai",
+      config: { apiKey: "test-key", model: "text-embedding-3-small" },
+    },
+    vectorStore: {
+      provider: "memory",
+      config: {
+        collectionName: `test-dedup-${Date.now()}-${Math.random()}`,
+        dimension: 1536,
+        dbPath: ":memory:",
+      },
+    },
+    llm: {
+      provider: "openai",
+      config: { apiKey: "test-key", model: "gpt-5-mini" },
+    },
+    historyDbPath: ":memory:",
+  });
+}
+
+describe("Phase 7a entity type dedup (#5587)", () => {
+  let memory: Memory;
+
+  beforeEach(async () => {
+    memory = createMemory();
+    const m = memory as any;
+    await m._ensureInitialized();
+
+    const insert = jest.fn().mockResolvedValue(undefined);
+    m._entityStore = {
+      search: jest.fn().mockResolvedValue([]),
+      insert,
+      update: jest.fn().mockResolvedValue(undefined),
+      initialize: jest.fn().mockResolvedValue(undefined),
+    };
+    m._entityStoreInsertSpy = insert;
+  });
+
+  afterEach(async () => {
+    await memory.reset();
+  });
+
+  it("creates separate entity records for same name with different types", async () => {
+    const m = memory as any;
+    const result = await memory.add("Python language and snake", {
+      userId: "u1",
+    });
+
+    expect(result.results.length).toBe(2);
+    expect(m._entityStoreInsertSpy).toHaveBeenCalledTimes(1);
+
+    const payloads = m._entityStoreInsertSpy.mock.calls[0][2] as Array<
+      Record<string, unknown>
+    >;
+    expect(payloads).toHaveLength(2);
+    expect(new Set(payloads.map((p) => p.entityType))).toEqual(
+      new Set(["PROPER", "NOUN"]),
+    );
+    for (const payload of payloads) {
+      expect(payload.linkedMemoryIds).toHaveLength(1);
+    }
+  });
+});

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -967,11 +967,11 @@ class Memory(MemoryBase):
             all_entities = extract_entities_batch(all_texts)
 
             # 7a: Global dedup — collect unique entities across all memories
-            global_entities = {}  # normalized_key -> (entity_type, entity_text, set of memory_ids)
+            global_entities = {}  # (entity_type, text) -> (entity_type, entity_text, set of memory_ids)
             for idx, (memory_id, text, embedding, payload) in enumerate(records):
                 entities = all_entities[idx] if idx < len(all_entities) else []
                 for entity_type, entity_text in entities:
-                    key = entity_text.strip().lower()
+                    key = (entity_type.strip().lower(), entity_text.strip().lower())
                     if key in global_entities:
                         global_entities[key][2].add(memory_id)
                     else:
@@ -2509,7 +2509,7 @@ class AsyncMemory(MemoryBase):
             for idx, (memory_id, text, embedding, payload) in enumerate(records):
                 entities = all_entities[idx] if idx < len(all_entities) else []
                 for entity_type, entity_text in entities:
-                    key = entity_text.strip().lower()
+                    key = (entity_type.strip().lower(), entity_text.strip().lower())
                     if key in global_entities:
                         global_entities[key][2].add(memory_id)
                     else:

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -988,3 +988,101 @@ class TestAddPipelineEntityEmbeddingCountGuard:
         assert any("padding/truncating" in r.message for r in caplog.records), (
             "expected count-mismatch warning was not emitted"
         )
+
+
+class TestPhase7aEntityTypeDedup:
+    """Phase 7a global dedup must not merge same-name entities with different types.
+
+    Related to #5587 — open #5497 adds merge gates at upsert/7d but left this path.
+    """
+
+    @pytest.fixture
+    def mock_memory(self, mocker):
+        mock_llm, _ = _setup_mocks(mocker)
+        memory = Memory()
+        memory.config = mocker.MagicMock()
+        memory.config.custom_instructions = None
+        memory.config.custom_update_memory_prompt = None
+        memory.custom_instructions = None
+        memory.api_version = "v1.1"
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        memory.db.batch_add_history = MagicMock()
+        return memory
+
+    @pytest.fixture
+    def mock_async_memory(self, mocker):
+        mock_llm, _ = _setup_mocks(mocker)
+        memory = AsyncMemory()
+        memory.config = mocker.MagicMock()
+        memory.config.custom_instructions = None
+        memory.config.custom_update_memory_prompt = None
+        memory.custom_instructions = None
+        memory.api_version = "v1.1"
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        memory.db.batch_add_history = MagicMock()
+        return memory
+
+    @staticmethod
+    def _entity_batch_return():
+        return [
+            [("PROPER", "Python")],
+            [("NOUN", "Python")],
+        ]
+
+    def _setup_entity_mocks(self, memory, mocker):
+        memory.llm.generate_response.return_value = (
+            '{"memory": [{"text": "Python is a language"}, {"text": "Python is a snake"}]}'
+        )
+        memory.embedding_model = Mock()
+        memory.embedding_model.embed_batch = Mock(
+            side_effect=lambda texts, memory_action="add": [[0.1] * 10 for _ in texts]
+        )
+        memory.embedding_model.embed = Mock(return_value=[0.1] * 10)
+        memory._entity_store = Mock()
+        memory._entity_store.search_batch = Mock(return_value=[[], []])
+        memory._entity_store.insert = Mock()
+        memory._entity_store.update = Mock()
+        mocker.patch(
+            "mem0.memory.main.extract_entities_batch",
+            return_value=self._entity_batch_return(),
+        )
+        mocker.patch("mem0.memory.main.capture_event")
+
+    def test_sync_same_name_different_types_create_separate_entities(self, mock_memory, mocker):
+        self._setup_entity_mocks(mock_memory, mocker)
+
+        result = mock_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "Python language and snake"}],
+            metadata={},
+            filters={"user_id": "u1"},
+            infer=True,
+        )
+
+        assert len(result) == 2
+        assert mock_memory._entity_store.insert.call_count == 1
+        payloads = mock_memory._entity_store.insert.call_args.kwargs["payloads"]
+        assert len(payloads) == 2
+        assert {p["entity_type"] for p in payloads} == {"PROPER", "NOUN"}
+        assert all(len(p["linked_memory_ids"]) == 1 for p in payloads)
+
+    @pytest.mark.asyncio
+    async def test_async_same_name_different_types_create_separate_entities(
+        self, mock_async_memory, mocker
+    ):
+        self._setup_entity_mocks(mock_async_memory, mocker)
+
+        result = await mock_async_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "Python language and snake"}],
+            metadata={},
+            effective_filters={"user_id": "u1"},
+            infer=True,
+        )
+
+        assert len(result) == 2
+        assert mock_async_memory._entity_store.insert.call_count == 1
+        payloads = mock_async_memory._entity_store.insert.call_args.kwargs["payloads"]
+        assert len(payloads) == 2
+        assert {p["entity_type"] for p in payloads} == {"PROPER", "NOUN"}
+        assert all(len(p["linked_memory_ids"]) == 1 for p in payloads)


### PR DESCRIPTION
## Linked Issue

Related to #5587

## Description

During a single `add()` call, Phase 7a global entity dedup keyed only on normalized entity text (`entity_text.strip().lower()`). When the same name appeared with different POS categories in one batch (e.g. `PROPER` "Python" vs `NOUN` "Python"), they were merged into one entity record and both memories were cross-linked.

Open #5497 adds merge gates at `_upsert_entity` and Phase 7d, but leaves this within-batch dedup path untouched.

**Fix:** composite dedup key `(entity_type, entity_text)` in sync/async Python and TS OSS Phase 7a.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added regression tests:
- `tests/memory/test_main.py::TestPhase7aEntityTypeDedup` (sync + async)
- `mem0-ts/src/oss/tests/memory.entity-dedup.test.ts`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed