### PR TITLE
fix(llms): use http_client_proxies for xai config conversion

### DIFF
--- a/mem0/llms/xai.py
+++ b/mem0/llms/xai.py
@@ -28,7 +28,7 @@ class XAILLM(LLMBase):
                 top_k=config.top_k,
                 enable_vision=config.enable_vision,
                 vision_details=config.vision_details,
-                http_client_proxies=config.http_client,
+                http_client_proxies=config.http_client_proxies,
             )
 
         super().__init__(config)

--- a/tests/llms/test_xai.py
+++ b/tests/llms/test_xai.py
@@ -1,6 +1,7 @@
 import os
 from unittest.mock import Mock, patch
 
+import httpx
 import pytest
 
 from mem0.configs.llms.base import BaseLlmConfig
@@ -45,6 +46,15 @@ def test_xai_accepts_base_llm_config():
     llm = XAILLM(BaseLlmConfig(model="grok-2-latest", api_key="k"))
     assert isinstance(llm.config, XAIConfig)
     assert llm.config.xai_base_url is None
+
+
+def test_xai_preserves_http_client_proxies_from_base_config(mock_xai_client):
+    # Converting a BaseLlmConfig used to pass the already-built client as the
+    # proxies value, so any configured proxy crashed in build_http_client.
+    config = BaseLlmConfig(model="grok-2-latest", api_key="k", http_client_proxies="http://localhost:8080")
+    llm = XAILLM(config)
+    assert isinstance(llm.config, XAIConfig)
+    assert isinstance(llm.config.http_client, httpx.Client)
 
 
 def test_generate_response_without_tools(mock_xai_client):


### PR DESCRIPTION
## Linked Issue

No separate issue — this completes the migration started in #5447 (merged), which fixed the same `http_client` → `http_client_proxies` wiring in the 8 sibling LLM providers but did not touch `xai`.

## Description

`XAILLM.__init__` converts a `BaseLlmConfig` into an `XAIConfig` and was passing `http_client_proxies=config.http_client` — the already-built `httpx.Client` — instead of `config.http_client_proxies` (the raw proxy URL/dict). `build_http_client` expects `None | dict | str`, so once a proxy is configured it receives an `httpx.Client` and crashes during construction:

```
AttributeError: 'Client' object has no attribute 'url'
```

Every sibling provider (`anthropic`, `azure_openai`, `deepseek`, `lmstudio`, `minimax`, `ollama`, `openai`, `vllm`) already uses `config.http_client_proxies`; `xai` was the lone outlier missed by #5447. The bug is silent until a proxy is set (otherwise `config.http_client` is `None`).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

Added `test_xai_preserves_http_client_proxies_from_base_config` (mocked, no network): it constructs `XAILLM(BaseLlmConfig(..., http_client_proxies="http://localhost:8080"))` and asserts the HTTP client is built. It fails before this change (the `AttributeError` above) and passes after. `ruff check`, `ruff format`, and the existing `tests/llms/test_xai.py` suite pass locally.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (N/A — internal fix)
