### PR TITLE
fix(cli): return False instead of crashing on invalid int in `config set`

### DIFF
--- a/cli/python/src/mem0_cli/config.py
+++ b/cli/python/src/mem0_cli/config.py
@@ -231,11 +231,15 @@ def set_nested_value(config: Mem0Config, dotted_key: str, value: str) -> bool:
         return False
 
     current = getattr(obj, final_key)
-    # Type coercion
+    # Type coercion. A non-numeric value for an int field is a failed set, not a
+    # crash: honor the documented bool return instead of raising ValueError.
     if isinstance(current, bool):
         value = value.lower() in ("true", "1", "yes")  # type: ignore[assignment]
     elif isinstance(current, int):
-        value = int(value)  # type: ignore[assignment]
+        try:
+            value = int(value)  # type: ignore[assignment]
+        except ValueError:
+            return False
 
     setattr(obj, final_key, value)
     return True

--- a/cli/python/tests/test_config.py
+++ b/cli/python/tests/test_config.py
@@ -143,6 +143,20 @@ class TestNestedAccess:
         config = Mem0Config()
         assert set_nested_value(config, "nonexistent.key", "val") is False
 
+    def test_set_invalid_int_returns_false_without_raising(self):
+        # `version` is an int field. A non-numeric value must be reported as a
+        # failed set (return False), not crash with an uncaught ValueError.
+        config = Mem0Config()
+        original = config.version
+        assert set_nested_value(config, "version", "not-a-number") is False
+        # The bad value must not have been applied.
+        assert config.version == original
+
+    def test_set_valid_int_is_coerced(self):
+        config = Mem0Config()
+        assert set_nested_value(config, "version", "2")
+        assert config.version == 2
+
     def test_get_defaults_user_id(self):
         config = Mem0Config()
         config.defaults.user_id = "alice"


### PR DESCRIPTION
## Linked Issue

Closes #5933

## Description

`set_nested_value()` promises a bool return ("Returns True on success"), and the rest of the code leans on that — `test_set_nonexistent_key` expects `False` for a bad key, and `cmd_config_set` decides success/failure from the return value. The int branch broke that promise:

```python
elif isinstance(current, int):
    value = int(value)   # raises ValueError on non-numeric input, uncaught
```

`version` is an int field on `Mem0Config`, and `mem0 config set <key> <value>` passes the key through unchanged, so a simple typo like `mem0 config set version abc` takes the CLI down with a raw `ValueError` traceback instead of a clean "couldn't set that" result.

The fix wraps the coercion and returns `False` on a bad value — the same signal already used for an unknown key — and leaves the existing value untouched. Bool fields are unaffected (they were already lenient), and valid integers still coerce as before.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed

Added two tests: a non-numeric value returns `False` and doesn't mutate the field (this one raises without the fix), and a valid numeric string still coerces to `int`. Full config suite passes and `ruff check` is clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed (no user-facing docs affected)
