### PR TITLE
fix(core): AsyncMemory.reset() uses VectorStoreFactory.reset() when available

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -3586,20 +3586,25 @@ class AsyncMemory(MemoryBase):
             Recreates the vector store with a new client
         """
         logger.warning("Resetting all memories")
-        await asyncio.to_thread(self.vector_store.delete_col)
 
-        gc.collect()
+        if hasattr(self.vector_store, "reset"):
+            self.vector_store = await asyncio.to_thread(VectorStoreFactory.reset, self.vector_store)
+        else:
+            logger.warning("Vector store does not support reset. Skipping.")
+            await asyncio.to_thread(self.vector_store.delete_col)
 
-        if hasattr(self.vector_store, "client") and hasattr(self.vector_store.client, "close"):
-            await asyncio.to_thread(self.vector_store.client.close)
+            gc.collect()
+
+            if hasattr(self.vector_store, "client") and hasattr(self.vector_store.client, "close"):
+                await asyncio.to_thread(self.vector_store.client.close)
+
+            self.vector_store = VectorStoreFactory.create(
+                self.config.vector_store.provider, self.config.vector_store.config
+            )
 
         await asyncio.to_thread(self.db.reset)
         await asyncio.to_thread(self.db.close)
         self.db = SQLiteManager(self.config.history_db_path)
-
-        self.vector_store = VectorStoreFactory.create(
-            self.config.vector_store.provider, self.config.vector_store.config
-        )
 
         if self._entity_store is not None:
             try:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1529,3 +1529,67 @@ async def test_async_procedural_memory_langchain_strips_code_blocks(mock_llm_fac
     insert_call = memory.vector_store.insert.call_args
     stored_data = insert_call[1]["payloads"][0]["data"]
     assert "```" not in stored_data
+
+
+# ─── AsyncMemory.reset() VectorStoreFactory.reset() parity tests ──────────────
+
+@pytest.mark.asyncio
+@patch("mem0.memory.main.VectorStoreFactory")
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.storage.SQLiteManager")
+async def test_async_reset_uses_factory_reset_when_available(
+    mock_sqlite, mock_llm, mock_emb, MockVSFactory
+):
+    """AsyncMemory.reset() must call VectorStoreFactory.reset() when the vector
+    store exposes a reset() method, not fall back to the slower delete_col() path."""
+    mock_emb.return_value = MagicMock()
+    mock_llm.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    mock_vs = MagicMock(spec=["reset", "insert", "search", "delete", "list", "get"])
+    MockVSFactory.create.return_value = mock_vs
+    MockVSFactory.reset.return_value = mock_vs
+
+    from mem0 import AsyncMemory
+
+    config = MemoryConfig()
+    memory = AsyncMemory(config)
+    memory.vector_store = mock_vs
+
+    create_calls_before = MockVSFactory.create.call_count
+    await memory.reset()
+
+    MockVSFactory.reset.assert_called_once_with(mock_vs)
+    assert MockVSFactory.create.call_count == create_calls_before, (
+        "VectorStoreFactory.create() must not be called when reset() path is taken"
+    )
+
+
+@pytest.mark.asyncio
+@patch("mem0.memory.main.VectorStoreFactory")
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.storage.SQLiteManager")
+async def test_async_reset_falls_back_to_delete_col_when_no_reset(
+    mock_sqlite, mock_llm, mock_emb, MockVSFactory
+):
+    """AsyncMemory.reset() must fall back to delete_col() + VectorStoreFactory.create()
+    when the vector store does not expose a reset() method."""
+    mock_emb.return_value = MagicMock()
+    mock_llm.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    mock_vs = MagicMock(spec=["delete_col", "insert", "search", "delete", "list", "get"])
+    MockVSFactory.create.return_value = mock_vs
+
+    from mem0 import AsyncMemory
+
+    config = MemoryConfig()
+    memory = AsyncMemory(config)
+    memory.vector_store = mock_vs
+
+    await memory.reset()
+
+    mock_vs.delete_col.assert_called_once()
+    MockVSFactory.reset.assert_not_called()


### PR DESCRIPTION
## Linked Issue

Closes #5915 

## Description

`AsyncMemory.reset()` hardcoded `delete_col()` unconditionally, skipping the `hasattr(self.vector_store, "reset")` check and `VectorStoreFactory.reset()` optimisation that `Memory.reset()` already uses. This meant async callers always took the slower delete-and-recreate path even on vector stores that support an efficient in-place reset.

This PR adds the same `hasattr` guard to `AsyncMemory.reset()`: when `reset()` is present on the vector store, it delegates to `VectorStoreFactory.reset()` via `asyncio.to_thread`; otherwise it falls back to the existing `delete_col()` + `gc.collect()` + `VectorStoreFactory.create()` path, now with a matching `logger.warning` mirroring the sync path.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Two new tests in `tests/test_memory.py`:
- `test_async_reset_uses_factory_reset_when_available` — verifies `VectorStoreFactory.reset()` is called and `VectorStoreFactory.create()` is not called again when the vector store exposes `reset()`
- `test_async_reset_falls_back_to_delete_col_when_no_reset` — verifies `delete_col()` is called and `VectorStoreFactory.reset()` is not called when the vector store lacks `reset()`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed