### PR TITLE
fix(core): add missing llm param to sync Memory.add()

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -697,6 +697,7 @@ class Memory(MemoryBase):
         infer: bool = True,
         memory_type: Optional[str] = None,
         prompt: Optional[str] = None,
+        llm=None,
     ):
         """
         Create a new memory.
@@ -720,6 +721,9 @@ class Memory(MemoryBase):
                 creating procedural memories (typically requires 'agent_id'). Otherwise, memories
                 are treated as general conversational/factual memories.
             prompt (str, optional): Prompt to use for the memory creation. Defaults to None.
+            llm (optional): A LangChain ``BaseChatModel`` instance to use when creating
+                procedural memories instead of the default ``self.llm``. Only has effect when
+                ``memory_type="procedural_memory"`` and ``agent_id`` is set. Defaults to None.
 
 
         Returns:
@@ -768,7 +772,7 @@ class Memory(MemoryBase):
             )
 
         if agent_id is not None and memory_type == MemoryType.PROCEDURAL.value:
-            results = self._create_procedural_memory(messages, metadata=processed_metadata, prompt=prompt)
+            results = self._create_procedural_memory(messages, metadata=processed_metadata, prompt=prompt, llm=llm)
             scale_threshold_notice = detect_scale_threshold_from_add_result(self, results)
             if temporal_usage_notice:
                 display_temporal_usage_notice(self, "sync", "add", *temporal_usage_notice)
@@ -1842,13 +1846,15 @@ class Memory(MemoryBase):
         )
         return memory_id
 
-    def _create_procedural_memory(self, messages, metadata=None, prompt=None):
+    def _create_procedural_memory(self, messages, metadata=None, llm=None, prompt=None):
         """
         Create a procedural memory
 
         Args:
             messages (list): List of messages to create a procedural memory from.
             metadata (dict): Metadata to create a procedural memory from.
