### PR TITLE
fix(cli): tolerate null id/memory fields in list and single formatters

### DIFF
--- a/cli/python/src/mem0_cli/output.py
+++ b/cli/python/src/mem0_cli/output.py
@@ -20,11 +20,15 @@ def format_memories_text(console: Console, memories: list[dict], title: str = "m
     console.print(f"\n[{BRAND_COLOR}]Found {count} {title}:[/]\n")
 
     for i, mem in enumerate(memories, 1):
-        memory_text = mem.get("memory", mem.get("text", ""))
-        mem_id = mem.get("id", "")[:8]
+        # Defensive against explicit JSON nulls: ``dict.get(k, default)`` returns
+        # ``None`` when the key is present with a null value, which would crash
+        # the slice/``len`` below. Mirror the ``r.get(...) or ""`` pattern
+        # already used by ``format_add_result`` — see #5931.
+        memory_text = mem.get("memory") or mem.get("text") or ""
+        mem_id = (mem.get("id") or "")[:8]
         score = mem.get("score")
         created = _format_date(mem.get("created_at"))
-        category = mem.get("categories", [None])
+        category = mem.get("categories") or [None]
         if isinstance(category, list):
             category = category[0] if category else None
 
@@ -67,11 +71,12 @@ def format_memories_table(
     table.add_column("Created", max_width=12)
 
     for mem in memories:
-        mem_id = mem.get("id", "")
-        memory_text = mem.get("memory", mem.get("text", ""))
+        # Defensive against explicit JSON nulls — see #5931.
+        mem_id = mem.get("id") or ""
+        memory_text = mem.get("memory") or mem.get("text") or ""
         if len(memory_text) > 60:
             memory_text = memory_text[:57] + "..."
-        categories = mem.get("categories", [])
+        categories = mem.get("categories") or []
         if isinstance(categories, list) and categories:
             cat = (
                 categories[0]
@@ -104,8 +109,8 @@ def format_single_memory(console: Console, mem: dict, output: str = "text") -> N
         format_json(console, mem)
         return
 
-    memory_text = mem.get("memory", mem.get("text", ""))
-    mem_id = mem.get("id", "")
+    memory_text = mem.get("memory") or mem.get("text") or ""
+    mem_id = mem.get("id") or ""
 
     lines = []
     lines.append(f"  [white bold]{memory_text}[/]")

--- a/cli/python/tests/test_output.py
+++ b/cli/python/tests/test_output.py
@@ -280,3 +280,48 @@ class TestSanitizeAgentData:
 
     def test_none_data(self):
         assert sanitize_agent_data("add", None) is None
+
+
+class TestNullFields:
+    """Regression tests for #5931.
+
+    Backend responses may carry explicit JSON ``null`` for ``id``/``memory``
+    fields. ``dict.get(k, default)`` returns ``None`` (not the default) when
+    the key is present with a null value, which used to make the slice/``len``
+    in the list/single formatters crash with ``TypeError``.
+    """
+
+    NULL_RECORDS = [
+        {
+            "id": None,
+            "memory": None,
+            "text": None,
+            "created_at": None,
+            "categories": None,
+            "score": None,
+        }
+    ]
+
+    def test_format_memories_text_handles_null_fields(self):
+        """Should not raise on records with explicit ``None`` fields."""
+        console, _buf = _make_console()
+        format_memories_text(console, self.NULL_RECORDS)  # no exception
+
+    def test_format_memories_table_handles_null_fields(self):
+        """Should not raise on records with explicit ``None`` fields."""
+        console, _buf = _make_console()
+        format_memories_table(console, self.NULL_RECORDS)  # no exception
+
+    def test_format_single_memory_handles_null_fields(self):
+        """Should not raise when the single-memory record is all-null."""
+        console, _buf = _make_console()
+        format_single_memory(console, self.NULL_RECORDS[0])  # no exception
+
+    def test_format_memories_table_renders_blank_id(self):
+        """A null ``id`` renders as an empty cell, not a crash."""
+        console, buf = _make_console()
+        format_memories_table(console, self.NULL_RECORDS)
+        output = buf.getvalue()
+        # Memory cell should be empty (None coerced to ""), no traceback.
+        assert "TypeError" not in output
+        assert "Memory" in output  # header still rendered


### PR DESCRIPTION
## What Problem This Solves

Closes #5931.

The list/single memory formatters in `cli/python/src/mem0_cli/output.py` assumed `id` and `memory` were always non-null strings. When the backend returned a record with an explicit JSON `null` for one of those fields, `dict.get(key, default)` returned `None` (the key *is* present, so the default never applied), and the subsequent slice/`len()` blew up:

- `format_memories_text` — `mem.get("id", "")[:8]` → `None[:8]` → `TypeError: 'NoneType' object is not subscriptable`
- `format_memories_table` — `len(mem.get("memory", ...))` → `len(None)` → `TypeError: object of type 'NoneType' has no len()`

`mem0 search` / `mem0 list` could hard-crash on otherwise valid API output instead of rendering a blank cell.

## Why This Change Was Made

`format_add_result` in the same file already guards against exactly this with the `r.get("id") or ""` pattern — the list/single formatters were simply missed. This PR applies the same defensive pattern to the three formatters that lacked it:

```python
# Before
memory_text = mem.get("memory", mem.get("text", ""))
mem_id = mem.get("id", "")[:8]

# After
memory_text = mem.get("memory") or mem.get("text") or ""
mem_id = (mem.get("id") or "")[:8]
```

The fix is uniform across `format_memories_text`, `format_memories_table`, and `format_single_memory`. Same pattern, same file, same author intent.

## User Impact

- `mem0 search` / `mem0 list` / `mem0 get` no longer crash on backend records that carry explicit JSON `null` for `id` / `memory` / `text`
- A null field renders as an empty cell in tables and as a blank line in text mode — consistent with `format_add_result`'s behavior
- Records with non-null fields render exactly as before

## Evidence

New `TestNullFields` class in `cli/python/tests/test_output.py` with 4 regression tests:

```python
NULL_RECORDS = [{
    "id": None, "memory": None, "text": None,
    "created_at": None, "categories": None, "score": None,
}]

def test_format_memories_text_handles_null_fields(self):
    console, _buf = _make_console()
    format_memories_text(console, self.NULL_RECORDS)  # no exception

def test_format_memories_table_handles_null_fields(self):
    console, _buf = _make_console()
    format_memories_table(console, self.NULL_RECORDS)  # no exception

def test_format_single_memory_handles_null_fields(self):
    console, _buf = _make_console()
    format_single_memory(console, self.NULL_RECORDS[0])  # no exception

def test_format_memories_table_renders_blank_id(self):
    """A null ``id`` renders as an empty cell, not a crash."""
    console, buf = _make_console()
    format_memories_table(console, self.NULL_RECORDS)
    output = buf.getvalue()
    assert "TypeError" not in output
```

Verified the tests catch the bug — 3 of 4 FAIL against the pre-fix code with the exact issue reproduction:

```
>           if len(memory_text) > 60:
E           TypeError: object of type 'NoneType' has no len()

src/mem0_cli/output.py:72: TypeError
========================= 3 failed, 1 passed in 0.09s =========================
```

With the fix, full output + commands suites pass — 91 tests:

```
PYTHONPATH=src uv run pytest tests/test_output.py tests/test_commands.py
============================== 91 passed in 0.36s ==============================
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
