### PR TITLE
fix(memory): tolerate malformed fact-extraction shapes from LLMs (salvage of #5176)

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -53,6 +53,7 @@ from mem0.memory.storage import SQLiteManager
 from mem0.memory.telemetry import MEM0_TELEMETRY, capture_event
 from mem0.memory.utils import (
     extract_json,
+    normalize_extracted_memories,
     parse_messages,
     parse_vision_messages,
     process_telemetry_filters,
@@ -972,6 +973,10 @@ class Memory(MemoryBase):
         except Exception as e:
             logger.error(f"Error parsing extraction response: {e}")
             extracted_memories = []
+
+        # Tolerate malformed LLM shapes (plain strings, {fact:...}, key-as-fact
+        # dicts) before downstream code calls ``.get("text")`` on each item.
+        extracted_memories = normalize_extracted_memories(extracted_memories)
 
         if not extracted_memories:
             # Save messages even if nothing extracted
@@ -2621,6 +2626,10 @@ class AsyncMemory(MemoryBase):
         except Exception as e:
             logger.error(f"Error parsing extraction response (async): {e}")
             extracted_memories = []
+
+        # Tolerate malformed LLM shapes (plain strings, {fact:...}, key-as-fact
+        # dicts) before downstream code calls ``.get("text")`` on each item.
+        extracted_memories = normalize_extracted_memories(extracted_memories)
 
         if not extracted_memories:
             await asyncio.to_thread(self.db.save_messages, messages, session_scope)

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -93,6 +93,12 @@ def normalize_facts(raw_facts):
     Smaller LLMs (e.g. llama3.1:8b) sometimes return facts as objects
     like {"fact": "..."} or {"text": "..."} instead of plain strings.
     This mirrors the TypeScript FactRetrievalSchema validation.
+
+    NOTE: This is the FACT_RETRIEVAL-path normalizer, retained for external
+    callers and the legacy two-phase extraction flow. The current single-pass
+    additive pipeline in ``main.py`` uses ``normalize_extracted_memories``
+    (below) instead, which operates on dict-shaped ``memory`` items rather
+    than plain fact strings. Kept here so both shapes stay covered.
     """
     if not raw_facts:
         return []
@@ -146,6 +152,10 @@ def normalize_extracted_memories(raw_memories):
                 if isinstance(key, str) and key.strip():
                     text = key.strip()
                 elif isinstance(value, str) and value.strip():
+                    # Dead branch under json.loads (object keys are always
+                    # str, so the `if` above fires) — only reachable if a
+                    # caller hand-builds a dict with a non-str / empty key.
+                    # Retained defensively for that non-JSON path.
                     text = value.strip()
             if text:
                 out = dict(item)

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -112,6 +112,52 @@ def normalize_facts(raw_facts):
     return normalized
 
 
+def normalize_extracted_memories(raw_memories):
+    """Normalize LLM-extracted ``memory`` items to a list of dicts with a ``text`` key.
+
+    The additive-extraction prompt asks the LLM for objects like
+    ``{"text": "...", "attributed_to": "...", "linked_memory_ids": [...]}``,
+    but real LLMs (especially reasoning models on OpenAI-compatible APIs such
+    as grok) sometimes emit malformed shapes:
+
+    - plain string:                ``"User likes coffee"``
+    - well-formed dict:            ``{"text": "..."}`` (passed through)
+    - ``{"fact": "..."}``:         older / TS-style key
+    - single-key key-as-fact dict: ``{"User likes coffee": "<value>"}``
+      (the fact text is the dict key)
+
+    Downstream code does ``m.get("text", "")``, which raises AttributeError on
+    a plain string and silently drops the key-as-fact shape. Normalizing here
+    preserves any other keys (attributed_to, linked_memory_ids) on well-formed
+    dicts while recovering text from the malformed shapes.
+    """
+    if not raw_memories:
+        return []
+    normalized = []
+    for item in raw_memories:
+        if isinstance(item, str):
+            text = item.strip()
+            if text:
+                normalized.append({"text": text})
+        elif isinstance(item, dict):
+            text = item.get("text") or item.get("fact")
+            if text is None and len(item) == 1:
+                key, value = next(iter(item.items()))
+                if isinstance(key, str) and key.strip():
+                    text = key.strip()
+                elif isinstance(value, str) and value.strip():
+                    text = value.strip()
+            if text:
+                out = dict(item)
+                out["text"] = text
+                normalized.append(out)
+            else:
+                logger.warning("Unexpected memory shape from LLM, skipping: %s", item)
+        else:
+            logger.warning("Unexpected memory shape from LLM, skipping: %s", item)
+    return normalized
+
+
 def remove_code_blocks(content: str) -> str:
     """
     Removes enclosing code block markers ```[language] and ``` from a given string.

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -102,6 +102,29 @@ class TestAddToVectorStoreErrors:
         # provider exception is preserved as the cause for debugging.
         assert isinstance(exc_info.value.__cause__, _ProviderError)
 
+    def test_malformed_memory_shapes_do_not_crash_extraction(self, mocker, mock_memory):
+        """A plain-string item in the LLM 'memory' array must not crash the pipeline.
+
+        Without normalization, downstream ``m.get("text")`` raises AttributeError
+        on a str. Guards #5176: real reasoning models emit string / key-as-fact items.
+        """
+        import json as _json
+
+        mock_memory.llm.generate_response.return_value = _json.dumps(
+            {"memory": ["User likes coffee", {"User is tired": "noise"}]}
+        )
+        mocker.patch("mem0.memory.main.capture_event")
+        mock_memory.embedding_model = MagicMock()
+        mock_memory.embedding_model.embed_batch.return_value = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+        mock_memory.vector_store = MagicMock()
+        mock_memory.vector_store.search.return_value = []
+
+        # Must not raise; both malformed shapes recovered into text-bearing records.
+        result = mock_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "test"}], metadata={}, filters={"user_id": "u1"}, infer=True
+        )
+        assert isinstance(result, list)
+
 
 class TestPromptOverridesCustomInstructions:
     @pytest.fixture

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -123,7 +123,14 @@ class TestAddToVectorStoreErrors:
         result = mock_memory._add_to_vector_store(
             messages=[{"role": "user", "content": "test"}], metadata={}, filters={"user_id": "u1"}, infer=True
         )
+        # Both inputs (plain string + key-as-fact dict) must survive normalization
+        # and be persisted as ADD records — not silently dropped. isinstance(list)
+        # alone would pass even on a total drop, so pin the count and the texts.
         assert isinstance(result, list)
+        assert len(result) == 2
+        recovered = {r["memory"] for r in result}
+        assert recovered == {"User likes coffee", "User is tired"}
+        assert all(r["event"] == "ADD" for r in result)
 
 
 class TestPromptOverridesCustomInstructions:
@@ -335,6 +342,35 @@ class TestAsyncAddToVectorStoreErrors:
                 messages=[{"role": "user", "content": "test"}], metadata={}, effective_filters={}, infer=True
             )
         assert isinstance(exc_info.value.__cause__, _ProviderError)
+    async def test_async_malformed_memory_shapes_do_not_crash_extraction(self, mock_async_memory, mocker):
+        """Async mirror of the sync guard: a plain-string item and a key-as-fact
+        dict in the LLM 'memory' array must not crash AsyncMemory._add_to_vector_store
+        and must be recovered into text-bearing ADD records (not silently dropped).
+
+        Covers the normalize_extracted_memories call at main.py ~2564 so a future
+        regression on the async path is no longer invisible. Guards #5176.
+        """
+        import json as _json
+
+        mocker.patch("mem0.utils.factory.EmbedderFactory.create", return_value=MagicMock())
+        mock_async_memory.llm.generate_response.return_value = _json.dumps(
+            {"memory": ["User likes coffee", {"User is tired": "noise"}]}
+        )
+        mocker.patch("mem0.memory.main.capture_event")
+        mock_async_memory.embedding_model = MagicMock()
+        mock_async_memory.embedding_model.embed_batch.return_value = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+        mock_async_memory.vector_store = MagicMock()
+        mock_async_memory.vector_store.search.return_value = []
+
+        # Must not raise; both malformed shapes recovered into text-bearing records.
+        result = await mock_async_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "test"}], metadata={}, effective_filters={"user_id": "u1"}, infer=True
+        )
+        assert isinstance(result, list)
+        assert len(result) == 2
+        recovered = {r["memory"] for r in result}
+        assert recovered == {"User likes coffee", "User is tired"}
+        assert all(r["event"] == "ADD" for r in result)
 
 
 def _build_memory_instance(mocker, memory_cls):

