### PR TITLE
docs: make example code fences copy-safe

### DIFF
--- a/docs/integrations/elevenlabs.mdx
+++ b/docs/integrations/elevenlabs.mdx
@@ -100,12 +100,12 @@ This section:
 Initialize both the ElevenLabs and Mem0 clients:
 
 ```python
-    # Initialize ElevenLabs client
-    client = ElevenLabs(api_key=API_KEY)
+# Initialize ElevenLabs client
+client = ElevenLabs(api_key=API_KEY)
 
-    # Initialize memory client and tools
-    client_tools = ClientTools()
-    mem0_client = AsyncMemoryClient()
+# Initialize memory client and tools
+client_tools = ClientTools()
+mem0_client = AsyncMemoryClient()
 ```
 
 Here we:
@@ -118,36 +118,36 @@ Here we:
 Define the two key memory functions that will be registered as tools:
 
 ```python
-    # Define memory-related functions for the agent
-    async def add_memories(parameters):
-        """Add a message to the memory store"""
-        message = parameters.get("message")
-        await mem0_client.add(
-            messages=message,
-            user_id=USER_ID
-        )
-        return "Memory added successfully"
+# Define memory-related functions for the agent
+async def add_memories(parameters):
+    """Add a message to the memory store"""
+    message = parameters.get("message")
+    await mem0_client.add(
+        messages=message,
+        user_id=USER_ID
+    )
+    return "Memory added successfully"
 
-    async def retrieve_memories(parameters):
-        """Retrieve relevant memories based on the input message"""
-        message = parameters.get("message")
+async def retrieve_memories(parameters):
+    """Retrieve relevant memories based on the input message"""
+    message = parameters.get("message")
 
-        # For Platform API, user_id goes in filters
-        filters = {"user_id": USER_ID}
+    # For Platform API, user_id goes in filters
+    filters = {"user_id": USER_ID}
 
-        # Search for relevant memories using the message as a query
-        results = await mem0_client.search(
-            query=message,
-            filters=filters
-        )
+    # Search for relevant memories using the message as a query
+    results = await mem0_client.search(
+        query=message,
+        filters=filters
+    )
 
-        # Extract and join the memory texts
-        memories = ' '.join([result["memory"] for result in results.get('results', [])])
-        print("[ Memories ]", memories)
+    # Extract and join the memory texts
+    memories = ' '.join([result["memory"] for result in results.get('results', [])])
+    print("[ Memories ]", memories)
 
-        if memories:
-            return memories
-        return "No memories found"
+    if memories:
+        return memories
+    return "No memories found"
 ```
 
 These functions:
@@ -171,9 +171,9 @@ These functions:
 Register the memory functions with the ElevenLabs ClientTools system:
 
 ```python
-    # Register the memory functions as tools for the agent
-    client_tools.register("addMemories", add_memories, is_async=True)
-    client_tools.register("retrieveMemories", retrieve_memories, is_async=True)
+# Register the memory functions as tools for the agent
+client_tools.register("addMemories", add_memories, is_async=True)
+client_tools.register("retrieveMemories", retrieve_memories, is_async=True)
 ```
 
 This allows the ElevenLabs agent to:
@@ -186,19 +186,19 @@ This allows the ElevenLabs agent to:
 Configure the conversation with ElevenLabs:
 
 ```python
-    # Initialize the conversation
-    conversation = Conversation(
-        client,
-        AGENT_ID,
-        # Assume auth is required when API_KEY is set
-        requires_auth=bool(API_KEY),
-        audio_interface=DefaultAudioInterface(),
-        client_tools=client_tools,
-        callback_agent_response=lambda response: print(f"Agent: {response}"),
-        callback_agent_response_correction=lambda original, corrected: print(f"Agent: {original} -> {corrected}"),
-        callback_user_transcript=lambda transcript: print(f"User: {transcript}"),
-        # callback_latency_measurement=lambda latency: print(f"Latency: {latency}ms"),
-    )
+# Initialize the conversation
+conversation = Conversation(
+    client,
+    AGENT_ID,
+    # Assume auth is required when API_KEY is set
+    requires_auth=bool(API_KEY),
+    audio_interface=DefaultAudioInterface(),
+    client_tools=client_tools,
+    callback_agent_response=lambda response: print(f"Agent: {response}"),
+    callback_agent_response_correction=lambda original, corrected: print(f"Agent: {original} -> {corrected}"),
+    callback_user_transcript=lambda transcript: print(f"User: {transcript}"),
+    # callback_latency_measurement=lambda latency: print(f"Latency: {latency}ms"),
+)
 ```
 
 This sets up the conversation with:
@@ -217,16 +217,16 @@ This sets up the conversation with:
 Start and manage the conversation:
 
 ```python
-    # Start the conversation
-    print(f"Starting conversation with user_id: {USER_ID}")
-    conversation.start_session()
+# Start the conversation
+print(f"Starting conversation with user_id: {USER_ID}")
+conversation.start_session()
 
-    # Handle Ctrl+C to gracefully end the session
-    signal.signal(signal.SIGINT, lambda sig, frame: conversation.end_session())
+# Handle Ctrl+C to gracefully end the session
+signal.signal(signal.SIGINT, lambda sig, frame: conversation.end_session())
 
-    # Wait for the conversation to end and get the conversation ID
-    conversation_id = conversation.wait_for_session_end()
-    print(f"Conversation ID: {conversation_id}")
+# Wait for the conversation to end and get the conversation ID
+conversation_id = conversation.wait_for_session_end()
+print(f"Conversation ID: {conversation_id}")
 
 
 if __name__ == '__main__':
@@ -445,4 +445,3 @@ By integrating ElevenLabs Conversational AI with Mem0, you can create voice agen
     Create voice-first AI applications
   </Card>
 </CardGroup>
-

--- a/docs/migration/api-changes.mdx
+++ b/docs/migration/api-changes.mdx
@@ -62,7 +62,8 @@ def add(
     filters: dict = None,
     output_format: str = None,  # ❌ REMOVED
     version: str = None         # ❌ REMOVED
-) -> Union[List[dict], dict]
+) -> Union[List[dict], dict]:
+    ...
 ```
 
 #### v1.0.0  Signature
