### PR TITLE
feat(ts-sdk): add MiniMax LLM provider

### DIFF
--- a/docs/components/llms/models/minimax.mdx
+++ b/docs/components/llms/models/minimax.mdx
@@ -54,10 +54,10 @@ const config = {
 };
 const memory = new Memory(config);
 const messages = [
-  {"role": "user", "content": "I'm planning to watch a movie tonight. Any recommendations?"},
-  {"role": "assistant", "content": "How about thriller movies? They can be quite engaging."},
-  {"role": "user", "content": "I'm not a big fan of thriller movies but I love sci-fi movies."},
-  {"role": "assistant", "content": "Got it! I'll avoid thriller recommendations and suggest sci-fi movies in the future."}
+  { role: "user", content: "I'm planning to watch a movie tonight. Any recommendations?" },
+  { role: "assistant", content: "How about thriller movies? They can be quite engaging." },
+  { role: "user", content: "I'm not a big fan of thriller movies but I love sci-fi movies." },
+  { role: "assistant", content: "Got it! I'll avoid thriller recommendations and suggest sci-fi movies in the future." },
 ];
 await memory.add(messages, { userId: 'alice', metadata: { category: 'movies' } });
 ```
@@ -66,7 +66,8 @@ await memory.add(messages, { userId: 'alice', metadata: { category: 'movies' } }
 
 You can also configure the API base URL in the config:
 
-```python
+<CodeGroup>
+```python Python
 config = {
     "llm": {
         "provider": "minimax",
@@ -78,6 +79,20 @@ config = {
     }
 }
 ```
+
+```typescript TypeScript
+const config = {
+  llm: {
+    provider: 'minimax',
+    config: {
+      model: 'MiniMax-M2.7',
+      baseURL: 'https://your-custom-endpoint.com',
+      apiKey: 'your-api-key', // alternatively to using the environment variable
+    },
+  },
+};
+```
+</CodeGroup>
 
 ## Config
 

--- a/docs/components/llms/models/minimax.mdx
+++ b/docs/components/llms/models/minimax.mdx
@@ -7,7 +7,8 @@ To use MiniMax LLM models, you have to set the `MINIMAX_API_KEY` environment var
 
 ## Usage
 
-```python
+<CodeGroup>
+```python Python
 import os
 from mem0 import Memory
 
@@ -35,6 +36,33 @@ messages = [
 ]
 m.add(messages, user_id="alice", metadata={"category": "movies"})
 ```
+
+```typescript TypeScript
+import { Memory } from 'mem0ai/oss';
+
+const config = {
+  llm: {
+    provider: 'minimax',
+    config: {
+      apiKey: process.env.MINIMAX_API_KEY || '',
+      model: 'MiniMax-M2.7',
+      temperature: 0.2,
+      maxTokens: 2000,
+      topP: 1.0,
+    },
+  },
+};
+const memory = new Memory(config);
+const messages = [
+  {"role": "user", "content": "I'm planning to watch a movie tonight. Any recommendations?"},
+  {"role": "assistant", "content": "How about thriller movies? They can be quite engaging."},
+  {"role": "user", "content": "I'm not a big fan of thriller movies but I love sci-fi movies."},
+  {"role": "assistant", "content": "Got it! I'll avoid thriller recommendations and suggest sci-fi movies in the future."}
+];
+await memory.add(messages, { userId: 'alice', metadata: { category: 'movies' } });
+```
+
+</CodeGroup>
 
 You can also configure the API base URL in the config:
 

--- a/mem0-ts/src/oss/src/llms/minimax.ts
+++ b/mem0-ts/src/oss/src/llms/minimax.ts
@@ -1,0 +1,43 @@
+import { OpenAILLM } from "./openai";
+import { LLMConfig, Message } from "../types";
+import { LLMResponse } from "./base";
+
+export class MiniMaxLLM extends OpenAILLM {
+  constructor(config: LLMConfig) {
+    const apiKey = config.apiKey || process.env.MINIMAX_API_KEY;
+    if (!apiKey) {
+      throw new Error("MiniMax API key is required");
+    }
+    super({
+      ...config,
+      apiKey,
+      baseURL:
+        config.baseURL ||
+        process.env.MINIMAX_API_BASE ||
+        "https://api.minimax.io/v1",
+      model: config.model || "MiniMax-M2.7",
+    });
+  }
+
+  async generateResponse(
+    messages: Message[],
+    responseFormat?: { type: string },
+    tools?: any[],
+  ): Promise<string | LLMResponse> {
+    try {
+      return await super.generateResponse(messages, responseFormat, tools);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`MiniMax LLM failed: ${message}`);
+    }
+  }
+
+  async generateChat(messages: Message[]): Promise<LLMResponse> {
+    try {
+      return await super.generateChat(messages);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`MiniMax LLM failed: ${message}`);
+    }
+  }
+}

--- a/mem0-ts/src/oss/src/utils/factory.ts
+++ b/mem0-ts/src/oss/src/utils/factory.ts
@@ -23,6 +23,7 @@ import { OllamaLLM } from "../llms/ollama";
 import { LMStudioLLM } from "../llms/lmstudio";
 import { DeepSeekLLM } from "../llms/deepseek";
 import { LiteLLM } from "../llms/litellm";
+import { MiniMaxLLM } from "../llms/minimax";
 import { SupabaseDB } from "../vector_stores/supabase";
 import { SQLiteManager } from "../storage/SQLiteManager";
 import { MemoryHistoryManager } from "../storage/MemoryHistoryManager";
@@ -88,6 +89,8 @@ export class LLMFactory {
         return new DeepSeekLLM(config);
       case "litellm":
         return new LiteLLM(config);
+      case "minimax":
+        return new MiniMaxLLM(config);
       default:
         throw new Error(`Unsupported LLM provider: ${provider}`);
     }

--- a/mem0-ts/src/oss/tests/factory.unit.test.ts
+++ b/mem0-ts/src/oss/tests/factory.unit.test.ts
@@ -97,6 +97,11 @@ jest.mock("../src/llms/litellm", () => ({
     .fn()
     .mockImplementation((config) => ({ type: "litellm-llm", config })),
 }));
+jest.mock("../src/llms/minimax", () => ({
+  MiniMaxLLM: jest
+    .fn()
+    .mockImplementation((config) => ({ type: "minimax-llm", config })),
+}));
 
 jest.mock("../src/vector_stores/qdrant", () => ({
   Qdrant: jest
@@ -212,6 +217,7 @@ describe("LLMFactory", () => {
     ["lmstudio"],
     ["deepseek"],
     ["litellm"],
+    ["minimax"],
   ])("creates LLM for provider '%s'", (provider) => {
     expect(() => LLMFactory.create(provider, dummyLLMConfig)).not.toThrow();
   });

--- a/mem0-ts/src/oss/tests/minimax.test.ts
+++ b/mem0-ts/src/oss/tests/minimax.test.ts
@@ -1,0 +1,166 @@
+/// <reference types="jest" />
+/**
+ * MiniMax LLM - unit tests (mocked OpenAI).
+ */
+
+let capturedConstructorArgs: any;
+const mockCreate = jest.fn();
+
+jest.mock("openai", () => {
+  return jest.fn().mockImplementation((args: any) => {
+    capturedConstructorArgs = args;
+    return {
+      chat: { completions: { create: mockCreate } },
+    };
+  });
+});
+
+import { MiniMaxLLM } from "../src/llms/minimax";
+
+describe("MiniMaxLLM (unit)", () => {
+  beforeEach(() => {
+    capturedConstructorArgs = undefined;
+    mockCreate.mockClear();
+    delete process.env.MINIMAX_API_KEY;
+    delete process.env.MINIMAX_API_BASE;
+  });
+
+  it("throws when no API key is provided", () => {
+    expect(() => new MiniMaxLLM({})).toThrow("MiniMax API key is required");
+  });
+
+  it("uses MiniMax defaults with an explicit API key", () => {
+    new MiniMaxLLM({ apiKey: "test-key" });
+
+    expect(capturedConstructorArgs).toMatchObject({
+      apiKey: "test-key",
+      baseURL: "https://api.minimax.io/v1",
+    });
+  });
+
+  it("uses environment variables when config does not provide credentials", () => {
+    process.env.MINIMAX_API_KEY = "env-key";
+    process.env.MINIMAX_API_BASE = "https://example.minimax.test/v1";
+
+    new MiniMaxLLM({});
+
+    expect(capturedConstructorArgs).toMatchObject({
+      apiKey: "env-key",
+      baseURL: "https://example.minimax.test/v1",
+    });
+  });
+
+  it("config values take precedence over environment variables", () => {
+    process.env.MINIMAX_API_KEY = "env-key";
+    process.env.MINIMAX_API_BASE = "https://env.minimax.test/v1";
+
+    new MiniMaxLLM({
+      apiKey: "config-key",
+      baseURL: "https://config.minimax.test/v1",
+      model: "MiniMax-M1",
+    });
+
+    expect(capturedConstructorArgs).toMatchObject({
+      apiKey: "config-key",
+      baseURL: "https://config.minimax.test/v1",
+    });
+  });
+
+  it("generateResponse() returns a text response", async () => {
+    mockCreate.mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            content: "Hello from MiniMax",
+            role: "assistant",
+            tool_calls: null,
+          },
+        },
+      ],
+    });
+
+    const llm = new MiniMaxLLM({ apiKey: "test-key" });
+    const result = await llm.generateResponse([
+      { role: "user", content: "Hi" },
+    ]);
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "MiniMax-M2.7" }),
+    );
+    expect(result).toBe("Hello from MiniMax");
+  });
+
+  it("generateResponse() handles tool calls", async () => {
+    mockCreate.mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            content: "",
+            role: "assistant",
+            tool_calls: [
+              {
+                function: {
+                  name: "search_memory",
+                  arguments: '{"query": "alice"}',
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const llm = new MiniMaxLLM({ apiKey: "test-key" });
+    const result = await llm.generateResponse(
+      [{ role: "user", content: "Find Alice" }],
+      undefined,
+      [{ type: "function", function: { name: "search_memory" } }],
+    );
+
+    expect(result).toEqual({
+      content: "",
+      role: "assistant",
+      toolCalls: [{ name: "search_memory", arguments: '{"query": "alice"}' }],
+    });
+  });
+
+  it("generateResponse() wraps API errors with a clear message", async () => {
+    mockCreate.mockRejectedValueOnce(new Error("Connection refused"));
+
+    const llm = new MiniMaxLLM({ apiKey: "test-key" });
+
+    await expect(
+      llm.generateResponse([{ role: "user", content: "Hi" }]),
+    ).rejects.toThrow("MiniMax LLM failed: Connection refused");
+  });
+
+  it("generateChat() returns LLMResponse shape", async () => {
+    mockCreate.mockResolvedValueOnce({
+      choices: [
+        {
+          message: { content: "I can help with that.", role: "assistant" },
+        },
+      ],
+    });
+
+    const llm = new MiniMaxLLM({ apiKey: "test-key" });
+    const result = await llm.generateChat([
+      { role: "user", content: "Help me" },
+    ]);
+
+    expect(result).toEqual({
+      content: "I can help with that.",
+      role: "assistant",
+    });
+  });
+
+  it("generateChat() wraps API errors with a clear message", async () => {
+    mockCreate.mockRejectedValueOnce(new Error("Timeout"));
+
+    const llm = new MiniMaxLLM({ apiKey: "test-key" });
+
+    await expect(
+      llm.generateChat([{ role: "user", content: "Hi" }]),
+    ).rejects.toThrow("MiniMax LLM failed: Timeout");
+  });
+});


### PR DESCRIPTION
## Linked Issue

Closes #5763

## Description

Adds MiniMax as an OpenAI-compatible LLM provider in the TypeScript OSS SDK. The implementation mirrors the existing thin TypeScript adapters for OpenAI-compatible providers:

- adds `MiniMaxLLM` with `MINIMAX_API_KEY` / `MINIMAX_API_BASE` environment fallback
- defaults to `MiniMax-M2.7`, matching the current Python provider default
- registers `"minimax"` in `LLMFactory`
- adds mocked unit coverage for defaults, env fallback, precedence, text responses, tool calls, and wrapped errors
- documents TypeScript usage beside the existing Python MiniMax example

No new dependency is added; the provider reuses the existing `openai` client with a custom `baseURL`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Verified locally:

```bash
pnpm exec jest src/oss/tests/minimax.test.ts src/oss/tests/factory.unit.test.ts --runInBand
pnpm run build
python scripts/check-llms-txt-coverage.py
```

I also reviewed the implementation manually. This PR was prepared with AI assistance and human-reviewed before submission.