### PR TITLE
fix(cli): keep every result in `entity delete`, not just the last

### DIFF
--- a/cli/python/src/mem0_cli/backend/platform.py
+++ b/cli/python/src/mem0_cli/backend/platform.py
@@ -296,13 +296,15 @@ class PlatformBackend(Backend):
         entities = {t: v for t, v in type_map.items() if v}
         if not entities:
             raise ValueError("At least one entity ID is required for delete_entities.")
-        # Delete each provided entity via the v2 path-based endpoint
-        result: dict = {}
+        # Delete each provided entity via the v2 path-based endpoint. Key each
+        # response by entity type so a multi-entity delete (e.g. --user-id and
+        # --agent-id together) doesn't discard everything but the last result.
+        results: dict = {}
         for entity_type, entity_id in entities.items():
-            result = self._request(
+            results[entity_type] = self._request(
                 "DELETE", f"/v2/entities/{entity_type}/{entity_id}/", params={"source": "CLI"}
             )
-        return result
+        return results
 
     def ping(self, timeout: float | None = None) -> dict:
         """Call the ping endpoint and return the raw response.

--- a/cli/python/tests/test_platform_backend.py
+++ b/cli/python/tests/test_platform_backend.py
@@ -1,0 +1,46 @@
+"""Tests for the Platform backend (mem0 Platform API client)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from mem0_cli.backend.platform import PlatformBackend
+from mem0_cli.config import PlatformConfig
+
+
+def _make_backend() -> PlatformBackend:
+    # api_key/base_url are only used to build the httpx client; every test here
+    # patches _request, so no real network calls are made.
+    return PlatformBackend(PlatformConfig(api_key="test-key", base_url="https://api.mem0.ai"))
+
+
+class TestDeleteEntities:
+    def test_multiple_entities_returns_all_results(self):
+        backend = _make_backend()
+        responses = {
+            "/v2/entities/user/alice/": {"message": "user deleted"},
+            "/v2/entities/agent/bob/": {"message": "agent deleted"},
+        }
+        with patch.object(backend, "_request") as mock_request:
+            mock_request.side_effect = lambda method, path, **kw: responses[path]
+            result = backend.delete_entities(user_id="alice", agent_id="bob")
+
+        # Regression: previously only the last entity's response survived.
+        assert result == {
+            "user": {"message": "user deleted"},
+            "agent": {"message": "agent deleted"},
+        }
+        assert mock_request.call_count == 2
+
+    def test_single_entity_keyed_by_type(self):
+        backend = _make_backend()
+        with patch.object(backend, "_request", return_value={"message": "user deleted"}):
+            result = backend.delete_entities(user_id="alice")
+        assert result == {"user": {"message": "user deleted"}}
+
+    def test_no_entities_raises(self):
+        backend = _make_backend()
+        import pytest
+
+        with pytest.raises(ValueError):
+            backend.delete_entities()


### PR DESCRIPTION
## Linked Issue

Closes #5935

## Description

`delete_entities()` walks every entity it's asked to delete, but it writes each API response into one `result` variable that gets overwritten on the next pass — so only the last entity's response makes it back to the caller:

```python
result: dict = {}
for entity_type, entity_id in entities.items():
    result = self._request("DELETE", f"/v2/entities/{entity_type}/{entity_id}/", ...)
return result
```

That matters because `mem0 entity delete` lets you pass `--user-id`, `--agent-id`, `--app-id`, and `--run-id` together, and `cmd_entities_delete` prints this value straight out under `--output json`. Delete two entities and the JSON only shows one — anything scripting against that output silently loses the rest.

The fix collects each response into a dict keyed by entity type (`{"user": {...}, "agent": {...}}`). Nothing is dropped, the deletes themselves were always happening (one request each), and the `-> dict` return type stays intact. Single-entity deletes just return a one-key dict.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

The JSON shape of `mem0 entity delete --output json` changes from a single raw API response to a map keyed by entity type. This only affects the multi-entity case (which was lossy before) and the human/agent output modes are unaffected, so I've treated it as a bug fix rather than a breaking change — happy to adjust if you'd prefer to preserve the single-entity raw shape.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed

Added `tests/test_platform_backend.py` covering multi-entity (fails without the fix), single-entity, and the no-entity `ValueError`. `_request` is patched, so no network calls. Full CLI suite passes and `ruff check` is clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed (no user-facing docs affected)
