### PR TITLE
fix(openclaw): pass recall rerank to search

### DIFF
--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -314,7 +314,7 @@ Enabled by default during `openclaw mem0 init`. `autoRecall` and `autoCapture` a
 | `skills.recall.enabled` | `boolean` | `true` | Enable memory recall before each turn |
 | `skills.recall.tokenBudget` | `number` | `1500` | Max tokens for injected memories |
 | `skills.recall.rerank` | `boolean` | `true` | Rerank search results for relevance |
-| `skills.recall.keywordSearch` | `boolean` | `true` | Augment with keyword-based search |
+| `skills.recall.keywordSearch` | `boolean` | `true` | Reserved for compatibility; keyword matching is handled by the Mem0 search backend |
 | `skills.recall.identityAlwaysInclude` | `boolean` | `true` | Always include identity memories |
 | `skills.dream.enabled` | `boolean` | `true` | Enable periodic memory consolidation |
 | `skills.domain` | `string` | `"companion"` | Domain overlay for triage rules |

--- a/integrations/openclaw/index.ts
+++ b/integrations/openclaw/index.ts
@@ -299,7 +299,7 @@ const memoryPlugin = definePluginEntry({
     }
 
     // Helper: build search options (skills config overrides legacy defaults)
-    // v3.0.0: removed keyword_search, reranking, filter_memories, limit
+    // v3.0.0: keyword_search, filter_memories, and limit were removed.
     function buildSearchOptions(
       userIdOverride?: string,
       limit?: number,
@@ -313,6 +313,7 @@ const memoryPlugin = definePluginEntry({
         threshold: recallCfg?.threshold ?? cfg.searchThreshold,
         source: "OPENCLAW",
       };
+      if (recallCfg?.rerank !== false) opts.rerank = true;
       if (runId) opts.run_id = runId;
       return opts;
     }

--- a/integrations/openclaw/providers.ts
+++ b/integrations/openclaw/providers.ts
@@ -145,6 +145,7 @@ class PlatformProvider implements Mem0Provider {
     const opts: Record<string, unknown> = {};
     if (options.top_k != null) opts.topK = options.top_k;
     if (options.threshold != null) opts.threshold = options.threshold;
+    if (options.rerank) opts.rerank = true;
     if (options.categories != null) opts.categories = options.categories;
 
     // Build filters with user_id/run_id inside (v3.0.0 requirement)
@@ -574,11 +575,12 @@ export function providerToBackend(
     },
 
     async search(query, opts = {}) {
-      // v3.0.0: removed keyword_search, reranking
+      // v3.0.0: keyword_search removed; rerank remains supported.
       const results = await provider.search(query, {
         user_id: opts.userId ?? userId,
         top_k: opts.topK,
         threshold: opts.threshold,
+        rerank: opts.rerank,
         filters: opts.filters,
         source: "OPENCLAW",
       });

--- a/integrations/openclaw/recall.ts
+++ b/integrations/openclaw/recall.ts
@@ -253,11 +253,12 @@ export async function recall(
   const categoryOrder = recallConfig.categoryOrder ?? DEFAULT_CATEGORY_ORDER;
   const identityAlwaysInclude = recallConfig.identityAlwaysInclude !== false;
 
-  // Build search options (v3.0.0: keyword_search, reranking, filter_memories removed)
+  // Build search options (v3.0.0: keyword_search and filter_memories removed)
   const searchOpts: SearchOptions = {
     user_id: userId,
     top_k: maxMemories * 2, // Over-fetch for ranking
     threshold,
+    rerank: recallConfig.rerank !== false,
     source: "OPENCLAW",
   };
 

--- a/integrations/openclaw/tests/providers.test.ts
+++ b/integrations/openclaw/tests/providers.test.ts
@@ -117,7 +117,7 @@ describe("PlatformProvider", () => {
 // ---------------------------------------------------------------------------
 
 describe("providerToBackend — search", () => {
-  // v3.0.0: keyword_search, reranking removed from SDK
+  // v3.0.0: keyword_search removed from SDK
   it("delegates to provider.search with correct options", async () => {
     const provider = createMockProvider();
     const backend = providerToBackend(provider as any, DEFAULT_USER);
@@ -132,11 +132,28 @@ describe("providerToBackend — search", () => {
       user_id: DEFAULT_USER,
       top_k: 10,
       threshold: 0.5,
+      rerank: undefined,
       filters: { category: "preference" },
       source: "OPENCLAW",
     });
     expect(results).toHaveLength(1);
     expect((results[0] as any).id).toBe("m1");
+  });
+
+  it("passes rerank through when requested", async () => {
+    const provider = createMockProvider();
+    const backend = providerToBackend(provider as any, DEFAULT_USER);
+
+    await backend.search("hello world", { rerank: true });
+
+    expect(provider.search).toHaveBeenCalledWith("hello world", {
+      user_id: DEFAULT_USER,
+      top_k: undefined,
+      threshold: undefined,
+      rerank: true,
+      filters: undefined,
+      source: "OPENCLAW",
+    });
   });
 
   it("uses default userId when opts.userId is not provided", async () => {
@@ -145,11 +162,12 @@ describe("providerToBackend — search", () => {
 
     await backend.search("query");
 
-    // v3.0.0: keyword_search, reranking removed
+    // v3.0.0: keyword_search removed
     expect(provider.search).toHaveBeenCalledWith("query", {
       user_id: DEFAULT_USER,
       top_k: undefined,
       threshold: undefined,
+      rerank: undefined,
       filters: undefined,
       source: "OPENCLAW",
     });

--- a/integrations/openclaw/tests/recall.test.ts
+++ b/integrations/openclaw/tests/recall.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { recall } from "../recall.ts";
+
+function createProvider() {
+  return {
+    search: vi.fn().mockResolvedValue([
+      {
+        id: "m1",
+        memory: "User prefers detailed technical explanations",
+        score: 0.9,
+        metadata: { category: "preference" },
+      },
+    ]),
+  };
+}
+
+describe("recall", () => {
+  it("requests reranking by default for skills recall", async () => {
+    const provider = createProvider();
+
+    await recall(provider as any, "technical explanation style", "alice", {
+      recall: { maxMemories: 5 },
+    });
+
+    expect(provider.search).toHaveBeenCalledWith(
+      "technical explanation style",
+      expect.objectContaining({
+        user_id: "alice",
+        top_k: 10,
+        rerank: true,
+        source: "OPENCLAW",
+      }),
+    );
+  });
+
+  it("honors explicit rerank opt-out", async () => {
+    const provider = createProvider();
+
+    await recall(provider as any, "technical explanation style", "alice", {
+      recall: { maxMemories: 5, rerank: false },
+    });
+
+    expect(provider.search).toHaveBeenCalledWith(
+      "technical explanation style",
+      expect.objectContaining({
+        rerank: false,
+      }),
+    );
+  });
+});

--- a/integrations/openclaw/types.ts
+++ b/integrations/openclaw/types.ts
@@ -49,6 +49,7 @@ export interface SearchOptions {
   run_id?: string;
   top_k?: number;
   threshold?: number;
+  rerank?: boolean;
   categories?: string[];
   filters?: Record<string, unknown>;
   source?: string;


### PR DESCRIPTION
## Linked Issue

Closes #5351

## Description

OpenClaw exposes `skills.recall.rerank`, but recall searches never forwarded that setting to Mem0. As a result, changing the option had no effect.

This PR threads the existing setting through auto-recall, the memory tools, and the provider adapter:

- recall searches request reranking by default
- `rerank: false` remains an explicit opt-out
- the Mem0 provider forwards the value to `MemoryClient.search`
- the README clarifies that `keywordSearch` remains backend-managed

The configuration shape and existing defaults remain backward compatible.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## AI Assistance

- [ ] No AI assistance
- [ ] AI-assisted (AI suggested or generated parts of the code)
- [x] AI-generated (an agent wrote most or all of this diff)

Codex was used to implement and rebase the change. I reviewed the full config-to-provider call path, the conflict-free diff, and the test coverage locally.

- [x] I can explain every line of AI-generated code in this PR

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Local verification:

- `pnpm exec tsc --noEmit`
- `pnpm run test` (449 tests)
- `pnpm run build`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
