### PR TITLE
fix(plugin): parse Cursor role=assistant transcript entries in stop hook

### DIFF
--- a/integrations/mem0-plugin/scripts/capture_session_summary.py
+++ b/integrations/mem0-plugin/scripts/capture_session_summary.py
@@ -70,19 +70,34 @@ def tail_lines(filepath: str, n: int) -> list[str]:
         return []
 
 
+def _line_might_be_assistant(line: str) -> bool:
+    """Fast pre-filter for Claude (type) and Cursor (role) assistant entries."""
+    return (
+        '"type":"assistant"' in line
+        or '"type": "assistant"' in line
+        or '"role":"assistant"' in line
+        or '"role": "assistant"' in line
+    )
+
+
+def _is_assistant_entry(entry: dict) -> bool:
+    """Claude transcripts use type=assistant; Cursor transcripts use role=assistant."""
+    return entry.get("type") == "assistant" or entry.get("role") == "assistant"
+
+
 def extract_last_assistant_message(lines: list[str]) -> str:
     """Walk transcript backwards, return text content of the last assistant message."""
     for line in reversed(lines):
         line = line.strip()
         if not line:
             continue
-        if '"type":"assistant"' not in line and '"type": "assistant"' not in line:
+        if not _line_might_be_assistant(line):
             continue
         try:
             entry = json.loads(line)
         except json.JSONDecodeError:
             continue
-        if entry.get("type") != "assistant":
+        if not _is_assistant_entry(entry):
             continue
         message = entry.get("message", {})
         content = message.get("content", [])

--- a/integrations/mem0-plugin/tests/test_capture_session_summary.py
+++ b/integrations/mem0-plugin/tests/test_capture_session_summary.py
@@ -77,3 +77,60 @@ def test_files_touched_omitted_when_no_files(monkeypatch):
     )
 
     assert "files_touched" not in captured["body"]["metadata"]
+
+
+def test_extract_last_assistant_message_claude_type_format():
+    import capture_session_summary as css
+
+    lines = [
+        json.dumps({"type": "user", "message": {"content": "hello"}}),
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [{"type": "text", "text": "Claude-style assistant reply with enough characters to pass the summary length gate."}],
+                },
+            }
+        ),
+    ]
+
+    assert css.extract_last_assistant_message(lines).startswith("Claude-style assistant reply")
+
+
+def test_extract_last_assistant_message_cursor_role_format():
+    import capture_session_summary as css
+
+    lines = [
+        json.dumps({"role": "user", "message": {"content": [{"type": "text", "text": "fix the bug"}]}}),
+        json.dumps(
+            {
+                "role": "assistant",
+                "message": {
+                    "content": [{"type": "text", "text": "Cursor-style assistant reply with enough characters to pass the summary length gate."}],
+                },
+            }
+        ),
+    ]
+
+    assert css.extract_last_assistant_message(lines).startswith("Cursor-style assistant reply")
+
+
+def test_extract_last_assistant_message_prefers_last_assistant():
+    import capture_session_summary as css
+
+    lines = [
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "older assistant reply that should not be returned because a newer assistant message exists later in the transcript."}]},
+            }
+        ),
+        json.dumps(
+            {
+                "role": "assistant",
+                "message": {"content": [{"type": "text", "text": "newer Cursor assistant reply with enough characters to pass the summary length gate and win selection."}]},
+            }
+        ),
+    ]
+
+    assert css.extract_last_assistant_message(lines).startswith("newer Cursor assistant reply")


### PR DESCRIPTION
## Summary

Fix the Cursor stop hook session-summary parser so it recognizes Cursor agent transcript entries that use `role=assistant` instead of Claude's `type=assistant`.

## Motivation

Closes #6006.

The mem0 Cursor plugin's `capture_session_summary.py` stop hook only parsed Claude-style transcript lines with `type == "assistant"`. Cursor agent transcripts use `role == "assistant"` at the top level, so the hook extracted an empty assistant message and skipped summary storage with:

```
Assistant message too short (0 chars) — skipping
```

## Changes

- Add `_line_might_be_assistant()` and `_is_assistant_entry()` helpers in `capture_session_summary.py`
- Update `extract_last_assistant_message()` to accept both Claude (`type`) and Cursor (`role`) assistant entry formats
- Add regression tests for Claude format, Cursor format, and last-assistant selection across mixed transcripts

## Tests

```bash
cd integrations/mem0-plugin
python3 -m pytest tests/test_capture_session_summary.py -v
```

Result: **5 passed**

## Notes

- Content extraction logic is unchanged; only assistant-entry detection is broadened.
- Composer 2.5 review: **APPROVE** (backward-compatible, minimal diff).