### PR TITLE
fix(memory): add llm parameter to Memory.add() for procedural memory parity

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -726,6 +726,7 @@ class Memory(MemoryBase):
         infer: bool = True,
         memory_type: Optional[str] = None,
         prompt: Optional[str] = None,
+        llm=None,
     ):
         """
         Create a new memory.
@@ -751,6 +752,9 @@ class Memory(MemoryBase):
                 creating procedural memories (typically requires 'agent_id'). Otherwise, memories
                 are treated as general conversational/factual memories.
             prompt (str, optional): Prompt to use for the memory creation. Defaults to None.
+            llm (BaseChatModel, optional): LLM class to use for generating procedural memories.
+                Defaults to None. Useful when the user supplies a LangChain ChatModel — mirrors
+                AsyncMemory.add().
 
 
         Returns:
@@ -802,7 +806,7 @@ class Memory(MemoryBase):
             )
 
         if agent_id is not None and memory_type == MemoryType.PROCEDURAL.value:
-            results = self._create_procedural_memory(messages, metadata=processed_metadata, prompt=prompt)
+            results = self._create_procedural_memory(messages, metadata=processed_metadata, prompt=prompt, llm=llm)
             scale_threshold_notice = detect_scale_threshold_from_add_result(self, results)
             if temporal_usage_notice:
                 display_temporal_usage_notice(self, "sync", "add", *temporal_usage_notice)
@@ -1910,13 +1914,16 @@ class Memory(MemoryBase):
         )
         return memory_id
 
-    def _create_procedural_memory(self, messages, metadata=None, prompt=None):
+    def _create_procedural_memory(self, messages, metadata=None, llm=None, prompt=None):
         """
         Create a procedural memory
 
         Args:
             messages (list): List of messages to create a procedural memory from.
             metadata (dict): Metadata to create a procedural memory from.
+            llm (BaseChatModel, optional): LLM class to use for the procedural memory creation.
+                When provided, ``llm.invoke(...)`` is called instead of ``self.llm.generate_response``.
+                Mirrors AsyncMemory._create_procedural_memory — see #5911.
             prompt (str, optional): Prompt to use for the procedural memory creation. Defaults to None.
         """
         logger.info("Creating procedural memory")
@@ -1931,8 +1938,22 @@ class Memory(MemoryBase):
         ]
 
         try:
-            procedural_memory = self.llm.generate_response(messages=parsed_messages)
-            procedural_memory = remove_code_blocks(procedural_memory)
+            if llm is not None:
+                try:
+                    from langchain_core.messages.utils import (  # type: ignore
+                        convert_to_messages,
+                    )
+                except Exception:
+                    logger.error(
+                        "Import error while loading langchain-core. Please install 'langchain-core' to use procedural memory."
+                    )
+                    raise
+                converted = convert_to_messages(parsed_messages)
+                response = llm.invoke(input=converted)
+                procedural_memory = remove_code_blocks(response.content)
+            else:
+                procedural_memory = self.llm.generate_response(messages=parsed_messages)
+                procedural_memory = remove_code_blocks(procedural_memory)
         except Exception as e:
             logger.error(f"Error generating procedural memory summary: {e}")
             raise

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1529,3 +1529,75 @@ async def test_async_procedural_memory_langchain_strips_code_blocks(mock_llm_fac
     insert_call = memory.vector_store.insert.call_args
     stored_data = insert_call[1]["payloads"][0]["data"]
     assert "```" not in stored_data
+
+
+@patch("mem0.memory.main.VectorStoreFactory")
+@patch("mem0.memory.main.EmbedderFactory")
+@patch("mem0.memory.main.LlmFactory")
+def test_sync_procedural_memory_langchain_strips_code_blocks(mock_llm_factory, mock_emb, mock_vs):
+    """Regression #5911: sync Memory.add/_create_procedural_memory must accept
+    a LangChain ``llm`` and call ``remove_code_blocks`` on its response —
+    mirroring AsyncMemory.add (which gained the ``llm`` parameter in #5710)."""
+    mock_vs.return_value = MagicMock()
+    mock_emb.return_value = MagicMock()
+    mock_emb.return_value.embed.return_value = [0.1] * 1536
+    mock_llm_factory.return_value = MagicMock()
+
+    from mem0.memory.main import Memory
+
+    config = MemoryConfig()
+    memory = Memory(config)
+    memory.vector_store = MagicMock()
+    memory.vector_store.insert = MagicMock()
+
+    mock_langchain_llm = MagicMock()
+    mock_response = MagicMock()
+    mock_response.content = '```json\n{"key": "value"}\n```'
+    mock_langchain_llm.invoke.return_value = mock_response
+
+    messages = [{"role": "user", "content": "test"}]
+    metadata = {"user_id": "test_user"}
+
+    memory._create_procedural_memory(messages, metadata=metadata, llm=mock_langchain_llm)
+
+    mock_langchain_llm.invoke.assert_called_once()
+    insert_call = memory.vector_store.insert.call_args
+    stored_data = insert_call[1]["payloads"][0]["data"]
+    assert "```" not in stored_data
+
+
+@patch("mem0.memory.main.VectorStoreFactory")
+@patch("mem0.memory.main.EmbedderFactory")
+@patch("mem0.memory.main.LlmFactory")
+def test_sync_add_accepts_llm_kwarg_for_procedural_memory(mock_llm_factory, mock_emb, mock_vs):
+    """Regression #5911: Memory.add() must accept the ``llm`` kwarg without
+    raising TypeError. Previously only AsyncMemory.add accepted it."""
+    mock_vs.return_value = MagicMock()
+    mock_emb.return_value = MagicMock()
+    mock_emb.return_value.embed.return_value = [0.1] * 1536
+    mock_llm_factory.return_value = MagicMock()
+
+    from mem0.memory.main import Memory
+
+    config = MemoryConfig()
+    memory = Memory(config)
+    memory.vector_store = MagicMock()
+    memory.vector_store.insert = MagicMock()
+
+    mock_langchain_llm = MagicMock()
+    mock_response = MagicMock()
+    mock_response.content = "Always verify inputs."
+    mock_langchain_llm.invoke.return_value = mock_response
+
+    # Must not raise TypeError: Memory.add() got an unexpected keyword argument 'llm'
+    result = memory.add(
+        [{"role": "user", "content": "verify inputs"}],
+        agent_id="agent-1",
+        memory_type="procedural_memory",
+        llm=mock_langchain_llm,
+    )
+
+    mock_langchain_llm.invoke.assert_called_once()
+    assert result["results"][0]["event"] == "ADD"
+    assert result["results"][0]["memory"] == "Always verify inputs."
+


### PR DESCRIPTION
## Problem

Closes #5911.

`AsyncMemory.add()` has accepted a `llm=None` parameter since #5710 and forwards it to `AsyncMemory._create_procedural_memory()`, which calls `llm.invoke(...)` via the LangChain `BaseChatModel` interface. The synchronous `Memory.add()` and `Memory._create_procedural_memory()` were never updated, leaving the two classes with divergent public APIs. Sync users passing a custom LangChain model hit:

```
TypeError: Memory.add() got an unexpected keyword argument 'llm'
```

## Why This Change Was Made

- **API parity.** Sync `Memory` and async `AsyncMemory` should accept the same keyword arguments for procedural-memory creation. The async path set the contract in #5710; this PR closes the gap.
- **Minimal blast radius.** The new parameter defaults to `None`, in which case `_create_procedural_memory` continues to call `self.llm.generate_response` exactly as before. No existing caller's behavior changes.
- **No new abstraction.** The branching pattern (`llm is not None` → LangChain path, else → `self.llm.generate_response`) mirrors the async implementation line-for-line.

## User Impact

- Sync users who supply a LangChain `BaseChatModel` for procedural-memory creation can now do so without workarounds.
- All other callers (the vast majority) see no behavior change — `llm` defaults to `None` and the existing `self.llm.generate_response` path is used.

## Change

- `mem0/memory/main.py`
  - `Memory.add()` gains `llm=None` parameter (mirrors `AsyncMemory.add`), with docstring entry. Forwards `llm=llm` into `_create_procedural_memory()` on the procedural path.
  - `Memory._create_procedural_memory()` gains `llm=None` parameter. When `llm` is provided, the helper imports `convert_to_messages` lazily (same import-guard pattern as the async path), converts the parsed message list, and calls `llm.invoke(input=...)`; otherwise it falls back to `self.llm.generate_response` unchanged.

## Evidence

```
$ uv run pytest tests/test_memory.py -k "sync_procedural_memory_langchain or sync_add_accepts_llm_kwarg" -v
tests/test_memory.py::test_async_procedural_memory_langchain_strips_code_blocks PASSED [ 33%]
tests/test_memory.py::test_sync_procedural_memory_langchain_strips_code_blocks PASSED [ 66%]
tests/test_memory.py::test_sync_add_accepts_llm_kwarg_for_procedural_memory PASSED [100%]
```

Two new regression tests:

- `test_sync_procedural_memory_langchain_strips_code_blocks` — mirrors the existing async #5710 regression: a LangChain mock returns ```` ```json\\n{...}\\n``` ````, the sync helper must call `llm.invoke` and apply `remove_code_blocks` before storing.
- `test_sync_add_accepts_llm_kwarg_for_procedural_memory` — end-to-end `Memory.add(...)` with `memory_type="procedural_memory"` and a LangChain `llm`, asserting no `TypeError` and the expected `ADD` result.

### Regression verification

Reverting only `mem0/memory/main.py` to `main` (keeping the tests) reproduces the original bug — both new tests fail:

```
FAILED tests/test_memory.py::test_sync_procedural_memory_langchain_strips_code_blocks
FAILED tests/test_memory.py::test_sync_add_accepts_llm_kwarg_for_procedural_memory
E       TypeError: Memory.add() got an unexpected keyword argument 'llm'
```

Restoring the fix makes both tests pass.