### PR TITLE
fix: handle CRLF fenced code blocks

### DIFF
--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -121,7 +121,7 @@ def remove_code_blocks(content: str) -> str:
     - If a code block is detected, it returns only the inner content, stripping out the markers.
     - If no code block markers are found, the original content is returned as-is.
     """
-    pattern = r"^```[a-zA-Z0-9]*\n([\s\S]*?)\n```$"
+    pattern = r"^```[^\r\n]*\r?\n([\s\S]*?)\r?\n```$"
     match = re.match(pattern, content.strip())
     match_res=match.group(1).strip() if match else content.strip()
     return re.sub(r"<think>.*?</think>", "", match_res, flags=re.DOTALL).strip()

--- a/tests/test_chatty_llm_parsing.py
+++ b/tests/test_chatty_llm_parsing.py
@@ -103,6 +103,12 @@ class TestRemoveCodeBlocks:
         parsed = json.loads(result)
         assert parsed == {"memory": []}
 
+    def test_crlf_code_block(self):
+        text = '```json\r\n{"memory": []}\r\n```'
+        result = remove_code_blocks(text)
+        parsed = json.loads(result)
+        assert parsed == {"memory": []}
+
     def test_no_code_block(self):
         """Without code blocks, returns content as-is (may not be valid JSON)."""
         text = 'Here is the result: {"memory": []}'


### PR DESCRIPTION
## Linked Issue

No existing issue found. This is a focused regression fix for `remove_code_blocks()` handling of CRLF fenced code blocks.

## Description

`remove_code_blocks()` documents that it removes enclosing triple-backtick code block markers, but the current regex only matches LF-delimited fences. CRLF-delimited responses, which are common on Windows and can be emitted by local LLM tooling, keep the fences intact and can fail downstream parsing paths that call `remove_code_blocks()` directly.

This updates the regex to accept both LF and CRLF fence newlines, while still requiring an enclosing fenced block, and adds a regression test.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Validation run locally:

- `uv run --with-editable . --with pytest pytest tests/test_chatty_llm_parsing.py::TestRemoveCodeBlocks::test_crlf_code_block -q` -> 1 passed
- `uv run --with-editable . --with pytest pytest tests/test_chatty_llm_parsing.py -q` -> 22 passed
- `uv run --with-editable . --with ruff ruff check mem0/memory/utils.py tests/test_chatty_llm_parsing.py` -> passed
- `git diff --check -- mem0/memory/utils.py tests/test_chatty_llm_parsing.py` -> passed, with Windows autocrlf warnings only

I also tried the documented `hatch run test` path via `uvx hatch` because `hatch` is not installed on this Windows host. The repository's test script did not forward the targeted test argument and attempted full-suite collection, which failed on local environment setup / optional dependency issues unrelated to this change (`mem0ai` package metadata not found, missing optional vector-store dependencies). The targeted checks above pass in an editable uv environment.

`ruff format --check` would reformat pre-existing lines in these files, so I did not apply broad formatting changes in this bugfix PR.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed