### PR TITLE
docs: fix typos and grammar errors across docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ mintlify dev
 
 ### Publishing Changes
 
-Install our Github App to auto propagate changes from your repo to your deployment. Changes will be deployed to production automatically after pushing to the default branch. Find the link to install on your dashboard. 
+Install our GitHub App to auto-propagate changes from your repo to your deployment. Changes will be deployed to production automatically after pushing to the default branch. Find the link to install on your dashboard. 
 
 #### Troubleshooting
 

--- a/docs/components/embedders/models/azure_openai.mdx
+++ b/docs/components/embedders/models/azure_openai.mdx
@@ -3,7 +3,7 @@ title: Azure OpenAI
 description: "Configure Azure OpenAI as an embedding provider in Mem0 with API key, deployment, and endpoint settings."
 ---
 
-To use Azure OpenAI embedding models, set the `EMBEDDING_AZURE_OPENAI_API_KEY`, `EMBEDDING_AZURE_DEPLOYMENT`, `EMBEDDING_AZURE_ENDPOINT` and `EMBEDDING_AZURE_API_VERSION` environment variables. You can obtain the Azure OpenAI API key from the Azure.
+To use Azure OpenAI embedding models, set the `EMBEDDING_AZURE_OPENAI_API_KEY`, `EMBEDDING_AZURE_DEPLOYMENT`, `EMBEDDING_AZURE_ENDPOINT` and `EMBEDDING_AZURE_API_VERSION` environment variables. You can obtain the Azure OpenAI API key from the Azure Portal.
 
 ### Usage
 

--- a/docs/components/llms/models/azure_openai.mdx
+++ b/docs/components/llms/models/azure_openai.mdx
@@ -5,7 +5,7 @@ description: "Configure Azure OpenAI as an LLM provider in Mem0 with Azure Ident
 
 <Note> Mem0 Now Supports Azure OpenAI Models in TypeScript SDK </Note>
 
