### PR TITLE
[codex] Fix provider config merge on provider change

### DIFF
--- a/server/server_state.py
+++ b/server/server_state.py
@@ -65,6 +65,14 @@ def _merge_config(base: Dict[str, Any], updates: Dict[str, Any]) -> Dict[str, An
     merged = deepcopy(base)
 
     for key, value in updates.items():
+        if (
+            isinstance(value, dict)
+            and isinstance(merged.get(key), dict)
+            and "provider" in value
+            and value.get("provider") != merged[key].get("provider")
+        ):
+            merged[key] = deepcopy(value)
+            continue
         if isinstance(value, dict) and isinstance(merged.get(key), dict):
             merged[key] = _merge_config(merged[key], value)
         else:

--- a/tests/test_server_state.py
+++ b/tests/test_server_state.py
@@ -1,0 +1,64 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "server"))
+
+from server_state import _merge_config
+
+
+def test_merge_config_replaces_provider_specific_config_when_provider_changes():
+    base = {
+        "vector_store": {
+            "provider": "pgvector",
+            "config": {
+                "host": "localhost",
+                "port": 5432,
+                "dbname": "postgres",
+                "user": "postgres",
+                "password": "",
+                "collection_name": "memories",
+            },
+        },
+    }
+    updates = {
+        "vector_store": {
+            "provider": "qdrant",
+            "config": {
+                "path": r"C:\tmp\qdrant",
+                "collection_name": "memories",
+            },
+        },
+    }
+
+    merged = _merge_config(base, updates)
+
+    assert merged["vector_store"] == updates["vector_store"]
+
+
+def test_merge_config_deep_merges_same_provider_config():
+    base = {
+        "llm": {
+            "provider": "openai",
+            "config": {
+                "api_key": "sk-test",
+                "temperature": 0.2,
+                "model": "gpt-4.1-nano-2025-04-14",
+            },
+        },
+    }
+    updates = {
+        "llm": {
+            "provider": "openai",
+            "config": {
+                "temperature": 0.1,
+            },
+        },
+    }
+
+    merged = _merge_config(base, updates)
+
+    assert merged["llm"]["config"] == {
+        "api_key": "sk-test",
+        "temperature": 0.1,
+        "model": "gpt-4.1-nano-2025-04-14",
+    }


### PR DESCRIPTION
## Summary

- Replace provider-specific config objects when the provider changes instead of deep-merging incompatible nested keys.
- Preserve deep-merge behavior when the provider remains the same.
- Add regression coverage for both behaviors.

## Why

Switching providers could leave stale configuration fields from the previous provider in place, producing mixed configs such as Qdrant settings merged with leftover PostgreSQL fields.

## Validation

- `python -m pytest tests/test_server_state.py`
