### PR TITLE
feat(embeddings): add TwelveLabs Marengo multimodal embedder

### DIFF
--- a/docs/components/embedders/models/twelvelabs.mdx
+++ b/docs/components/embedders/models/twelvelabs.mdx
@@ -1,0 +1,68 @@
+---
+title: TwelveLabs
+description: "Configure TwelveLabs Marengo as a multimodal embedding provider in Mem0, with optional Pegasus video summarization."
+---
+
+[TwelveLabs](https://twelvelabs.io) provides video-native foundation models. The
+**Marengo** model embeds text, image, audio and video into a single
+512-dimensional latent space, so a text memory describing a video shares the
+same space as embeddings generated directly from the video. The **Pegasus**
+model can summarize a video into text you can store as a memory.
+
+To use TwelveLabs, set the `TWELVELABS_API_KEY` environment variable. You can grab a free API key at [twelvelabs.io](https://twelvelabs.io) — there's a generous free tier.
+
+### Usage
+
+<Note> The `embedding_model_dims` parameter for `vector_store` should be set to `512` for the TwelveLabs embedder. </Note>
+
+```python
+import os
+from mem0 import Memory
+
+os.environ["TWELVELABS_API_KEY"] = "your_api_key"
+os.environ["OPENAI_API_KEY"] = "your_api_key"  # For the LLM
+
+config = {
+    "embedder": {
+        "provider": "twelvelabs",
+        "config": {
+            "model": "marengo3.0"
+        }
+    }
+}
+
+m = Memory.from_config(config)
+messages = [
+    {"role": "user", "content": "I'm planning to watch a movie tonight. Any recommendations?"},
+    {"role": "assistant", "content": "How about thriller movies? They can be quite engaging."},
+    {"role": "user", "content": "I'm not a big fan of thriller movies but I love sci-fi movies."},
+    {"role": "assistant", "content": "Got it! I'll suggest sci-fi movies in the future."}
+]
+m.add(messages, user_id="john")
+```
+
+### Multimodal memory with Pegasus
+
+Use Pegasus to summarize a video into memory text, then store it. Because the
+summary is embedded with Marengo, it lives in the same multimodal latent space
+as the video it describes.
+
+```python
+from mem0.embeddings.twelvelabs import TwelveLabsEmbedding
+from mem0.configs.embeddings.base import BaseEmbedderConfig
+
+embedder = TwelveLabsEmbedding(BaseEmbedderConfig())
+summary = embedder.summarize_video("https://example.com/my-video.mp4")
+
+m.add(summary, user_id="john", metadata={"source": "video"})
+```
+
+### Config
+
+Here are the parameters available for configuring the TwelveLabs embedder:
+
+| Parameter | Description | Default Value |
+| --- | --- | --- |
+| `model` | The Marengo embedding model to use | `marengo3.0` |
+| `embedding_dims` | Dimensions of the embedding model | `512` |
+| `api_key` | The TwelveLabs API key | `None` |

--- a/docs/components/embedders/overview.mdx
+++ b/docs/components/embedders/overview.mdx
@@ -24,6 +24,7 @@ See the list of supported embedders below.
   <Card title="LM Studio" href="/components/embedders/models/lmstudio"></Card>
   <Card title="Langchain" href="/components/embedders/models/langchain"></Card>
   <Card title="AWS Bedrock" href="/components/embedders/models/aws_bedrock"></Card>
+  <Card title="TwelveLabs" href="/components/embedders/models/twelvelabs"></Card>
 </CardGroup>
 
 ## Usage

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -273,7 +273,8 @@
                               "components/embedders/models/lmstudio",
                               "components/embedders/models/together",
                               "components/embedders/models/langchain",
-                              "components/embedders/models/aws_bedrock"
+                              "components/embedders/models/aws_bedrock",
+                              "components/embedders/models/twelvelabs"
                             ]
                           }
                         ]

--- a/mem0/embeddings/configs.py
+++ b/mem0/embeddings/configs.py
@@ -25,6 +25,7 @@ class EmbedderConfig(BaseModel):
             "langchain",
             "aws_bedrock",
             "fastembed",
+            "twelvelabs",
         ]:
             return v
         else:

--- a/mem0/embeddings/twelvelabs.py
+++ b/mem0/embeddings/twelvelabs.py
@@ -1,0 +1,81 @@
+import os
+from typing import Literal, Optional
+
+try:
+    from twelvelabs import TwelveLabs
+except ImportError:
+    raise ImportError("The 'twelvelabs' library is required. Please install it using 'pip install twelvelabs'.")
+
+from mem0.configs.embeddings.base import BaseEmbedderConfig
+from mem0.embeddings.base import EmbeddingBase
+
+
+class TwelveLabsEmbedding(EmbeddingBase):
+    """Embeddings using TwelveLabs Marengo.
+
+    Marengo embeds text, image, audio and video into a single 512-dimensional
+    multimodal latent space, so text describing a video memory shares a space
+    with embeddings generated directly from the video itself. This makes it a
+    good fit for multimodal memory.
+
+    To summarize a video into memory text before storing it, see
+    :meth:`summarize_video`, which uses the Pegasus video-understanding model.
+    """
+
+    def __init__(self, config: Optional[BaseEmbedderConfig] = None):
+        super().__init__(config)
+
+        self.config.model = self.config.model or "marengo3.0"
+        self.config.embedding_dims = self.config.embedding_dims or 512
+        api_key = self.config.api_key or os.getenv("TWELVELABS_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "TwelveLabs API key is required. Set TWELVELABS_API_KEY or pass api_key in the config. "
+                "You can get a free key at https://twelvelabs.io."
+            )
+        self.client = TwelveLabs(api_key=api_key)
+
+    def embed(self, text, memory_action: Optional[Literal["add", "search", "update"]] = None):
+        """
+        Get the embedding for the given text using TwelveLabs Marengo.
+
+        Args:
+            text (str): The text to embed.
+            memory_action (optional): The type of embedding to use. Must be one of "add", "search", or "update". Defaults to None.
+        Returns:
+            list: The 512-dimensional embedding vector.
+        """
+        response = self.client.embed.create(model_name=self.config.model, text=text)
+        return response.text_embedding.segments[0].float_
+
+    def summarize_video(
+        self,
+        video_url: str,
+        prompt: str = "Summarize this video in a few sentences for use as a memory.",
+        model_name: str = "pegasus1.5",
+        max_tokens: int = 2048,
+    ) -> str:
+        """Summarize a video into memory text using the Pegasus model.
+
+        The returned text can be passed to ``Memory.add`` so the video's content
+        becomes a searchable memory. Embedding that memory with Marengo keeps it
+        in the same multimodal latent space as the video.
+
+        Args:
+            video_url: A publicly accessible URL of the video to summarize.
+            prompt: Instruction passed to Pegasus.
+            model_name: Pegasus model to use.
+            max_tokens: Maximum number of tokens to generate.
+
+        Returns:
+            The generated summary text.
+        """
+        from twelvelabs.types.video_context import VideoContext_Url
+
+        response = self.client.analyze(
+            model_name=model_name,
+            video=VideoContext_Url(url=video_url),
+            prompt=prompt,
+            max_tokens=max_tokens,
+        )
+        return response.data

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -160,6 +160,7 @@ class EmbedderFactory:
         "langchain": "mem0.embeddings.langchain.LangchainEmbedding",
         "aws_bedrock": "mem0.embeddings.aws_bedrock.AWSBedrockEmbedding",
         "fastembed": "mem0.embeddings.fastembed.FastEmbedEmbedding",
+        "twelvelabs": "mem0.embeddings.twelvelabs.TwelveLabsEmbedding",
     }
 
     @classmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ extras = [
     "elasticsearch>=8.0.0,<9.0.0",
     "opensearch-py>=2.0.0",
     "fastembed>=0.3.1",
+    "twelvelabs>=1.2.8",
 ]
 test = [
     "pytest>=8.2.2",

--- a/tests/embeddings/test_twelvelabs_embeddings.py
+++ b/tests/embeddings/test_twelvelabs_embeddings.py
@@ -1,0 +1,58 @@
+import os
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mem0.configs.embeddings.base import BaseEmbedderConfig
+from mem0.embeddings.twelvelabs import TwelveLabsEmbedding
+
+
+@pytest.fixture
+def mock_twelvelabs_client():
+    with patch("mem0.embeddings.twelvelabs.TwelveLabs") as mock_twelvelabs:
+        mock_client = Mock()
+        mock_twelvelabs.return_value = mock_client
+        yield mock_client
+
+
+def test_defaults_and_embed(mock_twelvelabs_client):
+    config = BaseEmbedderConfig(api_key="test_key")
+    embedder = TwelveLabsEmbedding(config)
+
+    # Marengo defaults: marengo3.0, 512 dims.
+    assert embedder.config.model == "marengo3.0"
+    assert embedder.config.embedding_dims == 512
+
+    segment = Mock(float_=[0.1, 0.2, 0.3])
+    response = Mock(text_embedding=Mock(segments=[segment]))
+    mock_twelvelabs_client.embed.create.return_value = response
+
+    embedding = embedder.embed("Sample text to embed.")
+
+    mock_twelvelabs_client.embed.create.assert_called_once_with(model_name="marengo3.0", text="Sample text to embed.")
+    assert embedding == [0.1, 0.2, 0.3]
+
+
+def test_missing_api_key_raises(monkeypatch):
+    monkeypatch.delenv("TWELVELABS_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="API key is required"):
+        TwelveLabsEmbedding(BaseEmbedderConfig())
+
+
+def test_summarize_video(mock_twelvelabs_client):
+    embedder = TwelveLabsEmbedding(BaseEmbedderConfig(api_key="test_key"))
+    mock_twelvelabs_client.analyze.return_value = Mock(data="A cat plays the piano.")
+
+    summary = embedder.summarize_video("https://example.com/cat.mp4")
+
+    assert summary == "A cat plays the piano."
+    _, kwargs = mock_twelvelabs_client.analyze.call_args
+    assert kwargs["model_name"] == "pegasus1.5"
+
+
+@pytest.mark.skipif(not os.getenv("TWELVELABS_API_KEY"), reason="TWELVELABS_API_KEY not set")
+def test_embed_live():
+    embedder = TwelveLabsEmbedding(BaseEmbedderConfig())
+    embedding = embedder.embed("a cat playing piano")
+    assert len(embedding) == 512
+    assert all(isinstance(x, float) for x in embedding)


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

## Description

This PR adds an opt-in `twelvelabs` embedding provider for multimodal memory.

- **Marengo** (`marengo3.0`) embeds text, image, audio and video into a single **512-dimensional** latent space, so a text memory describing a video shares a space with embeddings generated directly from the video itself.
- An optional `TwelveLabsEmbedding.summarize_video(...)` helper uses the **Pegasus** video-understanding model to turn a video into memory text you can store with `Memory.add(...)`.

It plugs into the existing embedder seam exactly like the other providers: registered in `EmbedderFactory`, allow-listed in `EmbedderConfig`, with a focused test, docs, and the dependency added under the `extras` group.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Breaking Changes

N/A — this is fully opt-in. The default embedder is unchanged; you only get TwelveLabs when you set `provider: "twelvelabs"`.

## Test Coverage

- [x] I added/updated unit tests
- [x] I tested manually (describe below)

`tests/embeddings/test_twelvelabs_embeddings.py` covers the no-network path (mocked client, defaults, missing-key error, Pegasus wiring) and includes a live test gated on `TWELVELABS_API_KEY` that asserts a real 512-dim vector. Verified locally:

```
tests/embeddings/test_twelvelabs_embeddings.py::test_defaults_and_embed PASSED
tests/embeddings/test_twelvelabs_embeddings.py::test_missing_api_key_raises PASSED
tests/embeddings/test_twelvelabs_embeddings.py::test_summarize_video PASSED
tests/embeddings/test_twelvelabs_embeddings.py::test_embed_live PASSED
```

`ruff check` and `ruff format --check` pass on the changed files.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.
