### PR TITLE
fix(memory): remove dead deepcopy in Memory.__init__ telemetry block

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -485,7 +485,6 @@ class Memory(MemoryBase):
             telemetry_config_dict['collection_name'] = "mem0migrations"
 
             # Set path for file-based vector stores
-            telemetry_config = _safe_deepcopy_config(self.config.vector_store.config)
             if self.config.vector_store.provider in ["faiss", "qdrant"]:
                 provider_path = f"migrations_{self.config.vector_store.provider}"
                 telemetry_config_dict['path'] = os.path.join(mem0_dir, provider_path)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1529,3 +1529,36 @@ async def test_async_procedural_memory_langchain_strips_code_blocks(mock_llm_fac
     insert_call = memory.vector_store.insert.call_args
     stored_data = insert_call[1]["payloads"][0]["data"]
     assert "```" not in stored_data
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+def test_sync_memory_init_does_not_dead_deepcopy_vector_store_config_when_telemetry_enabled(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    """Regression for #5871: Memory.__init__'s telemetry block used to call
+    ``_safe_deepcopy_config(self.config.vector_store.config)`` and assign the
+    result to ``telemetry_config``, then immediately overwrite that variable
+    with a dict-based constructor call. The deepcopy result was never read,
+    so every ``Memory()`` instantiation with ``MEM0_TELEMETRY=True`` wasted a
+    full config copy on the floor.
+
+    The sync class builds its telemetry config purely from
+    ``telemetry_config_dict``; the only ``_safe_deepcopy_config`` call site
+    inside ``__init__`` should therefore be... none. (The entity-store
+    deepcopy lives behind a ``@property`` and is not exercised during
+    construction.)
+    """
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    with patch('mem0.memory.main.MEM0_TELEMETRY', True):
+        with patch('mem0.memory.main._safe_deepcopy_config') as mock_deepcopy:
+            config = MemoryConfig()
+            Memory(config)
+            mock_deepcopy.assert_not_called()
+


### PR DESCRIPTION
## Problem

Closes #5871.

`Memory.__init__` calls `_safe_deepcopy_config(self.config.vector_store.config)` inside the telemetry block and assigns the result to `telemetry_config`. The very next relevant assignment overwrites that variable entirely with a dict-based constructor call (`self.config.vector_store.config.__class__(**telemetry_config_dict)`), making the deepcopy completely dead — it allocates a full config copy on every `Memory()` instantiation (when `MEM0_TELEMETRY=True`) and discards it immediately.

The block comment directly above the telemetry block already reads *"Create telemetry config manually to avoid deepcopy issues with thread locks"*, confirming the dict-based approach was a deliberate replacement for deepcopy. The old call was simply left behind.

`AsyncMemory.__init__` does not have this issue — its deepcopy is load-bearing because the result is mutated in place (`telemetry_config.collection_name = "mem0migrations"`) rather than rebuilt from a dict.

## Why This Change Was Made

- **Dead code removal, not a behavior change.** The deepcopy result is overwritten before any read, so removing it cannot affect runtime behavior. The dict-based construction path on the next line is the one actually used.
- **Avoids unnecessary work on a hot path.** Every `Memory()` instantiation with `MEM0_TELEMETRY=True` runs `_safe_deepcopy_config`, which can be expensive for config objects that hold connection/client state (the existing block comment about thread locks is precisely the reason the dict-based path was introduced).
- **Aligns sync class with its own documented intent** — the dict-based path is the chosen approach; the leftover deepcopy contradicts the comment above it.

## User Impact

- No runtime behavior change for any user. The deleted line's result was never read.
- Users who instantiate `Memory` repeatedly (e.g. test suites, per-request memory instances with `MEM0_TELEMETRY=True`) no longer pay for a wasted config deepcopy per instantiation.

## Change

- `mem0/memory/main.py` — delete the single dead assignment `telemetry_config = _safe_deepcopy_config(self.config.vector_store.config)` inside the `Memory.__init__` telemetry block. The dict-based construction path that follows is unchanged.

## Evidence

```
$ uv run pytest tests/test_memory.py -k "test_sync_memory_init_does_not_dead_deepcopy" -v
tests/test_memory.py::test_sync_memory_init_does_not_dead_deepcopy_vector_store_config_when_telemetry_enabled PASSED [100%]
```

### Regression verification

With only `mem0/memory/main.py` reverted to `main` (keeping the new test), the test fails exactly as expected — proving it catches the dead call:

```
FAILED tests/test_memory.py::test_sync_memory_init_does_not_dead_deepcopy_vector_store_config_when_telemetry_enabled
E       AssertionError: Expected call: assert_not_called()
E       Actual calls: [call(QdrantConfig(...))]
```

Restoring the fix makes the test pass.

### Pre-existing failures noted on `main` (unrelated)

Two tests fail identically on stock `main` and are not touched by this change:

- `tests/test_memory.py::test_add_infer_true_caches_embedding_on_llm_rewrite`
- `tests/test_memory.py::test_update_infer_true_caches_embedding_on_llm_rewrite`

Both fail with `embed_batch.call_count == 2 != 1` regardless of whether this fix is applied.