### PR TITLE
fix(memory): paginate delete_all so it does not stop at the first page

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -81,6 +81,12 @@ warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*swigva
 logger = logging.getLogger(__name__)
 
 
+# Page size used by `delete_all` when iterating the vector store. Some vector
+# stores cap `list` at a default page size (e.g. 100); without paging,
+# `delete_all` silently leaves older matching memories behind (issue #4869).
+_DELETE_ALL_PAGE_SIZE = 1000
+
+
 def _vector_store_list_rows(listed):
     if isinstance(listed, (list, tuple)) and listed and isinstance(listed[0], list):
         return listed[0]
@@ -1849,14 +1855,25 @@ class Memory(MemoryBase):
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "sync"})
-        # delete all vector memories and reset the collections
-        memories = self.vector_store.list(filters=filters)[0]
-        for memory in memories:
-            self._delete_memory(memory.id)
+        # delete all vector memories and reset the collections.
+        # Iterate in pages because some vector stores cap `list` at a default
+        # page size (e.g. 100). A single call would leave older matching
+        # memories behind. See issue #4869. We stop when a page is shorter
+        # than requested (last page) or empty.
+        total_deleted = 0
+        while True:
+            page = self.vector_store.list(filters=filters, top_k=_DELETE_ALL_PAGE_SIZE)[0]
+            if not page:
+                break
+            for memory in page:
+                self._delete_memory(memory.id)
+            total_deleted += len(page)
+            if len(page) < _DELETE_ALL_PAGE_SIZE:
+                break
 
-        logger.info(f"Deleted {len(memories)} memories")
+        logger.info(f"Deleted {total_deleted} memories")
 
-        decay_usage_notice = detect_decay_usage_from_delete_all(len(memories))
+        decay_usage_notice = detect_decay_usage_from_delete_all(total_deleted)
         if decay_usage_notice:
             display_decay_usage_notice(self, "sync", "delete_all", *decay_usage_notice)
         else:
@@ -3468,10 +3485,24 @@ class AsyncMemory(MemoryBase):
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "async"})
-        memories = await asyncio.to_thread(self.vector_store.list, filters=filters)
+        # Iterate in pages because some vector stores cap `list` at a default
+        # page size (e.g. 100). A single call would leave older matching
+        # memories behind. See issue #4869. We stop when a page is shorter
+        # than requested (last page) or empty.
+        all_memories = []
+        while True:
+            page = await asyncio.to_thread(
+                self.vector_store.list, filters=filters, top_k=_DELETE_ALL_PAGE_SIZE
+            )
+            page_memories = page[0] if page else []
+            if not page_memories:
+                break
+            all_memories.extend(page_memories)
+            if len(page_memories) < _DELETE_ALL_PAGE_SIZE:
+                break
 
         delete_tasks = []
-        for memory in memories[0]:
+        for memory in all_memories:
             delete_tasks.append(self._delete_memory(memory.id, skip_entity_cleanup=True))
 
         results = await asyncio.gather(*delete_tasks, return_exceptions=True)
@@ -3487,7 +3518,7 @@ class AsyncMemory(MemoryBase):
 
         logger.info(f"Deleted {len(results) - len(errors)} memories")
 
-        decay_usage_notice = detect_decay_usage_from_delete_all(len(memories[0]))
+        decay_usage_notice = detect_decay_usage_from_delete_all(len(all_memories))
         if decay_usage_notice:
             await display_decay_usage_notice_async(self, "async", "delete_all", *decay_usage_notice)
         else:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1000,6 +1000,146 @@ async def test_async_delete_all_continues_on_partial_failure(mock_sqlite, mock_l
     assert mock_vector_store.delete.call_count == 2
 
 
+def _make_list_page(n, prefix):
+    """Helper: build a list of N MagicMock memories with ids like '<prefix>-0'."""
+    page = []
+    for i in range(n):
+        m = MagicMock()
+        m.id = f"{prefix}-{i}"
+        m.payload = {"data": f"{prefix}-{i}", "created_at": "2024-01-01T00:00:00+00:00"}
+        page.append(m)
+    return page
+
+
+def _paginated_list_factory(pages):
+    """Return a `list` side_effect that pops pages sequentially, then [].
+
+    Simulates a vector store that caps each `list` call at a fixed page
+    size (so callers must loop). Each call returns a `(rows,)` tuple to
+    match the production `[0]` indexing convention.
+    """
+    queue = list(pages)
+
+    def _side_effect(*args, **kwargs):
+        if not queue:
+            return ([],)
+        return (queue.pop(0),)
+
+    return _side_effect
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+def test_sync_delete_all_paginates_through_all_memories(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory, monkeypatch
+):
+    """Regression for issue #4869: when the vector store caps `list` at a
+    default page size, a single call only returns the first page and older
+    matching memories are left behind. `delete_all` must iterate.
+    """
+    from mem0.memory import main as memory_main
+    # Force a small page so we can exercise multiple iterations cheaply.
+    monkeypatch.setattr(memory_main, "_DELETE_ALL_PAGE_SIZE", 2)
+
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_store = MagicMock()
+    mock_vector_factory.return_value = mock_vector_store
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    # Three pages: [m0, m1], [m2, m3], [m4] — last page is short, loop ends.
+    mock_vector_store.list.side_effect = _paginated_list_factory([
+        _make_list_page(2, "mem"),
+        _make_list_page(2, "mem"),
+        _make_list_page(1, "mem"),
+    ])
+
+    from mem0.memory.main import Memory as MemoryClass
+    memory = MemoryClass(MemoryConfig())
+    # Stub `_delete_memory` so we don't have to fake the full vector_store.get
+    # + history path. The bug is about how many memories `delete_all` pulls
+    # out of the vector store, not what `_delete_memory` does internally.
+    memory._delete_memory = MagicMock()
+
+    result = memory.delete_all(user_id="bug-002-user")
+
+    assert result == {"message": "Memories deleted successfully!"}
+    # 3 pages (last one short → loop terminates without an empty call).
+    # A single-call implementation would only see page 1 and stop at 1 call.
+    assert mock_vector_store.list.call_count == 3
+    # Each memory from every page should have been deleted exactly once.
+    assert memory._delete_memory.call_count == 5
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+def test_sync_delete_all_stops_when_first_page_empty(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    """When the store returns an empty first page, `delete_all` should not
+    loop and should not delete anything."""
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_store = MagicMock()
+    mock_vector_factory.return_value = mock_vector_store
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    mock_vector_store.list.return_value = ([],)
+
+    from mem0.memory.main import Memory as MemoryClass
+    memory = MemoryClass(MemoryConfig())
+    memory._delete_memory = MagicMock()
+
+    result = memory.delete_all(user_id="no-memories-user")
+
+    assert result == {"message": "Memories deleted successfully!"}
+    assert mock_vector_store.list.call_count == 1
+    assert memory._delete_memory.call_count == 0
+
+
+@pytest.mark.asyncio
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+async def test_async_delete_all_paginates_through_all_memories(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory, monkeypatch
+):
+    """Async regression for issue #4869."""
+    from mem0.memory import main as memory_main
+    monkeypatch.setattr(memory_main, "_DELETE_ALL_PAGE_SIZE", 2)
+
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_store = MagicMock()
+    mock_vector_factory.return_value = mock_vector_store
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    mock_vector_store.list.side_effect = _paginated_list_factory([
+        _make_list_page(2, "mem"),
+        _make_list_page(2, "mem"),
+        _make_list_page(1, "mem"),
+    ])
+
+    from mem0.memory.main import AsyncMemory
+    config = MemoryConfig()
+    memory = AsyncMemory(config)
+
+    async def _noop(*a, **kw):
+        return None
+    memory._delete_memory = MagicMock(side_effect=_noop)
+
+    result = await memory.delete_all(user_id="bug-002-user")
+
+    assert result == {"message": "Memories deleted successfully!"}
+    assert mock_vector_store.list.call_count == 3
+    assert memory._delete_memory.call_count == 5
+
+
 @patch('mem0.utils.factory.EmbedderFactory.create')
 @patch('mem0.utils.factory.VectorStoreFactory.create')
 @patch('mem0.utils.factory.LlmFactory.create')


### PR DESCRIPTION
## What Problem This Solves

Closes #4869.

`Memory.delete_all` and `AsyncMemory.delete_all` previously called `vector_store.list(filters=filters)` exactly once and deleted whatever came back. Several production vector stores cap `list` at a default page size (Pinecone/Milvus/Turbopuffer default to 100), so when a user had more matching memories than the page size, the older entries were silently left behind.

Reproducing: create 150 memories for one `user_id` against any vector store that caps `list` at 100, then call `delete_all(user_id=...)` — only the first 100 memories get deleted.

## Why This Change Was Made

- The vector store `list` interface has no offset/page parameter — pagination has to happen on the caller side.
- The fix loops, stopping when a page is shorter than requested (last page) or empty. This is robust against stores that don't paginate (one call returns everything; loop terminates on the short-page check).
- The same bug exists in the TypeScript `deleteAll`; this PR addresses the Python SDK only. A separate PR can address the TS path.

## User Impact

- Bulk deletions now actually delete all matching memories, regardless of how many pages the vector store needs to return them.
- No behavior change for callers with fewer memories than the page size — the loop terminates after one call exactly as before.
- Existing tests `test_async_delete_all_continues_on_partial_failure` and `TestAsyncDeleteAllEntityRace::test_async_delete_all_bulk_clears_entity_store` still pass unchanged.

## Evidence

Three regression tests added under `tests/test_memory.py`:

- `test_sync_delete_all_paginates_through_all_memories` — mock returns 3 pages `[m0,m1] / [m2,m3] / [m4]`; asserts `vector_store.list.call_count == 3` and `_delete_memory.call_count == 5`.
- `test_sync_delete_all_stops_when_first_page_empty` — empty first page → exactly 1 list call, 0 deletes.
- `test_async_delete_all_paginates_through_all_memories` — same coverage for `AsyncMemory`.

Catch-bug verification: each pagination test was confirmed to fail when `delete_all` is forced back to a single-call implementation (`list.call_count == 1` vs expected 3), and to pass with the loop in place.

Full file green:
- `uv run pytest tests/test_memory.py -k delete_all` → 5 passed (3 new + 2 pre-existing).

### Diffstat

```
mem0/memory/main.py  |  49 ++++++++++++++----
tests/test_memory.py | 140 +++++++++++++++++++++++++++++++++++++++++++++++++++
2 files changed, 180 insertions(+), 9 deletions(-)
```