### PR TITLE
docs: clarify OpenCode Desktop environment setup

### DIFF
--- a/docs/integrations/opencode.mdx
+++ b/docs/integrations/opencode.mdx
@@ -22,6 +22,8 @@ echo 'export MEM0_API_KEY="m0-your-api-key"' >> ~/.bashrc && source ~/.bashrc
 ```
 </CodeGroup>
 
+OpenCode Desktop may not inherit variables from shell startup files such as `.zshrc` or `.bashrc`. If Desktop logs say `MEM0_API_KEY` is missing, set the variable in the environment that launches OpenCode Desktop, or start Desktop from a terminal where `MEM0_API_KEY` is already exported.
+
 ## Installation
 
 ### Option A: Plugin Install (Recommended)
@@ -103,6 +105,14 @@ The default persists in `~/.mem0/settings.json` (`default_scope`) and is read fr
 
 The project id (`app_id`) is derived from your git remote (`owner-repo`), falling back to the git repo's root directory name, then the current directory. Launch OpenCode from inside your repo so memories scope to the project rather than your home directory.
 
+If OpenCode Desktop resolves the wrong project id, set `MEM0_APP_ID` before launching OpenCode:
+
+```bash
+export MEM0_APP_ID="owner-repo"
+```
+
+Run `/mem0-status` after restart to confirm the active `app_id`.
+
 ## Lifecycle Hooks
 
 The plugin uses the [mem0ai](https://www.npmjs.com/package/mem0ai) TypeScript SDK directly. It is pure TypeScript, no Python, no shell scripts.
@@ -138,11 +148,11 @@ If auto-dream hasn't run yet, it's almost always because a gate hasn't been met 
 ## Troubleshooting
 
 - **No tools appearing**: Restart OpenCode after installing
-- **"Connection failed"**: Verify your key is set: `echo $MEM0_API_KEY`
+- **"Connection failed"**: Verify your key is set: `echo $MEM0_API_KEY`. For OpenCode Desktop, make sure the key is available to the Desktop process, not only to interactive shells.
 - **Plugin not loading**: Run `opencode plugin @mem0/opencode-plugin` again, then restart
 - **Hooks not firing**: Hooks require the plugin install (Option A). MCP-only installs don't include hooks.
 - **Auto-dream never runs**: It's gated (time + sessions + memories). Run `/mem0-status` to see which gate is blocking, or `/mem0-dream` to consolidate now.
-- **Wrong project name / memories not found**: The project id comes from your git remote; launch OpenCode from inside the repo (not your home directory). Check the resolved id with `/mem0-status`.
+- **Wrong project name / memories not found**: The project id comes from your git remote; launch OpenCode from inside the repo (not your home directory). If Desktop still resolves the wrong id, set `MEM0_APP_ID` before launching OpenCode. Check the resolved id with `/mem0-status`.
 
 <CardGroup cols={2}>
   <Card title="Mem0 MCP Setup" icon="puzzle-piece" href="/platform/mem0-mcp">

--- a/integrations/mem0-plugin/.opencode-plugin/README.md
+++ b/integrations/mem0-plugin/.opencode-plugin/README.md
@@ -22,6 +22,8 @@ Get your API key (free): [app.mem0.ai/dashboard/api-keys](https://app.mem0.ai/da
 echo 'export MEM0_API_KEY="m0-your-key"' >> ~/.zshrc && source ~/.zshrc
 ```
 
+OpenCode Desktop may not inherit variables from shell startup files such as `.zshrc` or `.bashrc`. If Desktop logs say `MEM0_API_KEY` is missing, set the variable in the environment that launches OpenCode Desktop, or start Desktop from a terminal where `MEM0_API_KEY` is already exported.
+
 Restart OpenCode.
 
 ## What's included
@@ -93,8 +95,9 @@ If the `mem0` tools respond, you're all set.
 | Problem | Fix |
 |---------|-----|
 | No tools appearing | Restart OpenCode after installing |
-| 401 Unauthorized | `echo $MEM0_API_KEY` must print your `m0-` key |
+| 401 Unauthorized | `echo $MEM0_API_KEY` must print your `m0-` key. For OpenCode Desktop, make sure the key is available to the Desktop process, not only to interactive shells. |
 | Plugin not loading | Run `opencode plugin @mem0/opencode-plugin` again |
+| Wrong project name / memories not found | Open the repo folder directly. If Desktop still resolves the wrong id, set `export MEM0_APP_ID="owner-repo"` before launching OpenCode, then verify with `/mem0-status`. |
 
 ## License
 


### PR DESCRIPTION
## Summary
- clarify that OpenCode Desktop may not inherit `MEM0_API_KEY` from shell startup files
- document `MEM0_APP_ID` as the supported override when Desktop resolves the wrong project id
- add the same troubleshooting guidance to the published OpenCode plugin README

Addresses part of #6003.

## Verification
- `git diff --check`

Not run: docs site build, because this is a Markdown-only clarification and the local sparse checkout does not include the full docs app dependencies.
