### PR TITLE
fix(elasticsearch): add top-level size to KNN search so top_k > 10 is honoured

### DIFF
--- a/mem0/vector_stores/elasticsearch.py
+++ b/mem0/vector_stores/elasticsearch.py
@@ -148,8 +148,11 @@ class ElasticsearchDB(VectorStoreBase):
         if self.custom_search_query:
             search_query = self.custom_search_query(vectors, top_k, filters)
         else:
+            # Elasticsearch caps the response at the default `size` of 10
+            # regardless of `knn.k`. Set `size` so top_k > 10 is honoured.
             search_query = {
-                "knn": {"field": "vector", "query_vector": vectors, "k": top_k, "num_candidates": top_k * 2}
+                "size": top_k,
+                "knn": {"field": "vector", "query_vector": vectors, "k": top_k, "num_candidates": top_k * 2},
             }
             if filters:
                 filter_conditions = []

--- a/tests/vector_stores/test_elasticsearch.py
+++ b/tests/vector_stores/test_elasticsearch.py
@@ -209,12 +209,47 @@ class TestElasticsearchDB(unittest.TestCase):
         self.assertEqual(body["knn"]["query_vector"], vectors)
         self.assertEqual(body["knn"]["k"], 5)
         self.assertEqual(body["knn"]["num_candidates"], 10)
+        # Elasticsearch caps the response at the default `size` of 10
+        # regardless of `knn.k`, so `size` must mirror `top_k`.
+        self.assertEqual(body["size"], 5)
 
         # Verify results
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].id, "id1")
         self.assertEqual(results[0].score, 0.8)
         self.assertEqual(results[0].payload, {"key1": "value1"})
+
+    def test_search_sets_size_above_default_cap(self):
+        # Regression for #5909: Memory.search passes an internal top_k of
+        # up to `max(limit * 4, 60)` to support hybrid re-ranking. Without
+        # `size` on the KNN body, Elasticsearch caps the response at 10
+        # hits regardless of `knn.k`, silently truncating recall.
+        self.client_mock.search.return_value = {"hits": {"hits": []}}
+
+        self.es_db.search(query="", vectors=[[0.1] * 1536], top_k=60)
+
+        body = self.client_mock.search.call_args[1]["body"]
+        self.assertEqual(body["size"], 60)
+        self.assertEqual(body["knn"]["k"], 60)
+        self.assertEqual(body["knn"]["num_candidates"], 120)
+
+    def test_search_with_filters_keeps_size(self):
+        # Filters must not displace the `size` field added for #5909.
+        self.client_mock.search.return_value = {"hits": {"hits": []}}
+
+        self.es_db.search(
+            query="",
+            vectors=[[0.1] * 1536],
+            top_k=25,
+            filters={"user_id": "u1"},
+        )
+
+        body = self.client_mock.search.call_args[1]["body"]
+        self.assertEqual(body["size"], 25)
+        self.assertEqual(
+            body["knn"]["filter"],
+            {"bool": {"must": [{"term": {"metadata.user_id": "u1"}}]}},
+        )
 
     def test_custom_search_query(self):
         # Mock custom search query


### PR DESCRIPTION
## What Problem This Solves

Fixes #5909.

`ElasticsearchDB.search()` built the KNN query body without a top-level `size`, so Elasticsearch capped the response at its default of 10 hits regardless of `knn.k`. `Memory.search()` calls the vector store with an internal limit of up to `max(limit * 4, 60)` to build the hybrid re-ranking candidate pool, so on Elasticsearch that pool was silently truncated to 10 — capping recall and degrading ranking quality for any `memory.search(query, limit=N)` where `N > 10`.

The sibling `keyword_search()` and `list()` paths already set `size`; only the KNN `search()` omitted it.

## Why This Change Was Made

- `knn.k` controls how many nearest neighbours each shard returns, not how many hits the response carries. The response size is governed by the top-level `size` field, which defaults to 10.
- `num_candidates = top_k * 2` was already correct on the candidate side; only the response size was uncapped-from-default.
- The fix is one line in the default (non-custom) KNN path. When `custom_search_query` is supplied, the user callable owns the body and we continue to pass it through unchanged.

## User Impact

- `memory.search(query, limit=N)` on Elasticsearch now returns up to N memories instead of stopping at 10.
- Hybrid re-ranking now sees the full intended candidate pool (up to 60 by default), improving ranking quality.
- No behaviour change for `top_k <= 10` (existing default-sized responses).
- No behaviour change for callers that supply `custom_search_query`.

## Evidence

- New regression tests:
  - `test_search_sets_size_above_default_cap` — `top_k=60` yields `body["size"] == 60` (mirrors `Memory.search`'s internal candidate pool size).
  - `test_search_with_filters_keeps_size` — filters do not displace `size` (`body["size"] == 25`, filter bool clause still present).
- Existing `test_search` extended to assert `body["size"] == top_k`.
- Catch-bug verified: with the `size` line removed, all three tests fail with `KeyError: 'size'`.
- Full suite: `uv run pytest tests/vector_stores/test_elasticsearch.py` — 16/16 pass.

```
$ uv run pytest tests/vector_stores/test_elasticsearch.py -q
................                                                         [100%]
16 passed in 2.43s
```