### PR TITLE
fix(memory): avoid silent memory loss when LLM prose contains braces before JSON

### DIFF
--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -132,40 +132,45 @@ def remove_code_blocks(content: str) -> str:
 def _first_parseable_json_object(text: str) -> Optional[str]:
     """Return the first balanced ``{...}`` substring that parses as JSON.
 
-    Scans brace depth while respecting string literals (so braces inside JSON
-    string values do not affect nesting) and validates each candidate with
-    ``json.loads``. This skips brace-containing prose that precedes the real
-    JSON object, e.g. ``"the user said {hi}. {\"memory\": [...]}"``.
+    Single linear pass over ``text``: brace depth is tracked while respecting
+    string literals (so braces inside JSON string values do not affect nesting).
+    A candidate span opens only when depth returns to 0, and each completed
+    top-level ``{...}`` span is validated with ``json.loads``; on a failed parse
+    the scan simply continues rather than restarting, keeping this O(n) even for
+    long runs of unbalanced braces (e.g. truncated output). This skips
+    brace-containing prose preceding the real JSON, e.g.
+    ``"the user said {hi}. {\"memory\": [...]}"``.
     """
-    for start in range(len(text)):
-        if text[start] != "{":
+    start = -1
+    depth = 0
+    in_string = False
+    escaped = False
+    for i, char in enumerate(text):
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
             continue
-        depth = 0
-        in_string = False
-        escaped = False
-        for i in range(start, len(text)):
-            char = text[i]
-            if in_string:
-                if escaped:
-                    escaped = False
-                elif char == "\\":
-                    escaped = True
-                elif char == '"':
-                    in_string = False
-                continue
-            if char == '"':
-                in_string = True
-            elif char == "{":
-                depth += 1
-            elif char == "}":
-                depth -= 1
-                if depth == 0:
-                    candidate = text[start : i + 1]
-                    try:
-                        json.loads(candidate, strict=False)
-                    except json.JSONDecodeError:
-                        break  # this '{' does not start a valid object; try the next one
-                    return candidate
+        if char == '"':
+            in_string = True
+        elif char == "{":
+            if depth == 0:
+                start = i
+            depth += 1
+        elif char == "}":
+            if depth == 0:
+                continue  # stray closing brace, ignore
+            depth -= 1
+            if depth == 0:
+                candidate = text[start : i + 1]
+                try:
+                    json.loads(candidate, strict=False)
+                except json.JSONDecodeError:
+                    continue  # not valid JSON; keep scanning for the next object
+                return candidate
     return None
 
 

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -1,7 +1,8 @@
 import hashlib
