### PR TITLE
fix(embeddings): guard embed_batch count mismatch in OpenAI and Azure OpenAI

### DIFF
--- a/mem0-ts/src/oss/src/embeddings/azure.ts
+++ b/mem0-ts/src/oss/src/embeddings/azure.ts
@@ -52,6 +52,11 @@ export class AzureOpenAIEmbedder implements Embedder {
           .map((item) => item.embedding),
       );
     }
+    if (allEmbeddings.length !== texts.length) {
+      throw new Error(
+        `Azure OpenAI embedBatch() returned ${allEmbeddings.length} embeddings for ${texts.length} texts using model '${this.model}'`,
+      );
+    }
     return allEmbeddings;
   }
 }

--- a/mem0-ts/src/oss/src/embeddings/openai.ts
+++ b/mem0-ts/src/oss/src/embeddings/openai.ts
@@ -47,6 +47,11 @@ export class OpenAIEmbedder implements Embedder {
           .map((item) => item.embedding),
       );
     }
+    if (allEmbeddings.length !== texts.length) {
+      throw new Error(
+        `OpenAI embedBatch() returned ${allEmbeddings.length} embeddings for ${texts.length} texts using model '${this.model}'`,
+      );
+    }
     return allEmbeddings;
   }
 }

--- a/mem0-ts/src/oss/tests/azure-embedder.test.ts
+++ b/mem0-ts/src/oss/tests/azure-embedder.test.ts
@@ -134,6 +134,19 @@ describe("AzureOpenAIEmbedder (unit)", () => {
       expect(result).toEqual(batch);
     });
 
+    it("embedBatch() throws when provider returns fewer embeddings than texts", async () => {
+      // Provider returns only 1 embedding for 2 texts (short-batch response).
+      mockEmbeddingsCreate.mockResolvedValue({
+        data: [{ index: 0, embedding: mockEmbedding }],
+      });
+
+      const embedder = new AzureOpenAIEmbedder(baseConfig);
+
+      await expect(embedder.embedBatch(["text1", "text2"])).rejects.toThrow(
+        /returned 1 embeddings for 2 texts/,
+      );
+    });
+
     it("uses custom model when provided", async () => {
       const embedder = new AzureOpenAIEmbedder({
         ...baseConfig,

--- a/mem0-ts/src/oss/tests/openai-embedder.test.ts
+++ b/mem0-ts/src/oss/tests/openai-embedder.test.ts
@@ -142,6 +142,21 @@ describe("OpenAIEmbedder (unit)", () => {
       expect(result).toEqual(batch);
     });
 
+    it("embedBatch() throws when provider returns fewer embeddings than texts", async () => {
+      // Provider returns only 1 embedding for 2 texts (short-batch response).
+      mockEmbeddingsCreate.mockResolvedValue({
+        data: [{ index: 0, embedding: mockEmbedding }],
+      });
+
+      const embedder = new OpenAIEmbedder({
+        apiKey: "test-key",
+      });
+
+      await expect(embedder.embedBatch(["text1", "text2"])).rejects.toThrow(
+        /returned 1 embeddings for 2 texts/,
+      );
+    });
+
     it("uses custom model when provided", async () => {
       const embedder = new OpenAIEmbedder({
         apiKey: "test-key",

--- a/mem0/embeddings/azure_openai.py
+++ b/mem0/embeddings/azure_openai.py
@@ -69,4 +69,9 @@ class AzureOpenAIEmbedding(EmbeddingBase):
                 model=self.config.model,
             )
             all_embeddings.extend(item.embedding for item in sorted(response.data, key=lambda x: x.index))
+        if len(all_embeddings) != len(texts):
+            raise ValueError(
+                f"Azure OpenAI embed_batch() returned {len(all_embeddings)} embeddings for {len(texts)} texts"
+                f" using model '{self.config.model}'"
+            )
         return all_embeddings

--- a/mem0/embeddings/openai.py
+++ b/mem0/embeddings/openai.py
@@ -73,4 +73,9 @@ class OpenAIEmbedding(EmbeddingBase):
                 kwargs["dimensions"] = self.config.embedding_dims
             response = self.client.embeddings.create(**kwargs)
             all_embeddings.extend(item.embedding for item in sorted(response.data, key=lambda x: x.index))
+        if len(all_embeddings) != len(texts):
+            raise ValueError(
+                f"OpenAI embed_batch() returned {len(all_embeddings)} embeddings for {len(texts)} texts"
+                f" using model '{self.config.model}'"
+            )
         return all_embeddings

--- a/tests/embeddings/test_azure_openai_embeddings.py
+++ b/tests/embeddings/test_azure_openai_embeddings.py
@@ -164,3 +164,30 @@ def test_init_with_placeholder_api_key(monkeypatch, base_embedder_config):
             http_client=None,
             default_headers=None,
         )
+
+
+def test_embed_batch_returns_all_embeddings(mock_openai_client):
+    config = BaseEmbedderConfig(model="text-embedding-ada-002")
+    embedder = AzureOpenAIEmbedding(config)
+    mock_response = Mock()
+    mock_response.data = [
+        Mock(index=0, embedding=[0.1, 0.2]),
+        Mock(index=1, embedding=[0.3, 0.4]),
+    ]
+    mock_openai_client.embeddings.create.return_value = mock_response
+
+    result = embedder.embed_batch(["first text", "second text"])
+
+    assert result == [[0.1, 0.2], [0.3, 0.4]]
+
+
+def test_embed_batch_count_mismatch_raises(mock_openai_client):
+    config = BaseEmbedderConfig(model="text-embedding-ada-002")
+    embedder = AzureOpenAIEmbedding(config)
+    # Provider returns fewer embeddings than inputs (partial/dropped batch).
+    mock_response = Mock()
+    mock_response.data = [Mock(index=0, embedding=[0.1, 0.2])]
+    mock_openai_client.embeddings.create.return_value = mock_response
+
+    with pytest.raises(ValueError, match="returned 1 embeddings for 2 texts"):
+        embedder.embed_batch(["first text", "second text"])

--- a/tests/embeddings/test_openai_embeddings.py
+++ b/tests/embeddings/test_openai_embeddings.py
@@ -122,3 +122,30 @@ def test_embed_passes_dimensions_only_when_explicit(mock_openai_client):
     mock_openai_client.embeddings.create.assert_called_once_with(
         input=["truncate me"], model="text-embedding-3-small", dimensions=256, encoding_format="float"
     )
+
+
+def test_embed_batch_returns_all_embeddings(mock_openai_client):
+    config = BaseEmbedderConfig()
+    embedder = OpenAIEmbedding(config)
+    mock_response = Mock()
+    mock_response.data = [
+        Mock(index=0, embedding=[0.1, 0.2]),
+        Mock(index=1, embedding=[0.3, 0.4]),
+    ]
+    mock_openai_client.embeddings.create.return_value = mock_response
+
+    result = embedder.embed_batch(["first text", "second text"])
+
+    assert result == [[0.1, 0.2], [0.3, 0.4]]
+
+
+def test_embed_batch_count_mismatch_raises(mock_openai_client):
+    config = BaseEmbedderConfig()
+    embedder = OpenAIEmbedding(config)
+    # Provider returns fewer embeddings than inputs (partial/dropped batch).
+    mock_response = Mock()
+    mock_response.data = [Mock(index=0, embedding=[0.1, 0.2])]
+    mock_openai_client.embeddings.create.return_value = mock_response
+
+    with pytest.raises(ValueError, match="returned 1 embeddings for 2 texts"):
+        embedder.embed_batch(["first text", "second text"])


### PR DESCRIPTION
## Summary

- OpenAI and Azure OpenAI were the only two batch-capable embedders missing the `embed_batch()` length-mismatch guard.
- A short/partial batch now raises `ValueError` instead of silently dropping extracted memories.

## Root Cause

**Symptom** — When the embedding provider returns fewer embeddings than the number of input texts (partial batch, throttle/5xx, malformed response), the missing texts are silently dropped during `Memory.add()`. No exception reaches the caller, so the application never learns a fact was not persisted.

**Root cause** — Every other batch-capable embedder validates `len(embeddings) != len(texts)` and raises (added across providers in #5609, and for the entity path in #5604). `OpenAIEmbedding.embed_batch()` (`mem0/embeddings/openai.py`) and `AzureOpenAIEmbedding.embed_batch()` (`mem0/embeddings/azure_openai.py`) were never given that guard. Downstream, the V3 add pipeline does `dict(zip(mem_texts, mem_embeddings_list))` — `zip()` truncates to the shorter list, so a short batch maps memories to nothing and they vanish. This is the same silent-memory-loss class tracked in #5245.

**Evidence** — The two `embed_batch` implementations `return all_embeddings` directly with no count check, while the sibling implementations (`gemini.py`, `together.py`, `lmstudio.py`, `vertexai.py`, `huggingface.py`, `ollama.py`) all raise a `ValueError` with the message `"... returned N embeddings for M texts ..."`. The regression tests below reproduce the drop on a mocked short batch.

**Fix + why this level** — Add the same guard at the end of each `embed_batch()`, mirroring the sibling message format. Fixing here (at the embedder boundary, where the count contract is known) fails loudly at the source rather than letting the truncation propagate silently into `zip()` downstream — consistent with how the other providers already behave.

**Scope / risk** — Two `embed_batch` methods only. The happy path (provider returns one embedding per input) is unchanged. Only the previously-silent short-batch case now raises. `embed()` (single) is untouched.

## Verification

- `pytest tests/embeddings/test_openai_embeddings.py tests/embeddings/test_azure_openai_embeddings.py` — 19 passed.

## Real behavior proof

- **Behavior addressed:** provider returns 1 embedding for a 2-text batch.
- **Real environment:** Python 3.13 venv, editable install of this branch.
- **Regression tests:** `test_embed_batch_count_mismatch_raises` in both test files; each asserts the new `ValueError` and FAILS without the fix.
- **Captured output — tests run AGAINST main (source reverted, tests kept):**
  ```
  >       with pytest.raises(ValueError, match="returned 1 embeddings for 2 texts"):
  E       Failed: DID NOT RAISE ValueError
  FAILED tests/embeddings/test_openai_embeddings.py::test_embed_batch_count_mismatch_raises
  FAILED tests/embeddings/test_azure_openai_embeddings.py::test_embed_batch_count_mismatch_raises
  2 failed in 0.81s
  ```
- **Captured output — full suites WITH the fix:**
  ```
  19 passed in 1.27s
  ```

## Related

Completes the embedder-consistency work from #5609 / #5604 for the two OpenAI embedders; mitigates the silent-loss class in #5245. Distinct from open PRs #5252 / #5922 (FastEmbed/AWS Bedrock/Langchain native batch) — those do not touch `openai.py` or `azure_openai.py`.
