### PR TITLE
fix(cli): reject invalid int config values without traceback

### DIFF
--- a/cli/python/src/mem0_cli/config.py
+++ b/cli/python/src/mem0_cli/config.py
@@ -235,7 +235,10 @@ def set_nested_value(config: Mem0Config, dotted_key: str, value: str) -> bool:
     if isinstance(current, bool):
         value = value.lower() in ("true", "1", "yes")  # type: ignore[assignment]
     elif isinstance(current, int):
-        value = int(value)  # type: ignore[assignment]
+        try:
+            value = int(value)  # type: ignore[assignment]
+        except ValueError:
+            return False
 
     setattr(obj, final_key, value)
     return True

--- a/cli/python/tests/test_config.py
+++ b/cli/python/tests/test_config.py
@@ -139,6 +139,11 @@ class TestNestedAccess:
         assert set_nested_value(config, "platform.api_key", "new-key")
         assert config.platform.api_key == "new-key"
 
+    def test_set_int_value_rejects_invalid_input(self):
+        config = Mem0Config()
+        assert set_nested_value(config, "version", "abc") is False
+        assert config.version == 1
+
     def test_set_nonexistent_key(self):
         config = Mem0Config()
         assert set_nested_value(config, "nonexistent.key", "val") is False


### PR DESCRIPTION
Fixes #5933.

## Summary
- return `False` when an int config field receives a non-numeric value
- keep the existing boolean success/failure contract used by `cmd_config_set`
- add regression coverage for invalid `version` input

## Tests
- `PYTHONPATH=cli/python/src pytest cli/python/tests/test_config.py -q`
- `PYTHONPATH=cli/python/src pytest cli/python/tests/test_commands.py -q`
- `python -m compileall -q cli/python/src/mem0_cli cli/python/tests`
- `git diff --check`

AI-assisted: yes. I manually reviewed the diff and test output before opening this PR.
