### PR TITLE
fix(ts-sdk): preserve custom category names

### DIFF
--- a/mem0-ts/src/client/mem0.types.ts
+++ b/mem0-ts/src/client/mem0.types.ts
@@ -169,7 +169,7 @@ export interface PaginatedMemories {
 
 export interface ProjectResponse {
   customInstructions?: string;
-  customCategories?: string[];
+  customCategories?: custom_categories[];
   [key: string]: any;
 }
 

--- a/mem0-ts/src/client/tests/utils.test.ts
+++ b/mem0-ts/src/client/tests/utils.test.ts
@@ -99,4 +99,38 @@ describe("camelToSnakeKeys / snakeToCamelKeys", () => {
       });
     });
   });
+
+  describe("user-controlled customCategories blob", () => {
+    it("converts the outer key but leaves custom category names on write", () => {
+      expect(
+        camelToSnakeKeys({
+          customCategories: [
+            { work_life_balance: "Work and personal life" },
+            { AIResearch: "AI research topics" },
+          ],
+        }),
+      ).toEqual({
+        custom_categories: [
+          { work_life_balance: "Work and personal life" },
+          { AIResearch: "AI research topics" },
+        ],
+      });
+    });
+
+    it("converts the outer key but leaves custom category names on read", () => {
+      expect(
+        snakeToCamelKeys({
+          custom_categories: [
+            { work_life_balance: "Work and personal life" },
+            { AIResearch: "AI research topics" },
+          ],
+        }),
+      ).toEqual({
+        customCategories: [
+          { work_life_balance: "Work and personal life" },
+          { AIResearch: "AI research topics" },
+        ],
+      });
+    });
+  });
 });

--- a/mem0-ts/src/client/utils.ts
+++ b/mem0-ts/src/client/utils.ts
@@ -29,6 +29,8 @@ const OPAQUE_VALUE_KEYS = new Set([
   "metadata",
   "structuredDataSchema",
   "structured_data_schema",
+  "customCategories",
+  "custom_categories",
 ]);
 
 /**


### PR DESCRIPTION
Fixes #5738.

## Summary
- Treat `customCategories` / `custom_categories` as opaque user-controlled values during TS SDK key conversion.
- Preserve category names such as `work_life_balance` and `AIResearch` instead of recursively camel/snake converting them.
- Correct `ProjectResponse.customCategories` from `string[]` to the existing category record array type.

## Testing
- `corepack pnpm@10.5.2 --dir mem0-ts test:ts -- src/client/tests/utils.test.ts --runInBand` -> `10 passed`
- `corepack pnpm@10.5.2 --dir mem0-ts exec tsc --noEmit --strict --moduleResolution node --module esnext --target es2018 --types node,jest src/client/utils.ts src/client/mem0.types.ts src/client/tests/utils.test.ts` -> passed
- `corepack pnpm@10.5.2 --dir mem0-ts exec prettier --check src/client/utils.ts src/client/mem0.types.ts src/client/tests/utils.test.ts` -> `All matched files use Prettier code style!`
- `git diff --check` -> clean

Note: I also tried the broader `corepack pnpm@10.5.2 --dir mem0-ts exec tsc --noEmit -p tsconfig.test.json`, but it is currently blocked by pre-existing `src/community/src/integrations/langchain/mem0.ts` type/module errors unrelated to these client files.
