### PR TITLE
feat: recall memories from extracted facts before final extraction

### DIFF
--- a/docs/changelog/sdk.mdx
+++ b/docs/changelog/sdk.mdx
@@ -7,6 +7,16 @@ mode: "wide"
 <Tabs>
 <Tab title="Python">
 
+<Update label="2026-06-29" description="Fact-first memory recall">
+
+**Memory add pipeline now supports fact-first recall**
+
+- **Memory:** `add()` can now extract candidate memories first, recall existing memories from those candidates, and then run a final reconciliation pass with the recalled context.
+- **Memory:** Added `fact_first_recall` config to opt out and keep the legacy single-pass recall flow when lower latency or cost is preferred.
+- **Memory:** Async recall now runs candidate lookups concurrently to reduce the added latency from the extra recall phase.
+
+</Update>
+
 <Update label="2026-06-17" description="v2.0.7">
 
 **New Features:**

--- a/mem0-ts/src/oss/src/config/defaults.ts
+++ b/mem0-ts/src/oss/src/config/defaults.ts
@@ -2,6 +2,7 @@ import { MemoryConfig } from "../types";
 
 export const DEFAULT_MEMORY_CONFIG: MemoryConfig = {
   disableHistory: false,
+  factFirstRecall: true,
   version: "v1.1",
   embedder: {
     provider: "openai",

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -155,6 +155,59 @@ function validateSearchParams(threshold?: number, topK?: number): void {
   }
 }
 
+function parseAdditiveExtractionResponse(response: string): Array<{
+  id?: string;
+  text?: string;
+  attributed_to?: string;
+  linked_memory_ids?: string[];
+}> {
+  const cleanResponse = extractJson(response);
+  if (!cleanResponse || !cleanResponse.trim()) {
+    return [];
+  }
+
+  try {
+    const parsed = AdditiveExtractionSchema.parse(JSON.parse(cleanResponse));
+    return parsed.memory;
+  } catch {
+    const fallbackJson = extractJson(cleanResponse);
+    return JSON.parse(fallbackJson)?.memory ?? [];
+  }
+}
+
+function mapExistingMemories(existingResults: Array<{ id: string; payload: Record<string, any> }>) {
+  const existingMemories: Array<{ id: string; text: string }> = [];
+  const uuidMapping: Record<string, string> = {};
+  for (let idx = 0; idx < existingResults.length; idx++) {
+    const mem = existingResults[idx];
+    uuidMapping[String(idx)] = mem.id;
+    existingMemories.push({
+      id: String(idx),
+      text: mem.payload?.data ?? "",
+    });
+  }
+  return { existingMemories, uuidMapping };
+}
+
+function replaceLinkedMemoryIds(
+  extractedMemories: Array<{
+    id?: string;
+    text?: string;
+    attributed_to?: string;
+    linked_memory_ids?: string[];
+  }>,
+  uuidMapping: Record<string, string>,
+): void {
+  for (const memory of extractedMemories) {
+    if (!Array.isArray(memory.linked_memory_ids)) {
+      continue;
+    }
+    memory.linked_memory_ids = memory.linked_memory_ids.map(
+      (linkedId) => uuidMapping[String(linkedId)] ?? linkedId,
+    );
+  }
+}
+
 export class Memory {
   private config: MemoryConfig;
   private customInstructions: string | undefined;
@@ -466,6 +519,162 @@ export class Memory {
     return parts.join("&");
   }
 
+  private async generateAdditiveExtractionMemories(options: {
+    parsedMessages: string;
+    lastMessages: Array<{ role: string; content: string; name?: string }>;
+    customInstructions?: string;
+    existingMemories?: Array<{ id: string; text: string }>;
+    recentlyExtractedMemories?: Array<{
+      id?: string;
+      text?: string;
+      attributed_to?: string;
+      linked_memory_ids?: string[];
+    }>;
+    isAgentScoped?: boolean;
+  }): Promise<
+    Array<{
+      id?: string;
+      text?: string;
+      attributed_to?: string;
+      linked_memory_ids?: string[];
+    }>
+  > {
+    let systemPrompt = ADDITIVE_EXTRACTION_PROMPT;
+    if (options.isAgentScoped) {
+      systemPrompt += AGENT_CONTEXT_SUFFIX;
+    }
+
+    const userPrompt = generateAdditiveExtractionPrompt({
+      existingMemories: options.existingMemories,
+      recentlyExtractedMemories: options.recentlyExtractedMemories,
+      newMessages: options.parsedMessages,
+      lastKMessages: options.lastMessages,
+      customInstructions: options.customInstructions,
+    });
+
+    const response = (await this.llm.generateResponse(
+      [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: userPrompt },
+      ],
+      { type: "json_object" },
+    )) as string;
+
+    return parseAdditiveExtractionResponse(response);
+  }
+
+  private async recallExistingMemoriesForCandidates(
+    candidateMemories: Array<{
+      id?: string;
+      text?: string;
+      attributed_to?: string;
+      linked_memory_ids?: string[];
+    }>,
+    filters: SearchFilters,
+    topK = 5,
+  ): Promise<VectorStoreResult[]> {
+    const recalledResults: VectorStoreResult[] = [];
+    const seenIds = new Set<string>();
+
+    await Promise.all(
+      candidateMemories.map(async (mem) => {
+        const text = mem.text;
+        if (!text) {
+          return;
+        }
+
+        try {
+          const queryEmbedding = await this.embedder.embed(text);
+          const matches = await this.vectorStore.search(
+            queryEmbedding,
+            topK,
+            filters,
+          );
+          for (const match of matches) {
+            if (seenIds.has(match.id)) {
+              continue;
+            }
+            seenIds.add(match.id);
+            recalledResults.push(match);
+          }
+        } catch (error) {
+          console.warn("Failed to recall existing memories for candidate:", error);
+        }
+      }),
+    );
+
+    return recalledResults;
+  }
+
+  private async extractMemoriesWithOptionalFactFirstRecall(options: {
+    parsedMessages: string;
+    lastMessages: Array<{ role: string; content: string; name?: string }>;
+    customInstructions?: string;
+    filters: SearchFilters;
+    isAgentScoped: boolean;
+  }): Promise<
+    [
+      Array<{
+        id?: string;
+        text?: string;
+        attributed_to?: string;
+        linked_memory_ids?: string[];
+      }>,
+      VectorStoreResult[],
+    ]
+  > {
+    if (!this.config.factFirstRecall) {
+      const queryEmbedding = await this.embedder.embed(options.parsedMessages);
+      const existingResults = await this.vectorStore.search(
+        queryEmbedding,
+        10,
+        options.filters,
+      );
+      const { existingMemories } = mapExistingMemories(existingResults);
+      const extractedMemories = await this.generateAdditiveExtractionMemories({
+        parsedMessages: options.parsedMessages,
+        lastMessages: options.lastMessages,
+        customInstructions: options.customInstructions,
+        existingMemories,
+        isAgentScoped: options.isAgentScoped,
+      });
+      return [extractedMemories, existingResults];
+    }
+
+    // Intentional semantic change: if phase 1 extracts nothing, recall is skipped.
+    const initialMemories = await this.generateAdditiveExtractionMemories({
+      parsedMessages: options.parsedMessages,
+      lastMessages: options.lastMessages,
+      customInstructions: options.customInstructions,
+      isAgentScoped: options.isAgentScoped,
+    });
+    if (initialMemories.length === 0) {
+      return [[], []];
+    }
+
+    const existingResults = await this.recallExistingMemoriesForCandidates(
+      initialMemories,
+      options.filters,
+      5,
+    );
+    const { existingMemories, uuidMapping } = mapExistingMemories(existingResults);
+    let extractedMemories = initialMemories;
+
+    if (existingMemories.length > 0) {
+      extractedMemories = await this.generateAdditiveExtractionMemories({
+        parsedMessages: options.parsedMessages,
+        lastMessages: options.lastMessages,
+        customInstructions: options.customInstructions,
+        existingMemories,
+        recentlyExtractedMemories: initialMemories,
+        isAgentScoped: options.isAgentScoped,
+      });
+    }
+
+    replaceLinkedMemoryIds(extractedMemories, uuidMapping);
+    return [extractedMemories, existingResults];
+  }
+
   private async _initializeTelemetry() {
     try {
       await this._getTelemetryId();
@@ -758,77 +967,19 @@ export class Memory {
       .map((m) => `${m.role}: ${m.content}`)
       .join("\n");
 
-    // Phase 1: Existing memory retrieval
-    const queryEmbedding = await this.embedder.embed(parsedMessages);
-    const existingResults = await this.vectorStore.search(
-      queryEmbedding,
-      10,
-      filters,
-    );
-
-    // Map UUIDs to integers (anti-hallucination)
-    const existingMemories: Array<{ id: string; text: string }> = [];
-    const uuidMapping: Record<string, string> = {};
-    for (let idx = 0; idx < existingResults.length; idx++) {
-      const mem = existingResults[idx];
-      uuidMapping[String(idx)] = mem.id;
-      existingMemories.push({
-        id: String(idx),
-        text: mem.payload?.data ?? "",
-      });
-    }
-
-    // Phase 2: LLM extraction (single call)
     const isAgentScoped = !!filters.agent_id && !filters.user_id;
-    let systemPrompt = ADDITIVE_EXTRACTION_PROMPT;
-    if (isAgentScoped) {
-      systemPrompt += AGENT_CONTEXT_SUFFIX;
-    }
-
-    const userPrompt = generateAdditiveExtractionPrompt({
-      existingMemories,
-      newMessages: parsedMessages,
-      lastKMessages: lastMessages,
-      customInstructions: this.customInstructions,
-    });
-
-    let response: string;
     try {
-      response = (await this.llm.generateResponse(
-        [
-          { role: "system", content: systemPrompt },
-          { role: "user", content: userPrompt },
-        ],
-        { type: "json_object" },
-      )) as string;
+      var [extractedMemories, existingResults] =
+        await this.extractMemoriesWithOptionalFactFirstRecall({
+          parsedMessages,
+          lastMessages,
+          customInstructions: this.customInstructions,
+          filters,
+          isAgentScoped,
+        });
     } catch (e) {
       console.error("LLM extraction failed:", e);
       return [];
-    }
-
-    // Parse response
-    let extractedMemories: Array<{
-      id?: string;
-      text?: string;
-      attributed_to?: string;
-      linked_memory_ids?: string[];
-    }> = [];
-    try {
-      const cleanResponse = extractJson(response);
-      if (cleanResponse && cleanResponse.trim()) {
-        try {
-          const parsed = AdditiveExtractionSchema.parse(
-            JSON.parse(cleanResponse),
-          );
-          extractedMemories = parsed.memory;
-        } catch {
-          const fallbackJson = extractJson(cleanResponse);
-          extractedMemories = JSON.parse(fallbackJson)?.memory ?? [];
-        }
-      }
-    } catch (e) {
-      console.error("Error parsing extraction response:", e);
-      extractedMemories = [];
     }
 
     if (extractedMemories.length === 0) {

--- a/mem0-ts/src/oss/src/prompts/index.ts
+++ b/mem0-ts/src/oss/src/prompts/index.ts
@@ -821,6 +821,12 @@ function serializeMemories(
 
 export function generateAdditiveExtractionPrompt(options: {
   existingMemories?: Array<{ id: string; text: string }>;
+  recentlyExtractedMemories?: Array<{
+    id?: string;
+    text?: string;
+    attributed_to?: string;
+    linked_memory_ids?: string[];
+  }>;
   newMessages?: string;
   lastKMessages?: Array<{ role: string; content: string }>;
   customInstructions?: string;
@@ -841,7 +847,11 @@ export function generateAdditiveExtractionPrompt(options: {
   );
 
   // Recently Extracted Memories — empty for now
-  sections.push("## Recently Extracted Memories\n[]");
+  sections.push(
+    `## Recently Extracted Memories\n${serializeMemories(
+      options.recentlyExtractedMemories,
+    )}`,
+  );
 
   sections.push(
     `## Existing Memories\n${serializeMemories(options.existingMemories)}`,

--- a/mem0-ts/src/oss/src/types/index.ts
+++ b/mem0-ts/src/oss/src/types/index.ts
@@ -72,6 +72,7 @@ export interface MemoryConfig {
   disableHistory?: boolean;
   historyDbPath?: string;
   customInstructions?: string;
+  factFirstRecall?: boolean;
 }
 
 export interface MemoryItem {
@@ -141,6 +142,7 @@ export const MemoryConfigSchema = z.object({
   }),
   historyDbPath: z.string().optional(),
   customInstructions: z.string().optional(),
+  factFirstRecall: z.boolean().optional(),
   historyStore: z
     .object({
       provider: z.string(),

--- a/mem0-ts/src/oss/tests/memory.add.test.ts
+++ b/mem0-ts/src/oss/tests/memory.add.test.ts
@@ -191,4 +191,76 @@ describe("Memory - add()", () => {
       expect.objectContaining({ event: "ADD" }),
     );
   });
+
+  test("fact-first recall uses extracted memory as the recall anchor", async () => {
+    const mem = createMemory();
+    await (mem as any)._initPromise;
+
+    const llm = (mem as any).llm;
+    llm.generateResponse
+      .mockResolvedValueOnce(
+        JSON.stringify({
+          memory: [{ text: "User likes pour-over coffee", attributed_to: "user" }],
+        }),
+      )
+      .mockResolvedValueOnce(
+        JSON.stringify({
+          memory: [
+            {
+              text: "User likes pour-over coffee",
+              attributed_to: "user",
+              linked_memory_ids: ["0"],
+            },
+          ],
+        }),
+      );
+
+    const searchSpy = jest
+      .spyOn((mem as any).vectorStore, "search")
+      .mockResolvedValue([
+        {
+          id: "mem-123",
+          payload: { data: "User prefers light roast beans" },
+        },
+      ]);
+
+    const result: SearchResult = await mem.add("我最近更喜欢手冲咖啡", {
+      userId: "u1",
+    });
+
+    expect(searchSpy).toHaveBeenCalledTimes(1);
+    expect((mem as any).embedder.embed).toHaveBeenCalledWith(
+      "User likes pour-over coffee",
+    );
+    expect(llm.generateResponse).toHaveBeenCalledTimes(2);
+    const secondPrompt = llm.generateResponse.mock.calls[1][0][1].content;
+    expect(secondPrompt).toContain("User prefers light roast beans");
+    expect(result.results[0].memory).toBe("User likes pour-over coffee");
+  });
+
+  test("factFirstRecall=false preserves the legacy single-pass recall flow", async () => {
+    const mem = createMemory({ factFirstRecall: false });
+    await (mem as any)._initPromise;
+
+    const llm = (mem as any).llm;
+    llm.generateResponse.mockResolvedValueOnce(
+      JSON.stringify({
+        memory: [{ text: "legacy extracted memory", attributed_to: "user" }],
+      }),
+    );
+
+    const searchSpy = jest
+      .spyOn((mem as any).vectorStore, "search")
+      .mockResolvedValue([]);
+
+    await mem.add("我最近更喜欢手冲咖啡", {
+      userId: "u1",
+    });
+
+    expect(searchSpy).toHaveBeenCalledTimes(1);
+    expect((mem as any).embedder.embed).toHaveBeenCalledWith(
+      "user: 我最近更喜欢手冲咖啡",
+    );
+    expect(llm.generateResponse).toHaveBeenCalledTimes(1);
+  });
 });

--- a/mem0/configs/base.py
+++ b/mem0/configs/base.py
@@ -55,6 +55,10 @@ class MemoryConfig(BaseModel):
         description="Custom instructions for fact extraction",
         default=None,
     )
+    fact_first_recall: bool = Field(
+        description="Whether to extract candidate memories first and use them as recall anchors before final extraction.",
+        default=True,
+    )
 
 
 class AzureConfig(BaseModel):

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -370,6 +370,29 @@ def _entity_collection_name(provider: str, collection_name: str) -> str:
     return f"{collection_name}{separator}entities"
 
 
+def _parse_additive_extraction_response(response: str) -> list[dict]:
+    """Parse additive extraction JSON response into extracted memory items."""
+    response = remove_code_blocks(response)
+    if not response or not response.strip():
+        return []
+
+    try:
+        return json.loads(response, strict=False).get("memory", [])
+    except json.JSONDecodeError:
+        extracted_json = extract_json(response)
+        return json.loads(extracted_json, strict=False).get("memory", [])
+
+
+def _map_existing_memories(existing_results):
+    """Map recalled memories to prompt payloads and anti-hallucination ID aliases."""
+    existing_memories = []
+    uuid_mapping = {}
+    for idx, mem in enumerate(existing_results):
+        uuid_mapping[str(idx)] = mem.id
+        existing_memories.append({"id": str(idx), "text": mem.payload.get("data", "")})
+    return existing_memories, uuid_mapping
+
+
 setup_config()
 logger = logging.getLogger(__name__)
 
@@ -650,6 +673,67 @@ class Memory(MemoryBase):
         # Use agent memory extraction if agent_id is present and there are assistant messages
         return has_agent_id and has_assistant_messages
 
+    def _generate_additive_extraction_memories(
+        self,
+        *,
+        parsed_messages,
+        last_messages,
+        custom_instructions,
+        existing_memories=None,
+        recently_extracted_memories=None,
+        is_agent_scoped=False,
+    ):
+        system_prompt = ADDITIVE_EXTRACTION_PROMPT
+        if is_agent_scoped:
+            system_prompt += AGENT_CONTEXT_SUFFIX
+
+        user_prompt = generate_additive_extraction_prompt(
+            existing_memories=existing_memories,
+            recently_extracted_memories=recently_extracted_memories,
+            new_messages=parsed_messages,
+            last_k_messages=last_messages,
+            custom_instructions=custom_instructions,
+        )
+
+        response = self.llm.generate_response(
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            response_format={"type": "json_object"},
+        )
+        return _parse_additive_extraction_response(response)
+
+    def _recall_existing_memories_for_candidates(self, candidate_memories, search_filters, top_k=5):
+        """Recall relevant memories using extracted memory candidates as search queries."""
+        recalled_results = []
+        seen_ids = set()
+
+        for mem in candidate_memories:
+            text = mem.get("text")
+            if not text:
+                continue
+
+            try:
+                query_embedding = self.embedding_model.embed(text, "search")
+                matches = self.vector_store.search(
+                    query=text,
+                    vectors=query_embedding,
+                    top_k=top_k,
+                    filters=search_filters,
+                )
+            except Exception as e:
+                logger.warning(f"Failed to recall existing memories for candidate: {e}")
+                continue
+
+            for match in matches:
+                if match.id in seen_ids:
+                    continue
+                seen_ids.add(match.id)
+                recalled_results.append(match)
+
+        return recalled_results
+
     def add(
         self,
         messages,
@@ -802,64 +886,56 @@ class Memory(MemoryBase):
         last_messages = self.db.get_last_messages(session_scope, limit=10)
         parsed_messages = parse_messages(messages)
 
-        # Phase 1: Existing memory retrieval
+        # Phase 1: Initial extraction from recent context only
         search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
-        query_embedding = self.embedding_model.embed(parsed_messages, "search")
-        existing_results = self.vector_store.search(
-            query=parsed_messages,
-            vectors=query_embedding,
-            top_k=10,
-            filters=search_filters,
-        )
-
-        # Map UUIDs to integers (anti-hallucination)
-        existing_memories = []
-        uuid_mapping = {}
-        for idx, mem in enumerate(existing_results):
-            uuid_mapping[str(idx)] = mem.id
-            existing_memories.append({"id": str(idx), "text": mem.payload.get("data", "")})
-
-        # Phase 2: LLM extraction (single call)
         is_agent_scoped = bool(filters.get("agent_id")) and not filters.get("user_id")
-        system_prompt = ADDITIVE_EXTRACTION_PROMPT
-        if is_agent_scoped:
-            system_prompt += AGENT_CONTEXT_SUFFIX
-
         custom_instr = prompt or self.custom_instructions
 
-        user_prompt = generate_additive_extraction_prompt(
-            existing_memories=existing_memories,
-            new_messages=parsed_messages,
-            last_k_messages=last_messages,
-            custom_instructions=custom_instr,
-        )
-
         try:
-            response = self.llm.generate_response(
-                messages=[
-                    {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": user_prompt},
-                ],
-                response_format={"type": "json_object"},
+            initial_memories = self._generate_additive_extraction_memories(
+                parsed_messages=parsed_messages,
+                last_messages=last_messages,
+                custom_instructions=custom_instr,
+                is_agent_scoped=is_agent_scoped,
             )
         except Exception as e:
             logger.error(f"LLM extraction failed: {e}")
             return []
 
-        # Parse response
-        try:
-            response = remove_code_blocks(response)
-            if not response or not response.strip():
-                extracted_memories = []
-            else:
-                try:
-                    extracted_memories = json.loads(response, strict=False).get("memory", [])
-                except json.JSONDecodeError:
-                    extracted_json = extract_json(response)
-                    extracted_memories = json.loads(extracted_json, strict=False).get("memory", [])
-        except Exception as e:
-            logger.error(f"Error parsing extraction response: {e}")
-            extracted_memories = []
+        if not initial_memories:
+            self.db.save_messages(messages, session_scope)
+            return []
+
+        # Phase 2: Recall existing memories from extracted candidate memories
+        existing_results = self._recall_existing_memories_for_candidates(
+            initial_memories,
+            search_filters=search_filters,
+            top_k=5,
+        )
+
+        # Phase 3: Final extraction with recalled memory context
+        existing_memories, uuid_mapping = _map_existing_memories(existing_results)
+        extracted_memories = initial_memories
+        if existing_memories:
+            try:
+                extracted_memories = self._generate_additive_extraction_memories(
+                    parsed_messages=parsed_messages,
+                    last_messages=last_messages,
+                    custom_instructions=custom_instr,
+                    existing_memories=existing_memories,
+                    recently_extracted_memories=initial_memories,
+                    is_agent_scoped=is_agent_scoped,
+                )
+            except Exception as e:
+                logger.error(f"LLM reconciliation failed: {e}")
+                extracted_memories = initial_memories
+
+        if uuid_mapping:
+            for mem in extracted_memories:
+                linked_ids = mem.get("linked_memory_ids")
+                if not isinstance(linked_ids, list):
+                    continue
+                mem["linked_memory_ids"] = [uuid_mapping.get(str(linked_id), linked_id) for linked_id in linked_ids]
 
         if not extracted_memories:
             # Save messages even if nothing extracted
@@ -2201,6 +2277,69 @@ class AsyncMemory(MemoryBase):
         # Use agent memory extraction if agent_id is present and there are assistant messages
         return has_agent_id and has_assistant_messages
 
+    async def _generate_additive_extraction_memories_async(
+        self,
+        *,
+        parsed_messages,
+        last_messages,
+        custom_instructions,
+        existing_memories=None,
+        recently_extracted_memories=None,
+        is_agent_scoped=False,
+    ):
+        system_prompt = ADDITIVE_EXTRACTION_PROMPT
+        if is_agent_scoped:
+            system_prompt += AGENT_CONTEXT_SUFFIX
+
+        user_prompt = generate_additive_extraction_prompt(
+            existing_memories=existing_memories,
+            recently_extracted_memories=recently_extracted_memories,
+            new_messages=parsed_messages,
+            last_k_messages=last_messages,
+            custom_instructions=custom_instructions,
+        )
+
+        response = await asyncio.to_thread(
+            self.llm.generate_response,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            response_format={"type": "json_object"},
+        )
+        return _parse_additive_extraction_response(response)
+
+    async def _recall_existing_memories_for_candidates_async(self, candidate_memories, search_filters, top_k=5):
+        """Async counterpart for candidate-memory-driven recall."""
+        recalled_results = []
+        seen_ids = set()
+
+        for mem in candidate_memories:
+            text = mem.get("text")
+            if not text:
+                continue
+
+            try:
+                query_embedding = await asyncio.to_thread(self.embedding_model.embed, text, "search")
+                matches = await asyncio.to_thread(
+                    self.vector_store.search,
+                    query=text,
+                    vectors=query_embedding,
+                    top_k=top_k,
+                    filters=search_filters,
+                )
+            except Exception as e:
+                logger.warning(f"Failed to recall existing memories for candidate (async): {e}")
+                continue
+
+            for match in matches:
+                if match.id in seen_ids:
+                    continue
+                seen_ids.add(match.id)
+                recalled_results.append(match)
+
+        return recalled_results
+
     async def add(
         self,
         messages,
@@ -2339,66 +2478,56 @@ class AsyncMemory(MemoryBase):
         last_messages = await asyncio.to_thread(self.db.get_last_messages, session_scope, 10)
         parsed_messages = parse_messages(messages)
 
-        # Phase 1: Existing memory retrieval
+        # Phase 1: Initial extraction from recent context only
         search_filters = {k: v for k, v in effective_filters.items() if k in ("user_id", "agent_id", "run_id") and v}
-        query_embedding = await asyncio.to_thread(self.embedding_model.embed, parsed_messages, "search")
-        existing_results = await asyncio.to_thread(
-            self.vector_store.search,
-            query=parsed_messages,
-            vectors=query_embedding,
-            top_k=10,
-            filters=search_filters,
-        )
-
-        # Map UUIDs to integers (anti-hallucination)
-        existing_memories = []
-        uuid_mapping = {}
-        for idx, mem in enumerate(existing_results):
-            uuid_mapping[str(idx)] = mem.id
-            existing_memories.append({"id": str(idx), "text": mem.payload.get("data", "")})
-
-        # Phase 2: LLM extraction (single call)
         is_agent_scoped = bool(effective_filters.get("agent_id")) and not effective_filters.get("user_id")
-        system_prompt = ADDITIVE_EXTRACTION_PROMPT
-        if is_agent_scoped:
-            system_prompt += AGENT_CONTEXT_SUFFIX
-
         custom_instr = prompt or self.custom_instructions
 
-        user_prompt = generate_additive_extraction_prompt(
-            existing_memories=existing_memories,
-            new_messages=parsed_messages,
-            last_k_messages=last_messages,
-            custom_instructions=custom_instr,
-        )
-
         try:
-            response = await asyncio.to_thread(
-                self.llm.generate_response,
-                messages=[
-                    {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": user_prompt},
-                ],
-                response_format={"type": "json_object"},
+            initial_memories = await self._generate_additive_extraction_memories_async(
+                parsed_messages=parsed_messages,
+                last_messages=last_messages,
+                custom_instructions=custom_instr,
+                is_agent_scoped=is_agent_scoped,
             )
         except Exception as e:
             logger.error(f"LLM extraction failed (async): {e}")
             return []
 
-        # Parse response
-        try:
-            response = remove_code_blocks(response)
-            if not response or not response.strip():
-                extracted_memories = []
-            else:
-                try:
-                    extracted_memories = json.loads(response, strict=False).get("memory", [])
-                except json.JSONDecodeError:
-                    extracted_json = extract_json(response)
-                    extracted_memories = json.loads(extracted_json, strict=False).get("memory", [])
-        except Exception as e:
-            logger.error(f"Error parsing extraction response (async): {e}")
-            extracted_memories = []
+        if not initial_memories:
+            await asyncio.to_thread(self.db.save_messages, messages, session_scope)
+            return []
+
+        # Phase 2: Recall existing memories from extracted candidate memories
+        existing_results = await self._recall_existing_memories_for_candidates_async(
+            initial_memories,
+            search_filters=search_filters,
+            top_k=5,
+        )
+
+        # Phase 3: Final extraction with recalled memory context
+        existing_memories, uuid_mapping = _map_existing_memories(existing_results)
+        extracted_memories = initial_memories
+        if existing_memories:
+            try:
+                extracted_memories = await self._generate_additive_extraction_memories_async(
+                    parsed_messages=parsed_messages,
+                    last_messages=last_messages,
+                    custom_instructions=custom_instr,
+                    existing_memories=existing_memories,
+                    recently_extracted_memories=initial_memories,
+                    is_agent_scoped=is_agent_scoped,
+                )
+            except Exception as e:
+                logger.error(f"LLM reconciliation failed (async): {e}")
+                extracted_memories = initial_memories
+
+        if uuid_mapping:
+            for mem in extracted_memories:
+                linked_ids = mem.get("linked_memory_ids")
+                if not isinstance(linked_ids, list):
+                    continue
+                mem["linked_memory_ids"] = [uuid_mapping.get(str(linked_id), linked_id) for linked_id in linked_ids]
 
         if not extracted_memories:
             await asyncio.to_thread(self.db.save_messages, messages, session_scope)

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -393,6 +393,17 @@ def _map_existing_memories(existing_results):
     return existing_memories, uuid_mapping
 
 
+def _replace_linked_memory_ids(extracted_memories, uuid_mapping):
+    """Replace prompt-time alias IDs with actual vector-store IDs."""
+    if not uuid_mapping:
+        return
+    for mem in extracted_memories:
+        linked_ids = mem.get("linked_memory_ids")
+        if not isinstance(linked_ids, list):
+            continue
+        mem["linked_memory_ids"] = [uuid_mapping.get(str(linked_id), linked_id) for linked_id in linked_ids]
+
+
 setup_config()
 logger = logging.getLogger(__name__)
 
@@ -734,6 +745,64 @@ class Memory(MemoryBase):
 
         return recalled_results
 
+    def _extract_memories_with_optional_fact_first_recall(
+        self,
+        *,
+        parsed_messages,
+        last_messages,
+        custom_instructions,
+        search_filters,
+        is_agent_scoped,
+    ):
+        """Extract memories either via the legacy single-pass flow or the fact-first recall flow."""
+        if not self.config.fact_first_recall:
+            query_embedding = self.embedding_model.embed(parsed_messages, "search")
+            existing_results = self.vector_store.search(
+                query=parsed_messages,
+                vectors=query_embedding,
+                top_k=10,
+                filters=search_filters,
+            )
+            existing_memories, _ = _map_existing_memories(existing_results)
+            extracted_memories = self._generate_additive_extraction_memories(
+                parsed_messages=parsed_messages,
+                last_messages=last_messages,
+                custom_instructions=custom_instructions,
+                existing_memories=existing_memories,
+                is_agent_scoped=is_agent_scoped,
+            )
+            return extracted_memories, existing_results
+
+        # Intentional semantic change: if phase 1 yields no candidate memories,
+        # we skip recall entirely instead of giving the LLM existing memories to no-op against.
+        initial_memories = self._generate_additive_extraction_memories(
+            parsed_messages=parsed_messages,
+            last_messages=last_messages,
+            custom_instructions=custom_instructions,
+            is_agent_scoped=is_agent_scoped,
+        )
+        if not initial_memories:
+            return [], []
+
+        existing_results = self._recall_existing_memories_for_candidates(
+            initial_memories,
+            search_filters=search_filters,
+            top_k=5,
+        )
+        existing_memories, uuid_mapping = _map_existing_memories(existing_results)
+        extracted_memories = initial_memories
+        if existing_memories:
+            extracted_memories = self._generate_additive_extraction_memories(
+                parsed_messages=parsed_messages,
+                last_messages=last_messages,
+                custom_instructions=custom_instructions,
+                existing_memories=existing_memories,
+                recently_extracted_memories=initial_memories,
+                is_agent_scoped=is_agent_scoped,
+            )
+        _replace_linked_memory_ids(extracted_memories, uuid_mapping)
+        return extracted_memories, existing_results
+
     def add(
         self,
         messages,
@@ -886,56 +955,22 @@ class Memory(MemoryBase):
         last_messages = self.db.get_last_messages(session_scope, limit=10)
         parsed_messages = parse_messages(messages)
 
-        # Phase 1: Initial extraction from recent context only
         search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
         is_agent_scoped = bool(filters.get("agent_id")) and not filters.get("user_id")
         custom_instr = prompt or self.custom_instructions
 
         try:
-            initial_memories = self._generate_additive_extraction_memories(
+            extracted_memories, existing_results = self._extract_memories_with_optional_fact_first_recall(
                 parsed_messages=parsed_messages,
                 last_messages=last_messages,
                 custom_instructions=custom_instr,
+                search_filters=search_filters,
                 is_agent_scoped=is_agent_scoped,
             )
         except Exception as e:
             logger.error(f"LLM extraction failed: {e}")
-            return []
-
-        if not initial_memories:
             self.db.save_messages(messages, session_scope)
             return []
-
-        # Phase 2: Recall existing memories from extracted candidate memories
-        existing_results = self._recall_existing_memories_for_candidates(
-            initial_memories,
-            search_filters=search_filters,
-            top_k=5,
-        )
-
-        # Phase 3: Final extraction with recalled memory context
-        existing_memories, uuid_mapping = _map_existing_memories(existing_results)
-        extracted_memories = initial_memories
-        if existing_memories:
-            try:
-                extracted_memories = self._generate_additive_extraction_memories(
-                    parsed_messages=parsed_messages,
-                    last_messages=last_messages,
-                    custom_instructions=custom_instr,
-                    existing_memories=existing_memories,
-                    recently_extracted_memories=initial_memories,
-                    is_agent_scoped=is_agent_scoped,
-                )
-            except Exception as e:
-                logger.error(f"LLM reconciliation failed: {e}")
-                extracted_memories = initial_memories
-
-        if uuid_mapping:
-            for mem in extracted_memories:
-                linked_ids = mem.get("linked_memory_ids")
-                if not isinstance(linked_ids, list):
-                    continue
-                mem["linked_memory_ids"] = [uuid_mapping.get(str(linked_id), linked_id) for linked_id in linked_ids]
 
         if not extracted_memories:
             # Save messages even if nothing extracted
@@ -2311,17 +2346,14 @@ class AsyncMemory(MemoryBase):
 
     async def _recall_existing_memories_for_candidates_async(self, candidate_memories, search_filters, top_k=5):
         """Async counterpart for candidate-memory-driven recall."""
-        recalled_results = []
-        seen_ids = set()
-
-        for mem in candidate_memories:
+        async def recall_one(mem):
             text = mem.get("text")
             if not text:
-                continue
+                return []
 
             try:
                 query_embedding = await asyncio.to_thread(self.embedding_model.embed, text, "search")
-                matches = await asyncio.to_thread(
+                return await asyncio.to_thread(
                     self.vector_store.search,
                     query=text,
                     vectors=query_embedding,
@@ -2330,8 +2362,13 @@ class AsyncMemory(MemoryBase):
                 )
             except Exception as e:
                 logger.warning(f"Failed to recall existing memories for candidate (async): {e}")
-                continue
+                return []
 
+        recalled_results = []
+        seen_ids = set()
+        matches_per_candidate = await asyncio.gather(*(recall_one(mem) for mem in candidate_memories))
+
+        for matches in matches_per_candidate:
             for match in matches:
                 if match.id in seen_ids:
                     continue
@@ -2339,6 +2376,65 @@ class AsyncMemory(MemoryBase):
                 recalled_results.append(match)
 
         return recalled_results
+
+    async def _extract_memories_with_optional_fact_first_recall_async(
+        self,
+        *,
+        parsed_messages,
+        last_messages,
+        custom_instructions,
+        search_filters,
+        is_agent_scoped,
+    ):
+        """Async extraction via legacy single-pass or fact-first recall flow."""
+        if not self.config.fact_first_recall:
+            query_embedding = await asyncio.to_thread(self.embedding_model.embed, parsed_messages, "search")
+            existing_results = await asyncio.to_thread(
+                self.vector_store.search,
+                query=parsed_messages,
+                vectors=query_embedding,
+                top_k=10,
+                filters=search_filters,
+            )
+            existing_memories, _ = _map_existing_memories(existing_results)
+            extracted_memories = await self._generate_additive_extraction_memories_async(
+                parsed_messages=parsed_messages,
+                last_messages=last_messages,
+                custom_instructions=custom_instructions,
+                existing_memories=existing_memories,
+                is_agent_scoped=is_agent_scoped,
+            )
+            return extracted_memories, existing_results
+
+        # Intentional semantic change: if phase 1 yields no candidate memories,
+        # we skip recall entirely instead of giving the LLM existing memories to no-op against.
+        initial_memories = await self._generate_additive_extraction_memories_async(
+            parsed_messages=parsed_messages,
+            last_messages=last_messages,
+            custom_instructions=custom_instructions,
+            is_agent_scoped=is_agent_scoped,
+        )
+        if not initial_memories:
+            return [], []
+
+        existing_results = await self._recall_existing_memories_for_candidates_async(
+            initial_memories,
+            search_filters=search_filters,
+            top_k=5,
+        )
+        existing_memories, uuid_mapping = _map_existing_memories(existing_results)
+        extracted_memories = initial_memories
+        if existing_memories:
+            extracted_memories = await self._generate_additive_extraction_memories_async(
+                parsed_messages=parsed_messages,
+                last_messages=last_messages,
+                custom_instructions=custom_instructions,
+                existing_memories=existing_memories,
+                recently_extracted_memories=initial_memories,
+                is_agent_scoped=is_agent_scoped,
+            )
+        _replace_linked_memory_ids(extracted_memories, uuid_mapping)
+        return extracted_memories, existing_results
 
     async def add(
         self,
@@ -2478,56 +2574,23 @@ class AsyncMemory(MemoryBase):
         last_messages = await asyncio.to_thread(self.db.get_last_messages, session_scope, 10)
         parsed_messages = parse_messages(messages)
 
-        # Phase 1: Initial extraction from recent context only
+        # Phase 1: Extraction and optional recall flow
         search_filters = {k: v for k, v in effective_filters.items() if k in ("user_id", "agent_id", "run_id") and v}
         is_agent_scoped = bool(effective_filters.get("agent_id")) and not effective_filters.get("user_id")
         custom_instr = prompt or self.custom_instructions
 
         try:
-            initial_memories = await self._generate_additive_extraction_memories_async(
+            extracted_memories, existing_results = await self._extract_memories_with_optional_fact_first_recall_async(
                 parsed_messages=parsed_messages,
                 last_messages=last_messages,
                 custom_instructions=custom_instr,
+                search_filters=search_filters,
                 is_agent_scoped=is_agent_scoped,
             )
         except Exception as e:
             logger.error(f"LLM extraction failed (async): {e}")
-            return []
-
-        if not initial_memories:
             await asyncio.to_thread(self.db.save_messages, messages, session_scope)
             return []
-
-        # Phase 2: Recall existing memories from extracted candidate memories
-        existing_results = await self._recall_existing_memories_for_candidates_async(
-            initial_memories,
-            search_filters=search_filters,
-            top_k=5,
-        )
-
-        # Phase 3: Final extraction with recalled memory context
-        existing_memories, uuid_mapping = _map_existing_memories(existing_results)
-        extracted_memories = initial_memories
-        if existing_memories:
-            try:
-                extracted_memories = await self._generate_additive_extraction_memories_async(
-                    parsed_messages=parsed_messages,
-                    last_messages=last_messages,
-                    custom_instructions=custom_instr,
-                    existing_memories=existing_memories,
-                    recently_extracted_memories=initial_memories,
-                    is_agent_scoped=is_agent_scoped,
-                )
-            except Exception as e:
-                logger.error(f"LLM reconciliation failed (async): {e}")
-                extracted_memories = initial_memories
-
-        if uuid_mapping:
-            for mem in extracted_memories:
-                linked_ids = mem.get("linked_memory_ids")
-                if not isinstance(linked_ids, list):
-                    continue
-                mem["linked_memory_ids"] = [uuid_mapping.get(str(linked_id), linked_id) for linked_id in linked_ids]
 
         if not extracted_memories:
             await asyncio.to_thread(self.db.save_messages, messages, session_scope)

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -62,7 +62,7 @@ class TestAddToVectorStoreErrors:
         # Verify — v3 single-pass pipeline makes 1 LLM call, returns [] on parse error
         assert mock_memory.llm.generate_response.call_count == 1
         assert result == []
-        assert any("Error parsing extraction response" in record.message for record in caplog.records), "Expected error message not found in logs"
+        assert any("LLM extraction failed" in record.message for record in caplog.records), "Expected error message not found in logs"
 
     def test_empty_llm_response_memory_actions(self, mock_memory, caplog):
         """Test empty response from LLM during memory actions (v3: single-pass, 1 LLM call)"""
@@ -115,37 +115,6 @@ class TestPromptOverridesCustomInstructions:
 
         user_prompt = mock_memory.llm.generate_response.call_args[1]["messages"][1]["content"]
         assert "config-level instructions" in user_prompt
-
-    def test_recalls_using_extracted_memory_instead_of_full_context(self, mock_memory):
-        mock_memory.llm.generate_response.side_effect = [
-            '{"memory": [{"text": "User likes pour-over coffee"}]}',
-            '{"memory": [{"text": "User likes pour-over coffee", "linked_memory_ids": ["0"]}]}',
-        ]
-        recalled = MagicMock()
-        recalled.id = "mem-123"
-        recalled.payload = {"data": "User prefers light roast beans"}
-        mock_memory.vector_store.search.return_value = [recalled]
-        mock_memory.embedding_model.embed_batch = Mock(return_value=[[0.1, 0.2, 0.3]])
-        mock_memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
-        mock_memory.vector_store.insert = Mock()
-        mock_memory.db.batch_add_history = Mock()
-
-        result = mock_memory._add_to_vector_store(
-            messages=[{"role": "user", "content": "我最近更喜欢手冲咖啡"}],
-            metadata={},
-            filters={"user_id": "u1"},
-            infer=True,
-        )
-
-        assert mock_memory.vector_store.search.call_count == 1
-        search_kwargs = mock_memory.vector_store.search.call_args.kwargs
-        assert search_kwargs["query"] == "User likes pour-over coffee"
-        assert search_kwargs["top_k"] == 5
-        assert mock_memory.llm.generate_response.call_count == 2
-        second_prompt = mock_memory.llm.generate_response.call_args_list[1].kwargs["messages"][1]["content"]
-        assert "User prefers light roast beans" in second_prompt
-        assert result[0]["memory"] == "User likes pour-over coffee"
-
 
 class TestAsyncUpdate:
     @pytest.fixture
@@ -230,7 +199,7 @@ class TestAsyncAddToVectorStoreErrors:
             )
         assert mock_async_memory.llm.generate_response.call_count == 1
         assert result == []
-        assert any("Error parsing extraction response" in record.message for record in caplog.records), "Expected error message not found in logs"
+        assert any("LLM extraction failed (async)" in record.message for record in caplog.records), "Expected error message not found in logs"
 
     @pytest.mark.asyncio
     async def test_async_empty_llm_response_memory_actions(self, mock_async_memory, caplog, mocker):
@@ -247,6 +216,56 @@ class TestAsyncAddToVectorStoreErrors:
 
         assert result == []
         assert mock_async_memory.llm.generate_response.call_count == 1
+
+
+class TestFactFirstRecall:
+    @pytest.fixture
+    def mock_memory(self, mocker):
+        _setup_mocks(mocker)
+        memory = Memory()
+        memory.custom_instructions = None
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        return memory
+
+    @pytest.fixture
+    def mock_async_memory(self, mocker):
+        _setup_mocks(mocker)
+        memory = AsyncMemory()
+        memory.custom_instructions = None
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        return memory
+
+    def test_sync_recalls_using_extracted_memory_instead_of_full_context(self, mock_memory):
+        mock_memory.llm.generate_response.side_effect = [
+            '{"memory": [{"text": "User likes pour-over coffee"}]}',
+            '{"memory": [{"text": "User likes pour-over coffee", "linked_memory_ids": ["0"]}]}',
+        ]
+        recalled = MagicMock()
+        recalled.id = "mem-123"
+        recalled.payload = {"data": "User prefers light roast beans"}
+        mock_memory.vector_store.search.return_value = [recalled]
+        mock_memory.embedding_model.embed_batch = Mock(return_value=[[0.1, 0.2, 0.3]])
+        mock_memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+        mock_memory.vector_store.insert = Mock()
+        mock_memory.db.batch_add_history = Mock()
+
+        result = mock_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "我最近更喜欢手冲咖啡"}],
+            metadata={},
+            filters={"user_id": "u1"},
+            infer=True,
+        )
+
+        assert mock_memory.vector_store.search.call_count == 1
+        search_kwargs = mock_memory.vector_store.search.call_args.kwargs
+        assert search_kwargs["query"] == "User likes pour-over coffee"
+        assert search_kwargs["top_k"] == 5
+        assert mock_memory.llm.generate_response.call_count == 2
+        second_prompt = mock_memory.llm.generate_response.call_args_list[1].kwargs["messages"][1]["content"]
+        assert "User prefers light roast beans" in second_prompt
+        assert result[0]["memory"] == "User likes pour-over coffee"
 
     @pytest.mark.asyncio
     async def test_async_recalls_using_extracted_memory_instead_of_full_context(self, mock_async_memory):
@@ -278,7 +297,6 @@ class TestAsyncAddToVectorStoreErrors:
         second_prompt = mock_async_memory.llm.generate_response.call_args_list[1].kwargs["messages"][1]["content"]
         assert "User prefers light roast beans" in second_prompt
         assert result[0]["memory"] == "User likes pour-over coffee"
-
 
 def _build_memory_instance(mocker, memory_cls):
     _setup_mocks(mocker)

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -116,6 +116,36 @@ class TestPromptOverridesCustomInstructions:
         user_prompt = mock_memory.llm.generate_response.call_args[1]["messages"][1]["content"]
         assert "config-level instructions" in user_prompt
 
+    def test_recalls_using_extracted_memory_instead_of_full_context(self, mock_memory):
+        mock_memory.llm.generate_response.side_effect = [
+            '{"memory": [{"text": "User likes pour-over coffee"}]}',
+            '{"memory": [{"text": "User likes pour-over coffee", "linked_memory_ids": ["0"]}]}',
+        ]
+        recalled = MagicMock()
+        recalled.id = "mem-123"
+        recalled.payload = {"data": "User prefers light roast beans"}
+        mock_memory.vector_store.search.return_value = [recalled]
+        mock_memory.embedding_model.embed_batch = Mock(return_value=[[0.1, 0.2, 0.3]])
+        mock_memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+        mock_memory.vector_store.insert = Mock()
+        mock_memory.db.batch_add_history = Mock()
+
+        result = mock_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "我最近更喜欢手冲咖啡"}],
+            metadata={},
+            filters={"user_id": "u1"},
+            infer=True,
+        )
+
+        assert mock_memory.vector_store.search.call_count == 1
+        search_kwargs = mock_memory.vector_store.search.call_args.kwargs
+        assert search_kwargs["query"] == "User likes pour-over coffee"
+        assert search_kwargs["top_k"] == 5
+        assert mock_memory.llm.generate_response.call_count == 2
+        second_prompt = mock_memory.llm.generate_response.call_args_list[1].kwargs["messages"][1]["content"]
+        assert "User prefers light roast beans" in second_prompt
+        assert result[0]["memory"] == "User likes pour-over coffee"
+
 
 class TestAsyncUpdate:
     @pytest.fixture
@@ -217,6 +247,37 @@ class TestAsyncAddToVectorStoreErrors:
 
         assert result == []
         assert mock_async_memory.llm.generate_response.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_async_recalls_using_extracted_memory_instead_of_full_context(self, mock_async_memory):
+        mock_async_memory.llm.generate_response.side_effect = [
+            '{"memory": [{"text": "User likes pour-over coffee"}]}',
+            '{"memory": [{"text": "User likes pour-over coffee", "linked_memory_ids": ["0"]}]}',
+        ]
+        recalled = MagicMock()
+        recalled.id = "mem-123"
+        recalled.payload = {"data": "User prefers light roast beans"}
+        mock_async_memory.vector_store.search.return_value = [recalled]
+        mock_async_memory.embedding_model.embed_batch = Mock(return_value=[[0.1, 0.2, 0.3]])
+        mock_async_memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+        mock_async_memory.vector_store.insert = Mock()
+        mock_async_memory.db.batch_add_history = Mock()
+
+        result = await mock_async_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "我最近更喜欢手冲咖啡"}],
+            metadata={},
+            effective_filters={"user_id": "u1"},
+            infer=True,
+        )
+
+        assert mock_async_memory.vector_store.search.call_count == 1
+        search_kwargs = mock_async_memory.vector_store.search.call_args.kwargs
+        assert search_kwargs["query"] == "User likes pour-over coffee"
+        assert search_kwargs["top_k"] == 5
+        assert mock_async_memory.llm.generate_response.call_count == 2
+        second_prompt = mock_async_memory.llm.generate_response.call_args_list[1].kwargs["messages"][1]["content"]
+        assert "User prefers light roast beans" in second_prompt
+        assert result[0]["memory"] == "User likes pour-over coffee"
 
 
 def _build_memory_instance(mocker, memory_cls):


### PR DESCRIPTION
## Linked Issue
N/A

## Description

This PR updates the `Memory._add_to_vector_store` flow to recall existing memories from extracted memory candidates instead of recalling directly from the full conversation context.

Previously, the pipeline first retrieved recent session context, then performed vector recall using the entire parsed conversation, and finally passed both the recalled memories and the conversation context into the LLM for memory extraction. In practice, this could lead to unnecessarily large recall queries and more unrelated results.

This change introduces a fact-first recall flow:

1. Extract candidate memories from the current messages plus recent session context
2. Use each extracted candidate memory to recall related existing memories
3. Run a final extraction pass with the candidate memories, recalled memories, and recent context

This keeps the recall query more focused, reduces irrelevant retrieved context, and better matches real-world usage where structured candidate memories are a better retrieval anchor than raw multi-turn conversation text.

The PR also adds regression tests for both sync and async flows to verify that recall is driven by extracted memory text rather than the full conversation.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Manual verification:
- Ran `python -m compileall mem0\memory\main.py tests\memory\test_main.py`
- Attempted to run `python -m pytest tests\memory\test_main.py -q`
- Test collection was blocked in the current environment because local package metadata for `mem0ai` was not available (`importlib.metadata.PackageNotFoundError`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] I have updated documentation if needed