### PR TITLE
fix(chroma): wrap update() ids/embeddings/metadatas in lists

### DIFF
--- a/mem0/vector_stores/chroma.py
+++ b/mem0/vector_stores/chroma.py
@@ -185,7 +185,11 @@ class ChromaDB(VectorStoreBase):
             vector (Optional[List[float]], optional): Updated vector. Defaults to None.
             payload (Optional[Dict], optional): Updated payload. Defaults to None.
         """
-        self.collection.update(ids=vector_id, embeddings=vector, metadatas=payload)
+        self.collection.update(
+            ids=[vector_id],
+            embeddings=[vector] if vector is not None else None,
+            metadatas=[payload] if payload is not None else None,
+        )
 
     def get(self, vector_id: str) -> Optional[OutputData]:
         """

--- a/tests/vector_stores/test_chroma.py
+++ b/tests/vector_stores/test_chroma.py
@@ -133,7 +133,31 @@ def test_update_vector(chromadb_instance):
     chromadb_instance.update(vector_id=vector_id, vector=new_vector, payload=new_payload)
 
     chromadb_instance.collection.update.assert_called_once_with(
-        ids=vector_id, embeddings=new_vector, metadatas=new_payload
+        ids=[vector_id], embeddings=[new_vector], metadatas=[new_payload]
+    )
+
+
+def test_update_vector_metadata_only(chromadb_instance):
+    # Metadata-only update (vector=None) must not wrap None in a list.
+    vector_id = "id1"
+    new_payload = {"name": "updated_vector"}
+
+    chromadb_instance.update(vector_id=vector_id, vector=None, payload=new_payload)
+
+    chromadb_instance.collection.update.assert_called_once_with(
+        ids=[vector_id], embeddings=None, metadatas=[new_payload]
+    )
+
+
+def test_update_vector_embedding_only(chromadb_instance):
+    # Vector-only update (payload=None) must not wrap None in a list.
+    vector_id = "id1"
+    new_vector = [0.7, 0.8, 0.9]
+
+    chromadb_instance.update(vector_id=vector_id, vector=new_vector, payload=None)
+
+    chromadb_instance.collection.update.assert_called_once_with(
+        ids=[vector_id], embeddings=[new_vector], metadatas=None
     )
 
 


### PR DESCRIPTION
## Summary

- `ChromaDB.update()` now wraps `ids`/`embeddings`/`metadatas` in lists, matching ChromaDB's API and the existing `insert()`/`get()` calls in this same file.
- Fixes silent no-op updates when a scalar string `vector_id` is passed (ChromaDB iterates the string character-by-character).

## Motivation

This is the `update()` half of the scalar-vs-list defect class. PR #5703 fixed `ChromaDB.delete()` (issue #5698) — it changed `self.collection.delete(ids=vector_id)` to `ids=[vector_id]` — but left the adjacent `update()` method with the identical bug:

```python
self.collection.update(ids=vector_id, embeddings=vector, metadatas=payload)
```

ChromaDB's `collection.update()` expects list arguments (the same contract as `add()`/`get()`, which this file already calls with `ids=[vector_id]`). When a plain string id is passed, ChromaDB iterates it character-by-character, so the targeted record is silently not updated.

## Fix

```python
self.collection.update(
    ids=[vector_id],
    embeddings=[vector] if vector is not None else None,
    metadatas=[payload] if payload is not None else None,
)
```

`embeddings`/`metadatas` are wrapped only when non-`None` so the metadata-only update (`vector=None`) and vector-only update (`payload=None`) paths keep passing `None` through instead of `[None]` (which ChromaDB rejects).

## Verification

- `python -m pytest tests/vector_stores/test_chroma.py` — **27 passed**.
- The 3 update tests **fail without the source fix** and pass with it (confirmed by stashing the source change and re-running: `3 failed`).

## Real behavior proof

Behavior addressed: scalar vs list args to `collection.update()`. Captured on `chromadb 1.5.9`, Python 3.14, against a real in-memory ChromaDB client (not mocked):

```
# metadata-only update (embeddings=None):
col.update(ids=["bb"], embeddings=None, metadatas=[{"x":77}])  -> get -> [{'x': 77}]   # OK
# vector-only update (metadatas=None):
col.update(ids=["bb"], embeddings=[[5.0,5.0]], metadatas=None) -> OK
```

(Note: on chromadb 1.5.9 the scalar form is internally normalized and no longer crashes, but the list form is the documented/contract-correct call and matches #5703's accepted reasoning and the rest of this file. Older ChromaDB versions exhibit the silent char-iteration no-op described in #5698.)

## Tests

- Updated `test_update_vector` to assert the list-wrapped call.
- Added `test_update_vector_metadata_only` and `test_update_vector_embedding_only` covering the `None` pass-through paths.

## Differential value

Complements #5703 (delete fix, issue #5698). Same file, same defect class, non-overlapping method — `update()` is not touched by #5703.
