### PR TITLE
fix(memory): anchor extraction prompt date to created_at metadata (salvage of #5087)

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -896,11 +896,25 @@ class Memory(MemoryBase):
 
         custom_instr = prompt or self.custom_instructions
 
+        # When created_at is supplied via metadata (e.g. backfilled/imported
+        # memories), anchor the extraction prompt's "current date" to it so the
+        # LLM's temporal reasoning matches the timestamp ultimately stored in
+        # the memory metadata, instead of drifting to wall-clock now().
+        extraction_current_date = None
+        if metadata and metadata.get("created_at"):
+            try:
+                extraction_current_date = (
+                    datetime.fromisoformat(metadata["created_at"]).astimezone(timezone.utc).date().isoformat()
+                )
+            except (ValueError, TypeError):
+                extraction_current_date = None
+
         user_prompt = generate_additive_extraction_prompt(
             existing_memories=existing_memories,
             new_messages=parsed_messages,
             last_k_messages=last_messages,
             custom_instructions=custom_instr,
+            current_date=extraction_current_date,
         )
 
         try:
@@ -2519,11 +2533,25 @@ class AsyncMemory(MemoryBase):
 
         custom_instr = prompt or self.custom_instructions
 
+        # When created_at is supplied via metadata (e.g. backfilled/imported
+        # memories), anchor the extraction prompt's "current date" to it so the
+        # LLM's temporal reasoning matches the timestamp ultimately stored in
+        # the memory metadata, instead of drifting to wall-clock now().
+        extraction_current_date = None
+        if metadata and metadata.get("created_at"):
+            try:
+                extraction_current_date = (
+                    datetime.fromisoformat(metadata["created_at"]).astimezone(timezone.utc).date().isoformat()
+                )
+            except (ValueError, TypeError):
+                extraction_current_date = None
+
         user_prompt = generate_additive_extraction_prompt(
             existing_memories=existing_memories,
             new_messages=parsed_messages,
             last_k_messages=last_messages,
             custom_instructions=custom_instr,
+            current_date=extraction_current_date,
         )
 
         try:

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -79,6 +79,29 @@ class TestAddToVectorStoreErrors:
         assert mock_memory.llm.generate_response.call_count == 1
         assert result == []  # Should return empty list when no memories processed
 
+    def test_created_at_metadata_anchors_extraction_prompt_date(self, mocker, mock_memory):
+        """When created_at is supplied via metadata, the extraction prompt's
+        current_date must be anchored to it (not wall-clock now()).
+
+        Guards #5087: prompt/metadata timestamp mismatch for backfilled memories.
+        Without the fix, current_date is None (-> defaults to today).
+        """
+        spy = mocker.patch(
+            "mem0.memory.main.generate_additive_extraction_prompt", return_value="PROMPT"
+        )
+        mock_memory.llm.generate_response.return_value = "{}"  # no memories -> early return ok
+        mocker.patch("mem0.memory.main.capture_event")
+
+        mock_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "test"}],
+            metadata={"created_at": "2021-06-15T12:00:00+00:00"},
+            filters={"user_id": "u1"},
+            infer=True,
+        )
+
+        assert spy.call_count == 1
+        assert spy.call_args.kwargs.get("current_date") == "2021-06-15"
+
 
 class TestPromptOverridesCustomInstructions:
     @pytest.fixture


### PR DESCRIPTION
Salvage of #5087 by @Deadpoolmine — rebased onto current main with a guardrail test.

## Summary

When `created_at` is supplied via metadata, anchor the additive-extraction prompt's "Current Date" to that timestamp so the LLM's temporal reasoning matches the date ultimately stored in the memory.

## Root Cause

**Symptom** — For backfilled/imported memories where `created_at` is passed in metadata, the timestamp the LLM sees in the extraction prompt (used for relative-date reasoning like "yesterday") differs from the `created_at` stored in the memory metadata. The two time sources disagree.

**Root cause** — Both `Memory._add_to_vector_store` and `AsyncMemory._add_to_vector_store` call `generate_additive_extraction_prompt(...)` without passing `current_date`. The prompt builder then falls back through `_resolve_dates()` to `datetime.now(timezone.utc).date()` (mem0/configs/prompts.py:1007-1014) — wall-clock now — while the stored `created_at` comes from the caller's metadata.

**Evidence** — Confirmed on current `main` (`0fbbb2f`): `generate_additive_extraction_prompt` already accepts `current_date`/`timestamp` (signature at prompts.py:1016), but neither call site in `main.py` forwards anything, so it always defaults to today. The new guardrail test fails on unmodified main (`current_date` is `None`).

**Fix + why this level** — At each call site, derive `extraction_current_date` from `metadata["created_at"]` (parsed via `datetime.fromisoformat(...).astimezone(utc).date()`, falling back to `None` on malformed values) and pass it as `current_date`. This is the correct level: the prompt builder already supports an injected date — the only gap was the caller not supplying the value it already has in `metadata`. Parsing failures degrade gracefully to the previous now()-based behavior.

**Scope / risk** — Touches only the two `generate_additive_extraction_prompt` call sites. When `created_at` is absent or unparseable, behavior is identical to before (`current_date=None` → defaults to today). No prompt-format or API change.

## Why it needed salvage
Original #5087 predates the v3 single-pass pipeline + prompt-builder refactor and conflicted. Re-applied to current `main`.

## Changes from original
- Rebased onto current `main` (single clean commit, credited to @Deadpoolmine).
- Added a guardrail test asserting the prompt receives `current_date="2021-06-15"` for `created_at="2021-06-15T12:00:00+00:00"`. **Fails without the fix.**

## Verification / Real behavior proof
```
$ python -m pytest tests/memory/test_main.py -q
..............................................                           [100%]
46 passed in 1.14s

# Without the fix:
FAILED tests/memory/test_main.py::...::test_created_at_metadata_anchors_extraction_prompt_date
```
`ruff check` clean.

Credit: salvage of #5087 by @Deadpoolmine.
