### PR TITLE
perf(entity-extraction): compile substring-filter regex once per entity (O(n²) → O(n))

### DIFF
--- a/mem0/utils/entity_extraction.py
+++ b/mem0/utils/entity_extraction.py
@@ -174,6 +174,23 @@ def extract_entities_batch(texts: List[str], batch_size: int = 32) -> List[List[
     return results
 
 
+def _remove_whole_word_substring_entities(entities: List[Tuple[str, str]]) -> List[Tuple[str, str]]:
+    """Drop entities whose text is a whole-word substring of another entity.
+
+    Word-boundary anchoring keeps distinct entities that only share a leading
+    substring (e.g. "Sam" survives alongside "Samsung"). Each entity's boundary
+    pattern is compiled once -- O(n) compilations -- instead of recompiling the
+    pattern for every (entity, other) pair, which was O(n^2).
+    """
+    lowered = [text.lower() for _, text in entities]
+    kept: List[Tuple[str, str]] = []
+    for (etype, etext), needle in zip(entities, lowered):
+        pattern = re.compile(rf"\b{re.escape(needle)}\b")
+        if not any(needle != other and pattern.search(other) for other in lowered):
+            kept.append((etype, etext))
+    return kept
+
+
 def _extract_entities_from_doc(doc) -> List[Tuple[str, str]]:
     """Extract entities from a spaCy Doc object.
 
@@ -353,11 +370,4 @@ def _extract_entities_from_doc(doc) -> List[Tuple[str, str]]:
     deduped = list(best.values())
 
     # Remove entities that are whole-word substrings of longer entities.
-    # Word-boundary anchoring avoids dropping distinct entities that only share a
-    # leading substring (e.g. "Sam" must survive alongside "Samsung").
-    all_lower = [e[1].lower() for e in deduped]
-    return [
-        (t, e)
-        for t, e in deduped
-        if not any(e.lower() != o and re.search(rf"\b{re.escape(e.lower())}\b", o) for o in all_lower)
-    ]
+    return _remove_whole_word_substring_entities(deduped)

--- a/tests/utils/test_entity_substring_filter.py
+++ b/tests/utils/test_entity_substring_filter.py
@@ -1,0 +1,55 @@
+"""Unit tests for the whole-word substring entity filter.
+
+Pure-Python (no spaCy required): exercises ``_remove_whole_word_substring_entities``
+directly and pins it to the exact behavior of the original inline O(n^2) filter.
+"""
+
+import re
+
+from mem0.utils.entity_extraction import _remove_whole_word_substring_entities
+
+
+def _reference(entities):
+    """The original inline O(n^2) filter, kept as a parity oracle."""
+    all_lower = [e[1].lower() for e in entities]
+    return [
+        (t, e)
+        for t, e in entities
+        if not any(e.lower() != o and re.search(rf"\b{re.escape(e.lower())}\b", o) for o in all_lower)
+    ]
+
+
+def test_drops_whole_word_substring():
+    ents = [("NOUN", "machine"), ("COMPOUND", "machine learning")]
+    result = _remove_whole_word_substring_entities(ents)
+    assert ("COMPOUND", "machine learning") in result
+    assert ("NOUN", "machine") not in result
+
+
+def test_keeps_leading_substring_not_on_word_boundary():
+    # "Sam" is only a leading substring of "Samsung" (not a whole word) -> both kept.
+    ents = [("PROPER", "Sam"), ("PROPER", "Samsung")]
+    assert _remove_whole_word_substring_entities(ents) == ents
+
+
+def test_case_insensitive():
+    ents = [("PROPER", "Google"), ("COMPOUND", "google cloud"), ("NOUN", "cloud")]
+    # "Google" and "cloud" are whole-word substrings of "google cloud" (case-insensitive).
+    assert _remove_whole_word_substring_entities(ents) == [("COMPOUND", "google cloud")]
+
+
+def test_empty_and_single():
+    assert _remove_whole_word_substring_entities([]) == []
+    assert _remove_whole_word_substring_entities([("NOUN", "alone")]) == [("NOUN", "alone")]
+
+
+def test_parity_with_reference_naive_filter():
+    cases = [
+        [("A", "ai"), ("B", "ai model"), ("C", "model"), ("D", "open ai"), ("E", "ai"), ("F", "deep")],
+        [("P", "New York"), ("Q", "York"), ("R", "New"), ("S", "New Yorker")],
+        [("X", "c++"), ("Y", "c"), ("Z", "c++ guide")],  # regex special chars must be escaped
+        [("M", "data"), ("N", "database"), ("O", "data lake")],
+        [("U", "Sam"), ("V", "Samsung"), ("W", "Sam Altman")],
+    ]
+    for ents in cases:
+        assert _remove_whole_word_substring_entities(ents) == _reference(ents), ents


### PR DESCRIPTION
## Linked Issue

N/A — standalone performance + testability improvement.

## Description

The final step of `_extract_entities_from_doc` drops entities that are whole-word substrings of another entity. It did so with an inline comprehension that **recompiled the boundary regex for every (entity, other) pair**:

```python
all_lower = [e[1].lower() for e in deduped]
return [
    (t, e)
    for t, e in deduped
    if not any(e.lower() != o and re.search(rf"\b{re.escape(e.lower())}\b", o) for o in all_lower)
]
```

For `n` entities that's **O(n²) `re.compile` calls** (every `re.search(pattern_string, ...)` recompiles), plus `e.lower()` recomputed on every inner iteration. This runs on the entity-extraction path used by `search()`, `add(infer=True)` (once per extracted memory), and `update()`.

This extracts the logic into a pure helper `_remove_whole_word_substring_entities` that **compiles each entity's boundary pattern once** (O(n) compilations) and hoists the lowercasing:

```python
lowered = [text.lower() for _, text in entities]
kept = []
for (etype, etext), needle in zip(entities, lowered):
    pattern = re.compile(rf"\b{re.escape(needle)}\b")
    if not any(needle != other and pattern.search(other) for other in lowered):
        kept.append((etype, etext))
return kept
```

Output is **identical** — same word-boundary semantics, same order. The extraction also makes this logic unit-testable without the spaCy model (the existing `_extract_entities_from_doc` tests are skipped when `en_core_web_sm` is unavailable).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor (no functional changes) — performance + testability, behavior preserved

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

`tests/utils/test_entity_substring_filter.py` (new) — drops whole-word substrings, keeps non-boundary leading substrings (`Sam`/`Samsung`), case-insensitivity, empty/single, and a **parity test** asserting the helper returns exactly what the original inline O(n²) filter returned across several cases (incl. regex-special chars like `c++` and duplicate entities). 5 passed; `ruff check` clean. Existing `tests/utils/test_entity_extraction.py` unchanged (skips without spaCy, as before).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed (N/A)
