### PR TITLE
docs: remove instructions for unavailable Cursor marketplace plugin

### DIFF
--- a/docs/integrations/cursor.mdx
+++ b/docs/integrations/cursor.mdx
@@ -1,9 +1,9 @@
 ---
 title: Cursor
-description: "Add persistent memory to Cursor with the Mem0 plugin — MCP server, lifecycle hooks, and SDK skill for context-aware coding."
+description: "Add persistent memory to Cursor with the Mem0 MCP server for context-aware coding."
 ---
 
-Add persistent memory to [**Cursor**](https://cursor.com) with the Mem0 plugin. Your AI assistant forgets everything between sessions — this plugin fixes that by connecting to Mem0's cloud memory layer via MCP, automatically capturing learnings at key lifecycle points, and retrieving relevant context before every response.
+Add persistent memory to [**Cursor**](https://cursor.com) with the Mem0 MCP server. Your AI assistant forgets everything between sessions — Mem0 fixes that by connecting Cursor to Mem0's cloud memory layer via MCP so you can save and retrieve relevant context during coding sessions.
 
 ## Prerequisites
 
@@ -68,21 +68,10 @@ Add the following to your `.cursor/mcp.json`:
 }
 ```
 
-### Option D — Cursor Marketplace (Full Plugin)
-
-Install from the [Cursor Marketplace](https://cursor.com/marketplace) for the complete experience including lifecycle hooks, the Mem0 SDK skill, and automatic memory capture.
-
 <Info icon="check">
   Start a new Cursor session and ask: *"List my mem0 entities"* or *"Search my memories for hello"*. If the `mem0` tools appear and respond, you're all set.
 </Info>
 
-## What's Included
-
-| Component | Marketplace Install | Deeplink / Manual / npx |
-|-----------|:-------------------:|:-----------------------:|
-| MCP Server (9 memory tools) | Yes | Yes |
-| Lifecycle Hooks | Yes | No |
-| Mem0 SDK Skill | Yes | No |
 
 ## Available MCP Tools
 
@@ -99,19 +88,6 @@ Once installed, the following tools are available in every Cursor session:
 | `delete_all_memories` | Bulk delete all memories in scope |
 | `delete_entities` | Delete a user/agent/app/run entity and its memories |
 | `list_entities` | List users/agents/apps/runs stored in Mem0 |
-
-## Lifecycle Hooks (Marketplace Install)
-
-When installed via the Cursor Marketplace, Mem0 hooks into Cursor's lifecycle:
-
-| Hook | Event | What it does |
-|------|-------|-------------|
-| **Session start** | `sessionStart` | Loads prior memories and displays status banner |
-| **User prompt** | `beforeSubmitPrompt` | Searches relevant memories before each message; skips short prompts |
-| **Pre-tool (3 handlers)** | `preToolUse` | Blocks MEMORY.md writes; enforces `user_id`/`app_id` on mem0 tool calls; scans files being read for relevant memory context |
-| **Post-tool (2 handlers)** | `postToolUse` | Tracks stats, scans bash errors for related memories |
-| **Stop** | `stop` | Stores a session summary when the session ends |
-| **Pre-compact** | `preCompact` | Stores a summary before the context is compacted |
 
 ## Example Workflow
 
@@ -137,7 +113,6 @@ You: The /orders endpoint is also slow, same pattern as before.
 - **"Connection failed"** — Verify `MEM0_API_KEY` is set: `echo $MEM0_API_KEY`
 - **Duplicate tools** — If you had a previous MCP config for `mem0`, remove it before installing the plugin
 - **No tools appearing** — Go to Cursor Settings > MCP and verify the `mem0` server shows as connected
-- **Hooks not running** — Hooks require the Marketplace install (Option D). Deeplink/manual installs only provide MCP tools.
 
 <CardGroup cols={2}>
   <Card title="Mem0 MCP Setup" icon="puzzle-piece" href="/platform/mem0-mcp">

--- a/integrations/mem0-plugin/README.md
+++ b/integrations/mem0-plugin/README.md
@@ -151,10 +151,6 @@ Add the following to your `.cursor/mcp.json`:
 }
 ```
 
-**Option C — Cursor Marketplace** (full plugin with hooks and skills):
-
-Install from the [Cursor Marketplace](https://cursor.com/marketplace) for the complete experience including lifecycle hooks and the Mem0 SDK skill.
-
 ### OpenCode
 
 ```bash
@@ -225,14 +221,14 @@ The plugin includes 17 skills accessible via `/mem0:` commands:
 
 ## What's included
 
-| Component | Claude Code / Cowork | Cursor (Marketplace) | Cursor (Deeplink/Manual) | Codex (Sideload) | Codex (Direct MCP) | OpenCode (Full) | OpenCode (MCP) | Antigravity |
-|-----------|:--------------------:|:--------------------:|:------------------------:|:----------------:|:------------------:|:---------------:|:--------------:|:-----------:|
-| MCP Server | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| Lifecycle Hooks | Yes | Yes | No | Opt-in | No | Yes | No | Yes |
-| Mem0 SDK Skill | Yes | Yes | No | Yes | No | Yes | No | Yes |
+| Component | Claude Code / Cowork | Cursor (MCP) | Codex (Sideload) | Codex (Direct MCP) | OpenCode (Full) | OpenCode (MCP) | Antigravity |
+|-----------|:--------------------:|:------------:|:----------------:|:------------------:|:---------------:|:--------------:|:-----------:|
+| MCP Server | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Lifecycle Hooks | Yes | No | Opt-in | No | Yes | No | Yes |
+| Mem0 SDK Skill | Yes | No | Yes | No | Yes | No | Yes |
 
 - **MCP Server** — Connects to the Mem0 remote MCP server (`mcp.mem0.ai`), providing tools to add, search, update, and delete memories. No local dependencies required.
-- **Lifecycle Hooks** — Automatic memory capture at key points. Claude Code, Cursor, OpenCode, and Antigravity wire hooks natively when the full plugin is installed. Codex hooks are opt-in via a one-time installer (`scripts/install_codex_hooks.py`).
+- **Lifecycle Hooks** — Automatic memory capture at key points. Claude Code, OpenCode, and Antigravity wire hooks natively when the full plugin is installed. Codex hooks are opt-in via a one-time installer (`scripts/install_codex_hooks.py`).
 - **Mem0 SDK Skill** — Guides the AI on how to integrate the Mem0 SDK (Python & TypeScript) into your applications.
 
 ## Updating the plugin


### PR DESCRIPTION
## Linked Issue

Refs #5955, but this PR should not close #5955 yet. I suggest keep this issue open until the Cursor Marketplace plugin is approved and publicly installable, so it can track availability and the eventual restoration of the removed full-plugin docs.

## Description

This PR temporarily removes the unavailable Cursor Marketplace full-plugin instructions from the docs.

Cursor currently only has a public MCP-only setup. The full plugin with lifecycle hooks, SDK skills, and automatic memory capture is still pending Cursor Marketplace approval, so the related guidance has been removed from the Cursor docs and directly related plugin documentation.

These sections can be restored once the Cursor Marketplace listing is approved and publicly installable.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [x] No tests needed (explain why)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed