### PR TITLE
fix(mem0-plugin): store files_touched as a list to stop double JSON-encoding

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "mem0",
       "source": "./integrations/mem0-plugin",
       "description": "Mem0 memory layer for AI applications. Add persistent memory, personalization, and semantic search to Claude workflows.",
-      "version": "0.2.10"
+      "version": "0.2.11"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "mem0",
       "source": "./integrations/mem0-plugin",
       "description": "Mem0 memory layer for AI applications. Add persistent memory, personalization, and semantic search.",
-      "version": "0.2.10"
+      "version": "0.2.11"
     }
   ]
 }

--- a/docs/core-concepts/memory-evaluation.mdx
+++ b/docs/core-concepts/memory-evaluation.mdx
@@ -345,7 +345,7 @@ When evaluating memory systems, keep these considerations in mind:
   <Card title="Research" icon="flask" href="https://mem0.ai/research">
     Published research papers and technical reports
   </Card>
-  <Card title="Blog Post" icon="newspaper" href="https://mem0.ai/blog/new-algorithm">
+  <Card title="Blog Post" icon="newspaper" href="https://mem0.ai/blog/the-token-efficient-memory-algorithm-now-has-temporal-reasoning">
     Detailed writeup of the new algorithm design and results
   </Card>
   <Card title="Platform Migration" icon="arrow-right" href="/migration/platform-v2-to-v3">

--- a/docs/integrations/antigravity.mdx
+++ b/docs/integrations/antigravity.mdx
@@ -65,6 +65,7 @@ The plugin uses the same shell scripts as Claude Code, Cursor, and Codex — hoo
 | **User prompt** | `UserPromptSubmit` | Searches relevant memories before each message |
 | **Pre-tool** | `PreToolUse` | Blocks MEMORY.md writes, enforces `user_id`/`app_id` on mem0 tools |
 | **Post-tool** | `PostToolUse` | Tracks stats, scans bash errors for related memories |
+| **Stop** | `Stop` | Stores a session summary when the session ends |
 
 ## Troubleshooting
 

--- a/docs/integrations/claude-code.mdx
+++ b/docs/integrations/claude-code.mdx
@@ -64,7 +64,7 @@ Add the Mem0 MCP server directly with a single command:
 npx mcp-add \
   --name mem0-mcp \
   --type http \
-  --url "https://mcp.mem0.ai/mcp" \
+  --url "https://mcp.mem0.ai/mcp/" \
   --clients "claude code"
 ```
 
@@ -142,7 +142,8 @@ When installed via the plugin marketplace, Mem0 hooks into Claude Code's lifecyc
 | **User prompt** | `UserPromptSubmit` | Searches relevant memories before each message; skips short prompts |
 | **Pre-tool** | `PreToolUse` | Blocks MEMORY.md writes, enforces `user_id`/`app_id` on mem0 tool calls |
 | **Post-tool** | `PostToolUse` | Tracks stats, scans bash errors for related memories |
-| **Pre-compact** | `PreCompact` | Stores a session summary before context compaction |
+| **Stop** | `Stop` | Stores a session summary when the session ends |
+| **Pre-compact** | `PreCompact` | Stores a summary before the context is compacted |
 
 ## Example Workflow
 

--- a/docs/integrations/codex.mdx
+++ b/docs/integrations/codex.mdx
@@ -41,7 +41,13 @@ Install the full plugin including MCP server, lifecycle hooks, and SDK skill.
    codex plugin marketplace add mem0ai/mem0
    ```
 
-2. Restart Codex, open the Plugin Directory, browse the **Mem0 Plugins** marketplace, and install **Mem0**.
+2. Install the plugin:
+
+   ```bash
+   codex plugin add mem0@mem0-plugins
+   ```
+
+   Or, in the app: restart Codex, open the Plugin Directory, browse the **Mem0 Plugins** marketplace, and install **Mem0**.
 
 <Info>
   Do not combine with Option B. The plugin manifest auto-registers the `mem0` MCP server, so adding both will create a duplicate registration.