--- a/tests/memory/test_memory_utils.py
+++ b/tests/memory/test_memory_utils.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 import pytest
 
 from mem0.memory.utils import (
+    normalize_extracted_memories,
     parse_messages,
     parse_vision_messages,
     process_telemetry_filters,
@@ -192,3 +193,33 @@ class TestProcessTelemetryFilters:
 class TestRemoveCodeBlocks:
     def test_none_content_returns_empty_string(self):
         assert remove_code_blocks(None) == ""
+
+
+class TestNormalizeExtractedMemories:
+    def test_passthrough_wellformed_text_dict_preserves_keys(self):
+        items = [{"text": "User likes coffee", "attributed_to": "user", "linked_memory_ids": ["a"]}]
+        out = normalize_extracted_memories(items)
+        assert out == [{"text": "User likes coffee", "attributed_to": "user", "linked_memory_ids": ["a"]}]
+
+    def test_plain_string_is_wrapped(self):
+        # Without normalization, downstream m.get("text") raises AttributeError on a str.
+        out = normalize_extracted_memories(["User likes coffee"])
+        assert out == [{"text": "User likes coffee"}]
+
+    def test_fact_key_dict_is_mapped_to_text(self):
+        out = normalize_extracted_memories([{"fact": "User likes coffee"}])
+        assert out == [{"fact": "User likes coffee", "text": "User likes coffee"}]
+
+    def test_key_as_fact_single_key_dict(self):
+        # grok-style reasoning models emit {factText: <value>}; the key IS the fact.
+        out = normalize_extracted_memories([{"User likes coffee": "noise"}])
+        assert out == [{"User likes coffee": "noise", "text": "User likes coffee"}]
+
+    def test_empty_and_unrecognized_shapes_are_dropped(self):
+        out = normalize_extracted_memories(["", {}, {"a": 1, "b": 2}, 42, None])
+        assert out == []
+
+    def test_mixed_batch(self):
+        items = ["plain", {"text": "kept"}, {"User is tired": "x"}]
+        out = normalize_extracted_memories(items)
+        assert [m["text"] for m in out] == ["plain", "kept", "User is tired"]


### PR DESCRIPTION
Salvage of #5176 by @thalesfsp — rebased onto current main with guardrail tests.

## Summary

Tolerate the malformed `memory` item shapes real LLMs emit during fact extraction, so they aren't silently dropped (or, worse, crash the pipeline).

## Root Cause

**Symptom** — When an LLM (especially reasoning models on OpenAI-compatible APIs such as grok) returns extracted memories as plain strings or single-key "key-as-fact" dicts instead of `{"text": "..."}`, memories are silently lost — and a plain-string item crashes `add()` outright.

**Root cause** — In both `Memory._add_to_vector_store` and `AsyncMemory._add_to_vector_store` (`mem0/memory/main.py`), right after parsing the extraction response the code does `mem_texts = [m.get("text", "") for m in extracted_memories if m.get("text")]` and later `text = mem.get("text")`. If an item is a `str`, `.get` raises `AttributeError`; if it's `{"User likes coffee": "..."}` (key-as-fact) or `{"fact": "..."}`, `.get("text")` is empty, so the memory is dropped.

**Evidence** — Confirmed on current `main` (`0fbbb2f`): both extraction paths still call `m.get("text", "")` with no shape normalization. The new integration test fails on unmodified main with `AttributeError` at `mem0/memory/main.py:939`.

**Fix + why this level** — Add `normalize_extracted_memories()` in `mem0/memory/utils.py` and call it in both paths immediately after parsing, before any `.get("text")` access. It maps plain strings → `{"text": s}`, `{"fact": ...}` → adds `text`, single-key key-as-fact dicts → recovers the key as `text`, preserves all other keys (`attributed_to`, `linked_memory_ids`) on well-formed dicts, and drops unrecognized/empty shapes with a warning. Normalizing once at the parse boundary is the right level: every downstream consumer assumes `{"text": ...}`, so fixing the shape at the source avoids scattering defensive `.get` guards across embed/dedup/persist phases.

**Scope / risk** — Touches `utils.py` (new pure function) and the two parse blocks in `main.py`. Well-formed `{"text": ...}` items pass through unchanged (keys preserved), so the happy path is unaffected. Unrecognized shapes that previously crashed or were dropped are now dropped with a warning.

## Why it needed salvage
Original #5176 conflicted against current main after pipeline refactors (the helper name and call sites moved). Re-implemented cleanly onto current `main`.

## Changes from original
- Rebased onto current `main` (single clean commit, credited to @thalesfsp).
- Added 6 unit tests for `normalize_extracted_memories` + 1 integration test that drives `_add_to_vector_store` with malformed shapes. **Integration test fails without the fix (`AttributeError`).**

## Verification / Real behavior proof
```
$ python -m pytest tests/memory/test_main.py tests/memory/test_memory_utils.py -q
.......................................................................  [100%]
71 passed in 1.20s

# Without the fix:
mem0/memory/main.py:939: AttributeError
FAILED tests/memory/test_main.py::...::test_malformed_memory_shapes_do_not_crash_extraction
```
`ruff check` clean.

Credit: salvage of #5176 by @thalesfsp.
