### PR TITLE
fix: honor auto_search setting in UserPromptSubmit hook

### DIFF
--- a/integrations/mem0-plugin/scripts/on_user_prompt.sh
+++ b/integrations/mem0-plugin/scripts/on_user_prompt.sh
@@ -25,6 +25,14 @@ if [ ${#PROMPT} -lt 20 ]; then
   exit 0
 fi
 
+# Honor auto_search setting: when false, skip all automatic searches and
+# rubric injection.  The agent can still call search_memories via MCP
+# manually — this only disables the hook-driven auto-retrieval that
+# consumes the monthly retrieval quota.
+if [ "${MEM0_AUTO_SEARCH:-true}" = "false" ]; then
+  exit 0
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=_identity.sh
 . "$SCRIPT_DIR/_identity.sh" 2>/dev/null || true


### PR DESCRIPTION
## Summary

The `auto_search` setting in `~/.mem0/settings.json` is read and exported as `MEM0_AUTO_SEARCH` by `_identity.sh`, but no hook script actually consumes it. Setting `auto_search: false` has no effect — the UserPromptSubmit hook still performs automatic searches on every message, consuming the monthly retrieval quota.

This is the same class of bug as #5449 (`auto_save`), which was already fixed.

## Fix

Add an early exit check at the top of `on_user_prompt.sh` that skips all automatic searches and rubric injection when `MEM0_AUTO_SEARCH` is `false`. The agent can still call `search_memories` via MCP manually — this only disables the hook-driven auto-retrieval.

This mirrors how `auto_save` is already honored by `on_stop.sh`, `on_session_start.sh`, and the auto-capture path in this same script.

## Test

1. Set `"auto_search": false` in `~/.mem0/settings.json`
2. Restart Claude Code session
3. Verify: UserPromptSubmit hook exits early (no resume detection searches, no rubric injection)
4. Verify: agent can still call `search_memories` MCP tool manually