### PR TITLE
fix(gemini): map tool_choice 'required' to ANY and accept per-call kwargs (salvage of #5452)

### DIFF
--- a/mem0/llms/gemini.py
+++ b/mem0/llms/gemini.py
@@ -161,6 +161,7 @@ class GeminiLLM(LLMBase):
         response_format=None,
         tools: Optional[List[Dict]] = None,
         tool_choice: str = "auto",
+        **kwargs,
     ):
         """
         Generate a response based on the given messages using Gemini.
@@ -169,7 +170,12 @@ class GeminiLLM(LLMBase):
             messages (list): List of message dicts containing 'role' and 'content'.
             response_format (str or object, optional): Format for the response. Defaults to "text".
             tools (list, optional): List of tools that the model can call. Defaults to None.
-            tool_choice (str, optional): Tool choice method. Defaults to "auto".
+            tool_choice (str, optional): Tool choice method, one of "auto", "any",
+                "required", or "none". "required" is treated as "any" (force a tool
+                call). Defaults to "auto".
+            **kwargs: Additional per-call overrides (e.g. ``max_tokens``,
+                ``temperature``, ``top_p``) that take precedence over configured
+                defaults. Unknown kwargs are ignored.
 
         Returns:
             str: The generated response.
@@ -180,13 +186,18 @@ class GeminiLLM(LLMBase):
 
         # Prepare generation config — only include non-None values so the
         # Gemini SDK uses its own defaults instead of rejecting None.
+        # Per-call kwargs override configured defaults; note Gemini names the
+        # token limit ``max_output_tokens``.
+        temperature = kwargs.get("temperature", self.config.temperature)
+        max_tokens = kwargs.get("max_tokens", self.config.max_tokens)
+        top_p = kwargs.get("top_p", self.config.top_p)
         config_params = {}
-        if self.config.temperature is not None:
-            config_params["temperature"] = self.config.temperature
-        if self.config.max_tokens is not None:
-            config_params["max_output_tokens"] = self.config.max_tokens
-        if self.config.top_p is not None:
-            config_params["top_p"] = self.config.top_p
+        if temperature is not None:
+            config_params["temperature"] = temperature
+        if max_tokens is not None:
+            config_params["max_output_tokens"] = max_tokens
+        if top_p is not None:
+            config_params["top_p"] = top_p
 
         # Add system instruction to config if present
         if system_instruction:
@@ -202,18 +213,23 @@ class GeminiLLM(LLMBase):
             config_params["tools"] = formatted_tools
 
             if tool_choice:
-                if tool_choice == "auto":
-                    mode = types.FunctionCallingConfigMode.AUTO
-                elif tool_choice == "any":
+                if tool_choice in ("any", "required"):
+                    # Both mean "the model must call a tool" -> Gemini ANY mode.
                     mode = types.FunctionCallingConfigMode.ANY
-                else:
+                elif tool_choice == "none":
                     mode = types.FunctionCallingConfigMode.NONE
+                else:
+                    # "auto" or any unrecognized value: let the model decide.
+                    mode = types.FunctionCallingConfigMode.AUTO
 
                 tool_config = types.ToolConfig(
                     function_calling_config=types.FunctionCallingConfig(
                         mode=mode,
+                        # Constrain to the provided tool names only when forcing a call.
                         allowed_function_names=(
-                            [tool["function"]["name"] for tool in tools] if tool_choice == "any" else None
+                            [tool["function"]["name"] for tool in tools]
+                            if tool_choice in ("any", "required")
+                            else None
                         ),
                     )
                 )

--- a/tests/llms/test_gemini.py
+++ b/tests/llms/test_gemini.py
@@ -298,3 +298,60 @@ def test_init_base_config_respects_vertexai_env(monkeypatch):
     with patch("mem0.llms.gemini.genai.Client") as mock_client_class:
         GeminiLLM(BaseLlmConfig(model="gemini-2.0-flash", api_key="ignored-key"))
     mock_client_class.assert_called_once_with(vertexai=True, project="env-project", location="us-west1")
+
+
+def _tool_mock_response():
+    mock_part = Mock(text="ok", function_call=None)
+    mock_content = Mock(parts=[mock_part])
+    mock_candidate = Mock(content=mock_content)
+    return Mock(candidates=[mock_candidate])
+
+
+def _basic_tools():
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": "add_memory",
+                "description": "Add a memory",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+
+def test_tool_choice_required_maps_to_any(mock_gemini_client: Mock):
+    """tool_choice='required' must map to Gemini ANY mode and constrain function names.
+
+    Guards #5452: previously only 'auto'/'any' were handled; 'required' (the
+    OpenAI-style value mem0 passes for forced extraction) fell through to NONE,
+    disabling the tool entirely.
+    """
+    config = BaseLlmConfig(model="gemini-2.0-flash-latest", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = GeminiLLM(config)
+    mock_gemini_client.models.generate_content.return_value = _tool_mock_response()
+
+    llm.generate_response(
+        [{"role": "user", "content": "hi"}], tools=_basic_tools(), tool_choice="required"
+    )
+
+    cfg = mock_gemini_client.models.generate_content.call_args.kwargs["config"]
+    fcc = cfg.tool_config.function_calling_config
+    assert fcc.mode == types.FunctionCallingConfigMode.ANY
+    assert fcc.allowed_function_names == ["add_memory"]
+
+
+def test_generate_response_kwargs_override_config(mock_gemini_client: Mock):
+    """Per-call kwargs (max_tokens/temperature/top_p) override configured defaults."""
+    config = BaseLlmConfig(model="gemini-2.0-flash-latest", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = GeminiLLM(config)
+    mock_gemini_client.models.generate_content.return_value = _tool_mock_response()
+
+    llm.generate_response(
+        [{"role": "user", "content": "hi"}], max_tokens=4096, temperature=0.1, top_p=0.5
+    )
+
+    cfg = mock_gemini_client.models.generate_content.call_args.kwargs["config"]
+    assert cfg.max_output_tokens == 4096
+    assert cfg.temperature == 0.1
+    assert cfg.top_p == 0.5


### PR DESCRIPTION
Salvage of #5452 by @bennyyuan1008 — rebased onto current main with guardrail tests.

## Summary

Map `tool_choice="required"` to Gemini's ANY mode (instead of silently disabling tools) and accept per-call generation kwargs.

## Root Cause

**Symptom** — Calling the Gemini LLM with `tool_choice="required"` (the OpenAI-style value used to force a tool call) makes Gemini *not* call the tool. Per-call overrides like `max_tokens` are also ignored, so callers can't raise the token limit for a single extraction.

**Root cause** — In `GeminiLLM.generate_response` (`mem0/llms/gemini.py`), the `tool_choice` branch handled only `"auto"` (AUTO) and `"any"` (ANY) explicitly; everything else — including `"required"` — fell into the `else` arm and set mode `NONE`, which disables function calling. And `generate_response` had no `**kwargs`, so per-call generation params were dropped on the floor.

**Evidence** — Confirmed on current `main` (`0fbbb2f`): the branch is `if tool_choice == "auto" ... elif == "any" ... else: NONE`, `allowed_function_names` is set only for `"any"`, and the signature has no `**kwargs`. New guardrail tests fail on unmodified main (`required` yields NONE; `max_tokens` override ignored).

**Fix + why this level** — Treat `"any"` and `"required"` identically (both = "must call a tool" → ANY mode + constrained `allowed_function_names`), map `"none"` → NONE, and default any unrecognized value (including `"auto"`) to AUTO. Add `**kwargs` and let `max_tokens`/`temperature`/`top_p` override the configured defaults (preserving main's None-guards so the SDK still applies its own defaults). Fixing in the adapter's tool_choice mapping is the right level: this is where the cross-provider `tool_choice` vocabulary is translated to Gemini's enum.

**Scope / risk** — Touches only `GeminiLLM.generate_response`. `"auto"`/`"any"` behavior is unchanged; only `"required"`/`"none"`/unknown values and the new kwargs path are added. Unknown kwargs are ignored.

## Why it needed salvage
Original #5452 conflicted after the gemini config_params None-guard refactor. Re-applied onto current `main`.

## Changes from original
- Rebased onto current `main` (single clean commit, credited to @bennyyuan1008).
- Guardrail tests: `required` → ANY + constrained function names; per-call kwargs override config. **Both fail without the fix.**

## Verification / Real behavior proof
```
$ python -m pytest tests/llms/test_gemini.py -q
...................                                                      [100%]
19 passed

# Without the fix:
FAILED tests/llms/test_gemini.py::test_tool_choice_required_maps_to_any
FAILED tests/llms/test_gemini.py::test_generate_response_kwargs_override_config
```
`ruff check` clean.

Credit: salvage of #5452 by @bennyyuan1008.
