### PR TITLE
docs(changelog): fix score_details fields, graph-store note & dead link

### DIFF
--- a/docs/changelog/highlights.mdx
+++ b/docs/changelog/highlights.mdx
@@ -113,7 +113,7 @@ Launched a unified Mem0 plugin across three major AI development environments �
 
 Major expansion of the provider ecosystem:
 
-- **Apache AGE** — New graph store support, bringing the total to 4 graph store backends (Neo4j, Memgraph, Kuzu, Apache AGE)
+- **Apache AGE** — New graph store support, bringing the total to 4 graph store backends (Neo4j, Memgraph, Kuzu, Apache AGE). **Note:** All external graph store backends (Neo4j, Memgraph, Kuzu, Apache AGE) were subsequently removed in v2.0.0 (2026-04-14). Graph memory is now built-in entity linking with no external graph store required; see the [v2.0.0 entry above](#mem0-sdk-v2-0-0-v3-0-0).
 - **Turbopuffer** — New vector database provider for Python SDK
 - **MiniMax** — New LLM provider with dedicated AWS Bedrock support
 - **pgvector for Node.js** — PostgreSQL vector support added to the TypeScript OSS SDK

--- a/docs/changelog/sdk.mdx
+++ b/docs/changelog/sdk.mdx
@@ -121,7 +121,7 @@ mode: "wide"
 
 **New Features:**
 - **Memory:** Warn at init time when hybrid/BM25 search silently degrades to semantic-only because the configured vector store does not implement `keyword_search`. Affected stores: Chroma, FAISS, Cassandra, LangChain, Neptune Analytics, S3 Vectors, Supabase, TurboPuffer, Valkey ([#5444](https://github.com/mem0ai/mem0/pull/5444))
-- **Memory:** Add opt-in `explain=True` parameter to `Memory.search()` and `AsyncMemory.search()`. When enabled, each result includes a `score_breakdown` dict with `semantic`, `keyword` (normalized BM25), `entity_boost`, and `temporal_boost` signals so callers can understand and tune retrieval ranking ([#5102](https://github.com/mem0ai/mem0/pull/5102))
+- **Memory:** Add opt-in `explain=True` parameter to `Memory.search()` and `AsyncMemory.search()`. When enabled, each result includes a `score_details` dict with `semantic_score`, `bm25_score`, `entity_boost`, `raw_score`, `max_possible_score`, `final_score`, and `threshold` so callers can understand and tune retrieval ranking ([#5102](https://github.com/mem0ai/mem0/pull/5102))
 
 **Bug Fixes:**
 - **Vector Stores:** Normalize similarity scores to `[0, 1]` (higher = better) consistently across all backends. 11 adapters previously returned raw distance metrics (lower = better) — FAISS, Chroma, Milvus, Redis, Cassandra, PGVector, S3 Vectors, Supabase, Valkey, Azure MySQL, and Vertex AI Vector Search — causing incorrect ranking in multi-store setups ([#5391](https://github.com/mem0ai/mem0/pull/5391))
@@ -229,7 +229,7 @@ mode: "wide"
 **Improvements:**
 - **Telemetry:** Sample OSS hot-path events at 10% via PostHog `before_send` hook to reduce event volume ([#4771](https://github.com/mem0ai/mem0/pull/4771))
 
-See the [OSS v1 to v2 migration guide](https://docs.mem0.ai/migration/oss-v1-to-v2) and [Platform migration guide](https://docs.mem0.ai/migration/platform-v2-to-v3) for upgrade instructions.
+See the [OSS v2 to v3 migration guide](https://docs.mem0.ai/migration/oss-v2-to-v3) and [Platform migration guide](https://docs.mem0.ai/migration/platform-v2-to-v3) for upgrade instructions.
 
 </Update>
 


### PR DESCRIPTION
## Description

Stale-data pass over `docs/changelog/` — verified every change against Python SDK source before editing. Three targeted fixes:

## What changed

- **`docs/changelog/highlights.mdx` L116**: Appended a clarifying **Note** to the 2026-03-21 Apache AGE bullet pointing out that all four external graph store backends (Neo4j, Memgraph, Kuzu, Apache AGE) were subsequently removed in v2.0.0 (2026-04-14) and graph memory is now built-in entity linking. Does not rewrite history — the original feature announcement stays intact. Verified: `mem0/graphs/` contains only `neptune/` and `__pycache__/` — all other graph drivers were deleted.

- **`docs/changelog/sdk.mdx` L124**: Corrected the `explain=True` result field name from the wrong `score_breakdown` to the actual `score_details`, and replaced the wrong key list (`semantic`, `keyword`, `entity_boost`, `temporal_boost`) with the exact keys from `mem0/utils/scoring.py` L127–135: `semantic_score`, `bm25_score`, `entity_boost`, `raw_score`, `max_possible_score`, `final_score`, `threshold`. There is no `temporal_boost` key in the source.

- **`docs/changelog/sdk.mdx` L232**: Repointed the dead link `https://docs.mem0.ai/migration/oss-v1-to-v2` → `https://docs.mem0.ai/migration/oss-v2-to-v3`. Verified: `docs/migration/oss-v1-to-v2.mdx` does not exist; `docs/migration/oss-v2-to-v3.mdx` exists.

## Type of Change

- [x] Documentation update

## Test Coverage

- [x] No tests needed (docs-only)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code