### PR TITLE
fix(server): parse /generate-instructions response without dropping data

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -355,9 +355,12 @@ def generate_instructions(req: GenerateInstructionsRequest, _auth=Depends(verify
         instructions = response
         test_message = "I like to hike on weekends."
         if "INSTRUCTIONS:" in response and "TEST_MESSAGE:" in response:
-            parts = response.split("TEST_MESSAGE:")
-            instructions = parts[0].replace("INSTRUCTIONS:", "").strip()
-            test_message = parts[1].strip()
+            # Split on the first TEST_MESSAGE: marker so a test message that itself
+            # contains the marker keeps its full text, and strip only the leading
+            # INSTRUCTIONS: label rather than every occurrence in the body.
+            before, _, after = response.partition("TEST_MESSAGE:")
+            instructions = before.split("INSTRUCTIONS:", 1)[-1].strip()
+            test_message = after.strip()
         return {"custom_instructions": instructions, "test_message": test_message}
     except Exception:
         raise upstream_error()

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Shared pytest setup for the self-hosted server tests.
+
+Importing ``main`` runs module-level initialization (auth check, DB engine,
+Mem0 runtime). Set safe defaults here so the import works without a live
+Postgres/provider; individual tests stub ``get_memory_instance`` as needed.
+"""
+
+import os
+import tempfile
+
+os.environ.setdefault("AUTH_DISABLED", "true")
+os.environ.setdefault("MEM0_TELEMETRY", "false")
+os.environ.setdefault("OPENAI_API_KEY", "sk-test")
+os.environ.setdefault(
+    "HISTORY_DB_PATH", os.path.join(tempfile.gettempdir(), "mem0_server_test_history.db")
+)

--- a/server/tests/test_generate_instructions.py
+++ b/server/tests/test_generate_instructions.py
@@ -1,0 +1,38 @@
+"""Regression tests for LLM response parsing in POST /generate-instructions."""
+
+import main
+from main import GenerateInstructionsRequest, generate_instructions
+
+
+class _StubLLM:
+    def __init__(self, text):
+        self._text = text
+
+    def generate_response(self, messages):
+        return self._text
+
+
+class _StubMemory:
+    def __init__(self, text):
+        self.llm = _StubLLM(text)
+
+
+def _run(monkeypatch, response_text):
+    monkeypatch.setattr(main, "get_memory_instance", lambda: _StubMemory(response_text))
+    return generate_instructions(GenerateInstructionsRequest(use_case="trip planning"), _auth=None)
+
+
+def test_test_message_keeps_full_text_when_marker_recurs(monkeypatch):
+    # The model echoes the literal marker inside the test message. Splitting on
+    # every occurrence would truncate it; only the first split should count.
+    resp = "INSTRUCTIONS: Focus on travel.\nTEST_MESSAGE: I typed TEST_MESSAGE: by mistake."
+    out = _run(monkeypatch, resp)
+    assert out["test_message"] == "I typed TEST_MESSAGE: by mistake."
+
+
+def test_instructions_body_keeps_inner_label_occurrences(monkeypatch):
+    # Only the leading INSTRUCTIONS: label should be stripped, not every
+    # occurrence in the body.
+    resp = "INSTRUCTIONS: see INSTRUCTIONS: below\nTEST_MESSAGE: hello"
+    out = _run(monkeypatch, resp)
+    assert out["custom_instructions"] == "see INSTRUCTIONS: below"


### PR DESCRIPTION
## Linked Issue

Closes #5974

## Description

`POST /generate-instructions` parses the model's response like this:

```python
parts = response.split("TEST_MESSAGE:")
instructions = parts[0].replace("INSTRUCTIONS:", "").strip()
test_message = parts[1].strip()
```

Two ways this silently loses data when the model doesn't perfectly honor the single-marker format:

1. `split("TEST_MESSAGE:")` with no `maxsplit` — if the generated test message itself contains `TEST_MESSAGE:`, `parts[1]` stops at the second marker and the rest of the message is dropped.
2. `replace("INSTRUCTIONS:", "")` strips *every* occurrence — if the instructions body legitimately contains `INSTRUCTIONS:`, it disappears from the returned text.

The fix splits on the first `TEST_MESSAGE:` marker via `partition`, so the test message keeps its full text, and strips only the leading `INSTRUCTIONS:` label via `split("INSTRUCTIONS:", 1)`, so inner occurrences survive. Well-formed responses parse exactly as before.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed

Added `server/tests/` with a `conftest.py` (safe import-time env defaults so `main` imports without a live Postgres/provider) and two cases: a test message containing the literal `TEST_MESSAGE:` keeps its full text, and an instructions body containing `INSTRUCTIONS:` keeps the inner label. Both fail without the fix; the `get_memory_instance().llm` call is stubbed, so no network is used.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed (no user-facing docs affected)
