### PR TITLE
fix(reranker): log fallback failures

### DIFF
--- a/mem0/reranker/base.py
+++ b/mem0/reranker/base.py
@@ -1,19 +1,32 @@
 from abc import ABC, abstractmethod
+import logging
 from typing import List, Dict, Any
+
+logger = logging.getLogger(__name__)
+
+
+def log_reranker_fallback(provider: str, exc: Exception) -> None:
+    """Log reranker failures before preserving the existing fallback behavior."""
+    logger.warning(
+        "%s reranking failed; returning fallback rerank scores.",
+        provider,
+        exc_info=exc,
+    )
+
 
 class BaseReranker(ABC):
     """Abstract base class for all rerankers."""
-    
+
     @abstractmethod
     def rerank(self, query: str, documents: List[Dict[str, Any]], top_k: int = None) -> List[Dict[str, Any]]:
         """
         Rerank documents based on relevance to the query.
-        
+
         Args:
             query: The search query
-            documents: List of documents to rerank, each with 'memory' field  
+            documents: List of documents to rerank, each with 'memory' field
             top_k: Number of top documents to return (None = return all)
-            
+
         Returns:
             List of reranked documents with added 'rerank_score' field
         """

--- a/mem0/reranker/cohere_reranker.py
+++ b/mem0/reranker/cohere_reranker.py
@@ -1,10 +1,11 @@
 import os
 from typing import List, Dict, Any
 
-from mem0.reranker.base import BaseReranker
+from mem0.reranker.base import BaseReranker, log_reranker_fallback
 
 try:
     import cohere
+
     COHERE_AVAILABLE = True
 except ImportError:
     COHERE_AVAILABLE = False
@@ -12,52 +13,54 @@ except ImportError:
 
 class CohereReranker(BaseReranker):
     """Cohere-based reranker implementation."""
-    
+
     def __init__(self, config):
         """
         Initialize Cohere reranker.
-        
+
         Args:
             config: CohereRerankerConfig object with configuration parameters
         """
         if not COHERE_AVAILABLE:
             raise ImportError("cohere package is required for CohereReranker. Install with: pip install cohere")
-        
+
         self.config = config
         self.api_key = config.api_key or os.getenv("COHERE_API_KEY")
         if not self.api_key:
-            raise ValueError("Cohere API key is required. Set COHERE_API_KEY environment variable or pass api_key in config.")
-            
+            raise ValueError(
+                "Cohere API key is required. Set COHERE_API_KEY environment variable or pass api_key in config."
+            )
+
         self.model = config.model
         self.client = cohere.Client(self.api_key)
-        
+
     def rerank(self, query: str, documents: List[Dict[str, Any]], top_k: int = None) -> List[Dict[str, Any]]:
         """
         Rerank documents using Cohere's rerank API.
-        
+
         Args:
             query: The search query
             documents: List of documents to rerank
             top_k: Number of top documents to return
-            
+
         Returns:
             List of reranked documents with rerank_score
         """
         if not documents:
             return documents
-            
+
         # Extract text content for reranking
         doc_texts = []
         for doc in documents:
-            if 'memory' in doc:
-                doc_texts.append(doc['memory'])
-            elif 'text' in doc:
-                doc_texts.append(doc['text'])  
-            elif 'content' in doc:
-                doc_texts.append(doc['content'])
+            if "memory" in doc:
+                doc_texts.append(doc["memory"])
+            elif "text" in doc:
+                doc_texts.append(doc["text"])
+            elif "content" in doc:
+                doc_texts.append(doc["content"])
             else:
                 doc_texts.append(str(doc))
-        
+
         try:
             # Call Cohere rerank API
             response = self.client.rerank(
@@ -68,19 +71,20 @@ class CohereReranker(BaseReranker):
                 return_documents=self.config.return_documents,
                 max_chunks_per_doc=self.config.max_chunks_per_doc,
             )
-            
+
             # Create reranked results
             reranked_docs = []
             for result in response.results:
                 original_doc = documents[result.index].copy()
-                original_doc['rerank_score'] = result.relevance_score
+                original_doc["rerank_score"] = result.relevance_score
                 reranked_docs.append(original_doc)
-                
+
             return reranked_docs
 
