### PR TITLE
docs: add first-contribution fast path in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,20 @@ Other packages include the CLIs (`cli/python/`, `cli/node/`), integrations
    `Closes #<number>` and filling out the
    [PR template](./.github/PULL_REQUEST_TEMPLATE.md).
 
+### First-contribution fast path (docs and small quality fixes)
+
+If you are shipping a docs-only or tiny quality fix, use this lightweight lane to speed reviews:
+
+1. Start from an agreed issue and keep scope to one clear user-facing improvement
+2. Use a focused branch name, for example `docs/fix-api-example-typo`
+3. Run quick local checks before opening PR:
+   - `pre-commit run --files <changed-files>`
+   - package-specific tests only when code paths are touched
+4. Link issue in the PR body with `Closes #<number>`
+5. Add before/after snippets for docs clarifications when useful
+
+This keeps contribution quality high while reducing review overhead for maintainers.
+
 ### Contributing to the Python SDK (`mem0/`)
 
 We use [`hatch`](https://hatch.pypa.io/latest/install/) to manage environments.


### PR DESCRIPTION
## Summary
- add a lightweight first-contribution fast path section for docs and small quality fixes
- include a minimal pre-PR checklist and branch naming example
- keep scope aligned with current CONTRIBUTING structure

## Context
Closes #5649

## Notes
Supersedes #5995 to provide a conflict-free branch for review.

## Validation
- docs-only change in `CONTRIBUTING.md`
- guidance is optional and non-breaking
