### PR TITLE
fix(elasticsearch): validate filter keys and values to prevent term injection

### DIFF
--- a/mem0/vector_stores/elasticsearch.py
+++ b/mem0/vector_stores/elasticsearch.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import Any, Dict, List, Optional
 
 try:
@@ -19,6 +20,19 @@ class OutputData(BaseModel):
     id: str
     score: float
     payload: Dict
+
+
+_SAFE_FILTER_KEY = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+
+def _validate_filter(key: str, value: Any) -> None:
+    if not isinstance(key, str) or not _SAFE_FILTER_KEY.match(key):
+        raise ValueError(f"Invalid filter key: {key!r}")
+    if not isinstance(value, (str, int, float, bool)):
+        raise ValueError(
+            f"Filter value for {key!r} must be str, int, float, or bool, "
+            f"got {type(value).__name__}"
+        )
 
 
 class ElasticsearchDB(VectorStoreBase):
@@ -154,6 +168,7 @@ class ElasticsearchDB(VectorStoreBase):
             if filters:
                 filter_conditions = []
                 for key, value in filters.items():
+                    _validate_filter(key, value)
                     filter_conditions.append({"term": {f"metadata.{key}": value}})
                 search_query["knn"]["filter"] = {"bool": {"must": filter_conditions}}
 
@@ -192,6 +207,7 @@ class ElasticsearchDB(VectorStoreBase):
         if filters:
             filter_conditions = []
             for key, value in filters.items():
+                _validate_filter(key, value)
                 filter_conditions.append({"term": {f"metadata.{key}": value}})
             bool_query["filter"] = filter_conditions
 
@@ -262,6 +278,7 @@ class ElasticsearchDB(VectorStoreBase):
         if filters:
             filter_conditions = []
             for key, value in filters.items():
+                _validate_filter(key, value)
                 filter_conditions.append({"term": {f"metadata.{key}": value}})
             query["query"] = {"bool": {"must": filter_conditions}}
 

--- a/tests/vector_stores/test_elasticsearch.py
+++ b/tests/vector_stores/test_elasticsearch.py
@@ -10,7 +10,7 @@ except ImportError:
     raise ImportError("Elasticsearch requires extra dependencies. Install with `pip install elasticsearch`") from None
 
 from mem0.configs.vector_stores.elasticsearch import ElasticsearchConfig
-from mem0.vector_stores.elasticsearch import ElasticsearchDB, OutputData
+from mem0.vector_stores.elasticsearch import ElasticsearchDB, OutputData, _validate_filter
 
 
 class TestElasticsearchDB(unittest.TestCase):
@@ -360,3 +360,33 @@ class TestElasticsearchDB(unittest.TestCase):
             with self.assertRaises(ValueError):
                 config = {**base_config, "headers": headers}
                 ElasticsearchConfig(**config)
+
+    def test_filter_rejects_dict_value(self):
+        with self.assertRaises(ValueError):
+            _validate_filter("user_id", {"value": "alice", "boost": 0})
+
+    def test_filter_rejects_list_value(self):
+        with self.assertRaises(ValueError):
+            _validate_filter("user_id", ["alice", "bob"])
+
+    def test_filter_rejects_invalid_key(self):
+        with self.assertRaises(ValueError):
+            _validate_filter("user_id; DROP", "alice")
+
+    def test_filter_accepts_scalar_values(self):
+        _validate_filter("user_id", "alice")
+        _validate_filter("count", 42)
+        _validate_filter("score", 0.95)
+        _validate_filter("active", True)
+
+    def test_search_with_dict_filter_raises(self):
+        with self.assertRaises(ValueError):
+            self.es_db.search(
+                query="test",
+                vectors=[0.1] * 1536,
+                filters={"user_id": {"value": "*", "case_insensitive": True}},
+            )
+
+    def test_list_with_dict_filter_raises(self):
+        with self.assertRaises(ValueError):
+            self.es_db.list(filters={"user_id": {"$ne": ""}})


### PR DESCRIPTION
Closes #5976

## Summary

- Validate filter keys against `^[a-zA-Z_][a-zA-Z0-9_]*$` to prevent key injection
- Validate filter values are scalar types (str, int, float, bool) -- reject dict/list values that could inject Elasticsearch query operators
- Add `_validate_filter()` helper called before every `term` query construction in `search()`, `keyword_search()`, and `list()`

## Test plan

- [x] 6 new tests added covering key validation, value type rejection, and scalar acceptance
- [x] All 20 existing + new tests pass
- [x] `ruff check` clean

Signed-off-by: Hrushikesh Yadav <yadavhrushikesh65@gmail.com>