-To use Azure OpenAI models, you have to set the `LLM_AZURE_OPENAI_API_KEY`, `LLM_AZURE_ENDPOINT`, `LLM_AZURE_DEPLOYMENT` and `LLM_AZURE_API_VERSION` environment variables. You can obtain the Azure API key from the [Azure](https://azure.microsoft.com/).
+To use Azure OpenAI models, you have to set the `LLM_AZURE_OPENAI_API_KEY`, `LLM_AZURE_ENDPOINT`, `LLM_AZURE_DEPLOYMENT` and `LLM_AZURE_API_VERSION` environment variables. You can obtain the Azure API key from the [Azure Portal](https://azure.microsoft.com/).
 
 Optionally, you can use Azure Identity to authenticate with Azure OpenAI, which allows you to use managed identities or service principals for production and Azure CLI login for development instead of an API key. If an Azure Identity is to be used, ***do not*** set the `LLM_AZURE_OPENAI_API_KEY` environment variable or the api_key in the config dictionary.
 

--- a/docs/components/llms/overview.mdx
+++ b/docs/components/llms/overview.mdx
@@ -7,7 +7,7 @@ Mem0 includes built-in support for various popular large language models. Memory
 
 ## Usage
 
-To use a llm, you must provide a configuration to customize its usage. If no configuration is supplied, a default configuration will be applied, and `OpenAI` will be used as the llm.
+To use an LLM, you must provide a configuration to customize its usage. If no configuration is supplied, a default configuration will be applied, and `OpenAI` will be used as the LLM.
 
 For a comprehensive list of available parameters for llm configuration, please refer to [Config](./config).
 

--- a/docs/components/vectordbs/dbs/azure.mdx
+++ b/docs/components/vectordbs/dbs/azure.mdx
@@ -81,13 +81,13 @@ Azure client ID, secret, tenant ID, or certificate in environment variables for 
 Utilizes Azure Workload Identity (relevant for Kubernetes and Azure workloads).
 
 3. **Managed Identity Credential:**
-Authenticates as a Managed Identity (for apps/services hosted in Azure with Managed Identity enabled), this is the most secure production credential.
+Authenticates as a Managed Identity (for apps/services hosted in Azure with Managed Identity enabled); this is the most secure production credential.
 
 4. **Shared Token Cache Credential / Visual Studio Credential (Windows only):**
 Uses cached credentials from Visual Studio sign-ins (and sometimes VS Code if SSO is enabled).
 
 5. **Azure CLI Credential:**
-Uses the currently logged-in user from the Azure CLI (`az login`), this is the most common development credential.
+Uses the currently logged-in user from the Azure CLI (`az login`); this is the most common development credential.
 
 6. **Azure PowerShell Credential:**
 Uses the identity from Azure PowerShell (`Connect-AzAccount`).
@@ -135,7 +135,7 @@ config = {
 ```
 
 ### Environment Variables to Use Azure Identity Credential
-* For an Environment Credential, you will need to setup a Service Principal and set the following environment variables:
+* For an Environment Credential, you will need to set up a Service Principal and set the following environment variables:
   - `AZURE_TENANT_ID`: Your Azure Active Directory tenant ID.
   - `AZURE_CLIENT_ID`: The client ID of your service principal or managed identity.
   - `AZURE_CLIENT_SECRET`: The client secret of your service principal.

--- a/docs/cookbooks/companions/voice-companion-openai.mdx
+++ b/docs/cookbooks/companions/voice-companion-openai.mdx
@@ -156,7 +156,7 @@ def create_memory_voice_agent():
             """You're speaking to a human, so be polite and concise.
             Always respond in clear, natural English.
             You have the ability to remember information about the user.
-            Use the save_memories tool when the user shares an important information worth remembering.
+            Use the save_memories tool when the user shares important information worth remembering.
             Use the search_memories tool when you need context from past conversations or user asks you to recall something.
             """,
         ),
@@ -362,7 +362,7 @@ def create_memory_voice_agent():
             """You're speaking to a human, so be polite and concise.
             Always respond in clear, natural English.
             You have the ability to remember information about the user.
-            Use the save_memories tool when the user shares an important information worth remembering.
+            Use the save_memories tool when the user shares important information worth remembering.
             Use the search_memories tool when you need context from past conversations or user asks you to recall something.
             """,
         ),

--- a/docs/cookbooks/essentials/exporting-memories.mdx
+++ b/docs/cookbooks/essentials/exporting-memories.mdx
@@ -128,7 +128,7 @@ Dev works at TechCorp as a senior engineer (score: 0.89)
 
 ```
 
-Search works across all memory fields and ranks by relevance. Use it when you have a specific question, use `get_all()` when you need everything.
+Search works across all memory fields and ranks by relevance. Use it when you have a specific question; use `get_all()` when you need everything.
 
 ---
 

--- a/docs/cookbooks/integrations/tavily-search.mdx
+++ b/docs/cookbooks/integrations/tavily-search.mdx
@@ -39,7 +39,7 @@ Let’s break down the main components.
 
 ### 1: Initialize Mem0 with Custom Instructions
 
-We configure Mem0 with custom instructions that guide it to infer user memories tailored specifically for our usecase.
+We configure Mem0 with custom instructions that guide it to infer user memories tailored specifically for our use case.
 
 ```python
 from mem0 import MemoryClient

--- a/docs/cookbooks/overview.mdx
+++ b/docs/cookbooks/overview.mdx
@@ -9,7 +9,7 @@ With Mem0, you can create stateful LLM-based applications such as chatbots, virt
 - More reliable
 - Cost-effective by reducing the number of LLM interactions
 - More engaging
-- Enables long-term memory
+- Enriched by long-term memory
 
 Here are some examples of how Mem0 can be integrated into various applications:
 

--- a/docs/platform/overview.mdx
+++ b/docs/platform/overview.mdx
@@ -21,7 +21,7 @@ Mem0 is the memory engine that keeps conversations contextual so users never rep
     | --- | --- |
     | Fast setup | Add a few lines of code and you’re production-ready: no vector database or LLM configuration required. |
     | Production scale | Automatic scaling, high availability, and managed infrastructure so you focus on product work. |
-    | Advanced features | webhooks, multimodal support, and custom categories are ready to enable. |
+    | Advanced features | Webhooks, multimodal support, and custom categories are ready to enable. |
     | Enterprise ready | Audit logs, workspace governance, and dedicated support keep security and governance covered. |
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Linked Issue

Closes #6032 

## Description

Fixes 10 spelling, punctuation, and grammar errors across the docs — wrong articles, comma splices, incomplete sentences, incorrect capitalization, and inconsistent word usage. Found via a full read-through of `docs/`. No content, structure, or code examples were changed — text-only corrections.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [X] Documentation update

## Breaking Changes
N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [X] No tests needed (explain why)

Text-only typo/grammar fixes in `.mdx`/`.md` prose — no code, config, or logic changed, so no tests apply.

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [X] I have updated documentation if needed