### PR TITLE
Add planner-aware memory search

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -10,7 +10,7 @@ import uuid
 import warnings
 from copy import deepcopy
 from datetime import date, datetime, timezone
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Sequence
 
 from pydantic import ValidationError
 
@@ -65,6 +65,7 @@ from mem0.utils.factory import (
     VectorStoreFactory,
 )
 from mem0.utils.lemmatization import lemmatize_for_bm25
+from mem0.utils.planner_retrieval import build_planner_query, rerank_plan_memories
 from mem0.utils.scoring import (
     ENTITY_BOOST_WEIGHT,
     get_bm25_params,
@@ -1467,6 +1468,78 @@ class Memory(MemoryBase):
         else:
             display_first_run_notice(self, "sync", "search")
         return {"results": original_memories}
+
+    def search_for_plan(
+        self,
+        user_goal: str,
+        *,
+        plan: Optional[Sequence[str]] = None,
+        current_step: Optional[str] = None,
+        tools: Optional[Sequence[str]] = None,
+        previous_failures: Optional[Sequence[str]] = None,
+        limit: int = 5,
+        candidate_limit: Optional[int] = None,
+        filters: Optional[Dict[str, Any]] = None,
+        threshold: float = 0.1,
+        rerank: bool = False,
+        explain: bool = False,
+        reference_date: Optional[Any] = None,
+        show_expired: bool = False,
+        rerank_plan_results: bool = True,
+        **kwargs,
+    ):
+        """
+        Search memories using planner-executor context.
+
+        Args:
+            user_goal (str): Overall user goal the plan is serving.
+            plan (list[str], optional): Current plan steps.
+            current_step (str, optional): Step currently being executed.
+            tools (list[str], optional): Available tools for the agent.
+            previous_failures (list[str], optional): Prior failures or lessons to avoid repeating.
+            limit (int, optional): Number of memories to return. Defaults to 5.
+            candidate_limit (int, optional): Number of candidates to retrieve before local plan reranking.
+            filters (dict): Same filters accepted by `search()`.
+            threshold (float, optional): Same threshold accepted by `search()`.
+            rerank (bool, optional): Whether to use the configured search reranker. Defaults to False.
+            explain (bool, optional): Whether to include score details in search results.
+            reference_date (Any, optional): Platform-only temporal parameter. Not supported in OSS.
+            show_expired (bool, optional): Include expired memories.
+            rerank_plan_results (bool, optional): Whether to apply lightweight plan-aware reranking.
+
+        Returns:
+            dict: Search result with planner-aware candidates under the "results" key.
+        """
+        query = build_planner_query(
+            user_goal=user_goal,
+            plan=plan,
+            current_step=current_step,
+            tools=tools,
+            previous_failures=previous_failures,
+        )
+        search_limit = candidate_limit or (max(limit * 4, limit) if rerank_plan_results else limit)
+        result = self.search(
+            query,
+            top_k=search_limit,
+            filters=filters,
+            threshold=threshold,
+            rerank=rerank,
+            explain=explain,
+            reference_date=reference_date,
+            show_expired=show_expired,
+            **kwargs,
+        )
+
+        if rerank_plan_results:
+            result = dict(result)
+            result["results"] = rerank_plan_memories(
+                result.get("results", []),
+                user_goal=user_goal,
+                current_step=current_step,
+                tools=tools,
+                limit=limit,
+            )
+        return result
 
     def _process_metadata_filters(self, metadata_filters: Dict[str, Any]) -> Dict[str, Any]:
         """
@@ -3095,6 +3168,78 @@ class AsyncMemory(MemoryBase):
         else:
             await display_first_run_notice_async(self, "async", "search")
         return {"results": original_memories}
+
+    async def search_for_plan(
+        self,
+        user_goal: str,
+        *,
+        plan: Optional[Sequence[str]] = None,
+        current_step: Optional[str] = None,
+        tools: Optional[Sequence[str]] = None,
+        previous_failures: Optional[Sequence[str]] = None,
+        limit: int = 5,
+        candidate_limit: Optional[int] = None,
+        filters: Optional[Dict[str, Any]] = None,
+        threshold: float = 0.1,
+        rerank: bool = False,
+        explain: bool = False,
+        reference_date: Optional[Any] = None,
+        show_expired: bool = False,
+        rerank_plan_results: bool = True,
+        **kwargs,
+    ):
+        """
+        Search memories asynchronously using planner-executor context.
+
+        Args:
+            user_goal (str): Overall user goal the plan is serving.
+            plan (list[str], optional): Current plan steps.
+            current_step (str, optional): Step currently being executed.
+            tools (list[str], optional): Available tools for the agent.
+            previous_failures (list[str], optional): Prior failures or lessons to avoid repeating.
+            limit (int, optional): Number of memories to return. Defaults to 5.
+            candidate_limit (int, optional): Number of candidates to retrieve before local plan reranking.
+            filters (dict): Same filters accepted by `search()`.
+            threshold (float, optional): Same threshold accepted by `search()`.
+            rerank (bool, optional): Whether to use the configured search reranker. Defaults to False.
+            explain (bool, optional): Whether to include score details in search results.
+            reference_date (Any, optional): Platform-only temporal parameter. Not supported in OSS.
+            show_expired (bool, optional): Include expired memories.
+            rerank_plan_results (bool, optional): Whether to apply lightweight plan-aware reranking.
+
+        Returns:
+            dict: Search result with planner-aware candidates under the "results" key.
+        """
+        query = build_planner_query(
+            user_goal=user_goal,
+            plan=plan,
+            current_step=current_step,
+            tools=tools,
+            previous_failures=previous_failures,
+        )
+        search_limit = candidate_limit or (max(limit * 4, limit) if rerank_plan_results else limit)
+        result = await self.search(
+            query,
+            top_k=search_limit,
+            filters=filters,
+            threshold=threshold,
+            rerank=rerank,
+            explain=explain,
+            reference_date=reference_date,
+            show_expired=show_expired,
+            **kwargs,
+        )
+
+        if rerank_plan_results:
+            result = dict(result)
+            result["results"] = rerank_plan_memories(
+                result.get("results", []),
+                user_goal=user_goal,
+                current_step=current_step,
+                tools=tools,
+                limit=limit,
+            )
+        return result
 
     def _process_metadata_filters(self, metadata_filters: Dict[str, Any]) -> Dict[str, Any]:
         """

--- a/mem0/utils/planner_retrieval.py
+++ b/mem0/utils/planner_retrieval.py
@@ -1,0 +1,114 @@
+import re
+from typing import Any, Mapping, Sequence
+
+
+_WORD_RE = re.compile(r"[A-Za-z0-9_]+")
+_PROCEDURAL_TERMS = {
+    "avoid",
+    "choose",
+    "error",
+    "fail",
+    "failure",
+    "fix",
+    "plan",
+    "prefer",
+    "retry",
+    "step",
+    "tool",
+    "workflow",
+}
+
+
+def _clean_items(items: Sequence[str] | None) -> list[str]:
+    if not items:
+        return []
+    return [item.strip() for item in items if isinstance(item, str) and item.strip()]
+
+
+def build_planner_query(
+    user_goal: str,
+    plan: Sequence[str] | None = None,
+    current_step: str | None = None,
+    tools: Sequence[str] | None = None,
+    previous_failures: Sequence[str] | None = None,
+) -> str:
+    """Build a retrieval query for planner-executor agent workflows."""
+    goal = user_goal.strip()
+    if not goal:
+        raise ValueError("user_goal must be a non-empty string")
+
+    sections = [f"User goal: {goal}"]
+
+    plan_items = _clean_items(plan)
+    if plan_items:
+        plan_text = "\n".join(f"{index}. {item}" for index, item in enumerate(plan_items, start=1))
+        sections.append(f"Plan:\n{plan_text}")
+
+    if current_step and current_step.strip():
+        sections.append(f"Current step: {current_step.strip()}")
+
+    tool_items = _clean_items(tools)
+    if tool_items:
+        sections.append(f"Available tools: {', '.join(tool_items)}")
+
+    failure_items = _clean_items(previous_failures)
+    if failure_items:
+        failure_text = "\n".join(f"- {item}" for item in failure_items)
+        sections.append(f"Previous failures or lessons:\n{failure_text}")
+
+    sections.append(
+        "Retrieve memories that help choose the next action, reuse procedural experience, "
+        "avoid repeated failures, and select appropriate tools."
+    )
+    return "\n\n".join(sections)
+
+
+def _tokens(text: str) -> set[str]:
+    return {match.group(0).lower() for match in _WORD_RE.finditer(text)}
+
+
+def _memory_text(memory: Mapping[str, Any]) -> str:
+    parts = []
+    for key in ("memory", "text", "content", "data"):
+        value = memory.get(key)
+        if isinstance(value, str):
+            parts.append(value)
+
+    metadata = memory.get("metadata")
+    if isinstance(metadata, Mapping):
+        for value in metadata.values():
+            if isinstance(value, str):
+                parts.append(value)
+
+    return " ".join(parts)
+
+
+def rerank_plan_memories(
+    memories: Sequence[Mapping[str, Any]],
+    user_goal: str,
+    current_step: str | None = None,
+    tools: Sequence[str] | None = None,
+    limit: int = 5,
+) -> list[Mapping[str, Any]]:
+    """Rank memory candidates using planning-oriented lexical signals."""
+    if limit <= 0:
+        return []
+
+    goal_terms = _tokens(user_goal)
+    step_terms = _tokens(current_step or "")
+    tool_terms = _tokens(" ".join(_clean_items(tools)))
+
+    def score(memory: Mapping[str, Any]) -> float:
+        text_terms = _tokens(_memory_text(memory))
+        semantic_score = memory.get("score", 0)
+        base_score = semantic_score if isinstance(semantic_score, (int, float)) else 0
+        return (
+            float(base_score)
+            + len(text_terms & goal_terms) * 1.0
+            + len(text_terms & step_terms) * 2.0
+            + len(text_terms & tool_terms) * 2.5
+            + len(text_terms & _PROCEDURAL_TERMS) * 0.5
+        )
+
+    ranked = sorted(enumerate(memories), key=lambda item: (-score(item[1]), item[0]))
+    return [memory for _, memory in ranked[:limit]]

--- a/tests/test_planner_retrieval.py
+++ b/tests/test_planner_retrieval.py
@@ -1,0 +1,108 @@
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from mem0.memory.main import AsyncMemory, Memory
+from mem0.utils.planner_retrieval import build_planner_query, rerank_plan_memories
+
+
+def test_build_planner_query_includes_planning_context():
+    query = build_planner_query(
+        user_goal="Prepare a pull request for a memory-agent project",
+        plan=["Inspect contribution rules", "Implement a minimal example", "Add tests"],
+        current_step="Implement a minimal example",
+        tools=["github", "pytest", "python"],
+        previous_failures=["Avoid changing core APIs before maintainer confirmation"],
+    )
+
+    assert "User goal: Prepare a pull request for a memory-agent project" in query
+    assert "1. Inspect contribution rules" in query
+    assert "Current step: Implement a minimal example" in query
+    assert "Available tools: github, pytest, python" in query
+    assert "- Avoid changing core APIs before maintainer confirmation" in query
+
+
+def test_build_planner_query_requires_user_goal():
+    with pytest.raises(ValueError, match="user_goal"):
+        build_planner_query("   ")
+
+
+def test_rerank_plan_memories_prioritizes_current_step_and_tools():
+    memories = [
+        {"memory": "General preference: write concise summaries.", "score": 0.9},
+        {"memory": "When implementing examples, add pytest coverage before opening a PR.", "score": 0.2},
+        {"memory": "Use GitHub labels when triaging bugs.", "score": 0.3},
+    ]
+
+    result = rerank_plan_memories(
+        memories,
+        user_goal="Prepare a pull request for a memory-agent project",
+        current_step="Implement example tests",
+        tools=["pytest"],
+        limit=2,
+    )
+
+    assert result[0]["memory"] == "When implementing examples, add pytest coverage before opening a PR."
+    assert len(result) == 2
+
+
+def test_search_for_plan_builds_query_and_reranks_candidates():
+    with patch.object(Memory, "__init__", return_value=None):
+        memory = Memory()
+    memory.search = Mock(
+        return_value={
+            "results": [
+                {"memory": "General preference: write concise summaries.", "score": 0.9},
+                {"memory": "When implementing examples, add pytest coverage before opening a PR.", "score": 0.2},
+            ]
+        }
+    )
+
+    result = memory.search_for_plan(
+        user_goal="Prepare a pull request for a memory-agent project",
+        plan=["Inspect contribution rules", "Implement a minimal example", "Add tests"],
+        current_step="Implement a minimal example",
+        tools=["pytest"],
+        filters={"user_id": "u1"},
+        limit=1,
+    )
+
+    called_query = memory.search.call_args.args[0]
+    called_kwargs = memory.search.call_args.kwargs
+    assert "Current step: Implement a minimal example" in called_query
+    assert called_kwargs["top_k"] == 4
+    assert called_kwargs["filters"] == {"user_id": "u1"}
+    assert result["results"] == [
+        {"memory": "When implementing examples, add pytest coverage before opening a PR.", "score": 0.2}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_search_for_plan_builds_query_and_reranks_candidates():
+    with patch.object(AsyncMemory, "__init__", return_value=None):
+        memory = AsyncMemory()
+    memory.search = AsyncMock(
+        return_value={
+            "results": [
+                {"memory": "General preference: write concise summaries.", "score": 0.9},
+                {"memory": "When implementing examples, add pytest coverage before opening a PR.", "score": 0.2},
+            ]
+        }
+    )
+
+    result = await memory.search_for_plan(
+        user_goal="Prepare a pull request for a memory-agent project",
+        current_step="Implement a minimal example",
+        tools=["pytest"],
+        filters={"user_id": "u1"},
+        limit=1,
+    )
+
+    called_query = memory.search.call_args.args[0]
+    called_kwargs = memory.search.call_args.kwargs
+    assert "Current step: Implement a minimal example" in called_query
+    assert called_kwargs["top_k"] == 4
+    assert called_kwargs["filters"] == {"user_id": "u1"}
+    assert result["results"] == [
+        {"memory": "When implementing examples, add pytest coverage before opening a PR.", "score": 0.2}
+    ]


### PR DESCRIPTION
## Summary
- add a planner-aware query builder for long-horizon agent workflows
- add lightweight plan-oriented candidate reranking
- expose `search_for_plan()` on both `Memory` and `AsyncMemory`
- cover query construction, reranking, and sync/async search helpers

Closes #6010

## Tests
- `uv run --extra test pytest tests/test_planner_retrieval.py`
- `uv run --extra dev ruff check mem0/utils/planner_retrieval.py mem0/memory/main.py tests/test_planner_retrieval.py`
