### PR TITLE
perf(memory): eliminate redundant vector_store.get() in delete_all()

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1852,7 +1852,10 @@ class Memory(MemoryBase):
         # delete all vector memories and reset the collections
         memories = self.vector_store.list(filters=filters)[0]
         for memory in memories:
-            self._delete_memory(memory.id)
+            # Pass the already-fetched ``memory`` as ``existing_memory`` so
+            # ``_delete_memory`` does not re-fetch it via ``vector_store.get``
+            # on every iteration — see #5869.
+            self._delete_memory(memory.id, existing_memory=memory)
 
         logger.info(f"Deleted {len(memories)} memories")
 
@@ -3472,7 +3475,10 @@ class AsyncMemory(MemoryBase):
 
         delete_tasks = []
         for memory in memories[0]:
-            delete_tasks.append(self._delete_memory(memory.id, skip_entity_cleanup=True))
+            # Pass the already-fetched ``memory`` as ``existing_memory`` so
+            # ``_delete_memory`` does not re-fetch it via ``vector_store.get``
+            # on every iteration — see #5869.
+            delete_tasks.append(self._delete_memory(memory.id, existing_memory=memory, skip_entity_cleanup=True))
 
         results = await asyncio.gather(*delete_tasks, return_exceptions=True)
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1529,3 +1529,72 @@ async def test_async_procedural_memory_langchain_strips_code_blocks(mock_llm_fac
     insert_call = memory.vector_store.insert.call_args
     stored_data = insert_call[1]["payloads"][0]["data"]
     assert "```" not in stored_data
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+def test_delete_all_does_not_refetch_each_memory_from_vector_store(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    """Regression for #5869: ``Memory.delete_all`` already had every memory
+    in hand from ``vector_store.list()``, but called ``_delete_memory(memory.id)``
+    without forwarding the object — forcing ``_delete_memory`` to issue a
+    redundant ``vector_store.get()`` per memory (N extra reads).
+    """
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_store = MagicMock()
+    # Pre-populate list() with three fake memories so delete_all has work to do.
+    fake_memories = [
+        MagicMock(id=f"mem-{i}", payload={"data": f"fact {i}", "user_id": "u1"})
+        for i in range(3)
+    ]
+    mock_vector_store.list.return_value = (fake_memories, 0)
+    mock_vector_factory.return_value = mock_vector_store
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    config = MemoryConfig()
+    memory = Memory(config)
+
+    memory.delete_all(user_id="u1")
+
+    # ``get`` must never be called: every memory was forwarded via existing_memory.
+    mock_vector_store.get.assert_not_called()
+    # And we did call ``delete`` exactly once per memory.
+    assert mock_vector_store.delete.call_count == len(fake_memories)
+
+
+@pytest.mark.asyncio
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+async def test_async_delete_all_does_not_refetch_each_memory_from_vector_store(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    """Regression for #5869 (async): ``AsyncMemory.delete_all`` had the same
+    N+1 read pattern as the sync path — fix forwards the already-fetched
+    memory into ``_delete_memory``."""
+    from mem0 import AsyncMemory
+
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_store = MagicMock()
+    fake_memories = [
+        MagicMock(id=f"mem-{i}", payload={"data": f"fact {i}", "user_id": "u1"})
+        for i in range(3)
+    ]
+    mock_vector_store.list.return_value = (fake_memories, 0)
+    mock_vector_factory.return_value = mock_vector_store
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    config = MemoryConfig()
+    memory = AsyncMemory(config)
+
+    await memory.delete_all(user_id="u1")
+
+    mock_vector_store.get.assert_not_called()
+    assert mock_vector_store.delete.call_count == len(fake_memories)
+


### PR DESCRIPTION
## Problem

Closes #5869.

`Memory.delete_all()` and `AsyncMemory.delete_all()` fetch every memory via `vector_store.list()`, then call `_delete_memory(memory.id)` without forwarding the just-fetched object. `_delete_memory` re-fetches each memory via `vector_store.get(vector_id=memory_id)`, turning what should be an O(1) read into **N redundant round trips** to the vector store (N+1 total reads: 1 `list` + N `get`).

## Why This Change Was Made

- **`_delete_memory` already supports receiving the existing memory** via its `existing_memory` parameter (used by callers like `update()`). The fix is a one-line forwarding per call site, not new API surface.
- **O(N) → O(1) read amplification on a user-facing method.** With 100 memories, `delete_all()` currently fires 100 extra `vector_store.get()` calls. For network-backed stores (Qdrant, PGVector, Milvus), each `get` is a real round trip.
- **Same fix shape for sync and async.** Both `Memory.delete_all` and `AsyncMemory.delete_all` have the identical bug pattern; both are fixed in this PR.

## User Impact

- Users calling `delete_all()` see roughly half as many vector-store round trips (drops from `1 + N` reads to `1` read for the listing step).
- No behavior change for any caller — the same memories are deleted, the same history rows are written, the same entity-store cleanup runs.

## Change

- `mem0/memory/main.py` — `Memory.delete_all`: forward `existing_memory=memory` into `_delete_memory`.
- `mem0/memory/main.py` — `AsyncMemory.delete_all`: forward `existing_memory=memory` into `_delete_memory` (alongside the existing `skip_entity_cleanup=True`).

## Evidence

```
$ uv run pytest tests/test_memory.py -k "delete_all_does_not_refetch" -v
tests/test_memory.py::test_delete_all_does_not_refetch_each_memory_from_vector_store PASSED [ 50%]
tests/test_memory.py::test_async_delete_all_does_not_refetch_each_memory_from_vector_store PASSED [100%]
```

Both regression tests:

- Pre-populate `vector_store.list()` with three fake memories.
- Call `delete_all(user_id="u1")`.
- Assert `vector_store.get.assert_not_called()` (was called N times before the fix).
- Assert `vector_store.delete.call_count == 3` (one delete per memory, unchanged).

### Regression verification

Reverting only `mem0/memory/main.py` to `main` (keeping the tests) reproduces the original bug — both tests fail with `vector_store.get` being called:

```
FAILED tests/test_memory.py::test_delete_all_does_not_refetch_each_memory_from_vector_store
FAILED tests/test_memory.py::test_async_delete_all_does_not_refetch_each_memory_from_vector_store
```

Restoring the fix makes both tests pass.