### PR TITLE
fix(memory): defer langchain-core import in async procedural memory

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -3556,16 +3556,6 @@ class AsyncMemory(MemoryBase):
             llm (llm, optional): LLM to use for the procedural memory creation. Defaults to None.
             prompt (str, optional): Prompt to use for the procedural memory creation. Defaults to None.
         """
-        try:
-            from langchain_core.messages.utils import (
-                convert_to_messages,  # type: ignore
-            )
-        except Exception:
-            logger.error(
-                "Import error while loading langchain-core. Please install 'langchain-core' to use procedural memory."
-            )
-            raise
-
         logger.info("Creating procedural memory")
 
         parsed_messages = [
@@ -3576,13 +3566,25 @@ class AsyncMemory(MemoryBase):
 
         try:
             if llm is not None:
+                # langchain-core is an optional dependency; defer the import
+                # to the custom-LLM branch so the default path (llm=None) works
+                # on a base `pip install mem0ai` without [extras]. See #5907.
+                try:
+                    from langchain_core.messages.utils import (
+                        convert_to_messages,  # type: ignore
+                    )
+                except Exception:
+                    logger.error(
+                        "Import error while loading langchain-core. Please install 'langchain-core' to use procedural memory."
+                    )
+                    raise
                 parsed_messages = convert_to_messages(parsed_messages)
                 response = await asyncio.to_thread(llm.invoke, input=parsed_messages)
                 procedural_memory = remove_code_blocks(response.content)
             else:
                 procedural_memory = await asyncio.to_thread(self.llm.generate_response, messages=parsed_messages)
                 procedural_memory = remove_code_blocks(procedural_memory)
-        
+
         except Exception as e:
             logger.error(f"Error generating procedural memory summary: {e}")
             raise

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1529,3 +1529,97 @@ async def test_async_procedural_memory_langchain_strips_code_blocks(mock_llm_fac
     insert_call = memory.vector_store.insert.call_args
     stored_data = insert_call[1]["payloads"][0]["data"]
     assert "```" not in stored_data
+
+
+@pytest.mark.asyncio
+@patch("mem0.memory.main.VectorStoreFactory")
+@patch("mem0.memory.main.EmbedderFactory")
+@patch("mem0.memory.main.LlmFactory")
+async def test_async_procedural_memory_default_path_does_not_require_langchain_core(
+    mock_llm_factory, mock_emb, mock_vs
+):
+    """Regression #5907: the default async path (llm=None) must not import
+    langchain_core at function entry. Previously the unconditional import
+    raised ModuleNotFoundError on a base `pip install mem0ai` even when no
+    custom LLM was supplied, while the sync equivalent worked."""
+    mock_vs.return_value = MagicMock()
+    mock_emb.return_value = MagicMock()
+    mock_emb.return_value.embed.return_value = [0.1] * 1536
+    mock_llm_factory.return_value = MagicMock()
+
+    from mem0.memory import main as memory_main
+
+    config = MemoryConfig()
+    memory = memory_main.AsyncMemory(config)
+    memory.vector_store = MagicMock()
+    memory.vector_store.insert = MagicMock()
+
+    # Stub the default LLM so generate_response returns a clean string; the
+    # regression is about the import boundary, not the response shape.
+    memory.llm.generate_response.return_value = "remember to validate inputs"
+
+    # If anything in the function unconditionally imports langchain_core this
+    # patch turns the import into ImportError, which the function would re-raise.
+    import builtins
+
+    real_import = builtins.__import__
+
+    def blocking_import(name, *args, **kwargs):
+        if name == "langchain_core.messages.utils" or name.startswith("langchain_core"):
+            raise ImportError("simulated missing langchain-core")
+        return real_import(name, *args, **kwargs)
+
+    messages = [{"role": "user", "content": "test"}]
+    metadata = {"user_id": "test_user"}
+
+    with patch("builtins.__import__", side_effect=blocking_import):
+        # Default path (llm=None) should succeed despite langchain-core being
+        # unimportable. The custom-LLM branch would raise; we don't take it.
+        result = await memory._create_procedural_memory(messages, metadata=metadata)
+
+    assert result["results"][0]["memory"] == "remember to validate inputs"
+    memory.llm.generate_response.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("mem0.memory.main.VectorStoreFactory")
+@patch("mem0.memory.main.EmbedderFactory")
+@patch("mem0.memory.main.LlmFactory")
+async def test_async_procedural_memory_custom_llm_still_requires_langchain_core(
+    mock_llm_factory, mock_emb, mock_vs
+):
+    """Symmetric regression for #5907: when a custom llm IS supplied, the
+    langchain-core import still runs and a missing dependency still raises
+    rather than silently skipping the conversion."""
+    mock_vs.return_value = MagicMock()
+    mock_emb.return_value = MagicMock()
+    mock_emb.return_value.embed.return_value = [0.1] * 1536
+    mock_llm_factory.return_value = MagicMock()
+
+    from mem0.memory import main as memory_main
+
+    config = MemoryConfig()
+    memory = memory_main.AsyncMemory(config)
+    memory.vector_store = MagicMock()
+    memory.vector_store.insert = MagicMock()
+
+    mock_langchain_llm = MagicMock()
+
+    import builtins
+
+    real_import = builtins.__import__
+
+    def blocking_import(name, *args, **kwargs):
+        if name == "langchain_core.messages.utils" or name.startswith("langchain_core"):
+            raise ImportError("simulated missing langchain-core")
+        return real_import(name, *args, **kwargs)
+
+    messages = [{"role": "user", "content": "test"}]
+    metadata = {"user_id": "test_user"}
+
+    with patch("builtins.__import__", side_effect=blocking_import):
+        with pytest.raises(ImportError, match="langchain-core"):
+            await memory._create_procedural_memory(messages, metadata=metadata, llm=mock_langchain_llm)
+
+    # The custom LLM was never invoked because conversion failed first.
+    mock_langchain_llm.invoke.assert_not_called()


### PR DESCRIPTION
## What Problem This Solves

Fixes #5907.

`AsyncMemory._create_procedural_memory()` imported `convert_to_messages` from `langchain_core.messages.utils` at function entry, but the symbol is only used inside the `if llm is not None:` branch. `langchain-core` is an optional dependency (the `[extras]` group in `pyproject.toml`), so on a base `pip install mem0ai` the default path (`llm=None`) raised `ModuleNotFoundError` before doing any work. The sync `Memory._create_procedural_memory()` has no langchain dependency on the default path and works for the same call, so async was the only broken side.

```python
import asyncio
from mem0 import AsyncMemory

m = AsyncMemory()
asyncio.run(m.add([{"role": "user", "content": "..."}], agent_id="a1", memory_type="procedural_memory"))
# ModuleNotFoundError: No module named 'langchain_core'
```

## Why This Change Was Made

- The default path (`llm=None`) calls `self.llm.generate_response(...)` directly; it has no need for `convert_to_messages` and therefore no need for `langchain-core`.
- The sync equivalent (`Memory._create_procedural_memory`) already works without `langchain-core` because the import lives in the custom-LLM branch (effectively, by virtue of not existing on the default path).
- Moving the import into the `if llm is not None:` branch aligns the async behaviour with sync, restoring parity. The existing `try/except` around the import is preserved so callers that supply a custom langchain LLM without the dependency installed still get the friendly `"install 'langchain-core'"` log message and a clear re-raise.

## User Impact

- `AsyncMemory.add(..., memory_type=\"procedural_memory\")` on a base install (no `[extras]`) now works, matching the sync `Memory` behaviour.
- Callers supplying a custom `llm` still need `langchain-core`; if missing, they see the same ImportError as before.
- No behaviour change for callers already installing `[extras]`.

## Evidence

Two new regression tests in `tests/test_memory.py`:

- `test_async_procedural_memory_default_path_does_not_require_langchain_core` — patches `builtins.__import__` to reject `langchain_core` and verifies the default path (`llm=None`) succeeds, returns the LLM response, and only invokes `self.llm.generate_response` once.
- `test_async_procedural_memory_custom_llm_still_requires_langchain_core` — symmetric: with the same import block, supplying a custom `llm` re-raises `ImportError(\"...langchain-core...\")` and never invokes `llm.invoke`.

Catch-bug verified: with the import restored to function entry, the default-path test fails with `ImportError: simulated missing langchain-core`. With the import deferred to the branch, both new tests and the existing `test_async_procedural_memory_langchain_strips_code_blocks` pass.

```
$ uv run pytest tests/test_memory.py::test_async_procedural_memory_default_path_does_not_require_langchain_core tests/test_memory.py::test_async_procedural_memory_custom_llm_still_requires_langchain_core tests/test_memory.py::test_async_procedural_memory_langchain_strips_code_blocks -v
...
3 passed in 4.24s
```