### PR TITLE
feat(ts-sdk): add FastEmbed embedding provider

### DIFF
--- a/docs/components/embedders/models/fastembed.mdx
+++ b/docs/components/embedders/models/fastembed.mdx
@@ -1,0 +1,86 @@
+---
+title: "FastEmbed"
+description: "Configure FastEmbed as an embedding provider in Mem0 to generate embeddings locally and offline using ONNX models."
+---
+
+[FastEmbed](https://github.com/qdrant/fastembed) is a lightweight, fast library for generating embeddings locally with ONNX models — no external API or network calls required at inference time (models are downloaded once and cached).
+
+### Usage
+
+<CodeGroup>
+```python Python
+import os
+from mem0 import Memory
+
+os.environ["OPENAI_API_KEY"] = "your_api_key" # For LLM
+
+config = {
+    "embedder": {
+        "provider": "fastembed",
+        "config": {
+            "model": "thenlper/gte-large"
+        }
+    }
+}
+
+m = Memory.from_config(config)
+messages = [
+    {"role": "user", "content": "I'm planning to watch a movie tonight. Any recommendations?"},
+    {"role": "assistant", "content": "How about thriller movies? They can be quite engaging."},
+    {"role": "user", "content": "I'm not a big fan of thriller movies but I love sci-fi movies."},
+    {"role": "assistant", "content": "Got it! I'll avoid thriller recommendations and suggest sci-fi movies in the future."}
+]
+m.add(messages, user_id="john")
+```
+
+```typescript TypeScript
+import { Memory } from 'mem0ai/oss';
+
+const config = {
+  embedder: {
+    provider: 'fastembed',
+    config: {
+      model: 'fast-bge-small-en-v1.5', // any model from FastEmbed's supported list
+    },
+  },
+};
+
+const memory = new Memory(config);
+const messages = [
+    {"role": "user", "content": "I'm planning to watch a movie tonight. Any recommendations?"},
+    {"role": "assistant", "content": "How about thriller movies? They can be quite engaging."},
+    {"role": "user", "content": "I'm not a big fan of thriller movies but I love sci-fi movies."},
+    {"role": "assistant", "content": "Got it! I'll avoid thriller recommendations and suggest sci-fi movies in the future."}
+]
+await memory.add(messages, { userId: "john" });
+```
+</CodeGroup>
+
+<Note>
+  FastEmbed is an optional dependency. Install it before using this provider:
+  Python — `pip install fastembed`; TypeScript — `npm install fastembed` (or `pnpm add fastembed`).
+</Note>
+
+<Note>
+  The Python and TypeScript ports of FastEmbed support **different model sets**. The Python package accepts HuggingFace model names (default `thenlper/gte-large`), while the TypeScript [`fastembed`](https://github.com/Anush008/fastembed-js) package supports a fixed set of models exposed via its `EmbeddingModel` enum — for example `fast-bge-small-en-v1.5` (default, 384 dims), `fast-bge-base-en-v1.5` (768 dims), `fast-multilingual-e5-large` (1024 dims), and `fast-all-MiniLM-L6-v2` (384 dims). Make sure your vector store dimension matches the chosen model.
+</Note>
+
+### Config
+
+Here are the parameters available for configuring the FastEmbed embedder:
+
+<Tabs>
+<Tab title="Python">
+| Parameter | Description | Default Value |
+| --- | --- | --- |
+| `model` | The HuggingFace model name to use | `thenlper/gte-large` |
+| `embedding_dims` | Dimensions of the embedding model | Derived from the model |
+</Tab>
+<Tab title="TypeScript">
+| Parameter | Description | Default Value |
+| --- | --- | --- |
+| `model` | A FastEmbed-supported model name | `fast-bge-small-en-v1.5` |
+| `embeddingDims` | Dimensions of the embedding model | Derived from the model |
+| `modelProperties` | Extra init options passed to FastEmbed (e.g. `maxLength`, `cacheDir`, `showDownloadProgress`) | `undefined` |
+</Tab>
+</Tabs>

--- a/docs/components/embedders/overview.mdx
+++ b/docs/components/embedders/overview.mdx
@@ -24,6 +24,7 @@ See the list of supported embedders below.
   <Card title="LM Studio" href="/components/embedders/models/lmstudio"></Card>
   <Card title="Langchain" href="/components/embedders/models/langchain"></Card>
   <Card title="AWS Bedrock" href="/components/embedders/models/aws_bedrock"></Card>
+  <Card title="FastEmbed" href="/components/embedders/models/fastembed"></Card>
 </CardGroup>
 
 ## Usage

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -273,7 +273,8 @@
                               "components/embedders/models/lmstudio",
                               "components/embedders/models/together",
                               "components/embedders/models/langchain",
-                              "components/embedders/models/aws_bedrock"
+                              "components/embedders/models/aws_bedrock",
+                              "components/embedders/models/fastembed"
                             ]
                           }
                         ]

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -460,6 +460,7 @@ Everything below is OSS-only provider configuration. Skip this entire section wh
 - [LM Studio Embeddings](https://docs.mem0.ai/components/embedders/models/lmstudio) [OSS]: Use when embeddings run through LM Studio.
 - [Together Embeddings](https://docs.mem0.ai/components/embedders/models/together) [OSS]: Use when embeddings run on Together.
 - [LangChain Embeddings](https://docs.mem0.ai/components/embedders/models/langchain) [OSS]: Use when embeddings are wrapped behind a LangChain adapter.
+- [FastEmbed Embeddings](https://docs.mem0.ai/components/embedders/models/fastembed) [OSS]: Use when embeddings run locally/offline via FastEmbed ONNX models.
 
 ### Vector Databases [OSS]
 - [Vector Database Overview](https://docs.mem0.ai/components/vectordbs/overview) [OSS]: Use when choosing a vector store.

--- a/mem0-ts/package.json
+++ b/mem0-ts/package.json
@@ -124,7 +124,13 @@
     "pg": "8.11.3",
     "redis": "^4.6.13",
     "compromise": "^14.0.0",
-    "natural": "^8.0.1"
+    "natural": "^8.0.1",
+    "fastembed": "^2.1.0"
+  },
+  "peerDependenciesMeta": {
+    "fastembed": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=18"

--- a/mem0-ts/pnpm-lock.yaml
+++ b/mem0-ts/pnpm-lock.yaml
@@ -73,6 +73,9 @@ importers:
       compromise:
         specifier: ^14.0.0
         version: 14.15.1
+      fastembed:
+        specifier: ^2.1.0
+        version: 2.1.0
       groq-sdk:
         specifier: 0.3.0
         version: 0.3.0
@@ -142,6 +145,27 @@ packages:
 
   '@anthropic-ai/sdk@0.40.1':
     resolution: {integrity: sha512-DJMWm8lTEM9Lk/MSFL+V+ugF7jKOn0M2Ujvb5fN8r2nY14aHbGPZ1k6sgjL+tpJ3VuOGJNG+4R83jEpOuYPv8w==}
+
+  '@anush008/tokenizers-darwin-universal@0.0.0':
+    resolution: {integrity: sha512-SACpWEooTjFX89dFKRVUhivMxxcZRtA3nJGVepdLyrwTkQ1TZQ8581B5JoXp0TcTMHfgnDaagifvVoBiFEdNCQ==}
+    engines: {node: '>= 10'}
+    os: [darwin]
+
+  '@anush008/tokenizers-linux-x64-gnu@0.0.0':
+    resolution: {integrity: sha512-TLjByOPWUEq51L3EJkS+slyH57HKJ7lAz/aBtEt7TIPq4QsE2owOPGovByOLIq1x5Wgh9b+a4q2JasrEFSDDhg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@anush008/tokenizers-win32-x64-msvc@0.0.0':
+    resolution: {integrity: sha512-/5kP0G96+Cr6947F0ZetXnmL31YCaN15dbNbh2NHg7TXXRwfqk95+JtPP5Q7v4jbR2xxAmuseBqB4H/V7zKWuw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@anush008/tokenizers@0.0.0':
+    resolution: {integrity: sha512-IQD9wkVReKAhsEAbDjh/0KrBGTEXelqZLpOBRDaIRvlzZ9sjmUP+gKbpvzyJnei2JHQiE8JAgj7YcNloINbGBw==}
+    engines: {node: '>= 10'}
 
   '@azure/abort-controller@2.1.2':
     resolution: {integrity: sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==}
@@ -542,9 +566,27 @@ packages:
       '@modelcontextprotocol/sdk':
         optional: true
 
+  '@huggingface/blake3-jit@0.0.2':
+    resolution: {integrity: sha512-Bq7B5qabyjrJfhBsl85Jd2QBtf+HzRD7h7A9GfN2lzrrsABhOa5evVPgzoCTxR7Ub0QFj7YDK1YkYRWBU25+2w==}
+
+  '@huggingface/hub@2.13.2':
+    resolution: {integrity: sha512-I1Pbn9UcBHCt0M/SbZkKzYr3JVnbJp4YIFv74eVRH2Y22yT9Jpm6DtfM74tcjNLbC7SyFZ433znUw0szdFd4Fg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@huggingface/tasks@0.21.16':
+    resolution: {integrity: sha512-MJeUZTHEwW7FOBnSNGaVfWSEMJ/lM47O3cI1kJWiFsT4M7IolhmFi+imWE7+37cMuwfjWdpE7A0Hq5OfcQQ7Mg==}
+
+  '@huggingface/xetchunk-wasm@0.1.0':
+    resolution: {integrity: sha512-wWpp2qwPgf9kv1KLJjcDUk/OrpDOsFoQ3Qpz0U5LGn20csoymBf8eneOv6wm/GzPBzlWac1OYiR0aa1vT6aM2Q==}
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
+
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
 
   '@istanbuljs/load-nyc-config@1.1.0':
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
@@ -1157,6 +1199,10 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  boolean@3.2.0:
+    resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
   brace-expansion@1.1.15:
     resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
 
@@ -1255,12 +1301,24 @@ packages:
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
+  chownr@2.0.0:
+    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
+    engines: {node: '>=10'}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
+
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
 
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+
+  cli-progress@3.12.0:
+    resolution: {integrity: sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==}
+    engines: {node: '>=4'}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -1368,9 +1426,17 @@ packages:
     resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
     engines: {node: '>=18'}
 
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
   define-lazy-prop@3.0.0:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
     engines: {node: '>=12'}
+
+  define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -1383,6 +1449,9 @@ packages:
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
+
+  detect-node@2.1.0:
+    resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
 
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
@@ -1452,6 +1521,9 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
+  es6-error@4.1.1:
+    resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
+
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
@@ -1464,6 +1536,10 @@ packages:
   escape-string-regexp@2.0.0:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
     engines: {node: '>=8'}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
 
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
@@ -1501,6 +1577,9 @@ packages:
 
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fastembed@2.1.0:
+    resolution: {integrity: sha512-oQkpcRHBppJ3+a3w9dU0uytSY0N1cnEa/iVMc8AXEd+tvT529GekOEFhNviJy89R3lvQXF6cdIMTXHj1Gi00xQ==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -1570,6 +1649,10 @@ packages:
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
+  fs-minipass@2.1.0:
+    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
+    engines: {node: '>= 8'}
+
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
@@ -1588,6 +1671,9 @@ packages:
   gcp-metadata@8.1.2:
     resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
     engines: {node: '>=18'}
+
+  gearhash-jit@1.0.2:
+    resolution: {integrity: sha512-UhzJL4KXSdqAKepy/tZwmi2Rcy0YMmtiC4DQS4SURCuIWdh8ECZtnXK2ePRMLigfB61hRKdLK/Vgg2bSw73izQ==}
 
   generic-pool@3.9.0:
     resolution: {integrity: sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==}
@@ -1633,6 +1719,14 @@ packages:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
+  global-agent@3.0.0:
+    resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
+    engines: {node: '>=10.0'}
+
+  globalthis@1.0.4:
+    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
+    engines: {node: '>= 0.4'}
+
   google-auth-library@10.7.0:
     resolution: {integrity: sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==}
     engines: {node: '>=18'}
@@ -1667,6 +1761,9 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
@@ -1975,6 +2072,9 @@ packages:
     resolution: {integrity: sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -2090,6 +2190,10 @@ packages:
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
+  matcher@3.0.0:
+    resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
+    engines: {node: '>=10'}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -2145,12 +2249,33 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  minipass@3.3.6:
+    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+    engines: {node: '>=8'}
+
+  minipass@5.0.0:
+    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
+    engines: {node: '>=8'}
+
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minizlib@2.1.2:
+    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
+    engines: {node: '>= 8'}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
@@ -2271,6 +2396,10 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+
   obuf@1.1.2:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
 
@@ -2283,6 +2412,13 @@ packages:
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
+
+  onnxruntime-common@1.21.0:
+    resolution: {integrity: sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==}
+
+  onnxruntime-node@1.21.0:
+    resolution: {integrity: sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==}
+    os: [win32, darwin, linux]
 
   open@10.2.0:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
@@ -2509,6 +2645,10 @@ packages:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -2600,6 +2740,10 @@ packages:
     resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
     hasBin: true
 
+  roarr@2.15.4:
+    resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
+    engines: {node: '>=8.0'}
+
   rollup@4.61.1:
     resolution: {integrity: sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -2619,6 +2763,9 @@ packages:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
 
+  semver-compare@1.0.0:
+    resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -2627,6 +2774,10 @@ packages:
     resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  serialize-error@7.0.1:
+    resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
+    engines: {node: '>=10'}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -2692,6 +2843,9 @@ packages:
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
+
+  sprintf-js@1.1.3:
+    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
@@ -2774,6 +2928,15 @@ packages:
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
+
+  tar@6.2.1:
+    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
+    engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  tar@7.5.16:
+    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
+    engines: {node: '>=18'}
 
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
@@ -2887,6 +3050,10 @@ packages:
   type-detect@4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
     engines: {node: '>=4'}
+
+  type-fest@0.13.1:
+    resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
+    engines: {node: '>=10'}
 
   type-fest@0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
@@ -3041,6 +3208,10 @@ packages:
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -3078,6 +3249,21 @@ snapshots:
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
+
+  '@anush008/tokenizers-darwin-universal@0.0.0':
+    optional: true
+
+  '@anush008/tokenizers-linux-x64-gnu@0.0.0':
+    optional: true
+
+  '@anush008/tokenizers-win32-x64-msvc@0.0.0':
+    optional: true
+
+  '@anush008/tokenizers@0.0.0':
+    optionalDependencies:
+      '@anush008/tokenizers-darwin-universal': 0.0.0
+      '@anush008/tokenizers-linux-x64-gnu': 0.0.0
+      '@anush008/tokenizers-win32-x64-msvc': 0.0.0
 
   '@azure/abort-controller@2.1.2':
     dependencies:
@@ -3472,6 +3658,22 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@huggingface/blake3-jit@0.0.2': {}
+
+  '@huggingface/hub@2.13.2':
+    dependencies:
+      '@huggingface/tasks': 0.21.16
+      '@huggingface/xetchunk-wasm': 0.1.0
+    optionalDependencies:
+      cli-progress: 3.12.0
+
+  '@huggingface/tasks@0.21.16': {}
+
+  '@huggingface/xetchunk-wasm@0.1.0':
+    dependencies:
+      '@huggingface/blake3-jit': 0.0.2
+      gearhash-jit: 1.0.2
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -3480,6 +3682,10 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
 
   '@istanbuljs/load-nyc-config@1.1.0':
     dependencies:
@@ -4170,6 +4376,8 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  boolean@3.2.0: {}
+
   brace-expansion@1.1.15:
     dependencies:
       balanced-match: 1.0.2
@@ -4267,9 +4475,18 @@ snapshots:
 
   chownr@1.1.4: {}
 
+  chownr@2.0.0: {}
+
+  chownr@3.0.0: {}
+
   ci-info@3.9.0: {}
 
   cjs-module-lexer@1.4.3: {}
+
+  cli-progress@3.12.0:
+    dependencies:
+      string-width: 4.2.3
+    optional: true
 
   cliui@8.0.1:
     dependencies:
@@ -4371,13 +4588,27 @@ snapshots:
       bundle-name: 4.1.0
       default-browser-id: 5.0.1
 
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   define-lazy-prop@3.0.0: {}
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
 
   delayed-stream@1.0.0: {}
 
   detect-libc@2.1.2: {}
 
   detect-newline@3.1.0: {}
+
+  detect-node@2.1.0: {}
 
   diff-sequences@29.6.3: {}
 
@@ -4437,6 +4668,8 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.4
 
+  es6-error@4.1.1: {}
+
   esbuild@0.28.1:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.28.1
@@ -4469,6 +4702,8 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-string-regexp@2.0.0: {}
+
+  escape-string-regexp@4.0.0: {}
 
   event-target-shim@5.0.1: {}
 
@@ -4511,6 +4746,14 @@ snapshots:
       micromatch: 4.0.8
 
   fast-json-stable-stringify@2.1.0: {}
+
+  fastembed@2.1.0:
+    dependencies:
+      '@anush008/tokenizers': 0.0.0
+      '@huggingface/hub': 2.13.2
+      onnxruntime-node: 1.21.0
+      progress: 2.0.3
+      tar: 6.2.1
 
   fastq@1.20.1:
     dependencies:
@@ -4581,6 +4824,10 @@ snapshots:
 
   fs-constants@1.0.0: {}
 
+  fs-minipass@2.1.0:
+    dependencies:
+      minipass: 3.3.6
+
   fs.realpath@1.0.0: {}
 
   fsevents@2.3.3:
@@ -4603,6 +4850,8 @@ snapshots:
       json-bigint: 1.0.0
     transitivePeerDependencies:
       - supports-color
+
+  gearhash-jit@1.0.2: {}
 
   generic-pool@3.9.0: {}
 
@@ -4656,6 +4905,20 @@ snapshots:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
+  global-agent@3.0.0:
+    dependencies:
+      boolean: 3.2.0
+      es6-error: 4.1.1
+      matcher: 3.0.0
+      roarr: 2.15.4
+      semver: 7.8.4
+      serialize-error: 7.0.1
+
+  globalthis@1.0.4:
+    dependencies:
+      define-properties: 1.2.1
+      gopd: 1.2.0
+
   google-auth-library@10.7.0:
     dependencies:
       base64-js: 1.5.1
@@ -4701,6 +4964,10 @@ snapshots:
   has-flag@3.0.0: {}
 
   has-flag@4.0.0: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
 
   has-symbols@1.1.0: {}
 
@@ -5183,6 +5450,8 @@ snapshots:
 
   json-parse-even-better-errors@3.0.2: {}
 
+  json-stringify-safe@5.0.1: {}
+
   json5@2.2.3: {}
 
   jsonwebtoken@9.0.3:
@@ -5274,6 +5543,10 @@ snapshots:
     dependencies:
       tmpl: 1.0.5
 
+  matcher@3.0.0:
+    dependencies:
+      escape-string-regexp: 4.0.0
+
   math-intrinsics@1.1.0: {}
 
   md5@2.3.0:
@@ -5319,9 +5592,26 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minipass@3.3.6:
+    dependencies:
+      yallist: 4.0.0
+
+  minipass@5.0.0: {}
+
   minipass@7.1.3: {}
 
+  minizlib@2.1.2:
+    dependencies:
+      minipass: 3.3.6
+      yallist: 4.0.0
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
+
   mkdirp-classic@0.5.3: {}
+
+  mkdirp@1.0.4: {}
 
   mlly@1.8.2:
     dependencies:
@@ -5453,6 +5743,8 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-keys@1.1.1: {}
+
   obuf@1.1.2: {}
 
   ollama@0.5.18:
@@ -5466,6 +5758,14 @@ snapshots:
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
+
+  onnxruntime-common@1.21.0: {}
+
+  onnxruntime-node@1.21.0:
+    dependencies:
+      global-agent: 3.0.0
+      onnxruntime-common: 1.21.0
+      tar: 7.5.16
 
   open@10.2.0:
     dependencies:
@@ -5683,6 +5983,8 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
+  progress@2.0.3: {}
+
   prompts@2.4.2:
     dependencies:
       kleur: 3.0.3
@@ -5791,6 +6093,15 @@ snapshots:
     dependencies:
       glob: 10.5.0
 
+  roarr@2.15.4:
+    dependencies:
+      boolean: 3.2.0
+      detect-node: 2.1.0
+      globalthis: 1.0.4
+      json-stringify-safe: 5.0.1
+      semver-compare: 1.0.0
+      sprintf-js: 1.1.3
+
   rollup@4.61.1:
     dependencies:
       '@types/estree': 1.0.9
@@ -5832,9 +6143,15 @@ snapshots:
 
   safe-stable-stringify@2.5.0: {}
 
+  semver-compare@1.0.0: {}
+
   semver@6.3.1: {}
 
   semver@7.8.4: {}
+
+  serialize-error@7.0.1:
+    dependencies:
+      type-fest: 0.13.1
 
   shebang-command@2.0.0:
     dependencies:
@@ -5892,6 +6209,8 @@ snapshots:
   spdx-license-ids@3.0.23: {}
 
   split2@4.2.0: {}
+
+  sprintf-js@1.1.3: {}
 
   stack-utils@2.0.6:
     dependencies:
@@ -5978,6 +6297,23 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  tar@6.2.1:
+    dependencies:
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      minipass: 5.0.0
+      minizlib: 2.1.2
+      mkdirp: 1.0.4
+      yallist: 4.0.0
+
+  tar@7.5.16:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
 
   test-exclude@6.0.0:
     dependencies:
@@ -6092,6 +6428,8 @@ snapshots:
 
   type-detect@4.0.8: {}
 
+  type-fest@0.13.1: {}
+
   type-fest@0.21.3: {}
 
   type-fest@3.13.1: {}
@@ -6204,6 +6542,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yallist@4.0.0: {}
+
+  yallist@5.0.0: {}
 
   yargs-parser@21.1.1: {}
 

--- a/mem0-ts/src/oss/src/config/manager.ts
+++ b/mem0-ts/src/oss/src/config/manager.ts
@@ -3,16 +3,24 @@ import { DEFAULT_MEMORY_CONFIG } from "./defaults";
 
 export class ConfigManager {
   static mergeConfig(userConfig: Partial<MemoryConfig> = {}): MemoryConfig {
+    const embedderProvider =
+      userConfig.embedder?.provider || DEFAULT_MEMORY_CONFIG.embedder.provider;
+    // Providers that ship their own default model and reject the generic
+    // OpenAI default (e.g. FastEmbed only accepts its enum model names).
+    const embedderProviderUsesOwnDefault =
+      embedderProvider.toLowerCase() === "fastembed";
     const mergedConfig = {
       version: userConfig.version || DEFAULT_MEMORY_CONFIG.version,
       embedder: {
-        provider:
-          userConfig.embedder?.provider ||
-          DEFAULT_MEMORY_CONFIG.embedder.provider,
+        provider: embedderProvider,
         config: (() => {
           const defaultConf = DEFAULT_MEMORY_CONFIG.embedder.config;
           const userConf = userConfig.embedder?.config;
-          let finalModel: string | any = defaultConf.model;
+          // Leave the model undefined for providers that resolve their own
+          // default, so the embedder default wins instead of OpenAI's.
+          let finalModel: string | any = embedderProviderUsesOwnDefault
+            ? undefined
+            : defaultConf.model;
 
           if (userConf?.model && typeof userConf.model === "object") {
             finalModel = userConf.model;

--- a/mem0-ts/src/oss/src/embeddings/fastembed.ts
+++ b/mem0-ts/src/oss/src/embeddings/fastembed.ts
@@ -116,7 +116,9 @@ export class FastEmbedEmbedder implements Embedder {
         `FastEmbed returned no embedding for model '${this.model}'`,
       );
     }
-    return batch[0];
+    // FastEmbed yields Float32Array values; normalize to a plain number[]
+    // to satisfy the Embedder contract and downstream vector-store handling.
+    return Array.from(batch[0]);
   }
 
   async embedBatch(texts: string[]): Promise<number[][]> {
@@ -129,7 +131,10 @@ export class FastEmbedEmbedder implements Embedder {
     const embedding = await this.getEmbedding();
     const results: number[][] = [];
     for await (const batch of embedding.embed(normalized)) {
-      results.push(...batch);
+      // Normalize each Float32Array to a plain number[].
+      for (const vector of batch) {
+        results.push(Array.from(vector));
+      }
     }
     if (results.length !== normalized.length) {
       throw new Error(

--- a/mem0-ts/src/oss/src/embeddings/fastembed.ts
+++ b/mem0-ts/src/oss/src/embeddings/fastembed.ts
@@ -64,6 +64,9 @@ export class FastEmbedEmbedder implements Embedder {
 
   private async getEmbedding(): Promise<FastEmbedFlagEmbedding> {
     if (!this.embeddingPromise) {
+      // Clear the cached promise on failure so a transient init error
+      // (e.g. a flaky one-time model download) can be retried on the next
+      // call instead of being permanently cached as a rejection.
       this.embeddingPromise = (async () => {
         let mod: FastEmbedModule;
         try {
@@ -95,7 +98,10 @@ export class FastEmbedEmbedder implements Embedder {
               `Original error: ${error instanceof Error ? error.message : String(error)}`,
           );
         }
-      })();
+      })().catch((error) => {
+        this.embeddingPromise = null;
+        throw error;
+      });
     }
     return this.embeddingPromise;
   }

--- a/mem0-ts/src/oss/src/embeddings/fastembed.ts
+++ b/mem0-ts/src/oss/src/embeddings/fastembed.ts
@@ -1,0 +1,135 @@
+import { Embedder } from "./base";
+import { EmbeddingConfig } from "../types";
+
+// Minimal structural types for the lazily-imported `fastembed` package so we
+// don't take a hard dependency on its type declarations at build time.
+interface FastEmbedModelInfo {
+  model: string;
+  dim: number;
+  description: string;
+}
+
+interface FastEmbedFlagEmbedding {
+  embed(
+    texts: string[],
+    batchSize?: number,
+  ): AsyncGenerator<number[][], void, unknown>;
+  passageEmbed(
+    texts: string[],
+    batchSize?: number,
+  ): AsyncGenerator<number[][], void, unknown>;
+  listSupportedModels(): FastEmbedModelInfo[];
+}
+
+interface FastEmbedModule {
+  FlagEmbedding: {
+    init(options: {
+      model: string;
+      maxLength?: number;
+      cacheDir?: string;
+      showDownloadProgress?: boolean;
+      [key: string]: any;
+    }): Promise<FastEmbedFlagEmbedding>;
+  };
+  EmbeddingModel: Record<string, string>;
+}
+
+/**
+ * Local, offline embeddings via FastEmbed (Qdrant's ONNX-based embedding
+ * library). Mirrors the Python provider in `mem0/embeddings/fastembed.py`.
+ *
+ * Unlike the Python `fastembed` package, the JavaScript port only supports a
+ * fixed set of models exposed through its `EmbeddingModel` enum (e.g.
+ * `fast-bge-small-en-v1.5`). It does not accept arbitrary HuggingFace model
+ * names such as the Python default `thenlper/gte-large`, so the default here is
+ * `fast-bge-small-en-v1.5` (384 dims) — FastEmbed's own documented default.
+ *
+ * The `fastembed` package is an optional peer dependency and is imported
+ * lazily so it is only required when this provider is actually used.
+ */
+export class FastEmbedEmbedder implements Embedder {
+  private model: string;
+  private embeddingDims?: number;
+  private initOptions: Record<string, any>;
+  private embeddingPromise: Promise<FastEmbedFlagEmbedding> | null = null;
+
+  constructor(config: EmbeddingConfig) {
+    this.model =
+      typeof config.model === "string" && config.model.length > 0
+        ? config.model
+        : "fast-bge-small-en-v1.5";
+    this.embeddingDims = config.embeddingDims;
+    this.initOptions = config.modelProperties ?? {};
+  }
+
+  private async getEmbedding(): Promise<FastEmbedFlagEmbedding> {
+    if (!this.embeddingPromise) {
+      this.embeddingPromise = (async () => {
+        let mod: FastEmbedModule;
+        try {
+          mod = (await import("fastembed")) as unknown as FastEmbedModule;
+        } catch {
+          throw new Error(
+            "FastEmbed is not installed. Please install it using `npm install fastembed` (or `pnpm add fastembed`).",
+          );
+        }
+
+        try {
+          return await mod.FlagEmbedding.init({
+            model: this.model,
+            ...this.initOptions,
+          });
+        } catch (error) {
+          const supported = (() => {
+            try {
+              return Object.values(mod.EmbeddingModel)
+                .filter((m) => m !== "custom")
+                .join(", ");
+            } catch {
+              return "";
+            }
+          })();
+          const hint = supported ? ` Supported models: ${supported}.` : "";
+          throw new Error(
+            `Failed to initialize FastEmbed model '${this.model}'.${hint} ` +
+              `Original error: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      })();
+    }
+    return this.embeddingPromise;
+  }
+
+  async embed(text: string): Promise<number[]> {
+    const input = typeof text === "string" ? text : JSON.stringify(text);
+    const normalized = input.replace(/\n/g, " ");
+    const embedding = await this.getEmbedding();
+    const batch = (await embedding.embed([normalized]).next()).value;
+    if (!batch || batch.length === 0) {
+      throw new Error(
+        `FastEmbed returned no embedding for model '${this.model}'`,
+      );
+    }
+    return batch[0];
+  }
+
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    if (texts.length === 0) {
+      return [];
+    }
+    const normalized = texts.map((t) =>
+      (typeof t === "string" ? t : JSON.stringify(t)).replace(/\n/g, " "),
+    );
+    const embedding = await this.getEmbedding();
+    const results: number[][] = [];
+    for await (const batch of embedding.embed(normalized)) {
+      results.push(...batch);
+    }
+    if (results.length !== normalized.length) {
+      throw new Error(
+        `FastEmbed returned ${results.length} embeddings for ${normalized.length} inputs`,
+      );
+    }
+    return results;
+  }
+}

--- a/mem0-ts/src/oss/src/index.ts
+++ b/mem0-ts/src/oss/src/index.ts
@@ -8,6 +8,7 @@ export * from "./embeddings/lmstudio";
 export * from "./embeddings/google";
 export * from "./embeddings/azure";
 export * from "./embeddings/langchain";
+export * from "./embeddings/fastembed";
 export * from "./llms/base";
 export * from "./llms/openai";
 export * from "./llms/google";

--- a/mem0-ts/src/oss/src/tests/fastembed.test.ts
+++ b/mem0-ts/src/oss/src/tests/fastembed.test.ts
@@ -114,6 +114,27 @@ describe("FastEmbedEmbedder", () => {
     expect(initMock).toHaveBeenCalledTimes(1);
   });
 
+  it("normalizes Float32Array output to a plain number[]", async () => {
+    initMock.mockResolvedValue({
+      embed: async function* () {
+        yield [new Float32Array([0.1, 0.2, 0.3])];
+      },
+      passageEmbed: async function* () {},
+      listSupportedModels: () => [],
+    });
+    const embedder = new FastEmbedEmbedder({});
+
+    const result = await embedder.embed("x");
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).not.toBeInstanceOf(Float32Array);
+    expect(result).toEqual([
+      expect.closeTo(0.1),
+      expect.closeTo(0.2),
+      expect.closeTo(0.3),
+    ]);
+  });
+
   it("embeds a batch of texts in order", async () => {
     initMock.mockResolvedValue(
       fakeEmbedding({ one: [1, 1], two: [2, 2], three: [3, 3] }),

--- a/mem0-ts/src/oss/src/tests/fastembed.test.ts
+++ b/mem0-ts/src/oss/src/tests/fastembed.test.ts
@@ -1,0 +1,135 @@
+import { FastEmbedEmbedder } from "../embeddings/fastembed";
+import { EmbedderFactory } from "../utils/factory";
+
+// ---------------------------------------------------------------------------
+// Mock the optional `fastembed` package so tests don't download ONNX models.
+// ---------------------------------------------------------------------------
+
+const initMock = jest.fn();
+
+jest.mock(
+  "fastembed",
+  () => ({
+    FlagEmbedding: {
+      init: (...args: any[]) => initMock(...args),
+    },
+    EmbeddingModel: {
+      BGESmallENV15: "fast-bge-small-en-v1.5",
+      BGEBaseENV15: "fast-bge-base-en-v1.5",
+      CUSTOM: "custom",
+    },
+  }),
+  { virtual: true },
+);
+
+/** Build a fake FlagEmbedding instance whose embed() yields the given batches. */
+function fakeEmbedding(vectorsByText: Record<string, number[]>) {
+  return {
+    embed: async function* (texts: string[]) {
+      yield texts.map((t) => vectorsByText[t] ?? [0, 0, 0]);
+    },
+    passageEmbed: async function* (texts: string[]) {
+      yield texts.map((t) => vectorsByText[t] ?? [0, 0, 0]);
+    },
+    listSupportedModels: () => [],
+  };
+}
+
+describe("FastEmbedEmbedder", () => {
+  beforeEach(() => {
+    initMock.mockReset();
+  });
+
+  it("is registered in EmbedderFactory under 'fastembed'", () => {
+    const embedder = EmbedderFactory.create("fastembed", {});
+    expect(embedder).toBeInstanceOf(FastEmbedEmbedder);
+  });
+
+  it("defaults to fast-bge-small-en-v1.5 when no model is provided", async () => {
+    initMock.mockResolvedValue(fakeEmbedding({ hello: [0.1, 0.2, 0.3] }));
+    const embedder = new FastEmbedEmbedder({});
+
+    await embedder.embed("hello");
+
+    expect(initMock).toHaveBeenCalledTimes(1);
+    expect(initMock.mock.calls[0][0]).toMatchObject({
+      model: "fast-bge-small-en-v1.5",
+    });
+  });
+
+  it("uses the configured model and passes through modelProperties", async () => {
+    initMock.mockResolvedValue(fakeEmbedding({ hi: [1, 2] }));
+    const embedder = new FastEmbedEmbedder({
+      model: "fast-bge-base-en-v1.5",
+      modelProperties: { maxLength: 256, showDownloadProgress: false },
+    });
+
+    await embedder.embed("hi");
+
+    expect(initMock.mock.calls[0][0]).toMatchObject({
+      model: "fast-bge-base-en-v1.5",
+      maxLength: 256,
+      showDownloadProgress: false,
+    });
+  });
+
+  it("embeds a single text and normalizes newlines", async () => {
+    const captured: string[] = [];
+    initMock.mockResolvedValue({
+      embed: async function* (texts: string[]) {
+        captured.push(...texts);
+        yield texts.map(() => [0.5, 0.5]);
+      },
+      passageEmbed: async function* () {},
+      listSupportedModels: () => [],
+    });
+
+    const embedder = new FastEmbedEmbedder({});
+    const result = await embedder.embed("line one\nline two");
+
+    expect(result).toEqual([0.5, 0.5]);
+    expect(captured).toEqual(["line one line two"]);
+  });
+
+  it("initializes the model only once across multiple embed calls", async () => {
+    initMock.mockResolvedValue(fakeEmbedding({ a: [1], b: [2] }));
+    const embedder = new FastEmbedEmbedder({});
+
+    await embedder.embed("a");
+    await embedder.embed("b");
+
+    expect(initMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("embeds a batch of texts in order", async () => {
+    initMock.mockResolvedValue(
+      fakeEmbedding({ one: [1, 1], two: [2, 2], three: [3, 3] }),
+    );
+    const embedder = new FastEmbedEmbedder({});
+
+    const result = await embedder.embedBatch(["one", "two", "three"]);
+
+    expect(result).toEqual([
+      [1, 1],
+      [2, 2],
+      [3, 3],
+    ]);
+  });
+
+  it("returns an empty array for an empty batch without initializing", async () => {
+    const embedder = new FastEmbedEmbedder({});
+    const result = await embedder.embedBatch([]);
+
+    expect(result).toEqual([]);
+    expect(initMock).not.toHaveBeenCalled();
+  });
+
+  it("throws a helpful error when model initialization fails", async () => {
+    initMock.mockRejectedValue(new Error("unknown model"));
+    const embedder = new FastEmbedEmbedder({ model: "not-a-real-model" });
+
+    await expect(embedder.embed("x")).rejects.toThrow(
+      /Failed to initialize FastEmbed model 'not-a-real-model'/,
+    );
+  });
+});

--- a/mem0-ts/src/oss/src/tests/fastembed.test.ts
+++ b/mem0-ts/src/oss/src/tests/fastembed.test.ts
@@ -57,6 +57,19 @@ describe("FastEmbedEmbedder", () => {
     });
   });
 
+  it("applies the default model when model is explicitly undefined (config-merge path)", async () => {
+    // ConfigManager.mergeConfig() passes `model: undefined` for fastembed so
+    // the provider's own default wins instead of OpenAI's default model.
+    initMock.mockResolvedValue(fakeEmbedding({ hi: [0.4] }));
+    const embedder = new FastEmbedEmbedder({ model: undefined });
+
+    await embedder.embed("hi");
+
+    expect(initMock.mock.calls[0][0]).toMatchObject({
+      model: "fast-bge-small-en-v1.5",
+    });
+  });
+
   it("uses the configured model and passes through modelProperties", async () => {
     initMock.mockResolvedValue(fakeEmbedding({ hi: [1, 2] }));
     const embedder = new FastEmbedEmbedder({
@@ -131,5 +144,22 @@ describe("FastEmbedEmbedder", () => {
     await expect(embedder.embed("x")).rejects.toThrow(
       /Failed to initialize FastEmbed model 'not-a-real-model'/,
     );
+  });
+
+  it("retries initialization after a transient init failure", async () => {
+    initMock.mockRejectedValueOnce(new Error("transient init failure"));
+    initMock.mockResolvedValueOnce(fakeEmbedding({ second: [0.9] }));
+    const embedder = new FastEmbedEmbedder({});
+
+    // First call fails (rejected init promise must not be cached).
+    await expect(embedder.embed("first")).rejects.toThrow(
+      /Failed to initialize FastEmbed model/,
+    );
+
+    // Second call should re-attempt init and succeed.
+    const result = await embedder.embed("second");
+
+    expect(initMock).toHaveBeenCalledTimes(2);
+    expect(result).toEqual([0.9]);
   });
 });

--- a/mem0-ts/src/oss/src/utils/factory.ts
+++ b/mem0-ts/src/oss/src/utils/factory.ts
@@ -35,6 +35,7 @@ import { AzureOpenAILLM } from "../llms/azure";
 import { AzureOpenAIEmbedder } from "../embeddings/azure";
 import { LangchainLLM } from "../llms/langchain";
 import { LangchainEmbedder } from "../embeddings/langchain";
+import { FastEmbedEmbedder } from "../embeddings/fastembed";
 import { LangchainVectorStore } from "../vector_stores/langchain";
 import { AzureAISearch } from "../vector_stores/azure_ai_search";
 import { PGVector } from "../vector_stores/pgvector";
@@ -55,6 +56,8 @@ export class EmbedderFactory {
         return new AzureOpenAIEmbedder(config);
       case "langchain":
         return new LangchainEmbedder(config);
+      case "fastembed":
+        return new FastEmbedEmbedder(config);
       default:
         throw new Error(`Unsupported embedder provider: ${provider}`);
     }

--- a/mem0-ts/src/oss/tests/config-manager.test.ts
+++ b/mem0-ts/src/oss/tests/config-manager.test.ts
@@ -361,6 +361,47 @@ describe("ConfigManager", () => {
       expect(cfg.vectorStore.config.port).toBe(6333);
     });
   });
+
+  describe("mergeConfig - FastEmbed defaults", () => {
+    const baseLlm = { provider: "openai", config: { apiKey: "k" } };
+
+    it("does not inject the OpenAI default embedder model into fastembed", () => {
+      const cfg = ConfigManager.mergeConfig({
+        embedder: { provider: "fastembed", config: {} },
+        vectorStore: { provider: "memory", config: {} },
+        llm: baseLlm,
+      });
+
+      expect(cfg.embedder.provider).toBe("fastembed");
+      // Must stay undefined so FastEmbedEmbedder applies its own default
+      // model instead of OpenAI's text-embedding-3-small.
+      expect(cfg.embedder.config.model).toBeUndefined();
+    });
+
+    it("treats FastEmbed provider casing the same as the factory", () => {
+      const cfg = ConfigManager.mergeConfig({
+        embedder: { provider: "FastEmbed", config: {} },
+        vectorStore: { provider: "memory", config: {} },
+        llm: baseLlm,
+      });
+
+      expect(cfg.embedder.provider).toBe("FastEmbed");
+      expect(cfg.embedder.config.model).toBeUndefined();
+    });
+
+    it("still honors an explicitly provided fastembed model", () => {
+      const cfg = ConfigManager.mergeConfig({
+        embedder: {
+          provider: "fastembed",
+          config: { model: "fast-bge-base-en-v1.5" },
+        },
+        vectorStore: { provider: "memory", config: {} },
+        llm: baseLlm,
+      });
+
+      expect(cfg.embedder.config.model).toBe("fast-bge-base-en-v1.5");
+    });
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -489,6 +530,24 @@ describe("Memory – LM Studio end-to-end flow", () => {
     expect(mockEmbedder.embed).toHaveBeenCalledWith("dimension probe");
     const vsCall = mockVectorStoreFactory.create.mock.calls[0];
     expect(vsCall[1].dimension).toBe(768);
+  });
+
+  it("preserves the FastEmbed default model through the Memory config path", async () => {
+    const mem = new MemoryClass({
+      embedder: { provider: "fastembed", config: {} },
+      vectorStore: { provider: "memory", config: { collectionName: "test" } },
+      llm: { provider: "openai", config: { apiKey: "test-key" } },
+      disableHistory: true,
+    });
+
+    await mem.getAll({ filters: { user_id: "u1" } });
+
+    // The OpenAI default model must NOT leak into the fastembed config;
+    // FastEmbedEmbedder is responsible for applying its own default.
+    expect(mockEmbedderFactory.create).toHaveBeenCalledWith(
+      "fastembed",
+      expect.objectContaining({ model: undefined }),
+    );
   });
 
   it("handles snake_case OpenClaw config through full Memory stack", async () => {

--- a/mem0-ts/src/oss/tests/factory.unit.test.ts
+++ b/mem0-ts/src/oss/tests/factory.unit.test.ts
@@ -30,6 +30,11 @@ jest.mock("../src/embeddings/langchain", () => ({
     .fn()
     .mockImplementation((config) => ({ type: "langchain-embedder", config })),
 }));
+jest.mock("../src/embeddings/fastembed", () => ({
+  FastEmbedEmbedder: jest
+    .fn()
+    .mockImplementation((config) => ({ type: "fastembed-embedder", config })),
+}));
 jest.mock("../src/embeddings/lmstudio", () => ({
   LMStudioEmbedder: jest
     .fn()
@@ -173,6 +178,7 @@ describe("EmbedderFactory", () => {
     ["google"],
     ["gemini"],
     ["azure_openai"],
+    ["fastembed"],
     ["langchain"],
     ["lmstudio"],
   ])("creates embedder for provider '%s'", (provider) => {

--- a/mem0-ts/tsup.config.ts
+++ b/mem0-ts/tsup.config.ts
@@ -22,6 +22,7 @@ const external = [
   "@langchain/core",
   "compromise",
   "natural",
+  "fastembed",
 ];
 
 const define = {


### PR DESCRIPTION
## Linked Issue

Closes #5770

## Description

The TypeScript OSS SDK (`mem0ai/oss`) rejected `embedder.provider = "fastembed"` even though the Python SDK already supports FastEmbed (`mem0/embeddings/fastembed.py`). `EmbedderFactory.create()` fell through to `Unsupported embedder provider: fastembed`, so TypeScript OSS users could not use this local/offline embedding backend at all.

This PR adds a `FastEmbedEmbedder` to bring the TS SDK to parity with the Python provider:

- Implements `FastEmbedEmbedder` (`embed` / `embedBatch`) in `mem0-ts/src/oss/src/embeddings/fastembed.ts`, extending the `Embedder` interface. The `fastembed` package is **lazily imported** so it stays a truly optional dependency (only loaded when the provider is actually used), with a clear "not installed" message and a helpful error listing the supported models on init failure.
- Registers `"fastembed"` in `EmbedderFactory` and exports it from the OSS barrel.
- Fixes the config-merge path in `ConfigManager.mergeConfig()`: previously a model-less fastembed config (`provider: "fastembed", config: {}`) inherited OpenAI's default embedding model (`text-embedding-3-small`), which FastEmbed rejects. The merge now leaves the model `undefined` for fastembed (case-insensitive) so `FastEmbedEmbedder` applies its own default.
- Hardens initialization: the cached init promise is cleared on failure so a transient one-time model download error can retry instead of being permanently cached.
- Adds `fastembed` as an **optional** peer dependency (`peerDependenciesMeta`) and to the `tsup` externals array so it is never bundled.
- Adds documentation under `docs/` (provider page, embedders overview, `docs.json` nav, `llms.txt`).

### Note on model parity

The JavaScript `fastembed` package supports a fixed set of models via its `EmbeddingModel` enum (e.g. `fast-bge-small-en-v1.5`), not arbitrary HuggingFace names like the Python default `thenlper/gte-large`. The TS default is therefore `fast-bge-small-en-v1.5` (384 dims, FastEmbed's own documented default). This is documented in code and in the docs page.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [x] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added/updated tests (82 tests passing across the affected suites):

- `src/oss/src/tests/fastembed.test.ts` — embedder unit tests with a mocked `fastembed` module: factory registration, default model, default-when-`undefined` (the config-merge path), `modelProperties` passthrough, single/batch embedding, newline normalization, single-init caching, empty batch, init-error message, and transient-init retry.
- `src/oss/tests/config-manager.test.ts` — `mergeConfig` keeps the model `undefined` for fastembed (and honors an explicit model / provider casing), plus a `Memory` end-to-end test verifying `model: undefined` reaches the factory.
- `src/oss/tests/factory.unit.test.ts` — registers `fastembed` in the provider dispatch matrix.
- `src/oss/tests/tsup-externals.test.ts` (existing drift-prevention test) confirms `fastembed` is externalized.

Manual end-to-end test against the real `fastembed` package (not mocked): built the OSS bundle, created the embedder via `EmbedderFactory.create("fastembed", {})`, and confirmed `embed()` returns a 384-dim plain `number[]` (default model `fast-bge-small-en-v1.5`), `embedBatch(["a","b"])` returns 2×384 vectors, and `embedBatch([])` returns `[]`. This surfaced that FastEmbed yields `Float32Array`, which is now normalized to `number[]`.

Verified locally:

- `npx jest fastembed config-manager factory tsup-externals` — 82/82 pass.
- `npx tsup` — build succeeds, type declarations generate, `fastembed` externalized.
- `pnpm install --frozen-lockfile` — lockfile in sync.
- `python scripts/check-llms-txt-coverage.py` — `docs/llms.txt` in sync.

> **Note:** the repo-wide `npx prettier --check .` Lint/Build gate currently reports pre-existing formatting drift across ~150 files unrelated to this change (also present on `main`). All files added/modified in this PR are prettier-clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed