### PR TITLE
feat(ts-sdk): add HuggingFace embedder

### DIFF
--- a/docs/open-source/configuration.mdx
+++ b/docs/open-source/configuration.mdx
@@ -120,7 +120,7 @@ Change the `provider` string to switch backends. The most common options:
 | Component | Python | TypeScript |
 | --- | --- | --- |
 | LLM | `openai`, `anthropic`, `gemini`, `groq`, `ollama`, `aws_bedrock`, `azure_openai`, `litellm` | `openai`, `anthropic`, `gemini`, `groq`, `ollama`, `azure_openai`, `mistral`, `deepseek` |
-| Embedder | `openai`, `gemini`, `azure_openai`, `ollama`, `huggingface`, `vertexai`, `aws_bedrock` | `openai`, `gemini`, `azure_openai`, `ollama` |
+| Embedder | `openai`, `gemini`, `azure_openai`, `ollama`, `huggingface`, `vertexai`, `aws_bedrock` | `openai`, `gemini`, `azure_openai`, `ollama`, `huggingface` |
 | Vector store | `qdrant`, `pgvector`, `chroma`, `pinecone`, `redis`, `weaviate`, `milvus`, `elasticsearch` | `memory`, `qdrant`, `pgvector`, `redis`, `supabase`, `azure-ai-search`, `vectorize` |
 
 See the full catalog in <Link href="/components/llms/overview">Components</Link>.

--- a/mem0-ts/package.json
+++ b/mem0-ts/package.json
@@ -114,6 +114,7 @@
     "@cloudflare/workers-types": "^4.20250504.0",
     "@google-cloud/aiplatform": "^6.8.0",
     "@google/genai": "^1.40.0",
+    "@huggingface/inference": "^4.13.21",
     "@langchain/core": "^1.1.47",
     "@mistralai/mistralai": "^1.5.2",
     "@opensearch-project/opensearch": "^3.5.1",

--- a/mem0-ts/pnpm-lock.yaml
+++ b/mem0-ts/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@google/genai':
         specifier: ^1.40.0
         version: 1.52.0
+      '@huggingface/inference':
+        specifier: ^4.13.21
+        version: 4.13.21
       '@langchain/core':
         specifier: ^1.1.47
         version: 1.1.48(@opentelemetry/api@1.9.1)(openai@4.104.0(ws@8.21.0)(zod@3.25.76))(ws@8.21.0)
@@ -764,6 +767,17 @@ packages:
 
   '@huggingface/xetchunk-wasm@0.1.0':
     resolution: {integrity: sha512-wWpp2qwPgf9kv1KLJjcDUk/OrpDOsFoQ3Qpz0U5LGn20csoymBf8eneOv6wm/GzPBzlWac1OYiR0aa1vT6aM2Q==}
+
+  '@huggingface/inference@4.13.21':
+    resolution: {integrity: sha512-B2gsY92aN8mxgQ1zqibQPFyq05KOlE4sTmRj1wYEEghOo/D4n6lVkH6v/7HcMzwUvfrKzYid0Cl1Nw0tEY5xTQ==}
+    engines: {node: '>=18'}
+
+  '@huggingface/jinja@0.5.9':
+    resolution: {integrity: sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==}
+    engines: {node: '>=18'}
+
+  '@huggingface/tasks@0.21.17':
+    resolution: {integrity: sha512-vdhQXFBb8hFm4U4KLGDT5a3C1JzSUU16Zoh4DJ1KDL3cdnIrUt+tIX+P1IxqZoXXx55PUQTJBu8iHH2HXtnBGg==}
 
   '@iovalkey/commands@0.1.0':
     resolution: {integrity: sha512-/B9W4qKSSITDii5nkBCHyPkIkAi+ealUtr1oqBJsLxjSRLka4pxun2VvMNSmcwgAMxgXtQfl0qRv7TE+udPJzg==}
@@ -4587,6 +4601,15 @@ snapshots:
     dependencies:
       '@huggingface/blake3-jit': 0.0.2
       gearhash-jit: 1.0.2
+
+  '@huggingface/inference@4.13.21':
+    dependencies:
+      '@huggingface/jinja': 0.5.9
+      '@huggingface/tasks': 0.21.17
+
+  '@huggingface/jinja@0.5.9': {}
+
+  '@huggingface/tasks@0.21.17': {}
 
   '@iovalkey/commands@0.1.0': {}
 

--- a/mem0-ts/src/oss/src/embeddings/huggingface.ts
+++ b/mem0-ts/src/oss/src/embeddings/huggingface.ts
@@ -1,0 +1,117 @@
+import { InferenceClient } from "@huggingface/inference";
+import { Embedder } from "./base";
+import { EmbeddingConfig } from "../types";
+
+const DEFAULT_MODEL = "sentence-transformers/multi-qa-MiniLM-L6-cos-v1";
+
+export class HuggingFaceEmbedder implements Embedder {
+  private client: InferenceClient;
+  private model: string;
+  private endpointUrl?: string;
+  private embeddingDims?: number;
+  private modelProperties?: Record<string, any>;
+
+  constructor(config: EmbeddingConfig) {
+    const apiKey =
+      config.apiKey ||
+      process.env.HF_TOKEN ||
+      process.env.HUGGINGFACE_API_KEY ||
+      "";
+    this.client = new InferenceClient(apiKey);
+    this.model = config.model || DEFAULT_MODEL;
+    this.endpointUrl = config.baseURL || config.url;
+    this.embeddingDims = config.embeddingDims;
+    this.modelProperties = config.modelProperties;
+  }
+
+  async embed(text: string): Promise<number[]> {
+    try {
+      const response = await this.client.featureExtraction({
+        model: this.model,
+        inputs: text,
+        ...(this.endpointUrl && { endpointUrl: this.endpointUrl }),
+        ...(this.embeddingDims !== undefined && {
+          dimensions: this.embeddingDims,
+        }),
+        ...this.modelProperties,
+      });
+      return HuggingFaceEmbedder.toEmbedding(response, this.model);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`HuggingFace embedder failed: ${message}`);
+    }
+  }
+
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    if (texts.length === 0) {
+      return [];
+    }
+    try {
+      const response = await this.client.featureExtraction({
+        model: this.model,
+        inputs: texts,
+        ...(this.endpointUrl && { endpointUrl: this.endpointUrl }),
+        ...(this.embeddingDims !== undefined && {
+          dimensions: this.embeddingDims,
+        }),
+        ...this.modelProperties,
+      });
+      return HuggingFaceEmbedder.toEmbeddings(
+        response,
+        texts.length,
+        this.model,
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`HuggingFace embedder failed: ${message}`);
+    }
+  }
+
+  private static isNumberArray(value: unknown): value is number[] {
+    return (
+      Array.isArray(value) && value.every((item) => typeof item === "number")
+    );
+  }
+
+  private static toEmbedding(response: unknown, model: string): number[] {
+    if (HuggingFaceEmbedder.isNumberArray(response)) {
+      return response;
+    }
+    if (
+      Array.isArray(response) &&
+      response.length === 1 &&
+      HuggingFaceEmbedder.isNumberArray(response[0])
+    ) {
+      return response[0];
+    }
+    throw new Error(
+      `HuggingFace embed() returned an unsupported embedding response for model '${model}'`,
+    );
+  }
+
+  private static toEmbeddings(
+    response: unknown,
+    expectedCount: number,
+    model: string,
+  ): number[][] {
+    if (
+      Array.isArray(response) &&
+      response.every(HuggingFaceEmbedder.isNumberArray)
+    ) {
+      if (response.length !== expectedCount) {
+        throw new Error(
+          `HuggingFace embedBatch() returned ${response.length} embeddings for ${expectedCount} texts using model '${model}'`,
+        );
+      }
+      return response;
+    }
+
+    if (expectedCount === 1) {
+      return [HuggingFaceEmbedder.toEmbedding(response, model)];
+    }
+
+    throw new Error(
+      `HuggingFace embedBatch() returned an unsupported embedding response for model '${model}'`,
+    );
+  }
+}

--- a/mem0-ts/src/oss/src/index.ts
+++ b/mem0-ts/src/oss/src/index.ts
@@ -8,6 +8,7 @@ export * from "./embeddings/lmstudio";
 export * from "./embeddings/together";
 export * from "./embeddings/google";
 export * from "./embeddings/azure";
+export * from "./embeddings/huggingface";
 export * from "./embeddings/langchain";
 export * from "./embeddings/fastembed";
 export * from "./llms/base";

--- a/mem0-ts/src/oss/src/utils/factory.ts
+++ b/mem0-ts/src/oss/src/utils/factory.ts
@@ -39,6 +39,7 @@ import { GoogleLLM } from "../llms/google";
 import { AzureOpenAILLM } from "../llms/azure";
 import { AzureOpenAIEmbedder } from "../embeddings/azure";
 import { FastEmbedEmbedder } from "../embeddings/fastembed";
+import { HuggingFaceEmbedder } from "../embeddings/huggingface";
 import { LangchainLLM } from "../llms/langchain";
 import { LangchainEmbedder } from "../embeddings/langchain";
 import { LangchainVectorStore } from "../vector_stores/langchain";
@@ -73,6 +74,8 @@ export class EmbedderFactory {
         return new AzureOpenAIEmbedder(config);
       case "fastembed":
         return new FastEmbedEmbedder(config);
+      case "huggingface":
+        return new HuggingFaceEmbedder(config);
       case "langchain":
         return new LangchainEmbedder(config);
       default:

--- a/mem0-ts/src/oss/tests/factory.unit.test.ts
+++ b/mem0-ts/src/oss/tests/factory.unit.test.ts
@@ -45,6 +45,11 @@ jest.mock("../src/embeddings/together", () => ({
     .fn()
     .mockImplementation((config) => ({ type: "together-embedder", config })),
 }));
+jest.mock("../src/embeddings/huggingface", () => ({
+  HuggingFaceEmbedder: jest
+    .fn()
+    .mockImplementation((config) => ({ type: "huggingface-embedder", config })),
+}));
 
 jest.mock("../src/llms/openai", () => ({
   OpenAILLM: jest
@@ -227,6 +232,7 @@ describe("EmbedderFactory", () => {
     ["langchain"],
     ["lmstudio"],
     ["together"],
+    ["huggingface"],
   ])("creates embedder for provider '%s'", (provider) => {
     expect(() =>
       EmbedderFactory.create(provider, dummyEmbedConfig),

--- a/mem0-ts/src/oss/tests/huggingface-embedder.test.ts
+++ b/mem0-ts/src/oss/tests/huggingface-embedder.test.ts
@@ -1,0 +1,139 @@
+/// <reference types="jest" />
+/**
+ * HuggingFace Embedder - unit tests (mocked InferenceClient).
+ */
+
+const mockFeatureExtraction = jest.fn();
+const mockInferenceClient = jest.fn().mockImplementation(() => ({
+  featureExtraction: mockFeatureExtraction,
+}));
+
+jest.mock("@huggingface/inference", () => ({
+  InferenceClient: mockInferenceClient,
+}));
+
+import { HuggingFaceEmbedder } from "../src/embeddings/huggingface";
+
+const mockEmbedding = [0.1, 0.2, 0.3, 0.4, 0.5];
+
+describe("HuggingFaceEmbedder (unit)", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.HF_TOKEN;
+    delete process.env.HUGGINGFACE_API_KEY;
+    mockFeatureExtraction.mockResolvedValue(mockEmbedding);
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it("uses config apiKey and the default model", async () => {
+    const embedder = new HuggingFaceEmbedder({
+      apiKey: "hf-test-key",
+    });
+
+    await embedder.embed("hello");
+
+    expect(mockInferenceClient).toHaveBeenCalledWith("hf-test-key");
+    expect(mockFeatureExtraction).toHaveBeenCalledWith({
+      model: "sentence-transformers/multi-qa-MiniLM-L6-cos-v1",
+      inputs: "hello",
+    });
+  });
+
+  it("falls back to HF_TOKEN when apiKey is not provided", () => {
+    process.env.HF_TOKEN = "hf-env-token";
+
+    new HuggingFaceEmbedder({});
+
+    expect(mockInferenceClient).toHaveBeenCalledWith("hf-env-token");
+  });
+
+  it("passes model, endpointUrl, dimensions, and modelProperties", async () => {
+    const embedder = new HuggingFaceEmbedder({
+      apiKey: "hf-test-key",
+      model: "BAAI/bge-small-en-v1.5",
+      baseURL: "https://example.endpoints.huggingface.cloud",
+      embeddingDims: 384,
+      modelProperties: { provider: "hf-inference" },
+    });
+
+    await embedder.embed("hello");
+
+    expect(mockFeatureExtraction).toHaveBeenCalledWith({
+      model: "BAAI/bge-small-en-v1.5",
+      inputs: "hello",
+      endpointUrl: "https://example.endpoints.huggingface.cloud",
+      dimensions: 384,
+      provider: "hf-inference",
+    });
+  });
+
+  it("unwraps single-item embedding responses", async () => {
+    mockFeatureExtraction.mockResolvedValueOnce([mockEmbedding]);
+
+    const embedder = new HuggingFaceEmbedder({ apiKey: "hf-test-key" });
+
+    await expect(embedder.embed("hello")).resolves.toEqual(mockEmbedding);
+  });
+
+  it("embedBatch() returns vectors for multiple inputs", async () => {
+    const batch = [
+      [0.1, 0.2],
+      [0.3, 0.4],
+    ];
+    mockFeatureExtraction.mockResolvedValueOnce(batch);
+
+    const embedder = new HuggingFaceEmbedder({ apiKey: "hf-test-key" });
+
+    const result = await embedder.embedBatch(["text1", "text2"]);
+
+    expect(mockFeatureExtraction).toHaveBeenCalledWith({
+      model: "sentence-transformers/multi-qa-MiniLM-L6-cos-v1",
+      inputs: ["text1", "text2"],
+    });
+    expect(result).toEqual(batch);
+  });
+
+  it("embedBatch() returns an empty result for empty input without calling the API", async () => {
+    const embedder = new HuggingFaceEmbedder({ apiKey: "hf-test-key" });
+
+    await expect(embedder.embedBatch([])).resolves.toEqual([]);
+
+    expect(mockFeatureExtraction).not.toHaveBeenCalled();
+  });
+
+  it("embedBatch() throws when provider returns fewer embeddings than texts", async () => {
+    mockFeatureExtraction.mockResolvedValueOnce([[0.1, 0.2]]);
+
+    const embedder = new HuggingFaceEmbedder({ apiKey: "hf-test-key" });
+
+    await expect(embedder.embedBatch(["text1", "text2"])).rejects.toThrow(
+      /returned 1 embeddings for 2 texts/,
+    );
+  });
+
+  it("wraps API errors with a clear message", async () => {
+    mockFeatureExtraction.mockRejectedValueOnce(new Error("Unauthorized"));
+
+    const embedder = new HuggingFaceEmbedder({ apiKey: "bad-key" });
+
+    await expect(embedder.embed("hello")).rejects.toThrow(
+      "HuggingFace embedder failed: Unauthorized",
+    );
+  });
+
+  it("throws for unsupported token-level feature extraction responses", async () => {
+    mockFeatureExtraction.mockResolvedValueOnce([[[0.1, 0.2]]]);
+
+    const embedder = new HuggingFaceEmbedder({ apiKey: "hf-test-key" });
+
+    await expect(embedder.embed("hello")).rejects.toThrow(
+      /unsupported embedding response/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a TypeScript HuggingFace embedder backed by @huggingface/inference
- wire the provider through EmbedderFactory and OSS exports
- add mocked unit coverage for config, env token fallback, batching, error wrapping, and unsupported responses
- document `huggingface` as a TypeScript embedder provider

Closes #5769

## Verification
- `node_modules/.bin/jest --config jest.config.js src/oss/tests/huggingface-embedder.test.ts --runInBand`
- `node_modules/.bin/jest --config jest.config.js src/oss/tests/factory.unit.test.ts --runInBand --testNamePattern EmbedderFactory`
- `node_modules/.bin/tsc --noEmit --target ES2020 --module commonjs --moduleResolution node --esModuleInterop --skipLibCheck src/oss/src/embeddings/huggingface.ts`
- `node_modules/.bin/tsup`
- `git diff --check`