### PR TITLE
feat(aws_bedrock): add bedrock_provider override for application infe…

### DIFF
--- a/mem0/configs/llms/aws_bedrock.py
+++ b/mem0/configs/llms/aws_bedrock.py
@@ -23,6 +23,7 @@ class AWSBedrockConfig(BaseLlmConfig):
         aws_region: str = "",
         aws_session_token: Optional[str] = None,
         aws_profile: Optional[str] = None,
+        bedrock_provider: Optional[str] = None,
         model_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs,
     ):
@@ -41,6 +42,10 @@ class AWSBedrockConfig(BaseLlmConfig):
             aws_region: AWS region for Bedrock service
             aws_session_token: AWS session token for temporary credentials
             aws_profile: AWS profile name for credentials
+            bedrock_provider: Explicit provider override for opaque model ARNs (e.g.,
+                application inference profiles). When set, skips regex-based provider
+                detection. Example: ``"anthropic"`` for an application inference profile
+                that wraps a Claude model. Defaults to ``None`` (auto-detect).
             model_kwargs: Additional model-specific parameters
             **kwargs: Additional arguments passed to base class
         """
@@ -58,6 +63,7 @@ class AWSBedrockConfig(BaseLlmConfig):
         self.aws_region = aws_region or os.getenv("AWS_REGION", "us-west-2")
         self.aws_session_token = aws_session_token
         self.aws_profile = aws_profile
+        self.bedrock_provider = bedrock_provider
         self.model_kwargs = model_kwargs or {}
 
     @property

--- a/mem0/llms/aws_bedrock.py
+++ b/mem0/llms/aws_bedrock.py
@@ -59,6 +59,7 @@ class AWSBedrockLLM(LLMBase):
                 top_p=config.top_p,
                 top_k=config.top_k,
                 enable_vision=getattr(config, "enable_vision", False),
+                bedrock_provider=getattr(config, "bedrock_provider", None),
             )
 
         super().__init__(config)
@@ -69,7 +70,10 @@ class AWSBedrockLLM(LLMBase):
 
         # Get model configuration
         self.model_config = self.config.get_model_config()
-        self.provider = extract_provider(self.config.model)
+        self.provider = (
+            getattr(self.config, "bedrock_provider", None)
+            or extract_provider(self.config.model)
+        )
 
         # Initialize provider-specific settings
         self._initialize_provider_settings()

--- a/tests/llms/test_aws_bedrock.py
+++ b/tests/llms/test_aws_bedrock.py
@@ -114,6 +114,75 @@ class TestAWSBedrockConfig:
         )
         assert config.aws_region == "us-east-2"
 
+    def test_bedrock_provider_defaults_to_none(self):
+        config = AWSBedrockConfig(model="anthropic.claude-3-5-sonnet-20240620-v1:0")
+        assert config.bedrock_provider is None
+
+    def test_bedrock_provider_stored_when_set(self):
+        config = AWSBedrockConfig(
+            model="arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abcdef012345",
+            bedrock_provider="anthropic",
+        )
+        assert config.bedrock_provider == "anthropic"
+
+
+# ---------------------------------------------------------------------------
+# bedrock_provider override
+# ---------------------------------------------------------------------------
+
+APPLICATION_INFERENCE_PROFILE_ARN = (
+    "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abcdef012345"
+)
+
+
+class TestBedrockProviderOverride:
+    """Tests for the bedrock_provider explicit override (PR: feat/bedrock-application-inference-profile-override).
+
+    Application inference profile ARNs contain an opaque profile ID with no provider
+    name, so extract_provider() raises ValueError. The bedrock_provider field lets
+    callers bypass regex-based detection entirely.
+    """
+
+    def test_explicit_override_bypasses_regex_for_opaque_arn(self, mock_boto3):
+        """bedrock_provider='anthropic' must be used even when the model ARN is opaque.
+
+        Without the fix this raises ValueError: Unknown provider in model: arn:aws:...
+        """
+        config = AWSBedrockConfig(
+            model=APPLICATION_INFERENCE_PROFILE_ARN,
+            bedrock_provider="anthropic",
+        )
+        llm = AWSBedrockLLM(config)
+        assert llm.provider == "anthropic"
+
+    def test_backward_compatibility_without_override(self, mock_boto3):
+        """When bedrock_provider is not set, extract_provider still runs for normal model IDs."""
+        config = AWSBedrockConfig(model="anthropic.claude-3-haiku-20240307-v1:0")
+        llm = AWSBedrockLLM(config)
+        assert llm.provider == "anthropic"
+
+    def test_base_llm_config_conversion_preserves_bedrock_provider(self, mock_boto3):
+        """bedrock_provider must survive the BaseLlmConfig -> AWSBedrockConfig conversion path.
+
+        Callers that pass a plain BaseLlmConfig (e.g. the factory) go through a manual
+        attribute-by-attribute conversion inside AWSBedrockLLM.__init__. The fix adds
+        getattr(config, 'bedrock_provider', None) so the field is not silently dropped.
+        """
+        from mem0.configs.llms.base import BaseLlmConfig
+
+        base_cfg = BaseLlmConfig(
+            model=APPLICATION_INFERENCE_PROFILE_ARN,
+            temperature=0.1,
+            max_tokens=500,
+        )
+        # Attach the field as if the factory or caller set it
+        base_cfg.bedrock_provider = "anthropic"
+
+        llm = AWSBedrockLLM(base_cfg)
+        assert isinstance(llm.config, AWSBedrockConfig)
+        assert llm.config.bedrock_provider == "anthropic"
+        assert llm.provider == "anthropic"
+
 
 # ---------------------------------------------------------------------------
 # LlmFactory


### PR DESCRIPTION
## Linked Issue

Closes #5913

## Description

Application inference profile ARNs (e.g. `arn:aws:bedrock:<region>:<account>:application-inference-profile/<id>`) contain an opaque profile ID with no provider name in the string. The existing `extract_provider()` regex helper raises `ValueError: Unknown provider in model: arn:aws:bedrock:...` for these ARNs, making it impossible to use mem0 with AWS Bedrock's enterprise cost-tagging / traffic-routing pattern.

This PR adds an optional `bedrock_provider` field to `AWSBedrockConfig`. When set, it short-circuits `extract_provider()` so the caller can explicitly name the underlying model family (e.g. `"anthropic"`). When not set, behaviour is identical to before.

**Before:**
```python
config = {
    "model": "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abcdef012345",
}
# → ValueError: Unknown provider in model: arn:aws:bedrock:...
```

**After:**
```python
config = {
    "model": "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abcdef012345",
    "bedrock_provider": "anthropic",  # new — explicit override
}
# → works; routes through Anthropic Converse API correctly
```

Related: PR #4139 fixed cross-region prefixes (`us.anthropic.*`, `apac.anthropic.*`) where the provider name is still in the string. This PR handles the distinct case where the ARN contains no provider hint at all.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

5 new unit tests added to `tests/llms/test_aws_bedrock.py`:

| Test | What it covers |
|------|----------------|
| `test_bedrock_provider_defaults_to_none` | Field exists and is `None` by default — no behaviour change |
| `test_bedrock_provider_stored_when_set` | Field correctly stores the override value |
| `test_explicit_override_bypasses_regex_for_opaque_arn` | Core fix — opaque ARN + override → no `ValueError` |
| `test_backward_compatibility_without_override` | Normal model IDs still go through `extract_provider()` as before |
| `test_base_llm_config_conversion_preserves_bedrock_provider` | Override survives the `BaseLlmConfig → AWSBedrockConfig` conversion path |

All 46 tests pass (`pytest tests/llms/test_aws_bedrock.py`).

Manually verified end-to-end: `Memory.from_config()` constructs without error with an application inference profile ARN + `bedrock_provider` override. The only failure observed was an unrelated IAM `AccessDeniedException` on the underlying foundation model — the mem0 code path was fully exercised before reaching that IAM check.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
