### PR TITLE
fix(server): propagate POSTGRES_SSLMODE into DB URL and pgvector config (salvage of #5374)

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -11,6 +11,8 @@ POSTGRES_DB=postgres
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=
 POSTGRES_COLLECTION_NAME=memories
+# Optional: set if your Postgres connection requires a specific SSL mode
+# POSTGRES_SSLMODE=require
 
 ADMIN_API_KEY=
 JWT_SECRET=

--- a/server/db.py
+++ b/server/db.py
@@ -10,7 +10,12 @@ def _build_database_url() -> str:
     user = os.environ.get("POSTGRES_USER", "postgres")
     password = os.environ.get("POSTGRES_PASSWORD", "postgres")
     db = os.environ.get("APP_DB_NAME", "mem0_app")
-    return f"postgresql+psycopg://{user}:{password}@{host}:{port}/{db}"
+    sslmode = os.environ.get("POSTGRES_SSLMODE")
+
+    url = f"postgresql+psycopg://{user}:{password}@{host}:{port}/{db}"
+    if sslmode:
+        url += f"?sslmode={sslmode}"
+    return url
 
 
 engine = create_engine(_build_database_url(), pool_pre_ping=True)

--- a/server/main.py
+++ b/server/main.py
@@ -110,6 +110,7 @@ POSTGRES_DB = os.environ.get("POSTGRES_DB", "postgres")
 POSTGRES_USER = os.environ.get("POSTGRES_USER", "postgres")
 POSTGRES_PASSWORD = os.environ.get("POSTGRES_PASSWORD", "postgres")
 POSTGRES_COLLECTION_NAME = os.environ.get("POSTGRES_COLLECTION_NAME", "memories")
+POSTGRES_SSLMODE = os.environ.get("POSTGRES_SSLMODE")
 
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
 HISTORY_DB_PATH = os.environ.get("HISTORY_DB_PATH", "/app/history/history.db")
@@ -127,6 +128,7 @@ DEFAULT_CONFIG = {
             "user": POSTGRES_USER,
             "password": POSTGRES_PASSWORD,
             "collection_name": POSTGRES_COLLECTION_NAME,
+            "sslmode": POSTGRES_SSLMODE,
         },
     },
     "llm": {

--- a/tests/test_server_db_url.py
+++ b/tests/test_server_db_url.py
@@ -1,0 +1,39 @@
+"""Tests for server.db._build_database_url SSL mode handling (salvage of #5374)."""
+import importlib
+import os
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("sqlalchemy", reason="sqlalchemy not installed")
+
+
+def _build_url(env):
+    base = {
+        "POSTGRES_HOST": "h",
+        "POSTGRES_PORT": "5432",
+        "POSTGRES_USER": "u",
+        "POSTGRES_PASSWORD": "p",
+        "APP_DB_NAME": "appdb",
+    }
+    base.update(env)
+    with patch.dict(os.environ, base, clear=False):
+        # Avoid actually creating the engine at import time.
+        with patch("sqlalchemy.create_engine"):
+            import server.db as server_db
+            importlib.reload(server_db)
+            return server_db._build_database_url()
+
+
+def test_no_sslmode_omits_query_string():
+    # ensure POSTGRES_SSLMODE absent
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("POSTGRES_SSLMODE", None)
+        url = _build_url({})
+    assert url == "postgresql+psycopg://u:p@h:5432/appdb"
+    assert "sslmode" not in url
+
+
+def test_sslmode_appended_when_set():
+    url = _build_url({"POSTGRES_SSLMODE": "require"})
+    assert url == "postgresql+psycopg://u:p@h:5432/appdb?sslmode=require"


### PR DESCRIPTION
Salvage of #5374 by @gitchrisqueen — rebased onto current main with a guardrail test.

## Summary

Propagate a `POSTGRES_SSLMODE` env var into both the server's SQLAlchemy DB URL and the pgvector store config so managed/hosted Postgres (which often requires `sslmode=require`) can connect.

## Root Cause

**Symptom** — The self-hosted server can't connect to a Postgres that mandates SSL: there's no way to set `sslmode`. The app DB URL and the pgvector connection both omit it, so connections to managed Postgres (RDS, Supabase, Neon, etc.) are refused.

**Root cause** — `server/db._build_database_url()` hardcodes `postgresql+psycopg://{user}:{password}@{host}:{port}/{db}` with no sslmode. Separately, the server's `DEFAULT_CONFIG` pgvector block (`server/main.py`) never sets `sslmode`, even though `PGVectorConfig` already supports it (`mem0/configs/vector_stores/pgvector.py:19`).

**Evidence** — Confirmed on current `main` (`0fbbb2f`): `_build_database_url` returns the bare URL, and the `DEFAULT_CONFIG` pgvector config has no `sslmode` key. The new test shows `_build_database_url` ignores `POSTGRES_SSLMODE` on unmodified main.

**Fix + why this level** — Read `POSTGRES_SSLMODE` once and (a) append `?sslmode=<mode>` to the app DB URL when set, (b) pass it into the pgvector `DEFAULT_CONFIG` (the config field already exists). Reading from env at the connection-construction boundary is the right level: it keeps the knob a deploy-time concern and reuses `PGVectorConfig`'s existing `sslmode` support rather than inventing a new path.

**Scope / risk** — When `POSTGRES_SSLMODE` is unset, behavior is byte-for-byte identical (no query string; `sslmode=None` passed to pgvector, which already treats None as "unset"). Only deployments that opt in by setting the var change.

## Why it needed salvage
Original #5374 conflicted against current main. Re-applied onto current `main`.

## Changes from original
- Rebased onto current `main` (single clean commit, credited to @gitchrisqueen).
- Added `tests/test_server_db_url.py` asserting the URL gains `?sslmode=require` only when set. **Fails without the fix.**
- Documented the optional var in `server/.env.example`.

## Verification / Real behavior proof
```
$ python -m pytest tests/test_server_db_url.py -q
..                                                                       [100%]
2 passed

# Without the fix:
FAILED tests/test_server_db_url.py::test_sslmode_appended_when_set
```
`ruff check` clean.

Credit: salvage of #5374 by @gitchrisqueen.