+            llm (optional): A LangChain ``BaseChatModel`` instance. When provided, used instead of
+                ``self.llm`` to generate the procedural memory. Defaults to None.
             prompt (str, optional): Prompt to use for the procedural memory creation. Defaults to None.
         """
         logger.info("Creating procedural memory")
@@ -1862,9 +1868,23 @@ class Memory(MemoryBase):
             },
         ]
 
+        if llm is not None:
+            try:
+                from langchain_core.messages.utils import convert_to_messages  # type: ignore
+            except Exception:
+                logger.error(
+                    "Import error while loading langchain-core. Please install 'langchain-core' to use a custom LLM for procedural memory."
+                )
+                raise
+
         try:
-            procedural_memory = self.llm.generate_response(messages=parsed_messages)
-            procedural_memory = remove_code_blocks(procedural_memory)
+            if llm is not None:
+                parsed_messages = convert_to_messages(parsed_messages)
+                response = llm.invoke(input=parsed_messages)
+                procedural_memory = remove_code_blocks(response.content)
+            else:
+                procedural_memory = self.llm.generate_response(messages=parsed_messages)
+                procedural_memory = remove_code_blocks(procedural_memory)
         except Exception as e:
             logger.error(f"Error generating procedural memory summary: {e}")
             raise

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -988,3 +988,108 @@ class TestAddPipelineEntityEmbeddingCountGuard:
         assert any("padding/truncating" in r.message for r in caplog.records), (
             "expected count-mismatch warning was not emitted"
         )
+
+
+class TestSyncAddLlmParam:
+    """Memory.add() was missing the llm parameter that AsyncMemory.add() already had.
+
+    These tests verify the parameter exists, is forwarded correctly to
+    _create_procedural_memory(), and that the default (None) preserves the
+    existing self.llm path.
+    """
+
+    @pytest.fixture
+    def mock_memory(self, mocker):
+        _setup_mocks(mocker)
+        memory = Memory()
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        return memory
+
+    def test_add_signature_accepts_llm_kwarg(self, mock_memory):
+        import inspect
+
+        params = inspect.signature(mock_memory.add).parameters
+        assert "llm" in params, "Memory.add() must accept an llm keyword argument"
+
+    def test_add_forwards_llm_to_create_procedural_memory(self, mock_memory, mocker):
+        fake_result = {"results": [{"id": "mem-1", "memory": "do this", "event": "ADD"}]}
+        create_pm = mocker.patch.object(mock_memory, "_create_procedural_memory", return_value=fake_result)
+        mocker.patch("mem0.memory.main.capture_event")
+        mocker.patch("mem0.memory.main.display_first_run_notice")
+
+        custom_llm = MagicMock()
+        mock_memory.add(
+            [{"role": "user", "content": "test"}],
+            agent_id="agent-1",
+            memory_type="procedural_memory",
+            llm=custom_llm,
+        )
+
+        _, kwargs = create_pm.call_args
+        assert kwargs.get("llm") is custom_llm, "llm kwarg must be forwarded to _create_procedural_memory"
+
+    def test_add_llm_defaults_to_none(self, mock_memory, mocker):
+        fake_result = {"results": [{"id": "mem-1", "memory": "do this", "event": "ADD"}]}
+        create_pm = mocker.patch.object(mock_memory, "_create_procedural_memory", return_value=fake_result)
+        mocker.patch("mem0.memory.main.capture_event")
+        mocker.patch("mem0.memory.main.display_first_run_notice")
+
+        mock_memory.add(
+            [{"role": "user", "content": "test"}],
+            agent_id="agent-1",
+            memory_type="procedural_memory",
+        )
+
+        _, kwargs = create_pm.call_args
+        assert kwargs.get("llm") is None, "llm must default to None so existing callers are unaffected"
+
+    def test_create_procedural_memory_uses_custom_llm_invoke(self, mock_memory, mocker):
+        """When llm is provided, _create_procedural_memory calls llm.invoke, not self.llm.generate_response."""
+        mock_convert = MagicMock(return_value=[MagicMock()])
+        mock_lc_module = MagicMock()
+        mock_lc_module.convert_to_messages = mock_convert
+        mocker.patch.dict(
+            "sys.modules",
+            {
+                "langchain_core": MagicMock(),
+                "langchain_core.messages": MagicMock(),
+                "langchain_core.messages.utils": mock_lc_module,
+            },
+        )
+
+        custom_llm = MagicMock()
+        mock_response = MagicMock()
+        mock_response.content = "step 1: do A\nstep 2: do B"
+        custom_llm.invoke.return_value = mock_response
+
+        mock_memory.embedding_model = MagicMock()
+        mock_memory.embedding_model.embed.return_value = [0.1] * 10
+        mock_memory._create_memory = MagicMock(return_value="mem-99")
+        mocker.patch("mem0.memory.main.capture_event")
+
+        result = mock_memory._create_procedural_memory(
+            [{"role": "user", "content": "test"}],
+            metadata={"agent_id": "agent-1"},
+            llm=custom_llm,
+        )
+
+        custom_llm.invoke.assert_called_once()
+        mock_memory.llm.generate_response.assert_not_called()
+        assert result["results"][0]["memory"] == "step 1: do A\nstep 2: do B"
+
+    def test_create_procedural_memory_uses_self_llm_when_no_custom_llm(self, mock_memory, mocker):
+        """When llm=None (default), _create_procedural_memory uses self.llm.generate_response."""
+        mock_memory.llm.generate_response.return_value = "default llm output"
+        mock_memory.embedding_model = MagicMock()
+        mock_memory.embedding_model.embed.return_value = [0.1] * 10
+        mock_memory._create_memory = MagicMock(return_value="mem-88")
+        mocker.patch("mem0.memory.main.capture_event")
+
+        result = mock_memory._create_procedural_memory(
+            [{"role": "user", "content": "test"}],
+            metadata={"agent_id": "agent-1"},
+        )
+
+        mock_memory.llm.generate_response.assert_called_once()
+        assert result["results"][0]["memory"] == "default llm output"

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1529,3 +1529,43 @@ async def test_async_procedural_memory_langchain_strips_code_blocks(mock_llm_fac
     insert_call = memory.vector_store.insert.call_args
     stored_data = insert_call[1]["payloads"][0]["data"]
     assert "```" not in stored_data
+
+
+@patch("mem0.memory.main.VectorStoreFactory")
+@patch("mem0.memory.main.EmbedderFactory")
+@patch("mem0.memory.main.LlmFactory")
+def test_sync_procedural_memory_langchain_strips_code_blocks(mock_llm_factory, mock_emb, mock_vs):
+    """Sync LangChain path must call remove_code_blocks(), matching async parity (#5710)."""
+    mock_vs.return_value = MagicMock()
+    mock_emb.return_value = MagicMock()
+    mock_emb.return_value.embed.return_value = [0.1] * 1536
+    mock_llm_factory.return_value = MagicMock()
+
+    config = MemoryConfig()
+    memory = Memory(config)
+    memory.vector_store = MagicMock()
+    memory.vector_store.insert = MagicMock()
+
+    mock_langchain_llm = MagicMock()
+    mock_response = MagicMock()
+    mock_response.content = '```json\n{"key": "value"}\n```'
+    mock_langchain_llm.invoke.return_value = mock_response
+
+    messages = [{"role": "user", "content": "test"}]
+    metadata = {"user_id": "test_user"}
+
+    mock_lc_utils = MagicMock()
+    mock_lc_utils.convert_to_messages = MagicMock(side_effect=lambda msgs: msgs)
+    with patch.dict(
+        "sys.modules",
+        {
+            "langchain_core": MagicMock(),
+            "langchain_core.messages": MagicMock(),
+            "langchain_core.messages.utils": mock_lc_utils,
+        },
+    ):
+        memory._create_procedural_memory(messages, metadata=metadata, llm=mock_langchain_llm)
+
+    insert_call = memory.vector_store.insert.call_args
+    stored_data = insert_call[1]["payloads"][0]["data"]
+    assert "```" not in stored_data


### PR DESCRIPTION
## Linked Issue

Closes #5911 

## Description

`AsyncMemory.add()` has accepted an `llm=None` parameter since #5710, letting callers supply a LangChain `BaseChatModel` for procedural memory generation. `Memory.add()` was never updated to match, so the sync API silently diverged.

This PR closes the gap by adding `llm=None` to `Memory.add()` and to sync `Memory._create_procedural_memory()`, implementing the `convert_to_messages` + `llm.invoke()` LangChain path identical to the async version. The `langchain_core` import is placed inside the `llm is not None` guard so callers without a custom LLM never require `langchain-core` installed. No behaviour changes when `llm` is not passed (default `None`).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Six new tests across two files. `TestSyncAddLlmParam` in `tests/memory/test_main.py` covers: parameter exists on `Memory.add()`, `llm` is forwarded to `_create_procedural_memory()`, default `None` leaves existing callers unaffected, custom `llm.invoke()` path is taken when provided, and `self.llm.generate_response` path is preserved when not.

`test_sync_procedural_memory_langchain_strips_code_blocks` in `tests/test_memory.py` is the sync counterpart to the existing async regression test confirming `remove_code_blocks()` is called on the response.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed