### PR TITLE
feat(ts-sdk): add Together embedding and Sarvam LLM providers

### DIFF
--- a/mem0-ts/src/oss/src/embeddings/together.ts
+++ b/mem0-ts/src/oss/src/embeddings/together.ts
@@ -1,0 +1,12 @@
+import { OpenAIEmbedder } from "./openai";
+import { EmbeddingConfig } from "../types";
+
+export class TogetherEmbedder extends OpenAIEmbedder {
+  constructor(config: EmbeddingConfig) {
+    super({
+      ...config,
+      baseURL: config.baseURL || "https://api.together.xyz/v1",
+      model: config.model || "sentence-transformers__all-minilm-l6-v2",
+    });
+  }
+}

--- a/mem0-ts/src/oss/src/llms/sarvam.ts
+++ b/mem0-ts/src/oss/src/llms/sarvam.ts
@@ -1,0 +1,43 @@
+import { OpenAILLM } from "./openai";
+import { LLMConfig, Message } from "../types";
+import { LLMResponse } from "./base";
+
+export class SarvamLLM extends OpenAILLM {
+  constructor(config: LLMConfig) {
+    const apiKey = config.apiKey || process.env.SARVAM_API_KEY;
+    if (!apiKey) {
+      throw new Error("Sarvam API key is required");
+    }
+    super({
+      ...config,
+      apiKey,
+      baseURL:
+        config.baseURL ||
+        process.env.SARVAM_API_BASE ||
+        "https://api.sarvam.ai",
+      model: config.model || "sarvam-m",
+    });
+  }
+
+  async generateResponse(
+    messages: Message[],
+    responseFormat?: { type: string },
+    tools?: any[],
+  ): Promise<string | LLMResponse> {
+    try {
+      return await super.generateResponse(messages, responseFormat, tools);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`Sarvam LLM failed: ${message}`);
+    }
+  }
+
+  async generateChat(messages: Message[]): Promise<LLMResponse> {
+    try {
+      return await super.generateChat(messages);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`Sarvam LLM failed: ${message}`);
+    }
+  }
+}

--- a/mem0-ts/src/oss/src/utils/factory.ts
+++ b/mem0-ts/src/oss/src/utils/factory.ts
@@ -33,9 +33,11 @@ import { AzureOpenAILLM } from "../llms/azure";
 import { AzureOpenAIEmbedder } from "../embeddings/azure";
 import { LangchainLLM } from "../llms/langchain";
 import { LangchainEmbedder } from "../embeddings/langchain";
+import { TogetherEmbedder } from "../embeddings/together";
 import { LangchainVectorStore } from "../vector_stores/langchain";
 import { AzureAISearch } from "../vector_stores/azure_ai_search";
 import { PGVector } from "../vector_stores/pgvector";
+import { SarvamLLM } from "../llms/sarvam";
 
 export class EmbedderFactory {
   static create(provider: string, config: EmbeddingConfig): Embedder {
@@ -53,6 +55,8 @@ export class EmbedderFactory {
         return new AzureOpenAIEmbedder(config);
       case "langchain":
         return new LangchainEmbedder(config);
+      case "together":
+        return new TogetherEmbedder(config);
       default:
         throw new Error(`Unsupported embedder provider: ${provider}`);
     }
@@ -85,6 +89,8 @@ export class LLMFactory {
         return new LangchainLLM(config);
       case "deepseek":
         return new DeepSeekLLM(config);
+      case "sarvam":
+        return new SarvamLLM(config);
       default:
         throw new Error(`Unsupported LLM provider: ${provider}`);
     }

--- a/mem0-ts/src/oss/tests/factory.unit.test.ts
+++ b/mem0-ts/src/oss/tests/factory.unit.test.ts
@@ -35,6 +35,11 @@ jest.mock("../src/embeddings/lmstudio", () => ({
     .fn()
     .mockImplementation((config) => ({ type: "lmstudio-embedder", config })),
 }));
+jest.mock("../src/embeddings/together", () => ({
+  TogetherEmbedder: jest
+    .fn()
+    .mockImplementation((config) => ({ type: "together-embedder", config })),
+}));
 
 jest.mock("../src/llms/openai", () => ({
   OpenAILLM: jest
@@ -91,6 +96,11 @@ jest.mock("../src/llms/deepseek", () => ({
   DeepSeekLLM: jest
     .fn()
     .mockImplementation((config) => ({ type: "deepseek-llm", config })),
+}));
+jest.mock("../src/llms/sarvam", () => ({
+  SarvamLLM: jest
+    .fn()
+    .mockImplementation((config) => ({ type: "sarvam-llm", config })),
 }));
 
 jest.mock("../src/vector_stores/qdrant", () => ({
@@ -165,6 +175,7 @@ describe("EmbedderFactory", () => {
     ["azure_openai"],
     ["langchain"],
     ["lmstudio"],
+    ["together"],
   ])("creates embedder for provider '%s'", (provider) => {
     expect(() =>
       EmbedderFactory.create(provider, dummyEmbedConfig),
@@ -206,6 +217,7 @@ describe("LLMFactory", () => {
     ["langchain"],
     ["lmstudio"],
     ["deepseek"],
+    ["sarvam"],
   ])("creates LLM for provider '%s'", (provider) => {
     expect(() => LLMFactory.create(provider, dummyLLMConfig)).not.toThrow();
   });


### PR DESCRIPTION
# feat(ts-sdk): add Together embedding and Sarvam LLM providers

## Summary

This PR adds two providers to the TypeScript OSS SDK to bring it to parity with the Python SDK:

### 1. Together Embedding Provider (#5766)
- **File**: `mem0-ts/src/oss/src/embeddings/together.ts`
- **Pattern**: Extends `OpenAIEmbedder` (OpenAI-compatible `/v1/embeddings`)
- **baseURL**: `https://api.together.xyz/v1`
- **Default model**: `sentence-transformers__all-minilm-l6-v2`
- **No new dependency** — reuses the existing `openai` npm package

### 2. Sarvam LLM Provider (#5764)
- **File**: `mem0-ts/src/oss/src/llms/sarvam.ts`
- **Pattern**: Extends `OpenAILLM` (OpenAI-compatible endpoint)
- **baseURL**: `https://api.sarvam.ai`
- **Default model**: `sarvam-m`
- **Env vars**: `SARVAM_API_KEY`, `SARVAM_API_BASE`
- **Error wrapping**: Same pattern as `DeepSeekLLM`

## Changes

| File | Action |
|------|--------|
| `mem0-ts/src/oss/src/embeddings/together.ts` | **New** — TogetherEmbedder class |
| `mem0-ts/src/oss/src/llms/sarvam.ts` | **New** — SarvamLLM class |
| `mem0-ts/src/oss/src/utils/factory.ts` | Added imports + switch cases for both |
| `mem0-ts/src/oss/tests/factory.unit.test.ts` | Added jest mocks + test cases for both |

## Tests

- Factory unit tests: **40/40 passed** (includes `together` and `sarvam` in `test.each`)
- TypeScript compilation: no new errors from new files