### PR TITLE
fix(memory): re-raise LLM extraction failures instead of returning [] (salvage of #5178)

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -22,6 +22,7 @@ from mem0.configs.prompts import (
     PROCEDURAL_MEMORY_SYSTEM_PROMPT,
     generate_additive_extraction_prompt,
 )
+from mem0.exceptions import LLMError
 from mem0.exceptions import ValidationError as Mem0ValidationError
 from mem0.memory.base import MemoryBase
 from mem0.memory.setup import mem0_dir, setup_config
@@ -917,7 +918,7 @@ class Memory(MemoryBase):
             # distinguish "LLM unavailable" (429/5xx/timeout) from "LLM
             # extracted no facts" -- both surfaced as an empty list.
             logger.error(f"LLM extraction failed: {e}")
-            raise
+            raise LLMError(f"LLM extraction failed: {e}") from e
 
         # Parse response
         try:
@@ -2543,7 +2544,7 @@ class AsyncMemory(MemoryBase):
             # Re-raise so callers can implement provider fallback / retry
             # (see sync counterpart for rationale).
             logger.error(f"LLM extraction failed (async): {e}")
-            raise
+            raise LLMError(f"LLM extraction failed: {e}") from e
 
         # Parse response
         try:

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -912,8 +912,12 @@ class Memory(MemoryBase):
                 response_format={"type": "json_object"},
             )
         except Exception as e:
+            # Re-raise so callers can implement provider fallback / retry.
+            # The original silent ``return []`` made upstream callers unable to
+            # distinguish "LLM unavailable" (429/5xx/timeout) from "LLM
+            # extracted no facts" -- both surfaced as an empty list.
             logger.error(f"LLM extraction failed: {e}")
-            return []
+            raise
 
         # Parse response
         try:
@@ -2536,8 +2540,10 @@ class AsyncMemory(MemoryBase):
                 response_format={"type": "json_object"},
             )
         except Exception as e:
+            # Re-raise so callers can implement provider fallback / retry
+            # (see sync counterpart for rationale).
             logger.error(f"LLM extraction failed (async): {e}")
-            return []
+            raise
 
         # Parse response
         try:

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -79,6 +79,25 @@ class TestAddToVectorStoreErrors:
         assert mock_memory.llm.generate_response.call_count == 1
         assert result == []  # Should return empty list when no memories processed
 
+    def test_llm_extraction_exception_is_reraised(self, mocker, mock_memory):
+        """A provider error during fact extraction must propagate, not be swallowed.
+
+        Regression guard for the silent ``return []`` that made it impossible for
+        callers to tell "LLM unavailable" (429/5xx/timeout) from "no facts found".
+        Without the fix this raises AssertionError because the call returns [].
+        """
+
+        class _ProviderError(Exception):
+            pass
+
+        mock_memory.llm.generate_response.side_effect = _ProviderError("429 rate limit")
+        mocker.patch("mem0.memory.main.capture_event")
+
+        with pytest.raises(_ProviderError):
+            mock_memory._add_to_vector_store(
+                messages=[{"role": "user", "content": "test"}], metadata={}, filters={}, infer=True
+            )
+
 
 class TestPromptOverridesCustomInstructions:
     @pytest.fixture

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, Mock
 
 import pytest
 
+from mem0.exceptions import LLMError
 from mem0.memory.main import AsyncMemory, Memory
 
 
@@ -93,10 +94,13 @@ class TestAddToVectorStoreErrors:
         mock_memory.llm.generate_response.side_effect = _ProviderError("429 rate limit")
         mocker.patch("mem0.memory.main.capture_event")
 
-        with pytest.raises(_ProviderError):
+        with pytest.raises(LLMError) as exc_info:
             mock_memory._add_to_vector_store(
                 messages=[{"role": "user", "content": "test"}], metadata={}, filters={}, infer=True
             )
+        # The documented LLMError contract is honoured, and the original
+        # provider exception is preserved as the cause for debugging.
+        assert isinstance(exc_info.value.__cause__, _ProviderError)
 
 
 class TestPromptOverridesCustomInstructions:
