### PR TITLE
perf(core): eliminate N redundant vector_store.get() calls in delete_all (#5869)

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -605,6 +605,26 @@ class Memory(MemoryBase):
         except Exception as e:
             logger.warning(f"Entity upsert failed for '{entity_text}': {e}")
 
+    def _bulk_clear_entity_store(self, filters):
+        """Delete all entity records matching the given scope filters.
+
+        Used by delete_all to avoid N read-modify-write passes when every
+        memory in scope is being removed anyway. Mirrors the async helper.
+        """
+        if self._entity_store is None:
+            return
+        search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
+        try:
+            listed = self.entity_store.list(filters=search_filters, top_k=10000)
+            rows = listed[0] if isinstance(listed, (list, tuple)) and listed and isinstance(listed[0], list) else listed
+            for row in rows or []:
+                try:
+                    self.entity_store.delete(vector_id=row.id)
+                except Exception as e:
+                    logger.debug(f"Bulk entity delete failed for id={row.id}: {e}")
+        except Exception as e:
+            logger.warning(f"Bulk entity store cleanup failed: {e}")
+
     def _remove_memory_from_entity_store(self, memory_id, filters):
         """Strip `memory_id` from every entity record scoped to `filters`.
 
@@ -1851,8 +1871,13 @@ class Memory(MemoryBase):
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "sync"})
         # delete all vector memories and reset the collections
         memories = self.vector_store.list(filters=filters)[0]
+        # Pass the already-fetched memory so _delete_memory doesn't re-fetch
+        # each one via vector_store.get(). Skip per-memory entity cleanup so
+        # we can do a single bulk clear after the loop (mirrors async path).
         for memory in memories:
-            self._delete_memory(memory.id)
+            self._delete_memory(memory.id, existing_memory=memory, skip_entity_cleanup=True)
+
+        self._bulk_clear_entity_store(filters)
 
         logger.info(f"Deleted {len(memories)} memories")
 
@@ -2015,7 +2040,7 @@ class Memory(MemoryBase):
 
         return memory_id
 
-    def _delete_memory(self, memory_id, existing_memory=None):
+    def _delete_memory(self, memory_id, existing_memory=None, skip_entity_cleanup=False):
         logger.info(f"Deleting memory with {memory_id=}")
         if existing_memory is None:
             existing_memory = self.vector_store.get(vector_id=memory_id)
@@ -2040,8 +2065,11 @@ class Memory(MemoryBase):
         )
 
         # Entity-store cleanup: strip this memory's id from any entity records
-        # that linked to it. Non-fatal — the helper swallows errors.
-        self._remove_memory_from_entity_store(memory_id, session_filters)
+        # that linked to it. Non-fatal — the helper swallows errors. Skipped
+        # when the caller is doing a bulk clear (e.g. delete_all) that wipes
+        # every matching entity in one pass.
+        if not skip_entity_cleanup:
+            self._remove_memory_from_entity_store(memory_id, session_filters)
 
         return memory_id
 
@@ -3472,7 +3500,9 @@ class AsyncMemory(MemoryBase):
 
         delete_tasks = []
         for memory in memories[0]:
-            delete_tasks.append(self._delete_memory(memory.id, skip_entity_cleanup=True))
+            delete_tasks.append(
+                self._delete_memory(memory.id, existing_memory=memory, skip_entity_cleanup=True)
+            )
 
         results = await asyncio.gather(*delete_tasks, return_exceptions=True)
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -984,20 +984,19 @@ async def test_async_delete_all_continues_on_partial_failure(mock_sqlite, mock_l
 
     mock_vector_store.list.return_value = ([mem1, mem2, mem3],)
 
-    def _get_side_effect(vector_id):
+    # delete_all now passes existing_memory straight through, so the failure
+    # must be simulated on vector_store.delete (not get) to exercise the
+    # partial-failure handling in asyncio.gather(return_exceptions=True).
+    def _delete_side_effect(vector_id):
         if vector_id == "mem-2":
             raise RuntimeError("simulated store failure")
-        return {
-            "mem-1": mem1,
-            "mem-3": mem3,
-        }.get(vector_id)
 
-    mock_vector_store.get.side_effect = _get_side_effect
+    mock_vector_store.delete.side_effect = _delete_side_effect
 
     result = await memory.delete_all(user_id="test-user")
 
     assert result == {"message": "Memories deleted successfully!"}
-    assert mock_vector_store.delete.call_count == 2
+    assert mock_vector_store.delete.call_count == 3
 
 
 @patch('mem0.utils.factory.EmbedderFactory.create')
@@ -1495,6 +1494,86 @@ class TestAsyncDeleteAllEntityRace:
 
         mock_entity_store.delete.assert_called_once_with(vector_id="entity-alice")
 
+        assert mock_vector_store.delete.call_count == 2
+
+
+class TestDeleteAllSkipsRedundantVectorStoreGets:
+    """Regression #5869: delete_all must not re-fetch each memory via
+    vector_store.get() after list() already returned them, and must use
+    a single bulk entity-clear instead of N per-memory cleanups."""
+
+    @patch('mem0.utils.factory.EmbedderFactory.create')
+    @patch('mem0.utils.factory.VectorStoreFactory.create')
+    @patch('mem0.utils.factory.LlmFactory.create')
+    @patch('mem0.memory.storage.SQLiteManager')
+    def test_sync_delete_all_passes_existing_memory_and_uses_bulk_clear(
+        self, mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+    ):
+        mock_embedder_factory.return_value = MagicMock()
+        mock_llm_factory.return_value = MagicMock()
+        mock_sqlite.return_value = MagicMock()
+
+        mock_vector_store = MagicMock()
+        mem_a = MagicMock()
+        mem_a.id = "mem-a"
+        mem_a.payload = {"data": "Alice likes Python", "user_id": "alice"}
+        mem_b = MagicMock()
+        mem_b.id = "mem-b"
+        mem_b.payload = {"data": "Alice works at Acme", "user_id": "alice"}
+        mock_vector_store.list.return_value = ([mem_a, mem_b],)
+        mock_vector_factory.return_value = mock_vector_store
+
+        mock_entity_store = MagicMock()
+        mock_entity_store.list.return_value = ([],)
+
+        from mem0.memory.main import Memory
+        config = MemoryConfig()
+        memory = Memory(config)
+        memory._entity_store = mock_entity_store
+
+        memory.delete_all(user_id="alice")
+
+        # No re-fetch: list() already gave us the memories.
+        mock_vector_store.get.assert_not_called()
+        assert mock_vector_store.delete.call_count == 2
+        # One bulk pass instead of N per-memory cleanups.
+        assert mock_entity_store.list.call_count == 1
+        # Per-memory _remove_memory_from_entity_store would have called
+        # entity_store.list N times; bulk clear calls it exactly once.
+
+    @pytest.mark.asyncio
+    @patch('mem0.utils.factory.EmbedderFactory.create')
+    @patch('mem0.utils.factory.VectorStoreFactory.create')
+    @patch('mem0.utils.factory.LlmFactory.create')
+    @patch('mem0.memory.storage.SQLiteManager')
+    async def test_async_delete_all_passes_existing_memory(
+        self, mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+    ):
+        mock_embedder_factory.return_value = MagicMock()
+        mock_llm_factory.return_value = MagicMock()
+        mock_sqlite.return_value = MagicMock()
+
+        mock_vector_store = MagicMock()
+        mem_a = MagicMock()
+        mem_a.id = "mem-a"
+        mem_a.payload = {"data": "Alice likes Python", "user_id": "alice"}
+        mem_b = MagicMock()
+        mem_b.id = "mem-b"
+        mem_b.payload = {"data": "Alice works at Acme", "user_id": "alice"}
+        mock_vector_store.list.return_value = ([mem_a, mem_b],)
+        mock_vector_factory.return_value = mock_vector_store
+
+        mock_entity_store = MagicMock()
+        mock_entity_store.list.return_value = ([],)
+
+        from mem0.memory.main import AsyncMemory
+        config = MemoryConfig()
+        memory = AsyncMemory(config)
+        memory._entity_store = mock_entity_store
+
+        await memory.delete_all(user_id="alice")
+
+        mock_vector_store.get.assert_not_called()
         assert mock_vector_store.delete.call_count == 2
 
 


### PR DESCRIPTION
## What Problem This Solves

`Memory.delete_all()` and `AsyncMemory.delete_all()` make N redundant `vector_store.get()` calls — one for every memory they just fetched via `list()` — turning an O(1) read into O(N). The sync path also does per-memory entity-store cleanup instead of the single bulk pass the async path already uses.

Closes #5869.

## Why This Change Was Made

`_delete_memory(memory_id, existing_memory=None)` fetches the memory via `vector_store.get()` when `existing_memory` is `None`. `delete_all` already had each fetched memory in hand but called `_delete_memory(memory.id)` without forwarding it, so every call re-fetched. For 100 memories that's 1 `list` + 100 `get` round trips where 1 `list` was sufficient. The sync path additionally ran per-memory entity-store cleanup (`_remove_memory_from_entity_store`) on every delete, producing N+1 entity-store passes where one bulk clear would do.

## User Impact

- `delete_all()` is now O(N) total round trips to the vector store (1 `list` + N `delete`) instead of O(2N) (1 `list` + N `get` + N `delete`).
- Sync `delete_all()` entity cleanup is now a single bulk pass, matching async behavior. Large stores see the biggest win.
- Behavior is otherwise unchanged: history is still recorded per memory, partial failures still don't abort (async uses `return_exceptions=True`; sync still best-effort inside the loop).

## Evidence

- `MEM0_TELEMETRY=False python3 -m pytest tests/test_memory.py` — 62/62 pass (was 60; +2 new regression tests).
- `test_sync_delete_all_passes_existing_memory_and_uses_bulk_clear` asserts `vector_store.get` is never called and the entity store's `list` runs exactly once (proving bulk-clear, not per-memory).
- `test_async_delete_all_passes_existing_memory` asserts the same for the async path.
- Updated `test_async_delete_all_continues_on_partial_failure`: it previously injected the simulated store failure on `vector_store.get(mem-2)`, which my fix skips entirely. Moved the failure injection to `vector_store.delete(mem-2)` to exercise the same `return_exceptions=True` recovery path. Assertion updated to `call_count == 3` (delete is now invoked for every memory; one fails internally).