### PR TITLE
fix(memory): mirror Memory.reset() vector store optimisation in AsyncMemory.reset()

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -3706,20 +3706,32 @@ class AsyncMemory(MemoryBase):
             Recreates the vector store with a new client
         """
         logger.warning("Resetting all memories")
-        await asyncio.to_thread(self.vector_store.delete_col)
 
-        gc.collect()
+        # Mirror Memory.reset(): use the in-place VectorStoreFactory.reset()
+        # optimization when the vector store supports it, falling back to
+        # delete_col + recreate only when it does not. The previous code
+        # always tore down + recreated, losing the optimization for every
+        # async caller — see #5915.
+        if hasattr(self.vector_store, "reset"):
+            self.vector_store = await asyncio.to_thread(
+                VectorStoreFactory.reset, self.vector_store
+            )
+        else:
+            logger.warning("Vector store does not support reset. Skipping.")
+            await asyncio.to_thread(self.vector_store.delete_col)
 
-        if hasattr(self.vector_store, "client") and hasattr(self.vector_store.client, "close"):
-            await asyncio.to_thread(self.vector_store.client.close)
+            gc.collect()
+
+            if hasattr(self.vector_store, "client") and hasattr(self.vector_store.client, "close"):
+                await asyncio.to_thread(self.vector_store.client.close)
+
+            self.vector_store = VectorStoreFactory.create(
+                self.config.vector_store.provider, self.config.vector_store.config
+            )
 
         await asyncio.to_thread(self.db.reset)
         await asyncio.to_thread(self.db.close)
         self.db = SQLiteManager(self.config.history_db_path)
-
-        self.vector_store = VectorStoreFactory.create(
-            self.config.vector_store.provider, self.config.vector_store.config
-        )
 
         if self._entity_store is not None:
             try:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -169,6 +169,79 @@ async def test_async_memory_reset_clears_messages_table(mock_llm_factory, mock_v
     assert hist_count == 0, "history must be empty after AsyncMemory.reset()"
 
 
+@pytest.mark.asyncio
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+async def test_async_memory_reset_uses_in_place_reset_when_available(
+    mock_llm_factory, mock_vector_factory, mock_embedder_factory, tmp_path
+):
+    """Regression for #5915: when the vector store supports ``reset``, use the
+    in-place ``VectorStoreFactory.reset()`` path and skip the more expensive
+    ``delete_col`` + recreate teardown."""
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_store = MagicMock()
+    # MagicMock auto-creates a ``reset`` attribute, so hasattr(...) is True —
+    # this is the "supports reset" case.
+    mock_vector_factory.return_value = mock_vector_store
+    mock_llm_factory.return_value = MagicMock()
+
+    from mem0 import AsyncMemory
+
+    config = MemoryConfig()
+    config.history_db_path = str(tmp_path / "test.db")
+    memory = AsyncMemory(config)
+
+    calls_before_reset = mock_vector_factory.call_count
+    await memory.reset()
+    calls_after_reset = mock_vector_factory.call_count
+
+    # In-place reset path was taken: VectorStoreFactory.reset was exercised
+    # through the vector store's own reset() method.
+    mock_vector_store.reset.assert_called_once()
+    # The expensive teardown was skipped entirely.
+    mock_vector_store.delete_col.assert_not_called()
+    # And no recreation via the factory during reset (whatever construction did).
+    assert calls_after_reset == calls_before_reset, (
+        "in-place reset must not recreate the vector store via VectorStoreFactory.create"
+    )
+
+
+@pytest.mark.asyncio
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+async def test_async_memory_reset_falls_back_to_delete_col_when_reset_unavailable(
+    mock_llm_factory, mock_vector_factory, mock_embedder_factory, tmp_path
+):
+    """Regression for #5915: when the vector store does NOT expose ``reset``,
+    fall back to the ``delete_col`` + recreate path (the legacy behaviour)."""
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_store = MagicMock()
+    # Simulate a vector store that does NOT support in-place reset.
+    del mock_vector_store.reset
+    mock_vector_factory.return_value = mock_vector_store
+    mock_llm_factory.return_value = MagicMock()
+
+    from mem0 import AsyncMemory
+
+    config = MemoryConfig()
+    config.history_db_path = str(tmp_path / "test.db")
+    memory = AsyncMemory(config)
+
+    calls_before_reset = mock_vector_factory.call_count
+    await memory.reset()
+    calls_after_reset = mock_vector_factory.call_count
+
+    # Fallback path was taken: delete_col was called.
+    mock_vector_store.delete_col.assert_called_once()
+    # And VectorStoreFactory.create was invoked exactly once more to rebuild.
+    assert calls_after_reset == calls_before_reset + 1, (
+        "fallback reset must recreate the vector store exactly once"
+    )
+
+
+
 @patch('mem0.utils.factory.EmbedderFactory.create')
 @patch('mem0.utils.factory.VectorStoreFactory.create')
 @patch('mem0.utils.factory.LlmFactory.create')


### PR DESCRIPTION
## Problem

Closes #5915.

`AsyncMemory.reset()` unconditionally calls `self.vector_store.delete_col()` followed by `VectorStoreFactory.create()` to recreate the store. The sync counterpart `Memory.reset()` already has a smarter branching pattern: when the vector store exposes `reset()`, it takes the cheaper in-place `VectorStoreFactory.reset()` path that resets the store without tearing down the client/connection. Async users always pay the full teardown + recreation cost, even when the underlying store supports the in-place optimisation (Qdrant, PGVector, etc.).

## Why This Change Was Made

- **Parity with sync `Memory.reset()`**: the sync/async divergence is silent — async callers do not get the optimisation that the equivalent sync path provides. Fixing this lets async users benefit from in-place reset where supported.
- **Performance**: in-place `VectorStoreFactory.reset()` avoids re-creating the underlying client/connection on every reset, which matters for long-lived async services that call `reset()` during re-onboarding, tenant wipe, or test teardown.
- **Minimal blast radius**: the change preserves the existing fallback path exactly — stores without `reset()` still go through `delete_col()` + recreate.

## User Impact

- Users of `AsyncMemory.reset()` whose vector store supports in-place reset will now see faster resets with no client/connection churn.
- Users whose vector store does not support `reset()` see no behavior change — the fallback path is unchanged.

## Change

- `mem0/memory/main.py` — `AsyncMemory.reset()` now branches on `hasattr(self.vector_store, "reset")`:
  - when supported: `await asyncio.to_thread(VectorStoreFactory.reset, self.vector_store)` (in-place)
  - otherwise: existing `delete_col()` + client close + `VectorStoreFactory.create()` (fallback)

This mirrors the sync `Memory.reset()` branching pattern already present at `mem0/memory/main.py:2061`.

## Evidence

```
$ uv run pytest tests/test_memory.py -k "async_memory_reset" -v
============================= test session starts ==============================
platform darwin -- Python 3.13.5, pytest-9.1.1, pluggy-1.6.0 -- /private/tmp/mem0/.venv/bin/python
cachedir: .pytest_cache
rootdir: /private/tmp/mem0
configfile: pyproject.toml
plugins: mock-3.15.1, anyio-4.14.1, asyncio-1.4.0, langsmith-0.9.3
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 60 items / 57 deselected / 3 selected

tests/test_memory.py::test_async_memory_reset_clears_messages_table PASSED [ 33%]
tests/test_memory.py::test_async_memory_reset_uses_in_place_reset_when_available PASSED [ 66%]
tests/test_memory.py::test_async_memory_reset_falls_back_to_delete_col_when_reset_unavailable PASSED [100%]

======================= 3 passed, 57 deselected in 1.03s =======================
```

Two new regression tests added:

- `test_async_memory_reset_uses_in_place_reset_when_available` — verifies the in-place `reset()` path is taken when the store supports it, and that `VectorStoreFactory.create` is NOT called during reset (delta-based call_count assertion).
- `test_async_memory_reset_falls_back_to_delete_col_when_reset_unavailable` — uses `del mock_vector_store.reset` to simulate a store without `reset()`, and verifies `delete_col()` is called once and the store is recreated exactly once.

### Regression verification

Reverting only `mem0/memory/main.py` (keeping the new tests) reproduces the original bug:

```
FAILED tests/test_memory.py::test_async_memory_reset_uses_in_place_reset_when_available
>   mock_vector_store.reset.assert_called_once()
E   AssertionError: Expected 'reset' to have been called once. Called 0 times.
```

Restoring the fix makes both tests pass.