### PR TITLE
docs(integrations): sync agent-plugin hook tables with actual hooks.json

### DIFF
--- a/docs/integrations/claude-code.mdx
+++ b/docs/integrations/claude-code.mdx
@@ -138,7 +138,7 @@ When installed via the plugin marketplace, Mem0 hooks into Claude Code's lifecyc
 
 | Hook | Event | What it does |
 |------|-------|-------------|
-| **Setup** | `Setup` | Installs the mem0 SDK and dependencies on first run |
+| **Setup** | `Setup` | Installs the mem0 SDK and dependencies (runs on init and maintenance) |
 | **Session start** | `SessionStart` | Loads prior memories and displays status banner |
 | **User prompt** | `UserPromptSubmit` | Searches relevant memories before each message; skips short prompts |
 | **Pre-tool (3 handlers)** | `PreToolUse` | Blocks MEMORY.md writes; enforces `user_id`/`app_id` on mem0 tool calls; scans files being read for relevant memory context |

--- a/docs/integrations/claude-code.mdx
+++ b/docs/integrations/claude-code.mdx
@@ -138,9 +138,10 @@ When installed via the plugin marketplace, Mem0 hooks into Claude Code's lifecyc
 
 | Hook | Event | What it does |
 |------|-------|-------------|
+| **Setup** | `Setup` | Installs the mem0 SDK and dependencies on first run |
 | **Session start** | `SessionStart` | Loads prior memories and displays status banner |
 | **User prompt** | `UserPromptSubmit` | Searches relevant memories before each message; skips short prompts |
-| **Pre-tool** | `PreToolUse` | Blocks MEMORY.md writes, enforces `user_id`/`app_id` on mem0 tool calls |
+| **Pre-tool (3 handlers)** | `PreToolUse` | Blocks MEMORY.md writes; enforces `user_id`/`app_id` on mem0 tool calls; scans files being read for relevant memory context |
 | **Post-tool** | `PostToolUse` | Tracks stats, scans bash errors for related memories |
 | **Stop** | `Stop` | Stores a session summary when the session ends |
 | **Pre-compact** | `PreCompact` | Stores a summary before the context is compacted |

--- a/docs/integrations/codex.mdx
+++ b/docs/integrations/codex.mdx
@@ -123,7 +123,7 @@ When installed via the plugin marketplace, Mem0 hooks into Codex's lifecycle to 
 |------|-------|-------------|
 | **Session start** | `SessionStart` | Loads prior memories and displays status banner |
 | **User prompt** | `UserPromptSubmit` | Searches relevant memories before each message |
-| **Pre-tool** | `PreToolUse` | Blocks MEMORY.md writes, enforces `user_id`/`app_id` on mem0 tool calls |
+| **Pre-tool (3 handlers)** | `PreToolUse` | Blocks MEMORY.md writes; enforces `user_id`/`app_id` on mem0 tool calls; scans files being read for relevant memory context |
 | **Post-tool** | `PostToolUse` | Tracks stats, scans bash errors for related memories |
 | **Stop** | `Stop` | Stores a session summary when the session ends |
 | **Pre-compact** | `PreCompact` | Stores a summary before the context is compacted |

--- a/docs/integrations/cursor.mdx
+++ b/docs/integrations/cursor.mdx
@@ -108,7 +108,7 @@ When installed via the Cursor Marketplace, Mem0 hooks into Cursor's lifecycle:
 |------|-------|-------------|
 | **Session start** | `sessionStart` | Loads prior memories and displays status banner |
 | **User prompt** | `beforeSubmitPrompt` | Searches relevant memories before each message; skips short prompts |
-| **Pre-tool (2 handlers)** | `preToolUse` | Blocks MEMORY.md writes, enforces `user_id`/`app_id` on mem0 tool calls |
+| **Pre-tool (3 handlers)** | `preToolUse` | Blocks MEMORY.md writes; enforces `user_id`/`app_id` on mem0 tool calls; scans files being read for relevant memory context |
 | **Post-tool (2 handlers)** | `postToolUse` | Tracks stats, scans bash errors for related memories |
 | **Stop** | `stop` | Stores a session summary when the session ends |
 | **Pre-compact** | `preCompact` | Stores a summary before the context is compacted |


### PR DESCRIPTION
## Description

Stale-data pass: verified every lifecycle hook table row in the four agent-plugin docs against the real JSON config files under `integrations/mem0-plugin/hooks/` and `integrations/mem0-plugin/hooks.json`. Corrected all discrepancies; no new content was invented.

## Type of Change

- [x] Documentation update

## What changed

- **`docs/integrations/claude-code.mdx`** (confirmed by `integrations/mem0-plugin/hooks/hooks.json`):
  - Added missing `Setup` hook row — `hooks/hooks.json` has a `Setup` event pointing to `ensure_deps.sh` (installs the mem0 SDK on first run); the table omitted it entirely
  - Expanded `PreToolUse` row from "Pre-tool" to "Pre-tool (3 handlers)" and extended description to include the Read file-scan handler (`on_file_read.sh`, matched by `"Read"` in the JSON)

- **`docs/integrations/codex.mdx`** (confirmed by `integrations/mem0-plugin/hooks/codex-hooks.json`):
  - Expanded `PreToolUse` row to "Pre-tool (3 handlers)" and added the Read file-scan handler (`on_file_read.sh`) to the description — `codex-hooks.json` has three distinct `preToolUse` matchers: `Write|Edit|MultiEdit`, mem0 tool names, and `Read`

- **`docs/integrations/cursor.mdx`** (confirmed by `integrations/mem0-plugin/hooks/cursor-hooks.json`):
  - Corrected `preToolUse` handler count from 2 → 3; `cursor-hooks.json` has three `preToolUse` entries: `block_memory_write_cursor.sh`, `enforce_metadata_defaults.sh`, and `on_file_read_cursor.sh`
  - Extended description to mention the Read-scan handler
  - `stop` row was already present — no change needed there

- **`docs/integrations/antigravity.mdx`** (confirmed by `integrations/mem0-plugin/hooks.json`):
  - No changes needed — `Stop` row already present; all hooks match the JSON exactly

## Test Coverage

- [x] No tests needed (docs-only)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed