### PR TITLE
fix(openmemory): correct audit history old_state for new memories

### DIFF
--- a/openmemory/api/app/mcp_server.py
+++ b/openmemory/api/app/mcp_server.py
@@ -101,6 +101,7 @@ async def add_memories(text: str, infer: bool = True) -> str:
                     memory = db.query(Memory).filter(Memory.id == memory_id).first()
 
                     if result['event'] == 'ADD':
+                        was_existing = memory is not None
                         if not memory:
                             memory = Memory(
                                 id=memory_id,
@@ -118,7 +119,7 @@ async def add_memories(text: str, infer: bool = True) -> str:
                         history = MemoryStatusHistory(
                             memory_id=memory_id,
                             changed_by=user.id,
-                            old_state=MemoryState.deleted if memory else None,
+                            old_state=MemoryState.deleted if was_existing else None,
                             new_state=MemoryState.active
                         )
                         db.add(history)

--- a/openmemory/api/tests/test_audit_history.py
+++ b/openmemory/api/tests/test_audit_history.py
@@ -1,0 +1,111 @@
+import json
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from app.models import Memory, MemoryState, MemoryStatusHistory
+from app.mcp_server import add_memories, user_id_var, client_name_var
+
+@pytest.mark.asyncio
+@patch("app.mcp_server.SessionLocal")
+@patch("app.mcp_server.get_user_and_app")
+@patch("app.mcp_server.get_memory_client_safe")
+async def test_add_memories_audit_history_new_memory(mock_get_client, mock_get_user_app, mock_session):
+    # Setup context vars
+    u_token = user_id_var.set("test-user")
+    c_token = client_name_var.set("test-client")
+    
+    try:
+        mock_db = MagicMock()
+        mock_session.return_value = mock_db
+        
+        mock_user = MagicMock()
+        mock_user.id = "user_123"
+        mock_app = MagicMock()
+        mock_app.id = "app_123"
+        mock_app.is_active = True
+        mock_get_user_app.return_value = (mock_user, mock_app)
+        
+        mock_client = MagicMock()
+        memory_id_str = str(uuid.uuid4())
+        mock_client.add.return_value = {
+            "results": [
+                {
+                    "id": memory_id_str,
+                    "event": "ADD",
+                    "memory": "Test memory content"
+                }
+            ]
+        }
+        mock_get_client.return_value = mock_client
+        
+        # Mock that the memory does NOT exist in the database initially
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+        
+        response_str = await add_memories("Test memory", infer=False)
+        assert json.loads(response_str) == mock_client.add.return_value
+        
+        # Verify history entry was created with old_state=None
+        added_objects = mock_db.add.call_args_list
+        history_entry = next((call[0][0] for call in added_objects if isinstance(call[0][0], MemoryStatusHistory)), None)
+        
+        assert history_entry is not None
+        assert history_entry.old_state is None
+        assert history_entry.new_state == MemoryState.active
+        
+    finally:
+        user_id_var.reset(u_token)
+        client_name_var.reset(c_token)
+
+
+@pytest.mark.asyncio
+@patch("app.mcp_server.SessionLocal")
+@patch("app.mcp_server.get_user_and_app")
+@patch("app.mcp_server.get_memory_client_safe")
+async def test_add_memories_audit_history_existing_memory(mock_get_client, mock_get_user_app, mock_session):
+    # Setup context vars
+    u_token = user_id_var.set("test-user")
+    c_token = client_name_var.set("test-client")
+    
+    try:
+        mock_db = MagicMock()
+        mock_session.return_value = mock_db
+        
+        mock_user = MagicMock()
+        mock_user.id = "user_123"
+        mock_app = MagicMock()
+        mock_app.id = "app_123"
+        mock_app.is_active = True
+        mock_get_user_app.return_value = (mock_user, mock_app)
+        
+        mock_client = MagicMock()
+        memory_id_str = str(uuid.uuid4())
+        mock_client.add.return_value = {
+            "results": [
+                {
+                    "id": memory_id_str,
+                    "event": "ADD",
+                    "memory": "Test memory content"
+                }
+            ]
+        }
+        mock_get_client.return_value = mock_client
+        
+        # Mock that the memory DOES exist in the database (e.g. was previously deleted)
+        existing_memory = Memory(id=uuid.UUID(memory_id_str), state=MemoryState.deleted)
+        mock_db.query.return_value.filter.return_value.first.return_value = existing_memory
+        
+        response_str = await add_memories("Test memory", infer=False)
+        assert json.loads(response_str) == mock_client.add.return_value
+        
+        # Verify history entry was created with old_state=deleted
+        added_objects = mock_db.add.call_args_list
+        history_entry = next((call[0][0] for call in added_objects if isinstance(call[0][0], MemoryStatusHistory)), None)
+        
+        assert history_entry is not None
+        assert history_entry.old_state == MemoryState.deleted
+        assert history_entry.new_state == MemoryState.active
+        
+    finally:
+        user_id_var.reset(u_token)
+        client_name_var.reset(c_token)


### PR DESCRIPTION
## Linked Issue

Closes #5923

## Description

This PR fixes a bug where new memories created via the MCP server were incorrectly logging an `old_state` of `deleted` in the `MemoryStatusHistory` table. 

By capturing whether the memory existed (`was_existing = memory is not None`) before the `memory` variable is overwritten with the new instantiation, the history log now correctly records `None` as the old state for new memories, while preserving the `deleted` state logging for memories that were actually previously deleted.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added unit tests in `openmemory/api/tests/test_audit_history.py` using a mocked database session to verify that new memories log `old_state=None`, and previously deleted memories log `old_state=deleted`. Tests passed locally via pytest.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
