### PR TITLE
fix(llms/aws_bedrock): route profile_name through Session, not client kwarg (salvage of #5039)

### DIFF
--- a/mem0/llms/aws_bedrock.py
+++ b/mem0/llms/aws_bedrock.py
@@ -103,7 +103,7 @@ class AWSBedrockLLM(LLMBase):
                 raise ValueError(f"AWS Bedrock error: {e}")
 
     @staticmethod
-    def _build_client(service_name, aws_config):
+    def _build_client(service_name: str, aws_config: Dict[str, Any]) -> Any:
         """Build a boto3 client, routing `profile_name` through Session().
 
         boto3.client() rejects `profile_name`; only boto3.Session() accepts it.

--- a/mem0/llms/aws_bedrock.py
+++ b/mem0/llms/aws_bedrock.py
@@ -79,8 +79,10 @@ class AWSBedrockLLM(LLMBase):
         try:
             aws_config = self.config.get_aws_config()
 
-            # Create Bedrock runtime client
-            self.client = boto3.client("bedrock-runtime", **aws_config)
+            # Create Bedrock runtime client. boto3.client() does NOT accept
+            # `profile_name` as a kwarg -- only boto3.Session() does. If
+            # `profile_name` is present in aws_config, build a Session first.
+            self.client = self._build_client("bedrock-runtime", aws_config)
 
             # Test connection
             self._test_connection()
@@ -100,11 +102,24 @@ class AWSBedrockLLM(LLMBase):
             else:
                 raise ValueError(f"AWS Bedrock error: {e}")
 
+    @staticmethod
+    def _build_client(service_name, aws_config):
+        """Build a boto3 client, routing `profile_name` through Session().
+
+        boto3.client() rejects `profile_name`; only boto3.Session() accepts it.
+        """
+        cfg = dict(aws_config)
+        profile_name = cfg.pop("profile_name", None)
+        if profile_name:
+            session = boto3.Session(profile_name=profile_name)
+            return session.client(service_name, **cfg)
+        return boto3.client(service_name, **cfg)
+
     def _test_connection(self):
         """Test connection to AWS Bedrock service."""
         try:
             # List available models to test connection
-            bedrock_client = boto3.client("bedrock", **self.config.get_aws_config())
+            bedrock_client = self._build_client("bedrock", self.config.get_aws_config())
             response = bedrock_client.list_foundation_models()
             self.available_models = [model["modelId"] for model in response["modelSummaries"]]
 
@@ -648,7 +663,7 @@ class AWSBedrockLLM(LLMBase):
     def list_available_models(self) -> List[Dict[str, Any]]:
         """List all available models in the current region."""
         try:
-            bedrock_client = boto3.client("bedrock", **self.config.get_aws_config())
+            bedrock_client = self._build_client("bedrock", self.config.get_aws_config())
             response = bedrock_client.list_foundation_models()
 
             models = []

--- a/mem0/llms/aws_bedrock.py
+++ b/mem0/llms/aws_bedrock.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional, Union
 
 try:
     import boto3
-    from botocore.exceptions import ClientError, NoCredentialsError
+    from botocore.exceptions import ClientError, NoCredentialsError, ProfileNotFound
 except ImportError:
     raise ImportError("The 'boto3' library is required. Please install it using 'pip install boto3'.")
 
@@ -79,9 +79,7 @@ class AWSBedrockLLM(LLMBase):
         try:
             aws_config = self.config.get_aws_config()
 
-            # Create Bedrock runtime client. boto3.client() does NOT accept
-            # `profile_name` as a kwarg -- only boto3.Session() does. If
-            # `profile_name` is present in aws_config, build a Session first.
+            # see _build_client: profile_name routes through Session, not client().
             self.client = self._build_client("bedrock-runtime", aws_config)
 
             # Test connection
@@ -92,6 +90,11 @@ class AWSBedrockLLM(LLMBase):
                 "AWS credentials not found. Please set AWS_ACCESS_KEY_ID, "
                 "AWS_SECRET_ACCESS_KEY, and AWS_REGION environment variables, "
                 "or provide them in the config."
+            )
+        except ProfileNotFound as e:
+            raise ValueError(
+                f"AWS profile not found: {e}. Please check aws_profile / AWS_PROFILE "
+                "or provide explicit credentials in the config."
             )
         except ClientError as e:
             if e.response["Error"]["Code"] == "UnauthorizedOperation":

--- a/tests/llms/test_aws_bedrock.py
+++ b/tests/llms/test_aws_bedrock.py
@@ -493,6 +493,8 @@ class TestProfileNameRouting:
             # Session built with the profile; client created from the session.
             mock_b3.Session.assert_any_call(profile_name="my-sso-profile")
             session.client.assert_any_call("bedrock-runtime", region_name=config.aws_region)
+            # _test_connection reaches the `bedrock` service through the same Session.
+            session.client.assert_any_call("bedrock", region_name=config.aws_region)
             # profile_name must NOT be forwarded as a client kwarg (boto3 rejects it).
             for call in session.client.call_args_list:
                 assert "profile_name" not in call.kwargs

--- a/tests/llms/test_aws_bedrock.py
+++ b/tests/llms/test_aws_bedrock.py
@@ -452,3 +452,49 @@ class TestParseResponseLegacy:
         response = {"body": body}
         result = llm._parse_response(response, tools=None)
         assert result == "hello from ai21"
+
+
+# ---------------------------------------------------------------------------
+# profile_name routing
+#
+# AWSBedrockConfig.get_aws_config() includes `profile_name` when aws_profile is
+# set. boto3.client() rejects that kwarg -- only boto3.Session() accepts it.
+# Verify construction is routed accordingly.
+# ---------------------------------------------------------------------------
+
+class TestProfileNameRouting:
+    def test_no_profile_uses_boto3_client_directly(self):
+        with patch("mem0.llms.aws_bedrock.boto3") as mock_b3:
+            runtime_client = MagicMock()
+            bedrock_client = MagicMock()
+            bedrock_client.list_foundation_models.return_value = {"modelSummaries": []}
+            mock_b3.client.side_effect = lambda service, **_: (
+                runtime_client if service == "bedrock-runtime" else bedrock_client
+            )
+            config = AWSBedrockConfig(model="anthropic.claude-3-sonnet-20240229-v1:0")
+            AWSBedrockLLM(config)
+            mock_b3.client.assert_any_call("bedrock-runtime", region_name=config.aws_region)
+            mock_b3.Session.assert_not_called()
+
+    def test_profile_routes_through_session(self):
+        with patch("mem0.llms.aws_bedrock.boto3") as mock_b3:
+            runtime_client = MagicMock()
+            bedrock_client = MagicMock()
+            bedrock_client.list_foundation_models.return_value = {"modelSummaries": []}
+            session = MagicMock()
+            session.client.side_effect = lambda service, **_: (
+                runtime_client if service == "bedrock-runtime" else bedrock_client
+            )
+            mock_b3.Session.return_value = session
+            config = AWSBedrockConfig(
+                model="anthropic.claude-3-sonnet-20240229-v1:0", aws_profile="my-sso-profile"
+            )
+            AWSBedrockLLM(config)
+            # Session built with the profile; client created from the session.
+            mock_b3.Session.assert_any_call(profile_name="my-sso-profile")
+            session.client.assert_any_call("bedrock-runtime", region_name=config.aws_region)
+            # profile_name must NOT be forwarded as a client kwarg (boto3 rejects it).
+            for call in session.client.call_args_list:
+                assert "profile_name" not in call.kwargs
+            for call in mock_b3.client.call_args_list:
+                assert "profile_name" not in call.kwargs

--- a/tests/llms/test_aws_bedrock.py
+++ b/tests/llms/test_aws_bedrock.py
@@ -500,3 +500,50 @@ class TestProfileNameRouting:
                 assert "profile_name" not in call.kwargs
             for call in mock_b3.client.call_args_list:
                 assert "profile_name" not in call.kwargs
+
+    def test_profile_with_explicit_creds_passes_overrides(self):
+        """aws_profile + explicit keys: Session gets profile; client gets creds."""
+        with patch("mem0.llms.aws_bedrock.boto3") as mock_b3:
+            runtime_client = MagicMock()
+            bedrock_client = MagicMock()
+            bedrock_client.list_foundation_models.return_value = {"modelSummaries": []}
+            session = MagicMock()
+            session.client.side_effect = lambda service, **_: (
+                runtime_client if service == "bedrock-runtime" else bedrock_client
+            )
+            mock_b3.Session.return_value = session
+            config = AWSBedrockConfig(
+                model="anthropic.claude-3-sonnet-20240229-v1:0",
+                aws_profile="my-sso-profile",
+                aws_access_key_id="AKIATEST",
+                aws_secret_access_key="secret",
+                aws_session_token="token",
+            )
+            AWSBedrockLLM(config)
+            mock_b3.Session.assert_any_call(profile_name="my-sso-profile")
+            # Explicit creds must reach session.client as kwargs (overrides).
+            session.client.assert_any_call(
+                "bedrock-runtime",
+                region_name=config.aws_region,
+                aws_access_key_id="AKIATEST",
+                aws_secret_access_key="secret",
+                aws_session_token="token",
+            )
+            for call in session.client.call_args_list:
+                assert "profile_name" not in call.kwargs
+
+    def test_invalid_profile_raises_value_error(self):
+        """ProfileNotFound from Session must be wrapped as ValueError."""
+        from botocore.exceptions import ProfileNotFound
+
+        with patch("mem0.llms.aws_bedrock.boto3") as mock_b3:
+            mock_b3.Session.side_effect = ProfileNotFound(profile="missing-profile")
+            config = AWSBedrockConfig(
+                model="anthropic.claude-3-sonnet-20240229-v1:0",
+                aws_profile="missing-profile",
+            )
+            try:
+                AWSBedrockLLM(config)
+                assert False, "expected ValueError"
+            except ValueError as e:
+                assert "profile" in str(e).lower()


### PR DESCRIPTION
Salvage of #5039 by @gaxunil — rebased onto current main with the original guardrail tests preserved.

## Summary

Route `profile_name` through `boto3.Session()` instead of passing it as a `boto3.client()` kwarg, so AWS Bedrock works with SSO/profile-based auth.

## Root Cause

**Symptom** — Setting `aws_profile` (SSO-based auth) on the Bedrock LLM/config crashes client init: `boto3.client("bedrock-runtime", profile_name=...)` raises because `profile_name` is not a valid client kwarg.

**Root cause** — `AWSBedrockConfig.get_aws_config()` (mem0/configs/llms/aws_bedrock.py:109-110) adds `config["profile_name"] = self.aws_profile` when `aws_profile` is set. That dict is then splatted straight into `boto3.client("bedrock-runtime", **aws_config)` in `_initialize_aws_client` and into `boto3.client("bedrock", **self.config.get_aws_config())` in `_test_connection`/`list_available_models`. Only `boto3.Session(profile_name=...)` accepts `profile_name`; `boto3.client()` does not.

**Evidence** — Confirmed on current `main` (`0fbbb2f`): `get_aws_config()` still emits `profile_name`, and all three client construction sites still call `boto3.client(..., **aws_config)` directly. The new regression test (`test_profile_routes_through_session`) fails on unmodified main.

**Fix + why this level** — Add a `_build_client(service, aws_config)` static helper that pops `profile_name` and, when present, builds a `boto3.Session(profile_name=...)` and calls `session.client(service, **rest)`; otherwise falls back to `boto3.client`. Route all three construction sites through it. This fixes the issue at the construction boundary (where `profile_name` must be split out), rather than mutating `get_aws_config()` (which legitimately models the profile) or special-casing each call site.

**Scope / risk** — Touches only `mem0/llms/aws_bedrock.py` client construction. No-profile path is byte-for-byte equivalent to before (`boto3.client(service, **cfg)` with no `profile_name`). No public API change.

## Why it needed salvage
Original #5039 conflicted against current main. Re-applied cleanly; kept the original profile-routing tests.

## Changes from original
- Rebased onto current `main` (single clean commit, authorship credited to @gaxunil).
- Guardrail tests assert (a) no-profile uses `boto3.client` directly and (b) profile routes through `boto3.Session` and `profile_name` is never forwarded as a client kwarg. **Fails without the fix.**

## Verification / Real behavior proof
```
$ python -m pytest tests/llms/test_aws_bedrock.py -q
...........................................                              [100%]
43 passed in 0.85s

# Without the fix:
FAILED tests/llms/test_aws_bedrock.py::TestProfileNameRouting::test_profile_routes_through_session
1 failed, 1 passed
```
`ruff check` clean.

Credit: salvage of #5039 by @gaxunil.