-        except Exception:
+        except Exception as exc:
+            log_reranker_fallback("CohereReranker", exc)
             # Fallback to original order if reranking fails
             for doc in documents:
-                doc['rerank_score'] = 0.0
+                doc["rerank_score"] = 0.0
             final_top_k = top_k or self.config.top_k
             return documents[:final_top_k] if final_top_k else documents

--- a/mem0/reranker/huggingface_reranker.py
+++ b/mem0/reranker/huggingface_reranker.py
@@ -1,13 +1,14 @@
 from typing import List, Dict, Any, Union
 import numpy as np
 
-from mem0.reranker.base import BaseReranker
+from mem0.reranker.base import BaseReranker, log_reranker_fallback
 from mem0.configs.rerankers.base import BaseRerankerConfig
 from mem0.configs.rerankers.huggingface import HuggingFaceRerankerConfig
 
 try:
     from transformers import AutoTokenizer, AutoModelForSequenceClassification
     import torch
+
     TRANSFORMERS_AVAILABLE = True
 except ImportError:
     TRANSFORMERS_AVAILABLE = False
@@ -24,7 +25,9 @@ class HuggingFaceReranker(BaseReranker):
             config: Configuration object with reranker parameters
         """
         if not TRANSFORMERS_AVAILABLE:
-            raise ImportError("transformers package is required for HuggingFaceReranker. Install with: pip install transformers torch")
+            raise ImportError(
+                "transformers package is required for HuggingFaceReranker. Install with: pip install transformers torch"
+            )
 
         # Convert to HuggingFaceRerankerConfig if needed
         if isinstance(config, dict):
@@ -32,10 +35,10 @@ class HuggingFaceReranker(BaseReranker):
         elif isinstance(config, BaseRerankerConfig) and not isinstance(config, HuggingFaceRerankerConfig):
             # Convert BaseRerankerConfig to HuggingFaceRerankerConfig with defaults
             config = HuggingFaceRerankerConfig(
-                provider=getattr(config, 'provider', 'huggingface'),
-                model=getattr(config, 'model', 'BAAI/bge-reranker-base'),
-                api_key=getattr(config, 'api_key', None),
-                top_k=getattr(config, 'top_k', None),
+                provider=getattr(config, "provider", "huggingface"),
+                model=getattr(config, "model", "BAAI/bge-reranker-base"),
+                api_key=getattr(config, "api_key", None),
+                top_k=getattr(config, "top_k", None),
                 device=None,  # Will auto-detect
                 batch_size=32,  # Default
                 max_length=512,  # Default
@@ -74,12 +77,12 @@ class HuggingFaceReranker(BaseReranker):
         # Extract text content for reranking
         doc_texts = []
         for doc in documents:
-            if 'memory' in doc:
-                doc_texts.append(doc['memory'])
-            elif 'text' in doc:
-                doc_texts.append(doc['text'])
-            elif 'content' in doc:
-                doc_texts.append(doc['content'])
+            if "memory" in doc:
+                doc_texts.append(doc["memory"])
+            elif "text" in doc:
+                doc_texts.append(doc["text"])
+            elif "content" in doc:
+                doc_texts.append(doc["content"])
             else:
                 doc_texts.append(str(doc))
 
@@ -88,16 +91,12 @@ class HuggingFaceReranker(BaseReranker):
 
             # Process documents in batches
             for i in range(0, len(doc_texts), self.config.batch_size):
-                batch_docs = doc_texts[i:i + self.config.batch_size]
+                batch_docs = doc_texts[i : i + self.config.batch_size]
                 batch_pairs = [[query, doc] for doc in batch_docs]
 
                 # Tokenize batch
                 inputs = self.tokenizer(
-                    batch_pairs,
-                    padding=True,
-                    truncation=True,
-                    max_length=self.config.max_length,
-                    return_tensors="pt"
+                    batch_pairs, padding=True, truncation=True, max_length=self.config.max_length, return_tensors="pt"
                 ).to(self.device)
 
                 # Get scores
@@ -134,14 +133,15 @@ class HuggingFaceReranker(BaseReranker):
             reranked_docs = []
             for doc, score in doc_score_pairs:
                 reranked_doc = doc.copy()
-                reranked_doc['rerank_score'] = float(score)
+                reranked_doc["rerank_score"] = float(score)
                 reranked_docs.append(reranked_doc)
 
             return reranked_docs
 
-        except Exception:
+        except Exception as exc:
+            log_reranker_fallback("HuggingFaceReranker", exc)
             # Fallback to original order if reranking fails
             for doc in documents:
-                doc['rerank_score'] = 0.0
+                doc["rerank_score"] = 0.0
             final_top_k = top_k or self.config.top_k
             return documents[:final_top_k] if final_top_k else documents

--- a/mem0/reranker/llm_reranker.py
+++ b/mem0/reranker/llm_reranker.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Union
 
 from mem0.configs.rerankers.base import BaseRerankerConfig
 from mem0.configs.rerankers.llm import LLMRerankerConfig
-from mem0.reranker.base import BaseReranker
+from mem0.reranker.base import BaseReranker, log_reranker_fallback
 from mem0.utils.factory import LlmFactory
 
 
@@ -23,12 +23,12 @@ class LLMReranker(BaseReranker):
         elif isinstance(config, BaseRerankerConfig) and not isinstance(config, LLMRerankerConfig):
             # Convert BaseRerankerConfig to LLMRerankerConfig with defaults
             config = LLMRerankerConfig(
-                provider=getattr(config, 'provider', 'openai'),
-                model=getattr(config, 'model', 'gpt-4o-mini'),
-                api_key=getattr(config, 'api_key', None),
-                top_k=getattr(config, 'top_k', None),
+                provider=getattr(config, "provider", "openai"),
+                model=getattr(config, "model", "gpt-4o-mini"),
+                api_key=getattr(config, "api_key", None),
+                top_k=getattr(config, "top_k", None),
                 temperature=0.0,  # Default for reranking
-                max_tokens=100,   # Default for reranking
+                max_tokens=100,  # Default for reranking
             )
 
         self.config = config
@@ -59,9 +59,10 @@ class LLMReranker(BaseReranker):
         self.llm = LlmFactory.create(llm_provider, llm_config)
 
         # Honor custom scoring_prompt from config if provided
-        custom_prompt = getattr(self.config, 'scoring_prompt', None)
+        custom_prompt = getattr(self.config, "scoring_prompt", None)
         if custom_prompt:
             import warnings
+
             warnings.warn(
                 "LLMRerankerConfig.scoring_prompt is deprecated and will be removed in a future version. "
                 "The prompt is now used as the system message.",
@@ -92,7 +93,7 @@ class LLMReranker(BaseReranker):
         """Extract numerical score from LLM response."""
         # Prefer a decimal, fall back to an integer, then clamp: out-of-range outputs
         # like "2.0"/"5" become 1.0 instead of being mis-parsed into a stray 0/1 digit.
-        matches = re.findall(r'-?\d+\.\d+', response_text) or re.findall(r'-?\d+', response_text)
+        matches = re.findall(r"-?\d+\.\d+", response_text) or re.findall(r"-?\d+", response_text)
 
         if matches:
             score = float(matches[0])
@@ -100,35 +101,35 @@ class LLMReranker(BaseReranker):
 
         # Fallback: return 0.5 if no valid score found
         return 0.5
-    
+
     def rerank(self, query: str, documents: List[Dict[str, Any]], top_k: int = None) -> List[Dict[str, Any]]:
         """
         Rerank documents using LLM scoring.
-        
+
         Args:
             query: The search query
             documents: List of documents to rerank
             top_k: Number of top documents to return
-            
+
         Returns:
             List of reranked documents with rerank_score
         """
         if not documents:
             return documents
-        
+
         scored_docs = []
-        
+
         for doc in documents:
             # Extract text content
-            if 'memory' in doc:
-                doc_text = doc['memory']
-            elif 'text' in doc:
-                doc_text = doc['text']  
-            elif 'content' in doc:
-                doc_text = doc['content']
+            if "memory" in doc:
+                doc_text = doc["memory"]
+            elif "text" in doc:
+                doc_text = doc["text"]
+            elif "content" in doc:
+                doc_text = doc["content"]
             else:
                 doc_text = str(doc)
-            
+
             try:
                 # Truncate inputs to prevent prompt flooding, then send as separate
                 # system/user messages so instructions cannot be overridden by user data.
@@ -142,28 +143,29 @@ class LLMReranker(BaseReranker):
                         {"role": "user", "content": user_message},
                     ]
                 )
-                
+
                 # Extract score from response
                 score = self._extract_score(response)
-                
+
                 # Create scored document
                 scored_doc = doc.copy()
-                scored_doc['rerank_score'] = score
+                scored_doc["rerank_score"] = score
                 scored_docs.append(scored_doc)
 
-            except Exception:
+            except Exception as exc:
+                log_reranker_fallback("LLMReranker", exc)
                 # Fallback: assign neutral score if scoring fails
                 scored_doc = doc.copy()
-                scored_doc['rerank_score'] = 0.5
+                scored_doc["rerank_score"] = 0.5
                 scored_docs.append(scored_doc)
-        
+
         # Sort by relevance score in descending order
-        scored_docs.sort(key=lambda x: x['rerank_score'], reverse=True)
-        
+        scored_docs.sort(key=lambda x: x["rerank_score"], reverse=True)
+
         # Apply top_k limit
         if top_k:
             scored_docs = scored_docs[:top_k]
         elif self.config.top_k:
-            scored_docs = scored_docs[:self.config.top_k]
-            
+            scored_docs = scored_docs[: self.config.top_k]
+
         return scored_docs

--- a/mem0/reranker/sentence_transformer_reranker.py
+++ b/mem0/reranker/sentence_transformer_reranker.py
@@ -1,12 +1,13 @@
 from typing import List, Dict, Any, Union
 import numpy as np
 
-from mem0.reranker.base import BaseReranker
+from mem0.reranker.base import BaseReranker, log_reranker_fallback
 from mem0.configs.rerankers.base import BaseRerankerConfig
 from mem0.configs.rerankers.sentence_transformer import SentenceTransformerRerankerConfig
 
 try:
     from sentence_transformers import CrossEncoder
+
     SENTENCE_TRANSFORMERS_AVAILABLE = True
 except ImportError:
     SENTENCE_TRANSFORMERS_AVAILABLE = False
@@ -23,7 +24,9 @@ class SentenceTransformerReranker(BaseReranker):
             config: Configuration object with reranker parameters
         """
         if not SENTENCE_TRANSFORMERS_AVAILABLE:
