### PR TITLE
fix(mem0-plugin): parse Cursor role-style entries in PreCompact/Stop fallback

### DIFF
--- a/integrations/mem0-plugin/scripts/on_pre_compact.py
+++ b/integrations/mem0-plugin/scripts/on_pre_compact.py
@@ -85,7 +85,12 @@ def parse_transcript(lines: list[str]) -> dict:
         except json.JSONDecodeError:
             continue
 
+        # Claude Code / Codex transcripts discriminate turns with ``type``;
+        # Cursor agent transcripts use ``role`` instead. Accept either so the
+        # PreCompact/Stop fallback works across all supported editors.
         entry_type = entry.get("type")
+        if entry_type not in ("user", "assistant"):
+            entry_type = entry.get("role")
         if entry_type not in ("user", "assistant"):
             continue
         if entry.get("isSidechain"):
@@ -109,6 +114,11 @@ def parse_transcript(lines: list[str]) -> dict:
                 user_messages.append(text)
 
         elif entry_type == "assistant":
+            if isinstance(content_blocks, str):
+                text = content_blocks.strip()
+                if text:
+                    last_assistant_text = text
+                continue
             for block in content_blocks:
                 if not isinstance(block, dict):
                     continue

--- a/integrations/mem0-plugin/tests/test_pre_compact_parse.py
+++ b/integrations/mem0-plugin/tests/test_pre_compact_parse.py
@@ -1,0 +1,99 @@
+"""Regression tests for on_pre_compact.parse_transcript transcript dialects.
+
+Cursor agent transcripts mark turns with ``role`` instead of the Claude/Codex
+``type``. The PreCompact/Stop fallback parser only matched on ``type``, so for
+Cursor sessions it extracted no user messages and no assistant text, leaving the
+safety-net capture empty.
+"""
+
+from __future__ import annotations
+
+import json
+
+
+def test_parse_transcript_claude_type_style():
+    """Claude Code / Codex style entries use ``type``."""
+    from on_pre_compact import parse_transcript
+
+    lines = [
+        json.dumps(
+            {"type": "user", "message": {"content": "please refactor the parser module"}}
+        ),
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {"type": "text", "text": "Refactored the parser as requested."},
+                        {
+                            "type": "tool_use",
+                            "name": "Edit",
+                            "input": {"file_path": "parser.py"},
+                        },
+                    ]
+                },
+            }
+        ),
+    ]
+    state = parse_transcript(lines)
+    assert "please refactor the parser module" in state["user_messages"]
+    assert state["last_assistant_text"] == "Refactored the parser as requested."
+    assert "parser.py" in state["files_modified"]
+
+
+def test_parse_transcript_cursor_role_style():
+    """Cursor agent transcripts use ``role`` instead of ``type`` (issue #6006).
+
+    Without the fix, parse_transcript skips every Cursor entry and returns
+    empty user_messages / last_assistant_text.
+    """
+    from on_pre_compact import parse_transcript
+
+    lines = [
+        json.dumps(
+            {"role": "user", "message": {"content": "please update the configuration"}}
+        ),
+        json.dumps(
+            {
+                "role": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "I updated the requested configuration and verified it.",
+                        }
+                    ]
+                },
+            }
+        ),
+    ]
+    state = parse_transcript(lines)
+    assert "please update the configuration" in state["user_messages"]
+    assert (
+        state["last_assistant_text"]
+        == "I updated the requested configuration and verified it."
+    )
+
+
+def test_parse_transcript_cursor_assistant_string_content():
+    """Cursor assistant entry whose content is a bare string is captured."""
+    from on_pre_compact import parse_transcript
+
+    lines = [
+        json.dumps({"role": "assistant", "message": {"content": "done, all green"}}),
+    ]
+    state = parse_transcript(lines)
+    assert state["last_assistant_text"] == "done, all green"
+
+
+def test_parse_transcript_ignores_other_roles():
+    """Non user/assistant roles are still skipped."""
+    from on_pre_compact import parse_transcript
+
+    lines = [
+        json.dumps({"role": "system", "message": {"content": "system config here"}}),
+        json.dumps({"role": "tool", "message": {"content": "tool output"}}),
+    ]
+    state = parse_transcript(lines)
+    assert state["user_messages"] == []
+    assert state["last_assistant_text"] == ""


### PR DESCRIPTION
## Summary

- Make the PreCompact/Stop fallback transcript parser (`on_pre_compact.py`) understand Cursor's `role`-based transcript entries, not just Claude/Codex `type`-based ones.
- Restores the session-state safety net for Cursor users, which was silently capturing nothing.

## Motivation

Same transcript-dialect mismatch as #6006, but in a different hook script. Cursor agent transcripts mark turns with `role == "assistant"` / `role == "user"`:

```json
{"role":"assistant","message":{"content":[{"type":"text","text":"I updated the requested configuration and verified it."}]}}
```

`parse_transcript()` filtered on `entry.get("type")` only, so every Cursor entry was skipped and the fallback produced empty `user_messages` / `last_assistant_text`.

## Root Cause

**Symptom** — For Cursor sessions, the PreCompact/Stop fallback (`on_pre_compact_cursor.sh` → `on_pre_compact.sh` → `on_pre_compact.py`) captures no session state even when the session had real activity.

**Root cause** — `parse_transcript()` did `entry_type = entry.get("type")` and `continue`d when it wasn't `user`/`assistant`. Cursor carries that discriminator under `role`, so the loop skipped every Cursor turn.

**Evidence** — issue #6006's transcript sample; `parse_transcript()` in `on_pre_compact.py`. New `test_parse_transcript_cursor_role_style` reproduces the bug (empty results without the fix — see below).

**Fix + why this level** — Fall back to `entry.get("role")` when `type` is absent, mirroring the fix for the summary parser, and handle a bare-string assistant `content` (Cursor emits both list-of-blocks and plain-string shapes). Fixed inside `parse_transcript` — the single extraction point shared by both PreCompact and Stop fallback paths.

**Scope / risk** — Touches only `parse_transcript`. Claude/Codex `type`-style parsing is unchanged (test). `system`/`tool` roles are still rejected (test). No request-body, network, or storage changes.

## Verification

- `python3 -m pytest tests/test_pre_compact_parse.py tests/test_write_path.py -q` — **13 passed**
- FAILS-without-fix confirmed: stashing the parser change makes the 2 Cursor tests fail, then pass once restored.

## Real behavior proof

- **Behavior addressed:** Cursor `role`-style user+assistant transcript → state extracted (was empty).
- **Real environment:** Python 3, repo `integrations/mem0-plugin`.
- **Command run after the patch:**
  ```
  python3 -c 'import sys; sys.path.insert(0,"scripts"); from on_pre_compact import parse_transcript; import json; print(parse_transcript([json.dumps({"role":"user","message":{"content":"please update the configuration"}}), json.dumps({"role":"assistant","message":{"content":[{"type":"text","text":"I updated the requested configuration and verified it."}]}})]))'
  ```
- **Captured output AFTER fix:**
  ```
  user_messages: ['please update the configuration']
  last_assistant_text: 'I updated the requested configuration and verified it.'
  ```
- **Regression test:** `tests/test_pre_compact_parse.py::test_parse_transcript_cursor_role_style` (+ string-content variant) — asserts the new behavior and FAILS without the fix.
- **What was NOT tested:** end-to-end Cursor hook shell invocation (needs a live MEM0_API_KEY + Cursor runtime); covered at the parser unit level.

## Related

Companion to #6008 (same Cursor `role` vs `type` dialect mismatch, in `capture_session_summary.py`). This PR covers the separate `on_pre_compact.py` fallback hook.
