### PR TITLE
fix(server): ignore empty-string entity ids when building memory filters

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -426,7 +426,7 @@ def get_all_memories(
             # Admin all-memory listing is intentionally raw; scoped get_all below applies expiry visibility.
             return _list_all_memories(limit=top_k if top_k is not None else ALL_MEMORIES_LIMIT)
         filters = {
-            k: v for k, v in {"user_id": user_id, "run_id": run_id, "agent_id": agent_id}.items() if v is not None
+            k: v for k, v in {"user_id": user_id, "run_id": run_id, "agent_id": agent_id}.items() if v
         }
         params = {"filters": filters}
         if top_k is not None:

--- a/server/main.py
+++ b/server/main.py
@@ -456,7 +456,7 @@ def search_memories(search_req: SearchRequest, _auth=Depends(verify_auth)):
         deprecated_keys = []
         for entity_key in ("user_id", "agent_id", "run_id"):
             entity_val = getattr(search_req, entity_key, None)
-            if entity_val is not None:
+            if entity_val:
                 filters[entity_key] = entity_val
                 deprecated_keys.append(entity_key)
         if deprecated_keys:
@@ -535,7 +535,7 @@ def delete_all_memories(
         raise HTTPException(status_code=400, detail="At least one identifier is required.")
     try:
         params = {
-            k: v for k, v in {"user_id": user_id, "run_id": run_id, "agent_id": agent_id}.items() if v is not None
+            k: v for k, v in {"user_id": user_id, "run_id": run_id, "agent_id": agent_id}.items() if v
         }
         get_memory_instance().delete_all(**params)
         return MessageResponse(message="All relevant memories deleted")

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Shared pytest setup for the self-hosted server tests.
+
+Importing ``main`` runs module-level initialization (auth check, DB engine,
+Mem0 runtime). Set safe defaults here so the import works without a live
+Postgres/provider; individual tests stub ``get_memory_instance`` as needed.
+"""
+
+import os
+import tempfile
+
+os.environ.setdefault("AUTH_DISABLED", "true")
+os.environ.setdefault("MEM0_TELEMETRY", "false")
+os.environ.setdefault("OPENAI_API_KEY", "sk-test")
+os.environ.setdefault(
+    "HISTORY_DB_PATH", os.path.join(tempfile.gettempdir(), "mem0_server_test_history.db")
+)

--- a/server/tests/test_get_memories_filters.py
+++ b/server/tests/test_get_memories_filters.py
@@ -1,0 +1,34 @@
+"""Regression tests for filter building in GET /memories (get_all_memories)."""
+
+import main
+from main import get_all_memories
+
+
+class _StubMemory:
+    def __init__(self):
+        self.calls = []
+
+    def get_all(self, **params):
+        self.calls.append(params)
+        return {"results": []}
+
+
+def test_empty_string_ids_are_not_forwarded_as_filters(monkeypatch):
+    # A real user_id plus empty-string agent_id/run_id (e.g. `?agent_id=&run_id=`).
+    # The empty strings must be dropped, consistent with the `any([...])` guard
+    # above, instead of being passed through as real (empty) filter values.
+    stub = _StubMemory()
+    monkeypatch.setattr(main, "get_memory_instance", lambda: stub)
+
+    get_all_memories(
+        request=None,
+        user_id="alice",
+        run_id="",
+        agent_id="",
+        top_k=None,
+        show_expired=False,
+        _auth=None,
+    )
+
+    assert stub.calls, "get_all should have been called"
+    assert stub.calls[0]["filters"] == {"user_id": "alice"}

--- a/server/tests/test_get_memories_filters.py
+++ b/server/tests/test_get_memories_filters.py
@@ -1,22 +1,35 @@
-"""Regression tests for filter building in GET /memories (get_all_memories)."""
+"""Regression tests for entity-id filter scoping in server/main.py.
+
+Empty-string entity ids (e.g. `?agent_id=`) must be dropped when building the
+downstream filter/params, consistent with the `any([...])` "list all" / "id
+required" guards. Otherwise they are forwarded as real (empty) filter values
+and silently over-scope the query. Covers GET /memories, /search, and
+DELETE /memories, which all shared the same `is not None` pattern.
+"""
 
 import main
-from main import get_all_memories
+from main import SearchRequest, delete_all_memories, get_all_memories, search_memories
 
 
 class _StubMemory:
     def __init__(self):
-        self.calls = []
+        self.get_all_calls = []
+        self.search_calls = []
+        self.delete_all_calls = []
 
     def get_all(self, **params):
-        self.calls.append(params)
+        self.get_all_calls.append(params)
         return {"results": []}
 
+    def search(self, query, filters=None, **params):
+        self.search_calls.append(filters)
+        return {"results": []}
 
-def test_empty_string_ids_are_not_forwarded_as_filters(monkeypatch):
-    # A real user_id plus empty-string agent_id/run_id (e.g. `?agent_id=&run_id=`).
-    # The empty strings must be dropped, consistent with the `any([...])` guard
-    # above, instead of being passed through as real (empty) filter values.
+    def delete_all(self, **params):
+        self.delete_all_calls.append(params)
+
+
+def test_get_all_drops_empty_string_ids(monkeypatch):
     stub = _StubMemory()
     monkeypatch.setattr(main, "get_memory_instance", lambda: stub)
 
@@ -30,5 +43,27 @@ def test_empty_string_ids_are_not_forwarded_as_filters(monkeypatch):
         _auth=None,
     )
 
-    assert stub.calls, "get_all should have been called"
-    assert stub.calls[0]["filters"] == {"user_id": "alice"}
+    assert stub.get_all_calls, "get_all should have been called"
+    assert stub.get_all_calls[0]["filters"] == {"user_id": "alice"}
+
+
+def test_search_drops_empty_string_ids(monkeypatch):
+    stub = _StubMemory()
+    monkeypatch.setattr(main, "get_memory_instance", lambda: stub)
+
+    search_memories(
+        SearchRequest(query="hi", user_id="alice", agent_id="", run_id=""),
+        _auth=None,
+    )
+
+    # Only the real id ends up in the deprecated-param -> filters promotion.
+    assert stub.search_calls == [{"user_id": "alice"}]
+
+
+def test_delete_all_drops_empty_string_ids(monkeypatch):
+    stub = _StubMemory()
+    monkeypatch.setattr(main, "get_memory_instance", lambda: stub)
+
+    delete_all_memories(user_id="alice", run_id="", agent_id="", _auth=None)
+
+    assert stub.delete_all_calls == [{"user_id": "alice"}]


### PR DESCRIPTION
## Linked Issue

Closes #5972

## Description

`GET /memories` (`get_all_memories`) is inconsistent about empty-string entity ids.

The list-all guard uses truthiness, so an empty string means "not provided":

```python
if not any([user_id, run_id, agent_id]):
    ...  # admin-only list-all path
```

But the filters dict built immediately after keeps anything that isn't `None`:

```python
filters = {k: v for k, v in {...}.items() if v is not None}
```

So `GET /memories?user_id=alice&agent_id=` ends up sending `{"user_id": "alice", "agent_id": ""}` to `get_all`, scoping the query to an empty `agent_id` the caller never meaningfully provided. Empty query params are easy to send from forms and clients, and the two checks disagree on what counts as "provided".

The fix changes the filter comprehension from `if v is not None` to `if v`, so empty strings are dropped, matching the `any([...])` guard right above it. Real ids behave exactly as before.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed

There were no server tests yet, so this adds a small `server/tests/` package (a `conftest.py` that sets safe env defaults so `main` imports without a live Postgres/provider, plus the test). The test calls `get_all_memories` with a real `user_id` and empty-string `agent_id`/`run_id` and asserts only the real id is forwarded. It fails without the fix and passes with it.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed (no user-facing docs affected)
