### PR TITLE
fix(azure-ai-search): validate filter value types and escape quotes in OData

### DIFF
--- a/mem0/vector_stores/azure_ai_search.py
+++ b/mem0/vector_stores/azure_ai_search.py
@@ -199,8 +199,15 @@ class AzureAISearch(VectorStoreBase):
             if isinstance(value, str):
                 safe_value = value.replace("'", "''")
                 condition = f"{safe_key} eq '{safe_value}'"
-            else:
+            elif isinstance(value, bool):
+                condition = f"{safe_key} eq {str(value).lower()}"
+            elif isinstance(value, (int, float)):
                 condition = f"{safe_key} eq {value}"
+            else:
+                raise ValueError(
+                    f"Filter value for {key!r} must be str, int, float, or bool, "
+                    f"got {type(value).__name__}"
+                )
             filter_conditions.append(condition)
         filter_expression = " and ".join(filter_conditions)
         return filter_expression

--- a/tests/vector_stores/test_azure_ai_search.py
+++ b/tests/vector_stores/test_azure_ai_search.py
@@ -687,3 +687,35 @@ def test_init_calls_create_col_if_collection_missing(mock_clients):
         embedding_model_dims=16,
     )
     mock_index_client.create_or_update_index.assert_called_once()
+
+
+def test_build_filter_rejects_dict_value(azure_ai_search_instance):
+    instance, _, _ = azure_ai_search_instance
+    with pytest.raises(ValueError):
+        instance._build_filter_expression({"user_id": {"$ne": ""}})
+
+
+def test_build_filter_rejects_list_value(azure_ai_search_instance):
+    instance, _, _ = azure_ai_search_instance
+    with pytest.raises(ValueError):
+        instance._build_filter_expression({"user_id": ["alice", "bob"]})
+
+
+def test_build_filter_accepts_scalars(azure_ai_search_instance):
+    instance, _, _ = azure_ai_search_instance
+    expr = instance._build_filter_expression({
+        "user_id": "alice",
+        "count": 42,
+        "score": 0.95,
+        "active": True,
+    })
+    assert "user_id eq 'alice'" in expr
+    assert "count eq 42" in expr
+    assert "score eq 0.95" in expr
+    assert "active eq true" in expr
+
+
+def test_build_filter_escapes_quotes(azure_ai_search_instance):
+    instance, _, _ = azure_ai_search_instance
+    expr = instance._build_filter_expression({"name": "O'Brien"})
+    assert "name eq 'O''Brien'" in expr


### PR DESCRIPTION
Closes #5979

## Summary

- Add explicit type-based branching in `_build_filter_expression()` for str, bool, int, float
- Reject dict/list filter values with `ValueError`
- Escape single quotes in string values (`'` -> `''` per OData convention)
- Check bool before int (since `isinstance(True, int)` is True in Python)

## Test plan

- [x] 4 new tests added covering type rejection, scalar acceptance, and quote escaping
- [x] All 27 existing + new tests pass
- [x] `ruff check` clean

Signed-off-by: Hrushikesh Yadav <yadavhrushikesh65@gmail.com>