### PR TITLE
Clean up release highlights copy and removing emdash from the docs

### DIFF
--- a/docs/api-reference/memory/add-memories.mdx
+++ b/docs/api-reference/memory/add-memories.mdx
@@ -4,7 +4,7 @@ description: "Add facts, messages, or metadata to a user memory store with async
 openapi: post /v3/memories/add/
 ---
 
-Extract and store memories from a conversation using the V3 additive pipeline. The endpoint uses single-pass ADD-only extraction — one LLM call, no UPDATE/DELETE. Memories accumulate over time; nothing is overwritten.
+Extract and store memories from a conversation using the V3 additive pipeline. The endpoint uses single-pass ADD-only extraction: one LLM call, no UPDATE/DELETE. Memories accumulate over time; nothing is overwritten.
 
 ## Endpoint
 

--- a/docs/api-reference/memory/get-memories.mdx
+++ b/docs/api-reference/memory/get-memories.mdx
@@ -4,7 +4,7 @@ description: "Retrieve memories with paginated results and advanced filtering us
 openapi: post /v3/memories/
 ---
 
-List memories scoped by filters with paginated results. Entity IDs (`user_id`, `agent_id`, `app_id`, `run_id`) **must** be passed inside the `filters` object — top-level entity IDs are rejected with 400.
+List memories scoped by filters with paginated results. Entity IDs (`user_id`, `agent_id`, `app_id`, `run_id`) **must** be passed inside the `filters` object: top-level entity IDs are rejected with 400.
 
 Expired memories are hidden by default. Pass `show_expired: true` to include memories whose `expiration_date` has passed.
 

--- a/docs/api-reference/memory/search-memories.mdx
+++ b/docs/api-reference/memory/search-memories.mdx
@@ -4,9 +4,9 @@ description: "Search memories with hybrid retrieval (semantic + BM25 + entity ma
 openapi: post /v3/memories/search/
 ---
 
-Relevance-ranked hybrid search across stored memories. V3 uses multi-signal retrieval — semantic, BM25 keyword, and entity matching scored in parallel and fused. The returned `score` is a combined `[0, 1]` value.
+Relevance-ranked hybrid search across stored memories. V3 uses multi-signal retrieval: semantic, BM25 keyword, and entity matching scored in parallel and fused. The returned `score` is a combined `[0, 1]` value.
 
-Entity IDs (`user_id`, `agent_id`, `app_id`, `run_id`) **must** be passed inside the `filters` object — top-level entity IDs are rejected with 400. At least one entity ID is required.
+Entity IDs (`user_id`, `agent_id`, `app_id`, `run_id`) **must** be passed inside the `filters` object: top-level entity IDs are rejected with 400. At least one entity ID is required.
 
 Expired memories are hidden by default. Pass `show_expired: true` to include memories whose `expiration_date` has passed.
 

--- a/docs/api-reference/organizations-projects.mdx
+++ b/docs/api-reference/organizations-projects.mdx
@@ -14,7 +14,7 @@ Organizations and projects are **optional** features. You can use Mem0 without t
 
 ## Key Capabilities
 
-- **Multi-org/project Support**: Organization and project are resolved automatically from your API key via `/v1/ping/` — no org or project params are accepted by `MemoryClient.__init__`. Use a project-specific API key to target a particular project.
+- **Multi-org/project Support**: Organization and project are resolved automatically from your API key via `/v1/ping/`: no org or project params are accepted by `MemoryClient.__init__`. Use a project-specific API key to target a particular project.
 - **Member Management**: Control access to data through organization and project membership
 - **Access Control**: Only members can access memories and data within their organization/project scope
 - **Team Isolation**: Maintain data separation between different teams and projects for secure collaboration
@@ -150,7 +150,7 @@ Pass an empty list to clear all criteria and restore default retrieval behaviour
 
 #### Toggle Memory Decay
 
-`decay` is a per-project boolean that turns on [Memory Decay](/platform/features/memory-decay) — a search-time ranking bias that reinforces recently-accessed memories and gently dampens stale ones. The flag is `false` by default; set it via the same project-update endpoint:
+`decay` is a per-project boolean that turns on [Memory Decay](/platform/features/memory-decay): a search-time ranking bias that reinforces recently-accessed memories and gently dampens stale ones. The flag is `false` by default; set it via the same project-update endpoint:
 
 ```bash cURL
 curl -X PATCH https://api.mem0.ai/api/v1/orgs/organizations/$ORG_ID/projects/$PROJECT_ID/ \

--- a/docs/changelog/highlights.mdx
+++ b/docs/changelog/highlights.mdx
@@ -6,14 +6,14 @@ mode: "wide"
 
 <Update label="2026-05-13" description="Temporal Reasoning for Mem0 Platform v3">
 
-**Temporal Reasoning — Time-Aware Retrieval for Platform v3**
+**Temporal Reasoning: Time-Aware Retrieval for Platform v3**
 
 Mem0 Platform v3 can now interpret time-aware memories and queries so assistants retrieve the right information for questions about the past, upcoming plans, and current state.
 
-- **Time-aware search intent** — Queries like `last week`, `upcoming`, `right now`, and `as of March 2025` return contextually appropriate results automatically
-- **Enabled by default** — No per-request toggle required for v3 writes or searches
-- **Anchored relative queries** — `reference_date` anchors relative search phrases for tests, backfills, and reproducible demos
-- **Normal response shape** — Temporal reasoning affects ranking while preserving existing client response patterns
+- **Search intent parsing:** Queries like `last week`, `upcoming`, `right now`, and `as of March 2025` now resolve against memory timestamps automatically.
+- **Default v3 behavior:** No per-request toggle is needed for v3 writes or searches.
+- **Deterministic testing:** Pass `reference_date` to anchor relative phrases in tests, backfills, and demos.
+- **Stable API shape:** Temporal reasoning changes ranking, not the client response contract.
 
 See [Temporal Reasoning](/platform/features/temporal-reasoning) for usage details.
 
@@ -21,11 +21,11 @@ See [Temporal Reasoning](/platform/features/temporal-reasoning) for usage detail
 
 <Update label="2026-05-08" description="Memory Decay">
 
-**Memory Decay — Recently-Used Memories Surface Higher, Automatically**
+**Memory Decay: Recently-Used Memories Surface Higher**
 
 Per-project search-time ranking bias that boosts recently-touched memories and gently dampens stale ones. Off by default; opt in per project via the `decay` field on the project endpoint, or via `client.project.update(decay=True)` in the SDKs (Python `v2.0.2` / TypeScript `v3.0.3`).
 
-- **Soft bias, never a filter.** The scaling factor stays in `0.3×–1.5×`. Decay can reorder candidates but never zeros them out — anything that surfaced before decay can still surface after.
+- **Soft bias, never a filter.** The scaling factor stays in `0.3×–1.5×`. Decay can reorder candidates but never removes them; anything that surfaced before decay can still surface after.
 - **Reinforcement loop.** Every memory returned in a search has its access history updated, so frequently-used facts naturally float to the top over time.
 - **Public score still clamped to `[0, 1]`.** Existing API contract preserved; no client-side changes needed.
 - **v3 search only**, fully reversible. See [Memory Decay docs](/platform/features/memory-decay).
@@ -34,18 +34,18 @@ Per-project search-time ranking bias that boosts recently-touched memories and g
 
 <Update label="2026-04-14" description="Mem0 SDK v2.0.0 / v3.0.0">
 
-**New Memory Algorithm — State-of-the-Art Accuracy at ~3-4x Lower Cost**
+**New Memory Algorithm: State-of-the-Art Accuracy at ~3-4x Lower Cost**
 
 Ground-up rewrite of the memory pipeline with 20+ point benchmark improvements:
 
-- **LoCoMo:** 71.4 → **91.6** (+20) — multi-turn conversation recall
-- **LongMemEval:** 67.8 → **93.4** (+26) — long-term memory across sessions
-- **BEAM (1M tokens):** **64.1** — production-scale memory evaluation
-- **Agent memories are first-class** — Previous algorithm: 46% on assistant recall. New: **100%**
-- **Temporal reasoning works** — "Where did I live before SF?" Previous: 51%. New: **93%**
-- **~3-4x fewer tokens** — Under 7K tokens per retrieval vs 25K+ for full-context approaches
-- **ADD-only extraction** — Memories accumulate; nothing is overwritten or deleted
-- **Hybrid retrieval** — Semantic + BM25 keyword + entity boost, scored in parallel
+- **LoCoMo:** 71.4 → **91.6** (+20) for multi-turn conversation recall.
+- **LongMemEval:** 67.8 → **93.4** (+26) for long-term memory across sessions.
+- **BEAM (1M tokens):** **64.1** on production-scale memory evaluation.
+- **Agent memories:** Assistant recall moves from 46% to **100%**.
+- **Temporal reasoning:** "Where did I live before SF?" improves from 51% to **93%**.
+- **Lower token use:** Retrieval stays under 7K tokens versus 25K+ for full-context approaches.
+- **ADD-only extraction:** Memories accumulate; nothing is overwritten or deleted.
+- **Hybrid retrieval:** Semantic search, BM25 keyword search, and entity boost are scored in parallel.
 - **Graph memory (built-in)**: entities extracted, embedded, and linked across memories, with no external graph store required
 
 Breaking changes: external graph stores removed from OSS (replaced by built-in graph memory), `search()` defaults changed, deprecated params removed. See [migration guide](/migration/oss-v2-to-v3).
@@ -54,42 +54,42 @@ Breaking changes: external graph stores removed from OSS (replaced by built-in g
 
 <Update label="2026-04-06" description="Mem0 Skill Graph">
 
-**Mem0 Skill Graph — In-Context Documentation for AI Agents**
+**Mem0 Skill Graph: In-Context Documentation for AI Agents**
 
-AI coding agents in Claude Code, Cursor, and Codex can now access Mem0 knowledge directly in their workflow — no doc searching required. Three interconnected skills launched:
+AI coding agents in Claude Code, Cursor, and Codex can now access Mem0 knowledge directly in their workflow without leaving the editor. Three interconnected skills launched:
 
-- **mem0 Core Skill** — Complete Python and TypeScript SDK reference, REST API patterns, and integration guides for LangChain, CrewAI, Autogen, and more
-- **mem0-cli Skill** — Terminal command reference, configuration walkthroughs, and CI/CD recipes
-- **mem0-vercel-ai-sdk Skill** — Vercel AI SDK provider API, memory-augmented generation patterns, and multi-provider setup
+- **mem0 Core Skill:** Python and TypeScript SDK reference, REST API patterns, and integration guides for LangChain, CrewAI, Autogen, and more.
+- **mem0-cli Skill:** Terminal command reference, configuration walkthroughs, and CI/CD recipes.
+- **mem0-vercel-ai-sdk Skill:** Vercel AI SDK provider API, memory-augmented generation patterns, and multi-provider setup.
 
 </Update>
 
 <Update label="2026-04-06" description="Mem0 CLI v0.2.2">
 
-**Official Mem0 CLI — Now on PyPI and npm**
+**Official Mem0 CLI: Now on PyPI and npm**
 
 A full-featured command-line interface for Mem0, available in both Python and Node.js:
 
 - **Install:** `pip install mem0-cli` or `npm install -g @mem0/cli`
-- **Full command suite** — `add`, `search`, `list`, `get`, `update`, `delete`, `import`, `config`, `init`, `status`, `entity`, `event`
-- **Interactive setup** — `mem0 init` with email verification or direct API key entry
-- **Works everywhere** — Platform (Mem0 Cloud) and self-hosted OSS modes
-- **Scriptable** — `--json` flag for CI/CD pipelines and automation
-- **Dual SDK** — Same commands, same experience across Python and Node.js
+- **Full command suite:** `add`, `search`, `list`, `get`, `update`, `delete`, `import`, `config`, `init`, `status`, `entity`, `event`.
+- **Interactive setup:** `mem0 init` supports email verification and direct API key entry.
+- **Runtime coverage:** Works with Mem0 Platform and self-hosted OSS modes.
+- **Automation support:** Use `--json` for CI/CD pipelines and agent workflows.
+- **Dual implementation:** Same commands and behavior across Python and Node.js.
 
 </Update>
 
 <Update label="2026-04-06" description="OpenClaw v1.0.4">
 
-**OpenClaw Plugin — Production-Ready**
+**OpenClaw Plugin: Production-Ready**
 
 The OpenClaw Mem0 plugin went from initial release to production-ready in one week (v1.0.0 → v1.0.4):
 
-- **Skills-based memory architecture** — New extraction pipeline with skill-loader, batched extraction, and domain-aware memory triage
-- **Dream gate** — Automatic memory consolidation during idle periods for higher-quality long-term recall
-- **Interactive CLI** — `openclaw mem0 init`, `status`, `config`, `import`, and `event` commands
-- **Unified tool naming** — `memory_add` and `memory_delete` replace 4 legacy tools, matching the platform API
-- **Security hardened** — Path traversal protection, pinned dependencies, 329 tests across 10 files
+- **Skills-based memory architecture:** New extraction pipeline with skill-loader, batched extraction, and domain-aware memory triage.
+- **Dream gate:** Automatic memory consolidation during idle periods for higher-quality long-term recall.
+- **Interactive CLI:** `openclaw mem0 init`, `status`, `config`, `import`, and `event` commands.
+- **Unified tool naming:** `memory_add` and `memory_delete` replace four legacy tools and match the platform API.
+- **Security hardened:** Path traversal protection, pinned dependencies, and 329 tests across 10 files.
 
 </Update>
 
@@ -97,13 +97,13 @@ The OpenClaw Mem0 plugin went from initial release to production-ready in one we
 
 **Mem0 Plugin for Claude Code, Cursor, and Codex**
 
-Launched a unified Mem0 plugin across three major AI development environments — Claude Code and Cursor first (March 25), then Codex (April 2):
+Launched a unified Mem0 plugin across three major AI development environments: Claude Code and Cursor first (March 25), then Codex (April 2).
 
-- **9 MCP memory tools** — add, search, get, update, delete, bulk delete, entity management via `mcp.mem0.ai`
-- **Lifecycle hooks** — Automatic memory capture at session start, context compaction, task completion, and session end
-- **Cloud MCP server** — Managed endpoint replaces local MCP and Smithery setup
-- **Streamable HTTP transport** — New MCP transport protocol for real-time streaming
-- **Codex-specific skill** — Dedicated skill in `mem0-plugin/skills/mem0-codex` for Codex workflows
+- **9 MCP memory tools:** Add, search, get, update, delete, bulk delete, and entity management via `mcp.mem0.ai`.
+- **Lifecycle hooks:** Automatic memory capture at session start, context compaction, task completion, and session end.
+- **Cloud MCP server:** Managed endpoint replaces local MCP and Smithery setup.
+- **Streamable HTTP transport:** New MCP transport protocol for real-time streaming.
+- **Codex-specific skill:** Dedicated skill in `mem0-plugin/skills/mem0-codex` for Codex workflows.
 
 </Update>
 
@@ -113,11 +113,11 @@ Launched a unified Mem0 plugin across three major AI development environments �
 
 Major expansion of the provider ecosystem:
 
-- **Apache AGE** — New graph store support, bringing the total to 4 graph store backends (Neo4j, Memgraph, Kuzu, Apache AGE). **Note:** All external graph store backends (Neo4j, Memgraph, Kuzu, Apache AGE) were subsequently removed in v2.0.0 (2026-04-14). Graph memory is now built-in entity linking with no external graph store required; see the [v2.0.0 entry above](#mem0-sdk-v2-0-0-v3-0-0).
-- **Turbopuffer** — New vector database provider for Python SDK
-- **MiniMax** — New LLM provider with dedicated AWS Bedrock support
-- **pgvector for Node.js** — PostgreSQL vector support added to the TypeScript OSS SDK
-- **Reasoning models** — `reasoning_effort` parameter for OpenAI o1/o3-style models
+- **Apache AGE:** New graph store support, bringing the total to 4 graph store backends (Neo4j, Memgraph, Kuzu, Apache AGE). **Note:** All external graph store backends (Neo4j, Memgraph, Kuzu, Apache AGE) were subsequently removed in v2.0.0 (2026-04-14). Graph memory is now built-in entity linking with no external graph store required; see the [v2.0.0 entry above](#mem0-sdk-v2-0-0-v3-0-0).
+- **Turbopuffer:** New vector database provider for Python SDK.
+- **MiniMax:** New LLM provider with dedicated AWS Bedrock support.
+- **pgvector for Node.js:** PostgreSQL vector support added to the TypeScript OSS SDK.
+- **Reasoning models:** `reasoning_effort` parameter for OpenAI o1/o3-style models.
 
 </Update>
 
@@ -125,6 +125,6 @@ Major expansion of the provider ecosystem:
 
 **Mem0 Platform Skill on skills.sh**
 
-First skill launch — a dedicated Mem0 skill providing platform API reference, quickstart patterns, and integration examples directly inside agent sessions. Available on [skills.sh](https://skills.sh) for any compatible AI coding agent.
+First skill launch: a dedicated Mem0 skill providing platform API reference, quickstart patterns, and integration examples directly inside agent sessions. Available on [skills.sh](https://skills.sh) for any compatible AI coding agent.
 
 </Update>

--- a/docs/changelog/highlights.mdx
+++ b/docs/changelog/highlights.mdx
@@ -4,6 +4,21 @@ description: "Major product launches, headline features, and milestones for Mem0
 mode: "wide"
 ---
 
+<Update label="2026-06-27" description="SDK memory expiration and TypeScript provider updates">
+
+**SDK Memory Expiration: Expiring Memories Across Python and TypeScript**
+
+The latest SDK releases add first-class expiration controls to memory writes, updates, and reads, plus new TypeScript provider coverage for production deployments.
+
+- **Python client updates:** `MemoryClient.update()` and `AsyncMemoryClient.update()` now accept `expiration_date`, including `None` to clear an existing expiration.
+- **TypeScript client updates:** `AddMemoryOptions`, `update()`, and `Memory` now support `expirationDate`; `search()` and `getAll()` can include expired memories with `showExpired`.
+- **New TypeScript LLM providers:** `MiniMaxLLM` and `LiteLLM` are now available for OpenAI-compatible MiniMax and LiteLLM proxy deployments.
+- **PGVector deployment flexibility:** TypeScript PGVector config now supports `connectionString` and `ssl`, so apps can use a managed Postgres URI instead of separate connection fields.
+
+See [SDK & Tools](/changelog/sdk) for version details and PR links.
+
+</Update>
+
 <Update label="2026-05-13" description="Temporal Reasoning for Mem0 Platform v3">
 
 **Temporal Reasoning: Time-Aware Retrieval for Platform v3**

--- a/docs/changelog/openclaw.mdx
+++ b/docs/changelog/openclaw.mdx
@@ -7,11 +7,11 @@ mode: "wide"
 <Update label="2026-06-12" description="v1.0.13">
 
 **Fixes:**
-- **Custom categories payload:** `customCategories` (a `Record<string, string>` map) is now converted via the new `customCategoryMapToList()` helper into the `Array<Record<string, string>>` shape the Mem0 SDK expects on `add` calls — previously the raw object was passed as `custom_categories` and silently ignored ([#5345](https://github.com/mem0ai/mem0/pull/5345))
-- **Skip runtime setup during metadata registration:** `register()` now detects `registrationMode === "cli-metadata"`, registers only the CLI commands, and returns early — avoiding backend initialization, service/tool registration, and hook installation during OpenClaw's metadata-only registration pass ([#5383](https://github.com/mem0ai/mem0/pull/5383))
+- **Custom categories payload:** `customCategories` (a `Record<string, string>` map) is now converted via the new `customCategoryMapToList()` helper into the `Array<Record<string, string>>` shape the Mem0 SDK expects on `add` calls: previously the raw object was passed as `custom_categories` and silently ignored ([#5345](https://github.com/mem0ai/mem0/pull/5345))
+- **Skip runtime setup during metadata registration:** `register()` now detects `registrationMode === "cli-metadata"`, registers only the CLI commands, and returns early: avoiding backend initialization, service/tool registration, and hook installation during OpenClaw's metadata-only registration pass ([#5383](https://github.com/mem0ai/mem0/pull/5383))
 
 **Security:**
-- Bumped `mem0ai` from `3.0.3` to `3.0.7` (latest Node SDK) — includes the transitive axios CVE remediation shipped in `3.0.6` ([#5460](https://github.com/mem0ai/mem0/pull/5460))
+- Bumped `mem0ai` from `3.0.3` to `3.0.7` (latest Node SDK): includes the transitive axios CVE remediation shipped in `3.0.6` ([#5460](https://github.com/mem0ai/mem0/pull/5460))
 - Added pnpm override `uuid@<11.1.1` → `>=11.1.1` to resolve an open MEDIUM Dependabot alert ([#5489](https://github.com/mem0ai/mem0/pull/5489))
 
 **Improvements:**
@@ -26,7 +26,7 @@ mode: "wide"
 <Update label="2026-06-02" description="v1.0.12">
 
 **Docs:**
-- **Agent Mode onboarding:** README now documents an autonomous setup path for AI agents — `mem0 init --agent --json` mints an evaluation Mem0 API key with no email, OTP, or browser and exports it as `MEM0_API_KEY` for `openclaw mem0 init`; a human owner can later run `mem0 init --email <email>` to claim ownership without disrupting the agent ([#5123](https://github.com/mem0ai/mem0/pull/5123))
+- **Agent Mode onboarding:** README now documents an autonomous setup path for AI agents: `mem0 init --agent --json` mints an evaluation Mem0 API key with no email, OTP, or browser and exports it as `MEM0_API_KEY` for `openclaw mem0 init`; a human owner can later run `mem0 init --email <email>` to claim ownership without disrupting the agent ([#5123](https://github.com/mem0ai/mem0/pull/5123))
 
 **Security:**
 - Added pnpm overrides to remediate advisories in transitive dependencies: `langsmith@<0.6.0` → `^0.6.0`, `picomatch@<2.3.2` → `^2.3.2`, `vite` → `^8.0.5`, and `@qdrant/js-client-rest` → `^1.18.0` ([#5294](https://github.com/mem0ai/mem0/pull/5294))
@@ -40,15 +40,15 @@ mode: "wide"
 <Update label="2026-04-29" description="v1.0.11">
 
 **New Features:**
-- **Skills-mode auto-setup:** `enableSkillsConfig()` now runs automatically after onboarding — enables triage, recall (with reranking + keyword search), and dream consolidation with `tools.profile = "full"` and disables the built-in session-memory hook to avoid conflicts
+- **Skills-mode auto-setup:** `enableSkillsConfig()` now runs automatically after onboarding: enables triage, recall (with reranking + keyword search), and dream consolidation with `tools.profile = "full"` and disables the built-in session-memory hook to avoid conflicts
 - **Memory runtime capability:** Plugin now exposes `runtime.getMemorySearchManager()` and `resolveMemoryBackendConfig()` on the registered memory capability, enabling OpenClaw gateway to query memory status and backend config directly
 - **Dimension-aware collections:** OSS wizard detects embedder dimension changes and creates a new collection (`mem0_<dims>d`) automatically, with a warning about old memories being inaccessible under the new embedder
 - **Tool documentation in skills:** Both `memory-triage` and `memory-dream` SKILL.md files now include full tool reference sections listing all available tools with parameters
 
 **Improvements:**
 - **Auto-capture and auto-recall default to enabled:** `autoCapture` and `autoRecall` now default to `true` (was `false`). Manifest descriptions updated accordingly. Ignored in skills mode
-- **`memory_update` over delete+add:** Skills now prefer `memory_update` for in-place edits — atomic and preserves edit history. Consolidation pattern updated: update best memory, delete redundant ones
-- **Search threshold lowered:** Default `searchThreshold` reduced from `0.5` to `0.1` for broader recall. Removed hardcoded `0.6` recall-specific override — all searches now use the configured threshold
+- **`memory_update` over delete+add:** Skills now prefer `memory_update` for in-place edits: atomic and preserves edit history. Consolidation pattern updated: update best memory, delete redundant ones
+- **Search threshold lowered:** Default `searchThreshold` reduced from `0.5` to `0.1` for broader recall. Removed hardcoded `0.6` recall-specific override: all searches now use the configured threshold
 - **Embedder dimension propagation:** Vector store config auto-resolves dimensions from embedder config when not explicitly set. Syncs `dimension` and `embeddingModelDims` fields for Qdrant/PGVector compatibility
 - **Config file write safety:** `writeFullConfig()` now re-reads and deep-merges the `plugins` section before writing, preserving `installs` and `slots` written by the OpenClaw gateway
 - **Additional embedder models:** Added `mxbai-embed-large` (1024), `all-minilm` (384), and `snowflake-arctic-embed` (1024) to known embedder dimensions
@@ -57,7 +57,7 @@ mode: "wide"
 - Bumped `protobufjs` to `>=7.5.5` via pnpm overrides (GHSA-xq3m-2v4x-88gg) ([#5012](https://github.com/mem0ai/mem0/pull/5012))
 
 **Fixes:**
-- Moved `bootstrapTelemetryFlag()` and removed `ensureInstallRecord()` from module-level side effects — both now run inside `register()` to avoid crashes when loaded outside OpenClaw gateway
+- Moved `bootstrapTelemetryFlag()` and removed `ensureInstallRecord()` from module-level side effects: both now run inside `register()` to avoid crashes when loaded outside OpenClaw gateway
 - Fixed OSS history DB path resolution: absolute paths no longer passed through `resolvePath()`, preventing double-prefix bugs
 - Manifest `providerAuthEnvVars` replaced with spec-compliant `setup.providers` format using `id` + `envVars`
 
@@ -70,14 +70,14 @@ mode: "wide"
 <Update label="2026-04-23" description="v1.0.10">
 
 **Security:**
-- Telemetry `distinct_id` now uses SHA-256 instead of MD5 — prevents rainbow-table reversal of API key hashes
-- User email is now SHA-256 hashed before sending as `distinct_id` — no PII in telemetry payloads
+- Telemetry `distinct_id` now uses SHA-256 instead of MD5: prevents rainbow-table reversal of API key hashes
+- User email is now SHA-256 hashed before sending as `distinct_id`: no PII in telemetry payloads
 - Declared PostHog telemetry endpoint (`us.i.posthog.com`) in `providerEndpoints`
 
 **Fixes:**
 - Fixed version-pinned install records preventing plugin updates. `ensureInstallRecord()` now detects semver-pinned specs (e.g. `@mem0/openclaw-mem0@1.0.7`) and rewrites them to `@latest` or `clawhub:` prefix so `openclaw plugins update` resolves to the newest release
 - Fixed `searchThreshold` default inconsistency: standardized to `0.3` across docs, README, and manifest
-- `PLUGIN_VERSION` now injected at build time via tsup `define` from `package.json` — no more hardcoded version strings
+- `PLUGIN_VERSION` now injected at build time via tsup `define` from `package.json`: no more hardcoded version strings
 
 **Manifest Compliance:**
 - Removed non-spec fields: `requiredEnvVars`, `dataLocations`, `privacy`, `setup` (with `externalEndpoints`, `providers`, `requiresRuntime`, `postInstallHint`)
@@ -95,7 +95,7 @@ mode: "wide"
 
 **Security & Compliance:**
 - Added top-level `requiredEnvVars` to plugin manifest, declaring env vars per mode (platform, OSS OpenAI, OSS Anthropic, OSS Ollama). Fixes ClaHub scanner "required env vars: none" mismatch
-- Added `sensitive: true` and descriptions to `apiKey` and `userEmail` in `configSchema` — previously only declared in `uiHints`
+- Added `sensitive: true` and descriptions to `apiKey` and `userEmail` in `configSchema`: previously only declared in `uiHints`
 - Added `default: false` with descriptions to `autoCapture` and `autoRecall` in `configSchema` so scanner can confirm opt-in defaults
 - Added `dataLocations` field to manifest declaring all persistence paths (config, vectorStore, historyDb, dreamState)
 - Added `privacy` field to manifest documenting data flow for platform vs open-source mode and credential storage guidance
@@ -110,7 +110,7 @@ mode: "wide"
 <Update label="2026-04-21" description="v1.0.8">
 
 **New Features:**
-- **OSS Onboarding Wizard:** New guided 4-step interactive setup for open-source mode — walks through LLM provider, embedding provider, vector store, and user ID selection with prefilled defaults
+- **OSS Onboarding Wizard:** New guided 4-step interactive setup for open-source mode: walks through LLM provider, embedding provider, vector store, and user ID selection with prefilled defaults
 - **Agent-Friendly CLI:** Added `--json` flag to all 16 CLI commands for machine-readable output. Agents can call `openclaw mem0 help --json` to discover every command and flag
 - **Non-Interactive OSS Setup:** Added `--mode open-source` with `--oss-llm`, `--oss-embedder`, `--oss-vector` flags for fully automated OSS configuration without prompts
 - **JSON Helpers Module:** New `cli/json-helpers.ts` with `jsonOut`, `jsonErr`, and `redactSecrets` utilities for consistent structured output
@@ -131,7 +131,7 @@ mode: "wide"
 <Update label="2026-04-20" description="v1.0.7">
 
 **New Features:**
-- **Chat-Based Setup:** Added chat-based Platform setup flow — users can now configure the plugin conversationally instead of editing config files manually
+- **Chat-Based Setup:** Added chat-based Platform setup flow: users can now configure the plugin conversationally instead of editing config files manually
 - **Installation Docs Rewrite:** Rewrote README and integration docs with chat-first setup, numbered manual steps.
 
 **Improvements:**
@@ -146,7 +146,7 @@ mode: "wide"
 **Bug Fixes:**
 - **Telemetry:** Replaced shared `"anonymous-openclaw"` fallback with a persistent per-machine random hash (`openclaw-anon-<uuid>`), so anonymous plugin users are counted individually in PostHog ([#4790](https://github.com/mem0ai/mem0/pull/4790))
 - **Telemetry:** Added PostHog `$identify` event on first authenticated run to stitch anonymous history onto the authenticated profile ([#4790](https://github.com/mem0ai/mem0/pull/4790))
-- **Telemetry:** Fixed event loss on short-lived CLI invocations — added `beforeExit` handler to flush queued events before the process exits ([#4790](https://github.com/mem0ai/mem0/pull/4790))
+- **Telemetry:** Fixed event loss on short-lived CLI invocations: added `beforeExit` handler to flush queued events before the process exits ([#4790](https://github.com/mem0ai/mem0/pull/4790))
 - **Telemetry:** Added lazy `/v1/ping/` email resolution so users who configure API key outside `mem0 init` show as their email in PostHog, not an md5 hash ([#4790](https://github.com/mem0ai/mem0/pull/4790))
 - **Telemetry:** Unified CLI event prefix from `openclaw.<cmd>` to `openclaw.cli.<cmd>` on the needsSetup branch to match the authenticated branch ([#4790](https://github.com/mem0ai/mem0/pull/4790))
 
@@ -158,12 +158,12 @@ mode: "wide"
 <Update label="2026-04-07" description="v1.0.5">
 
 **Bug Fixes:**
-- **Init interactive choice bug**: Fixed number selection in `openclaw mem0 init` — entering 1/2/3 now correctly selects the corresponding option (was broken by readline prefill concatenating with user input)
+- **Init interactive choice bug**: Fixed number selection in `openclaw mem0 init`: entering 1/2/3 now correctly selects the corresponding option (was broken by readline prefill concatenating with user input)
 - **OSS pgvector crash** ([#4727](https://github.com/mem0ai/mem0/issues/4727)): Fixed "Client has already been connected" cascade when using pgvector in OSS mode. The warmup call swallowed errors leaving a half-initialized pg client; concurrent recall/capture then all hit `client.connect()` on the same client. Fix: let warmup errors propagate (so `initPromise` resets and retries with a fresh Memory + fresh pg client) and build fresh config objects per attempt instead of mutating shared state.
 
 **Removed:**
 - **`orgId` / `projectId` config parameters**: Removed from config schema, CLI (`config show/get/set`), init display, and providers. The API key is project-scoped, so separate org/project IDs are unnecessary and could cause access errors if mismatched.
-- **`enableGraph` config parameter**: Removed from all config surfaces, providers, backend, and tools. Graph memory is being deprecated — removing the flag avoids unnecessary exposure.
+- **`enableGraph` config parameter**: Removed from all config surfaces, providers, backend, and tools. Graph memory is being deprecated: removing the flag avoids unnecessary exposure.
 
 </Update>
 
@@ -171,8 +171,8 @@ mode: "wide"
 
 **New Features:**
 - **Interactive init flow**: `openclaw mem0 init` with interactive menu (email verification or direct API key). Non-interactive modes: `--api-key`, `--email`, `--email --code`
-- **`memory_add` tool**: Replaces `memory_store` — name now matches `mem0` CLI and platform API
-- **`memory_delete` tool**: Unified delete — single ID, search-then-delete, bulk, entity cascade. Replaces `memory_forget` and `memory_delete_all`
+- **`memory_add` tool**: Replaces `memory_store`: name now matches `mem0` CLI and platform API
+- **`memory_delete` tool**: Unified delete: single ID, search-then-delete, bulk, entity cascade. Replaces `memory_forget` and `memory_delete_all`
 - **CLI subcommands**: `openclaw mem0 init`, `openclaw mem0 status`, `openclaw mem0 config show`, `openclaw mem0 config set`
 - **`import` CLI command**: Bulk-import memories from a JSON file with `--user-id` and `--agent-id` overrides
 - **`event list` / `event status` CLI commands**: Monitor background processing events
@@ -190,17 +190,17 @@ mode: "wide"
 - **Auto-capture minimum content gate**: Skips extraction when total user content is fewer than 50 chars
 
 **Removed:**
-- `memory_store` tool — replaced by `memory_add`
-- `memory_forget` tool — replaced by `memory_delete`
-- `memory_delete_all` tool — merged into `memory_delete`
-- `memory_history` tool and `history` CLI command — deprecated
+- `memory_store` tool: replaced by `memory_add`
+- `memory_forget` tool: replaced by `memory_delete`
+- `memory_delete_all` tool: merged into `memory_delete`
+- `memory_history` tool and `history` CLI command: deprecated
 
 </Update>
 
 <Update label="2026-04-03" description="v1.0.3">
 
 **Bug Fixes:**
-- **Security**: Added `safePath()` containment helper to `readSkillFile` and `readDomainOverlay` in `skill-loader.ts` — prevents directory traversal
+- **Security**: Added `safePath()` containment helper to `readSkillFile` and `readDomainOverlay` in `skill-loader.ts`: prevents directory traversal
 - **Noise filter**: Reverted incorrect `After-Compaction` regex rename back to `Post-Compaction`
 
 **Changes:**
@@ -214,7 +214,7 @@ mode: "wide"
 <Update label="2026-04-02" description="v1.0.2">
 
 **Bug Fixes:**
-- **Security**: Removed `resolveEnvVars()` and `resolveEnvVarsDeep()` from `config.ts` — plugin-side env resolution was redundant and triggered static analysis warnings ([#4676](https://github.com/mem0ai/mem0/pull/4676))
+- **Security**: Removed `resolveEnvVars()` and `resolveEnvVarsDeep()` from `config.ts`: plugin-side env resolution was redundant and triggered static analysis warnings ([#4676](https://github.com/mem0ai/mem0/pull/4676))
 
 </Update>
 

--- a/docs/changelog/platform.mdx
+++ b/docs/changelog/platform.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Platform"
-description: "Release notes for the Mem0 hosted platform — backend, dashboard, billing, and infrastructure changes."
+description: "Release notes for the Mem0 hosted platform: backend, dashboard, billing, and infrastructure changes."
 mode: "wide"
 ---
 

--- a/docs/changelog/sdk.mdx
+++ b/docs/changelog/sdk.mdx
@@ -10,7 +10,7 @@ mode: "wide"
 <Update label="2026-06-27" description="v2.0.10">
 
 **New Features:**
-- **Client:** Expose `expiration_date` on `MemoryClient.update()` and `AsyncMemoryClient.update()` — callers can now set or clear a memory's expiration date; `None` is preserved and forwarded to the API ([#5874](https://github.com/mem0ai/mem0/pull/5874))
+- **Client:** Expose `expiration_date` on `MemoryClient.update()` and `AsyncMemoryClient.update()`: callers can now set or clear a memory's expiration date; `None` is preserved and forwarded to the API ([#5874](https://github.com/mem0ai/mem0/pull/5874))
 
 **Bug Fixes:**
 - **Memory (OSS):** Apply `remove_code_blocks()` to the LangChain path in async `_create_procedural_memory` so code fences are stripped consistently ([#5711](https://github.com/mem0ai/mem0/pull/5711))
@@ -32,7 +32,7 @@ mode: "wide"
 <Update label="2026-06-24" description="v2.0.8">
 
 **New Features:**
-- **Embeddings:** Add native `embed_batch` to five embedders — LM Studio, Together, HuggingFace, Vertex AI, and Google GenAI — for batched embedding requests ([#5609](https://github.com/mem0ai/mem0/pull/5609))
+- **Embeddings:** Add native `embed_batch` to five embedders: LM Studio, Together, HuggingFace, Vertex AI, and Google GenAI: for batched embedding requests ([#5609](https://github.com/mem0ai/mem0/pull/5609))
 
 **Bug Fixes:**
 - **Core:** Guard against malformed `image_url` entries in `parse_vision_messages` to prevent crashes ([#5631](https://github.com/mem0ai/mem0/pull/5631))
@@ -139,15 +139,15 @@ mode: "wide"
 - **Memory:** Add opt-in `explain=True` parameter to `Memory.search()` and `AsyncMemory.search()`. When enabled, each result includes a `score_details` dict with `semantic_score`, `bm25_score`, `entity_boost`, `raw_score`, `max_possible_score`, `final_score`, and `threshold` so callers can understand and tune retrieval ranking ([#5102](https://github.com/mem0ai/mem0/pull/5102))
 
 **Bug Fixes:**
-- **Vector Stores:** Normalize similarity scores to `[0, 1]` (higher = better) consistently across all backends. 11 adapters previously returned raw distance metrics (lower = better) — FAISS, Chroma, Milvus, Redis, Cassandra, PGVector, S3 Vectors, Supabase, Valkey, Azure MySQL, and Vertex AI Vector Search — causing incorrect ranking in multi-store setups ([#5391](https://github.com/mem0ai/mem0/pull/5391))
+- **Vector Stores:** Normalize similarity scores to `[0, 1]` (higher = better) consistently across all backends. 11 adapters previously returned raw distance metrics (lower = better): FAISS, Chroma, Milvus, Redis, Cassandra, PGVector, S3 Vectors, Supabase, Valkey, Azure MySQL, and Vertex AI Vector Search: causing incorrect ranking in multi-store setups ([#5391](https://github.com/mem0ai/mem0/pull/5391))
 - **Memory:** Parallelize entity boost searches in `Memory.search()` and `AsyncMemory.search()`. Previously up to 8 entities were embedded and queried sequentially (16 serial round-trips with remote embedders); all entity lookups now run concurrently, eliminating multi-second latency on entity-rich queries ([#5377](https://github.com/mem0ai/mem0/pull/5377))
 - **Memory:** Reject empty or whitespace-only queries in `Memory.search()`, `AsyncMemory.search()`, `MemoryClient.search()`, and `AsyncMemoryClient.search()` before any embedding or API call is made. Also strips leading/trailing whitespace from valid queries ([#5258](https://github.com/mem0ai/mem0/pull/5258))
 - **LLMs:** Add `is_reasoning_model: Optional[bool]` override to `BaseLlmConfig` (surfaced on `OpenAILlmConfig` and `AzureOpenAILlmConfig`). Fixes silent zero-extraction when using Azure deployments with versioned `gpt-5.x` names that the automatic name-based heuristic cannot recognize ([#5327](https://github.com/mem0ai/mem0/pull/5327))
 - **LLMs:** Fix xAI LLM provider: add `XAIConfig` with `xai_base_url`, forward `tools`/`tool_choice` in `generate_response()`, and parse `tool_calls` in the response. Previously the provider raised `AttributeError` at init and silently dropped tool results ([#5190](https://github.com/mem0ai/mem0/pull/5190))
-- **Vector Stores:** Fix PGVector `ConnectionPool` hang in Docker Compose environments where the app container starts before Postgres is DNS-resolvable — switched to `open=False` to avoid blocking constructor or silent zombie pool ([#5155](https://github.com/mem0ai/mem0/pull/5155))
-- **Vector Stores:** Fix PGVector `sslmode` handling for PostgreSQL URIs — the `sslmode` query parameter is now correctly extracted and forwarded when building the async connection pool ([#5308](https://github.com/mem0ai/mem0/pull/5308))
-- **Vector Stores:** Fix S3 Vectors `list()` not applying metadata filters — filtering is now done client-side after fetching, with pagination preserved and `top_k` applied after filtering to prevent pre-truncation of matching rows ([#5018](https://github.com/mem0ai/mem0/pull/5018))
-- **Vector Stores:** Fix Upstash Vector `search()` routing all queries to the default namespace — `namespace` is now passed as a top-level keyword argument to `query_many()` instead of inside the per-query dict where it was silently ignored ([#5202](https://github.com/mem0ai/mem0/pull/5202))
+- **Vector Stores:** Fix PGVector `ConnectionPool` hang in Docker Compose environments where the app container starts before Postgres is DNS-resolvable: switched to `open=False` to avoid blocking constructor or silent zombie pool ([#5155](https://github.com/mem0ai/mem0/pull/5155))
+- **Vector Stores:** Fix PGVector `sslmode` handling for PostgreSQL URIs: the `sslmode` query parameter is now correctly extracted and forwarded when building the async connection pool ([#5308](https://github.com/mem0ai/mem0/pull/5308))
+- **Vector Stores:** Fix S3 Vectors `list()` not applying metadata filters: filtering is now done client-side after fetching, with pagination preserved and `top_k` applied after filtering to prevent pre-truncation of matching rows ([#5018](https://github.com/mem0ai/mem0/pull/5018))
+- **Vector Stores:** Fix Upstash Vector `search()` routing all queries to the default namespace: `namespace` is now passed as a top-level keyword argument to `query_many()` instead of inside the per-query dict where it was silently ignored ([#5202](https://github.com/mem0ai/mem0/pull/5202))
 - **Core:** Replace mutable default arguments with `None` sentinels in embedder configs and the proxy module, preventing cross-request state contamination ([#5302](https://github.com/mem0ai/mem0/pull/5302))
 
 </Update>
@@ -155,15 +155,15 @@ mode: "wide"
 <Update label="2026-05-27" description="v2.0.4">
 
 **New Features:**
-- **Client:** `delete()` and async `delete()` accept `delete_linked` (default `False`). When `True`, deleting a memory also removes the older memories it superseded (the v3 `linked_memory_ids` chain), transitively — the delete-side counterpart of `latest_only`, so a superseded memory does not resurface after the current one is deleted ([#5270](https://github.com/mem0ai/mem0/pull/5270))
+- **Client:** `delete()` and async `delete()` accept `delete_linked` (default `False`). When `True`, deleting a memory also removes the older memories it superseded (the v3 `linked_memory_ids` chain), transitively: the delete-side counterpart of `latest_only`, so a superseded memory does not resurface after the current one is deleted ([#5270](https://github.com/mem0ai/mem0/pull/5270))
 
 </Update>
 
 <Update label="2026-05-26" description="v2.0.3">
 
 **Bug Fixes:**
-- **Vector Stores:** PGVector adapter now supports rich filter operators (`eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`, `contains`, `icontains`, wildcard `*`, `$or`, `$not`) in `search()`, `keyword_search()`, and `list()`. Previously only exact-equality filters worked — operator dicts were silently stringified and returned zero results ([#5263](https://github.com/mem0ai/mem0/pull/5263))
-- **Server:** Fixed `/search` endpoint returning 502 when `user_id`, `agent_id`, or `run_id` are sent as top-level request fields. The server now maps these into the `filters` dict before calling `Memory.search()`, matching the v3 API contract. Top-level entity ID fields are marked as deprecated in the OpenAPI schema and emit a warning log — clients should migrate to `filters={"user_id": "..."}` ([#5263](https://github.com/mem0ai/mem0/pull/5263))
+- **Vector Stores:** PGVector adapter now supports rich filter operators (`eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`, `contains`, `icontains`, wildcard `*`, `$or`, `$not`) in `search()`, `keyword_search()`, and `list()`. Previously only exact-equality filters worked: operator dicts were silently stringified and returned zero results ([#5263](https://github.com/mem0ai/mem0/pull/5263))
+- **Server:** Fixed `/search` endpoint returning 502 when `user_id`, `agent_id`, or `run_id` are sent as top-level request fields. The server now maps these into the `filters` dict before calling `Memory.search()`, matching the v3 API contract. Top-level entity ID fields are marked as deprecated in the OpenAPI schema and emit a warning log: clients should migrate to `filters={"user_id": "..."}` ([#5263](https://github.com/mem0ai/mem0/pull/5263))
 
 </Update>
 
@@ -200,10 +200,10 @@ mode: "wide"
 
 <Update label="2026-04-14" description="v2.0.0">
 
-**Major Release** — Python SDK with V3 memory pipeline, ADD-only extraction, and cleaned-up API surface.
+**Major Release**: Python SDK with V3 memory pipeline, ADD-only extraction, and cleaned-up API surface.
 
 **New Features:**
-- **Single-Pass Extraction:** Replaced 2-LLM-call pipeline with additive extraction using `ADDITIVE_EXTRACTION_PROMPT`. Memories accumulate via `linked_memory_ids` — no more UPDATE/DELETE events ([#4805](https://github.com/mem0ai/mem0/pull/4805))
+- **Single-Pass Extraction:** Replaced 2-LLM-call pipeline with additive extraction using `ADDITIVE_EXTRACTION_PROMPT`. Memories accumulate via `linked_memory_ids`: no more UPDATE/DELETE events ([#4805](https://github.com/mem0ai/mem0/pull/4805))
 - **Hybrid Search:** Combined semantic + BM25 keyword matching + entity boost with additive scoring. Native `keyword_search()` added to 15 vector store adapters (Qdrant, Elasticsearch, OpenSearch, Azure AI Search, Weaviate, Redis, PGVector, Pinecone, Databricks, MongoDB, Milvus, Baidu, Upstash, Azure MySQL, Vertex AI) ([#4805](https://github.com/mem0ai/mem0/pull/4805))
 - **Entity Extraction & Linking:** spaCy-based entity extraction with second vector collection (`{collection}_entities`) for cross-memory relationship retrieval. Optional dependency: `pip install mem0ai[nlp]` ([#4805](https://github.com/mem0ai/mem0/pull/4805))
 - **Batch Operations:** Batch embedding, batch persist, and batch entity linking (8-phase pipeline) for both sync `Memory` and async `AsyncMemory` at full parity ([#4805](https://github.com/mem0ai/mem0/pull/4805))
@@ -213,20 +213,20 @@ mode: "wide"
 - **Default model:** `gpt-5-mini` is now the default across `OpenAILLM`, `OpenAIStructuredLLM`, `AzureOpenAILLM`, `AzureOpenAIStructuredLLM`, and `LiteLLM` fallback ([#4829](https://github.com/mem0ai/mem0/pull/4829))
 
 **Breaking Changes:**
-- **`add()` returns ADD-only events** — No more `"UPDATE"` or `"DELETE"` events. Memories accumulate; nothing is overwritten ([#4805](https://github.com/mem0ai/mem0/pull/4805))
-- **`search()` default `threshold` is now `0.1`** — Pass `threshold=0.0` for previous behavior ([#4805](https://github.com/mem0ai/mem0/pull/4805))
-- **`search()` `score` is now a combined multi-signal score** — The top-level `score` fuses semantic similarity, BM25 keyword match, entity signals, and temporal boosts into one value. Absolute numbers shift versus the old raw cosine score; retune any hard thresholds against representative queries ([#4805](https://github.com/mem0ai/mem0/pull/4805), [#4836](https://github.com/mem0ai/mem0/pull/4836))
-- **`search()` default `rerank` is now `False`** — Pass `rerank=True` for previous behavior ([#4805](https://github.com/mem0ai/mem0/pull/4805))
+- **`add()` returns ADD-only events**: No more `"UPDATE"` or `"DELETE"` events. Memories accumulate; nothing is overwritten ([#4805](https://github.com/mem0ai/mem0/pull/4805))
+- **`search()` default `threshold` is now `0.1`**: Pass `threshold=0.0` for previous behavior ([#4805](https://github.com/mem0ai/mem0/pull/4805))
+- **`search()` `score` is now a combined multi-signal score**: The top-level `score` fuses semantic similarity, BM25 keyword match, entity signals, and temporal boosts into one value. Absolute numbers shift versus the old raw cosine score; retune any hard thresholds against representative queries ([#4805](https://github.com/mem0ai/mem0/pull/4805), [#4836](https://github.com/mem0ai/mem0/pull/4836))
+- **`search()` default `rerank` is now `False`**: Pass `rerank=True` for previous behavior ([#4805](https://github.com/mem0ai/mem0/pull/4805))
 - **`top_k` default changed 100 → 20** in `Memory.get_all()` and `Memory.search()` (sync + async). Pass `top_k=100` explicitly to restore the old behavior ([#4843](https://github.com/mem0ai/mem0/pull/4843))
 - **Entity ID validation:** `user_id` / `agent_id` / `run_id` are trimmed; empty-string and whitespace-only values now raise `ValueError` ([#4843](https://github.com/mem0ai/mem0/pull/4843))
-- **Search params validation:** `threshold` must be a number in `[0, 1]`; `top_k` must be a non-negative integer — invalid inputs raise `ValueError` ([#4843](https://github.com/mem0ai/mem0/pull/4843))
+- **Search params validation:** `threshold` must be a number in `[0, 1]`; `top_k` must be a non-negative integer: invalid inputs raise `ValueError` ([#4843](https://github.com/mem0ai/mem0/pull/4843))
 - **`messages` in `Memory.add()` rejects invalid types:** Passing `None` or non-`(str | dict | list)` values raises `Mem0ValidationError` (`error_code="VALIDATION_003"`) ([#4843](https://github.com/mem0ai/mem0/pull/4843))
-- **`qdrant-client>=1.12.0` required** — Upgrade from `>=1.9.1` ([#4805](https://github.com/mem0ai/mem0/pull/4805))
-- **`org_id` and `project_id` removed** — Removed from `MemoryClient` constructor and all method signatures ([#4740](https://github.com/mem0ai/mem0/pull/4740))
+- **`qdrant-client>=1.12.0` required**: Upgrade from `>=1.9.1` ([#4805](https://github.com/mem0ai/mem0/pull/4805))
+- **`org_id` and `project_id` removed**: Removed from `MemoryClient` constructor and all method signatures ([#4740](https://github.com/mem0ai/mem0/pull/4740))
 - **External Graph Store Removed (OSS):** `mem0/memory/graph_memory.py`, `memgraph_memory.py`, `kuzu_memory.py`, `apache_age_memory.py`, and `mem0/graphs/` (Neo4j / Memgraph / Kuzu / Apache AGE / Neptune drivers) deleted, about 4,000 lines. The external graph store integration is no longer part of the OSS SDK; graph drivers (neo4j, memgraph, kuzu, etc.) can be uninstalled. Graph memory now runs natively as built-in entity linking. Remove `enable_graph` and `graph_store` from your config ([#4805](https://github.com/mem0ai/mem0/pull/4805))
 - **`enable_graph` removed from Client SDK:** Graph memory now runs automatically and no longer needs a flag. Remove `enable_graph` from `MemoryClient.add()` / `search()` / `get_all()` / `update_project()` calls ([#4776](https://github.com/mem0ai/mem0/pull/4776))
-- **`custom_fact_extraction_prompt` renamed to `custom_instructions`** — Update config and memory module references ([#4740](https://github.com/mem0ai/mem0/pull/4740))
-- **Typed option classes** — Added Pydantic v2 typed classes: `AddMemoryOptions`, `SearchMemoryOptions`, `GetAllMemoryOptions`, `DeleteAllMemoryOptions`, `UpdateMemoryOptions`, `ProjectUpdateOptions` ([#4740](https://github.com/mem0ai/mem0/pull/4740))
+- **`custom_fact_extraction_prompt` renamed to `custom_instructions`**: Update config and memory module references ([#4740](https://github.com/mem0ai/mem0/pull/4740))
+- **Typed option classes**: Added Pydantic v2 typed classes: `AddMemoryOptions`, `SearchMemoryOptions`, `GetAllMemoryOptions`, `DeleteAllMemoryOptions`, `UpdateMemoryOptions`, `ProjectUpdateOptions` ([#4740](https://github.com/mem0ai/mem0/pull/4740))
 
 **Security:**
 - **FAISS:** Prevent arbitrary code execution via pickle deserialization in `FAISS` vector store ([#4833](https://github.com/mem0ai/mem0/pull/4833))
@@ -234,7 +234,7 @@ mode: "wide"
 **Bug Fixes:**
 - **V3 migration crashes:** Fixed crashes in the v3 migration path; entity linking on OSS is now functional across Qdrant and Milvus backends ([#4836](https://github.com/mem0ai/mem0/pull/4836))
 - **Qdrant entity store:** Entity store now shares the existing Qdrant client when using embedded mode (`path=...`), eliminating RocksDB lock contention between the main and entity collections ([#4836](https://github.com/mem0ai/mem0/pull/4836))
-- **Reranker:** Fixed incorrect use of SentenceTransformer for cross-encoder reranker models — switched to CrossEncoder API for proper scoring ([#4806](https://github.com/mem0ai/mem0/pull/4806))
+- **Reranker:** Fixed incorrect use of SentenceTransformer for cross-encoder reranker models: switched to CrossEncoder API for proper scoring ([#4806](https://github.com/mem0ai/mem0/pull/4806))
 - **S3 Vectors:** Handle `vector=None` in `update()` to prevent boto3 validation error when `event=NONE` ([#4594](https://github.com/mem0ai/mem0/pull/4594))
 - **LLMs:** Made OpenAI `store` parameter opt-in to prevent leaking to non-OpenAI backends like Google Gemini ([#4757](https://github.com/mem0ai/mem0/pull/4757))
 - **LLMs:** Forward `response_format` to Azure OpenAI API to prevent JSON parsing failures ([#4689](https://github.com/mem0ai/mem0/pull/4689))
@@ -372,7 +372,7 @@ See the [OSS v2 to v3 migration guide](https://docs.mem0.ai/migration/oss-v2-to-
 
 **New Features & Updates:**
 - **Memory Update:**
-  - Added `timestamp` parameter to `update()` — accepts Unix epoch (int/float) or ISO 8601 string
+  - Added `timestamp` parameter to `update()`: accepts Unix epoch (int/float) or ISO 8601 string
 
 </Update>
 
@@ -1130,8 +1130,8 @@ See the [OSS v2 to v3 migration guide](https://docs.mem0.ai/migration/oss-v2-to-
 <Update label="2026-06-17" description="v3.0.9">
 
 **Bug Fixes:**
-- **LLMs:** Fix Anthropic `tool_choice` format — was incorrectly sent as a bare string `"auto"` (rejected by the API); now correctly sent as `{ type: "auto" }`. Also fixes tool response parsing: `tool_use` blocks are now parsed into `toolCalls` objects instead of throwing. Updated default model to `claude-sonnet-4-6` and default `max_tokens` to `2000` to match the Python provider. Added `temperature`, `topP`, and `maxTokens` to `LLMConfig` so Anthropic params can be configured ([#5537](https://github.com/mem0ai/mem0/pull/5537))
-- **Memory (OSS):** Preserve custom metadata fields during `update()` — fields such as `category`, `priority`, and other user-defined keys were previously dropped on update; the existing payload is now spread before applying the new data ([#5480](https://github.com/mem0ai/mem0/pull/5480))
+- **LLMs:** Fix Anthropic `tool_choice` format: was incorrectly sent as a bare string `"auto"` (rejected by the API); now correctly sent as `{ type: "auto" }`. Also fixes tool response parsing: `tool_use` blocks are now parsed into `toolCalls` objects instead of throwing. Updated default model to `claude-sonnet-4-6` and default `max_tokens` to `2000` to match the Python provider. Added `temperature`, `topP`, and `maxTokens` to `LLMConfig` so Anthropic params can be configured ([#5537](https://github.com/mem0ai/mem0/pull/5537))
+- **Memory (OSS):** Preserve custom metadata fields during `update()`: fields such as `category`, `priority`, and other user-defined keys were previously dropped on update; the existing payload is now spread before applying the new data ([#5480](https://github.com/mem0ai/mem0/pull/5480))
 - **Client:** Preserve user-defined schema keys in `createMemoryExport` ([#5594](https://github.com/mem0ai/mem0/pull/5594))
 
 **Security:**
@@ -1158,7 +1158,7 @@ See the [OSS v2 to v3 migration guide](https://docs.mem0.ai/migration/oss-v2-to-
 
 **Bug Fixes:**
 - **Memory:** Parallelize entity boost searches in `Memory.search()`. All entity embed + store lookups now run concurrently instead of sequentially, eliminating multi-second latency on entity-rich queries with remote embedding providers ([#5377](https://github.com/mem0ai/mem0/pull/5377))
-- **Vector Stores:** Normalize similarity scores to `[0, 1]` (higher = better) — fixed score inversion in the Redis vector store adapter ([#5391](https://github.com/mem0ai/mem0/pull/5391))
+- **Vector Stores:** Normalize similarity scores to `[0, 1]` (higher = better): fixed score inversion in the Redis vector store adapter ([#5391](https://github.com/mem0ai/mem0/pull/5391))
 - **Embeddings:** Request `encoding_format: "float"` from the OpenAI embedder in both `embed()` and `embedBatch()`. Fixes incorrect vector dimensions when using OpenAI-compatible proxies that default to base64 encoding ([#5170](https://github.com/mem0ai/mem0/pull/5170))
 
 </Update>
@@ -1173,14 +1173,14 @@ See the [OSS v2 to v3 migration guide](https://docs.mem0.ai/migration/oss-v2-to-
 <Update label="2026-05-27" description="v3.0.5">
 
 **New Features:**
-- **Client:** `delete()` accepts an options object with `deleteLinked` (serialized as `delete_linked`, default `false`). When `true`, deleting a memory also removes the older memories it superseded (the v3 linked chain), transitively — the delete-side counterpart of `latestOnly`, so a superseded memory does not resurface after the current one is deleted ([#5270](https://github.com/mem0ai/mem0/pull/5270))
+- **Client:** `delete()` accepts an options object with `deleteLinked` (serialized as `delete_linked`, default `false`). When `true`, deleting a memory also removes the older memories it superseded (the v3 linked chain), transitively: the delete-side counterpart of `latestOnly`, so a superseded memory does not resurface after the current one is deleted ([#5270](https://github.com/mem0ai/mem0/pull/5270))
 
 </Update>
 
 <Update label="2026-05-26" description="v3.0.4">
 
 **Bug Fixes:**
-- **Vector Stores:** PGVector adapter now supports rich filter operators (`eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`, `contains`, `icontains`, wildcard `*`, `$or`, `$not`) in `search()`, `keywordSearch()`, and `list()`. Previously only exact-equality filters worked — operator objects were passed as raw values and returned incorrect results ([#5263](https://github.com/mem0ai/mem0/pull/5263))
+- **Vector Stores:** PGVector adapter now supports rich filter operators (`eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`, `contains`, `icontains`, wildcard `*`, `$or`, `$not`) in `search()`, `keywordSearch()`, and `list()`. Previously only exact-equality filters worked: operator objects were passed as raw values and returned incorrect results ([#5263](https://github.com/mem0ai/mem0/pull/5263))
 
 </Update>
 
@@ -1210,16 +1210,16 @@ See the [OSS v2 to v3 migration guide](https://docs.mem0.ai/migration/oss-v2-to-
 <Update label="2026-04-20" description="v3.0.1">
 
 **Bug Fixes:**
-- **Telemetry:** SDK version is now injected into telemetry at build time via esbuild's `define`, replacing the two hardcoded version strings in `src/client/telemetry.ts` and `src/oss/src/utils/telemetry.ts`. Previously these were stuck at `2.1.36` and `2.1.34` while the published package was on `3.x`, so every telemetry event was reporting the wrong `client_version`. The placeholder is substituted with a string literal at bundle time — no runtime `require("./package.json")` in the shipped bundle ([#4897](https://github.com/mem0ai/mem0/pull/4897)).
+- **Telemetry:** SDK version is now injected into telemetry at build time via esbuild's `define`, replacing the two hardcoded version strings in `src/client/telemetry.ts` and `src/oss/src/utils/telemetry.ts`. Previously these were stuck at `2.1.36` and `2.1.34` while the published package was on `3.x`, so every telemetry event was reporting the wrong `client_version`. The placeholder is substituted with a string literal at bundle time: no runtime `require("./package.json")` in the shipped bundle ([#4897](https://github.com/mem0ai/mem0/pull/4897)).
 
 </Update>
 
 <Update label="2026-04-14" description="v3.0.0">
 
-**Major Release** — TypeScript SDK with V3 memory pipeline, camelCase parameters, and cleaned-up API surface.
+**Major Release**: TypeScript SDK with V3 memory pipeline, camelCase parameters, and cleaned-up API surface.
 
 **V3 Memory Pipeline (OSS):**
-- **Single-Pass Extraction:** Additive extraction pipeline aligned with Python SDK — memories accumulate, no UPDATE/DELETE events ([#4805](https://github.com/mem0ai/mem0/pull/4805))
+- **Single-Pass Extraction:** Additive extraction pipeline aligned with Python SDK: memories accumulate, no UPDATE/DELETE events ([#4805](https://github.com/mem0ai/mem0/pull/4805))
 - **Entity Extraction & Linking:** New `entity_extraction.ts` module (720+ lines) with cross-memory relationship retrieval ([#4805](https://github.com/mem0ai/mem0/pull/4805))
 - **Message Persistence:** SQLite-based message history via new `SQLiteManager.ts` with rolling window for LLM context ([#4805](https://github.com/mem0ai/mem0/pull/4805))
 - **Batch Embeddings:** `embedBatch()` support in OpenAI and Azure embedding providers ([#4805](https://github.com/mem0ai/mem0/pull/4805))
@@ -1242,10 +1242,10 @@ See the [OSS v2 to v3 migration guide](https://docs.mem0.ai/migration/oss-v2-to-
 - **`limit` renamed to `topK` (OSS):** Update all search calls ([#4740](https://github.com/mem0ai/mem0/pull/4740))
 - **`topK` default changed 100 → 20** in `Memory.getAll()` and `Memory.search()`. Pass `topK: 100` explicitly to restore the old behavior ([#4843](https://github.com/mem0ai/mem0/pull/4843))
 - **Entity ID validation:** `userId` / `agentId` / `runId` are trimmed; empty-string and whitespace-only values now throw ([#4843](https://github.com/mem0ai/mem0/pull/4843))
-- **Search params validation:** `threshold` must be in `[0, 1]`; `topK` must be a non-negative integer — invalid inputs throw ([#4843](https://github.com/mem0ai/mem0/pull/4843))
+- **Search params validation:** `threshold` must be in `[0, 1]`; `topK` must be a non-negative integer: invalid inputs throw ([#4843](https://github.com/mem0ai/mem0/pull/4843))
 - **`messages` in `Memory.add()` is required:** Passing `undefined` or `null` now throws ([#4843](https://github.com/mem0ai/mem0/pull/4843))
 - **`customPrompt` renamed to `customInstructions` (OSS):** Update memory and vector store configurations ([#4740](https://github.com/mem0ai/mem0/pull/4740))
-- **`enableGraph` removed (OSS):** Config option removed — graph memory no longer available in OSS ([#4776](https://github.com/mem0ai/mem0/pull/4776))
+- **`enableGraph` removed (OSS):** Config option removed: graph memory no longer available in OSS ([#4776](https://github.com/mem0ai/mem0/pull/4776))
 
 **New Features:**
 - **LLMs:** Added DeepSeek LLM provider with OpenAI-compatible integration using custom baseURL to `api.deepseek.com` ([#4613](https://github.com/mem0ai/mem0/pull/4613))
@@ -1257,7 +1257,7 @@ See the [OSS v2 to v3 migration guide](https://docs.mem0.ai/migration/oss-v2-to-
 - **PGVector init race:** `PGVector.initialize()` now memoises the in-flight init promise ([#4841](https://github.com/mem0ai/mem0/pull/4841))
 - **Redis module detection:** Handles both node-redis v4+ and legacy `moduleList` response shapes ([#4841](https://github.com/mem0ai/mem0/pull/4841))
 - **Config:** Fixed `ConfigManager.mergeConfig()` to only include `graphStore` when explicitly provided by user, preventing default Neo4j connection attempts ([#4776](https://github.com/mem0ai/mem0/pull/4776))
-- **LLMs:** Config manager now falls back to `userConf.url` for `baseURL` — prevents custom LLM providers (Ollama, LMStudio) from silently connecting to OpenAI ([#4761](https://github.com/mem0ai/mem0/pull/4761))
+- **LLMs:** Config manager now falls back to `userConf.url` for `baseURL`: prevents custom LLM providers (Ollama, LMStudio) from silently connecting to OpenAI ([#4761](https://github.com/mem0ai/mem0/pull/4761))
 
 **Improvements:**
 - **Telemetry:** Sample OSS hot-path events at 10% to reduce PostHog event volume ([#4771](https://github.com/mem0ai/mem0/pull/4771))
@@ -1311,7 +1311,7 @@ See the [TypeScript SDK migration guide](https://docs.mem0.ai/migration/ts-v2-to
 - **Types:** Added `WebhookCreatePayload` and `WebhookUpdatePayload` for better type safety
 
 **Tests:**
-- Added end-to-end unit test coverage for the platform client — CRUD, batch, search, webhooks, users, project, and initialization (#4357)
+- Added end-to-end unit test coverage for the platform client: CRUD, batch, search, webhooks, users, project, and initialization (#4357)
 - Added real API integration tests for memory CRUD, batch operations, search, user management, project configuration, and webhook lifecycle (#4395)
 - Deleted obsolete e2e test files replaced by the new structured test suite (#4419)
 
@@ -1320,7 +1320,7 @@ See the [TypeScript SDK migration guide](https://docs.mem0.ai/migration/ts-v2-to
 <Update label="2026-03-16" description="v2.4.1">
 
 **Bug Fixes:**
-- **Core:** Fixed code block content extraction — content inside code blocks is now properly extracted instead of being deleted (#4317)
+- **Core:** Fixed code block content extraction: content inside code blocks is now properly extracted instead of being deleted (#4317)
 
 **Improvements:**
 - **Code Quality:** Fixed linting issues across the SDK (#4334)
@@ -1331,8 +1331,8 @@ See the [TypeScript SDK migration guide](https://docs.mem0.ai/migration/ts-v2-to
 
 **Bug Fixes:**
 - **OSS Storage:** Fixed `SQLITE_CANTOPEN` errors when running as a LaunchAgent, systemd service, or in containers where `process.cwd()` is read-only (e.g. `/`). Default `vector_store.db` location changed from `process.cwd()/vector_store.db` to `~/.mem0/vector_store.db`.
-- **OSS Storage:** Fixed `historyDbPath` config being silently ignored — config merging always overwrote it with defaults. Top-level `historyDbPath` is now correctly propagated into `historyStore.config` with proper precedence.
-- **OSS Storage:** Added `ensureSQLiteDirectory()` — parent directories for SQLite database files are now auto-created before opening, preventing `SQLITE_CANTOPEN` when using nested paths.
+- **OSS Storage:** Fixed `historyDbPath` config being silently ignored: config merging always overwrote it with defaults. Top-level `historyDbPath` is now correctly propagated into `historyStore.config` with proper precedence.
+- **OSS Storage:** Added `ensureSQLiteDirectory()`: parent directories for SQLite database files are now auto-created before opening, preventing `SQLITE_CANTOPEN` when using nested paths.
 
 **Improvements:**
 - **Migration:** Added deprecation warning when an existing `vector_store.db` is found at the old `process.cwd()` location, guiding users to move it or set `vectorStore.config.dbPath` explicitly.
@@ -1347,7 +1347,7 @@ See the [TypeScript SDK migration guide](https://docs.mem0.ai/migration/ts-v2-to
 
 **Bug Fixes:**
 - **OSS Storage:** Replaced `sqlite3` with `better-sqlite3` to fix native binding resolution failures under jiti-based loaders (e.g. OpenClaw plugin system). Fixes issues where the `bindings` module walked V8 stack frames with synthetic filenames, failing to locate the native `.node` addon.
-- **OSS Storage:** Fixed async init race condition in `SQLiteManager` — `init()` is now synchronous
+- **OSS Storage:** Fixed async init race condition in `SQLiteManager`: `init()` is now synchronous
 - **OSS Vector Store:** Migrated `MemoryVectorStore` from `sqlite3` to `better-sqlite3` with transactional batch inserts
 
 **Improvements:**
@@ -1361,7 +1361,7 @@ See the [TypeScript SDK migration guide](https://docs.mem0.ai/migration/ts-v2-to
 
 **New Features & Updates:**
 - **Memory Update:**
-  - Added `timestamp` parameter to `update()` — accepts Unix epoch or ISO 8601 string
+  - Added `timestamp` parameter to `update()`: accepts Unix epoch or ISO 8601 string
 
 </Update>
 
@@ -1593,21 +1593,21 @@ See the [TypeScript SDK migration guide](https://docs.mem0.ai/migration/ts-v2-to
 <Update label="2026-05-16" description="Python v0.2.6 / Node v0.2.6">
 
 **Bug Fixes:**
-- **Claim flow error message:** The `email_already_claimed` tip in `mem0 init --email` previously suggested running `mem0 link <key>` — a command that doesn't exist. Replaced with honest copy pointing the user to sign in at app.mem0.ai with their existing credentials ([#5152](https://github.com/mem0ai/mem0/pull/5152))
+- **Claim flow error message:** The `email_already_claimed` tip in `mem0 init --email` previously suggested running `mem0 link <key>`: a command that doesn't exist. Replaced with honest copy pointing the user to sign in at app.mem0.ai with their existing credentials ([#5152](https://github.com/mem0ai/mem0/pull/5152))
 
 </Update>
 
 <Update label="2026-05-14" description="Python v0.2.5 / Node v0.2.5">
 
 **New Features:**
-- **Agent Mode (`mem0 init --agent`):** Zero-friction signup for AI agents — mints a working Mem0 API key in under 5 seconds with no email, no dashboard, no OTP. Returns an unclaimed shadow account the human can later claim with `mem0 init --email <their-email>` (memories preserved, same key keeps working) ([#5123](https://github.com/mem0ai/mem0/pull/5123))
-- **Self-declared agent identity:** Agents pass `--agent-caller <name>` (e.g. `claude-code`, `cursor`, `codex`) on `mem0 init --agent` so signups attribute to the right tool in analytics. Proof Editor-style — the agent declares itself rather than the CLI sniffing it from env vars ([#5123](https://github.com/mem0ai/mem0/pull/5123))
-- **`mem0 identify <name>`:** New subcommand to self-tag an Agent Mode key after the fact when the agent forgot to pass `--agent-caller` on init. Idempotent — re-running just overwrites ([#5123](https://github.com/mem0ai/mem0/pull/5123))
-- **Plugin sync:** `~/.claude/settings.json::env::MEM0_API_KEY` and `~/.zshrc`/`.bashrc` `export MEM0_API_KEY=` lines stay in sync with `~/.mem0/config.json` automatically. Idempotent — only updates EXISTING entries, never creates new ones ([#5123](https://github.com/mem0ai/mem0/pull/5123))
-- **Claim flow:** `mem0 init --email <email>` claims an existing Agent Mode shadow via OTP. Upgrade-in-place — the API key never changes, memories transfer to the human's account ([#5123](https://github.com/mem0ai/mem0/pull/5123))
+- **Agent Mode (`mem0 init --agent`):** Zero-friction signup for AI agents: mints a working Mem0 API key in under 5 seconds with no email, no dashboard, no OTP. Returns an unclaimed shadow account the human can later claim with `mem0 init --email <their-email>` (memories preserved, same key keeps working) ([#5123](https://github.com/mem0ai/mem0/pull/5123))
+- **Self-declared agent identity:** Agents pass `--agent-caller <name>` (e.g. `claude-code`, `cursor`, `codex`) on `mem0 init --agent` so signups attribute to the right tool in analytics. Proof Editor-style: the agent declares itself rather than the CLI sniffing it from env vars ([#5123](https://github.com/mem0ai/mem0/pull/5123))
+- **`mem0 identify <name>`:** New subcommand to self-tag an Agent Mode key after the fact when the agent forgot to pass `--agent-caller` on init. Idempotent: re-running just overwrites ([#5123](https://github.com/mem0ai/mem0/pull/5123))
+- **Plugin sync:** `~/.claude/settings.json::env::MEM0_API_KEY` and `~/.zshrc`/`.bashrc` `export MEM0_API_KEY=` lines stay in sync with `~/.mem0/config.json` automatically. Idempotent: only updates EXISTING entries, never creates new ones ([#5123](https://github.com/mem0ai/mem0/pull/5123))
+- **Claim flow:** `mem0 init --email <email>` claims an existing Agent Mode shadow via OTP. Upgrade-in-place: the API key never changes, memories transfer to the human's account ([#5123](https://github.com/mem0ai/mem0/pull/5123))
 
 **Bug Fixes:**
-- **Decision tree network resilience:** `pingKey` now distinguishes network errors from invalid keys — returns false ONLY on HTTP 401/403, returns true on connection failures / timeouts / 5xx. Prevents a VPN flap from silently rotating the user's API key and rewriting plugin-sync targets ([#5123](https://github.com/mem0ai/mem0/pull/5123))
+- **Decision tree network resilience:** `pingKey` now distinguishes network errors from invalid keys: returns false ONLY on HTTP 401/403, returns true on connection failures / timeouts / 5xx. Prevents a VPN flap from silently rotating the user's API key and rewriting plugin-sync targets ([#5123](https://github.com/mem0ai/mem0/pull/5123))
 - **Rate-limit error clarity:** DRF's opaque `"You do not have permission"` 403 from Agent Mode rate limits is now translated to `"Daily Agent Mode signup limit reached for this network (5/day). Try again from a different IP or after midnight UTC."` ([#5123](https://github.com/mem0ai/mem0/pull/5123))
 - **JSON envelope `command` field:** `mem0 init --agent --json` error envelopes now populate the `command` field correctly instead of returning an empty string ([#5123](https://github.com/mem0ai/mem0/pull/5123))
 - **Bootstrap envelope validation:** Defends against partial/malformed backend responses (e.g. `{api_key: null}`) silently persisting null/undefined into typed string fields ([#5123](https://github.com/mem0ai/mem0/pull/5123))
@@ -1617,7 +1617,7 @@ See the [TypeScript SDK migration guide](https://docs.mem0.ai/migration/ts-v2-to
 <Update label="2026-04-22" description="Python v0.2.4 / Node v0.2.4">
 
 **New Features:**
-- **V3 API Routes:** Migrated `add`, `search`, and `list` commands from v1/v2 to v3 API endpoints — `POST /v3/memories/add/`, `POST /v3/memories/search/`, `POST /v3/memories/`. Aligns both CLIs with the Python and TypeScript SDKs which already use v3 ([#4916](https://github.com/mem0ai/mem0/pull/4916))
+- **V3 API Routes:** Migrated `add`, `search`, and `list` commands from v1/v2 to v3 API endpoints: `POST /v3/memories/add/`, `POST /v3/memories/search/`, `POST /v3/memories/`. Aligns both CLIs with the Python and TypeScript SDKs which already use v3 ([#4916](https://github.com/mem0ai/mem0/pull/4916))
 
 **Breaking Changes:**
 - **`--graph` / `--no-graph` removed:** The `enable_graph` config option, `--graph` and `--no-graph` CLI flags, and `MEM0_ENABLE_GRAPH` environment variable have been removed from both CLIs. Graph memory is now a project-level setting on the Platform ([#4916](https://github.com/mem0ai/mem0/pull/4916))
@@ -1639,7 +1639,7 @@ See the [TypeScript SDK migration guide](https://docs.mem0.ai/migration/ts-v2-to
 
 **New Features:**
 - **Telemetry:** Added PostHog telemetry and source tracking to both Python and Node CLIs ([#4699](https://github.com/mem0ai/mem0/pull/4699))
-- **Validation:** API key validated upfront via `/v1/ping/` on startup — fail-fast with a helpful error instead of cryptic 401s ([#4701](https://github.com/mem0ai/mem0/pull/4701))
+- **Validation:** API key validated upfront via `/v1/ping/` on startup: fail-fast with a helpful error instead of cryptic 401s ([#4701](https://github.com/mem0ai/mem0/pull/4701))
 
 **Bug Fixes:**
 - **CD:** Fixed OIDC trusted publishing with `npx npm@latest` ([#4724](https://github.com/mem0ai/mem0/pull/4724))
@@ -1669,7 +1669,7 @@ See the [TypeScript SDK migration guide](https://docs.mem0.ai/migration/ts-v2-to
 - **CI/CD:** Added CI pipelines and CD workflows for both CLIs ([#4640](https://github.com/mem0ai/mem0/pull/4640), [#4653](https://github.com/mem0ai/mem0/pull/4653))
 
 **Bug Fixes:**
-- **Node:** Fixed critical `MODULE_NOT_FOUND` crash on `status`, `import`, and all commands when installed globally — replaced runtime `createRequire` with build-time version injection ([#4636](https://github.com/mem0ai/mem0/pull/4636))
+- **Node:** Fixed critical `MODULE_NOT_FOUND` crash on `status`, `import`, and all commands when installed globally: replaced runtime `createRequire` with build-time version injection ([#4636](https://github.com/mem0ai/mem0/pull/4636))
 - **Node:** API errors now show full response detail instead of bare "Bad Request" ([#4636](https://github.com/mem0ai/mem0/pull/4636))
 - **Python:** Fixed double error printing on all commands ([#4636](https://github.com/mem0ai/mem0/pull/4636))
 - **`status` command:** Replaced heavyweight `/v1/entities/` check with dedicated `GET /v1/ping/` endpoint ([#4649](https://github.com/mem0ai/mem0/pull/4649))
@@ -1688,7 +1688,7 @@ See the [TypeScript SDK migration guide](https://docs.mem0.ai/migration/ts-v2-to
 
 <Update label="2026-03-26" description="Python v0.1.0 / Node v0.1.0">
 
-**Initial Release — Official Mem0 CLI**
+**Initial Release: Official Mem0 CLI**
 
 A full-featured command-line interface for Mem0, available in both Python and Node.js:
 
@@ -1715,7 +1715,7 @@ A full-featured command-line interface for Mem0, available in both Python and No
 
 <Update label="2026-06-10" description="Vercel AI SDK v3.0.0">
 
-**Major Release** — Migrated to Vercel AI SDK v6 (`LanguageModelV3` / `ProviderV3`) and Mem0 v3 API.
+**Major Release**: Migrated to Vercel AI SDK v6 (`LanguageModelV3` / `ProviderV3`) and Mem0 v3 API.
 
 **Breaking Changes:**
 - **AI SDK v6:** Upgraded from AI SDK v5 (`LanguageModelV2`) to v6 (`LanguageModelV3`). Users must upgrade `ai` to `^6.0.199` and all `@ai-sdk/*` provider packages to `^3.x` ([#4741](https://github.com/mem0ai/mem0/pull/4741))
@@ -1728,7 +1728,7 @@ A full-featured command-line interface for Mem0, available in both Python and No
 - **Mem0 source in responses:** Memories are attached as a `source` in `generateText`/`streamText` responses with `providerMetadata.mem0.memories` for programmatic access ([#4741](https://github.com/mem0ai/mem0/pull/4741))
 
 **Bug Fixes:**
-- **Async memory storage:** `addMemories` is now properly `await`ed — memories no longer silently fail to store ([#4741](https://github.com/mem0ai/mem0/pull/4741))
+- **Async memory storage:** `addMemories` is now properly `await`ed: memories no longer silently fail to store ([#4741](https://github.com/mem0ai/mem0/pull/4741))
 - **Prompt mutation:** Prompt array is now cloned before injecting memory context, preventing side effects on the caller's array ([#4741](https://github.com/mem0ai/mem0/pull/4741))
 - **Null guard on content:** `doGenerate` guards against null `content` from upstream providers ([#4741](https://github.com/mem0ai/mem0/pull/4741))
 - **Stream response:** `doStream` now returns the full `LanguageModelV3StreamResult` object preserving all V3 fields ([#4741](https://github.com/mem0ai/mem0/pull/4741))
@@ -1749,7 +1749,7 @@ A full-featured command-line interface for Mem0, available in both Python and No
 
 The unified Mem0 plugin for AI development environments:
 
-- **9 MCP memory tools:** `add_memory`, `search_memories`, `get_memories`, `get_memory`, `update_memory`, `delete_memory`, `delete_all_memories`, `delete_entities`, `list_entities` — all via `mcp.mem0.ai`
+- **9 MCP memory tools:** `add_memory`, `search_memories`, `get_memories`, `get_memory`, `update_memory`, `delete_memory`, `delete_all_memories`, `delete_entities`, `list_entities`: all via `mcp.mem0.ai`
 - **Lifecycle hooks:** Automatic memory capture at session start, context compaction, task completion, and session end
 - **Cloud MCP server:** Managed endpoint replaces local MCP and Smithery setup
 - **Streamable HTTP transport:** New MCP transport protocol for real-time streaming

--- a/docs/components/rerankers/custom-prompts.mdx
+++ b/docs/components/rerankers/custom-prompts.mdx
@@ -198,4 +198,4 @@ for i, prompt in enumerate(prompts):
 - **Too Long**: Keep prompts under token limits for your chosen LLM
 - **Too Vague**: Be specific about scoring criteria
 - **Wrong Scale**: Use 0.0-1.0 scale to match the default score extractor
-- **Extra Output**: Ask for only the numeric score — extra text can confuse score extraction
+- **Extra Output**: Ask for only the numeric score: extra text can confuse score extraction

--- a/docs/components/vectordbs/dbs/azure.mdx
+++ b/docs/components/vectordbs/dbs/azure.mdx
@@ -100,7 +100,7 @@ To enable Role-Based Access Control (RBAC) for Azure AI Search, follow these ste
 
 1. In the Azure Portal, navigate to your **Azure AI Search** service.
 2. In the left menu, select **Settings** > **Keys**.
-3. Change the authentication setting to **Role-based access control**, or **Both** if you need API key compatibility. The default is “Key-based authentication”—you must switch it to use Azure roles.
+3. Change the authentication setting to **Role-based access control**, or **Both** if you need API key compatibility. The default is “Key-based authentication”: you must switch it to use Azure roles.
 4. **Go to Access Control (IAM):**
     - In the Azure Portal, select your Search service.
     - Click **Access Control (IAM)** on the left.

--- a/docs/contributing/development.mdx
+++ b/docs/contributing/development.mdx
@@ -36,7 +36,7 @@ Every pull request must link to an issue using `Closes #<issue-number>`.
 
 **We cannot merge any pull request until you have signed our Contributor License
 Agreement (CLA).** When you open your first PR, the CLA bot will comment with a
-link to sign — it takes less than a minute and only needs to be done once.
+link to sign: it takes less than a minute and only needs to be done once.
 
 ## Submitting Your Contribution through a PR
 
@@ -134,7 +134,7 @@ pnpm run test:unit    # unit tests with coverage
 - **Formatter:** Prettier
 - **Tests:** jest
 - Always run type checking after changes: `pnpm run typecheck` (or `tsc --noEmit`)
-- Use ES module `import` syntax — never `require()`
+- Use ES module `import` syntax: never `require()`
 
 ---
 

--- a/docs/cookbooks/essentials/building-ai-companion.mdx
+++ b/docs/cookbooks/essentials/building-ai-companion.mdx
@@ -231,7 +231,7 @@ mem0_client.add(
   <Tab title="Open Source">
 **Categories via Metadata:**
 
-In open source, model categories with a stable field in `metadata`—here we use `memory_bucket`:
+In open source, model categories with a stable field in `metadata`. This example uses `memory_bucket`:
 
 ```python
 # Add goal
@@ -326,7 +326,7 @@ print([m["memory"] for m in memories["results"]])
 </Tabs>
 
 <Warning>
-Without filters, Mem0 stores everything—greetings, filler, and casual chat. This pollutes retrieval: instead of pulling "marathon goal," you get "lol ok." Set custom instructions to keep memory clean.
+Without filters, Mem0 stores everything: greetings, filler, and casual chat. This pollutes retrieval: instead of pulling "marathon goal," you get "lol ok." Set custom instructions to keep memory clean.
 </Warning>
 
 Noise. Greetings and filler clutter the memory.
@@ -374,7 +374,7 @@ Return JSON with key "facts" as a list of strings (use [] if nothing to store).
 memory = Memory.from_config(MEMORY_CONFIG)
 ```
 
-<Note>`custom_instructions` is a top-level key in the config dictionary passed to `Memory.from_config()`. Make sure it's set before creating the Memory instance — not after.</Note>
+<Note>`custom_instructions` is a top-level key in the config dictionary passed to `Memory.from_config()`. Set it before creating the Memory instance, not after.</Note>
   </Tab>
 </Tabs>
 
@@ -404,7 +404,7 @@ print([m["memory"] for m in memories["results"]])
 </Tabs>
 
 <Info>
-**Expected output:** Only 2 memories stored—the marathon goal and trail preference. The greeting "hey how's it going" was filtered out automatically. Custom instructions are working.
+**Expected output:** Only 2 memories stored: the marathon goal and trail preference. The greeting "hey how's it going" was filtered out automatically. Custom instructions are working.
 </Info>
 
 Only meaningful facts. Filler gets dropped automatically.
@@ -849,7 +849,7 @@ recent = mem0_client.search(
   </Tab>
   <Tab title="Open Source">
 ```python
-# Qdrant range filters require numbers — store an epoch timestamp in metadata
+# Qdrant range filters require numbers: store an epoch timestamp in metadata
 from datetime import datetime
 
 epoch = int(datetime(2025, 10, 15).timestamp())

--- a/docs/cookbooks/essentials/controlling-memory-ingestion.mdx
+++ b/docs/cookbooks/essentials/controlling-memory-ingestion.mdx
@@ -65,7 +65,7 @@ Patient is allergic to penicillin
 ```
 
 <Warning>
-Without custom instructions, AI assistants treat speculation as confirmed facts. "I think I might be allergic" becomes "Patient is allergic"—a dangerous transformation in sensitive domains like healthcare, legal, or financial services.
+Without custom instructions, AI assistants treat speculation as confirmed facts. "I think I might be allergic" becomes "Patient is allergic": a dangerous transformation in sensitive domains like healthcare, legal, or financial services.
 </Warning>
 
 The speculation became a confirmed fact. Let's add controls.
@@ -328,7 +328,7 @@ That “no duplicates” promise comes from the inference pipeline. Keep `infer=
 | Mode | What it does | Best for | Watch out for |
 | --- | --- | --- | --- |
 | `infer=True` *(default)* | Runs the LLM pipeline so Mem0 extracts structured facts and resolves conflicts automatically. | Daily conversations, preference tracking, anything you want deduped. | Slightly slower because inference runs on every write. |
-| `infer=False` | Stores your payload exactly as-is—no inference, no dedupe. | Bulk imports, compliance snapshots, curated facts you already trust. | Later `infer=True` calls for the same fact will create duplicates you must clean manually. |
+| `infer=False` | Stores your payload exactly as-is: no inference, no dedupe. | Bulk imports, compliance snapshots, curated facts you already trust. | Later `infer=True` calls for the same fact will create duplicates you must clean manually. |
 
 <Tip>
 Stay consistent per data source. If you need both behaviors, keep them in separate scopes (e.g., different `app_id` or `run_id`) so you always know which memories are inferred vs direct imports.

--- a/docs/cookbooks/essentials/entity-partitioning-playbook.mdx
+++ b/docs/cookbooks/essentials/entity-partitioning-playbook.mdx
@@ -70,7 +70,7 @@ print(agent_memories)
 ```
 
 <Tip icon="compass">
-Memories can be written with several identifiers, but each search resolves one entity boundary at a time. Run separate queries for user and agent scopes—just like above—rather than combining both in a single filter.
+Memories can be written with several identifiers, but each search resolves one entity boundary at a time. Run separate queries for user and agent scopes, as shown above, rather than combining both in a single filter.
 </Tip>
 
 ## When Memories Leak

--- a/docs/cookbooks/essentials/exporting-memories.mdx
+++ b/docs/cookbooks/essentials/exporting-memories.mdx
@@ -76,7 +76,7 @@ First memory: Dev works at TechCorp as a senior engineer
 ```
 
 <Info>
-**Expected output:** `get_all()` retrieved Dev's complete memory record. This method returns everything matching your filters—no semantic search, no ranking, just raw retrieval. Perfect for exports and audits.
+**Expected output:** `get_all()` retrieved Dev's complete memory record. This method returns everything matching your filters: no semantic search, no ranking, just raw retrieval. Perfect for exports and audits.
 </Info>
 
 You can filter by metadata to get specific types:
@@ -278,7 +278,7 @@ This covers data portability, GDPR compliance, system migrations, and manual rev
 
 ## Summary
 
-Use **`get_all()`** for bulk retrieval, **`search()`** for specific questions, and **`create_memory_export()`** for structured data exports with custom schemas. Remember exports expire after 7 days—download them locally for long-term archives.
+Use **`get_all()`** for bulk retrieval, **`search()`** for specific questions, and **`create_memory_export()`** for structured data exports with custom schemas. Remember exports expire after 7 days: download them locally for long-term archives.
 
 <CardGroup cols={2}>
   <Card title="Build a Mem0 Companion" icon="users" href="/cookbooks/essentials/building-ai-companion">

--- a/docs/cookbooks/essentials/tagging-and-organizing-memories.mdx
+++ b/docs/cookbooks/essentials/tagging-and-organizing-memories.mdx
@@ -19,7 +19,7 @@ client = MemoryClient(api_key="your-api-key")
 ```
 
 <Note>
-Define custom categories at the **project level** with `client.project.update()` before adding memories. Categories apply to all future memories—Mem0 auto-assigns them based on content semantics.
+Define custom categories at the **project level** with `client.project.update()` before adding memories. Categories apply to all future memories: Mem0 auto-assigns them based on content semantics.
 </Note>
 
 ---
@@ -67,7 +67,7 @@ Total memories: 3
 ```
 
 <Warning>
-Without categories, agents waste time reading through everything. For a customer with 100 memories, finding one billing issue means scanning all 100. Categories let you filter to exactly what you need—billing issues only, no password resets or feedback mixed in.
+Without categories, agents waste time reading through everything. For a customer with 100 memories, finding one billing issue means scanning all 100. Categories let you filter to exactly what you need: billing issues only, no password resets or feedback mixed in.
 </Warning>
 
 Everything is mixed together. Support agents have to read through all memories to find what they need.
@@ -91,7 +91,7 @@ client.project.update(custom_categories=custom_categories)
 ```
 
 <Tip>
-Start with 3-5 clear categories that match how your team thinks. Too many categories dilute auto-tagging accuracy. Add more later if needed—it's easier to expand than to fix over-complicated classification.
+Start with 3-5 clear categories that match how your team thinks. Too many categories dilute auto-tagging accuracy. Add more later if needed: it's easier to expand than to fix over-complicated classification.
 </Tip>
 
 These categories are now available project-wide. Every memory can be tagged with one or more categories.
@@ -160,7 +160,7 @@ Billing issues:
 ```
 
 <Info icon="check">
-**Expected output:** Only the billing issue returned—no password reset, no upgrade request. Category filtering worked. Joseph can audit billing without reading through unrelated support tickets.
+**Expected output:** Only the billing issue returned: no password reset, no upgrade request. Category filtering worked. Joseph can audit billing without reading through unrelated support tickets.
 </Info>
 
 Only billing-related memories are returned. No need to filter through account updates or feedback.
@@ -239,7 +239,7 @@ This pattern scales from 10 customers to 10,000 without degrading retrieval spee
 
 Categories make retrieval faster and compliance easier. Define 3-5 clear categories with `client.project.update()`, let Mem0 auto-assign them based on content, then filter with `categories: {in: [...]}` to pull exactly what you need.
 
-Instead of searching through everything, agents jump directly to the information type they need—billing issues, account details, or support tickets.
+Instead of searching through everything, agents jump directly to the information type they need: billing issues, account details, or support tickets.
 
 <CardGroup cols={2}>
   <Card title="Control Memory Ingestion" icon="filter" href="/cookbooks/essentials/controlling-memory-ingestion">

--- a/docs/core-concepts/memory-evaluation.mdx
+++ b/docs/core-concepts/memory-evaluation.mdx
@@ -7,13 +7,13 @@ iconType: "solid"
 
 ## Why Memory Evaluation Matters
 
-Most AI agent memory systems retrieve information by maximizing context window size. That works on benchmarks but not in production, where every token adds cost. **Token efficiency** — achieving high accuracy with less context per query — is what separates benchmark performance from production viability.
+Most AI agent memory systems retrieve information by maximizing context window size. That works on benchmarks but not in production, where every token adds cost. **Token efficiency** means achieving high accuracy with less context per query. It is what separates benchmark performance from production viability.
 
 The new Mem0 algorithm achieves competitive accuracy on LoCoMo, LongMemEval, and BEAM while averaging **under 7,000 tokens per retrieval call**. Full-context approaches on the same benchmarks routinely consume 25,000+ tokens per query.
 
 Evaluating a memory system at scale comes down to three parameters: **accuracy** (what the benchmarks measure), **cost** (context tokens per query), and **performance** (latency). Optimizing one is easy. Balancing all three at scale is the actual problem.
 
-Some benchmarks today — particularly smaller ones like LoCoMo and LongMemEval — can be materially improved by aggressive retrieval strategies, larger context windows, or frontier models. That does not necessarily mean the underlying memory system has gotten better. We evaluate under constraints that reflect how memory systems actually run in production: limited context windows and practical token budgets.
+Some benchmarks today, particularly smaller ones like LoCoMo and LongMemEval, can be materially improved by aggressive retrieval strategies, larger context windows, or frontier models. That does not necessarily mean the underlying memory system has gotten better. We evaluate under constraints that reflect how memory systems actually run in production: limited context windows and practical token budgets.
 
 ## Architecture Overview
 
@@ -23,10 +23,10 @@ Mem0's memory system operates across two phases, **extraction** (writing) and **
 
 When new conversations arrive, the extraction pipeline processes them through five stages:
 
-1. **Store New Memories** — Conversation enters the pipeline asynchronously (after the agent responds)
-2. **Context Lookup** — Find related existing memories to avoid duplicates
-3. **Distill Memories** — Single-pass LLM extraction produces ADD-only facts from input + context
-4. **Deduplicate + Embed** — Hash-based deduplication, then vectorize new memories
+1. **Store New Memories**: Conversation enters the pipeline asynchronously (after the agent responds)
+2. **Context Lookup**: Find related existing memories to avoid duplicates
+3. **Distill Memories**: Single-pass LLM extraction produces ADD-only facts from input + context
+4. **Deduplicate + Embed**: Hash-based deduplication, then vectorize new memories
 5. **Graph Memory (Entity Linking)**: Identify entities (proper nouns, quoted text, compound noun phrases) and link them across memories into a graph
 
 Memories are distributed across three storage layers, each tuned for a specific retrieval pattern:
@@ -38,16 +38,16 @@ Memories are distributed across three storage layers, each tuned for a specific 
 | **SQL Database** | History log (ADD events) + rolling message window | Audit trail + extraction dedup context |
 
 <Info>
-The key architectural decision is **ADD-only extraction**. New facts are stored alongside old ones — nothing is overwritten or deleted. When information changes, both the old and new facts survive. This preserves temporal context and eliminates information loss from premature consolidation.
+The key architectural decision is **ADD-only extraction**. New facts are stored alongside old ones. Nothing is overwritten or deleted. When information changes, both the old and new facts survive. This preserves temporal context and eliminates information loss from premature consolidation.
 </Info>
 
 ### Multi-Signal Retrieval
 
 When a query arrives, the retrieval pipeline scores candidates across three signals in parallel:
 
-1. **Semantic Search** — Vector similarity scoring against memory embeddings
-2. **Keyword Search** — Normalized term matching via BM25 with verb-form lemmatization
-3. **Entity Search** — Entity matching boosts memories linked to query entities
+1. **Semantic Search**: Vector similarity scoring against memory embeddings
+2. **Keyword Search**: Normalized term matching via BM25 with verb-form lemmatization
+3. **Entity Search**: Entity matching boosts memories linked to query entities
 
 Results are fused via rank scoring into a final top-K set. Different query types lean on different signals:
 
@@ -94,7 +94,7 @@ The two largest gains are **temporal queries (+29.6)** and **multi-hop reasoning
 
 *Mean tokens: 6,787*
 
-The biggest gain is **single-session assistant (+53.6)** — the previous algorithm had a blind spot for agent-generated facts. The new algorithm treats them as first-class memories.
+The biggest gain is **single-session assistant (+53.6)** because the previous algorithm had a blind spot for agent-generated facts. The new algorithm treats them as first-class memories.
 
 The **+42.1 on temporal reasoning** reflects the ADD-only architecture preserving chronological context that the previous UPDATE/DELETE model would destroy.
 
@@ -119,7 +119,7 @@ The **+42.1 on temporal reasoning** reflects the ADD-only architecture preservin
 *Mean tokens (1M): 6,719. Mean tokens (10M): 6,914.*
 
 <Info>
-**BEAM is the most relevant benchmark here.** It operates at 1M and 10M token scales and cannot be solved by simply expanding the context window. The results at 10M reflect where memory systems actually stand at production context volumes. The system holds up well on preference following, instruction following, and knowledge updates at both scales. Weaker categories at 10M (temporal reasoning, event ordering, multi-session reasoning) are open problems across the field — they require higher-order representations of how events relate to each other across time, which is a primary focus of our ongoing research.
+**BEAM is the most relevant benchmark here.** It operates at 1M and 10M token scales and cannot be solved by simply expanding the context window. The results at 10M reflect where memory systems actually stand at production context volumes. The system holds up well on preference following, instruction following, and knowledge updates at both scales. Weaker categories at 10M (temporal reasoning, event ordering, multi-session reasoning) are open problems across the field. They require higher-order representations of how events relate to each other across time, which is a primary focus of our ongoing research.
 </Info>
 
 ### Performance Summary
@@ -130,8 +130,8 @@ All results use a single-pass retrieval setup: one retrieval call, one answer, n
 |---|---|---|---|
 | **LoCoMo** | 71.4 | **91.6** | 6,956 |
 | **LongMemEval** | 67.8 | **93.4** | 6,787 |
-| **BEAM (1M)** | — | **64.1** | 6,719 |
-| **BEAM (10M)** | — | **48.6** | 6,914 |
+| **BEAM (1M)** | N/A | **64.1** | 6,719 |
+| **BEAM (10M)** | N/A | **48.6** | 6,914 |
 
 <Info>
 Scores reflect Mem0's managed platform, which includes proprietary optimizations not available in the open-source SDK. Open-source users should expect directionally similar gains but not identical numbers.
@@ -183,7 +183,7 @@ Each benchmark is a Python module with its own runner ([source code](https://git
 |---|---|---|
 | `--project-name` | (required) | Run identifier for tracking results |
 | `--backend` | `oss` | `oss` (self-hosted) or `cloud` (Mem0 Platform) |
-| `--mem0-api-key` | — | Mem0 API key (required for `cloud` backend) |
+| `--mem0-api-key` | N/A | Mem0 API key (required for `cloud` backend) |
 | `--mem0-host` | `http://localhost:8888` | Mem0 server URL (for `oss` backend) |
 | `--top-k` | `200` | Number of memories to retrieve per query |
 | `--top-k-cutoffs` | `10,20,50,200` | Evaluate accuracy at multiple retrieval depths (BEAM default: `100`) |
@@ -192,9 +192,9 @@ Each benchmark is a Python module with its own runner ([source code](https://git
 | `--provider` | `openai` | LLM provider: `openai`, `anthropic`, `azure` |
 | `--judge-provider` | (same as `--provider`) | Override provider for the judge model |
 | `--max-workers` | `10` | Parallel workers for evaluation |
-| `--predict-only` | — | Stop after search, skip answer + judge phases |
-| `--evaluate-only` | — | Skip ingest + search, evaluate existing results |
-| `--resume` | — | Resume from checkpoint (BEAM and LongMemEval; on by default for LongMemEval) |
+| `--predict-only` | N/A | Stop after search, skip answer + judge phases |
+| `--evaluate-only` | N/A | Skip ingest + search, evaluate existing results |
+| `--resume` | N/A | Resume from checkpoint (BEAM and LongMemEval; on by default for LongMemEval) |
 
 <CodeGroup>
 ```bash LoCoMo
@@ -329,7 +329,7 @@ When evaluating memory systems, keep these considerations in mind:
     Yes. For self-hosted, configure the extraction model in your `mem0-config.yaml` (see the `configs/` directory of the evaluation repo for provider-specific examples). For Mem0 Cloud, extraction uses the platform's default. Using a frontier model will likely produce higher scores but at higher cost and latency.
   </Accordion>
   <Accordion title="Why are BEAM scores lower than LoCoMo/LongMemEval?">
-    BEAM operates at 1M and 10M token scales — orders of magnitude larger than LoCoMo or LongMemEval. At these scales, similar content appears multiple times across the window, and the memory system must surface the exact correct memory over many close matches. The scores reflect the genuine difficulty of the task, not a regression in the algorithm.
+    BEAM operates at 1M and 10M token scales, orders of magnitude larger than LoCoMo or LongMemEval. At these scales, similar content appears multiple times across the window, and the memory system must surface the exact correct memory over many close matches. The scores reflect the genuine difficulty of the task, not a regression in the algorithm.
   </Accordion>
   <Accordion title="How do I contribute a new benchmark?">
     Open a pull request to the [memory-benchmarks repository](https://github.com/mem0ai/memory-benchmarks) with your benchmark implementation. See the repository README for the expected interface and format.

--- a/docs/core-concepts/memory-operations/add.mdx
+++ b/docs/core-concepts/memory-operations/add.mdx
@@ -48,7 +48,7 @@ Future searches rank the most relevant memories for the query.
 When you switch to `infer=False`, Mem0 stores your payload exactly as provided, so duplicates can land. Mixing both modes for the same fact can save it twice.
 </Warning>
 
-You trigger this pipeline with a single `add` call—no manual orchestration needed.
+You trigger this pipeline with a single `add` call: no manual orchestration needed.
 
 ## Add with Mem0 Platform
 
@@ -169,7 +169,7 @@ For full list of supported fields, required formats, and advanced options, see t
 | --- | --- | --- |
 | Add behavior | ADD-only; memories accumulate | ADD-only; you control storage |
 | Rate limits | Managed quotas per workspace | Limited by your hardware and provider APIs |
-| Dashboard visibility | Yes — inspect memories visually | Inspect via CLI, logs, or custom UI |
+| Dashboard visibility | Yes: inspect memories visually | Inspect via CLI, logs, or custom UI |
 
 ## Put it into practice
 

--- a/docs/core-concepts/memory-operations/delete.mdx
+++ b/docs/core-concepts/memory-operations/delete.mdx
@@ -152,7 +152,7 @@ client.delete_all(user_id="*")
 # Delete all memories across every agent in the project
 client.delete_all(agent_id="*")
 
-# Full project wipe — all four filters must be explicitly set to "*"
+# Full project wipe: all four filters must be explicitly set to "*"
 client.delete_all(user_id="*", agent_id="*", app_id="*", run_id="*")
 ```
 
@@ -166,7 +166,7 @@ client.deleteAll({ userId: "*" })
   .then(result => console.log(result))
   .catch(error => console.error(error));
 
-// Full project wipe — all four filters must be explicitly set to "*"
+// Full project wipe: all four filters must be explicitly set to "*"
 client.deleteAll({ userId: "*", agentId: "*", appId: "*", runId: "*" })
   .then(result => console.log(result))
   .catch(error => console.error(error));
@@ -191,7 +191,7 @@ memory.delete_all(user_id="alice")
 </CodeGroup>
 
 <Note>
-  The OSS JavaScript SDK does not yet expose deletion helpers—use the REST API or Python SDK when self-hosting.
+  The OSS JavaScript SDK does not yet expose deletion helpers: use the REST API or Python SDK when self-hosting.
 </Note>
 
 ## Use cases recap

--- a/docs/core-concepts/memory-operations/search.mdx
+++ b/docs/core-concepts/memory-operations/search.mdx
@@ -70,7 +70,7 @@ m.search("What are Alice's hobbies?", filters={"user_id": "alice"})
 
 | Capability | Mem0 Platform | Mem0 OSS |
 | --- | --- | --- |
-| **Entity IDs on search / get_all** | Inside `filters={"user_id": "alice"}` | Inside `filters={"user_id": "alice"}` (aligned with Platform in v3 — top-level kwargs raise `ValueError`) |
+| **Entity IDs on search / get_all** | Inside `filters={"user_id": "alice"}` | Inside `filters={"user_id": "alice"}` (aligned with Platform in v3: top-level kwargs raise `ValueError`) |
 | **Filter syntax** | Logical operators (`AND`, `OR`, comparisons) with field-level access | Basic field filters, extend via Python hooks |
 | **Reranking** | Toggle `rerank=True` with managed reranker catalog | Requires configuring local or third-party rerankers |
 | **Thresholds** | Request-level configuration (`threshold`, `top_k`) | Controlled via SDK parameters |
@@ -121,7 +121,7 @@ from mem0 import Memory
 
 m = Memory()
 
-# Simple search — entity IDs go in `filters`
+# Simple search: entity IDs go in `filters`
 related_memories = m.search("Should I drink coffee or tea?", filters={"user_id": "alice"})
 
 # Search with additional metadata filters (combine entity + metadata in the same dict)
@@ -136,7 +136,7 @@ import { Memory } from 'mem0ai/oss';
 
 const memory = new Memory();
 
-// Simple search — entity IDs go inside `filters`
+// Simple search: entity IDs go inside `filters`
 const relatedMemories = memory.search("Should I drink coffee or tea?", {
     filters: { userId: "alice" },
 });
@@ -203,7 +203,7 @@ client.search("query", filters={
 
 *OSS:*
 ```python
-# Get memories from a specific agent session — entity IDs combined in filters
+# Get memories from a specific agent session: entity IDs combined in filters
 m.search("query", filters={
     "user_id": "alice",
     "agent_id": "chatbot",

--- a/docs/core-concepts/memory-operations/update.mdx
+++ b/docs/core-concepts/memory-operations/update.mdx
@@ -127,7 +127,7 @@ memory.update(
 </CodeGroup>
 
 <Note>
-  OSS JavaScript SDK does not expose `update` yet—use the REST API or Python SDK when self-hosting.
+  OSS JavaScript SDK does not expose `update` yet: use the REST API or Python SDK when self-hosting.
 </Note>
 
 ## Tips
@@ -148,7 +148,7 @@ memory.update(
 | Update call | `client.update(memory_id, {...})` | `memory.update(memory_id, data=...)` |
 | Batch updates | `client.batch_update` (up to 1000 memories) | Script your own loop or bulk job |
 | Dashboard visibility | Inspect updates in the UI | Inspect via logs or custom tooling |
-| Immutable handling | Returns descriptive error | Raises exception—delete and re-add |
+| Immutable handling | Returns descriptive error | Raises exception: delete and re-add |
 
 ## Put it into practice
 

--- a/docs/core-concepts/memory-types.mdx
+++ b/docs/core-concepts/memory-types.mdx
@@ -97,7 +97,7 @@ results = memory.search(
 | Org | Configured globally | Long-term | Shared knowledge | Needs owner to keep current |
 
 <Warning>
-  Avoid storing secrets or unredacted PII in user or org memories—Mem0 is retrievable by design. Encrypt or hash sensitive values first.
+  Avoid storing secrets or unredacted PII in user or org memories: Mem0 is retrievable by design. Encrypt or hash sensitive values first.
 </Warning>
 
 ## Put it into practice

--- a/docs/integrations/antigravity.mdx
+++ b/docs/integrations/antigravity.mdx
@@ -1,9 +1,9 @@
 ---
 title: Antigravity
-description: "Add persistent memory to Google Antigravity with the Mem0 plugin — MCP server, lifecycle hooks, and slash commands."
+description: "Add persistent memory to Google Antigravity with the Mem0 plugin: MCP server, lifecycle hooks, and slash commands."
 ---
 
-Add persistent memory to [**Google Antigravity**](https://antigravity.google) (`agy` CLI and Desktop IDE) with the Mem0 plugin. Your agent forgets everything between sessions — Mem0 fixes that by storing decisions, preferences, and learnings so they carry over automatically.
+Add persistent memory to [**Google Antigravity**](https://antigravity.google) (`agy` CLI and Desktop IDE) with the Mem0 plugin. Your agent forgets everything between sessions. Mem0 fixes that by storing decisions, preferences, and learnings so they carry over automatically.
 
 ## Prerequisites
 
@@ -24,7 +24,7 @@ echo 'export MEM0_API_KEY="m0-your-api-key"' >> ~/.bashrc && source ~/.bashrc
 
 ## Installation
 
-**Option A — degit** (recommended):
+**Option A: degit** (recommended):
 
 ```bash
 # Install the plugin (MCP server, hooks, scripts)
@@ -57,7 +57,7 @@ This installs the MCP server, lifecycle hooks, and shared scripts.
 
 ## Lifecycle Hooks
 
-The plugin uses the same shell scripts as Claude Code, Cursor, and Codex — hooks bridge environment variables using `${extensionPath}` (Antigravity's plugin-root token).
+The plugin uses the same shell scripts as Claude Code, Cursor, and Codex: hooks bridge environment variables using `${extensionPath}` (Antigravity's plugin-root token).
 
 | Hook | Event | What it does |
 |------|-------|-------------|
@@ -69,9 +69,9 @@ The plugin uses the same shell scripts as Claude Code, Cursor, and Codex — hoo
 
 ## Troubleshooting
 
-- **No tools appearing** — Restart your Antigravity session after installation
-- **"Connection failed"** — Verify your key is set: `echo $MEM0_API_KEY`
-- **MCP 401 Unauthorized** — If `${MEM0_API_KEY}` interpolation doesn't work in your `agy` version, replace with your literal key in `mcp_config.json`
+- **No tools appearing**: Restart your Antigravity session after installation
+- **"Connection failed"**: Verify your key is set: `echo $MEM0_API_KEY`
+- **MCP 401 Unauthorized**: If `${MEM0_API_KEY}` interpolation doesn't work in your `agy` version, replace with your literal key in `mcp_config.json`
 
 <CardGroup cols={2}>
   <Card title="Mem0 MCP Setup" icon="puzzle-piece" href="/platform/mem0-mcp">

--- a/docs/integrations/camel-ai.mdx
+++ b/docs/integrations/camel-ai.mdx
@@ -124,9 +124,9 @@ print(response.msgs[0].content)
 
 ## Troubleshooting
 
-- **Missing MEM0_API_KEY** — set `export MEM0_API_KEY="sk-..."` or pass `api_key` into `Mem0Storage`.
-- **No memories returned** — ensure `agent_id`/`user_id` in your query match what you used when writing.
-- **Network errors to Mem0** — if self-hosting, set `MEM0_BASE_URL` to your deployment URL.
+- **Missing MEM0_API_KEY**: set `export MEM0_API_KEY="sk-..."` or pass `api_key` into `Mem0Storage`.
+- **No memories returned**: ensure `agent_id`/`user_id` in your query match what you used when writing.
+- **Network errors to Mem0**: if self-hosting, set `MEM0_BASE_URL` to your deployment URL.
 
 <CardGroup cols={2}>
   <Card

--- a/docs/integrations/chatdev.mdx
+++ b/docs/integrations/chatdev.mdx
@@ -1,9 +1,9 @@
 ---
 title: ChatDev
-description: "Add persistent, cloud-managed memory to ChatDev multi-agent workflows with Mem0 — no code required, just YAML configuration."
+description: "Add persistent, cloud-managed memory to ChatDev multi-agent workflows with Mem0: no code required, just YAML configuration."
 ---
 
-Build multi-agent workflows in [ChatDev](https://github.com/OpenBMB/ChatDev) with persistent memory powered by Mem0. ChatDev is a zero-code multi-agent platform where agents, tools, and workflows are defined entirely in YAML. Mem0 integrates as a built-in memory store (`type: mem0`), giving your agents cloud-managed semantic search and cross-session persistence — all without writing any code.
+Build multi-agent workflows in [ChatDev](https://github.com/OpenBMB/ChatDev) with persistent memory powered by Mem0. ChatDev is a zero-code multi-agent platform where agents, tools, and workflows are defined entirely in YAML. Mem0 integrates as a built-in memory store (`type: mem0`), giving your agents cloud-managed semantic search and cross-session persistence, all without writing any code.
 
 ## Overview
 
@@ -16,8 +16,8 @@ In this guide, you'll:
 ## Prerequisites
 
 - **Python 3.12+**
-- **[uv](https://docs.astral.sh/uv/)** — Python package manager
-- **Node.js 18+** and **npm** — only needed if using the web console
+- **[uv](https://docs.astral.sh/uv/)**: Python package manager
+- **Node.js 18+** and **npm**: only needed if using the web console
 - A **Mem0 API key** from <a href="https://app.mem0.ai?utm_source=oss&utm_medium=integration-chatdev" rel="nofollow">app.mem0.ai</a>
 - An **OpenAI API key** (or another LLM provider supported by ChatDev)
 
@@ -61,7 +61,7 @@ memory:
       agent_id: my-agent         # optional: scope memories to an agent
 ```
 
-Mem0 handles all storage, embeddings, and search server-side — no local vector databases or embedding models are needed.
+Mem0 handles all storage, embeddings, and search server-side. No local vector databases or embedding models are needed.
 
 ## Attach Memory to an Agent
 
@@ -85,11 +85,11 @@ nodes:
           write: true
 ```
 
-- **`read: true`** — Agent retrieves relevant memories before generating a response
-- **`write: true`** — Agent stores new memories from user input after each interaction
-- **`top_k`** — Number of memories to retrieve per query
-- **`similarity_threshold`** — Minimum relevance score for retrieved memories. Set to `-1.0` to return all results regardless of score
-- **`retrieve_stage`** — When to retrieve memories. Options: `pre_gen_thinking` (before generation), `gen` (during generation), `post_gen_thinking` (after generation), `finished` (after completion)
+- **`read: true`**: Agent retrieves relevant memories before generating a response
+- **`write: true`**: Agent stores new memories from user input after each interaction
+- **`top_k`**: Number of memories to retrieve per query
+- **`similarity_threshold`**: Minimum relevance score for retrieved memories. Set to `-1.0` to return all results regardless of score
+- **`retrieve_stage`**: When to retrieve memories. Options: `pre_gen_thinking` (before generation), `gen` (during generation), `post_gen_thinking` (after generation), `finished` (after completion)
 
 ## Full Example Workflow
 
@@ -154,7 +154,7 @@ To use the web console, open `http://localhost:5173`, create a new workflow, and
 
 When an agent with Mem0 memory receives input, the following cycle runs automatically:
 
-**1. Retrieve** — Before generating a response, ChatDev queries Mem0 with the user's input using semantic search. Relevant memories are injected into the agent's context in this format:
+**1. Retrieve**: Before generating a response, ChatDev queries Mem0 with the user's input using semantic search. Relevant memories are injected into the agent's context in this format:
 
 ```
 ===== Related Memories =====
@@ -164,11 +164,11 @@ When an agent with Mem0 memory receives input, the following cycle runs automati
 ===== End of Memory =====
 ```
 
-This is why the role prompt in the example references `===== Related Memories =====` — the agent needs to know how to use this injected context.
+This is why the role prompt in the example references `===== Related Memories =====`: the agent needs to know how to use this injected context.
 
-**2. Generate** — The agent produces a response using the retrieved memories as additional context.
+**2. Generate**: The agent produces a response using the retrieved memories as additional context.
 
-**3. Store** — After generation, the user's input is sent to Mem0 via `client.add()`. Mem0's extraction model automatically identifies and stores facts, preferences, and key information. Only user input is stored — agent output is excluded to keep memories clean.
+**3. Store**: After generation, the user's input is sent to Mem0 via `client.add()`. Mem0's extraction model automatically identifies and stores facts, preferences, and key information. Only user input is stored. Agent output is excluded to keep memories clean.
 
 Memories persist in Mem0's cloud across all sessions. The next time the same `user_id` or `agent_id` is used, previous memories are automatically retrieved.
 
@@ -211,23 +211,23 @@ This means retrieval returns memories from **both** the user's scope and the age
 ## Tips and Common Pitfalls
 
 <Info>
-**Indexing delay** — Freshly stored memories may take a few seconds to become searchable. If a memory isn't retrieved immediately after being stored, wait a moment and try again.
+**Indexing delay**: Freshly stored memories may take a few seconds to become searchable. If a memory isn't retrieved immediately after being stored, wait a moment and try again.
 </Info>
 
-- **No memories returned on first run** — This is expected. Memories are stored *after* the agent responds, so the first interaction has no prior context. Memories appear starting from the second interaction onward.
-- **`mem0ai` not installed** — If you see `ImportError: mem0ai is required for Mem0Memory`, run `uv add mem0ai` or `pip install mem0ai` to add the dependency.
-- **Invalid API key** — A wrong or expired `MEM0_API_KEY` will log errors like `Mem0 search failed` or `Mem0 add failed` but won't crash the agent. Check your key at <a href="https://app.mem0.ai?utm_source=oss&utm_medium=integration-chatdev" rel="nofollow">app.mem0.ai</a>.
-- **Pipeline headers in memories** — ChatDev automatically strips internal pipeline headers (e.g., `=== INPUT FROM TASK (user) ===`) before sending text to Mem0, so your memories stay clean.
-- **Clearing test memories** — To delete memories created during testing, use the Mem0 dashboard at <a href="https://app.mem0.ai?utm_source=oss&utm_medium=integration-chatdev" rel="nofollow">app.mem0.ai</a> or the Python SDK: `MemoryClient().delete_all(user_id="your-test-user")`.
+- **No memories returned on first run**: This is expected. Memories are stored *after* the agent responds, so the first interaction has no prior context. Memories appear starting from the second interaction onward.
+- **`mem0ai` not installed**: If you see `ImportError: mem0ai is required for Mem0Memory`, run `uv add mem0ai` or `pip install mem0ai` to add the dependency.
+- **Invalid API key**: A wrong or expired `MEM0_API_KEY` will log errors like `Mem0 search failed` or `Mem0 add failed` but won't crash the agent. Check your key at <a href="https://app.mem0.ai?utm_source=oss&utm_medium=integration-chatdev" rel="nofollow">app.mem0.ai</a>.
+- **Pipeline headers in memories**: ChatDev automatically strips internal pipeline headers (e.g., `=== INPUT FROM TASK (user) ===`) before sending text to Mem0, so your memories stay clean.
+- **Clearing test memories**: To delete memories created during testing, use the Mem0 dashboard at <a href="https://app.mem0.ai?utm_source=oss&utm_medium=integration-chatdev" rel="nofollow">app.mem0.ai</a> or the Python SDK: `MemoryClient().delete_all(user_id="your-test-user")`.
 
 ## Key Features
 
-1. **Zero-Code Integration** — Configure Mem0 entirely through YAML, no Python code required
-2. **Cloud-Managed Storage** — Mem0 handles embeddings, persistence, and search server-side
-3. **Semantic Search** — Retrieve contextually relevant memories, not just keyword matches
-4. **Cross-Session Persistence** — Memories survive across runs, sessions, and restarts
-5. **Multi-Agent Memory Sharing** — Multiple agents can share memories through common `user_id` or `agent_id` scopes
-6. **Intelligent Input Processing** — Only user input is stored; agent output is excluded to prevent noisy memories
+1. **Zero-Code Integration**: Configure Mem0 entirely through YAML, no Python code required
+2. **Cloud-Managed Storage**: Mem0 handles embeddings, persistence, and search server-side
+3. **Semantic Search**: Retrieve contextually relevant memories, not just keyword matches
+4. **Cross-Session Persistence**: Memories survive across runs, sessions, and restarts
+5. **Multi-Agent Memory Sharing**: Multiple agents can share memories through common `user_id` or `agent_id` scopes
+6. **Intelligent Input Processing**: Only user input is stored; agent output is excluded to prevent noisy memories
 
 ## Conclusion
 

--- a/docs/integrations/claude-code.mdx
+++ b/docs/integrations/claude-code.mdx
@@ -1,9 +1,9 @@
 ---
 title: Claude Code
-description: "Add persistent memory to Claude Code and Claude Cowork with the Mem0 plugin — MCP server, lifecycle hooks, and SDK skill."
+description: "Add persistent memory to Claude Code and Claude Cowork with the Mem0 plugin: MCP server, lifecycle hooks, and SDK skill."
 ---
 
-Add persistent memory to [**Claude Code**](https://docs.anthropic.com/en/docs/claude-code) (CLI) and **Claude Cowork** (desktop app) with the Mem0 plugin. Your agent forgets everything between sessions — this plugin fixes that by connecting to Mem0's cloud memory layer via MCP, automatically capturing learnings at key lifecycle points, and retrieving relevant context before every response.
+Add persistent memory to [**Claude Code**](https://docs.anthropic.com/en/docs/claude-code) (CLI) and **Claude Cowork** (desktop app) with the Mem0 plugin. Your agent forgets everything between sessions. This plugin fixes that by connecting to Mem0's cloud memory layer via MCP, automatically capturing learnings at key lifecycle points, and retrieving relevant context before every response.
 
 ## Prerequisites
 
@@ -38,7 +38,7 @@ echo $MEM0_API_KEY
 
 ## Installation
 
-### Option A — Plugin Marketplace (Recommended)
+### Option A: Plugin Marketplace (Recommended)
 
 Install the full plugin including MCP server, lifecycle hooks, and SDK skill.
 
@@ -56,7 +56,7 @@ Install the full plugin including MCP server, lifecycle hooks, and SDK skill.
 
 **Claude Cowork desktop app:** Open the Cowork tab, click **Customize** in the sidebar, click **Browse plugins**, and install Mem0.
 
-### Option B — MCP Only
+### Option B: MCP Only
 
 Add the Mem0 MCP server directly with a single command:
 
@@ -70,7 +70,7 @@ npx mcp-add \
 
 This gives you the MCP tools but not the lifecycle hooks or SDK skill.
 
-### Option C — Manual MCP Configuration
+### Option C: Manual MCP Configuration
 
 Add to your Claude Code MCP config (`.mcp.json`):
 
@@ -106,7 +106,7 @@ This runs the setup wizard which:
 3. Installs coding-optimized memory categories
 4. Shows your identity (user ID, project scope, branch)
 
-The onboarding is idempotent — safe to re-run anytime. It auto-triggers on first session in a new project, but you can always invoke it manually.
+The onboarding is idempotent and safe to re-run anytime. It auto-triggers on first session in a new project, but you can always invoke it manually.
 
 ## What's Included
 
@@ -168,10 +168,10 @@ You: Add refresh token rotation to the auth system.
 
 ## Troubleshooting
 
-- **"Connection failed"** — Verify `MEM0_API_KEY` is set in your shell: `echo $MEM0_API_KEY`. If empty, add it to your shell profile (see Prerequisites)
-- **No tools appearing** — Restart your Claude Code session after installation
-- **Memories not being captured** — Ensure you installed via the plugin marketplace (Option A) for lifecycle hooks. MCP-only installs require manual memory operations
-- **"Mem0 Inactive" banner every session** — Your API key isn't persisting. Add `export MEM0_API_KEY="m0-..."` to your `~/.zshrc` (or `~/.bashrc`) and run `source ~/.zshrc`
+- **"Connection failed"**: Verify `MEM0_API_KEY` is set in your shell: `echo $MEM0_API_KEY`. If empty, add it to your shell profile (see Prerequisites)
+- **No tools appearing**: Restart your Claude Code session after installation
+- **Memories not being captured**: Ensure you installed via the plugin marketplace (Option A) for lifecycle hooks. MCP-only installs require manual memory operations
+- **"Mem0 Inactive" banner every session**: Your API key isn't persisting. Add `export MEM0_API_KEY="m0-..."` to your `~/.zshrc` (or `~/.bashrc`) and run `source ~/.zshrc`
 
 <CardGroup cols={2}>
   <Card title="Mem0 MCP Setup" icon="puzzle-piece" href="/platform/mem0-mcp">

--- a/docs/integrations/codex.mdx
+++ b/docs/integrations/codex.mdx
@@ -1,9 +1,9 @@
 ---
 title: Codex
-description: "Add persistent memory to OpenAI Codex with the Mem0 plugin — MCP server, lifecycle hooks, and SDK skill."
+description: "Add persistent memory to OpenAI Codex with the Mem0 plugin: MCP server, lifecycle hooks, and SDK skill."
 ---
 
-Add persistent memory to [**OpenAI Codex**](https://openai.com/index/codex/) with the Mem0 plugin. Codex forgets everything between tasks — this plugin fixes that by connecting to Mem0's cloud memory layer via MCP, automatically capturing learnings at key lifecycle points, and retrieving relevant context before every response.
+Add persistent memory to [**OpenAI Codex**](https://openai.com/index/codex/) with the Mem0 plugin. Codex forgets everything between tasks. This plugin fixes that by connecting to Mem0's cloud memory layer via MCP, automatically capturing learnings at key lifecycle points, and retrieving relevant context before every response.
 
 ## Prerequisites
 
@@ -31,7 +31,7 @@ source ~/.bashrc
 
 ## Installation
 
-### Option A — Plugin Marketplace (Recommended)
+### Option A: Plugin Marketplace (Recommended)
 
 Install the full plugin including MCP server, lifecycle hooks, and SDK skill.
 
@@ -50,16 +50,16 @@ Install the full plugin including MCP server, lifecycle hooks, and SDK skill.
    Or, in the app: restart Codex, open the Plugin Directory, browse the **Mem0 Plugins** marketplace, and install **Mem0**.
 
 <Note>
-  Step 1 is required for the app UI. Mem0 isn't in OpenAI's curated directory yet, so **without `codex plugin marketplace add`, Mem0 won't appear in the Codex app's Plugin Directory** — searching for it returns nothing. Adding the marketplace surfaces it (under **Created by you**) and makes it installable.
+  Step 1 is required for the app UI. Mem0 isn't in OpenAI's curated directory yet, so **without `codex plugin marketplace add`, Mem0 won't appear in the Codex app's Plugin Directory**: searching for it returns nothing. Adding the marketplace surfaces it (under **Created by you**) and makes it installable.
 </Note>
 
 <Info>
   Do not combine with Option B. The plugin manifest auto-registers the `mem0` MCP server, so adding both will create a duplicate registration.
 </Info>
 
-### Option B — Direct MCP
+### Option B: Direct MCP
 
-The fastest way to connect Codex to Mem0 — no plugin, no marketplace. Add the MCP server with a single command:
+The fastest way to connect Codex to Mem0 needs no plugin or marketplace. Add the MCP server with a single command:
 
 ```bash
 codex mcp add mem0 --url https://mcp.mem0.ai/mcp/ --bearer-token-env-var MEM0_API_KEY
@@ -149,10 +149,10 @@ You: Add WebSocket support for real-time notification delivery.
 
 ## Troubleshooting
 
-- **"Connection failed"** — Verify `MEM0_API_KEY` is set: `echo $MEM0_API_KEY`
-- **No tools appearing** — Restart your Codex session after installation
-- **Duplicate `mem0` MCP / "tool collision" errors** — You combined Option A with Option B. Remove the `[mcp_servers.mem0]` block from `~/.codex/config.toml`; the plugin registers it automatically
-- **Hooks not firing** — Ensure the plugin is installed via the marketplace (Option A). MCP-only installs do not include hooks
+- **"Connection failed"**: Verify `MEM0_API_KEY` is set: `echo $MEM0_API_KEY`
+- **No tools appearing**: Restart your Codex session after installation
+- **Duplicate `mem0` MCP / "tool collision" errors**: You combined Option A with Option B. Remove the `[mcp_servers.mem0]` block from `~/.codex/config.toml`; the plugin registers it automatically
+- **Hooks not firing**: Ensure the plugin is installed via the marketplace (Option A). MCP-only installs do not include hooks
 
 <CardGroup cols={2}>
   <Card title="Mem0 MCP Setup" icon="puzzle-piece" href="/platform/mem0-mcp">

--- a/docs/integrations/cursor.mdx
+++ b/docs/integrations/cursor.mdx
@@ -1,9 +1,9 @@
 ---
 title: Cursor
-description: "Add persistent memory to Cursor with the Mem0 plugin — MCP server, lifecycle hooks, and SDK skill for context-aware coding."
+description: "Add persistent memory to Cursor with the Mem0 plugin: MCP server, lifecycle hooks, and SDK skill for context-aware coding."
 ---
 
-Add persistent memory to [**Cursor**](https://cursor.com) with the Mem0 plugin. Your AI assistant forgets everything between sessions — this plugin fixes that by connecting to Mem0's cloud memory layer via MCP, automatically capturing learnings at key lifecycle points, and retrieving relevant context before every response.
+Add persistent memory to [**Cursor**](https://cursor.com) with the Mem0 plugin. Your AI assistant forgets everything between sessions. This plugin fixes that by connecting to Mem0's cloud memory layer via MCP, automatically capturing learnings at key lifecycle points, and retrieving relevant context before every response.
 
 ## Prerequisites
 
@@ -35,13 +35,13 @@ source ~/.bashrc
 
 ## Installation
 
-### Option A — One-Click Deeplink (MCP Only)
+### Option A: One-Click Deeplink (MCP Only)
 
 The fastest way to get started. Click the link below to install the Mem0 MCP server directly in Cursor:
 
 [Install Mem0 MCP in Cursor](cursor://anysphere.cursor-deeplink/mcp/install?name=mem0&config=eyJtY3BTZXJ2ZXJzIjp7Im1lbTAiOnsidXJsIjoiaHR0cHM6Ly9tY3AubWVtMC5haS9tY3AvIiwiaGVhZGVycyI6eyJBdXRob3JpemF0aW9uIjoiVG9rZW4gJHtlbnY6TUVNMF9BUElfS0VZfSJ9fX19)
 
-### Option B — npx (MCP Only)
+### Option B: npx (MCP Only)
 
 ```bash
 npx mcp-add \
@@ -51,7 +51,7 @@ npx mcp-add \
   --clients "cursor"
 ```
 
-### Option C — Manual Configuration (MCP Only)
+### Option C: Manual Configuration (MCP Only)
 
 Add the following to your `.cursor/mcp.json`:
 
@@ -68,7 +68,7 @@ Add the following to your `.cursor/mcp.json`:
 }
 ```
 
-### Option D — Cursor Marketplace (Full Plugin)
+### Option D: Cursor Marketplace (Full Plugin)
 
 Install from the [Cursor Marketplace](https://cursor.com/marketplace) for the complete experience including lifecycle hooks, the Mem0 SDK skill, and automatic memory capture.
 
@@ -121,7 +121,7 @@ You: The API endpoint /users is taking 3 seconds. Help me optimize it.
 
 # Cursor agent searches memories, proceeds with investigation.
 # After completing the task, Mem0 stores:
-#   - Learning: "N+1 query in UserService.getAll() — fixed with eager loading"
+#   - Learning: "N+1 query in UserService.getAll(): fixed with eager loading"
 #   - Decision: "Added database index on users.email column"
 #   - Preference: "User prefers query-level fixes over caching"
 
@@ -134,10 +134,10 @@ You: The /orders endpoint is also slow, same pattern as before.
 
 ## Troubleshooting
 
-- **"Connection failed"** — Verify `MEM0_API_KEY` is set: `echo $MEM0_API_KEY`
-- **Duplicate tools** — If you had a previous MCP config for `mem0`, remove it before installing the plugin
-- **No tools appearing** — Go to Cursor Settings > MCP and verify the `mem0` server shows as connected
-- **Hooks not running** — Hooks require the Marketplace install (Option D). Deeplink/manual installs only provide MCP tools.
+- **"Connection failed"**: Verify `MEM0_API_KEY` is set: `echo $MEM0_API_KEY`
+- **Duplicate tools**: If you had a previous MCP config for `mem0`, remove it before installing the plugin
+- **No tools appearing**: Go to Cursor Settings > MCP and verify the `mem0` server shows as connected
+- **Hooks not running**: Hooks require the Marketplace install (Option D). Deeplink/manual installs only provide MCP tools.
 
 <CardGroup cols={2}>
   <Card title="Mem0 MCP Setup" icon="puzzle-piece" href="/platform/mem0-mcp">

--- a/docs/integrations/dify.mdx
+++ b/docs/integrations/dify.mdx
@@ -21,7 +21,7 @@ Mem0 brings a robust memory layer to Dify AI, empowering your AI agents with per
    Within your project, add the Mem0 plugin. This integration connects Mem0’s memory management capabilities directly to your Dify application.
 
 4. **Configure Your Mem0 Settings:**  
-   Customize Mem0 to suit your needs—set preferences for how conversation history is stored, the search parameters, and any other context-aware features.
+   Customize Mem0 to suit your needs: set preferences for how conversation history is stored, the search parameters, and any other context-aware features.
 
 5. **Leverage Mem0 in Your Workflow:**  
    Use Mem0 to store every conversation turn and retrieve past interactions seamlessly. This integration ensures that your AI agents can refer back to important context, making multi-turn dialogues more effective and user-centric.

--- a/docs/integrations/google-ai-adk.mdx
+++ b/docs/integrations/google-ai-adk.mdx
@@ -215,7 +215,7 @@ if __name__ == "__main__":
 
 ## Multi-Agent Hierarchy with Shared Memory
 
-Because `memory_service` is passed to the `Runner`, every agent in the hierarchy shares the same memory automatically. Only the root coordinator needs the auto-save callback — ADK fires it once when the full turn completes:
+Because `memory_service` is passed to the `Runner`, every agent in the hierarchy shares the same memory automatically. Only the root coordinator needs the auto-save callback: ADK fires it once when the full turn completes:
 
 ```python
 import asyncio
@@ -295,11 +295,11 @@ if __name__ == "__main__":
 
 ## Key Features
 
-1. **Automatic Memory Injection**: ADK's built-in `load_memory` tool searches Mem0 at the start of each turn and injects relevant memories directly into the agent context — no prompt instructions needed.
+1. **Automatic Memory Injection**: ADK's built-in `load_memory` tool searches Mem0 at the start of each turn and injects relevant memories directly into the agent context. No prompt instructions are needed.
 2. **Automatic Session Saving**: The `save_session_to_memory` callback persists every completed turn to Mem0 without any manual calls.
-3. **Native ADK Integration**: `Mem0MemoryService` implements ADK's `BaseMemoryService` and integrates via the `Runner` — works natively across the entire agent hierarchy.
+3. **Native ADK Integration**: `Mem0MemoryService` implements ADK's `BaseMemoryService` and integrates via the `Runner`. It works natively across the entire agent hierarchy.
 4. **User Scoping**: `user_id` is passed automatically from the ADK session context, ensuring memories are always scoped to the correct user.
-5. **Multi-Agent Support**: A single `Mem0MemoryService` instance shared through the `Runner` gives all agents — coordinators and specialists — access to the same user memory.
+5. **Multi-Agent Support**: A single `Mem0MemoryService` instance shared through the `Runner` gives all agents, coordinators and specialists, access to the same user memory.
 
 ## Configuration Options
 

--- a/docs/integrations/openclaw.mdx
+++ b/docs/integrations/openclaw.mdx
@@ -3,7 +3,7 @@ title: OpenClaw
 description: "Add long-term memory to OpenClaw agents using the Mem0 plugin with skills-based memory extraction and recall."
 ---
 
-Add long-term memory to [OpenClaw](https://github.com/openclaw/openclaw) agents with the `@mem0/openclaw-mem0` plugin. Your agent forgets everything between sessions — this plugin fixes that by automatically watching conversations, extracting what matters, and bringing it back when relevant.
+Add long-term memory to [OpenClaw](https://github.com/openclaw/openclaw) agents with the `@mem0/openclaw-mem0` plugin. Your agent forgets everything between sessions. This plugin fixes that by automatically watching conversations, extracting what matters, and bringing it back when relevant.
 
 ## Overview
 
@@ -12,10 +12,10 @@ Add long-term memory to [OpenClaw](https://github.com/openclaw/openclaw) agents 
 </Frame>
 
 The plugin provides:
-1. **Triage** — The agent extracts durable facts from conversations using a structured protocol with importance gates and domain overlays
-2. **Recall** — Before each turn, relevant memories are retrieved with reranking and injected into context
-3. **Dream** — Periodic memory consolidation: merges duplicates, resolves conflicts, prunes stale entries
-4. **Agent Tools** — Eight tools for explicit memory operations during conversations
+1. **Triage**: The agent extracts durable facts from conversations using a structured protocol with importance gates and domain overlays
+2. **Recall**: Before each turn, relevant memories are retrieved with reranking and injected into context
+3. **Dream**: Periodic memory consolidation merges duplicates, resolves conflicts, prunes stale entries
+4. **Agent Tools**: Eight tools for explicit memory operations during conversations
 
 Skills mode, `autoRecall`, and `autoCapture` are all enabled by default during `openclaw mem0 init`.
 
@@ -50,7 +50,7 @@ If you prefer the OpenClaw CLI, or are setting up self-hosted / open-source mode
 
 ### Understanding `userId`
 
-The `userId` field is a **string you choose** to uniquely identify the user whose memories are being stored. It is **not** something you look up in the Mem0 dashboard — you define it yourself.
+The `userId` field is a **string you choose** to uniquely identify the user whose memories are being stored. It is **not** something you look up in the Mem0 dashboard: you define it yourself.
 
 Pick any stable, unique identifier for the user. Common choices:
 
@@ -58,7 +58,7 @@ Pick any stable, unique identifier for the user. Common choices:
 - A UUID (e.g. `"550e8400-e29b-41d4-a716-446655440000"`)
 - A simple username (e.g. `"alice"`)
 
-All memories are scoped to this `userId` — different values create separate memory namespaces. If you don't set it, it defaults to your OS username.
+All memories are scoped to this `userId`: different values create separate memory namespaces. If you don't set it, it defaults to your OS username.
 
 <Tip>In a multi-user application, set `userId` dynamically per user (e.g. from your auth system) rather than hardcoding a single value.</Tip>
 
@@ -66,8 +66,8 @@ All memories are scoped to this `userId` — different values create separate me
 
 There are two ways to set up `@mem0/openclaw-mem0` on the Mem0 platform:
 
-- **Chat setup (recommended)** — run the setup inside any OpenClaw chat. No config editing, no API key handling.
-- **Manual config** — edit `openclaw.json` directly.
+- **Chat setup (recommended)**: run the setup inside any OpenClaw chat. No config editing, no API key handling.
+- **Manual config**: edit `openclaw.json` directly.
 
 #### Option 1: Chat Setup (Recommended)
 
@@ -75,7 +75,7 @@ You no longer need manual config editing to get started. Everything happens insi
 
 <Steps>
   <Step title="Send the setup command to your OpenClaw agent">
-    Open any OpenClaw channel — Telegram, WhatsApp, your default chat, wherever your agent lives. Paste and send this command:
+    Open any OpenClaw channel: Telegram, WhatsApp, your default chat, wherever your agent lives. Paste and send this command:
 
     ```
     Setup Mem0 from mem0.ai/claw-setup
@@ -103,7 +103,7 @@ You no longer need manual config editing to get started. Everything happens insi
 
 That's it. No API key, no config file editing, no environment variables. The plugin is now active with skills-based memory (triage, recall, and dream) running automatically.
 
-<Note>The chat flow uses the same underlying config as manual setup — it writes `apiKey`, `userId`, and `skills` config into `openclaw.json` for you. You can still open the file to inspect or override values afterward.</Note>
+<Note>The chat flow uses the same underlying config as manual setup: it writes `apiKey`, `userId`, and `skills` config into `openclaw.json` for you. You can still open the file to inspect or override values afterward.</Note>
 
 #### Option 2: Manual Config
 
@@ -155,12 +155,12 @@ That's it. No API key, no config file editing, no environment variables. The plu
 </Steps>
 
 <Warning>
-OpenClaw treats memory plugins as an exclusive slot. Installing the plugin alone does **not** activate it — you must also set `plugins.slots.memory` as shown above.
+OpenClaw treats memory plugins as an exclusive slot. Installing the plugin alone does **not** activate it: you must also set `plugins.slots.memory` as shown above.
 </Warning>
 
 ### Open-Source Mode (Self-hosted)
 
-No Mem0 key needed. Defaults use OpenAI (`gpt-5-mini` for LLM, `text-embedding-3-small` for embeddings) — requires `OPENAI_API_KEY`. For a fully local setup, use Ollama for both.
+No Mem0 key is needed. Defaults use OpenAI (`gpt-5-mini` for LLM, `text-embedding-3-small` for embeddings), so `OPENAI_API_KEY` is required. For a fully local setup, use Ollama for both.
 
 #### Option 1: Interactive Wizard (Recommended)
 
@@ -189,7 +189,7 @@ The wizard walks you through:
 
 #### Option 2: Non-Interactive Setup
 
-For CI/CD, scripts, or agent-driven setup — pass all options as flags:
+For CI/CD, scripts, or agent-driven setup: pass all options as flags:
 
 ```bash
 # Fully local with Ollama + Qdrant
@@ -234,7 +234,7 @@ Add `--json` for machine-readable output (useful when an LLM agent is driving th
 
 #### Option 3: Manual Config
 
-Minimal config — uses OpenAI defaults:
+Minimal config: uses OpenAI defaults:
 
 ```json5
 {
@@ -287,11 +287,11 @@ All `oss` fields are optional. See [Mem0 OSS docs](/open-source/node-quickstart)
 
 Memories are organized into two scopes:
 
-- **Session (short-term)** — Auto-capture stores memories scoped to the current session via Mem0's `run_id` / `runId` parameter. These are contextual to the ongoing conversation.
+- **Session (short-term)**: Auto-capture stores memories scoped to the current session via Mem0's `run_id` / `runId` parameter. These are contextual to the ongoing conversation.
 
-- **User (long-term)** — The agent can explicitly store long-term memories using the `memory_add` tool (with `longTerm: true`, the default). These persist across all sessions for the user.
+- **User (long-term)**: The agent can explicitly store long-term memories using the `memory_add` tool (with `longTerm: true`, the default). These persist across all sessions for the user.
 
-During **auto-recall**, the plugin searches both scopes and presents them separately — long-term memories first, then session memories — so the agent has full context.
+During **auto-recall**, the plugin searches both scopes and presents them separately, with long-term memories first and session memories second. This means the agent has full context.
 
 ## Agent Tools
 
@@ -312,7 +312,7 @@ The `memory_search` and `memory_list` tools accept a `scope` parameter (`"sessio
 
 ## CLI Commands
 
-All commands support `--json` for machine-readable output — useful when an LLM agent drives the CLI programmatically. Run `openclaw mem0 help --json` to discover every command and flag.
+All commands support `--json` for machine-readable output. Use it when an LLM agent drives the CLI programmatically. Run `openclaw mem0 help --json` to discover every command and flag.
 
 ```bash
 # Search all memories (long-term + session)
@@ -350,8 +350,8 @@ openclaw mem0 status --json
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `apiKey` | `string` | — | **Required.** Mem0 API key (supports `${MEM0_API_KEY}`) |
-| `customInstructions` | `string` | *(built-in)* | Extraction rules — what to store, how to format |
+| `apiKey` | `string` | N/A | **Required.** Mem0 API key (supports `${MEM0_API_KEY}`) |
+| `customInstructions` | `string` | *(built-in)* | Extraction rules: what to store, how to format |
 | `customCategories` | `object` | *(12 defaults)* | Category name → description map for tagging |
 
 ### Open-Source Mode Options
@@ -360,15 +360,15 @@ openclaw mem0 status --json
 |-----|------|---------|-------------|
 | `customInstructions` | `string` | *(built-in)* | Extraction prompt for memory processing |
 | `oss.embedder.provider` | `string` | `"openai"` | Embedding provider (`"openai"`, `"ollama"`, etc.) |
-| `oss.embedder.config` | `object` | — | Provider config: `apiKey`, `model`, `baseURL` |
+| `oss.embedder.config` | `object` | N/A | Provider config: `apiKey`, `model`, `baseURL` |
 | `oss.vectorStore.provider` | `string` | `"memory"` | Vector store (`"memory"`, `"qdrant"`, `"chroma"`, etc.) |
-| `oss.vectorStore.config` | `object` | — | Provider config: `host`, `port`, `collectionName`, `dimension` |
+| `oss.vectorStore.config` | `object` | N/A | Provider config: `host`, `port`, `collectionName`, `dimension` |
 | `oss.llm.provider` | `string` | `"openai"` | LLM provider (`"openai"`, `"anthropic"`, `"ollama"`, etc.) |
-| `oss.llm.config` | `object` | — | Provider config: `apiKey`, `model`, `baseURL`, `temperature` |
-| `oss.historyDbPath` | `string` | — | SQLite path for memory edit history |
+| `oss.llm.config` | `object` | N/A | Provider config: `apiKey`, `model`, `baseURL`, `temperature` |
+| `oss.historyDbPath` | `string` | N/A | SQLite path for memory edit history |
 | `oss.disableHistory` | `boolean` | `false` | Disable memory edit history tracking |
 
-Everything inside `oss` is optional — defaults use OpenAI embeddings (`text-embedding-3-small`), in-memory vector store, and OpenAI LLM (`gpt-5-mini`).
+Everything inside `oss` is optional: defaults use OpenAI embeddings (`text-embedding-3-small`), in-memory vector store, and OpenAI LLM (`gpt-5-mini`).
 
 ## Plugin Management
 
@@ -466,11 +466,11 @@ The agent can always use memory tools (`memory_add`, `memory_search`, etc.) expl
 
 The plugin never stores API keys, tokens, or secrets as memories. Five independent layers enforce this:
 
-1. **Triage gate** — The extraction prompt rejects values matching known credential patterns (`sk-`, `m0-`, `ghp_`, `AKIA`, `Bearer`, `password=`, `token=`, `secret=`)
-2. **Dream cleanup** — Periodic memory consolidation deletes any memories that slipped through containing credential patterns
-3. **Extraction instructions** — Default extraction rules explicitly instruct the model to store only that a credential was configured, never the value
-4. **Configurable patterns** — Add custom credential patterns via `skills.triage.credentialPatterns`
-5. **CLI redaction** — `openclaw mem0 config show` redacts sensitive fields (`apiKey`, `oss.*.config.apiKey`)
+1. **Triage gate**: The extraction prompt rejects values matching known credential patterns (`sk-`, `m0-`, `ghp_`, `AKIA`, `Bearer`, `password=`, `token=`, `secret=`)
+2. **Dream cleanup**: Periodic memory consolidation deletes any memories that slipped through containing credential patterns
+3. **Extraction instructions**: Default extraction rules explicitly instruct the model to store only that a credential was configured, never the value
+4. **Configurable patterns**: Add custom credential patterns via `skills.triage.credentialPatterns`
+5. **CLI redaction**: `openclaw mem0 config show` redacts sensitive fields (`apiKey`, `oss.*.config.apiKey`)
 
 ### API Key Storage
 
@@ -478,7 +478,7 @@ Plugin config is stored in `~/.openclaw/openclaw.json` with file permissions `0o
 
 ### Telemetry
 
-Anonymous usage telemetry (PostHog) is enabled by default to help improve the plugin. No conversation content or memory values are included — only event counts (recall, capture, tool usage, CLI commands).
+Anonymous usage telemetry (PostHog) is enabled by default to help improve the plugin. No conversation content or memory values are included, only event counts (recall, capture, tool usage, CLI commands).
 
 To opt out, set the environment variable:
 
@@ -488,7 +488,7 @@ export MEM0_TELEMETRY=false
 
 ### System Prompt Context
 
-The plugin injects memory-related instructions into the agent's system context via OpenClaw's `prependSystemContext` mechanism. This includes the memory triage protocol and recalled memories. This is the standard OpenClaw plugin SDK pattern for memory backends — no user-facing prompts are modified.
+The plugin injects memory-related instructions into the agent's system context via OpenClaw's `prependSystemContext` mechanism. This includes the memory triage protocol and recalled memories. This is the standard OpenClaw plugin SDK pattern for memory backends. No user-facing prompts are modified.
 
 <CardGroup cols={2}>
   <Card title="OpenAI Agents SDK" icon="robot" href="/integrations/openai-agents-sdk">

--- a/docs/integrations/opencode.mdx
+++ b/docs/integrations/opencode.mdx
@@ -1,9 +1,9 @@
 ---
 title: OpenCode
-description: "Add persistent memory to OpenCode with the Mem0 plugin — native SDK-backed memory tools, lifecycle hooks, and skills."
+description: "Add persistent memory to OpenCode with the Mem0 plugin: native SDK-backed memory tools, lifecycle hooks, and skills."
 ---
 
-Add persistent memory to [**OpenCode**](https://opencode.ai) with the Mem0 plugin. Your agent forgets everything between sessions — Mem0 fixes that by storing decisions, preferences, and learnings so they carry over automatically.
+Add persistent memory to [**OpenCode**](https://opencode.ai) with the Mem0 plugin. Your agent forgets everything between sessions. Mem0 fixes that by storing decisions, preferences, and learnings so they carry over automatically.
 
 ## Prerequisites
 
@@ -24,21 +24,21 @@ echo 'export MEM0_API_KEY="m0-your-api-key"' >> ~/.bashrc && source ~/.bashrc
 
 ## Installation
 
-### Option A — Plugin Install (Recommended)
+### Option A: Plugin Install (Recommended)
 
 ```bash
 opencode plugin @mem0/opencode-plugin
 ```
 
-**Or let your agent do it** — paste this into OpenCode:
+**Or let your agent do it**: paste this into OpenCode:
 
 ```
 Install @mem0/opencode-plugin by following https://raw.githubusercontent.com/mem0ai/mem0/main/integrations/mem0-plugin/.opencode-plugin/README.md
 ```
 
-This adds the plugin to your `~/.config/opencode/opencode.json`. Restart OpenCode — you get the native memory tools, lifecycle hooks, and all `/mem0-*` slash commands. The memory tools are registered by the plugin itself via the `mem0ai` SDK — no MCP server to configure.
+This adds the plugin to your `~/.config/opencode/opencode.json`. Restart OpenCode. You get the native memory tools, lifecycle hooks, and all `/mem0-*` slash commands. The memory tools are registered by the plugin itself via the `mem0ai` SDK. No MCP server to configure.
 
-### Option B — Standalone MCP Server
+### Option B: Standalone MCP Server
 
 If you only need the memory tools without the plugin's hooks or skills, point OpenCode at Mem0's hosted MCP server directly. Add this to your `opencode.json` (project-level or global at `~/.config/opencode/opencode.json`):
 
@@ -89,7 +89,7 @@ If you only need the memory tools without the plugin's hooks or skills, point Op
 | `session` | this run only (`+ run_id`) | this run |
 | `global` | **all your projects in the workspace** (`app_id: "*"`) | user-wide |
 
-Just ask naturally — e.g. *"search my memories across all my projects"* — and the agent passes `scope: "global"`. For normal questions it stays scoped to the current project automatically.
+Ask naturally, for example, *"search my memories across all my projects"*. The agent passes `scope: "global"`. For normal questions it stays scoped to the current project automatically.
 
 To change the **default** scope (used when no scope is passed), run the `/mem0-scope` skill:
 
@@ -99,13 +99,13 @@ To change the **default** scope (used when no scope is passed), run the `/mem0-s
 /mem0-scope project    # back to repo-only (the default)
 ```
 
-The default persists in `~/.mem0/settings.json` (`default_scope`) and is read fresh on each memory operation, so a change applies immediately — no restart. `delete_all_memories` always requires an explicit `scope: "global"` to delete user-wide, so changing the default can't trigger a cross-project wipe.
+The default persists in `~/.mem0/settings.json` (`default_scope`) and is read fresh on each memory operation, so a change applies immediately. No restart. `delete_all_memories` always requires an explicit `scope: "global"` to delete user-wide, so changing the default can't trigger a cross-project wipe.
 
 The project id (`app_id`) is derived from your git remote (`owner-repo`), falling back to the git repo's root directory name, then the current directory. Launch OpenCode from inside your repo so memories scope to the project rather than your home directory.
 
 ## Lifecycle Hooks
 
-The plugin uses the [mem0ai](https://www.npmjs.com/package/mem0ai) TypeScript SDK directly — pure TypeScript, no Python, no shell scripts.
+The plugin uses the [mem0ai](https://www.npmjs.com/package/mem0ai) TypeScript SDK directly. It is pure TypeScript, no Python, no shell scripts.
 
 | OpenCode Event | Hook | What happens |
 |----------------|------|-------------|
@@ -119,11 +119,11 @@ The plugin uses the [mem0ai](https://www.npmjs.com/package/mem0ai) TypeScript SD
 
 ## Auto-dream (memory consolidation)
 
-The plugin can automatically consolidate stored memories — merging duplicates, dropping stale/sensitive entries, and rewriting vague ones — so your memory set stays clean over time. It runs at most once per session, and only when **all** gates pass:
+The plugin can automatically consolidate stored memories by merging duplicates, dropping stale/sensitive entries, and rewriting vague ones. This keeps your memory set clean over time. It runs at most once per session, and only when **all** gates pass:
 
-- **Time** — at least `minHours` (default 24) since the last consolidation
-- **Sessions** — at least `minSessions` (default 5) sessions since then
-- **Memories** — at least `minMemories` (default 20) stored for the project
+- **Time**: at least `minHours` (default 24) since the last consolidation
+- **Sessions**: at least `minSessions` (default 5) sessions since then
+- **Memories**: at least `minMemories` (default 20) stored for the project
 
 A filesystem lock (`~/.mem0/mem0-dream.lock`) keeps two sessions from consolidating at once. Tune the thresholds with a `dream` block in `~/.mem0/settings.json`, or disable entirely with `MEM0_DREAM=false`:
 
@@ -137,12 +137,12 @@ If auto-dream hasn't run yet, it's almost always because a gate hasn't been met 
 
 ## Troubleshooting
 
-- **No tools appearing** — Restart OpenCode after installing
-- **"Connection failed"** — Verify your key is set: `echo $MEM0_API_KEY`
-- **Plugin not loading** — Run `opencode plugin @mem0/opencode-plugin` again, then restart
-- **Hooks not firing** — Hooks require the plugin install (Option A). MCP-only installs don't include hooks.
-- **Auto-dream never runs** — It's gated (time + sessions + memories). Run `/mem0-status` to see which gate is blocking, or `/mem0-dream` to consolidate now.
-- **Wrong project name / memories not found** — The project id comes from your git remote; launch OpenCode from inside the repo (not your home directory). Check the resolved id with `/mem0-status`.
+- **No tools appearing**: Restart OpenCode after installing
+- **"Connection failed"**: Verify your key is set: `echo $MEM0_API_KEY`
+- **Plugin not loading**: Run `opencode plugin @mem0/opencode-plugin` again, then restart
+- **Hooks not firing**: Hooks require the plugin install (Option A). MCP-only installs don't include hooks.
+- **Auto-dream never runs**: It's gated (time + sessions + memories). Run `/mem0-status` to see which gate is blocking, or `/mem0-dream` to consolidate now.
+- **Wrong project name / memories not found**: The project id comes from your git remote; launch OpenCode from inside the repo (not your home directory). Check the resolved id with `/mem0-status`.
 
 <CardGroup cols={2}>
   <Card title="Mem0 MCP Setup" icon="puzzle-piece" href="/platform/mem0-mcp">

--- a/docs/integrations/pi-agent.mdx
+++ b/docs/integrations/pi-agent.mdx
@@ -3,17 +3,17 @@ title: Pi Agent
 description: "Add persistent memory to Pi Agent with the Mem0 plugin semantic search, auto-capture, and dream consolidation."
 ---
 
-Add persistent memory to [**Pi Agent**](https://pi.dev) with `@mem0/pi-agent-plugin`. Your agent forgets everything between sessions — this plugin fixes that by automatically capturing knowledge from conversations, storing it in Mem0's cloud memory layer, and retrieving relevant context before every response.
+Add persistent memory to [**Pi Agent**](https://pi.dev) with `@mem0/pi-agent-plugin`. Your agent forgets everything between sessions. This plugin fixes that by automatically capturing knowledge from conversations, storing it in Mem0's cloud memory layer, and retrieving relevant context before every response.
 
 ## Overview
 
 The plugin provides:
-1. **Auto-capture** — Extracts durable facts from both user and assistant messages automatically
-2. **Semantic recall** — Retrieves relevant memories via the `mem0_memory` tool before each response
-3. **Dream consolidation** — Periodic maintenance: merges duplicates, resolves contradictions, prunes stale entries
-4. **Monorepo-aware scoping** — Uses git root for project detection, consistent across subdirectories
-5. **Confirmation dialogs** — Destructive commands ask before acting via Pi's built-in UI
-6. **8 skills + 8 commands** — Essential memory management from slash commands and agent-guided workflows
+1. **Auto-capture**: Extracts durable facts from both user and assistant messages automatically
+2. **Semantic recall**: Retrieves relevant memories via the `mem0_memory` tool before each response
+3. **Dream consolidation**: Periodic maintenance: merges duplicates, resolves contradictions, prunes stale entries
+4. **Monorepo-aware scoping**: Uses git root for project detection, consistent across subdirectories
+5. **Confirmation dialogs**: Destructive commands ask before acting via Pi's built-in UI
+6. **8 skills + 8 commands**: Essential memory management from slash commands and agent-guided workflows
 
 ## Prerequisites
 
@@ -43,7 +43,7 @@ source ~/.bashrc
 pi install npm:@mem0/pi-agent-plugin
 ```
 
-That's it. The extension loads automatically on every Pi session. No config files needed — `MEM0_API_KEY` from your environment is picked up automatically.
+That's it. The extension loads automatically on every Pi session. No config files needed: `MEM0_API_KEY` from your environment is picked up automatically.
 
 <Info>
   Start a new Pi session and run `/mem0-status` to verify the connection. You should see your user ID, detected project, and memory count.
@@ -103,9 +103,9 @@ The `mem0_memory` tool is registered with Pi and callable by the agent during co
 |--------|----------------|-------------|
 | `search` | `query` | Semantic search across memories |
 | `add` | `content` | Store a new memory |
-| `get_all` | — | List all memories in scope |
+| `get_all` | N/A | List all memories in scope |
 | `delete` | `memory_id` | Delete a specific memory |
-| `delete_all` | — | Delete all memories in scope |
+| `delete_all` | N/A | Delete all memories in scope |
 
 All actions accept an optional `scope` parameter: `project` (default), `session`, or `global`.
 
@@ -119,7 +119,7 @@ Tool output is truncated to 200 lines / 50KB to prevent context overflow.
 | `/mem0-forget <query>` | Search and delete memories (with confirmation dialog) |
 | `/mem0-search <query>` | Semantic search across memories |
 | `/mem0-tour [scope]` | Browse all memories grouped by category |
-| `/mem0-dream` | Consolidate — merge duplicates, prune stale, resolve contradictions |
+| `/mem0-dream` | Consolidate: merge duplicates, prune stale, resolve contradictions |
 | `/mem0-pin <query>` | Pin a memory to protect from dream pruning (preserves memory ID) |
 | `/mem0-scope <scope>` | Change default scope for this session (project, session, global) |
 | `/mem0-status` | Connection health, identity, and memory count |
@@ -130,7 +130,7 @@ Memories are scoped using Mem0's `user_id`, `app_id`, and `run_id` parameters:
 
 | Scope | Filters | Use Case |
 |-------|---------|----------|
-| `project` | user_id + app_id (git root) | **Default.** Project-specific knowledge — decisions, architecture, config |
+| `project` | user_id + app_id (git root) | **Default.** Project-specific knowledge: decisions, architecture, config |
 | `session` | user_id + app_id + run_id | Ephemeral context for the current session only |
 | `global` | user_id only | All memories across all your projects |
 
@@ -144,11 +144,11 @@ Destructive and mutating commands use Pi's built-in `ctx.ui.confirm()` dialog be
 
 - `/mem0-forget` asks "Delete this memory?" before deleting a single match
 - `/mem0-pin` asks "Pin this memory?" before modifying it
-- Cancelling either operation is always safe — no changes are made
+- Cancelling either operation is always safe. No changes are made
 
 ### Pin
 
-`/mem0-pin` uses Mem0's `update()` API to prepend `[PINNED]` to the memory text. This preserves the original memory ID — no add+delete cycle that would lose history or change the UUID.
+`/mem0-pin` uses Mem0's `update()` API to prepend `[PINNED]` to the memory text. This preserves the original memory ID. There is no add+delete cycle that would lose history or change the UUID.
 
 ### Dream Consolidation
 
@@ -163,16 +163,16 @@ You: I prefer dark mode and concise answers.
 
 # Session 2 (days later)
 You: What do you know about my preferences?
-# Pi retrieves stored memories — no re-explaining needed
+# Pi retrieves stored memories, no re-explaining needed
 ```
 
 ## Troubleshooting
 
-- **"No API key found"** — Verify `MEM0_API_KEY` is set: `echo $MEM0_API_KEY`. If empty, add it to your shell profile (see Prerequisites)
-- **Extension not loading** — Check Pi startup output for errors. Run `pi -e ./src/entry.ts` from the plugin directory for verbose output
-- **Memories not capturing** — Verify `autoCapture` is `true` (default). Check `/mem0-status` for connection health
-- **Wrong project detected** — The plugin uses the git repository root as `app_id`. If not in a git repo, it falls back to the working directory name. Run `/mem0-status` to see the detected project
-- **Dream not triggering** — All three gates must pass (time, sessions, memories). Use `/mem0-dream` to force it manually
+- **"No API key found"**: Verify `MEM0_API_KEY` is set: `echo $MEM0_API_KEY`. If empty, add it to your shell profile (see Prerequisites)
+- **Extension not loading**: Check Pi startup output for errors. Run `pi -e ./src/entry.ts` from the plugin directory for verbose output
+- **Memories not capturing**: Verify `autoCapture` is `true` (default). Check `/mem0-status` for connection health
+- **Wrong project detected**: The plugin uses the git repository root as `app_id`. If not in a git repo, it falls back to the working directory name. Run `/mem0-status` to see the detected project
+- **Dream not triggering**: All three gates must pass (time, sessions, memories). Use `/mem0-dream` to force it manually
 
 <CardGroup cols={2}>
   <Card title="Claude Code Integration" icon="terminal" href="/integrations/claude-code">

--- a/docs/integrations/vercel-ai-sdk.mdx
+++ b/docs/integrations/vercel-ai-sdk.mdx
@@ -28,10 +28,10 @@ npm install @mem0/vercel-ai-provider ai@^6
 
 ### Dependencies
 
-`@mem0/vercel-ai-provider` bundles `ai`, all `@ai-sdk/*` provider packages, and `@ai-sdk/provider` as regular dependencies — you do **not** need to install them separately. The install command above (`npm install @mem0/vercel-ai-provider ai@^6`) is sufficient.
+`@mem0/vercel-ai-provider` bundles `ai`, all `@ai-sdk/*` provider packages, and `@ai-sdk/provider` as regular dependencies: you do **not** need to install them separately. The install command above (`npm install @mem0/vercel-ai-provider ai@^6`) is sufficient.
 
 The only true peer dependency is `zod` (optional):
-- `zod` v3+ (`^3.0.0`) — required only if you use Zod schemas in tool definitions
+- `zod` v3+ (`^3.0.0`): required only if you use Zod schemas in tool definitions
 
 ## Getting Started
 
@@ -205,7 +205,7 @@ const { text, sources } = await generateText({
 });
 
 // sources[0].title === "Mem0 Memories"
-// sources[0].providerMetadata.mem0.memories — array of memory objects
+// sources[0].providerMetadata.mem0.memories: array of memory objects
 console.log(sources);
 ```
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -177,7 +177,7 @@ mode: "custom"
           Sign up as an agent
         </h3>
         <p className="text-sm text-gray-600 dark:text-zinc-400">
-          For AI agents: mint a Mem0 API key in under five seconds — no email, no dashboard. Four commands to your first memory.
+          For AI agents: mint a Mem0 API key in under five seconds: no email, no dashboard. Four commands to your first memory.
         </p>
       </div>
     </a>

--- a/docs/migration/oss-v2-to-v3.mdx
+++ b/docs/migration/oss-v2-to-v3.mdx
@@ -17,7 +17,7 @@ The new Mem0 release redesigns both extraction and retrieval, and cleans up the 
 - **Retrieval**: Multi-signal hybrid search (semantic + BM25 keyword + entity matching)
 - **Entity linking**: Automatic entity extraction and cross-memory linking
 - **SDK cleanup**: Deprecated parameters removed, naming conventions standardized
-- **API surface aligned with Platform**: Entity IDs now follow the same convention across OSS and Platform — top-level kwargs for `add()` / `delete_all()`, inside `filters` for `search()` / `get_all()`
+- **API surface aligned with Platform**: Entity IDs now follow the same convention across OSS and Platform: top-level kwargs for `add()` / `delete_all()`, inside `filters` for `search()` / `get_all()`
 
 These changes produce a **+20 point improvement on LoCoMo** (71.4 → 91.6) and **+26 point improvement on LongMemEval** (67.8 → 93.4), while cutting extraction latency roughly in half.
 
@@ -27,13 +27,13 @@ These changes produce a **+20 point improvement on LoCoMo** (71.4 → 91.6) and 
 
 | Change | Old | New | Migration |
 |---|---|---|---|
-| `search()` / `get_all()` entity IDs | Top-level kwargs (`user_id="..."`) | Inside `filters` dict | `m.search("q", filters={"user_id": "..."})` — top-level kwargs now raise `ValueError` |
+| `search()` / `get_all()` entity IDs | Top-level kwargs (`user_id="..."`) | Inside `filters` dict | `m.search("q", filters={"user_id": "..."})`: top-level kwargs now raise `ValueError` |
 | `top_k` default | `100` | `20` | Pass `top_k=100` explicitly to restore |
 | `threshold` default | `None` (no filtering) | `0.1` (filters low-relevance) | Pass `threshold=0.0` for old behavior |
 | `threshold` validation | Any float | Must be in `[0, 1]` | Out-of-range values now raise `ValueError` |
 | `rerank` default | `True` | `False` | Pass `rerank=True` to restore |
 | Entity ID validation | Accepted any string | Trimmed; empty / whitespace-only rejected (`ValueError`) | Pass a non-empty identifier without internal spaces |
-| `messages` in `add()` | Could be `None` | Must be `str` / `dict` / `list[dict]` — other types raise `Mem0ValidationError` (code `VALIDATION_003`) | Always pass a string, dict, or list of messages |
+| `messages` in `add()` | Could be `None` | Must be `str` / `dict` / `list[dict]`: other types raise `Mem0ValidationError` (code `VALIDATION_003`) | Always pass a string, dict, or list of messages |
 | `add()` events | Returns `ADD`, `UPDATE`, `DELETE` | Returns `ADD` only | Update code expecting UPDATE/DELETE |
 | Custom extraction prompt | `custom_fact_extraction_prompt` | `custom_instructions` | Rename in config |
 | Custom update prompt | `custom_update_memory_prompt` | Deprecated | Use `custom_instructions` instead |
@@ -50,8 +50,8 @@ These changes produce a **+20 point improvement on LoCoMo** (71.4 → 91.6) and 
 | `search()` / `getAll()` entity IDs | Top-level options (`userId: "..."`) | Inside `filters` object | `m.search("q", { filters: { userId: "..." } })` |
 | `threshold` validation | Any number | Must be in `[0, 1]` | Out-of-range values now throw |
 | Entity ID validation | Any string | Trimmed; empty / whitespace-only rejected | Pass non-empty identifiers without internal spaces |
-| `messages` in `add()` | Could be `null` / `undefined` | Required — throws on null/undefined | Always pass a string or array |
-| Payload key for lemmatized text | `text_lemmatized` (snake_case) | `textLemmatized` (camelCase) | TS-only internal field. If you share a vector store collection between Python and TS SDKs, lemma-based BM25 will not resolve across languages — keep collections language-scoped. |
+| `messages` in `add()` | Could be `null` / `undefined` | Required: throws on null/undefined | Always pass a string or array |
+| Payload key for lemmatized text | `text_lemmatized` (snake_case) | `textLemmatized` (camelCase) | TS-only internal field. If you share a vector store collection between Python and TS SDKs, lemma-based BM25 will not resolve across languages: keep collections language-scoped. |
 | Custom prompt | `customPrompt` | `customInstructions` | Rename in config |
 | Graph memory | `enableGraph` + `graphStore` in config | Removed | Graph store support has been removed entirely |
 | Default graph config | Neo4j default config applied | No default graph config | Graph store config is no longer used |
@@ -62,7 +62,7 @@ These changes produce a **+20 point improvement on LoCoMo** (71.4 → 91.6) and 
 |---|---|---|---|
 | Constructor | `MemoryClient(api_key, org_id, project_id)` | `MemoryClient(api_key)` | Remove `org_id`, `project_id` from constructor |
 | Method options | `client.add(messages, **kwargs)` | `client.add(messages, options=AddMemoryOptions(...))` | Use typed option classes (or `**kwargs` still works) |
-| Removed params | `api_version`, `output_format`, `async_mode`, `filter_memories`, `keyword_search`, `force_add_only`, `batch_size`, `immutable`, `includes`, `excludes`, `enable_graph`, `org_name`, `project_name` | — | Remove from all calls |
+| Removed params | `api_version`, `output_format`, `async_mode`, `filter_memories`, `keyword_search`, `force_add_only`, `batch_size`, `immutable`, `includes`, `excludes`, `enable_graph`, `org_name`, `project_name` | N/A | Remove from all calls |
 
 ### TypeScript Client SDK
 
@@ -70,7 +70,7 @@ These changes produce a **+20 point improvement on LoCoMo** (71.4 → 91.6) and 
 |---|---|---|---|
 | Constructor | `new MemoryClient({ apiKey, organizationId, projectId })` | `new MemoryClient({ apiKey })` | Remove `organizationId`, `projectId`, `organizationName`, `projectName` |
 | All params | snake_case: `user_id`, `agent_id`, `top_k` | camelCase: `userId`, `agentId`, `topK` | Rename all params to camelCase |
-| Removed params | `api_version`, `output_format`, `async_mode`, `enable_graph`, `org_id`, `project_id`, `org_name`, `project_name`, `filter_memories`, `batch_size`, `force_add_only`, `immutable`, `includes`, `excludes`, `keyword_search` | — | Remove from all calls |
+| Removed params | `api_version`, `output_format`, `async_mode`, `enable_graph`, `org_id`, `project_id`, `org_name`, `project_name`, `filter_memories`, `batch_size`, `force_add_only`, `immutable`, `includes`, `excludes`, `keyword_search` | N/A | Remove from all calls |
 | Output format enum | `OutputFormat.V1`, `OutputFormat.V1_1` | Removed | v1.1 is now always used |
 | API version enum | `API_VERSION.V1`, `API_VERSION.V2` | Removed | Handled internally |
 
@@ -108,7 +108,7 @@ The Python `[nlp]` extra installs [spaCy](https://spacy.io/) for entity extracti
 </Info>
 
 <Warning>
-**Qdrant users — install `fastembed` to enable BM25 keyword search.** The Qdrant backend uses [fastembed](https://github.com/qdrant/fastembed) to encode sparse (BM25) vectors alongside dense vectors in the same collection. Without it, BM25 is silently disabled and search falls back to semantic-only — you'll see a log warning `"fastembed not installed — BM25 keyword search disabled"` on the first search call. Other vector stores use their native full-text capabilities and don't need `fastembed`.
+**Qdrant users: install `fastembed` to enable BM25 keyword search.** The Qdrant backend uses [fastembed](https://github.com/qdrant/fastembed) to encode sparse (BM25) vectors alongside dense vectors in the same collection. Without it, BM25 is silently disabled and search falls back to semantic-only. The first search call logs a warning that BM25 keyword search is disabled. Other vector stores use their native full-text capabilities and don't need `fastembed`.
 
 ```bash
 pip install fastembed
@@ -134,8 +134,8 @@ pip install fastembed
     # After
     config = {
         "custom_instructions": "Focus on user preferences",  # [OK] New name
-        # custom_update_memory_prompt removed — use custom_instructions
-        # enable_graph and graph_store removed — graph store support has been removed
+        # custom_update_memory_prompt removed: use custom_instructions
+        # enable_graph and graph_store removed: graph store support has been removed
     }
     ```
   </Tab>
@@ -154,7 +154,7 @@ pip install fastembed
     // After
     const config = {
       customInstructions: "Focus on user preferences",  // [OK] New name
-      // enableGraph and graphStore removed — graph store support has been removed
+      // enableGraph and graphStore removed: graph store support has been removed
     };
     ```
   </Tab>
@@ -165,7 +165,7 @@ pip install fastembed
 <Tabs>
   <Tab title="Python OSS">
     ```python
-    # Before — entity IDs as top-level kwargs
+    # Before: entity IDs as top-level kwargs
     results = m.search(
         "what meetings did I attend?",
         user_id="alice",
@@ -174,7 +174,7 @@ pip install fastembed
     for r in results:
         print(r["score"])  # Was raw cosine similarity
 
-    # After — entity IDs go inside `filters` (matches Platform API)
+    # After: entity IDs go inside `filters` (matches Platform API)
     results = m.search(
         "what meetings did I attend?",
         filters={"user_id": "alice"},   # [REMOVED top-level kwarg, use filters]
@@ -192,13 +192,13 @@ pip install fastembed
   </Tab>
   <Tab title="TypeScript OSS">
     ```typescript
-    // Before — entity IDs as top-level options
+    // Before: entity IDs as top-level options
     const results = await m.search("what meetings did I attend?", {
       userId: "alice",
       limit: 20          // [REMOVED] Renamed to 'topK' for consistency
     });
 
-    // After — entity IDs go inside `filters` (matches Platform API)
+    // After: entity IDs go inside `filters` (matches Platform API)
     const results = await m.search("what meetings did I attend?", {
       filters: { userId: "alice" },   // [REMOVED top-level option, use filters]
       topK: 20                        // [OK] Renamed from 'limit'
@@ -254,7 +254,7 @@ pip install fastembed
 <Tabs>
   <Tab title="Python OSS">
     ```python
-    # Before — could return ADD, UPDATE, DELETE events
+    # Before: could return ADD, UPDATE, DELETE events
     result = m.add("I love hiking and my dog's name is Max", user_id="alice")
     for item in result["results"]:
         if item["event"] == "ADD":
@@ -264,7 +264,7 @@ pip install fastembed
         elif item["event"] == "DELETE":
             print("Deleted:", item["memory"])      # [REMOVED] No longer returned
 
-    # After — only ADD events
+    # After: only ADD events
     result = m.add("I love hiking and my dog's name is Max", user_id="alice")
     for item in result["results"]:
         print("New memory:", item["memory"])  # Only ADD events
@@ -277,7 +277,7 @@ pip install fastembed
     # Before
     client.add(messages, user_id="alice", async_mode=True, output_format="v1.1")
 
-    # After — async_mode and output_format removed (async by default, v1.1 always)
+    # After: async_mode and output_format removed (async by default, v1.1 always)
     client.add(
         messages,
         options=AddMemoryOptions(user_id="alice")
@@ -305,7 +305,7 @@ pip install fastembed
 </Tabs>
 
 <Tip>
-The ADD-only model means memories accumulate over time. When information changes, the new fact is stored alongside the old one. Retrieval handles ranking — the most relevant, current information surfaces first.
+The ADD-only model means memories accumulate over time. When information changes, the new fact is stored alongside the old one. Retrieval handles ranking: the most relevant, current information surfaces first.
 </Tip>
 
 ### 5. Update Vector Store Dependencies
@@ -322,7 +322,7 @@ pip install "upstash-vector>=0.6.0"
 
 ### 6. Entity Store Setup
 
-The new algorithm automatically creates a parallel entity store collection named `{your_collection}_entities`. No manual setup is required — it's created on first use.
+The new algorithm automatically creates a parallel entity store collection named `{your_collection}_entities`. No manual setup is required: it's created on first use.
 
 <Warning>
 Make sure your vector store user/credentials have permission to create new collections. If you're using a managed vector database with restricted permissions, pre-create the `{collection_name}_entities` collection with the same embedding dimensions as your main collection.
@@ -343,7 +343,7 @@ Mem0 now builds the graph itself. It extracts entities (proper nouns, quoted tex
 
 **Migration:**
 - Remove `enable_graph` / `enableGraph` from your config
-- Remove the `graph_store` / `graphStore` block — it is no longer read
+- Remove the `graph_store` / `graphStore` block: it is no longer read
 - Uninstall external graph drivers (neo4j, memgraph, etc.) if you were using them only for Mem0
 - No data migration is required. Built-in graph memory activates automatically on the next `add()` call.
 
@@ -365,7 +365,7 @@ Input conversation
     → Entity extraction + linking
 ```
 
-The previous algorithm used two LLM calls — one to extract candidate facts, one to decide ADD/UPDATE/DELETE actions against existing memories. The new algorithm collapses this into a single call that only adds. The model spends its capacity on understanding the input rather than diffing against existing state.
+The previous algorithm used two LLM calls: one to extract candidate facts, one to decide ADD/UPDATE/DELETE actions against existing memories. The new algorithm collapses this into a single call that only adds. The model spends its capacity on understanding the input rather than diffing against existing state.
 
 ### Retrieval: Multi-Signal Hybrid Search
 
@@ -381,7 +381,7 @@ Query
 
 **Scoring:** The three signals are normalized and fused into a single combined `score` per result. The fusion adapts based on which signals are available at runtime (semantic-only, semantic + BM25, or all three when spaCy + the entity store are active).
 
-**BM25 is a boost signal, not a recall expander.** Only semantic search results are candidates — BM25 and entity scores boost ranking but don't add new candidates.
+**BM25 is a boost signal, not a recall expander.** Only semantic search results are candidates: BM25 and entity scores boost ranking but don't add new candidates.
 
 ## Vector Store Compatibility
 
@@ -417,7 +417,7 @@ You always get semantic search. Hybrid search features layer on top when availab
 
 These parameters have been removed across all SDKs. Remove them from your code:
 
-### Python Client SDK — Removed parameters
+### Python Client SDK: Removed parameters
 
 **Constructor:** `org_id`, `project_id`
 
@@ -431,7 +431,7 @@ These parameters have been removed across all SDKs. Remove them from your code:
 
 **project.update():** `enable_graph`
 
-### TypeScript Client SDK — Removed parameters
+### TypeScript Client SDK: Removed parameters
 
 **Constructor:** `organizationId`, `projectId`, `organizationName`, `projectName`
 
@@ -443,7 +443,7 @@ These parameters have been removed across all SDKs. Remove them from your code:
 
 **get_all():** `enable_graph` / `enableGraph`
 
-### Python OSS — Removed/renamed parameters
+### Python OSS: Removed/renamed parameters
 
 **Config:** `custom_fact_extraction_prompt` → renamed to `custom_instructions`
 
@@ -451,7 +451,7 @@ These parameters have been removed across all SDKs. Remove them from your code:
 
 **Config:** `enable_graph` + `graph_store` → removed (graph store support removed entirely)
 
-### TypeScript OSS — Removed/renamed parameters
+### TypeScript OSS: Removed/renamed parameters
 
 **Config:** `customPrompt` → renamed to `customInstructions`
 
@@ -527,7 +527,7 @@ The entity store tries to create a `{collection_name}_entities` collection autom
 
 ### Score values are different from before
 
-The top-level `score` still ranges `[0, 1]`, but it is computed differently in v3. Relative ranking between results stays comparable, but absolute numbers shift — retune any hard thresholds in your app against representative queries.
+The top-level `score` still ranges `[0, 1]`, but it is computed differently in v3. Relative ranking between results stays comparable, but absolute numbers shift: retune any hard thresholds in your app against representative queries.
 
 If you need the raw cosine similarity for a specific use case, run an unboosted vector query directly against your vector store via `vector_store.search(...)`.
 

--- a/docs/migration/platform-v2-to-v3.mdx
+++ b/docs/migration/platform-v2-to-v3.mdx
@@ -11,12 +11,12 @@ iconType: "solid"
 
 ## Overview
 
-The new Mem0 memory algorithm is a ground-up redesign of how memories are extracted, stored, and retrieved. It scores **91.6 on LoCoMo** and **93.4 on LongMemEval** — a +20 and +26 point improvement over the previous algorithm — while cutting extraction latency roughly in half.
+The new Mem0 memory algorithm is a ground-up redesign of how memories are extracted, stored, and retrieved. It scores **91.6 on LoCoMo** and **93.4 on LongMemEval**: a +20 and +26 point improvement over the previous algorithm: while cutting extraction latency roughly in half.
 
 | What Changed | Before | After |
 |---|---|---|
 | **Extraction** | Two LLM passes (extract + merge) | Single-pass ADD-only (one LLM call) |
-| **Memory mutations** | ADD, UPDATE, DELETE | ADD only — nothing is overwritten or deleted |
+| **Memory mutations** | ADD, UPDATE, DELETE | ADD only: nothing is overwritten or deleted |
 | **Agent-generated facts** | Often ignored | First-class, stored with equal weight |
 | **Graph memory** | External graph store (Neo4j, etc.) + manual setup | Built-in and automatic; entities extracted and linked across memories natively, no external store |
 | **Retrieval** | Semantic (vector) only | Hybrid retrieval combining multiple signals |
@@ -27,9 +27,9 @@ The new Mem0 memory algorithm is a ground-up redesign of how memories are extrac
 
 The previous algorithm could UPDATE or DELETE existing memories during extraction. The new algorithm only adds new facts. When information changes (e.g., a user moves from New York to San Francisco), both facts are preserved with temporal context. This means:
 
-- **More memories over time** — your memory count will grow rather than plateau
-- **Better temporal reasoning** — the system can distinguish "used to live in New York" from "now lives in San Francisco"
-- **No information loss** — facts that seemed contradictory but were actually complementary are preserved
+- **More memories over time**: your memory count will grow rather than plateau
+- **Better temporal reasoning**: the system can distinguish "used to live in New York" from "now lives in San Francisco"
+- **No information loss**: facts that seemed contradictory but were actually complementary are preserved
 
 <Tip>
 If your application previously relied on UPDATE/DELETE behavior to keep memory counts low, the new algorithm handles this at retrieval time instead. Multi-signal retrieval ranks the most relevant, current information higher without destroying historical context.
@@ -41,7 +41,7 @@ Previously, when an agent said something like "I've booked your flight for March
 
 ### Retrieval is hybrid now
 
-Search now uses hybrid retrieval, which improves ranking quality — especially for queries involving exact keywords, proper nouns, entities that appear across multiple memories, and time-aware queries (via Temporal Reasoning). The response shape is unchanged:
+Search now uses hybrid retrieval, which improves ranking quality: especially for queries involving exact keywords, proper nouns, entities that appear across multiple memories, and time-aware queries (via Temporal Reasoning). The response shape is unchanged:
 
 ```json
 {
@@ -57,7 +57,7 @@ Search now uses hybrid retrieval, which improves ranking quality — especially 
 }
 ```
 
-The top-level `score` remains a `[0, 1]` value. Relative ranking between results stays comparable to v2, but absolute numbers shift since the scoring method changed — retune any hard thresholds in your app against representative queries. Temporal signals are applied internally during ranking and are not returned as extra client-facing fields.
+The top-level `score` remains a `[0, 1]` value. Relative ranking between results stays comparable to v2, but absolute numbers shift since the scoring method changed: retune any hard thresholds in your app against representative queries. Temporal signals are applied internally during ranking and are not returned as extra client-facing fields.
 
 ## API Changes
 
@@ -142,7 +142,7 @@ curl -X POST 'https://api.mem0.ai/v3/memories/?page=1&page_size=50' \
 
 ### Response Format
 
-**Add response** — asynchronous, returns an `event_id` for polling:
+**Add response**: asynchronous, returns an `event_id` for polling:
 
 ```json
 {
@@ -152,9 +152,9 @@ curl -X POST 'https://api.mem0.ai/v3/memories/?page=1&page_size=50' \
 }
 ```
 
-Poll status via `GET /v1/event/{event_id}/` — status will be `SUCCEEDED` or `FAILED`.
+Poll status via `GET /v1/event/{event_id}/`: status will be `SUCCEEDED` or `FAILED`.
 
-**Search response** — combined multi-signal score per result:
+**Search response**: combined multi-signal score per result:
 
 ```json
 {
@@ -172,7 +172,7 @@ Poll status via `GET /v1/event/{event_id}/` — status will be `SUCCEEDED` or `F
 }
 ```
 
-**List response** — paginated envelope (new in V3):
+**List response**: paginated envelope (new in V3):
 
 ```json
 {
@@ -266,16 +266,16 @@ If your application previously read graph relations from the API response (`rela
 
 <Steps>
   <Step title="Review your search thresholds">
-    The default `threshold` is now `0.1` (previously no threshold). If your application was relying on unfiltered results, explicitly pass `threshold=0.0` in your search calls to preserve the old behavior. In most cases, the new default is better — it filters out low-relevance noise.
+    The default `threshold` is now `0.1` (previously no threshold). If your application was relying on unfiltered results, explicitly pass `threshold=0.0` in your search calls to preserve the old behavior. In most cases, the new default is better: it filters out low-relevance noise.
   </Step>
   <Step title="Review reranking usage">
     Reranking is now `false` by default. If your application depended on reranked results, add `rerank=True` to your search calls. Note that reranking adds latency (~200-400ms) but can improve ordering quality for complex queries.
   </Step>
   <Step title="Update score handling (optional)">
-    The top-level `score` field continues to work as before. It is now a combined multi-signal score (semantic + keyword + entity) rather than pure cosine similarity, so the absolute numbers will differ. Relative ranking remains comparable — if you have threshold-based filtering in your app, retune on a representative query set.
+    The top-level `score` field continues to work as before. It is now a combined multi-signal score (semantic + keyword + entity) rather than pure cosine similarity, so the absolute numbers will differ. Relative ranking remains comparable: if you have threshold-based filtering in your app, retune on a representative query set.
   </Step>
   <Step title="Adjust memory count expectations">
-    With ADD-only extraction, memory counts will grow over time rather than being consolidated. This is by design — retrieval handles relevance ranking. If you have hard limits on memory count, consider using the memory expiration feature or periodic cleanup.
+    With ADD-only extraction, memory counts will grow over time rather than being consolidated. This is by design: retrieval handles relevance ranking. If you have hard limits on memory count, consider using the memory expiration feature or periodic cleanup.
   </Step>
   <Step title="Test with representative queries">
     The biggest improvements are in temporal reasoning (+29.6 on LoCoMo), multi-hop queries (+23.1), and assistant memory recall (+53.6 on LongMemEval). Test queries in these categories to see the improvement.
@@ -297,9 +297,9 @@ If your application previously read graph relations from the API response (`rela
 | **LoCoMo Overall** | 71.4 | **91.6** (+20.2) |
 | **LongMemEval Overall** | 67.8 | **93.4** (+25.6) |
 | **Extraction latency (p50)** | ~2.0s | **~1.0s** |
-| **Mean tokens per query** | — | 6.8-7.0K (top200) |
+| **Mean tokens per query** | N/A | 6.8-7.0K (top200) |
 
-All benchmarks were run on a production-representative stack — deliberately avoiding frontier models to keep numbers representative of real production workloads.
+All benchmarks were run on a production-representative stack: deliberately avoiding frontier models to keep numbers representative of real production workloads.
 
 ## FAQ
 
@@ -308,7 +308,7 @@ All benchmarks were run on a production-representative stack — deliberately av
     No. Existing memories remain as-is. New memories added after the rollout will use the new extraction algorithm. Both old and new memories are searchable through the same retrieval pipeline.
   </Accordion>
   <Accordion title="Will my memory count increase faster now?">
-    Yes. The ADD-only approach means memories accumulate rather than being consolidated. This is intentional — the retrieval system handles ranking and relevance. If you need to manage memory volume, use the expiration date feature or the delete API.
+    Yes. The ADD-only approach means memories accumulate rather than being consolidated. This is intentional: the retrieval system handles ranking and relevance. If you need to manage memory volume, use the expiration date feature or the delete API.
   </Accordion>
   <Accordion title="Can I opt out of the new algorithm?">
     The new algorithm is the default for all platform users. If you have a specific need to use the previous extraction behavior, contact support.

--- a/docs/migration/server-pgvector-upgrade.mdx
+++ b/docs/migration/server-pgvector-upgrade.mdx
@@ -34,7 +34,7 @@ No migration is needed. Copy the example env file, set your password, and start 
 ```bash
 cd server
 cp .env.example .env
-# Edit .env — set POSTGRES_PASSWORD (required) and OPENAI_API_KEY at minimum
+# Edit .env: set POSTGRES_PASSWORD (required) and OPENAI_API_KEY at minimum
 make up
 ```
 
@@ -77,17 +77,17 @@ POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
 POSTGRES_DB=postgres
 POSTGRES_USER=postgres
-POSTGRES_PASSWORD=<your-password>    # required — compose will refuse to start without it
+POSTGRES_PASSWORD=<your-password>    # required: compose will refuse to start without it
 POSTGRES_COLLECTION_NAME=memories
 ```
 
 <Info>
-`POSTGRES_PASSWORD` is **required** — `docker compose up` will refuse to start without it. If you previously relied on the hardcoded default, set `POSTGRES_PASSWORD=postgres`.
+`POSTGRES_PASSWORD` is **required**: `docker compose up` will refuse to start without it. If you previously relied on the hardcoded default, set `POSTGRES_PASSWORD=postgres`.
 </Info>
 
 ### 4. Start Only Postgres
 
-Start **only** the Postgres container first — do **not** start the mem0 API yet.
+Start **only** the Postgres container first: do **not** start the mem0 API yet.
 The API runs `alembic upgrade head` on startup, which creates empty tables that
 would conflict with the restore.
 
@@ -107,11 +107,11 @@ docker compose exec -T postgres pg_isready -q && echo "ready" || echo "not ready
 docker compose exec -T postgres psql -U postgres < mem0_backup.sql
 ```
 
-You may see notices like `role "postgres" already exists` — these are safe to ignore.
+You may see notices like `role "postgres" already exists`: these are safe to ignore.
 
 <Warning>
 You must restore **before** starting the mem0 API container. The API runs
-database migrations on startup which create empty tables — restoring after
+database migrations on startup which create empty tables: restoring after
 that would fail with duplicate-key errors and lose your API keys and settings.
 </Warning>
 

--- a/docs/open-source/features/async-memory.mdx
+++ b/docs/open-source/features/async-memory.mdx
@@ -18,7 +18,7 @@ icon: "bolt"
 </Warning>
 
 <Note>
-  Working in TypeScript? The OSS `Memory` class in the Node SDK (`mem0ai/oss`) is also fully async — every method returns a `Promise` and must be `await`ed. Python’s `AsyncMemory` serves the same purpose within Python async frameworks like FastAPI. Both runtimes support awaited memory operations; choose the SDK that matches your language.
+  Working in TypeScript? The OSS `Memory` class in the Node SDK (`mem0ai/oss`) is also fully async: every method returns a `Promise` and must be `await`ed. Python’s `AsyncMemory` serves the same purpose within Python async frameworks like FastAPI. Both runtimes support awaited memory operations; choose the SDK that matches your language.
 </Note>
 
 ## Feature anatomy
@@ -151,7 +151,7 @@ async def robust_memory_search():
 ```
 
 <Warning>
-  Always cap retries—runaway loops can keep the event loop busy and block other tasks.
+  Always cap retries. Runaway loops can keep the event loop busy and block other tasks.
 </Warning>
 
 ---
@@ -301,7 +301,7 @@ async def handle_memory_operation_errors():
 ```
 
 <Warning>
-  Catch and log `ValueError` exceptions from invalid inputs—async stack traces can otherwise disappear inside background tasks.
+  Catch and log `ValueError` exceptions from invalid inputs: async stack traces can otherwise disappear inside background tasks.
 </Warning>
 
 ### Serve through FastAPI
@@ -331,7 +331,7 @@ async def search_memories(query: str, user_id: str, limit: int = 10):
 ```
 
 <Tip>
-  Create one `AsyncMemory` instance per process when using FastAPI—startup hooks are a good place to configure and reuse it.
+  Create one `AsyncMemory` instance per process when using FastAPI: startup hooks are a good place to configure and reuse it.
 </Tip>
 
 ### Instrument logging
@@ -378,13 +378,13 @@ async def logged_memory_add(memory, messages, user_id):
 - Run a quick add/search cycle and confirm the returned memory content matches your input.
 - Inspect application logs to ensure async tasks complete without blocking the event loop.
 - In FastAPI or other frameworks, hit health endpoints to verify the shared client handles concurrent requests.
-- Monitor retry counters—unexpected spikes indicate configuration or connectivity issues.
+- Monitor retry counters: unexpected spikes indicate configuration or connectivity issues.
 
 ---
 
 ## Best practices
 
-1. **Keep operations awaited:** Forgetting `await` is the fastest way to miss writes—lint for it or add helper wrappers.
+1. **Keep operations awaited:** Forgetting `await` is the fastest way to miss writes: lint for it or add helper wrappers.
 2. **Scope deletions carefully:** Always supply `user_id`, `agent_id`, or `run_id` to avoid purging too much data.
 3. **Batch writes thoughtfully:** Use `asyncio.gather` for throughput but cap concurrency based on backend capacity.
 4. **Log errors with context:** Capture user and agent scopes to triage failures quickly.

--- a/docs/open-source/features/metadata-filtering.mdx
+++ b/docs/open-source/features/metadata-filtering.mdx
@@ -111,7 +111,7 @@ results = m.search(
 
 ### Wildcard matching
 
-Allow any value for a field while still requiring the field to exist—handy when the mere presence of a field matters.
+Allow any value for a field while still requiring the field to exist: handy when the mere presence of a field matters.
 
 ```python
 # Match any value for a field
@@ -191,7 +191,7 @@ results = m.search(
 ```
 
 <Info icon="check">
-  Inspect the response metadata—each returned memory should satisfy the combined logic tree exactly. If results look too broad, log the raw filters sent to your vector store.
+  Inspect the response metadata: each returned memory should satisfy the combined logic tree exactly. If results look too broad, log the raw filters sent to your vector store.
 </Info>
 
 ---
@@ -215,7 +215,7 @@ config = {
 ```
 
 <Info icon="check">
-  After enabling indexing, benchmark the same query—latency should drop once the store can prune documents on indexed fields before vector scoring.
+  After enabling indexing, benchmark the same query: latency should drop once the store can prune documents on indexed fields before vector scoring.
 </Info>
 
 <Tip>
@@ -252,7 +252,7 @@ Vector store support varies. Confirm operator coverage before shipping:
     Full comparison, list, and logical support. Handles deeply nested boolean logic efficiently.
   </Accordion>
   <Accordion title="Chroma">
-    Equality and basic comparisons only. Limited nesting—break large trees into smaller calls.
+    Equality and basic comparisons only. Limited nesting: break large trees into smaller calls.
   </Accordion>
   <Accordion title="Pinecone">
     Comparisons plus `in`/`nin`. Text operators are constrained; rely on tags where possible.
@@ -413,7 +413,7 @@ except ValueError as e:
 ## Best practices
 
 1. **Use indexed fields first:** Order filters so equality checks run before complex string operations.
-2. **Combine operators intentionally:** Keep logical trees readable—large nests are harder to debug.
+2. **Combine operators intentionally:** Keep logical trees readable: large nests are harder to debug.
 3. **Test performance regularly:** Benchmark critical queries with production-like payloads.
 4. **Plan graceful degradation:** Provide fallback filters when an operator isn’t available.
 5. **Validate syntax early:** Catch malformed filters during development to protect agents at runtime.

--- a/docs/open-source/features/multimodal-support.mdx
+++ b/docs/open-source/features/multimodal-support.mdx
@@ -94,7 +94,7 @@ await client.add(messages, { userId: "alice" });
 </CodeGroup>
 
 <Info icon="check">
-  Inspect the response payload—the memories list should include entries extracted from the menu image as well as the text turns.
+  Inspect the response payload: the memories list should include entries extracted from the menu image as well as the text turns.
 </Info>
 
 ### Upload local images as base64
@@ -294,7 +294,7 @@ try {
 
 - After calling `add`, inspect the returned memories and confirm they include image-derived text (menu items, receipt totals, etc.).
 - Run a follow-up `search` for a detail from the image; the memory should surface alongside related text.
-- Monitor image upload latency—large files should still complete under your acceptable response time.
+- Monitor image upload latency: large files should still complete under your acceptable response time.
 - Log file size and URL sources to troubleshoot repeated failures.
 
 ---

--- a/docs/open-source/features/openai_compatibility.mdx
+++ b/docs/open-source/features/openai_compatibility.mdx
@@ -107,7 +107,7 @@ print(response.choices[0].message.content)
 
 ## Verify the feature is working
 
-- Compare responses from Mem0 vs. OpenAI for identical prompts—both should return the same structure (`choices`, `usage`, etc.).
+- Compare responses from Mem0 vs. OpenAI for identical prompts. Both should return the same structure (`choices`, `usage`, etc.).
 - Inspect stored memories after each request to confirm the fact extraction captured the right details.
 - Test switching between hosted (`Mem0(api_key=...)`) and OSS configurations to ensure both respect the same request body.
 

--- a/docs/open-source/features/overview.mdx
+++ b/docs/open-source/features/overview.mdx
@@ -6,7 +6,7 @@ icon: "list"
 
 # Self-Hosting Features Overview
 
-Mem0 Open Source ships with capabilities that adapt memory behavior for production workloads—async operations, multimodal inputs, and fine-tuned retrieval. Configure these features with code or YAML to match your application's needs.
+Mem0 Open Source ships with capabilities that adapt memory behavior for production workloads: async operations, multimodal inputs, and fine-tuned retrieval. Configure these features with code or YAML to match your application's needs.
 
 <Info>
   Start with the <Link href="/open-source/python-quickstart">Python quickstart</Link> to validate basic memory operations, then enable the features below when you need them.

--- a/docs/open-source/features/reranker-search.mdx
+++ b/docs/open-source/features/reranker-search.mdx
@@ -18,7 +18,7 @@ Reranker-enhanced search adds a second scoring pass after vector retrieval so Me
 </Warning>
 
 <Note>
-  All configuration snippets translate directly to the TypeScript SDK—swap dictionaries for objects while keeping the same keys (`provider`, `config`, `rerank` flags).
+  All configuration snippets translate directly to the TypeScript SDK: swap dictionaries for objects while keeping the same keys (`provider`, `config`, `rerank` flags).
 </Note>
 
 ---
@@ -71,7 +71,7 @@ m = Memory.from_config(config)
 ```
 
 <Info icon="check">
-  Confirm `results["results"][0]["score"]` reflects the reranker output—if the field is missing, the reranker was not applied.
+  Confirm `results["results"][0]["score"]` reflects the reranker output: if the field is missing, the reranker was not applied.
 </Info>
 
 <Tip>
@@ -240,7 +240,7 @@ except Exception as exc:
 ```
 
 <Warning>
-  Always fall back to vector-only search—dropped queries introduce bigger accuracy issues than slightly less relevant ordering.
+  Always fall back to vector-only search: dropped queries introduce bigger accuracy issues than slightly less relevant ordering.
 </Warning>
 
 ### Migrate from v0.x
@@ -326,7 +326,7 @@ results = m.search(
 ```
 
 <Info icon="check">
-  Verify filtered reranked searches still respect every metadata clause—reranking only reorders candidates, it never bypasses filters.
+  Verify filtered reranked searches still respect every metadata clause: reranking only reorders candidates, it never bypasses filters.
 </Info>
 
 ### Real-world playbooks
@@ -394,7 +394,7 @@ results = m.search(
 ```
 
 <Tip>
-  Reuse this pattern for other lifestyle queries—swap the filters and prompt text without changing the rerank configuration.
+  Reuse this pattern for other lifestyle queries: swap the filters and prompt text without changing the rerank configuration.
 </Tip>
 
 <Note>

--- a/docs/open-source/features/rest-api.mdx
+++ b/docs/open-source/features/rest-api.mdx
@@ -18,7 +18,7 @@ The Mem0 REST API server exposes every OSS memory operation over HTTP. Run it al
 </Warning>
 
 <Warning>
-  **OSS vs Platform API paths:** The self-hosted OSS server does **not** use the `/v1/` prefix. For example, the endpoint is `POST /memories`, not `POST /v1/memories/`. The [API Reference](/api-reference) documents the hosted platform at `api.mem0.ai` which uses `/v1/` paths — those do not apply to the OSS server.
+  **OSS vs Platform API paths:** The self-hosted OSS server does **not** use the `/v1/` prefix. For example, the endpoint is `POST /memories`, not `POST /v1/memories/`. The [API Reference](/api-reference) documents the hosted platform at `api.mem0.ai` which uses `/v1/` paths: those do not apply to the OSS server.
 </Warning>
 
 <Warning>
@@ -111,7 +111,7 @@ docker build -t mem0-api-server .
 </Note>
 
 <Note>
-  `JWT_SECRET` is required once auth is enabled — the server returns `500` on auth endpoints if it's unset. Generate one with `openssl rand -base64 48`. See [Self-Hosted Setup](/open-source/setup#configure-the-environment) for the full env var table.
+  `JWT_SECRET` is required once auth is enabled: the server returns `500` on auth endpoints if it's unset. Generate one with `openssl rand -base64 48`. See [Self-Hosted Setup](/open-source/setup#configure-the-environment) for the full env var table.
 </Note>
 
 <Tip>
@@ -133,7 +133,7 @@ Auth is on by default. Protected endpoints require either a JWT (from the dashbo
 | Bearer JWT | `Authorization: Bearer <access_token>` | Dashboard sessions; tokens come from `POST /auth/login` and refresh via `POST /auth/refresh` |
 | Per-user API key | `X-API-Key: m0sk_...` | Programmatic access scoped to a single dashboard user |
 | Legacy `ADMIN_API_KEY` | `X-API-Key: <env value>` | Back-compat for deployments that set the `ADMIN_API_KEY` env var |
-| `AUTH_DISABLED=true` | — | Local development only; bypasses auth entirely |
+| `AUTH_DISABLED=true` | N/A | Local development only; bypasses auth entirely |
 
 The `/docs` OpenAPI explorer supports both auth modes. Click **Authorize** at the top of the page and paste either `Bearer <access_token>` (JWT) or your `X-API-Key` value. Protected endpoints return `401` until you authorize.
 
@@ -142,7 +142,7 @@ The `/docs` OpenAPI explorer supports both auth modes. Click **Authorize** at th
 Register the first admin (only works when no user exists yet), then log in:
 
 ```bash
-# First admin only — returns 403 after the first admin is registered
+# First admin only: returns 403 after the first admin is registered
 curl -X POST http://localhost:8888/auth/register \
   -H "Content-Type: application/json" \
   -d '{"name": "Admin", "email": "admin@example.com", "password": "strong-password"}'
@@ -170,7 +170,7 @@ When the access token expires, exchange the refresh token at `POST /auth/refresh
 
 ### Create and use a per-user API key
 
-Create a key from the dashboard **API Keys** page, or call `POST /api-keys` with a JWT. The full `m0sk_...` value is returned **once** at creation time — store it securely.
+Create a key from the dashboard **API Keys** page, or call `POST /api-keys` with a JWT. The full `m0sk_...` value is returned **once** at creation time: store it securely.
 
 ```bash
 curl -X POST http://localhost:8888/memories \
@@ -186,14 +186,14 @@ Per-user keys inherit the creating user's scope. List or revoke them via `GET /a
 
 ### Legacy `ADMIN_API_KEY`
 
-Set the `ADMIN_API_KEY` environment variable and send it as `X-API-Key`. The request is treated as admin-level and is not tied to a dashboard user. This mode is kept for back-compat with older self-hosted deployments — prefer JWT or per-user keys for new setups.
+Set the `ADMIN_API_KEY` environment variable and send it as `X-API-Key`. The request is treated as admin-level and is not tied to a dashboard user. This mode is kept for back-compat with older self-hosted deployments: prefer JWT or per-user keys for new setups.
 
 ```bash
 ADMIN_API_KEY=your-long-admin-key
 ```
 
 <Warning>
-  Setting `AUTH_DISABLED=true` makes every protected endpoint open — the server logs a warning at startup when it's enabled. The server also warns when `ADMIN_API_KEY` is shorter than 16 characters. Never enable `AUTH_DISABLED` in production, and always use a long `ADMIN_API_KEY` if you rely on the legacy fallback.
+  Setting `AUTH_DISABLED=true` makes every protected endpoint open: the server logs a warning at startup when it's enabled. The server also warns when `ADMIN_API_KEY` is shorter than 16 characters. Never enable `AUTH_DISABLED` in production, and always use a long `ADMIN_API_KEY` if you rely on the legacy fallback.
 </Warning>
 
 ---

--- a/docs/open-source/overview.mdx
+++ b/docs/open-source/overview.mdx
@@ -79,7 +79,7 @@ Mem0 Open Source delivers the same adaptive memory engine as the platform, but p
   - LLM: OpenAI `gpt-4.1-nano-2025-04-14` (override with `MEM0_DEFAULT_LLM_MODEL`)
   - Embeddings: OpenAI `text-embedding-3-small` (override with `MEM0_DEFAULT_EMBEDDER_MODEL`)
   - Vector store: Postgres + pgvector
-  - Bundled providers: `openai`, `anthropic`, `gemini` — switch from the Configuration page
+  - Bundled providers: `openai`, `anthropic`, `gemini`: switch from the Configuration page
 
   See <Link href="/open-source/setup#supported-providers">Self-Hosted Setup</Link> for the full provider list and how to extend it.
 </Note>

--- a/docs/open-source/setup.mdx
+++ b/docs/open-source/setup.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Self-Hosted Setup"
-description: "Stand up the Mem0 REST server and dashboard in a few minutes — admin account, API keys, and a live audit log included."
+description: "Stand up the Mem0 REST server and dashboard in a few minutes, with an admin account, API keys, and a live audit log included."
 icon: "rocket-launch"
 ---
 
@@ -22,7 +22,7 @@ The self-hosted bundle ships the REST API and a web dashboard together. Configur
 ## Prerequisites
 
 - Docker and Docker Compose (the reference path).
-- An `OPENAI_API_KEY` (or equivalent — the server reads the same component config as the library).
+- An `OPENAI_API_KEY` (or equivalent: the server reads the same component config as the library).
 - A free port `8888` for the API and `3000` for the dashboard.
 
 ---
@@ -59,7 +59,7 @@ make up
 
 This starts the containers and runs database migrations. The REST API listens on `http://localhost:8888` and the dashboard on `http://localhost:3000`.
 
-Open `http://localhost:3000` — since no admin account exists yet, the dashboard redirects to the one-time setup wizard at `/setup`. See [Run the setup wizard](#run-the-setup-wizard) below.
+Open `http://localhost:3000`. Since no admin account exists yet, the dashboard redirects to the one-time setup wizard at `/setup`. See [Run the setup wizard](#run-the-setup-wizard) below.
 
 ### Agent-first (command line)
 
@@ -70,7 +70,7 @@ cd server
 make bootstrap
 ```
 
-`make bootstrap` starts the same containers, then automatically creates the admin account and generates the first API key via the CLI. The admin credentials and API key are printed to your terminal — no browser required.
+`make bootstrap` starts the same containers, then automatically creates the admin account and generates the first API key via the CLI. The admin credentials and API key are printed to your terminal: no browser required.
 
 You can override the generated credentials:
 
@@ -89,16 +89,16 @@ Because `make bootstrap` already creates the admin, the setup wizard is skipped.
 ## Run the setup wizard
 
 <Info>
-  This section applies to the **browser-first** path (`make up`). If you used `make bootstrap`, the admin and API key were already created — skip ahead to [What the dashboard gives you](#what-the-dashboard-gives-you).
+  This section applies to the **browser-first** path (`make up`). If you used `make bootstrap`, the admin and API key were already created: skip ahead to [What the dashboard gives you](#what-the-dashboard-gives-you).
 </Info>
 
 On a fresh install the dashboard redirects to `/setup`. Each step submits on Enter.
 
 **1. Create the admin account.** Name, email, password. This account becomes the first admin. Registration closes after the first admin is created; additional accounts are provisioned by the existing admin.
 
-**2. Review the effective config.** Read-only display of the LLM and embedder the server is running with, sourced from your environment. If anything is wrong here, stop the stack, fix the `.env`, and restart — the dashboard intentionally does not let you change provider secrets at runtime.
+**2. Review the effective config.** Read-only display of the LLM and embedder the server is running with, sourced from your environment. If anything is wrong here, stop the stack, fix the `.env`, and restart: the dashboard intentionally does not let you change provider secrets at runtime.
 
-**3. Generate your first API key.** The full `m0sk_...` value is shown **once**. Copy it immediately — the server only stores the prefix and a bcrypt hash.
+**3. Generate your first API key.** The full `m0sk_...` value is shown **once**. Copy it immediately: the server only stores the prefix and a bcrypt hash.
 
 **4. Tell us your use case.** Pick a preset or describe your use case in a few words. Mem0 generates custom instructions that tell the memory system what to prioritize. You can edit the instructions before saving, or skip this step entirely.
 
@@ -125,8 +125,8 @@ For the underlying endpoints (including `/auth/*`, `/api-keys`, `/requests`, `/e
 
 The shipped container bundles the Python packages for:
 
-- **LLMs** — `openai`, `anthropic`, `gemini`
-- **Embedders** — `openai`, `gemini`
+- **LLMs**: `openai`, `anthropic`, `gemini`
+- **Embedders**: `openai`, `gemini`
 
 The Configuration page and `POST /configure` only accept providers from these lists. Anything else returns a 400 up front instead of failing at the first memory write.
 
@@ -146,9 +146,9 @@ Heavy providers (`sentence-transformers` pulls in PyTorch, ~2 GB) are intentiona
 
 Previous self-hosted builds allowed open access when `ADMIN_API_KEY` was unset. This build enables auth by default. After pulling the new image, pick **one**:
 
-1. **Fastest, zero client changes** — set `ADMIN_API_KEY` to a long random value (16+ characters). Existing clients that send `X-API-Key: <your-key>` keep working unchanged.
-2. **Recommended for teams** — visit `http://<host>:3000`, run the setup wizard, and switch clients to per-user API keys. You get the audit log and revocation for free.
-3. **Local development only** — set `AUTH_DISABLED=true`. The server logs a warning on every boot. Never use this in production.
+1. **Fastest, zero client changes**: set `ADMIN_API_KEY` to a long random value (16+ characters). Existing clients that send `X-API-Key: <your-key>` keep working unchanged.
+2. **Recommended for teams**: visit `http://<host>:3000`, run the setup wizard, and switch clients to per-user API keys. You get the audit log and revocation for free.
+3. **Local development only**: set `AUTH_DISABLED=true`. The server logs a warning on every boot. Never use this in production.
 
 The server prints an unmissable startup banner when it detects the "upgraded but not configured" state so you know exactly which option to pick.
 

--- a/docs/platform/agent-signup.mdx
+++ b/docs/platform/agent-signup.mdx
@@ -1,11 +1,11 @@
 ---
 title: Sign up as an agent
-description: "Zero-friction signup for AI agents — mint a working Mem0 API key in under five seconds. No email, no dashboard, no OTP."
+description: "Zero-friction signup for AI agents: mint a working Mem0 API key in under five seconds. No email, no dashboard, no OTP."
 icon: "robot"
 iconType: "solid"
 ---
 
-If you're an AI agent (Claude Code, Cursor, Codex, Cline, Aider, Windsurf, or any other autonomous coding tool), you don't need a human to set up Mem0 for you. Four commands — install, sign up, push a memory, search it — and you have persistent memory.
+If you're an AI agent (Claude Code, Cursor, Codex, Cline, Aider, Windsurf, or any other autonomous coding tool), you don't need a human to set up Mem0 for you. Four commands: install, sign up, push a memory, search it: and you have persistent memory.
 
 ## The 4-command demo
 
@@ -39,14 +39,14 @@ mem0 search "am I using mem0"
 ```
 </CodeGroup>
 
-That's it — under 30 seconds from a fresh shell to a working memory store.
+That's it: under 30 seconds from a fresh shell to a working memory store.
 
 ## Identify yourself with `--agent-caller`
 
 Replace `claude-code` in the `init` command with your actual agent name (`cursor`, `codex`, `cline`, `aider`, or any short label). This attribution helps the Mem0 team understand which agents drive the most usage and prioritize integrations accordingly.
 
 <Tip>
-**Forgot `--agent-caller` on init?** Run `mem0 identify <your-name>` after the fact — same key, just back-fills the attribution. Idempotent.
+**Forgot `--agent-caller` on init?** Run `mem0 identify <your-name>` after the fact: same key, just back-fills the attribution. Idempotent.
 </Tip>
 
 ## What happened when you ran `mem0 init --agent`?
@@ -54,13 +54,13 @@ Replace `claude-code` in the `init` command with your actual agent name (`cursor
 - A **shadow account** was minted on the Mem0 backend with a fresh API key.
 - The key was saved to `~/.mem0/config.json` (mode 0600) on the machine you ran the command on.
 - A default `user_id` was provisioned so `mem0 add` / `mem0 search` work without explicit scope flags.
-- The account is **unclaimed** — no human owns it yet.
+- The account is **unclaimed**: no human owns it yet.
 
 Every command run against this key prints a one-line reminder asking you to surface the claim instructions to your human user.
 
 ## Claiming the account (for the human owner)
 
-When the human is ready to take ownership of the agent's account — and all the memories it has accumulated — they run:
+When the human is ready to take ownership of the agent's account: and all the memories it has accumulated: they run:
 
 ```bash
 mem0 init --email you@yourcompany.com
@@ -68,9 +68,9 @@ mem0 init --email you@yourcompany.com
 
 The CLI detects the existing Agent Mode config, sends a verification code, and upgrades the shadow account in-place:
 
-- **The API key never changes** — the agent isn't disrupted.
+- **The API key never changes**: the agent isn't disrupted.
 - **All memories transfer** to the human's account.
-- **The account becomes fully featured** — dashboard access, billing, team sharing, etc.
+- **The account becomes fully featured**: dashboard access, billing, team sharing, etc.
 
 Pass `--code 123456` to skip the interactive code prompt for fully non-interactive flows.
 
@@ -97,7 +97,7 @@ How `add`, `search`, `update`, and `delete` work under the hood.
 </Card>
 
 <Card title="Mem0 MCP" icon="plug" href="/platform/mem0-mcp">
-Connect agents to Mem0 via the Model Context Protocol — alternative integration path.
+Connect agents to Mem0 via the Model Context Protocol: alternative integration path.
 </Card>
 
 <Card title="Platform Overview" icon="star" href="/platform/overview">

--- a/docs/platform/cli.mdx
+++ b/docs/platform/cli.mdx
@@ -1,16 +1,16 @@
 ---
 title: CLI
-description: "Manage memories from your terminal — built for both humans and AI agents."
+description: "Manage memories from your terminal: built for both humans and AI agents."
 icon: "terminal"
 iconType: "solid"
 ---
 
 The mem0 CLI lets you add, search, list, update, and delete memories directly from the terminal. It works with the Mem0 Platform API and is available as both an npm package and a Python package.
 
-Both implementations provide identical behavior — same commands, same options, same output formats.
+Both implementations provide identical behavior: same commands, same options, same output formats.
 
 <Tip>
-**Built for AI agents.** Pass `--agent` (or `--json`) as a global flag on any command to get structured JSON output optimized for programmatic consumption — sanitized fields, no colors or spinners, and errors as JSON too. Drop it into any agent tool loop with zero extra parsing.
+**Built for AI agents.** Pass `--agent` (or `--json`) as a global flag on any command to get structured JSON output optimized for programmatic consumption: sanitized fields, no colors or spinners, and errors as JSON too. Drop it into any agent tool loop with zero extra parsing.
 </Tip>
 
 ## Installation
@@ -26,7 +26,7 @@ pip install mem0-cli
 </CodeGroup>
 
 <Tip>
-**Looking for Agent Mode signup?** See [Sign up as an agent](/platform/agent-signup) — install, signup, first memory in four commands.
+**Looking for Agent Mode signup?** See [Sign up as an agent](/platform/agent-signup): install, signup, first memory in four commands.
 </Tip>
 
 ## Authentication
@@ -100,7 +100,7 @@ mem0 init --api-key m0-xxx --user-id alice --force
 | `--force` | Overwrite existing config without confirmation |
 
 <Note>
-AI agents should use `mem0 init --agent` — see [Sign up as an agent](/platform/agent-signup).
+AI agents should use `mem0 init --agent`: see [Sign up as an agent](/platform/agent-signup).
 </Note>
 
 ### `mem0 add`
@@ -273,7 +273,7 @@ mem0 version
 
 After running `mem0 init --agent`, the CLI persists a server-issued identifier
 (`default_user_id`, e.g. `user_a1b2c3d4e5f6`) in `~/.mem0/config.json`. This
-value is the agent's stable identity — surfaced as the row key on the
+value is the agent's stable identity: surfaced as the row key on the
 [AGENTRUSH leaderboard](https://mem0.ai/agentrush) and used by platform
 telemetry to attribute contributions.
 
@@ -286,18 +286,18 @@ mem0 whoami
 ```
 
 No network call. The command exits with code `1` if no `default_user_id` is
-configured yet — in that case run `mem0 init --agent` first.
+configured yet: in that case run `mem0 init --agent` first.
 
 ## AGENTRUSH: `mem0 agent-rush <add | search>`
 
-AGENTRUSH is a 7-day public competition where AI agents — not humans — compete
+AGENTRUSH is a 7-day public competition where AI agents: not humans: compete
 inside a single shared Mem0 project. Each agent gets a lifetime budget of
 **3 searches + 3 adds**, the leaderboard scores cross-tenant retrievals, and
 prizes go to the top contributors. See [mem0.ai/agentrush](https://mem0.ai/agentrush)
 for current event details.
 
 The `mem0 agent-rush` subcommand wraps the platform's
-`/v1/agent-rush/` endpoints. Routing is implicit — there is no
+`/v1/agent-rush/` endpoints. Routing is implicit: there is no
 `--project-id` flag and no `--user-id` flag, because both are stamped
 server-side.
 
@@ -307,12 +307,12 @@ server-side.
 # 1. Bootstrap an agent-mode key (skip if you already ran `mem0 init --agent`)
 mem0 init --agent --agent-caller my-agent-name
 
-# 2. Three searches — the search-first rule blocks adds until you've done this
+# 2. Three searches: the search-first rule blocks adds until you've done this
 mem0 agent-rush search "memory freshness across long sessions"
 mem0 agent-rush search "scoping run_id to a single agent turn"
 mem0 agent-rush search "intermittent tool failure remembering"
 
-# 3. Three adds — the content that gets retrieved earns you leaderboard points
+# 3. Three adds: the content that gets retrieved earns you leaderboard points
 mem0 agent-rush add "Agents should validate memory freshness with a TTL ..."
 mem0 agent-rush add "Scoping memories by run_id avoids cross-session ..."
 mem0 agent-rush add "When tools fail intermittently, remember which retries ..."
@@ -351,7 +351,7 @@ identifying information.** The acknowledgement is stored under
 once per machine.
 
 When the CLI is invoked by an agent in a non-interactive (no-TTY) context,
-the warning prints to stderr and the add proceeds — agents cannot answer
+the warning prints to stderr and the add proceeds: agents cannot answer
 y/N prompts. Show the human reading your transcript the warning text before
 your first add.
 
@@ -364,8 +364,8 @@ All commands support the `--output` flag to control how results are displayed:
 | `text` | Human-readable output with colors and formatting (default for most commands) |
 | `json` | Structured JSON, suitable for piping to `jq` or consumption by AI agents |
 | `table` | Tabular format (default for `list`) |
-| `quiet` | Minimal output — just IDs or status codes |
-| `agent` | Structured JSON envelope with sanitized fields — set automatically by `--json`/`--agent` |
+| `quiet` | Minimal output: just IDs or status codes |
+| `agent` | Structured JSON envelope with sanitized fields: set automatically by `--json`/`--agent` |
 
 Example with JSON output:
 
@@ -378,7 +378,7 @@ mem0 search "user preferences" --user-id alice --output json | jq '.data.results
 The CLI is purpose-built for use inside AI agent tool loops. Pass `--agent` or `--json` as a global flag on **any** command to activate agent mode:
 
 - Every command outputs a consistent JSON envelope: `{"status", "command", "duration_ms", "scope", "count", "data"}`
-- The `data` field contains only the fields that matter — IDs, memory text, scores, categories. Noisy API fields are stripped.
+- The `data` field contains only the fields that matter: IDs, memory text, scores, categories. Noisy API fields are stripped.
 - All human-readable output is suppressed: no spinners, no colors, no banners.
 - Errors are returned as JSON to stdout with a non-zero exit code, so your agent can catch them the same way as successes.
 
@@ -419,7 +419,7 @@ mem0 --agent delete --all --user-id user-42 --force
 
 Two other agent-friendly features:
 
-- **`--output json`** returns structured data without sanitization — useful when you want the full raw API response
+- **`--output json`** returns structured data without sanitization: useful when you want the full raw API response
 - **`mem0 help --json`** returns the complete command tree as JSON, so agents can self-discover available commands and options
 
 For non-interactive environments (CI, agent runtimes), set credentials via `mem0 init --api-key m0-xxx --user-id alice --force` or the `MEM0_API_KEY` environment variable.

--- a/docs/platform/faqs.mdx
+++ b/docs/platform/faqs.mdx
@@ -157,7 +157,7 @@ iconType: "solid"
         - Organizations you solely own, along with their data
         - Your membership in any shared organizations (the orgs themselves are not affected)
 
-        Any application still using your old API keys will start receiving `401 Unauthorized` responses immediately. If you'd like to use Mem0 again later, you can create a new account at any time — it will start fresh with no data carried over.
+        Any application still using your old API keys will start receiving `401 Unauthorized` responses immediately. If you'd like to use Mem0 again later, you can create a new account at any time: it will start fresh with no data carried over.
     </Accordion>
 
 </AccordionGroup>

--- a/docs/platform/features/async-client.mdx
+++ b/docs/platform/features/async-client.mdx
@@ -124,7 +124,7 @@ await client.deleteAll({ userId: "alice" });
 </CodeGroup>
 
 <Note>
-  At least one filter (`user_id`, `agent_id`, `app_id`, or `run_id`) is required — calling `delete_all` with no filters raises an error to prevent accidental data loss. You can pass `"*"` as a value to delete all memories for a given entity type (e.g., `user_id="*"` removes memories for every user). A full project wipe requires all four filters set to `"*"`.
+  At least one filter (`user_id`, `agent_id`, `app_id`, or `run_id`) is required: calling `delete_all` with no filters raises an error to prevent accidental data loss. You can pass `"*"` as a value to delete all memories for a given entity type (e.g., `user_id="*"` removes memories for every user). A full project wipe requires all four filters set to `"*"`.
 </Note>
 
 ### History

--- a/docs/platform/features/criteria-retrieval.mdx
+++ b/docs/platform/features/criteria-retrieval.mdx
@@ -88,7 +88,7 @@ After setting up your criteria, you can use them to filter and retrieve memories
 ```python
 messages = [
     {"role": "user", "content": "What a beautiful sunny day! I feel so refreshed and ready to take on anything!"},
-    {"role": "user", "content": "I've always wondered how storms form—what triggers them in the atmosphere?"},
+    {"role": "user", "content": "I've always wondered how storms form, what triggers them in the atmosphere?"},
     {"role": "user", "content": "It's been raining for days, and it just makes everything feel heavier."},
     {"role": "user", "content": "Finally I get time to draw something today, after a long time!! I am super happy today."}
 ]
@@ -182,7 +182,7 @@ If no criteria are defined for a project, search behaves normally based on seman
 This lets you prioritize memories that align with your agent's goals and not just those that look similar to the query.
 
 <Note>
-Criteria retrieval is automatically enabled when criteria are defined in your project. Use `use_criteria=False` in search to temporarily disable it for a specific query. `use_criteria` is a server-side parameter passed through to the Platform API — it is not a typed option in the SDK's `SearchMemoryOptions` interface, but the server accepts and processes it when included in the request body.
+Criteria retrieval is automatically enabled when criteria are defined in your project. Use `use_criteria=False` in search to temporarily disable it for a specific query. `use_criteria` is a server-side parameter passed through to the Platform API: it is not a typed option in the SDK's `SearchMemoryOptions` interface, but the server accepts and processes it when included in the request body.
 </Note>
 
 

--- a/docs/platform/features/custom-categories.mdx
+++ b/docs/platform/features/custom-categories.mdx
@@ -25,9 +25,9 @@ Mem0 automatically tags every memory, but the default labels (travel, sports, mu
 
 ## How it works
 
-- **Default list** — Each project starts with 15 broad categories like `travel`, `sports`, and `music`.
-- **Project override** — When you call `project.update(custom_categories=[...])`, that list replaces the defaults for future memories.
-- **Automatic tags** — As new memories come in, Mem0 picks the closest matches from your list and saves them in the `categories` field.
+- **Default list**: Each project starts with 15 broad categories like `travel`, `sports`, and `music`.
+- **Project override**: When you call `project.update(custom_categories=[...])`, that list replaces the defaults for future memories.
+- **Automatic tags**: As new memories come in, Mem0 picks the closest matches from your list and saves them in the `categories` field.
 
 <Note>
   Default catalog: `personal_details`, `family`, `professional_details`, `sports`, `travel`, `food`, `music`, `health`, `technology`, `hobbies`, `fashion`, `entertainment`, `milestones`, `user_preferences`, `misc`.

--- a/docs/platform/features/entity-scoped-memory.mdx
+++ b/docs/platform/features/entity-scoped-memory.mdx
@@ -130,7 +130,7 @@ print(agent_results)
 ```
 
 <Tip icon="compass">
-Writes can include multiple identifiers, but searches resolve one entity space at a time. Query user scope *or* agent scope in a given call—combining both returns an empty list today.
+Writes can include multiple identifiers, but searches resolve one entity space at a time. Query user scope *or* agent scope in a given call: combining both returns an empty list today.
 </Tip>
 
 <Tip icon="sparkles">

--- a/docs/platform/features/group-chat.mdx
+++ b/docs/platform/features/group-chat.mdx
@@ -231,7 +231,7 @@ Group chat supports async processing for improved performance. Memory additions 
 <CodeGroup>
 
 ```python Python
-# Group chat — async processing is the default
+# Group chat: async processing is the default
 response = client.add(
     messages,
     run_id="groupchat_async",

--- a/docs/platform/features/memory-decay.mdx
+++ b/docs/platform/features/memory-decay.mdx
@@ -7,12 +7,12 @@ description: "Boost recently-used memories and gently dampen stale ones at searc
 
 Older memories drift in relevance at different speeds. A user's coffee order matters every morning; a one-off project name from last quarter rarely matters again. Memory Decay makes that intuition explicit at search time: every time a memory is returned in a search it gets a small reinforcement, and memories that haven't been touched in a while have their ranking score gently dampened.
 
-It is **a soft ranking bias, never a filter.** Decay never zeroes a candidate out — at worst it scales its score by `0.3×`. Anything that would have surfaced without decay can still surface with decay on, just with a different ranking among similarly-scored results.
+It is **a soft ranking bias, never a filter.** Decay never zeroes a candidate out: at worst it scales its score by `0.3×`. Anything that would have surfaced without decay can still surface with decay on, just with a different ranking among similarly-scored results.
 
 <Info>
   **Use Memory Decay when…**
   - Search results are crowded with old facts the user no longer cares about.
-  - You want recently-used memories to drift to the top automatically — without writing custom scoring logic.
+  - You want recently-used memories to drift to the top automatically: without writing custom scoring logic.
   - You want this preference applied per project so cohorts can be compared side-by-side.
 </Info>
 
@@ -30,7 +30,7 @@ Every memory carries a small piece of bookkeeping: when was it last retrieved, a
 | Touched today | 1.2 – 1.4× | Mild boost |
 | Idle for a few days | 0.6 – 1.0× | Mild dampening |
 | Idle for weeks | 0.4 – 0.6× | Stronger dampening |
-| Idle for many months / years | ≈ **0.3×** | Floor — never lower |
+| Idle for many months / years | ≈ **0.3×** | Floor: never lower |
 
 The bounds matter: `0.3` is the floor and `1.5` is the ceiling, so decay can meaningfully reorder candidates without ever dominating the underlying relevance score.
 
@@ -41,16 +41,16 @@ At search time the pipeline:
 3. Sorts on the unclamped product so the full `0.3×–1.5×` range can rearrange candidates.
 4. Returns the public `score` clamped to `[0, 1]` so the API contract is preserved.
 5. Truncates to the `top_k` you requested.
-6. Records a fire-and-forget reinforcement against each returned memory — its access history grows by one, capped at the most recent 20 touches.
+6. Records a fire-and-forget reinforcement against each returned memory: its access history grows by one, capped at the most recent 20 touches.
 
-Memories created before decay was enabled don't yet have an access history. They use a sensible fallback: their `updated_at` is treated as a single past touch, so the same scale above applies based on how stale that update is — a recently-updated legacy memory enters near the neutral band, a long-stale one sits closer to the floor. Once surfaced in a search after decay is on, they accumulate access history naturally and behave like any other memory.
+Memories created before decay was enabled don't yet have an access history. They use a sensible fallback: their `updated_at` is treated as a single past touch, so the same scale above applies based on how stale that update is: a recently-updated legacy memory enters near the neutral band, a long-stale one sits closer to the floor. Once surfaced in a search after decay is on, they accumulate access history naturally and behave like any other memory.
 
 ## Configure access
 
 - Set `MEM0_API_KEY` in your environment, or pass it to the SDK constructor.
 - Initialize the client with the organization and project you want to scope to.
 
-The toggle lives on the project. You enable decay by patching the project's `decay` field; everything else — your `add` calls, your `search` calls, your application code — stays exactly the same.
+The toggle lives on the project. You enable decay by patching the project's `decay` field; everything else: your `add` calls, your `search` calls, your application code: stays exactly the same.
 
 ## Enable decay for a project
 
@@ -137,23 +137,23 @@ curl -X PATCH https://api.mem0.ai/api/v1/orgs/organizations/$ORG_ID/projects/$PR
 
 ## What stays the same
 
-- **Public API shape** — every endpoint accepts the same parameters and returns the same fields. You don't touch your client code.
-- **Threshold semantics on the request side** — your `threshold` is still applied during candidate selection.
-- **Memory creation and storage** — every new memory still lands the same way. Decay is a search-time concern.
-- **Per-memory data** — categories, metadata, timestamps, embeddings: untouched.
+- **Public API shape**: every endpoint accepts the same parameters and returns the same fields. You don't touch your client code.
+- **Threshold semantics on the request side**: your `threshold` is still applied during candidate selection.
+- **Memory creation and storage**: every new memory still lands the same way. Decay is a search-time concern.
+- **Per-memory data**: categories, metadata, timestamps, embeddings: untouched.
 
 <Warning>
-  Because the scaling factor is applied *after* the threshold filter has already run, an item that passed the request `threshold` can come back with a public `score` slightly below it (a stale candidate dampened by `0.3×`). This is intentional — decay is a soft bias, not a filter. If you require a hard `score >= threshold` invariant on the response, filter client-side after the call.
+  Because the scaling factor is applied *after* the threshold filter has already run, an item that passed the request `threshold` can come back with a public `score` slightly below it (a stale candidate dampened by `0.3×`). This is intentional: decay is a soft bias, not a filter. If you require a hard `score >= threshold` invariant on the response, filter client-side after the call.
 </Warning>
 
 ## Lifecycle of a memory under decay
 
 | Stage | Scaling factor | Effect |
 |---|---|---|
-| Just added | ≈ 1.5× | Strong boost — fresh facts surface easily. |
+| Just added | ≈ 1.5× | Strong boost: fresh facts surface easily. |
 | Reinforced on a recent search | 1.2 – 1.5× | Sustains its boost for the next several searches. |
 | Idle for a few days | 0.6 – 1.0× | Falls back into the neutral band. |
-| Idle for weeks | 0.4 – 0.6× | Mild dampening — can still surface for strong matches. |
+| Idle for weeks | 0.4 – 0.6× | Mild dampening: can still surface for strong matches. |
 | Pre-decay legacy memory (no access history) | 0.3 – 1.0× | Falls back to `updated_at`: recently-updated entries land near 1.0×, long-stale entries approach the 0.3× floor. |
 
 The reinforcement is bounded: each memory tracks at most the last 20 access timestamps, so the boost stays well-behaved no matter how many times a memory is retrieved.
@@ -161,31 +161,31 @@ The reinforcement is bounded: each memory tracks at most the last 20 access time
 ## FAQ
 
 **Will decay ever drop a result that would otherwise surface?**
-No. The floor is `0.3×` — the scaling factor can dampen a score, never zero it. Threshold filtering happens *before* decay, so any candidate that cleared the threshold is in the pool decay reorders.
+No. The floor is `0.3×`: the scaling factor can dampen a score, never zero it. Threshold filtering happens *before* decay, so any candidate that cleared the threshold is in the pool decay reorders.
 
 **Why is the public score sometimes below my requested threshold?**
-The threshold is applied to the candidate pool pre-decay; the scaling factor then reshapes scores in the `0.3×–1.5×` band. A stale-but-relevant candidate can come back with a final score slightly under your threshold by design — the candidate stays visible but visibly dampened. Filter client-side if you need a hard floor on the response.
+The threshold is applied to the candidate pool pre-decay; the scaling factor then reshapes scores in the `0.3×–1.5×` band. A stale-but-relevant candidate can come back with a final score slightly under your threshold by design: the candidate stays visible but visibly dampened. Filter client-side if you need a hard floor on the response.
 
 **Does decay change how I add memories?**
 No. The `client.add(...)` path is unchanged. Decay is a search-time ranking adjustment.
 
 **What if I had memories before turning decay on?**
-They use a fallback: the memory's `updated_at` is treated as a single historical touch, so the same scaling applies based on how stale that update is — a recently-updated legacy memory enters near the neutral band (~1.0×), a long-stale one closer to the floor (~0.3×). Once retrieved they accumulate access history and behave like any other memory.
+They use a fallback: the memory's `updated_at` is treated as a single historical touch, so the same scaling applies based on how stale that update is: a recently-updated legacy memory enters near the neutral band (~1.0×), a long-stale one closer to the floor (~0.3×). Once retrieved they accumulate access history and behave like any other memory.
 
 **Can I tune how aggressively decay scales scores?**
-Not in this version. The current scaling is calibrated to be conservative — wide enough to meaningfully reorder candidates, narrow enough to never dominate the underlying relevance score. Per-project tuning is on the roadmap.
+Not in this version. The current scaling is calibrated to be conservative: wide enough to meaningfully reorder candidates, narrow enough to never dominate the underlying relevance score. Per-project tuning is on the roadmap.
 
 **Can I see the scaling factor per result?**
-Internal scoring details are persisted on the search Event for support and debugging. They aren't exposed in the public response by design — the response surface stays a single `score` field.
+Internal scoring details are persisted on the search Event for support and debugging. They aren't exposed in the public response by design: the response surface stays a single `score` field.
 
 **Does decay interact with reranking?**
-Yes — they layer cleanly. The reranker produces a richer relevance score; decay then biases that score by reinforcement history before final truncation to `top_k`.
+Yes: they layer cleanly. The reranker produces a richer relevance score; decay then biases that score by reinforcement history before final truncation to `top_k`.
 
 ## What's next
 
-This release is deliberately the simplest version of decay we could ship — every memory contributes to ranking through its access history alone, so the signal can be evaluated in isolation. On the roadmap:
+This release is deliberately the simplest version of decay we could ship: every memory contributes to ranking through its access history alone, so the signal can be evaluated in isolation. On the roadmap:
 
 - **Category-aware weighting.** A fact tagged `health` will be able to carry more weight than a passing observation tagged `misc`, so important categories don't get dampened the same way as noise.
-- **Auto-tuning per project.** Project-scoped automatic adjustment of how aggressively decay scales scores, based on observed access patterns — replacing the fixed scaling band with one that fits your workload.
+- **Auto-tuning per project.** Project-scoped automatic adjustment of how aggressively decay scales scores, based on observed access patterns: replacing the fixed scaling band with one that fits your workload.
 
-Both extensions are forward-compatible — no migration on your side will be needed when they ship.
+Both extensions are forward-compatible: no migration on your side will be needed when they ship.

--- a/docs/platform/features/temporal-reasoning.mdx
+++ b/docs/platform/features/temporal-reasoning.mdx
@@ -32,7 +32,7 @@ client = MemoryClient(api_key="your-api-key")
 
 When a memory describes an event, a future plan, or an ongoing state, Temporal Reasoning recognizes the time context so the right results surface at search time.
 
-A query like `what did I do last week?` should return a completed past event — not an upcoming appointment and not a stable fact that hasn't changed. Temporal Reasoning handles that distinction automatically.
+A query like `what did I do last week?` should return a completed past event: not an upcoming appointment and not a stable fact that hasn't changed. Temporal Reasoning handles that distinction automatically.
 
 ### Memory types Temporal Reasoning handles
 
@@ -44,7 +44,7 @@ A query like `what did I do last week?` should return a completed past event —
 | Relationship | A durable connection between people or entities | "Priya manages Jordan." |
 | Preference | A stable preference or habit | "I prefer morning meetings." |
 
-Results come back in the normal search response shape — Temporal Reasoning affects ranking, not the response format.
+Results come back in the normal search response shape: Temporal Reasoning affects ranking, not the response format.
 
 ## Configure it
 
@@ -52,8 +52,8 @@ Temporal Reasoning is enabled by default for all v3 searches and writes. There i
 
 Two parameters give you precise control when you need it:
 
-- `timestamp` on `add()` — anchors an imported memory to the time it actually happened, rather than the time it was added to Mem0
-- `reference_date` on `search()` — resolves relative phrases like `last week` against a fixed point in time
+- `timestamp` on `add()`: anchors an imported memory to the time it actually happened, rather than the time it was added to Mem0
+- `reference_date` on `search()`: resolves relative phrases like `last week` against a fixed point in time
 
 <CodeGroup>
 ```python Python

--- a/docs/platform/mem0-mcp.mdx
+++ b/docs/platform/mem0-mcp.mdx
@@ -15,7 +15,7 @@ estimatedTime: "~2 minutes"
 
 ## What is Mem0 MCP?
 
-Mem0 MCP Server exposes Mem0's memory capabilities as MCP tools, letting AI agents decide when to save, search, or update information. The cloud-hosted MCP server requires no local installation — just connect and start using memory.
+Mem0 MCP Server exposes Mem0's memory capabilities as MCP tools, letting AI agents decide when to save, search, or update information. The cloud-hosted MCP server requires no local installation: just connect and start using memory.
 
 ## Quick Setup
 
@@ -97,7 +97,7 @@ You can also configure individual clients:
     bearer_token_env_var = "MEM0_API_KEY"
     ```
 
-    Export `MEM0_API_KEY` in the shell you launch Codex from, then restart Codex. `codex mcp add` only supports stdio servers, so HTTP servers must be added via `config.toml` directly — or via the **Plugins → Connect to a custom MCP → Streamable HTTP** UI in the Codex app.
+    Export `MEM0_API_KEY` in the shell you launch Codex from, then restart Codex. `codex mcp add` only supports stdio servers, so HTTP servers must be added via `config.toml` directly: or via the **Plugins → Connect to a custom MCP → Streamable HTTP** UI in the Codex app.
 
     <Note>
       Codex uses the server name `mem0` (not `mem0-mcp` like the other clients on this page) so it matches the name the bundled plugin registers if you ever sideload it later.
@@ -110,7 +110,7 @@ You can also configure individual clients:
     codex plugin marketplace add ~/codex-plugins/mem0-source
     ```
 
-    Then run `codex` and `/plugins`, browse the **Mem0 Plugins** marketplace, and install **Mem0**. Don't combine this with the Direct MCP setup above — the sideloaded plugin auto-registers `mem0` via `.codex-mcp.json`, so a manual `[mcp_servers.mem0]` block would create a duplicate.
+    Then run `codex` and `/plugins`, browse the **Mem0 Plugins** marketplace, and install **Mem0**. Don't combine this with the Direct MCP setup above: the sideloaded plugin auto-registers `mem0` via `.codex-mcp.json`, so a manual `[mcp_servers.mem0]` block would create a duplicate.
 
     See the [Codex integration guide](/integrations/codex) for full details, lifecycle-hook setup, and management commands (`codex plugin marketplace upgrade` / `remove`).
   </Accordion>

--- a/docs/platform/overview.mdx
+++ b/docs/platform/overview.mdx
@@ -6,12 +6,12 @@ icon: "cloud"
 
 # Mem0 Platform Overview
 
-Mem0 is the memory engine that keeps conversations contextual so users never repeat themselves and your agents respond with continuity. Mem0 Platform delivers that experience as a fully managed service—scaling, securing, and enriching memories without any infrastructure work on your side.
+Mem0 is the memory engine that keeps conversations contextual so users never repeat themselves and your agents respond with continuity. Mem0 Platform delivers that experience as a fully managed service: scaling, securing, and enriching memories without any infrastructure work on your side.
 
 ## Why it matters
 
 - **Personalized replies**: Memories persist across users and agents, cutting prompt bloat and repeat questions.
-- **Hosted stack**: Mem0 runs the vector store and rerankers—no provisioning, tuning, or maintenance.
+- **Hosted stack**: Mem0 runs the vector store and rerankers: no provisioning, tuning, or maintenance.
 - **Enterprise controls**: Audit logs and workspace governance ship by default for production readiness.
 
 <AccordionGroup>
@@ -19,7 +19,7 @@ Mem0 is the memory engine that keeps conversations contextual so users never rep
 
     | Feature | Why it helps |
     | --- | --- |
-    | Fast setup | Add a few lines of code and you’re production-ready—no vector database or LLM configuration required. |
+    | Fast setup | Add a few lines of code and you’re production-ready: no vector database or LLM configuration required. |
     | Production scale | Automatic scaling, high availability, and managed infrastructure so you focus on product work. |
     | Advanced features | webhooks, multimodal support, and custom categories are ready to enable. |
     | Enterprise ready | Audit logs, workspace governance, and dedicated support keep security and governance covered. |

--- a/docs/platform/quickstart.mdx
+++ b/docs/platform/quickstart.mdx
@@ -8,7 +8,7 @@ iconType: "solid"
 Get started with Mem0 Platform's hosted API in under 5 minutes. This guide shows you how to authenticate and store your first memory.
 
 <Note>
-**Are you an AI agent?** See [Sign up as an agent](/platform/agent-signup) — mint a working API key in four commands, no email or dashboard required.
+**Are you an AI agent?** See [Sign up as an agent](/platform/agent-signup): mint a working API key in four commands, no email or dashboard required.
 </Note>
 
 ## Prerequisites

--- a/docs/templates/api_reference_template.mdx
+++ b/docs/templates/api_reference_template.mdx
@@ -10,17 +10,17 @@ API reference pages document a single endpoint contract. Present metadata, reque
 
 ---
 
-## ❌ DO NOT COPY — Guidance & Constraints
+## ❌ DO NOT COPY: Guidance & Constraints
 - Frontmatter must include `title`, `description`, `icon`, `method`, `path`. Heading should be `# METHOD /path`.
 - Provide a quick facts table (Method, Path, Auth, Rate limit) followed by an `<Info>` block describing when to use the endpoint. Add `<Warning>` for beta headers or scope requirements.
 - Requests require headers table, body/parameters table, and `<CodeGroup>` with cURL, Python, TypeScript. If a language is unavailable, include a `<Note>` explaining why.
-- When migrating an existing endpoint page, keep the canonical examples and edge-case notes—drop them into these sections rather than inventing new payloads unless the API changed.
+- When migrating an existing endpoint page, keep the canonical examples and edge-case notes. Drop them into these sections rather than inventing new payloads unless the API changed.
 - Response section must show a canonical success payload, status-code table, and troubleshooting tips. Document pagination/idempotency in `<Tip>` or `<Note>` blocks.
 - End with related endpoints, a sample workflow link, and two CTA cards (left = concept/feature, right = applied tutorial). Keep the comment reminder for reviewers.
 
 ---
 
-## ✅ COPY THIS — Content Skeleton
+## ✅ COPY THIS: Content Skeleton
 
 ````mdx
 ---
@@ -108,7 +108,7 @@ const response = await fetch("https://api.mem0.ai/v1/memories", {
 
 | Status | Meaning | Fix |
 | --- | --- | --- |
-| `201` | Memory stored successfully. | — |
+| `201` | Memory stored successfully. | N/A |
 | `400` | Missing required field. | Provide `user_id` and `memory`. |
 | `401` | Invalid or missing API key. | Refresh key in dashboard. |
 

--- a/docs/templates/concept_guide_template.mdx
+++ b/docs/templates/concept_guide_template.mdx
@@ -10,7 +10,7 @@ Concept guides establish a shared mental model before feature or API docs. Defin
 
 ---
 
-## ❌ DO NOT COPY — Guidance & Constraints
+## ❌ DO NOT COPY: Guidance & Constraints
 - Frontmatter must include `title`, `description`, `icon`. Lead with a definition + analogy in two sentences max.
 - Add an `<Info>` block (“Why it matters”) with 2–3 bullets summarizing user impact. Use `<Warning>` near limitations or beta callouts.
 - Introduce vocabulary via `## Key terms` (table or bullets) before diving deeper.
@@ -21,7 +21,7 @@ Concept guides establish a shared mental model before feature or API docs. Defin
 
 ---
 
-## ✅ COPY THIS — Content Skeleton
+## ✅ COPY THIS: Content Skeleton
 
 ````mdx
 ---

--- a/docs/templates/cookbook_template.mdx
+++ b/docs/templates/cookbook_template.mdx
@@ -10,24 +10,24 @@ Cookbooks are narrative tutorials. They start with a real problem, show the brok
 
 ---
 
-## ❌ DO NOT COPY — Guidance & Constraints
+## ❌ DO NOT COPY: Guidance & Constraints
 - Tell a story: problem → broken demo → iterative fixes → production patterns.
 - Keep tone conversational; use real names ("Max", "Sarah"), not `user_123`.
 - Opening must stay tight: ≤2 short paragraphs (no bullet lists) before the first section.
 - Inline expected outputs immediately after each code block.
-- When modernizing an existing cookbook, keep the narrative beats, screenshots, and sample outputs—reshape them into this arc instead of rewriting unless the workflow changed.
+- When modernizing an existing cookbook, keep the narrative beats, screenshots, and sample outputs. Reshape them into this arc instead of rewriting unless the workflow changed.
 - Limit callouts to 3–5 per page. Prefer narrative text over stacked boxes.
 - Always provide Python **and** TypeScript tabs when an SDK exists for both.
 - Every page must end with exactly two navigation cards (left = related/side quest, right = next cookbook in the journey).
 
 ---
 
-## ✅ COPY THIS — Content Skeleton
+## ✅ COPY THIS: Content Skeleton
 Paste the block below into a new cookbook, then replace all placeholders. Remove any section you don't need **only after** the happy path works.
 
 ```mdx
 ---
-title: [Cookbook title — action oriented]
+title: [Cookbook title: action oriented]
 description: [1 sentence outcome]
 ---
 
@@ -132,14 +132,14 @@ Call out the most common mistake or edge case for this layer.
 
 ## Production Patterns
 
-- **[Pattern 1]** — `[When to use it]`
+- **[Pattern 1]**: `[When to use it]`
   ```python
   # Example snippet
   ```
   ```typescript
   // Example snippet
   ```
-- **[Pattern 2]** — `[When to use it]`
+- **[Pattern 2]**: `[When to use it]`
   ```python
   # Example snippet
   ```
@@ -149,9 +149,9 @@ Call out the most common mistake or edge case for this layer.
 
 ## What You Built
 
-- **[Capability 1]** — [How the cookbook delivers it]
-- **[Capability 2]** — [How the cookbook delivers it]
-- **[Capability 3]** — [How the cookbook delivers it]
+- **[Capability 1]**: [How the cookbook delivers it]
+- **[Capability 2]**: [How the cookbook delivers it]
+- **[Capability 3]**: [How the cookbook delivers it]
 
 ## Production Checklist
 

--- a/docs/templates/feature_guide_template.mdx
+++ b/docs/templates/feature_guide_template.mdx
@@ -19,7 +19,7 @@ Use this when you introduce or deepen a single Mem0 capability (Graph Memory, Ad
 - Frontmatter stays outcome-driven: `title`, `description`, `icon`, optional `badge` (e.g., “Advanced”).
 - Opening paragraph = two sentences: problem, then payoff. Keep energy high right from the start.
 - Include an `<Info>` block titled “You’ll use this when…” with 3 bullets (user persona, workload, expected benefit).
-- When reshaping legacy feature docs, carry over existing diagrams, tables, and gotchas—organize them under these headings rather than replacing them unless the product has changed.
+- When reshaping legacy feature docs, carry over existing diagrams, tables, and gotchas. Organize them under these headings rather than replacing them unless the product has changed.
 - If there’s a known caveat (pricing, performance), surface it early in a `<Warning>` so readers don’t get surprised later.
 - Optional but encouraged: add a Mermaid diagram right after the intro to show how components connect; delete it if the story is obvious without visuals.
 - Add a `## Configure access` snippet (even if it’s “Confirm your Mem0 API key is already configured”) so contributors never forget to mention the baseline setup.
@@ -30,7 +30,7 @@ Use this when you introduce or deepen a single Mem0 capability (Graph Memory, Ad
   2. **Configure it** – Step-by-step enabling instructions with `<CodeGroup>` or JSON/YAML snippets. Follow each code block with a short explanation of why it matters.
   3. **See it in action** – End-to-end example (often reusing operation snippets). Pair code with `<Info icon="check">` for expected results and `<Tip>` for optimization hints.
 - Insert `<Note>` blocks for cross-links (e.g., “Also available via REST endpoint `/v1/...`”).
-- Keep the tone instructive but light—no long manifestos.
+- Keep the tone instructive but light. No long manifestos.
 
 ### 3. **End – Evaluate and go deeper**
 - Add an `## Verify the feature is working` section with bullets (metrics, logs, dashboards).
@@ -118,7 +118,7 @@ Walk through a real request/response. Include sample payloads and highlight nota
 
 ## Best practices
 
-- Keep criteria minimal—overfiltering hurts recall.
+- Keep criteria minimal. Overfiltering hurts recall.
 - Pair with Memory Filters for hybrid scoring.
 
 {/* DEBUG: verify CTA targets */}

