### PR TITLE
fix(ts-oss/redis): fall back to "*" for empty or all-null filters

### DIFF
--- a/mem0-ts/src/oss/src/vector_stores/redis.ts
+++ b/mem0-ts/src/oss/src/vector_stores/redis.ts
@@ -133,6 +133,18 @@ function toSnakeCase(obj: Record<string, any>): Record<string, any> {
   );
 }
 
+// Build a RediSearch pre-filter expression from filters. Returns "*" (match
+// all) when there are no usable conditions — including an empty filters object
+// or one whose values are all null/undefined — since an empty expression is an
+// invalid RediSearch query (e.g. ` =>[KNN ...]`).
+export function buildRedisFilterExpr(filters?: SearchFilters): string {
+  if (!filters) return "*";
+  const conditions = Object.entries(toSnakeCase(filters))
+    .filter(([, value]) => value !== null && value !== undefined)
+    .map(([key, value]) => `@${key}:{${escapeRedisTagValue(value)}}`);
+  return conditions.length > 0 ? conditions.join(" ") : "*";
+}
+
 // Utility function to convert object keys to camelCase
 function toCamelCase(obj: Record<string, any>): Record<string, any> {
   if (typeof obj !== "object" || obj === null) return obj;
@@ -406,13 +418,7 @@ export class RedisDB implements VectorStore {
     filters?: SearchFilters,
   ): Promise<VectorStoreResult[]> {
     await this.initialize();
-    const snakeFilters = filters ? toSnakeCase(filters) : undefined;
-    const filterExpr = snakeFilters
-      ? Object.entries(snakeFilters)
-          .filter(([_, value]) => value !== null && value !== undefined)
-          .map(([key, value]) => `@${key}:{${escapeRedisTagValue(value)}}`)
-          .join(" ")
-      : "*";
+    const filterExpr = buildRedisFilterExpr(filters);
 
     const queryVector = new Float32Array(query).buffer;
 
@@ -655,13 +661,7 @@ export class RedisDB implements VectorStore {
     topK: number = 100,
   ): Promise<[VectorStoreResult[], number]> {
     await this.initialize();
-    const snakeFilters = filters ? toSnakeCase(filters) : undefined;
-    const filterExpr = snakeFilters
-      ? Object.entries(snakeFilters)
-          .filter(([_, value]) => value !== null && value !== undefined)
-          .map(([key, value]) => `@${key}:{${escapeRedisTagValue(value)}}`)
-          .join(" ")
-      : "*";
+    const filterExpr = buildRedisFilterExpr(filters);
 
     const searchOptions = {
       SORTBY: "created_at",

--- a/mem0-ts/src/oss/tests/redis.filter-expr.test.ts
+++ b/mem0-ts/src/oss/tests/redis.filter-expr.test.ts
@@ -1,0 +1,35 @@
+import { buildRedisFilterExpr } from "../src/vector_stores/redis";
+
+describe("buildRedisFilterExpr", () => {
+  it("returns '*' when filters is undefined", () => {
+    expect(buildRedisFilterExpr(undefined)).toBe("*");
+  });
+
+  it("returns '*' for an empty filters object", () => {
+    // Regression: previously produced "" -> invalid RediSearch query
+    // (` =>[KNN ...]`).
+    expect(buildRedisFilterExpr({})).toBe("*");
+  });
+
+  it("returns '*' when every filter value is null/undefined", () => {
+    expect(
+      buildRedisFilterExpr({ user_id: null as any, agent_id: undefined }),
+    ).toBe("*");
+  });
+
+  it("builds a tag clause for a single filter", () => {
+    expect(buildRedisFilterExpr({ user_id: "alice" })).toBe("@user_id:{alice}");
+  });
+
+  it("snake-cases keys and joins multiple clauses", () => {
+    expect(buildRedisFilterExpr({ userId: "alice", runId: "r1" })).toBe(
+      "@user_id:{alice} @run_id:{r1}",
+    );
+  });
+
+  it("drops null/undefined values but keeps the rest", () => {
+    expect(
+      buildRedisFilterExpr({ user_id: "alice", agent_id: null as any }),
+    ).toBe("@user_id:{alice}");
+  });
+});


### PR DESCRIPTION
## Linked Issue

Closes #6013

## Description

The OSS Redis vector store builds its RediSearch pre-filter in both `search()` and `list()` like this:

```ts
const snakeFilters = filters ? toSnakeCase(filters) : undefined;
const filterExpr = snakeFilters
  ? Object.entries(snakeFilters)
      .filter(([_, value]) => value !== null && value !== undefined)
      .map(([key, value]) => `@${key}:{${escapeRedisTagValue(value)}}`)
      .join(" ")
  : "*";
```

The `"*"` fallback only fires when `filters` is falsy. If `filters` is a truthy-but-empty object (`{}`), or has only null/undefined values, the chain produces `""`, which gets interpolated as `" =>[KNN ...]"` — a malformed RediSearch query rather than match-all.

I pulled the duplicated logic into a shared `buildRedisFilterExpr()` helper that returns `"*"` whenever there are no usable conditions, and used it in both `search()` and `list()`. Non-empty filters behave exactly as before.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed

Added `redis-filter-expr.test.ts` covering undefined, empty `{}`, all-null/undefined, single, multi (with snake_case), and mixed filters. The empty and all-null cases fail without the fix. `tsc --noEmit` shows no new errors in the changed file and `prettier --check` is clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed (no user-facing docs affected)
