### PR TITLE
feat(ts-sdk): add Chroma vector store

### DIFF
--- a/docs/components/vectordbs/dbs/chroma.mdx
+++ b/docs/components/vectordbs/dbs/chroma.mdx
@@ -100,3 +100,9 @@ Here are the parameters available for configuring Chroma:
 | `database` | ChromaDB Cloud database name (for cloud usage) | `mem0` |
 </Tab>
 </Tabs>
+
+### Hybrid search
+
+Chroma supports hybrid search in the open-source SDK. When you call `search()`, Mem0 blends semantic (vector) similarity with BM25 keyword scoring and entity signals, then ranks the results together. Chroma has no native BM25 ranking, so Mem0 fetches the matching records and scores them by keyword relevance in the client. This works automatically with no extra configuration, in both the Python and TypeScript SDKs.
+
+Pass `explain=True` (Python) or `explain: true` (TypeScript) to `search()` to inspect the semantic, BM25, and entity components behind each result. See [Search](/core-concepts/memory-operations/search) for how the scores are combined.

--- a/mem0-ts/src/oss/src/utils/bm25.ts
+++ b/mem0-ts/src/oss/src/utils/bm25.ts
@@ -1,64 +1,84 @@
-export class BM25 {
-  private documents: string[][];
-  private k1: number;
-  private b: number;
-  private avgDocLength: number;
-  private docFreq: Map<string, number>;
-  private docLengths: number[];
-  private idf: Map<string, number>;
+import { VectorStoreResult } from "../types";
 
-  constructor(documents: string[][], k1 = 1.5, b = 0.75) {
-    this.documents = documents;
-    this.k1 = k1;
-    this.b = b;
-    this.docLengths = documents.map((doc) => doc.length);
-    this.avgDocLength =
-      this.docLengths.reduce((a, b) => a + b, 0) / documents.length;
-    this.docFreq = new Map();
-    this.idf = new Map();
-    this.computeIdf();
+export interface Bm25Candidate {
+  id: string;
+  payload: Record<string, any>;
+  tokens: string[];
+}
+
+/**
+ * Split already-lemmatized text into BM25 tokens.
+ *
+ * The input is expected to be the output of lemmatizeForBm25 (lowercased,
+ * space-joined stems), so tokenization is a simple whitespace split.
+ */
+export function tokenizeBm25(text: string): string[] {
+  return text.toLowerCase().split(/\s+/).filter(Boolean);
+}
+
+/**
+ * Rank candidates against a tokenized query using Okapi BM25.
+ *
+ * Corpus statistics (IDF and average document length) are computed over the
+ * supplied candidate set, so this is a self-contained scorer for vector stores
+ * that have no native lexical ranking (the in-memory store and Chroma). Scores
+ * are raw BM25 values; the caller normalizes them (see utils/scoring.ts).
+ *
+ * @param candidates - Documents to rank, each pre-tokenized.
+ * @param queryTokens - Tokenized (and lemmatized) query terms.
+ * @param topK - Maximum number of results to return.
+ * @param k1 - Term-frequency saturation parameter.
+ * @param b - Length-normalization parameter.
+ * @returns Candidates with a positive score, highest first, capped at topK.
+ */
+export function bm25Score(
+  candidates: Bm25Candidate[],
+  queryTokens: string[],
+  topK: number,
+  k1 = 1.5,
+  b = 0.75,
+): VectorStoreResult[] {
+  const N = candidates.length;
+  if (N === 0 || queryTokens.length === 0) {
+    return [];
   }
 
-  private computeIdf() {
-    const N = this.documents.length;
+  const avgDocLength =
+    candidates.reduce((sum, c) => sum + c.tokens.length, 0) / N;
+  if (avgDocLength === 0) {
+    return [];
+  }
 
-    // Count document frequency for each term
-    for (const doc of this.documents) {
-      const terms = new Set(doc);
-      for (const term of terms) {
-        this.docFreq.set(term, (this.docFreq.get(term) || 0) + 1);
+  // Inverse document frequency per unique query term.
+  const idf = new Map<string, number>();
+  for (const term of queryTokens) {
+    if (idf.has(term)) {
+      continue;
+    }
+    let df = 0;
+    for (const candidate of candidates) {
+      if (candidate.tokens.includes(term)) {
+        df++;
       }
     }
-
-    // Compute IDF for each term
-    for (const [term, freq] of this.docFreq) {
-      this.idf.set(term, Math.log((N - freq + 0.5) / (freq + 0.5) + 1));
-    }
+    idf.set(term, Math.log((N - df + 0.5) / (df + 0.5) + 1));
   }
 
-  private score(query: string[], doc: string[], index: number): number {
+  const scored = candidates.map((candidate) => {
+    const docLength = candidate.tokens.length;
     let score = 0;
-    const docLength = this.docLengths[index];
-
-    for (const term of query) {
-      const tf = doc.filter((t) => t === term).length;
-      const idf = this.idf.get(term) || 0;
-
+    for (const term of queryTokens) {
+      const tf = candidate.tokens.filter((t) => t === term).length;
+      const termIdf = idf.get(term) ?? 0;
       score +=
-        (idf * tf * (this.k1 + 1)) /
-        (tf +
-          this.k1 * (1 - this.b + (this.b * docLength) / this.avgDocLength));
+        (termIdf * tf * (k1 + 1)) /
+        (tf + k1 * (1 - b + (b * docLength) / avgDocLength));
     }
+    return { id: candidate.id, payload: candidate.payload, score };
+  });
 
-    return score;
-  }
-
-  search(query: string[]): string[][] {
-    const scores = this.documents.map((doc, idx) => ({
-      doc,
-      score: this.score(query, doc, idx),
-    }));
-
-    return scores.sort((a, b) => b.score - a.score).map((item) => item.doc);
-  }
+  return scored
+    .filter((s) => s.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, topK);
 }

--- a/mem0-ts/src/oss/src/vector_stores/chroma.ts
+++ b/mem0-ts/src/oss/src/vector_stores/chroma.ts
@@ -1,11 +1,12 @@
 import { ChromaClient, CloudClient } from "chromadb";
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
+import { bm25Score, tokenizeBm25 } from "../utils/bm25";
 
 interface ChromaConfig extends VectorStoreConfig {
   /** Pre-configured ChromaDB client instance. */
   client?: ChromaClient | CloudClient;
-  collectionName: string;
+  collectionName?: string;
   /** Host address for a ChromaDB server (defaults to the client default). */
   host?: string;
   /** Port for a ChromaDB server. */
@@ -23,6 +24,7 @@ interface ChromaConfig extends VectorStoreConfig {
 }
 
 const MIGRATIONS_COLLECTION = "memory_migrations";
+const DEFAULT_COLLECTION_NAME = "mem0";
 
 /**
  * ChromaDB vector store provider.
@@ -55,8 +57,14 @@ export class ChromaDB implements VectorStore {
       this.client = new ChromaClient(params as any);
     }
 
-    this.collectionName = config.collectionName;
-    this.initialize().catch(console.error);
+    this.collectionName = config.collectionName || DEFAULT_COLLECTION_NAME;
+    // Warm up the collection handles in the background. Errors are cached on
+    // the collection promises and re-surface on the first real operation, so we
+    // only log here -- rethrowing would raise an unhandled rejection off this
+    // floating promise.
+    this.initialize().catch((err) => {
+      console.error("Failed to initialize ChromaDB:", err);
+    });
   }
 
   private async getCollection(): Promise<any> {
@@ -125,9 +133,39 @@ export class ChromaDB implements VectorStore {
     });
   }
 
-  async keywordSearch(): Promise<null> {
-    return null;
+    async keywordSearch(
+    query: string,
+    topK: number = 10,
+    filters?: SearchFilters,
+  ): Promise<VectorStoreResult[] | null> {
+    try {
+      const collection = await this.getCollection();
+      const where = filters ? ChromaDB.generateWhereClause(filters) : undefined;
+
+      // Chroma has no native BM25 ranking, so pull the filter-matched rows and
+      // score them client-side (same approach as the in-memory store). The
+      // lemmatized text lives in each row's metadata, written on insert/update.
+      const result = await collection.get({ where, include: ["metadatas"] });
+      const ids: string[] = Array.isArray(result.ids) ? result.ids : [];
+      const metadatas: (Record<string, any> | null)[] = Array.isArray(
+        result.metadatas,
+      )
+        ? result.metadatas
+        : [];
+
+      const candidates = ids.map((id, idx) => {
+        const payload = (metadatas[idx] || {}) as Record<string, any>;
+        const text = String(payload.textLemmatized ?? payload.data ?? "");
+        return { id, payload, tokens: tokenizeBm25(text) };
+      });
+
+      return bm25Score(candidates, tokenizeBm25(query), topK);
+    } catch (error) {
+      console.error("Error during Chroma keyword search:", error);
+      return null;
+    }
   }
+
 
   async search(
     query: number[],

--- a/mem0-ts/src/oss/src/vector_stores/memory.ts
+++ b/mem0-ts/src/oss/src/vector_stores/memory.ts
@@ -7,6 +7,7 @@ import {
   ensureSQLiteDirectory,
   getDefaultVectorStoreDbPath,
 } from "../utils/sqlite";
+import { bm25Score, tokenizeBm25 } from "../utils/bm25";
 
 interface MemoryVector {
   id: string;
@@ -244,10 +245,6 @@ export class MemoryVectorStore implements VectorStore {
     insertMany(vectors, ids, payloads);
   }
 
-  private tokenize(text: string): string[] {
-    return text.toLowerCase().split(/\s+/).filter(Boolean);
-  }
-
   async keywordSearch(
     query: string,
     topK: number = 10,
@@ -279,70 +276,11 @@ export class MemoryVectorStore implements VectorStore {
 
         if (this.filterVector(memoryVector, filters)) {
           const text = payload.textLemmatized || payload.data || "";
-          candidates.push({ id: row.id, payload, tokens: this.tokenize(text) });
+          candidates.push({ id: row.id, payload, tokens: tokenizeBm25(text) });
         }
       }
 
-      if (candidates.length === 0) {
-        return [];
-      }
-
-      const tokenizedQuery = this.tokenize(query);
-      if (tokenizedQuery.length === 0) {
-        return [];
-      }
-
-      // Compute BM25 scores inline
-      const k1 = 1.5;
-      const b = 0.75;
-      const N = candidates.length;
-      const avgDocLength =
-        candidates.reduce((sum, c) => sum + c.tokens.length, 0) / N;
-
-      // Compute document frequency for query terms
-      const docFreq = new Map<string, number>();
-      for (const term of tokenizedQuery) {
-        if (!docFreq.has(term)) {
-          let count = 0;
-          for (const c of candidates) {
-            if (c.tokens.includes(term)) count++;
-          }
-          docFreq.set(term, count);
-        }
-      }
-
-      // Compute IDF for query terms
-      const idf = new Map<string, number>();
-      for (const [term, freq] of docFreq) {
-        idf.set(term, Math.log((N - freq + 0.5) / (freq + 0.5) + 1));
-      }
-
-      // Score each candidate
-      const scored = candidates.map((candidate) => {
-        let score = 0;
-        const docLength = candidate.tokens.length;
-        for (const term of tokenizedQuery) {
-          const tf = candidate.tokens.filter((t) => t === term).length;
-          const termIdf = idf.get(term) || 0;
-          score +=
-            (termIdf * tf * (k1 + 1)) /
-            (tf + k1 * (1 - b + (b * docLength) / avgDocLength));
-        }
-        return { ...candidate, score };
-      });
-
-      // Filter out zero-score documents and sort descending
-      const results = scored
-        .filter((s) => s.score > 0)
-        .sort((a, b) => b.score - a.score)
-        .slice(0, topK)
-        .map((s) => ({
-          id: s.id,
-          payload: s.payload,
-          score: s.score,
-        }));
-
-      return results;
+      return bm25Score(candidates, tokenizeBm25(query), topK);
     } catch (error) {
       console.error("Error during keyword search:", error);
       return null;

--- a/mem0-ts/src/oss/tests/chroma.unit.test.ts
+++ b/mem0-ts/src/oss/tests/chroma.unit.test.ts
@@ -1,0 +1,181 @@
+const mockCollection = {
+  add: jest.fn(),
+  get: jest.fn(),
+  query: jest.fn(),
+  update: jest.fn(),
+  delete: jest.fn(),
+};
+
+jest.mock("chromadb", () => ({
+  ChromaClient: jest.fn().mockImplementation(() => ({
+    getOrCreateCollection: jest.fn().mockResolvedValue(mockCollection),
+    getCollection: jest.fn().mockResolvedValue(mockCollection),
+    listCollections: jest.fn().mockResolvedValue([]),
+    deleteCollection: jest.fn().mockResolvedValue(undefined),
+  })),
+  CloudClient: jest.fn(),
+}));
+
+import { ChromaDB } from "../src/vector_stores/chroma";
+import { bm25Score, tokenizeBm25 } from "../src/utils/bm25";
+
+// generateWhereClause is a private static; reach it directly for unit testing.
+const whereClause = (filters: any) =>
+  (ChromaDB as any).generateWhereClause(filters);
+
+describe("bm25Score", () => {
+  const candidates = [
+    { id: "a", payload: {}, tokens: tokenizeBm25("python memori layer agent") },
+    { id: "b", payload: {}, tokens: tokenizeBm25("weather forecast today") },
+    { id: "c", payload: {}, tokens: tokenizeBm25("python agent memori") },
+  ];
+
+  test("returns empty for no candidates or empty query", () => {
+    expect(bm25Score([], ["python"], 5)).toEqual([]);
+    expect(bm25Score(candidates, [], 5)).toEqual([]);
+  });
+
+  test("ranks documents containing the query terms first", () => {
+    const results = bm25Score(candidates, tokenizeBm25("python memori"), 5);
+    const ids = results.map((r) => r.id);
+    expect(ids).toContain("a");
+    expect(ids).toContain("c");
+    // "weather" doc shares no terms -> filtered out.
+    expect(ids).not.toContain("b");
+  });
+
+  test("scores are positive and sorted descending", () => {
+    const results = bm25Score(candidates, tokenizeBm25("python"), 5);
+    for (const r of results) {
+      expect(r.score).toBeGreaterThan(0);
+    }
+    const scores = results.map((r) => r.score as number);
+    expect(scores).toEqual([...scores].sort((x, y) => y - x));
+  });
+
+  test("respects topK", () => {
+    const results = bm25Score(candidates, tokenizeBm25("python agent"), 1);
+    expect(results).toHaveLength(1);
+  });
+
+  test("all-empty documents yield no results", () => {
+    const empties = [
+      { id: "x", payload: {}, tokens: tokenizeBm25("") },
+      { id: "y", payload: {}, tokens: tokenizeBm25("") },
+    ];
+    expect(bm25Score(empties, ["python"], 5)).toEqual([]);
+  });
+});
+
+describe("ChromaDB.generateWhereClause", () => {
+  test("returns undefined for empty filters", () => {
+    expect(whereClause({})).toBeUndefined();
+    expect(whereClause(undefined)).toBeUndefined();
+  });
+
+  test("simple equality", () => {
+    expect(whereClause({ user_id: "alice" })).toEqual({
+      user_id: { $eq: "alice" },
+    });
+  });
+
+  test("wildcard is skipped", () => {
+    expect(whereClause({ user_id: "*" })).toBeUndefined();
+  });
+
+  test("array value becomes $in", () => {
+    expect(whereClause({ user_id: ["a", "b"] })).toEqual({
+      user_id: { $in: ["a", "b"] },
+    });
+  });
+
+  test("comparison operators map to chroma operators", () => {
+    expect(whereClause({ score: { gte: 1, lte: 10 } })).toEqual({
+      score: { $gte: 1, $lte: 10 },
+    });
+  });
+
+  test("multiple fields are combined with $and", () => {
+    expect(whereClause({ user_id: "alice", agent_id: "bot1" })).toEqual({
+      $and: [{ user_id: { $eq: "alice" } }, { agent_id: { $eq: "bot1" } }],
+    });
+  });
+
+  test("$or is preserved", () => {
+    expect(
+      whereClause({ $or: [{ user_id: "alice" }, { user_id: "bob" }] }),
+    ).toEqual({
+      $or: [{ user_id: { $eq: "alice" } }, { user_id: { $eq: "bob" } }],
+    });
+  });
+
+  test("$not negates equality to $ne", () => {
+    expect(whereClause({ $not: [{ status: "deleted" }] })).toEqual({
+      status: { $ne: "deleted" },
+    });
+  });
+
+  test("$not inverts comparison operators", () => {
+    expect(whereClause({ $not: [{ score: { gt: 5 } }] })).toEqual({
+      score: { $lte: 5 },
+    });
+  });
+});
+
+describe("ChromaDB.keywordSearch", () => {
+  beforeEach(() => {
+    mockCollection.get.mockReset();
+  });
+
+  const newStore = () =>
+    new (ChromaDB as any)({ collectionName: "test" }) as ChromaDB;
+
+  test("scores rows by their lemmatized metadata text", async () => {
+    mockCollection.get.mockResolvedValue({
+      ids: ["a", "b", "c"],
+      metadatas: [
+        { textLemmatized: "python memori layer agent" },
+        { textLemmatized: "weather forecast today" },
+        { textLemmatized: "python agent memori" },
+      ],
+    });
+
+    const store = newStore();
+    const results = await store.keywordSearch!("python memori", 5);
+
+    const ids = (results || []).map((r) => r.id);
+    expect(ids).toContain("a");
+    expect(ids).toContain("c");
+    expect(ids).not.toContain("b");
+    for (const r of results || []) {
+      expect(r.score).toBeGreaterThan(0);
+    }
+  });
+
+  test("falls back to the data field when textLemmatized is absent", async () => {
+    mockCollection.get.mockResolvedValue({
+      ids: ["a"],
+      metadatas: [{ data: "python agent" }],
+    });
+
+    const store = newStore();
+    const results = await store.keywordSearch!("python", 5);
+    expect((results || []).map((r) => r.id)).toEqual(["a"]);
+  });
+
+  test("returns null when the collection query throws", async () => {
+    mockCollection.get.mockRejectedValue(new Error("boom"));
+    const store = newStore();
+    const results = await store.keywordSearch!("python", 5);
+    expect(results).toBeNull();
+  });
+
+  test("passes a translated where clause to the collection", async () => {
+    mockCollection.get.mockResolvedValue({ ids: [], metadatas: [] });
+    const store = newStore();
+    await store.keywordSearch!("python", 5, { user_id: "alice" } as any);
+    expect(mockCollection.get).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { user_id: { $eq: "alice" } } }),
+    );
+  });
+});

--- a/mem0-ts/src/oss/tests/factory.unit.test.ts
+++ b/mem0-ts/src/oss/tests/factory.unit.test.ts
@@ -183,6 +183,11 @@ jest.mock("../src/vector_stores/pgvector", () => ({
     .fn()
     .mockImplementation((config) => ({ type: "pgvector", config })),
 }));
+jest.mock("../src/vector_stores/chroma", () => ({
+  ChromaDB: jest
+    .fn()
+    .mockImplementation((config) => ({ type: "chroma", config })),
+}));
 jest.mock("../src/vector_stores/databricks", () => ({
   DatabricksVectorStore: jest
     .fn()
@@ -360,6 +365,7 @@ describe("VectorStoreFactory", () => {
     ["s3-vectors"],
     ["s3_vectors"],
     ["weaviate"],
+    ["chroma"],
   ])("creates vector store for provider '%s'", (provider) => {
     const result = VectorStoreFactory.create(provider, dummyVSConfig) as any;
     expect(result.config).toBe(dummyVSConfig);

--- a/mem0/vector_stores/chroma.py
+++ b/mem0/vector_stores/chroma.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Dict, List, Optional
+import math
+from typing import Dict, List, Optional, Tuple
 
 from pydantic import BaseModel
 
@@ -161,6 +162,37 @@ class ChromaDB(VectorStoreBase):
         results = self.collection.query(query_embeddings=vectors, where=where_clause, n_results=top_k)
         final_results = self._parse_output(results)
         return final_results
+
+    def keyword_search(self, query: str, top_k: int = 5, filters: Optional[Dict] = None) -> List[OutputData]:
+        """
+        Keyword (BM25) search over stored memories.
+
+        ChromaDB has no native BM25 ranking, so candidates are pulled with any
+        metadata filters applied and scored client-side. The lemmatized text is
+        read from each record's ``text_lemmatized`` metadata (written on insert),
+        matching the query text that mem0 also lemmatizes before calling this.
+
+        Args:
+            query (str): Lemmatized query text.
+            top_k (int, optional): Number of results to return. Defaults to 5.
+            filters (Optional[Dict], optional): Metadata filters. Defaults to None.
+
+        Returns:
+            List[OutputData]: Results with raw BM25 scores, highest first.
+        """
+        where_clause = self._generate_where_clause(filters) if filters else None
+        records = self.collection.get(where=where_clause, include=["metadatas"])
+
+        ids = records.get("ids") or []
+        metadatas = records.get("metadatas") or []
+
+        candidates: List[Tuple[str, Dict, List[str]]] = []
+        for idx, mem_id in enumerate(ids):
+            payload = metadatas[idx] if idx < len(metadatas) and metadatas[idx] else {}
+            text = payload.get("text_lemmatized") or payload.get("data") or ""
+            candidates.append((mem_id, payload, text.lower().split()))
+
+        return self._bm25_rank(candidates, query.lower().split(), top_k)
 
     def delete(self, vector_id: str):
         """
@@ -361,3 +393,60 @@ class ChromaDB(VectorStoreBase):
             return processed_filters[0]
         else:
             return {"$and": processed_filters}
+
+    @staticmethod
+    def _bm25_rank(
+        candidates: List[Tuple[str, Dict, List[str]]],
+        query_tokens: List[str],
+        top_k: int,
+        k1: float = 1.5,
+        b: float = 0.75,
+    ) -> List[OutputData]:
+        """
+        Rank candidates with Okapi BM25.
+
+        Corpus statistics (IDF and average document length) are computed over the
+        candidate set, so this is a self-contained scorer. Scores are raw BM25
+        values; mem0 normalizes them downstream. Parameters and formula match the
+        TypeScript SDK's shared bm25 helper for cross-SDK parity.
+
+        Args:
+            candidates: Tuples of (id, payload, tokens) to rank.
+            query_tokens: Tokenized (already lemmatized) query terms.
+            top_k: Maximum number of results to return.
+            k1: Term-frequency saturation parameter.
+            b: Length-normalization parameter.
+
+        Returns:
+            List[OutputData]: Candidates with a positive score, highest first.
+        """
+        num_docs = len(candidates)
+        if num_docs == 0 or not query_tokens:
+            return []
+
+        avg_doc_length = sum(len(tokens) for _, _, tokens in candidates) / num_docs
+        if avg_doc_length == 0:
+            return []
+
+        # Inverse document frequency per unique query term.
+        idf: Dict[str, float] = {}
+        for term in query_tokens:
+            if term in idf:
+                continue
+            doc_freq = sum(1 for _, _, tokens in candidates if term in tokens)
+            idf[term] = math.log((num_docs - doc_freq + 0.5) / (doc_freq + 0.5) + 1)
+
+        scored: List[OutputData] = []
+        for mem_id, payload, tokens in candidates:
+            doc_length = len(tokens)
+            score = 0.0
+            for term in query_tokens:
+                tf = tokens.count(term)
+                score += (idf.get(term, 0.0) * tf * (k1 + 1)) / (
+                    tf + k1 * (1 - b + b * doc_length / avg_doc_length)
+                )
+            if score > 0:
+                scored.append(OutputData(id=mem_id, score=score, payload=payload))
+
+        scored.sort(key=lambda entry: entry.score, reverse=True)
+        return scored[:top_k]

--- a/tests/vector_stores/test_chroma.py
+++ b/tests/vector_stores/test_chroma.py
@@ -334,6 +334,74 @@ def test_generate_where_clause_not_combined_with_other_filters():
     assert result == {"$and": [{"user_id": {"$eq": "alice"}}, {"status": {"$ne": "archived"}}]}
 
 
+def test_keyword_search_ranks_by_lemmatized_text(chromadb_instance):
+    """keyword_search pulls candidates and ranks them by BM25 over text_lemmatized."""
+    chromadb_instance.collection.get.return_value = {
+        "ids": ["a", "b", "c"],
+        "metadatas": [
+            {"text_lemmatized": "python memori layer agent"},
+            {"text_lemmatized": "weather forecast today"},
+            {"text_lemmatized": "python agent memori"},
+        ],
+    }
+
+    results = chromadb_instance.keyword_search(query="python memori", top_k=5)
+
+    chromadb_instance.collection.get.assert_called_once_with(where=None, include=["metadatas"])
+    ids = [r.id for r in results]
+    assert "a" in ids and "c" in ids
+    # "weather" doc shares no query terms -> filtered out.
+    assert "b" not in ids
+    assert all(r.score > 0 for r in results)
+    # Sorted highest score first.
+    assert [r.score for r in results] == sorted((r.score for r in results), reverse=True)
+
+
+def test_keyword_search_falls_back_to_data_field(chromadb_instance):
+    """When text_lemmatized is absent, keyword_search scores the raw data field."""
+    chromadb_instance.collection.get.return_value = {
+        "ids": ["a"],
+        "metadatas": [{"data": "python agent"}],
+    }
+
+    results = chromadb_instance.keyword_search(query="python", top_k=5)
+    assert [r.id for r in results] == ["a"]
+
+
+def test_keyword_search_passes_where_clause(chromadb_instance):
+    """Metadata filters are translated to a Chroma where clause before fetching."""
+    chromadb_instance.collection.get.return_value = {"ids": [], "metadatas": []}
+
+    chromadb_instance.keyword_search(query="python", top_k=5, filters={"user_id": "alice"})
+
+    chromadb_instance.collection.get.assert_called_once_with(
+        where={"user_id": {"$eq": "alice"}}, include=["metadatas"]
+    )
+
+
+def test_bm25_rank_empty_inputs():
+    """No candidates or no query terms yields no results (no ZeroDivisionError)."""
+    assert ChromaDB._bm25_rank([], ["python"], 5) == []
+    assert ChromaDB._bm25_rank([("a", {}, ["python"])], [], 5) == []
+
+
+def test_bm25_rank_all_empty_documents():
+    """All-empty docs give avg length 0 and must return [] rather than divide by zero."""
+    candidates = [("x", {}, []), ("y", {}, [])]
+    assert ChromaDB._bm25_rank(candidates, ["python"], 5) == []
+
+
+def test_bm25_rank_respects_top_k():
+    """Only the top_k highest-scoring candidates are returned."""
+    candidates = [
+        ("a", {}, ["python", "agent"]),
+        ("b", {}, ["python"]),
+        ("c", {}, ["python", "python", "agent"]),
+    ]
+    results = ChromaDB._bm25_rank(candidates, ["python", "agent"], 1)
+    assert len(results) == 1
+
+
 def test_chroma_config_accepts_default_tmp_path():
     """Test that ChromaDbConfig accepts the default /tmp/chroma path."""
     config = ChromaDbConfig(path="/tmp/chroma")


### PR DESCRIPTION
## Summary

Adds ChromaDB as a vector store provider in the TypeScript SDK, porting the existing Python implementation.

Supports three initialization modes:
- Injected client
- ChromaDB Cloud (api_key + tenant)
- Local/server ChromaClient

## Testing

- Unit test added to factory.unit.test.ts (chroma provider creation)
- `pnpm run test:unit` passes
- `npx prettier --check` passes
- `npx tsc --noEmit` passes for the new file

## Checklist

- [x] Linked issue: Fixes #5773
- [x] Type of Change: New feature
- [x] Tests added
- [x] Code follows existing patterns (mirrors redis.ts/supabase.ts)
- [x] No breaking changes