### PR TITLE
fix(memory): lazy-import langchain-core in async procedural memory

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -3556,16 +3556,6 @@ class AsyncMemory(MemoryBase):
             llm (llm, optional): LLM to use for the procedural memory creation. Defaults to None.
             prompt (str, optional): Prompt to use for the procedural memory creation. Defaults to None.
         """
-        try:
-            from langchain_core.messages.utils import (
-                convert_to_messages,  # type: ignore
-            )
-        except Exception:
-            logger.error(
-                "Import error while loading langchain-core. Please install 'langchain-core' to use procedural memory."
-            )
-            raise
-
         logger.info("Creating procedural memory")
 
         parsed_messages = [
@@ -3576,6 +3566,17 @@ class AsyncMemory(MemoryBase):
 
         try:
             if llm is not None:
+                # convert_to_messages comes from the optional `langchain-core` package, which is
+                # only required when a custom LangChain `llm` is supplied. Import it lazily here so
+                # the default path (llm=None) matches the sync class and works without the extra.
+                try:
+                    from langchain_core.messages.utils import convert_to_messages  # type: ignore
+                except Exception:
+                    logger.error(
+                        "Import error while loading langchain-core. "
+                        "Please install 'langchain-core' to pass a custom LLM for procedural memory."
+                    )
+                    raise
                 parsed_messages = convert_to_messages(parsed_messages)
                 response = await asyncio.to_thread(llm.invoke, input=parsed_messages)
                 procedural_memory = remove_code_blocks(response.content)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1529,3 +1529,47 @@ async def test_async_procedural_memory_langchain_strips_code_blocks(mock_llm_fac
     insert_call = memory.vector_store.insert.call_args
     stored_data = insert_call[1]["payloads"][0]["data"]
     assert "```" not in stored_data
+
+
+@pytest.mark.asyncio
+@patch("mem0.memory.main.VectorStoreFactory")
+@patch("mem0.memory.main.EmbedderFactory")
+@patch("mem0.memory.main.LlmFactory")
+async def test_async_procedural_memory_does_not_require_langchain_when_llm_none(mock_llm_factory, mock_emb, mock_vs):
+    """Regression: async procedural memory with the default ``llm=None`` must not require
+    the optional ``langchain-core`` package.
+
+    ``convert_to_messages`` comes from langchain-core, which is an optional ``extras``
+    dependency and is only needed when a custom LangChain ``llm`` is supplied. The sync
+    path (``Memory._create_procedural_memory``) has no langchain dependency, so the async
+    path must behave the same on a default ``pip install mem0ai``. Previously the import
+    ran unconditionally at function entry, so this call raised ``ImportError`` and stored
+    nothing whenever langchain-core was not installed.
+    """
+    import sys
+
+    mock_vs.return_value = MagicMock()
+    mock_emb.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+
+    from mem0.memory.main import AsyncMemory
+
+    config = MemoryConfig()
+    memory = AsyncMemory(config)
+    memory.vector_store = MagicMock()
+    memory.vector_store.insert = MagicMock()
+    memory.llm = MagicMock()
+    memory.llm.generate_response.return_value = "Step 1: open the file. Step 2: save it."
+
+    messages = [{"role": "user", "content": "How do I save a file?"}]
+    metadata = {"user_id": "test_user"}
+
+    # Simulate langchain-core not being installed (it lives in the optional `extras` group):
+    # setting the module entries to None makes any `import langchain_core...` raise ImportError.
+    blocked = {"langchain_core": None, "langchain_core.messages": None, "langchain_core.messages.utils": None}
+    with patch.dict(sys.modules, blocked):
+        await memory._create_procedural_memory(messages, metadata=metadata, llm=None)
+
+    # The procedural memory is still generated via the built-in llm and persisted.
+    memory.llm.generate_response.assert_called_once()
+    memory.vector_store.insert.assert_called_once()


### PR DESCRIPTION
## Linked Issue

Closes #5907

## Description

`AsyncMemory._create_procedural_memory()` imported `langchain_core` at function entry, but `convert_to_messages` is only used when a custom LangChain `llm` is supplied. Because `langchain-core` is an optional `extras` dependency, the default path (`llm=None`) raised `ImportError` on a plain `pip install mem0ai`, while the sync `Memory._create_procedural_memory()` — which has no langchain dependency — worked for the same call.

This moves the import inside the `if llm is not None` branch, so the default async procedural-memory path matches the sync class and no longer requires the optional package. langchain-core is still imported (and its error surfaced) when a custom LangChain `llm` is actually passed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added `test_async_procedural_memory_does_not_require_langchain_when_llm_none`: it blocks `langchain_core` in `sys.modules` and asserts the `llm=None` path still generates and stores the memory. Fails before the fix, passes after. Existing `test_async_procedural_memory_langchain_strips_code_blocks` (custom-llm path) still passes; full `tests/test_memory.py` passes (59 tests).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
