### PR TITLE
feat: Add native embed_batch() to FastEmbed, AWS Bedrock, and Langchain

### DIFF
--- a/mem0/embeddings/aws_bedrock.py
+++ b/mem0/embeddings/aws_bedrock.py
@@ -108,3 +108,41 @@ class AWSBedrockEmbedding(EmbeddingBase):
             list: The embedding vector.
         """
         return self._get_embedding(text)
+
+    def embed_batch(self, texts, memory_action="add"):
+        """Embed multiple texts using AWS Bedrock.
+
+        Cohere models natively support batch embedding via their ``texts``
+        list field, so all inputs are sent in a single API call.  Titan and
+        other Amazon models only accept one text per invocation, so they
+        fall back to sequential calls.
+
+        Args:
+            texts: List of text strings to embed.
+            memory_action: The action context ("add", "search", "update").
+
+        Returns:
+            List of embedding vectors (list of floats), one per input text.
+        """
+        if not texts:
+            return []
+
+        provider = self.config.model.split(".")[0]
+
+        if provider == "cohere":
+            input_body = {"input_type": "search_document", "texts": texts}
+            body = json.dumps(input_body)
+            try:
+                response = self.client.invoke_model(
+                    body=body,
+                    modelId=self.config.model,
+                    accept="application/json",
+                    contentType="application/json",
+                )
+                response_body = json.loads(response.get("body").read())
+                return response_body.get("embeddings")
+            except Exception as e:
+                raise ValueError(f"Error getting batch embeddings from AWS Bedrock (Cohere): {e}")
+        else:
+            # Titan and other providers: sequential calls (no native batch API)
+            return [self._get_embedding(text) for text in texts]

--- a/mem0/embeddings/fastembed.py
+++ b/mem0/embeddings/fastembed.py
@@ -1,12 +1,13 @@
-from typing import Optional, Literal
+from typing import Literal, Optional
 
-from mem0.embeddings.base import EmbeddingBase
 from mem0.configs.embeddings.base import BaseEmbedderConfig
+from mem0.embeddings.base import EmbeddingBase
 
 try:
     from fastembed import TextEmbedding
 except ImportError:
     raise ImportError("FastEmbed is not installed.  Please install it using `pip install fastembed`")
+
 
 class FastEmbedEmbedding(EmbeddingBase):
     def __init__(self, config: Optional[BaseEmbedderConfig] = None):
@@ -30,3 +31,22 @@ class FastEmbedEmbedding(EmbeddingBase):
         text = text.replace("\n", " ")
         embeddings = list(self.dense_model.embed(text))
         return embeddings[0]
+
+    def embed_batch(self, texts, memory_action="add"):
+        """Embed multiple texts in a single FastEmbed call.
+
+        FastEmbed's embed() natively accepts a list of strings and
+        returns embeddings via its ONNX runtime, avoiding the sequential
+        per-text overhead of the base class fallback.
+
+        Args:
+            texts: List of text strings to embed.
+            memory_action: The action context ("add", "search", "update").
+
+        Returns:
+            List of embedding vectors (list of floats), one per input text.
+        """
+        if not texts:
+            return []
+        texts = [text.replace("\n", " ") for text in texts]
+        return list(self.dense_model.embed(texts))

--- a/mem0/embeddings/langchain.py
+++ b/mem0/embeddings/langchain.py
@@ -33,3 +33,20 @@ class LangchainEmbedding(EmbeddingBase):
         """
 
         return self.langchain_model.embed_query(text)
+
+    def embed_batch(self, texts, memory_action="add"):
+        """Embed multiple texts using Langchain's native batch API.
+
+        Uses embed_documents() which is optimized for batch operations,
+        avoiding the sequential per-text overhead of the base class fallback.
+
+        Args:
+            texts: List of text strings to embed.
+            memory_action: The action context ("add", "search", "update").
+
+        Returns:
+            List of embedding vectors (list of floats), one per input text.
+        """
+        if not texts:
+            return []
+        return self.langchain_model.embed_documents(texts)

--- a/tests/embeddings/test_aws_bedrock_embeddings.py
+++ b/tests/embeddings/test_aws_bedrock_embeddings.py
@@ -105,3 +105,61 @@ def test_titan_v1_ignores_embedding_dims(mock_boto3_client):
         body = _captured_request_body(mock_boto3_client, config)
 
     assert "dimensions" not in body
+
+
+def test_embed_batch_cohere_single_api_call(mock_boto3_client):
+    """Cohere models should embed all texts in a single invoke_model call."""
+    with patch("mem0.embeddings.aws_bedrock.os.environ", {}):
+        runtime = mock_boto3_client.return_value
+        response_stream = Mock()
+        response_stream.read.return_value = json.dumps({"embeddings": [[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]}).encode()
+        runtime.invoke_model.return_value = {"body": response_stream}
+
+        config = BaseEmbedderConfig(model="cohere.embed-english-v3")
+        embedder = AWSBedrockEmbedding(config)
+
+        texts = ["first", "second", "third"]
+        embeddings = embedder.embed_batch(texts)
+
+    assert embeddings == [[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]
+    runtime.invoke_model.assert_called_once()
+    call_body = json.loads(runtime.invoke_model.call_args[1]["body"])
+    assert call_body["texts"] == texts
+    assert call_body["input_type"] == "search_document"
+
+
+def test_embed_batch_titan_sequential_calls(mock_boto3_client):
+    """Titan models should call invoke_model once per text (no native batch)."""
+    with patch("mem0.embeddings.aws_bedrock.os.environ", {}):
+        runtime = mock_boto3_client.return_value
+
+        def make_response(embedding):
+            stream = Mock()
+            stream.read.return_value = json.dumps({"embedding": embedding}).encode()
+            return {"body": stream}
+
+        runtime.invoke_model.side_effect = [
+            make_response([0.1, 0.2]),
+            make_response([0.3, 0.4]),
+        ]
+
+        config = BaseEmbedderConfig(model="amazon.titan-embed-text-v1")
+        embedder = AWSBedrockEmbedding(config)
+
+        embeddings = embedder.embed_batch(["first", "second"])
+
+    assert embeddings == [[0.1, 0.2], [0.3, 0.4]]
+    assert runtime.invoke_model.call_count == 2
+
+
+def test_embed_batch_empty_list(mock_boto3_client):
+    """embed_batch() with an empty list should return [] without any API call."""
+    with patch("mem0.embeddings.aws_bedrock.os.environ", {}):
+        runtime = mock_boto3_client.return_value
+        config = BaseEmbedderConfig(model="amazon.titan-embed-text-v1")
+        embedder = AWSBedrockEmbedding(config)
+
+        result = embedder.embed_batch([])
+
+    assert result == []
+    runtime.invoke_model.assert_not_called()

--- a/tests/embeddings/test_fastembed_embeddings.py
+++ b/tests/embeddings/test_fastembed_embeddings.py
@@ -1,14 +1,15 @@
 from unittest.mock import Mock, patch
 
-import pytest
 import numpy as np
+import pytest
+
 from mem0.configs.embeddings.base import BaseEmbedderConfig
 
 try:
     from mem0.embeddings.fastembed import FastEmbedEmbedding
 except ImportError:
     pytest.skip("fastembed not installed", allow_module_level=True)
-  
+
 
 @pytest.fixture
 def mock_fastembed_client():
@@ -21,13 +22,13 @@ def mock_fastembed_client():
 def test_embed_with_jina_model(mock_fastembed_client):
     config = BaseEmbedderConfig(model="jinaai/jina-embeddings-v2-base-en", embedding_dims=768)
     embedder = FastEmbedEmbedding(config)
-    
+
     mock_embedding = np.array([0.1, 0.2, 0.3, 0.4, 0.5])
     mock_fastembed_client.embed.return_value = iter([mock_embedding])
-    
+
     text = "Sample text to embed."
     embedding = embedder.embed(text)
-    
+
     mock_fastembed_client.embed.assert_called_once_with(text)
     assert list(embedding) == [0.1, 0.2, 0.3, 0.4, 0.5]
 
@@ -35,12 +36,56 @@ def test_embed_with_jina_model(mock_fastembed_client):
 def test_embed_removes_newlines(mock_fastembed_client):
     config = BaseEmbedderConfig(model="jinaai/jina-embeddings-v2-base-en", embedding_dims=768)
     embedder = FastEmbedEmbedding(config)
-    
+
     mock_embedding = np.array([0.7, 0.8, 0.9])
     mock_fastembed_client.embed.return_value = iter([mock_embedding])
-    
+
     text_with_newlines = "Hello\nworld"
     embedding = embedder.embed(text_with_newlines)
-    
+
     mock_fastembed_client.embed.assert_called_once_with("Hello world")
     assert list(embedding) == [0.7, 0.8, 0.9]
+
+
+def test_embed_batch_single_call(mock_fastembed_client):
+    """embed_batch() should pass all texts to FastEmbed's embed() in one call."""
+    config = BaseEmbedderConfig(model="jinaai/jina-embeddings-v2-base-en", embedding_dims=768)
+    embedder = FastEmbedEmbedding(config)
+
+    mock_embeddings = [
+        np.array([0.1, 0.2, 0.3]),
+        np.array([0.4, 0.5, 0.6]),
+        np.array([0.7, 0.8, 0.9]),
+    ]
+    mock_fastembed_client.embed.return_value = iter(mock_embeddings)
+
+    texts = ["First text.", "Second text.", "Third text."]
+    embeddings = embedder.embed_batch(texts)
+
+    mock_fastembed_client.embed.assert_called_once_with(texts)
+    assert len(embeddings) == 3
+
+
+def test_embed_batch_empty_list(mock_fastembed_client):
+    """embed_batch() with an empty list should return [] without calling the model."""
+    config = BaseEmbedderConfig(model="jinaai/jina-embeddings-v2-base-en", embedding_dims=768)
+    embedder = FastEmbedEmbedding(config)
+
+    result = embedder.embed_batch([])
+
+    assert result == []
+    mock_fastembed_client.embed.assert_not_called()
+
+
+def test_embed_batch_removes_newlines(mock_fastembed_client):
+    """embed_batch() should strip newlines from each text before embedding."""
+    config = BaseEmbedderConfig(model="jinaai/jina-embeddings-v2-base-en", embedding_dims=768)
+    embedder = FastEmbedEmbedding(config)
+
+    mock_embeddings = [np.array([0.1, 0.2]), np.array([0.3, 0.4])]
+    mock_fastembed_client.embed.return_value = iter(mock_embeddings)
+
+    texts = ["Hello\nworld", "Foo\nbar"]
+    embedder.embed_batch(texts)
+
+    mock_fastembed_client.embed.assert_called_once_with(["Hello world", "Foo bar"])

--- a/tests/embeddings/test_langchain_embeddings.py
+++ b/tests/embeddings/test_langchain_embeddings.py
@@ -1,0 +1,74 @@
+from unittest.mock import Mock
+
+import pytest
+
+from mem0.configs.embeddings.base import BaseEmbedderConfig
+
+try:
+    from langchain.embeddings.base import Embeddings
+
+    from mem0.embeddings.langchain import LangchainEmbedding
+except ImportError:
+    pytest.skip("langchain not installed", allow_module_level=True)
+
+
+@pytest.fixture
+def mock_langchain_model():
+    """Create a mock Langchain Embeddings instance that passes isinstance checks."""
+    mock_model = Mock(spec=Embeddings)
+    yield mock_model
+
+
+def test_embed_batch_uses_embed_documents(mock_langchain_model):
+    """embed_batch() should delegate to Langchain's embed_documents()."""
+    config = BaseEmbedderConfig(model=mock_langchain_model)
+    embedder = LangchainEmbedding(config)
+
+    mock_langchain_model.embed_documents.return_value = [
+        [0.1, 0.2, 0.3],
+        [0.4, 0.5, 0.6],
+        [0.7, 0.8, 0.9],
+    ]
+
+    texts = ["First text.", "Second text.", "Third text."]
+    embeddings = embedder.embed_batch(texts)
+
+    mock_langchain_model.embed_documents.assert_called_once_with(texts)
+    assert embeddings == [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]]
+
+
+def test_embed_batch_empty_list(mock_langchain_model):
+    """embed_batch() with an empty list should return [] without calling the model."""
+    config = BaseEmbedderConfig(model=mock_langchain_model)
+    embedder = LangchainEmbedding(config)
+
+    result = embedder.embed_batch([])
+
+    assert result == []
+    mock_langchain_model.embed_documents.assert_not_called()
+
+
+def test_embed_batch_single_text(mock_langchain_model):
+    """embed_batch() with a single text should still use embed_documents()."""
+    config = BaseEmbedderConfig(model=mock_langchain_model)
+    embedder = LangchainEmbedding(config)
+
+    mock_langchain_model.embed_documents.return_value = [[0.1, 0.2, 0.3]]
+
+    embeddings = embedder.embed_batch(["Only text."])
+
+    mock_langchain_model.embed_documents.assert_called_once_with(["Only text."])
+    assert embeddings == [[0.1, 0.2, 0.3]]
+
+
+def test_embed_single_uses_embed_query(mock_langchain_model):
+    """embed() should delegate to Langchain's embed_query()."""
+    config = BaseEmbedderConfig(model=mock_langchain_model)
+    embedder = LangchainEmbedding(config)
+
+    mock_langchain_model.embed_query.return_value = [0.1, 0.2, 0.3]
+
+    embedding = embedder.embed("Test text.")
+
+    mock_langchain_model.embed_query.assert_called_once_with("Test text.")
+    assert embedding == [0.1, 0.2, 0.3]


### PR DESCRIPTION
Closes #5921

## Linked Issue

Closes #5921

## Description

The base `EmbeddingBase.embed_batch()` falls back to calling `embed()` sequentially per text. This PR adds native `embed_batch()` overrides for three providers that have native batch APIs, significantly reducing per-text overhead and improving performance:

- **FastEmbed** — Uses `TextEmbedding.embed()` which natively accepts lists and processes them via ONNX.
- **AWS Bedrock** — Cohere models process batch inputs via their `texts` list field. Titan and other Amazon models fall back to sequential calls as they lack a native batch API.
- **Langchain** — Uses Langchain's optimized `embed_documents()` method.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added comprehensive unit tests in `tests/embeddings/` for the new `embed_batch()` methods, covering batch calls, single calls, and empty lists. Ran `make test` (pytest) locally and all tests passed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
