### PR TITLE
fix(opencode-plugin): use OpenCode project context and publish a Node-safe bundle

### DIFF
--- a/docs/integrations/opencode.mdx
+++ b/docs/integrations/opencode.mdx
@@ -101,7 +101,7 @@ To change the **default** scope (used when no scope is passed), run the `/mem0-s
 
 The default persists in `~/.mem0/settings.json` (`default_scope`) and is read fresh on each memory operation, so a change applies immediately. No restart. `delete_all_memories` always requires an explicit `scope: "global"` to delete user-wide, so changing the default can't trigger a cross-project wipe.
 
-The plugin first chooses OpenCode's active `worktree`, then `directory`, as the path it will inspect. From that path it derives the project id (`app_id`) from the git remote (`owner-repo`), falling back to the git repo's root directory name, then the current directory.
+The plugin first chooses OpenCode's active `worktree`, then `directory`, as the path it will inspect. From that path it derives the project id (`app_id`) from the git remote (`owner-repo`), falling back to the git repo's root directory name, the selected project-path basename, then the process current-directory basename.
 
 ## Lifecycle Hooks
 
@@ -142,7 +142,7 @@ If auto-dream hasn't run yet, it's almost always because a gate hasn't been met 
 - **Plugin not loading**: Run `opencode plugin @mem0/opencode-plugin` again, then restart
 - **Hooks not firing**: Hooks require the plugin install (Option A). MCP-only installs don't include hooks.
 - **Auto-dream never runs**: It's gated (time + sessions + memories). Run `/mem0-status` to see which gate is blocking, or `/mem0-dream` to consolidate now.
-- **Wrong project name / memories not found**: Check the resolved id with `/mem0-status`. The plugin prefers OpenCode's active `worktree` or `directory`; if neither is present, it falls back to git and then the current directory, so a wrong cwd can still scope memories to the wrong project.
+- **Wrong project name / memories not found**: Check the resolved id with `/mem0-status`. The plugin derives git identity from the selected OpenCode project path, preferring the active `worktree` or `directory`; if neither is present, it uses the git remote, git root basename, selected project-path basename, and process current-directory basename.
 
 <CardGroup cols={2}>
   <Card title="Mem0 MCP Setup" icon="puzzle-piece" href="/platform/mem0-mcp">

--- a/docs/integrations/opencode.mdx
+++ b/docs/integrations/opencode.mdx
@@ -101,7 +101,7 @@ To change the **default** scope (used when no scope is passed), run the `/mem0-s
 
 The default persists in `~/.mem0/settings.json` (`default_scope`) and is read fresh on each memory operation, so a change applies immediately. No restart. `delete_all_memories` always requires an explicit `scope: "global"` to delete user-wide, so changing the default can't trigger a cross-project wipe.
 
-The project id (`app_id`) is derived from your git remote (`owner-repo`), falling back to the git repo's root directory name, then the current directory. Launch OpenCode from inside your repo so memories scope to the project rather than your home directory.
+The project id (`app_id`) comes from OpenCode's active `worktree` first, then `directory`. When OpenCode does not supply either, the plugin falls back to your git remote (`owner-repo`), then the git repo's root directory name, then the current directory.
 
 ## Lifecycle Hooks
 
@@ -142,7 +142,7 @@ If auto-dream hasn't run yet, it's almost always because a gate hasn't been met 
 - **Plugin not loading**: Run `opencode plugin @mem0/opencode-plugin` again, then restart
 - **Hooks not firing**: Hooks require the plugin install (Option A). MCP-only installs don't include hooks.
 - **Auto-dream never runs**: It's gated (time + sessions + memories). Run `/mem0-status` to see which gate is blocking, or `/mem0-dream` to consolidate now.
-- **Wrong project name / memories not found**: The project id comes from your git remote; launch OpenCode from inside the repo (not your home directory). Check the resolved id with `/mem0-status`.
+- **Wrong project name / memories not found**: Check the resolved id with `/mem0-status`. The plugin prefers OpenCode's active `worktree` or `directory`; if neither is present, it falls back to git and then the current directory, so a wrong cwd can still scope memories to the wrong project.
 
 <CardGroup cols={2}>
   <Card title="Mem0 MCP Setup" icon="puzzle-piece" href="/platform/mem0-mcp">

--- a/docs/integrations/opencode.mdx
+++ b/docs/integrations/opencode.mdx
@@ -101,7 +101,7 @@ To change the **default** scope (used when no scope is passed), run the `/mem0-s
 
 The default persists in `~/.mem0/settings.json` (`default_scope`) and is read fresh on each memory operation, so a change applies immediately. No restart. `delete_all_memories` always requires an explicit `scope: "global"` to delete user-wide, so changing the default can't trigger a cross-project wipe.
 
-The project id (`app_id`) comes from OpenCode's active `worktree` first, then `directory`. When OpenCode does not supply either, the plugin falls back to your git remote (`owner-repo`), then the git repo's root directory name, then the current directory.
+The plugin first chooses OpenCode's active `worktree`, then `directory`, as the path it will inspect. From that path it derives the project id (`app_id`) from the git remote (`owner-repo`), falling back to the git repo's root directory name, then the current directory.
 
 ## Lifecycle Hooks
 

--- a/integrations/mem0-plugin/.opencode-plugin/bun.lock
+++ b/integrations/mem0-plugin/.opencode-plugin/bun.lock
@@ -12,9 +12,6 @@
         "bun-types": ">=1.3.14",
         "typescript": "^5.7.3",
       },
-      "peerDependencies": {
-        "bun": ">=1.0.0",
-      },
     },
   },
   "packages": {
@@ -87,38 +84,6 @@
     "@opencode-ai/plugin": ["@opencode-ai/plugin@1.15.11", "", { "dependencies": { "@opencode-ai/sdk": "1.15.11", "effect": "4.0.0-beta.66", "zod": "4.1.8" }, "peerDependencies": { "@opentui/core": ">=0.2.15", "@opentui/keymap": ">=0.2.15", "@opentui/solid": ">=0.2.15" }, "optionalPeers": ["@opentui/core", "@opentui/keymap", "@opentui/solid"] }, "sha512-RDvYDCHO0+3OAGD590oDQqtryrENrUW04SjtoA4sgRV2efpZeBFjx3TnonBsXKq6nWqYg172nhltUEZsihGnXQ=="],
 
     "@opencode-ai/sdk": ["@opencode-ai/sdk@1.15.11", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-IyYyDVsO8SKbKbkSadHpDuYnYC+2vmEeLU+rW+rH2M54Sigq6l3gDHno16+U6SRut+lowbph7v/ry3WbV67V3w=="],
-
-    "@oven/bun-darwin-aarch64": ["@oven/bun-darwin-aarch64@1.3.14", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Omj20SuiHBOUjUBIyqtkNjSUIjOtEOJwmbix/ZyFH4BaQ6OZTaaRWIR4TjHVz0yadHgli6lLTiAh1uarnvD49A=="],
-
-    "@oven/bun-darwin-x64": ["@oven/bun-darwin-x64@1.3.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-FFj3QdU/OhlDyZOJ8CWfN5eWLpRlT4qjZg7lMQi7jA6GuoY5ajlO1zWLP/MuHYRSbXQUvV52RejNi8DVnAp13w=="],
-
-    "@oven/bun-darwin-x64-baseline": ["@oven/bun-darwin-x64-baseline@1.3.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-OSfsTZstc898HHElhU4NccaBGOSSDn5VfahiVTnidZ9B/+wb7WTyfZJaBeJcfjwJ9H2W9uTh2TGtl3UfcXgV9g=="],
-
-    "@oven/bun-freebsd-aarch64": ["@oven/bun-freebsd-aarch64@1.3.14", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-LIKrXaFxAHybVO5Pf+9XP2FHUj/5APvXTUKk9dqHm5iFz4oH+W24cmhjkJirNujh9hKeTyrpWSe3no9JZKowIw=="],
-
-    "@oven/bun-freebsd-x64": ["@oven/bun-freebsd-x64@1.3.14", "", { "os": "freebsd", "cpu": "x64" }, "sha512-uwD+fGUH1ADpIF3B1U2jWzzb20QwRLZfj5QZ28GUCGrAJ/nTmWrD6YYGsblCY1wuhldRez3lU40AyuvSCyLYmw=="],
-
-    "@oven/bun-linux-aarch64": ["@oven/bun-linux-aarch64@1.3.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-X5SsPZHs+iYO8R/efIcRtc7gT2Q2DgPfliCxEkx4cXBumwkw0c/EsHMNwH3EgGpCDaZ7IYVPhpCG/xBOQHEwZw=="],
-
-    "@oven/bun-linux-aarch64-android": ["@oven/bun-linux-aarch64-android@1.3.14", "", { "os": "android", "cpu": "arm64" }, "sha512-y4kq5b85lsrmFb9Xvi4w9mA5IEFJkLMrSmYn06q24KjL9rUWDWO3VFZEtteZxUN5+ec3Zm5S8OnJw1umaCbVjA=="],
-
-    "@oven/bun-linux-aarch64-musl": ["@oven/bun-linux-aarch64-musl@1.3.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-jmqOA92Cd1NL/1XBd4bFkJLxQ86K0RW7ohxS2qzzAvuitO4JiIxjjTeCspoU44zCozH72HpfZfUE2On31OjnWA=="],
-
-    "@oven/bun-linux-x64": ["@oven/bun-linux-x64@1.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-7OVTAKvwfPmSbIV1HpdOoVVx5VRc427GuPPne93N6vk4eQBPId9nXmZDh9/zGaKPdbVjVtQSZafWQoUjx38Utw=="],
-
-    "@oven/bun-linux-x64-android": ["@oven/bun-linux-x64-android@1.3.14", "", { "os": "android", "cpu": "x64" }, "sha512-qe9e1d+3VAEU7nAA2ol9Jvmy/o99PVMSgZhHn7Q/9O3YcDrfEqyQ8zm4zoe5qTEo8HZH0dN03Le0Ys2eQPs7eg=="],
-
-    "@oven/bun-linux-x64-baseline": ["@oven/bun-linux-x64-baseline@1.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-q/8EdOC0yUE8FPeoOVq8/Pw5I9/tJaYmUfO/uDUAREx8IUnOJH1RJ5A3BjFqre8pvJoiZA9AovPJq5FnNNjSxA=="],
-
-    "@oven/bun-linux-x64-musl": ["@oven/bun-linux-x64-musl@1.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-GBCB/k/sIqcr06eTNgg7g46qiUv35Jasx4XiccJ/n7RGqrE4RWUD/XJBbWFprVPjvqd59+QtSnS99XGqvftHfg=="],
-
-    "@oven/bun-linux-x64-musl-baseline": ["@oven/bun-linux-x64-musl-baseline@1.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-n6iE71G4lQE4XkrZhQQcL5YUlxDbnq6nqV7zeQi33PMsLT/0kYE+RvHOtBWZ3w0wMdXZfINmp63hIb9ijUBGtw=="],
-
-    "@oven/bun-windows-aarch64": ["@oven/bun-windows-aarch64@1.3.14", "", { "os": "win32", "cpu": "arm64" }, "sha512-T7s3x/BsVKQObGU6QDkZeI6wKynzqGbBH1yI77jrrj5siElclxr3DQrDIk8CV4G5/SJq2HHq4kpLyYY2DKCSmA=="],
-
-    "@oven/bun-windows-x64": ["@oven/bun-windows-x64@1.3.14", "", { "os": "win32", "cpu": "x64" }, "sha512-mUFWL3BoYkNpjd8e9PqROiFF/1Xeotq20mABJsiQH62jM1g5zqWh4khw1RZ6bX8Q8fWvlPaxG1PjofkmjUi3vg=="],
-
-    "@oven/bun-windows-x64-baseline": ["@oven/bun-windows-x64-baseline@1.3.14", "", { "os": "win32", "cpu": "x64" }, "sha512-uIjLUC1S9DWgICzuoMba7vurBJnBruE4S5CxnvmZkdqWVXRzx1Rgu636HoH+k0qeaQCFh3jeG3JQ1y6fRHv0sw=="],
 
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
@@ -243,8 +208,6 @@
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "buffer-writer": ["buffer-writer@2.0.0", "", {}, "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="],
-
-    "bun": ["bun@1.3.14", "", { "optionalDependencies": { "@oven/bun-darwin-aarch64": "1.3.14", "@oven/bun-darwin-x64": "1.3.14", "@oven/bun-darwin-x64-baseline": "1.3.14", "@oven/bun-freebsd-aarch64": "1.3.14", "@oven/bun-freebsd-x64": "1.3.14", "@oven/bun-linux-aarch64": "1.3.14", "@oven/bun-linux-aarch64-android": "1.3.14", "@oven/bun-linux-aarch64-musl": "1.3.14", "@oven/bun-linux-x64": "1.3.14", "@oven/bun-linux-x64-android": "1.3.14", "@oven/bun-linux-x64-baseline": "1.3.14", "@oven/bun-linux-x64-musl": "1.3.14", "@oven/bun-linux-x64-musl-baseline": "1.3.14", "@oven/bun-windows-aarch64": "1.3.14", "@oven/bun-windows-x64": "1.3.14", "@oven/bun-windows-x64-baseline": "1.3.14" }, "os": [ "!aix", "!sunos", "!openbsd", ], "cpu": [ "x64", "arm64", ], "bin": { "bun": "bin/bun.exe", "bunx": "bin/bunx.exe" } }, "sha512-aB6GVd42x1Y5ie1K16SF+oLGtgSkwX9hgoDdIW88pjvfTccU8F1vfpoOt34QLv0dZ1v3XimtaxPlZUG81Gx9Zg=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 

--- a/integrations/mem0-plugin/.opencode-plugin/opencode-mem0.test.ts
+++ b/integrations/mem0-plugin/.opencode-plugin/opencode-mem0.test.ts
@@ -1,0 +1,112 @@
+import {afterEach, describe, expect, test} from "bun:test";
+import {getProjectId} from "./opencode-mem0";
+
+type ShellCall = {
+  command: string;
+  cwd?: string;
+};
+
+type ShellResponse = string | Error;
+
+function mockShell(responses: Record<string, ShellResponse>, calls: ShellCall[]) {
+  return ((strings: TemplateStringsArray, ...values: unknown[]) => {
+    const command = String.raw({raw: strings}, ...values);
+    const call: ShellCall = {command};
+    const shellCommand = {
+      cwd(path: string) {
+        call.cwd = path;
+        return shellCommand;
+      },
+      async quiet() {
+        calls.push(call);
+        const response = responses[command];
+        if (response instanceof Error) throw response;
+        return {stdout: {toString: () => response ?? ""}};
+      },
+    };
+    return shellCommand;
+  }) as any;
+}
+
+describe("getProjectId", () => {
+  afterEach(() => {
+    delete process.env.MEM0_APP_ID;
+  });
+
+  test("keeps MEM0_APP_ID as the first override", async () => {
+    const calls: ShellCall[] = [];
+    process.env.MEM0_APP_ID = "explicit-app";
+
+    await expect(getProjectId({
+      $: mockShell({}, calls),
+      worktree: "D:\\Repos\\selected",
+      directory: "D:\\Repos\\directory",
+    })).resolves.toBe("explicit-app");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("scopes remote parsing to the OpenCode worktree", async () => {
+    const calls: ShellCall[] = [];
+    const worktree = "D:\\Repos\\selected-project";
+
+    await expect(getProjectId({
+      $: mockShell({
+        "git remote get-url origin": "git@github.com:mem0ai/selected-project.git",
+      }, calls),
+      worktree,
+      directory: "D:\\Repos\\wrong-directory",
+    })).resolves.toBe("mem0ai-selected-project");
+
+    expect(calls).toEqual([{command: "git remote get-url origin", cwd: worktree}]);
+  });
+
+  test("uses directory before process cwd for git top-level fallback", async () => {
+    const calls: ShellCall[] = [];
+    const directory = "D:\\Repos\\directory-project";
+
+    await expect(getProjectId({
+      $: mockShell({
+        "git remote get-url origin": new Error("no remote"),
+        "git rev-parse --show-toplevel": directory,
+      }, calls),
+      directory,
+    })).resolves.toBe("directory-project");
+
+    expect(calls).toEqual([
+      {command: "git remote get-url origin", cwd: directory},
+      {command: "git rev-parse --show-toplevel", cwd: directory},
+    ]);
+  });
+
+  test("falls back to the selected project path basename before process cwd", async () => {
+    const calls: ShellCall[] = [];
+    const directory = "D:\\Repos\\path-only-project";
+
+    await expect(getProjectId({
+      $: mockShell({
+        "git remote get-url origin": new Error("no remote"),
+        "git rev-parse --show-toplevel": new Error("no git repo"),
+      }, calls),
+      directory,
+    })).resolves.toBe("path-only-project");
+
+    expect(calls).toEqual([
+      {command: "git remote get-url origin", cwd: directory},
+      {command: "git rev-parse --show-toplevel", cwd: directory},
+    ]);
+  });
+
+  test("preserves remote-derived id when OpenCode path matches process cwd", async () => {
+    const calls: ShellCall[] = [];
+    const cwd = process.cwd();
+
+    await expect(getProjectId({
+      $: mockShell({
+        "git remote get-url origin": "https://github.com/mem0ai/mem0.git",
+      }, calls),
+      worktree: cwd,
+    })).resolves.toBe("mem0ai-mem0");
+
+    expect(calls).toEqual([{command: "git remote get-url origin", cwd}]);
+  });
+});

--- a/integrations/mem0-plugin/.opencode-plugin/opencode-mem0.test.ts
+++ b/integrations/mem0-plugin/.opencode-plugin/opencode-mem0.test.ts
@@ -1,5 +1,6 @@
 import {afterEach, describe, expect, test} from "bun:test";
-import {getBranch, getProjectId} from "./opencode-mem0";
+import * as opencodeModule from "./opencode-mem0";
+import {getBranch, getProjectId} from "./project";
 
 type ShellCall = {
   command: string;
@@ -103,6 +104,12 @@ describe("getProjectId", () => {
     )).resolves.toBe("mem0ai-mem0");
 
     expect(calls).toEqual([{command: "git remote get-url origin", cwd}]);
+  });
+});
+
+describe("opencode-mem0 entry module", () => {
+  test("exports only the default plugin factory", () => {
+    expect(Object.keys(opencodeModule).sort()).toEqual(["default"]);
   });
 });
 

--- a/integrations/mem0-plugin/.opencode-plugin/opencode-mem0.test.ts
+++ b/integrations/mem0-plugin/.opencode-plugin/opencode-mem0.test.ts
@@ -111,6 +111,43 @@ describe("opencode-mem0 entry module", () => {
   test("exports only the default plugin factory", () => {
     expect(Object.keys(opencodeModule).sort()).toEqual(["default"]);
   });
+
+  test.each([
+    {name: "worktree", worktree: "/home/user/active-worktree", directory: "/home/user/fallback-directory"},
+    {name: "directory", directory: "/home/user/active-directory"},
+  ])("passes the active $name path from plugin context to project helpers", async ({worktree, directory}) => {
+    const calls: ShellCall[] = [];
+    const projectPath = worktree ?? directory!;
+    const previousApiKey = process.env.MEM0_API_KEY;
+    const previousAppId = process.env.MEM0_APP_ID;
+    process.env.MEM0_API_KEY = "m0-test-key";
+    delete process.env.MEM0_APP_ID;
+
+    try {
+      const plugin = await opencodeModule.default({
+        $: mockShell({
+          "git remote get-url origin": "git@github.com:mem0ai/selected-project.git",
+          "git branch --show-current": "feature/selected-project\n",
+        }, calls),
+        client: {app: {log: async () => {}}},
+        worktree,
+        directory,
+      } as any);
+
+      expect(plugin).toHaveProperty("tool");
+      expect(calls.filter((call) => call.command === "git remote get-url origin")).toEqual([
+        {command: "git remote get-url origin", cwd: projectPath},
+      ]);
+      expect(calls.filter((call) => call.command === "git branch --show-current")).toEqual([
+        {command: "git branch --show-current", cwd: projectPath},
+      ]);
+    } finally {
+      if (previousApiKey === undefined) delete process.env.MEM0_API_KEY;
+      else process.env.MEM0_API_KEY = previousApiKey;
+      if (previousAppId === undefined) delete process.env.MEM0_APP_ID;
+      else process.env.MEM0_APP_ID = previousAppId;
+    }
+  });
 });
 
 describe("getBranch", () => {

--- a/integrations/mem0-plugin/.opencode-plugin/opencode-mem0.test.ts
+++ b/integrations/mem0-plugin/.opencode-plugin/opencode-mem0.test.ts
@@ -1,5 +1,5 @@
 import {afterEach, describe, expect, test} from "bun:test";
-import {getProjectId} from "./opencode-mem0";
+import {getBranch, getProjectId} from "./opencode-mem0";
 
 type ShellCall = {
   command: string;
@@ -37,40 +37,35 @@ describe("getProjectId", () => {
     const calls: ShellCall[] = [];
     process.env.MEM0_APP_ID = "explicit-app";
 
-    await expect(getProjectId({
-      $: mockShell({}, calls),
-      worktree: "D:\\Repos\\selected",
-      directory: "D:\\Repos\\directory",
-    })).resolves.toBe("explicit-app");
+    await expect(getProjectId(mockShell({}, calls), "/home/user/selected")).resolves.toBe("explicit-app");
     expect(calls).toHaveLength(0);
   });
 
   test("scopes remote parsing to the OpenCode worktree", async () => {
     const calls: ShellCall[] = [];
-    const worktree = "D:\\Repos\\selected-project";
+    const worktree = "/home/user/selected-project";
 
-    await expect(getProjectId({
-      $: mockShell({
+    await expect(getProjectId(
+      mockShell({
         "git remote get-url origin": "git@github.com:mem0ai/selected-project.git",
       }, calls),
       worktree,
-      directory: "D:\\Repos\\wrong-directory",
-    })).resolves.toBe("mem0ai-selected-project");
+    )).resolves.toBe("mem0ai-selected-project");
 
     expect(calls).toEqual([{command: "git remote get-url origin", cwd: worktree}]);
   });
 
   test("uses directory before process cwd for git top-level fallback", async () => {
     const calls: ShellCall[] = [];
-    const directory = "D:\\Repos\\directory-project";
+    const directory = "/home/user/directory-project";
 
-    await expect(getProjectId({
-      $: mockShell({
+    await expect(getProjectId(
+      mockShell({
         "git remote get-url origin": new Error("no remote"),
         "git rev-parse --show-toplevel": directory,
       }, calls),
       directory,
-    })).resolves.toBe("directory-project");
+    )).resolves.toBe("directory-project");
 
     expect(calls).toEqual([
       {command: "git remote get-url origin", cwd: directory},
@@ -80,15 +75,15 @@ describe("getProjectId", () => {
 
   test("falls back to the selected project path basename before process cwd", async () => {
     const calls: ShellCall[] = [];
-    const directory = "D:\\Repos\\path-only-project";
+    const directory = "/home/user/path-only-project";
 
-    await expect(getProjectId({
-      $: mockShell({
+    await expect(getProjectId(
+      mockShell({
         "git remote get-url origin": new Error("no remote"),
         "git rev-parse --show-toplevel": new Error("no git repo"),
       }, calls),
       directory,
-    })).resolves.toBe("path-only-project");
+    )).resolves.toBe("path-only-project");
 
     expect(calls).toEqual([
       {command: "git remote get-url origin", cwd: directory},
@@ -100,13 +95,43 @@ describe("getProjectId", () => {
     const calls: ShellCall[] = [];
     const cwd = process.cwd();
 
-    await expect(getProjectId({
-      $: mockShell({
+    await expect(getProjectId(
+      mockShell({
         "git remote get-url origin": "https://github.com/mem0ai/mem0.git",
       }, calls),
-      worktree: cwd,
-    })).resolves.toBe("mem0ai-mem0");
+      cwd,
+    )).resolves.toBe("mem0ai-mem0");
 
     expect(calls).toEqual([{command: "git remote get-url origin", cwd}]);
+  });
+});
+
+describe("getBranch", () => {
+  test("scopes branch lookup to the selected OpenCode project path", async () => {
+    const calls: ShellCall[] = [];
+    const projectPath = "/home/user/selected-project";
+
+    await expect(getBranch(
+      mockShell({
+        "git branch --show-current": "feature/current-project\n",
+      }, calls),
+      projectPath,
+    )).resolves.toBe("feature/current-project");
+
+    expect(calls).toEqual([{command: "git branch --show-current", cwd: projectPath}]);
+  });
+
+  test("falls back to main when branch lookup fails", async () => {
+    const calls: ShellCall[] = [];
+    const projectPath = "/home/user/selected-project";
+
+    await expect(getBranch(
+      mockShell({
+        "git branch --show-current": new Error("no git repo"),
+      }, calls),
+      projectPath,
+    )).resolves.toBe("main");
+
+    expect(calls).toEqual([{command: "git branch --show-current", cwd: projectPath}]);
   });
 });

--- a/integrations/mem0-plugin/.opencode-plugin/opencode-mem0.ts
+++ b/integrations/mem0-plugin/.opencode-plugin/opencode-mem0.ts
@@ -24,7 +24,7 @@ import {
   DREAM_PROTOCOL,
 } from "./dream";
 import {asScope, scopeSearchFilters, scopeWriteParams, resolveDefaultScope, SCOPE_GUIDANCE, type Scope} from "./scope";
-import {parseProjectFromRemote} from "./project";
+import {parseProjectFromRemote, selectActiveProjectPath, type ProjectContext} from "./project";
 import {resolveApiKey} from "./api-key";
 
 async function getUserId(): Promise<string> {
@@ -36,12 +36,23 @@ async function getUserId(): Promise<string> {
   return process.env.USER || process.env.USERNAME || "unknown";
 }
 
-async function getProjectId($: any): Promise<string> {
+type ShellCommand = {
+  cwd?: (path: string) => ShellCommand;
+  quiet: () => Promise<{ stdout: { toString(): string } }>;
+};
+
+function commandInProject(command: ShellCommand, projectPath: string): ShellCommand {
+  if (typeof command.cwd === "function") return command.cwd(projectPath);
+  return command;
+}
+
+export async function getProjectId(input: ProjectContext & {$: any}): Promise<string> {
   if (process.env.MEM0_APP_ID) return process.env.MEM0_APP_ID;
+  const projectPath = selectActiveProjectPath(input);
   // Prefer the git remote's owner/repo — stable across clones, worktrees, and
   // sub-directories (handles https + ssh, incl. custom host aliases).
   try {
-    const r = await $`git remote get-url origin`.quiet();
+    const r = await commandInProject(input.$`git remote get-url origin`, projectPath).quiet();
     const project = parseProjectFromRemote(r.stdout.toString());
     if (project) return project;
   } catch {
@@ -49,11 +60,13 @@ async function getProjectId($: any): Promise<string> {
   // No usable remote: use the git repo ROOT dir name, not cwd (which may be a
   // sub-directory, or your home dir if OpenCode was launched outside a repo).
   try {
-    const r = await $`git rev-parse --show-toplevel`.quiet();
+    const r = await commandInProject(input.$`git rev-parse --show-toplevel`, projectPath).quiet();
     const top = r.stdout.toString().trim();
     if (top) return basename(top);
   } catch {
   }
+  const selectedBasename = basename(projectPath);
+  if (selectedBasename) return selectedBasename;
   return basename(process.cwd());
 }
 
@@ -278,7 +291,7 @@ const Mem0Plugin: Plugin = async (ctx) => {
 
   const mem0 = new MemoryClient({apiKey});
   const userId = await getUserId();
-  const appId = await getProjectId($);
+  const appId = await getProjectId(ctx);
   const branch = await getBranch($);
   const stats = {adds: 0, searches: 0, messages: 0};
   const sessionId = generateSessionId();

--- a/integrations/mem0-plugin/.opencode-plugin/opencode-mem0.ts
+++ b/integrations/mem0-plugin/.opencode-plugin/opencode-mem0.ts
@@ -6,7 +6,7 @@ import type {Plugin} from "@opencode-ai/plugin";
 import {tool} from "@opencode-ai/plugin";
 import {MemoryClient} from "mem0ai";
 import {userInfo} from "os";
-import {basename, resolve, dirname} from "path";
+import {resolve, dirname} from "path";
 import {randomBytes} from "crypto";
 import {existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync} from "fs";
 import {homedir} from "os";
@@ -24,7 +24,7 @@ import {
   DREAM_PROTOCOL,
 } from "./dream";
 import {asScope, scopeSearchFilters, scopeWriteParams, resolveDefaultScope, SCOPE_GUIDANCE, type Scope} from "./scope";
-import {parseProjectFromRemote, selectActiveProjectPath, type ProjectContext} from "./project";
+import {getBranch, getProjectId, selectActiveProjectPath} from "./project";
 import {resolveApiKey} from "./api-key";
 
 async function getUserId(): Promise<string> {
@@ -34,44 +34,6 @@ async function getUserId(): Promise<string> {
   } catch {
   }
   return process.env.USER || process.env.USERNAME || "unknown";
-}
-
-type ShellCommand = {
-  cwd?: (path: string) => ShellCommand;
-  quiet: () => Promise<{ stdout: { toString(): string } }>;
-};
-
-function commandInProject(command: ShellCommand, projectPath: string): ShellCommand {
-  if (typeof command.cwd === "function") return command.cwd(projectPath);
-  return command;
-}
-
-export async function getProjectId($: any, projectPath: string): Promise<string> {
-  if (process.env.MEM0_APP_ID) return process.env.MEM0_APP_ID;
-  try {
-    const r = await commandInProject($`git remote get-url origin`, projectPath).quiet();
-    const project = parseProjectFromRemote(r.stdout.toString());
-    if (project) return project;
-  } catch {
-  }
-  try {
-    const r = await commandInProject($`git rev-parse --show-toplevel`, projectPath).quiet();
-    const top = r.stdout.toString().trim();
-    if (top) return basename(top);
-  } catch {
-  }
-  const selectedBasename = basename(projectPath);
-  if (selectedBasename) return selectedBasename;
-  return basename(process.cwd());
-}
-
-export async function getBranch($: any, projectPath: string): Promise<string> {
-  try {
-    const r = await commandInProject($`git branch --show-current`, projectPath).quiet();
-    return r.stdout.toString().trim() || "main";
-  } catch {
-  }
-  return "main";
 }
 
 function extractMemories(res: any): Array<{ memory: string; id: string }> {

--- a/integrations/mem0-plugin/.opencode-plugin/opencode-mem0.ts
+++ b/integrations/mem0-plugin/.opencode-plugin/opencode-mem0.ts
@@ -46,21 +46,16 @@ function commandInProject(command: ShellCommand, projectPath: string): ShellComm
   return command;
 }
 
-export async function getProjectId(input: ProjectContext & {$: any}): Promise<string> {
+export async function getProjectId($: any, projectPath: string): Promise<string> {
   if (process.env.MEM0_APP_ID) return process.env.MEM0_APP_ID;
-  const projectPath = selectActiveProjectPath(input);
-  // Prefer the git remote's owner/repo — stable across clones, worktrees, and
-  // sub-directories (handles https + ssh, incl. custom host aliases).
   try {
-    const r = await commandInProject(input.$`git remote get-url origin`, projectPath).quiet();
+    const r = await commandInProject($`git remote get-url origin`, projectPath).quiet();
     const project = parseProjectFromRemote(r.stdout.toString());
     if (project) return project;
   } catch {
   }
-  // No usable remote: use the git repo ROOT dir name, not cwd (which may be a
-  // sub-directory, or your home dir if OpenCode was launched outside a repo).
   try {
-    const r = await commandInProject(input.$`git rev-parse --show-toplevel`, projectPath).quiet();
+    const r = await commandInProject($`git rev-parse --show-toplevel`, projectPath).quiet();
     const top = r.stdout.toString().trim();
     if (top) return basename(top);
   } catch {
@@ -70,9 +65,9 @@ export async function getProjectId(input: ProjectContext & {$: any}): Promise<st
   return basename(process.cwd());
 }
 
-async function getBranch($: any): Promise<string> {
+export async function getBranch($: any, projectPath: string): Promise<string> {
   try {
-    const r = await $`git branch --show-current`.quiet();
+    const r = await commandInProject($`git branch --show-current`, projectPath).quiet();
     return r.stdout.toString().trim() || "main";
   } catch {
   }
@@ -291,8 +286,9 @@ const Mem0Plugin: Plugin = async (ctx) => {
 
   const mem0 = new MemoryClient({apiKey});
   const userId = await getUserId();
-  const appId = await getProjectId(ctx);
-  const branch = await getBranch($);
+  const projectPath = selectActiveProjectPath(ctx);
+  const appId = await getProjectId($, projectPath);
+  const branch = await getBranch($, projectPath);
   const stats = {adds: 0, searches: 0, messages: 0};
   const sessionId = generateSessionId();
   const globalSearch = loadGlobalSearch();

--- a/integrations/mem0-plugin/.opencode-plugin/package.json
+++ b/integrations/mem0-plugin/.opencode-plugin/package.json
@@ -34,7 +34,7 @@
     "opencode-skills"
   ],
   "scripts": {
-    "build": "bun build opencode-mem0.ts --outdir dist --target bun --format esm --entry-naming index.[ext] && tsc --emitDeclarationOnly --outDir dist --declaration",
+    "build": "bun build opencode-mem0.ts --outdir dist --target node --format esm --entry-naming index.[ext] && tsc --emitDeclarationOnly --outDir dist --declaration",
     "dev": "bun build opencode-mem0.ts --outdir dist --target bun --format esm --entry-naming index.[ext] --watch",
     "type-check": "tsc --noEmit",
     "prepack": "bun run build",

--- a/integrations/mem0-plugin/.opencode-plugin/package.json
+++ b/integrations/mem0-plugin/.opencode-plugin/package.json
@@ -59,8 +59,5 @@
   "devDependencies": {
     "bun-types": ">=1.3.14",
     "typescript": "^5.7.3"
-  },
-  "peerDependencies": {
-    "bun": ">=1.0.0"
   }
 }

--- a/integrations/mem0-plugin/.opencode-plugin/project.test.ts
+++ b/integrations/mem0-plugin/.opencode-plugin/project.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { parseProjectFromRemote } from "./project";
+import { parseProjectFromRemote, selectActiveProjectPath } from "./project";
 
 describe("parseProjectFromRemote", () => {
   test("ssh remote with a custom host alias (github.com-work)", () => {
@@ -25,5 +25,24 @@ describe("parseProjectFromRemote", () => {
   test("returns null when no owner/repo can be parsed", () => {
     expect(parseProjectFromRemote("not-a-remote")).toBeNull();
     expect(parseProjectFromRemote("")).toBeNull();
+  });
+});
+
+describe("selectActiveProjectPath", () => {
+  test("prefers worktree over directory", () => {
+    expect(selectActiveProjectPath({
+      worktree: "D:\\Repos\\active-worktree",
+      directory: "D:\\Repos\\fallback-directory",
+    })).toBe("D:\\Repos\\active-worktree");
+  });
+
+  test("uses directory when worktree is absent", () => {
+    expect(selectActiveProjectPath({
+      directory: "D:\\Repos\\active-directory",
+    })).toBe("D:\\Repos\\active-directory");
+  });
+
+  test("falls back to process cwd", () => {
+    expect(selectActiveProjectPath()).toBe(process.cwd());
   });
 });

--- a/integrations/mem0-plugin/.opencode-plugin/project.test.ts
+++ b/integrations/mem0-plugin/.opencode-plugin/project.test.ts
@@ -31,15 +31,15 @@ describe("parseProjectFromRemote", () => {
 describe("selectActiveProjectPath", () => {
   test("prefers worktree over directory", () => {
     expect(selectActiveProjectPath({
-      worktree: "D:\\Repos\\active-worktree",
-      directory: "D:\\Repos\\fallback-directory",
-    })).toBe("D:\\Repos\\active-worktree");
+      worktree: "/home/user/active-worktree",
+      directory: "/home/user/fallback-directory",
+    })).toBe("/home/user/active-worktree");
   });
 
   test("uses directory when worktree is absent", () => {
     expect(selectActiveProjectPath({
-      directory: "D:\\Repos\\active-directory",
-    })).toBe("D:\\Repos\\active-directory");
+      directory: "/home/user/active-directory",
+    })).toBe("/home/user/active-directory");
   });
 
   test("falls back to process cwd", () => {

--- a/integrations/mem0-plugin/.opencode-plugin/project.ts
+++ b/integrations/mem0-plugin/.opencode-plugin/project.ts
@@ -7,6 +7,21 @@
  * cwd. Keeping the parser pure makes the tricky remote formats testable.
  */
 
+export type ProjectContext = {
+  worktree?: string;
+  directory?: string;
+};
+
+export function selectActiveProjectPath(input: ProjectContext = {}): string {
+  const worktree = input.worktree?.trim();
+  if (worktree) return worktree;
+
+  const directory = input.directory?.trim();
+  if (directory) return directory;
+
+  return process.cwd();
+}
+
 /**
  * Parse `owner/repo` out of a git remote URL and return it as `owner-repo`.
  * Handles https, scp-style ssh, custom ssh host aliases (e.g.

--- a/integrations/mem0-plugin/.opencode-plugin/project.ts
+++ b/integrations/mem0-plugin/.opencode-plugin/project.ts
@@ -1,4 +1,4 @@
-import {basename} from "path";
+import { basename } from "path";
 
 /**
  * Project identity resolution for the Mem0 OpenCode plugin.
@@ -29,25 +29,35 @@ type ShellCommand = {
   quiet: () => Promise<{ stdout: { toString(): string } }>;
 };
 
-function commandInProject(command: ShellCommand, projectPath: string): ShellCommand {
+function commandInProject(
+  command: ShellCommand,
+  projectPath: string,
+): ShellCommand {
   if (typeof command.cwd === "function") return command.cwd(projectPath);
   return command;
 }
 
-export async function getProjectId($: any, projectPath: string): Promise<string> {
+export async function getProjectId(
+  $: any,
+  projectPath: string,
+): Promise<string> {
   if (process.env.MEM0_APP_ID) return process.env.MEM0_APP_ID;
   try {
-    const r = await commandInProject($`git remote get-url origin`, projectPath).quiet();
+    const r = await commandInProject(
+      $`git remote get-url origin`,
+      projectPath,
+    ).quiet();
     const project = parseProjectFromRemote(r.stdout.toString());
     if (project) return project;
-  } catch {
-  }
+  } catch {}
   try {
-    const r = await commandInProject($`git rev-parse --show-toplevel`, projectPath).quiet();
+    const r = await commandInProject(
+      $`git rev-parse --show-toplevel`,
+      projectPath,
+    ).quiet();
     const top = r.stdout.toString().trim();
     if (top) return basename(top);
-  } catch {
-  }
+  } catch {}
   const selectedBasename = basename(projectPath);
   if (selectedBasename) return selectedBasename;
   return basename(process.cwd());
@@ -55,10 +65,12 @@ export async function getProjectId($: any, projectPath: string): Promise<string>
 
 export async function getBranch($: any, projectPath: string): Promise<string> {
   try {
-    const r = await commandInProject($`git branch --show-current`, projectPath).quiet();
+    const r = await commandInProject(
+      $`git branch --show-current`,
+      projectPath,
+    ).quiet();
     return r.stdout.toString().trim() || "main";
-  } catch {
-  }
+  } catch {}
   return "main";
 }
 

--- a/integrations/mem0-plugin/.opencode-plugin/project.ts
+++ b/integrations/mem0-plugin/.opencode-plugin/project.ts
@@ -1,10 +1,12 @@
+import {basename} from "path";
+
 /**
  * Project identity resolution for the Mem0 OpenCode plugin.
  *
  * The project id (`app_id`) scopes memories to a repo. We derive it from the
- * git remote so it is stable across clones, worktrees, and sub-directories —
- * falling back (in opencode-mem0.ts) to the git repo root dir name, then the
- * cwd. Keeping the parser pure makes the tricky remote formats testable.
+ * git remote so it is stable across clones, worktrees, and sub-directories,
+ * falling back to the git repo root dir name, then the cwd. Keeping the parser
+ * pure makes the tricky remote formats testable.
  */
 
 export type ProjectContext = {
@@ -20,6 +22,44 @@ export function selectActiveProjectPath(input: ProjectContext = {}): string {
   if (directory) return directory;
 
   return process.cwd();
+}
+
+type ShellCommand = {
+  cwd?: (path: string) => ShellCommand;
+  quiet: () => Promise<{ stdout: { toString(): string } }>;
+};
+
+function commandInProject(command: ShellCommand, projectPath: string): ShellCommand {
+  if (typeof command.cwd === "function") return command.cwd(projectPath);
+  return command;
+}
+
+export async function getProjectId($: any, projectPath: string): Promise<string> {
+  if (process.env.MEM0_APP_ID) return process.env.MEM0_APP_ID;
+  try {
+    const r = await commandInProject($`git remote get-url origin`, projectPath).quiet();
+    const project = parseProjectFromRemote(r.stdout.toString());
+    if (project) return project;
+  } catch {
+  }
+  try {
+    const r = await commandInProject($`git rev-parse --show-toplevel`, projectPath).quiet();
+    const top = r.stdout.toString().trim();
+    if (top) return basename(top);
+  } catch {
+  }
+  const selectedBasename = basename(projectPath);
+  if (selectedBasename) return selectedBasename;
+  return basename(process.cwd());
+}
+
+export async function getBranch($: any, projectPath: string): Promise<string> {
+  try {
+    const r = await commandInProject($`git branch --show-current`, projectPath).quiet();
+    return r.stdout.toString().trim() || "main";
+  } catch {
+  }
+  return "main";
 }
 
 /**


### PR DESCRIPTION
## Linked Issue

Part of #6003

Follow-up to https://github.com/mem0ai/mem0/pull/6005, which documented the OpenCode Desktop workaround and narrowed this PR to the remaining runtime fixes.

## Description

`@mem0/opencode-plugin` needs two Desktop runtime fixes. The published entrypoint must be Node-compatible, and project metadata must come from OpenCode's active `worktree` or `directory` instead of startup shell state. `MEM0_APP_ID` remains the highest-priority override.

This change keeps the existing current-main API-key resolution and shell-profile behavior, composes the active project context into the git helpers, keeps helper exports off the published entrypoint, and updates the package metadata and docs for the Node-targeted runtime contract.

## Scope

The scope is limited to the OpenCode package entrypoint, project context resolution, package metadata and lockfile, focused tests, and the related integration documentation. It does not change Desktop setup documentation from #6005 or add new API-key discovery behavior.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually
- [ ] No tests needed

Verification from `integrations/mem0-plugin/.opencode-plugin`:

- [x] `bun test opencode-mem0.test.ts project.test.ts`: 19 passed, 0 failed
- [x] `bun run type-check`
- [ ] `bun run build`, blocked by Bun failing to remap the local `node_modules` binary
- [x] `git diff --check`
- [ ] Full package formatting check, current-main files include existing Prettier differences

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [ ] New and existing tests pass locally
- [x] I have updated documentation if needed