-            raise ImportError("sentence-transformers package is required for SentenceTransformerReranker. Install with: pip install sentence-transformers")
+            raise ImportError(
+                "sentence-transformers package is required for SentenceTransformerReranker. Install with: pip install sentence-transformers"
+            )
 
         # Convert to SentenceTransformerRerankerConfig if needed
         if isinstance(config, dict):
@@ -31,10 +34,10 @@ class SentenceTransformerReranker(BaseReranker):
         elif isinstance(config, BaseRerankerConfig) and not isinstance(config, SentenceTransformerRerankerConfig):
             # Convert BaseRerankerConfig to SentenceTransformerRerankerConfig with defaults
             config = SentenceTransformerRerankerConfig(
-                provider=getattr(config, 'provider', 'sentence_transformer'),
-                model=getattr(config, 'model', 'cross-encoder/ms-marco-MiniLM-L-6-v2'),
-                api_key=getattr(config, 'api_key', None),
-                top_k=getattr(config, 'top_k', None),
+                provider=getattr(config, "provider", "sentence_transformer"),
+                model=getattr(config, "model", "cross-encoder/ms-marco-MiniLM-L-6-v2"),
+                api_key=getattr(config, "api_key", None),
+                top_k=getattr(config, "top_k", None),
                 device=None,  # Will auto-detect
                 batch_size=32,  # Default
                 show_progress_bar=False,  # Default
@@ -42,38 +45,38 @@ class SentenceTransformerReranker(BaseReranker):
 
         self.config = config
         self.model = CrossEncoder(self.config.model, device=self.config.device)
-        
+
     def rerank(self, query: str, documents: List[Dict[str, Any]], top_k: int = None) -> List[Dict[str, Any]]:
         """
         Rerank documents using sentence transformer cross-encoder.
-        
+
         Args:
             query: The search query
             documents: List of documents to rerank
             top_k: Number of top documents to return
-            
+
         Returns:
             List of reranked documents with rerank_score
         """
         if not documents:
             return documents
-            
+
         # Extract text content for reranking
         doc_texts = []
         for doc in documents:
-            if 'memory' in doc:
-                doc_texts.append(doc['memory'])
-            elif 'text' in doc:
-                doc_texts.append(doc['text'])  
-            elif 'content' in doc:
-                doc_texts.append(doc['content'])
+            if "memory" in doc:
+                doc_texts.append(doc["memory"])
+            elif "text" in doc:
+                doc_texts.append(doc["text"])
+            elif "content" in doc:
+                doc_texts.append(doc["content"])
             else:
                 doc_texts.append(str(doc))
-        
+
         try:
             # Create query-document pairs
             pairs = [[query, doc_text] for doc_text in doc_texts]
-            
+
             scores = self.model.predict(
                 pairs,
                 batch_size=self.config.batch_size,
@@ -81,30 +84,31 @@ class SentenceTransformerReranker(BaseReranker):
             )
             if isinstance(scores, np.ndarray):
                 scores = scores.tolist()
-            
+
             # Combine documents with scores
             doc_score_pairs = list(zip(documents, scores))
-            
+
             # Sort by score (descending)
             doc_score_pairs.sort(key=lambda x: x[1], reverse=True)
-            
+
             # Apply top_k limit
             final_top_k = top_k or self.config.top_k
             if final_top_k:
                 doc_score_pairs = doc_score_pairs[:final_top_k]
-                
+
             # Create reranked results
             reranked_docs = []
             for doc, score in doc_score_pairs:
                 reranked_doc = doc.copy()
-                reranked_doc['rerank_score'] = float(score)
+                reranked_doc["rerank_score"] = float(score)
                 reranked_docs.append(reranked_doc)
-                
+
             return reranked_docs
 
-        except Exception:
+        except Exception as exc:
+            log_reranker_fallback("SentenceTransformerReranker", exc)
             # Fallback to original order if reranking fails
             for doc in documents:
-                doc['rerank_score'] = 0.0
+                doc["rerank_score"] = 0.0
             final_top_k = top_k or self.config.top_k
             return documents[:final_top_k] if final_top_k else documents

--- a/mem0/reranker/zero_entropy_reranker.py
+++ b/mem0/reranker/zero_entropy_reranker.py
@@ -1,10 +1,11 @@
 import os
 from typing import List, Dict, Any
 
-from mem0.reranker.base import BaseReranker
+from mem0.reranker.base import BaseReranker, log_reranker_fallback
 
 try:
     from zeroentropy import ZeroEntropy
+
     ZERO_ENTROPY_AVAILABLE = True
 except ImportError:
     ZERO_ENTROPY_AVAILABLE = False
@@ -12,57 +13,61 @@ except ImportError:
 
 class ZeroEntropyReranker(BaseReranker):
     """Zero Entropy-based reranker implementation."""
-    
+
     def __init__(self, config):
         """
         Initialize Zero Entropy reranker.
-        
+
         Args:
             config: ZeroEntropyRerankerConfig object with configuration parameters
         """
         if not ZERO_ENTROPY_AVAILABLE:
-            raise ImportError("zeroentropy package is required for ZeroEntropyReranker. Install with: pip install zeroentropy")
-        
+            raise ImportError(
+                "zeroentropy package is required for ZeroEntropyReranker. Install with: pip install zeroentropy"
+            )
+
         self.config = config
         self.api_key = config.api_key or os.getenv("ZERO_ENTROPY_API_KEY")
         if not self.api_key:
-            raise ValueError("Zero Entropy API key is required. Set ZERO_ENTROPY_API_KEY environment variable or pass api_key in config.")
-            
+            raise ValueError(
+                "Zero Entropy API key is required. Set ZERO_ENTROPY_API_KEY environment variable or pass api_key in config."
+            )
+
         self.model = config.model or "zerank-1"
-        
+
         # Initialize Zero Entropy client
         if self.api_key:
             self.client = ZeroEntropy(api_key=self.api_key)
         else:
             self.client = ZeroEntropy()  # Will use ZERO_ENTROPY_API_KEY from environment
-        
+
     def rerank(self, query: str, documents: List[Dict[str, Any]], top_k: int = None) -> List[Dict[str, Any]]:
         """
         Rerank documents using Zero Entropy's rerank API.
-        
+
         Args:
             query: The search query
             documents: List of documents to rerank
             top_k: Number of top documents to return
-            
+
         Returns:
             List of reranked documents with rerank_score
         """
         if not documents:
             return documents
-            
+
         # Extract text content for reranking
         doc_texts = []
         for doc in documents:
-            if 'memory' in doc:
-                doc_texts.append(doc['memory'])
-            elif 'text' in doc:
-                doc_texts.append(doc['text'])  
-            elif 'content' in doc:
-                doc_texts.append(doc['content'])
+            if "memory" in doc:
+                doc_texts.append(doc["memory"])
+            elif "text" in doc:
+                doc_texts.append(doc["text"])
+            elif "content" in doc:
+                doc_texts.append(doc["content"])
             else:
                 doc_texts.append(str(doc))
-        
+
         try:
             # Call Zero Entropy rerank API
             response = self.client.models.rerank(
@@ -70,28 +75,29 @@ class ZeroEntropyReranker(BaseReranker):
                 query=query,
                 documents=doc_texts,
             )
-            
+
             # Create reranked results
             reranked_docs = []
             for result in response.results:
                 original_doc = documents[result.index].copy()
-                original_doc['rerank_score'] = result.relevance_score
+                original_doc["rerank_score"] = result.relevance_score
                 reranked_docs.append(original_doc)
-            
+
             # Sort by relevance score in descending order
-            reranked_docs.sort(key=lambda x: x['rerank_score'], reverse=True)
-            
+            reranked_docs.sort(key=lambda x: x["rerank_score"], reverse=True)
+
             # Apply top_k limit
             if top_k:
                 reranked_docs = reranked_docs[:top_k]
             elif self.config.top_k:
-                reranked_docs = reranked_docs[:self.config.top_k]
-                
+                reranked_docs = reranked_docs[: self.config.top_k]
+
             return reranked_docs
 
-        except Exception:
+        except Exception as exc:
+            log_reranker_fallback("ZeroEntropyReranker", exc)
             # Fallback to original order if reranking fails
             for doc in documents:
-                doc['rerank_score'] = 0.0
+                doc["rerank_score"] = 0.0
             final_top_k = top_k or self.config.top_k
             return documents[:final_top_k] if final_top_k else documents

--- a/tests/rerankers/test_reranker_fallback_logging.py
+++ b/tests/rerankers/test_reranker_fallback_logging.py
@@ -1,0 +1,121 @@
+import logging
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from mem0.configs.rerankers.cohere import CohereRerankerConfig
+from mem0.configs.rerankers.zero_entropy import ZeroEntropyRerankerConfig
+
+
+LOGGER_NAME = "mem0.reranker.base"
+
+
+@pytest.fixture
+def mock_cohere(monkeypatch):
+    fake_cohere = ModuleType("cohere")
+    fake_client = MagicMock()
+    fake_cohere.Client = MagicMock(return_value=fake_client)
+    monkeypatch.setitem(sys.modules, "cohere", fake_cohere)
+
+    import mem0.reranker.cohere_reranker as cohere_reranker
+
+    monkeypatch.setattr(cohere_reranker, "cohere", fake_cohere, raising=False)
+    monkeypatch.setattr(cohere_reranker, "COHERE_AVAILABLE", True, raising=False)
+    return cohere_reranker, fake_client
+
+
+@pytest.fixture
+def mock_zero_entropy(monkeypatch):
+    fake_module = ModuleType("zeroentropy")
+    fake_client = MagicMock()
+    fake_module.ZeroEntropy = MagicMock(return_value=fake_client)
+    monkeypatch.setitem(sys.modules, "zeroentropy", fake_module)
+
+    import mem0.reranker.zero_entropy_reranker as zero_entropy_reranker
+
+    monkeypatch.setattr(zero_entropy_reranker, "ZeroEntropy", fake_module.ZeroEntropy, raising=False)
+    monkeypatch.setattr(zero_entropy_reranker, "ZERO_ENTROPY_AVAILABLE", True, raising=False)
+    return zero_entropy_reranker, fake_client
+
+
+def _docs():
+    return [{"memory": "doc0"}, {"memory": "doc1"}]
+
+
+def _assert_fallback_warning(caplog, provider):
+    assert any(
+        record.levelno == logging.WARNING
+        and provider in record.getMessage()
+        and "returning fallback rerank scores" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_cohere_fallback_logs_warning(caplog, mock_cohere):
+    module, fake_client = mock_cohere
+    fake_client.rerank.side_effect = RuntimeError("cohere down")
+
+    reranker = module.CohereReranker(CohereRerankerConfig(api_key="test-key"))
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        result = reranker.rerank("query", _docs())
+
+    _assert_fallback_warning(caplog, "CohereReranker")
+    assert [doc["rerank_score"] for doc in result] == [0.0, 0.0]
+
+
+def test_zero_entropy_fallback_logs_warning(caplog, mock_zero_entropy):
+    module, fake_client = mock_zero_entropy
+    fake_client.models.rerank.side_effect = RuntimeError("zero entropy down")
+
+    reranker = module.ZeroEntropyReranker(ZeroEntropyRerankerConfig(api_key="test-key"))
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        result = reranker.rerank("query", _docs())
+
+    _assert_fallback_warning(caplog, "ZeroEntropyReranker")
+    assert [doc["rerank_score"] for doc in result] == [0.0, 0.0]
+
+
+def test_huggingface_fallback_logs_warning(caplog):
+    from mem0.reranker.huggingface_reranker import HuggingFaceReranker
+
+    reranker = object.__new__(HuggingFaceReranker)
+    reranker.config = SimpleNamespace(batch_size=32, max_length=512, normalize=True, top_k=None)
+    reranker.device = "cpu"
+    reranker.tokenizer = MagicMock(side_effect=RuntimeError("tokenizer failed"))
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        result = reranker.rerank("query", _docs())
+
+    _assert_fallback_warning(caplog, "HuggingFaceReranker")
+    assert [doc["rerank_score"] for doc in result] == [0.0, 0.0]
+
+
+def test_sentence_transformer_fallback_logs_warning(caplog):
+    from mem0.reranker.sentence_transformer_reranker import SentenceTransformerReranker
+
+    reranker = object.__new__(SentenceTransformerReranker)
+    reranker.config = SimpleNamespace(batch_size=32, show_progress_bar=False, top_k=None)
+    reranker.model = MagicMock()
+    reranker.model.predict.side_effect = RuntimeError("predict failed")
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        result = reranker.rerank("query", _docs())
+
+    _assert_fallback_warning(caplog, "SentenceTransformerReranker")
+    assert [doc["rerank_score"] for doc in result] == [0.0, 0.0]
+
+
+def test_llm_fallback_logs_warning(caplog, mock_llm):
+    from mem0.reranker.llm_reranker import LLMReranker
+
+    _, mock_llm_instance = mock_llm
+    mock_llm_instance.generate_response.side_effect = RuntimeError("llm down")
+
+    reranker = LLMReranker({"provider": "openai"})
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        result = reranker.rerank("query", [{"memory": "doc"}])
+
+    _assert_fallback_warning(caplog, "LLMReranker")
+    assert result[0]["rerank_score"] == 0.5


### PR DESCRIPTION
Fixes #5716.

## Summary

- log reranker provider failures at WARNING before returning existing fallback scores
- keep the current graceful fallback behavior and score defaults unchanged
- cover Cohere, HuggingFace, SentenceTransformer, ZeroEntropy, and LLM reranker fallback paths

## Root cause

The reranker providers caught broad `Exception`s and returned fallback scores without any log entry, so bad credentials, SDK errors, or network failures looked like successful reranks.

## Validation

- `uv run --extra test pytest tests/rerankers/test_reranker_fallback_logging.py tests/rerankers/test_reranker_fallback_topk.py tests/rerankers/test_llm_reranker_rerank.py -q` -> `33 passed, 1 warning`
- `uv run --extra dev ruff check mem0/reranker/base.py mem0/reranker/cohere_reranker.py mem0/reranker/huggingface_reranker.py mem0/reranker/sentence_transformer_reranker.py mem0/reranker/zero_entropy_reranker.py mem0/reranker/llm_reranker.py tests/rerankers/test_reranker_fallback_logging.py` -> `All checks passed!`
- `uv run --extra dev ruff format --check mem0/reranker/base.py mem0/reranker/cohere_reranker.py mem0/reranker/huggingface_reranker.py mem0/reranker/sentence_transformer_reranker.py mem0/reranker/zero_entropy_reranker.py mem0/reranker/llm_reranker.py tests/rerankers/test_reranker_fallback_logging.py` -> `7 files already formatted`
