### PR TITLE
fix(entity-extraction): degrade gracefully when noun_chunks is unsupported (salvage of #5550)

### DIFF
--- a/mem0/utils/entity_extraction.py
+++ b/mem0/utils/entity_extraction.py
@@ -588,7 +588,16 @@ def _add_quoted_candidates(text: str, candidates: list[_EntityCandidate]) -> Non
 
 
 def _add_topic_phrase_candidates(doc, candidates: list[_EntityCandidate]) -> None:
-    for chunk in doc.noun_chunks:
+    # ``doc.noun_chunks`` relies on a language-specific syntax iterator that
+    # spaCy does not implement for every language (e.g. ``zh``/``ja`` raise
+    # ``NotImplementedError`` [E894]). Degrade gracefully for those languages
+    # instead of aborting all entity extraction (#5285) -- the proper-noun,
+    # quoted-text and other strategies still run.
+    try:
+        noun_chunks = list(doc.noun_chunks)
+    except NotImplementedError:
+        noun_chunks = []
+    for chunk in noun_chunks:
         chunk_tokens = list(chunk)
         split_indices: list[int] = []
         poss_splits: list[int] = []

--- a/tests/utils/test_entity_extraction.py
+++ b/tests/utils/test_entity_extraction.py
@@ -139,3 +139,47 @@ class TestExtractEntitiesBatch:
         assert len(batch) == 1
         # Both should extract the same entities
         assert set(t for _, t in single) == set(t for _, t in batch[0])
+
+
+class _NoNounChunksDoc:
+    """Wrap a real spaCy Doc but make ``noun_chunks`` raise NotImplementedError.
+
+    spaCy does not implement the noun_chunks syntax iterator for every language
+    (zh/ja raise NotImplementedError [E894]). This reproduces that on a real
+    English Doc so the rest of the extraction pipeline runs against real tokens.
+    """
+
+    def __init__(self, doc):
+        self._doc = doc
+
+    @property
+    def noun_chunks(self):
+        raise NotImplementedError(
+            "[E894] The 'noun_chunks' syntax iterator is not implemented for language 'zh'."
+        )
+
+    def __iter__(self):
+        return iter(self._doc)
+
+    def __getattr__(self, name):
+        return getattr(self._doc, name)
+
+
+class TestUnsupportedLanguageNounChunks:
+    def test_noun_chunks_not_implemented_does_not_abort_extraction(self):
+        """A language without noun_chunks (#5285) must not crash extraction.
+
+        Guards #5550: _add_topic_phrase_candidates iterated doc.noun_chunks
+        directly, so a NotImplementedError aborted ALL entity extraction.
+        """
+        import spacy
+
+        from mem0.utils.entity_extraction import _EntityCandidate, _add_topic_phrase_candidates
+
+        nlp = spacy.load("en_core_web_sm")
+        real_doc = nlp("John Smith works at Google on machine learning projects")
+        wrapped = _NoNounChunksDoc(real_doc)
+
+        candidates: list[_EntityCandidate] = []
+        # Must not raise even though noun_chunks is unavailable.
+        _add_topic_phrase_candidates(wrapped, candidates)


### PR DESCRIPTION
Salvage of #5550 by @immuhammadfurqan — rebased onto current main with a guardrail test.

## Summary

Degrade gracefully when spaCy can't compute `noun_chunks` for a language, instead of aborting all entity extraction.

## Root Cause

**Symptom** — For languages whose spaCy model lacks a noun-chunk syntax iterator (e.g. Chinese `zh`, Japanese `ja`), entity extraction raises `NotImplementedError [E894]` and returns nothing — even though the proper-noun, quoted-text, and other strategies would have worked (issue #5285).

**Root cause** — `_add_topic_phrase_candidates` in `mem0/utils/entity_extraction.py` iterates `doc.noun_chunks` directly. `noun_chunks` is a lazy property backed by a per-language syntax iterator that spaCy only implements for some languages; for the rest it raises `NotImplementedError`. Because the iteration is unguarded, that exception propagates up and kills the whole extraction pass.

**Evidence** — Confirmed on current `main` (`0fbbb2f`): `_add_topic_phrase_candidates` still does `for chunk in doc.noun_chunks:` with no guard. The new test wraps a real English `Doc` so `noun_chunks` raises `NotImplementedError` and shows the function aborts on unmodified main.

**Fix + why this level** — Wrap the `noun_chunks` access in `try/except NotImplementedError`, falling back to an empty list so the noun-compound strategy is simply skipped while every other candidate strategy still runs. Guarding at the single point of use is the right level: the limitation is specific to `noun_chunks`, and the surrounding pipeline is already strategy-additive, so skipping one strategy is the intended degradation.

**Scope / risk** — Touches only `_add_topic_phrase_candidates`. Languages that DO support `noun_chunks` are unaffected (the `try` succeeds). Only the previously-crashing languages change behavior — from "no entities + exception" to "entities from the remaining strategies."

## Why it needed salvage
Original #5550 conflicted after the entity-extraction refactor (the loop moved into `_add_topic_phrase_candidates`). Re-applied onto current `main`.

## Changes from original
- Rebased onto current `main` (single clean commit, credited to @immuhammadfurqan).
- Guardrail test wraps a real spaCy Doc to raise `NotImplementedError` on `noun_chunks` and asserts extraction does not crash. **Fails without the fix.**

## Verification / Real behavior proof
```
$ python -m pytest tests/utils/test_entity_extraction.py -q
.............                                                            [100%]
13 passed in 3.98s

# Without the fix:
NotImplementedError: [E894] The 'noun_chunks' syntax iterator is not implemented for language 'zh'.
FAILED ...TestUnsupportedLanguageNounChunks::test_noun_chunks_not_implemented_does_not_abort_extraction
```
`ruff check` clean.

Credit: salvage of #5550 by @immuhammadfurqan.
