### PR TITLE
[codex] Add OpenMemory stdio MCP workflow

### DIFF
--- a/openmemory/README.md
+++ b/openmemory/README.md
@@ -140,6 +140,49 @@ npx @openmemory/install local http://localhost:8765/mcp/<client-name>/sse/<user-
 
 Replace `<client-name>` with the desired client name and `<user-id>` with the value specified in your environment variables.
 
+### Codex stdio MCP setup
+
+OpenMemory also provides a stdio MCP entrypoint for local clients that launch MCP servers as child processes, such as Codex.
+
+Example Codex configuration:
+
+```toml
+[mcp_servers.mem0]
+command = "/path/to/mem0/.venv-openmemory/bin/python"
+args = ["/path/to/mem0/openmemory/api/mcp_stdio.py"]
+
+[mcp_servers.mem0.env]
+OPENMEMORY_USER_ID = "<user-id>"
+OPENMEMORY_CLIENT_NAME = "codex"
+```
+
+On Windows, use the virtual environment Python executable and script path for your checkout:
+
+```toml
+[mcp_servers.mem0]
+command = "C:\\path\\to\\mem0\\.venv-openmemory\\Scripts\\python.exe"
+args = ["C:\\path\\to\\mem0\\openmemory\\api\\mcp_stdio.py"]
+
+[mcp_servers.mem0.env]
+OPENMEMORY_USER_ID = "<user-id>"
+OPENMEMORY_CLIENT_NAME = "codex"
+```
+
+When `mcp_stdio.py` starts, it ensures the local API is listening on `127.0.0.1:8765` and the UI is listening on `127.0.0.1:3000`. Startup uses local lock files so multiple stdio MCP processes reuse the same API and UI instead of launching duplicate OpenMemory instances. The API and UI keep running after an individual MCP process exits, so the dashboard remains available in the browser.
+
+Autostart can be configured with these environment variables:
+
+| Variable | Description | Default |
+|---|---|---|
+| `OPENMEMORY_AUTOSTART_API` | Set to `false` to disable automatic API startup. | `true` |
+| `OPENMEMORY_AUTOSTART_UI` | Set to `false` to disable automatic UI startup. | `true` |
+| `OPENMEMORY_API_HOST` | API host used by the stdio launcher. | `127.0.0.1` |
+| `OPENMEMORY_API_PORT` | API port used by the stdio launcher. | `8765` |
+| `OPENMEMORY_UI_HOST` | UI host used by the stdio launcher. | `127.0.0.1` |
+| `OPENMEMORY_UI_PORT` | UI port used by the stdio launcher. | `3000` |
+
+Logs for autostarted services are written under `api/.openmemory-runtime/`.
+
 
 ## Project Structure
 

--- a/openmemory/api/app/mcp_server.py
+++ b/openmemory/api/app/mcp_server.py
@@ -42,6 +42,11 @@ load_dotenv()
 # Initialize MCP
 mcp = FastMCP("mem0-mcp-server")
 
+
+def _mcp_json_response(data, *, indent=None) -> str:
+    return json.dumps(data, ensure_ascii=False, indent=indent)
+
+
 # Don't initialize memory client at import time - do it lazily when needed
 def get_memory_client_safe():
     """Get memory client with error handling. Returns None if client cannot be initialized."""
@@ -138,7 +143,7 @@ async def add_memories(text: str, infer: bool = True) -> str:
 
                 db.commit()
 
-            return json.dumps(response)
+            return _mcp_json_response(response)
         finally:
             db.close()
     except Exception as e:
@@ -179,7 +184,7 @@ async def search_memory(query: str) -> str:
             hits = memory_client.vector_store.search(
                 query=query, 
                 vectors=embeddings, 
-                limit=10, 
+                top_k=10, 
                 filters=filters,
             )
 
@@ -216,7 +221,7 @@ async def search_memory(query: str) -> str:
                     db.add(access_log)
             db.commit()
 
-            return json.dumps({"results": results}, indent=2)
+            return _mcp_json_response({"results": results}, indent=2)
         finally:
             db.close()
     except Exception as e:
@@ -245,7 +250,7 @@ async def list_memories() -> str:
             user, app = get_user_and_app(db, user_id=uid, app_id=client_name)
 
             # Get all memories
-            memories = memory_client.get_all(user_id=uid)
+            memories = memory_client.get_all(filters={"user_id": uid})
             filtered_memories = []
 
             # Filter memories based on permissions
@@ -285,7 +290,7 @@ async def list_memories() -> str:
                         db.add(access_log)
                         filtered_memories.append(memory)
                 db.commit()
-            return json.dumps(filtered_memories, indent=2)
+            return _mcp_json_response(filtered_memories, indent=2)
         finally:
             db.close()
     except Exception as e:

--- a/openmemory/api/app/schemas.py
+++ b/openmemory/api/app/schemas.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import List, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class MemoryBase(BaseModel):
@@ -51,7 +51,8 @@ class MemoryResponse(BaseModel):
     categories: List[str]
     metadata_: Optional[dict] = None
 
-    @validator('created_at', pre=True)
+    @field_validator("created_at", mode="before")
+    @classmethod
     def convert_to_epoch(cls, v):
         if isinstance(v, datetime):
             return int(v.timestamp())

--- a/openmemory/api/app/utils/categorization.py
+++ b/openmemory/api/app/utils/categorization.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import List
 
 from app.utils.prompts import MEMORY_CATEGORIZATION_PROMPT
@@ -8,7 +9,14 @@ from pydantic import BaseModel
 from tenacity import retry, stop_after_attempt, wait_exponential
 
 load_dotenv()
-openai_client = OpenAI()
+_base_url = os.getenv("OPENAI_BASE_URL") or os.getenv("LLM_BASE_URL")
+openai_client = OpenAI(
+    api_key=os.getenv("OPENAI_API_KEY") or os.getenv("LLM_API_KEY"),
+    base_url=_base_url or None,
+)
+categorization_model = os.getenv("OPENMEMORY_CATEGORIZATION_MODEL", "gpt-4o-mini")
+categorization_disabled = os.getenv("OPENMEMORY_DISABLE_CATEGORIZATION", "").lower() in {"1", "true", "yes", "on"}
+logger = logging.getLogger(__name__)
 
 
 class MemoryCategories(BaseModel):
@@ -17,6 +25,9 @@ class MemoryCategories(BaseModel):
 
 @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=4, max=15))
 def get_categories_for_memory(memory: str) -> List[str]:
+    if categorization_disabled:
+        return []
+
     try:
         messages = [
             {"role": "system", "content": MEMORY_CATEGORIZATION_PROMPT},
@@ -25,7 +36,7 @@ def get_categories_for_memory(memory: str) -> List[str]:
 
         # Let OpenAI handle the pydantic parsing directly
         completion = openai_client.beta.chat.completions.parse(
-            model="gpt-4o-mini",
+            model=categorization_model,
             messages=messages,
             response_format=MemoryCategories,
             temperature=0
@@ -35,9 +46,9 @@ def get_categories_for_memory(memory: str) -> List[str]:
         return [cat.strip().lower() for cat in parsed.categories]
 
     except Exception as e:
-        logging.error(f"[ERROR] Failed to get categories: {e}")
+        logger.warning("Failed to categorize memory; continuing without categories: %s", e)
         try:
-            logging.debug(f"[DEBUG] Raw response: {completion.choices[0].message.content}")
+            logger.debug(f"[DEBUG] Raw response: {completion.choices[0].message.content}")
         except Exception as debug_e:
-            logging.debug(f"[DEBUG] Could not extract raw response: {debug_e}")
-        raise
+            logger.debug(f"[DEBUG] Could not extract raw response: {debug_e}")
+        return []

--- a/openmemory/api/app/utils/memory.py
+++ b/openmemory/api/app/utils/memory.py
@@ -29,6 +29,7 @@ Example configuration that will be automatically adjusted:
 
 import hashlib
 import json
+import logging
 import os
 import socket
 
@@ -39,6 +40,7 @@ from mem0 import Memory
 
 _memory_client = None
 _config_hash = None
+logger = logging.getLogger(__name__)
 
 
 def _get_config_hash(config_dict):
@@ -55,7 +57,7 @@ def _get_docker_host_url():
     # Check for custom environment variable first
     custom_host = os.environ.get('OLLAMA_HOST')
     if custom_host:
-        print(f"Using custom Ollama host from OLLAMA_HOST: {custom_host}")
+        logger.info("Using custom Ollama host from OLLAMA_HOST: %s", custom_host)
         return custom_host.replace('http://', '').replace('https://', '').split(':')[0]
     
     # Check if we're running inside Docker
@@ -63,7 +65,7 @@ def _get_docker_host_url():
         # Not in Docker, return localhost as-is
         return "localhost"
     
-    print("Detected Docker environment, adjusting host URL for Ollama...")
+    logger.info("Detected Docker environment, adjusting host URL for Ollama...")
     
     # Try different host resolution strategies
     host_candidates = []
@@ -72,7 +74,7 @@ def _get_docker_host_url():
     try:
         socket.gethostbyname('host.docker.internal')
         host_candidates.append('host.docker.internal')
-        print("Found host.docker.internal")
+        logger.info("Found host.docker.internal")
     except socket.gaierror:
         pass
     
@@ -85,7 +87,7 @@ def _get_docker_host_url():
                     gateway_hex = fields[2]
                     gateway_ip = socket.inet_ntoa(bytes.fromhex(gateway_hex)[::-1])
                     host_candidates.append(gateway_ip)
-                    print(f"Found Docker gateway: {gateway_ip}")
+                    logger.info("Found Docker gateway: %s", gateway_ip)
                     break
     except (FileNotFoundError, IndexError, ValueError):
         pass
@@ -93,7 +95,7 @@ def _get_docker_host_url():
     # 3. Fallback to common Docker bridge IP
     if not host_candidates:
         host_candidates.append('172.17.0.1')
-        print("Using fallback Docker bridge IP: 172.17.0.1")
+        logger.info("Using fallback Docker bridge IP: 172.17.0.1")
     
     # Return the first available candidate
     return host_candidates[0]
@@ -121,7 +123,7 @@ def _fix_ollama_urls(config_section):
             if docker_host != "localhost":
                 new_url = url.replace("localhost", docker_host).replace("127.0.0.1", docker_host)
                 ollama_config["ollama_base_url"] = new_url
-                print(f"Adjusted Ollama URL from {url} to {new_url}")
+                logger.info("Adjusted Ollama URL from %s to %s", url, new_url)
     
     return config_section
 
@@ -325,7 +327,7 @@ def get_default_memory_config():
             "port": 6333,
         })
     
-    print(f"Auto-detected vector store: {vector_store_provider} with config: {vector_store_config}")
+    logger.info("Auto-detected vector store: %s with config: %s", vector_store_provider, vector_store_config)
 
     # Detect LLM provider from environment variables
     llm_provider = os.environ.get('LLM_PROVIDER', 'openai').lower()
@@ -341,7 +343,7 @@ def get_default_memory_config():
         base_url=llm_base_url,
         ollama_base_url=ollama_base_url,
     )
-    print(f"Auto-detected LLM provider: {llm_provider}")
+    logger.info("Auto-detected LLM provider: %s", llm_provider)
 
     # Detect embedder provider from environment variables
     embedder_provider = os.environ.get('EMBEDDER_PROVIDER', llm_provider if llm_provider == 'ollama' else 'openai').lower()
