### PR TITLE
fix(ts-oss): isolate entity linking by scope

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -100,6 +100,9 @@ const ENTITY_PARAMS = [
   "agentId",
   "runId",
 ];
+const ENTITY_SCOPE_KEYS = ["user_id", "agent_id", "run_id"] as const;
+const ENTITY_LINK_SEARCH_LIMIT = 10;
+const ENTITY_LINK_SIMILARITY_THRESHOLD = 0.95;
 
 // Identity keys stripped from update() metadata: ENTITY_PARAMS covers user_id/agent_id/run_id
 // in both casings (the default store promotes camelCase on read); actor_id has no camelCase alias.
@@ -329,10 +332,55 @@ export class Memory {
     payload: Record<string, any>,
   ): Record<string, any> {
     const filters: Record<string, any> = {};
-    if (payload.user_id) filters.user_id = payload.user_id;
-    if (payload.agent_id) filters.agent_id = payload.agent_id;
-    if (payload.run_id) filters.run_id = payload.run_id;
+    for (const key of ENTITY_SCOPE_KEYS) {
+      if (payload[key]) filters[key] = payload[key];
+    }
     return filters;
+  }
+
+  private _entityPayloadMatchesScope(
+    payload: Record<string, any> | undefined,
+    filters: Record<string, any>,
+  ): boolean {
+    const payloadScope = this._sessionFiltersFromPayload(payload ?? {});
+    const filterScope = this._sessionFiltersFromPayload(filters);
+    return ENTITY_SCOPE_KEYS.every(
+      (key) => payloadScope[key] === filterScope[key],
+    );
+  }
+
+  private _findScopedEntityMatch(
+    matches: Array<{
+      id: string;
+      score?: number;
+      payload: Record<string, any>;
+    }>,
+    filters: Record<string, any>,
+  ):
+    | {
+        id: string;
+        score?: number;
+        payload: Record<string, any>;
+      }
+    | undefined {
+    let bestMatch:
+      | {
+          id: string;
+          score?: number;
+          payload: Record<string, any>;
+        }
+      | undefined;
+    let bestScore = ENTITY_LINK_SIMILARITY_THRESHOLD;
+
+    for (const match of matches) {
+      const score = match.score ?? 0;
+      if (score < bestScore) continue;
+      if (!this._entityPayloadMatchesScope(match.payload, filters)) continue;
+
+      bestMatch = match;
+      bestScore = score;
+    }
+    return bestMatch;
   }
 
   private _normalizeEntityText(value: string): string {
@@ -363,6 +411,8 @@ export class Memory {
     }
 
     for (const row of rows) {
+      if (!this._entityPayloadMatchesScope(row.payload, filters)) continue;
+
       const text = row.payload?.data;
       if (typeof text !== "string") continue;
       const key = this._normalizeEntityText(text);
@@ -490,19 +540,25 @@ export class Memory {
             score?: number;
             payload: Record<string, any>;
           }> = [];
-          const exactMatch = exactMatches.get(
+          const rawExactMatch = exactMatches.get(
             this._normalizeEntityText(entity.text),
           );
+          const exactMatch =
+            rawExactMatch &&
+            this._entityPayloadMatchesScope(rawExactMatch.payload, filters)
+              ? rawExactMatch
+              : undefined;
           if (!exactMatch) {
             try {
-              matches = await entityStore.search(entityVec, 1, filters);
+              matches = await entityStore.search(
+                entityVec,
+                ENTITY_LINK_SEARCH_LIMIT,
+                filters,
+              );
             } catch {}
           }
 
-          const semanticMatch =
-            matches.length > 0 && (matches[0].score ?? 0) >= 0.95
-              ? matches[0]
-              : undefined;
+          const semanticMatch = this._findScopedEntityMatch(matches, filters);
           const match = exactMatch ?? semanticMatch;
           if (match) {
             const payload = match.payload || {};
@@ -1176,17 +1232,23 @@ export class Memory {
               score?: number;
               payload: Record<string, any>;
             }> = [];
-            const exactMatch = exactMatches.get(key);
+            const rawExactMatch = exactMatches.get(key);
+            const exactMatch =
+              rawExactMatch &&
+              this._entityPayloadMatchesScope(rawExactMatch.payload, filters)
+                ? rawExactMatch
+                : undefined;
             if (!exactMatch) {
               try {
-                matches = await entityStore.search(entityVec, 1, filters);
+                matches = await entityStore.search(
+                  entityVec,
+                  ENTITY_LINK_SEARCH_LIMIT,
+                  filters,
+                );
               } catch {}
             }
 
-            const semanticMatch =
-              matches.length > 0 && (matches[0].score ?? 0) >= 0.95
-                ? matches[0]
-                : undefined;
+            const semanticMatch = this._findScopedEntityMatch(matches, filters);
             const match = exactMatch ?? semanticMatch;
             if (match) {
               // Update existing entity
@@ -1499,6 +1561,9 @@ export class Memory {
                 if (similarity < 0.5) continue;
 
                 const payload = match.payload || {};
+                if (!this._entityPayloadMatchesScope(payload, effectiveFilters))
+                  continue;
+
                 const linkedMemoryIds = payload.linkedMemoryIds ?? [];
                 if (!Array.isArray(linkedMemoryIds)) continue;
 

--- a/mem0-ts/src/oss/tests/memory.entity-linking.test.ts
+++ b/mem0-ts/src/oss/tests/memory.entity-linking.test.ts
@@ -1,0 +1,608 @@
+/**
+ * Entity linking scope isolation tests.
+ *
+ * Regression coverage for cross-scope entity candidates returned by vector
+ * stores despite scoped search filters.
+ */
+/// <reference types="jest" />
+import { Memory } from "../src/memory";
+import type { MemoryConfig, VectorStoreResult } from "../src/types";
+
+jest.setTimeout(15000);
+
+jest.mock("../src/embeddings/google", () => ({
+  GoogleEmbedder: jest.fn(),
+}));
+jest.mock("../src/llms/google", () => ({
+  GoogleLLM: jest.fn(),
+}));
+
+jest.mock("../src/utils/entity_extraction", () => ({
+  extractEntities: jest.fn(() => [{ text: "OpenClaw", type: "ORG" }]),
+  extractEntitiesBatch: jest.fn((texts: string[]) =>
+    texts.map(() => [{ text: "OpenClaw", type: "ORG" }]),
+  ),
+}));
+
+jest.mock("../src/llms/openai", () => ({
+  OpenAILLM: jest.fn().mockImplementation(() => ({
+    generateResponse: jest.fn().mockResolvedValue(
+      JSON.stringify({
+        memory: [
+          {
+            id: "0",
+            text: "OpenClaw editor integration is enabled",
+            attributed_to: "user",
+          },
+        ],
+      }),
+    ),
+  })),
+}));
+
+const mockEmbedding = new Array(1536).fill(0.1);
+jest.mock("../src/embeddings/openai", () => ({
+  OpenAIEmbedder: jest.fn().mockImplementation(() => ({
+    embed: jest.fn().mockResolvedValue(mockEmbedding),
+    embedBatch: jest
+      .fn()
+      .mockImplementation((texts: string[]) =>
+        Promise.resolve(texts.map(() => mockEmbedding)),
+      ),
+    embeddingDims: 1536,
+  })),
+}));
+
+function createMemory(overrides: Partial<MemoryConfig> = {}): Memory {
+  return new Memory({
+    version: "v1.1",
+    embedder: {
+      provider: "openai",
+      config: { apiKey: "test-key", model: "text-embedding-3-small" },
+    },
+    vectorStore: {
+      provider: "memory",
+      config: {
+        collectionName: `test-entity-linking-${Date.now()}-${Math.random()}`,
+        dimension: 1536,
+        dbPath: ":memory:",
+      },
+    },
+    llm: {
+      provider: "openai",
+      config: { apiKey: "test-key", model: "gpt-5-mini" },
+    },
+    historyDbPath: ":memory:",
+    ...overrides,
+  });
+}
+
+function crossScopeEntity(
+  payload: Record<string, any> = { user_id: "user-a" },
+): VectorStoreResult {
+  return {
+    id: "entity-user-a",
+    score: 0.99,
+    payload: {
+      data: "OpenClaw",
+      entityType: "ORG",
+      linkedMemoryIds: ["memory-user-a"],
+      ...payload,
+    },
+  };
+}
+
+function makeEntityStore({
+  listMatches = [],
+  searchMatches = [crossScopeEntity()],
+}: {
+  listMatches?: VectorStoreResult[];
+  searchMatches?: VectorStoreResult[];
+} = {}) {
+  return {
+    list: jest.fn().mockResolvedValue([listMatches, listMatches.length]),
+    search: jest.fn().mockResolvedValue(searchMatches),
+    insert: jest.fn().mockResolvedValue(undefined),
+    update: jest.fn().mockResolvedValue(undefined),
+    deleteCol: jest.fn().mockResolvedValue(undefined),
+    initialize: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("Memory entity linking scope isolation", () => {
+  let memory: Memory;
+
+  beforeEach(() => {
+    memory = createMemory();
+  });
+
+  afterEach(async () => {
+    await memory.reset();
+  });
+
+  it("does not merge single-memory entities into a returned candidate from another user scope", async () => {
+    const m = memory as any;
+    await m._ensureInitialized();
+
+    const mockEntityStore = makeEntityStore();
+    m._entityStore = mockEntityStore;
+
+    await m._linkEntitiesForMemory("memory-user-b", "OpenClaw enabled", {
+      user_id: "user-b",
+    });
+
+    expect(mockEntityStore.search).toHaveBeenCalledWith(expect.any(Array), 10, {
+      user_id: "user-b",
+    });
+    expect(mockEntityStore.update).not.toHaveBeenCalled();
+    expect(mockEntityStore.insert).toHaveBeenCalledTimes(1);
+    expect(mockEntityStore.insert.mock.calls[0][2][0]).toMatchObject({
+      data: "OpenClaw",
+      entityType: "ORG",
+      user_id: "user-b",
+      linkedMemoryIds: ["memory-user-b"],
+    });
+  });
+
+  it("uses the first in-scope semantic match when an out-of-scope candidate ranks first", async () => {
+    const m = memory as any;
+    await m._ensureInitialized();
+
+    const mockEntityStore = makeEntityStore({
+      searchMatches: [
+        crossScopeEntity({
+          user_id: "user-a",
+          linkedMemoryIds: ["memory-user-a"],
+        }),
+        {
+          ...crossScopeEntity({
+            user_id: "user-b",
+            linkedMemoryIds: ["memory-user-c"],
+          }),
+          id: "entity-user-b",
+          score: 0.97,
+        },
+      ],
+    });
+    m._entityStore = mockEntityStore;
+
+    await m._linkEntitiesForMemory("memory-user-b", "OpenClaw enabled", {
+      user_id: "user-b",
+    });
+
+    expect(mockEntityStore.search).toHaveBeenCalledWith(expect.any(Array), 10, {
+      user_id: "user-b",
+    });
+    expect(mockEntityStore.insert).not.toHaveBeenCalled();
+    expect(mockEntityStore.update).toHaveBeenCalledWith(
+      "entity-user-b",
+      expect.any(Array),
+      expect.objectContaining({
+        user_id: "user-b",
+        linkedMemoryIds: ["memory-user-b", "memory-user-c"],
+      }),
+    );
+  });
+
+  it("uses the highest-scoring in-scope semantic match when results are unordered", async () => {
+    const m = memory as any;
+    await m._ensureInitialized();
+
+    const mockEntityStore = makeEntityStore({
+      searchMatches: [
+        {
+          ...crossScopeEntity({
+            user_id: "user-b",
+            linkedMemoryIds: ["memory-user-low"],
+          }),
+          id: "entity-user-low",
+          score: 0.96,
+        },
+        {
+          ...crossScopeEntity({
+            user_id: "user-b",
+            linkedMemoryIds: ["memory-user-high"],
+          }),
+          id: "entity-user-high",
+          score: 0.99,
+        },
+      ],
+    });
+    m._entityStore = mockEntityStore;
+
+    await m._linkEntitiesForMemory("memory-user-b", "OpenClaw enabled", {
+      user_id: "user-b",
+    });
+
+    expect(mockEntityStore.insert).not.toHaveBeenCalled();
+    expect(mockEntityStore.update).toHaveBeenCalledWith(
+      "entity-user-high",
+      expect.any(Array),
+      expect.objectContaining({
+        user_id: "user-b",
+        linkedMemoryIds: ["memory-user-b", "memory-user-high"],
+      }),
+    );
+  });
+
+  it("continues to merge single-memory entities into an in-scope semantic match", async () => {
+    const m = memory as any;
+    await m._ensureInitialized();
+
+    const mockEntityStore = makeEntityStore({
+      searchMatches: [
+        crossScopeEntity({
+          user_id: "user-b",
+          linkedMemoryIds: ["memory-user-a"],
+        }),
+      ],
+    });
+    m._entityStore = mockEntityStore;
+
+    await m._linkEntitiesForMemory("memory-user-b", "OpenClaw enabled", {
+      user_id: "user-b",
+    });
+
+    expect(mockEntityStore.insert).not.toHaveBeenCalled();
+    expect(mockEntityStore.update).toHaveBeenCalledTimes(1);
+    expect(mockEntityStore.update).toHaveBeenCalledWith(
+      "entity-user-a",
+      expect.any(Array),
+      expect.objectContaining({
+        data: "OpenClaw",
+        entityType: "ORG",
+        user_id: "user-b",
+        linkedMemoryIds: ["memory-user-a", "memory-user-b"],
+      }),
+    );
+  });
+
+  it("does not merge single-memory entities into an exact text match from another compound scope", async () => {
+    const m = memory as any;
+    await m._ensureInitialized();
+
+    const mockEntityStore = makeEntityStore({
+      listMatches: [
+        crossScopeEntity({
+          user_id: "user-b",
+          agent_id: "agent-a",
+          run_id: "run-b",
+        }),
+      ],
+      searchMatches: [],
+    });
+    m._entityStore = mockEntityStore;
+
+    await m._linkEntitiesForMemory("memory-user-b", "OpenClaw enabled", {
+      user_id: "user-b",
+      agent_id: "agent-b",
+      run_id: "run-b",
+    });
+
+    expect(mockEntityStore.update).not.toHaveBeenCalled();
+    expect(mockEntityStore.insert).toHaveBeenCalledTimes(1);
+    expect(mockEntityStore.insert.mock.calls[0][2][0]).toMatchObject({
+      data: "OpenClaw",
+      entityType: "ORG",
+      user_id: "user-b",
+      agent_id: "agent-b",
+      run_id: "run-b",
+      linkedMemoryIds: ["memory-user-b"],
+    });
+  });
+
+  it("uses an in-scope exact text match when an out-of-scope exact row appears first", async () => {
+    const m = memory as any;
+    await m._ensureInitialized();
+
+    const mockEntityStore = makeEntityStore({
+      listMatches: [
+        crossScopeEntity({
+          user_id: "user-a",
+          linkedMemoryIds: ["memory-user-a"],
+        }),
+        {
+          ...crossScopeEntity({
+            user_id: "user-b",
+            linkedMemoryIds: ["memory-user-c"],
+          }),
+          id: "entity-user-b",
+        },
+      ],
+      searchMatches: [],
+    });
+    m._entityStore = mockEntityStore;
+
+    await m._linkEntitiesForMemory("memory-user-b", "OpenClaw enabled", {
+      user_id: "user-b",
+    });
+
+    expect(mockEntityStore.search).not.toHaveBeenCalled();
+    expect(mockEntityStore.insert).not.toHaveBeenCalled();
+    expect(mockEntityStore.update).toHaveBeenCalledWith(
+      "entity-user-b",
+      expect.any(Array),
+      expect.objectContaining({
+        user_id: "user-b",
+        linkedMemoryIds: ["memory-user-b", "memory-user-c"],
+      }),
+    );
+  });
+
+  it("does not merge batched add entities into a returned candidate from another user scope", async () => {
+    const m = memory as any;
+    await m._ensureInitialized();
+
+    const mockEntityStore = makeEntityStore();
+    m._entityStore = mockEntityStore;
+
+    const result = await memory.add("OpenClaw is enabled", {
+      userId: "user-b",
+    });
+
+    expect(mockEntityStore.search).toHaveBeenCalledWith(expect.any(Array), 10, {
+      user_id: "user-b",
+    });
+    expect(result.results).toHaveLength(1);
+    expect(mockEntityStore.update).not.toHaveBeenCalled();
+    expect(mockEntityStore.insert).toHaveBeenCalledTimes(1);
+    expect(mockEntityStore.insert.mock.calls[0][2][0]).toMatchObject({
+      data: "OpenClaw",
+      entityType: "ORG",
+      user_id: "user-b",
+      linkedMemoryIds: [result.results[0].id],
+    });
+  });
+
+  it("uses the first in-scope semantic match during batched add when an out-of-scope candidate ranks first", async () => {
+    const m = memory as any;
+    await m._ensureInitialized();
+
+    const mockEntityStore = makeEntityStore({
+      searchMatches: [
+        crossScopeEntity({
+          user_id: "user-a",
+          linkedMemoryIds: ["memory-user-a"],
+        }),
+        {
+          ...crossScopeEntity({
+            user_id: "user-b",
+            linkedMemoryIds: ["memory-user-c"],
+          }),
+          id: "entity-user-b",
+          score: 0.97,
+        },
+      ],
+    });
+    m._entityStore = mockEntityStore;
+
+    const result = await memory.add("OpenClaw is enabled", {
+      userId: "user-b",
+    });
+
+    expect(mockEntityStore.search).toHaveBeenCalledWith(expect.any(Array), 10, {
+      user_id: "user-b",
+    });
+    expect(result.results).toHaveLength(1);
+    expect(mockEntityStore.insert).not.toHaveBeenCalled();
+    expect(mockEntityStore.update).toHaveBeenCalledTimes(1);
+    const updatePayload = mockEntityStore.update.mock.calls[0][2];
+    expect(mockEntityStore.update.mock.calls[0][0]).toBe("entity-user-b");
+    expect(updatePayload).toMatchObject({
+      user_id: "user-b",
+    });
+    expect(updatePayload.linkedMemoryIds).toEqual(
+      expect.arrayContaining(["memory-user-c", result.results[0].id]),
+    );
+    expect(updatePayload.linkedMemoryIds).toHaveLength(2);
+  });
+
+  it("uses an in-scope semantic match beyond the first five polluted batched add candidates", async () => {
+    const m = memory as any;
+    await m._ensureInitialized();
+
+    const pollutedMatches = Array.from({ length: 6 }, (_, index) => ({
+      ...crossScopeEntity({
+        user_id: `user-a-${index}`,
+        linkedMemoryIds: [`memory-user-a-${index}`],
+      }),
+      id: `entity-user-a-${index}`,
+      score: 0.99 - index * 0.001,
+    }));
+    const mockEntityStore = makeEntityStore({
+      searchMatches: [
+        ...pollutedMatches,
+        {
+          ...crossScopeEntity({
+            user_id: "user-b",
+            linkedMemoryIds: ["memory-user-c"],
+          }),
+          id: "entity-user-b",
+          score: 0.96,
+        },
+      ],
+    });
+    m._entityStore = mockEntityStore;
+
+    const result = await memory.add("OpenClaw is enabled", {
+      userId: "user-b",
+    });
+
+    expect(mockEntityStore.search).toHaveBeenCalledWith(expect.any(Array), 10, {
+      user_id: "user-b",
+    });
+    expect(result.results).toHaveLength(1);
+    expect(mockEntityStore.insert).not.toHaveBeenCalled();
+    expect(mockEntityStore.update.mock.calls[0][0]).toBe("entity-user-b");
+    const updatePayload = mockEntityStore.update.mock.calls[0][2];
+    expect(updatePayload).toMatchObject({
+      user_id: "user-b",
+    });
+    expect(updatePayload.linkedMemoryIds).toEqual(
+      expect.arrayContaining(["memory-user-c", result.results[0].id]),
+    );
+    expect(updatePayload.linkedMemoryIds).toHaveLength(2);
+  });
+
+  it("does not merge batched add entities into an exact text match from another compound scope", async () => {
+    const m = memory as any;
+    await m._ensureInitialized();
+
+    const mockEntityStore = makeEntityStore({
+      listMatches: [
+        crossScopeEntity({
+          user_id: "user-b",
+          agent_id: "agent-a",
+          run_id: "run-b",
+        }),
+      ],
+      searchMatches: [],
+    });
+    m._entityStore = mockEntityStore;
+
+    const result = await memory.add("OpenClaw is enabled", {
+      userId: "user-b",
+      agentId: "agent-b",
+      runId: "run-b",
+    });
+
+    expect(result.results).toHaveLength(1);
+    expect(mockEntityStore.update).not.toHaveBeenCalled();
+    expect(mockEntityStore.insert).toHaveBeenCalledTimes(1);
+    expect(mockEntityStore.insert.mock.calls[0][2][0]).toMatchObject({
+      data: "OpenClaw",
+      entityType: "ORG",
+      user_id: "user-b",
+      agent_id: "agent-b",
+      run_id: "run-b",
+      linkedMemoryIds: [result.results[0].id],
+    });
+  });
+
+  it("continues to merge batched add entities into an in-scope exact text match", async () => {
+    const m = memory as any;
+    await m._ensureInitialized();
+
+    const mockEntityStore = makeEntityStore({
+      listMatches: [
+        crossScopeEntity({
+          user_id: "user-b",
+          agent_id: "agent-b",
+          run_id: "run-b",
+          linkedMemoryIds: ["memory-user-a"],
+        }),
+      ],
+      searchMatches: [],
+    });
+    m._entityStore = mockEntityStore;
+
+    const result = await memory.add("OpenClaw is enabled", {
+      userId: "user-b",
+      agentId: "agent-b",
+      runId: "run-b",
+    });
+
+    expect(result.results).toHaveLength(1);
+    expect(mockEntityStore.insert).not.toHaveBeenCalled();
+    expect(mockEntityStore.update).toHaveBeenCalledTimes(1);
+    const updatePayload = mockEntityStore.update.mock.calls[0][2];
+    expect(updatePayload).toMatchObject({
+      data: "OpenClaw",
+      entityType: "ORG",
+      user_id: "user-b",
+      agent_id: "agent-b",
+      run_id: "run-b",
+    });
+    expect(updatePayload.linkedMemoryIds).toEqual(
+      expect.arrayContaining(["memory-user-a", result.results[0].id]),
+    );
+    expect(updatePayload.linkedMemoryIds).toHaveLength(2);
+  });
+
+  it("does not use out-of-scope entity matches for search-time entity boosts", async () => {
+    const m = memory as any;
+    await m._ensureInitialized();
+
+    const mockEntityStore = makeEntityStore({
+      searchMatches: [
+        crossScopeEntity({
+          user_id: "user-a",
+          linkedMemoryIds: ["boosted-memory"],
+        }),
+      ],
+    });
+    m._entityStore = mockEntityStore;
+    m.vectorStore.search = jest.fn().mockResolvedValue([
+      {
+        id: "plain-memory",
+        score: 0.6,
+        payload: { data: "plain OpenClaw memory", user_id: "user-b" },
+      },
+      {
+        id: "boosted-memory",
+        score: 0.4,
+        payload: { data: "lower-score OpenClaw memory", user_id: "user-b" },
+      },
+    ]);
+    m.vectorStore.keywordSearch = jest.fn().mockResolvedValue(null);
+
+    const result = await memory.search("OpenClaw", {
+      filters: { user_id: "user-b" },
+      topK: 2,
+      explain: true,
+    });
+
+    expect(result.results.map((item) => item.id)).toEqual([
+      "plain-memory",
+      "boosted-memory",
+    ]);
+    expect(result.results[1].score_details?.entityBoost).toBe(0);
+  });
+
+  it("continues to use in-scope entity matches for search-time entity boosts", async () => {
+    const m = memory as any;
+    await m._ensureInitialized();
+
+    const mockEntityStore = makeEntityStore({
+      searchMatches: [
+        crossScopeEntity({
+          user_id: "user-b",
+          linkedMemoryIds: ["boosted-memory"],
+        }),
+      ],
+    });
+    m._entityStore = mockEntityStore;
+    m.vectorStore.search = jest.fn().mockResolvedValue([
+      {
+        id: "plain-memory",
+        score: 0.6,
+        payload: { data: "plain OpenClaw memory", user_id: "user-b" },
+      },
+      {
+        id: "boosted-memory",
+        score: 0.59,
+        payload: { data: "lower-score OpenClaw memory", user_id: "user-b" },
+      },
+    ]);
+    m.vectorStore.keywordSearch = jest.fn().mockResolvedValue(null);
+
+    const result = await memory.search("OpenClaw", {
+      filters: { user_id: "user-b" },
+      topK: 2,
+      explain: true,
+    });
+
+    expect(mockEntityStore.search).toHaveBeenCalledWith(
+      expect.any(Array),
+      500,
+      {
+        user_id: "user-b",
+      },
+    );
+    expect(result.results.map((item) => item.id)).toEqual([
+      "boosted-memory",
+      "plain-memory",
+    ]);
+    expect(result.results[0].score_details?.entityBoost).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Linked Issue

Closes #5597

## Description

This fixes TypeScript OSS entity linking so entity candidates are only reused when their stored `user_id` / `agent_id` / `run_id` scope exactly matches the current write or search scope. It is the TypeScript counterpart to the prior Python-side scope isolation fix: vector stores may still return polluted entity candidates despite filters, so Mem0 now re-checks the entity payload scope before exact-text reuse, semantic reuse, and search-time entity boosts.

The public API, configuration shape, and persisted memory schema are unchanged. The write-time semantic entity lookup now checks up to 10 candidates and selects the highest-scoring same-scope match above the existing `0.95` threshold, which lets it recover when top candidates are out of scope while still failing safe by inserting a new scoped entity instead of linking across scope.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Commands run:

- `cd mem0-ts && pnpm test -- src/oss/tests/memory.entity-linking.test.ts --runInBand` — passed, 13 tests.
- `cd mem0-ts && pnpm test -- src/oss/tests/memory.entity-linking.test.ts src/oss/tests/memory.add.test.ts src/oss/tests/memory.entity-boost.test.ts --runInBand` — passed, 3 suites / 28 tests.
- `cd mem0-ts && pnpm run build` — passed; includes `rimraf dist`, `prettier --check .`, and `tsup`.
- `cd mem0-ts && pnpm test --runInBand` — passed; 57 suites passed, 5 skipped, 822 tests passed, 42 skipped.
- `git diff --check` — passed.
- `git diff --cached --check` — passed.

Notes:

- Integration tests that require `MEM0_API_KEY` were not run.
- Full Jest emitted existing non-failing console warnings from vector-store/telemetry-related tests, but exited successfully.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed

## Maintainer Notes

This PR intentionally keeps broader hardening out of scope:

- Primary memory-store post-filtering for `vectorStore.search()` / `keywordSearch()` would be a separate defense-in-depth PR because it changes the main memory retrieval/dedup path, not entity row reuse.
- Historical cleanup or rebuild of previously polluted entity rows is also a separate migration/repair task.
