### PR TITLE
fix(llms/gemini): map tool_choice="required" to ANY and accept **kwargs

### DIFF
--- a/mem0/llms/gemini.py
+++ b/mem0/llms/gemini.py
@@ -161,6 +161,7 @@ class GeminiLLM(LLMBase):
         response_format=None,
         tools: Optional[List[Dict]] = None,
         tool_choice: str = "auto",
+        **kwargs,
     ):
         """
         Generate a response based on the given messages using Gemini.
@@ -169,7 +170,11 @@ class GeminiLLM(LLMBase):
             messages (list): List of message dicts containing 'role' and 'content'.
             response_format (str or object, optional): Format for the response. Defaults to "text".
             tools (list, optional): List of tools that the model can call. Defaults to None.
-            tool_choice (str, optional): Tool choice method. Defaults to "auto".
+            tool_choice (str, optional): Tool choice method. One of "auto", "any",
+                "required" (forces a tool call by mapping to ANY mode + allowed_function_names),
+                or any other value (NONE). Defaults to "auto".
+            **kwargs: Additional provider-specific parameters. ``max_tokens`` overrides
+                ``self.config.max_tokens`` for this call only — see #5430.
 
         Returns:
             str: The generated response.
@@ -183,8 +188,11 @@ class GeminiLLM(LLMBase):
         config_params = {}
         if self.config.temperature is not None:
             config_params["temperature"] = self.config.temperature
-        if self.config.max_tokens is not None:
-            config_params["max_output_tokens"] = self.config.max_tokens
+        # Per-call ``max_tokens`` override (the base ``**kwargs`` contract);
+        # falls back to the configured value when not supplied — see #5430.
+        max_tokens = kwargs.pop("max_tokens", self.config.max_tokens)
+        if max_tokens is not None:
+            config_params["max_output_tokens"] = max_tokens
         if self.config.top_p is not None:
             config_params["top_p"] = self.config.top_p
 
@@ -204,16 +212,24 @@ class GeminiLLM(LLMBase):
             if tool_choice:
                 if tool_choice == "auto":
                     mode = types.FunctionCallingConfigMode.AUTO
-                elif tool_choice == "any":
+                elif tool_choice in ("any", "required"):
+                    # Gemini has no "required" mode; map standard "required"
+                    # (force-a-tool-call) to ANY + allowed_function_names,
+                    # matching the behaviour callers expect from other
+                    # providers — see #5430. Without this, "required" fell
+                    # through to NONE and silently disabled tool calling.
                     mode = types.FunctionCallingConfigMode.ANY
                 else:
                     mode = types.FunctionCallingConfigMode.NONE
 
+                # Restrict the call to the provided tool names whenever the
+                # caller is forcing a tool call (any / required).
+                force_tool_call = tool_choice in ("any", "required")
                 tool_config = types.ToolConfig(
                     function_calling_config=types.FunctionCallingConfig(
                         mode=mode,
                         allowed_function_names=(
-                            [tool["function"]["name"] for tool in tools] if tool_choice == "any" else None
+                            [tool["function"]["name"] for tool in tools] if force_tool_call else None
                         ),
                     )
                 )

--- a/tests/llms/test_gemini.py
+++ b/tests/llms/test_gemini.py
@@ -232,6 +232,123 @@ def test_explicit_config_values_passed_to_generation_config(mock_gemini_client: 
     assert config_arg.top_p == 0.9
 
 
+def _make_tool_call_response() -> Mock:
+    """Build a generate_content response whose tool_calls parse cleanly."""
+    mock_tool_call = Mock()
+    mock_tool_call.name = "add_memory"
+    mock_tool_call.args = {"data": "Today is a sunny day."}
+
+    mock_text_part = Mock()
+    mock_text_part.text = "I've added the memory for you."
+    mock_text_part.function_call = None
+
+    mock_func_part = Mock()
+    mock_func_part.text = None
+    mock_func_part.function_call = mock_tool_call
+
+    mock_content = Mock()
+    mock_content.parts = [mock_text_part, mock_func_part]
+
+    mock_candidate = Mock()
+    mock_candidate.content = mock_content
+    return Mock(candidates=[mock_candidate])
+
+
+def _single_tool() -> list:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": "add_memory",
+                "description": "Add a memory",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"data": {"type": "string", "description": "Data to add to memory"}},
+                    "required": ["data"],
+                },
+            },
+        }
+    ]
+
+
+def test_generate_response_tool_choice_required_maps_to_any_and_locks_names(mock_gemini_client: Mock):
+    """Regression #5430: ``tool_choice="required"`` is the standard value for
+    "force a tool call". Gemini has no required mode, so we map it to ANY with
+    allowed_function_names set — matching caller expectations from other
+    providers. Previously, ``"required"`` fell through to the else branch and
+    mapped to NONE, silently disabling tool calling."""
+    config = BaseLlmConfig(model="gemini-2.0-flash", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = GeminiLLM(config)
+
+    mock_gemini_client.models.generate_content.return_value = _make_tool_call_response()
+
+    llm.generate_response(
+        [{"role": "user", "content": "Add a memory: Today is a sunny day."}],
+        tools=_single_tool(),
+        tool_choice="required",
+    )
+
+    config_arg = mock_gemini_client.models.generate_content.call_args.kwargs["config"]
+    fc = config_arg.tool_config.function_calling_config
+    assert fc.mode == types.FunctionCallingConfigMode.ANY
+    # ``required`` must restrict to the provided tool names, matching ``any``.
+    assert fc.allowed_function_names == ["add_memory"]
+
+
+def test_generate_response_tool_choice_any_still_maps_to_any_and_locks_names(mock_gemini_client: Mock):
+    """Existing ``tool_choice="any"`` behaviour is preserved by the #5430 fix."""
+    config = BaseLlmConfig(model="gemini-2.0-flash", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = GeminiLLM(config)
+
+    mock_gemini_client.models.generate_content.return_value = _make_tool_call_response()
+
+    llm.generate_response(
+        [{"role": "user", "content": "Add a memory: Today is a sunny day."}],
+        tools=_single_tool(),
+        tool_choice="any",
+    )
+
+    config_arg = mock_gemini_client.models.generate_content.call_args.kwargs["config"]
+    fc = config_arg.tool_config.function_calling_config
+    assert fc.mode == types.FunctionCallingConfigMode.ANY
+    assert fc.allowed_function_names == ["add_memory"]
+
+
+def test_generate_response_accepts_kwargs_max_tokens_override(mock_gemini_client: Mock):
+    """Regression #5430: base ``LLMBase.generate_response`` accepts ``**kwargs``
+    for per-call overrides. Gemini's signature previously omitted ``**kwargs``
+    so any caller passing e.g. ``max_tokens=...`` raised TypeError."""
+    config = BaseLlmConfig(model="gemini-2.0-flash", temperature=0.5, max_tokens=200, top_p=0.9)
+    llm = GeminiLLM(config)
+
+    mock_part = Mock(text="ok")
+    mock_content = Mock(parts=[mock_part])
+    mock_candidate = Mock(content=mock_content)
+    mock_gemini_client.models.generate_content.return_value = Mock(candidates=[mock_candidate])
+
+    llm.generate_response([{"role": "user", "content": "hi"}], max_tokens=4096)
+
+    config_arg = mock_gemini_client.models.generate_content.call_args.kwargs["config"]
+    # Per-call override wins over the configured default.
+    assert "max_output_tokens" in config_arg.model_fields_set
+    assert config_arg.max_output_tokens == 4096
+
+
+def test_generate_response_accepts_unknown_kwargs_without_raising(mock_gemini_client: Mock):
+    """Arbitrary ``**kwargs`` must not raise — they are silently dropped,
+    matching the base-class contract for provider-specific extras."""
+    config = BaseLlmConfig(model="gemini-2.0-flash", temperature=0.5, max_tokens=200, top_p=0.9)
+    llm = GeminiLLM(config)
+
+    mock_part = Mock(text="ok")
+    mock_content = Mock(parts=[mock_part])
+    mock_candidate = Mock(content=mock_content)
+    mock_gemini_client.models.generate_content.return_value = Mock(candidates=[mock_candidate])
+
+    # Should not raise TypeError.
+    llm.generate_response([{"role": "user", "content": "hi"}], some_future_param=True)
+
+
 # --- Vertex AI backend initialization (issue #3990, PR #4030) ---
 
 


### PR DESCRIPTION
## Problem

Closes #5430.

Two small tool-handling bugs in `mem0/llms/gemini.py` `generate_response`:

1. **`tool_choice="required"` silently disables tool calling.** The mapping has an `else` branch that maps anything other than `"auto"` / `"any"` to `FunctionCallingConfigMode.NONE`. `"required"` is the standard value for "force a tool call" (used by other providers and the base contract), so callers asking Gemini to force a tool silently got no tool call. The same branch also gated `allowed_function_names`, so `"required"` ended up with no allowed names either.
2. **`generate_response` did not accept `**kwargs`.** The base `LLMBase.generate_response` signature is `(self, messages, tools=None, tool_choice="auto", **kwargs)`, and other providers accept `**kwargs` for per-call overrides (e.g. a per-call `max_tokens`). Gemini's signature omitted `**kwargs`, so any caller passing an extra parameter raised `TypeError`.

## Why This Change Was Made

- **Silent breakage is the worst kind.** `"required"` mapping to `NONE` does not raise — it just produces a response without a tool call, which is hard to debug. Mapping it to `ANY` (the closest correct mode, since Gemini has no native \"required\") plus `allowed_function_names` matches what callers expect from the contract that the other providers already honor.
- **API parity with the base class.** Other providers already accept `**kwargs`; this just brings Gemini into line.
- **Minimal, surgical change.** Both fixes are in the same file and touch the same code block. No new abstraction.

## User Impact

- Callers using `tool_choice="required"` on Gemini now get a forced tool call instead of a no-op. (Gemini's ANY mode is the closest analogue to OpenAI's `required`.)
- Callers passing per-call overrides like `max_tokens=4096` no longer hit `TypeError`.
- All other callers see no behavior change — `tool_choice` defaults to `"auto"`, and unknown kwargs are silently dropped (matching the base-class contract for provider-specific extras).

## Change

- `mem0/llms/gemini.py`
  - `generate_response` gains `**kwargs` in its signature.
  - `tool_choice in ("any", "required")` now maps to `FunctionCallingConfigMode.ANY`. The `else` branch (still `NONE`) is now reached only for genuine unknown values.
  - `allowed_function_names` is set whenever the caller is forcing a tool call (`"any"` or `"required"`), computed via a `force_tool_call` boolean.
  - A per-call `max_tokens` override is honored as `max_output_tokens`, falling back to `self.config.max_tokens` when not supplied.

## Evidence

```
$ uv run pytest tests/llms/test_gemini.py -v
============================== 21 passed in 1.82s ==============================
```

Four new regression tests:

- `test_generate_response_tool_choice_required_maps_to_any_and_locks_names` — the core #5430 fix: `"required"` → `ANY` + `allowed_function_names == ["add_memory"]`.
- `test_generate_response_tool_choice_any_still_maps_to_any_and_locks_names` — preserves existing `"any"` behavior (no regression).
- `test_generate_response_accepts_kwargs_max_tokens_override` — `max_tokens=4096` kwarg overrides `config.max_tokens=200` and surfaces as `max_output_tokens=4096`.
- `test_generate_response_accepts_unknown_kwargs_without_raising` — arbitrary kwargs are accepted (silently dropped) instead of raising `TypeError`.

### Regression verification

Reverting only `mem0/llms/gemini.py` to `main` (keeping the tests) reproduces the original bugs — three of the four new tests fail:

```
FAILED tests/llms/test_gemini.py::test_generate_response_tool_choice_required_maps_to_any_and_locks_names
FAILED tests/llms/test_gemini.py::test_generate_response_accepts_kwargs_max_tokens_override
FAILED tests/llms/test_gemini.py::test_generate_response_accepts_unknown_kwargs_without_raising
E       TypeError: GeminiLLM.generate_response() got an unexpected keyword argument 'some_future_param'
```

Restoring the fix makes all 21 tests pass.