### PR TITLE
feat(ts-sdk): add Together embedding provider

### DIFF
--- a/mem0-ts/src/oss/src/embeddings/together.ts
+++ b/mem0-ts/src/oss/src/embeddings/together.ts
@@ -1,0 +1,55 @@
+import OpenAI from "openai";
+import { Embedder } from "./base";
+import { EmbeddingConfig } from "../types";
+
+/**
+ * Together embedding provider.
+ *
+ * Together exposes an OpenAI-compatible `/v1/embeddings` endpoint, so this
+ * embedder reuses the `openai` client pointed at `https://api.together.xyz/v1`.
+ * Mirrors the Python `TogetherEmbedding` provider (`mem0/embeddings/together.py`).
+ *
+ * Note: Together does not support the OpenAI `dimensions` parameter, so it is
+ * intentionally never forwarded.
+ */
+export class TogetherEmbedder implements Embedder {
+  private openai: OpenAI;
+  private model: string;
+
+  constructor(config: EmbeddingConfig) {
+    this.openai = new OpenAI({
+      apiKey: config.apiKey || process.env.TOGETHER_API_KEY,
+      baseURL:
+        config.baseURL || config.url || "https://api.together.xyz/v1",
+    });
+    this.model = config.model || "togethercomputer/m2-bert-80M-8k-retrieval";
+  }
+
+  async embed(text: string): Promise<number[]> {
+    const response = await this.openai.embeddings.create({
+      model: this.model,
+      input: text,
+    });
+    return response.data[0].embedding;
+  }
+
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    if (texts.length === 0) {
+      return [];
+    }
+    const response = await this.openai.embeddings.create({
+      model: this.model,
+      input: texts,
+    });
+    const embeddings = response.data
+      .sort((a, b) => a.index - b.index)
+      .map((item) => item.embedding);
+    if (embeddings.length !== texts.length) {
+      throw new Error(
+        `Together embedBatch() returned ${embeddings.length} embeddings for ` +
+          `${texts.length} texts using model '${this.model}'`,
+      );
+    }
+    return embeddings;
+  }
+}

--- a/mem0-ts/src/oss/src/embeddings/together.ts
+++ b/mem0-ts/src/oss/src/embeddings/together.ts
@@ -19,8 +19,7 @@ export class TogetherEmbedder implements Embedder {
   constructor(config: EmbeddingConfig) {
     this.openai = new OpenAI({
       apiKey: config.apiKey || process.env.TOGETHER_API_KEY,
-      baseURL:
-        config.baseURL || config.url || "https://api.together.xyz/v1",
+      baseURL: config.baseURL || config.url || "https://api.together.xyz/v1",
     });
     this.model = config.model || "togethercomputer/m2-bert-80M-8k-retrieval";
   }

--- a/mem0-ts/src/oss/src/utils/factory.ts
+++ b/mem0-ts/src/oss/src/utils/factory.ts
@@ -35,6 +35,7 @@ import { AzureOpenAILLM } from "../llms/azure";
 import { AzureOpenAIEmbedder } from "../embeddings/azure";
 import { LangchainLLM } from "../llms/langchain";
 import { LangchainEmbedder } from "../embeddings/langchain";
+import { TogetherEmbedder } from "../embeddings/together";
 import { LangchainVectorStore } from "../vector_stores/langchain";
 import { AzureAISearch } from "../vector_stores/azure_ai_search";
 import { PGVector } from "../vector_stores/pgvector";
@@ -55,6 +56,8 @@ export class EmbedderFactory {
         return new AzureOpenAIEmbedder(config);
       case "langchain":
         return new LangchainEmbedder(config);
+      case "together":
+        return new TogetherEmbedder(config);
       default:
         throw new Error(`Unsupported embedder provider: ${provider}`);
     }

--- a/mem0-ts/src/oss/tests/together-embedder.test.ts
+++ b/mem0-ts/src/oss/tests/together-embedder.test.ts
@@ -1,0 +1,122 @@
+/// <reference types="jest" />
+/**
+ * Together Embedder — unit tests (mocked OpenAI client).
+ * Together exposes an OpenAI-compatible embeddings endpoint, so the embedder
+ * reuses the `openai` client with a Together baseURL. These tests verify the
+ * default model / baseURL, request shape, and batch ordering.
+ */
+
+const mockEmbeddingsCreate = jest.fn();
+const mockOpenAICtor = jest.fn();
+
+jest.mock("openai", () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation((opts: any) => {
+      mockOpenAICtor(opts);
+      return { embeddings: { create: mockEmbeddingsCreate } };
+    }),
+  };
+});
+
+import { TogetherEmbedder } from "../src/embeddings/together";
+
+const mockEmbedding = [0.1, 0.2, 0.3, 0.4, 0.5];
+
+describe("TogetherEmbedder (unit)", () => {
+  beforeEach(() => {
+    mockEmbeddingsCreate.mockReset();
+    mockOpenAICtor.mockReset();
+    mockEmbeddingsCreate.mockResolvedValue({
+      data: [{ index: 0, embedding: mockEmbedding }],
+    });
+  });
+
+  describe("configuration", () => {
+    it("defaults to the Together baseURL and model", async () => {
+      const embedder = new TogetherEmbedder({ apiKey: "test-key" });
+      await embedder.embed("hello");
+
+      expect(mockOpenAICtor).toHaveBeenCalledTimes(1);
+      expect(mockOpenAICtor.mock.calls[0][0]).toMatchObject({
+        apiKey: "test-key",
+        baseURL: "https://api.together.xyz/v1",
+      });
+
+      const callArgs = mockEmbeddingsCreate.mock.calls[0][0];
+      expect(callArgs).toEqual({
+        model: "togethercomputer/m2-bert-80M-8k-retrieval",
+        input: "hello",
+      });
+    });
+
+    it("honors a custom model and baseURL", async () => {
+      const embedder = new TogetherEmbedder({
+        apiKey: "test-key",
+        model: "BAAI/bge-large-en-v1.5",
+        baseURL: "https://proxy.example.com/v1",
+      });
+      await embedder.embed("hello");
+
+      expect(mockOpenAICtor.mock.calls[0][0]).toMatchObject({
+        baseURL: "https://proxy.example.com/v1",
+      });
+      expect(mockEmbeddingsCreate.mock.calls[0][0].model).toBe(
+        "BAAI/bge-large-en-v1.5",
+      );
+    });
+
+    it("never forwards a dimensions parameter", async () => {
+      const embedder = new TogetherEmbedder({
+        apiKey: "test-key",
+        embeddingDims: 768,
+      });
+      await embedder.embed("hello");
+
+      const callArgs = mockEmbeddingsCreate.mock.calls[0][0];
+      expect(callArgs).not.toHaveProperty("dimensions");
+    });
+  });
+
+  describe("basic functionality", () => {
+    it("embed() returns the embedding vector", async () => {
+      const embedder = new TogetherEmbedder({ apiKey: "test-key" });
+      const result = await embedder.embed("hello");
+      expect(result).toEqual(mockEmbedding);
+    });
+
+    it("embedBatch() returns [] for empty input without calling the API", async () => {
+      const embedder = new TogetherEmbedder({ apiKey: "test-key" });
+      const result = await embedder.embedBatch([]);
+      expect(result).toEqual([]);
+      expect(mockEmbeddingsCreate).not.toHaveBeenCalled();
+    });
+
+    it("embedBatch() sorts results by index", async () => {
+      mockEmbeddingsCreate.mockResolvedValue({
+        data: [
+          { index: 1, embedding: [0.3, 0.4] },
+          { index: 0, embedding: [0.1, 0.2] },
+        ],
+      });
+
+      const embedder = new TogetherEmbedder({ apiKey: "test-key" });
+      const result = await embedder.embedBatch(["text1", "text2"]);
+      expect(result).toEqual([
+        [0.1, 0.2],
+        [0.3, 0.4],
+      ]);
+    });
+
+    it("embedBatch() throws when the count mismatches the input", async () => {
+      mockEmbeddingsCreate.mockResolvedValue({
+        data: [{ index: 0, embedding: [0.1, 0.2] }],
+      });
+
+      const embedder = new TogetherEmbedder({ apiKey: "test-key" });
+      await expect(embedder.embedBatch(["a", "b"])).rejects.toThrow(
+        /returned 1 embeddings for 2 texts/,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Linked Issue

Closes #5766

## Problem

The Python SDK supports **Together** as an embedding provider (`mem0/embeddings/together.py`), but the TypeScript OSS SDK does not. TS users cannot configure `{ embedder: { provider: "together" } }`, leaving a Python↔TypeScript parity gap.

## Root cause

There is no `TogetherEmbedder` in `mem0-ts/src/oss/src/embeddings/`, and `EmbedderFactory` has no `"together"` case, so the factory throws `Unsupported embedder provider: together`.

## Fix

Add `TogetherEmbedder` in `mem0-ts/src/oss/src/embeddings/together.ts`. Together exposes an OpenAI-compatible `/v1/embeddings` endpoint, so the embedder reuses the existing `openai` client pointed at `https://api.together.xyz/v1` — **no new dependency**.

Defaults mirror the Python provider:
- model `togethercomputer/m2-bert-80M-8k-retrieval`
- `TOGETHER_API_KEY` env fallback

The OpenAI-only `dimensions` parameter is intentionally never forwarded (Together does not support it). `embedBatch` sorts results by `index` and guards against a count mismatch, mirroring the Python provider. Registered the `"together"` case in `EmbedderFactory`.

No config-type change was needed — `EmbeddingConfig` already exposes `apiKey`, `model`, `baseURL`/`url`.

## Tests

Added `mem0-ts/src/oss/tests/together-embedder.test.ts` (7 cases):
default baseURL/model, custom model+baseURL overrides, no `dimensions` leak, `embed()` return, empty-batch short-circuit (no API call), index sorting, and count-mismatch error.

## Verification

- `npx jest together-embedder` → **7/7 pass**
- `npx jest embedder` → **6 suites / 44 tests pass** (no regressions)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Breaking Changes

N/A — purely additive.