@@ -76,7 +77,8 @@ def add(
     metadata: dict = None,
     filters: dict = None,
     infer: bool = True          # ✅ NEW: Control memory inference
-) -> dict  # Always returns dict with "results" key
+) -> dict:  # Always returns dict with "results" key
+    ...
 ```
 
 #### Changes Summary
@@ -147,7 +149,8 @@ def search(
     filters: dict = None,       # Basic key-value only
     output_format: str = None,  # ❌ REMOVED
     version: str = None         # ❌ REMOVED
-) -> Union[List[dict], dict]
+) -> Union[List[dict], dict]:
+    ...
 ```
 
 #### v1.0.0  Signature
@@ -161,7 +164,8 @@ def search(
     limit: int = 100,
     filters: dict = None,       # ✅ ENHANCED: Advanced operators
     rerank: bool = True         # ✅ NEW: Reranking support
-) -> dict  # Always returns dict with "results" key
+) -> dict:  # Always returns dict with "results" key
+    ...
 ```
 
 #### Enhanced Filtering
@@ -216,7 +220,8 @@ def get_all(
     filters: dict = None,
     output_format: str = None,  # ❌ REMOVED
     version: str = None         # ❌ REMOVED
-) -> Union[List[dict], dict]
+) -> Union[List[dict], dict]:
+    ...
 ```
 
 #### v1.0.0  Signature
@@ -227,7 +232,8 @@ def get_all(
     agent_id: str = None,
     run_id: str = None,
     filters: dict = None        # ✅ ENHANCED: Advanced operators
-) -> dict  # Always returns dict with "results" key
+) -> dict:  # Always returns dict with "results" key
+    ...
 ```
 
 ### update() Method
@@ -239,7 +245,8 @@ def update(
     self,
     memory_id: str,
     data: str
-) -> dict
+) -> dict:
+    ...
 ```
 
 ### delete() Method
@@ -250,7 +257,8 @@ def update(
 def delete(
     self,
     memory_id: str
-) -> dict
+) -> dict:
+    ...
 ```
 
 ### delete_all() Method
@@ -344,7 +352,7 @@ config = {
 ### New Configuration Options
 
 #### Reranker Configuration
-```python
+```text
 # Cohere reranker
 "reranker": {
     "provider": "cohere",

--- a/docs/platform/features/criteria-retrieval.mdx
+++ b/docs/platform/features/criteria-retrieval.mdx
@@ -117,7 +117,7 @@ results_without_criteria = client.search(
 ### Compare Results
 
 ### Search Results (with Criteria)
-```python
+```text
 [
     {"memory": "User feels refreshed and ready to take on anything on a beautiful sunny day", "score": 0.666, ...},
     {"memory": "User finally has time to draw something after a long time", "score": 0.616, ...},
@@ -128,7 +128,7 @@ results_without_criteria = client.search(
 ```
 
 ### Search Results (without Criteria)
-```python
+```text
 [
     {"memory": "User is happy today", "score": 0.607, ...},
     {"memory": "User feels refreshed and ready to take on anything on a beautiful sunny day", "score": 0.512, ...},

--- a/docs/platform/features/custom-categories.mdx
+++ b/docs/platform/features/custom-categories.mdx
@@ -190,7 +190,7 @@ messages = [
 client.add(messages, user_id='alice')
 ```
 
-```python Memories with categories
+```text Memories with categories
 # Following categories will be created for the memories added
 Sometimes draws and sketches in free time (hobbies)
 Is quite athletic (sports)

--- a/docs/platform/features/memory-export.mdx
+++ b/docs/platform/features/memory-export.mdx
@@ -108,10 +108,10 @@ print(response)
 
 ```javascript JavaScript
 // Basic Export request
-const filters = {"user_id": "alice"};
+const basicFilters = {"user_id": "alice"};
 const response = await client.createMemoryExport({
     schema: json_schema,
-    filters: filters
+    filters: basicFilters
 });
 
 // Export with custom instructions and additional filters
@@ -124,16 +124,16 @@ const export_instructions = `
 `;
 
 // For create operation, using only user_id filter as requested
-const filters = {
+const exportFilters = {
     "AND": [
         {"user_id": "alex"},
         {"created_at": {"gte": "2024-01-01"}}
     ]
-}
+};
 
 const responseWithInstructions = await client.createMemoryExport({
     schema: json_schema,
-    filters: filters,
+    filters: exportFilters,
     exportInstructions: export_instructions
 });
 


### PR DESCRIPTION
## Description

Fixes several documentation code examples that were mislabeled or not copy-safe.

This PR:
- Marks illustrative output blocks as `text` instead of runnable Python.
- Fixes duplicate JavaScript `const filters` declarations in the memory export example.
- Makes ElevenLabs Python snippets valid top-level examples.
- Keeps API signature examples syntax-highlighted as Python while making them valid reference snippets.

These changes reduce copy/paste errors for users and make docs snippet validation cleaner.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Tested manually with:

```bash
python3 scripts/check-llms-txt-coverage.py
git diff --check

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
