### PR TITLE
fix(oss): truncate Phase 1 embed query to prevent token-limit crash

### DIFF
--- a/docs/changelog/sdk.mdx
+++ b/docs/changelog/sdk.mdx
@@ -10,6 +10,7 @@ mode: "wide"
 <Update label="2026-06-24" description="v2.0.9">
 
 **Bug Fixes:**
+- **Core:** Truncate Phase 1 retrieval embed input to avoid 8192-token crashes on long conversations in `add()` ([#5865](https://github.com/mem0ai/mem0/pull/5865))
 - **Memory (OSS):** Improve entity extraction precision by avoiding sentence-start common noun noise, preserving useful topic phrases, and exact-deduplicating entity links before semantic matching ([#5829](https://github.com/mem0ai/mem0/pull/5829))
 
 </Update>
@@ -1073,6 +1074,7 @@ See the [OSS v1 to v2 migration guide](https://docs.mem0.ai/migration/oss-v1-to-
 <Update label="2026-06-24" description="v3.0.11">
 
 **Bug Fixes:**
+- **Memory (OSS):** Truncate Phase 1 retrieval embed input to avoid token-limit crashes on long conversations in `add()` ([#5865](https://github.com/mem0ai/mem0/pull/5865))
 - **Memory (OSS):** Align entity extraction with Python by reducing generic entity noise, preserving useful topic phrases, and exact-deduplicating entity links before semantic matching ([#5829](https://github.com/mem0ai/mem0/pull/5829))
 
 </Update>

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -39,6 +39,10 @@ import {
   UpdateProjectOptions,
 } from "./memory.types";
 import { parse_vision_messages } from "../utils/memory";
+import {
+  DEFAULT_EMBED_TOKEN_LIMIT,
+  truncateTextToTokenLimit,
+} from "../utils/embed_text";
 import { HistoryManager } from "../storage/base";
 import { captureClientEvent } from "../utils/telemetry";
 import {
@@ -810,7 +814,17 @@ export class Memory {
       .join("\n");
 
     // Phase 1: Existing memory retrieval
-    const queryEmbedding = await this.embedder.embed(parsedMessages);
+    const embedQuery = truncateTextToTokenLimit(
+      parsedMessages,
+      DEFAULT_EMBED_TOKEN_LIMIT,
+    );
+    if (embedQuery !== parsedMessages && embedQuery.length < parsedMessages.length) {
+      console.warn(
+        `Conversation text exceeds embedding token limit (~${DEFAULT_EMBED_TOKEN_LIMIT} tokens); ` +
+          "truncating Phase 1 retrieval query. Fact extraction still uses the full conversation.",
+      );
+    }
+    const queryEmbedding = await this.embedder.embed(embedQuery);
     const existingResults = await this.vectorStore.search(
       queryEmbedding,
       10,

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -818,7 +818,10 @@ export class Memory {
       parsedMessages,
       DEFAULT_EMBED_TOKEN_LIMIT,
     );
-    if (embedQuery !== parsedMessages && embedQuery.length < parsedMessages.length) {
+    if (
+      embedQuery !== parsedMessages &&
+      embedQuery.length < parsedMessages.length
+    ) {
       console.warn(
         `Conversation text exceeds embedding token limit (~${DEFAULT_EMBED_TOKEN_LIMIT} tokens); ` +
           "truncating Phase 1 retrieval query. Fact extraction still uses the full conversation.",

--- a/mem0-ts/src/oss/src/utils/embed_text.ts
+++ b/mem0-ts/src/oss/src/utils/embed_text.ts
@@ -1,0 +1,21 @@
+/** Conservative ceiling for OpenAI embedding models (8192 hard cap). */
+export const DEFAULT_EMBED_TOKEN_LIMIT = 8000;
+
+/**
+ * Truncate text so it stays under an embedding model's token budget.
+ * Uses a conservative ~4 chars/token heuristic (no tiktoken dependency in TS).
+ */
+export function truncateTextToTokenLimit(
+  text: string,
+  maxTokens: number = DEFAULT_EMBED_TOKEN_LIMIT,
+): string {
+  if (!text) {
+    return text;
+  }
+
+  const charBudget = maxTokens * 4;
+  if (text.length <= charBudget) {
+    return text;
+  }
+  return text.slice(0, charBudget);
+}

--- a/mem0-ts/src/oss/tests/embed_text.test.ts
+++ b/mem0-ts/src/oss/tests/embed_text.test.ts
@@ -1,0 +1,18 @@
+/// <reference types="jest" />
+import {
+  DEFAULT_EMBED_TOKEN_LIMIT,
+  truncateTextToTokenLimit,
+} from "../src/utils/embed_text";
+
+describe("truncateTextToTokenLimit", () => {
+  it("returns short text unchanged", () => {
+    const text = "user: hello\n";
+    expect(truncateTextToTokenLimit(text)).toBe(text);
+  });
+
+  it("truncates long text using char budget", () => {
+    const longText = "x".repeat(DEFAULT_EMBED_TOKEN_LIMIT * 4 + 100);
+    const truncated = truncateTextToTokenLimit(longText);
+    expect(truncated.length).toBe(DEFAULT_EMBED_TOKEN_LIMIT * 4);
+  });
+});

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -51,11 +51,13 @@ from mem0.memory.notices import (
     get_temporal_feature_error_message_async,
 )
 from mem0.memory.utils import (
+    DEFAULT_EMBED_TOKEN_LIMIT,
     extract_json,
     parse_messages,
     parse_vision_messages,
     process_telemetry_filters,
     remove_code_blocks,
+    truncate_text_to_token_limit,
 )
 from mem0.utils.entity_extraction import extract_entities, extract_entities_batch
 from mem0.utils.factory import (
@@ -839,9 +841,16 @@ class Memory(MemoryBase):
 
         # Phase 1: Existing memory retrieval
         search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
-        query_embedding = self.embedding_model.embed(parsed_messages, "search")
+        embed_query = truncate_text_to_token_limit(parsed_messages, DEFAULT_EMBED_TOKEN_LIMIT)
+        if embed_query is not parsed_messages and len(embed_query) < len(parsed_messages):
+            logger.warning(
+                "Conversation text exceeds embedding token limit (~%d tokens); "
+                "truncating Phase 1 retrieval query. Fact extraction still uses the full conversation.",
+                DEFAULT_EMBED_TOKEN_LIMIT,
+            )
+        query_embedding = self.embedding_model.embed(embed_query, "search")
         existing_results = self.vector_store.search(
-            query=parsed_messages,
+            query=embed_query,
             vectors=query_embedding,
             top_k=10,
             filters=search_filters,
@@ -2415,10 +2424,17 @@ class AsyncMemory(MemoryBase):
 
         # Phase 1: Existing memory retrieval
         search_filters = {k: v for k, v in effective_filters.items() if k in ("user_id", "agent_id", "run_id") and v}
-        query_embedding = await asyncio.to_thread(self.embedding_model.embed, parsed_messages, "search")
+        embed_query = truncate_text_to_token_limit(parsed_messages, DEFAULT_EMBED_TOKEN_LIMIT)
+        if embed_query is not parsed_messages and len(embed_query) < len(parsed_messages):
+            logger.warning(
+                "Conversation text exceeds embedding token limit (~%d tokens); "
+                "truncating Phase 1 retrieval query. Fact extraction still uses the full conversation.",
+                DEFAULT_EMBED_TOKEN_LIMIT,
+            )
+        query_embedding = await asyncio.to_thread(self.embedding_model.embed, embed_query, "search")
         existing_results = await asyncio.to_thread(
             self.vector_store.search,
-            query=parsed_messages,
+            query=embed_query,
             vectors=query_embedding,
             top_k=10,
             filters=search_filters,

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -76,6 +76,46 @@ def parse_messages(messages):
     return response
 
 
+# Conservative ceiling that fits every current OpenAI embedding model
+# (text-embedding-3-small/large and ada-002 all top out at 8192 tokens).
+DEFAULT_EMBED_TOKEN_LIMIT = 8000
+
+
+def truncate_text_to_token_limit(text: str, max_tokens: int = DEFAULT_EMBED_TOKEN_LIMIT) -> str:
+    """Truncate ``text`` so its tokenized length does not exceed ``max_tokens``.
+
+    Used before passing concatenated conversation text to an embedding model in
+    ``Memory.add()`` Phase 1. Sending more than the model limit raises a 400
+    error and fails the entire add() call before extraction (issue #5148).
+
+    Prefers ``tiktoken`` when available (transitive via the OpenAI SDK) and
+    falls back to a conservative ~4 chars/token heuristic.
+    """
+    if not text:
+        return text
+
+    try:
+        import tiktoken  # type: ignore
+
+        try:
+            encoding = tiktoken.get_encoding("cl100k_base")
+        except Exception:  # pragma: no cover - narrow tiktoken init failure
+            encoding = None
+
+        if encoding is not None:
+            tokens = encoding.encode(text)
+            if len(tokens) <= max_tokens:
+                return text
+            return encoding.decode(tokens[:max_tokens])
+    except ImportError:
+        pass
+
+    char_budget = max_tokens * 4
+    if len(text) <= char_budget:
+        return text
+    return text[:char_budget]
+
+
 def format_entities(entities):
     if not entities:
         return ""

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -219,6 +219,97 @@ class TestAsyncAddToVectorStoreErrors:
         assert mock_async_memory.llm.generate_response.call_count == 1
 
 
+class TestLongConversationPhase1Embed:
+    """Regression tests for issue #5148."""
+
+    @pytest.fixture
+    def mock_memory(self, mocker):
+        mock_llm, _ = _setup_mocks(mocker)
+        mock_llm.return_value.generate_response.return_value = (
+            '{"memory": [{"text": "user is planning a trip to Japan"}]}'
+        )
+
+        memory = Memory()
+        memory.config = mocker.MagicMock()
+        memory.config.custom_instructions = None
+        memory.config.custom_update_memory_prompt = None
+        memory.custom_instructions = None
+        memory.api_version = "v1.1"
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        memory.db.batch_add_history = MagicMock()
+        return memory
+
+    @staticmethod
+    def _make_long_messages(num_turns: int = 400):
+        filler = (
+            "I've been thinking through a bunch of unrelated topics today including "
+            "Japan travel plans, my current side project in Rust, dinner ideas, "
+            "and a tricky bug at work involving Kafka consumer rebalancing."
+        )
+        messages = []
+        for i in range(num_turns):
+            messages.append({"role": "user", "content": f"Turn {i} (user): {filler}"})
+            messages.append({"role": "assistant", "content": f"Turn {i} (assistant): {filler}"})
+        return messages
+
+    def test_long_conversation_does_not_crash_phase1_embed(self, mock_memory, caplog):
+        embed_calls = []
+
+        def _record_embed(text, mode):
+            embed_calls.append((text, mode))
+            if mode == "search" and len(text) > 8192 * 5:
+                raise RuntimeError("Embedding input exceeds model token limit")
+            return [0.1, 0.2, 0.3]
+
+        mock_memory.embedding_model = Mock()
+        mock_memory.embedding_model.embed = Mock(side_effect=_record_embed)
+        mock_memory.embedding_model.embed_batch = Mock(return_value=[[0.1, 0.2, 0.3]])
+        mock_memory.vector_store = Mock()
+        mock_memory.vector_store.search = Mock(return_value=[])
+        mock_memory.vector_store.insert = Mock()
+
+        with caplog.at_level(logging.WARNING):
+            result = mock_memory._add_to_vector_store(
+                messages=self._make_long_messages(),
+                metadata={},
+                filters={"user_id": "u1"},
+                infer=True,
+            )
+
+        search_embed_calls = [c for c in embed_calls if c[1] == "search"]
+        assert len(search_embed_calls) == 1
+        assert len(search_embed_calls[0][0]) <= 8192 * 5
+        assert any(item.get("memory") == "user is planning a trip to Japan" for item in result)
+        assert any("embedding token limit" in record.message.lower() for record in caplog.records)
+
+    def test_short_conversation_is_not_truncated(self, mock_memory, caplog):
+        embed_calls = []
+
+        def _record_embed(text, mode):
+            embed_calls.append((text, mode))
+            return [0.1, 0.2, 0.3]
+
+        mock_memory.embedding_model = Mock()
+        mock_memory.embedding_model.embed = Mock(side_effect=_record_embed)
+        mock_memory.embedding_model.embed_batch = Mock(return_value=[[0.1, 0.2, 0.3]])
+        mock_memory.vector_store = Mock()
+        mock_memory.vector_store.search = Mock(return_value=[])
+        mock_memory.vector_store.insert = Mock()
+
+        with caplog.at_level(logging.WARNING):
+            mock_memory._add_to_vector_store(
+                messages=[{"role": "user", "content": "Hello, I love sushi."}],
+                metadata={},
+                filters={"user_id": "u1"},
+                infer=True,
+            )
+
+        search_embed_calls = [c for c in embed_calls if c[1] == "search"]
+        assert "Hello, I love sushi." in search_embed_calls[0][0]
+        assert not any("embedding token limit" in record.message.lower() for record in caplog.records)
+
+
 def _build_memory_instance(mocker, memory_cls):
     _setup_mocks(mocker)
     mocker.patch("mem0.memory.main.SQLiteManager", mocker.MagicMock())

--- a/tests/memory/test_memory_utils.py
+++ b/tests/memory/test_memory_utils.py
@@ -2,10 +2,12 @@ import pytest
 from unittest.mock import Mock
 
 from mem0.memory.utils import (
+    DEFAULT_EMBED_TOKEN_LIMIT,
     parse_messages,
     parse_vision_messages,
     remove_spaces_from_entities,
     sanitize_relationship_for_cypher,
+    truncate_text_to_token_limit,
 )
 
 
@@ -168,3 +170,32 @@ class TestRemoveSpacesFromEntities:
         f = remove_spaces_from_entities([dict(base)], sanitize_relationship=False)[0]["relationship"]
         assert t == sanitize_relationship_for_cypher("a/b")
         assert f == "a/b"
+
+
+class TestTruncateTextToTokenLimit:
+    def test_no_op_for_short_text(self):
+        text = "user: hello\n"
+        assert truncate_text_to_token_limit(text) is text
+
+    def test_truncates_beyond_budget(self):
+        long_text = "word " * (DEFAULT_EMBED_TOKEN_LIMIT + 100)
+        truncated = truncate_text_to_token_limit(long_text)
+        try:
+            import tiktoken
+
+            encoding = tiktoken.get_encoding("cl100k_base")
+            assert len(encoding.encode(truncated)) <= DEFAULT_EMBED_TOKEN_LIMIT
+        except ImportError:
+            assert len(truncated) <= DEFAULT_EMBED_TOKEN_LIMIT * 4
+        assert truncated != long_text
+
+    def test_tiktoken_path_when_available(self):
+        try:
+            import tiktoken
+        except ImportError:
+            pytest.skip("tiktoken not installed")
+
+        encoding = tiktoken.get_encoding("cl100k_base")
+        long_text = "word " * (DEFAULT_EMBED_TOKEN_LIMIT + 50)
+        truncated = truncate_text_to_token_limit(long_text)
+        assert len(encoding.encode(truncated)) <= DEFAULT_EMBED_TOKEN_LIMIT


### PR DESCRIPTION
## Linked Issue

Closes #5148

## Description

`Memory.add()` Phase 1 embeds the full concatenated conversation to search for existing memories. Conversations beyond the embedding model's ~8192-token limit raise a 400 error and fail the entire `add()` before any fact extraction runs.

**Fix:** truncate the Phase 1 retrieval query to a conservative 8000-token budget before embedding. Phase 2 LLM extraction still receives the full conversation.

Implemented in:
- Python sync + async `_add_to_vector_store` via `truncate_text_to_token_limit()` (tiktoken when available, char heuristic fallback)
- TypeScript OSS `addToVectorStore` via `truncateTextToTokenLimit()`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added:
- `tests/memory/test_memory_utils.py::TestTruncateTextToTokenLimit`
- `tests/memory/test_main.py::TestLongConversationPhase1Embed` (long + short conversation)
- `mem0-ts/src/oss/tests/embed_text.test.ts`

Local: `pytest tests/memory/test_memory_utils.py::TestTruncateTextToTokenLimit tests/memory/test_main.py::TestLongConversationPhase1Embed` (5 passed); `pnpm run test:unit -- embed_text.test.ts` (2 passed)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed