### PR TITLE
fix(vector_stores): list() must return [[]] not [] on empty/error paths

### DIFF
--- a/mem0/vector_stores/databricks.py
+++ b/mem0/vector_stores/databricks.py
@@ -827,7 +827,7 @@ class Databricks(VectorStoreBase):
             return [memory_results]
         except Exception as e:
             logger.error(f"Failed to list memories: {e}")
-            return []
+            return [[]]
 
     def reset(self):
         """Reset the vector search index and underlying source table.

--- a/mem0/vector_stores/langchain.py
+++ b/mem0/vector_stores/langchain.py
@@ -205,10 +205,11 @@ class Langchain(VectorStoreBase):
                 # Convert the result to the expected format
                 if result and isinstance(result, dict):
                     return [self._parse_output(result)]
-                return []
+                return [[]]
+            return [[]]
         except Exception as e:
             logger.error(f"Error listing vectors from Chroma: {e}")
-            return []
+            return [[]]
 
     def reset(self):
         """Reset the index by deleting and recreating it."""

--- a/tests/vector_stores/test_databricks.py
+++ b/tests/vector_stores/test_databricks.py
@@ -538,6 +538,15 @@ def test_list_memories_default_limit(db_instance_delta, mock_workspace_client):
     assert call_kwargs["num_results"] == 100
 
 
+def test_list_memories_returns_nested_empty_list_on_error(db_instance_delta, mock_workspace_client):
+    """list() must return [[]] not [] when an exception is raised."""
+    mock_workspace_client.vector_search_indexes.query_index.side_effect = Exception("boom")
+
+    result = db_instance_delta.list(top_k=1)
+
+    assert result == [[]]
+
+
 # ---------------------- Table Creation Tests ---------------------- #
 
 

--- a/tests/vector_stores/test_langchain_vector_store.py
+++ b/tests/vector_stores/test_langchain_vector_store.py
@@ -225,8 +225,17 @@ def test_list_with_exception(langchain_instance):
 
     results = langchain_instance.list(filters={"user_id": "alice"}, top_k=10)
 
-    # Verify that an empty list is returned when an exception occurs
-    assert results == []
+    # Verify that a nested empty list is returned when an exception occurs
+    assert results == [[]]
+
+
+def test_list_when_collection_lacks_get_method(langchain_instance):
+    """Test list() when _collection exists but has no .get — should return [[]] not None."""
+    langchain_instance.client._collection = object()  # no .get attribute
+
+    results = langchain_instance.list()
+
+    assert results == [[]]
 
 
 def test_search_score_is_never_none(langchain_instance):


### PR DESCRIPTION
Memory.get_all() calls self.vector_store.list(filters=filters)[0] in mem0/memory/main.py. That means every vector store backend's list() needs to return a list-wrapped result, even when it's empty or errors out. A bare [] crashes with IndexError, and if a function implicitly returns None, that's a TypeError instead.

Went through all 26 vector store providers checking for this. Found two that break it:

langchain.py has three paths that return a bare [] or fall through to an implicit None: when _collection doesn't have a .get method, when the result is falsy or not a dict, and in the exception handler. There was already a test for the exception case (test_list_with_exception), but it was asserting the buggy behavior as correct, so I had to fix that assertion too, not just add a new one.

databricks.py's exception handler also returns a bare [] (the happy path was already fine).

Fixed all the paths in both files, corrected that one wrong test assertion, and added two new regression tests for paths that weren't covered before.

74/74 tests pass (15 in langchain, 59 in databricks). Did a red-green check on each of the three fixes individually to make sure the tests actually catch the bug. Ruff's clean too.