@@ -263,6 +267,29 @@ class TestAsyncAddToVectorStoreErrors:
 
         assert result == []
         assert mock_async_memory.llm.generate_response.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_async_llm_extraction_exception_is_reraised(self, mock_async_memory, mocker):
+        """Async counterpart of the sync re-raise guard.
+
+        A provider error during fact extraction must propagate as ``LLMError``
+        (with the original exception preserved as the cause), not be swallowed
+        into ``return []``. Without the fix a future revert of the async
+        ``raise`` back to ``return []`` would pass the suite silently.
+        """
+        mocker.patch("mem0.utils.factory.EmbedderFactory.create", return_value=MagicMock())
+
+        class _ProviderError(Exception):
+            pass
+
+        mock_async_memory.llm.generate_response.side_effect = _ProviderError("429 rate limit")
+        mocker.patch("mem0.memory.main.capture_event")
+
+        with pytest.raises(LLMError) as exc_info:
+            await mock_async_memory._add_to_vector_store(
+                messages=[{"role": "user", "content": "test"}], metadata={}, effective_filters={}, infer=True
+            )
+        assert isinstance(exc_info.value.__cause__, _ProviderError)
 
 
 def _build_memory_instance(mocker, memory_cls):


### PR DESCRIPTION
Salvage of #5178 by @thalesfsp — rebased onto current main with a regression guardrail test added.

## Summary

Re-raise provider errors during fact extraction instead of swallowing them and returning `[]`.

## Root Cause

**Symptom** — When the LLM call in `_add_to_vector_store` fails (HTTP 429, 5xx, connection error, timeout), `add()` silently returns an empty result. Callers cannot tell "LLM was unavailable" from "LLM ran fine and extracted no facts" — both look like `[]`.

**Root cause** — Both the sync `Memory._add_to_vector_store` and async `AsyncMemory._add_to_vector_store` wrap `self.llm.generate_response(...)` in a bare `except Exception` that logs and `return []`. The exception is destroyed at the point it occurs, so no signal reaches the caller.

**Evidence** — `mem0/memory/main.py`: the sync path (`logger.error("LLM extraction failed: {e}"); return []`) and the async path (`... (async): {e}"); return []`). Confirmed present on current `main` (`0fbbb2f`). The new regression test below fails on unmodified main (the call returns `[]`, no exception) and passes with the fix.

**Fix + why this level** — Replace `return []` with `raise` in both extraction error handlers, keeping the existing `logger.error`. This is the correct layer: extraction is where provider transport errors first surface, and re-raising lets any wrapping retry/fallback layer (e.g. a multi-provider failover) distinguish transport failure from an empty extraction. Patching a downstream caller can't recover information already discarded here. Parse errors further down still return `[]` (that genuinely means "no usable facts"), so only true provider exceptions propagate.

**Scope / risk** — Touches only the two extraction `except` blocks. Behavior change: an `add()` that previously returned `[]` on a provider outage now raises. This is the intended, documented contract change; callers relying on the silent-swallow behavior should wrap in try/except. Parse-error and empty-response handling is unchanged.

## Why it needed salvage

The original #5178 was conflicting against current main after pipeline refactors. Re-applied cleanly onto current `main` and added a guardrail test the original lacked.

## Changes from original
- Rebased onto current `main` (single clean commit, authorship credited).
- Added `test_llm_extraction_exception_is_reraised` — asserts a provider error propagates; **fails without the fix** (returns `[]`), passes with it.

## Verification / Real behavior proof

```
$ python -m pytest tests/memory/test_main.py::TestAddToVectorStoreErrors -q
...                                                                      [100%]
3 passed in 0.49s

# Without the fix (main.py reverted), the new test fails as expected:
ERROR    mem0.memory.main:main.py:915 LLM extraction failed: 429 rate limit
FAILED tests/memory/test_main.py::...::test_llm_extraction_exception_is_reraised
1 failed
```
`ruff check` clean. Full `tests/memory/test_main.py` suite (46 tests) passes.

Credit: salvage of #5178 by @thalesfsp.
