### PR TITLE
fix(openmemory): align MCP server with mem0 2.x API

### DIFF
--- a/openmemory/api/app/mcp_server.py
+++ b/openmemory/api/app/mcp_server.py
@@ -177,9 +177,9 @@ async def search_memory(query: str) -> str:
             embeddings = memory_client.embedding_model.embed(query, "search")
 
             hits = memory_client.vector_store.search(
-                query=query, 
-                vectors=embeddings, 
-                limit=10, 
+                query=query,
+                vectors=embeddings,
+                top_k=10,
                 filters=filters,
             )
 
@@ -245,7 +245,7 @@ async def list_memories() -> str:
             user, app = get_user_and_app(db, user_id=uid, app_id=client_name)
 
             # Get all memories
-            memories = memory_client.get_all(user_id=uid)
+            memories = memory_client.get_all(filters={"user_id": uid})
             filtered_memories = []
 
             # Filter memories based on permissions


### PR DESCRIPTION
## Summary

The OpenMemory MCP server still calls the pre-2.0 mem0ai API. Because `openmemory/api/requirements.txt` pins only `mem0ai>=0.1.92`, any fresh install today resolves to mem0ai 2.x and breaks the `search_memory` and `list_memories` MCP tools at runtime.

This patches the two affected call sites in `mcp_server.py`. Saves are unaffected — they go through `Memory.add`, whose signature is stable.

## Errors before the fix

```
search_memory  -> Qdrant.search() got an unexpected keyword argument 'limit'
list_memories  -> Top-level entity parameters frozenset({'user_id'}) are not
                  supported in get_all(). Use filters={'user_id': '...'} instead.
```

## Root cause

mem0 2.x renamed/refactored two public methods used by the MCP server:

| Method | Before | After |
| --- | --- | --- |
| `vector_store.search(...)` | `limit=N` | `top_k=N` |
| `Memory.get_all(...)` | `get_all(user_id="...")` | `get_all(filters={"user_id": "..."})` |

Verified against mem0ai 2.0.2 + qdrant-client 1.18:

```python
>>> inspect.signature(Memory.get_all)
(self, *, filters: Optional[Dict[str, Any]] = None, top_k: int = 20, **kwargs)
>>> inspect.signature(Qdrant.search)
(self, query: str, vectors: list, top_k: int = 5, filters: dict = None) -> list
```

## Fix

Two-line change in `openmemory/api/app/mcp_server.py`:

- `search_memory`: `limit=10` → `top_k=10`
- `list_memories`: `get_all(user_id=uid)` → `get_all(filters={"user_id": uid})`

## Verification

Tested end-to-end against a self-hosted OpenMemory stack (Qdrant 4337 points, mem0ai 2.0.2):

- `list_memories` now returns the full memory list
- `search_memory("...")` returns semantically ranked hits
- `Memory.add` (save worker path) confirmed unaffected — it was already working before this fix, and still works after

## Test plan

- [ ] CI passes
- [ ] Verified `search_memory` and `list_memories` against mem0ai 2.x in a self-hosted deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)