### PR TITLE
fix(server): use psycopg[binary] so pgvector works on the slim image

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -3,7 +3,10 @@ uvicorn==0.34.0
 pydantic[email]==2.10.4
 mem0ai>=0.1.48
 python-dotenv==1.2.2
-psycopg>=3.2.8
+# [binary] bundles libpq + the C extension. Without it, the slim runtime image
+# (server/Dockerfile, python:3.12-slim, no system libpq) cannot import psycopg,
+# so the default pgvector store crashes at startup ("libpq library not found").
+psycopg[binary]>=3.2.8
 psycopg-pool>=3.2.6,<4.0.0
 
 # Bundled LLM/embedder providers. Extend by adding the provider's package


### PR DESCRIPTION
## Summary
- `server/requirements.txt` pins bare `psycopg`, but the production image (`server/Dockerfile`) builds on `python:3.12-slim` and only runs `pip install -r requirements.txt` — there's no system `libpq`. So `psycopg`'s pure-python impl can't find `libpq`, the C impl (`psycopg_binary`) isn't installed, and importing `psycopg` fails.
- Since **pgvector is the default `vector_store`**, the server crash-loops on startup out of the box:

```
ImportError: no pq wrapper available.
- couldn't import psycopg 'binary' implementation: No module named 'psycopg_binary'
- couldn't import psycopg 'python' implementation: libpq library not found
```

- Fix: use **`psycopg[binary]`**, which bundles `libpq` + the C extension — pgvector works on the slim image with no extra `apt` layer.

## Reproduction
Build `server/Dockerfile` and start it with the default config (pgvector) → the traceback above. Hit while self-hosting the server image; `psycopg[binary]` resolves it.

## Notes
One-line dependency change; `psycopg-pool` is unaffected. An alternative would be `apt-get install libpq5` in `server/Dockerfile`, but `[binary]` keeps the image self-contained.