### PR TITLE
feat(vector_store): add Aerospike vector search integration

### DIFF
--- a/mem0/configs/vector_stores/aerospike.py
+++ b/mem0/configs/vector_stores/aerospike.py
@@ -1,0 +1,53 @@
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class AerospikeConfig(BaseModel):
+    """Configuration for the Aerospike Vector Search vector store."""
+
+    host: str = Field("localhost", description="Aerospike Vector Search service host")
+    port: int = Field(5000, description="Aerospike Vector Search service port")
+    namespace: str = Field("mem0", description="Aerospike namespace to store vectors in")
+    set_name: str = Field("memories", description="Aerospike set (table) name within the namespace")
+    index_name: str = Field("mem0_index", description="Name of the HNSW vector index")
+    vector_field: str = Field("embedding", description="Bin name that holds the vector data")
+    embedding_model_dims: int = Field(1536, description="Dimensionality of the embedding vectors")
+    distance_metric: str = Field(
+        "COSINE",
+        description=(
+            "Distance metric for the vector index. "
+            "Supported values: 'COSINE', 'SQUARED_EUCLIDEAN', 'DOT_PRODUCT'"
+        ),
+    )
+    username: Optional[str] = Field(None, description="Username for Aerospike authentication (optional)")
+    password: Optional[str] = Field(None, description="Password for Aerospike authentication (optional)")
+    use_tls: bool = Field(False, description="Whether to use TLS for the AVS connection")
+    tls_cafile: Optional[str] = Field(None, description="Path to CA certificate file for TLS verification")
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_extra_fields(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        allowed_fields = {
+            "host",
+            "port",
+            "namespace",
+            "set_name",
+            "index_name",
+            "vector_field",
+            "embedding_model_dims",
+            "distance_metric",
+            "username",
+            "password",
+            "use_tls",
+            "tls_cafile",
+        }
+        extra = set(values.keys()) - allowed_fields
+        if extra:
+            raise ValueError(
+                f"Extra fields not allowed: {', '.join(sorted(extra))}. "
+                f"Allowed fields: {', '.join(sorted(allowed_fields))}"
+            )
+        return values

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -177,6 +177,7 @@ class EmbedderFactory:
 
 class VectorStoreFactory:
     provider_to_class = {
+        "aerospike": "mem0.vector_stores.aerospike.AerospikeDB",
         "qdrant": "mem0.vector_stores.qdrant.Qdrant",
         "chroma": "mem0.vector_stores.chroma.ChromaDB",
         "pgvector": "mem0.vector_stores.pgvector.PGVector",

--- a/mem0/vector_stores/aerospike.py
+++ b/mem0/vector_stores/aerospike.py
@@ -1,0 +1,330 @@
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
+
+from mem0.vector_stores.base import VectorStoreBase
+
+logger = logging.getLogger(__name__)
+
+# Bin name used to store the serialised JSON payload alongside the vector.
+_PAYLOAD_BIN = "payload"
+
+
+class OutputData(BaseModel):
+    id: Optional[str]
+    score: Optional[float]
+    payload: Optional[Dict]
+
+
+class AerospikeDB(VectorStoreBase):
+    """
+    Aerospike Vector Search (AVS) vector store for mem0.
+
+    Uses the ``aerospike-vector-search`` Python client to store and retrieve
+    memory vectors inside an Aerospike namespace/set backed by an HNSW index.
+
+    Setup
+    -----
+    1. Run an Aerospike cluster with the AVS sidecar (or use Aerospike Cloud).
+    2. ``pip install aerospike-vector-search``
+    3. Pass the connection details via ``AerospikeConfig``.
+
+    Example config::
+
+        {
+            "vector_store": {
+                "provider": "aerospike",
+                "config": {
+                    "host": "localhost",
+                    "port": 5000,
+                    "namespace": "mem0",
+                    "set_name": "memories",
+                    "index_name": "mem0_index",
+                    "embedding_model_dims": 1536,
+                    "distance_metric": "COSINE"
+                }
+            }
+        }
+    """
+
+    def __init__(
+        self,
+        host: str = "localhost",
+        port: int = 5000,
+        namespace: str = "mem0",
+        set_name: str = "memories",
+        index_name: str = "mem0_index",
+        vector_field: str = "embedding",
+        embedding_model_dims: int = 1536,
+        distance_metric: str = "COSINE",
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        use_tls: bool = False,
+        tls_cafile: Optional[str] = None,
+    ):
+        """
+        Initialize the Aerospike Vector Search store.
+
+        Args:
+            host: AVS service host.
+            port: AVS service port (default 5000).
+            namespace: Aerospike namespace.
+            set_name: Aerospike set (table) name.
+            index_name: Name of the HNSW vector index.
+            vector_field: Bin name storing the embedding vector.
+            embedding_model_dims: Embedding dimensionality.
+            distance_metric: One of ``'COSINE'``, ``'SQUARED_EUCLIDEAN'``,
+                ``'DOT_PRODUCT'``.
+            username: Optional username for authentication.
+            password: Optional password for authentication.
+            use_tls: Enable TLS for the AVS connection.
+            tls_cafile: Path to CA certificate file when ``use_tls=True``.
+        """
+        # Lazy import — allows tests to stub sys.modules before instantiation
+        # without the module-level ImportError firing at collection time.
+        try:
+            import aerospike_vector_search as _avs
+            from aerospike_vector_search import types as _avs_types
+        except ImportError:
+            raise ImportError(
+                "The 'aerospike-vector-search' library is required. "
+                "Please install it using 'pip install aerospike-vector-search'."
+            )
+
+        self._avs = _avs
+        self._avs_types = _avs_types
+
+        self.namespace = namespace
+        self.set_name = set_name
+        self.index_name = index_name
+        self.vector_field = vector_field
+        self.embedding_model_dims = embedding_model_dims
+        self.distance_metric = distance_metric
+
+        # Build AVS connection objects
+        seed = _avs_types.HostPort(host=host, port=port)
+
+        tls_config = None
+        if use_tls:
+            tls_config = _avs_types.TLSConfig(cafile=tls_cafile)
+
+        credentials = None
+        if username and password:
+            credentials = _avs_types.Credentials(username=username, password=password)
+
+        self.client = _avs.Client(
+            seeds=seed,
+            listener_name=None,
+            is_loadbalancer=False,
+            credentials=credentials,
+            tls_config=tls_config,
+        )
+
+        # Ensure the vector index exists
+        self.create_col(
+            name=self.index_name,
+            vector_size=self.embedding_model_dims,
+            distance=self.distance_metric,
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _metric_type(self, distance: str) -> Any:
+        """Resolve a distance string to the AVS VectorDistanceMetric enum."""
+        mapping = {
+            "COSINE": self._avs_types.VectorDistanceMetric.COSINE,
+            "SQUARED_EUCLIDEAN": self._avs_types.VectorDistanceMetric.SQUARED_EUCLIDEAN,
+            "DOT_PRODUCT": self._avs_types.VectorDistanceMetric.DOT_PRODUCT,
+        }
+        metric = mapping.get(distance.upper())
+        if metric is None:
+            raise ValueError(
+                f"Unsupported distance metric '{distance}'. "
+                f"Choose from: {list(mapping.keys())}"
+            )
+        return metric
+
+    def _score_from_distance(self, distance: float) -> float:
+        """Convert an AVS distance value to a similarity score in [0, 1]."""
+        metric = self.distance_metric.upper()
+        if metric == "COSINE":
+            # AVS returns cosine distance (0 = identical, 2 = opposite)
+            return max(0.0, 1.0 - distance)
+        elif metric == "SQUARED_EUCLIDEAN":
+            return 1.0 / (1.0 + distance)
+        else:
+            # DOT_PRODUCT: higher raw value = more similar
+            return float(distance)
+
+    def _record_to_output(self, record: Any) -> OutputData:
+        """Convert an AVS neighbour / get result object to OutputData."""
+        key = record.key.key if hasattr(record.key, "key") else str(record.key)
+        bins: dict = record.bins if hasattr(record, "bins") else {}
+        raw_payload = bins.get(_PAYLOAD_BIN, "{}")
+        try:
+            payload = json.loads(raw_payload) if isinstance(raw_payload, str) else raw_payload
+        except (json.JSONDecodeError, TypeError):
+            payload = {}
+        distance = getattr(record, "distance", None)
+        score = self._score_from_distance(distance) if distance is not None else None
+        return OutputData(id=key, score=score, payload=payload)
+
+    # ------------------------------------------------------------------
+    # VectorStoreBase interface
+    # ------------------------------------------------------------------
+
+    def create_col(self, name: str, vector_size: int, distance: str = "COSINE"):
+        """Create the HNSW vector index (idempotent — skips if it already exists)."""
+        try:
+            self.client.index_create(
+                namespace=self.namespace,
+                name=name,
+                vector_field=self.vector_field,
+                dimensions=vector_size,
+                vector_distance_metric=self._metric_type(distance),
+                sets=self.set_name,
+            )
+            logger.info(f"Created Aerospike vector index '{name}'.")
+        except Exception as exc:
+            if "already exists" in str(exc).lower() or "exists" in str(exc).lower():
+                logger.debug(f"Aerospike index '{name}' already exists — skipping creation.")
+            else:
+                raise
+
+    def insert(self, vectors: List[list], payloads: List[Dict] = None, ids: List[str] = None):
+        """Upsert vectors with their payloads into Aerospike."""
+        payloads = payloads or [{}] * len(vectors)
+        ids = ids or [str(i) for i in range(len(vectors))]
+
+        for vec, payload, key in zip(vectors, payloads, ids):
+            bins = {
+                self.vector_field: vec,
+                _PAYLOAD_BIN: json.dumps(payload),
+            }
+            self.client.upsert(
+                namespace=self.namespace,
+                set_name=self.set_name,
+                key=key,
+                record_data=bins,
+            )
+
+    def search(
+        self, query: str, vectors: List[float], top_k: int = 5, filters: Optional[Dict] = None
+    ) -> List[OutputData]:
+        """Search for the top-k nearest vectors to ``vectors``."""
+        raw = self.client.vector_search(
+            namespace=self.namespace,
+            index_name=self.index_name,
+            query=vectors,
+            limit=top_k,
+        )
+        output = [self._record_to_output(r) for r in raw]
+
+        # Client-side metadata filtering (AVS OSS does not yet expose
+        # server-side pre-filters on arbitrary payload bins in all setups).
+        if filters:
+            output = [
+                item
+                for item in output
+                if all(item.payload.get(k) == v for k, v in filters.items() if v is not None)
+            ]
+
+        return output
+
+    def delete(self, vector_id: str):
+        """Delete a record by its key."""
+        self.client.delete(
+            namespace=self.namespace,
+            set_name=self.set_name,
+            key=vector_id,
+        )
+
+    def update(self, vector_id: str, vector: Optional[List[float]] = None, payload: Optional[Dict] = None):
+        """Update a record's vector and/or payload bins in-place (upsert semantics)."""
+        bins: dict = {}
+        if vector is not None:
+            bins[self.vector_field] = vector
+        if payload is not None:
+            bins[_PAYLOAD_BIN] = json.dumps(payload)
+
+        if bins:
+            self.client.upsert(
+                namespace=self.namespace,
+                set_name=self.set_name,
+                key=vector_id,
+                record_data=bins,
+            )
+
+    def get(self, vector_id: str) -> Optional[OutputData]:
+        """Retrieve a single record by its key. Returns None if not found."""
+        try:
+            record = self.client.get(
+                namespace=self.namespace,
+                set_name=self.set_name,
+                key=vector_id,
+            )
+            if record is None:
+                return None
+            return self._record_to_output(record)
+        except Exception as exc:
+            if "not found" in str(exc).lower() or "key not found" in str(exc).lower():
+                return None
+            raise
+
+    def list_cols(self) -> List[str]:
+        """List all vector index names in the configured namespace."""
+        indexes = self.client.index_list()
+        return [idx.id.name for idx in indexes if idx.id.namespace == self.namespace]
+
+    def delete_col(self):
+        """Drop the vector index. Records stored in the set are NOT deleted."""
+        try:
+            self.client.index_drop(namespace=self.namespace, name=self.index_name)
+        except Exception as exc:
+            logger.warning(f"Could not drop Aerospike index '{self.index_name}': {exc}")
+
+    def col_info(self) -> Dict:
+        """Return metadata about the current vector index."""
+        try:
+            return self.client.index_get(namespace=self.namespace, name=self.index_name)
+        except Exception:
+            return {}
+
+    def list(self, filters: Optional[Dict] = None, top_k: int = 100) -> List[List[OutputData]]:
+        """
+        List stored memories.
+
+        Performs a vector search with a zero vector to retrieve up to ``top_k``
+        records, then applies ``filters`` (user_id, agent_id, run_id) client-side.
+        """
+        zero_vector = [0.0] * self.embedding_model_dims
+        raw = self.client.vector_search(
+            namespace=self.namespace,
+            index_name=self.index_name,
+            query=zero_vector,
+            limit=top_k,
+        )
+        results = [self._record_to_output(r) for r in raw]
+
+        if filters:
+            results = [
+                item
+                for item in results
+                if all(item.payload.get(k) == v for k, v in filters.items() if v is not None)
+            ]
+
+        return [results]
+
+    def reset(self):
+        """Drop and recreate the vector index (underlying records are preserved)."""
+        logger.warning(f"Resetting Aerospike index '{self.index_name}'...")
+        self.delete_col()
+        self.create_col(
+            name=self.index_name,
+            vector_size=self.embedding_model_dims,
+            distance=self.distance_metric,
+        )

--- a/mem0/vector_stores/configs.py
+++ b/mem0/vector_stores/configs.py
@@ -11,6 +11,7 @@ class VectorStoreConfig(BaseModel):
     config: Optional[Dict] = Field(description="Configuration for the specific vector store", default=None)
 
     _provider_configs: Dict[str, str] = {
+        "aerospike": "AerospikeConfig",
         "qdrant": "QdrantConfig",
         "chroma": "ChromaDbConfig",
         "pgvector": "PGVectorConfig",

--- a/tests/vector_stores/test_aerospike.py
+++ b/tests/vector_stores/test_aerospike.py
@@ -1,0 +1,344 @@
+"""
+Unit tests for mem0.vector_stores.aerospike.AerospikeDB
+
+All Aerospike AVS client calls are mocked — no running Aerospike instance is
+required.  Spin up a real AVS (e.g. via Docker) and run end-to-end tests when
+you have the service available.
+
+The sys.modules stub at the top must come before any mem0 imports so that the
+lazy import inside AerospikeDB.__init__ resolves to the mock without needing
+the real aerospike-vector-search package installed.
+"""
+
+import json
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub out aerospike_vector_search BEFORE importing mem0 modules.
+# The lazy import inside AerospikeDB.__init__ will pick this up.
+# ---------------------------------------------------------------------------
+_avs_stub = MagicMock()
+_avs_stub.types.VectorDistanceMetric.COSINE = "COSINE"
+_avs_stub.types.VectorDistanceMetric.SQUARED_EUCLIDEAN = "SQUARED_EUCLIDEAN"
+_avs_stub.types.VectorDistanceMetric.DOT_PRODUCT = "DOT_PRODUCT"
+_avs_stub.types.HostPort = MagicMock(return_value=MagicMock())
+_avs_stub.types.TLSConfig = MagicMock(return_value=MagicMock())
+_avs_stub.types.Credentials = MagicMock(return_value=MagicMock())
+sys.modules.setdefault("aerospike_vector_search", _avs_stub)
+sys.modules.setdefault("aerospike_vector_search.types", _avs_stub.types)
+
+# Now it is safe to import AerospikeDB.
+from mem0.configs.vector_stores.aerospike import AerospikeConfig  # noqa: E402
+from mem0.vector_stores.aerospike import AerospikeDB, OutputData, _PAYLOAD_BIN  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_neighbour(key: str, payload: dict, distance: float = 0.1):
+    """Build a minimal mock AVS search / neighbour result."""
+    rec = MagicMock()
+    rec.key.key = key
+    rec.bins = {_PAYLOAD_BIN: json.dumps(payload)}
+    rec.distance = distance
+    return rec
+
+
+def _make_get_result(key: str, payload: dict):
+    """Build a minimal mock AVS get result (no distance attribute)."""
+    rec = MagicMock(spec=["key", "bins"])
+    rec.key.key = key
+    rec.bins = {_PAYLOAD_BIN: json.dumps(payload)}
+    return rec
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def store():
+    """Return an AerospikeDB instance whose AVS client is a fresh MagicMock."""
+    db = AerospikeDB(
+        host="localhost",
+        port=5000,
+        namespace="mem0",
+        set_name="memories",
+        index_name="mem0_index",
+        embedding_model_dims=4,
+        distance_metric="COSINE",
+    )
+    # Replace the real (mocked) client with a clean mock so __init__ call
+    # counts don't bleed into individual tests.
+    db.client = MagicMock()
+    return db
+
+
+# ---------------------------------------------------------------------------
+# AerospikeConfig
+# ---------------------------------------------------------------------------
+
+class TestAerospikeConfig:
+    def test_defaults(self):
+        cfg = AerospikeConfig()
+        assert cfg.host == "localhost"
+        assert cfg.port == 5000
+        assert cfg.namespace == "mem0"
+        assert cfg.distance_metric == "COSINE"
+        assert cfg.embedding_model_dims == 1536
+
+    def test_custom_values(self):
+        cfg = AerospikeConfig(
+            host="avs.example.com",
+            port=4000,
+            namespace="prod",
+            embedding_model_dims=768,
+            distance_metric="DOT_PRODUCT",
+        )
+        assert cfg.host == "avs.example.com"
+        assert cfg.embedding_model_dims == 768
+
+    def test_extra_fields_rejected(self):
+        with pytest.raises(ValueError, match="Extra fields not allowed"):
+            AerospikeConfig(unknown_field="oops")
+
+
+# ---------------------------------------------------------------------------
+# create_col
+# ---------------------------------------------------------------------------
+
+class TestCreateCol:
+    def test_creates_index(self, store):
+        store.create_col(name="new_index", vector_size=4, distance="COSINE")
+        store.client.index_create.assert_called_once()
+        kw = store.client.index_create.call_args.kwargs
+        assert kw["name"] == "new_index"
+        assert kw["dimensions"] == 4
+
+    def test_already_exists_is_silent(self, store):
+        store.client.index_create.side_effect = Exception("Index already exists")
+        store.create_col(name="mem0_index", vector_size=4, distance="COSINE")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# insert
+# ---------------------------------------------------------------------------
+
+class TestInsert:
+    def test_upsert_called_for_each_vector(self, store):
+        vectors = [[0.1, 0.2, 0.3, 0.4], [0.5, 0.6, 0.7, 0.8]]
+        payloads = [{"data": "hello", "user_id": "u1"}, {"data": "world", "user_id": "u2"}]
+        ids = ["id1", "id2"]
+
+        store.insert(vectors=vectors, payloads=payloads, ids=ids)
+
+        assert store.client.upsert.call_count == 2
+
+    def test_upsert_stores_vector_and_payload_bin(self, store):
+        store.insert(vectors=[[0.1, 0.2, 0.3, 0.4]], payloads=[{"data": "test", "user_id": "u1"}], ids=["id1"])
+
+        kw = store.client.upsert.call_args.kwargs
+        assert kw["key"] == "id1"
+        bins = kw["record_data"]
+        assert bins["embedding"] == [0.1, 0.2, 0.3, 0.4]
+        assert json.loads(bins[_PAYLOAD_BIN]) == {"data": "test", "user_id": "u1"}
+
+
+# ---------------------------------------------------------------------------
+# search
+# ---------------------------------------------------------------------------
+
+class TestSearch:
+    def test_returns_output_data(self, store):
+        store.client.vector_search.return_value = [
+            _make_neighbour("id1", {"data": "hello", "user_id": "u1"}, distance=0.1),
+            _make_neighbour("id2", {"data": "world", "user_id": "u2"}, distance=0.3),
+        ]
+
+        results = store.search(query="test", vectors=[0.1, 0.2, 0.3, 0.4], top_k=2)
+
+        assert len(results) == 2
+        assert results[0].id == "id1"
+        assert results[0].payload["data"] == "hello"
+        assert results[0].score == pytest.approx(0.9)  # cosine: 1 - 0.1
+
+    def test_vector_search_called_with_correct_args(self, store):
+        store.client.vector_search.return_value = []
+        query_vec = [0.1, 0.2, 0.3, 0.4]
+
+        store.search(query="q", vectors=query_vec, top_k=5)
+
+        store.client.vector_search.assert_called_once_with(
+            namespace="mem0",
+            index_name="mem0_index",
+            query=query_vec,
+            limit=5,
+        )
+
+    def test_client_side_filter_applied(self, store):
+        store.client.vector_search.return_value = [
+            _make_neighbour("id1", {"data": "match", "user_id": "alice"}, distance=0.1),
+            _make_neighbour("id2", {"data": "no-match", "user_id": "bob"}, distance=0.2),
+        ]
+
+        results = store.search(query="q", vectors=[0.1, 0.2, 0.3, 0.4], filters={"user_id": "alice"})
+
+        assert len(results) == 1
+        assert results[0].id == "id1"
+
+    def test_no_filter_returns_all(self, store):
+        store.client.vector_search.return_value = [
+            _make_neighbour("id1", {"user_id": "alice"}, distance=0.1),
+            _make_neighbour("id2", {"user_id": "bob"}, distance=0.2),
+        ]
+
+        results = store.search(query="q", vectors=[0.1, 0.2, 0.3, 0.4], filters=None)
+
+        assert len(results) == 2
+
+
+# ---------------------------------------------------------------------------
+# delete
+# ---------------------------------------------------------------------------
+
+class TestDelete:
+    def test_delete_calls_client(self, store):
+        store.delete("id1")
+        store.client.delete.assert_called_once_with(namespace="mem0", set_name="memories", key="id1")
+
+
+# ---------------------------------------------------------------------------
+# update
+# ---------------------------------------------------------------------------
+
+class TestUpdate:
+    def test_update_vector_and_payload(self, store):
+        store.update("id1", vector=[0.9, 0.8, 0.7, 0.6], payload={"data": "new"})
+        kw = store.client.upsert.call_args.kwargs
+        assert kw["key"] == "id1"
+        bins = kw["record_data"]
+        assert bins["embedding"] == [0.9, 0.8, 0.7, 0.6]
+        assert json.loads(bins[_PAYLOAD_BIN]) == {"data": "new"}
+
+    def test_update_payload_only(self, store):
+        store.update("id1", vector=None, payload={"data": "only_payload"})
+        bins = store.client.upsert.call_args.kwargs["record_data"]
+        assert "embedding" not in bins
+        assert json.loads(bins[_PAYLOAD_BIN]) == {"data": "only_payload"}
+
+    def test_update_vector_only(self, store):
+        store.update("id1", vector=[1.0, 0.0, 0.0, 0.0], payload=None)
+        bins = store.client.upsert.call_args.kwargs["record_data"]
+        assert bins["embedding"] == [1.0, 0.0, 0.0, 0.0]
+        assert _PAYLOAD_BIN not in bins
+
+    def test_update_nothing_does_not_call_upsert(self, store):
+        store.update("id1", vector=None, payload=None)
+        store.client.upsert.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# get
+# ---------------------------------------------------------------------------
+
+class TestGet:
+    def test_get_existing_record(self, store):
+        store.client.get.return_value = _make_get_result("id1", {"data": "hello", "user_id": "u1"})
+
+        result = store.get("id1")
+
+        assert isinstance(result, OutputData)
+        assert result.id == "id1"
+        assert result.payload["data"] == "hello"
+
+    def test_get_missing_record_returns_none(self, store):
+        store.client.get.return_value = None
+        assert store.get("nonexistent") is None
+
+    def test_get_not_found_exception_returns_none(self, store):
+        store.client.get.side_effect = Exception("Key not found")
+        assert store.get("nonexistent") is None
+
+
+# ---------------------------------------------------------------------------
+# list_cols / delete_col / col_info
+# ---------------------------------------------------------------------------
+
+class TestManagement:
+    def test_list_cols_filters_by_namespace(self, store):
+        idx1, idx2 = MagicMock(), MagicMock()
+        idx1.id.name = "mem0_index"
+        idx1.id.namespace = "mem0"
+        idx2.id.name = "other_index"
+        idx2.id.namespace = "other_ns"
+        store.client.index_list.return_value = [idx1, idx2]
+
+        assert store.list_cols() == ["mem0_index"]
+
+    def test_delete_col_calls_index_drop(self, store):
+        store.delete_col()
+        store.client.index_drop.assert_called_once_with(namespace="mem0", name="mem0_index")
+
+    def test_col_info_returns_index_info(self, store):
+        store.client.index_get.return_value = {"name": "mem0_index", "dimensions": 4}
+        assert store.col_info()["name"] == "mem0_index"
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+class TestList:
+    def test_list_returns_nested_list(self, store):
+        store.client.vector_search.return_value = [
+            _make_neighbour("id1", {"data": "a", "user_id": "u1"}, distance=0.0),
+            _make_neighbour("id2", {"data": "b", "user_id": "u2"}, distance=0.0),
+        ]
+
+        results = store.list(top_k=10)
+
+        assert isinstance(results, list)
+        assert isinstance(results[0], list)
+        assert len(results[0]) == 2
+
+    def test_list_applies_filter(self, store):
+        store.client.vector_search.return_value = [
+            _make_neighbour("id1", {"user_id": "alice"}, distance=0.0),
+            _make_neighbour("id2", {"user_id": "bob"}, distance=0.0),
+        ]
+
+        results = store.list(filters={"user_id": "alice"}, top_k=10)
+
+        assert len(results[0]) == 1
+        assert results[0][0].id == "id1"
+
+
+# ---------------------------------------------------------------------------
+# reset
+# ---------------------------------------------------------------------------
+
+class TestReset:
+    def test_reset_drops_and_recreates_index(self, store):
+        store.reset()
+        store.client.index_drop.assert_called_once_with(namespace="mem0", name="mem0_index")
+        store.client.index_create.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# score conversion
+# ---------------------------------------------------------------------------
+
+class TestScoreConversion:
+    def test_cosine_score(self, store):
+        assert store._score_from_distance(0.0) == pytest.approx(1.0)
+        assert store._score_from_distance(1.0) == pytest.approx(0.0)
+        assert store._score_from_distance(0.4) == pytest.approx(0.6)
+
+    def test_squared_euclidean_score(self, store):
+        store.distance_metric = "SQUARED_EUCLIDEAN"
+        assert store._score_from_distance(0.0) == pytest.approx(1.0)
+        assert store._score_from_distance(3.0) == pytest.approx(0.25)


### PR DESCRIPTION
Adds AerospikeDB vector store using the aerospike-vector-search python client. Includes Pydantic configuration and mocked test suite.

## Linked Issue

Closes #5918

## Description

This PR adds native support for Aerospike Vector Search (AVS) as a vector store provider in Mem0. 

Aerospike is widely used in enterprise environments for low-latency, high-throughput storage, making it an excellent backend for massive AI agent memory systems.

**Key Additions:**
- `AerospikeDB` class implementing the `VectorStoreBase` interface.
- `AerospikeConfig` Pydantic model for type-safe configuration (defaults to `localhost:5000`).
- Seamless distance metric mapping (Cosine, Squared Euclidean, Dot Product).
- Complete mocked unit test suite covering index creation, upsert, search, filters, deletion, and score conversion.

*Note: As AVS is an enterprise-only feature, I fully implemented the integration and thoroughly tested the logic via `unittest.mock`. It would be great if a maintainer with an active enterprise license could run a quick sanity check against a live AVS instance!*

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

I added a comprehensive mocked test suite (`tests/vector_stores/test_aerospike.py`) which intercepts the `aerospike-vector-search` gRPC client to verify that Mem0 passes the correct indices, payload schemas, and metadata filters.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
