### PR TITLE
feat(ts-sdk): add InvokeModelCommand support to AWS Bedrock LLM provider (closes #6023)

### DIFF
--- a/mem0-ts/src/oss/README.md
+++ b/mem0-ts/src/oss/README.md
@@ -107,6 +107,49 @@ The memory system comes with sensible defaults:
 
 You only need to provide API keys - all other settings are optional.
 
+### AWS Bedrock LLM
+
+The `aws_bedrock` provider drives Bedrock-hosted models (Anthropic, Amazon Nova,
+Meta Llama, Mistral, Cohere, etc.) via the Bedrock Converse API. The AWS SDK is an
+**optional peer dependency** - install it only if you use this provider:
+
+```bash
+npm install @aws-sdk/client-bedrock-runtime
+```
+
+Credentials resolve via the standard AWS credential chain (env vars, shared
+config, or IAM role) unless you pass them explicitly:
+
+```typescript
+const memory = new Memory({
+  llm: {
+    provider: "aws_bedrock",
+    config: {
+      model: "anthropic.claude-3-5-sonnet-20240620-v1:0",
+      awsRegion: "us-east-1",
+      // Optional - omit to use the default AWS credential chain:
+      // awsAccessKeyId: process.env.AWS_ACCESS_KEY_ID,
+      // awsSecretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    },
+  },
+});
+```
+
+> Note: the provider uses the Bedrock **Converse API** by default, which covers
+> the current Bedrock model families through a single uniform interface
+> (recommended). For legacy models that are only reachable via `InvokeModel`,
+> set `bedrockApi: "invoke_model"` in the LLM config to opt into the
+> per-family `InvokeModelCommand` path (no tool-calling support on that path).
+> Streaming remains out of scope for now.
+>
+> ```typescript
+> // opt into the legacy InvokeModel path for a non-Converse model
+> llm: {
+>   provider: "aws_bedrock",
+>   config: { model: "ai21.j2-ultra-v1", bedrockApi: "invoke_model" },
+> }
+> ```
+
 ### Methods
 
 - `add(messages: string | Message[], userId?: string, ...): Promise<SearchResult>`

--- a/mem0-ts/src/oss/src/llms/aws_bedrock.ts
+++ b/mem0-ts/src/oss/src/llms/aws_bedrock.ts
@@ -50,18 +50,25 @@ type AWSBedrockConfig = LLMConfig;
  * AWS Bedrock LLM provider for the TypeScript OSS SDK.
  *
  * Mirrors `mem0/llms/aws_bedrock.py`. Uses the Bedrock **Converse API**
- * (`ConverseCommand`), which provides a uniform message/tool interface across
- * the Anthropic / Amazon (Nova) / Meta / Mistral / Cohere model families, so a
- * single code path serves them all (the Python provider keeps per-family
- * `invoke_model` branches for legacy reasons; Converse supersedes them).
+ * (`ConverseCommand`) by default, which provides a uniform message/tool interface
+ * across the Anthropic / Amazon (Nova) / Meta / Mistral / Cohere model families.
+ * Opt into the legacy `InvokeModelCommand` path via `bedrockApi: "invoke_model"`
+ * for older models not reachable through Converse (#6023).
  *
  * The `@aws-sdk/client-bedrock-runtime` dependency is loaded on first use via
  * dynamic `import()` so the package stays optional. Credentials resolve via the
  * standard AWS chain unless provided explicitly in config.
  */
+/**
+ * Bedrock API path. `converse` (default) uses the uniform Converse API.
+ * `invoke_model` uses legacy InvokeModelCommand for older models (#6023).
+ */
+export type BedrockApi = "converse" | "invoke_model";
+
 interface BedrockSDK {
   BedrockRuntimeClient: new (config: Record<string, any>) => any;
   ConverseCommand: new (input: Record<string, any>) => any;
+  InvokeModelCommand: new (input: Record<string, any>) => any;
 }
 
 export class AWSBedrockLLM implements LLM {
@@ -70,6 +77,7 @@ export class AWSBedrockLLM implements LLM {
   private temperature: number;
   private maxTokens: number;
   private topP?: number;
+  private api: BedrockApi;
   private clientConfig: Record<string, any>;
   private clientOverride?: any;
   private sdkPromise?: Promise<BedrockSDK>;
@@ -83,6 +91,8 @@ export class AWSBedrockLLM implements LLM {
     this.temperature = config.temperature ?? 0.1;
     this.maxTokens = config.maxTokens ?? 2000;
     this.topP = config.topP;
+    this.api =
+      config.bedrockApi === "invoke_model" ? "invoke_model" : "converse";
 
     const region =
       config.awsRegion ||
@@ -114,6 +124,8 @@ export class AWSBedrockLLM implements LLM {
    */
   private async getSDK(): Promise<BedrockSDK> {
     if (!this.sdkPromise) {
+      // Peer dep may be absent in the typecheck environment.
+      // @ts-expect-error optional peer @aws-sdk/client-bedrock-runtime
       this.sdkPromise = import("@aws-sdk/client-bedrock-runtime").then(
         (sdk) => sdk as unknown as BedrockSDK,
         (err) => {
@@ -216,6 +228,142 @@ export class AWSBedrockLLM implements LLM {
     return converseTools.length ? { tools: converseTools } : undefined;
   }
 
+  /**
+   * Build a provider-family-specific request body for the legacy InvokeModel
+   * path. Unlike Converse, each model family has its own body shape. Mirrors
+   * the per-family branches in the Python provider (`mem0/llms/aws_bedrock.py`).
+   */
+  private buildInvokeBody(messages: Message[]): Record<string, any> {
+    const systemParts: string[] = [];
+    const turns: { role: string; content: string }[] = [];
+    for (const msg of messages) {
+      const content =
+        typeof msg.content === "string"
+          ? msg.content
+          : JSON.stringify(msg.content);
+      if (msg.role === "system") systemParts.push(content);
+      else
+        turns.push({
+          role: msg.role === "assistant" ? "assistant" : "user",
+          content,
+        });
+    }
+    const system = systemParts.join("\n");
+    const prompt = turns.map((t) => `${t.role}: ${t.content}`).join("\n");
+
+    switch (this.provider) {
+      case "anthropic":
+        return {
+          anthropic_version: "bedrock-2023-05-31",
+          max_tokens: this.maxTokens,
+          temperature: this.temperature,
+          ...(this.topP != null ? { top_p: this.topP } : {}),
+          ...(system ? { system } : {}),
+          messages: turns.map((t) => ({
+            role: t.role,
+            content: [{ type: "text", text: t.content }],
+          })),
+        };
+      case "amazon":
+      case "titan":
+        return {
+          inputText: `${system ? system + "\n" : ""}${prompt}`,
+          textGenerationConfig: {
+            maxTokenCount: this.maxTokens,
+            temperature: this.temperature,
+            ...(this.topP != null ? { topP: this.topP } : {}),
+          },
+        };
+      case "meta":
+      case "llama":
+        return {
+          prompt: `${system ? system + "\n" : ""}${prompt}`,
+          max_gen_len: this.maxTokens,
+          temperature: this.temperature,
+          ...(this.topP != null ? { top_p: this.topP } : {}),
+        };
+      case "mistral":
+        return {
+          prompt: `${system ? system + "\n" : ""}${prompt}`,
+          max_tokens: this.maxTokens,
+          temperature: this.temperature,
+          ...(this.topP != null ? { top_p: this.topP } : {}),
+        };
+      case "cohere":
+        return {
+          message: prompt,
+          max_tokens: this.maxTokens,
+          temperature: this.temperature,
+          ...(this.topP != null ? { p: this.topP } : {}),
+        };
+      case "ai21":
+      case "j2":
+        return {
+          prompt: `${system ? system + "\n" : ""}${prompt}`,
+          maxTokens: this.maxTokens,
+          temperature: this.temperature,
+          ...(this.topP != null ? { topP: this.topP } : {}),
+        };
+      default:
+        throw new Error(
+          `InvokeModel body not implemented for provider '${this.provider}'. ` +
+            `Use the default Converse API for this model, or add a body builder for '${this.provider}'.`,
+        );
+    }
+  }
+
+  /** Parse a provider-family-specific InvokeModel response body into text. */
+  private parseInvokeResponse(body: any): string {
+    switch (this.provider) {
+      case "anthropic":
+        return body?.content?.[0]?.text ?? body?.completion ?? "";
+      case "amazon":
+      case "titan":
+        return body?.results?.[0]?.outputText ?? "";
+      case "meta":
+      case "llama":
+        return body?.generation ?? "";
+      case "mistral":
+        return body?.outputs?.[0]?.text ?? "";
+      case "cohere":
+        return body?.text ?? body?.generations?.[0]?.text ?? "";
+      case "ai21":
+      case "j2":
+        return body?.completions?.[0]?.data?.text ?? "";
+      default:
+        return "";
+    }
+  }
+
+  /** Legacy InvokeModel path for models not covered by Converse (#6023). */
+  private async invokeModel(messages: Message[]): Promise<string> {
+    const body = this.buildInvokeBody(messages);
+    const [{ InvokeModelCommand }, client] = await Promise.all([
+      this.getSDK(),
+      this.getClient(),
+    ]);
+    const response = await client.send(
+      new InvokeModelCommand({
+        modelId: this.model,
+        contentType: "application/json",
+        accept: "application/json",
+        body: JSON.stringify(body),
+      }),
+    );
+    // Response body is a Uint8Array in the real SDK.
+    const raw = response?.body;
+    let parsed: any = raw;
+    if (raw instanceof Uint8Array || Buffer.isBuffer(raw)) {
+      parsed = JSON.parse(Buffer.from(raw).toString("utf8"));
+    } else if (typeof raw === "string") {
+      parsed = JSON.parse(raw);
+    } else if (raw && typeof raw === "object" && "transformToString" in raw) {
+      // Some SDK versions expose a streaming blob with transformToString.
+      parsed = JSON.parse(await (raw as any).transformToString());
+    }
+    return this.parseInvokeResponse(parsed);
+  }
+
   private async converse(messages: Message[], tools?: any[]): Promise<any> {
     const { system, converseMessages } = this.formatMessages(messages);
     const input: Record<string, any> = {
@@ -264,6 +412,10 @@ export class AWSBedrockLLM implements LLM {
     tools?: any[],
   ): Promise<string | LLMResponse> {
     try {
+      // Legacy InvokeModel path does not support Converse-style tool config.
+      if (this.api === "invoke_model") {
+        return await this.invokeModel(messages);
+      }
       const response = await this.converse(messages, tools);
       if (tools && tools.length) {
         const toolCalls = this.parseToolCalls(response);

--- a/mem0-ts/src/oss/src/llms/aws_bedrock.ts
+++ b/mem0-ts/src/oss/src/llms/aws_bedrock.ts
@@ -124,8 +124,7 @@ export class AWSBedrockLLM implements LLM {
    */
   private async getSDK(): Promise<BedrockSDK> {
     if (!this.sdkPromise) {
-      // Peer dep may be absent in the typecheck environment.
-      // @ts-expect-error optional peer @aws-sdk/client-bedrock-runtime
+      // Peer dep may be absent in light installs; keep import dynamic for ESM.
       this.sdkPromise = import("@aws-sdk/client-bedrock-runtime").then(
         (sdk) => sdk as unknown as BedrockSDK,
         (err) => {

--- a/mem0-ts/src/oss/src/tests/aws_bedrock.test.ts
+++ b/mem0-ts/src/oss/src/tests/aws_bedrock.test.ts
@@ -41,6 +41,12 @@ jest.mock(
         this.input = input;
       }
     },
+    InvokeModelCommand: class {
+      input: any;
+      constructor(input: any) {
+        this.input = input;
+      }
+    },
   }),
   { virtual: true },
 );
@@ -184,6 +190,55 @@ describe("AWSBedrockLLM", () => {
       awsRegion: "us-west-2",
     });
     expect(mockClientConstructions).toBe(before);
+  });
+});
+
+describe("invoke_model API (#6023)", () => {
+  // Fake client returning a raw JSON body, as InvokeModel does.
+  function makeInvokeClient(bodyObj: any) {
+    return new FakeBedrockClient({
+      body: Buffer.from(JSON.stringify(bodyObj), "utf8"),
+    });
+  }
+
+  it("uses InvokeModel with an anthropic body and parses content", async () => {
+    const client = makeInvokeClient({ content: [{ text: "legacy reply" }] });
+    const llm = makeLLM(client, {
+      bedrockApi: "invoke_model",
+    });
+    const out = await llm.generateResponse([{ role: "user", content: "hi" }]);
+    expect(out).toBe("legacy reply");
+    expect(client.lastInput.modelId).toContain("anthropic");
+    expect(client.lastInput.contentType).toBe("application/json");
+    const body = JSON.parse(client.lastInput.body);
+    expect(body.anthropic_version).toBe("bedrock-2023-05-31");
+    expect(body.messages[0].content[0].text).toBe("hi");
+  });
+
+  it("builds an ai21/j2 body for j2 model ids", async () => {
+    const client = makeInvokeClient({
+      completions: [{ data: { text: "j2 reply" } }],
+    });
+    const llm = makeLLM(client, {
+      model: "ai21.j2-ultra-v1",
+      bedrockApi: "invoke_model",
+    });
+    const out = await llm.generateResponse([{ role: "user", content: "hi" }]);
+    expect(out).toBe("j2 reply");
+    const body = JSON.parse(client.lastInput.body);
+    expect(body.maxTokens).toBeDefined();
+    expect(body.prompt).toContain("user: hi");
+  });
+
+  it("defaults to converse when bedrockApi is not set", async () => {
+    const client = new FakeBedrockClient({
+      output: { message: { content: [{ text: "c" }] } },
+    });
+    const llm = makeLLM(client);
+    await llm.generateResponse([{ role: "user", content: "hi" }]);
+    // Converse uses inferenceConfig; InvokeModel does not.
+    expect(client.lastInput.inferenceConfig).toBeDefined();
+    expect(client.lastInput.body).toBeUndefined();
   });
 });
 

--- a/mem0-ts/src/oss/src/types/index.ts
+++ b/mem0-ts/src/oss/src/types/index.ts
@@ -78,6 +78,9 @@ export interface LLMConfig {
   awsAccessKeyId?: string;
   awsSecretAccessKey?: string;
   awsSessionToken?: string;
+  // Bedrock API path: "converse" (default, recommended) or "invoke_model"
+  // (opt-in, for legacy models not reachable via Converse — see #6023).
+  bedrockApi?: "converse" | "invoke_model";
   // Optional pre-constructed client (e.g. BedrockRuntimeClient) for DI/testing.
   client?: any;
 }
@@ -240,6 +243,7 @@ export const MemoryConfigSchema = z.object({
         awsAccessKeyId: z.string().optional(),
         awsSecretAccessKey: z.string().optional(),
         awsSessionToken: z.string().optional(),
+        bedrockApi: z.enum(["converse", "invoke_model"]).optional(),
         client: z.any().optional(),
       })
       .passthrough(),


### PR DESCRIPTION
## Summary

Follow-up to #5890 (Bedrock Converse provider), as suggested in review by @YinkaMetrics — adds opt-in `InvokeModelCommand` support for legacy Bedrock models that aren't reachable through the Converse API.

Tracks #6023.

## What changed
- **`bedrockApi` config option** (`"converse"` default, `"invoke_model"` opt-in) on the LLM config + zod schema.
- **Per-family request-body builders + response parsers** for the InvokeModel path: anthropic, amazon/titan, meta/llama, mistral, cohere, ai21/j2 — mirroring the per-family branches in the Python provider (`mem0/llms/aws_bedrock.py`).
- Lazily loads `InvokeModelCommand` alongside `ConverseCommand` (SDK stays optional).
- README updated: Converse is the default/recommended path; `invoke_model` documented as opt-in for legacy models (with example), streaming still out of scope.

## Scope / notes
- **Converse remains the default and recommended path** and is unchanged.
- The InvokeModel path intentionally has **no tool-calling** support (Converse remains the tool-capable path) — legacy models generally predate uniform tool use.
- Unknown provider families on the InvokeModel path throw a clear error pointing back to Converse.

## Tests
- 3 new tests (anthropic invoke_model body+parse, ai21/j2 invoke_model, and a guard that `bedrockApi` unset still uses Converse).
- Full bedrock suite: **13/13 passing**. Prettier clean; no new typecheck errors introduced in touched files.