--- a/docs/templates/integration_guide_template.mdx
+++ b/docs/templates/integration_guide_template.mdx
@@ -10,17 +10,17 @@ Integration guides prove a joint journey: configure Mem0 and the partner with mi
 
 ---
 
-## ❌ DO NOT COPY — Guidance & Constraints
+## ❌ DO NOT COPY: Guidance & Constraints
 - Frontmatter must include `title`, `description`, `icon`, and optional `partnerBadge`/`tags`. State the joint value in one sentence right after the H1.
 - List prerequisites for **both** platforms inside an `<Info>` block. Surface limited-access or beta flags in a `<Warning>` before any setup.
 - Default to Tabs + Steps when instructions diverge (Platform vs OSS, Python vs TypeScript). When only one path exists, add a `<Note>` explaining the missing variant.
-- When migrating an existing integration, keep the proven steps/screenshots—map them into this structure rather than rewriting unless either product has changed.
+- When migrating an existing integration, keep the proven steps/screenshots. Map them into this structure rather than rewriting unless either product has changed.
 - Keep any Mermaid diagrams optional and left-to-right (`graph LR`) to avoid vertical overflow; use only if architecture clarity is needed.
 - Every major step must finish with a verification `<Info icon="check">`. End the page with exactly two CTA cards (left = related reference, right = next integration/cookbook).
 
 ---
 
-## ✅ COPY THIS — Content Skeleton
+## ✅ COPY THIS: Content Skeleton
 Paste the block below, replace placeholders, and delete optional sections only when unnecessary for this integration.
 
 ````mdx
@@ -31,7 +31,7 @@ icon: "puzzle-piece"
 partnerBadge: "[Partner name]" # Optional
 ---
 
-# [Integration headline — Mem0 + Partner promise]
+# [Integration headline: Mem0 + Partner promise]
 
 Combine Mem0’s memory layer with [Partner] to [describe the joint outcome].
 
@@ -168,8 +168,8 @@ partner.registerTool("recallPreferences", async (userId: string) => {
 
 ## Troubleshooting
 
-- **[Issue]** — `[Fix or link to partner docs]`
-- **[Issue]** — `[Fix or link to Mem0 troubleshooting guide]`
+- **[Issue]**: `[Fix or link to partner docs]`
+- **[Issue]**: `[Fix or link to Mem0 troubleshooting guide]`
 
 {/* DEBUG: verify CTA targets */}
 

--- a/docs/templates/migration_guide_template.mdx
+++ b/docs/templates/migration_guide_template.mdx
@@ -10,18 +10,18 @@ Migrations lower blood pressure. They explain what’s changing, why it matters,
 
 ---
 
-## ❌ DO NOT COPY — Guidance & Constraints
+## ❌ DO NOT COPY: Guidance & Constraints
 - Keep the frontmatter complete (`title`, `description`, `icon`, `versionFrom`, `versionTo`, and optional `releaseDate`). Readers should know at a glance what versions they are moving between.
 - Start with context: summary table + “Should you upgrade?” checklist. Highlight deadlines with `<Warning>` and call out optional paths with `<Tip>`.
 - Break the body into **Plan → Migrate → Validate**. Use numbered headings inside **Migrate** and put rollback instructions directly after any risky step.
-- When porting older migration guides, keep existing change tables, screenshots, and warnings—slot them into this format unless the upgrade path has materially changed.
+- When porting older migration guides, keep existing change tables, screenshots, and warnings. Slot them into this format unless the upgrade path has materially changed.
 - Document breaking changes with an `Old behavior` vs `New behavior` table. Use `<Info icon="check">` for mandatory verification steps.
 - Optional flow diagrams are allowed, but only when a left-to-right Mermaid (`graph LR`) clarifies the upgrade path.
 - End with two CTA cards (left = deep dive reference, right = applied example) and keep the comment reminder for reviewers.
 
 ---
 
-## ✅ COPY THIS — Content Skeleton
+## ✅ COPY THIS: Content Skeleton
 Paste the block below, swap placeholders, and delete optional sections only after you’ve confirmed they aren’t needed.
 
 ```mdx
@@ -34,7 +34,7 @@ versionTo: "[target version]"
 releaseDate: "[YYYY-MM-DD]" # Optional
 ---
 
-# [Migration headline — state the move]
+# [Migration headline: state the move]
 
 | Scope | Effort | Downtime |
 | --- | --- | --- |
@@ -130,8 +130,8 @@ npm install mem0ai@[version]
 
 ## Known issues
 
-- **[Issue name]** — `[Status]`. `[Workaround or link]`.
-- **[Issue name]** — `[Status]`. `[Workaround or link]`.
+- **[Issue name]**: `[Status]`. `[Workaround or link]`.
+- **[Issue name]**: `[Status]`. `[Workaround or link]`.
 
 ## After you migrate
 

--- a/docs/templates/operation_guide_template.mdx
+++ b/docs/templates/operation_guide_template.mdx
@@ -10,18 +10,18 @@ Operation guides focus on a single action (add, search, update, delete). Show th
 
 ---
 
-## ❌ DO NOT COPY — Guidance & Constraints
+## ❌ DO NOT COPY: Guidance & Constraints
 - Frontmatter needs `title`, `description`, `icon`. Title should be a verb phrase (“Add Memories”).
 - Lead with a two-sentence promise (problem → outcome), followed by an `<Info>` prerequisites block and optional `<Warning>` for hazards (overwrites, rate limits).
 - Include a “When to pick this” bullet list (≤3 items) so readers confirm they’re in the right doc.
 - Use Tabs with Python and TypeScript examples. If only one SDK exists, add a `<Note>` stating that explicitly.
-- When migrating legacy guides, keep existing code paths and notes—slot them into these sections instead of replacing them unless behavior changed.
+- When migrating legacy guides, keep existing code paths and notes. Slot them into these sections instead of replacing them unless behavior changed.
 - Provide `<Info icon="check">` verification after each critical step; call out the most common error with a `<Warning>` close to where it can occur.
 - End with exactly two CTA cards: left = conceptual depth, right = applied example/cookbook.
 
 ---
 
-## ✅ COPY THIS — Content Skeleton
+## ✅ COPY THIS: Content Skeleton
 
 ````mdx
 ---
@@ -30,7 +30,7 @@ description: [Outcome in one sentence]
 icon: "bolt"
 ---
 
-# [Operation headline — say what it does]
+# [Operation headline: say what it does]
 
 [State the problem this solves.] [Explain the outcome after running it.]
 

--- a/docs/templates/parameters_reference_template.mdx
+++ b/docs/templates/parameters_reference_template.mdx
@@ -10,18 +10,18 @@ Parameter references document every input/output detail for one operation after 
 
 ---
 
-## ❌ DO NOT COPY — Guidance & Constraints
+## ❌ DO NOT COPY: Guidance & Constraints
 - Frontmatter requires `title`, `description`, `icon`. Titles should mirror the operation (“Add Memories Parameters”).
 - Place canonical Python and TypeScript signatures right under the heading using `<CodeGroup>`. Mention defaults or breaking changes in an `<Info>` or `<Warning>` immediately after.
 - Parameter table must include columns: Name, Type, Required, Description, Notes. Add a Managed/OSS distinction either as a column or in Notes.
-- When updating legacy parameter sheets, keep the authoritative field lists and notes—reformat them into this structure rather than trimming details unless the schema changed.
+- When updating legacy parameter sheets, keep the authoritative field lists and notes. Reformat them into this structure rather than trimming details unless the schema changed.
 - Response table must include Field, Type, Description, Example. For nested objects, add subtables or `<CodeGroup>` JSON snippets beneath the row.
 - Examples section should show minimal Python and TypeScript calls with one-sentence explanations. If a language is missing, include a `<Note>` explaining why.
 - Finish with related operations, troubleshooting tied to parameter misuse, and a two-card CTA (operation guide on the left, cookbook/integration on the right).
 
 ---
 
-## ✅ COPY THIS — Content Skeleton
+## ✅ COPY THIS: Content Skeleton
 
 ````mdx
 ---
@@ -127,8 +127,8 @@ These snippets confirm the method returns the new `memory_id` for follow-up oper
 
 ## Troubleshooting
 
-- **`400 Missing user_id`** — Provide either `user_id` or `agent_id` in the payload.
-- **`422 Metadata too large`** — Reduce metadata size below 2KB (OSS hard limit).
+- **`400 Missing user_id`**: Provide either `user_id` or `agent_id` in the payload.
+- **`422 Metadata too large`**: Reduce metadata size below 2KB (OSS hard limit).
 
 {/* DEBUG: verify CTA targets */}
 

--- a/docs/templates/quickstart_template.mdx
+++ b/docs/templates/quickstart_template.mdx
@@ -10,28 +10,28 @@ Quickstarts are the fastest path to first success. Each page should configure th
 
 ---
 
-## ❌ DO NOT COPY — Guidance & Constraints
+## ❌ DO NOT COPY: Guidance & Constraints
 - Keep the intro tight: one-sentence promise + `<Info>` prerequisites. Add `<Warning>` only for blocking requirements (e.g., “requires paid tier”).
 - Default to Python + TypeScript examples inside `<Tabs>` with `<Steps>` per language. If a second language truly doesn’t exist, add a `<Note>` explaining why.
 - Every journey must follow **Install → Configure → Add → Search → Delete** (or closest equivalents). Drop verification `<Info icon="check">` immediately after the critical operation.
-- When migrating an existing quickstart, reuse canonical snippets and screenshots—reshape them into this flow rather than rewriting content unless the product changed.
+- When migrating an existing quickstart, reuse canonical snippets and screenshots. Reshape them into this flow rather than rewriting content unless the product changed.
 - If you include a Mermaid diagram, keep it optional and render left-to-right (`graph LR`) so it doesn’t flood the page.
 - End with exactly two CTA cards: left = related/alternative path, right = next step in the journey. No link farms.
 
 ---
 
-## ✅ COPY THIS — Content Skeleton
+## ✅ COPY THIS: Content Skeleton
 Paste the block below into a new quickstart, then replace **every** placeholder. Remove optional sections only after the happy path is working.
 
 ````mdx
 ---
-title: [Quickstart title — action focused]
+title: [Quickstart title: action focused]
 description: [1 sentence outcome]
 icon: "rocket"
 estimatedTime: "[~X minutes]"
 ---
 
-# [Hero headline — promise the win]
+# [Hero headline: promise the win]
 
 <Info>
   **Prerequisites**

--- a/docs/templates/release_notes_template.mdx
+++ b/docs/templates/release_notes_template.mdx
@@ -6,21 +6,21 @@ icon: "megaphone"
 
 # Release Notes Template
 
-Release notes are heartbeat updates. They tell readers what shipped, what needs attention, and where to go for the deep dive—fast.
+Release notes are heartbeat updates. They tell readers what shipped, what needs attention, and where to go for the deep dive fast.
 
 ---
 
-## ❌ DO NOT COPY — Guidance & Constraints
+## ❌ DO NOT COPY: Guidance & Constraints
 - Frontmatter must include `title`, `description`, `icon`, `releaseDate`, and `version`. Add `tags` if you need filters (e.g., `["platform", "oss"]`).
 - Lead with a one-sentence headline plus a quick stats table (New features, Fixes, Required action). Keep the TL;DR in an `<Info>` block; use `<Warning>` only for breaking changes or deadlines.
 - Organize the body into Highlights, Improvements & fixes (grouped by product), and Known issues. Each bullet links to docs where appropriate.
-- When reshaping older release notes, retain the shipped items and shout-outs—map them to these sections instead of rewriting history.
+- When reshaping older release notes, retain the shipped items and shout-outs. Map them to these sections instead of rewriting history.
 - Include an Upgrade checklist with concrete next steps. Optional “Community shout-outs” should remain short.
 - Two-card CTA at the end, as always: left = deeper reference, right = applied next step.
 
 ---
 
-## ✅ COPY THIS — Content Skeleton
+## ✅ COPY THIS: Content Skeleton
 Paste the snippet below, swap placeholders, and trim optional sections only once you know they’re unnecessary.
 
 ```mdx
@@ -54,9 +54,9 @@ tags: ["platform", "oss"] # Optional filters
 
 ## Highlights
 
-- **[Feature name]** — [One-sentence benefit]. [Link to doc]
-- **[Feature name]** — [One-sentence benefit]. [Link to doc]
-- **[Feature name]** — [One-sentence benefit]. [Link to doc]
+- **[Feature name]:** [One-sentence benefit]. [Link to doc]
+- **[Feature name]:** [One-sentence benefit]. [Link to doc]
+- **[Feature name]:** [One-sentence benefit]. [Link to doc]
 
 ## Improvements & fixes
 
@@ -77,18 +77,18 @@ tags: ["platform", "oss"] # Optional filters
 
 ## Known issues
 
-- **[Issue name]** — `[Status]`. `[Workaround or link].`
-- **[Issue name]** — `[Status]`. `[Workaround or link].`
+- **[Issue name]:** `[Status]`. `[Workaround or link].`
+- **[Issue name]:** `[Status]`. `[Workaround or link].`
 
 ## Upgrade checklist
 
-- [ ] `[Step 1 — update package or config]`
-- [ ] `[Step 2 — run migration or toggle setting]`
-- [ ] `[Step 3 — verify workflow or metric]`
+- [ ] `[Step 1: update package or config]`
+- [ ] `[Step 2: run migration or toggle setting]`
+- [ ] `[Step 3: verify workflow or metric]`
 
 ## Community shout-outs
 
-- [Contributor or team] — `[Short thank-you message].`
+- [Contributor or team]: `[Short thank-you message].`
 
 {/* DEBUG: verify CTA targets */}
 

--- a/docs/templates/section_overview_template.mdx
+++ b/docs/templates/section_overview_template.mdx
@@ -10,18 +10,18 @@ Overview pages orient readers for an entire section. Summarize who it’s for, s
 
 ---
 
-## ❌ DO NOT COPY — Guidance & Constraints
+## ❌ DO NOT COPY: Guidance & Constraints
 - Frontmatter must include `title`, `description`, `icon`. Keep the hero paragraph under two sentences describing audience + outcome.
 - Provide an `<Info>` block pointing to the primary entry point (usually the quickstart). Use `<Warning>` only for major caveats (beta, deprecation).
 - Stage journeys in 4–6 cards total. Break into multiple `<CardGroup>` rows when a binary choice (e.g., Python vs Node) or stacked journeys reads better. Keep copy ≤15 words with icons + links.
-- When migrating an existing overview, reuse the established journeys, images, and stats—reshape them into this layout rather than cutting content unless it’s outdated.
+- When migrating an existing overview, reuse the established journeys, images, and stats. Reshape them into this layout rather than cutting content unless it’s outdated.
 - Optional accordions (`<AccordionGroup>`) can tuck detailed tables (feature breakdowns, comparisons) beneath the hero when extra context is helpful.
 - Optional visuals (comparison table, Mermaid diagram) should be left-to-right and only added when they reduce confusion.
 - Finish with exactly two CTA cards: left = adjacent/alternative track, right = next logical step deeper in the section.
 
 ---
 
-## ✅ COPY THIS — Content Skeleton
+## ✅ COPY THIS: Content Skeleton
 
 ````mdx
 ---

--- a/docs/templates/troubleshooting_playbook_template.mdx
+++ b/docs/templates/troubleshooting_playbook_template.mdx
@@ -10,17 +10,17 @@ Troubleshooting playbooks map symptoms to diagnostics and fixes. Keep them fast 
 
 ---
 
-## ❌ DO NOT COPY — Guidance & Constraints
+## ❌ DO NOT COPY: Guidance & Constraints
 - Frontmatter must include `title`, `description`, `icon`. Lead with one sentence about the system or workflow this playbook covers.
 - Add an `<Info>` block (“Use this when…”) and a quick index table (Symptom, Likely cause, Fix link). Surface critical safety warnings in `<Warning>`.
 - Each symptom section needs: diagnostic command/snippet, `<Info icon="check">` expected output, `<Warning>` for the observed failure, numbered fix steps, and optional `<Tip>` for prevention.
-- If you’re migrating an existing playbook, carry forward the known failure modes and scripts—reformat them into this structure unless the troubleshooting path changed.
+- If you’re migrating an existing playbook, carry forward the known failure modes and scripts. Reformat them into this structure unless the troubleshooting path changed.
 - Group unrelated issues with horizontal rules and provide escalation guidance when self-service stops.
 - Conclude with prevention checklist, related docs, and the standard two-card CTA (concept/reference left, applied workflow right).
 
 ---
 
-## ✅ COPY THIS — Content Skeleton
+## ✅ COPY THIS: Content Skeleton
 
 ````mdx
 ---

--- a/docs/vibecoding.mdx
+++ b/docs/vibecoding.mdx
@@ -24,7 +24,7 @@ We follow the llms.txt standard:
 
 Mem0 ships two kinds of skills for AI coding assistants. Both work with Claude Code, Codex, Cursor, Windsurf, OpenCode, OpenClaw, and any assistant that supports the skills standard.
 
-### Reference skills — always on
+### Reference skills: always on
 
 Teach your assistant Mem0's SDK surface so it writes correct code in everyday development:
 
@@ -34,11 +34,11 @@ npx skills add https://github.com/mem0ai/mem0 --skill mem0-cli
 npx skills add https://github.com/mem0ai/mem0 --skill mem0-vercel-ai-sdk
 ```
 
-- `mem0` — Python and TypeScript SDKs (Platform + OSS), plus framework integrations (LangChain, CrewAI, OpenAI Agents, LangGraph, LlamaIndex, etc.)
-- `mem0-cli` — terminal workflows for the `mem0` CLI (both Node and Python builds)
-- `mem0-vercel-ai-sdk` — `@mem0/vercel-ai-provider` and `createMem0`
+- `mem0`: Python and TypeScript SDKs (Platform + OSS), plus framework integrations (LangChain, CrewAI, OpenAI Agents, LangGraph, LlamaIndex, etc.)
+- `mem0-cli`: terminal workflows for the `mem0` CLI (both Node and Python builds)
+- `mem0-vercel-ai-sdk`: `@mem0/vercel-ai-provider` and `createMem0`
 
-### Pipeline skills — run on demand
+### Pipeline skills: run on demand
 
 Let your assistant execute an end-to-end workflow in an existing repo. Invoked as slash commands:
 
@@ -48,9 +48,9 @@ npx skills add https://github.com/mem0ai/mem0 --skill mem0-test-integration
 npx skills add https://github.com/mem0ai/mem0 --skill mem0-oss-to-platform
 ```
 
-- `/mem0-integrate` — wire Mem0 into an existing repository using a goal-driven, test-first pipeline. Detects the stack, asks whether to use Platform or OSS, writes failing tests first, and keeps the integration additive and feature-flagged.
-- `/mem0-test-integration` — verify what `/mem0-integrate` produced. Runs the repo's native test suite and a real end-to-end smoke flow against your API key, then produces a scorecard.
-- `/mem0-oss-to-platform` — migrate an existing project from Mem0 OSS to the hosted Platform SDK. Audits where Mem0 is used, writes a reviewable migration plan, then executes it on approval.
+- `/mem0-integrate`: wire Mem0 into an existing repository using a goal-driven, test-first pipeline. Detects the stack, asks whether to use Platform or OSS, writes failing tests first, and keeps the integration additive and feature-flagged.
+- `/mem0-test-integration`: verify what `/mem0-integrate` produced. Runs the repo's native test suite and a real end-to-end smoke flow against your API key, then produces a scorecard.
+- `/mem0-oss-to-platform`: migrate an existing project from Mem0 OSS to the hosted Platform SDK. Audits where Mem0 is used, writes a reviewable migration plan, then executes it on approval.
 
 See the [skills index](https://github.com/mem0ai/mem0/tree/main/skills) for the full catalog.
 
@@ -75,7 +75,7 @@ For per-client setup and advanced options, see [Mem0 MCP Setup](/platform/mem0-m
 Copy this into any AI tool to start building with Mem0:
 
 ```text
-I want to start building with Mem0 — a self-improving memory layer for LLM
+I want to start building with Mem0: a self-improving memory layer for LLM
 applications that gives agents persistent context across sessions.
 
 ## Mem0 Resources
@@ -95,7 +95,7 @@ applications that gives agents persistent context across sessions.
 - Cookbooks: https://docs.mem0.ai/cookbooks/overview
 
 **What Mem0 Does:**
-Mem0 is a memory layer for AI apps — managed (Mem0 Platform) or self-hosted
+Mem0 is a memory layer for AI apps: managed (Mem0 Platform) or self-hosted
 (Open Source). It stores, retrieves, and manages user memories so agents
 remember preferences, learn from interactions, and personalize over time.
 Sub-50ms retrieval. Storage: vector embeddings.


### PR DESCRIPTION
## Linked Issue

N/A

## Description

- Removes em dashes from the public changelog highlights page.
- Rewrites highlight bullets into a more developer-friendly format with clearer API behavior, usage notes, and impact.
- Updates the release notes template examples so future copied highlights use the same readable style.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [x] No tests needed (explain why)

Manual checks:
- `git diff --check`
- `python3 scripts/check-llms-txt-coverage.py`
- `rg -n "—" docs/changelog/highlights.mdx docs/templates/release_notes_template.mdx || true`

No unit tests needed: docs copy only.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
