### PR TITLE
fix: remove unused uuid_mapping variable in _add_to_vector_store

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -814,9 +814,7 @@ class Memory(MemoryBase):
 
         # Map UUIDs to integers (anti-hallucination)
         existing_memories = []
-        uuid_mapping = {}
         for idx, mem in enumerate(existing_results):
-            uuid_mapping[str(idx)] = mem.id
             existing_memories.append({"id": str(idx), "text": mem.payload.get("data", "")})
 
         # Phase 2: LLM extraction (single call)
@@ -2355,9 +2353,7 @@ class AsyncMemory(MemoryBase):
 
         # Map UUIDs to integers (anti-hallucination)
         existing_memories = []
-        uuid_mapping = {}
         for idx, mem in enumerate(existing_results):
-            uuid_mapping[str(idx)] = mem.id
             existing_memories.append({"id": str(idx), "text": mem.payload.get("data", "")})
 
         # Phase 2: LLM extraction (single call)


### PR DESCRIPTION
## Description
Removed the unused `uuid_mapping` variable in the `_add_to_vector_store` method. This variable was initialized but not utilized in the subsequent logic; removing it cleans up the codebase and avoids unnecessary dictionary operations.

## Type of Change
- [x] Refactor (no functional changes)

## Test Coverage
- [x] I tested manually (Verified that the code runs correctly without the unused variable).

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally