### PR TITLE
fix(llms): anchor Azure assistant keyword rewrite on word boundaries

### DIFF
--- a/mem0/llms/azure_openai.py
+++ b/mem0/llms/azure_openai.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import os
+import re
 from typing import Dict, List, Optional, Union
 
 from azure.identity import DefaultAzureCredential, get_bearer_token_provider
@@ -87,7 +88,7 @@ class AzureOpenAILLM(LLMBase):
         messages = copy.deepcopy(messages)
         last_content = messages[-1].get("content")
         if isinstance(last_content, str):
-            messages[-1]["content"] = last_content.replace("assistant", "ai")
+            messages[-1]["content"] = re.sub(r'(?i)\bassistant\b', 'ai', last_content)
         return messages
 
     def _parse_response(self, response, tools):

--- a/mem0/llms/azure_openai_structured.py
+++ b/mem0/llms/azure_openai_structured.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import os
+import re
 from typing import Dict, List, Optional
 
 from azure.identity import DefaultAzureCredential, get_bearer_token_provider
@@ -119,7 +120,7 @@ class AzureOpenAIStructuredLLM(LLMBase):
         messages = copy.deepcopy(messages)
         last_content = messages[-1].get("content")
         if isinstance(last_content, str):
-            messages[-1]["content"] = last_content.replace("assistant", "ai")
+            messages[-1]["content"] = re.sub(r'(?i)\bassistant\b', 'ai', last_content)
         return messages
 
     def _parse_response(self, response, tools):

--- a/tests/llms/test_azure_openai.py
+++ b/tests/llms/test_azure_openai.py
@@ -165,6 +165,22 @@ def test_generate_response_rewrites_assistant_keyword_for_model_only(mock_openai
     assert messages[-1]["content"] == "my assistant helps me"
 
 
+def test_generate_response_preserves_assistant_substring(mock_openai_client):
+    config = AzureOpenAIConfig(model=MODEL, temperature=TEMPERATURE, max_tokens=MAX_TOKENS, top_p=TOP_P)
+    llm = AzureOpenAILLM(config)
+    messages = [{"role": "user", "content": "i need assistance"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="ok"))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    sent_messages = mock_openai_client.chat.completions.create.call_args[1]["messages"]
+    assert sent_messages[-1]["content"] == "i need assistance"
+    assert messages[-1]["content"] == "i need assistance"
+
+
 def test_generate_response_handles_multimodal_content(mock_openai_client):
     config = AzureOpenAIConfig(model=MODEL, temperature=TEMPERATURE, max_tokens=MAX_TOKENS, top_p=TOP_P)
     llm = AzureOpenAILLM(config)

--- a/tests/llms/test_azure_openai_structured.py
+++ b/tests/llms/test_azure_openai_structured.py
@@ -305,6 +305,26 @@ def test_generate_response_rewrites_assistant_keyword_for_model_only(mock_azure_
 
 
 @mock.patch("mem0.llms.azure_openai_structured.AzureOpenAI")
+def test_generate_response_preserves_assistant_substring(mock_azure_openai):
+    mock_client = Mock()
+    mock_azure_openai.return_value = mock_client
+
+    config = DummyConfig(model="test-model", azure_kwargs=DummyAzureKwargs(api_key="real-key"))
+    llm = AzureOpenAIStructuredLLM(config)
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="ok"))]
+    mock_client.chat.completions.create.return_value = mock_response
+
+    messages = [{"role": "user", "content": "i need assistance"}]
+    llm.generate_response(messages)
+
+    sent_messages = mock_client.chat.completions.create.call_args[1]["messages"]
+    assert sent_messages[-1]["content"] == "i need assistance"
+    assert messages[-1]["content"] == "i need assistance"
+
+
+@mock.patch("mem0.llms.azure_openai_structured.AzureOpenAI")
 def test_generate_response_handles_multimodal_content(mock_azure_openai):
     mock_client = Mock()
     mock_azure_openai.return_value = mock_client


### PR DESCRIPTION
## Linked Issue

Closes #6036

## Description

The `_rewrite_assistant_keyword` method in both `azure_openai.py` and `azure_openai_structured.py` previously used a global string `.replace("assistant", "ai")`. This was originally introduced to safely bypass Azure's content filter, but it accidentally corrupts any word containing the substring "assistant". For example, "assistance" is silently mutated to "aiance".
This PR refactors the replacement logic to use a case-insensitive regex substitution with exact word boundaries (`\b`). This securely targets only the isolated word "assistant" without corrupting surrounding text or substrings.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update
## Breaking Changes
N/A

## Test Coverage
- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)
I added regression tests (`test_generate_response_preserves_assistant_substring`) to both `test_azure_openai.py` and `test_azure_openai_structured.py` to assert that strings like `"i need assistance"` remain completely unmutated. All tests pass locally via `pytest`.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed