### PR TITLE
fix(cli): return all entity delete responses

### DIFF
--- a/cli/python/src/mem0_cli/backend/platform.py
+++ b/cli/python/src/mem0_cli/backend/platform.py
@@ -297,12 +297,12 @@ class PlatformBackend(Backend):
         if not entities:
             raise ValueError("At least one entity ID is required for delete_entities.")
         # Delete each provided entity via the v2 path-based endpoint
-        result: dict = {}
+        results: dict[str, Any] = {}
         for entity_type, entity_id in entities.items():
-            result = self._request(
+            results[entity_type] = self._request(
                 "DELETE", f"/v2/entities/{entity_type}/{entity_id}/", params={"source": "CLI"}
             )
-        return result
+        return results
 
     def ping(self, timeout: float | None = None) -> dict:
         """Call the ping endpoint and return the raw response.

--- a/cli/python/tests/test_commands.py
+++ b/cli/python/tests/test_commands.py
@@ -11,6 +11,7 @@ import pytest
 from rich.console import Console
 from typer import Exit as TyperExit
 
+from mem0_cli.backend.platform import PlatformBackend
 from mem0_cli.commands.config_cmd import (
     cmd_config_get,
     cmd_config_set,
@@ -894,6 +895,27 @@ class TestConfigCommands:
 
 
 class TestEntitiesDeleteCommand:
+    def test_platform_delete_entities_returns_each_response(self):
+        backend = PlatformBackend.__new__(PlatformBackend)
+        calls = []
+
+        def fake_request(method, path, **kwargs):
+            calls.append((method, path, kwargs))
+            return {"path": path}
+
+        backend._request = fake_request  # type: ignore[method-assign]
+
+        result = backend.delete_entities(user_id="alice", agent_id="bot")
+
+        assert result == {
+            "user": {"path": "/v2/entities/user/alice/"},
+            "agent": {"path": "/v2/entities/agent/bot/"},
+        }
+        assert calls == [
+            ("DELETE", "/v2/entities/user/alice/", {"params": {"source": "CLI"}}),
+            ("DELETE", "/v2/entities/agent/bot/", {"params": {"source": "CLI"}}),
+        ]
+
     def test_delete_entity_with_force(self, mock_backend):
         console, buf = _make_console()
         err_console, _err_buf = _make_err_console()


### PR DESCRIPTION
## Summary

- Return one response per deleted entity type from PlatformBackend.delete_entities
- Preserve the existing dict return shape for JSON output
- Add regression coverage for multi-entity deletes

Fixes #5935.

## Testing

- PYTHONPATH=cli/python/src pytest cli/python/tests/test_commands.py -q
- PYTHONPATH=cli/python/src pytest cli/python/tests/test_output.py -q
- python -m compileall -q cli/python/src/mem0_cli cli/python/tests
- git diff --check

## Notes

AI-assisted implementation; manually reviewed the diff and local verification output before opening this PR.