### PR TITLE
docs(graph-memory): gate Graph view visualization to Pro/Enterprise

### DIFF
--- a/docs/platform/features/graph-memory.mdx
+++ b/docs/platform/features/graph-memory.mdx
@@ -58,7 +58,14 @@ Graph Memory captures **which entities your memories are about and how they conn
 
 ## Availability
 
-Graph Memory is **automatic and included on all plans**. It activates on the new memory algorithm with no flag, no configuration, and no external dependencies. You don't need to do anything to benefit from it.
+Graph Memory has two parts, and they are gated differently:
+
+| What | Availability |
+| --- | --- |
+| **Graph memory**: entity extraction, linking, and the retrieval boost | **All plans**, automatic |
+| **Graph view**: interactive visualization in the dashboard | **Pro and Enterprise** |
+
+Every plan gets the graph working behind the scenes to sharpen retrieval. **Pro and Enterprise** unlock the interactive **Graph view**, where you can explore your entities, trace how memories connect, and search and filter the whole graph right in your dashboard.
 
 ```python
 from mem0 import MemoryClient


### PR DESCRIPTION
## What
Splits the **Availability** section of the Graph Memory page so plan gating is clear: the graph algorithm (entity extraction, linking, retrieval boost) stays on **all plans**, and the interactive **Graph view** in the dashboard is **Pro and Enterprise**.

## Why
The page previously stated Graph Memory is "included on all plans". That holds for the algorithm, but the interactive dashboard visualization is gated to Pro/Enterprise, so the blanket statement is now misleading. This makes the split explicit and reassures that retrieval quality is unchanged on lower plans.

## Change
- `platform/features/graph-memory.mdx` Availability: per-capability table + short explainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
