### PR TITLE
fix(ts-oss): post-filter memory reads by requested scope

### DIFF
--- a/docs/changelog/sdk.mdx
+++ b/docs/changelog/sdk.mdx
@@ -1100,6 +1100,13 @@ See the [OSS v2 to v3 migration guide](https://docs.mem0.ai/migration/oss-v2-to-
 
 <Tab title="TypeScript">
 
+<Update label="Unreleased" description="Next TypeScript SDK">
+
+**Bug Fixes:**
+- **Memory (OSS):** Post-filter scoped `search()`, `getAll()`, add-time dedupe, and `deleteAll()` results by requested scope so provider filter drift cannot leak or delete wrong-scope memories. Read filters continue to use `user_id`, `agent_id`, and `run_id`; `deleteAll()` options continue to use `userId`, `agentId`, and `runId`. Wildcard scope filters now throw in `search()`, `getAll()`, and `deleteAll()`, cursorless providers fail closed when full pages cannot prove completeness, and public results normalize stored scope/timestamp aliases. ([#6020](https://github.com/mem0ai/mem0/pull/6020))
+
+</Update>
+
 <Update label="2026-07-01" description="v3.0.13">
 
 **Bug Fixes:**

--- a/docs/changelog/sdk.mdx
+++ b/docs/changelog/sdk.mdx
@@ -1102,8 +1102,12 @@ See the [OSS v2 to v3 migration guide](https://docs.mem0.ai/migration/oss-v2-to-
 
 <Update label="Unreleased" description="Next TypeScript SDK">
 
+**Breaking / Behavior Changes:**
+- **Memory (OSS):** Scoped read/delete filters now reject wildcard and broad scope predicates such as `{ user_id: "*" }`, `{ user_id: { ne: "u1" } }`, `{ user_id: ["u1", "u2"] }`, and `deleteAll({ userId: "*" })`. Use explicit positive scope equality filters/options instead, or `reset()` when intentionally deleting everything. ([#6020](https://github.com/mem0ai/mem0/pull/6020))
+- **Memory (OSS):** `search()`, inferred `add()`, cursorless `getAll()`, and ambiguous `deleteAll()` calls now fail closed when provider pages cannot prove scoped completeness. This primarily affects providers without cursor-aware scoped reads or reliable total counts (for example Qdrant, Azure AI Search, and Vectorize on full pages); narrow filters, lower `topK`, or use `reset()` for intentional full-collection deletion. Public results also normalize stored scope/timestamp aliases to top-level fields instead of repeating them in `metadata`. ([#6020](https://github.com/mem0ai/mem0/pull/6020))
+
 **Bug Fixes:**
-- **Memory (OSS):** Post-filter scoped `search()`, `getAll()`, add-time dedupe, and `deleteAll()` results by requested scope so provider filter drift cannot leak or delete wrong-scope memories. Read filters continue to use `user_id`, `agent_id`, and `run_id`; `deleteAll()` options continue to use `userId`, `agentId`, and `runId`. Wildcard scope filters now throw in `search()`, `getAll()`, and `deleteAll()`, cursorless providers fail closed when full pages cannot prove completeness, and public results normalize stored scope/timestamp aliases. ([#6020](https://github.com/mem0ai/mem0/pull/6020))
+- **Memory (OSS):** Post-filter scoped `search()`, `getAll()`, add-time dedupe, and `deleteAll()` candidates by requested scope so provider filter drift cannot leak, suppress, or delete wrong-scope memories. Read filters continue to use `user_id`, `agent_id`, and `run_id`, while camelCase aliases are normalized before provider reads and `deleteAll()` options continue to use `userId`, `agentId`, and `runId`. ([#6020](https://github.com/mem0ai/mem0/pull/6020))
 
 </Update>
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -140,8 +140,8 @@ const memory = new Memory();
 await memory.add("I love hiking on weekends", { userId: "alice" });
 
 // Read
-await memory.search("What does Alice like to do?", { userId: "alice" });
-await memory.getAll({ userId: "alice" });
+await memory.search("What does Alice like to do?", { filters: { user_id: "alice" } });
+await memory.getAll({ filters: { user_id: "alice" } });
 await memory.get("<memory_id>");
 
 // Update
@@ -150,6 +150,7 @@ await memory.update("<memory_id>", "Alice loves mountain hiking");
 // Delete
 await memory.delete("<memory_id>");
 await memory.deleteAll({ userId: "alice" });
+await memory.reset(); // Intentionally delete the whole local collection.
 ```
 
 Relevant docs: same as OSS Python.

--- a/docs/open-source/node-quickstart.mdx
+++ b/docs/open-source/node-quickstart.mdx
@@ -43,7 +43,7 @@ await memory.add(messages, { userId: "alice", metadata: { category: "movie_recom
 
 <Step title="Search memories">
 ```ts
-const results = await memory.search("What do you know about me?", { filters: { userId: "alice" } });
+const results = await memory.search("What do you know about me?", { filters: { user_id: "alice" } });
 console.log(results);
 ```
 
@@ -58,13 +58,56 @@ console.log(results);
       "metadata": {
         "category": "movie_recommendations"
       },
-      "userId": "alice"
+      "user_id": "alice"
     }
   ]
 }
 ```
 </Step>
 </Steps>
+
+## Scoped reads and safe deletes
+
+`search()` and `getAll()` must receive scoped read filters under `filters`. Prefer the canonical snake_case keys (`user_id`, `agent_id`, `run_id`) in typed code; camelCase aliases (`userId`, `agentId`, `runId`) are accepted at runtime for compatibility. Results expose canonical top-level `user_id`, `agent_id`, and `run_id` fields.
+
+```ts
+// ✅ Scoped read
+await memory.search("What does Alice like?", {
+  filters: { user_id: "alice" },
+});
+
+await memory.getAll({
+  filters: { user_id: "alice" },
+});
+```
+
+Avoid broad scope selectors on read or delete paths. Wildcards, negative predicates, set membership, range operators, text operators, and negative logical scope filters are rejected because they can cross tenant or agent boundaries.
+
+```ts
+// ❌ Rejected: wildcard or broad scope selectors
+await memory.search("Anything?", { filters: { user_id: "*" } });
+await memory.search("Anything?", { filters: { user_id: { ne: "alice" } } });
+await memory.search("Anything?", { filters: { user_id: ["alice", "bob"] } });
+await memory.deleteAll({ userId: "*" });
+```
+
+For destructive cleanup, pass an explicit scope value to `deleteAll()`. If you intentionally want to remove the entire local collection, use `reset()` instead.
+
+```ts
+// Delete one user's memories
+await memory.deleteAll({ userId: "alice" });
+
+// Delete the whole local collection intentionally
+await memory.reset();
+```
+
+<Note>
+When using the `langchain` vector store provider, `reset()` clears Mem0 history and reinitializes internal factories and clients, but it does not delete the underlying LangChain vector store collection.
+</Note>
+
+<Note>
+Some vector stores do not expose cursor-aware scoped reads. If Mem0 cannot prove that a full provider page contains the complete scoped result set, `search()`, `getAll()`, inferred `add()`, or `deleteAll()` can fail closed with a safety error. Narrow the scope filters, lower `topK`, or choose a provider with total-count support for large scoped reads/deletes.
+</Note>
 
 <Snippet file="star-on-github.mdx" />
 

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -101,6 +101,9 @@ const RESERVED_PAYLOAD_KEYS = new Set<string>([
   "attributedTo",
 ]);
 
+const MIN_SCOPE_POST_FILTER_FETCH = 60;
+const DELETE_ALL_SCOPE_FETCH_LIMIT = 10000;
+
 /**
  * Validates that no top-level entity parameters are passed in config.
  * @throws Error if entity params are found at top level
@@ -336,6 +339,20 @@ export class Memory {
     return metadata;
   }
 
+  private _providerFiltersForRequestedScope(
+    filters: Record<string, any>,
+  ): Record<string, any> | undefined {
+    const providerFilters: Record<string, any> = { ...filters };
+    for (const key of SCOPE_KEYS) {
+      if (providerFilters[key] === "*") {
+        delete providerFilters[key];
+      }
+    }
+    return Object.keys(providerFilters).length > 0
+      ? providerFilters
+      : undefined;
+  }
+
   private _normalizeEntityText(value: string): string {
     return value.trim().toLowerCase().replace(/\s+/g, " ");
   }
@@ -569,6 +586,10 @@ export class Memory {
       return results;
     }
 
+    // Defense-in-depth after provider filtering: enforce only the scope keys
+    // explicitly requested by the caller. Bounded vector-store APIs do not
+    // expose a shared cursor, so callers may see fewer rows if a provider
+    // returns polluted rows before valid in-scope rows.
     return results.filter((result) =>
       requestedKeys.every((key) => {
         const payload = result.payload ?? {};
@@ -875,8 +896,13 @@ export class Memory {
 
     // Phase 1: Existing memory retrieval
     const queryEmbedding = await this.embedder.embed(parsedMessages);
+    const providerFilters = this._providerFiltersForRequestedScope(filters);
     const existingResults = this.filterByRequestedScope(
-      await this.vectorStore.search(queryEmbedding, 10, filters),
+      await this.vectorStore.search(
+        queryEmbedding,
+        MIN_SCOPE_POST_FILTER_FETCH,
+        providerFilters,
+      ),
       filters,
     );
 
@@ -1401,11 +1427,13 @@ export class Memory {
 
     // Step 3: Semantic search (over-fetch for scoring pool)
     const internalLimit = Math.max(topK * 4, 60);
+    const providerFilters =
+      this._providerFiltersForRequestedScope(effectiveFilters);
     const semanticResults = this.filterByRequestedScope(
       await this.vectorStore.search(
         queryEmbedding,
         internalLimit,
-        effectiveFilters,
+        providerFilters,
       ),
       effectiveFilters,
     );
@@ -1422,7 +1450,7 @@ export class Memory {
           (await this.vectorStore.keywordSearch(
             queryLemmatized,
             internalLimit,
-            effectiveFilters,
+            providerFilters,
           )) ?? null;
         keywordResults = rawKeywordResults
           ? this.filterByRequestedScope(rawKeywordResults, effectiveFilters)
@@ -1649,7 +1677,11 @@ export class Memory {
       );
     }
 
-    const [rawMemories] = await this.vectorStore.list(filters);
+    const providerFilters = this._providerFiltersForRequestedScope(filters);
+    const [rawMemories] = await this.vectorStore.list(
+      providerFilters,
+      DELETE_ALL_SCOPE_FETCH_LIMIT,
+    );
     const memories = this.filterByRequestedScope(rawMemories, filters);
     for (const memory of memories) {
       await this.deleteMemory(memory.id);
@@ -1766,8 +1798,17 @@ export class Memory {
       );
     }
 
-    const [rawMemories] = await this.vectorStore.list(filters, topK);
-    const memories = this.filterByRequestedScope(rawMemories, filters);
+    const providerFilters = this._providerFiltersForRequestedScope(filters);
+    const fetchLimit =
+      topK === 0 ? 0 : Math.max(topK * 4, MIN_SCOPE_POST_FILTER_FETCH);
+    const [rawMemories] = await this.vectorStore.list(
+      providerFilters,
+      fetchLimit,
+    );
+    const memories = this.filterByRequestedScope(rawMemories, filters).slice(
+      0,
+      topK,
+    );
 
     const results = memories.map((mem) => ({
       id: mem.id,

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -75,15 +75,31 @@ import {
 import { getDefaultVectorStoreDbPath } from "../utils/sqlite";
 import { getOrCreateMem0UserId } from "../../../client/config";
 
+const SCOPE_KEYS = ["user_id", "agent_id", "run_id"] as const;
+type ScopeKey = (typeof SCOPE_KEYS)[number];
+
+const SCOPE_KEY_ALIASES: Record<ScopeKey, "userId" | "agentId" | "runId"> = {
+  user_id: "userId",
+  agent_id: "agentId",
+  run_id: "runId",
+};
+
 // Entity params that must be passed via filters - check both snake_case and camelCase
-const ENTITY_PARAMS = [
-  "user_id",
-  "agent_id",
-  "run_id",
-  "userId",
-  "agentId",
-  "runId",
+const ENTITY_PARAMS: string[] = [
+  ...SCOPE_KEYS,
+  ...Object.values(SCOPE_KEY_ALIASES),
 ];
+
+const RESERVED_PAYLOAD_KEYS = new Set<string>([
+  ...SCOPE_KEYS,
+  ...Object.values(SCOPE_KEY_ALIASES),
+  "hash",
+  "data",
+  "createdAt",
+  "updatedAt",
+  "textLemmatized",
+  "attributedTo",
+]);
 
 /**
  * Validates that no top-level entity parameters are passed in config.
@@ -291,10 +307,33 @@ export class Memory {
     payload: Record<string, any>,
   ): Record<string, any> {
     const filters: Record<string, any> = {};
-    if (payload.user_id) filters.user_id = payload.user_id;
-    if (payload.agent_id) filters.agent_id = payload.agent_id;
-    if (payload.run_id) filters.run_id = payload.run_id;
+    for (const key of SCOPE_KEYS) {
+      const value = this._payloadScopeValue(payload, key);
+      if (value !== undefined && value !== null) {
+        filters[key] = value;
+      }
+    }
     return filters;
+  }
+
+  private _payloadScopeValue(payload: Record<string, any>, key: ScopeKey): any {
+    const canonicalValue = payload[key];
+    if (canonicalValue !== undefined && canonicalValue !== null) {
+      return canonicalValue;
+    }
+    return payload[SCOPE_KEY_ALIASES[key]];
+  }
+
+  private _metadataFromPayload(
+    payload: Record<string, any>,
+  ): Record<string, any> {
+    const metadata: Record<string, any> = {};
+    for (const [key, value] of Object.entries(payload)) {
+      if (!RESERVED_PAYLOAD_KEYS.has(key)) {
+        metadata[key] = value;
+      }
+    }
+    return metadata;
   }
 
   private _normalizeEntityText(value: string): string {
@@ -522,13 +561,7 @@ export class Memory {
     results: T[],
     filters: Record<string, any>,
   ): T[] {
-    const scopeKeys = ["user_id", "agent_id", "run_id"] as const;
-    const payloadAliases = {
-      user_id: "userId",
-      agent_id: "agentId",
-      run_id: "runId",
-    } as const;
-    const requestedKeys = scopeKeys.filter(
+    const requestedKeys = SCOPE_KEYS.filter(
       (key) => filters[key] !== undefined && filters[key] !== null,
     );
 
@@ -539,13 +572,11 @@ export class Memory {
     return results.filter((result) =>
       requestedKeys.every((key) => {
         const payload = result.payload ?? {};
-        const scopeValues = [payload[key], payload[payloadAliases[key]]];
+        const scopeValue = this._payloadScopeValue(payload, key);
         if (filters[key] === "*") {
-          return scopeValues.some(
-            (value) => value !== undefined && value !== null,
-          );
+          return scopeValue !== undefined && scopeValue !== null;
         }
-        return scopeValues.some((value) => value === filters[key]);
+        return scopeValue === filters[key];
       }),
     );
   }
@@ -1250,44 +1281,23 @@ export class Memory {
       return null;
     }
 
-    const filters = {
-      ...(memory.payload.user_id && { user_id: memory.payload.user_id }),
-      ...(memory.payload.agent_id && { agent_id: memory.payload.agent_id }),
-      ...(memory.payload.run_id && { run_id: memory.payload.run_id }),
-    };
+    const payload = memory.payload || {};
+    const filters = this._sessionFiltersFromPayload(payload);
 
     const memoryItem: MemoryItem = {
       id: memory.id,
-      memory: memory.payload.data,
-      hash: memory.payload.hash,
-      createdAt: memory.payload.createdAt,
-      updatedAt: memory.payload.updatedAt,
-      metadata: {},
+      memory: payload.data,
+      hash: payload.hash,
+      createdAt: payload.createdAt,
+      updatedAt: payload.updatedAt,
+      metadata: this._metadataFromPayload(payload),
     };
-
-    // Add additional metadata
-    const excludedKeys = new Set([
-      "userId",
-      "agentId",
-      "runId",
-      "hash",
-      "data",
-      "createdAt",
-      "updatedAt",
-      "textLemmatized",
-      "attributedTo",
-    ]);
-    for (const [key, value] of Object.entries(memory.payload)) {
-      if (!excludedKeys.has(key)) {
-        memoryItem.metadata![key] = value;
-      }
-    }
 
     const result = {
       ...memoryItem,
       ...filters,
-      ...(memory.payload.attributedTo && {
-        attributedTo: memory.payload.attributedTo,
+      ...(payload.attributedTo && {
+        attributedTo: payload.attributedTo,
       }),
     };
     await this._displayFirstRunNotice("get");
@@ -1530,18 +1540,6 @@ export class Memory {
     );
 
     // Step 9: Format results
-    const excludedKeys = new Set([
-      "user_id",
-      "agent_id",
-      "run_id",
-      "hash",
-      "data",
-      "createdAt",
-      "updatedAt",
-      "textLemmatized",
-      "attributedTo",
-    ]);
-
     const results = scoredResults
       .filter((scored) => scored.payload?.data)
       .map((scored) => {
@@ -1553,12 +1551,8 @@ export class Memory {
           createdAt: payload.createdAt,
           updatedAt: payload.updatedAt,
           score: scored.score,
-          metadata: Object.entries(payload)
-            .filter(([key]) => !excludedKeys.has(key))
-            .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {}),
-          ...(payload.user_id && { user_id: payload.user_id }),
-          ...(payload.agent_id && { agent_id: payload.agent_id }),
-          ...(payload.run_id && { run_id: payload.run_id }),
+          metadata: this._metadataFromPayload(payload),
+          ...this._sessionFiltersFromPayload(payload),
           ...(payload.attributedTo && { attributedTo: payload.attributedTo }),
           ...(scored.scoreDetails && { score_details: scored.scoreDetails }),
         };
@@ -1775,29 +1769,14 @@ export class Memory {
     const [rawMemories] = await this.vectorStore.list(filters, topK);
     const memories = this.filterByRequestedScope(rawMemories, filters);
 
-    const excludedKeys = new Set([
-      "user_id",
-      "agent_id",
-      "run_id",
-      "hash",
-      "data",
-      "createdAt",
-      "updatedAt",
-      "textLemmatized",
-      "attributedTo",
-    ]);
     const results = memories.map((mem) => ({
       id: mem.id,
       memory: mem.payload.data,
       hash: mem.payload.hash,
       createdAt: mem.payload.createdAt,
       updatedAt: mem.payload.updatedAt,
-      metadata: Object.entries(mem.payload)
-        .filter(([key]) => !excludedKeys.has(key))
-        .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {}),
-      ...(mem.payload.user_id && { user_id: mem.payload.user_id }),
-      ...(mem.payload.agent_id && { agent_id: mem.payload.agent_id }),
-      ...(mem.payload.run_id && { run_id: mem.payload.run_id }),
+      metadata: this._metadataFromPayload(mem.payload),
+      ...this._sessionFiltersFromPayload(mem.payload),
       ...(mem.payload.attributedTo && {
         attributedTo: mem.payload.attributedTo,
       }),

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -523,6 +523,11 @@ export class Memory {
     filters: Record<string, any>,
   ): T[] {
     const scopeKeys = ["user_id", "agent_id", "run_id"] as const;
+    const payloadAliases = {
+      user_id: "userId",
+      agent_id: "agentId",
+      run_id: "runId",
+    } as const;
     const requestedKeys = scopeKeys.filter(
       (key) => filters[key] !== undefined && filters[key] !== null,
     );
@@ -532,7 +537,16 @@ export class Memory {
     }
 
     return results.filter((result) =>
-      requestedKeys.every((key) => result.payload?.[key] === filters[key]),
+      requestedKeys.every((key) => {
+        const payload = result.payload ?? {};
+        const scopeValues = [payload[key], payload[payloadAliases[key]]];
+        if (filters[key] === "*") {
+          return scopeValues.some(
+            (value) => value !== undefined && value !== null,
+          );
+        }
+        return scopeValues.some((value) => value === filters[key]);
+      }),
     );
   }
 

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -354,60 +354,189 @@ export class Memory {
   private _providerFiltersForRequestedScope(
     filters: Record<string, any>,
   ): Record<string, any> | undefined {
-    const providerFilters: Record<string, any> = { ...filters };
-    const scopeAlternatives: Record<string, any>[] = [{}];
+    const providerFilters = this._stripScopeWildcardsForProvider(filters);
+    if (!providerFilters) {
+      return undefined;
+    }
+
     const provider = this.config.vectorStore.provider.toLowerCase();
-    const supportsScopeAliasOr = ["pgvector", "qdrant"].includes(provider);
-    const existingOr = supportsScopeAliasOr ? providerFilters.$or : undefined;
-    if (supportsScopeAliasOr) {
-      delete providerFilters.$or;
+    if (!["pgvector", "qdrant"].includes(provider)) {
+      return providerFilters;
     }
 
-    for (const key of SCOPE_KEYS) {
-      const value = providerFilters[key];
-      if (value === undefined || value === null) {
+    return this._providerFilterFromAlternatives(
+      this._providerScopeAliasAlternatives(providerFilters),
+    );
+  }
+
+  private _stripScopeWildcardsForProvider(
+    filter: Record<string, any>,
+  ): Record<string, any> | undefined {
+    const result: Record<string, any> = {};
+
+    for (const [key, value] of Object.entries(filter)) {
+      const isLogicalKey =
+        key === "AND" ||
+        key === "OR" ||
+        key === "NOT" ||
+        key === "$and" ||
+        key === "$or" ||
+        key === "$not";
+
+      if (this._canonicalScopeKey(key) && value === "*") {
         continue;
       }
 
-      delete providerFilters[key];
+      if (isLogicalKey && Array.isArray(value)) {
+        const logicalFilters: Record<string, any>[] = [];
+        let logicalFilterIsUnrestricted = false;
 
-      if (value === "*") {
-        continue;
-      }
+        for (const condition of value) {
+          if (
+            !condition ||
+            typeof condition !== "object" ||
+            Array.isArray(condition)
+          ) {
+            logicalFilters.push(condition);
+            continue;
+          }
 
-      if (supportsScopeAliasOr) {
-        const currentAlternatives = scopeAlternatives.splice(0);
-        for (const alternative of currentAlternatives) {
-          scopeAlternatives.push({ ...alternative, [key]: value });
-          scopeAlternatives.push({
-            ...alternative,
-            [SCOPE_KEY_ALIASES[key]]: value,
-          });
+          const stripped = this._stripScopeWildcardsForProvider(condition);
+          if (!stripped) {
+            if (key === "OR" || key === "$or") {
+              logicalFilterIsUnrestricted = true;
+              break;
+            }
+            continue;
+          }
+          logicalFilters.push(stripped);
         }
-      } else {
-        providerFilters[key] = value;
+
+        if (!logicalFilterIsUnrestricted && logicalFilters.length > 0) {
+          result[key] = logicalFilters;
+        }
+        continue;
       }
+
+      result[key] = value;
     }
 
-    if (supportsScopeAliasOr) {
-      const existingOrClauses = Array.isArray(existingOr)
-        ? existingOr
-        : undefined;
+    return Object.keys(result).length > 0 ? result : undefined;
+  }
 
-      if (scopeAlternatives.length > 1 && existingOrClauses) {
-        providerFilters.$or = existingOrClauses.flatMap((clause) =>
-          scopeAlternatives.map((scope) => ({ ...clause, ...scope })),
+  private _providerScopeAliasAlternatives(
+    filter: Record<string, any>,
+  ): Record<string, any>[] {
+    let alternatives: Record<string, any>[] = [{}];
+
+    const mergeAlternatives = (branches: Record<string, any>[]) => {
+      alternatives = alternatives.flatMap((alternative) =>
+        branches.map((branch) => ({ ...alternative, ...branch })),
+      );
+    };
+
+    const appendToAlternatives = (key: string, value: any) => {
+      alternatives = alternatives.map((alternative) => ({
+        ...alternative,
+        [key]: value,
+      }));
+    };
+
+    for (const [key, value] of Object.entries(filter)) {
+      if (key === "AND" || key === "$and") {
+        if (!Array.isArray(value)) {
+          appendToAlternatives(key, value);
+          continue;
+        }
+        for (const condition of value) {
+          if (
+            condition &&
+            typeof condition === "object" &&
+            !Array.isArray(condition)
+          ) {
+            mergeAlternatives(this._providerScopeAliasAlternatives(condition));
+          }
+        }
+        continue;
+      }
+
+      if (key === "OR" || key === "$or") {
+        if (!Array.isArray(value)) {
+          appendToAlternatives(key, value);
+          continue;
+        }
+        const branches = value.flatMap((condition) =>
+          condition &&
+          typeof condition === "object" &&
+          !Array.isArray(condition)
+            ? this._providerScopeAliasAlternatives(condition)
+            : [],
         );
-      } else if (scopeAlternatives.length > 1) {
-        providerFilters.$or = scopeAlternatives;
-      } else if (existingOr !== undefined) {
-        providerFilters.$or = existingOr;
+        if (branches.some((branch) => Object.keys(branch).length === 0)) {
+          continue;
+        }
+        if (branches.length > 0) {
+          mergeAlternatives(branches);
+        }
+        continue;
       }
+
+      if (key === "NOT" || key === "$not") {
+        if (!Array.isArray(value)) {
+          appendToAlternatives(key, value);
+          continue;
+        }
+        const notBranches = value.flatMap((condition) =>
+          condition &&
+          typeof condition === "object" &&
+          !Array.isArray(condition)
+            ? this._providerScopeAliasAlternatives(condition)
+            : [],
+        );
+        const nonEmptyBranches = notBranches.filter(
+          (branch) => Object.keys(branch).length > 0,
+        );
+        if (nonEmptyBranches.length > 0) {
+          alternatives = alternatives.map((alternative) => ({
+            ...alternative,
+            $not: [
+              ...((alternative.$not as Record<string, any>[] | undefined) ??
+                []),
+              ...nonEmptyBranches,
+            ],
+          }));
+        }
+        continue;
+      }
+
+      const scopeKey = this._canonicalScopeKey(key);
+      if (scopeKey) {
+        mergeAlternatives([
+          { [scopeKey]: value },
+          { [SCOPE_KEY_ALIASES[scopeKey]]: value },
+        ]);
+        continue;
+      }
+
+      appendToAlternatives(key, value);
     }
 
-    return Object.keys(providerFilters).length > 0
-      ? providerFilters
-      : undefined;
+    return alternatives;
+  }
+
+  private _providerFilterFromAlternatives(
+    alternatives: Record<string, any>[],
+  ): Record<string, any> | undefined {
+    const nonEmptyAlternatives = alternatives.filter(
+      (alternative) => Object.keys(alternative).length > 0,
+    );
+    if (nonEmptyAlternatives.length === 0) {
+      return undefined;
+    }
+    if (nonEmptyAlternatives.length === 1) {
+      return nonEmptyAlternatives[0];
+    }
+    return { $or: nonEmptyAlternatives };
   }
 
   private _providerListCountIsTotal(): boolean {
@@ -712,10 +841,10 @@ export class Memory {
       return results;
     }
 
-    // Defense-in-depth after provider filtering: enforce only the scope keys
-    // explicitly requested by the caller. Bounded vector-store APIs do not
-    // expose a shared cursor, so callers may see fewer rows if a provider
-    // returns polluted rows before valid in-scope rows.
+    // Defense-in-depth after provider filtering: replay filters that contain
+    // requested scope keys so provider drift cannot leak or delete wrong-scope
+    // rows. Bounded vector-store APIs do not expose a shared cursor, so callers
+    // may see fewer rows if polluted rows crowd out valid in-scope rows.
     return results.filter((result) =>
       this._matchesScopeFilter(result.payload ?? {}, filters),
     );
@@ -806,11 +935,8 @@ export class Memory {
         if (!Array.isArray(value)) {
           return false;
         }
-        const scopeConditions = value.filter((condition) =>
-          this._filterContainsScope(condition),
-        );
         if (
-          scopeConditions.some((condition) =>
+          value.some((condition) =>
             this._matchesScopeFilter(payload, condition),
           )
         ) {
@@ -820,11 +946,11 @@ export class Memory {
       }
 
       const scopeKey = this._canonicalScopeKey(key);
-      if (!scopeKey || value === undefined || value === null) {
+      if (value === undefined || value === null) {
         continue;
       }
 
-      if (!this._matchesScopeCondition(payload, scopeKey, value)) {
+      if (!this._matchesFieldCondition(payload, key, value, scopeKey)) {
         return false;
       }
     }
@@ -832,57 +958,62 @@ export class Memory {
     return true;
   }
 
-  private _matchesScopeCondition(
+  private _matchesFieldCondition(
     payload: Record<string, any>,
-    key: ScopeKey,
+    key: string,
     condition: any,
+    scopeKey?: ScopeKey,
   ): boolean {
-    const scopeValue = this._payloadScopeValue(payload, key);
+    const payloadValue = scopeKey
+      ? this._payloadScopeValue(payload, scopeKey)
+      : payload[key];
 
     if (condition === "*") {
-      return scopeValue !== undefined && scopeValue !== null;
+      return scopeKey
+        ? payloadValue !== undefined && payloadValue !== null
+        : true;
     }
 
     if (Array.isArray(condition)) {
-      return condition.includes(scopeValue);
+      return condition.includes(payloadValue);
     }
 
     if (typeof condition === "object" && condition !== null) {
       for (const [operator, value] of Object.entries(condition)) {
         if (operator === "eq") {
-          if (scopeValue !== value) return false;
+          if (payloadValue !== value) return false;
         } else if (operator === "ne") {
           if (
-            scopeValue === undefined ||
-            scopeValue === null ||
-            scopeValue === value
+            (scopeKey &&
+              (payloadValue === undefined || payloadValue === null)) ||
+            payloadValue === value
           ) {
             return false;
           }
         } else if (operator === "in") {
-          if (!Array.isArray(value) || !value.includes(scopeValue)) {
+          if (!Array.isArray(value) || !value.includes(payloadValue)) {
             return false;
           }
         } else if (operator === "nin") {
           if (
             !Array.isArray(value) ||
-            scopeValue === undefined ||
-            scopeValue === null ||
-            value.includes(scopeValue)
+            (scopeKey &&
+              (payloadValue === undefined || payloadValue === null)) ||
+            value.includes(payloadValue)
           ) {
             return false;
           }
         } else if (operator === "contains") {
           if (
-            typeof scopeValue !== "string" ||
-            !scopeValue.includes(String(value))
+            typeof payloadValue !== "string" ||
+            !payloadValue.includes(String(value))
           ) {
             return false;
           }
         } else if (operator === "icontains") {
           if (
-            typeof scopeValue !== "string" ||
-            !scopeValue.toLowerCase().includes(String(value).toLowerCase())
+            typeof payloadValue !== "string" ||
+            !payloadValue.toLowerCase().includes(String(value).toLowerCase())
           ) {
             return false;
           }
@@ -893,7 +1024,7 @@ export class Memory {
       return true;
     }
 
-    return scopeValue === condition;
+    return payloadValue === condition;
   }
 
   private async _initializeTelemetry() {

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -990,6 +990,22 @@ export class Memory {
           ) {
             return false;
           }
+        } else if (operator === "gt") {
+          if (!this._compareFilterValues(payloadValue, value, ">")) {
+            return false;
+          }
+        } else if (operator === "gte") {
+          if (!this._compareFilterValues(payloadValue, value, ">=")) {
+            return false;
+          }
+        } else if (operator === "lt") {
+          if (!this._compareFilterValues(payloadValue, value, "<")) {
+            return false;
+          }
+        } else if (operator === "lte") {
+          if (!this._compareFilterValues(payloadValue, value, "<=")) {
+            return false;
+          }
         } else if (operator === "in") {
           if (!Array.isArray(value) || !value.includes(payloadValue)) {
             return false;
@@ -1025,6 +1041,42 @@ export class Memory {
     }
 
     return payloadValue === condition;
+  }
+
+  private _compareFilterValues(
+    payloadValue: any,
+    filterValue: any,
+    operator: ">" | ">=" | "<" | "<=",
+  ): boolean {
+    if (payloadValue === undefined || payloadValue === null) {
+      return false;
+    }
+
+    const payloadNumber = Number(payloadValue);
+    const filterNumber = Number(filterValue);
+    if (Number.isFinite(payloadNumber) && Number.isFinite(filterNumber)) {
+      if (operator === ">") return payloadNumber > filterNumber;
+      if (operator === ">=") return payloadNumber >= filterNumber;
+      if (operator === "<") return payloadNumber < filterNumber;
+      return payloadNumber <= filterNumber;
+    }
+
+    const payloadTime =
+      payloadValue instanceof Date
+        ? payloadValue.getTime()
+        : Date.parse(String(payloadValue));
+    const filterTime =
+      filterValue instanceof Date
+        ? filterValue.getTime()
+        : Date.parse(String(filterValue));
+    if (Number.isFinite(payloadTime) && Number.isFinite(filterTime)) {
+      if (operator === ">") return payloadTime > filterTime;
+      if (operator === ">=") return payloadTime >= filterTime;
+      if (operator === "<") return payloadTime < filterTime;
+      return payloadTime <= filterTime;
+    }
+
+    return false;
   }
 
   private async _initializeTelemetry() {
@@ -1812,21 +1864,7 @@ export class Memory {
 
     // Apply enhanced metadata filtering if advanced operators are detected
     if (this._hasAdvancedOperators(effectiveFilters)) {
-      const processedFilters = this._processMetadataFilters(effectiveFilters);
-      // Remove logical/operator keys that have been reprocessed
-      for (const logicalKey of ["AND", "OR", "NOT"]) {
-        delete effectiveFilters[logicalKey];
-      }
-      for (const fk of Object.keys(effectiveFilters)) {
-        if (
-          !["AND", "OR", "NOT", "user_id", "agent_id", "run_id"].includes(fk) &&
-          typeof effectiveFilters[fk] === "object" &&
-          effectiveFilters[fk] !== null
-        ) {
-          delete effectiveFilters[fk];
-        }
-      }
-      effectiveFilters = { ...effectiveFilters, ...processedFilters };
+      effectiveFilters = this._processMetadataFilters(effectiveFilters);
     }
 
     // Validate filters contains at least one entity ID (snake_case)
@@ -2423,8 +2461,6 @@ export class Memory {
   private _processMetadataFilters(
     metadataFilters: Record<string, any>,
   ): Record<string, any> {
-    const processedFilters: Record<string, any> = {};
-
     const processCondition = (
       key: string,
       condition: any,
@@ -2469,56 +2505,52 @@ export class Memory {
       return result;
     };
 
-    for (const [key, value] of Object.entries(metadataFilters)) {
-      if (key === "AND") {
-        // Logical AND: combine multiple conditions
-        if (!Array.isArray(value)) {
-          throw new Error("AND operator requires a list of conditions");
-        }
-        for (const condition of value) {
-          for (const [subKey, subValue] of Object.entries(condition)) {
-            Object.assign(processedFilters, processCondition(subKey, subValue));
-          }
-        }
-      } else if (key === "OR") {
-        // Logical OR: Pass through to vector store for implementation-specific handling
-        if (!Array.isArray(value) || value.length === 0) {
-          throw new Error(
-            "OR operator requires a non-empty list of conditions",
-          );
-        }
-        processedFilters["$or"] = [];
-        for (const condition of value) {
-          const orCondition: Record<string, any> = {};
-          for (const [subKey, subValue] of Object.entries(
-            condition as Record<string, any>,
-          )) {
-            Object.assign(orCondition, processCondition(subKey, subValue));
-          }
-          processedFilters["$or"].push(orCondition);
-        }
-      } else if (key === "NOT") {
-        // Logical NOT: Pass through to vector store for implementation-specific handling
-        if (!Array.isArray(value) || value.length === 0) {
-          throw new Error(
-            "NOT operator requires a non-empty list of conditions",
-          );
-        }
-        processedFilters["$not"] = [];
-        for (const condition of value) {
-          const notCondition: Record<string, any> = {};
-          for (const [subKey, subValue] of Object.entries(
-            condition as Record<string, any>,
-          )) {
-            Object.assign(notCondition, processCondition(subKey, subValue));
-          }
-          processedFilters["$not"].push(notCondition);
-        }
-      } else {
-        Object.assign(processedFilters, processCondition(key, value));
-      }
-    }
+    const processFilterObject = (
+      filters: Record<string, any>,
+    ): Record<string, any> => {
+      const processedFilters: Record<string, any> = {};
 
-    return processedFilters;
+      for (const [key, value] of Object.entries(filters)) {
+        if (key === "AND" || key === "$and") {
+          // Logical AND: combine multiple conditions into the same filter
+          // object where vector stores interpret fields as implicit AND.
+          if (!Array.isArray(value)) {
+            throw new Error("AND operator requires a list of conditions");
+          }
+          for (const condition of value) {
+            Object.assign(
+              processedFilters,
+              processFilterObject(condition as Record<string, any>),
+            );
+          }
+        } else if (key === "OR" || key === "$or") {
+          // Logical OR: Pass through to vector store for implementation-specific handling
+          if (!Array.isArray(value) || value.length === 0) {
+            throw new Error(
+              "OR operator requires a non-empty list of conditions",
+            );
+          }
+          processedFilters["$or"] = value.map((condition) =>
+            processFilterObject(condition as Record<string, any>),
+          );
+        } else if (key === "NOT" || key === "$not") {
+          // Logical NOT: Pass through to vector store for implementation-specific handling
+          if (!Array.isArray(value) || value.length === 0) {
+            throw new Error(
+              "NOT operator requires a non-empty list of conditions",
+            );
+          }
+          processedFilters["$not"] = value.map((condition) =>
+            processFilterObject(condition as Record<string, any>),
+          );
+        } else {
+          Object.assign(processedFilters, processCondition(key, value));
+        }
+      }
+
+      return processedFilters;
+    };
+
+    return processFilterObject(metadataFilters);
   }
 }

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -708,11 +708,7 @@ export class Memory {
     results: T[],
     filters: Record<string, any>,
   ): T[] {
-    const requestedKeys = SCOPE_KEYS.filter(
-      (key) => filters[key] !== undefined && filters[key] !== null,
-    );
-
-    if (requestedKeys.length === 0) {
+    if (!this._filterContainsScope(filters)) {
       return results;
     }
 
@@ -721,15 +717,183 @@ export class Memory {
     // expose a shared cursor, so callers may see fewer rows if a provider
     // returns polluted rows before valid in-scope rows.
     return results.filter((result) =>
-      requestedKeys.every((key) => {
-        const payload = result.payload ?? {};
-        const scopeValue = this._payloadScopeValue(payload, key);
-        if (filters[key] === "*") {
-          return scopeValue !== undefined && scopeValue !== null;
-        }
-        return scopeValue === filters[key];
-      }),
+      this._matchesScopeFilter(result.payload ?? {}, filters),
     );
+  }
+
+  private _canonicalScopeKey(key: string): ScopeKey | undefined {
+    if ((SCOPE_KEYS as readonly string[]).includes(key)) {
+      return key as ScopeKey;
+    }
+
+    for (const [scopeKey, alias] of Object.entries(SCOPE_KEY_ALIASES)) {
+      if (alias === key) {
+        return scopeKey as ScopeKey;
+      }
+    }
+
+    return undefined;
+  }
+
+  private _filterContainsScope(filter: any): boolean {
+    if (!filter || typeof filter !== "object" || Array.isArray(filter)) {
+      return false;
+    }
+
+    for (const [key, value] of Object.entries(filter)) {
+      if (
+        this._canonicalScopeKey(key) &&
+        value !== undefined &&
+        value !== null
+      ) {
+        return true;
+      }
+      if (
+        (key === "AND" ||
+          key === "OR" ||
+          key === "NOT" ||
+          key === "$and" ||
+          key === "$or" ||
+          key === "$not") &&
+        Array.isArray(value) &&
+        value.some((condition) => this._filterContainsScope(condition))
+      ) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private _matchesScopeFilter(
+    payload: Record<string, any>,
+    filter: any,
+  ): boolean {
+    if (!filter || typeof filter !== "object" || Array.isArray(filter)) {
+      return true;
+    }
+
+    for (const [key, value] of Object.entries(filter)) {
+      if (key === "AND" || key === "$and") {
+        if (!Array.isArray(value)) {
+          return false;
+        }
+        if (
+          !value.every((condition) =>
+            this._matchesScopeFilter(payload, condition),
+          )
+        ) {
+          return false;
+        }
+        continue;
+      }
+
+      if (key === "OR" || key === "$or") {
+        if (!Array.isArray(value) || value.length === 0) {
+          return false;
+        }
+        if (
+          !value.some((condition) =>
+            this._matchesScopeFilter(payload, condition),
+          )
+        ) {
+          return false;
+        }
+        continue;
+      }
+
+      if (key === "NOT" || key === "$not") {
+        if (!Array.isArray(value)) {
+          return false;
+        }
+        const scopeConditions = value.filter((condition) =>
+          this._filterContainsScope(condition),
+        );
+        if (
+          scopeConditions.some((condition) =>
+            this._matchesScopeFilter(payload, condition),
+          )
+        ) {
+          return false;
+        }
+        continue;
+      }
+
+      const scopeKey = this._canonicalScopeKey(key);
+      if (!scopeKey || value === undefined || value === null) {
+        continue;
+      }
+
+      if (!this._matchesScopeCondition(payload, scopeKey, value)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private _matchesScopeCondition(
+    payload: Record<string, any>,
+    key: ScopeKey,
+    condition: any,
+  ): boolean {
+    const scopeValue = this._payloadScopeValue(payload, key);
+
+    if (condition === "*") {
+      return scopeValue !== undefined && scopeValue !== null;
+    }
+
+    if (Array.isArray(condition)) {
+      return condition.includes(scopeValue);
+    }
+
+    if (typeof condition === "object" && condition !== null) {
+      for (const [operator, value] of Object.entries(condition)) {
+        if (operator === "eq") {
+          if (scopeValue !== value) return false;
+        } else if (operator === "ne") {
+          if (
+            scopeValue === undefined ||
+            scopeValue === null ||
+            scopeValue === value
+          ) {
+            return false;
+          }
+        } else if (operator === "in") {
+          if (!Array.isArray(value) || !value.includes(scopeValue)) {
+            return false;
+          }
+        } else if (operator === "nin") {
+          if (
+            !Array.isArray(value) ||
+            scopeValue === undefined ||
+            scopeValue === null ||
+            value.includes(scopeValue)
+          ) {
+            return false;
+          }
+        } else if (operator === "contains") {
+          if (
+            typeof scopeValue !== "string" ||
+            !scopeValue.includes(String(value))
+          ) {
+            return false;
+          }
+        } else if (operator === "icontains") {
+          if (
+            typeof scopeValue !== "string" ||
+            !scopeValue.toLowerCase().includes(String(value).toLowerCase())
+          ) {
+            return false;
+          }
+        } else {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    return scopeValue === condition;
   }
 
   private async _initializeTelemetry() {
@@ -1804,6 +1968,13 @@ export class Memory {
     if (!Object.keys(filters).length) {
       throw new Error(
         "At least one filter is required to delete all memories. If you want to delete all memories, use the `reset()` method.",
+      );
+    }
+
+    const wildcardScopeKeys = SCOPE_KEYS.filter((key) => filters[key] === "*");
+    if (wildcardScopeKeys.length > 0) {
+      throw new Error(
+        `Wildcard scope filters [${wildcardScopeKeys.join(", ")}] are not supported in deleteAll() because it is destructive. Provide explicit scope values, or use reset() to delete all memories.`,
       );
     }
 

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -7,6 +7,7 @@ import {
   Message,
   SearchFilters,
   SearchResult,
+  VectorStoreResult,
 } from "../types";
 import {
   EmbedderFactory,
@@ -517,6 +518,24 @@ export class Memory {
     return parts.join("&");
   }
 
+  private filterByRequestedScope<T extends Pick<VectorStoreResult, "payload">>(
+    results: T[],
+    filters: Record<string, any>,
+  ): T[] {
+    const scopeKeys = ["user_id", "agent_id", "run_id"] as const;
+    const requestedKeys = scopeKeys.filter(
+      (key) => filters[key] !== undefined && filters[key] !== null,
+    );
+
+    if (requestedKeys.length === 0) {
+      return results;
+    }
+
+    return results.filter((result) =>
+      requestedKeys.every((key) => result.payload?.[key] === filters[key]),
+    );
+  }
+
   private async _initializeTelemetry() {
     try {
       await this._getTelemetryId();
@@ -811,9 +830,8 @@ export class Memory {
 
     // Phase 1: Existing memory retrieval
     const queryEmbedding = await this.embedder.embed(parsedMessages);
-    const existingResults = await this.vectorStore.search(
-      queryEmbedding,
-      10,
+    const existingResults = this.filterByRequestedScope(
+      await this.vectorStore.search(queryEmbedding, 10, filters),
       filters,
     );
 
@@ -1359,9 +1377,12 @@ export class Memory {
 
     // Step 3: Semantic search (over-fetch for scoring pool)
     const internalLimit = Math.max(topK * 4, 60);
-    const semanticResults = await this.vectorStore.search(
-      queryEmbedding,
-      internalLimit,
+    const semanticResults = this.filterByRequestedScope(
+      await this.vectorStore.search(
+        queryEmbedding,
+        internalLimit,
+        effectiveFilters,
+      ),
       effectiveFilters,
     );
 
@@ -1373,12 +1394,15 @@ export class Memory {
     }> | null = null;
     if (typeof this.vectorStore.keywordSearch === "function") {
       try {
-        keywordResults =
+        const rawKeywordResults =
           (await this.vectorStore.keywordSearch(
             queryLemmatized,
             internalLimit,
             effectiveFilters,
           )) ?? null;
+        keywordResults = rawKeywordResults
+          ? this.filterByRequestedScope(rawKeywordResults, effectiveFilters)
+          : null;
       } catch {
         keywordResults = null;
       }
@@ -1617,7 +1641,8 @@ export class Memory {
       );
     }
 
-    const [memories] = await this.vectorStore.list(filters);
+    const [rawMemories] = await this.vectorStore.list(filters);
+    const memories = this.filterByRequestedScope(rawMemories, filters);
     for (const memory of memories) {
       await this.deleteMemory(memory.id);
     }
@@ -1733,7 +1758,8 @@ export class Memory {
       );
     }
 
-    const [memories] = await this.vectorStore.list(filters, topK);
+    const [rawMemories] = await this.vectorStore.list(filters, topK);
+    const memories = this.filterByRequestedScope(rawMemories, filters);
 
     const excludedKeys = new Set([
       "user_id",

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -429,9 +429,64 @@ export class Memory {
   ): Record<string, any>[] {
     let alternatives: Record<string, any>[] = [{}];
 
+    const appendAndClauses = (
+      filterObject: Record<string, any>,
+      clauses: Record<string, any>[],
+    ): Record<string, any> => {
+      const nonEmptyClauses = clauses.filter(
+        (clause) => Object.keys(clause).length > 0,
+      );
+      if (nonEmptyClauses.length === 0) {
+        return filterObject;
+      }
+
+      const existingAnd = Array.isArray(filterObject.$and)
+        ? filterObject.$and
+        : filterObject.$and !== undefined
+          ? [filterObject.$and]
+          : [];
+
+      return {
+        ...filterObject,
+        $and: [...existingAnd, ...nonEmptyClauses],
+      };
+    };
+
+    const mergeConjunctiveFilters = (
+      left: Record<string, any>,
+      right: Record<string, any>,
+    ): Record<string, any> => {
+      let merged = { ...left };
+
+      for (const [key, value] of Object.entries(right)) {
+        if (!(key in merged)) {
+          merged[key] = value;
+          continue;
+        }
+
+        if (
+          key === "$and" &&
+          Array.isArray(merged.$and) &&
+          Array.isArray(value)
+        ) {
+          merged = appendAndClauses(merged, value);
+          continue;
+        }
+
+        const existingValue = merged[key];
+        delete merged[key];
+        merged = appendAndClauses(merged, [
+          { [key]: existingValue },
+          { [key]: value },
+        ]);
+      }
+
+      return merged;
+    };
+
     const mergeAlternatives = (branches: Record<string, any>[]) => {
       alternatives = alternatives.flatMap((alternative) =>
-        branches.map((branch) => ({ ...alternative, ...branch })),
+        branches.map((branch) => mergeConjunctiveFilters(alternative, branch)),
       );
     };
 
@@ -608,6 +663,65 @@ export class Memory {
         return options.topK === undefined
           ? scoped
           : scoped.slice(0, options.topK);
+      }
+    }
+  }
+
+  private async _deleteAllByRequestedScope(
+    filters: Record<string, any>,
+  ): Promise<number> {
+    const providerFilters = this._providerFiltersForRequestedScope(filters);
+    const providerReturnsTotalCount = this._providerListCountIsTotal();
+    const provider = this.config.vectorStore.provider;
+    let deletedCount = 0;
+    const deletedIds = new Set<string>();
+
+    while (true) {
+      const [rawMemories, rawCount] = await this.vectorStore.list(
+        providerFilters,
+        DELETE_ALL_SCOPE_FETCH_LIMIT,
+      );
+      const scoped = this.filterByRequestedScope(rawMemories, filters);
+
+      if (
+        !providerReturnsTotalCount &&
+        rawMemories.length >= DELETE_ALL_SCOPE_FETCH_LIMIT
+      ) {
+        throw new Error(
+          `deleteAll cannot safely delete all scoped memories for vector store provider '${provider}' because list() returned a full page without a total count. Narrow the scope filters or delete matching memories individually.`,
+        );
+      }
+
+      if (scoped.length === 0) {
+        const total = providerReturnsTotalCount ? Number(rawCount) : undefined;
+        if (
+          total !== undefined &&
+          Number.isFinite(total) &&
+          total > 0 &&
+          rawMemories.length >= DELETE_ALL_SCOPE_FETCH_LIMIT
+        ) {
+          throw new Error(
+            `deleteAll cannot safely delete all scoped memories for vector store provider '${provider}' because scoped rows may be hidden behind a full provider page. Narrow the scope filters or delete matching memories individually.`,
+          );
+        }
+        return deletedCount;
+      }
+
+      const nextScoped = scoped.filter((memory) => !deletedIds.has(memory.id));
+      if (nextScoped.length === 0) {
+        throw new Error(
+          `deleteAll cannot safely delete all scoped memories for vector store provider '${provider}' because repeated list() calls made no deletion progress. Narrow the scope filters or delete matching memories individually.`,
+        );
+      }
+
+      for (const memory of nextScoped) {
+        await this.deleteMemory(memory.id);
+        deletedIds.add(memory.id);
+      }
+      deletedCount += nextScoped.length;
+
+      if (rawMemories.length < DELETE_ALL_SCOPE_FETCH_LIMIT) {
+        return deletedCount;
       }
     }
   }
@@ -2147,21 +2261,15 @@ export class Memory {
       );
     }
 
-    const memories = await this._listByRequestedScope(filters, {
-      initialLimit: DELETE_ALL_SCOPE_FETCH_LIMIT,
-      exhaustive: true,
-    });
-    for (const memory of memories) {
-      await this.deleteMemory(memory.id);
-    }
+    const deletedCount = await this._deleteAllByRequestedScope(filters);
 
     const result = { message: "Memories deleted successfully!" };
-    if (memories.length > 0) {
+    if (deletedCount > 0) {
       await this._displayDecayUsageNotice({
         triggerFunction: "delete_all",
         triggerSource: "delete_all",
         triggerReason: "bulk_delete",
-        deletedCount: memories.length,
+        deletedCount,
       });
     } else {
       await this._displayFirstRunNotice("delete_all");
@@ -2418,7 +2526,14 @@ export class Memory {
 
     for (const [key, value] of Object.entries(filters)) {
       // Check for platform-style logical operators
-      if (key === "AND" || key === "OR" || key === "NOT") {
+      if (
+        key === "AND" ||
+        key === "OR" ||
+        key === "NOT" ||
+        key === "$and" ||
+        key === "$or" ||
+        key === "$not"
+      ) {
         return true;
       }
       // Check for comparison operators
@@ -2510,19 +2625,52 @@ export class Memory {
     ): Record<string, any> => {
       const processedFilters: Record<string, any> = {};
 
+      const appendAndFilters = (clauses: Record<string, any>[]) => {
+        const nonEmptyClauses = clauses.filter(
+          (clause) => Object.keys(clause).length > 0,
+        );
+        if (nonEmptyClauses.length === 0) {
+          return;
+        }
+        processedFilters["$and"] = [
+          ...((processedFilters["$and"] as Record<string, any>[] | undefined) ??
+            []),
+          ...nonEmptyClauses,
+        ];
+      };
+
+      const setProcessedClause = (key: string, value: any) => {
+        if (
+          key === "$and" &&
+          Array.isArray(processedFilters["$and"]) &&
+          Array.isArray(value)
+        ) {
+          appendAndFilters(value as Record<string, any>[]);
+          return;
+        }
+
+        if (!(key in processedFilters)) {
+          processedFilters[key] = value;
+          return;
+        }
+
+        const existingValue = processedFilters[key];
+        delete processedFilters[key];
+        appendAndFilters([{ [key]: existingValue }, { [key]: value }]);
+      };
+
       for (const [key, value] of Object.entries(filters)) {
         if (key === "AND" || key === "$and") {
-          // Logical AND: combine multiple conditions into the same filter
-          // object where vector stores interpret fields as implicit AND.
+          // Logical AND: preserve each conjunct so repeated keys/logical
+          // groups cannot overwrite each other while filters are normalized.
           if (!Array.isArray(value)) {
             throw new Error("AND operator requires a list of conditions");
           }
-          for (const condition of value) {
-            Object.assign(
-              processedFilters,
+          appendAndFilters(
+            value.map((condition) =>
               processFilterObject(condition as Record<string, any>),
-            );
-          }
+            ),
+          );
         } else if (key === "OR" || key === "$or") {
           // Logical OR: Pass through to vector store for implementation-specific handling
           if (!Array.isArray(value) || value.length === 0) {
@@ -2530,8 +2678,11 @@ export class Memory {
               "OR operator requires a non-empty list of conditions",
             );
           }
-          processedFilters["$or"] = value.map((condition) =>
-            processFilterObject(condition as Record<string, any>),
+          setProcessedClause(
+            "$or",
+            value.map((condition) =>
+              processFilterObject(condition as Record<string, any>),
+            ),
           );
         } else if (key === "NOT" || key === "$not") {
           // Logical NOT: Pass through to vector store for implementation-specific handling
@@ -2540,11 +2691,18 @@ export class Memory {
               "NOT operator requires a non-empty list of conditions",
             );
           }
-          processedFilters["$not"] = value.map((condition) =>
-            processFilterObject(condition as Record<string, any>),
+          setProcessedClause(
+            "$not",
+            value.map((condition) =>
+              processFilterObject(condition as Record<string, any>),
+            ),
           );
         } else {
-          Object.assign(processedFilters, processCondition(key, value));
+          for (const [processedKey, processedValue] of Object.entries(
+            processCondition(key, value),
+          )) {
+            setProcessedClause(processedKey, processedValue);
+          }
         }
       }
 

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -97,6 +97,8 @@ const RESERVED_PAYLOAD_KEYS = new Set<string>([
   "data",
   "createdAt",
   "updatedAt",
+  "created_at",
+  "updated_at",
   "textLemmatized",
   "attributedTo",
 ]);
@@ -339,18 +341,130 @@ export class Memory {
     return metadata;
   }
 
+  private _payloadCreatedAt(payload: Record<string, any>): any {
+    return payload.createdAt ?? payload.created_at;
+  }
+
+  private _payloadUpdatedAt(payload: Record<string, any>): any {
+    return payload.updatedAt ?? payload.updated_at;
+  }
+
   private _providerFiltersForRequestedScope(
     filters: Record<string, any>,
   ): Record<string, any> | undefined {
     const providerFilters: Record<string, any> = { ...filters };
+    const scopeAlternatives: Record<string, any>[] = [{}];
+    const provider = this.config.vectorStore.provider.toLowerCase();
+    const supportsScopeAliasOr = ["pgvector", "qdrant"].includes(provider);
+    const prefersCamelScope = provider === "vectorize";
+    const existingOr = supportsScopeAliasOr ? providerFilters.$or : undefined;
+    if (supportsScopeAliasOr) {
+      delete providerFilters.$or;
+    }
+
     for (const key of SCOPE_KEYS) {
-      if (providerFilters[key] === "*") {
-        delete providerFilters[key];
+      const value = providerFilters[key];
+      if (value === undefined || value === null) {
+        continue;
+      }
+
+      delete providerFilters[key];
+
+      if (value === "*") {
+        continue;
+      }
+
+      if (supportsScopeAliasOr) {
+        const currentAlternatives = scopeAlternatives.splice(0);
+        for (const alternative of currentAlternatives) {
+          scopeAlternatives.push({ ...alternative, [key]: value });
+          scopeAlternatives.push({
+            ...alternative,
+            [SCOPE_KEY_ALIASES[key]]: value,
+          });
+        }
+      } else if (prefersCamelScope) {
+        providerFilters[SCOPE_KEY_ALIASES[key]] = value;
+      } else {
+        providerFilters[key] = value;
       }
     }
+
+    if (supportsScopeAliasOr) {
+      const existingOrClauses = Array.isArray(existingOr)
+        ? existingOr
+        : undefined;
+
+      if (scopeAlternatives.length > 1 && existingOrClauses) {
+        providerFilters.$or = existingOrClauses.flatMap((clause) =>
+          scopeAlternatives.map((scope) => ({ ...clause, ...scope })),
+        );
+      } else if (scopeAlternatives.length > 1) {
+        providerFilters.$or = scopeAlternatives;
+      } else if (existingOr !== undefined) {
+        providerFilters.$or = existingOr;
+      }
+    }
+
     return Object.keys(providerFilters).length > 0
       ? providerFilters
       : undefined;
+  }
+
+  private async _listByRequestedScope(
+    filters: Record<string, any>,
+    options: {
+      topK?: number;
+      initialLimit: number;
+      exhaustive?: boolean;
+    },
+  ): Promise<VectorStoreResult[]> {
+    if (!options.exhaustive && options.topK === 0) {
+      return [];
+    }
+
+    const providerFilters = this._providerFiltersForRequestedScope(filters);
+    let fetchLimit = options.initialLimit;
+    let scoped: VectorStoreResult[] = [];
+
+    while (true) {
+      const [rawMemories, rawCount] = await this.vectorStore.list(
+        providerFilters,
+        fetchLimit,
+      );
+      scoped = this.filterByRequestedScope(rawMemories, filters);
+
+      if (
+        !options.exhaustive &&
+        options.topK !== undefined &&
+        scoped.length >= options.topK
+      ) {
+        return scoped.slice(0, options.topK);
+      }
+
+      const total = Number(rawCount);
+      if (
+        !Number.isFinite(total) ||
+        total <= rawMemories.length ||
+        fetchLimit >= total
+      ) {
+        return options.topK === undefined
+          ? scoped
+          : scoped.slice(0, options.topK);
+      }
+
+      const nextLimit = options.exhaustive
+        ? total
+        : Math.min(total, Math.max(fetchLimit * 2, fetchLimit + 1));
+
+      if (nextLimit <= fetchLimit) {
+        return options.topK === undefined
+          ? scoped
+          : scoped.slice(0, options.topK);
+      }
+
+      fetchLimit = nextLimit;
+    }
   }
 
   private _normalizeEntityText(value: string): string {
@@ -1314,8 +1428,8 @@ export class Memory {
       id: memory.id,
       memory: payload.data,
       hash: payload.hash,
-      createdAt: payload.createdAt,
-      updatedAt: payload.updatedAt,
+      createdAt: this._payloadCreatedAt(payload),
+      updatedAt: this._payloadUpdatedAt(payload),
       metadata: this._metadataFromPayload(payload),
     };
 
@@ -1576,8 +1690,8 @@ export class Memory {
           id: scored.id,
           memory: payload.data,
           hash: payload.hash,
-          createdAt: payload.createdAt,
-          updatedAt: payload.updatedAt,
+          createdAt: this._payloadCreatedAt(payload),
+          updatedAt: this._payloadUpdatedAt(payload),
           score: scored.score,
           metadata: this._metadataFromPayload(payload),
           ...this._sessionFiltersFromPayload(payload),
@@ -1677,12 +1791,10 @@ export class Memory {
       );
     }
 
-    const providerFilters = this._providerFiltersForRequestedScope(filters);
-    const [rawMemories] = await this.vectorStore.list(
-      providerFilters,
-      DELETE_ALL_SCOPE_FETCH_LIMIT,
-    );
-    const memories = this.filterByRequestedScope(rawMemories, filters);
+    const memories = await this._listByRequestedScope(filters, {
+      initialLimit: DELETE_ALL_SCOPE_FETCH_LIMIT,
+      exhaustive: true,
+    });
     for (const memory of memories) {
       await this.deleteMemory(memory.id);
     }
@@ -1798,24 +1910,19 @@ export class Memory {
       );
     }
 
-    const providerFilters = this._providerFiltersForRequestedScope(filters);
     const fetchLimit =
       topK === 0 ? 0 : Math.max(topK * 4, MIN_SCOPE_POST_FILTER_FETCH);
-    const [rawMemories] = await this.vectorStore.list(
-      providerFilters,
-      fetchLimit,
-    );
-    const memories = this.filterByRequestedScope(rawMemories, filters).slice(
-      0,
+    const memories = await this._listByRequestedScope(filters, {
       topK,
-    );
+      initialLimit: fetchLimit,
+    });
 
     const results = memories.map((mem) => ({
       id: mem.id,
       memory: mem.payload.data,
       hash: mem.payload.hash,
-      createdAt: mem.payload.createdAt,
-      updatedAt: mem.payload.updatedAt,
+      createdAt: this._payloadCreatedAt(mem.payload),
+      updatedAt: this._payloadUpdatedAt(mem.payload),
       metadata: this._metadataFromPayload(mem.payload),
       ...this._sessionFiltersFromPayload(mem.payload),
       ...(mem.payload.attributedTo && {

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -104,6 +104,8 @@ const RESERVED_PAYLOAD_KEYS = new Set<string>([
 ]);
 
 const MIN_SCOPE_POST_FILTER_FETCH = 60;
+// deleteAll has no cursor-aware vector-store list API today, so use a large
+// one-shot page and fail closed for providers that cannot prove total counts.
 const DELETE_ALL_SCOPE_FETCH_LIMIT = 10000;
 
 /**
@@ -356,7 +358,6 @@ export class Memory {
     const scopeAlternatives: Record<string, any>[] = [{}];
     const provider = this.config.vectorStore.provider.toLowerCase();
     const supportsScopeAliasOr = ["pgvector", "qdrant"].includes(provider);
-    const prefersCamelScope = provider === "vectorize";
     const existingOr = supportsScopeAliasOr ? providerFilters.$or : undefined;
     if (supportsScopeAliasOr) {
       delete providerFilters.$or;
@@ -383,8 +384,6 @@ export class Memory {
             [SCOPE_KEY_ALIASES[key]]: value,
           });
         }
-      } else if (prefersCamelScope) {
-        providerFilters[SCOPE_KEY_ALIASES[key]] = value;
       } else {
         providerFilters[key] = value;
       }
@@ -411,6 +410,12 @@ export class Memory {
       : undefined;
   }
 
+  private _providerListCountIsTotal(): boolean {
+    return ["memory", "pgvector", "redis", "supabase"].includes(
+      this.config.vectorStore.provider.toLowerCase(),
+    );
+  }
+
   private async _listByRequestedScope(
     filters: Record<string, any>,
     options: {
@@ -424,6 +429,8 @@ export class Memory {
     }
 
     const providerFilters = this._providerFiltersForRequestedScope(filters);
+    const providerReturnsTotalCount = this._providerListCountIsTotal();
+    const provider = this.config.vectorStore.provider;
     let fetchLimit = options.initialLimit;
     let scoped: VectorStoreResult[] = [];
 
@@ -442,28 +449,37 @@ export class Memory {
         return scoped.slice(0, options.topK);
       }
 
-      const total = Number(rawCount);
+      const total = providerReturnsTotalCount ? Number(rawCount) : undefined;
+      if (total !== undefined && Number.isFinite(total) && fetchLimit < total) {
+        const nextLimit = options.exhaustive
+          ? total
+          : Math.min(total, Math.max(fetchLimit * 2, fetchLimit + 1));
+
+        if (nextLimit > fetchLimit) {
+          fetchLimit = nextLimit;
+          continue;
+        }
+      }
+
       if (
+        options.exhaustive &&
+        !providerReturnsTotalCount &&
+        rawMemories.length >= fetchLimit
+      ) {
+        throw new Error(
+          `deleteAll cannot safely delete all scoped memories for vector store provider '${provider}' because list() returned a full page without a total count. Narrow the scope filters or delete matching memories individually.`,
+        );
+      }
+
+      if (
+        total === undefined ||
         !Number.isFinite(total) ||
-        total <= rawMemories.length ||
         fetchLimit >= total
       ) {
         return options.topK === undefined
           ? scoped
           : scoped.slice(0, options.topK);
       }
-
-      const nextLimit = options.exhaustive
-        ? total
-        : Math.min(total, Math.max(fetchLimit * 2, fetchLimit + 1));
-
-      if (nextLimit <= fetchLimit) {
-        return options.topK === undefined
-          ? scoped
-          : scoped.slice(0, options.topK);
-      }
-
-      fetchLimit = nextLimit;
     }
   }
 

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -360,13 +360,47 @@ export class Memory {
     }
 
     const provider = this.config.vectorStore.provider.toLowerCase();
-    if (!["pgvector", "qdrant"].includes(provider)) {
-      return providerFilters;
+    if (["pgvector", "qdrant"].includes(provider)) {
+      return this._providerFilterFromAlternatives(
+        this._providerScopeAliasAlternatives(providerFilters),
+      );
     }
 
-    return this._providerFilterFromAlternatives(
-      this._providerScopeAliasAlternatives(providerFilters),
+    if (!this._providerSupportsLogicalFilters(provider)) {
+      return this._stripUnsupportedLogicalFiltersForProvider(providerFilters);
+    }
+
+    return providerFilters;
+  }
+
+  private _isLogicalFilterKey(key: string): boolean {
+    return (
+      key === "AND" ||
+      key === "OR" ||
+      key === "NOT" ||
+      key === "$and" ||
+      key === "$or" ||
+      key === "$not"
     );
+  }
+
+  private _providerSupportsLogicalFilters(provider: string): boolean {
+    return provider === "memory";
+  }
+
+  private _stripUnsupportedLogicalFiltersForProvider(
+    filter: Record<string, any>,
+  ): Record<string, any> | undefined {
+    const result: Record<string, any> = {};
+
+    for (const [key, value] of Object.entries(filter)) {
+      if (this._isLogicalFilterKey(key)) {
+        continue;
+      }
+      result[key] = value;
+    }
+
+    return Object.keys(result).length > 0 ? result : undefined;
   }
 
   private _stripScopeWildcardsForProvider(
@@ -375,19 +409,11 @@ export class Memory {
     const result: Record<string, any> = {};
 
     for (const [key, value] of Object.entries(filter)) {
-      const isLogicalKey =
-        key === "AND" ||
-        key === "OR" ||
-        key === "NOT" ||
-        key === "$and" ||
-        key === "$or" ||
-        key === "$not";
-
       if (this._canonicalScopeKey(key) && value === "*") {
         continue;
       }
 
-      if (isLogicalKey && Array.isArray(value)) {
+      if (this._isLogicalFilterKey(key) && Array.isArray(value)) {
         const logicalFilters: Record<string, any>[] = [];
         let logicalFilterIsUnrestricted = false;
 
@@ -422,6 +448,57 @@ export class Memory {
     }
 
     return Object.keys(result).length > 0 ? result : undefined;
+  }
+
+  private _wildcardScopeKeys(
+    filter: unknown,
+    keys = new Set<ScopeKey>(),
+  ): Set<ScopeKey> {
+    if (!filter || typeof filter !== "object") {
+      return keys;
+    }
+
+    if (Array.isArray(filter)) {
+      for (const item of filter) {
+        this._wildcardScopeKeys(item, keys);
+      }
+      return keys;
+    }
+
+    for (const [key, value] of Object.entries(filter)) {
+      const scopeKey = this._canonicalScopeKey(key);
+      if (scopeKey && value === "*") {
+        keys.add(scopeKey);
+      }
+
+      if (this._isLogicalFilterKey(key)) {
+        this._wildcardScopeKeys(value, keys);
+      }
+    }
+
+    return keys;
+  }
+
+  private _rejectWildcardScopeFilters(
+    filter: Record<string, any>,
+    methodName: string,
+  ): void {
+    const wildcardScopeKeys = SCOPE_KEYS.filter((key) =>
+      this._wildcardScopeKeys(filter).has(key),
+    );
+
+    if (wildcardScopeKeys.length === 0) {
+      return;
+    }
+
+    const suffix =
+      methodName === "deleteAll"
+        ? " because it is destructive. Provide explicit scope values, or use reset() to delete all memories."
+        : ". Provide explicit scope values.";
+
+    throw new Error(
+      `Wildcard scope filters [${wildcardScopeKeys.join(", ")}] are not supported in ${methodName}()${suffix}`,
+    );
   }
 
   private _providerScopeAliasAlternatives(
@@ -656,6 +733,18 @@ export class Memory {
       }
 
       if (
+        !options.exhaustive &&
+        !providerReturnsTotalCount &&
+        options.topK !== undefined &&
+        scoped.length < options.topK &&
+        rawMemories.length >= fetchLimit
+      ) {
+        throw new Error(
+          `getAll cannot safely return all requested scoped memories for vector store provider '${provider}' because list() returned a full page without a total count. Narrow the scope filters or lower topK.`,
+        );
+      }
+
+      if (
         total === undefined ||
         !Number.isFinite(total) ||
         fetchLimit >= total
@@ -698,6 +787,7 @@ export class Memory {
           total !== undefined &&
           Number.isFinite(total) &&
           total > 0 &&
+          total > rawMemories.length &&
           rawMemories.length >= DELETE_ALL_SCOPE_FETCH_LIMIT
         ) {
           throw new Error(
@@ -1965,6 +2055,8 @@ export class Memory {
         )
       : {};
 
+    this._rejectWildcardScopeFilters(normalizedFilters, "search");
+
     await this._ensureInitialized();
     const { topK = 20, threshold = 0.1, explain = false } = config;
 
@@ -2254,12 +2346,7 @@ export class Memory {
       );
     }
 
-    const wildcardScopeKeys = SCOPE_KEYS.filter((key) => filters[key] === "*");
-    if (wildcardScopeKeys.length > 0) {
-      throw new Error(
-        `Wildcard scope filters [${wildcardScopeKeys.join(", ")}] are not supported in deleteAll() because it is destructive. Provide explicit scope values, or use reset() to delete all memories.`,
-      );
-    }
+    this._rejectWildcardScopeFilters(filters, "deleteAll");
 
     const deletedCount = await this._deleteAllByRequestedScope(filters);
 
@@ -2358,6 +2445,8 @@ export class Memory {
         run_id: validateAndTrimEntityId(config.filters?.run_id, "run_id"),
       }).filter(([, v]) => v !== undefined),
     );
+
+    this._rejectWildcardScopeFilters(filters, "getAll");
 
     await this._captureEvent("get_all", {
       topK,

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -83,6 +83,7 @@ const SCOPE_KEY_ALIASES: Record<ScopeKey, "userId" | "agentId" | "runId"> = {
   agent_id: "agentId",
   run_id: "runId",
 };
+const CONFLICTING_SCOPE_EQUALITY = Symbol("conflictingScopeEquality");
 
 // Entity params that must be passed via filters - check both snake_case and camelCase
 const ENTITY_PARAMS: string[] = [
@@ -104,9 +105,35 @@ const RESERVED_PAYLOAD_KEYS = new Set<string>([
 ]);
 
 const MIN_SCOPE_POST_FILTER_FETCH = 60;
+// Scope post-filter recovery intentionally caps read-side over-fetching so a
+// broad provider filter cannot turn a small scoped getAll() into a full-store
+// scan/load when Memory must replay stricter filters itself.
+const MAX_SCOPE_POST_FILTER_FETCH = 10000;
+const MAX_SCOPE_FILTER_DEPTH = 32;
+const MAX_SCOPE_FILTER_NODES = 256;
+const MAX_PROVIDER_SCOPE_ALIAS_FILTER_DEPTH = MAX_SCOPE_FILTER_DEPTH;
+const MAX_PROVIDER_SCOPE_ALIAS_FILTER_NODES = MAX_SCOPE_FILTER_NODES;
+// Keep the add-time prompt context aligned with the previous search topK while
+// still over-fetching from providers so Memory can discard polluted rows first.
+const EXISTING_MEMORY_CONTEXT_LIMIT = 10;
 // deleteAll has no cursor-aware vector-store list API today, so use a large
 // one-shot page and fail closed for providers that cannot prove total counts.
 const DELETE_ALL_SCOPE_FETCH_LIMIT = 10000;
+const ENTITY_SCOPE_FETCH_LIMIT = 10000;
+const PROVIDER_RESULT_LIMITS: Record<string, number> = {
+  "azure-ai-search": 1000,
+  azure_ai_search: 1000,
+  vectorize: 50,
+};
+type ProviderSearchResult<T> = {
+  results: T[];
+  pageFull: boolean;
+};
+type ProviderListResult<T> = {
+  rows: T[];
+  rawCount: unknown;
+  pageFull: boolean;
+};
 
 /**
  * Validates that no top-level entity parameters are passed in config.
@@ -122,7 +149,7 @@ function rejectTopLevelEntityParams(
   if (invalidKeys.length > 0) {
     throw new Error(
       `Top-level entity parameters [${invalidKeys.join(", ")}] are not supported in ${methodName}(). ` +
-        `Use filters: { userId: "..." } instead.`,
+        `Use filters: { user_id: "..." } instead.`,
     );
   }
 }
@@ -360,17 +387,92 @@ export class Memory {
     }
 
     const provider = this.config.vectorStore.provider.toLowerCase();
+    if (provider === "memory") {
+      return this._canonicalizeScopeKeysForProvider(providerFilters);
+    }
+
     if (["pgvector", "qdrant"].includes(provider)) {
-      return this._providerFilterFromAlternatives(
-        this._providerScopeAliasAlternatives(providerFilters),
-      );
+      return this._providerScopeAliasFilter(providerFilters, provider);
     }
 
     if (!this._providerSupportsLogicalFilters(provider)) {
-      return this._stripUnsupportedLogicalFiltersForProvider(providerFilters);
+      return this._stripUnsupportedLogicalFiltersForProvider(
+        this._canonicalizeScopeKeysForProvider(providerFilters),
+      );
     }
 
     return providerFilters;
+  }
+
+  private _providerFilterVariantsForRequestedScope(
+    filters: Record<string, any>,
+  ): Array<Record<string, any> | undefined> {
+    const provider = this.config.vectorStore.provider.toLowerCase();
+    if (provider !== "vectorize") {
+      return [this._providerFiltersForRequestedScope(filters)];
+    }
+
+    const providerFilters = this._stripScopeWildcardsForProvider(filters);
+    if (!providerFilters) {
+      return [undefined];
+    }
+
+    const requiredScopeFilters = this._requiredScopeProviderFilters(
+      this._canonicalizeScopeKeysForProvider(providerFilters),
+    );
+    const requiredEntries = SCOPE_KEYS.map((scopeKey) => ({
+      scopeKey,
+      value: requiredScopeFilters[scopeKey],
+    })).filter(({ value }) => value !== undefined && value !== null);
+
+    if (requiredEntries.length === 0) {
+      return [undefined];
+    }
+
+    let variants: Record<string, any>[] = [{}];
+    for (const { scopeKey, value } of requiredEntries) {
+      const alias = SCOPE_KEY_ALIASES[scopeKey];
+      variants = variants.flatMap((variant) => [
+        { ...variant, [scopeKey]: value },
+        { ...variant, [alias]: value },
+      ]);
+    }
+
+    return variants;
+  }
+
+  private _dedupeProviderRows<T extends { id: unknown; score?: number }>(
+    rows: T[],
+  ): T[] {
+    const byId = new Map<string, T>();
+    let hasScores = false;
+
+    for (const row of rows) {
+      const id = String(row.id);
+      const existing = byId.get(id);
+      if (typeof row.score === "number") {
+        hasScores = true;
+      }
+      if (!existing) {
+        byId.set(id, row);
+        continue;
+      }
+
+      const rowScore =
+        typeof row.score === "number" ? row.score : Number.NEGATIVE_INFINITY;
+      const existingScore =
+        typeof existing.score === "number"
+          ? existing.score
+          : Number.NEGATIVE_INFINITY;
+      if (rowScore > existingScore) {
+        byId.set(id, row);
+      }
+    }
+
+    const deduped = Array.from(byId.values());
+    return hasScores
+      ? deduped.sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
+      : deduped;
   }
 
   private _isLogicalFilterKey(key: string): boolean {
@@ -388,19 +490,142 @@ export class Memory {
     return provider === "memory";
   }
 
-  private _stripUnsupportedLogicalFiltersForProvider(
+  private _requiredScopeProviderFilters(filter: any): Record<string, any> {
+    const scopeFilters: Record<string, any> = {};
+    for (const [key, value] of this._requiredScopeEqualities(filter)) {
+      if (value !== CONFLICTING_SCOPE_EQUALITY) {
+        scopeFilters[key] = value;
+      }
+    }
+    return scopeFilters;
+  }
+
+  private _canonicalizeScopeKeysForProvider(
     filter: Record<string, any>,
-  ): Record<string, any> | undefined {
+  ): Record<string, any> {
     const result: Record<string, any> = {};
 
     for (const [key, value] of Object.entries(filter)) {
       if (this._isLogicalFilterKey(key)) {
+        result[key] = Array.isArray(value)
+          ? value.map((condition) =>
+              condition &&
+              typeof condition === "object" &&
+              !Array.isArray(condition)
+                ? this._canonicalizeScopeKeysForProvider(condition)
+                : condition,
+            )
+          : value;
         continue;
       }
+
+      const scopeKey = this._canonicalScopeKey(key);
+      if (scopeKey) {
+        const alias = SCOPE_KEY_ALIASES[scopeKey];
+        if (key === alias && scopeKey in filter) {
+          continue;
+        }
+        result[scopeKey] = value;
+        continue;
+      }
+
       result[key] = value;
     }
 
-    return Object.keys(result).length > 0 ? result : undefined;
+    return result;
+  }
+
+  private _stripUnsupportedLogicalFiltersForProvider(
+    filter: Record<string, any>,
+  ): Record<string, any> | undefined {
+    const requiredScopeFilters = this._requiredScopeProviderFilters(filter);
+
+    // Providers without logical-filter support also vary in which arbitrary
+    // metadata fields are indexed/filterable. Send only the required canonical
+    // scope equalities provider-side, then replay the complete caller filter in
+    // Memory so unsupported metadata predicates cannot create false negatives or
+    // provider-side filter errors.
+    return Object.keys(requiredScopeFilters).length > 0
+      ? requiredScopeFilters
+      : undefined;
+  }
+
+  private _assertFilterComplexity(filter: unknown, methodName: string): void {
+    const stack: Array<{ node: unknown; depth: number }> = [
+      { node: filter, depth: 0 },
+    ];
+    let nodes = 0;
+
+    while (stack.length > 0) {
+      const { node, depth } = stack.pop()!;
+      if (!node || typeof node !== "object") {
+        continue;
+      }
+
+      nodes += 1;
+      if (depth > MAX_SCOPE_FILTER_DEPTH || nodes > MAX_SCOPE_FILTER_NODES) {
+        throw new Error(
+          `Scope filter is too complex to safely evaluate in ${methodName}(). Simplify scope filters.`,
+        );
+      }
+
+      if (Array.isArray(node)) {
+        for (const item of node) {
+          stack.push({ node: item, depth: depth + 1 });
+        }
+        continue;
+      }
+
+      for (const value of Object.values(node)) {
+        if (value && typeof value === "object") {
+          stack.push({ node: value, depth: depth + 1 });
+        }
+      }
+    }
+  }
+
+  private _assertLogicalFilterShapes(
+    filter: unknown,
+    _methodName: string,
+  ): void {
+    if (!filter || typeof filter !== "object" || Array.isArray(filter)) {
+      return;
+    }
+
+    for (const [key, value] of Object.entries(filter)) {
+      if (key === "AND" || key === "$and") {
+        if (!Array.isArray(value)) {
+          throw new Error("AND operator requires a list of conditions");
+        }
+        for (const condition of value) {
+          this._assertLogicalFilterShapes(condition, _methodName);
+        }
+        continue;
+      }
+
+      if (key === "OR" || key === "$or") {
+        if (!Array.isArray(value) || value.length === 0) {
+          throw new Error(
+            "OR operator requires a non-empty list of conditions",
+          );
+        }
+        for (const condition of value) {
+          this._assertLogicalFilterShapes(condition, _methodName);
+        }
+        continue;
+      }
+
+      if (key === "NOT" || key === "$not") {
+        if (!Array.isArray(value) || value.length === 0) {
+          throw new Error(
+            "NOT operator requires a non-empty list of conditions",
+          );
+        }
+        for (const condition of value) {
+          this._assertLogicalFilterShapes(condition, _methodName);
+        }
+      }
+    }
   }
 
   private _stripScopeWildcardsForProvider(
@@ -501,10 +726,421 @@ export class Memory {
     );
   }
 
-  private _providerScopeAliasAlternatives(
+  private _scopeEqualityValue(condition: any): {
+    valid: boolean;
+    value?: string | number | boolean;
+  } {
+    if (condition === undefined || condition === null || condition === "*") {
+      return { valid: false };
+    }
+
+    if (
+      typeof condition === "string" ||
+      typeof condition === "number" ||
+      typeof condition === "boolean"
+    ) {
+      return { valid: true, value: condition };
+    }
+
+    if (Array.isArray(condition)) {
+      return { valid: false };
+    }
+
+    if (typeof condition === "object") {
+      const entries = Object.entries(condition);
+      if (entries.length !== 1 || entries[0][0] !== "eq") {
+        return { valid: false };
+      }
+      return this._scopeEqualityValue(entries[0][1]);
+    }
+
+    return { valid: false };
+  }
+
+  private _normalizeScopeFilterValue(value: any, scopeKey: ScopeKey): any {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value === "string") {
+      return validateAndTrimEntityId(value, scopeKey);
+    }
+
+    if (Array.isArray(value) || value === null || typeof value !== "object") {
+      return value;
+    }
+
+    if ("eq" in value && typeof value.eq === "string") {
+      return {
+        ...value,
+        eq: validateAndTrimEntityId(value.eq, scopeKey),
+      };
+    }
+
+    return value;
+  }
+
+  private _normalizeScopeFilterValues(
+    filter: any,
+    state: { nodes: number } = { nodes: 0 },
+    depth = 0,
+  ): Record<string, any> {
+    if (!filter || typeof filter !== "object" || Array.isArray(filter)) {
+      return {};
+    }
+
+    state.nodes += 1;
+    if (
+      depth > MAX_SCOPE_FILTER_DEPTH ||
+      state.nodes > MAX_SCOPE_FILTER_NODES
+    ) {
+      throw new Error(
+        "Scope filter is too complex to safely evaluate. Simplify scope filters.",
+      );
+    }
+
+    const normalized: Record<string, any> = {};
+
+    for (const [key, value] of Object.entries(filter)) {
+      if (
+        (key === "AND" ||
+          key === "OR" ||
+          key === "NOT" ||
+          key === "$and" ||
+          key === "$or" ||
+          key === "$not") &&
+        Array.isArray(value)
+      ) {
+        normalized[key] = value.map((condition) =>
+          condition &&
+          typeof condition === "object" &&
+          !Array.isArray(condition)
+            ? this._normalizeScopeFilterValues(condition, state, depth + 1)
+            : condition,
+        );
+        continue;
+      }
+
+      const scopeKey = this._canonicalScopeKey(key);
+      if (scopeKey) {
+        const normalizedValue = this._normalizeScopeFilterValue(
+          value,
+          scopeKey,
+        );
+        if (normalizedValue !== undefined) {
+          normalized[key] = normalizedValue;
+        }
+        continue;
+      }
+
+      normalized[key] = value;
+    }
+
+    return normalized;
+  }
+
+  private _assertScopePredicatesAreExact(
+    filter: any,
+    methodName: string,
+    insideNot = false,
+  ): void {
+    if (!filter || typeof filter !== "object" || Array.isArray(filter)) {
+      return;
+    }
+
+    for (const [key, value] of Object.entries(filter)) {
+      if (key === "AND" || key === "$and" || key === "OR" || key === "$or") {
+        if (Array.isArray(value)) {
+          for (const condition of value) {
+            this._assertScopePredicatesAreExact(
+              condition,
+              methodName,
+              insideNot,
+            );
+          }
+        }
+        continue;
+      }
+
+      if (key === "NOT" || key === "$not") {
+        if (Array.isArray(value)) {
+          for (const condition of value) {
+            this._assertScopePredicatesAreExact(condition, methodName, true);
+          }
+        }
+        continue;
+      }
+
+      const scopeKey = this._canonicalScopeKey(key);
+      if (!scopeKey) {
+        continue;
+      }
+
+      if (insideNot) {
+        throw new Error(
+          `Negative scope filters [${scopeKey}] are not supported in ${methodName}(). Provide explicit positive scope equality filters.`,
+        );
+      }
+
+      if (!this._scopeEqualityValue(value).valid) {
+        throw new Error(
+          `Scope filter [${scopeKey}] in ${methodName}() must use explicit equality. Broad scope operators such as arrays, in, ne, nin, contains, and range comparisons are not supported.`,
+        );
+      }
+    }
+  }
+
+  private _scopeRepresentationsForKey(
+    source: Record<string, any>,
+    scopeKey: ScopeKey,
+  ): Array<{ key: string; value: unknown }> {
+    const alias = SCOPE_KEY_ALIASES[scopeKey];
+    return [scopeKey, alias]
+      .filter((key) => source[key] !== undefined && source[key] !== null)
+      .map((key) => ({ key, value: source[key] }));
+  }
+
+  private _assertScopeRepresentationsMatchEquality(
+    representations: Array<{ key: string; value: unknown }>,
+    scopeKey: ScopeKey,
+    expectedValue: string | number | boolean,
+    methodName: string,
+    detail: string,
+  ): void {
+    for (const representation of representations) {
+      const equality = this._scopeEqualityValue(representation.value);
+      if (!equality.valid || !Object.is(equality.value, expectedValue)) {
+        throw new Error(
+          `Conflicting scope filters [${scopeKey}] are not supported in ${methodName}(). ${detail}`,
+        );
+      }
+    }
+  }
+
+  private _mergeTopLevelScopeFilter(
+    filters: Record<string, any>,
+    scopeKey: ScopeKey,
+    value: string | undefined,
+    optionName: "userId" | "agentId" | "runId",
+  ): void {
+    if (value === undefined) {
+      return;
+    }
+
+    this._assertScopeRepresentationsMatchEquality(
+      this._scopeRepresentationsForKey(filters, scopeKey),
+      scopeKey,
+      value,
+      "add",
+      `${optionName} must match filters.${scopeKey} exactly; provide exactly one equality value per scope key.`,
+    );
+
+    filters[scopeKey] = value;
+    delete filters[SCOPE_KEY_ALIASES[scopeKey]];
+  }
+
+  private _applyAuthoritativeScopeToMetadata(
+    metadata: Record<string, any>,
+    filters: Record<string, any>,
+    methodName: string,
+  ): void {
+    const requiredScopeFilters = this._requiredScopeProviderFilters(filters);
+
+    for (const scopeKey of SCOPE_KEYS) {
+      const requestedValue = requiredScopeFilters[scopeKey];
+      const metadataScopes = this._scopeRepresentationsForKey(
+        metadata,
+        scopeKey,
+      );
+
+      if (metadataScopes.length > 0 && requestedValue === undefined) {
+        throw new Error(
+          `Metadata field [${metadataScopes[0].key}] is reserved for ${methodName}() scope. Pass ${scopeKey} via filters or the top-level ${SCOPE_KEY_ALIASES[scopeKey]} option instead.`,
+        );
+      }
+
+      if (requestedValue !== undefined && requestedValue !== null) {
+        for (const metadataScope of metadataScopes) {
+          if (!Object.is(metadataScope.value, requestedValue)) {
+            throw new Error(
+              `Metadata field [${metadataScope.key}] conflicts with requested ${scopeKey} scope in ${methodName}(). Scope metadata is managed by Memory; pass scope through filters or top-level options instead.`,
+            );
+          }
+        }
+      }
+
+      delete metadata[scopeKey];
+      delete metadata[SCOPE_KEY_ALIASES[scopeKey]];
+
+      if (requestedValue !== undefined && requestedValue !== null) {
+        metadata[scopeKey] = requestedValue;
+      }
+    }
+  }
+
+  private _combineScopeEqualities(
+    left: Map<ScopeKey, unknown>,
+    right: Map<ScopeKey, unknown>,
+  ): Map<ScopeKey, unknown> {
+    const combined = new Map(left);
+    for (const [key, value] of right.entries()) {
+      if (!combined.has(key)) {
+        combined.set(key, value);
+        continue;
+      }
+
+      const existing = combined.get(key);
+      if (
+        existing !== CONFLICTING_SCOPE_EQUALITY &&
+        value !== CONFLICTING_SCOPE_EQUALITY &&
+        Object.is(existing, value)
+      ) {
+        continue;
+      }
+      combined.set(key, CONFLICTING_SCOPE_EQUALITY);
+    }
+    return combined;
+  }
+
+  private _intersectScopeEqualities(
+    branches: Map<ScopeKey, unknown>[],
+  ): Map<ScopeKey, unknown> {
+    if (branches.length === 0) {
+      return new Map();
+    }
+
+    const intersection = new Map(branches[0]);
+    for (const branch of branches.slice(1)) {
+      for (const [key, value] of Array.from(intersection.entries())) {
+        if (!branch.has(key) || !Object.is(branch.get(key), value)) {
+          intersection.delete(key);
+        }
+      }
+    }
+    return intersection;
+  }
+
+  private _requiredScopeEqualities(filter: any): Map<ScopeKey, unknown> {
+    if (!filter || typeof filter !== "object" || Array.isArray(filter)) {
+      return new Map();
+    }
+
+    let required = new Map<ScopeKey, unknown>();
+
+    for (const [key, value] of Object.entries(filter)) {
+      const scopeKey = this._canonicalScopeKey(key);
+      if (scopeKey) {
+        const equality = this._scopeEqualityValue(value);
+        if (equality.valid) {
+          required = this._combineScopeEqualities(
+            required,
+            new Map([[scopeKey, equality.value]]),
+          );
+        }
+        continue;
+      }
+
+      if (key === "AND" || key === "$and") {
+        if (Array.isArray(value)) {
+          for (const condition of value) {
+            required = this._combineScopeEqualities(
+              required,
+              this._requiredScopeEqualities(condition),
+            );
+          }
+        }
+        continue;
+      }
+
+      if (key === "OR" || key === "$or") {
+        if (Array.isArray(value)) {
+          required = this._combineScopeEqualities(
+            required,
+            this._intersectScopeEqualities(
+              value.map((condition) =>
+                this._requiredScopeEqualities(condition),
+              ),
+            ),
+          );
+        }
+      }
+    }
+
+    return required;
+  }
+
+  private _assertSafeScopeFilters(
     filter: Record<string, any>,
-  ): Record<string, any>[] {
-    let alternatives: Record<string, any>[] = [{}];
+    methodName: string,
+  ): void {
+    this._assertFilterComplexity(filter, methodName);
+    this._assertLogicalFilterShapes(filter, methodName);
+    this._rejectWildcardScopeFilters(filter, methodName);
+    this._assertScopePredicatesAreExact(filter, methodName);
+
+    const requiredScopeEqualities = this._requiredScopeEqualities(filter);
+    const conflictingScopeKeys = Array.from(requiredScopeEqualities.entries())
+      .filter(([, value]) => value === CONFLICTING_SCOPE_EQUALITY)
+      .map(([key]) => key);
+
+    if (conflictingScopeKeys.length > 0) {
+      throw new Error(
+        `Conflicting scope filters [${conflictingScopeKeys.join(", ")}] are not supported in ${methodName}(). Provide exactly one equality value per scope key.`,
+      );
+    }
+
+    if (requiredScopeEqualities.size === 0) {
+      throw new Error(
+        "filters must contain at least one of: user_id, agent_id, run_id. " +
+          "Example: filters: { user_id: 'u1' }",
+      );
+    }
+  }
+
+  private _assertDeleteAllConfigIsScopedOptions(
+    config: Record<string, any>,
+  ): void {
+    const supportedKeys = new Set(["userId", "agentId", "runId"]);
+    if ("filters" in config) {
+      throw new Error(
+        "deleteAll() does not support filters. Pass explicit userId, agentId, or runId options, or use reset() to delete all memories.",
+      );
+    }
+
+    const logicalKeys = Object.keys(config).filter((key) =>
+      this._isLogicalFilterKey(key),
+    );
+    if (logicalKeys.length > 0) {
+      throw new Error(
+        `Logical filters [${logicalKeys.join(", ")}] are not supported in deleteAll(). Pass explicit userId, agentId, or runId options, or use reset() to delete all memories.`,
+      );
+    }
+
+    const unsupportedKeys = Object.keys(config).filter(
+      (key) => !supportedKeys.has(key),
+    );
+    if (unsupportedKeys.length > 0) {
+      throw new Error(
+        `deleteAll() does not support option(s): ${unsupportedKeys.join(", ")}. Pass explicit userId, agentId, or runId options, or use reset() to delete all memories.`,
+      );
+    }
+  }
+
+  private _providerScopeAliasFilter(
+    filter: Record<string, any>,
+    provider: string,
+    state: { nodes: number } = { nodes: 0 },
+    depth = 0,
+  ): Record<string, any> | undefined {
+    state.nodes += 1;
+    if (
+      depth > MAX_PROVIDER_SCOPE_ALIAS_FILTER_DEPTH ||
+      state.nodes > MAX_PROVIDER_SCOPE_ALIAS_FILTER_NODES
+    ) {
+      throw new Error(
+        `Scope filter is too complex to safely widen for vector store provider '${provider}'. Simplify scope filters.`,
+      );
+    }
 
     const appendAndClauses = (
       filterObject: Record<string, any>,
@@ -515,6 +1151,13 @@ export class Memory {
       );
       if (nonEmptyClauses.length === 0) {
         return filterObject;
+      }
+
+      if (
+        Object.keys(filterObject).length === 0 &&
+        nonEmptyClauses.length === 1
+      ) {
+        return nonEmptyClauses[0];
       }
 
       const existingAnd = Array.isArray(filterObject.$and)
@@ -529,152 +1172,265 @@ export class Memory {
       };
     };
 
-    const mergeConjunctiveFilters = (
-      left: Record<string, any>,
-      right: Record<string, any>,
-    ): Record<string, any> => {
-      let merged = { ...left };
-
-      for (const [key, value] of Object.entries(right)) {
-        if (!(key in merged)) {
-          merged[key] = value;
-          continue;
-        }
-
-        if (
-          key === "$and" &&
-          Array.isArray(merged.$and) &&
-          Array.isArray(value)
-        ) {
-          merged = appendAndClauses(merged, value);
-          continue;
-        }
-
-        const existingValue = merged[key];
-        delete merged[key];
-        merged = appendAndClauses(merged, [
-          { [key]: existingValue },
-          { [key]: value },
-        ]);
-      }
-
-      return merged;
-    };
-
-    const mergeAlternatives = (branches: Record<string, any>[]) => {
-      alternatives = alternatives.flatMap((alternative) =>
-        branches.map((branch) => mergeConjunctiveFilters(alternative, branch)),
-      );
-    };
-
-    const appendToAlternatives = (key: string, value: any) => {
-      alternatives = alternatives.map((alternative) => ({
-        ...alternative,
-        [key]: value,
-      }));
-    };
+    const result: Record<string, any> = {};
+    const andClauses: Record<string, any>[] = [];
 
     for (const [key, value] of Object.entries(filter)) {
       if (key === "AND" || key === "$and") {
         if (!Array.isArray(value)) {
-          appendToAlternatives(key, value);
+          result[key] = value;
           continue;
         }
-        for (const condition of value) {
-          if (
+        const branches = value
+          .map((condition) =>
             condition &&
             typeof condition === "object" &&
             !Array.isArray(condition)
-          ) {
-            mergeAlternatives(this._providerScopeAliasAlternatives(condition));
-          }
+              ? this._providerScopeAliasFilter(
+                  condition,
+                  provider,
+                  state,
+                  depth + 1,
+                )
+              : condition,
+          )
+          .filter(Boolean);
+        if (branches.length > 0) {
+          result.$and = [
+            ...((result.$and as Record<string, any>[]) ?? []),
+            ...branches,
+          ];
         }
         continue;
       }
 
       if (key === "OR" || key === "$or") {
         if (!Array.isArray(value)) {
-          appendToAlternatives(key, value);
+          result[key] = value;
           continue;
         }
-        const branches = value.flatMap((condition) =>
-          condition &&
-          typeof condition === "object" &&
-          !Array.isArray(condition)
-            ? this._providerScopeAliasAlternatives(condition)
-            : [],
-        );
-        if (branches.some((branch) => Object.keys(branch).length === 0)) {
-          continue;
-        }
+        const branches = value
+          .map((condition) =>
+            condition &&
+            typeof condition === "object" &&
+            !Array.isArray(condition)
+              ? this._providerScopeAliasFilter(
+                  condition,
+                  provider,
+                  state,
+                  depth + 1,
+                )
+              : condition,
+          )
+          .filter(Boolean);
         if (branches.length > 0) {
-          mergeAlternatives(branches);
+          result.$or = branches;
         }
         continue;
       }
 
       if (key === "NOT" || key === "$not") {
         if (!Array.isArray(value)) {
-          appendToAlternatives(key, value);
+          result[key] = value;
           continue;
         }
-        const notBranches = value.flatMap((condition) =>
-          condition &&
-          typeof condition === "object" &&
-          !Array.isArray(condition)
-            ? this._providerScopeAliasAlternatives(condition)
-            : [],
-        );
-        const nonEmptyBranches = notBranches.filter(
-          (branch) => Object.keys(branch).length > 0,
-        );
-        if (nonEmptyBranches.length > 0) {
-          alternatives = alternatives.map((alternative) => ({
-            ...alternative,
-            $not: [
-              ...((alternative.$not as Record<string, any>[] | undefined) ??
-                []),
-              ...nonEmptyBranches,
-            ],
-          }));
+        const branches = value
+          .map((condition) =>
+            condition &&
+            typeof condition === "object" &&
+            !Array.isArray(condition)
+              ? this._providerScopeAliasFilter(
+                  condition,
+                  provider,
+                  state,
+                  depth + 1,
+                )
+              : condition,
+          )
+          .filter(Boolean);
+        if (branches.length > 0) {
+          result.$not = branches;
         }
         continue;
       }
 
       const scopeKey = this._canonicalScopeKey(key);
       if (scopeKey) {
-        mergeAlternatives([
-          { [scopeKey]: value },
-          { [SCOPE_KEY_ALIASES[scopeKey]]: value },
-        ]);
+        andClauses.push({
+          $or: [
+            { [scopeKey]: value },
+            { [SCOPE_KEY_ALIASES[scopeKey]]: value },
+          ],
+        });
         continue;
       }
 
-      appendToAlternatives(key, value);
+      result[key] = value;
     }
 
-    return alternatives;
-  }
-
-  private _providerFilterFromAlternatives(
-    alternatives: Record<string, any>[],
-  ): Record<string, any> | undefined {
-    const nonEmptyAlternatives = alternatives.filter(
-      (alternative) => Object.keys(alternative).length > 0,
-    );
-    if (nonEmptyAlternatives.length === 0) {
-      return undefined;
-    }
-    if (nonEmptyAlternatives.length === 1) {
-      return nonEmptyAlternatives[0];
-    }
-    return { $or: nonEmptyAlternatives };
+    const widened = appendAndClauses(result, andClauses);
+    return Object.keys(widened).length > 0 ? widened : undefined;
   }
 
   private _providerListCountIsTotal(): boolean {
     return ["memory", "pgvector", "redis", "supabase"].includes(
       this.config.vectorStore.provider.toLowerCase(),
     );
+  }
+
+  private _providerResultLimit(): number | undefined {
+    return PROVIDER_RESULT_LIMITS[
+      this.config.vectorStore.provider.toLowerCase()
+    ];
+  }
+
+  private _effectiveProviderLimit(requestedLimit: number): number {
+    const providerLimit = this._providerResultLimit();
+    return providerLimit === undefined
+      ? requestedLimit
+      : Math.min(requestedLimit, providerLimit);
+  }
+
+  private _listPageMayBeIncomplete(
+    rowCount: number,
+    rawCount: unknown,
+    fetchLimit: number,
+    pageFull = rowCount >= fetchLimit,
+  ): boolean {
+    if (this._providerListCountIsTotal()) {
+      const total = Number(rawCount);
+      if (Number.isFinite(total)) {
+        return total > rowCount;
+      }
+    }
+
+    return pageFull;
+  }
+
+  private async _searchProviderByRequestedScope<
+    T extends { id: unknown; score?: number; payload: Record<string, any> },
+  >(
+    store: VectorStore,
+    embedding: number[],
+    limit: number,
+    filters: Record<string, any>,
+  ): Promise<ProviderSearchResult<T>> {
+    const providerFilterVariants =
+      this._providerFilterVariantsForRequestedScope(filters);
+
+    if (providerFilterVariants.length === 1) {
+      const results = (await store.search(
+        embedding,
+        limit,
+        providerFilterVariants[0],
+      )) as T[];
+      return {
+        results,
+        pageFull: results.length >= limit,
+      };
+    }
+
+    const pages = await Promise.all(
+      providerFilterVariants.map((providerFilters) =>
+        store.search(embedding, limit, providerFilters),
+      ),
+    );
+
+    return {
+      results: this._dedupeProviderRows(pages.flat() as T[]),
+      pageFull: pages.some((page) => page.length >= limit),
+    };
+  }
+
+  private async _keywordSearchProviderByRequestedScope(
+    query: string,
+    limit: number,
+    filters: Record<string, any>,
+  ): Promise<ProviderSearchResult<{
+    id: string;
+    score?: number;
+    payload: Record<string, any>;
+  }> | null> {
+    if (typeof this.vectorStore.keywordSearch !== "function") {
+      return null;
+    }
+
+    const providerFilterVariants =
+      this._providerFilterVariantsForRequestedScope(filters);
+
+    if (providerFilterVariants.length === 1) {
+      const results =
+        (await this.vectorStore.keywordSearch(
+          query,
+          limit,
+          providerFilterVariants[0],
+        )) ?? null;
+      return results
+        ? {
+            results,
+            pageFull: results.length >= limit,
+          }
+        : null;
+    }
+
+    const pages = await Promise.all(
+      providerFilterVariants.map((providerFilters) =>
+        this.vectorStore.keywordSearch!(query, limit, providerFilters),
+      ),
+    );
+    const resultPages = pages.filter(
+      (
+        page,
+      ): page is Array<{
+        id: string;
+        score?: number;
+        payload: Record<string, any>;
+      }> => Array.isArray(page),
+    );
+
+    if (resultPages.length === 0) {
+      return null;
+    }
+
+    return {
+      results: this._dedupeProviderRows(resultPages.flat()),
+      pageFull: resultPages.some((page) => page.length >= limit),
+    };
+  }
+
+  private async _listProviderByRequestedScope<
+    T extends { id: unknown; payload: Record<string, any> },
+  >(
+    store: VectorStore,
+    filters: Record<string, any>,
+    limit: number,
+  ): Promise<ProviderListResult<T>> {
+    const providerFilterVariants =
+      this._providerFilterVariantsForRequestedScope(filters);
+
+    if (providerFilterVariants.length === 1) {
+      const [rows, rawCount] = await store.list(
+        providerFilterVariants[0],
+        limit,
+      );
+      return {
+        rows: rows as T[],
+        rawCount,
+        pageFull: rows.length >= limit,
+      };
+    }
+
+    const pages = await Promise.all(
+      providerFilterVariants.map((providerFilters) =>
+        store.list(providerFilters, limit),
+      ),
+    );
+
+    return {
+      rows: this._dedupeProviderRows(pages.flatMap(([rows]) => rows) as T[]),
+      rawCount: undefined,
+      pageFull: pages.some(([rows]) => rows.length >= limit),
+    };
   }
 
   private async _listByRequestedScope(
@@ -689,15 +1445,19 @@ export class Memory {
       return [];
     }
 
-    const providerFilters = this._providerFiltersForRequestedScope(filters);
     const providerReturnsTotalCount = this._providerListCountIsTotal();
     const provider = this.config.vectorStore.provider;
-    let fetchLimit = options.initialLimit;
+    let fetchLimit = this._effectiveProviderLimit(options.initialLimit);
     let scoped: VectorStoreResult[] = [];
 
     while (true) {
-      const [rawMemories, rawCount] = await this.vectorStore.list(
-        providerFilters,
+      const {
+        rows: rawMemories,
+        rawCount,
+        pageFull,
+      } = await this._listProviderByRequestedScope<VectorStoreResult>(
+        this.vectorStore,
+        filters,
         fetchLimit,
       );
       scoped = this.filterByRequestedScope(rawMemories, filters);
@@ -712,21 +1472,37 @@ export class Memory {
 
       const total = providerReturnsTotalCount ? Number(rawCount) : undefined;
       if (total !== undefined && Number.isFinite(total) && fetchLimit < total) {
-        const nextLimit = options.exhaustive
+        const recoveryLimit = options.exhaustive
           ? total
-          : Math.min(total, Math.max(fetchLimit * 2, fetchLimit + 1));
+          : Math.min(total, MAX_SCOPE_POST_FILTER_FETCH);
+        const nextLimit = Math.min(
+          recoveryLimit,
+          Math.max(fetchLimit * 2, fetchLimit + 1),
+        );
+        const effectiveNextLimit = this._effectiveProviderLimit(nextLimit);
 
-        if (nextLimit > fetchLimit) {
-          fetchLimit = nextLimit;
+        if (effectiveNextLimit > fetchLimit) {
+          fetchLimit = effectiveNextLimit;
           continue;
         }
       }
 
       if (
-        options.exhaustive &&
-        !providerReturnsTotalCount &&
-        rawMemories.length >= fetchLimit
+        !options.exhaustive &&
+        providerReturnsTotalCount &&
+        options.topK !== undefined &&
+        scoped.length < options.topK &&
+        total !== undefined &&
+        Number.isFinite(total) &&
+        total > fetchLimit &&
+        fetchLimit >= MAX_SCOPE_POST_FILTER_FETCH
       ) {
+        throw new Error(
+          `getAll cannot safely return all requested scoped memories for vector store provider '${provider}' because scoped post-filter recovery reached ${MAX_SCOPE_POST_FILTER_FETCH} rows while the provider reported ${total}. Narrow the scope filters or lower topK.`,
+        );
+      }
+
+      if (options.exhaustive && !providerReturnsTotalCount && pageFull) {
         throw new Error(
           `deleteAll cannot safely delete all scoped memories for vector store provider '${provider}' because list() returned a full page without a total count. Narrow the scope filters or delete matching memories individually.`,
         );
@@ -737,7 +1513,7 @@ export class Memory {
         !providerReturnsTotalCount &&
         options.topK !== undefined &&
         scoped.length < options.topK &&
-        rawMemories.length >= fetchLimit
+        pageFull
       ) {
         throw new Error(
           `getAll cannot safely return all requested scoped memories for vector store provider '${provider}' because list() returned a full page without a total count. Narrow the scope filters or lower topK.`,
@@ -759,61 +1535,44 @@ export class Memory {
   private async _deleteAllByRequestedScope(
     filters: Record<string, any>,
   ): Promise<number> {
-    const providerFilters = this._providerFiltersForRequestedScope(filters);
     const providerReturnsTotalCount = this._providerListCountIsTotal();
     const provider = this.config.vectorStore.provider;
     let deletedCount = 0;
-    const deletedIds = new Set<string>();
+    const fetchLimit = this._effectiveProviderLimit(
+      DELETE_ALL_SCOPE_FETCH_LIMIT,
+    );
 
-    while (true) {
-      const [rawMemories, rawCount] = await this.vectorStore.list(
-        providerFilters,
-        DELETE_ALL_SCOPE_FETCH_LIMIT,
+    const {
+      rows: rawMemories,
+      rawCount,
+      pageFull,
+    } = await this._listProviderByRequestedScope<VectorStoreResult>(
+      this.vectorStore,
+      filters,
+      fetchLimit,
+    );
+    const total = providerReturnsTotalCount ? Number(rawCount) : undefined;
+    const totalIsReliable = total !== undefined && Number.isFinite(total);
+    const scoped = this.filterByRequestedScope(rawMemories, filters);
+
+    if (!totalIsReliable && pageFull) {
+      throw new Error(
+        `deleteAll cannot safely delete all scoped memories for vector store provider '${provider}' because list() returned a full page without a total count. Narrow the scope filters or delete matching memories individually.`,
       );
-      const scoped = this.filterByRequestedScope(rawMemories, filters);
-
-      if (
-        !providerReturnsTotalCount &&
-        rawMemories.length >= DELETE_ALL_SCOPE_FETCH_LIMIT
-      ) {
-        throw new Error(
-          `deleteAll cannot safely delete all scoped memories for vector store provider '${provider}' because list() returned a full page without a total count. Narrow the scope filters or delete matching memories individually.`,
-        );
-      }
-
-      if (scoped.length === 0) {
-        const total = providerReturnsTotalCount ? Number(rawCount) : undefined;
-        if (
-          total !== undefined &&
-          Number.isFinite(total) &&
-          total > 0 &&
-          total > rawMemories.length &&
-          rawMemories.length >= DELETE_ALL_SCOPE_FETCH_LIMIT
-        ) {
-          throw new Error(
-            `deleteAll cannot safely delete all scoped memories for vector store provider '${provider}' because scoped rows may be hidden behind a full provider page. Narrow the scope filters or delete matching memories individually.`,
-          );
-        }
-        return deletedCount;
-      }
-
-      const nextScoped = scoped.filter((memory) => !deletedIds.has(memory.id));
-      if (nextScoped.length === 0) {
-        throw new Error(
-          `deleteAll cannot safely delete all scoped memories for vector store provider '${provider}' because repeated list() calls made no deletion progress. Narrow the scope filters or delete matching memories individually.`,
-        );
-      }
-
-      for (const memory of nextScoped) {
-        await this.deleteMemory(memory.id);
-        deletedIds.add(memory.id);
-      }
-      deletedCount += nextScoped.length;
-
-      if (rawMemories.length < DELETE_ALL_SCOPE_FETCH_LIMIT) {
-        return deletedCount;
-      }
     }
+
+    if (totalIsReliable && total > rawMemories.length) {
+      throw new Error(
+        `deleteAll cannot safely delete all scoped memories for vector store provider '${provider}' because scoped rows may be hidden behind an incomplete provider page. Narrow the scope filters or delete matching memories individually.`,
+      );
+    }
+
+    for (const memory of scoped) {
+      await this.deleteMemory(memory.id);
+      deletedCount += 1;
+    }
+
+    return deletedCount;
   }
 
   private _normalizeEntityText(value: string): string {
@@ -830,12 +1589,25 @@ export class Memory {
     >();
     let rows: Array<{ id: string; payload: Record<string, any> }> = [];
     try {
-      const listed = await entityStore.list(filters, 10000);
-      rows = (
-        Array.isArray(listed) && Array.isArray(listed[0])
-          ? listed[0]
-          : (listed as any)
-      ) as Array<{ id: string; payload: Record<string, any> }>;
+      const fetchLimit = this._effectiveProviderLimit(ENTITY_SCOPE_FETCH_LIMIT);
+      const listed = await this._listProviderByRequestedScope<{
+        id: string;
+        payload: Record<string, any>;
+      }>(entityStore, filters, fetchLimit);
+      rows = this.filterByRequestedScope(listed.rows, filters);
+      if (
+        this._listPageMayBeIncomplete(
+          listed.rows.length,
+          listed.rawCount,
+          fetchLimit,
+          listed.pageFull,
+        )
+      ) {
+        console.debug(
+          `Exact entity lookup skipped for provider '${this.config.vectorStore.provider}' because list() may be incomplete`,
+        );
+        return rowsByText;
+      }
     } catch (e) {
       console.debug(
         `Exact entity lookup failed, falling back to semantic dedup: ${e}`,
@@ -876,12 +1648,25 @@ export class Memory {
 
     let rows: Array<{ id: string; payload: Record<string, any> }> = [];
     try {
-      const listed = await entityStore.list(filters, 10000);
-      rows = (
-        Array.isArray(listed) && Array.isArray(listed[0])
-          ? listed[0]
-          : (listed as any)
-      ) as Array<{ id: string; payload: Record<string, any> }>;
+      const fetchLimit = this._effectiveProviderLimit(ENTITY_SCOPE_FETCH_LIMIT);
+      const listed = await this._listProviderByRequestedScope<{
+        id: string;
+        payload: Record<string, any>;
+      }>(entityStore, filters, fetchLimit);
+      rows = this.filterByRequestedScope(listed.rows, filters);
+      if (
+        this._listPageMayBeIncomplete(
+          listed.rows.length,
+          listed.rawCount,
+          fetchLimit,
+          listed.pageFull,
+        )
+      ) {
+        console.debug(
+          `Entity cleanup skipped for provider '${this.config.vectorStore.provider}' because list() may be incomplete`,
+        );
+        return;
+      }
     } catch (e) {
       console.debug(`Entity store list failed during cleanup: ${e}`);
       return;
@@ -976,7 +1761,14 @@ export class Memory {
           );
           if (!exactMatch) {
             try {
-              matches = await entityStore.search(entityVec, 1, filters);
+              const searched = (
+                await this._searchProviderByRequestedScope<{
+                  id: string;
+                  score?: number;
+                  payload: Record<string, any>;
+                }>(entityStore, entityVec, 1, filters)
+              ).results;
+              matches = this.filterByRequestedScope(searched, filters);
             } catch {}
           }
 
@@ -1045,13 +1837,51 @@ export class Memory {
       return results;
     }
 
-    // Defense-in-depth after provider filtering: replay filters that contain
-    // requested scope keys so provider drift cannot leak or delete wrong-scope
-    // rows. Bounded vector-store APIs do not expose a shared cursor, so callers
-    // may see fewer rows if polluted rows crowd out valid in-scope rows.
+    // Defense-in-depth after provider filtering: replay the complete caller
+    // filter whenever it contains requested scope keys. This preserves metadata
+    // predicates even when simple providers receive scope-only filters. Bounded
+    // vector-store APIs do not expose a shared cursor, so callers may see fewer
+    // rows if polluted rows crowd out valid in-scope rows.
     return results.filter((result) =>
-      this._matchesScopeFilter(result.payload ?? {}, filters),
+      this._matchesRequestedFilter(result.payload ?? {}, filters),
     );
+  }
+
+  private filterSearchByRequestedScope<
+    T extends Pick<VectorStoreResult, "payload">,
+  >(
+    results: T[],
+    filters: Record<string, any>,
+    options: {
+      limit: number;
+      needed: number;
+      operation: "add" | "search";
+      pageFull?: boolean;
+    },
+  ): T[] {
+    const scoped = this.filterByRequestedScope(results, filters);
+    const pageFull = options.pageFull ?? results.length >= options.limit;
+
+    if (
+      this._filterContainsScope(filters) &&
+      pageFull &&
+      scoped.length < options.needed
+    ) {
+      const provider = this.config.vectorStore.provider;
+      const action =
+        options.operation === "add"
+          ? "infer scoped memories"
+          : "return all requested scoped memories";
+      const guidance =
+        options.operation === "add"
+          ? "Narrow the scope filters before adding inferred memories."
+          : "Narrow the scope filters or lower topK.";
+      throw new Error(
+        `${options.operation} cannot safely ${action} for vector store provider '${provider}' because search() returned a full provider page before enough requested scoped rows could be proven. ${guidance}`,
+      );
+    }
+
+    return scoped;
   }
 
   private _canonicalScopeKey(key: string): ScopeKey | undefined {
@@ -1098,7 +1928,7 @@ export class Memory {
     return false;
   }
 
-  private _matchesScopeFilter(
+  private _matchesRequestedFilter(
     payload: Record<string, any>,
     filter: any,
   ): boolean {
@@ -1113,7 +1943,7 @@ export class Memory {
         }
         if (
           !value.every((condition) =>
-            this._matchesScopeFilter(payload, condition),
+            this._matchesRequestedFilter(payload, condition),
           )
         ) {
           return false;
@@ -1127,7 +1957,7 @@ export class Memory {
         }
         if (
           !value.some((condition) =>
-            this._matchesScopeFilter(payload, condition),
+            this._matchesRequestedFilter(payload, condition),
           )
         ) {
           return false;
@@ -1141,7 +1971,7 @@ export class Memory {
         }
         if (
           value.some((condition) =>
-            this._matchesScopeFilter(payload, condition),
+            this._matchesRequestedFilter(payload, condition),
           )
         ) {
           return false;
@@ -1173,9 +2003,7 @@ export class Memory {
       : payload[key];
 
     if (condition === "*") {
-      return scopeKey
-        ? payloadValue !== undefined && payloadValue !== null
-        : true;
+      return payloadValue !== undefined && payloadValue !== null;
     }
 
     if (Array.isArray(condition)) {
@@ -1188,8 +2016,8 @@ export class Memory {
           if (payloadValue !== value) return false;
         } else if (operator === "ne") {
           if (
-            (scopeKey &&
-              (payloadValue === undefined || payloadValue === null)) ||
+            payloadValue === undefined ||
+            payloadValue === null ||
             payloadValue === value
           ) {
             return false;
@@ -1217,8 +2045,8 @@ export class Memory {
         } else if (operator === "nin") {
           if (
             !Array.isArray(value) ||
-            (scopeKey &&
-              (payloadValue === undefined || payloadValue === null)) ||
+            payloadValue === undefined ||
+            payloadValue === null ||
             value.includes(payloadValue)
           ) {
             return false;
@@ -1467,23 +2295,31 @@ export class Memory {
       has_filters: !!config.filters,
       infer: config.infer,
     });
-    const { metadata = {}, filters = {}, infer = true } = config;
+    const { infer = true } = config;
+    const metadata = { ...(config.metadata ?? {}) };
+    const filters: Record<string, any> = this._normalizeScopeFilterValues(
+      config.filters || {},
+    );
 
     // Validate and trim entity IDs
     const userId = validateAndTrimEntityId(config.userId, "userId");
     const agentId = validateAndTrimEntityId(config.agentId, "agentId");
     const runId = validateAndTrimEntityId(config.runId, "runId");
 
-    // Convert camelCase entity params to snake_case for storage (matches API and search/getAll filters)
-    if (userId) filters.user_id = metadata.user_id = userId;
-    if (agentId) filters.agent_id = metadata.agent_id = agentId;
-    if (runId) filters.run_id = metadata.run_id = runId;
+    // Convert camelCase entity params to snake_case for storage (matches API and search/getAll filters).
+    // Top-level scope options must not silently override conflicting scoped filters.
+    this._mergeTopLevelScopeFilter(filters, "user_id", userId, "userId");
+    this._mergeTopLevelScopeFilter(filters, "agent_id", agentId, "agentId");
+    this._mergeTopLevelScopeFilter(filters, "run_id", runId, "runId");
 
-    if (!filters.user_id && !filters.agent_id && !filters.run_id) {
+    if (!this._filterContainsScope(filters)) {
       throw new Error(
         "One of the filters: userId, agentId or runId is required!",
       );
     }
+    this._assertSafeScopeFilters(filters, "add");
+
+    this._applyAuthoritativeScopeToMetadata(metadata, filters, "add");
 
     const parsedMessages = Array.isArray(messages)
       ? (messages as Message[])
@@ -1552,9 +2388,10 @@ export class Memory {
     }
 
     // === V3 PHASED BATCH PIPELINE ===
+    const scopeFilters = this._requiredScopeProviderFilters(filters);
 
     // Phase 0: Context gathering
-    const sessionScope = this.buildSessionScope(filters);
+    const sessionScope = this.buildSessionScope(scopeFilters);
     let lastMessages: Array<{
       role: string;
       content: string;
@@ -1577,15 +2414,26 @@ export class Memory {
 
     // Phase 1: Existing memory retrieval
     const queryEmbedding = await this.embedder.embed(parsedMessages);
-    const providerFilters = this._providerFiltersForRequestedScope(filters);
-    const existingResults = this.filterByRequestedScope(
-      await this.vectorStore.search(
-        queryEmbedding,
-        MIN_SCOPE_POST_FILTER_FETCH,
-        providerFilters,
-      ),
-      filters,
+    const existingFetchLimit = this._effectiveProviderLimit(
+      MIN_SCOPE_POST_FILTER_FETCH,
     );
+    const rawExistingResults =
+      await this._searchProviderByRequestedScope<VectorStoreResult>(
+        this.vectorStore,
+        queryEmbedding,
+        existingFetchLimit,
+        filters,
+      );
+    const existingResults = this.filterSearchByRequestedScope(
+      rawExistingResults.results,
+      filters,
+      {
+        limit: existingFetchLimit,
+        needed: EXISTING_MEMORY_CONTEXT_LIMIT,
+        operation: "add",
+        pageFull: rawExistingResults.pageFull,
+      },
+    ).slice(0, EXISTING_MEMORY_CONTEXT_LIMIT);
 
     // Map UUIDs to integers (anti-hallucination)
     const existingMemories: Array<{ id: string; text: string }> = [];
@@ -1600,7 +2448,7 @@ export class Memory {
     }
 
     // Phase 2: LLM extraction (single call)
-    const isAgentScoped = !!filters.agent_id && !filters.user_id;
+    const isAgentScoped = !!scopeFilters.agent_id && !scopeFilters.user_id;
     let systemPrompt = ADDITIVE_EXTRACTION_PROMPT;
     if (isAgentScoped) {
       systemPrompt += AGENT_CONTEXT_SUFFIX;
@@ -1729,9 +2577,9 @@ export class Memory {
       if (mem.attributed_to) {
         memPayload.attributedTo = mem.attributed_to;
       }
-      if (filters.user_id) memPayload.user_id = filters.user_id;
-      if (filters.agent_id) memPayload.agent_id = filters.agent_id;
-      if (filters.run_id) memPayload.run_id = filters.run_id;
+      if (scopeFilters.user_id) memPayload.user_id = scopeFilters.user_id;
+      if (scopeFilters.agent_id) memPayload.agent_id = scopeFilters.agent_id;
+      if (scopeFilters.run_id) memPayload.run_id = scopeFilters.run_id;
 
       records.push({
         memoryId,
@@ -1885,7 +2733,7 @@ export class Memory {
           const entityStore = await this.getEntityStore();
           const exactMatches = await this._existingEntitiesByText(
             entityStore,
-            filters,
+            scopeFilters,
           );
 
           // 7c: Search for existing entities one by one (no batch search)
@@ -1905,7 +2753,14 @@ export class Memory {
             const exactMatch = exactMatches.get(key);
             if (!exactMatch) {
               try {
-                matches = await entityStore.search(entityVec, 1, filters);
+                const searched = (
+                  await this._searchProviderByRequestedScope<{
+                    id: string;
+                    score?: number;
+                    payload: Record<string, any>;
+                  }>(entityStore, entityVec, 1, scopeFilters)
+                ).results;
+                matches = this.filterByRequestedScope(searched, scopeFilters);
               } catch {}
             }
 
@@ -1932,9 +2787,15 @@ export class Memory {
                 entityType,
                 linkedMemoryIds: Array.from(memoryIds).sort(),
               };
-              if (filters.user_id) entityPayload.user_id = filters.user_id;
-              if (filters.agent_id) entityPayload.agent_id = filters.agent_id;
-              if (filters.run_id) entityPayload.run_id = filters.run_id;
+              if (scopeFilters.user_id) {
+                entityPayload.user_id = scopeFilters.user_id;
+              }
+              if (scopeFilters.agent_id) {
+                entityPayload.agent_id = scopeFilters.agent_id;
+              }
+              if (scopeFilters.run_id) {
+                entityPayload.run_id = scopeFilters.run_id;
+              }
 
               toInsertVectors.push(entityVec);
               toInsertIds.push(uuidv4());
@@ -2036,26 +2897,12 @@ export class Memory {
     // Validate search parameters (before applying defaults)
     validateSearchParams(config.threshold, config.topK);
 
-    // Validate and trim entity IDs in filters. Only include keys whose
-    // validated value is defined — otherwise downstream vector stores
-    // receive `agent_id: undefined` / `run_id: undefined` and fail
-    // (Qdrant rejects the malformed match, pgvector binds NULL, Redis
-    // emits a literal "undefined" string in TAG filters).
+    // Validate and trim scope IDs anywhere they appear in logical filter trees.
+    // Drop scope keys whose value is undefined so downstream vector stores don't
+    // receive malformed provider filters such as `agent_id: undefined`.
     const normalizedFilters: Record<string, any> = config.filters
-      ? Object.fromEntries(
-          Object.entries({
-            ...config.filters,
-            user_id: validateAndTrimEntityId(config.filters.user_id, "user_id"),
-            agent_id: validateAndTrimEntityId(
-              config.filters.agent_id,
-              "agent_id",
-            ),
-            run_id: validateAndTrimEntityId(config.filters.run_id, "run_id"),
-          }).filter(([, v]) => v !== undefined),
-        )
+      ? this._normalizeScopeFilterValues(config.filters)
       : {};
-
-    this._rejectWildcardScopeFilters(normalizedFilters, "search");
 
     await this._ensureInitialized();
     const { topK = 20, threshold = 0.1, explain = false } = config;
@@ -2073,17 +2920,13 @@ export class Memory {
       effectiveFilters = this._processMetadataFilters(effectiveFilters);
     }
 
-    // Validate filters contains at least one entity ID (snake_case)
-    if (
-      !effectiveFilters.user_id &&
-      !effectiveFilters.agent_id &&
-      !effectiveFilters.run_id
-    ) {
+    if (!this._filterContainsScope(effectiveFilters)) {
       throw new Error(
         "filters must contain at least one of: user_id, agent_id, run_id. " +
           "Example: filters: { user_id: 'u1' }",
       );
     }
+    this._assertSafeScopeFilters(effectiveFilters, "search");
 
     const searchStartMs = Date.now();
 
@@ -2095,16 +2938,25 @@ export class Memory {
     const queryEmbedding = await this.embedder.embed(query);
 
     // Step 3: Semantic search (over-fetch for scoring pool)
-    const internalLimit = Math.max(topK * 4, 60);
-    const providerFilters =
-      this._providerFiltersForRequestedScope(effectiveFilters);
-    const semanticResults = this.filterByRequestedScope(
-      await this.vectorStore.search(
+    const internalLimit = this._effectiveProviderLimit(
+      Math.max(topK * 4, MIN_SCOPE_POST_FILTER_FETCH),
+    );
+    const rawSemanticResults =
+      await this._searchProviderByRequestedScope<VectorStoreResult>(
+        this.vectorStore,
         queryEmbedding,
         internalLimit,
-        providerFilters,
-      ),
+        effectiveFilters,
+      );
+    const semanticResults = this.filterSearchByRequestedScope(
+      rawSemanticResults.results,
       effectiveFilters,
+      {
+        limit: internalLimit,
+        needed: topK,
+        operation: "search",
+        pageFull: rawSemanticResults.pageFull,
+      },
     );
 
     // Step 4: Keyword search (if store supports it)
@@ -2114,19 +2966,36 @@ export class Memory {
       payload: Record<string, any>;
     }> | null = null;
     if (typeof this.vectorStore.keywordSearch === "function") {
+      let rawKeywordResults: Array<{
+        id: string;
+        score?: number;
+        payload: Record<string, any>;
+      }> | null = null;
+      let keywordPageFull = false;
       try {
-        const rawKeywordResults =
-          (await this.vectorStore.keywordSearch(
+        const keywordSearchResult =
+          await this._keywordSearchProviderByRequestedScope(
             queryLemmatized,
             internalLimit,
-            providerFilters,
-          )) ?? null;
-        keywordResults = rawKeywordResults
-          ? this.filterByRequestedScope(rawKeywordResults, effectiveFilters)
-          : null;
+            effectiveFilters,
+          );
+        rawKeywordResults = keywordSearchResult?.results ?? null;
+        keywordPageFull = keywordSearchResult?.pageFull ?? false;
       } catch {
-        keywordResults = null;
+        rawKeywordResults = null;
       }
+      keywordResults = rawKeywordResults
+        ? this.filterSearchByRequestedScope(
+            rawKeywordResults,
+            effectiveFilters,
+            {
+              limit: internalLimit,
+              needed: topK,
+              operation: "search",
+              pageFull: keywordPageFull,
+            },
+          )
+        : null;
     }
 
     // Step 5: Compute BM25 scores from keyword results
@@ -2158,56 +3027,81 @@ export class Memory {
         }
 
         if (deduped.length > 0) {
-          const entityStore = await this.getEntityStore();
-          const entitySearchFilters: Record<string, any> = {};
-          for (const k of ["user_id", "agent_id", "run_id"] as const) {
-            if (effectiveFilters[k])
-              entitySearchFilters[k] = effectiveFilters[k];
-          }
-          const entityTexts = deduped.map((e) => e.text);
-          const embeddings = await this.embedder.embedBatch(entityTexts);
+          const entitySearchFilters =
+            this._requiredScopeProviderFilters(effectiveFilters);
+          if (Object.keys(entitySearchFilters).length > 0) {
+            const entityStore = await this.getEntityStore();
+            const entityTexts = deduped.map((e) => e.text);
+            const embeddings = await this.embedder.embedBatch(entityTexts);
 
-          if (embeddings.length !== entityTexts.length) {
-            console.warn(
-              `embedBatch returned ${embeddings.length} vectors for ${entityTexts.length} texts — skipping entity boost`,
-            );
-          } else {
-            const searchResults = await Promise.allSettled(
-              deduped.map((_, i) =>
-                entityStore.search(embeddings[i], 500, entitySearchFilters),
-              ),
-            );
+            if (embeddings.length !== entityTexts.length) {
+              console.warn(
+                `embedBatch returned ${embeddings.length} vectors for ${entityTexts.length} texts — skipping entity boost`,
+              );
+            } else {
+              const entityBoostLimit = this._effectiveProviderLimit(500);
+              const providerResultLimit = this._providerResultLimit();
+              const searchResults = await Promise.allSettled(
+                deduped.map((_, i) =>
+                  this._searchProviderByRequestedScope<{
+                    id: string;
+                    score?: number;
+                    payload: Record<string, any>;
+                  }>(
+                    entityStore,
+                    embeddings[i],
+                    entityBoostLimit,
+                    entitySearchFilters,
+                  ),
+                ),
+              );
 
-            for (const result of searchResults) {
-              if (result.status === "rejected") {
-                console.warn(
-                  "Entity boost search failed for one entity:",
-                  result.reason,
+              for (const result of searchResults) {
+                if (result.status === "rejected") {
+                  console.warn(
+                    "Entity boost search failed for one entity:",
+                    result.reason,
+                  );
+                  continue;
+                }
+
+                if (
+                  providerResultLimit !== undefined &&
+                  result.value.pageFull
+                ) {
+                  console.debug(
+                    `Entity boost skipped for provider '${this.config.vectorStore.provider}' because search() returned a full capped page`,
+                  );
+                  continue;
+                }
+
+                const scopedEntityMatches = this.filterByRequestedScope(
+                  result.value.results,
+                  entitySearchFilters,
                 );
-                continue;
-              }
 
-              for (const match of result.value) {
-                const similarity = match.score ?? 0;
-                if (similarity < 0.5) continue;
+                for (const match of scopedEntityMatches) {
+                  const similarity = match.score ?? 0;
+                  if (similarity < 0.5) continue;
 
-                const payload = match.payload || {};
-                const linkedMemoryIds = payload.linkedMemoryIds ?? [];
-                if (!Array.isArray(linkedMemoryIds)) continue;
+                  const payload = match.payload || {};
+                  const linkedMemoryIds = payload.linkedMemoryIds ?? [];
+                  if (!Array.isArray(linkedMemoryIds)) continue;
 
-                const numLinked = Math.max(linkedMemoryIds.length, 1);
-                const memoryCountWeight =
-                  1.0 / (1.0 + 0.001 * (numLinked - 1) ** 2);
-                const boost =
-                  similarity * ENTITY_BOOST_WEIGHT * memoryCountWeight;
+                  const numLinked = Math.max(linkedMemoryIds.length, 1);
+                  const memoryCountWeight =
+                    1.0 / (1.0 + 0.001 * (numLinked - 1) ** 2);
+                  const boost =
+                    similarity * ENTITY_BOOST_WEIGHT * memoryCountWeight;
 
-                for (const memoryId of linkedMemoryIds) {
-                  if (memoryId) {
-                    const memKey = String(memoryId);
-                    entityBoosts[memKey] = Math.max(
-                      entityBoosts[memKey] ?? 0,
-                      boost,
-                    );
+                  for (const memoryId of linkedMemoryIds) {
+                    if (memoryId) {
+                      const memKey = String(memoryId);
+                      entityBoosts[memKey] = Math.max(
+                        entityBoosts[memKey] ?? 0,
+                        boost,
+                      );
+                    }
                   }
                 }
               }
@@ -2325,6 +3219,7 @@ export class Memory {
     config: DeleteAllMemoryOptions,
   ): Promise<{ message: string }> {
     await this._ensureInitialized();
+    this._assertDeleteAllConfigIsScopedOptions(config as Record<string, any>);
     await this._captureEvent("delete_all", {
       has_user_id: !!config.userId,
       has_agent_id: !!config.agentId,
@@ -2346,7 +3241,7 @@ export class Memory {
       );
     }
 
-    this._rejectWildcardScopeFilters(filters, "deleteAll");
+    this._assertSafeScopeFilters(filters, "deleteAll");
 
     const deletedCount = await this._deleteAllByRequestedScope(filters);
 
@@ -2434,19 +3329,12 @@ export class Memory {
 
     const { topK = 20 } = config;
 
-    // Validate and trim entity IDs in filters. Drop keys that resolve to
-    // undefined so downstream vector stores don't receive
-    // `agent_id: undefined` / `run_id: undefined` and fail.
-    const filters: Record<string, any> = Object.fromEntries(
-      Object.entries({
-        ...(config.filters || {}),
-        user_id: validateAndTrimEntityId(config.filters?.user_id, "user_id"),
-        agent_id: validateAndTrimEntityId(config.filters?.agent_id, "agent_id"),
-        run_id: validateAndTrimEntityId(config.filters?.run_id, "run_id"),
-      }).filter(([, v]) => v !== undefined),
+    // Validate and trim scope IDs anywhere they appear in logical filter trees.
+    // Drop scope keys whose value is undefined so downstream vector stores don't
+    // receive malformed provider filters such as `agent_id: undefined`.
+    const filters: Record<string, any> = this._normalizeScopeFilterValues(
+      config.filters || {},
     );
-
-    this._rejectWildcardScopeFilters(filters, "getAll");
 
     await this._captureEvent("get_all", {
       topK,
@@ -2455,16 +3343,21 @@ export class Memory {
       has_run_id: !!filters.run_id,
     });
 
-    // Validate filters contains at least one entity ID (snake_case)
-    if (!filters.user_id && !filters.agent_id && !filters.run_id) {
+    if (!this._filterContainsScope(filters)) {
       throw new Error(
         "filters must contain at least one of: user_id, agent_id, run_id. " +
           "Example: filters: { user_id: 'u1' }",
       );
     }
+    this._assertSafeScopeFilters(filters, "getAll");
 
     const fetchLimit =
-      topK === 0 ? 0 : Math.max(topK * 4, MIN_SCOPE_POST_FILTER_FETCH);
+      topK === 0
+        ? 0
+        : Math.min(
+            MAX_SCOPE_POST_FILTER_FETCH,
+            Math.max(topK * 4, MIN_SCOPE_POST_FILTER_FETCH),
+          );
     const memories = await this._listByRequestedScope(filters, {
       topK,
       initialLimit: fetchLimit,

--- a/mem0-ts/src/oss/src/types/index.ts
+++ b/mem0-ts/src/oss/src/types/index.ts
@@ -78,6 +78,9 @@ export interface MemoryItem {
   id: string;
   memory: string;
   hash?: string;
+  user_id?: string;
+  agent_id?: string;
+  run_id?: string;
   createdAt?: string;
   updatedAt?: string;
   score?: number;

--- a/mem0-ts/src/oss/src/vector_stores/pgvector.ts
+++ b/mem0-ts/src/oss/src/vector_stores/pgvector.ts
@@ -70,6 +70,22 @@ export function buildFilterConditions(
   }
 
   for (const [key, value] of Object.entries(filters)) {
+    if (key === "$and") {
+      const andGroups: string[] = [];
+      for (const andFilter of value as Record<string, any>[]) {
+        const sub = buildFilterConditions(andFilter, paramIndex);
+        if (sub.conditions.length > 0) {
+          andGroups.push("(" + sub.conditions.join(" AND ") + ")");
+          values.push(...sub.values);
+          paramIndex = sub.paramIndex;
+        }
+      }
+      if (andGroups.length > 0) {
+        conditions.push("(" + andGroups.join(" AND ") + ")");
+      }
+      continue;
+    }
+
     if (key === "$or") {
       const orGroups: string[] = [];
       for (const orFilter of value as Record<string, any>[]) {

--- a/mem0-ts/src/oss/src/vector_stores/vectorize.ts
+++ b/mem0-ts/src/oss/src/vector_stores/vectorize.ts
@@ -378,7 +378,14 @@ export class VectorizeDB implements VectorStore {
             },
           });
 
-          const properties = ["userId", "agentId", "runId"];
+          const properties = [
+            "user_id",
+            "agent_id",
+            "run_id",
+            "userId",
+            "agentId",
+            "runId",
+          ];
 
           for (const propertyName of properties) {
             await this.client?.vectorize.indexes.metadataIndex.create(
@@ -407,7 +414,14 @@ export class VectorizeDB implements VectorStore {
       for (const metadataIndex of metadataIndexes?.metadataIndexes || []) {
         existingMetadataIndexes.add(metadataIndex.propertyName!);
       }
-      const properties = ["userId", "agentId", "runId"];
+      const properties = [
+        "user_id",
+        "agent_id",
+        "run_id",
+        "userId",
+        "agentId",
+        "runId",
+      ];
       for (const propertyName of properties) {
         if (!existingMetadataIndexes.has(propertyName)) {
           await this.client?.vectorize.indexes.metadataIndex.create(

--- a/mem0-ts/src/oss/tests/memory.add.test.ts
+++ b/mem0-ts/src/oss/tests/memory.add.test.ts
@@ -232,4 +232,44 @@ describe("Memory - add()", () => {
       await scopedMemory.reset();
     }
   });
+
+  test("uses camelCase scoped existing search results when deduplicating inferred memories", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const extractedText = "user: I love Redis-compatible sushi.";
+    const searchSpy = jest.spyOn(vectorStore, "search").mockResolvedValueOnce([
+      {
+        id: "owned-memory",
+        score: 0.99,
+        payload: {
+          data: extractedText,
+          hash: createHash("md5").update(extractedText).digest("hex"),
+          userId: "target-user",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ]);
+    const insertSpy = jest.spyOn(vectorStore, "insert");
+
+    try {
+      const result: SearchResult = await scopedMemory.add(
+        "I love Redis-compatible sushi.",
+        { userId: "target-user" },
+      );
+
+      expect(searchSpy).toHaveBeenCalledWith(
+        mockEmbedding,
+        10,
+        expect.objectContaining({ user_id: "target-user" }),
+      );
+      expect(result.results).toHaveLength(0);
+      expect(insertSpy).not.toHaveBeenCalled();
+    } finally {
+      searchSpy.mockRestore();
+      insertSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
 });

--- a/mem0-ts/src/oss/tests/memory.add.test.ts
+++ b/mem0-ts/src/oss/tests/memory.add.test.ts
@@ -161,6 +161,325 @@ describe("Memory - add()", () => {
     );
   });
 
+  test.each([
+    [
+      "wildcard",
+      { user_id: "*" },
+      "Wildcard scope filters [user_id] are not supported in add()",
+    ],
+    [
+      "array shorthand",
+      { user_id: ["target-user", "other-user"] },
+      "Scope filter [user_id] in add() must use explicit equality",
+    ],
+    [
+      "negative operator",
+      { user_id: { ne: "other-user" } },
+      "Scope filter [user_id] in add() must use explicit equality",
+    ],
+    [
+      "nin operator",
+      { user_id: { nin: ["other-user"] } },
+      "Scope filter [user_id] in add() must use explicit equality",
+    ],
+    [
+      "negative logical scope",
+      { user_id: "target-user", NOT: [{ agent_id: "blocked-agent" }] },
+      "Negative scope filters [agent_id] are not supported in add()",
+    ],
+  ])(
+    "rejects broad %s scope filters before inferred existing-memory search",
+    async (_name, filters, message) => {
+      const scopedMemory = createMemory();
+      await (scopedMemory as any)._ensureInitialized();
+
+      const vectorStore = (scopedMemory as any).vectorStore;
+      const searchSpy = jest.spyOn(vectorStore, "search");
+
+      try {
+        await expect(
+          scopedMemory.add("I love carefully scoped sushi.", {
+            filters,
+          } as any),
+        ).rejects.toThrow(message);
+
+        expect(searchSpy).not.toHaveBeenCalled();
+      } finally {
+        searchSpy.mockRestore();
+        await scopedMemory.reset();
+      }
+    },
+  );
+
+  test("stores scope metadata when add scope is supplied via filters", async () => {
+    const scopedMemory = createMemory();
+
+    try {
+      const result: SearchResult = await scopedMemory.add(
+        "I love filter-only sushi.",
+        {
+          filters: { user_id: "target-user" },
+        },
+      );
+
+      expect(result.results).toHaveLength(1);
+      const stored = await scopedMemory.get(result.results[0].id);
+      expect(stored).toEqual(
+        expect.objectContaining({ user_id: "target-user" }),
+      );
+    } finally {
+      await scopedMemory.reset();
+    }
+  });
+
+  test("rejects reserved scope metadata that conflicts with requested add scope", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const insertSpy = jest.spyOn(vectorStore, "insert");
+
+    try {
+      await expect(
+        scopedMemory.add("Direct conflicting scope metadata", {
+          filters: { user_id: "target-user" },
+          metadata: { userId: "other-user", source: "chat" },
+          infer: false,
+        }),
+      ).rejects.toThrow(
+        "Metadata field [userId] conflicts with requested user_id scope in add()",
+      );
+
+      expect(insertSpy).not.toHaveBeenCalled();
+    } finally {
+      insertSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
+  test("rejects metadata with conflicting canonical and alias scope values", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const insertSpy = jest.spyOn(vectorStore, "insert");
+
+    try {
+      await expect(
+        scopedMemory.add("Direct internally conflicting scope metadata", {
+          filters: { user_id: "target-user" },
+          metadata: {
+            user_id: "target-user",
+            userId: "other-user",
+            source: "chat",
+          },
+          infer: false,
+        }),
+      ).rejects.toThrow(
+        "Metadata field [userId] conflicts with requested user_id scope in add()",
+      );
+
+      expect(insertSpy).not.toHaveBeenCalled();
+    } finally {
+      insertSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
+  test("stores authoritative canonical scope when metadata repeats the same scope", async () => {
+    const scopedMemory = createMemory();
+
+    try {
+      const result: SearchResult = await scopedMemory.add(
+        "Direct matching scope metadata",
+        {
+          filters: { user_id: "target-user" },
+          metadata: { userId: "target-user", source: "chat" },
+          infer: false,
+        },
+      );
+
+      const stored = await scopedMemory.get(result.results[0].id);
+      expect(stored).toEqual(
+        expect.objectContaining({
+          user_id: "target-user",
+          metadata: { source: "chat" },
+        }),
+      );
+      expect(stored!.metadata).not.toHaveProperty("userId");
+      expect(stored!.metadata).not.toHaveProperty("user_id");
+    } finally {
+      await scopedMemory.reset();
+    }
+  });
+
+  test.each([
+    ["wildcard", { user_id: "*" }],
+    ["ne", { user_id: { ne: "other-user" } }],
+    ["in", { user_id: { in: ["target-user"] } }],
+    ["range", { user_id: { gt: "other-user" } }],
+    ["conflicting alias", { user_id: "target-user", userId: "other-user" }],
+  ])(
+    "rejects top-level scope with malformed same-key %s filter before add search",
+    async (_name, filters) => {
+      const scopedMemory = createMemory();
+      await (scopedMemory as any)._ensureInitialized();
+
+      const vectorStore = (scopedMemory as any).vectorStore;
+      const searchSpy = jest.spyOn(vectorStore, "search");
+
+      try {
+        await expect(
+          scopedMemory.add("I love carefully scoped sushi.", {
+            userId: "target-user",
+            filters,
+          } as any),
+        ).rejects.toThrow(
+          "Conflicting scope filters [user_id] are not supported in add()",
+        );
+
+        expect(searchSpy).not.toHaveBeenCalled();
+      } finally {
+        searchSpy.mockRestore();
+        await scopedMemory.reset();
+      }
+    },
+  );
+
+  test("rejects conflicting top-level and filter scopes before add search", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const searchSpy = jest.spyOn(vectorStore, "search");
+
+    try {
+      await expect(
+        scopedMemory.add("I love carefully scoped sushi.", {
+          userId: "target-user",
+          filters: { user_id: "other-user" },
+        }),
+      ).rejects.toThrow(
+        "Conflicting scope filters [user_id] are not supported in add()",
+      );
+
+      expect(searchSpy).not.toHaveBeenCalled();
+    } finally {
+      searchSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
+  test("rejects overly complex scope filters before add search", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const searchSpy = jest.spyOn(vectorStore, "search");
+    let nested: Record<string, any> = { topic: "travel" };
+    for (let i = 0; i < 40; i += 1) {
+      nested = { AND: [nested] };
+    }
+
+    try {
+      await expect(
+        scopedMemory.add("I love carefully scoped sushi.", {
+          filters: { user_id: "target-user", AND: [nested] },
+        }),
+      ).rejects.toThrow("Scope filter is too complex to safely evaluate");
+
+      expect(searchSpy).not.toHaveBeenCalled();
+    } finally {
+      searchSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
+  test("rejects malformed logical filters before add search", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const searchSpy = jest.spyOn(vectorStore, "search");
+    const insertSpy = jest.spyOn(vectorStore, "insert");
+
+    try {
+      await expect(
+        scopedMemory.add("I love carefully scoped sushi.", {
+          filters: {
+            user_id: "target-user",
+            NOT: { topic: "secret" },
+          } as any,
+        }),
+      ).rejects.toThrow("NOT operator requires a non-empty list of conditions");
+
+      expect(searchSpy).not.toHaveBeenCalled();
+      expect(insertSpy).not.toHaveBeenCalled();
+    } finally {
+      searchSpy.mockRestore();
+      insertSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
+  test("uses canonical scope internally when add scope is supplied via camelCase filters", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const entityStore = {
+      list: jest.fn().mockResolvedValue([[], 0]),
+      search: jest.fn().mockResolvedValue([]),
+      insert: jest.fn().mockResolvedValue(undefined),
+      update: jest.fn().mockResolvedValue(undefined),
+      initialize: jest.fn().mockResolvedValue(undefined),
+    };
+    (scopedMemory as any)._entityStore = entityStore;
+
+    const db = (scopedMemory as any).db;
+    const getLastMessagesSpy = jest
+      .spyOn(db, "getLastMessages")
+      .mockResolvedValue([]);
+
+    try {
+      const result: SearchResult = await scopedMemory.add(
+        'Alice Liddell discussed "Project Hailstorm" with Bob Stone.',
+        {
+          filters: { userId: "target-user" },
+        },
+      );
+
+      expect(result.results).toHaveLength(1);
+      expect(getLastMessagesSpy).toHaveBeenCalledWith(
+        "user_id=target-user",
+        10,
+      );
+
+      const stored = await scopedMemory.get(result.results[0].id);
+      expect(stored).toEqual(
+        expect.objectContaining({ user_id: "target-user" }),
+      );
+
+      expect(entityStore.list).toHaveBeenCalledWith(
+        { user_id: "target-user" },
+        10000,
+      );
+      expect(entityStore.search).toHaveBeenCalledWith(expect.any(Array), 1, {
+        user_id: "target-user",
+      });
+      expect(entityStore.insert).toHaveBeenCalled();
+      const lastInsertCall =
+        entityStore.insert.mock.calls[entityStore.insert.mock.calls.length - 1];
+      const payloads = lastInsertCall[2] as Array<Record<string, any>>;
+      expect(payloads.length).toBeGreaterThan(0);
+      for (const payload of payloads) {
+        expect(payload.user_id).toBe("target-user");
+      }
+    } finally {
+      getLastMessagesSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
   test("passes metadata through to stored memory", async () => {
     const result: SearchResult = await memory.add("I love TypeScript", {
       userId,
@@ -233,6 +552,291 @@ describe("Memory - add()", () => {
     }
   });
 
+  test("fails closed when inferred dedupe search cannot prove scoped completeness", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const foreignRows = Array.from({ length: 60 }, (_, index) => ({
+      id: `foreign-memory-${index}`,
+      score: 1 - index / 1000,
+      payload: {
+        data: `foreign duplicate candidate ${index}`,
+        hash: createHash("md5")
+          .update(`foreign duplicate candidate ${index}`)
+          .digest("hex"),
+        user_id: "other-user",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    }));
+    const searchSpy = jest
+      .spyOn(vectorStore, "search")
+      .mockResolvedValueOnce(foreignRows)
+      .mockResolvedValueOnce([]);
+    const insertSpy = jest.spyOn(vectorStore, "insert");
+
+    try {
+      await expect(
+        scopedMemory.add("I love carefully scoped sushi.", {
+          userId: "target-user",
+        }),
+      ).rejects.toThrow(
+        "add cannot safely infer scoped memories for vector store provider 'memory'",
+      );
+
+      expect(searchSpy).toHaveBeenCalledWith(
+        mockEmbedding,
+        60,
+        expect.objectContaining({ user_id: "target-user" }),
+      );
+      expect(insertSpy).not.toHaveBeenCalled();
+    } finally {
+      searchSpy.mockRestore();
+      insertSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
+  test("fails closed when a capped provider returns its maximum search page during inferred dedupe", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    (scopedMemory as any).config.vectorStore.provider = "vectorize";
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const foreignRows = Array.from({ length: 50 }, (_, index) => ({
+      id: `foreign-memory-${index}`,
+      score: 1 - index / 1000,
+      payload: {
+        data: `foreign duplicate candidate ${index}`,
+        hash: createHash("md5")
+          .update(`foreign duplicate candidate ${index}`)
+          .digest("hex"),
+        user_id: "other-user",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    }));
+    const searchSpy = jest
+      .spyOn(vectorStore, "search")
+      .mockResolvedValueOnce(foreignRows);
+    const insertSpy = jest.spyOn(vectorStore, "insert");
+
+    try {
+      await expect(
+        scopedMemory.add("I love carefully scoped sushi.", {
+          userId: "target-user",
+        }),
+      ).rejects.toThrow(
+        "add cannot safely infer scoped memories for vector store provider 'vectorize'",
+      );
+
+      expect(searchSpy).toHaveBeenNthCalledWith(
+        1,
+        mockEmbedding,
+        50,
+        expect.objectContaining({ user_id: "target-user" }),
+      );
+      expect(searchSpy).toHaveBeenNthCalledWith(
+        2,
+        mockEmbedding,
+        50,
+        expect.objectContaining({ userId: "target-user" }),
+      );
+      expect(insertSpy).not.toHaveBeenCalled();
+    } finally {
+      searchSpy.mockRestore();
+      insertSpy.mockRestore();
+      (scopedMemory as any).config.vectorStore.provider = "memory";
+      await scopedMemory.reset();
+    }
+  });
+
+  test("keeps inferred dedupe prompt context capped after scoped over-fetching", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const rows = Array.from({ length: 12 }, (_, index) => ({
+      id: `owned-memory-${index}`,
+      score: 1 - index / 1000,
+      payload: {
+        data: `existing scoped memory ${index}`,
+        hash: createHash("md5")
+          .update(`existing scoped memory ${index}`)
+          .digest("hex"),
+        user_id: "target-user",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    }));
+    const searchSpy = jest
+      .spyOn(vectorStore, "search")
+      .mockResolvedValueOnce(rows);
+    const llmGenerateSpy = jest.spyOn(
+      (scopedMemory as any).llm,
+      "generateResponse",
+    );
+
+    try {
+      await scopedMemory.add("I love carefully scoped sushi.", {
+        userId: "target-user",
+      });
+
+      const llmMessages = llmGenerateSpy.mock.calls[0][0] as Array<{
+        role: string;
+        content: string;
+      }>;
+      const userPrompt = llmMessages.find(
+        (message) => message.role === "user",
+      )?.content;
+
+      expect(userPrompt).toContain("existing scoped memory 9");
+      expect(userPrompt).not.toContain("existing scoped memory 10");
+      expect(userPrompt).not.toContain("existing scoped memory 11");
+    } finally {
+      searchSpy.mockRestore();
+      llmGenerateSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
+  test("keeps logical metadata filtering in inferred context for simple providers", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    (scopedMemory as any).config.vectorStore.provider = "redis";
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const rows = [
+      {
+        id: "wrong-topic-memory",
+        score: 0.99,
+        payload: {
+          data: "same user wrong topic",
+          hash: createHash("md5").update("same user wrong topic").digest("hex"),
+          userId: "target-user",
+          topic: "food",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "topic-match-memory",
+        score: 0.98,
+        payload: {
+          data: "same user travel memory",
+          hash: createHash("md5")
+            .update("same user travel memory")
+            .digest("hex"),
+          userId: "target-user",
+          topic: "travel",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ];
+    const searchSpy = jest
+      .spyOn(vectorStore, "search")
+      .mockResolvedValueOnce(rows);
+    const llmGenerateSpy = jest.spyOn(
+      (scopedMemory as any).llm,
+      "generateResponse",
+    );
+
+    try {
+      await scopedMemory.add("I love carefully scoped sushi.", {
+        userId: "target-user",
+        filters: { OR: [{ topic: "travel" }, { agent_id: "agent-a" }] },
+      });
+
+      expect(searchSpy).toHaveBeenCalledWith(mockEmbedding, 60, {
+        user_id: "target-user",
+      });
+
+      const llmMessages = llmGenerateSpy.mock.calls[0][0] as Array<{
+        role: string;
+        content: string;
+      }>;
+      const userPrompt = llmMessages.find(
+        (message) => message.role === "user",
+      )?.content;
+
+      expect(userPrompt).toContain("same user travel memory");
+      expect(userPrompt).not.toContain("same user wrong topic");
+    } finally {
+      searchSpy.mockRestore();
+      llmGenerateSpy.mockRestore();
+      (scopedMemory as any).config.vectorStore.provider = "memory";
+      await scopedMemory.reset();
+    }
+  });
+
+  test("keeps advanced metadata filtering in inferred context for simple providers", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    (scopedMemory as any).config.vectorStore.provider = "redis";
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const rows = [
+      {
+        id: "wrong-topic-memory",
+        score: 0.99,
+        payload: {
+          data: "same user wrong topic",
+          hash: createHash("md5").update("same user wrong topic").digest("hex"),
+          userId: "target-user",
+          topic: "food",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "topic-match-memory",
+        score: 0.98,
+        payload: {
+          data: "same user travel memory",
+          hash: createHash("md5")
+            .update("same user travel memory")
+            .digest("hex"),
+          userId: "target-user",
+          topic: "travel plans",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ];
+    const searchSpy = jest
+      .spyOn(vectorStore, "search")
+      .mockResolvedValueOnce(rows);
+    const llmGenerateSpy = jest.spyOn(
+      (scopedMemory as any).llm,
+      "generateResponse",
+    );
+
+    try {
+      await scopedMemory.add("I love carefully scoped sushi.", {
+        userId: "target-user",
+        filters: { topic: { contains: "travel" } },
+      });
+
+      expect(searchSpy).toHaveBeenCalledWith(mockEmbedding, 60, {
+        user_id: "target-user",
+      });
+
+      const llmMessages = llmGenerateSpy.mock.calls[0][0] as Array<{
+        role: string;
+        content: string;
+      }>;
+      const userPrompt = llmMessages.find(
+        (message) => message.role === "user",
+      )?.content;
+
+      expect(userPrompt).toContain("same user travel memory");
+      expect(userPrompt).not.toContain("same user wrong topic");
+    } finally {
+      searchSpy.mockRestore();
+      llmGenerateSpy.mockRestore();
+      (scopedMemory as any).config.vectorStore.provider = "memory";
+      await scopedMemory.reset();
+    }
+  });
+
   test("uses camelCase scoped existing search results when deduplicating inferred memories", async () => {
     const scopedMemory = createMemory();
     await (scopedMemory as any)._ensureInitialized();
@@ -273,6 +877,59 @@ describe("Memory - add()", () => {
     }
   });
 
+  test("uses Vectorize legacy alias scoped results when deduplicating inferred memories", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    (scopedMemory as any).config.vectorStore.provider = "vectorize";
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const extractedText = "user: I love Vectorize-compatible sushi.";
+    const searchSpy = jest
+      .spyOn(vectorStore, "search")
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          id: "legacy-owned-memory",
+          score: 0.99,
+          payload: {
+            data: extractedText,
+            hash: createHash("md5").update(extractedText).digest("hex"),
+            userId: "target-user",
+            createdAt: "2026-01-01T00:00:00.000Z",
+          },
+        },
+      ]);
+    const insertSpy = jest.spyOn(vectorStore, "insert");
+
+    try {
+      const result: SearchResult = await scopedMemory.add(
+        "I love Vectorize-compatible sushi.",
+        { userId: "target-user" },
+      );
+
+      expect(searchSpy).toHaveBeenNthCalledWith(
+        1,
+        mockEmbedding,
+        50,
+        expect.objectContaining({ user_id: "target-user" }),
+      );
+      expect(searchSpy).toHaveBeenNthCalledWith(
+        2,
+        mockEmbedding,
+        50,
+        expect.objectContaining({ userId: "target-user" }),
+      );
+      expect(result.results).toHaveLength(0);
+      expect(insertSpy).not.toHaveBeenCalled();
+    } finally {
+      searchSpy.mockRestore();
+      insertSpy.mockRestore();
+      (scopedMemory as any).config.vectorStore.provider = "memory";
+      await scopedMemory.reset();
+    }
+  });
+
   test("prefers canonical scope over conflicting camelCase aliases during dedupe", async () => {
     const scopedMemory = createMemory();
     await (scopedMemory as any)._ensureInitialized();
@@ -308,6 +965,30 @@ describe("Memory - add()", () => {
       expect(result.results).toHaveLength(1);
       expect(result.results[0].memory).toBe(extractedText);
       expect(insertSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      searchSpy.mockRestore();
+      insertSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
+  test("rejects conflicting add scope aliases before persistence", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const searchSpy = jest.spyOn(vectorStore, "search");
+    const insertSpy = jest.spyOn(vectorStore, "insert");
+
+    try {
+      await expect(
+        scopedMemory.add("I love conflicting sushi.", {
+          filters: { user_id: "canonical-user", userId: "alias-user" },
+        }),
+      ).rejects.toThrow("Conflicting scope filters [user_id]");
+
+      expect(searchSpy).not.toHaveBeenCalled();
+      expect(insertSpy).not.toHaveBeenCalled();
     } finally {
       searchSpy.mockRestore();
       insertSpy.mockRestore();

--- a/mem0-ts/src/oss/tests/memory.add.test.ts
+++ b/mem0-ts/src/oss/tests/memory.add.test.ts
@@ -272,4 +272,46 @@ describe("Memory - add()", () => {
       await scopedMemory.reset();
     }
   });
+
+  test("prefers canonical scope over conflicting camelCase aliases during dedupe", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const extractedText = "user: I love canonical sushi.";
+    const searchSpy = jest.spyOn(vectorStore, "search").mockResolvedValueOnce([
+      {
+        id: "conflicting-memory",
+        score: 0.99,
+        payload: {
+          data: extractedText,
+          hash: createHash("md5").update(extractedText).digest("hex"),
+          user_id: "other-user",
+          userId: "target-user",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ]);
+    const insertSpy = jest.spyOn(vectorStore, "insert");
+
+    try {
+      const result: SearchResult = await scopedMemory.add(
+        "I love canonical sushi.",
+        { userId: "target-user" },
+      );
+
+      expect(searchSpy).toHaveBeenCalledWith(
+        mockEmbedding,
+        10,
+        expect.objectContaining({ user_id: "target-user" }),
+      );
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].memory).toBe(extractedText);
+      expect(insertSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      searchSpy.mockRestore();
+      insertSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
 });

--- a/mem0-ts/src/oss/tests/memory.add.test.ts
+++ b/mem0-ts/src/oss/tests/memory.add.test.ts
@@ -5,6 +5,7 @@
 /// <reference types="jest" />
 import { Memory } from "../src/memory";
 import type { MemoryConfig, MemoryItem, SearchResult } from "../src/types";
+import { createHash } from "crypto";
 
 jest.setTimeout(15000);
 
@@ -190,5 +191,45 @@ describe("Memory - add()", () => {
     expect(result.results[0].metadata).toEqual(
       expect.objectContaining({ event: "ADD" }),
     );
+  });
+
+  test("ignores wrong-scope existing search results when deduplicating inferred memories", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const extractedText = "user: I love carefully scoped sushi.";
+    const searchSpy = jest.spyOn(vectorStore, "search").mockResolvedValueOnce([
+      {
+        id: "foreign-memory",
+        score: 0.99,
+        payload: {
+          data: extractedText,
+          hash: createHash("md5").update(extractedText).digest("hex"),
+          user_id: "other-user",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ]);
+
+    try {
+      const result: SearchResult = await scopedMemory.add(
+        "I love carefully scoped sushi.",
+        { userId: "target-user" },
+      );
+
+      expect(searchSpy).toHaveBeenCalledWith(
+        mockEmbedding,
+        10,
+        expect.objectContaining({ user_id: "target-user" }),
+      );
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].memory).toBe(extractedText);
+      const stored = await scopedMemory.get(result.results[0].id);
+      expect((stored as any).user_id).toBe("target-user");
+    } finally {
+      searchSpy.mockRestore();
+      await scopedMemory.reset();
+    }
   });
 });

--- a/mem0-ts/src/oss/tests/memory.add.test.ts
+++ b/mem0-ts/src/oss/tests/memory.add.test.ts
@@ -220,7 +220,7 @@ describe("Memory - add()", () => {
 
       expect(searchSpy).toHaveBeenCalledWith(
         mockEmbedding,
-        10,
+        60,
         expect.objectContaining({ user_id: "target-user" }),
       );
       expect(result.results).toHaveLength(1);
@@ -261,7 +261,7 @@ describe("Memory - add()", () => {
 
       expect(searchSpy).toHaveBeenCalledWith(
         mockEmbedding,
-        10,
+        60,
         expect.objectContaining({ user_id: "target-user" }),
       );
       expect(result.results).toHaveLength(0);
@@ -302,7 +302,7 @@ describe("Memory - add()", () => {
 
       expect(searchSpy).toHaveBeenCalledWith(
         mockEmbedding,
-        10,
+        60,
         expect.objectContaining({ user_id: "target-user" }),
       );
       expect(result.results).toHaveLength(1);

--- a/mem0-ts/src/oss/tests/memory.crud.test.ts
+++ b/mem0-ts/src/oss/tests/memory.crud.test.ts
@@ -329,6 +329,28 @@ describe("Memory - provider scope filters", () => {
     });
   });
 
+  test("strips logical filters for providers without logical filter support", () => {
+    expect(
+      providerFiltersFor("redis", {
+        user_id: "target-user",
+        $and: [{ topic: "travel" }, { agent_id: "agent-a" }],
+        source: "import",
+      }),
+    ).toEqual({
+      user_id: "target-user",
+      source: "import",
+    });
+
+    expect(
+      providerFiltersFor("azure_ai_search", {
+        user_id: "target-user",
+        $or: [{ topic: "travel" }, { topic: "food" }],
+      }),
+    ).toEqual({
+      user_id: "target-user",
+    });
+  });
+
   test("passes widened provider scope filters through public getAll calls", async () => {
     const scopedMemory = createMemory();
     await (scopedMemory as any)._ensureInitialized();
@@ -617,26 +639,93 @@ describe("Memory - getAll()", () => {
     }
   });
 
-  test("keeps non-null scoped rows for wildcard filters", async () => {
+  test.each([
+    ["user_id", { user_id: "*" }],
+    ["agent_id", { agent_id: "*" }],
+    ["run_id", { run_id: "*" }],
+    [
+      "agent_id",
+      { user_id: "target-user", OR: [{ agent_id: "*" }, { topic: "travel" }] },
+    ],
+  ])("rejects wildcard %s scope filters for getAll", async (key, filters) => {
     const scopedMemory = createMemory();
     await (scopedMemory as any)._ensureInitialized();
 
     const vectorStore = (scopedMemory as any).vectorStore;
+    const listSpy = jest.spyOn(vectorStore, "list");
+
+    try {
+      await expect(
+        scopedMemory.getAll({
+          filters,
+          topK: 5,
+        }),
+      ).rejects.toThrow(
+        `Wildcard scope filters [${key}] are not supported in getAll()`,
+      );
+
+      expect(listSpy).not.toHaveBeenCalled();
+    } finally {
+      listSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
+  test("fails closed when cursorless list provider returns a full page before topK is satisfied", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    (scopedMemory as any).config.vectorStore.provider = "qdrant";
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const fullForeignPage = Array.from({ length: 60 }, (_, index) => ({
+      id: `foreign-memory-${index}`,
+      payload: {
+        data: `wrong user memory ${index}`,
+        hash: `foreign-hash-${index}`,
+        userId: "other-user",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    }));
+    const listSpy = jest
+      .spyOn(vectorStore, "list")
+      .mockResolvedValueOnce([fullForeignPage, fullForeignPage.length]);
+
+    try {
+      await expect(
+        scopedMemory.getAll({
+          filters: { user_id: "target-user" },
+          topK: 1,
+        }),
+      ).rejects.toThrow(
+        "getAll cannot safely return all requested scoped memories for vector store provider 'qdrant'",
+      );
+
+      expect(listSpy).toHaveBeenCalledWith(
+        { $or: [{ user_id: "target-user" }, { userId: "target-user" }] },
+        60,
+      );
+    } finally {
+      listSpy.mockRestore();
+      (scopedMemory as any).config.vectorStore.provider = "memory";
+      await scopedMemory.reset();
+    }
+  });
+
+  test("returns scoped results from cursorless providers when the page is not full", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    (scopedMemory as any).config.vectorStore.provider = "qdrant";
+
+    const vectorStore = (scopedMemory as any).vectorStore;
     const rows = [
       {
-        id: "user-scoped-memory",
+        id: "owned-memory",
         payload: {
-          data: "user scoped memory",
-          hash: "user-scoped-hash",
-          userId: "any-user",
-          createdAt: "2026-01-01T00:00:00.000Z",
-        },
-      },
-      {
-        id: "unscoped-memory",
-        payload: {
-          data: "missing user scope",
-          hash: "unscoped-hash",
+          data: "target user memory",
+          hash: "owned-hash",
+          userId: "target-user",
           createdAt: "2026-01-01T00:00:00.000Z",
         },
       },
@@ -647,20 +736,17 @@ describe("Memory - getAll()", () => {
 
     try {
       const result: SearchResult = await scopedMemory.getAll({
-        filters: { user_id: "*" },
+        filters: { user_id: "target-user" },
         topK: 5,
       });
 
-      expect(listSpy).toHaveBeenCalledWith(undefined, 60);
-      expect(result.results.map((item) => item.id)).toEqual([
-        "user-scoped-memory",
-      ]);
+      expect(result.results.map((item) => item.id)).toEqual(["owned-memory"]);
       expect(result.results[0]).toEqual(
-        expect.objectContaining({ user_id: "any-user" }),
+        expect.objectContaining({ user_id: "target-user" }),
       );
-      expect(result.results[0].metadata).not.toHaveProperty("userId");
     } finally {
       listSpy.mockRestore();
+      (scopedMemory as any).config.vectorStore.provider = "memory";
       await scopedMemory.reset();
     }
   });
@@ -1693,59 +1779,37 @@ describe("Memory - search()", () => {
     }
   });
 
-  test("keeps wildcard scope filtering in Memory instead of provider filters", async () => {
+  test.each([
+    ["user_id", { user_id: "*" }],
+    ["agent_id", { agent_id: "*" }],
+    ["run_id", { run_id: "*" }],
+    [
+      "agent_id",
+      { user_id: "target-user", OR: [{ agent_id: "*" }, { topic: "travel" }] },
+    ],
+  ])("rejects wildcard %s scope filters for search", async (key, filters) => {
     const scopedMemory = createMemory();
     await (scopedMemory as any)._ensureInitialized();
 
     const vectorStore = (scopedMemory as any).vectorStore;
-    const searchSpy = jest.spyOn(vectorStore, "search").mockResolvedValueOnce([
-      {
-        id: "user-scoped-memory",
-        score: 0.98,
-        payload: {
-          data: "target wildcard memory",
-          hash: "user-scoped-hash",
-          userId: "any-user",
-          createdAt: "2026-01-01T00:00:00.000Z",
-        },
-      },
-      {
-        id: "unscoped-memory",
-        score: 0.97,
-        payload: {
-          data: "target missing scope",
-          hash: "unscoped-hash",
-          createdAt: "2026-01-01T00:00:00.000Z",
-        },
-      },
-    ]);
+    const searchSpy = jest.spyOn(vectorStore, "search");
     const keywordSpy = jest
       .spyOn(vectorStore, "keywordSearch")
       .mockResolvedValueOnce(null);
 
     try {
-      const result: SearchResult = await scopedMemory.search("target", {
-        filters: { user_id: "*" },
-        threshold: 0,
-        topK: 5,
-      });
+      await expect(
+        scopedMemory.search("target", {
+          filters,
+          threshold: 0,
+          topK: 5,
+        }),
+      ).rejects.toThrow(
+        `Wildcard scope filters [${key}] are not supported in search()`,
+      );
 
-      expect(searchSpy).toHaveBeenCalledWith(
-        mockEmbedding,
-        expect.any(Number),
-        undefined,
-      );
-      expect(keywordSpy).toHaveBeenCalledWith(
-        "target",
-        expect.any(Number),
-        undefined,
-      );
-      expect(result.results.map((item) => item.id)).toEqual([
-        "user-scoped-memory",
-      ]);
-      expect(result.results[0]).toEqual(
-        expect.objectContaining({ user_id: "any-user" }),
-      );
+      expect(searchSpy).not.toHaveBeenCalled();
+      expect(keywordSpy).not.toHaveBeenCalled();
     } finally {
       searchSpy.mockRestore();
       keywordSpy.mockRestore();
@@ -2062,6 +2126,52 @@ describe("Memory - deleteAll() scope hardening", () => {
       listSpy.mockRestore();
       deleteSpy.mockRestore();
       entityCleanupSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
+  test("does not fail closed when an exact-count provider proves a full page is complete", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    (scopedMemory as any).config.vectorStore.provider = "pgvector";
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const fullForeignPage = Array.from({ length: 10000 }, (_, index) => ({
+      id: `foreign-memory-${index}`,
+      payload: {
+        data: `wrong user memory ${index}`,
+        hash: `foreign-hash-${index}`,
+        userId: "other-user",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    }));
+
+    const listSpy = jest
+      .spyOn(vectorStore, "list")
+      .mockResolvedValueOnce([fullForeignPage, fullForeignPage.length]);
+    const deleteSpy = jest
+      .spyOn(vectorStore, "delete")
+      .mockResolvedValue(undefined);
+    const entityCleanupSpy = jest
+      .spyOn(scopedMemory as any, "_removeMemoryFromEntityStore")
+      .mockResolvedValue(undefined);
+
+    try {
+      const result = await scopedMemory.deleteAll({ userId: "target-user" });
+
+      expect(result.message).toBe("Memories deleted successfully!");
+      expect(listSpy).toHaveBeenCalledWith(
+        { $or: [{ user_id: "target-user" }, { userId: "target-user" }] },
+        10000,
+      );
+      expect(deleteSpy).not.toHaveBeenCalled();
+      expect(entityCleanupSpy).not.toHaveBeenCalled();
+    } finally {
+      listSpy.mockRestore();
+      deleteSpy.mockRestore();
+      entityCleanupSpy.mockRestore();
+      (scopedMemory as any).config.vectorStore.provider = "memory";
       await scopedMemory.reset();
     }
   });

--- a/mem0-ts/src/oss/tests/memory.crud.test.ts
+++ b/mem0-ts/src/oss/tests/memory.crud.test.ts
@@ -1249,7 +1249,7 @@ describe("Memory - search()", () => {
       expect(searchSpy).toHaveBeenCalledWith(
         mockEmbedding,
         expect.any(Number),
-        { user_id: "target-user", agent_id: "agent-a" },
+        { user_id: "target-user", $and: [{ agent_id: "agent-a" }] },
       );
       expect(result.results.map((item) => item.id)).toEqual(["owned-memory"]);
       expect(result.results[0]).toEqual(
@@ -1468,14 +1468,147 @@ describe("Memory - search()", () => {
         {
           user_id: "target-user",
           $or: [
-            { agent_id: "agent-a", priority: { gte: 10 } },
-            { agent_id: "agent-b", $not: [{ topic: "secret" }] },
+            {
+              $and: [{ agent_id: "agent-a" }, { priority: { gte: 10 } }],
+            },
+            {
+              $and: [{ agent_id: "agent-b" }, { $not: [{ topic: "secret" }] }],
+            },
           ],
         },
       );
       expect(result.results.map((item) => item.id)).toEqual([
         "priority-memory",
         "allowed-topic-memory",
+      ]);
+    } finally {
+      searchSpy.mockRestore();
+      keywordSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
+  test("preserves conflicting top-level and AND scope filters in post-filtering", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const searchSpy = jest.spyOn(vectorStore, "search").mockResolvedValueOnce([
+      {
+        id: "trusted-scope-memory",
+        score: 0.99,
+        payload: {
+          data: "trusted scope memory",
+          hash: "trusted-scope-hash",
+          userId: "trusted-user",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "conflicting-and-memory",
+        score: 0.98,
+        payload: {
+          data: "conflicting AND scope memory",
+          hash: "conflicting-and-hash",
+          userId: "other-user",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ]);
+    const keywordSpy = jest
+      .spyOn(vectorStore, "keywordSearch")
+      .mockResolvedValueOnce(null);
+
+    try {
+      const result: SearchResult = await scopedMemory.search("target", {
+        filters: {
+          user_id: "trusted-user",
+          AND: [{ user_id: "other-user" }],
+        },
+        threshold: 0,
+        topK: 5,
+      });
+
+      expect(searchSpy).toHaveBeenCalledWith(
+        mockEmbedding,
+        expect.any(Number),
+        { user_id: "trusted-user", $and: [{ user_id: "other-user" }] },
+      );
+      expect(result.results).toEqual([]);
+    } finally {
+      searchSpy.mockRestore();
+      keywordSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
+  test("preserves same-field range conjuncts in post-filtering", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const searchSpy = jest.spyOn(vectorStore, "search").mockResolvedValueOnce([
+      {
+        id: "before-range-memory",
+        score: 0.99,
+        payload: {
+          data: "target before range",
+          hash: "before-range-hash",
+          userId: "target-user",
+          createdAt: "2024-12-31T00:00:00.000Z",
+        },
+      },
+      {
+        id: "in-range-memory",
+        score: 0.98,
+        payload: {
+          data: "target in range",
+          hash: "in-range-hash",
+          userId: "target-user",
+          createdAt: "2025-03-15T00:00:00.000Z",
+        },
+      },
+      {
+        id: "after-range-memory",
+        score: 0.97,
+        payload: {
+          data: "target after range",
+          hash: "after-range-hash",
+          userId: "target-user",
+          createdAt: "2025-12-01T00:00:00.000Z",
+        },
+      },
+    ]);
+    const keywordSpy = jest
+      .spyOn(vectorStore, "keywordSearch")
+      .mockResolvedValueOnce(null);
+
+    try {
+      const result: SearchResult = await scopedMemory.search("target", {
+        filters: {
+          user_id: "target-user",
+          AND: [
+            { createdAt: { gte: "2025-01-01T00:00:00.000Z" } },
+            { createdAt: { lte: "2025-06-30T23:59:59.999Z" } },
+          ],
+        },
+        threshold: 0,
+        topK: 5,
+      });
+
+      expect(searchSpy).toHaveBeenCalledWith(
+        mockEmbedding,
+        expect.any(Number),
+        {
+          user_id: "target-user",
+          $and: [
+            { createdAt: { gte: "2025-01-01T00:00:00.000Z" } },
+            { createdAt: { lte: "2025-06-30T23:59:59.999Z" } },
+          ],
+        },
+      );
+      expect(result.results.map((item) => item.id)).toEqual([
+        "in-range-memory",
       ]);
     } finally {
       searchSpy.mockRestore();
@@ -1830,44 +1963,32 @@ describe("Memory - deleteAll() scope hardening", () => {
     }
   });
 
-  test("refetches before bulk delete when provider count exceeds the first batch", async () => {
+  test("keeps bulk delete fetches bounded when provider count exceeds the first batch", async () => {
     const scopedMemory = createMemory();
     await (scopedMemory as any)._ensureInitialized();
 
     const vectorStore = (scopedMemory as any).vectorStore;
-    const firstPage = [
-      {
-        id: "foreign-memory",
-        payload: {
-          data: "wrong user memory",
-          hash: "foreign-hash",
-          userId: "other-user",
-          createdAt: "2026-01-01T00:00:00.000Z",
-        },
+    const firstPage = Array.from({ length: 10000 }, (_, index) => ({
+      id: index === 9999 ? "owned-memory" : `foreign-memory-${index}`,
+      payload: {
+        data:
+          index === 9999 ? "target user memory" : `wrong user memory ${index}`,
+        hash: index === 9999 ? "owned-hash" : `foreign-hash-${index}`,
+        userId: index === 9999 ? "target-user" : "other-user",
+        createdAt: "2026-01-01T00:00:00.000Z",
       },
-    ];
-    const secondPage = [
-      ...firstPage,
-      {
-        id: "owned-memory",
-        payload: {
-          data: "target user memory",
-          hash: "owned-hash",
-          userId: "target-user",
-          createdAt: "2026-01-01T00:00:00.000Z",
-        },
-      },
-    ];
+    }));
+    const secondPage: typeof firstPage = [];
 
     const listSpy = jest
       .spyOn(vectorStore, "list")
       .mockResolvedValueOnce([firstPage, 10001])
-      .mockResolvedValueOnce([secondPage, 10001]);
+      .mockResolvedValueOnce([secondPage, 0]);
     const getSpy = jest
       .spyOn(vectorStore, "get")
       .mockImplementation(async (...args: unknown[]) => {
         const id = String(args[0]);
-        const row = secondPage.find((item) => item.id === id);
+        const row = firstPage.find((item) => item.id === id);
         return row ?? null;
       });
     const deleteSpy = jest
@@ -1889,13 +2010,56 @@ describe("Memory - deleteAll() scope hardening", () => {
       expect(listSpy).toHaveBeenNthCalledWith(
         2,
         { user_id: "target-user" },
-        10001,
+        10000,
       );
       expect(deleteSpy).toHaveBeenCalledTimes(1);
       expect(deleteSpy).toHaveBeenCalledWith("owned-memory");
     } finally {
       listSpy.mockRestore();
       getSpy.mockRestore();
+      deleteSpy.mockRestore();
+      entityCleanupSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
+  test("fails closed when scoped rows may be hidden behind a full provider page", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const fullForeignPage = Array.from({ length: 10000 }, (_, index) => ({
+      id: `foreign-memory-${index}`,
+      payload: {
+        data: `wrong user memory ${index}`,
+        hash: `foreign-hash-${index}`,
+        userId: "other-user",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    }));
+
+    const listSpy = jest
+      .spyOn(vectorStore, "list")
+      .mockResolvedValueOnce([fullForeignPage, 10001]);
+    const deleteSpy = jest
+      .spyOn(vectorStore, "delete")
+      .mockResolvedValue(undefined);
+    const entityCleanupSpy = jest
+      .spyOn(scopedMemory as any, "_removeMemoryFromEntityStore")
+      .mockResolvedValue(undefined);
+
+    try {
+      await expect(
+        scopedMemory.deleteAll({ userId: "target-user" }),
+      ).rejects.toThrow(
+        "scoped rows may be hidden behind a full provider page",
+      );
+
+      expect(listSpy).toHaveBeenCalledWith({ user_id: "target-user" }, 10000);
+      expect(deleteSpy).not.toHaveBeenCalled();
+      expect(entityCleanupSpy).not.toHaveBeenCalled();
+    } finally {
+      listSpy.mockRestore();
       deleteSpy.mockRestore();
       entityCleanupSpy.mockRestore();
       await scopedMemory.reset();

--- a/mem0-ts/src/oss/tests/memory.crud.test.ts
+++ b/mem0-ts/src/oss/tests/memory.crud.test.ts
@@ -127,6 +127,47 @@ describe("Memory - get()", () => {
     expect(item!.createdAt).toBeDefined();
     expect(new Date(item!.createdAt!).toString()).not.toBe("Invalid Date");
   });
+
+  test("normalizes camelCase scope payloads without leaking aliases into metadata", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const getSpy = jest.spyOn(vectorStore, "get").mockResolvedValueOnce({
+      id: "redis-shaped-memory",
+      payload: {
+        data: "redis shaped memory",
+        hash: "redis-hash",
+        userId: "target-user",
+        agentId: "agent-a",
+        runId: "run-a",
+        source: "redis",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    });
+
+    try {
+      const item = await scopedMemory.get("redis-shaped-memory");
+
+      expect(getSpy).toHaveBeenCalledWith("redis-shaped-memory");
+      expect(item).toEqual(
+        expect.objectContaining({
+          id: "redis-shaped-memory",
+          memory: "redis shaped memory",
+          user_id: "target-user",
+          agent_id: "agent-a",
+          run_id: "run-a",
+        }),
+      );
+      expect(item!.metadata).toEqual({ source: "redis" });
+      expect(item!.metadata).not.toHaveProperty("userId");
+      expect(item!.metadata).not.toHaveProperty("agentId");
+      expect(item!.metadata).not.toHaveProperty("runId");
+    } finally {
+      getSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
 });
 
 // ─── update() ────────────────────────────────────────────
@@ -354,6 +395,14 @@ describe("Memory - getAll()", () => {
       expect(listSpy).toHaveBeenCalledWith({ user_id: "target-user" }, 5);
       expect(result.results.map((item) => item.id)).toEqual(["owned-memory"]);
       expect(result.results[0].memory).toBe("target user memory");
+      expect(result.results[0]).toEqual(
+        expect.objectContaining({
+          user_id: "target-user",
+          agent_id: "agent-extra",
+        }),
+      );
+      expect(result.results[0].metadata).not.toHaveProperty("userId");
+      expect(result.results[0].metadata).not.toHaveProperty("agentId");
     } finally {
       listSpy.mockRestore();
       await scopedMemory.reset();
@@ -398,6 +447,55 @@ describe("Memory - getAll()", () => {
       expect(result.results.map((item) => item.id)).toEqual([
         "user-scoped-memory",
       ]);
+      expect(result.results[0]).toEqual(
+        expect.objectContaining({ user_id: "any-user" }),
+      );
+      expect(result.results[0].metadata).not.toHaveProperty("userId");
+    } finally {
+      listSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
+  test("prefers canonical scope over conflicting camelCase aliases for list results", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const rows = [
+      {
+        id: "conflicting-memory",
+        payload: {
+          data: "conflicting user memory",
+          hash: "conflicting-hash",
+          user_id: "other-user",
+          userId: "target-user",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "owned-memory",
+        payload: {
+          data: "target user memory",
+          hash: "owned-hash",
+          user_id: "target-user",
+          userId: "target-user",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ];
+    const listSpy = jest
+      .spyOn(vectorStore, "list")
+      .mockResolvedValueOnce([rows, rows.length]);
+
+    try {
+      const result: SearchResult = await scopedMemory.getAll({
+        filters: { user_id: "target-user" },
+        topK: 5,
+      });
+
+      expect(listSpy).toHaveBeenCalledWith({ user_id: "target-user" }, 5);
+      expect(result.results.map((item) => item.id)).toEqual(["owned-memory"]);
     } finally {
       listSpy.mockRestore();
       await scopedMemory.reset();
@@ -495,6 +593,14 @@ describe("Memory - search()", () => {
       );
       expect(result.results.map((item) => item.id)).toEqual(["owned-memory"]);
       expect(result.results[0].memory).toBe("target user memory");
+      expect(result.results[0]).toEqual(
+        expect.objectContaining({
+          user_id: "target-user",
+          agent_id: "agent-extra",
+        }),
+      );
+      expect(result.results[0].metadata).not.toHaveProperty("userId");
+      expect(result.results[0].metadata).not.toHaveProperty("agentId");
     } finally {
       searchSpy.mockRestore();
       keywordSpy.mockRestore();
@@ -563,6 +669,59 @@ describe("Memory - search()", () => {
       await scopedMemory.reset();
     }
   });
+
+  test("prefers canonical scope over conflicting camelCase aliases for search results", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const searchSpy = jest.spyOn(vectorStore, "search").mockResolvedValueOnce([
+      {
+        id: "conflicting-memory",
+        score: 0.99,
+        payload: {
+          data: "conflicting user memory",
+          hash: "conflicting-hash",
+          user_id: "other-user",
+          userId: "target-user",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "owned-memory",
+        score: 0.98,
+        payload: {
+          data: "target user memory",
+          hash: "owned-hash",
+          user_id: "target-user",
+          userId: "target-user",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ]);
+    const keywordSpy = jest
+      .spyOn(vectorStore, "keywordSearch")
+      .mockResolvedValueOnce(null);
+
+    try {
+      const result: SearchResult = await scopedMemory.search("target", {
+        filters: { user_id: "target-user" },
+        threshold: 0,
+        topK: 5,
+      });
+
+      expect(searchSpy).toHaveBeenCalledWith(
+        mockEmbedding,
+        expect.any(Number),
+        { user_id: "target-user" },
+      );
+      expect(result.results.map((item) => item.id)).toEqual(["owned-memory"]);
+    } finally {
+      searchSpy.mockRestore();
+      keywordSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
 });
 
 describe("Memory - deleteAll() scope hardening", () => {
@@ -615,6 +774,9 @@ describe("Memory - deleteAll() scope hardening", () => {
       expect(listSpy).toHaveBeenCalledWith({ user_id: "target-user" });
       expect(deleteSpy).toHaveBeenCalledTimes(1);
       expect(deleteSpy).toHaveBeenCalledWith("owned-memory");
+      expect(entityCleanupSpy).toHaveBeenCalledWith("owned-memory", {
+        user_id: "target-user",
+      });
     } finally {
       listSpy.mockRestore();
       getSpy.mockRestore();
@@ -672,6 +834,72 @@ describe("Memory - deleteAll() scope hardening", () => {
       expect(listSpy).toHaveBeenCalledWith({ user_id: "*" });
       expect(deleteSpy).toHaveBeenCalledTimes(1);
       expect(deleteSpy).toHaveBeenCalledWith("user-scoped-memory");
+      expect(entityCleanupSpy).toHaveBeenCalledWith("user-scoped-memory", {
+        user_id: "any-user",
+      });
+    } finally {
+      listSpy.mockRestore();
+      getSpy.mockRestore();
+      deleteSpy.mockRestore();
+      entityCleanupSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
+  test("prefers canonical scope over conflicting camelCase aliases before deleting", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const rows = [
+      {
+        id: "conflicting-memory",
+        payload: {
+          data: "conflicting user memory",
+          hash: "conflicting-hash",
+          user_id: "other-user",
+          userId: "target-user",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "owned-memory",
+        payload: {
+          data: "target user memory",
+          hash: "owned-hash",
+          user_id: "target-user",
+          userId: "target-user",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ];
+
+    const listSpy = jest
+      .spyOn(vectorStore, "list")
+      .mockResolvedValueOnce([rows, rows.length]);
+    const getSpy = jest
+      .spyOn(vectorStore, "get")
+      .mockImplementation(async (id: string) => {
+        const row = rows.find((item) => item.id === id);
+        return row ?? null;
+      });
+    const deleteSpy = jest
+      .spyOn(vectorStore, "delete")
+      .mockResolvedValue(undefined);
+    const entityCleanupSpy = jest
+      .spyOn(scopedMemory as any, "_removeMemoryFromEntityStore")
+      .mockResolvedValue(undefined);
+
+    try {
+      const result = await scopedMemory.deleteAll({ userId: "target-user" });
+
+      expect(result.message).toBe("Memories deleted successfully!");
+      expect(listSpy).toHaveBeenCalledWith({ user_id: "target-user" });
+      expect(deleteSpy).toHaveBeenCalledTimes(1);
+      expect(deleteSpy).toHaveBeenCalledWith("owned-memory");
+      expect(entityCleanupSpy).toHaveBeenCalledWith("owned-memory", {
+        user_id: "target-user",
+      });
     } finally {
       listSpy.mockRestore();
       getSpy.mockRestore();

--- a/mem0-ts/src/oss/tests/memory.crud.test.ts
+++ b/mem0-ts/src/oss/tests/memory.crud.test.ts
@@ -168,6 +168,46 @@ describe("Memory - get()", () => {
       await scopedMemory.reset();
     }
   });
+
+  test("keeps canonical scope payloads out of metadata", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const getSpy = jest.spyOn(vectorStore, "get").mockResolvedValueOnce({
+      id: "canonical-memory",
+      payload: {
+        data: "canonical memory",
+        hash: "canonical-hash",
+        user_id: "target-user",
+        agent_id: "agent-a",
+        run_id: "run-a",
+        source: "memory",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    });
+
+    try {
+      const item = await scopedMemory.get("canonical-memory");
+
+      expect(item).toEqual(
+        expect.objectContaining({
+          id: "canonical-memory",
+          memory: "canonical memory",
+          user_id: "target-user",
+          agent_id: "agent-a",
+          run_id: "run-a",
+        }),
+      );
+      expect(item!.metadata).toEqual({ source: "memory" });
+      expect(item!.metadata).not.toHaveProperty("user_id");
+      expect(item!.metadata).not.toHaveProperty("agent_id");
+      expect(item!.metadata).not.toHaveProperty("run_id");
+    } finally {
+      getSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
 });
 
 // ─── update() ────────────────────────────────────────────
@@ -392,7 +432,7 @@ describe("Memory - getAll()", () => {
         topK: 5,
       });
 
-      expect(listSpy).toHaveBeenCalledWith({ user_id: "target-user" }, 5);
+      expect(listSpy).toHaveBeenCalledWith({ user_id: "target-user" }, 60);
       expect(result.results.map((item) => item.id)).toEqual(["owned-memory"]);
       expect(result.results[0].memory).toBe("target user memory");
       expect(result.results[0]).toEqual(
@@ -443,7 +483,7 @@ describe("Memory - getAll()", () => {
         topK: 5,
       });
 
-      expect(listSpy).toHaveBeenCalledWith({ user_id: "*" }, 5);
+      expect(listSpy).toHaveBeenCalledWith(undefined, 60);
       expect(result.results.map((item) => item.id)).toEqual([
         "user-scoped-memory",
       ]);
@@ -494,7 +534,7 @@ describe("Memory - getAll()", () => {
         topK: 5,
       });
 
-      expect(listSpy).toHaveBeenCalledWith({ user_id: "target-user" }, 5);
+      expect(listSpy).toHaveBeenCalledWith({ user_id: "target-user" }, 60);
       expect(result.results.map((item) => item.id)).toEqual(["owned-memory"]);
     } finally {
       listSpy.mockRestore();
@@ -670,6 +710,66 @@ describe("Memory - search()", () => {
     }
   });
 
+  test("keeps wildcard scope filtering in Memory instead of provider filters", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const searchSpy = jest.spyOn(vectorStore, "search").mockResolvedValueOnce([
+      {
+        id: "user-scoped-memory",
+        score: 0.98,
+        payload: {
+          data: "target wildcard memory",
+          hash: "user-scoped-hash",
+          userId: "any-user",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "unscoped-memory",
+        score: 0.97,
+        payload: {
+          data: "target missing scope",
+          hash: "unscoped-hash",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ]);
+    const keywordSpy = jest
+      .spyOn(vectorStore, "keywordSearch")
+      .mockResolvedValueOnce(null);
+
+    try {
+      const result: SearchResult = await scopedMemory.search("target", {
+        filters: { user_id: "*" },
+        threshold: 0,
+        topK: 5,
+      });
+
+      expect(searchSpy).toHaveBeenCalledWith(
+        mockEmbedding,
+        expect.any(Number),
+        undefined,
+      );
+      expect(keywordSpy).toHaveBeenCalledWith(
+        "target",
+        expect.any(Number),
+        undefined,
+      );
+      expect(result.results.map((item) => item.id)).toEqual([
+        "user-scoped-memory",
+      ]);
+      expect(result.results[0]).toEqual(
+        expect.objectContaining({ user_id: "any-user" }),
+      );
+    } finally {
+      searchSpy.mockRestore();
+      keywordSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
   test("prefers canonical scope over conflicting camelCase aliases for search results", async () => {
     const scopedMemory = createMemory();
     await (scopedMemory as any)._ensureInitialized();
@@ -756,7 +856,8 @@ describe("Memory - deleteAll() scope hardening", () => {
       .mockResolvedValueOnce([rows, rows.length]);
     const getSpy = jest
       .spyOn(vectorStore, "get")
-      .mockImplementation(async (id: string) => {
+      .mockImplementation(async (...args: unknown[]) => {
+        const id = String(args[0]);
         const row = rows.find((item) => item.id === id);
         return row ?? null;
       });
@@ -771,7 +872,7 @@ describe("Memory - deleteAll() scope hardening", () => {
       const result = await scopedMemory.deleteAll({ userId: "target-user" });
 
       expect(result.message).toBe("Memories deleted successfully!");
-      expect(listSpy).toHaveBeenCalledWith({ user_id: "target-user" });
+      expect(listSpy).toHaveBeenCalledWith({ user_id: "target-user" }, 10000);
       expect(deleteSpy).toHaveBeenCalledTimes(1);
       expect(deleteSpy).toHaveBeenCalledWith("owned-memory");
       expect(entityCleanupSpy).toHaveBeenCalledWith("owned-memory", {
@@ -816,7 +917,8 @@ describe("Memory - deleteAll() scope hardening", () => {
       .mockResolvedValueOnce([rows, rows.length]);
     const getSpy = jest
       .spyOn(vectorStore, "get")
-      .mockImplementation(async (id: string) => {
+      .mockImplementation(async (...args: unknown[]) => {
+        const id = String(args[0]);
         const row = rows.find((item) => item.id === id);
         return row ?? null;
       });
@@ -831,7 +933,7 @@ describe("Memory - deleteAll() scope hardening", () => {
       const result = await scopedMemory.deleteAll({ userId: "*" });
 
       expect(result.message).toBe("Memories deleted successfully!");
-      expect(listSpy).toHaveBeenCalledWith({ user_id: "*" });
+      expect(listSpy).toHaveBeenCalledWith(undefined, 10000);
       expect(deleteSpy).toHaveBeenCalledTimes(1);
       expect(deleteSpy).toHaveBeenCalledWith("user-scoped-memory");
       expect(entityCleanupSpy).toHaveBeenCalledWith("user-scoped-memory", {
@@ -879,7 +981,8 @@ describe("Memory - deleteAll() scope hardening", () => {
       .mockResolvedValueOnce([rows, rows.length]);
     const getSpy = jest
       .spyOn(vectorStore, "get")
-      .mockImplementation(async (id: string) => {
+      .mockImplementation(async (...args: unknown[]) => {
+        const id = String(args[0]);
         const row = rows.find((item) => item.id === id);
         return row ?? null;
       });
@@ -894,7 +997,7 @@ describe("Memory - deleteAll() scope hardening", () => {
       const result = await scopedMemory.deleteAll({ userId: "target-user" });
 
       expect(result.message).toBe("Memories deleted successfully!");
-      expect(listSpy).toHaveBeenCalledWith({ user_id: "target-user" });
+      expect(listSpy).toHaveBeenCalledWith({ user_id: "target-user" }, 10000);
       expect(deleteSpy).toHaveBeenCalledTimes(1);
       expect(deleteSpy).toHaveBeenCalledWith("owned-memory");
       expect(entityCleanupSpy).toHaveBeenCalledWith("owned-memory", {

--- a/mem0-ts/src/oss/tests/memory.crud.test.ts
+++ b/mem0-ts/src/oss/tests/memory.crud.test.ts
@@ -183,7 +183,8 @@ describe("Memory - get()", () => {
         agent_id: "agent-a",
         run_id: "run-a",
         source: "memory",
-        createdAt: "2026-01-01T00:00:00.000Z",
+        created_at: "2026-01-01T00:00:00.000Z",
+        updated_at: "2026-01-02T00:00:00.000Z",
       },
     });
 
@@ -197,16 +198,88 @@ describe("Memory - get()", () => {
           user_id: "target-user",
           agent_id: "agent-a",
           run_id: "run-a",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-02T00:00:00.000Z",
         }),
       );
       expect(item!.metadata).toEqual({ source: "memory" });
       expect(item!.metadata).not.toHaveProperty("user_id");
       expect(item!.metadata).not.toHaveProperty("agent_id");
       expect(item!.metadata).not.toHaveProperty("run_id");
+      expect(item!.metadata).not.toHaveProperty("created_at");
+      expect(item!.metadata).not.toHaveProperty("updated_at");
     } finally {
       getSpy.mockRestore();
       await scopedMemory.reset();
     }
+  });
+});
+
+describe("Memory - provider scope filters", () => {
+  function providerFiltersFor(
+    provider: string,
+    filters: Record<string, any>,
+  ): Record<string, any> | undefined {
+    const memory = Object.create(Memory.prototype) as any;
+    memory.config = { vectorStore: { provider } };
+    return memory._providerFiltersForRequestedScope(filters);
+  }
+
+  test("widens qdrant and pgvector scope filters to snake and camel aliases", () => {
+    const expected = {
+      topic: "preferences",
+      $or: [
+        { user_id: "target-user", agent_id: "agent-a" },
+        { user_id: "target-user", agentId: "agent-a" },
+        { userId: "target-user", agent_id: "agent-a" },
+        { userId: "target-user", agentId: "agent-a" },
+      ],
+    };
+
+    expect(
+      providerFiltersFor("qdrant", {
+        user_id: "target-user",
+        agent_id: "agent-a",
+        topic: "preferences",
+      }),
+    ).toEqual(expected);
+    expect(
+      providerFiltersFor("pgvector", {
+        user_id: "target-user",
+        agent_id: "agent-a",
+        topic: "preferences",
+      }),
+    ).toEqual(expected);
+  });
+
+  test("preserves caller OR filters when widening provider scope aliases", () => {
+    expect(
+      providerFiltersFor("pgvector", {
+        user_id: "target-user",
+        $or: [{ topic: "travel" }, { topic: "food" }],
+      }),
+    ).toEqual({
+      $or: [
+        { topic: "travel", user_id: "target-user" },
+        { topic: "travel", userId: "target-user" },
+        { topic: "food", user_id: "target-user" },
+        { topic: "food", userId: "target-user" },
+      ],
+    });
+  });
+
+  test("maps vectorize scope filters to camelCase metadata keys", () => {
+    expect(
+      providerFiltersFor("vectorize", {
+        user_id: "target-user",
+        agent_id: "agent-a",
+        topic: "preferences",
+      }),
+    ).toEqual({
+      topic: "preferences",
+      userId: "target-user",
+      agentId: "agent-a",
+    });
   });
 });
 
@@ -535,6 +608,62 @@ describe("Memory - getAll()", () => {
       });
 
       expect(listSpy).toHaveBeenCalledWith({ user_id: "target-user" }, 60);
+      expect(result.results.map((item) => item.id)).toEqual(["owned-memory"]);
+    } finally {
+      listSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
+  test("refetches when provider count shows scoped list results are incomplete", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const firstPage = [
+      {
+        id: "foreign-memory",
+        payload: {
+          data: "wrong user memory",
+          hash: "foreign-hash",
+          userId: "other-user",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ];
+    const secondPage = [
+      ...firstPage,
+      {
+        id: "owned-memory",
+        payload: {
+          data: "target user memory",
+          hash: "owned-hash",
+          userId: "target-user",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ];
+    const listSpy = jest
+      .spyOn(vectorStore, "list")
+      .mockResolvedValueOnce([firstPage, 61])
+      .mockResolvedValueOnce([secondPage, 61]);
+
+    try {
+      const result: SearchResult = await scopedMemory.getAll({
+        filters: { user_id: "target-user" },
+        topK: 1,
+      });
+
+      expect(listSpy).toHaveBeenNthCalledWith(
+        1,
+        { user_id: "target-user" },
+        60,
+      );
+      expect(listSpy).toHaveBeenNthCalledWith(
+        2,
+        { user_id: "target-user" },
+        61,
+      );
       expect(result.results.map((item) => item.id)).toEqual(["owned-memory"]);
     } finally {
       listSpy.mockRestore();
@@ -1003,6 +1132,78 @@ describe("Memory - deleteAll() scope hardening", () => {
       expect(entityCleanupSpy).toHaveBeenCalledWith("owned-memory", {
         user_id: "target-user",
       });
+    } finally {
+      listSpy.mockRestore();
+      getSpy.mockRestore();
+      deleteSpy.mockRestore();
+      entityCleanupSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
+  test("refetches before bulk delete when provider count exceeds the first batch", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const firstPage = [
+      {
+        id: "foreign-memory",
+        payload: {
+          data: "wrong user memory",
+          hash: "foreign-hash",
+          userId: "other-user",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ];
+    const secondPage = [
+      ...firstPage,
+      {
+        id: "owned-memory",
+        payload: {
+          data: "target user memory",
+          hash: "owned-hash",
+          userId: "target-user",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ];
+
+    const listSpy = jest
+      .spyOn(vectorStore, "list")
+      .mockResolvedValueOnce([firstPage, 10001])
+      .mockResolvedValueOnce([secondPage, 10001]);
+    const getSpy = jest
+      .spyOn(vectorStore, "get")
+      .mockImplementation(async (...args: unknown[]) => {
+        const id = String(args[0]);
+        const row = secondPage.find((item) => item.id === id);
+        return row ?? null;
+      });
+    const deleteSpy = jest
+      .spyOn(vectorStore, "delete")
+      .mockResolvedValue(undefined);
+    const entityCleanupSpy = jest
+      .spyOn(scopedMemory as any, "_removeMemoryFromEntityStore")
+      .mockResolvedValue(undefined);
+
+    try {
+      const result = await scopedMemory.deleteAll({ userId: "target-user" });
+
+      expect(result.message).toBe("Memories deleted successfully!");
+      expect(listSpy).toHaveBeenNthCalledWith(
+        1,
+        { user_id: "target-user" },
+        10000,
+      );
+      expect(listSpy).toHaveBeenNthCalledWith(
+        2,
+        { user_id: "target-user" },
+        10001,
+      );
+      expect(deleteSpy).toHaveBeenCalledTimes(1);
+      expect(deleteSpy).toHaveBeenCalledWith("owned-memory");
     } finally {
       listSpy.mockRestore();
       getSpy.mockRestore();

--- a/mem0-ts/src/oss/tests/memory.crud.test.ts
+++ b/mem0-ts/src/oss/tests/memory.crud.test.ts
@@ -227,12 +227,23 @@ describe("Memory - provider scope filters", () => {
 
   test("widens qdrant and pgvector scope filters to snake and camel aliases", () => {
     const expected = {
-      topic: "preferences",
       $or: [
-        { user_id: "target-user", agent_id: "agent-a" },
-        { user_id: "target-user", agentId: "agent-a" },
-        { userId: "target-user", agent_id: "agent-a" },
-        { userId: "target-user", agentId: "agent-a" },
+        {
+          user_id: "target-user",
+          agent_id: "agent-a",
+          topic: "preferences",
+        },
+        {
+          user_id: "target-user",
+          agentId: "agent-a",
+          topic: "preferences",
+        },
+        {
+          userId: "target-user",
+          agent_id: "agent-a",
+          topic: "preferences",
+        },
+        { userId: "target-user", agentId: "agent-a", topic: "preferences" },
       ],
     };
 
@@ -261,10 +272,46 @@ describe("Memory - provider scope filters", () => {
     ).toEqual({
       $or: [
         { topic: "travel", user_id: "target-user" },
-        { topic: "travel", userId: "target-user" },
         { topic: "food", user_id: "target-user" },
+        { topic: "travel", userId: "target-user" },
         { topic: "food", userId: "target-user" },
       ],
+    });
+  });
+
+  test("widens nested logical scope filters for alias-aware providers", () => {
+    expect(
+      providerFiltersFor("qdrant", {
+        user_id: "target-user",
+        $or: [{ agent_id: "agent-a" }, { topic: "travel" }],
+      }),
+    ).toEqual({
+      $or: [
+        { user_id: "target-user", agent_id: "agent-a" },
+        { user_id: "target-user", agentId: "agent-a" },
+        { user_id: "target-user", topic: "travel" },
+        { userId: "target-user", agent_id: "agent-a" },
+        { userId: "target-user", agentId: "agent-a" },
+        { userId: "target-user", topic: "travel" },
+      ],
+    });
+  });
+
+  test("keeps nested wildcard scope filters out of provider filters", () => {
+    expect(
+      providerFiltersFor("memory", {
+        user_id: "target-user",
+        $or: [{ agent_id: "*" }, { topic: "travel" }],
+      }),
+    ).toEqual({ user_id: "target-user" });
+
+    expect(
+      providerFiltersFor("qdrant", {
+        user_id: "target-user",
+        $or: [{ agent_id: "*" }, { topic: "travel" }],
+      }),
+    ).toEqual({
+      $or: [{ user_id: "target-user" }, { userId: "target-user" }],
     });
   });
 
@@ -1156,6 +1203,68 @@ describe("Memory - search()", () => {
     }
   });
 
+  test("honors nested scope AND filters when filtering search results", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const searchSpy = jest.spyOn(vectorStore, "search").mockResolvedValueOnce([
+      {
+        id: "wrong-agent-memory",
+        score: 0.99,
+        payload: {
+          data: "same user wrong nested agent",
+          hash: "wrong-agent-hash",
+          userId: "target-user",
+          agentId: "agent-c",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "owned-memory",
+        score: 0.98,
+        payload: {
+          data: "target user matching nested agent",
+          hash: "owned-hash",
+          userId: "target-user",
+          agentId: "agent-a",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ]);
+    const keywordSpy = jest
+      .spyOn(vectorStore, "keywordSearch")
+      .mockResolvedValueOnce(null);
+
+    try {
+      const result: SearchResult = await scopedMemory.search("target", {
+        filters: {
+          user_id: "target-user",
+          AND: [{ agent_id: "agent-a" }],
+        },
+        threshold: 0,
+        topK: 5,
+      });
+
+      expect(searchSpy).toHaveBeenCalledWith(
+        mockEmbedding,
+        expect.any(Number),
+        { user_id: "target-user", agent_id: "agent-a" },
+      );
+      expect(result.results.map((item) => item.id)).toEqual(["owned-memory"]);
+      expect(result.results[0]).toEqual(
+        expect.objectContaining({
+          user_id: "target-user",
+          agent_id: "agent-a",
+        }),
+      );
+    } finally {
+      searchSpy.mockRestore();
+      keywordSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
   test("honors nested scope NOT filters when filtering search results", async () => {
     const scopedMemory = createMemory();
     await (scopedMemory as any)._ensureInitialized();
@@ -1211,6 +1320,143 @@ describe("Memory - search()", () => {
           agent_id: "allowed-agent",
         }),
       );
+    } finally {
+      searchSpy.mockRestore();
+      keywordSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
+  test("preserves mixed scope and metadata OR semantics in post-filtering", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const searchSpy = jest.spyOn(vectorStore, "search").mockResolvedValueOnce([
+      {
+        id: "wrong-topic-memory",
+        score: 0.99,
+        payload: {
+          data: "matching scope wrong topic",
+          hash: "wrong-topic-hash",
+          userId: "target-user",
+          agentId: "agent-a",
+          topic: "food",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "owned-memory",
+        score: 0.98,
+        payload: {
+          data: "matching scope and topic",
+          hash: "owned-hash",
+          userId: "target-user",
+          agentId: "agent-a",
+          topic: "travel",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ]);
+    const keywordSpy = jest
+      .spyOn(vectorStore, "keywordSearch")
+      .mockResolvedValueOnce(null);
+
+    try {
+      const result: SearchResult = await scopedMemory.search("target", {
+        filters: {
+          user_id: "target-user",
+          OR: [{ agent_id: "agent-a", topic: "travel" }],
+        },
+        threshold: 0,
+        topK: 5,
+      });
+
+      expect(searchSpy).toHaveBeenCalledWith(
+        mockEmbedding,
+        expect.any(Number),
+        {
+          user_id: "target-user",
+          $or: [{ agent_id: "agent-a", topic: "travel" }],
+        },
+      );
+      expect(result.results.map((item) => item.id)).toEqual(["owned-memory"]);
+    } finally {
+      searchSpy.mockRestore();
+      keywordSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
+  test("preserves mixed scope and metadata NOT semantics in post-filtering", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const searchSpy = jest.spyOn(vectorStore, "search").mockResolvedValueOnce([
+      {
+        id: "blocked-secret-memory",
+        score: 0.99,
+        payload: {
+          data: "blocked agent secret topic",
+          hash: "blocked-secret-hash",
+          userId: "target-user",
+          agentId: "blocked-agent",
+          topic: "secret",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "blocked-public-memory",
+        score: 0.98,
+        payload: {
+          data: "blocked agent public topic",
+          hash: "blocked-public-hash",
+          userId: "target-user",
+          agentId: "blocked-agent",
+          topic: "public",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "owned-memory",
+        score: 0.97,
+        payload: {
+          data: "allowed agent secret topic",
+          hash: "owned-hash",
+          userId: "target-user",
+          agentId: "allowed-agent",
+          topic: "secret",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ]);
+    const keywordSpy = jest
+      .spyOn(vectorStore, "keywordSearch")
+      .mockResolvedValueOnce(null);
+
+    try {
+      const result: SearchResult = await scopedMemory.search("target", {
+        filters: {
+          user_id: "target-user",
+          NOT: [{ agent_id: "blocked-agent", topic: "secret" }],
+        },
+        threshold: 0,
+        topK: 5,
+      });
+
+      expect(searchSpy).toHaveBeenCalledWith(
+        mockEmbedding,
+        expect.any(Number),
+        {
+          user_id: "target-user",
+          $not: [{ agent_id: "blocked-agent", topic: "secret" }],
+        },
+      );
+      expect(result.results.map((item) => item.id)).toEqual([
+        "blocked-public-memory",
+        "owned-memory",
+      ]);
     } finally {
       searchSpy.mockRestore();
       keywordSpy.mockRestore();

--- a/mem0-ts/src/oss/tests/memory.crud.test.ts
+++ b/mem0-ts/src/oss/tests/memory.crud.test.ts
@@ -359,6 +359,119 @@ describe("Memory - search()", () => {
     });
     expect(result.results).toHaveLength(0);
   });
+
+  test("filters polluted vector store search results by requested scope", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const searchSpy = jest.spyOn(vectorStore, "search").mockResolvedValueOnce([
+      {
+        id: "foreign-memory",
+        score: 0.99,
+        payload: {
+          data: "wrong user memory",
+          hash: "foreign-hash",
+          user_id: "other-user",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "owned-memory",
+        score: 0.98,
+        payload: {
+          data: "target user memory",
+          hash: "owned-hash",
+          user_id: "target-user",
+          agent_id: "agent-extra",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ]);
+    const keywordSpy = jest
+      .spyOn(vectorStore, "keywordSearch")
+      .mockResolvedValueOnce(null);
+
+    try {
+      const result: SearchResult = await scopedMemory.search("target", {
+        filters: { user_id: "target-user" },
+        threshold: 0,
+        topK: 5,
+      });
+
+      expect(searchSpy).toHaveBeenCalledWith(
+        mockEmbedding,
+        expect.any(Number),
+        { user_id: "target-user" },
+      );
+      expect(result.results.map((item) => item.id)).toEqual(["owned-memory"]);
+      expect(result.results[0].memory).toBe("target user memory");
+    } finally {
+      searchSpy.mockRestore();
+      keywordSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+});
+
+describe("Memory - deleteAll() scope hardening", () => {
+  test("does not delete rows outside the requested scope when vector store list is polluted", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const rows = [
+      {
+        id: "foreign-memory",
+        payload: {
+          data: "wrong user memory",
+          hash: "foreign-hash",
+          user_id: "other-user",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "owned-memory",
+        payload: {
+          data: "target user memory",
+          hash: "owned-hash",
+          user_id: "target-user",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ];
+
+    const listSpy = jest
+      .spyOn(vectorStore, "list")
+      .mockResolvedValueOnce([rows, rows.length]);
+    const getSpy = jest
+      .spyOn(vectorStore, "get")
+      .mockImplementation(async (id: string) => {
+        const row = rows.find((item) => item.id === id);
+        return row ?? null;
+      });
+    const deleteSpy = jest
+      .spyOn(vectorStore, "delete")
+      .mockResolvedValue(undefined);
+    const entityCleanupSpy = jest
+      .spyOn(scopedMemory as any, "_removeMemoryFromEntityStore")
+      .mockResolvedValue(undefined);
+
+    try {
+      const result = await scopedMemory.deleteAll({ userId: "target-user" });
+
+      expect(result.message).toBe("Memories deleted successfully!");
+      expect(listSpy).toHaveBeenCalledWith({ user_id: "target-user" });
+      expect(deleteSpy).toHaveBeenCalledTimes(1);
+      expect(deleteSpy).toHaveBeenCalledWith("owned-memory");
+    } finally {
+      listSpy.mockRestore();
+      getSpy.mockRestore();
+      deleteSpy.mockRestore();
+      entityCleanupSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
 });
 
 // ─── attributedTo (#5666) ────────────────────────────────

--- a/mem0-ts/src/oss/tests/memory.crud.test.ts
+++ b/mem0-ts/src/oss/tests/memory.crud.test.ts
@@ -268,7 +268,7 @@ describe("Memory - provider scope filters", () => {
     });
   });
 
-  test("maps vectorize scope filters to camelCase metadata keys", () => {
+  test("keeps vectorize scope filters in stored snake_case metadata keys", () => {
     expect(
       providerFiltersFor("vectorize", {
         user_id: "target-user",
@@ -277,9 +277,57 @@ describe("Memory - provider scope filters", () => {
       }),
     ).toEqual({
       topic: "preferences",
-      userId: "target-user",
-      agentId: "agent-a",
+      user_id: "target-user",
+      agent_id: "agent-a",
     });
+  });
+
+  test("passes widened provider scope filters through public getAll calls", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    (scopedMemory as any).config.vectorStore.provider = "qdrant";
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const rows = [
+      {
+        id: "owned-memory",
+        payload: {
+          data: "target user memory",
+          hash: "owned-hash",
+          userId: "target-user",
+          agentId: "agent-a",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ];
+    const listSpy = jest
+      .spyOn(vectorStore, "list")
+      .mockResolvedValueOnce([rows, rows.length]);
+
+    try {
+      const result: SearchResult = await scopedMemory.getAll({
+        filters: { user_id: "target-user", agent_id: "agent-a" },
+        topK: 5,
+      });
+
+      expect(listSpy).toHaveBeenCalledWith(
+        {
+          $or: [
+            { user_id: "target-user", agent_id: "agent-a" },
+            { user_id: "target-user", agentId: "agent-a" },
+            { userId: "target-user", agent_id: "agent-a" },
+            { userId: "target-user", agentId: "agent-a" },
+          ],
+        },
+        60,
+      );
+      expect(result.results.map((item) => item.id)).toEqual(["owned-memory"]);
+    } finally {
+      listSpy.mockRestore();
+      (scopedMemory as any).config.vectorStore.provider = "memory";
+      await scopedMemory.reset();
+    }
   });
 });
 
@@ -670,6 +718,70 @@ describe("Memory - getAll()", () => {
       await scopedMemory.reset();
     }
   });
+
+  test("requires every requested scope key when filtering list results", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const rows = [
+      {
+        id: "wrong-agent-memory",
+        payload: {
+          data: "same user wrong agent",
+          hash: "wrong-agent-hash",
+          userId: "target-user",
+          agentId: "other-agent",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "wrong-user-memory",
+        payload: {
+          data: "wrong user same agent",
+          hash: "wrong-user-hash",
+          userId: "other-user",
+          agentId: "agent-a",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "owned-memory",
+        payload: {
+          data: "target user and agent",
+          hash: "owned-hash",
+          userId: "target-user",
+          agentId: "agent-a",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ];
+    const listSpy = jest
+      .spyOn(vectorStore, "list")
+      .mockResolvedValueOnce([rows, rows.length]);
+
+    try {
+      const result: SearchResult = await scopedMemory.getAll({
+        filters: { user_id: "target-user", agent_id: "agent-a" },
+        topK: 5,
+      });
+
+      expect(listSpy).toHaveBeenCalledWith(
+        { user_id: "target-user", agent_id: "agent-a" },
+        60,
+      );
+      expect(result.results.map((item) => item.id)).toEqual(["owned-memory"]);
+      expect(result.results[0]).toEqual(
+        expect.objectContaining({
+          user_id: "target-user",
+          agent_id: "agent-a",
+        }),
+      );
+    } finally {
+      listSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
 });
 
 // ─── search() ────────────────────────────────────────────
@@ -830,6 +942,76 @@ describe("Memory - search()", () => {
         expect.objectContaining({
           bm25Score: 0,
           maxPossibleScore: 1,
+        }),
+      );
+    } finally {
+      searchSpy.mockRestore();
+      keywordSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
+  test("requires every requested scope key when filtering search results", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const searchSpy = jest.spyOn(vectorStore, "search").mockResolvedValueOnce([
+      {
+        id: "wrong-agent-memory",
+        score: 0.99,
+        payload: {
+          data: "same user wrong agent",
+          hash: "wrong-agent-hash",
+          userId: "target-user",
+          agentId: "other-agent",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "wrong-user-memory",
+        score: 0.98,
+        payload: {
+          data: "wrong user same agent",
+          hash: "wrong-user-hash",
+          userId: "other-user",
+          agentId: "agent-a",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "owned-memory",
+        score: 0.97,
+        payload: {
+          data: "target user and agent",
+          hash: "owned-hash",
+          userId: "target-user",
+          agentId: "agent-a",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ]);
+    const keywordSpy = jest
+      .spyOn(vectorStore, "keywordSearch")
+      .mockResolvedValueOnce(null);
+
+    try {
+      const result: SearchResult = await scopedMemory.search("target", {
+        filters: { user_id: "target-user", agent_id: "agent-a" },
+        threshold: 0,
+        topK: 5,
+      });
+
+      expect(searchSpy).toHaveBeenCalledWith(
+        mockEmbedding,
+        expect.any(Number),
+        { user_id: "target-user", agent_id: "agent-a" },
+      );
+      expect(result.results.map((item) => item.id)).toEqual(["owned-memory"]);
+      expect(result.results[0]).toEqual(
+        expect.objectContaining({
+          user_id: "target-user",
+          agent_id: "agent-a",
         }),
       );
     } finally {
@@ -1209,6 +1391,136 @@ describe("Memory - deleteAll() scope hardening", () => {
       getSpy.mockRestore();
       deleteSpy.mockRestore();
       entityCleanupSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
+  test("requires every requested scope key before bulk deleting", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const rows = [
+      {
+        id: "wrong-agent-memory",
+        payload: {
+          data: "same user wrong agent",
+          hash: "wrong-agent-hash",
+          userId: "target-user",
+          agentId: "other-agent",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "wrong-user-memory",
+        payload: {
+          data: "wrong user same agent",
+          hash: "wrong-user-hash",
+          userId: "other-user",
+          agentId: "agent-a",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "owned-memory",
+        payload: {
+          data: "target user and agent",
+          hash: "owned-hash",
+          userId: "target-user",
+          agentId: "agent-a",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ];
+
+    const listSpy = jest
+      .spyOn(vectorStore, "list")
+      .mockResolvedValueOnce([rows, rows.length]);
+    const getSpy = jest
+      .spyOn(vectorStore, "get")
+      .mockImplementation(async (...args: unknown[]) => {
+        const id = String(args[0]);
+        const row = rows.find((item) => item.id === id);
+        return row ?? null;
+      });
+    const deleteSpy = jest
+      .spyOn(vectorStore, "delete")
+      .mockResolvedValue(undefined);
+    const entityCleanupSpy = jest
+      .spyOn(scopedMemory as any, "_removeMemoryFromEntityStore")
+      .mockResolvedValue(undefined);
+
+    try {
+      const result = await scopedMemory.deleteAll({
+        userId: "target-user",
+        agentId: "agent-a",
+      });
+
+      expect(result.message).toBe("Memories deleted successfully!");
+      expect(listSpy).toHaveBeenCalledWith(
+        { user_id: "target-user", agent_id: "agent-a" },
+        10000,
+      );
+      expect(deleteSpy).toHaveBeenCalledTimes(1);
+      expect(deleteSpy).toHaveBeenCalledWith("owned-memory");
+      expect(entityCleanupSpy).toHaveBeenCalledWith("owned-memory", {
+        user_id: "target-user",
+        agent_id: "agent-a",
+      });
+    } finally {
+      listSpy.mockRestore();
+      getSpy.mockRestore();
+      deleteSpy.mockRestore();
+      entityCleanupSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
+  test("fails closed when bulk delete cannot prove a full provider page is complete", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    (scopedMemory as any).config.vectorStore.provider = "qdrant";
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const fullPage = Array.from({ length: 10000 }, (_, index) => ({
+      id: `memory-${index}`,
+      payload: {
+        data: `target memory ${index}`,
+        hash: `hash-${index}`,
+        userId: "target-user",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    }));
+
+    const listSpy = jest
+      .spyOn(vectorStore, "list")
+      .mockResolvedValueOnce([fullPage, fullPage.length]);
+    const deleteSpy = jest
+      .spyOn(vectorStore, "delete")
+      .mockResolvedValue(undefined);
+    const entityCleanupSpy = jest
+      .spyOn(scopedMemory as any, "_removeMemoryFromEntityStore")
+      .mockResolvedValue(undefined);
+
+    try {
+      await expect(
+        scopedMemory.deleteAll({ userId: "target-user" }),
+      ).rejects.toThrow(
+        "deleteAll cannot safely delete all scoped memories for vector store provider 'qdrant'",
+      );
+
+      expect(listSpy).toHaveBeenCalledWith(
+        { $or: [{ user_id: "target-user" }, { userId: "target-user" }] },
+        10000,
+      );
+      expect(deleteSpy).not.toHaveBeenCalled();
+      expect(entityCleanupSpy).not.toHaveBeenCalled();
+    } finally {
+      listSpy.mockRestore();
+      deleteSpy.mockRestore();
+      entityCleanupSpy.mockRestore();
+      (scopedMemory as any).config.vectorStore.provider = "memory";
       await scopedMemory.reset();
     }
   });

--- a/mem0-ts/src/oss/tests/memory.crud.test.ts
+++ b/mem0-ts/src/oss/tests/memory.crud.test.ts
@@ -314,6 +314,95 @@ describe("Memory - getAll()", () => {
     });
     expect(result.results).toHaveLength(0);
   });
+
+  test("filters polluted vector store list results by requested scope", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const rows = [
+      {
+        id: "foreign-memory",
+        payload: {
+          data: "wrong user memory",
+          hash: "foreign-hash",
+          userId: "other-user",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "owned-memory",
+        payload: {
+          data: "target user memory",
+          hash: "owned-hash",
+          userId: "target-user",
+          agentId: "agent-extra",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ];
+    const listSpy = jest
+      .spyOn(vectorStore, "list")
+      .mockResolvedValueOnce([rows, rows.length]);
+
+    try {
+      const result: SearchResult = await scopedMemory.getAll({
+        filters: { user_id: "target-user" },
+        topK: 5,
+      });
+
+      expect(listSpy).toHaveBeenCalledWith({ user_id: "target-user" }, 5);
+      expect(result.results.map((item) => item.id)).toEqual(["owned-memory"]);
+      expect(result.results[0].memory).toBe("target user memory");
+    } finally {
+      listSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
+  test("keeps non-null scoped rows for wildcard filters", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const rows = [
+      {
+        id: "user-scoped-memory",
+        payload: {
+          data: "user scoped memory",
+          hash: "user-scoped-hash",
+          userId: "any-user",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "unscoped-memory",
+        payload: {
+          data: "missing user scope",
+          hash: "unscoped-hash",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ];
+    const listSpy = jest
+      .spyOn(vectorStore, "list")
+      .mockResolvedValueOnce([rows, rows.length]);
+
+    try {
+      const result: SearchResult = await scopedMemory.getAll({
+        filters: { user_id: "*" },
+        topK: 5,
+      });
+
+      expect(listSpy).toHaveBeenCalledWith({ user_id: "*" }, 5);
+      expect(result.results.map((item) => item.id)).toEqual([
+        "user-scoped-memory",
+      ]);
+    } finally {
+      listSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
 });
 
 // ─── search() ────────────────────────────────────────────
@@ -372,7 +461,7 @@ describe("Memory - search()", () => {
         payload: {
           data: "wrong user memory",
           hash: "foreign-hash",
-          user_id: "other-user",
+          userId: "other-user",
           createdAt: "2026-01-01T00:00:00.000Z",
         },
       },
@@ -382,8 +471,8 @@ describe("Memory - search()", () => {
         payload: {
           data: "target user memory",
           hash: "owned-hash",
-          user_id: "target-user",
-          agent_id: "agent-extra",
+          userId: "target-user",
+          agentId: "agent-extra",
           createdAt: "2026-01-01T00:00:00.000Z",
         },
       },
@@ -412,6 +501,68 @@ describe("Memory - search()", () => {
       await scopedMemory.reset();
     }
   });
+
+  test("ignores wrong-scope keyword results when scoring", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const searchSpy = jest.spyOn(vectorStore, "search").mockResolvedValueOnce([
+      {
+        id: "owned-memory",
+        score: 0.8,
+        payload: {
+          data: "target keyword memory",
+          hash: "owned-hash",
+          user_id: "target-user",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ]);
+    const keywordSpy = jest
+      .spyOn(vectorStore, "keywordSearch")
+      .mockResolvedValueOnce([
+        {
+          id: "foreign-keyword-memory",
+          score: 100,
+          payload: {
+            data: "wrong user keyword memory",
+            hash: "foreign-keyword-hash",
+            user_id: "other-user",
+            createdAt: "2026-01-01T00:00:00.000Z",
+          },
+        },
+      ]);
+
+    try {
+      const result: SearchResult = await scopedMemory.search("target", {
+        filters: { user_id: "target-user" },
+        threshold: 0,
+        topK: 5,
+        explain: true,
+      });
+
+      expect(searchSpy).toHaveBeenCalledWith(
+        mockEmbedding,
+        expect.any(Number),
+        { user_id: "target-user" },
+      );
+      expect(keywordSpy).toHaveBeenCalledWith("target", expect.any(Number), {
+        user_id: "target-user",
+      });
+      expect(result.results.map((item) => item.id)).toEqual(["owned-memory"]);
+      expect((result.results[0] as any).score_details).toEqual(
+        expect.objectContaining({
+          bm25Score: 0,
+          maxPossibleScore: 1,
+        }),
+      );
+    } finally {
+      searchSpy.mockRestore();
+      keywordSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
 });
 
 describe("Memory - deleteAll() scope hardening", () => {
@@ -426,7 +577,7 @@ describe("Memory - deleteAll() scope hardening", () => {
         payload: {
           data: "wrong user memory",
           hash: "foreign-hash",
-          user_id: "other-user",
+          userId: "other-user",
           createdAt: "2026-01-01T00:00:00.000Z",
         },
       },
@@ -435,7 +586,7 @@ describe("Memory - deleteAll() scope hardening", () => {
         payload: {
           data: "target user memory",
           hash: "owned-hash",
-          user_id: "target-user",
+          userId: "target-user",
           createdAt: "2026-01-01T00:00:00.000Z",
         },
       },
@@ -464,6 +615,63 @@ describe("Memory - deleteAll() scope hardening", () => {
       expect(listSpy).toHaveBeenCalledWith({ user_id: "target-user" });
       expect(deleteSpy).toHaveBeenCalledTimes(1);
       expect(deleteSpy).toHaveBeenCalledWith("owned-memory");
+    } finally {
+      listSpy.mockRestore();
+      getSpy.mockRestore();
+      deleteSpy.mockRestore();
+      entityCleanupSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
+  test("deletes only non-null scoped rows for wildcard filters", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const rows = [
+      {
+        id: "user-scoped-memory",
+        payload: {
+          data: "user scoped memory",
+          hash: "user-scoped-hash",
+          userId: "any-user",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "unscoped-memory",
+        payload: {
+          data: "missing user scope",
+          hash: "unscoped-hash",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ];
+
+    const listSpy = jest
+      .spyOn(vectorStore, "list")
+      .mockResolvedValueOnce([rows, rows.length]);
+    const getSpy = jest
+      .spyOn(vectorStore, "get")
+      .mockImplementation(async (id: string) => {
+        const row = rows.find((item) => item.id === id);
+        return row ?? null;
+      });
+    const deleteSpy = jest
+      .spyOn(vectorStore, "delete")
+      .mockResolvedValue(undefined);
+    const entityCleanupSpy = jest
+      .spyOn(scopedMemory as any, "_removeMemoryFromEntityStore")
+      .mockResolvedValue(undefined);
+
+    try {
+      const result = await scopedMemory.deleteAll({ userId: "*" });
+
+      expect(result.message).toBe("Memories deleted successfully!");
+      expect(listSpy).toHaveBeenCalledWith({ user_id: "*" });
+      expect(deleteSpy).toHaveBeenCalledTimes(1);
+      expect(deleteSpy).toHaveBeenCalledWith("user-scoped-memory");
     } finally {
       listSpy.mockRestore();
       getSpy.mockRestore();

--- a/mem0-ts/src/oss/tests/memory.crud.test.ts
+++ b/mem0-ts/src/oss/tests/memory.crud.test.ts
@@ -1388,6 +1388,102 @@ describe("Memory - search()", () => {
     }
   });
 
+  test("preserves nested logical scope comparisons in post-filtering", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const searchSpy = jest.spyOn(vectorStore, "search").mockResolvedValueOnce([
+      {
+        id: "low-priority-memory",
+        score: 0.99,
+        payload: {
+          data: "matching scope below priority threshold",
+          hash: "low-priority-hash",
+          userId: "target-user",
+          agentId: "agent-a",
+          priority: 5,
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "priority-memory",
+        score: 0.98,
+        payload: {
+          data: "matching priority threshold",
+          hash: "priority-hash",
+          userId: "target-user",
+          agentId: "agent-a",
+          priority: "12",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "blocked-topic-memory",
+        score: 0.97,
+        payload: {
+          data: "matching agent blocked by nested NOT",
+          hash: "blocked-topic-hash",
+          userId: "target-user",
+          agentId: "agent-b",
+          topic: "secret",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "allowed-topic-memory",
+        score: 0.96,
+        payload: {
+          data: "matching agent allowed by nested NOT",
+          hash: "allowed-topic-hash",
+          userId: "target-user",
+          agentId: "agent-b",
+          topic: "public",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ]);
+    const keywordSpy = jest
+      .spyOn(vectorStore, "keywordSearch")
+      .mockResolvedValueOnce(null);
+
+    try {
+      const result: SearchResult = await scopedMemory.search("target", {
+        filters: {
+          user_id: "target-user",
+          OR: [
+            { AND: [{ agent_id: "agent-a" }, { priority: { gte: 10 } }] },
+            {
+              AND: [{ agent_id: "agent-b" }, { NOT: [{ topic: "secret" }] }],
+            },
+          ],
+        },
+        threshold: 0,
+        topK: 5,
+      });
+
+      expect(searchSpy).toHaveBeenCalledWith(
+        mockEmbedding,
+        expect.any(Number),
+        {
+          user_id: "target-user",
+          $or: [
+            { agent_id: "agent-a", priority: { gte: 10 } },
+            { agent_id: "agent-b", $not: [{ topic: "secret" }] },
+          ],
+        },
+      );
+      expect(result.results.map((item) => item.id)).toEqual([
+        "priority-memory",
+        "allowed-topic-memory",
+      ]);
+    } finally {
+      searchSpy.mockRestore();
+      keywordSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
   test("preserves mixed scope and metadata NOT semantics in post-filtering", async () => {
     const scopedMemory = createMemory();
     await (scopedMemory as any)._ensureInitialized();

--- a/mem0-ts/src/oss/tests/memory.crud.test.ts
+++ b/mem0-ts/src/oss/tests/memory.crud.test.ts
@@ -782,6 +782,76 @@ describe("Memory - getAll()", () => {
       await scopedMemory.reset();
     }
   });
+
+  test("honors nested scope OR filters when filtering list results", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const rows = [
+      {
+        id: "wrong-agent-memory",
+        payload: {
+          data: "same user wrong nested agent",
+          hash: "wrong-agent-hash",
+          userId: "target-user",
+          agentId: "agent-c",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "wrong-user-memory",
+        payload: {
+          data: "wrong user matching nested agent",
+          hash: "wrong-user-hash",
+          userId: "other-user",
+          agentId: "agent-a",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "owned-memory",
+        payload: {
+          data: "target user matching nested agent",
+          hash: "owned-hash",
+          userId: "target-user",
+          agentId: "agent-b",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ];
+    const listSpy = jest
+      .spyOn(vectorStore, "list")
+      .mockResolvedValueOnce([rows, rows.length]);
+
+    try {
+      const result: SearchResult = await scopedMemory.getAll({
+        filters: {
+          user_id: "target-user",
+          OR: [{ agent_id: "agent-a" }, { agent_id: "agent-b" }],
+        },
+        topK: 5,
+      });
+
+      expect(listSpy).toHaveBeenCalledWith(
+        {
+          user_id: "target-user",
+          OR: [{ agent_id: "agent-a" }, { agent_id: "agent-b" }],
+        },
+        60,
+      );
+      expect(result.results.map((item) => item.id)).toEqual(["owned-memory"]);
+      expect(result.results[0]).toEqual(
+        expect.objectContaining({
+          user_id: "target-user",
+          agent_id: "agent-b",
+        }),
+      );
+    } finally {
+      listSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
 });
 
 // ─── search() ────────────────────────────────────────────
@@ -1021,6 +1091,133 @@ describe("Memory - search()", () => {
     }
   });
 
+  test("honors nested scope OR filters when filtering search results", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const searchSpy = jest.spyOn(vectorStore, "search").mockResolvedValueOnce([
+      {
+        id: "wrong-agent-memory",
+        score: 0.99,
+        payload: {
+          data: "same user wrong nested agent",
+          hash: "wrong-agent-hash",
+          userId: "target-user",
+          agentId: "agent-c",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "owned-memory",
+        score: 0.98,
+        payload: {
+          data: "target user matching nested agent",
+          hash: "owned-hash",
+          userId: "target-user",
+          agentId: "agent-b",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ]);
+    const keywordSpy = jest
+      .spyOn(vectorStore, "keywordSearch")
+      .mockResolvedValueOnce(null);
+
+    try {
+      const result: SearchResult = await scopedMemory.search("target", {
+        filters: {
+          user_id: "target-user",
+          OR: [{ agent_id: "agent-a" }, { agent_id: "agent-b" }],
+        },
+        threshold: 0,
+        topK: 5,
+      });
+
+      expect(searchSpy).toHaveBeenCalledWith(
+        mockEmbedding,
+        expect.any(Number),
+        {
+          user_id: "target-user",
+          $or: [{ agent_id: "agent-a" }, { agent_id: "agent-b" }],
+        },
+      );
+      expect(result.results.map((item) => item.id)).toEqual(["owned-memory"]);
+      expect(result.results[0]).toEqual(
+        expect.objectContaining({
+          user_id: "target-user",
+          agent_id: "agent-b",
+        }),
+      );
+    } finally {
+      searchSpy.mockRestore();
+      keywordSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
+  test("honors nested scope NOT filters when filtering search results", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const searchSpy = jest.spyOn(vectorStore, "search").mockResolvedValueOnce([
+      {
+        id: "blocked-agent-memory",
+        score: 0.99,
+        payload: {
+          data: "blocked nested agent",
+          hash: "blocked-agent-hash",
+          userId: "target-user",
+          agentId: "blocked-agent",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "owned-memory",
+        score: 0.98,
+        payload: {
+          data: "allowed nested agent",
+          hash: "owned-hash",
+          userId: "target-user",
+          agentId: "allowed-agent",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ]);
+    const keywordSpy = jest
+      .spyOn(vectorStore, "keywordSearch")
+      .mockResolvedValueOnce(null);
+
+    try {
+      const result: SearchResult = await scopedMemory.search("target", {
+        filters: {
+          user_id: "target-user",
+          NOT: [{ agent_id: "blocked-agent" }],
+        },
+        threshold: 0,
+        topK: 5,
+      });
+
+      expect(searchSpy).toHaveBeenCalledWith(
+        mockEmbedding,
+        expect.any(Number),
+        { user_id: "target-user", $not: [{ agent_id: "blocked-agent" }] },
+      );
+      expect(result.results.map((item) => item.id)).toEqual(["owned-memory"]);
+      expect(result.results[0]).toEqual(
+        expect.objectContaining({
+          user_id: "target-user",
+          agent_id: "allowed-agent",
+        }),
+      );
+    } finally {
+      searchSpy.mockRestore();
+      keywordSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
   test("keeps wildcard scope filtering in Memory instead of provider filters", async () => {
     const scopedMemory = createMemory();
     await (scopedMemory as any)._ensureInitialized();
@@ -1198,41 +1395,12 @@ describe("Memory - deleteAll() scope hardening", () => {
     }
   });
 
-  test("deletes only non-null scoped rows for wildcard filters", async () => {
+  test("rejects wildcard filters for destructive bulk deletes", async () => {
     const scopedMemory = createMemory();
     await (scopedMemory as any)._ensureInitialized();
 
     const vectorStore = (scopedMemory as any).vectorStore;
-    const rows = [
-      {
-        id: "user-scoped-memory",
-        payload: {
-          data: "user scoped memory",
-          hash: "user-scoped-hash",
-          userId: "any-user",
-          createdAt: "2026-01-01T00:00:00.000Z",
-        },
-      },
-      {
-        id: "unscoped-memory",
-        payload: {
-          data: "missing user scope",
-          hash: "unscoped-hash",
-          createdAt: "2026-01-01T00:00:00.000Z",
-        },
-      },
-    ];
-
-    const listSpy = jest
-      .spyOn(vectorStore, "list")
-      .mockResolvedValueOnce([rows, rows.length]);
-    const getSpy = jest
-      .spyOn(vectorStore, "get")
-      .mockImplementation(async (...args: unknown[]) => {
-        const id = String(args[0]);
-        const row = rows.find((item) => item.id === id);
-        return row ?? null;
-      });
+    const listSpy = jest.spyOn(vectorStore, "list");
     const deleteSpy = jest
       .spyOn(vectorStore, "delete")
       .mockResolvedValue(undefined);
@@ -1241,18 +1409,15 @@ describe("Memory - deleteAll() scope hardening", () => {
       .mockResolvedValue(undefined);
 
     try {
-      const result = await scopedMemory.deleteAll({ userId: "*" });
+      await expect(scopedMemory.deleteAll({ userId: "*" })).rejects.toThrow(
+        "Wildcard scope filters [user_id] are not supported in deleteAll()",
+      );
 
-      expect(result.message).toBe("Memories deleted successfully!");
-      expect(listSpy).toHaveBeenCalledWith(undefined, 10000);
-      expect(deleteSpy).toHaveBeenCalledTimes(1);
-      expect(deleteSpy).toHaveBeenCalledWith("user-scoped-memory");
-      expect(entityCleanupSpy).toHaveBeenCalledWith("user-scoped-memory", {
-        user_id: "any-user",
-      });
+      expect(listSpy).not.toHaveBeenCalled();
+      expect(deleteSpy).not.toHaveBeenCalled();
+      expect(entityCleanupSpy).not.toHaveBeenCalled();
     } finally {
       listSpy.mockRestore();
-      getSpy.mockRestore();
       deleteSpy.mockRestore();
       entityCleanupSpy.mockRestore();
       await scopedMemory.reset();

--- a/mem0-ts/src/oss/tests/memory.crud.test.ts
+++ b/mem0-ts/src/oss/tests/memory.crud.test.ts
@@ -225,25 +225,25 @@ describe("Memory - provider scope filters", () => {
     return memory._providerFiltersForRequestedScope(filters);
   }
 
+  function providerFilterVariantsFor(
+    provider: string,
+    filters: Record<string, any>,
+  ): Array<Record<string, any> | undefined> {
+    const memory = Object.create(Memory.prototype) as any;
+    memory.config = { vectorStore: { provider } };
+    return memory._providerFilterVariantsForRequestedScope(filters);
+  }
+
   test("widens qdrant and pgvector scope filters to snake and camel aliases", () => {
     const expected = {
-      $or: [
+      topic: "preferences",
+      $and: [
         {
-          user_id: "target-user",
-          agent_id: "agent-a",
-          topic: "preferences",
+          $or: [{ user_id: "target-user" }, { userId: "target-user" }],
         },
         {
-          user_id: "target-user",
-          agentId: "agent-a",
-          topic: "preferences",
+          $or: [{ agent_id: "agent-a" }, { agentId: "agent-a" }],
         },
-        {
-          userId: "target-user",
-          agent_id: "agent-a",
-          topic: "preferences",
-        },
-        { userId: "target-user", agentId: "agent-a", topic: "preferences" },
       ],
     };
 
@@ -270,11 +270,11 @@ describe("Memory - provider scope filters", () => {
         $or: [{ topic: "travel" }, { topic: "food" }],
       }),
     ).toEqual({
-      $or: [
-        { topic: "travel", user_id: "target-user" },
-        { topic: "food", user_id: "target-user" },
-        { topic: "travel", userId: "target-user" },
-        { topic: "food", userId: "target-user" },
+      $or: [{ topic: "travel" }, { topic: "food" }],
+      $and: [
+        {
+          $or: [{ user_id: "target-user" }, { userId: "target-user" }],
+        },
       ],
     });
   });
@@ -287,14 +287,25 @@ describe("Memory - provider scope filters", () => {
       }),
     ).toEqual({
       $or: [
-        { user_id: "target-user", agent_id: "agent-a" },
-        { user_id: "target-user", agentId: "agent-a" },
-        { user_id: "target-user", topic: "travel" },
-        { userId: "target-user", agent_id: "agent-a" },
-        { userId: "target-user", agentId: "agent-a" },
-        { userId: "target-user", topic: "travel" },
+        { $or: [{ agent_id: "agent-a" }, { agentId: "agent-a" }] },
+        { topic: "travel" },
+      ],
+      $and: [
+        {
+          $or: [{ user_id: "target-user" }, { userId: "target-user" }],
+        },
       ],
     });
+  });
+
+  test("fails closed when provider scope alias widening exceeds complexity caps", () => {
+    expect(() =>
+      providerFiltersFor("qdrant", {
+        $and: Array.from({ length: 257 }, () => ({
+          user_id: "target-user",
+        })),
+      }),
+    ).toThrow("Scope filter is too complex to safely widen");
   });
 
   test("keeps nested wildcard scope filters out of provider filters", () => {
@@ -315,7 +326,18 @@ describe("Memory - provider scope filters", () => {
     });
   });
 
-  test("keeps vectorize scope filters in stored snake_case metadata keys", () => {
+  test("keeps vectorize default provider filters scoped to stored snake_case metadata keys", () => {
+    expect(
+      providerFiltersFor("vectorize", {
+        userId: "target-user",
+        agentId: "agent-a",
+        topic: "preferences",
+      }),
+    ).toEqual({
+      user_id: "target-user",
+      agent_id: "agent-a",
+    });
+
     expect(
       providerFiltersFor("vectorize", {
         user_id: "target-user",
@@ -323,10 +345,49 @@ describe("Memory - provider scope filters", () => {
         topic: "preferences",
       }),
     ).toEqual({
-      topic: "preferences",
       user_id: "target-user",
       agent_id: "agent-a",
     });
+  });
+
+  test("queries both canonical and legacy Vectorize scope indexes", () => {
+    expect(
+      providerFilterVariantsFor("vectorize", {
+        userId: "target-user",
+        agentId: "agent-a",
+        topic: "preferences",
+      }),
+    ).toEqual([
+      { user_id: "target-user", agent_id: "agent-a" },
+      { user_id: "target-user", agentId: "agent-a" },
+      { userId: "target-user", agent_id: "agent-a" },
+      { userId: "target-user", agentId: "agent-a" },
+    ]);
+
+    expect(
+      providerFilterVariantsFor("vectorize", {
+        AND: [{ user_id: "target-user" }, { topic: "preferences" }],
+      }),
+    ).toEqual([{ user_id: "target-user" }, { userId: "target-user" }]);
+  });
+
+  test("uses the TypeScript Azure AI Search provider name for provider result caps", () => {
+    const memory = Object.create(Memory.prototype) as any;
+    memory.config = { vectorStore: { provider: "azure-ai-search" } };
+
+    expect(memory._effectiveProviderLimit(10000)).toBe(1000);
+    expect(memory._effectiveProviderLimit(60)).toBe(60);
+  });
+
+  test("rejects conflicting snake_case and camelCase scope equality filters", () => {
+    const memory = Object.create(Memory.prototype) as any;
+
+    expect(() =>
+      memory._assertSafeScopeFilters(
+        { user_id: "canonical-user", userId: "alias-user" },
+        "search",
+      ),
+    ).toThrow("Conflicting scope filters [user_id]");
   });
 
   test("strips logical filters for providers without logical filter support", () => {
@@ -338,17 +399,64 @@ describe("Memory - provider scope filters", () => {
       }),
     ).toEqual({
       user_id: "target-user",
-      source: "import",
+      agent_id: "agent-a",
     });
 
     expect(
-      providerFiltersFor("azure_ai_search", {
+      providerFiltersFor("azure-ai-search", {
         user_id: "target-user",
         $or: [{ topic: "travel" }, { topic: "food" }],
       }),
     ).toEqual({
       user_id: "target-user",
     });
+  });
+
+  test("keeps required nested scope filters for providers without logical support", () => {
+    expect(
+      providerFiltersFor("redis", {
+        AND: [{ userId: "target-user" }, { topic: "travel" }],
+        source: "import",
+      }),
+    ).toEqual({
+      user_id: "target-user",
+    });
+
+    expect(
+      providerFiltersFor("azure-ai-search", {
+        OR: [
+          { userId: "target-user", topic: "travel" },
+          { user_id: "target-user", topic: "food" },
+        ],
+      }),
+    ).toEqual({
+      user_id: "target-user",
+    });
+  });
+
+  test("omits unsupported advanced metadata predicates for providers without logical support", () => {
+    expect(
+      providerFiltersFor("redis", {
+        user_id: "target-user",
+        source: "import",
+        topic: { contains: "travel" },
+        tags: ["personal", "travel"],
+        marker: "*",
+      }),
+    ).toEqual({
+      user_id: "target-user",
+    });
+  });
+
+  test("fails closed when nested alias widening exceeds depth caps", () => {
+    const nested = Array.from({ length: 34 }).reduce<Record<string, any>>(
+      (acc) => ({ $and: [acc] }),
+      { user_id: "target-user" },
+    );
+
+    expect(() => providerFiltersFor("qdrant", nested)).toThrow(
+      "Scope filter is too complex to safely widen",
+    );
   });
 
   test("passes widened provider scope filters through public getAll calls", async () => {
@@ -382,11 +490,13 @@ describe("Memory - provider scope filters", () => {
 
       expect(listSpy).toHaveBeenCalledWith(
         {
-          $or: [
-            { user_id: "target-user", agent_id: "agent-a" },
-            { user_id: "target-user", agentId: "agent-a" },
-            { userId: "target-user", agent_id: "agent-a" },
-            { userId: "target-user", agentId: "agent-a" },
+          $and: [
+            {
+              $or: [{ user_id: "target-user" }, { userId: "target-user" }],
+            },
+            {
+              $or: [{ agent_id: "agent-a" }, { agentId: "agent-a" }],
+            },
           ],
         },
         60,
@@ -395,6 +505,169 @@ describe("Memory - provider scope filters", () => {
     } finally {
       listSpy.mockRestore();
       (scopedMemory as any).config.vectorStore.provider = "memory";
+      await scopedMemory.reset();
+    }
+  });
+
+  test("uses camelCase public read filters with the default memory provider", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const rows = [
+      {
+        id: "owned-memory",
+        payload: {
+          data: "target user memory",
+          hash: "owned-hash",
+          user_id: "target-user",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ];
+    const listSpy = jest
+      .spyOn(vectorStore, "list")
+      .mockResolvedValueOnce([rows, rows.length]);
+    const searchSpy = jest.spyOn(vectorStore, "search").mockResolvedValueOnce([
+      {
+        ...rows[0],
+        score: 0.99,
+      },
+    ]);
+    const keywordSpy = jest
+      .spyOn(vectorStore, "keywordSearch")
+      .mockResolvedValueOnce(null);
+
+    try {
+      const getAllResult: SearchResult = await scopedMemory.getAll({
+        filters: { userId: "  target-user  " },
+        topK: 5,
+      });
+      const searchResult: SearchResult = await scopedMemory.search("target", {
+        filters: { userId: "  target-user  " },
+        threshold: 0,
+        topK: 5,
+      });
+
+      expect(listSpy).toHaveBeenCalledWith({ user_id: "target-user" }, 60);
+      expect(searchSpy).toHaveBeenCalledWith(
+        mockEmbedding,
+        expect.any(Number),
+        { user_id: "target-user" },
+      );
+      expect(getAllResult.results.map((item) => item.id)).toEqual([
+        "owned-memory",
+      ]);
+      expect(searchResult.results.map((item) => item.id)).toEqual([
+        "owned-memory",
+      ]);
+    } finally {
+      listSpy.mockRestore();
+      searchSpy.mockRestore();
+      keywordSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
+  test("normalizes nested camelCase public read scope filters", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const rows = [
+      {
+        id: "owned-memory",
+        payload: {
+          data: "target user travel memory",
+          hash: "owned-hash",
+          user_id: "target-user",
+          topic: "travel",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ];
+    const listSpy = jest
+      .spyOn(vectorStore, "list")
+      .mockResolvedValueOnce([rows, rows.length]);
+    const searchSpy = jest.spyOn(vectorStore, "search").mockResolvedValueOnce([
+      {
+        ...rows[0],
+        score: 0.99,
+      },
+    ]);
+    const keywordSpy = jest
+      .spyOn(vectorStore, "keywordSearch")
+      .mockResolvedValueOnce(null);
+    const filters = {
+      AND: [{ userId: "  target-user  " }, { topic: "travel" }],
+    };
+
+    try {
+      const getAllResult: SearchResult = await scopedMemory.getAll({
+        filters,
+        topK: 5,
+      });
+      const searchResult: SearchResult = await scopedMemory.search("target", {
+        filters,
+        threshold: 0,
+        topK: 5,
+      });
+
+      expect(listSpy).toHaveBeenCalledWith(
+        { AND: [{ user_id: "target-user" }, { topic: "travel" }] },
+        60,
+      );
+      expect(searchSpy).toHaveBeenCalledWith(
+        mockEmbedding,
+        expect.any(Number),
+        { $and: [{ user_id: "target-user" }, { topic: "travel" }] },
+      );
+      expect(getAllResult.results.map((item) => item.id)).toEqual([
+        "owned-memory",
+      ]);
+      expect(searchResult.results.map((item) => item.id)).toEqual([
+        "owned-memory",
+      ]);
+    } finally {
+      listSpy.mockRestore();
+      searchSpy.mockRestore();
+      keywordSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
+  test("rejects invalid nested camelCase scope values before provider reads", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const listSpy = jest.spyOn(vectorStore, "list");
+    const searchSpy = jest.spyOn(vectorStore, "search");
+    const keywordSpy = jest.spyOn(vectorStore, "keywordSearch");
+    const filters = { AND: [{ userId: "target user" }] };
+
+    try {
+      await expect(
+        scopedMemory.getAll({
+          filters,
+          topK: 5,
+        }),
+      ).rejects.toThrow("Invalid user_id: cannot contain whitespace");
+      await expect(
+        scopedMemory.search("target", {
+          filters,
+          threshold: 0,
+          topK: 5,
+        }),
+      ).rejects.toThrow("Invalid user_id: cannot contain whitespace");
+
+      expect(listSpy).not.toHaveBeenCalled();
+      expect(searchSpy).not.toHaveBeenCalled();
+      expect(keywordSpy).not.toHaveBeenCalled();
+    } finally {
+      listSpy.mockRestore();
+      searchSpy.mockRestore();
+      keywordSpy.mockRestore();
       await scopedMemory.reset();
     }
   });
@@ -543,6 +816,37 @@ describe("Memory - deleteAll()", () => {
       "At least one filter is required to delete all memories",
     );
   });
+
+  test("rejects filters config instead of ignoring it for destructive deletes", async () => {
+    await expect(
+      memory.deleteAll({
+        userId,
+        filters: { NOT: { topic: "secret" } },
+      } as any),
+    ).rejects.toThrow("deleteAll() does not support filters");
+  });
+
+  test("rejects logical operator keys for destructive deletes", async () => {
+    await expect(
+      memory.deleteAll({
+        userId,
+        NOT: { topic: "secret" },
+      } as any),
+    ).rejects.toThrow("Logical filters [NOT] are not supported in deleteAll()");
+  });
+
+  test.each([
+    ["snake_case user scope", { userId, user_id: userId }],
+    ["snake_case agent scope", { userId, agent_id: "agent-a" }],
+    ["arbitrary metadata", { userId, topic: "travel" }],
+  ])(
+    "rejects unsupported %s options for destructive deletes",
+    async (_, config) => {
+      await expect(memory.deleteAll(config as any)).rejects.toThrow(
+        "deleteAll() does not support option(s):",
+      );
+    },
+  );
 });
 
 // ─── getAll() ────────────────────────────────────────────
@@ -671,6 +975,87 @@ describe("Memory - getAll()", () => {
     }
   });
 
+  test.each([
+    [
+      "array shorthand",
+      { user_id: ["target-user", "other-user"] },
+      "Scope filter [user_id] in getAll() must use explicit equality",
+    ],
+    [
+      "negative operator",
+      { user_id: { ne: "other-user" } },
+      "Scope filter [user_id] in getAll() must use explicit equality",
+    ],
+    [
+      "in operator",
+      { user_id: { in: ["target-user"] } },
+      "Scope filter [user_id] in getAll() must use explicit equality",
+    ],
+    [
+      "nin operator",
+      { user_id: { nin: ["other-user"] } },
+      "Scope filter [user_id] in getAll() must use explicit equality",
+    ],
+    [
+      "range operator",
+      { user_id: { gte: "target-user" } },
+      "Scope filter [user_id] in getAll() must use explicit equality",
+    ],
+    [
+      "text operator",
+      { user_id: { contains: "target" } },
+      "Scope filter [user_id] in getAll() must use explicit equality",
+    ],
+    [
+      "multi-scope OR",
+      { OR: [{ user_id: "target-user" }, { user_id: "other-user" }] },
+      "filters must contain at least one of: user_id, agent_id, run_id",
+    ],
+    [
+      "negative logical scope",
+      { user_id: "target-user", NOT: [{ agent_id: "blocked-agent" }] },
+      "Negative scope filters [agent_id] are not supported in getAll()",
+    ],
+    [
+      "malformed AND",
+      { user_id: "target-user", AND: { topic: "travel" } } as any,
+      "AND operator requires a list of conditions",
+    ],
+    [
+      "malformed OR",
+      { user_id: "target-user", OR: { topic: "travel" } } as any,
+      "OR operator requires a non-empty list of conditions",
+    ],
+    [
+      "malformed NOT",
+      { user_id: "target-user", NOT: { topic: "secret" } } as any,
+      "NOT operator requires a non-empty list of conditions",
+    ],
+  ])(
+    "rejects broad %s scope filters for getAll",
+    async (_name, filters, message) => {
+      const scopedMemory = createMemory();
+      await (scopedMemory as any)._ensureInitialized();
+
+      const vectorStore = (scopedMemory as any).vectorStore;
+      const listSpy = jest.spyOn(vectorStore, "list");
+
+      try {
+        await expect(
+          scopedMemory.getAll({
+            filters,
+            topK: 5,
+          }),
+        ).rejects.toThrow(message);
+
+        expect(listSpy).not.toHaveBeenCalled();
+      } finally {
+        listSpy.mockRestore();
+        await scopedMemory.reset();
+      }
+    },
+  );
+
   test("fails closed when cursorless list provider returns a full page before topK is satisfied", async () => {
     const scopedMemory = createMemory();
     await (scopedMemory as any)._ensureInitialized();
@@ -712,6 +1097,111 @@ describe("Memory - getAll()", () => {
     }
   });
 
+  test("fails closed when a capped cursorless provider returns its maximum page before topK is satisfied", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    (scopedMemory as any).config.vectorStore.provider = "vectorize";
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const cappedScopedPage = Array.from({ length: 50 }, (_, index) => ({
+      id: `owned-memory-${index}`,
+      payload: {
+        data: `target user memory ${index}`,
+        hash: `owned-hash-${index}`,
+        user_id: "target-user",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    }));
+    const listSpy = jest
+      .spyOn(vectorStore, "list")
+      .mockResolvedValueOnce([cappedScopedPage, cappedScopedPage.length])
+      .mockResolvedValueOnce([[], 0]);
+
+    try {
+      await expect(
+        scopedMemory.getAll({
+          filters: { user_id: "target-user" },
+          topK: 60,
+        }),
+      ).rejects.toThrow(
+        "getAll cannot safely return all requested scoped memories for vector store provider 'vectorize'",
+      );
+
+      expect(listSpy).toHaveBeenNthCalledWith(
+        1,
+        { user_id: "target-user" },
+        50,
+      );
+      expect(listSpy).toHaveBeenNthCalledWith(2, { userId: "target-user" }, 50);
+    } finally {
+      listSpy.mockRestore();
+      (scopedMemory as any).config.vectorStore.provider = "memory";
+      await scopedMemory.reset();
+    }
+  });
+
+  test("reads Vectorize legacy alias-only rows through scoped getAll", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    (scopedMemory as any).config.vectorStore.provider = "vectorize";
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const canonicalRows = [
+      {
+        id: "canonical-memory",
+        payload: {
+          data: "canonical target memory",
+          hash: "canonical-hash",
+          user_id: "target-user",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ];
+    const legacyRows = [
+      {
+        id: "legacy-memory",
+        payload: {
+          data: "legacy target memory",
+          hash: "legacy-hash",
+          userId: "target-user",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ];
+    const listSpy = jest
+      .spyOn(vectorStore, "list")
+      .mockResolvedValueOnce([canonicalRows, canonicalRows.length])
+      .mockResolvedValueOnce([legacyRows, legacyRows.length]);
+
+    try {
+      const result: SearchResult = await scopedMemory.getAll({
+        filters: { user_id: "target-user" },
+        topK: 5,
+      });
+
+      expect(listSpy).toHaveBeenNthCalledWith(
+        1,
+        { user_id: "target-user" },
+        50,
+      );
+      expect(listSpy).toHaveBeenNthCalledWith(2, { userId: "target-user" }, 50);
+      expect(result.results.map((item) => item.id)).toEqual([
+        "canonical-memory",
+        "legacy-memory",
+      ]);
+      expect(result.results[1]).toEqual(
+        expect.objectContaining({ user_id: "target-user" }),
+      );
+      expect(result.results[1].metadata).not.toHaveProperty("userId");
+    } finally {
+      listSpy.mockRestore();
+      (scopedMemory as any).config.vectorStore.provider = "memory";
+      await scopedMemory.reset();
+    }
+  });
+
   test("returns scoped results from cursorless providers when the page is not full", async () => {
     const scopedMemory = createMemory();
     await (scopedMemory as any)._ensureInitialized();
@@ -744,6 +1234,257 @@ describe("Memory - getAll()", () => {
       expect(result.results[0]).toEqual(
         expect.objectContaining({ user_id: "target-user" }),
       );
+    } finally {
+      listSpy.mockRestore();
+      (scopedMemory as any).config.vectorStore.provider = "memory";
+      await scopedMemory.reset();
+    }
+  });
+
+  test("does not fail closed when an exact-count provider proves a getAll page is complete", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    (scopedMemory as any).config.vectorStore.provider = "pgvector";
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const fullForeignPage = Array.from({ length: 60 }, (_, index) => ({
+      id: `foreign-memory-${index}`,
+      payload: {
+        data: `wrong user memory ${index}`,
+        hash: `foreign-hash-${index}`,
+        userId: "other-user",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    }));
+    const listSpy = jest
+      .spyOn(vectorStore, "list")
+      .mockResolvedValueOnce([fullForeignPage, fullForeignPage.length]);
+
+    try {
+      const result: SearchResult = await scopedMemory.getAll({
+        filters: { user_id: "target-user" },
+        topK: 1,
+      });
+
+      expect(listSpy).toHaveBeenCalledWith(
+        { $or: [{ user_id: "target-user" }, { userId: "target-user" }] },
+        60,
+      );
+      expect(result.results).toEqual([]);
+    } finally {
+      listSpy.mockRestore();
+      (scopedMemory as any).config.vectorStore.provider = "memory";
+      await scopedMemory.reset();
+    }
+  });
+
+  test("keeps exact metadata filtering in Memory when simple providers list with stripped filters", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    (scopedMemory as any).config.vectorStore.provider = "redis";
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const rows = [
+      {
+        id: "wrong-topic-memory",
+        payload: {
+          data: "target user wrong topic",
+          hash: "wrong-topic-hash",
+          userId: "target-user",
+          topic: "food",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "topic-match-memory",
+        payload: {
+          data: "target user travel memory",
+          hash: "topic-match-hash",
+          userId: "target-user",
+          topic: "travel",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "foreign-topic-match-memory",
+        payload: {
+          data: "wrong user travel memory",
+          hash: "foreign-topic-match-hash",
+          userId: "other-user",
+          topic: "travel",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ];
+    const listSpy = jest
+      .spyOn(vectorStore, "list")
+      .mockResolvedValueOnce([rows, rows.length]);
+
+    try {
+      const result: SearchResult = await scopedMemory.getAll({
+        filters: { user_id: "target-user", topic: "travel" },
+        topK: 5,
+      });
+
+      expect(listSpy).toHaveBeenCalledWith({ user_id: "target-user" }, 60);
+      expect(result.results.map((item) => item.id)).toEqual([
+        "topic-match-memory",
+      ]);
+    } finally {
+      listSpy.mockRestore();
+      (scopedMemory as any).config.vectorStore.provider = "memory";
+      await scopedMemory.reset();
+    }
+  });
+
+  test("keeps logical filtering in Memory when simple providers receive stripped filters", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    (scopedMemory as any).config.vectorStore.provider = "redis";
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const rows = [
+      {
+        id: "wrong-topic-memory",
+        payload: {
+          data: "target user wrong topic",
+          hash: "wrong-topic-hash",
+          userId: "target-user",
+          agentId: "agent-b",
+          topic: "food",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "topic-match-memory",
+        payload: {
+          data: "target user travel memory",
+          hash: "topic-match-hash",
+          userId: "target-user",
+          agentId: "agent-b",
+          topic: "travel",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "agent-match-memory",
+        payload: {
+          data: "target user agent memory",
+          hash: "agent-match-hash",
+          userId: "target-user",
+          agentId: "agent-a",
+          topic: "food",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "foreign-topic-match-memory",
+        payload: {
+          data: "wrong user travel memory",
+          hash: "foreign-topic-match-hash",
+          userId: "other-user",
+          agentId: "agent-a",
+          topic: "travel",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ];
+    const listSpy = jest
+      .spyOn(vectorStore, "list")
+      .mockResolvedValueOnce([rows, rows.length]);
+
+    try {
+      const result: SearchResult = await scopedMemory.getAll({
+        filters: {
+          user_id: "target-user",
+          OR: [{ topic: "travel" }, { agent_id: "agent-a" }],
+        },
+        topK: 5,
+      });
+
+      expect(listSpy).toHaveBeenCalledWith({ user_id: "target-user" }, 60);
+      expect(result.results.map((item) => item.id)).toEqual([
+        "topic-match-memory",
+        "agent-match-memory",
+      ]);
+    } finally {
+      listSpy.mockRestore();
+      (scopedMemory as any).config.vectorStore.provider = "memory";
+      await scopedMemory.reset();
+    }
+  });
+
+  test("fails closed when exact-count getAll recovery reaches the scan ceiling", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    (scopedMemory as any).config.vectorStore.provider = "redis";
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const listSpy = jest
+      .spyOn(vectorStore, "list")
+      .mockImplementation(async (...args: unknown[]) => {
+        const pageSize = typeof args[1] === "number" ? args[1] : 0;
+        return [
+          Array.from({ length: pageSize }, (_, index) => ({
+            id: `foreign-memory-${pageSize}-${index}`,
+            payload: {
+              data: `wrong user memory ${index}`,
+              hash: `foreign-hash-${pageSize}-${index}`,
+              userId: "other-user",
+              createdAt: "2026-01-01T00:00:00.000Z",
+            },
+          })),
+          10001,
+        ];
+      });
+
+    try {
+      await expect(
+        scopedMemory.getAll({
+          filters: {
+            user_id: "target-user",
+            OR: [{ topic: "travel" }, { agent_id: "agent-a" }],
+          },
+          topK: 1,
+        }),
+      ).rejects.toThrow("scoped post-filter recovery reached 10000 rows");
+
+      expect(listSpy).toHaveBeenLastCalledWith(
+        { user_id: "target-user" },
+        10000,
+      );
+    } finally {
+      listSpy.mockRestore();
+      (scopedMemory as any).config.vectorStore.provider = "memory";
+      await scopedMemory.reset();
+    }
+  });
+
+  test("caps exact-count getAll first fetches at the scoped recovery ceiling", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    (scopedMemory as any).config.vectorStore.provider = "redis";
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const listSpy = jest
+      .spyOn(vectorStore, "list")
+      .mockResolvedValueOnce([[], 10001]);
+
+    try {
+      await expect(
+        scopedMemory.getAll({
+          filters: { user_id: "target-user" },
+          topK: 1_000_000,
+        }),
+      ).rejects.toThrow("scoped post-filter recovery reached 10000 rows");
+
+      expect(listSpy).toHaveBeenCalledTimes(1);
+      expect(listSpy).toHaveBeenCalledWith({ user_id: "target-user" }, 10000);
     } finally {
       listSpy.mockRestore();
       (scopedMemory as any).config.vectorStore.provider = "memory";
@@ -1024,6 +1765,77 @@ describe("Memory - search()", () => {
     );
   });
 
+  test("accepts scope supplied by every top-level AND branch", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const searchSpy = jest.spyOn(vectorStore, "search").mockResolvedValueOnce([
+      {
+        id: "owned-memory",
+        score: 0.98,
+        payload: {
+          data: "target user travel memory",
+          hash: "owned-hash",
+          userId: "target-user",
+          topic: "travel",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ]);
+    const keywordSpy = jest
+      .spyOn(vectorStore, "keywordSearch")
+      .mockResolvedValueOnce(null);
+
+    try {
+      const result: SearchResult = await scopedMemory.search("target", {
+        filters: {
+          AND: [{ user_id: "target-user" }, { topic: "travel" }],
+        },
+        threshold: 0,
+        topK: 5,
+      });
+
+      expect(searchSpy).toHaveBeenCalledWith(
+        mockEmbedding,
+        expect.any(Number),
+        { $and: [{ user_id: "target-user" }, { topic: "travel" }] },
+      );
+      expect(result.results.map((item) => item.id)).toEqual(["owned-memory"]);
+    } finally {
+      searchSpy.mockRestore();
+      keywordSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
+  test("rejects OR filters when any branch lacks scope", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const searchSpy = jest.spyOn(vectorStore, "search");
+
+    try {
+      await expect(
+        scopedMemory.search("target", {
+          filters: {
+            OR: [{ user_id: "target-user" }, { topic: "travel" }],
+          },
+          threshold: 0,
+          topK: 5,
+        }),
+      ).rejects.toThrow(
+        "filters must contain at least one of: user_id, agent_id, run_id",
+      );
+
+      expect(searchSpy).not.toHaveBeenCalled();
+    } finally {
+      searchSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
   test("returns empty results for user with no memories", async () => {
     const result: SearchResult = await memory.search("query", {
       filters: { user_id: "empty_user" },
@@ -1092,6 +1904,208 @@ describe("Memory - search()", () => {
     }
   });
 
+  test("fails closed when search cannot prove scoped completeness from a full page", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const fullForeignPage = Array.from({ length: 60 }, (_, index) => ({
+      id: `foreign-memory-${index}`,
+      score: 1 - index / 1000,
+      payload: {
+        data: `wrong user memory ${index}`,
+        hash: `foreign-hash-${index}`,
+        userId: "other-user",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    }));
+    const searchSpy = jest
+      .spyOn(vectorStore, "search")
+      .mockResolvedValueOnce(fullForeignPage);
+    const keywordSpy = jest.spyOn(vectorStore, "keywordSearch");
+
+    try {
+      await expect(
+        scopedMemory.search("target", {
+          filters: { user_id: "target-user" },
+          threshold: 0,
+          topK: 5,
+        }),
+      ).rejects.toThrow(
+        "search cannot safely return all requested scoped memories for vector store provider 'memory'",
+      );
+
+      expect(searchSpy).toHaveBeenCalledWith(mockEmbedding, 60, {
+        user_id: "target-user",
+      });
+      expect(keywordSpy).not.toHaveBeenCalled();
+    } finally {
+      searchSpy.mockRestore();
+      keywordSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
+  test("fails closed when a capped search provider cannot satisfy requested topK", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    (scopedMemory as any).config.vectorStore.provider = "vectorize";
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const cappedScopedPage = Array.from({ length: 50 }, (_, index) => ({
+      id: `owned-memory-${index}`,
+      score: 1 - index / 1000,
+      payload: {
+        data: `target user memory ${index}`,
+        hash: `owned-hash-${index}`,
+        user_id: "target-user",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    }));
+    const searchSpy = jest
+      .spyOn(vectorStore, "search")
+      .mockResolvedValueOnce(cappedScopedPage)
+      .mockResolvedValueOnce([]);
+    const keywordSpy = jest.spyOn(vectorStore, "keywordSearch");
+
+    try {
+      await expect(
+        scopedMemory.search("target", {
+          filters: { user_id: "target-user" },
+          threshold: 0,
+          topK: 60,
+        }),
+      ).rejects.toThrow(
+        "search cannot safely return all requested scoped memories for vector store provider 'vectorize'",
+      );
+
+      expect(searchSpy).toHaveBeenNthCalledWith(1, mockEmbedding, 50, {
+        user_id: "target-user",
+      });
+      expect(searchSpy).toHaveBeenNthCalledWith(2, mockEmbedding, 50, {
+        userId: "target-user",
+      });
+      expect(keywordSpy).not.toHaveBeenCalled();
+    } finally {
+      searchSpy.mockRestore();
+      keywordSpy.mockRestore();
+      (scopedMemory as any).config.vectorStore.provider = "memory";
+      await scopedMemory.reset();
+    }
+  });
+
+  test("searches Vectorize canonical and legacy scope indexes before post-filtering", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    (scopedMemory as any).config.vectorStore.provider = "vectorize";
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const searchSpy = jest
+      .spyOn(vectorStore, "search")
+      .mockResolvedValueOnce([
+        {
+          id: "canonical-memory",
+          score: 0.8,
+          payload: {
+            data: "canonical target memory",
+            hash: "canonical-hash",
+            user_id: "target-user",
+            createdAt: "2026-01-01T00:00:00.000Z",
+          },
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: "legacy-memory",
+          score: 0.9,
+          payload: {
+            data: "legacy target memory",
+            hash: "legacy-hash",
+            userId: "target-user",
+            createdAt: "2026-01-01T00:00:00.000Z",
+          },
+        },
+      ]);
+    const keywordSpy = jest
+      .spyOn(vectorStore, "keywordSearch")
+      .mockResolvedValue(null);
+
+    try {
+      const result: SearchResult = await scopedMemory.search("target", {
+        filters: { user_id: "target-user" },
+        threshold: 0,
+        topK: 5,
+      });
+
+      expect(searchSpy).toHaveBeenNthCalledWith(1, mockEmbedding, 50, {
+        user_id: "target-user",
+      });
+      expect(searchSpy).toHaveBeenNthCalledWith(2, mockEmbedding, 50, {
+        userId: "target-user",
+      });
+      expect(result.results.map((item) => item.id)).toEqual([
+        "legacy-memory",
+        "canonical-memory",
+      ]);
+      expect(result.results[0]).toEqual(
+        expect.objectContaining({ user_id: "target-user" }),
+      );
+      expect(result.results[0].metadata).not.toHaveProperty("userId");
+    } finally {
+      searchSpy.mockRestore();
+      keywordSpy.mockRestore();
+      (scopedMemory as any).config.vectorStore.provider = "memory";
+      await scopedMemory.reset();
+    }
+  });
+
+  test("applies the Azure AI Search cap on search fail-closed checks", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    (scopedMemory as any).config.vectorStore.provider = "azure-ai-search";
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const cappedScopedPage = Array.from({ length: 1000 }, (_, index) => ({
+      id: `azure-owned-memory-${index}`,
+      score: 1 - index / 10000,
+      payload: {
+        data: `target user memory ${index}`,
+        hash: `azure-owned-hash-${index}`,
+        user_id: "target-user",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    }));
+    const searchSpy = jest
+      .spyOn(vectorStore, "search")
+      .mockResolvedValueOnce(cappedScopedPage);
+    const keywordSpy = jest.spyOn(vectorStore, "keywordSearch");
+
+    try {
+      await expect(
+        scopedMemory.search("target", {
+          filters: { user_id: "target-user" },
+          threshold: 0,
+          topK: 1001,
+        }),
+      ).rejects.toThrow(
+        "search cannot safely return all requested scoped memories for vector store provider 'azure-ai-search'",
+      );
+
+      expect(searchSpy).toHaveBeenCalledWith(mockEmbedding, 1000, {
+        user_id: "target-user",
+      });
+      expect(keywordSpy).not.toHaveBeenCalled();
+    } finally {
+      searchSpy.mockRestore();
+      keywordSpy.mockRestore();
+      (scopedMemory as any).config.vectorStore.provider = "memory";
+      await scopedMemory.reset();
+    }
+  });
+
   test("ignores wrong-scope keyword results when scoring", async () => {
     const scopedMemory = createMemory();
     await (scopedMemory as any)._ensureInitialized();
@@ -1147,6 +2161,280 @@ describe("Memory - search()", () => {
           maxPossibleScore: 1,
         }),
       );
+    } finally {
+      searchSpy.mockRestore();
+      keywordSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
+  test("keeps exact metadata filtering in Memory when simple providers search with stripped filters", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    (scopedMemory as any).config.vectorStore.provider = "redis";
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const rows = [
+      {
+        id: "wrong-topic-memory",
+        score: 0.99,
+        payload: {
+          data: "target user wrong topic",
+          hash: "wrong-topic-hash",
+          userId: "target-user",
+          topic: "food",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "topic-match-memory",
+        score: 0.98,
+        payload: {
+          data: "target user travel memory",
+          hash: "topic-match-hash",
+          userId: "target-user",
+          topic: "travel",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "foreign-topic-match-memory",
+        score: 0.97,
+        payload: {
+          data: "wrong user travel memory",
+          hash: "foreign-topic-match-hash",
+          userId: "other-user",
+          topic: "travel",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ];
+    const searchSpy = jest
+      .spyOn(vectorStore, "search")
+      .mockResolvedValueOnce(rows);
+    const keywordSpy = jest
+      .spyOn(vectorStore, "keywordSearch")
+      .mockResolvedValueOnce(null);
+
+    try {
+      const result: SearchResult = await scopedMemory.search("target", {
+        filters: { user_id: "target-user", topic: "travel" },
+        threshold: 0,
+        topK: 5,
+      });
+
+      expect(searchSpy).toHaveBeenCalledWith(mockEmbedding, 60, {
+        user_id: "target-user",
+      });
+      expect(result.results.map((item) => item.id)).toEqual([
+        "topic-match-memory",
+      ]);
+    } finally {
+      searchSpy.mockRestore();
+      keywordSpy.mockRestore();
+      (scopedMemory as any).config.vectorStore.provider = "memory";
+      await scopedMemory.reset();
+    }
+  });
+
+  test("keeps logical metadata filtering in Memory when simple providers search with stripped filters", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    (scopedMemory as any).config.vectorStore.provider = "redis";
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const rows = [
+      {
+        id: "wrong-topic-memory",
+        score: 0.99,
+        payload: {
+          data: "target user wrong topic",
+          hash: "wrong-topic-hash",
+          userId: "target-user",
+          agentId: "agent-b",
+          topic: "food",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "topic-match-memory",
+        score: 0.98,
+        payload: {
+          data: "target user travel memory",
+          hash: "topic-match-hash",
+          userId: "target-user",
+          agentId: "agent-b",
+          topic: "travel",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "agent-match-memory",
+        score: 0.97,
+        payload: {
+          data: "target user agent memory",
+          hash: "agent-match-hash",
+          userId: "target-user",
+          agentId: "agent-a",
+          topic: "food",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "foreign-topic-match-memory",
+        score: 0.96,
+        payload: {
+          data: "wrong user travel memory",
+          hash: "foreign-topic-match-hash",
+          userId: "other-user",
+          agentId: "agent-a",
+          topic: "travel",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ];
+    const searchSpy = jest
+      .spyOn(vectorStore, "search")
+      .mockResolvedValueOnce(rows);
+    const keywordSpy = jest
+      .spyOn(vectorStore, "keywordSearch")
+      .mockResolvedValueOnce(null);
+
+    try {
+      const result: SearchResult = await scopedMemory.search("target", {
+        filters: {
+          user_id: "target-user",
+          OR: [{ topic: "travel" }, { agent_id: "agent-a" }],
+        },
+        threshold: 0,
+        topK: 5,
+      });
+
+      expect(searchSpy).toHaveBeenCalledWith(mockEmbedding, 60, {
+        user_id: "target-user",
+      });
+      expect(result.results.map((item) => item.id)).toEqual([
+        "topic-match-memory",
+        "agent-match-memory",
+      ]);
+    } finally {
+      searchSpy.mockRestore();
+      keywordSpy.mockRestore();
+      (scopedMemory as any).config.vectorStore.provider = "memory";
+      await scopedMemory.reset();
+    }
+  });
+
+  test("keeps advanced metadata filtering in Memory when simple providers receive exact filters", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    (scopedMemory as any).config.vectorStore.provider = "redis";
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const rows = [
+      {
+        id: "wrong-topic-memory",
+        score: 0.99,
+        payload: {
+          data: "target user wrong topic",
+          hash: "wrong-topic-hash",
+          userId: "target-user",
+          topic: "food",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "topic-match-memory",
+        score: 0.98,
+        payload: {
+          data: "target user travel memory",
+          hash: "topic-match-hash",
+          userId: "target-user",
+          topic: "travel plans",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ];
+    const searchSpy = jest
+      .spyOn(vectorStore, "search")
+      .mockResolvedValueOnce(rows);
+    const keywordSpy = jest
+      .spyOn(vectorStore, "keywordSearch")
+      .mockResolvedValueOnce(null);
+
+    try {
+      const result: SearchResult = await scopedMemory.search("target", {
+        filters: {
+          user_id: "target-user",
+          topic: { contains: "travel" },
+        },
+        threshold: 0,
+        topK: 5,
+      });
+
+      expect(searchSpy).toHaveBeenCalledWith(mockEmbedding, 60, {
+        user_id: "target-user",
+      });
+      expect(result.results.map((item) => item.id)).toEqual([
+        "topic-match-memory",
+      ]);
+    } finally {
+      searchSpy.mockRestore();
+      keywordSpy.mockRestore();
+      (scopedMemory as any).config.vectorStore.provider = "memory";
+      await scopedMemory.reset();
+    }
+  });
+
+  test("fails closed when keyword search cannot prove scoped completeness from a full page", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const searchSpy = jest.spyOn(vectorStore, "search").mockResolvedValueOnce([
+      {
+        id: "owned-memory",
+        score: 0.8,
+        payload: {
+          data: "target keyword memory",
+          hash: "owned-hash",
+          user_id: "target-user",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ]);
+    const fullForeignKeywordPage = Array.from({ length: 60 }, (_, index) => ({
+      id: `foreign-keyword-memory-${index}`,
+      score: 100 - index,
+      payload: {
+        data: `wrong user keyword memory ${index}`,
+        hash: `foreign-keyword-hash-${index}`,
+        user_id: "other-user",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    }));
+    const keywordSpy = jest
+      .spyOn(vectorStore, "keywordSearch")
+      .mockResolvedValueOnce(fullForeignKeywordPage);
+
+    try {
+      await expect(
+        scopedMemory.search("target", {
+          filters: { user_id: "target-user" },
+          threshold: 0,
+          topK: 5,
+        }),
+      ).rejects.toThrow(
+        "search cannot safely return all requested scoped memories for vector store provider 'memory'",
+      );
+
+      expect(searchSpy).toHaveBeenCalled();
+      expect(keywordSpy).toHaveBeenCalledWith("target", 60, {
+        user_id: "target-user",
+      });
     } finally {
       searchSpy.mockRestore();
       keywordSpy.mockRestore();
@@ -1351,7 +2639,7 @@ describe("Memory - search()", () => {
     }
   });
 
-  test("honors nested scope NOT filters when filtering search results", async () => {
+  test("honors nested metadata NOT filters when filtering scoped search results", async () => {
     const scopedMemory = createMemory();
     await (scopedMemory as any)._ensureInitialized();
 
@@ -1365,6 +2653,7 @@ describe("Memory - search()", () => {
           hash: "blocked-agent-hash",
           userId: "target-user",
           agentId: "blocked-agent",
+          topic: "blocked",
           createdAt: "2026-01-01T00:00:00.000Z",
         },
       },
@@ -1376,6 +2665,7 @@ describe("Memory - search()", () => {
           hash: "owned-hash",
           userId: "target-user",
           agentId: "allowed-agent",
+          topic: "allowed",
           createdAt: "2026-01-01T00:00:00.000Z",
         },
       },
@@ -1388,7 +2678,7 @@ describe("Memory - search()", () => {
       const result: SearchResult = await scopedMemory.search("target", {
         filters: {
           user_id: "target-user",
-          NOT: [{ agent_id: "blocked-agent" }],
+          NOT: [{ topic: "blocked" }],
         },
         threshold: 0,
         topK: 5,
@@ -1397,7 +2687,7 @@ describe("Memory - search()", () => {
       expect(searchSpy).toHaveBeenCalledWith(
         mockEmbedding,
         expect.any(Number),
-        { user_id: "target-user", $not: [{ agent_id: "blocked-agent" }] },
+        { user_id: "target-user", $not: [{ topic: "blocked" }] },
       );
       expect(result.results.map((item) => item.id)).toEqual(["owned-memory"]);
       expect(result.results[0]).toEqual(
@@ -1574,53 +2864,28 @@ describe("Memory - search()", () => {
     }
   });
 
-  test("preserves conflicting top-level and AND scope filters in post-filtering", async () => {
+  test("rejects conflicting top-level and AND scope filters before searching", async () => {
     const scopedMemory = createMemory();
     await (scopedMemory as any)._ensureInitialized();
 
     const vectorStore = (scopedMemory as any).vectorStore;
-    const searchSpy = jest.spyOn(vectorStore, "search").mockResolvedValueOnce([
-      {
-        id: "trusted-scope-memory",
-        score: 0.99,
-        payload: {
-          data: "trusted scope memory",
-          hash: "trusted-scope-hash",
-          userId: "trusted-user",
-          createdAt: "2026-01-01T00:00:00.000Z",
-        },
-      },
-      {
-        id: "conflicting-and-memory",
-        score: 0.98,
-        payload: {
-          data: "conflicting AND scope memory",
-          hash: "conflicting-and-hash",
-          userId: "other-user",
-          createdAt: "2026-01-01T00:00:00.000Z",
-        },
-      },
-    ]);
-    const keywordSpy = jest
-      .spyOn(vectorStore, "keywordSearch")
-      .mockResolvedValueOnce(null);
+    const searchSpy = jest.spyOn(vectorStore, "search");
+    const keywordSpy = jest.spyOn(vectorStore, "keywordSearch");
 
     try {
-      const result: SearchResult = await scopedMemory.search("target", {
-        filters: {
-          user_id: "trusted-user",
-          AND: [{ user_id: "other-user" }],
-        },
-        threshold: 0,
-        topK: 5,
-      });
+      await expect(
+        scopedMemory.search("target", {
+          filters: {
+            user_id: "trusted-user",
+            AND: [{ user_id: "other-user" }],
+          },
+          threshold: 0,
+          topK: 5,
+        }),
+      ).rejects.toThrow("Conflicting scope filters [user_id]");
 
-      expect(searchSpy).toHaveBeenCalledWith(
-        mockEmbedding,
-        expect.any(Number),
-        { user_id: "trusted-user", $and: [{ user_id: "other-user" }] },
-      );
-      expect(result.results).toEqual([]);
+      expect(searchSpy).not.toHaveBeenCalled();
+      expect(keywordSpy).not.toHaveBeenCalled();
     } finally {
       searchSpy.mockRestore();
       keywordSpy.mockRestore();
@@ -1703,7 +2968,88 @@ describe("Memory - search()", () => {
     }
   });
 
-  test("preserves mixed scope and metadata NOT semantics in post-filtering", async () => {
+  test("requires metadata presence for wildcard and negative operators during post-filtering", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const searchSpy = jest.spyOn(vectorStore, "search").mockResolvedValueOnce([
+      {
+        id: "missing-topic-memory",
+        score: 0.99,
+        payload: {
+          data: "target missing topic",
+          hash: "missing-topic-hash",
+          userId: "target-user",
+          status: "active",
+          category: "allowed",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "missing-status-memory",
+        score: 0.98,
+        payload: {
+          data: "target missing status",
+          hash: "missing-status-hash",
+          userId: "target-user",
+          topic: "travel",
+          category: "allowed",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "missing-category-memory",
+        score: 0.97,
+        payload: {
+          data: "target missing category",
+          hash: "missing-category-hash",
+          userId: "target-user",
+          topic: "travel",
+          status: "active",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+      {
+        id: "owned-memory",
+        score: 0.96,
+        payload: {
+          data: "target complete metadata",
+          hash: "owned-hash",
+          userId: "target-user",
+          topic: "travel",
+          status: "active",
+          category: "allowed",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ]);
+    const keywordSpy = jest
+      .spyOn(vectorStore, "keywordSearch")
+      .mockResolvedValueOnce(null);
+
+    try {
+      const result: SearchResult = await scopedMemory.search("target", {
+        filters: {
+          user_id: "target-user",
+          topic: "*",
+          status: { ne: "archived" },
+          category: { nin: ["blocked"] },
+        },
+        threshold: 0,
+        topK: 5,
+      });
+
+      expect(searchSpy).toHaveBeenCalled();
+      expect(result.results.map((item) => item.id)).toEqual(["owned-memory"]);
+    } finally {
+      searchSpy.mockRestore();
+      keywordSpy.mockRestore();
+      await scopedMemory.reset();
+    }
+  });
+
+  test("preserves scoped metadata NOT semantics in post-filtering", async () => {
     const scopedMemory = createMemory();
     await (scopedMemory as any)._ensureInitialized();
 
@@ -1718,6 +3064,7 @@ describe("Memory - search()", () => {
           userId: "target-user",
           agentId: "blocked-agent",
           topic: "secret",
+          visibility: "private",
           createdAt: "2026-01-01T00:00:00.000Z",
         },
       },
@@ -1730,6 +3077,7 @@ describe("Memory - search()", () => {
           userId: "target-user",
           agentId: "blocked-agent",
           topic: "public",
+          visibility: "public",
           createdAt: "2026-01-01T00:00:00.000Z",
         },
       },
@@ -1742,6 +3090,7 @@ describe("Memory - search()", () => {
           userId: "target-user",
           agentId: "allowed-agent",
           topic: "secret",
+          visibility: "public",
           createdAt: "2026-01-01T00:00:00.000Z",
         },
       },
@@ -1754,7 +3103,7 @@ describe("Memory - search()", () => {
       const result: SearchResult = await scopedMemory.search("target", {
         filters: {
           user_id: "target-user",
-          NOT: [{ agent_id: "blocked-agent", topic: "secret" }],
+          NOT: [{ topic: "secret", visibility: "private" }],
         },
         threshold: 0,
         topK: 5,
@@ -1765,7 +3114,7 @@ describe("Memory - search()", () => {
         expect.any(Number),
         {
           user_id: "target-user",
-          $not: [{ agent_id: "blocked-agent", topic: "secret" }],
+          $not: [{ topic: "secret", visibility: "private" }],
         },
       );
       expect(result.results.map((item) => item.id)).toEqual([
@@ -1816,6 +3165,91 @@ describe("Memory - search()", () => {
       await scopedMemory.reset();
     }
   });
+
+  test.each([
+    [
+      "array shorthand",
+      { user_id: ["target-user", "other-user"] },
+      "Scope filter [user_id] in search() must use explicit equality",
+    ],
+    [
+      "negative operator",
+      { user_id: { ne: "other-user" } },
+      "Scope filter [user_id] in search() must use explicit equality",
+    ],
+    [
+      "in operator",
+      { user_id: { in: ["target-user"] } },
+      "Scope filter [user_id] in search() must use explicit equality",
+    ],
+    [
+      "nin operator",
+      { user_id: { nin: ["other-user"] } },
+      "Scope filter [user_id] in search() must use explicit equality",
+    ],
+    [
+      "range operator",
+      { user_id: { gte: "target-user" } },
+      "Scope filter [user_id] in search() must use explicit equality",
+    ],
+    [
+      "text operator",
+      { user_id: { contains: "target" } },
+      "Scope filter [user_id] in search() must use explicit equality",
+    ],
+    [
+      "multi-scope OR",
+      { OR: [{ user_id: "target-user" }, { user_id: "other-user" }] },
+      "filters must contain at least one of: user_id, agent_id, run_id",
+    ],
+    [
+      "negative logical scope",
+      { user_id: "target-user", NOT: [{ agent_id: "blocked-agent" }] },
+      "Negative scope filters [agent_id] are not supported in search()",
+    ],
+    [
+      "malformed AND",
+      { user_id: "target-user", AND: { topic: "travel" } } as any,
+      "AND operator requires a list of conditions",
+    ],
+    [
+      "malformed OR",
+      { user_id: "target-user", OR: { topic: "travel" } } as any,
+      "OR operator requires a non-empty list of conditions",
+    ],
+    [
+      "malformed NOT",
+      { user_id: "target-user", NOT: { topic: "secret" } } as any,
+      "NOT operator requires a non-empty list of conditions",
+    ],
+  ])(
+    "rejects broad %s scope filters for search",
+    async (_name, filters, message) => {
+      const scopedMemory = createMemory();
+      await (scopedMemory as any)._ensureInitialized();
+
+      const vectorStore = (scopedMemory as any).vectorStore;
+      const searchSpy = jest.spyOn(vectorStore, "search");
+      const keywordSpy = jest.spyOn(vectorStore, "keywordSearch");
+
+      try {
+        await expect(
+          scopedMemory.search("target", {
+            filters: filters as any,
+            threshold: 0,
+            topK: 5,
+          }),
+        ).rejects.toThrow(message);
+
+        expect(searchSpy).not.toHaveBeenCalled();
+        expect(keywordSpy).not.toHaveBeenCalled();
+      } finally {
+        searchSpy.mockRestore();
+        keywordSpy.mockRestore();
+        await scopedMemory.reset();
+      }
+    },
+  );
 
   test("prefers canonical scope over conflicting camelCase aliases for search results", async () => {
     const scopedMemory = createMemory();
@@ -1934,34 +3368,41 @@ describe("Memory - deleteAll() scope hardening", () => {
     }
   });
 
-  test("rejects wildcard filters for destructive bulk deletes", async () => {
-    const scopedMemory = createMemory();
-    await (scopedMemory as any)._ensureInitialized();
+  test.each([
+    ["user_id", { userId: "*" }],
+    ["agent_id", { agentId: "*" }],
+    ["run_id", { runId: "*" }],
+  ])(
+    "rejects wildcard %s filters for destructive bulk deletes",
+    async (key, config) => {
+      const scopedMemory = createMemory();
+      await (scopedMemory as any)._ensureInitialized();
 
-    const vectorStore = (scopedMemory as any).vectorStore;
-    const listSpy = jest.spyOn(vectorStore, "list");
-    const deleteSpy = jest
-      .spyOn(vectorStore, "delete")
-      .mockResolvedValue(undefined);
-    const entityCleanupSpy = jest
-      .spyOn(scopedMemory as any, "_removeMemoryFromEntityStore")
-      .mockResolvedValue(undefined);
+      const vectorStore = (scopedMemory as any).vectorStore;
+      const listSpy = jest.spyOn(vectorStore, "list");
+      const deleteSpy = jest
+        .spyOn(vectorStore, "delete")
+        .mockResolvedValue(undefined);
+      const entityCleanupSpy = jest
+        .spyOn(scopedMemory as any, "_removeMemoryFromEntityStore")
+        .mockResolvedValue(undefined);
 
-    try {
-      await expect(scopedMemory.deleteAll({ userId: "*" })).rejects.toThrow(
-        "Wildcard scope filters [user_id] are not supported in deleteAll()",
-      );
+      try {
+        await expect(scopedMemory.deleteAll(config)).rejects.toThrow(
+          `Wildcard scope filters [${key}] are not supported in deleteAll()`,
+        );
 
-      expect(listSpy).not.toHaveBeenCalled();
-      expect(deleteSpy).not.toHaveBeenCalled();
-      expect(entityCleanupSpy).not.toHaveBeenCalled();
-    } finally {
-      listSpy.mockRestore();
-      deleteSpy.mockRestore();
-      entityCleanupSpy.mockRestore();
-      await scopedMemory.reset();
-    }
-  });
+        expect(listSpy).not.toHaveBeenCalled();
+        expect(deleteSpy).not.toHaveBeenCalled();
+        expect(entityCleanupSpy).not.toHaveBeenCalled();
+      } finally {
+        listSpy.mockRestore();
+        deleteSpy.mockRestore();
+        entityCleanupSpy.mockRestore();
+        await scopedMemory.reset();
+      }
+    },
+  );
 
   test("prefers canonical scope over conflicting camelCase aliases before deleting", async () => {
     const scopedMemory = createMemory();
@@ -2027,7 +3468,7 @@ describe("Memory - deleteAll() scope hardening", () => {
     }
   });
 
-  test("keeps bulk delete fetches bounded when provider count exceeds the first batch", async () => {
+  test("fails closed before deleting when exact-count providers report hidden rows", async () => {
     const scopedMemory = createMemory();
     await (scopedMemory as any)._ensureInitialized();
 
@@ -2042,19 +3483,9 @@ describe("Memory - deleteAll() scope hardening", () => {
         createdAt: "2026-01-01T00:00:00.000Z",
       },
     }));
-    const secondPage: typeof firstPage = [];
-
     const listSpy = jest
       .spyOn(vectorStore, "list")
-      .mockResolvedValueOnce([firstPage, 10001])
-      .mockResolvedValueOnce([secondPage, 0]);
-    const getSpy = jest
-      .spyOn(vectorStore, "get")
-      .mockImplementation(async (...args: unknown[]) => {
-        const id = String(args[0]);
-        const row = firstPage.find((item) => item.id === id);
-        return row ?? null;
-      });
+      .mockResolvedValueOnce([firstPage, 10001]);
     const deleteSpy = jest
       .spyOn(vectorStore, "delete")
       .mockResolvedValue(undefined);
@@ -2063,24 +3494,18 @@ describe("Memory - deleteAll() scope hardening", () => {
       .mockResolvedValue(undefined);
 
     try {
-      const result = await scopedMemory.deleteAll({ userId: "target-user" });
+      await expect(
+        scopedMemory.deleteAll({ userId: "target-user" }),
+      ).rejects.toThrow(
+        "scoped rows may be hidden behind an incomplete provider page",
+      );
 
-      expect(result.message).toBe("Memories deleted successfully!");
-      expect(listSpy).toHaveBeenNthCalledWith(
-        1,
-        { user_id: "target-user" },
-        10000,
-      );
-      expect(listSpy).toHaveBeenNthCalledWith(
-        2,
-        { user_id: "target-user" },
-        10000,
-      );
-      expect(deleteSpy).toHaveBeenCalledTimes(1);
-      expect(deleteSpy).toHaveBeenCalledWith("owned-memory");
+      expect(listSpy).toHaveBeenCalledTimes(1);
+      expect(listSpy).toHaveBeenCalledWith({ user_id: "target-user" }, 10000);
+      expect(deleteSpy).not.toHaveBeenCalled();
+      expect(entityCleanupSpy).not.toHaveBeenCalled();
     } finally {
       listSpy.mockRestore();
-      getSpy.mockRestore();
       deleteSpy.mockRestore();
       entityCleanupSpy.mockRestore();
       await scopedMemory.reset();
@@ -2116,7 +3541,7 @@ describe("Memory - deleteAll() scope hardening", () => {
       await expect(
         scopedMemory.deleteAll({ userId: "target-user" }),
       ).rejects.toThrow(
-        "scoped rows may be hidden behind a full provider page",
+        "scoped rows may be hidden behind an incomplete provider page",
       );
 
       expect(listSpy).toHaveBeenCalledWith({ user_id: "target-user" }, 10000);
@@ -2276,7 +3701,8 @@ describe("Memory - deleteAll() scope hardening", () => {
 
     const listSpy = jest
       .spyOn(vectorStore, "list")
-      .mockResolvedValueOnce([fullPage, fullPage.length]);
+      .mockResolvedValueOnce([fullPage, fullPage.length])
+      .mockResolvedValueOnce([[], 0]);
     const deleteSpy = jest
       .spyOn(vectorStore, "delete")
       .mockResolvedValue(undefined);
@@ -2301,6 +3727,115 @@ describe("Memory - deleteAll() scope hardening", () => {
       listSpy.mockRestore();
       deleteSpy.mockRestore();
       entityCleanupSpy.mockRestore();
+      (scopedMemory as any).config.vectorStore.provider = "memory";
+      await scopedMemory.reset();
+    }
+  });
+
+  test("fails closed before deleting when a capped cursorless provider returns its maximum page", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    (scopedMemory as any).config.vectorStore.provider = "vectorize";
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const fullPage = Array.from({ length: 50 }, (_, index) => ({
+      id: `memory-${index}`,
+      payload: {
+        data: `target memory ${index}`,
+        hash: `hash-${index}`,
+        user_id: "target-user",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    }));
+
+    const listSpy = jest
+      .spyOn(vectorStore, "list")
+      .mockResolvedValueOnce([fullPage, fullPage.length]);
+    const deleteSpy = jest
+      .spyOn(vectorStore, "delete")
+      .mockResolvedValue(undefined);
+    const entityCleanupSpy = jest
+      .spyOn(scopedMemory as any, "_removeMemoryFromEntityStore")
+      .mockResolvedValue(undefined);
+
+    try {
+      await expect(
+        scopedMemory.deleteAll({ userId: "target-user" }),
+      ).rejects.toThrow(
+        "deleteAll cannot safely delete all scoped memories for vector store provider 'vectorize'",
+      );
+
+      expect(listSpy).toHaveBeenNthCalledWith(
+        1,
+        { user_id: "target-user" },
+        50,
+      );
+      expect(listSpy).toHaveBeenNthCalledWith(2, { userId: "target-user" }, 50);
+      expect(deleteSpy).not.toHaveBeenCalled();
+      expect(entityCleanupSpy).not.toHaveBeenCalled();
+    } finally {
+      listSpy.mockRestore();
+      deleteSpy.mockRestore();
+      entityCleanupSpy.mockRestore();
+      (scopedMemory as any).config.vectorStore.provider = "memory";
+      await scopedMemory.reset();
+    }
+  });
+
+  test("deletes Vectorize legacy alias-only rows in the requested scope", async () => {
+    const scopedMemory = createMemory();
+    await (scopedMemory as any)._ensureInitialized();
+
+    (scopedMemory as any).config.vectorStore.provider = "vectorize";
+
+    const vectorStore = (scopedMemory as any).vectorStore;
+    const canonicalRows = [
+      {
+        id: "canonical-memory",
+        payload: {
+          data: "canonical target memory",
+          hash: "canonical-hash",
+          user_id: "target-user",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ];
+    const legacyRows = [
+      {
+        id: "legacy-memory",
+        payload: {
+          data: "legacy target memory",
+          hash: "legacy-hash",
+          userId: "target-user",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ];
+    const listSpy = jest
+      .spyOn(vectorStore, "list")
+      .mockResolvedValueOnce([canonicalRows, canonicalRows.length])
+      .mockResolvedValueOnce([legacyRows, legacyRows.length]);
+    const deleteMemorySpy = jest
+      .spyOn(scopedMemory as any, "deleteMemory")
+      .mockResolvedValue(undefined);
+
+    try {
+      const result = await scopedMemory.deleteAll({ userId: "target-user" });
+
+      expect(result.message).toBe("Memories deleted successfully!");
+      expect(listSpy).toHaveBeenNthCalledWith(
+        1,
+        { user_id: "target-user" },
+        50,
+      );
+      expect(listSpy).toHaveBeenNthCalledWith(2, { userId: "target-user" }, 50);
+      expect(deleteMemorySpy).toHaveBeenCalledTimes(2);
+      expect(deleteMemorySpy).toHaveBeenNthCalledWith(1, "canonical-memory");
+      expect(deleteMemorySpy).toHaveBeenNthCalledWith(2, "legacy-memory");
+    } finally {
+      listSpy.mockRestore();
+      deleteMemorySpy.mockRestore();
       (scopedMemory as any).config.vectorStore.provider = "memory";
       await scopedMemory.reset();
     }

--- a/mem0-ts/src/oss/tests/memory.entity-boost.test.ts
+++ b/mem0-ts/src/oss/tests/memory.entity-boost.test.ts
@@ -110,7 +110,7 @@ describe("Entity boost parallelism (#5214)", () => {
     m.vectorStore.search = jest
       .fn()
       .mockResolvedValue([
-        { id: "mem-1", score: 0.8, payload: { data: "test" } },
+        { id: "mem-1", score: 0.8, payload: { data: "test", user_id: "u1" } },
       ]);
     m.vectorStore.keywordSearch = jest.fn().mockResolvedValue(null);
 
@@ -158,8 +158,16 @@ describe("Entity boost parallelism (#5214)", () => {
 
     // Semantic results include mem-1 and mem-2
     m.vectorStore.search = jest.fn().mockResolvedValue([
-      { id: "mem-1", score: 0.85, payload: { data: "alice memory" } },
-      { id: "mem-2", score: 0.75, payload: { data: "bob memory" } },
+      {
+        id: "mem-1",
+        score: 0.85,
+        payload: { data: "alice memory", user_id: "u1" },
+      },
+      {
+        id: "mem-2",
+        score: 0.75,
+        payload: { data: "bob memory", user_id: "u1" },
+      },
     ]);
     m.vectorStore.keywordSearch = jest.fn().mockResolvedValue(null);
 
@@ -202,11 +210,13 @@ describe("Entity boost parallelism (#5214)", () => {
           Promise.resolve(texts.map(() => mockEmbedding)),
         ),
     };
-    m.vectorStore.search = jest
-      .fn()
-      .mockResolvedValue([
-        { id: "mem-9", score: 0.85, payload: { data: "surviving memory" } },
-      ]);
+    m.vectorStore.search = jest.fn().mockResolvedValue([
+      {
+        id: "mem-9",
+        score: 0.85,
+        payload: { data: "surviving memory", user_id: "u1" },
+      },
+    ]);
     m.vectorStore.keywordSearch = jest.fn().mockResolvedValue(null);
 
     const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
@@ -257,7 +267,7 @@ describe("Entity boost parallelism (#5214)", () => {
     m.vectorStore.search = jest
       .fn()
       .mockResolvedValue([
-        { id: "mem-1", score: 0.8, payload: { data: "test" } },
+        { id: "mem-1", score: 0.8, payload: { data: "test", user_id: "u1" } },
       ]);
     m.vectorStore.keywordSearch = jest.fn().mockResolvedValue(null);
 

--- a/mem0-ts/src/oss/tests/memory.entity-boost.test.ts
+++ b/mem0-ts/src/oss/tests/memory.entity-boost.test.ts
@@ -120,6 +120,422 @@ describe("Entity boost parallelism (#5214)", () => {
     allSettledSpy.mockRestore();
   });
 
+  it("should scope entity boost searches with camelCase read filters", async () => {
+    const m = memory as any;
+    await m._ensureInitialized();
+
+    const mockEntityStore = {
+      search: jest.fn().mockResolvedValue([makeMatch("e1", 0.9, ["mem-1"])]),
+      initialize: jest.fn().mockResolvedValue(undefined),
+    };
+    m._entityStore = mockEntityStore;
+
+    m.embedder = {
+      embed: jest.fn().mockResolvedValue(mockEmbedding),
+      embedBatch: jest
+        .fn()
+        .mockImplementation((texts: string[]) =>
+          Promise.resolve(texts.map(() => mockEmbedding)),
+        ),
+    };
+
+    m.vectorStore.search = jest.fn().mockResolvedValue([
+      {
+        id: "mem-1",
+        score: 0.8,
+        payload: { data: "alice memory", user_id: "u1" },
+      },
+    ]);
+    m.vectorStore.keywordSearch = jest.fn().mockResolvedValue(null);
+
+    await m.search("Alice and Bob", { filters: { userId: "u1" } });
+
+    expect(mockEntityStore.search).toHaveBeenCalledWith(mockEmbedding, 500, {
+      user_id: "u1",
+    });
+  });
+
+  it("should scope entity boost searches from nested common scope filters", async () => {
+    const m = memory as any;
+    await m._ensureInitialized();
+
+    const mockEntityStore = {
+      search: jest.fn().mockResolvedValue([makeMatch("e1", 0.9, ["mem-1"])]),
+      initialize: jest.fn().mockResolvedValue(undefined),
+    };
+    m._entityStore = mockEntityStore;
+
+    m.embedder = {
+      embed: jest.fn().mockResolvedValue(mockEmbedding),
+      embedBatch: jest
+        .fn()
+        .mockImplementation((texts: string[]) =>
+          Promise.resolve(texts.map(() => mockEmbedding)),
+        ),
+    };
+
+    m.vectorStore.search = jest.fn().mockResolvedValue([
+      {
+        id: "mem-1",
+        score: 0.8,
+        payload: { data: "alice travel memory", user_id: "u1" },
+      },
+    ]);
+    m.vectorStore.keywordSearch = jest.fn().mockResolvedValue(null);
+
+    await m.search("Alice and Bob", {
+      filters: { AND: [{ userId: "u1" }, { topic: "travel" }] },
+    });
+
+    expect(mockEntityStore.search).toHaveBeenCalledWith(mockEmbedding, 500, {
+      user_id: "u1",
+    });
+  });
+
+  it("should skip exact entity dedupe when a capped provider returns a full page", async () => {
+    const m = memory as any;
+    await m._ensureInitialized();
+
+    m.config.vectorStore.provider = "vectorize";
+    const rows = Array.from({ length: 50 }, (_, index) => ({
+      id: `entity-${index}`,
+      payload: {
+        data: `Entity ${index}`,
+        linkedMemoryIds: [`mem-${index}`],
+        user_id: "u1",
+      },
+    }));
+    const mockEntityStore = {
+      list: jest
+        .fn()
+        .mockResolvedValueOnce([rows, rows.length])
+        .mockResolvedValueOnce([[], 0]),
+    };
+    const debugSpy = jest.spyOn(console, "debug").mockImplementation(() => {});
+
+    try {
+      const exactMatches = await m._existingEntitiesByText(mockEntityStore, {
+        user_id: "u1",
+      });
+
+      expect(mockEntityStore.list).toHaveBeenNthCalledWith(
+        1,
+        { user_id: "u1" },
+        50,
+      );
+      expect(mockEntityStore.list).toHaveBeenNthCalledWith(
+        2,
+        { userId: "u1" },
+        50,
+      );
+      expect(exactMatches.size).toBe(0);
+      expect(debugSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Exact entity lookup skipped"),
+      );
+    } finally {
+      debugSpy.mockRestore();
+      m.config.vectorStore.provider = "memory";
+    }
+  });
+
+  it("should skip entity cleanup when a capped provider returns a full page", async () => {
+    const m = memory as any;
+    await m._ensureInitialized();
+
+    m.config.vectorStore.provider = "vectorize";
+    const rows = Array.from({ length: 50 }, (_, index) => ({
+      id: `entity-${index}`,
+      payload: {
+        data: `Entity ${index}`,
+        linkedMemoryIds: ["mem-1", `other-${index}`],
+        user_id: "u1",
+      },
+    }));
+    const mockEntityStore = {
+      list: jest
+        .fn()
+        .mockResolvedValueOnce([rows, rows.length])
+        .mockResolvedValueOnce([[], 0]),
+      delete: jest.fn().mockResolvedValue(undefined),
+      update: jest.fn().mockResolvedValue(undefined),
+      initialize: jest.fn().mockResolvedValue(undefined),
+    };
+    m._entityStore = mockEntityStore;
+    const debugSpy = jest.spyOn(console, "debug").mockImplementation(() => {});
+
+    try {
+      await m._removeMemoryFromEntityStore("mem-1", { user_id: "u1" });
+
+      expect(mockEntityStore.list).toHaveBeenNthCalledWith(
+        1,
+        { user_id: "u1" },
+        50,
+      );
+      expect(mockEntityStore.list).toHaveBeenNthCalledWith(
+        2,
+        { userId: "u1" },
+        50,
+      );
+      expect(mockEntityStore.delete).not.toHaveBeenCalled();
+      expect(mockEntityStore.update).not.toHaveBeenCalled();
+      expect(debugSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Entity cleanup skipped"),
+      );
+    } finally {
+      debugSpy.mockRestore();
+      m._entityStore = undefined;
+      m.config.vectorStore.provider = "memory";
+    }
+  });
+
+  it("should ignore polluted entity rows during exact entity lookup", async () => {
+    const m = memory as any;
+    await m._ensureInitialized();
+
+    const mockEntityStore = {
+      list: jest.fn().mockResolvedValue([
+        [
+          {
+            id: "foreign-entity",
+            payload: {
+              data: "Alice",
+              linkedMemoryIds: ["foreign-memory"],
+              user_id: "other-user",
+            },
+          },
+          {
+            id: "owned-entity",
+            payload: {
+              data: "Alice",
+              linkedMemoryIds: ["owned-memory"],
+              user_id: "u1",
+            },
+          },
+        ],
+        2,
+      ]),
+    };
+
+    const exactMatches = await m._existingEntitiesByText(mockEntityStore, {
+      user_id: "u1",
+    });
+
+    expect(exactMatches.get("alice")?.id).toBe("owned-entity");
+  });
+
+  it("should not mutate polluted entity rows during cleanup", async () => {
+    const m = memory as any;
+    await m._ensureInitialized();
+
+    const mockEntityStore = {
+      list: jest.fn().mockResolvedValue([
+        [
+          {
+            id: "foreign-entity",
+            payload: {
+              data: "Alice",
+              linkedMemoryIds: ["mem-1"],
+              user_id: "other-user",
+            },
+          },
+          {
+            id: "owned-entity",
+            payload: {
+              data: "Alice",
+              linkedMemoryIds: ["mem-1"],
+              user_id: "u1",
+            },
+          },
+        ],
+        2,
+      ]),
+      delete: jest.fn().mockResolvedValue(undefined),
+      update: jest.fn().mockResolvedValue(undefined),
+      initialize: jest.fn().mockResolvedValue(undefined),
+    };
+    m._entityStore = mockEntityStore;
+
+    try {
+      await m._removeMemoryFromEntityStore("mem-1", { user_id: "u1" });
+
+      expect(mockEntityStore.delete).toHaveBeenCalledTimes(1);
+      expect(mockEntityStore.delete).toHaveBeenCalledWith("owned-entity");
+    } finally {
+      m._entityStore = undefined;
+    }
+  });
+
+  it("should not update polluted entity rows during semantic linking", async () => {
+    const m = memory as any;
+    await m._ensureInitialized();
+
+    const mockEntityStore = {
+      list: jest.fn().mockResolvedValue([[], 0]),
+      search: jest.fn().mockResolvedValue([
+        {
+          id: "foreign-entity",
+          score: 0.99,
+          payload: {
+            data: "Alice",
+            linkedMemoryIds: ["foreign-memory"],
+            user_id: "other-user",
+          },
+        },
+      ]),
+      insert: jest.fn().mockResolvedValue(undefined),
+      update: jest.fn().mockResolvedValue(undefined),
+      initialize: jest.fn().mockResolvedValue(undefined),
+    };
+    m._entityStore = mockEntityStore;
+    m.embedder = {
+      embed: jest.fn().mockResolvedValue(mockEmbedding),
+      embedBatch: jest
+        .fn()
+        .mockImplementation((texts: string[]) =>
+          Promise.resolve(texts.map(() => mockEmbedding)),
+        ),
+    };
+
+    try {
+      await m._linkEntitiesForMemory("mem-1", "Alice met Bob.", {
+        user_id: "u1",
+      });
+
+      expect(mockEntityStore.update).not.toHaveBeenCalled();
+      expect(mockEntityStore.insert).toHaveBeenCalled();
+    } finally {
+      m._entityStore = undefined;
+    }
+  });
+
+  it("should skip entity boosts when a capped provider returns a full search page", async () => {
+    const m = memory as any;
+    await m._ensureInitialized();
+
+    m.config.vectorStore.provider = "vectorize";
+    const fullEntityPage = Array.from({ length: 50 }, (_, index) =>
+      makeMatch(`entity-${index}`, 0.9, ["mem-1"]),
+    );
+    const mockEntityStore = {
+      search: jest
+        .fn()
+        .mockResolvedValueOnce(fullEntityPage)
+        .mockResolvedValueOnce([]),
+      initialize: jest.fn().mockResolvedValue(undefined),
+    };
+    m._entityStore = mockEntityStore;
+
+    m.embedder = {
+      embed: jest.fn().mockResolvedValue(mockEmbedding),
+      embedBatch: jest
+        .fn()
+        .mockImplementation((texts: string[]) =>
+          Promise.resolve(texts.map(() => mockEmbedding)),
+        ),
+    };
+
+    m.vectorStore.search = jest.fn().mockResolvedValue([
+      {
+        id: "mem-1",
+        score: 0.7,
+        payload: { data: "alice memory", user_id: "u1" },
+      },
+      {
+        id: "mem-2",
+        score: 0.8,
+        payload: { data: "other memory", user_id: "u1" },
+      },
+    ]);
+    m.vectorStore.keywordSearch = jest.fn().mockResolvedValue(null);
+    const debugSpy = jest.spyOn(console, "debug").mockImplementation(() => {});
+
+    try {
+      const result = await m.search("Alice and Bob", {
+        filters: { user_id: "u1" },
+        threshold: 0,
+        explain: true,
+      });
+
+      expect(mockEntityStore.search).toHaveBeenNthCalledWith(
+        1,
+        mockEmbedding,
+        50,
+        {
+          user_id: "u1",
+        },
+      );
+      expect(mockEntityStore.search).toHaveBeenNthCalledWith(
+        2,
+        mockEmbedding,
+        50,
+        {
+          userId: "u1",
+        },
+      );
+      expect(debugSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Entity boost skipped"),
+      );
+      expect(result.results.map((item: any) => item.id)).toEqual([
+        "mem-2",
+        "mem-1",
+      ]);
+      expect(result.results[1].score_details.entityBoost).toBe(0);
+    } finally {
+      debugSpy.mockRestore();
+      m._entityStore = undefined;
+      m.config.vectorStore.provider = "memory";
+    }
+  });
+
+  it("should ignore polluted entity rows during boost scoring", async () => {
+    const m = memory as any;
+    await m._ensureInitialized();
+
+    const mockEntityStore = {
+      search: jest.fn().mockResolvedValue([
+        {
+          id: "foreign-entity",
+          score: 0.95,
+          payload: {
+            linkedMemoryIds: ["mem-1"],
+            user_id: "other-user",
+          },
+        },
+      ]),
+      initialize: jest.fn().mockResolvedValue(undefined),
+    };
+    m._entityStore = mockEntityStore;
+    m.embedder = {
+      embed: jest.fn().mockResolvedValue(mockEmbedding),
+      embedBatch: jest
+        .fn()
+        .mockImplementation((texts: string[]) =>
+          Promise.resolve(texts.map(() => mockEmbedding)),
+        ),
+    };
+    m.vectorStore.search = jest.fn().mockResolvedValue([
+      {
+        id: "mem-1",
+        score: 0.75,
+        payload: { data: "alice memory", user_id: "u1" },
+      },
+    ]);
+    m.vectorStore.keywordSearch = jest.fn().mockResolvedValue(null);
+
+    try {
+      const result = await m.search("Alice", {
+        filters: { user_id: "u1" },
+        threshold: 0,
+        explain: true,
+      });
+
+      expect(result.results[0].id).toBe("mem-1");
+      expect(result.results[0].score_details.entityBoost).toBe(0);
+    } finally {
+      m._entityStore = undefined;
+    }
+  });
+
   it("should preserve scoring math with parallel execution", async () => {
     const m = memory as any;
     await m._ensureInitialized();

--- a/mem0-ts/src/oss/tests/memory.validation.test.ts
+++ b/mem0-ts/src/oss/tests/memory.validation.test.ts
@@ -330,7 +330,7 @@ describe("Memory Input Validation", () => {
 
     it("should trim userId before listing memories", async () => {
       const listSpy = jest.spyOn(memory["vectorStore"], "list");
-      listSpy.mockResolvedValue([[], null]);
+      listSpy.mockResolvedValue([[], 0]);
 
       await memory.deleteAll({ userId: "  alice  " });
 

--- a/mem0-ts/src/oss/tests/memory.validation.test.ts
+++ b/mem0-ts/src/oss/tests/memory.validation.test.ts
@@ -334,7 +334,7 @@ describe("Memory Input Validation", () => {
 
       await memory.deleteAll({ userId: "  alice  " });
 
-      expect(listSpy).toHaveBeenCalledWith({ user_id: "alice" });
+      expect(listSpy).toHaveBeenCalledWith({ user_id: "alice" }, 10000);
     });
   });
 });

--- a/mem0-ts/src/oss/tests/pgvector.filters.test.ts
+++ b/mem0-ts/src/oss/tests/pgvector.filters.test.ts
@@ -166,6 +166,21 @@ describe("buildFilterConditions", () => {
     expect(result.values).toEqual(["alice", "bob"]);
   });
 
+  test("$and operator preserves repeated field bounds", () => {
+    const result = buildFilterConditions(
+      {
+        $and: [{ score: { gte: 1 } }, { score: { lte: 10 } }],
+      },
+      1,
+    );
+    expect(result.conditions).toHaveLength(1);
+    expect(result.conditions[0]).toContain(" AND ");
+    expect(result.conditions[0]).toContain("::numeric >= $1");
+    expect(result.conditions[0]).toContain("::numeric <= $2");
+    expect(result.values).toEqual([1, 10]);
+    expect(result.paramIndex).toBe(3);
+  });
+
   test("$not operator", () => {
     const result = buildFilterConditions(
       {

--- a/mem0-ts/src/oss/tests/pgvector.filters.test.ts
+++ b/mem0-ts/src/oss/tests/pgvector.filters.test.ts
@@ -181,6 +181,28 @@ describe("buildFilterConditions", () => {
     expect(result.paramIndex).toBe(3);
   });
 
+  test("$and and $or preserve alias-widened scope filter shape", () => {
+    const result = buildFilterConditions(
+      {
+        $and: [
+          { $or: [{ user_id: "u1" }, { userId: "u1" }] },
+          { $or: [{ agent_id: "agent-a" }, { agentId: "agent-a" }] },
+        ],
+      },
+      1,
+    );
+
+    expect(result.conditions).toHaveLength(1);
+    expect(result.conditions[0]).toContain(" AND ");
+    expect(result.conditions[0]).toContain(" OR ");
+    expect(result.conditions[0]).toContain("payload->>'user_id' = $1");
+    expect(result.conditions[0]).toContain("payload->>'userId' = $2");
+    expect(result.conditions[0]).toContain("payload->>'agent_id' = $3");
+    expect(result.conditions[0]).toContain("payload->>'agentId' = $4");
+    expect(result.values).toEqual(["u1", "u1", "agent-a", "agent-a"]);
+    expect(result.paramIndex).toBe(5);
+  });
+
   test("$not operator", () => {
     const result = buildFilterConditions(
       {

--- a/mem0-ts/src/oss/tests/vector-stores-compat.test.ts
+++ b/mem0-ts/src/oss/tests/vector-stores-compat.test.ts
@@ -756,6 +756,34 @@ describe("Vectorize – backward compat with mocked client", () => {
     await Promise.all([p1, p2]);
     // No crash = idempotent
   });
+
+  it("creates canonical and legacy scope metadata indexes", async () => {
+    const store = new VectorizeDB({
+      apiKey: "fake-token",
+      indexName: "test-index",
+      accountId: "test-account",
+      dimension: 768,
+    });
+
+    await store.initialize();
+
+    const createCalls = (store as any).client.__mockIndexes.metadataIndex.create
+      .mock.calls;
+    const propertyNames = createCalls.map(
+      ([, options]: any[]) => options.propertyName,
+    );
+
+    expect(propertyNames).toEqual(
+      expect.arrayContaining([
+        "user_id",
+        "agent_id",
+        "run_id",
+        "userId",
+        "agentId",
+        "runId",
+      ]),
+    );
+  });
 });
 
 // ───────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Linked Issue

No existing issue. This was discovered during repository analysis after the TypeScript OSS entity-scope review in #6018.

## Description

This adds a Memory-level scope post-filter for TypeScript OSS vector-store reads. `Memory` already passes `user_id`, `agent_id`, and `run_id` filters to vector stores, but a backend bug or loose filter implementation could still return out-of-scope rows. Those polluted rows could be surfaced by `search()`, participate in keyword scoring, contaminate add-time inferred-memory context and dedupe decisions, or be deleted by `deleteAll()`.

The fix is intentionally narrow and preserves the existing TypeScript OSS runtime requirement that `search()` and `getAll()` include scope filters. After vector-store `search()`, `keywordSearch()`, and `list()` calls, `Memory` now replays filter trees that contain requested scope keys, including nested logical filters. That replay uses the same scope-key alias precedence as stored payload normalization and preserves mixed scope-plus-metadata logical semantics, including nested AND/OR combinations, metadata NOT filters, repeated logical groups, non-scope same-field conjuncts, and supported range operators. Public scoped reads and deletes now require at least one common positive scope equality; wildcard, negative, set-membership, range, text-matching, and conflicting alias predicates on scope keys are rejected instead of being sent to providers as broad tenant selectors. `add()` also treats requested scope as authoritative: conflicting top-level/filter scopes or reserved scope keys in metadata now fail before persistence, and matching metadata aliases are normalized to canonical scope fields. It does not require exact-scope equality on every scope dimension, so a user-scoped query can still return memories that also carry agent/run metadata.

For list-backed reads, `getAll()` refills only when the current provider's `list()` implementation reports a true total count (`memory`, `pgvector`, `redis`, `supabase`). `deleteAll()` now uses one bounded pre-delete fetch and fails closed before deleting if a cursorless/full-page response or exact-count response cannot prove the complete scoped delete set. Provider filters are widened recursively for OR-capable backends (`qdrant`, `pgvector`) so legacy camelCase scope payloads can reach the Memory-level post-filter even when scope keys appear inside logical branches, while providers without logical alias widening receive only canonical required snake_case scope equalities and Memory replays the full caller filter locally. PGVector filter construction now supports `$and` groups so repeated-field bounds can remain conjunctive instead of being flattened. The Node quickstart and `docs/llms.txt` examples now show scoped read filters under `filters` and document safe `deleteAll()` versus `reset()` usage; the Node quickstart also notes the LangChain-provider reset caveat.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

No persisted schema or public method signature change. This is caller-visible behavior hardening: the public result type surface now explicitly includes optional top-level `user_id`, `agent_id`, and `run_id` fields to match runtime results, and wildcard, broad/non-equality, conflicting alias scope filters, conflicting add-time top-level/filter scopes, and reserved conflicting scope metadata now throw, `search()` / inferred `add()` / cursorless `getAll()` may fail closed when a full provider page cannot prove scoped completeness, `deleteAll()` may refuse unsafe scoped deletes before deleting anything when provider pages are incomplete or ambiguous, unsupported `deleteAll()` option keys are rejected instead of being silently ignored, and public `metadata` no longer includes scope/timestamp storage aliases that are exposed as top-level fields.

Behavior change: wildcard scope filters such as `search(..., { filters: { user_id: "*" } })`, set/negative scope filters such as `{ user_id: { ne: "u1" } }` or `{ user_id: ["u1", "u2"] }`, widened OR-only scope filters, conflicting scope aliases such as `{ user_id: "u1", userId: "u2" }`, reserved metadata scope conflicts such as `add(..., { filters: { user_id: "u1" }, metadata: { userId: "u2" } })`, top-level/filter conflicts such as `add(..., { userId: "u1", filters: { user_id: "u2" } })`, and `deleteAll({ userId: "*" })` now throw before touching vector-store rows. Callers that want scoped reads/deletes should provide explicit positive `user_id` / `agent_id` / `run_id` equality filters for reads or explicit `userId` / `agentId` / `runId` options for `deleteAll()`. Callers that intentionally want to delete everything should use `reset()`.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Commands run:

- `cd mem0-ts && pnpm exec jest --runInBand src/oss/tests/memory.add.test.ts src/oss/tests/memory.crud.test.ts src/oss/tests/memory.entity-boost.test.ts src/oss/tests/memory.validation.test.ts src/oss/tests/pgvector.filters.test.ts src/oss/tests/vector-stores-compat.test.ts` — passed; 6 suites, 281 tests.
- `cd mem0-ts && pnpm run build` — passed; Prettier check and tsup CJS/ESM/DTS builds.
- `python3 scripts/check-llms-txt-coverage.py` — passed; `docs/llms.txt` is in sync with `docs/**/*.mdx`.
- `cd mem0-ts && pnpm test -- src/client/tests/telemetry-aliasing.test.ts src/oss/tests/telemetry-sampling.test.ts --runInBand` — passed; 2 suites, 39 tests.
- `cd mem0-ts && MEM0_TELEMETRY=false pnpm test --runInBand --testPathIgnorePatterns=src/client/tests/telemetry-aliasing.test.ts --testPathIgnorePatterns=src/oss/tests/telemetry-sampling.test.ts` — passed; 54 suites passed, 5 skipped, 915 tests passed, 42 skipped.
- `cd mem0-ts && pnpm exec tsc --noEmit --pretty false` — failed on existing unrelated typecheck issues in test helper globals (`jest`, `describe`, hooks) and `src/community/src/integrations/langchain/mem0.ts` missing `mem0ai` / LangChain declarations plus related existing `Mem0MemoryInput` / `Mem0Memory` property errors.
- `git diff --check` — passed.
- GitHub PR checks: CLA passed. Vercel preview/deploy validation is currently blocked by repository/team authorization (`Authorization required to deploy`), which is unrelated to this TypeScript SDK diff.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] Relevant targeted suites, build, docs coverage check, telemetry-specific tests, and non-telemetry package suites pass locally
- [x] I have updated documentation if needed

## Risk

Risk level: medium.

The change is limited to the TypeScript OSS `Memory` layer and only re-checks filters that contain requested scope keys. Add-time metadata scope keys are now reserved so requested scope cannot be silently overwritten during persistence. It accepts both snake_case and camelCase scope payload keys so legacy/vector-store-specific payloads remain compatible, preferring canonical snake_case keys when both shapes are present. For Cloudflare Vectorize, scoped reads query both canonical snake_case and legacy camelCase metadata-index variants before Memory post-filtering so existing alias-only deployments are not filtered out prematurely. The exported `MemoryItem` type now includes optional `user_id`, `agent_id`, and `run_id` fields to match the runtime result shape. Public scoped read paths and destructive `deleteAll()` reject wildcard and broad/non-equality scope filters to avoid tenant-wide reads or accidental deletion; search-backed paths fail closed when a full effective provider page cannot prove enough scoped candidates (including providers with smaller documented result caps such as the TypeScript `azure-ai-search` provider and Cloudflare Vectorize), entity boosting skips full capped provider pages rather than boosting from incomplete entity matches, and `deleteAll()` fails before deleting when list results cannot prove the full scoped delete set. Public `get()`, `search()`, and `getAll()` results emit canonical snake_case scope fields, support both camelCase and snake_case timestamp payloads, and keep scope/timestamp storage keys out of `metadata`; consumers should prefer those top-level fields instead of metadata alias keys. It does not change persisted payload schema or provider filter contracts. The main compatibility risk is for legacy rows that lack the requested scope metadata; those rows are now treated as not proven in-scope and are excluded from scoped reads/deletes.

Rollback is straightforward: remove the helper and the call-site filters.

## Notes for maintainers

This is a defense-in-depth backstop, not a replacement for provider-specific filtering fixes. It replays supported filter semantics only when a requested scope key is present so polluted provider results cannot bypass the Memory boundary; provider-specific filtering remains the first-pass narrowing mechanism.

The shared TypeScript vector-store `list()` API exposes a count but not a cursor/offset contract, and not every provider's count is a true total. This PR only expands `getAll()` list fetches for providers whose implementation returns total counts. For providers such as Qdrant, Azure AI Search, and Vectorize, `Memory` post-filters returned rows and refuses a full cursorless `getAll()` page when it cannot satisfy `topK` safely; `search()` and inferred `add()` also clamp safety checks to known provider result caps and fail closed when a full effective search page cannot prove enough scoped candidates. `deleteAll()` uses one bounded pre-delete page and refuses incomplete or cursorless full pages before deleting anything because deleting a partial scoped set would be unsafe. Vectorize metadata indexes now include canonical snake_case scope keys while retaining legacy camelCase indexes for compatibility, and Memory queries both representations when reading from Vectorize. Entity-store reads now replay requested scope locally before exact dedupe, cleanup mutation, semantic linking, or boost scoring. Provider-specific cursor pagination would be a separate API-level change.
