### PR TITLE
feat(opensearch): add configurable client timeout and honor pool_maxsize

### DIFF
--- a/docs/components/vectordbs/dbs/opensearch.mdx
+++ b/docs/components/vectordbs/dbs/opensearch.mdx
@@ -67,6 +67,8 @@ config = {
 | `embedding_model_dims` | int | 1536 | Dimension of embedding vectors |
 | `use_ssl` | bool | False | Enable SSL/TLS connection |
 | `verify_certs` | bool | False | Verify SSL certificates |
+| `pool_maxsize` | int | 20 | Maximum number of connections in the client pool |
+| `timeout` | int | None | Per-request client timeout in seconds. Defaults to opensearch-py's built-in default (10s) when unset. Raise it for AWS OpenSearch Serverless, whose cold-start can exceed 10s. |
 | `auto_refresh` | bool | False | Automatically refresh index after insert. OpenSearch refreshes every ~1 second by default, so this is rarely needed. |
 
 <Note>

--- a/mem0/configs/vector_stores/opensearch.py
+++ b/mem0/configs/vector_stores/opensearch.py
@@ -18,6 +18,12 @@ class OpenSearchConfig(BaseModel):
         "RequestsHttpConnection", description="Connection class for OpenSearch"
     )
     pool_maxsize: int = Field(20, description="Maximum number of connections in the pool")