@@ -357,7 +359,7 @@ def get_default_memory_config():
         ollama_base_url=ollama_base_url,
         llm_base_url=llm_base_url,
     )
-    print(f"Auto-detected embedder provider: {embedder_provider}")
+    logger.info("Auto-detected embedder provider: %s", embedder_provider)
 
     return {
         "vector_store": {
@@ -389,9 +391,9 @@ def _parse_environment_variables(config_dict):
                 env_value = os.environ.get(env_var)
                 if env_value:
                     parsed_config[key] = env_value
-                    print(f"Loaded {env_var} from environment for {key}")
+                    logger.info("Loaded %s from environment for %s", env_var, key)
                 else:
-                    print(f"Warning: Environment variable {env_var} not found, keeping original value")
+                    logger.warning("Environment variable %s not found, keeping original value", env_var)
                     parsed_config[key] = value
             elif isinstance(value, dict):
                 parsed_config[key] = _parse_environment_variables(value)
@@ -450,13 +452,13 @@ def get_memory_client(custom_instructions: str = None):
                     if "vector_store" in mem0_config and mem0_config["vector_store"] is not None:
                         config["vector_store"] = mem0_config["vector_store"]
             else:
-                print("No configuration found in database, using defaults")
+                logger.info("No configuration found in database, using defaults")
                     
             db.close()
                             
         except Exception as e:
-            print(f"Warning: Error loading configuration from database: {e}")
-            print("Using default configuration")
+            logger.warning("Error loading configuration from database: %s", e)
+            logger.warning("Using default configuration")
             # Continue with default configuration if database config can't be loaded
 
         # Use custom_instructions parameter first, then fall back to database value
@@ -472,7 +474,7 @@ def get_memory_client(custom_instructions: str = None):
 
         # ALWAYS parse environment variables in the final config
         # This ensures that even default config values like "env:OPENAI_API_KEY" get parsed
-        print("Parsing environment variables in final config...")
+        logger.info("Parsing environment variables in final config...")
         config = _parse_environment_variables(config)
 
         # Check if config has changed by comparing hashes
@@ -480,14 +482,14 @@ def get_memory_client(custom_instructions: str = None):
         
         # Only reinitialize if config changed or client doesn't exist
         if _memory_client is None or _config_hash != current_config_hash:
-            print(f"Initializing memory client with config hash: {current_config_hash}")
+            logger.info("Initializing memory client with config hash: %s", current_config_hash)
             try:
                 _memory_client = Memory.from_config(config_dict=config)
                 _config_hash = current_config_hash
-                print("Memory client initialized successfully")
+                logger.info("Memory client initialized successfully")
             except Exception as init_error:
-                print(f"Warning: Failed to initialize memory client: {init_error}")
-                print("Server will continue running with limited memory functionality")
+                logger.warning("Failed to initialize memory client: %s", init_error)
+                logger.warning("Server will continue running with limited memory functionality")
                 _memory_client = None
                 _config_hash = None
                 return None
@@ -495,8 +497,8 @@ def get_memory_client(custom_instructions: str = None):
         return _memory_client
         
     except Exception as e:
-        print(f"Warning: Exception occurred while initializing memory client: {e}")
-        print("Server will continue running with limited memory functionality")
+        logger.warning("Exception occurred while initializing memory client: %s", e)
+        logger.warning("Server will continue running with limited memory functionality")
         return None
 
 

--- a/openmemory/api/mcp_stdio.py
+++ b/openmemory/api/mcp_stdio.py
@@ -1,0 +1,323 @@
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+from mcp.types import JSONRPCMessage
+
+api_dir = Path(__file__).resolve().parent
+openmemory_dir = api_dir.parent
+ui_dir = openmemory_dir / "ui"
+runtime_dir = api_dir / ".openmemory-runtime"
+os.chdir(api_dir)
+
+
+def env_flag(name, default=True):
+    value = os.getenv(name)
+
+    if value is None:
+        return default
+
+    return value.lower() not in {"0", "false", "no", "off"}
+
+
+def local_port_is_open(host, port):
+    try:
+        with socket.create_connection((host, port), timeout=0.25):
+            return True
+    except OSError:
+        return False
+
+
+def wait_for_port(host, port, timeout=30):
+    deadline = time.monotonic() + timeout
+
+    while time.monotonic() < deadline:
+        if local_port_is_open(host, port):
+            return True
+        time.sleep(0.25)
+
+    return False
+
+
+def acquire_autostart_lock(name, host, port, timeout=60, stale_after=60):
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = runtime_dir / f"{name}.lock"
+    deadline = time.monotonic() + timeout
+
+    while True:
+        if local_port_is_open(host, port):
+            return "port-open"
+
+        try:
+            fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        except FileExistsError:
+            try:
+                lock_age = time.time() - lock_path.stat().st_mtime
+            except FileNotFoundError:
+                continue
+
+            if lock_age > stale_after:
+                try:
+                    lock_path.unlink()
+                except FileNotFoundError:
+                    pass
+                continue
+
+            if time.monotonic() >= deadline:
+                return None
+
+            time.sleep(0.25)
+            continue
+
+        os.write(fd, f"{os.getpid()}\n".encode("ascii"))
+        return fd, lock_path
+
+
+def release_autostart_lock(lock):
+    if lock is None:
+        return
+
+    fd, lock_path = lock
+    os.close(fd)
+
+    try:
+        lock_path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def open_runtime_log(name):
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    log_file = open(runtime_dir / f"{name}.log", "ab", buffering=0)
+    log_file.write(f"\n--- {time.strftime('%Y-%m-%d %H:%M:%S')} ---\n".encode("utf-8"))
+    return log_file
+
+
+def subprocess_creation_flags():
+    if sys.platform == "win32":
+        return subprocess.CREATE_NO_WINDOW
+
+    return 0
+
+
+def start_background_process(name, command, cwd, env):
+    log_file = open_runtime_log(name)
+
+    try:
+        process = subprocess.Popen(
+            command,
+            cwd=str(cwd),
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+            close_fds=True,
+            creationflags=subprocess_creation_flags(),
+        )
+    except Exception as exc:
+        log_file.write(f"Failed to start {name}: {exc}\n".encode("utf-8", errors="replace"))
+        log_file.close()
+        return None
+
+    log_file.close()
+    return process
+
+
+def ensure_openmemory_api(host, port):
+    if local_port_is_open(host, port) or not env_flag("OPENMEMORY_AUTOSTART_API"):
+        return
+
+    lock = acquire_autostart_lock("api", host, port)
+
+    if lock is None or lock == "port-open":
+        return
+
+    if local_port_is_open(host, port):
+        release_autostart_lock(lock)
+        return
+
+    try:
+        env = os.environ.copy()
+        env.setdefault("PYTHONWARNINGS", "ignore")
+        env["OPENMEMORY_API_HOST"] = host
+        env["OPENMEMORY_API_PORT"] = str(port)
+
+        process = start_background_process(
+            "api",
+            [sys.executable, str(api_dir / "run_openmemory.py")],
+            api_dir,
+            env,
+        )
+
+        if process is not None:
+            wait_for_port(host, port)
+    finally:
+        release_autostart_lock(lock)
+
+
+def find_next_command():
+    node = shutil.which("node")
+    next_bin = ui_dir / "node_modules" / "next" / "dist" / "bin" / "next"
+
+    if node and next_bin.exists():
+        return [node, str(next_bin)]
+
+    pnpm = shutil.which("pnpm.cmd") or shutil.which("pnpm")
+
+    if pnpm:
+        return [pnpm, "run", "dev", "--"]
+
+    return None
+
+
+def ensure_openmemory_ui(host, port, api_url, user_id):
+    if local_port_is_open(host, port) or not env_flag("OPENMEMORY_AUTOSTART_UI"):
+        return
+
+    lock = acquire_autostart_lock("ui", host, port)
+
+    if lock is None or lock == "port-open":
+        return
+
+    if local_port_is_open(host, port):
+        release_autostart_lock(lock)
+        return
+
+    try:
+        command = find_next_command()
+
+        if command is None:
+            log_file = open_runtime_log("ui")
+            log_file.write(b"Failed to start UI: neither node/next nor pnpm was found.\n")
+            log_file.close()
+            return
+
+        env = os.environ.copy()
+        env["NEXT_PUBLIC_API_URL"] = api_url
+        env["NEXT_PUBLIC_USER_ID"] = user_id
+
+        process = start_background_process(
+            "ui",
+            [*command, "dev", "-H", host, "-p", str(port)]
+            if len(command) == 2
+            else [*command, "-H", host, "-p", str(port)],
+            ui_dir,
+            env,
+        )
+
+        if process is not None:
+            wait_for_port(host, port)
+    finally:
+        release_autostart_lock(lock)
+
+
+def ensure_local_openmemory(user_id):
+    api_host = os.getenv("OPENMEMORY_API_HOST", "127.0.0.1")
+    api_port = int(os.getenv("OPENMEMORY_API_PORT", "8765"))
+    ui_host = os.getenv("OPENMEMORY_UI_HOST", "127.0.0.1")
+    ui_port = int(os.getenv("OPENMEMORY_UI_PORT", "3000"))
+    api_url = os.getenv("NEXT_PUBLIC_API_URL", f"http://{api_host}:{api_port}")
+
+    ensure_openmemory_api(api_host, api_port)
+    ensure_openmemory_ui(ui_host, ui_port, api_url, user_id)
+
+
+def default_user_id():
+    return os.getenv("USER") or os.getenv("USERNAME") or "default"
+
+
+def ignore_invalid_stdin_lines():
+    source = sys.stdin.buffer
+    output = sys.stdout.buffer
+    read_fd, write_fd = os.pipe()
+    output_lock = threading.Lock()
+
+    def write_jsonrpc_error(code, message, data=None, id_=None):
+        response = {
+            "jsonrpc": "2.0",
+            "id": id_,
+            "error": {
+                "code": code,
+                "message": message,
+            },
+        }
+
+        if data is not None:
+            response["error"]["data"] = data
+
+        encoded = (json.dumps(response, ensure_ascii=False, separators=(",", ":")) + "\n").encode("utf-8")
+
+        with output_lock:
+            output.write(encoded)
+            output.flush()
+
+    def extract_jsonrpc_id(value):
+        if not isinstance(value, dict):
+            return None
+
+        id_ = value.get("id")
+
+        if id_ is None or isinstance(id_, (str, int, float)):
+            return id_
+
+        return None
+
+    def copy_valid_lines():
+        with os.fdopen(write_fd, "wb") as writer:
+            for line in source:
+                if not line.strip():
+                    continue
+
+                try:
+                    value = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    write_jsonrpc_error(
+                        -32700,
+                        "Parse error",
+                        data=f"Invalid JSON received on stdin: {exc.msg} at line {exc.lineno} column {exc.colno}",
+                        id_=None,
+                    )
+                    continue
+
+                try:
+                    JSONRPCMessage.model_validate(value)
+                except Exception as exc:
+                    write_jsonrpc_error(
+                        -32600,
+                        "Invalid Request",
+                        data=f"Invalid JSON-RPC message received on stdin: {exc}",
+                        id_=extract_jsonrpc_id(value),
+                    )
+                    continue
+
+                writer.write(line)
+                writer.flush()
+
+    threading.Thread(target=copy_valid_lines, daemon=True).start()
+    sys.stdin = os.fdopen(read_fd, "r", encoding="utf-8", errors="replace")
+
+
+def main():
+    user_id = os.getenv("OPENMEMORY_USER_ID", default_user_id())
+    client_name = os.getenv("OPENMEMORY_CLIENT_NAME", "codex")
+    ensure_local_openmemory(user_id)
+
+    from app.database import Base, engine
+    from app.mcp_server import client_name_var, mcp, user_id_var
+
+    Base.metadata.create_all(bind=engine)
+    user_id_var.set(user_id)
+    client_name_var.set(client_name)
+    mcp._mcp_server.name = "mem0-mcp-server"
+    ignore_invalid_stdin_lines()
+    mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/openmemory/api/run_openmemory.py
+++ b/openmemory/api/run_openmemory.py
@@ -1,0 +1,67 @@
+import asyncio
+import logging
+import os
+import sys
+import warnings
+
+if sys.platform == "win32":
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
+warnings.filterwarnings("ignore")
+os.environ.setdefault("PYTHONWARNINGS", "ignore")
+
+logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s", force=True)
+
+for logger_name in (
+    "asyncio",
+    "httpcore",
+    "httpx",
+    "mcp",
+    "mem0",
+    "openmemory",
+    "qdrant_client",
+    "spacy",
+    "uvicorn.access",
+):
+    logging.getLogger(logger_name).setLevel(logging.WARNING)
+
+for noisy_logger in (
+    "mem0.memory.spacy_models",
+    "mem0.utils.spacy_models",
+):
+    logging.getLogger(noisy_logger).setLevel(logging.ERROR)
+
+import uvicorn
+
+
+def selector_loop_factory():
+    if sys.platform == "win32":
+        loop = asyncio.SelectorEventLoop()
+    else:
+        loop = asyncio.new_event_loop()
+
+    def ignore_client_disconnects(loop, context):
+        if isinstance(context.get("exception"), ConnectionResetError):
+            return
+        loop.default_exception_handler(context)
+
+    loop.set_exception_handler(ignore_client_disconnects)
+    return loop
+
+
+def main():
+    host = os.getenv("OPENMEMORY_API_HOST", "127.0.0.1")
+    port = int(os.getenv("OPENMEMORY_API_PORT", "8765"))
+
+    uvicorn.run(
+        "main:app",
+        host=host,
+        port=port,
+        access_log=False,
+        log_level="warning",
+        loop="run_openmemory:selector_loop_factory",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/openmemory/api/tests/test_mcp_server.py
+++ b/openmemory/api/tests/test_mcp_server.py
@@ -14,7 +14,8 @@ import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
-from app.mcp_server import client_name_var, mcp, mcp_router, user_id_var
+from app import mcp_server as mcp_server_module
+from app.mcp_server import add_memories, client_name_var, mcp, mcp_router, user_id_var
 
 # MCP Streamable HTTP requires the Accept header to include application/json.
 # Including text/event-stream as well satisfies GET (SSE) requests.
@@ -374,6 +375,71 @@ class TestStreamableHTTPResponses:
             headers={**MCP_HEADERS, "Content-Type": "text/plain"},
         )
         assert resp.status_code in (400, 415)
+
+
+# ---------------------------------------------------------------------------
+# Tool return serialization
+# ---------------------------------------------------------------------------
+
+class TestMCPToolSerialization:
+    """Verify tool JSON text remains readable for non-ASCII memory content."""
+
+    @pytest.mark.asyncio
+    async def test_add_memories_keeps_unicode_readable(self, monkeypatch):
+        class DummyMemoryClient:
+            def add(self, *args, **kwargs):
+                return {
+                    "results": [
+                        {
+                            "id": "11111111-1111-1111-1111-111111111111",
+                            "memory": "用户喜欢中文输出",
+                            "event": "ADD",
+                        }
+                    ]
+                }
+
+        class DummyQuery:
+            def filter(self, *args, **kwargs):
+                return self
+
+            def first(self):
+                return None
+
+        class DummySession:
+            def query(self, *args, **kwargs):
+                return DummyQuery()
+
+            def add(self, *args, **kwargs):
+                pass
+
+            def commit(self):
+                pass
+
+            def close(self):
+                pass
+
+        class DummyUser:
+            id = "22222222-2222-2222-2222-222222222222"
+
+        class DummyApp:
+            id = "33333333-3333-3333-3333-333333333333"
+            name = "codex"
+            is_active = True
+
+        monkeypatch.setattr(mcp_server_module, "get_memory_client_safe", lambda: DummyMemoryClient())
+        monkeypatch.setattr(mcp_server_module, "SessionLocal", lambda: DummySession())
+        monkeypatch.setattr(mcp_server_module, "get_user_and_app", lambda *args, **kwargs: (DummyUser(), DummyApp()))
+
+        user_token = user_id_var.set("Breaky")
+        client_token = client_name_var.set("codex")
+        try:
+            result = await add_memories("用户喜欢中文输出", infer=False)
+        finally:
+            user_id_var.reset(user_token)
+            client_name_var.reset(client_token)
+
+        assert "用户喜欢中文输出" in result
+        assert "\\u7528" not in result
 
 
 # ---------------------------------------------------------------------------

--- a/openmemory/ui/components/dashboard/Stats.tsx
+++ b/openmemory/ui/components/dashboard/Stats.tsx
@@ -35,28 +35,29 @@ const Stats = () => {
           <p className="text-zinc-400">Total Apps Connected</p>
           <div className="flex flex-col items-start gap-1 mt-2">
             <div className="flex -space-x-2">
-              {apps.map((app) => (
-                <div
-                  key={app.id}
-                  className={`h-8 w-8 rounded-full bg-primary flex items-center justify-center text-xs`}
-                >
-                  <div>
-                    <div className="w-7 h-7 rounded-full bg-zinc-700 flex items-center justify-center overflow-hidden">
-                      <Image
-                        src={
-                          constants[app.name as keyof typeof constants]
-                            ?.iconImage || ""
-                        }
-                        alt={
-                          constants[app.name as keyof typeof constants]?.name
-                        }
-                        width={32}
-                        height={32}
-                      />
+              {apps.map((app) => {
+                const appSource =
+                  constants[app.name as keyof typeof constants] ??
+                  constants.default;
+
+                return (
+                  <div
+                    key={app.id}
+                    className={`h-8 w-8 rounded-full bg-primary flex items-center justify-center text-xs`}
+                  >
+                    <div>
+                      <div className="w-7 h-7 rounded-full bg-zinc-700 flex items-center justify-center overflow-hidden">
+                        <Image
+                          src={appSource.iconImage}
+                          alt={appSource.name}
+                          width={32}
+                          height={32}
+                        />
+                      </div>
                     </div>
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
             <h3 className="text-lg font-bold text-white">{totalApps} Apps</h3>
           </div>


### PR DESCRIPTION
## Summary

- Add a stdio MCP entrypoint for local OpenMemory clients such as Codex.
- Autostart the local OpenMemory API and UI when the stdio MCP server starts, with lock files so concurrent MCP processes reuse one API/UI instance.
- Keep autostarted services running after an individual MCP process exits, so the dashboard remains available in the browser.
- Return JSON-RPC errors for invalid stdio input instead of exiting the MCP server.
- Add an icon fallback for unknown OpenMemory source apps in the dashboard stats panel.
- Document Codex stdio MCP setup and autostart environment variables in `openmemory/README.md`.

## Why

Codex and similar clients launch MCP servers over stdio. Without a local stdio entrypoint and autostart behavior, users need to manually start the OpenMemory API/UI before Codex can use local memories or before the dashboard is available.

## Validation

- `python -m py_compile openmemory/api/mcp_stdio.py openmemory/api/run_openmemory.py`
- `python -m pytest openmemory/api/tests/test_mcp_server.py`
- Manually smoke-tested concurrent stdio startup with 3 MCP processes; one API listener and one UI listener were created.
- Manually verified the dashboard loads memories from the local API.
