### PR TITLE
fix(ts-oss): normalize extracted memory shapes

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -155,6 +155,69 @@ function validateSearchParams(threshold?: number, topK?: number): void {
   }
 }
 
+type ExtractedMemory = {
+  id?: string;
+  text: string;
+  attributed_to?: "user" | "assistant";
+  linked_memory_ids?: string[];
+};
+
+function normalizeExtractedMemories(rawMemories: unknown): ExtractedMemory[] {
+  if (!Array.isArray(rawMemories)) {
+    return [];
+  }
+
+  const normalized: ExtractedMemory[] = [];
+  for (const item of rawMemories) {
+    let text: string | undefined;
+    let id: string | undefined;
+    let attributedTo: "user" | "assistant" | undefined;
+    let linkedMemoryIds: string[] | undefined;
+
+    if (typeof item === "string") {
+      text = item;
+    } else if (item && typeof item === "object" && !Array.isArray(item)) {
+      const record = item as Record<string, unknown>;
+      const textValue = record.text ?? record.fact ?? record.memory;
+      if (typeof textValue === "string") {
+        text = textValue;
+      } else {
+        const keys = Object.keys(record);
+        if (keys.length === 1) {
+          text = keys[0];
+        }
+      }
+
+      if (typeof record.id === "string") {
+        id = record.id;
+      }
+      if (
+        record.attributed_to === "user" ||
+        record.attributed_to === "assistant"
+      ) {
+        attributedTo = record.attributed_to;
+      }
+      if (Array.isArray(record.linked_memory_ids)) {
+        linkedMemoryIds = record.linked_memory_ids.filter(
+          (memoryId): memoryId is string => typeof memoryId === "string",
+        );
+      }
+    }
+
+    const trimmedText = text?.trim();
+    if (!trimmedText) continue;
+
+    normalized.push({
+      ...(id ? { id } : {}),
+      text: trimmedText,
+      ...(attributedTo ? { attributed_to: attributedTo } : {}),
+      ...(linkedMemoryIds ? { linked_memory_ids: linkedMemoryIds } : {}),
+    });
+  }
+
+  return normalized;
+}
+
 export class Memory {
   private config: MemoryConfig;
   private customInstructions: string | undefined;
@@ -858,12 +921,7 @@ export class Memory {
     }
 
     // Parse response
-    let extractedMemories: Array<{
-      id?: string;
-      text?: string;
-      attributed_to?: string;
-      linked_memory_ids?: string[];
-    }> = [];
+    let extractedMemories: ExtractedMemory[] = [];
     try {
       const cleanResponse = extractJson(response);
       if (cleanResponse && cleanResponse.trim()) {
@@ -871,10 +929,12 @@ export class Memory {
           const parsed = AdditiveExtractionSchema.parse(
             JSON.parse(cleanResponse),
           );
-          extractedMemories = parsed.memory;
+          extractedMemories = normalizeExtractedMemories(parsed.memory);
         } catch {
           const fallbackJson = extractJson(cleanResponse);
-          extractedMemories = JSON.parse(fallbackJson)?.memory ?? [];
+          extractedMemories = normalizeExtractedMemories(
+            JSON.parse(fallbackJson)?.memory,
+          );
         }
       }
     } catch (e) {

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -202,6 +202,69 @@ function validateSearchParams(threshold?: number, topK?: number): void {
   }
 }
 
+type ExtractedMemory = {
+  id?: string;
+  text: string;
+  attributed_to?: "user" | "assistant";
+  linked_memory_ids?: string[];
+};
+
+function normalizeExtractedMemories(rawMemories: unknown): ExtractedMemory[] {
+  if (!Array.isArray(rawMemories)) {
+    return [];
+  }
+
+  const normalized: ExtractedMemory[] = [];
+  for (const item of rawMemories) {
+    let text: string | undefined;
+    let id: string | undefined;
+    let attributedTo: "user" | "assistant" | undefined;
+    let linkedMemoryIds: string[] | undefined;
+
+    if (typeof item === "string") {
+      text = item;
+    } else if (item && typeof item === "object" && !Array.isArray(item)) {
+      const record = item as Record<string, unknown>;
+      const textValue = record.text ?? record.fact ?? record.memory;
+      if (typeof textValue === "string") {
+        text = textValue;
+      } else {
+        const keys = Object.keys(record);
+        if (keys.length === 1) {
+          text = keys[0];
+        }
+      }
+
+      if (typeof record.id === "string") {
+        id = record.id;
+      }
+      if (
+        record.attributed_to === "user" ||
+        record.attributed_to === "assistant"
+      ) {
+        attributedTo = record.attributed_to;
+      }
+      if (Array.isArray(record.linked_memory_ids)) {
+        linkedMemoryIds = record.linked_memory_ids.filter(
+          (memoryId): memoryId is string => typeof memoryId === "string",
+        );
+      }
+    }
+
+    const trimmedText = text?.trim();
+    if (!trimmedText) continue;
+
+    normalized.push({
+      ...(id ? { id } : {}),
+      text: trimmedText,
+      ...(attributedTo ? { attributed_to: attributedTo } : {}),
+      ...(linkedMemoryIds ? { linked_memory_ids: linkedMemoryIds } : {}),
+    });
+  }
+
+  return normalized;
+}
+
 export class Memory {
   private config: MemoryConfig;
   private customInstructions: string | undefined;
@@ -934,12 +997,7 @@ export class Memory {
     }
 
     // Parse response
-    let extractedMemories: Array<{
-      id?: string;
-      text?: string;
-      attributed_to?: string;
-      linked_memory_ids?: string[];
-    }> = [];
+    let extractedMemories: ExtractedMemory[] = [];
     try {
       const cleanResponse = extractJson(response);
       if (cleanResponse && cleanResponse.trim()) {
@@ -947,10 +1005,12 @@ export class Memory {
           const parsed = AdditiveExtractionSchema.parse(
             JSON.parse(cleanResponse),
           );
-          extractedMemories = parsed.memory;
+          extractedMemories = normalizeExtractedMemories(parsed.memory);
         } catch {
           const fallbackJson = extractJson(cleanResponse);
-          extractedMemories = JSON.parse(fallbackJson)?.memory ?? [];
+          extractedMemories = normalizeExtractedMemories(
+            JSON.parse(fallbackJson)?.memory,
+          );
         }
       }
     } catch (e) {

--- a/mem0-ts/src/oss/tests/memory.add.test.ts
+++ b/mem0-ts/src/oss/tests/memory.add.test.ts
@@ -8,6 +8,8 @@ import type { MemoryConfig, MemoryItem, SearchResult } from "../src/types";
 
 jest.setTimeout(15000);
 
+let mockExtractionResponse: string | undefined;
+
 // Mock Google modules to prevent @google/genai crash in CI
 jest.mock("../src/embeddings/google", () => ({
   GoogleEmbedder: jest.fn(),
@@ -22,6 +24,9 @@ jest.mock("../src/llms/openai", () => ({
       .fn()
       .mockImplementation(
         (messages: Array<{ role: string; content: string }>) => {
+          if (mockExtractionResponse) {
+            return mockExtractionResponse;
+          }
           // V3 pipeline: single LLM call with additive extraction prompt.
           const userMsg = messages.find((m) => m.role === "user");
           const content = userMsg?.content ?? "";
@@ -92,6 +97,10 @@ describe("Memory - add()", () => {
 
   afterAll(async () => {
     await memory.reset();
+  });
+
+  afterEach(() => {
+    mockExtractionResponse = undefined;
   });
 
   test("returns SearchResult with results array for string input", async () => {
@@ -190,5 +199,37 @@ describe("Memory - add()", () => {
     expect(result.results[0].metadata).toEqual(
       expect.objectContaining({ event: "ADD" }),
     );
+  });
+
+  test("normalizes loose additive extraction memory shapes", async () => {
+    mockExtractionResponse = JSON.stringify({
+      memory: [
+        "User likes coffee",
+        { fact: "User uses TypeScript" },
+        { memory: "User prefers concise examples" },
+        {
+          text: "User works on retrieval systems",
+          attributed_to: "user",
+          linked_memory_ids: ["existing-memory"],
+        },
+        { "User reads technical design docs": true },
+        "",
+        { text: "" },
+      ],
+    });
+
+    const result: SearchResult = await memory.add("loose extraction", {
+      userId,
+    });
+
+    expect(result.results.map((item) => item.memory)).toEqual([
+      "User likes coffee",
+      "User uses TypeScript",
+      "User prefers concise examples",
+      "User works on retrieval systems",
+      "User reads technical design docs",
+    ]);
+    const stored = await memory.get(result.results[3].id);
+    expect(stored?.attributedTo).toBe("user");
   });
 });

--- a/mem0-ts/src/oss/tests/memory.add.test.ts
+++ b/mem0-ts/src/oss/tests/memory.add.test.ts
@@ -8,6 +8,8 @@ import type { MemoryConfig, MemoryItem, SearchResult } from "../src/types";
 
 jest.setTimeout(15000);
 
+let mockExtractionResponse: string | undefined;
+
 jest.mock("../src/utils/factory", () => {
   const { MemoryVectorStore } = jest.requireActual(
     "../src/vector_stores/memory",
@@ -31,6 +33,10 @@ jest.mock("../src/utils/factory", () => {
 
   class MockLLM {
     async generateResponse(messages: Array<{ role: string; content: string }>) {
+      if (mockExtractionResponse !== undefined) {
+        return mockExtractionResponse;
+      }
+
       const userMsg = messages.find((m) => m.role === "user");
       const content = userMsg?.content ?? "";
       const newMsgMatch = content.match(
@@ -115,6 +121,10 @@ describe("Memory - add()", () => {
 
   afterAll(async () => {
     await memory.reset();
+  });
+
+  afterEach(() => {
+    mockExtractionResponse = undefined;
   });
 
   test("returns SearchResult with results array for string input", async () => {
@@ -339,5 +349,37 @@ describe("Memory - add()", () => {
     expect(result.results[0].metadata).toEqual(
       expect.objectContaining({ event: "ADD" }),
     );
+  });
+
+  test("normalizes loose additive extraction memory shapes", async () => {
+    mockExtractionResponse = JSON.stringify({
+      memory: [
+        "User likes coffee",
+        { fact: "User uses TypeScript" },
+        { memory: "User prefers concise examples" },
+        {
+          text: "User works on retrieval systems",
+          attributed_to: "user",
+          linked_memory_ids: ["existing-memory"],
+        },
+        { "User reads technical design docs": true },
+        "",
+        { text: "" },
+      ],
+    });
+
+    const result: SearchResult = await memory.add("loose extraction", {
+      userId,
+    });
+
+    expect(result.results.map((item) => item.memory)).toEqual([
+      "User likes coffee",
+      "User uses TypeScript",
+      "User prefers concise examples",
+      "User works on retrieval systems",
+      "User reads technical design docs",
+    ]);
+    const stored = await memory.get(result.results[3].id);
+    expect(stored?.attributedTo).toBe("user");
   });
 });


### PR DESCRIPTION
## Linked Issue

Closes #5902

## Description

The TypeScript OSS memory path assumes extracted memories always use the canonical `{ text: string }` shape. Some LLMs return valid facts as plain strings or under keys such as `fact` and `memory`; those values were silently reduced to `undefined` and never stored.

This PR normalizes supported extraction shapes before the add/update decision logic runs. It accepts:

- plain strings
- `text`, `fact`, or `memory` fields
- single-key objects where the key itself is the extracted fact

Canonical metadata such as `id`, `attributed_to`, and string `linked_memories` is preserved. Empty or malformed entries are skipped, and the existing canonical response remains unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## AI Assistance

- [ ] No AI assistance
- [ ] AI-assisted (AI suggested or generated parts of the code)
- [x] AI-generated (an agent wrote most or all of this diff)

Codex was used to implement and rebase the change. I reviewed the normalization rules, the memory-add flow, the conflict resolution against current `main`, and the regression coverage locally.

- [x] I can explain every line of AI-generated code in this PR

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Local verification:

- `pnpm exec prettier --check src/oss/src/memory/index.ts src/oss/tests/memory.add.test.ts`
- `pnpm exec jest src/oss/tests/memory.add.test.ts --runInBand` (20 tests)
- `pnpm run test:unit` (1,538 tests)
- `pnpm run build`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
