### PR TITLE
fix: remove unnecessary deepcopy in Memory.__init__ telemetry block

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -457,7 +457,6 @@ class Memory(MemoryBase):
             telemetry_config_dict['collection_name'] = "mem0migrations"
 
             # Set path for file-based vector stores
-            telemetry_config = _safe_deepcopy_config(self.config.vector_store.config)
             if self.config.vector_store.provider in ["faiss", "qdrant"]:
                 provider_path = f"migrations_{self.config.vector_store.provider}"
                 telemetry_config_dict['path'] = os.path.join(mem0_dir, provider_path)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1534,11 +1534,12 @@ async def test_async_procedural_memory_langchain_strips_code_blocks(mock_llm_fac
 @patch('mem0.utils.factory.EmbedderFactory.create')
 @patch('mem0.utils.factory.VectorStoreFactory.create')
 @patch('mem0.utils.factory.LlmFactory.create')
-@patch('mem0.memory.storage.SQLiteManager')
+@patch('mem0.memory.main.SQLiteManager')
 @patch('mem0.memory.main.MEM0_TELEMETRY', True)
 @patch('mem0.memory.main._safe_deepcopy_config')
+@patch('mem0.memory.main.os.makedirs')
 def test_memory_init_does_not_call_safe_deepcopy_config_for_telemetry(
-    mock_safe_deepcopy, mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+    mock_makedirs, mock_safe_deepcopy, mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
 ):
     """Regression #5871: Memory.__init__ should not call _safe_deepcopy_config in the telemetry block.
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1529,3 +1529,28 @@ async def test_async_procedural_memory_langchain_strips_code_blocks(mock_llm_fac
     insert_call = memory.vector_store.insert.call_args
     stored_data = insert_call[1]["payloads"][0]["data"]
     assert "```" not in stored_data
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+@patch('mem0.memory.main.MEM0_TELEMETRY', True)
+@patch('mem0.memory.main._safe_deepcopy_config')
+def test_memory_init_does_not_call_safe_deepcopy_config_for_telemetry(
+    mock_safe_deepcopy, mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    """Regression #5871: Memory.__init__ should not call _safe_deepcopy_config in the telemetry block.
+
+    The dict-based approach builds the config directly, making the deepcopy call dead code.
+    """
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    config = MemoryConfig()
+    Memory(config)
+
+    # _safe_deepcopy_config should NOT be called during __init__ for telemetry config
+    mock_safe_deepcopy.assert_not_called()


### PR DESCRIPTION
## Summary

Remove dead `_safe_deepcopy_config()` call in `Memory.__init__` that was immediately overwritten by dict-based config construction.

## Problem

`Memory.__init__` calls `_safe_deepcopy_config(self.config.vector_store.config)` inside the telemetry block and assigns the result to `telemetry_config`. The very next assignment overwrites that variable entirely with a dict-based constructor call, making the deepcopy completely dead — it allocates a full copy of the config object on every `Memory()` instantiation and discards it immediately.

The block comment directly above the telemetry block reads *"Create telemetry config manually to avoid deepcopy issues with thread locks"*, confirming the dict-based approach was a deliberate replacement for deepcopy. The old call was left behind by mistake.

## Fix

Remove the unnecessary `_safe_deepcopy_config()` call on line 460 of `mem0/memory/main.py`. The dict-based approach that follows builds the config correctly without it.

## Testing

Added regression test `test_memory_init_does_not_call_safe_deepcopy_config_for_telemetry` that verifies `_safe_deepcopy_config` is not called during `Memory.__init__` when telemetry is enabled.

Fixes #5871