--- a/docs/integrations/codex.mdx
+++ b/docs/integrations/codex.mdx
@@ -49,13 +49,23 @@ Install the full plugin including MCP server, lifecycle hooks, and SDK skill.
 
    Or, in the app: restart Codex, open the Plugin Directory, browse the **Mem0 Plugins** marketplace, and install **Mem0**.
 
+<Note>
+  Step 1 is required for the app UI. Mem0 isn't in OpenAI's curated directory yet, so **without `codex plugin marketplace add`, Mem0 won't appear in the Codex app's Plugin Directory** — searching for it returns nothing. Adding the marketplace surfaces it (under **Created by you**) and makes it installable.
+</Note>
+
 <Info>
   Do not combine with Option B. The plugin manifest auto-registers the `mem0` MCP server, so adding both will create a duplicate registration.
 </Info>
 
 ### Option B — Direct MCP
 
-The fastest way to connect Codex to Mem0 — no plugin, no marketplace. Add to `~/.codex/config.toml`:
+The fastest way to connect Codex to Mem0 — no plugin, no marketplace. Add the MCP server with a single command:
+
+```bash
+codex mcp add mem0 --url https://mcp.mem0.ai/mcp --bearer-token-env-var MEM0_API_KEY
+```
+
+Or add it manually to `~/.codex/config.toml`:
 
 ```toml
 [mcp_servers.mem0]
@@ -65,17 +75,14 @@ bearer_token_env_var = "MEM0_API_KEY"
 
 Make sure `MEM0_API_KEY` is exported in the shell you launch Codex from, then restart Codex.
 
-<Info>
-  Codex's `codex mcp add` CLI only supports stdio MCP servers. Because Mem0's MCP is HTTP/streamable, you configure it by editing `config.toml` directly (or via the **Plugins → Connect to a custom MCP → Streamable HTTP** UI in the Codex app).
-</Info>
-
 This gives you the MCP tools but not the lifecycle hooks or SDK skill.
 
 ### Managing the Plugin
 
 ```bash
 codex plugin marketplace upgrade               # pull latest plugin versions
-codex plugin marketplace remove mem0-plugins   # unregister the marketplace
+codex plugin remove mem0@mem0-plugins          # uninstall the plugin (keeps the marketplace)
+codex plugin marketplace remove mem0-plugins   # unregister the marketplace entirely
 ```
 
 To update, run `codex plugin marketplace upgrade` to pull the latest from the Mem0 repo.

--- a/docs/integrations/codex.mdx
+++ b/docs/integrations/codex.mdx
@@ -62,14 +62,14 @@ Install the full plugin including MCP server, lifecycle hooks, and SDK skill.
 The fastest way to connect Codex to Mem0 — no plugin, no marketplace. Add the MCP server with a single command:
 
 ```bash
-codex mcp add mem0 --url https://mcp.mem0.ai/mcp --bearer-token-env-var MEM0_API_KEY
+codex mcp add mem0 --url https://mcp.mem0.ai/mcp/ --bearer-token-env-var MEM0_API_KEY
 ```
 
 Or add it manually to `~/.codex/config.toml`:
 
 ```toml
 [mcp_servers.mem0]
-url = "https://mcp.mem0.ai/mcp"
+url = "https://mcp.mem0.ai/mcp/"
 bearer_token_env_var = "MEM0_API_KEY"
 ```
 
@@ -125,7 +125,8 @@ When installed via the plugin marketplace, Mem0 hooks into Codex's lifecycle to 
 | **User prompt** | `UserPromptSubmit` | Searches relevant memories before each message |
 | **Pre-tool** | `PreToolUse` | Blocks MEMORY.md writes, enforces `user_id`/`app_id` on mem0 tool calls |
 | **Post-tool** | `PostToolUse` | Tracks stats, scans bash errors for related memories |
-| **Pre-compact** | `PreCompact` | Stores a session summary before context compaction |
+| **Stop** | `Stop` | Stores a session summary when the session ends |
+| **Pre-compact** | `PreCompact` | Stores a summary before the context is compacted |
 
 ## Example Workflow
 

--- a/docs/integrations/cursor.mdx
+++ b/docs/integrations/cursor.mdx
@@ -47,7 +47,7 @@ The fastest way to get started. Click the link below to install the Mem0 MCP ser
 npx mcp-add \
   --name mem0-mcp \
   --type http \
-  --url "https://mcp.mem0.ai/mcp" \
+  --url "https://mcp.mem0.ai/mcp/" \
   --clients "cursor"
 ```
 
@@ -110,7 +110,8 @@ When installed via the Cursor Marketplace, Mem0 hooks into Cursor's lifecycle:
 | **User prompt** | `beforeSubmitPrompt` | Searches relevant memories before each message; skips short prompts |
 | **Pre-tool (2 handlers)** | `preToolUse` | Blocks MEMORY.md writes, enforces `user_id`/`app_id` on mem0 tool calls |
 | **Post-tool (2 handlers)** | `postToolUse` | Tracks stats, scans bash errors for related memories |
-| **Pre-compact** | `preCompact` | Stores a session summary before context compaction |
+| **Stop** | `stop` | Stores a session summary when the session ends |
+| **Pre-compact** | `preCompact` | Stores a summary before the context is compacted |
 
 ## Example Workflow
 

--- a/integrations/mem0-plugin/.claude-plugin/plugin.json
+++ b/integrations/mem0-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mem0",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Persistent memory for Claude Code. Remembers decisions, patterns, and preferences across sessions.",
   "author": {
     "name": "Mem0",

--- a/integrations/mem0-plugin/.codex-plugin/plugin.json
+++ b/integrations/mem0-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mem0",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Persistent memory for Codex. Remembers decisions, patterns, and preferences across sessions.",
   "author": {
     "name": "Mem0",

--- a/integrations/mem0-plugin/.cursor-plugin/plugin.json
+++ b/integrations/mem0-plugin/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mem0",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Mem0 memory layer for AI applications. Add persistent memory, personalization, and semantic search using the Mem0 Platform MCP server.",
   "author": {
     "name": "Mem0",

--- a/integrations/mem0-plugin/CHANGELOG.md
+++ b/integrations/mem0-plugin/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the Mem0 plugin will be documented in this file.
 
+## 0.2.11 — Session-summary metadata fix + rerank auto-injected context by default
+
+> Versions: Claude Code / Cursor / Codex `0.2.11`; Antigravity `0.1.3`. All four editors share `scripts/`, so the fix below applies to every editor.
+
+### Fixed
+
+- **`files_touched` was double-JSON-encoded in session summaries (`scripts/capture_session_summary.py`):** the Stop-hook summary set `metadata["files_touched"] = json.dumps(files[:20])` — a pre-serialized JSON string — and then serialized the whole request body again with `json.dumps(body)`. The stored memory therefore carried an escaped string blob (`"[\"mem0/memory/main.py\", \"src/client/index.ts\"]"`) instead of a real array, so file paths surfaced as backslash- and slash-heavy escaped text when those memories were returned by `search_memories`/`get_memories` and shown in Claude Code, Cursor, Codex, and Antigravity. The fix stores the list directly (`metadata["files_touched"] = files[:20]`) so the body is encoded exactly once. New `tests/test_capture_session_summary.py` asserts the posted body contains a JSON array and no escaped-string artifact.
+
+### Changed
+
+- **Auto-injected memory context is now reranked by default (`scripts/_search.py`, `scripts/file_context.py`, `scripts/on_bash_output.sh`, `scripts/on_user_prompt.sh`):** the REST search endpoint does not rerank when `rerank` is omitted, so hook-injected context (file-context, bash-error lookup, session-resume prefetch) was ordered by raw vector similarity and the single most relevant memory could fall outside the injected `top_k` window. A new `should_rerank()` helper turns reranking on for every auto-injection path; the extra ~150–200 ms stays within the hook's curl budget. Opt out with `MEM0_RERANK=0` (also accepts `false`/`no`/`off`). (#5690)
+
 ## 0.2.10 — Accurate per-editor telemetry attribution
 
 ### Fixed

--- a/integrations/mem0-plugin/plugin.json
+++ b/integrations/mem0-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "mem0",
   "name": "mem0",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Persistent semantic memory for Antigravity agents. Cross-session, user-level recall via the Mem0 Platform MCP server. 16 slash commands, lifecycle hooks for auto-capture and metadata enforcement.",
   "author": { "name": "Mem0", "email": "support@mem0.ai" },
   "publisher": "mem0ai",

--- a/integrations/mem0-plugin/scripts/capture_session_summary.py
+++ b/integrations/mem0-plugin/scripts/capture_session_summary.py
@@ -173,7 +173,7 @@ def store_summary(
     if branch:
         metadata["branch"] = branch
     if files:
-        metadata["files_touched"] = json.dumps(files[:20])
+        metadata["files_touched"] = files[:20]
 
     body = {
         "messages": [{"role": "user", "content": summary_prompt}],

--- a/integrations/mem0-plugin/tests/test_capture_session_summary.py
+++ b/integrations/mem0-plugin/tests/test_capture_session_summary.py
@@ -1,0 +1,95 @@
+"""Regression tests for capture_session_summary.py request body construction.
+
+Guards against the double-JSON-encoding bug where ``files_touched`` was stored
+as a pre-serialized JSON string and then encoded a second time with the rest of
+the request body — surfacing as escaped, slash-heavy blobs in the memories shown
+inside Claude Code / Cursor / Codex / Antigravity (all four editors share this
+script).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import pytest
+
+SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
+
+
+@pytest.fixture(autouse=True)
+def _scripts_path():
+    abs_scripts = os.path.abspath(SCRIPTS_DIR)
+    if abs_scripts not in sys.path:
+        sys.path.insert(0, abs_scripts)
+    yield
+    if abs_scripts in sys.path:
+        sys.path.remove(abs_scripts)
+
+
+class _FakeResp:
+    status = 200
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+
+def _capture_request_body(monkeypatch):
+    """Patch urlopen so store_summary posts nowhere; capture the request body."""
+    import capture_session_summary as css
+
+    captured: dict = {}
+
+    def fake_urlopen(req, timeout=0):
+        captured["raw"] = req.data.decode("utf-8")
+        captured["body"] = json.loads(captured["raw"])
+        return _FakeResp()
+
+    monkeypatch.setattr(css.urllib.request, "urlopen", fake_urlopen)
+    return captured, css
+
+
+def test_files_touched_is_json_array_not_double_encoded(monkeypatch):
+    """files_touched must be a real JSON array, encoded exactly once."""
+    captured, css = _capture_request_body(monkeypatch)
+    files = ["mem0/memory/main.py", "src/client/index.ts"]
+
+    css.store_summary(
+        api_key="test-key",
+        summary_prompt="did some work",
+        user_id="u1",
+        session_id="s1",
+        project_id="p1",
+        branch="main",
+        files=files,
+    )
+
+    files_touched = captured["body"]["metadata"]["files_touched"]
+    assert isinstance(files_touched, list), (
+        "files_touched must be a JSON array, not a double-encoded string; "
+        f"got {type(files_touched).__name__}: {files_touched!r}"
+    )
+    assert files_touched == files
+    # The file paths must not appear as an escaped JSON string inside the body.
+    assert '\\"' not in captured["raw"]
+
+
+def test_files_touched_omitted_when_no_files(monkeypatch):
+    """No files touched -> no files_touched key (unchanged behaviour)."""
+    captured, css = _capture_request_body(monkeypatch)
+
+    css.store_summary(
+        api_key="test-key",
+        summary_prompt="did some work",
+        user_id="u1",
+        session_id="s1",
+        project_id="p1",
+        branch="main",
+        files=[],
+    )
+
+    assert "files_touched" not in captured["body"]["metadata"]

--- a/integrations/mem0-plugin/tests/test_capture_session_summary.py
+++ b/integrations/mem0-plugin/tests/test_capture_session_summary.py
@@ -10,22 +10,6 @@ script).
 from __future__ import annotations
 
 import json
-import os
-import sys
-
-import pytest
-
-SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
-
-
-@pytest.fixture(autouse=True)
-def _scripts_path():
-    abs_scripts = os.path.abspath(SCRIPTS_DIR)
-    if abs_scripts not in sys.path:
-        sys.path.insert(0, abs_scripts)
-    yield
-    if abs_scripts in sys.path:
-        sys.path.remove(abs_scripts)
 
 
 class _FakeResp:


### PR DESCRIPTION
## Linked Issue

No tracked GitHub issue — reported directly (session-summary memories showing `files_touched` as escaped, slash-heavy blobs in editor search results). Small, root-cause-tied fix; happy to file an issue retroactively if preferred.

## Description

Two things, requested together:

**1. Bug fix — `files_touched` was double-JSON-encoded in session summaries.**
`integrations/mem0-plugin/scripts/capture_session_summary.py` set `metadata["files_touched"] = json.dumps(files[:20])` — a pre-serialized JSON string — and then serialized the whole request body again with `json.dumps(body)`. The stored memory therefore carried a double-encoded escaped string (`"[\"mem0/memory/main.py\", \"src/client/index.ts\"]"`) instead of a real array. When those memories came back through `search_memories` / `get_memories`, the file paths surfaced as backslash/slash-heavy escaped blobs in results shown inside **Claude Code, Cursor, Codex, and Antigravity**. All four editors share `scripts/`, so this **single-line fix covers every editor** — the list is now stored directly and the body is encoded exactly once.

**2. Docs — fix a dead blog link.**
The "Blog Post" card on the [Memory Evaluation](https://docs.mem0.ai/core-concepts/memory-evaluation) page pointed at a placeholder (`mem0.ai/blog/new-algorithm`). Repointed to the current token-efficient-memory-algorithm temporal-reasoning post, which carries the benchmark numbers the page already reflects and links back to the original announcement.

**Plus:** version bumps (Claude Code / Cursor / Codex `0.2.10 → 0.2.11`, Antigravity `0.1.2 → 0.1.3`) and a `0.2.11` CHANGELOG entry that also documents the previously-undocumented rerank-auto-injected-context-by-default change (#5690) shipped since 0.2.10.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A. Memories previously stored with an escaped-string `files_touched` remain readable; only newly captured summaries store a clean JSON array.

## Test Coverage

- [x] I added/updated unit tests (`integrations/mem0-plugin/tests/test_capture_session_summary.py`)
- [ ] I added/updated integration tests
- [x] I tested manually (full plugin suite below)
- [ ] No tests needed

**Red → green proof.**

Before the fix (RED):
```
AssertionError: files_touched must be a JSON array, not a double-encoded string;
got str: '["mem0/memory/main.py", "src/client/index.ts"]'
```

After the fix (GREEN):
```
tests/test_capture_session_summary.py::test_files_touched_is_json_array_not_double_encoded PASSED
tests/test_capture_session_summary.py::test_files_touched_omitted_when_no_files PASSED
2 passed
```

Full plugin suite: `155 passed in 3.68s`. `ruff check` and `ruff format --check` clean. `docs/llms.txt` in sync.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
