### PR TITLE
feat(memory): add compact() method for merging similar memories

### DIFF
--- a/mem0/configs/prompts.py
+++ b/mem0/configs/prompts.py
@@ -1060,3 +1060,18 @@ def generate_additive_extraction_prompt(
 
     sections.append("# Output:")
     return "\n\n".join(sections)
+
+
+MEMORY_MERGE_PROMPT = """You are a memory consolidator. Merge the following related memories into a single comprehensive memory.
+
+Rules:
+- Combine all unique facts into one concise statement
+- When facts directly contradict (e.g. "name is Alice" vs "name is Bob"), keep the most recent
+- Non-contradictory facts about the same topic should all be preserved (e.g. "likes pizza" and "likes sushi" are both valid)
+- Do not lose any information
+- Return ONLY the merged memory text, nothing else
+
+Memories to merge:
+{memories}
+
+Merged memory:"""

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -19,6 +19,7 @@ from mem0.configs.enums import MemoryType
 from mem0.configs.prompts import (
     ADDITIVE_EXTRACTION_PROMPT,
     AGENT_CONTEXT_SUFFIX,
+    MEMORY_MERGE_PROMPT,
     PROCEDURAL_MEMORY_SYSTEM_PROMPT,
     generate_additive_extraction_prompt,
 )
@@ -1878,6 +1879,168 @@ class Memory(MemoryBase):
         display_first_run_notice(self, "sync", "history")
         return history
 
+    def compact(self, *, filters, similarity_threshold=0.85):
+        """
+        Compact memories by merging semantically similar ones.
+
+        Clusters memories by embedding similarity and asks the LLM to consolidate
+        each cluster into a single, richer memory. Procedural memories are excluded.
+
+        Args:
+            filters (dict): Must contain at least one of: user_id, agent_id, run_id.
+            similarity_threshold (float): Minimum similarity score to cluster memories.
+                Defaults to 0.85.
+
+        Returns:
+            dict: Report with keys: merged_clusters, memories_deleted, memories_created.
+
+        Note:
+            Deleted originals are recoverable from the history table (is_deleted=1).
+            Memories are only clustered within the same agent_id/run_id scope.
+        """
+        search_filters = {}
+        if isinstance(filters, dict):
+            for key in ("user_id", "agent_id", "run_id"):
+                if filters.get(key):
+                    search_filters[key] = filters[key]
+
+        if not search_filters:
+            raise ValueError(
+                "filters must contain at least one of: user_id, agent_id, run_id. "
+                "Example: filters={'user_id': 'u1'}"
+            )
+
+        all_memories_result = self.vector_store.list(filters=search_filters, top_k=10000)
+        if isinstance(all_memories_result, (list, tuple)) and all_memories_result and isinstance(all_memories_result[0], list):
+            all_memories = all_memories_result[0]
+        else:
+            all_memories = all_memories_result if all_memories_result else []
+
+        all_memories = [
+            m for m in all_memories
+            if m.payload.get("memory_type") != MemoryType.PROCEDURAL.value
+        ]
+
+        if not all_memories:
+            return {"merged_clusters": 0, "memories_deleted": 0, "memories_created": 0}
+
+        # Cluster by similarity
+        clustered_ids = set()
+        clusters = []
+        for mem in all_memories:
+            if mem.id in clustered_ids:
+                continue
+            text = mem.payload.get("data", "")
+            if not text:
+                continue
+            try:
+                vec = self.embedding_model.embed(text, "search")
+                similar = self.vector_store.search(
+                    query=text, vectors=vec, top_k=20, filters=search_filters,
+                )
+            except Exception as e:
+                logger.warning(f"Embedding/search failed during compaction for memory {mem.id}: {e}")
+                continue
+
+            mem_scope = (mem.payload.get("agent_id", ""), mem.payload.get("run_id", ""))
+            cluster = [mem]
+            for s in similar:
+                if (
+                    s.id != mem.id
+                    and s.id not in clustered_ids
+                    and s.score is not None
+                    and s.score >= similarity_threshold
+                    and s.payload.get("memory_type") != MemoryType.PROCEDURAL.value
+                    and (s.payload.get("agent_id", ""), s.payload.get("run_id", "")) == mem_scope
+                ):
+                    cluster.append(s)
+
+            if len(cluster) >= 2:
+                clusters.append(cluster)
+                for c in cluster:
+                    clustered_ids.add(c.id)
+
+        if not clusters:
+            return {"merged_clusters": 0, "memories_deleted": 0, "memories_created": 0}
+
+        # Merge each cluster
+        core_keys = {"data", "hash", "updated_at", "id", "text_lemmatized", "user_id"}
+        total_deleted = 0
+        total_created = 0
+        merged_clusters = 0
+        for cluster in clusters:
+            memory_lines = []
+            for i, mem in enumerate(cluster):
+                mem_created = mem.payload.get("created_at", "unknown")
+                memory_lines.append(f"{i + 1}. [{mem_created}] {mem.payload.get('data', '')}")
+            prompt_text = MEMORY_MERGE_PROMPT.format(memories="\n".join(memory_lines))
+
+            try:
+                merged_text = self.llm.generate_response(
+                    messages=[{"role": "user", "content": prompt_text}],
+                )
+            except Exception as e:
+                logger.warning(f"LLM merge failed for cluster of {len(cluster)} memories: {e}")
+                continue
+
+            if isinstance(merged_text, str):
+                merged_text = remove_code_blocks(merged_text)
+            if not merged_text or not isinstance(merged_text, str) or not merged_text.strip():
+                logger.warning("LLM returned empty merge result, skipping cluster")
+                continue
+
+            merged_text = merged_text.strip()
+
+            # Build merged metadata from cluster members
+            sorted_cluster = sorted(cluster, key=lambda m: m.payload.get("created_at", ""))
+            merged_metadata = deepcopy(search_filters)
+
+            created_dates = [m.payload.get("created_at") for m in cluster if m.payload.get("created_at")]
+            if created_dates:
+                merged_metadata["created_at"] = min(created_dates)
+
+            has_permanent = any(m.payload.get("expiration_date") is None for m in cluster)
+            if not has_permanent:
+                exp_dates = [m.payload.get("expiration_date") for m in cluster if m.payload.get("expiration_date")]
+                if exp_dates:
+                    merged_metadata["expiration_date"] = max(exp_dates)
+
+            for mem in sorted_cluster:
+                for key, value in mem.payload.items():
+                    if key not in core_keys and key not in ("created_at", "expiration_date") and value is not None:
+                        merged_metadata[key] = value
+
+            merged_metadata["updated_at"] = datetime.now(timezone.utc).isoformat()
+
+            # Create merged memory — guarded so a failure doesn't abort remaining clusters
+            try:
+                merged_embeddings = {merged_text: self.embedding_model.embed(merged_text, "add")}
+                new_id = self._create_memory(merged_text, merged_embeddings, metadata=merged_metadata)
+                self._link_entities_for_memory(new_id, merged_text, search_filters)
+                total_created += 1
+                merged_clusters += 1
+            except Exception as e:
+                logger.warning(f"Failed to create merged memory for cluster of {len(cluster)}: {e}")
+                continue
+
+            # Delete old cluster members
+            for mem in cluster:
+                try:
+                    self._delete_memory(mem.id, existing_memory=mem)
+                    total_deleted += 1
+                except ValueError:
+                    pass
+                except Exception as e:
+                    logger.warning(f"Failed to delete memory {mem.id} during compaction: {e}")
+
+        capture_event(
+            "mem0.compact",
+            self,
+            {"merged_clusters": merged_clusters, "deleted": total_deleted, "created": total_created, "sync_type": "sync"},
+        )
+
+        return {"merged_clusters": merged_clusters, "memories_deleted": total_deleted, "memories_created": total_created}
+
     def _create_memory(self, data, existing_embeddings, metadata=None):
         logger.debug(f"Creating memory with {data=}")
         if data in existing_embeddings:
@@ -1890,7 +2053,8 @@ class Memory(MemoryBase):
         new_metadata["hash"] = hashlib.md5(data.encode()).hexdigest()
         if "created_at" not in new_metadata:
             new_metadata["created_at"] = datetime.now(timezone.utc).isoformat()
-        new_metadata["updated_at"] = new_metadata["created_at"]
+        if "updated_at" not in new_metadata:
+            new_metadata["updated_at"] = new_metadata["created_at"]
         new_metadata["text_lemmatized"] = lemmatize_for_bm25(data)
 
         self.vector_store.insert(
@@ -3509,6 +3673,166 @@ class AsyncMemory(MemoryBase):
         await display_first_run_notice_async(self, "async", "history")
         return history
 
+    async def compact(self, *, filters, similarity_threshold=0.85):
+        """
+        Compact memories by merging semantically similar ones (async version).
+
+        Clusters memories by embedding similarity and asks the LLM to consolidate
+        each cluster into a single, richer memory. Procedural memories are excluded.
+
+        Args:
+            filters (dict): Must contain at least one of: user_id, agent_id, run_id.
+            similarity_threshold (float): Minimum similarity score to cluster memories.
+                Defaults to 0.85.
+
+        Returns:
+            dict: Report with keys: merged_clusters, memories_deleted, memories_created.
+        """
+        search_filters = {}
+        if isinstance(filters, dict):
+            for key in ("user_id", "agent_id", "run_id"):
+                if filters.get(key):
+                    search_filters[key] = filters[key]
+
+        if not search_filters:
+            raise ValueError(
+                "filters must contain at least one of: user_id, agent_id, run_id. "
+                "Example: filters={'user_id': 'u1'}"
+            )
+
+        all_memories_result = await asyncio.to_thread(
+            self.vector_store.list, filters=search_filters, top_k=10000
+        )
+        if isinstance(all_memories_result, (list, tuple)) and all_memories_result and isinstance(all_memories_result[0], list):
+            all_memories = all_memories_result[0]
+        else:
+            all_memories = all_memories_result if all_memories_result else []
+
+        all_memories = [
+            m for m in all_memories
+            if m.payload.get("memory_type") != MemoryType.PROCEDURAL.value
+        ]
+
+        if not all_memories:
+            return {"merged_clusters": 0, "memories_deleted": 0, "memories_created": 0}
+
+        # Cluster by similarity
+        clustered_ids = set()
+        clusters = []
+        for mem in all_memories:
+            if mem.id in clustered_ids:
+                continue
+            text = mem.payload.get("data", "")
+            if not text:
+                continue
+            try:
+                vec = await asyncio.to_thread(self.embedding_model.embed, text, "search")
+                similar = await asyncio.to_thread(
+                    self.vector_store.search, query=text, vectors=vec, top_k=20, filters=search_filters,
+                )
+            except Exception as e:
+                logger.warning(f"Embedding/search failed during compaction for memory {mem.id}: {e}")
+                continue
+
+            mem_scope = (mem.payload.get("agent_id", ""), mem.payload.get("run_id", ""))
+            cluster = [mem]
+            for s in similar:
+                if (
+                    s.id != mem.id
+                    and s.id not in clustered_ids
+                    and s.score is not None
+                    and s.score >= similarity_threshold
+                    and s.payload.get("memory_type") != MemoryType.PROCEDURAL.value
+                    and (s.payload.get("agent_id", ""), s.payload.get("run_id", "")) == mem_scope
+                ):
+                    cluster.append(s)
+
+            if len(cluster) >= 2:
+                clusters.append(cluster)
+                for c in cluster:
+                    clustered_ids.add(c.id)
+
+        if not clusters:
+            return {"merged_clusters": 0, "memories_deleted": 0, "memories_created": 0}
+
+        # Merge each cluster
+        core_keys = {"data", "hash", "updated_at", "id", "text_lemmatized", "user_id"}
+        total_deleted = 0
+        total_created = 0
+        merged_clusters = 0
+        for cluster in clusters:
+            memory_lines = []
+            for i, mem in enumerate(cluster):
+                mem_created = mem.payload.get("created_at", "unknown")
+                memory_lines.append(f"{i + 1}. [{mem_created}] {mem.payload.get('data', '')}")
+            prompt_text = MEMORY_MERGE_PROMPT.format(memories="\n".join(memory_lines))
+
+            try:
+                merged_text = await asyncio.to_thread(
+                    self.llm.generate_response, messages=[{"role": "user", "content": prompt_text}],
+                )
+            except Exception as e:
+                logger.warning(f"LLM merge failed for cluster of {len(cluster)} memories: {e}")
+                continue
+
+            if isinstance(merged_text, str):
+                merged_text = remove_code_blocks(merged_text)
+            if not merged_text or not isinstance(merged_text, str) or not merged_text.strip():
+                logger.warning("LLM returned empty merge result, skipping cluster")
+                continue
+
+            merged_text = merged_text.strip()
+
+            # Build merged metadata from cluster members
+            sorted_cluster = sorted(cluster, key=lambda m: m.payload.get("created_at", ""))
+            merged_metadata = deepcopy(search_filters)
+
+            created_dates = [m.payload.get("created_at") for m in cluster if m.payload.get("created_at")]
+            if created_dates:
+                merged_metadata["created_at"] = min(created_dates)
+
+            has_permanent = any(m.payload.get("expiration_date") is None for m in cluster)
+            if not has_permanent:
+                exp_dates = [m.payload.get("expiration_date") for m in cluster if m.payload.get("expiration_date")]
+                if exp_dates:
+                    merged_metadata["expiration_date"] = max(exp_dates)
+
+            for mem in sorted_cluster:
+                for key, value in mem.payload.items():
+                    if key not in core_keys and key not in ("created_at", "expiration_date") and value is not None:
+                        merged_metadata[key] = value
+
+            merged_metadata["updated_at"] = datetime.now(timezone.utc).isoformat()
+
+            # Create merged memory — guarded so a failure doesn't abort remaining clusters
+            try:
+                merged_embeddings = {merged_text: await asyncio.to_thread(self.embedding_model.embed, merged_text, "add")}
+                new_id = await self._create_memory(merged_text, merged_embeddings, metadata=merged_metadata)
+                await self._link_entities_for_memory(new_id, merged_text, search_filters)
+                total_created += 1
+                merged_clusters += 1
+            except Exception as e:
+                logger.warning(f"Failed to create merged memory for cluster of {len(cluster)}: {e}")
+                continue
+
+            # Delete old cluster members
+            for mem in cluster:
+                try:
+                    await self._delete_memory(mem.id, existing_memory=mem)
+                    total_deleted += 1
+                except ValueError:
+                    pass
+                except Exception as e:
+                    logger.warning(f"Failed to delete memory {mem.id} during compaction: {e}")
+
+        capture_event(
+            "mem0.compact",
+            self,
+            {"merged_clusters": merged_clusters, "deleted": total_deleted, "created": total_created, "sync_type": "async"},
+        )
+
+        return {"merged_clusters": merged_clusters, "memories_deleted": total_deleted, "memories_created": total_created}
+
     async def _create_memory(self, data, existing_embeddings, metadata=None):
         logger.debug(f"Creating memory with {data=}")
         if data in existing_embeddings:
@@ -3522,7 +3846,8 @@ class AsyncMemory(MemoryBase):
         new_metadata["hash"] = hashlib.md5(data.encode()).hexdigest()
         if "created_at" not in new_metadata:
             new_metadata["created_at"] = datetime.now(timezone.utc).isoformat()
-        new_metadata["updated_at"] = new_metadata["created_at"]
+        if "updated_at" not in new_metadata:
+            new_metadata["updated_at"] = new_metadata["created_at"]
         new_metadata["text_lemmatized"] = lemmatize_for_bm25(data)
 
         await asyncio.to_thread(

--- a/tests/memory/test_compaction.py
+++ b/tests/memory/test_compaction.py
@@ -1,0 +1,367 @@
+from __future__ import annotations
+
+import inspect
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from mem0.memory.main import AsyncMemory, Memory
+
+
+def _make_memory_obj(memory_id, text, memory_type=None, created_at="2026-01-01T00:00:00Z"):
+    payload = {"data": text, "user_id": "test_user", "created_at": created_at}
+    if memory_type:
+        payload["memory_type"] = memory_type
+    return SimpleNamespace(id=memory_id, payload=payload, score=None)
+
+
+def _setup_mocks(mocker):
+    mock_embedder = mocker.MagicMock()
+    mock_embedder.return_value.embed.return_value = [0.1, 0.2, 0.3]
+    mocker.patch("mem0.utils.factory.EmbedderFactory.create", mock_embedder)
+
+    mock_vector_store = mocker.MagicMock()
+    mock_vector_store.return_value.search.return_value = []
+    mock_vector_store.return_value.list.return_value = [[]]
+    mocker.patch(
+        "mem0.utils.factory.VectorStoreFactory.create", side_effect=[mock_vector_store.return_value, mocker.MagicMock()]
+    )
+
+    mock_llm = mocker.MagicMock()
+    mocker.patch("mem0.utils.factory.LlmFactory.create", mock_llm)
+
+    mocker.patch("mem0.memory.storage.SQLiteManager", mocker.MagicMock())
+    mocker.patch("mem0.memory.telemetry.capture_event")
+
+    return mock_llm, mock_vector_store
+
+
+class TestCompaction:
+    @pytest.fixture
+    def mock_memory(self, mocker):
+        _setup_mocks(mocker)
+        memory = Memory()
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        memory.db.add_history = MagicMock()
+        return memory
+
+    def test_compact_merges_similar_memories(self, mock_memory):
+        m1 = _make_memory_obj("id1", "User likes Italian food")
+        m2 = _make_memory_obj("id2", "User loves Italian cuisine")
+        m3 = _make_memory_obj("id3", "User enjoys Italian dishes")
+
+        mock_memory.vector_store.list.return_value = [[m1, m2, m3]]
+
+        def search_side_effect(query, vectors, top_k, filters):
+            s1 = SimpleNamespace(id="id1", payload=m1.payload, score=0.95)
+            s2 = SimpleNamespace(id="id2", payload=m2.payload, score=0.92)
+            s3 = SimpleNamespace(id="id3", payload=m3.payload, score=0.90)
+            return [s1, s2, s3]
+
+        mock_memory.vector_store.search.side_effect = search_side_effect
+        mock_memory.llm.generate_response.return_value = "User loves Italian food and cuisine"
+        mock_memory.vector_store.get.side_effect = lambda vector_id: {"id1": m1, "id2": m2, "id3": m3}.get(vector_id)
+
+        report = mock_memory.compact(filters={"user_id": "test_user"})
+
+        assert report["merged_clusters"] == 1
+        assert report["memories_created"] == 1
+        assert report["memories_deleted"] == 3
+        mock_memory.llm.generate_response.assert_called_once()
+
+    def test_compact_preserves_unique_memories(self, mock_memory):
+        m1 = _make_memory_obj("id1", "User likes Italian food")
+        m2 = _make_memory_obj("id2", "User works at Google")
+
+        mock_memory.vector_store.list.return_value = [[m1, m2]]
+
+        def search_side_effect(query, vectors, top_k, filters):
+            if "Italian" in query:
+                return [SimpleNamespace(id="id1", payload=m1.payload, score=1.0)]
+            return [SimpleNamespace(id="id2", payload=m2.payload, score=1.0)]
+
+        mock_memory.vector_store.search.side_effect = search_side_effect
+
+        report = mock_memory.compact(filters={"user_id": "test_user"})
+
+        assert report["merged_clusters"] == 0
+        assert report["memories_deleted"] == 0
+        assert report["memories_created"] == 0
+        mock_memory.llm.generate_response.assert_not_called()
+
+    def test_compact_handles_llm_failure(self, mock_memory):
+        m1 = _make_memory_obj("id1", "User likes Italian food")
+        m2 = _make_memory_obj("id2", "User loves Italian cuisine")
+
+        mock_memory.vector_store.list.return_value = [[m1, m2]]
+
+        def search_side_effect(query, vectors, top_k, filters):
+            return [
+                SimpleNamespace(id="id1", payload=m1.payload, score=0.95),
+                SimpleNamespace(id="id2", payload=m2.payload, score=0.92),
+            ]
+
+        mock_memory.vector_store.search.side_effect = search_side_effect
+        mock_memory.llm.generate_response.side_effect = Exception("LLM unavailable")
+
+        report = mock_memory.compact(filters={"user_id": "test_user"})
+
+        assert report["merged_clusters"] == 0
+        assert report["memories_deleted"] == 0
+        mock_memory.vector_store.delete.assert_not_called()
+
+    def test_compact_requires_filters(self, mock_memory):
+        with pytest.raises(ValueError, match="filters must contain at least one"):
+            mock_memory.compact(filters={})
+
+    def test_compact_empty_store(self, mock_memory):
+        mock_memory.vector_store.list.return_value = [[]]
+
+        report = mock_memory.compact(filters={"user_id": "test_user"})
+
+        assert report == {"merged_clusters": 0, "memories_deleted": 0, "memories_created": 0}
+
+    def test_compact_handles_delete_race_condition(self, mock_memory):
+        m1 = _make_memory_obj("id1", "User likes Italian food")
+        m2 = _make_memory_obj("id2", "User loves Italian cuisine")
+
+        mock_memory.vector_store.list.return_value = [[m1, m2]]
+
+        def search_side_effect(query, vectors, top_k, filters):
+            return [
+                SimpleNamespace(id="id1", payload=m1.payload, score=0.95),
+                SimpleNamespace(id="id2", payload=m2.payload, score=0.92),
+            ]
+
+        mock_memory.vector_store.search.side_effect = search_side_effect
+        mock_memory.llm.generate_response.return_value = "User loves Italian food and cuisine"
+        mock_memory.vector_store.get.side_effect = ValueError("Memory not found")
+
+        report = mock_memory.compact(filters={"user_id": "test_user"})
+
+        assert report["memories_created"] == 1
+
+    def test_compact_preserves_metadata(self, mock_memory):
+        m1 = _make_memory_obj("id1", "User likes Italian food", created_at="2026-01-01T00:00:00Z")
+        m1.payload["expiration_date"] = "2027-06-01"
+        m1.payload["attributed_to"] = "chat_session_1"
+        m1.payload["actor_id"] = "alice"
+        m1.payload["role"] = "user"
+        m1.payload["custom_tag"] = "food_preference"
+
+        m2 = _make_memory_obj("id2", "User loves Italian cuisine", created_at="2026-06-01T00:00:00Z")
+        m2.payload["expiration_date"] = "2027-12-01"
+        m2.payload["attributed_to"] = "chat_session_2"
+        m2.payload["custom_tag"] = "dining"
+        m2.payload["custom_source"] = "conversation"
+
+        mock_memory.vector_store.list.return_value = [[m1, m2]]
+
+        def search_side_effect(query, vectors, top_k, filters):
+            return [
+                SimpleNamespace(id="id1", payload=m1.payload, score=0.95),
+                SimpleNamespace(id="id2", payload=m2.payload, score=0.92),
+            ]
+
+        mock_memory.vector_store.search.side_effect = search_side_effect
+        mock_memory.llm.generate_response.return_value = "User loves Italian food and cuisine"
+        mock_memory.vector_store.get.side_effect = lambda vector_id: {"id1": m1, "id2": m2}.get(vector_id)
+
+        mock_memory._create_memory = MagicMock(return_value="new-id")
+        mock_memory._link_entities_for_memory = MagicMock()
+        mock_memory._delete_memory = MagicMock()
+
+        mock_memory.compact(filters={"user_id": "test_user"})
+
+        create_call = mock_memory._create_memory.call_args
+        metadata = create_call[1]["metadata"] if "metadata" in create_call[1] else create_call[0][2]
+
+        assert metadata.get("created_at") == "2026-01-01T00:00:00Z", "Should use earliest created_at"
+        assert metadata.get("expiration_date") == "2027-12-01", "Should use latest expiration_date"
+        assert metadata.get("attributed_to") == "chat_session_2", "Should use newest attributed_to"
+        assert metadata.get("actor_id") == "alice", "Should preserve actor_id"
+        assert metadata.get("custom_tag") == "dining", "Newest value should win on conflict"
+        assert metadata.get("custom_source") == "conversation", "Should preserve unique custom metadata"
+
+    def test_compact_excludes_procedural_from_clusters(self, mock_memory):
+        m1 = _make_memory_obj("id1", "User likes Italian food")
+        m2 = _make_memory_obj("id2", "User loves Italian cuisine")
+        m_proc = _make_memory_obj("id_proc", "Always respond in JSON format", memory_type="procedural_memory")
+
+        # list returns all three — procedural is filtered from all_memories,
+        # but search() could still return it as a similar match
+        mock_memory.vector_store.list.return_value = [[m1, m2, m_proc]]
+
+        def search_side_effect(query, vectors, top_k, filters):
+            # search returns m1 + procedural as similar — procedural should be excluded from cluster
+            return [
+                SimpleNamespace(id="id1", payload=m1.payload, score=0.95),
+                SimpleNamespace(id="id_proc", payload=m_proc.payload, score=0.90),
+            ]
+
+        mock_memory.vector_store.search.side_effect = search_side_effect
+        mock_memory.llm.generate_response.return_value = "merged text"
+        mock_memory._create_memory = MagicMock(return_value="new-id")
+        mock_memory._link_entities_for_memory = MagicMock()
+        mock_memory._delete_memory = MagicMock()
+
+        mock_memory.compact(filters={"user_id": "test_user"})
+
+        # Procedural memory should never be passed to _delete_memory
+        deleted_ids = [call[0][0] for call in mock_memory._delete_memory.call_args_list]
+        assert "id_proc" not in deleted_ids, "Procedural memory should not be deleted by compaction"
+
+    def test_compact_preserves_scope(self, mock_memory):
+        m1 = _make_memory_obj("id1", "User likes Italian food")
+        m1.payload["agent_id"] = "agent_a"
+
+        m2 = _make_memory_obj("id2", "User loves Italian cuisine")
+        m2.payload["agent_id"] = "agent_b"
+
+        mock_memory.vector_store.list.return_value = [[m1, m2]]
+
+        def search_side_effect(query, vectors, top_k, filters):
+            return [
+                SimpleNamespace(id="id1", payload=m1.payload, score=0.95),
+                SimpleNamespace(id="id2", payload=m2.payload, score=0.92),
+            ]
+
+        mock_memory.vector_store.search.side_effect = search_side_effect
+        mock_memory.llm.generate_response.return_value = "merged text"
+        mock_memory._create_memory = MagicMock(return_value="new-id")
+        mock_memory._link_entities_for_memory = MagicMock()
+        mock_memory._delete_memory = MagicMock()
+
+        report = mock_memory.compact(filters={"user_id": "test_user"})
+
+        assert report["merged_clusters"] == 0, "Should not merge memories with different agent_id"
+
+    def test_compact_updated_at_survives_create_memory(self, mock_memory):
+        """F4: _create_memory overwrites updated_at with created_at.
+        compact() sets updated_at=now() but _create_memory clobbers it.
+        This test uses the REAL _create_memory (not mocked) to catch that."""
+        m1 = _make_memory_obj("id1", "User likes Italian food", created_at="2024-01-01T00:00:00Z")
+        m2 = _make_memory_obj("id2", "User loves Italian cuisine", created_at="2024-06-01T00:00:00Z")
+
+        mock_memory.vector_store.list.return_value = [[m1, m2]]
+
+        def search_side_effect(query, vectors, top_k, filters):
+            return [
+                SimpleNamespace(id="id1", payload=m1.payload, score=0.95),
+                SimpleNamespace(id="id2", payload=m2.payload, score=0.92),
+            ]
+
+        mock_memory.vector_store.search.side_effect = search_side_effect
+        mock_memory.llm.generate_response.return_value = "User loves Italian food and cuisine"
+        mock_memory.vector_store.get.side_effect = lambda vector_id: {"id1": m1, "id2": m2}.get(vector_id)
+
+        before = datetime.now(timezone.utc)
+        mock_memory.compact(filters={"user_id": "test_user"})
+
+        insert_call = mock_memory.vector_store.insert.call_args
+        payload = insert_call[1]["payloads"][0] if "payloads" in insert_call[1] else insert_call[0][2][0]
+        actual_updated = datetime.fromisoformat(payload["updated_at"].replace("Z", "+00:00"))
+        assert actual_updated >= before, f"updated_at should be current, got {payload['updated_at']}"
+
+    def test_compact_strips_code_fences(self, mock_memory):
+        """F5: LLM might return ```text``` wrapped output; other paths strip it."""
+        m1 = _make_memory_obj("id1", "User likes Italian food")
+        m2 = _make_memory_obj("id2", "User loves Italian cuisine")
+
+        mock_memory.vector_store.list.return_value = [[m1, m2]]
+
+        def search_side_effect(query, vectors, top_k, filters):
+            return [
+                SimpleNamespace(id="id1", payload=m1.payload, score=0.95),
+                SimpleNamespace(id="id2", payload=m2.payload, score=0.92),
+            ]
+
+        mock_memory.vector_store.search.side_effect = search_side_effect
+        mock_memory.llm.generate_response.return_value = "```\nUser loves Italian food\n```"
+        mock_memory._create_memory = MagicMock(return_value="new-id")
+        mock_memory._link_entities_for_memory = MagicMock()
+        mock_memory._delete_memory = MagicMock()
+
+        mock_memory.compact(filters={"user_id": "test_user"})
+
+        merged_text = mock_memory._create_memory.call_args[0][0]
+        assert "```" not in merged_text, f"Code fences should be stripped, got: {merged_text}"
+
+    def test_compact_guards_create_and_link_failure(self, mock_memory):
+        """F9: If _create_memory or _link_entities fails mid-cluster,
+        should not leave duplicates or abort remaining clusters."""
+        m1 = _make_memory_obj("id1", "User likes Italian food")
+        m2 = _make_memory_obj("id2", "User loves Italian cuisine")
+        m3 = _make_memory_obj("id3", "User enjoys pasta")
+        m4 = _make_memory_obj("id4", "User likes pasta dishes")
+
+        mock_memory.vector_store.list.return_value = [[m1, m2, m3, m4]]
+
+        call_count = {"n": 0}
+
+        def search_side_effect(query, vectors, top_k, filters):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return [
+                    SimpleNamespace(id="id1", payload=m1.payload, score=0.95),
+                    SimpleNamespace(id="id2", payload=m2.payload, score=0.92),
+                ]
+            return [
+                SimpleNamespace(id="id3", payload=m3.payload, score=0.95),
+                SimpleNamespace(id="id4", payload=m4.payload, score=0.90),
+            ]
+
+        mock_memory.vector_store.search.side_effect = search_side_effect
+        mock_memory.llm.generate_response.return_value = "merged text"
+
+        create_count = {"n": 0}
+
+        def failing_create(*args, **kwargs):
+            create_count["n"] += 1
+            if create_count["n"] == 1:
+                raise RuntimeError("Storage failure")
+            return "new-id"
+
+        mock_memory._create_memory = MagicMock(side_effect=failing_create)
+        mock_memory._link_entities_for_memory = MagicMock()
+        mock_memory._delete_memory = MagicMock()
+
+        report = mock_memory.compact(filters={"user_id": "test_user"})
+
+        assert report["merged_clusters"] >= 1, "Second cluster should still succeed after first fails"
+        assert mock_memory._delete_memory.call_count > 0, "Successful cluster should still delete"
+
+    def test_compact_preserves_permanent_memory(self, mock_memory):
+        """A permanent memory (no expiration_date) merged with an expiring one
+        should produce a permanent result — not inherit the expiry."""
+        m1 = _make_memory_obj("id1", "User likes Italian food")
+        # m1 has no expiration_date — permanent
+
+        m2 = _make_memory_obj("id2", "User loves Italian cuisine")
+        m2.payload["expiration_date"] = "2027-12-01"
+
+        mock_memory.vector_store.list.return_value = [[m1, m2]]
+
+        def search_side_effect(query, vectors, top_k, filters):
+            return [
+                SimpleNamespace(id="id1", payload=m1.payload, score=0.95),
+                SimpleNamespace(id="id2", payload=m2.payload, score=0.92),
+            ]
+
+        mock_memory.vector_store.search.side_effect = search_side_effect
+        mock_memory.llm.generate_response.return_value = "User loves Italian food and cuisine"
+        mock_memory._create_memory = MagicMock(return_value="new-id")
+        mock_memory._link_entities_for_memory = MagicMock()
+        mock_memory._delete_memory = MagicMock()
+
+        mock_memory.compact(filters={"user_id": "test_user"})
+
+        metadata = mock_memory._create_memory.call_args[1]["metadata"]
+        assert "expiration_date" not in metadata, "Merged memory should be permanent when any cluster member is permanent"
+
+    def test_async_compact_exists(self):
+        assert hasattr(AsyncMemory, "compact"), "AsyncMemory should have compact method"
+        assert inspect.iscoroutinefunction(AsyncMemory.compact), "AsyncMemory.compact should be async"


### PR DESCRIPTION
## Linked Issue

Closes #5850

## Description

Adds a `compact()` method to both `Memory` and `AsyncMemory` that merges 
semantically similar memories into richer, consolidated ones. This addresses 
cold accumulation of fragmented memories in the v3 ADD-only pipeline.

```python
report = memory.compact(filters={"user_id": "alice"})
# {"merged_clusters": 5, "memories_deleted": 13, "memories_created": 5}
```

**What it does:**
- Lists all memories for a given scope, excludes procedural memories
- Clusters by embedding similarity (threshold configurable, default 0.85)
- Asks the LLM to merge each cluster into one comprehensive memory
- Preserves all metadata: earliest created_at, latest expiration_date, 
  union of custom metadata (newest value wins on conflict)
- Permanent memories (no expiration_date) stay permanent after merge
- Only clusters within the same agent_id/run_id scope (no cross-scope merging)
- Fails safe: LLM or storage errors skip the cluster, originals preserved
- Deleted originals recoverable from history table (is_deleted=1)

**No conflicts with #5821 or #5799** — this PR does not touch the add() 
pipeline at all. It uses only existing primitives (_create_memory, 
_delete_memory, _link_entities_for_memory). 

As discussed in #5850, these three address different layers:
- #5821 (UPDATE/DELETE events) → reduces future duplicate inflow
- #5799 (per-candidate recall) → improves recall window at insert time
- This PR (compact) → cleans up existing cold accumulation

compact() works with or without those PRs landing first.

**Quality test with Ollama qwen2.5:7b:** 13 fragmented memories (5 topics × 
~3 wordings each) compacted to 5 consolidated memories with zero information 
loss at threshold=0.7.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

14 unit tests in `tests/memory/test_compaction.py`:
- Happy path merge (3→1)
- Preserves unique memories (no false merges)
- LLM failure handling (originals preserved)
- Filter validation
- Empty store edge case
- Delete race condition handling
- Metadata preservation (expiration_date, attributed_to, custom metadata)
- Procedural memories excluded from clusters
- Scope-aware clustering (different agent_id not merged)
- updated_at set to current time through real _create_memory
- Code fence stripping on LLM output
- Create/link failure doesn't abort remaining clusters
- Permanent memories stay permanent after merge
- AsyncMemory.compact exists and is async

Manual testing: compact() with Ollama qwen2.5:7b + nomic-embed-text on 13 
fragmented memories → 5 consolidated. Zero information loss.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed