### PR TITLE
perf(server): Optimize any() checks to native boolean operations

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -366,7 +366,7 @@ def generate_instructions(req: GenerateInstructionsRequest, _auth=Depends(verify
 @app.post("/memories", summary="Create memories")
 def add_memory(memory_create: MemoryCreate, _auth=Depends(verify_auth)):
     """Store new memories."""
-    if not any([memory_create.user_id, memory_create.agent_id, memory_create.run_id]):
+    if not (memory_create.user_id or memory_create.agent_id or memory_create.run_id):
         raise HTTPException(status_code=400, detail="At least one identifier (user_id, agent_id, run_id) is required.")
 
     params = {k: v for k, v in memory_create.model_dump().items() if v is not None and k != "messages"}
@@ -419,7 +419,7 @@ def get_all_memories(
 ):
     """Retrieve stored memories. Lists all memories when no identifier is provided (admin only)."""
     try:
-        if not any([user_id, run_id, agent_id]):
+        if not (user_id or run_id or agent_id):
             auth_type = getattr(request.state, "auth_type", "none")
             if _auth is not None and _auth.role != "admin" and auth_type not in {"admin_api_key", "disabled"}:
                 raise HTTPException(status_code=403, detail="Admin role required to list all memories.")
@@ -531,7 +531,7 @@ def delete_all_memories(
     _auth=Depends(require_admin),
 ):
     """Delete all memories for a given identifier. Requires admin role."""
-    if not any([user_id, run_id, agent_id]):
+    if not (user_id or run_id or agent_id):
         raise HTTPException(status_code=400, detail="At least one identifier is required.")
     try:
         params = {


### PR DESCRIPTION
## Linked Issue

Closes #5898

## Description

Currently, in `server/main.py`, multiple endpoints check for the presence of identifiers using `any()` with a dynamically constructed list:
`if not any([user_id, agent_id, run_id]):`

This PR optimizes this to use native boolean `or` operators:
`if not (user_id or agent_id or run_id):`

**Why this is better:**
1. **No list creation**: Avoids memory allocation for a new list object on every API request.
2. **Short-circuiting**: The evaluation stops as soon as the first truthy value is found.
3. **No function call**: It compiles directly into fast CPython `JUMP` bytecode instructions instead of invoking a C function overhead.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [x] No tests needed (explain why)

This is a trivial algorithmic equivalence. `any([a, b, c])` evaluates identically to `(a or b or c)` in Python booleans.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
