### PR TITLE
fix(cli): guard memory formatters against null id/memory fields

### DIFF
--- a/cli/python/src/mem0_cli/output.py
+++ b/cli/python/src/mem0_cli/output.py
@@ -20,8 +20,8 @@ def format_memories_text(console: Console, memories: list[dict], title: str = "m
     console.print(f"\n[{BRAND_COLOR}]Found {count} {title}:[/]\n")
 
     for i, mem in enumerate(memories, 1):
-        memory_text = mem.get("memory", mem.get("text", ""))
-        mem_id = mem.get("id", "")[:8]
+        memory_text = mem.get("memory") or mem.get("text") or ""
+        mem_id = (mem.get("id") or "")[:8]
         score = mem.get("score")
         created = _format_date(mem.get("created_at"))
         category = mem.get("categories", [None])
@@ -67,8 +67,8 @@ def format_memories_table(
     table.add_column("Created", max_width=12)
 
     for mem in memories:
-        mem_id = mem.get("id", "")
-        memory_text = mem.get("memory", mem.get("text", ""))
+        mem_id = mem.get("id") or ""
+        memory_text = mem.get("memory") or mem.get("text") or ""
         if len(memory_text) > 60:
             memory_text = memory_text[:57] + "..."
         categories = mem.get("categories", [])
@@ -104,8 +104,8 @@ def format_single_memory(console: Console, mem: dict, output: str = "text") -> N
         format_json(console, mem)
         return
 
-    memory_text = mem.get("memory", mem.get("text", ""))
-    mem_id = mem.get("id", "")
+    memory_text = mem.get("memory") or mem.get("text") or ""
+    mem_id = mem.get("id") or ""
 
     lines = []
     lines.append(f"  [white bold]{memory_text}[/]")

--- a/cli/python/tests/test_output.py
+++ b/cli/python/tests/test_output.py
@@ -88,6 +88,46 @@ class TestSingleMemory:
         assert '"memory"' in output
 
 
+NULL_MEMORIES = [
+    {"id": None, "memory": None, "score": None, "created_at": None, "categories": None},
+    {},  # every key missing
+]
+
+
+class TestNullFieldRobustness:
+    """Formatters must not crash when the backend returns explicit JSON nulls.
+
+    A record like ``{"id": null, "memory": null}`` makes ``dict.get(key, default)``
+    return ``None`` (the key exists, so the default is never used), so slicing/len
+    on the result raises ``TypeError``. ``format_add_result`` already guards with
+    ``or ""``; the list/single formatters must do the same.
+    """
+
+    def test_format_memories_text_handles_null_fields(self):
+        console, buf = _make_console()
+        # Must not raise (regression: None[:8] -> TypeError).
+        format_memories_text(console, NULL_MEMORIES)
+        assert "Found 2 memories" in buf.getvalue()
+
+    def test_format_memories_table_handles_null_fields(self):
+        console, buf = _make_console()
+        # Must not raise (regression: len(None) -> TypeError).
+        format_memories_table(console, NULL_MEMORIES)
+        assert "ID" in buf.getvalue()
+
+    def test_format_memories_text_falls_back_to_text_key(self):
+        console, buf = _make_console()
+        # memory is null but a "text" key is present -> should use it.
+        format_memories_text(console, [{"id": "x", "memory": None, "text": "from text key"}])
+        assert "from text key" in buf.getvalue()
+
+    def test_format_single_memory_handles_null_fields(self):
+        console, buf = _make_console()
+        # Must not render the literal string "None" for a null memory body.
+        format_single_memory(console, {"id": None, "memory": None}, "text")
+        assert "None" not in buf.getvalue()
+
+
 class TestAddResult:
     def test_format_add_result_text(self):
         console, buf = _make_console()


### PR DESCRIPTION
## Linked Issue

Closes #5931

## Description

While poking at the CLI output code I noticed the memory list formatters assume `id` and `memory` are always present, non-null strings. They aren't always — the API can hand back a record with an explicit `null` in one of those fields, and when it does the command crashes instead of just printing a blank cell.

The root cause is a classic `dict.get` gotcha: `mem.get("id", "")` only falls back to `""` when the key is **missing**. If the key is there but the value is `null`, you get `None` back, and then:

- `format_memories_text` does `mem.get("id", "")[:8]` → `None[:8]` → `TypeError: 'NoneType' object is not subscriptable`
- `format_memories_table` does `len(mem.get("memory", ...))` → `len(None)` → `TypeError: object of type 'NoneType' has no len()`

So a single odd record is enough to take down `mem0 search` / `mem0 list`.

The nice part is the codebase already has the answer: `format_add_result` in the same file guards every field with the `... or ""` pattern. The list/single formatters just never got the same treatment. This PR brings them in line — `mem.get("memory") or mem.get("text") or ""` and `(mem.get("id") or "")` — so a null or missing field renders as empty rather than blowing up. I applied the same guard to `format_single_memory` too, so it doesn't print a literal "None" for an empty body.

No behavior change for well-formed responses; this only affects the null/missing edge.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed

Added a `TestNullFieldRobustness` class covering null and fully-empty records across all three formatters. The new tests fail on `main` (the two `TypeError`s above) and pass with the fix. Full CLI suite stays green and `ruff check` is clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed (no user-facing docs affected)