+import json
 import logging
 import re
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from mem0.configs.prompts import (
     AGENT_MEMORY_EXTRACTION_PROMPT,
@@ -128,23 +129,68 @@ def remove_code_blocks(content: str) -> str:
 
 
 
+def _first_parseable_json_object(text: str) -> Optional[str]:
+    """Return the first balanced ``{...}`` substring that parses as JSON.
+
+    Scans brace depth while respecting string literals (so braces inside JSON
+    string values do not affect nesting) and validates each candidate with
+    ``json.loads``. This skips brace-containing prose that precedes the real
+    JSON object, e.g. ``"the user said {hi}. {\"memory\": [...]}"``.
+    """
+    for start in range(len(text)):
+        if text[start] != "{":
+            continue
+        depth = 0
+        in_string = False
+        escaped = False
+        for i in range(start, len(text)):
+            char = text[i]
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == '"':
+                    in_string = False
+                continue
+            if char == '"':
+                in_string = True
+            elif char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if depth == 0:
+                    candidate = text[start : i + 1]
+                    try:
+                        json.loads(candidate, strict=False)
+                    except json.JSONDecodeError:
+                        break  # this '{' does not start a valid object; try the next one
+                    return candidate
+    return None
+
+
 def extract_json(text):
     """
     Extracts JSON content from a string, removing enclosing triple backticks and optional 'json' tag if present.
-    If no code block is found, attempts to locate JSON by finding the first '{' and last '}'.
-    If that also fails, returns the text as-is.
+    If no code block is found, returns the first balanced ``{...}`` substring that parses as JSON, so that
+    brace-containing prose preceding the JSON does not corrupt the result. Falls back to the span between the
+    first '{' and last '}', and finally to the text as-is.
     """
     text = text.strip()
     match = re.search(r"```(?:json)?\s*(.*?)\s*```", text, re.DOTALL)
     if match:
         json_str = match.group(1)
     else:
-        start_idx = text.find("{")
-        end_idx = text.rfind("}")
-        if start_idx != -1 and end_idx != -1 and end_idx > start_idx:
-            json_str = text[start_idx : end_idx + 1]
+        parseable = _first_parseable_json_object(text)
+        if parseable is not None:
+            json_str = parseable
         else:
-            json_str = text
+            start_idx = text.find("{")
+            end_idx = text.rfind("}")
+            if start_idx != -1 and end_idx != -1 and end_idx > start_idx:
+                json_str = text[start_idx : end_idx + 1]
+            else:
+                json_str = text
     return json_str
 
 

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -130,47 +130,34 @@ def remove_code_blocks(content: str) -> str:
 
 
 def _first_parseable_json_object(text: str) -> Optional[str]:
-    """Return the first balanced ``{...}`` substring that parses as JSON.
+    """Return the first ``{...}`` substring of ``text`` that parses as JSON.
 
-    Single linear pass over ``text``: brace depth is tracked while respecting
-    string literals (so braces inside JSON string values do not affect nesting).
-    A candidate span opens only when depth returns to 0, and each completed
-    top-level ``{...}`` span is validated with ``json.loads``; on a failed parse
-    the scan simply continues rather than restarting, keeping this O(n) even for
-    long runs of unbalanced braces (e.g. truncated output). This skips
-    brace-containing prose preceding the real JSON, e.g.
-    ``"the user said {hi}. {\"memory\": [...]}"``.
+    Each candidate ``{`` is decoded with ``json.JSONDecoder.raw_decode``, which
+    consumes exactly one JSON value and fails fast on a non-JSON start. This
+    finds the real object even when earlier prose contains an unmatched or
+    otherwise invalid brace (e.g. ``"I'll fill in {the blank. JSON: {...}"``),
+    which a single running brace-depth counter cannot do -- one stray ``{`` would
+    pin the depth above zero and hide every following object.
+
+    To stay linear on long runs of braces (truncated output, ``{{ }}`` template
+    notation), only positions that can actually begin an object are decoded: the
+    next non-whitespace character must be ``"`` (a key) or ``}`` (empty object).
+    Runs of ``{{{...`` therefore cost O(1) each instead of a full raw_decode.
     """
-    start = -1
-    depth = 0
-    in_string = False
-    escaped = False
-    for i, char in enumerate(text):
-        if in_string:
-            if escaped:
-                escaped = False
-            elif char == "\\":
-                escaped = True
-            elif char == '"':
-                in_string = False
-            continue
-        if char == '"':
-            in_string = True
-        elif char == "{":
-            if depth == 0:
-                start = i
-            depth += 1
-        elif char == "}":
-            if depth == 0:
-                continue  # stray closing brace, ignore
-            depth -= 1
-            if depth == 0:
-                candidate = text[start : i + 1]
-                try:
-                    json.loads(candidate, strict=False)
-                except json.JSONDecodeError:
-                    continue  # not valid JSON; keep scanning for the next object
-                return candidate
+    decoder = json.JSONDecoder(strict=False)
+    length = len(text)
+    idx = text.find("{")
+    while idx != -1:
+        nxt = idx + 1
+        while nxt < length and text[nxt] in " \t\r\n":
+            nxt += 1
+        if nxt < length and text[nxt] in '"}':
+            try:
+                _, end = decoder.raw_decode(text, idx)
+                return text[idx:end]
+            except json.JSONDecodeError:
+                pass
+        idx = text.find("{", idx + 1)
     return None
 
 

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -130,53 +130,71 @@ def remove_code_blocks(content: str) -> str:
 
 
 def _first_parseable_json_object(text: str) -> Optional[str]:
-    """Return the first ``{...}`` substring of ``text`` that parses as JSON.
+    """Return the outermost trailing ``{...}`` substring of ``text`` that parses as JSON.
 
-    Each candidate ``{`` is decoded with ``json.JSONDecoder.raw_decode``, which
-    consumes exactly one JSON value and fails fast on a non-JSON start. This
-    finds the real object even when earlier prose contains an unmatched or
-    otherwise invalid brace (e.g. ``"I'll fill in {the blank. JSON: {...}"``),
-    which a single running brace-depth counter cannot do -- one stray ``{`` would
-    pin the depth above zero and hide every following object.
+    Candidate ``{`` positions are tried from the end of the text backward. The
+    LLM output this helper exists for is prose-then-JSON, so the payload is
+    reached within the first few candidates no matter how expensive the junk
+    braces in the prose would be to reject -- a forward scan has to pay to
+    reject every junk brace before ever reaching the payload, and any bound on
+    that work makes it give up too early (junk braces from truncated output
+    fail at end-of-text, so a couple of attempts exhaust any linear budget).
 
-    To stay linear on long runs of braces (truncated output, ``{{ }}`` template
-    notation), only positions that can actually begin an object are decoded: the
-    next non-whitespace character must be ``"`` (a key) or ``}`` (empty object).
-    Runs of ``{{{...`` therefore cost O(1) each instead of a full raw_decode.
+    Scanning backward, the first successful parse is usually an object nested
+    inside the payload (e.g. a single memory item), so the scan keeps walking
+    left and adopts any candidate whose parse ends strictly later -- which is
+    exactly an enclosing object. Junk candidates between or before successes
+    are simply skipped, so an unparseable fragment inside a string value does
+    not stop the walk from reaching the enclosing object. The result is the
+    outermost object of the trailing JSON payload; when the text contains
+    several disjoint objects, the last one wins.
 
-    Candidates that pass the prefilter can still be expensive to reject -- an
-    unterminated string (e.g. truncated ``'{"a":{"a":...'`` output) makes
-    raw_decode scan to end-of-text before failing, and repeating that at every
-    candidate is quadratic. A cumulative scan budget of ``2 * len(text)``
-    characters (charged per failed attempt from ``JSONDecodeError.pos``) plus an
-    attempt cap bounds total work to O(n); once exhausted, this returns None and
-    ``extract_json`` falls through to its naive-span fallback, the pre-existing
-    behavior.
+    Each candidate is decoded with ``json.JSONDecoder.raw_decode``.
+    ``RecursionError`` counts as a failed candidate: a deep brace run (e.g.
+    ``'{"a":' * 15000``) blows the interpreter recursion limit inside
+    ``raw_decode`` before it can raise ``JSONDecodeError``.
+
+    Only positions whose next non-whitespace character is ``"`` (a key) or
+    ``}`` (empty object) are decoded, so runs of ``{{{...`` cost O(1) each.
+    Failed decodes charge the characters they actually scanned
+    (``JSONDecodeError.pos``; the remaining text for ``RecursionError``)
+    against a ``2 * len(text)`` budget, keeping adversarial all-junk input
+    (where every candidate fails) linear. In the realistic prose-then-JSON
+    shape the payload is adopted before the junk is ever attempted, so
+    exhausting the budget cannot lose it: the best object found is returned
+    regardless. Only with no parseable object at all does this return None,
+    and ``extract_json`` falls through to its naive-span fallback, the
+    pre-existing behavior.
     """
     decoder = json.JSONDecoder(strict=False)
     length = len(text)
     budget = 2 * length
-    attempts_left = 100
-    idx = text.find("{")
-    while idx != -1 and budget > 0 and attempts_left > 0:
+    best_start = -1
+    best_end = -1
+    idx = text.rfind("{")
+    while idx != -1 and budget > 0:
         nxt = idx + 1
         while nxt < length and text[nxt] in " \t\r\n":
             nxt += 1
         if nxt < length and text[nxt] in '"}':
             try:
                 _, end = decoder.raw_decode(text, idx)
-                return text[idx:end]
+                if end > best_end:
+                    best_start, best_end = idx, end
             except json.JSONDecodeError as err:
                 budget -= max(err.pos - idx, 1)
-                attempts_left -= 1
-        idx = text.find("{", idx + 1)
+            except RecursionError:
+                budget -= length - idx
+        idx = text.rfind("{", 0, idx)
+    if best_start != -1:
+        return text[best_start:best_end]
     return None
 
 
 def extract_json(text):
     """
     Extracts JSON content from a string, removing enclosing triple backticks and optional 'json' tag if present.
-    If no code block is found, returns the first balanced ``{...}`` substring that parses as JSON, so that
+    If no code block is found, returns the outermost trailing ``{...}`` substring that parses as JSON, so that
     brace-containing prose preceding the JSON does not corrupt the result. Falls back to the span between the
     first '{' and last '}', and finally to the text as-is.
     """

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -143,11 +143,22 @@ def _first_parseable_json_object(text: str) -> Optional[str]:
     notation), only positions that can actually begin an object are decoded: the
     next non-whitespace character must be ``"`` (a key) or ``}`` (empty object).
     Runs of ``{{{...`` therefore cost O(1) each instead of a full raw_decode.
+
+    Candidates that pass the prefilter can still be expensive to reject -- an
+    unterminated string (e.g. truncated ``'{"a":{"a":...'`` output) makes
+    raw_decode scan to end-of-text before failing, and repeating that at every
+    candidate is quadratic. A cumulative scan budget of ``2 * len(text)``
+    characters (charged per failed attempt from ``JSONDecodeError.pos``) plus an
+    attempt cap bounds total work to O(n); once exhausted, this returns None and
+    ``extract_json`` falls through to its naive-span fallback, the pre-existing
+    behavior.
     """
     decoder = json.JSONDecoder(strict=False)
     length = len(text)
+    budget = 2 * length
+    attempts_left = 100
     idx = text.find("{")
-    while idx != -1:
+    while idx != -1 and budget > 0 and attempts_left > 0:
         nxt = idx + 1
         while nxt < length and text[nxt] in " \t\r\n":
             nxt += 1
@@ -155,8 +166,9 @@ def _first_parseable_json_object(text: str) -> Optional[str]:
             try:
                 _, end = decoder.raw_decode(text, idx)
                 return text[idx:end]
-            except json.JSONDecodeError:
-                pass
+            except json.JSONDecodeError as err:
+                budget -= max(err.pos - idx, 1)
+                attempts_left -= 1
         idx = text.find("{", idx + 1)
     return None
 

--- a/tests/test_chatty_llm_parsing.py
+++ b/tests/test_chatty_llm_parsing.py
@@ -9,7 +9,11 @@ import json
 
 import pytest
 
-from mem0.memory.utils import extract_json, remove_code_blocks
+from mem0.memory.utils import (
+    _first_parseable_json_object,
+    extract_json,
+    remove_code_blocks,
+)
 
 
 # --- Test extract_json ---
@@ -112,6 +116,26 @@ That's the result."""
         result = extract_json(text)
         parsed = json.loads(result)
         assert parsed["memory"][0]["text"] == "use {curly} braces"
+
+    def test_many_unbalanced_braces_stays_linear(self):
+        """Regression guard against O(n^2) rescanning of unbalanced braces.
+
+        The first implementation restarted a full scan from every '{', so a long
+        run of unbalanced braces (truncated output, or '{{ }}' templating) was
+        O(n^2): about 25s for 50k braces. The linear scan handles it in
+        milliseconds; the generous bound fails the quadratic version by a wide
+        margin without being flaky on slow CI.
+        """
+        import time
+
+        text = "{" * 50000
+        start = time.perf_counter()
+        result = extract_json(text)
+        elapsed = time.perf_counter() - start
+        # No balanced JSON object exists, so nothing parseable is found.
+        assert _first_parseable_json_object(text) is None
+        assert result == text  # falls through to the return-as-is branch
+        assert elapsed < 2.0
 
 
 # --- Test remove_code_blocks ---

--- a/tests/test_chatty_llm_parsing.py
+++ b/tests/test_chatty_llm_parsing.py
@@ -91,6 +91,28 @@ That's the result."""
         parsed = json.loads(result)
         assert parsed["memory"][0]["id"] == "0"
 
+    def test_chatty_prose_with_braces_before_json(self):
+        """Prose that itself contains braces must not corrupt extraction.
+
+        Regression test: the naive first-'{'-to-last-'}' fallback grabbed a
+        brace from the prose, producing invalid JSON and (via the outer except
+        in _add_to_vector_store) silently dropping all extracted memories.
+        """
+        text = (
+            "Based on the conversation {about travel}, here is the update: "
+            '{"memory": [{"id": "0", "text": "likes travel", "event": "ADD"}]}'
+        )
+        result = extract_json(text)
+        parsed = json.loads(result)
+        assert parsed["memory"][0]["text"] == "likes travel"
+
+    def test_braces_inside_json_string_value(self):
+        """Braces inside a JSON string value must not break extraction."""
+        text = '{"memory": [{"id": "0", "text": "use {curly} braces", "event": "ADD"}]}'
+        result = extract_json(text)
+        parsed = json.loads(result)
+        assert parsed["memory"][0]["text"] == "use {curly} braces"
+
 
 # --- Test remove_code_blocks ---
 
@@ -230,3 +252,16 @@ I hope this helps!"""
         response = 'Sure! Here are the facts:\n{"facts": ["Name is Alex", "Loves basketball"]}\nHope that helps!'
         result = self._parse_with_fallback(response)
         assert result["facts"] == ["Name is Alex", "Loves basketball"]
+
+    def test_chatty_prose_with_braces(self):
+        """Full chain: chatty prose containing braces before the JSON.
+
+        Previously the fallback produced invalid JSON and the outer except in
+        main.py swallowed it, silently dropping all extracted memories.
+        """
+        response = (
+            "The user mentioned {a trip}. Here is the update: "
+            '{"memory": [{"id": "0", "text": "planning a trip", "event": "ADD"}]}'
+        )
+        result = self._parse_with_fallback(response)
+        assert result["memory"][0]["text"] == "planning a trip"

--- a/tests/test_chatty_llm_parsing.py
+++ b/tests/test_chatty_llm_parsing.py
@@ -164,6 +164,43 @@ That's the result."""
         assert json.loads(result)["memory"][0]["text"] == "ok"
         assert elapsed < 2.0
 
+    def test_truncated_key_fragments_stay_linear(self):
+        """Truncated nested-key output must not make the scan quadratic.
+
+        Regression guard: in '{"a":{"a":...' (a small model stuck repeating a
+        key fragment, then cut off by max_tokens) every '{' passes the
+        object-start prefilter, and each raw_decode scans to end-of-text before
+        failing on the unterminated string -- repeating that at every candidate
+        was O(n^2) (~seconds at 75k chars). The cumulative scan budget bounds
+        total decode work to O(n) and falls through to the naive-span fallback.
+        """
+        import time
+
+        text = '{"a":' * 15000
+        start = time.perf_counter()
+        result = extract_json(text)
+        elapsed = time.perf_counter() - start
+        assert _first_parseable_json_object(text) is None
+        assert result == text  # no '}' anywhere, so the as-is fallback applies
+        assert elapsed < 2.0
+
+    def test_truncated_fragments_then_real_json_bounded(self):
+        """Truncated fragments before a real object: bounded time, naive-span fallback.
+
+        The scan budget is exhausted by the expensive dead-end candidates, so
+        extraction falls through to the first-'{'-to-last-'}' span -- the
+        pre-existing behavior for pathological input -- instead of spending
+        quadratic time trying every fragment.
+        """
+        import time
+
+        text = '{"a":' * 15000 + ' {"memory": [{"id": "0", "text": "ok", "event": "ADD"}]}'
+        start = time.perf_counter()
+        result = extract_json(text)
+        elapsed = time.perf_counter() - start
+        assert elapsed < 2.0
+        assert result == text[text.find("{") : text.rfind("}") + 1]
+
 
 # --- Test remove_code_blocks ---
 

--- a/tests/test_chatty_llm_parsing.py
+++ b/tests/test_chatty_llm_parsing.py
@@ -137,6 +137,33 @@ That's the result."""
         assert result == text  # falls through to the return-as-is branch
         assert elapsed < 2.0
 
+    def test_unmatched_brace_before_real_json(self):
+        """An unmatched '{' in prose must not hide a later valid object.
+
+        Regression: a single running brace-depth counter is pinned above zero
+        by one stray open brace, so the real object is never reached and
+        extract_json falls through to the naive span, reproducing #5998.
+        """
+        text = (
+            "Sure, I will fill in {the blank with details later. "
+            'Here is the extracted JSON: '
+            '{"memory": [{"id": "0", "text": "likes travel", "event": "ADD"}]}'
+        )
+        result = extract_json(text)
+        parsed = json.loads(result)
+        assert parsed["memory"][0]["text"] == "likes travel"
+
+    def test_many_unbalanced_braces_then_real_json_stays_linear(self):
+        """Unmatched braces followed by a real object: found, and still linear."""
+        import time
+
+        text = "{" * 50000 + ' {"memory": [{"id": "0", "text": "ok", "event": "ADD"}]}'
+        start = time.perf_counter()
+        result = extract_json(text)
+        elapsed = time.perf_counter() - start
+        assert json.loads(result)["memory"][0]["text"] == "ok"
+        assert elapsed < 2.0
+
 
 # --- Test remove_code_blocks ---
 
@@ -289,3 +316,12 @@ I hope this helps!"""
         )
         result = self._parse_with_fallback(response)
         assert result["memory"][0]["text"] == "planning a trip"
+
+    def test_unmatched_brace_before_json(self):
+        """Full chain: an unmatched '{' in prose before the real object."""
+        response = (
+            "Note: sketching {pseudocode for later. Final answer: "
+            '{"memory": [{"id": "0", "text": "Name is Alex", "event": "ADD"}]}'
+        )
+        result = self._parse_with_fallback(response)
+        assert result["memory"][0]["text"] == "Name is Alex"

--- a/tests/test_chatty_llm_parsing.py
+++ b/tests/test_chatty_llm_parsing.py
@@ -165,14 +165,17 @@ That's the result."""
         assert elapsed < 2.0
 
     def test_truncated_key_fragments_stay_linear(self):
-        """Truncated nested-key output must not make the scan quadratic.
+        """Truncated nested-key output must not make the scan quadratic or crash.
 
         Regression guard: in '{"a":{"a":...' (a small model stuck repeating a
         key fragment, then cut off by max_tokens) every '{' passes the
-        object-start prefilter, and each raw_decode scans to end-of-text before
-        failing on the unterminated string -- repeating that at every candidate
-        was O(n^2) (~seconds at 75k chars). The cumulative scan budget bounds
-        total decode work to O(n) and falls through to the naive-span fallback.
+        object-start prefilter, and raw_decode is expensive to reject at every
+        candidate -- repeating that unboundedly was O(n^2) (~seconds at 75k
+        chars), and decoding from a candidate with thousands of nesting levels
+        after it raises RecursionError (not JSONDecodeError) on the default
+        recursion limit, which must be caught, not crash. The cumulative scan
+        budget bounds total decode work to O(n) and falls through to the
+        naive-span fallback.
         """
         import time
 
@@ -184,13 +187,14 @@ That's the result."""
         assert result == text  # no '}' anywhere, so the as-is fallback applies
         assert elapsed < 2.0
 
-    def test_truncated_fragments_then_real_json_bounded(self):
-        """Truncated fragments before a real object: bounded time, naive-span fallback.
+    def test_truncated_fragments_then_real_json_recovered(self):
+        """Truncated fragments before a real object: the object is recovered, in bounded time.
 
-        The scan budget is exhausted by the expensive dead-end candidates, so
-        extraction falls through to the first-'{'-to-last-'}' span -- the
-        pre-existing behavior for pathological input -- instead of spending
-        quadratic time trying every fragment.
+        The backward scan reaches the real object within its first few
+        candidates, before any of the expensive dead-end fragments are
+        attempted, so the payload is genuinely recovered -- not merely handed
+        to the naive-span fallback (whose span would include the fragments and
+        fail to parse, silently dropping the memories in main.py).
         """
         import time
 
@@ -199,10 +203,66 @@ That's the result."""
         result = extract_json(text)
         elapsed = time.perf_counter() - start
         assert elapsed < 2.0
-        assert result == text[text.find("{") : text.rfind("}") + 1]
+        assert json.loads(result) == {"memory": [{"id": "0", "text": "ok", "event": "ADD"}]}
+
+    def test_few_truncated_fragments_then_real_json_recovered(self):
+        """A handful of truncated fragments must not exhaust the scan.
+
+        Regression: with a forward scan, each '{"a":' fragment fails only at
+        end-of-text, so just two or three fragments consumed a
+        2*len(text)-character budget and the real object right behind them was
+        never attempted -- 15 characters of junk prose defeated the whole
+        recovery path. Scanning backward, the object is found first and the
+        fragments are never even decoded.
+        """
+        text = '{"a":' * 3 + ' {"memory": [{"id": "0", "text": "ok", "event": "ADD"}]}'
+        result = extract_json(text)
+        assert json.loads(result) == {"memory": [{"id": "0", "text": "ok", "event": "ADD"}]}
+
+    def test_many_cheap_decoys_then_real_json_recovered(self):
+        """Many cheap-to-reject decoys must not exhaust the scan.
+
+        Regression: a flat cap of 100 decode attempts gave up after 100 decoys
+        costing ~5 characters each, even though the total work done was tiny.
+        Work is now bounded by characters scanned, not attempts, and the
+        backward scan never reaches the decoys anyway.
+        """
+        text = '{"a"}' * 100 + ' {"memory": [{"id": "0", "text": "ok", "event": "ADD"}]}'
+        result = extract_json(text)
+        assert json.loads(result) == {"memory": [{"id": "0", "text": "ok", "event": "ADD"}]}
+
+    def test_multiple_disjoint_objects_last_wins(self):
+        """With several disjoint parseable objects, the trailing one is returned.
+
+        The backward scan intentionally prefers the last object: when a chatty
+        model quotes a JSON example in its prose and then emits the actual
+        payload, the payload comes last.
+        """
+        text = (
+            'For example, {"memory": []} would mean no change. My answer: '
+            '{"memory": [{"id": "0", "text": "ok", "event": "ADD"}]}'
+        )
+        result = extract_json(text)
+        assert json.loads(result) == {"memory": [{"id": "0", "text": "ok", "event": "ADD"}]}
+
+    def test_brace_inside_string_value_before_nested_object(self):
+        """An unparseable '{\"' inside a string value must not hide the envelope.
+
+        Scanning backward from the nested memory item, the next candidate
+        leftward is the '{\"' inside the "note" string, which does not parse.
+        The walk must skip it and continue to the enclosing object rather than
+        stopping at the first failure and returning only the inner item.
+        """
+        text = '{"note": "see {\\" for quoting", "memory": [{"id": "0", "text": "ok", "event": "ADD"}]}'
+        result = extract_json(text)
+        assert json.loads(result) == {
+            "note": 'see {" for quoting',
+            "memory": [{"id": "0", "text": "ok", "event": "ADD"}],
+        }
 
 
 # --- Test remove_code_blocks ---
+
 
 class TestRemoveCodeBlocks:
     """Tests for remove_code_blocks — verify it does NOT handle chatty text."""
@@ -243,6 +303,7 @@ class TestRemoveCodeBlocks:
 
 
 # --- Test the full fallback chain (remove_code_blocks -> extract_json) ---
+
 
 class TestFallbackChain:
     """Tests the actual fallback pattern used in _add_to_vector_store:


### PR DESCRIPTION
## Linked Issue

Closes #5998

## Description

`extract_json`'s no-code-fence fallback returned the span from the first `{` to the last `}`. When a chatty LLM (common with local Ollama / LM Studio models) wraps its JSON in prose that itself contains braces, that span starts inside the prose and is not valid JSON. `json.loads` then raises, the outer `except` in `_add_to_vector_store` swallows it, and the extracted memories are silently dropped with no error surfaced.

This scans for the first balanced `{...}` substring that actually parses as JSON, walking brace depth while respecting string literals so braces inside JSON string values are ignored. The previous first-`{`-to-last-`}` span and the return-as-is behavior remain as fallbacks, so existing cases are unchanged.

This is the same silent-memory-loss class tracked in #5245 and #5509, and it sits squarely in the scope `tests/test_chatty_llm_parsing.py` already targets; the existing tests only cover prose without braces.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

Extends `tests/test_chatty_llm_parsing.py` with regression cases: prose containing braces before the JSON (which failed before this change), and braces inside a JSON string value (guard against the string-aware scan regressing). The two prose-with-braces cases fail on `main` and pass with this fix.

```
tests/test_chatty_llm_parsing.py .... 24 passed
related memory/util tests ............ 62 passed
ruff check ........................... All checks passed
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed (no public API or docs change)