### PR TITLE
chore: update changelog, bump SDK versions to Python 2.0.11 and TypeScript 3.0.13

### DIFF
--- a/cli/node/package.json
+++ b/cli/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mem0/cli",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "The official CLI for mem0 — the memory layer for AI agents",
   "type": "module",
   "bin": {

--- a/cli/python/pyproject.toml
+++ b/cli/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mem0-cli"
-version = "0.2.8"
+version = "0.2.9"
 description = "The official CLI for mem0 — the memory layer for AI agents"
 readme = "README.md"
 license = "Apache-2.0"

--- a/cli/python/src/mem0_cli/__init__.py
+++ b/cli/python/src/mem0_cli/__init__.py
@@ -1,3 +1,3 @@
 """mem0 CLI — the command-line interface for the mem0 memory layer."""
 
-__version__ = "0.2.8"
+__version__ = "0.2.9"

--- a/docs/changelog/sdk.mdx
+++ b/docs/changelog/sdk.mdx
@@ -7,6 +7,21 @@ mode: "wide"
 <Tabs>
 <Tab title="Python">
 
+<Update label="2026-07-01" description="v2.0.11">
+
+**Bug Fixes:**
+- **Embeddings:** Guard against an `embed_batch` count mismatch in the OpenAI and Azure OpenAI embedders ([#5966](https://github.com/mem0ai/mem0/pull/5966))
+- **Memory:** Re-raise LLM extraction failures instead of silently returning `[]` ([#5878](https://github.com/mem0ai/mem0/pull/5878))
+- **Vector Stores:** Normalize vectors for the cosine distance strategy in FAISS ([#5960](https://github.com/mem0ai/mem0/pull/5960))
+
+**Security:**
+- **Vector Stores:** Validate OpenSearch filter values to prevent term query injection ([#5986](https://github.com/mem0ai/mem0/pull/5986))
+- **Vector Stores:** Validate value types and escape quotes in Azure AI Search OData filters ([#5983](https://github.com/mem0ai/mem0/pull/5983))
+- **Vector Stores:** Validate Databricks catalog/schema/table identifiers to prevent SQL injection ([#5988](https://github.com/mem0ai/mem0/pull/5988))
+- **Graph:** Escape Neptune filter values in openCypher queries to prevent injection ([#5982](https://github.com/mem0ai/mem0/pull/5982))
+
+</Update>
+
 <Update label="2026-06-27" description="v2.0.10">
 
 **New Features:**
@@ -1084,6 +1099,14 @@ See the [OSS v2 to v3 migration guide](https://docs.mem0.ai/migration/oss-v2-to-
 </Tab>
 
 <Tab title="TypeScript">
+
+<Update label="2026-07-01" description="v3.0.13">
+
+**Bug Fixes:**
+- **Embeddings:** Guard against an `embed_batch` count mismatch in the OpenAI and Azure OpenAI embedders ([#5966](https://github.com/mem0ai/mem0/pull/5966))
+- **LLMs:** Handle empty Google chat candidates without crashing ([#5817](https://github.com/mem0ai/mem0/pull/5817))
+
+</Update>
 
 <Update label="2026-06-27" description="v3.0.12">
 

--- a/docs/changelog/sdk.mdx
+++ b/docs/changelog/sdk.mdx
@@ -1606,6 +1606,15 @@ See the [TypeScript SDK migration guide](https://docs.mem0.ai/migration/ts-v2-to
 
 <Tab title="CLI">
 
+<Update label="2026-07-01" description="Python v0.2.9 / Node v0.2.10">
+
+**Bug Fixes:**
+- **`entity delete`:** Keep every deleted entity in the result output instead of only the last one (Python [#5936](https://github.com/mem0ai/mem0/pull/5936), Node [#5970](https://github.com/mem0ai/mem0/pull/5970))
+- **Output formatters (Python):** Handle null memory fields in the output formatters instead of erroring ([#5957](https://github.com/mem0ai/mem0/pull/5957))
+- **Config (Python):** Reject invalid integer config values with a clean error instead of a traceback ([#5956](https://github.com/mem0ai/mem0/pull/5956))
+
+</Update>
+
 <Update label="2026-06-19" description="Python v0.2.8 / Node v0.2.9">
 
 **Security:**

--- a/mem0-ts/package.json
+++ b/mem0-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mem0ai",
-  "version": "3.0.12",
+  "version": "3.0.13",
   "description": "The Memory Layer For Your AI Apps",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mem0ai"
-version = "2.0.10"
+version = "2.0.11"
 description = "Long-term memory for AI Agents"
 authors = [
     { name = "Mem0", email = "support@mem0.ai" }


### PR DESCRIPTION
## Description

Routine release prep: bump the Python SDK (`mem0ai`) 2.0.10 → 2.0.11 and the TypeScript SDK (`mem0ai`) 3.0.12 → 3.0.13, and add the matching changelog entries to `docs/changelog/sdk.mdx`.

Changes collected since the last release tags (`v2.0.10`, `ts-v3.0.12`):

**Python 2.0.11**
- Bug fixes: `embed_batch` count guard for OpenAI/Azure OpenAI (#5966), re-raise LLM extraction failures (#5878), FAISS cosine normalization (#5960)
- Security: OpenSearch (#5986), Azure AI Search (#5983), Databricks (#5988) filter/identifier validation; Neptune openCypher escaping (#5982)

**TypeScript 3.0.13**
- Bug fixes: `embed_batch` count guard for OpenAI/Azure OpenAI (#5966), handle empty Google chat candidates (#5817)

Note: #5911 landed and was then reverted (#5990), so it is intentionally excluded.

## Linked Issue

N/A — routine release chore, no tracking issue.

## Type of Change

- [x] Refactor (no functional changes) — version bump + changelog only

## Test Coverage

- [x] No tests needed (version strings and release-notes docs only)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] No new tests needed (release chore)
- [x] I have updated documentation (changelog) as needed
