### PR TITLE
fix(anthropic): honor response_format in generate_response (revives #4939 per review)

### DIFF
--- a/mem0/llms/anthropic.py
+++ b/mem0/llms/anthropic.py
@@ -9,6 +9,7 @@ except ImportError:
 from mem0.configs.llms.anthropic import AnthropicConfig
 from mem0.configs.llms.base import BaseLlmConfig
 from mem0.llms.base import LLMBase
+from mem0.memory.utils import extract_json
 
 
 class AnthropicLLM(LLMBase):
@@ -137,7 +138,36 @@ class AnthropicLLM(LLMBase):
             params["tools"] = tools
             params["tool_choice"] = {"type": tool_choice}
 
+        wants_json_prefill = False
+        if response_format and isinstance(response_format, dict):
+            format_type = response_format.get("type")
+            if format_type == "json_schema" and "json_schema" in response_format:
+                # Use Anthropic structured outputs via output_config
+                schema = response_format["json_schema"]
+                if isinstance(schema, dict) and "schema" in schema:
+                    schema = schema["schema"]
+                params["output_config"] = {"format": {"type": "json_schema", "schema": schema}}
+            elif format_type == "json_object":
+                # Use assistant prefill to guide JSON output
+                wants_json_prefill = True
+                json_instruction = (
+                    "\n\nYou must respond with valid JSON only. "
+                    "Do not include any other text, markdown formatting, or code fences."
+                )
+                if params.get("system"):
+                    params["system"] += json_instruction
+                else:
+                    params["system"] = json_instruction.strip()
+                params["messages"] = list(params["messages"]) + [
+                    {"role": "assistant", "content": "{"}
+                ]
+
         response = self.client.messages.create(**params)
+
+        if wants_json_prefill:
+            # Re-attach the prefilled "{" and strip any stray wrapping.
+            return extract_json("{" + response.content[0].text)
+
         return self._parse_response(response, tools)
 
     def _parse_response(self, response, tools):

--- a/tests/llms/test_anthropic.py
+++ b/tests/llms/test_anthropic.py
@@ -2,15 +2,18 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+
 pytest.importorskip("anthropic", reason="anthropic package not installed")
 
 from mem0.configs.llms.anthropic import AnthropicConfig
 from mem0.configs.llms.base import BaseLlmConfig
+
 from mem0.llms.anthropic import AnthropicLLM
 
 
 @pytest.fixture
 def mock_anthropic_client():
+
     with patch("mem0.llms.anthropic.anthropic") as mock_anthropic:
         mock_client = Mock()
         mock_anthropic.Anthropic.return_value = mock_client
@@ -185,3 +188,101 @@ def test_enable_sampling_parameters_respects_explicit_override(mock_anthropic_cl
     call_kwargs = mock_anthropic_client.messages.create.call_args[1]
     assert "temperature" not in call_kwargs
     assert "top_p" not in call_kwargs
+
+
+def test_generate_response_without_response_format(mock_anthropic_client):
+    config = AnthropicConfig(model="claude-sonnet-4-20250514", api_key="test-key", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = AnthropicLLM(config)
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello, how are you?"},
+    ]
+
+    mock_response = Mock()
+    mock_response.content = [Mock(text="I'm doing well, thank you for asking!")]
+    mock_anthropic_client.messages.create.return_value = mock_response
+
+    response = llm.generate_response(messages)
+
+    call_kwargs = mock_anthropic_client.messages.create.call_args[1]
+    assert not any(m.get("content") == "{" for m in call_kwargs["messages"])
+    assert "output_config" not in call_kwargs
+    assert response == "I'm doing well, thank you for asking!"
+
+
+def test_generate_response_with_json_object_format(mock_anthropic_client):
+    config = AnthropicConfig(model="claude-sonnet-4-20250514", api_key="test-key", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = AnthropicLLM(config)
+    messages = [
+        {"role": "system", "content": "Extract facts."},
+        {"role": "user", "content": "My name is Alice."},
+    ]
+
+    mock_response = Mock()
+    mock_response.content = [Mock(text='"facts": ["Name is Alice"]}')]
+    mock_anthropic_client.messages.create.return_value = mock_response
+
+    response = llm.generate_response(messages, response_format={"type": "json_object"})
+
+    assert response == '{"facts": ["Name is Alice"]}'
+    call_kwargs = mock_anthropic_client.messages.create.call_args[1]
+    assert call_kwargs["messages"][-1] == {"role": "assistant", "content": "{"}
+    assert "valid JSON only" in call_kwargs["system"]
+
+
+def test_generate_response_json_object_without_system_message(mock_anthropic_client):
+    config = AnthropicConfig(model="claude-sonnet-4-20250514", api_key="test-key", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = AnthropicLLM(config)
+    messages = [
+        {"role": "user", "content": "My name is Bob."},
+    ]
+
+    mock_response = Mock()
+    mock_response.content = [Mock(text='"facts": ["Name is Bob"]}')]
+    mock_anthropic_client.messages.create.return_value = mock_response
+
+    response = llm.generate_response(messages, response_format={"type": "json_object"})
+
+    assert response == '{"facts": ["Name is Bob"]}'
+    call_kwargs = mock_anthropic_client.messages.create.call_args[1]
+    assert "valid JSON only" in call_kwargs["system"]
+
+
+def test_generate_response_json_object_strips_code_fences(mock_anthropic_client):
+    config = AnthropicConfig(model="claude-sonnet-4-20250514", api_key="test-key", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = AnthropicLLM(config)
+    messages = [{"role": "user", "content": "Extract facts."}]
+
+    mock_response = Mock()
+    mock_response.content = [Mock(text='"facts": []}')]
+    mock_anthropic_client.messages.create.return_value = mock_response
+
+    response = llm.generate_response(messages, response_format={"type": "json_object"})
+
+    assert response == '{"facts": []}'
+
+
+def test_generate_response_with_json_schema_format(mock_anthropic_client):
+    config = AnthropicConfig(model="claude-sonnet-4-20250514", api_key="test-key", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = AnthropicLLM(config)
+    messages = [{"role": "user", "content": "Extract info."}]
+    schema = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "required": ["name"],
+    }
+
+    mock_response = Mock()
+    mock_response.content = [Mock(text='{"name": "Alice"}')]
+    mock_anthropic_client.messages.create.return_value = mock_response
+
+    response = llm.generate_response(
+        messages,
+        response_format={"type": "json_schema", "json_schema": {"schema": schema}},
+    )
+
+    assert response == '{"name": "Alice"}'
+    call_kwargs = mock_anthropic_client.messages.create.call_args[1]
+    assert call_kwargs["output_config"]["format"]["type"] == "json_schema"
+    assert call_kwargs["output_config"]["format"]["schema"] == schema
+    assert not any(isinstance(m, dict) and m.get("content") == "{" for m in call_kwargs["messages"])


### PR DESCRIPTION
## Description

`AnthropicLLM.generate_response` accepts `response_format` but silently ignores it. Anthropic has no OpenAI-style `response_format`, so the shared extraction call site (`memory/main.py`, `{"type": "json_object"}`) gets no structured-output guarantee — Claude wraps JSON in ``` fences / prefixes prose, which the pipeline only salvages via `remove_code_blocks` + `extract_json`.

This honors `response_format` directly in `anthropic.py`:
- `json_object` → assistant **prefill** (`{`) + a "JSON only, no fences" instruction, so the response starts as clean JSON.
- `json_schema` → Anthropic native structured outputs via `output_config.format`.

## Credit / provenance

This is **not original work** — it revives prior contributions:
- The `anthropic.py` fix + tests are **@limsaehyun**'s (#4484) — preserved as the commit author here.
- **@mb-dev** carried it forward in **#4939**, where @kartik-mem0 reviewed: *"the structured outputs approach is the right call"*, but flagged that #4939's `main.py` switch to `json_schema` breaks Gemini/Ollama/OpenAI/LMStudio.

Per that review, this PR is **scoped to `anthropic.py` only** — `main.py`/`prompts.py` are **unchanged** (still `json_object`), so Anthropic users get the fix and no other provider breaks. Rebased onto current `main`; one stale tools test from the original (incompatible with the post-#5537 tool_choice format) was dropped.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test Coverage

- [x] Unit tests (@limsaehyun's): `tests/llms/test_anthropic.py` — `json_object` prefill returns clean JSON, with/without system message, `json_schema` → `output_config`, and no-`response_format` unchanged. 13 passed, ruff clean.
- Approach also verified against the live Anthropic API: `response_format={"type":"json_object"}` returns directly-parseable JSON (vs ``` -fenced before), and full `Memory.add()` extraction works end-to-end.

## Checklist

- [x] Code follows style guidelines (ruff clean)
- [x] Self-review performed
- [x] Tests added that prove the fix works
- [x] New and existing tests pass locally
