### PR TITLE
feat(ts-sdk): add xAI (Grok) LLM provider

### DIFF
--- a/docs/components/llms/models/xAI.mdx
+++ b/docs/components/llms/models/xAI.mdx
@@ -5,11 +5,12 @@ description: "Configure xAI Grok models as an LLM provider in Mem0 with API key 
 
 [xAI](https://x.ai/) is a new AI company founded by Elon Musk that develops large language models, including Grok. Grok is trained on real-time data from X (formerly Twitter) and aims to provide accurate, up-to-date responses with a touch of wit and humor.
 
-In order to use LLMs from xAI, go to their [platform](https://console.x.ai) and get the API key. Set the API key as `XAI_API_KEY` environment variable to use the model as given below in the example.
+In order to use LLMs from xAI, go to their [platform](https://console.x.ai) and get the API key. Set the API key as `XAI_API_KEY` environment variable to use the model as given below in the example. You can also optionally set `XAI_API_BASE` if you need to use a different API endpoint (defaults to "https://api.x.ai/v1").
 
 ## Usage
 
-```python
+<CodeGroup>
+```python Python
 import os
 from mem0 import Memory
 
@@ -36,6 +37,31 @@ messages = [
 ]
 m.add(messages, user_id="alice", metadata={"category": "movies"})
 ```
+
+```typescript TypeScript
+import { Memory } from 'mem0ai/oss';
+
+const config = {
+  llm: {
+    provider: 'xai',
+    config: {
+      apiKey: process.env.XAI_API_KEY || '',
+      model: 'grok-2-latest',
+      temperature: 0.1,
+      maxTokens: 2000,
+    },
+  },
+};
+const memory = new Memory(config);
+const messages = [
+    {"role": "user", "content": "I'm planning to watch a movie tonight. Any recommendations?"},
+    {"role": "assistant", "content": "How about thriller movies? They can be quite engaging."},
+    {"role": "user", "content": "I’m not a big fan of thriller movies but I love sci-fi movies."},
+    {"role": "assistant", "content": "Got it! I'll avoid thriller recommendations and suggest sci-fi movies in the future."}
+]
+await memory.add(messages, { userId: "alice", metadata: { category: "movies" } });
+```
+</CodeGroup>
 
 ## Config
 

--- a/mem0-ts/src/oss/src/llms/xai.ts
+++ b/mem0-ts/src/oss/src/llms/xai.ts
@@ -1,0 +1,41 @@
+import { OpenAILLM } from "./openai";
+import { LLMConfig, Message } from "../types";
+import { LLMResponse } from "./base";
+
+export class XAILLM extends OpenAILLM {
+  constructor(config: LLMConfig) {
+    const apiKey = config.apiKey || process.env.XAI_API_KEY;
+    if (!apiKey) {
+      throw new Error("xAI API key is required");
+    }
+    super({
+      ...config,
+      apiKey,
+      baseURL:
+        config.baseURL || process.env.XAI_API_BASE || "https://api.x.ai/v1",
+      model: config.model || "grok-2-latest",
+    });
+  }
+
+  async generateResponse(
+    messages: Message[],
+    responseFormat?: { type: string },
+    tools?: any[],
+  ): Promise<string | LLMResponse> {
+    try {
+      return await super.generateResponse(messages, responseFormat, tools);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`xAI LLM failed: ${message}`);
+    }
+  }
+
+  async generateChat(messages: Message[]): Promise<LLMResponse> {
+    try {
+      return await super.generateChat(messages);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`xAI LLM failed: ${message}`);
+    }
+  }
+}

--- a/mem0-ts/src/oss/src/tests/xai.test.ts
+++ b/mem0-ts/src/oss/src/tests/xai.test.ts
@@ -1,0 +1,100 @@
+import OpenAI from "openai";
+import { XAILLM } from "../llms/xai";
+import { LLMFactory } from "../utils/factory";
+
+jest.mock("openai");
+
+const createMock = jest.fn();
+const OpenAIMock = OpenAI as unknown as jest.Mock;
+
+describe("XAILLM", () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.XAI_API_KEY;
+    delete process.env.XAI_API_BASE;
+    OpenAIMock.mockImplementation(() => ({
+      chat: { completions: { create: createMock } },
+    }));
+    createMock.mockResolvedValue({
+      choices: [{ message: { content: "hi", role: "assistant" } }],
+    });
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it("defaults to grok-2-latest and the xAI base URL (matching the Python provider)", async () => {
+    const llm = new XAILLM({ apiKey: "test-key" });
+    const res = await llm.generateResponse([
+      { role: "user", content: "hello" },
+    ]);
+
+    expect(OpenAIMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: "test-key",
+        baseURL: "https://api.x.ai/v1",
+      }),
+    );
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "grok-2-latest" }),
+    );
+    expect(res).toBe("hi");
+  });
+
+  it("reads XAI_API_KEY / XAI_API_BASE from the environment", () => {
+    process.env.XAI_API_KEY = "env-key";
+    process.env.XAI_API_BASE = "https://custom.x.ai/v1";
+
+    new XAILLM({});
+
+    expect(OpenAIMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: "env-key",
+        baseURL: "https://custom.x.ai/v1",
+      }),
+    );
+  });
+
+  it("honors explicit config over defaults and environment", async () => {
+    process.env.XAI_API_KEY = "env-key";
+
+    const llm = new XAILLM({
+      apiKey: "explicit-key",
+      baseURL: "https://proxy.example.com/v1",
+      model: "grok-3",
+    });
+    await llm.generateResponse([{ role: "user", content: "hello" }]);
+
+    expect(OpenAIMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: "explicit-key",
+        baseURL: "https://proxy.example.com/v1",
+      }),
+    );
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "grok-3" }),
+    );
+  });
+
+  it("throws when no API key is configured", () => {
+    expect(() => new XAILLM({})).toThrow("xAI API key is required");
+  });
+
+  it("wraps downstream failures with an xAI-specific message", async () => {
+    createMock.mockRejectedValueOnce(new Error("boom"));
+    const llm = new XAILLM({ apiKey: "test-key" });
+
+    await expect(
+      llm.generateResponse([{ role: "user", content: "hi" }]),
+    ).rejects.toThrow("xAI LLM failed: boom");
+  });
+
+  it('is registered in the LLM factory under "xai"', () => {
+    const llm = LLMFactory.create("xai", { apiKey: "test-key" });
+    expect(llm).toBeInstanceOf(XAILLM);
+  });
+});

--- a/mem0-ts/src/oss/src/utils/factory.ts
+++ b/mem0-ts/src/oss/src/utils/factory.ts
@@ -22,6 +22,7 @@ import { RedisDB } from "../vector_stores/redis";
 import { OllamaLLM } from "../llms/ollama";
 import { LMStudioLLM } from "../llms/lmstudio";
 import { DeepSeekLLM } from "../llms/deepseek";
+import { XAILLM } from "../llms/xai";
 import { SupabaseDB } from "../vector_stores/supabase";
 import { SQLiteManager } from "../storage/SQLiteManager";
 import { MemoryHistoryManager } from "../storage/MemoryHistoryManager";
@@ -85,6 +86,8 @@ export class LLMFactory {
         return new LangchainLLM(config);
       case "deepseek":
         return new DeepSeekLLM(config);
+      case "xai":
+        return new XAILLM(config);
       default:
         throw new Error(`Unsupported LLM provider: ${provider}`);
     }


### PR DESCRIPTION
## Linked Issue

Closes #5760

## Description

The Python OSS SDK supports **xAI (Grok)** as an LLM provider, but the TypeScript OSS SDK does not. This adds `XAILLM` to bring the TS SDK to parity, exactly as the issue specifies.

xAI's Grok API is OpenAI-compatible, so — following the issue's suggested design and mirroring the existing `DeepSeekLLM` provider — `XAILLM` subclasses `OpenAILLM` and only overrides the connection defaults:

- `mem0-ts/src/oss/src/llms/xai.ts` — `XAILLM` extends `OpenAILLM`:
  - API key from `config.apiKey` or `XAI_API_KEY`
  - base URL from `config.baseURL`, `XAI_API_BASE`, else `https://api.x.ai/v1`
  - default model **`grok-2-latest`**, matching `mem0/llms/xai.py`
  - downstream errors wrapped with an `xAI LLM failed:` prefix (same pattern as `DeepSeekLLM`)
- `mem0-ts/src/oss/src/utils/factory.ts` — registers the `"xai"` provider in `LLMFactory`.
- **No new dependency** — reuses the existing `openai` client with a custom `baseURL`.

`LLMConfig` already exposes `apiKey` / `baseURL` / `model` / `temperature` / `topP` / `maxTokens`, so no new config type is needed (consistent with how `deepseek` / `groq` / `mistral` are wired).

Usage:

```typescript
import { Memory } from "mem0ai/oss";

const memory = new Memory({
  llm: {
    provider: "xai",
    config: { apiKey: process.env.XAI_API_KEY, model: "grok-2-latest" },
  },
});
```

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Test Coverage

- [x] I added/updated unit tests

Added `mem0-ts/src/oss/src/tests/xai.test.ts` (mocks the `openai` client — network-free) covering: the `grok-2-latest` + `https://api.x.ai/v1` defaults, `XAI_API_KEY` / `XAI_API_BASE` env resolution, explicit-config precedence, the missing-key guard, error wrapping, and `LLMFactory` registration.

Local results (run in `mem0-ts/`):

```
# pnpm run build  -> prettier --check . ✅, tsup CJS/ESM/DTS build ✅
# pnpm run test:unit
Test Suites: 54 passed, 54 total
Tests:       781 passed, 781 total   (includes 6 new xai tests)
```

Integration tests (`test:integration`) require `MEM0_API_KEY` and are not run on forks.

## Checklist

- [x] My code follows the project's style guidelines (mirrors `DeepSeekLLM`; `prettier --check` clean)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my feature works
- [x] New and existing tests pass locally (781/781)
- [x] I have updated documentation if needed (added a TypeScript tab + `XAI_API_BASE` note to `docs/components/llms/models/xAI.mdx`)

---

_Prepared with AI assistance (Claude Code); every line was human-reviewed and tested locally. Opened as a **draft** for maintainer review._
