### PR TITLE
fix(cli): handle null memory fields in output formatters

### DIFF
--- a/cli/python/src/mem0_cli/output.py
+++ b/cli/python/src/mem0_cli/output.py
@@ -20,8 +20,8 @@ def format_memories_text(console: Console, memories: list[dict], title: str = "m
     console.print(f"\n[{BRAND_COLOR}]Found {count} {title}:[/]\n")
 
     for i, mem in enumerate(memories, 1):
-        memory_text = mem.get("memory", mem.get("text", ""))
-        mem_id = mem.get("id", "")[:8]
+        memory_text = mem.get("memory") or mem.get("text") or ""
+        mem_id = (mem.get("id") or "")[:8]
         score = mem.get("score")
         created = _format_date(mem.get("created_at"))
         category = mem.get("categories", [None])
@@ -67,8 +67,8 @@ def format_memories_table(
     table.add_column("Created", max_width=12)
 
     for mem in memories:
-        mem_id = mem.get("id", "")
-        memory_text = mem.get("memory", mem.get("text", ""))
+        mem_id = mem.get("id") or ""
+        memory_text = mem.get("memory") or mem.get("text") or ""
         if len(memory_text) > 60:
             memory_text = memory_text[:57] + "..."
         categories = mem.get("categories", [])

--- a/cli/python/src/mem0_cli/output.py
+++ b/cli/python/src/mem0_cli/output.py
@@ -104,8 +104,8 @@ def format_single_memory(console: Console, mem: dict, output: str = "text") -> N
         format_json(console, mem)
         return
 
-    memory_text = mem.get("memory", mem.get("text", ""))
-    mem_id = mem.get("id", "")
+    memory_text = mem.get("memory") or mem.get("text") or ""
+    mem_id = mem.get("id") or ""
 
     lines = []
     lines.append(f"  [white bold]{memory_text}[/]")

--- a/cli/python/tests/test_output.py
+++ b/cli/python/tests/test_output.py
@@ -99,6 +99,17 @@ class TestSingleMemory:
         output = buf.getvalue()
         assert '"memory"' in output
 
+    def test_format_single_memory_handles_null_fields(self):
+        console, buf = _make_console()
+        format_single_memory(
+            console,
+            {"id": None, "memory": None, "text": "Fallback memory", "created_at": None},
+            "text",
+        )
+        output = buf.getvalue()
+        assert "Fallback memory" in output
+        assert "ID:" not in output
+
 
 class TestAddResult:
     def test_format_add_result_text(self):

--- a/cli/python/tests/test_output.py
+++ b/cli/python/tests/test_output.py
@@ -54,6 +54,11 @@ class TestTextFormat:
         output = buf.getvalue()
         assert "Found 0" in output
 
+    def test_format_memories_text_handles_null_fields(self):
+        console, buf = _make_console()
+        format_memories_text(console, [{"id": None, "memory": None, "created_at": None}])
+        assert "Found 1 memories" in buf.getvalue()
+
 
 class TestTableFormat:
     def test_format_memories_table(self):
@@ -69,6 +74,13 @@ class TestTableFormat:
         output = buf.getvalue()
         # Should still render (empty table)
         assert "ID" in output
+
+    def test_format_memories_table_handles_null_fields(self):
+        console, buf = _make_console()
+        format_memories_table(console, [{"id": None, "memory": None, "created_at": None}])
+        output = buf.getvalue()
+        assert "ID" in output
+        assert "Memory" in output
 
 
 class TestSingleMemory:


### PR DESCRIPTION
Fixes #5931.

## Summary
- treat explicit `null` memory/id fields like missing values in text and table output
- keep the existing blank-cell behavior instead of crashing on `None`
- add regression coverage for null memory records

## Tests
- `PYTHONPATH=cli/python/src pytest cli/python/tests/test_output.py -q`
- `PYTHONPATH=cli/python/src pytest cli/python/tests/test_commands.py -q`
- `python -m compileall -q cli/python/src/mem0_cli cli/python/tests`
- `git diff --check`

AI-assisted: yes. I manually reviewed the diff and test output before opening this PR.
