### PR TITLE
fix(cli): treat non-numeric int coercion as a failed set

### DIFF
--- a/cli/python/src/mem0_cli/config.py
+++ b/cli/python/src/mem0_cli/config.py
@@ -231,11 +231,16 @@ def set_nested_value(config: Mem0Config, dotted_key: str, value: str) -> bool:
         return False
 
     current = getattr(obj, final_key)
-    # Type coercion
+    # Type coercion. A failed coercion (e.g. non-numeric input for an int
+    # field) is treated as a failed set — return False and leave the current
+    # value untouched, matching the unknown-key contract.
     if isinstance(current, bool):
         value = value.lower() in ("true", "1", "yes")  # type: ignore[assignment]
     elif isinstance(current, int):
-        value = int(value)  # type: ignore[assignment]
+        try:
+            value = int(value)  # type: ignore[assignment]
+        except ValueError:
+            return False
 
     setattr(obj, final_key, value)
     return True

--- a/cli/python/tests/test_config.py
+++ b/cli/python/tests/test_config.py
@@ -143,6 +143,25 @@ class TestNestedAccess:
         config = Mem0Config()
         assert set_nested_value(config, "nonexistent.key", "val") is False
 
+    def test_set_non_numeric_int_value_returns_false(self):
+        """Non-numeric input for an int field fails the set instead of crashing.
+
+        Regression: ``int(value)`` used to raise an uncaught ``ValueError``,
+        surfacing a raw traceback for ``mem0 config set version abc``. The
+        documented contract is that a failed set returns ``False`` (matching
+        the unknown-key case), leaving the original value untouched.
+        """
+        config = Mem0Config()
+        original = config.version
+        assert set_nested_value(config, "version", "not-a-number") is False
+        assert config.version == original
+
+    def test_set_valid_int_value_coerced(self):
+        """Numeric input for an int field still coerces and succeeds."""
+        config = Mem0Config()
+        assert set_nested_value(config, "version", "42") is True
+        assert config.version == 42
+
     def test_get_defaults_user_id(self):
         config = Mem0Config()
         config.defaults.user_id = "alice"


### PR DESCRIPTION
## What Problem This Solves

Closes #5933.

`set_nested_value()` in `cli/python/src/mem0_cli/config.py` is documented as returning `bool` ("Returns True on success."), and the codebase relies on that — `test_set_nonexistent_key` asserts it returns `False` for a bad key, and `cmd_config_set` branches on the return value.

But for an int-typed config field it coerced with a bare `int(value)`:

```python
elif isinstance(current, int):
    value = int(value)  # type: ignore[assignment]
```

If the value isn't numeric, `int()` raises `ValueError`, which was never caught. Instead of reporting a failed set, the CLI crashed with a raw traceback.

`version` is an int field on `Mem0Config`, so `mem0 config set version abc` is reachable from the CLI and reproduces the crash.

## Why This Change Was Made

Wrap the coercion in `try/except ValueError` and return `False`, leaving the original value untouched. This matches the existing unknown-key contract: a failed set returns `False`, the caller (`cmd_config_set`) reports it cleanly, and the user sees a controlled error message instead of a stack trace.

The fix is intentionally narrow — only the int branch needs the guard. The bool branch (`value.lower() in (...)`) cannot raise.

## User Impact

- `mem0 config set version abc` now reports a clean error and exits, instead of dumping a traceback.
- Numeric int values (`mem0 config set version 42`) still coerce and succeed.
- The bool and string field paths are unchanged.

## Evidence

Two new regression tests in `cli/python/tests/test_config.py`:

```python
def test_set_non_numeric_int_value_returns_false(self):
    """Non-numeric input for an int field fails the set instead of crashing."""
    config = Mem0Config()
    original = config.version
    assert set_nested_value(config, "version", "not-a-number") is False
    assert config.version == original

def test_set_valid_int_value_coerced(self):
    """Numeric input for an int field still coerces and succeeds."""
    config = Mem0Config()
    assert set_nested_value(config, "version", "42") is True
    assert config.version == 42
```

Verified the first test catches the bug — it FAILS against the pre-fix code with exactly the issue's reproduction:

```
E           ValueError: invalid literal for int() with base 10: 'not-a-number'
src/mem0_cli/config.py:238: ValueError
========================= 1 failed, 7 passed in 0.09s =========================
```

And PASSES with the fix.

Full config test suite (no regressions):

```
PYTHONPATH=src uv run pytest tests/test_config.py
============================== 25 passed in 0.13s ==============================
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
