### PR TITLE
fix(chroma): wrap delete() ids in a list (completes scalar-vs-list fix, closes #5803)

### DIFF
--- a/mem0/vector_stores/chroma.py
+++ b/mem0/vector_stores/chroma.py
@@ -169,7 +169,7 @@ class ChromaDB(VectorStoreBase):
         Args:
             vector_id (str): ID of the vector to delete.
         """
-        self.collection.delete(ids=vector_id)
+        self.collection.delete(ids=[vector_id])
 
     def update(
         self,

--- a/tests/vector_stores/test_chroma.py
+++ b/tests/vector_stores/test_chroma.py
@@ -122,7 +122,7 @@ def test_delete_vector(chromadb_instance):
 
     chromadb_instance.delete(vector_id=vector_id)
 
-    chromadb_instance.collection.delete.assert_called_once_with(ids=vector_id)
+    chromadb_instance.collection.delete.assert_called_once_with(ids=[vector_id])
 
 
 def test_update_vector(chromadb_instance):


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #5757, completing the scalar-vs-list defect class in the Chroma provider that @kartik-mem0 asked to track in **#5803**.

`ChromaDB.delete()` passes a **scalar** `vector_id` to `collection.delete(ids=...)`, but ChromaDB expects `ids` to be a **list**. Passing a bare string is iterated character-by-character on older ChromaDB (deleting wrong/no ids) and trips length/type validation on newer versions — the same silent defect #5757 fixed for `update()`.

## Change

`mem0/vector_stores/chroma.py` — `delete()`:
```diff
- self.collection.delete(ids=vector_id)
+ self.collection.delete(ids=[vector_id])
```
This mirrors the already-correct `get()` (`ids=[vector_id]`) and `insert()` (`ids=ids`) call sites in the same file.

## Evidence

**Command run after the fix:**
```
python -m pytest tests/vector_stores/test_chroma.py -q
```
**Output:**
```
25 passed, 1 warning in 1.49s
```
`test_delete_vector` updated to assert the correct list-wrapped call: `collection.delete.assert_called_once_with(ids=[vector_id])`.

## Related

- Pairs with #5757 (update fix). Closes #5803.