+    timeout: Optional[int] = Field(
+        None,
+        description="Per-request timeout in seconds for the OpenSearch client. Defaults to "
+        "opensearch-py's built-in default (10s) when unset. Raise this for AWS OpenSearch "
+        "Serverless, whose cold-start can exceed 10s.",
+    )
     auto_refresh: bool = Field(
         False,
         description="Automatically refresh index after insert operations to make documents "

--- a/mem0/vector_stores/opensearch.py
+++ b/mem0/vector_stores/opensearch.py
@@ -26,16 +26,20 @@ class OpenSearchDB(VectorStoreBase):
         config = OpenSearchConfig(**kwargs)
 
         # Initialize OpenSearch client
-        self.client = OpenSearch(
-            hosts=[{"host": config.host, "port": config.port or 9200}],
-            http_auth=config.http_auth
+        client_kwargs = {
+            "hosts": [{"host": config.host, "port": config.port or 9200}],
+            "http_auth": config.http_auth
             if config.http_auth
             else ((config.user, config.password) if (config.user and config.password) else None),
-            use_ssl=config.use_ssl,
-            verify_certs=config.verify_certs,
-            connection_class=RequestsHttpConnection,
-            pool_maxsize=20,
-        )
+            "use_ssl": config.use_ssl,
+            "verify_certs": config.verify_certs,
+            "connection_class": RequestsHttpConnection,
+            "pool_maxsize": config.pool_maxsize,
+        }
+        # Pass timeout only when set, so an unset value preserves opensearch-py's default.
+        if config.timeout is not None:
+            client_kwargs["timeout"] = config.timeout
+        self.client = OpenSearch(**client_kwargs)
 
         self.collection_name = config.collection_name
         self.embedding_model_dims = config.embedding_model_dims

--- a/tests/vector_stores/test_opensearch.py
+++ b/tests/vector_stores/test_opensearch.py
@@ -200,6 +200,48 @@ class TestOpenSearchDB(unittest.TestCase):
         self.assertEqual(self.client_mock.index.call_count, 3)
         self.assertEqual(self.client_mock.indices.refresh.call_count, 1)
 
+    def test_timeout_omitted_by_default(self):
+        """When timeout is unset, no timeout kwarg is passed to the OpenSearch client.
+
+        Guarantees byte-identical behavior with prior releases: opensearch-py
+        applies its own default request timeout (10s) only when the kwarg is absent.
+        """
+        # self.os_db (built in setUp without a timeout) is the default case;
+        # self.mock_os captured that construction call.
+        _, kwargs = self.mock_os.call_args
+        self.assertNotIn("timeout", kwargs)
+
+    def test_timeout_passed_when_set(self):
+        """An explicit timeout is forwarded to the OpenSearch client constructor."""
+        with patch("mem0.vector_stores.opensearch.OpenSearch", return_value=self.client_mock) as mock_os:
+            OpenSearchDB(
+                host="localhost",
+                port=9200,
+                collection_name="test_timeout",
+                embedding_model_dims=1536,
+                timeout=60,
+            )
+        _, kwargs = mock_os.call_args
+        self.assertEqual(kwargs["timeout"], 60)
+
+    def test_pool_maxsize_passed_through(self):
+        """A custom pool_maxsize reaches the client (regression: it was hard-coded to 20)."""
+        with patch("mem0.vector_stores.opensearch.OpenSearch", return_value=self.client_mock) as mock_os:
+            OpenSearchDB(
+                host="localhost",
+                port=9200,
+                collection_name="test_pool",
+                embedding_model_dims=1536,
+                pool_maxsize=42,
+            )
+        _, kwargs = mock_os.call_args
+        self.assertEqual(kwargs["pool_maxsize"], 42)
+
+    def test_pool_maxsize_defaults_to_20(self):
+        """The pool_maxsize default stays 20 (no behavior change for existing users)."""
+        _, kwargs = self.mock_os.call_args
+        self.assertEqual(kwargs["pool_maxsize"], 20)
+
     def test_insert(self):
         vectors = [[0.1] * 1536, [0.2] * 1536]
         payloads = [{"key1": "value1"}, {"key2": "value2"}]


### PR DESCRIPTION
## Linked Issue

Closes #5835

(Related: #3739 added `auto_refresh` for the same OpenSearch Serverless-compatibility theme.)

## Description

`OpenSearchDB` constructs its `opensearch-py` client with **no request timeout**, so it uses the library's default of **10 seconds**. That is too low for **AWS OpenSearch Serverless**, whose collection cold-start can take 10–30s, producing `ConnectionTimeout` on the first operations after an idle period. Today the only workaround is monkeypatching the client's transport internals.

This adds an opt-in `timeout` to `OpenSearchConfig` and wires it into the client:

```python
config = {
    "vector_store": {
        "provider": "opensearch",
        "config": {
            "host": "xxxxx.us-west-2.aoss.amazonaws.com",
            "port": 443,
            "http_auth": auth,
            "use_ssl": True,
            "verify_certs": True,
            "timeout": 60,          # NEW: raise for Serverless cold-start
            "collection_name": "my-collection",
        },
    }
}
```

It also fixes a **latent bug in the same constructor**: `OpenSearchConfig.pool_maxsize` already exists, but `OpenSearchDB.__init__` hard-coded `pool_maxsize=20` and ignored the config value. The client now receives `config.pool_maxsize`, so a user-set value finally applies.

### Design

- `timeout` is **opt-in**: when unset (`None`), the `timeout` kwarg is **omitted** from the `OpenSearch(...)` call, so behavior is byte-identical to prior releases (opensearch-py applies its own 10s default only when the kwarg is absent — verified against opensearch-py 3.2.0; passing `timeout=None` explicitly would instead disable the timeout, which is why the kwarg is conditional).
- `pool_maxsize` default stays `20`, so there is no behavior change for users who never set it.
- Mirrors the existing `auto_refresh` field/test pattern (#3739).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue) — `pool_maxsize` was silently ignored
- [x] New feature (non-breaking change that adds functionality) — configurable `timeout`

## Breaking Changes

N/A. Purely additive and opt-in. The only behavioral change is the intended `pool_maxsize` fix: a user who *already* set `pool_maxsize` (expecting it to work) now gets it applied — strictly more correct and matching the documented field.

## Test Coverage

- [x] I added/updated unit tests

Added to `tests/vector_stores/test_opensearch.py` (mock the `OpenSearch` constructor, assert on its captured kwargs — no live cluster):
- `test_timeout_omitted_by_default` — no `timeout` kwarg when unset (backwards-compat guard; mutation-tested as load-bearing).
- `test_timeout_passed_when_set` — `timeout=60` reaches the client.
- `test_pool_maxsize_passed_through` — a custom `pool_maxsize` reaches the client (guards the bug fix).
- `test_pool_maxsize_defaults_to_20` — default unchanged.

Full `tests/vector_stores/test_opensearch.py` suite: **28 passed**. `ruff check` clean on all changed files.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation (OpenSearch vector-store config table)
