### PR TITLE
fix(ts-oss): omit empty Azure AI Search filters

### DIFF
--- a/docs/changelog/sdk.mdx
+++ b/docs/changelog/sdk.mdx
@@ -1105,6 +1105,7 @@ See the [OSS v2 to v3 migration guide](https://docs.mem0.ai/migration/oss-v2-to-
 **Bug Fixes:**
 - **Embeddings:** Guard against an `embed_batch` count mismatch in the OpenAI and Azure OpenAI embedders ([#5966](https://github.com/mem0ai/mem0/pull/5966))
 - **LLMs:** Handle empty Google chat candidates without crashing ([#5817](https://github.com/mem0ai/mem0/pull/5817))
+- **Vector Stores:** Omit empty Azure AI Search filters and fail fast for invalid filter containers, keys, or non-string values; Azure AI Search filters now accept only `user_id`, `run_id`, and `agent_id` ([#6045](https://github.com/mem0ai/mem0/pull/6045))
 
 </Update>
 

--- a/mem0-ts/src/oss/src/vector_stores/azure_ai_search.ts
+++ b/mem0-ts/src/oss/src/vector_stores/azure_ai_search.ts
@@ -66,6 +66,12 @@ interface AzureAISearchConfig extends VectorStoreConfig {
   vectorFilterMode?: string;
 }
 
+const AZURE_AI_SEARCH_FILTERABLE_FIELDS = [
+  "user_id",
+  "run_id",
+  "agent_id",
+] as const;
+
 /**
  * Azure AI Search vector store implementation
  * Supports vector search with hybrid search, compression, and filtering
@@ -283,28 +289,51 @@ export class AzureAISearch implements VectorStore {
   }
 
   /**
-   * Sanitize filter keys to remove non-alphanumeric characters
-   */
-  private sanitizeKey(key: string): string {
-    return key.replace(/[^\w]/g, "");
-  }
-
-  /**
    * Build OData filter expression from SearchFilters
    */
-  private buildFilterExpression(filters: SearchFilters): string {
+  private buildFilterExpression(filters?: SearchFilters): string | undefined {
+    if (filters === undefined) {
+      return undefined;
+    }
+
+    if (
+      typeof filters !== "object" ||
+      filters === null ||
+      Array.isArray(filters) ||
+      ![Object.prototype, null].includes(Object.getPrototypeOf(filters))
+    ) {
+      throw new Error("Azure AI Search filters must be a plain object.");
+    }
+
+    if (Object.keys(filters).length === 0) {
+      return undefined;
+    }
+
+    const filterableFields = new Set<string>(AZURE_AI_SEARCH_FILTERABLE_FIELDS);
     const filterConditions: string[] = [];
 
     for (const [key, value] of Object.entries(filters)) {
-      const safeKey = this.sanitizeKey(key);
-
-      if (typeof value === "string") {
-        // Escape single quotes in string values
-        const safeValue = value.replace(/'/g, "''");
-        filterConditions.push(`${safeKey} eq '${safeValue}'`);
-      } else {
-        filterConditions.push(`${safeKey} eq ${value}`);
+      if (value === null || value === undefined) {
+        throw new Error(
+          `Azure AI Search filter '${key}' must not be null or undefined.`,
+        );
       }
+
+      if (!filterableFields.has(key)) {
+        throw new Error(
+          `Unsupported Azure AI Search filter key '${key}'. Supported keys: ${AZURE_AI_SEARCH_FILTERABLE_FIELDS.join(", ")}.`,
+        );
+      }
+
+      if (typeof value !== "string") {
+        throw new Error(
+          `Unsupported Azure AI Search filter value for '${key}': expected string, received ${typeof value}.`,
+        );
+      }
+
+      // Escape single quotes in string values.
+      const safeValue = value.replace(/'/g, "''");
+      filterConditions.push(`${key} eq '${safeValue}'`);
     }
 
     return filterConditions.join(" and ");
@@ -334,13 +363,11 @@ export class AzureAISearch implements VectorStore {
     topK: number = 5,
     filters?: SearchFilters,
   ): Promise<VectorStoreResult[] | null> {
-    try {
-      const filterExpression = filters
-        ? this.buildFilterExpression(filters)
-        : undefined;
+    const filterExpression = this.buildFilterExpression(filters);
 
+    try {
       const searchResults = await this.searchClient.search(query, {
-        filter: filterExpression,
+        ...(filterExpression && { filter: filterExpression }),
         top: topK,
         searchFields: ["payload"],
       });
@@ -373,9 +400,7 @@ export class AzureAISearch implements VectorStore {
     topK: number = 5,
     filters?: SearchFilters,
   ): Promise<VectorStoreResult[]> {
-    const filterExpression = filters
-      ? this.buildFilterExpression(filters)
-      : undefined;
+    const filterExpression = this.buildFilterExpression(filters);
 
     const vectorQuery: VectorizedQuery<any> = {
       kind: "vector",
@@ -393,7 +418,7 @@ export class AzureAISearch implements VectorStore {
           queries: [vectorQuery],
           filterMode: this.vectorFilterMode as any,
         },
-        filter: filterExpression,
+        ...(filterExpression && { filter: filterExpression }),
         top: topK,
         searchFields: ["payload"],
       });
@@ -404,7 +429,7 @@ export class AzureAISearch implements VectorStore {
           queries: [vectorQuery],
           filterMode: this.vectorFilterMode as any,
         },
-        filter: filterExpression,
+        ...(filterExpression && { filter: filterExpression }),
         top: topK,
       });
     }
@@ -542,12 +567,10 @@ export class AzureAISearch implements VectorStore {
     filters?: SearchFilters,
     topK: number = 100,
   ): Promise<[VectorStoreResult[], number]> {
-    const filterExpression = filters
-      ? this.buildFilterExpression(filters)
-      : undefined;
+    const filterExpression = this.buildFilterExpression(filters);
 
     const searchResults = await this.searchClient.search("*", {
-      filter: filterExpression,
+      ...(filterExpression && { filter: filterExpression }),
       top: topK,
     });
 

--- a/mem0-ts/src/oss/tests/azure-ai-search.filters.test.ts
+++ b/mem0-ts/src/oss/tests/azure-ai-search.filters.test.ts
@@ -1,0 +1,270 @@
+import { AzureAISearch } from "../src/vector_stores/azure_ai_search";
+
+const mockSearch = jest.fn();
+const mockListIndexes = jest.fn();
+const mockCreateOrUpdateIndex = jest.fn();
+
+jest.mock("@azure/search-documents", () => ({
+  SearchClient: jest.fn().mockImplementation(() => ({
+    search: mockSearch,
+    uploadDocuments: jest.fn().mockResolvedValue({ results: [] }),
+    getDocument: jest.fn().mockResolvedValue(null),
+    mergeOrUploadDocuments: jest.fn().mockResolvedValue({}),
+    deleteDocuments: jest.fn().mockResolvedValue({}),
+  })),
+  SearchIndexClient: jest.fn().mockImplementation(() => ({
+    listIndexes: mockListIndexes,
+    createOrUpdateIndex: mockCreateOrUpdateIndex,
+    deleteIndex: jest.fn().mockResolvedValue({}),
+    getIndex: jest.fn().mockResolvedValue({ name: "test-index", fields: [] }),
+  })),
+  AzureKeyCredential: jest.fn().mockImplementation((key: string) => ({ key })),
+}));
+
+jest.mock("@azure/identity", () => ({
+  DefaultAzureCredential: jest.fn(),
+}));
+
+function emptyAzureSearchResult() {
+  return {
+    results: {
+      async *[Symbol.asyncIterator]() {
+        // Empty result set.
+      },
+    },
+  };
+}
+
+function createStore(): AzureAISearch {
+  return new AzureAISearch({
+    serviceName: "test-service",
+    collectionName: "test-index",
+    apiKey: "fake-key",
+    embeddingModelDims: 4,
+  });
+}
+
+describe("AzureAISearch filter expression handling", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSearch.mockReturnValue(emptyAzureSearchResult());
+    mockListIndexes.mockReturnValue({
+      async *[Symbol.asyncIterator]() {
+        // No existing indexes.
+      },
+    });
+    mockCreateOrUpdateIndex.mockResolvedValue({});
+  });
+
+  test("search omits filter option for empty filters", async () => {
+    const store = createStore();
+
+    await store.search([0.1, 0.2, 0.3, 0.4], 5, {});
+
+    const [, options] = mockSearch.mock.calls[0];
+    expect(options).not.toHaveProperty("filter");
+  });
+
+  test("search rejects malformed filter containers instead of treating them as empty", async () => {
+    const malformedFilters = [
+      null,
+      false,
+      "",
+      [],
+      new Date("2026-01-01T00:00:00.000Z"),
+    ];
+
+    for (const filters of malformedFilters) {
+      const store = createStore();
+      mockSearch.mockClear();
+
+      await expect(
+        store.search([0.1, 0.2, 0.3, 0.4], 5, filters as any),
+      ).rejects.toThrow("filters must be a plain object");
+
+      expect(mockSearch).not.toHaveBeenCalled();
+    }
+  });
+
+  test("search supports null-prototype filter dictionaries", async () => {
+    const store = createStore();
+    const filters = Object.create(null);
+    filters.user_id = "user-1";
+
+    await store.search([0.1, 0.2, 0.3, 0.4], 5, filters);
+
+    const [, options] = mockSearch.mock.calls[0];
+    expect(options).toEqual(
+      expect.objectContaining({ filter: "user_id eq 'user-1'" }),
+    );
+  });
+
+  test("hybrid search omits filter option for empty filters", async () => {
+    const store = new AzureAISearch({
+      serviceName: "test-service",
+      collectionName: "test-index",
+      apiKey: "fake-key",
+      embeddingModelDims: 4,
+      hybridSearch: true,
+    });
+
+    await store.search([0.1, 0.2, 0.3, 0.4], 5, {});
+
+    const [, options] = mockSearch.mock.calls[0];
+    expect(options).not.toHaveProperty("filter");
+    expect(options).toEqual(
+      expect.objectContaining({ top: 5, searchFields: ["payload"] }),
+    );
+  });
+
+  test("keywordSearch omits filter option for empty filters", async () => {
+    const store = createStore();
+
+    await store.keywordSearch("coffee", 3, {});
+
+    const [, options] = mockSearch.mock.calls[0];
+    expect(options).not.toHaveProperty("filter");
+    expect(options).toEqual(
+      expect.objectContaining({ top: 3, searchFields: ["payload"] }),
+    );
+  });
+
+  test("list omits filter option for empty filters", async () => {
+    const store = createStore();
+
+    await store.list({}, 10);
+
+    const [, options] = mockSearch.mock.calls[0];
+    expect(options).not.toHaveProperty("filter");
+    expect(options).toEqual(expect.objectContaining({ top: 10 }));
+  });
+
+  test("search preserves valid filter expressions", async () => {
+    const store = createStore();
+
+    await store.search([0.1, 0.2, 0.3, 0.4], 5, {
+      user_id: "o'hara",
+      run_id: "run-1",
+    });
+
+    const [, options] = mockSearch.mock.calls[0];
+    expect(options).toEqual(
+      expect.objectContaining({
+        filter: "user_id eq 'o''hara' and run_id eq 'run-1'",
+        top: 5,
+      }),
+    );
+  });
+
+  test("list preserves valid filter expressions", async () => {
+    const store = createStore();
+
+    await store.list({ agent_id: "agent-1" }, 10);
+
+    const [, options] = mockSearch.mock.calls[0];
+    expect(options).toEqual(
+      expect.objectContaining({
+        filter: "agent_id eq 'agent-1'",
+        top: 10,
+      }),
+    );
+  });
+
+  test("list rejects nullish filter values instead of broadening the read", async () => {
+    const store = createStore();
+
+    await expect(
+      store.list({ user_id: null, agent_id: undefined } as any, 10),
+    ).rejects.toThrow("must not be null or undefined");
+
+    expect(mockSearch).not.toHaveBeenCalled();
+  });
+
+  test("keywordSearch rejects nullish filter values instead of returning null", async () => {
+    const store = createStore();
+
+    await expect(
+      store.keywordSearch("coffee", 3, { run_id: null } as any),
+    ).rejects.toThrow("must not be null or undefined");
+
+    expect(mockSearch).not.toHaveBeenCalled();
+  });
+
+  test("keywordSearch preserves valid filter values and escapes strings", async () => {
+    const store = createStore();
+
+    await store.keywordSearch("coffee", 3, {
+      user_id: "o'hara",
+      agent_id: "agent-1",
+    });
+
+    expect(mockSearch).toHaveBeenCalledWith(
+      "coffee",
+      expect.objectContaining({
+        filter: "user_id eq 'o''hara' and agent_id eq 'agent-1'",
+        top: 3,
+        searchFields: ["payload"],
+      }),
+    );
+  });
+
+  test("search rejects unsupported filter value shapes", async () => {
+    const store = createStore();
+
+    await expect(
+      store.search([0.1, 0.2, 0.3, 0.4], 5, {
+        user_id: { $ne: "u1" },
+      } as any),
+    ).rejects.toThrow("Unsupported Azure AI Search filter value");
+
+    expect(mockSearch).not.toHaveBeenCalled();
+  });
+
+  test("search rejects non-string values for string filter fields", async () => {
+    const store = createStore();
+
+    await expect(
+      store.search([0.1, 0.2, 0.3, 0.4], 5, {
+        user_id: 123,
+      } as any),
+    ).rejects.toThrow("expected string");
+
+    expect(mockSearch).not.toHaveBeenCalled();
+  });
+
+  test("search rejects unsupported filter keys", async () => {
+    const store = createStore();
+
+    await expect(
+      store.search([0.1, 0.2, 0.3, 0.4], 5, {
+        metadata: "private",
+      } as any),
+    ).rejects.toThrow("Unsupported Azure AI Search filter key");
+
+    expect(mockSearch).not.toHaveBeenCalled();
+  });
+
+  test("search rejects id filters because id is not filterable in the Azure index", async () => {
+    const store = createStore();
+
+    await expect(
+      store.search([0.1, 0.2, 0.3, 0.4], 5, {
+        id: "memory-1",
+      } as any),
+    ).rejects.toThrow("Unsupported Azure AI Search filter key");
+
+    expect(mockSearch).not.toHaveBeenCalled();
+  });
+
+  test("search rejects malformed keys instead of sanitizing them into supported fields", async () => {
+    const store = createStore();
+
+    await expect(
+      store.search([0.1, 0.2, 0.3, 0.4], 5, {
+        "user_id!": "u1",
+      } as any),
+    ).rejects.toThrow("Unsupported Azure AI Search filter key");
+
+    expect(mockSearch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Linked Issue

No existing issue. This was discovered while triaging the related Redis empty-filter issue (#6013); the Redis case is already covered by open PR #6014.

## Description

The TS OSS Azure AI Search vector store built an OData filter string whenever the `filters` argument was truthy. Empty objects (`{}`) are truthy in JavaScript, so `buildFilterExpression()` returned an empty string and `keywordSearch()`, vector `search()`, and `list()` sent an empty filter to Azure instead of omitting the filter.

This PR makes the Azure AI Search filter helper return `undefined` when no filters are provided or the filter object is empty, and fail closed for explicit nullish values instead of broadening the read. It also rejects malformed filter containers, unsupported filter keys, malformed keys that previously could be sanitized into supported fields, and non-string values for Azure's string filter fields before they reach the OData expression builder. Valid non-empty filters keep the existing equality expression behavior, including escaping single quotes in string values.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Commands run:

- `cd mem0-ts && pnpm exec jest --runInBand src/oss/tests/azure-ai-search.filters.test.ts` - passed; 16 tests.
- `cd mem0-ts && pnpm exec jest --runInBand src/oss/tests/azure-ai-search.filters.test.ts src/oss/tests/vector-stores-compat.test.ts src/oss/tests/factory.unit.test.ts` - passed; 90 tests.
- `cd mem0-ts && pnpm exec prettier --check src/oss/src/vector_stores/azure_ai_search.ts src/oss/tests/azure-ai-search.filters.test.ts` - passed.
- `cd mem0-ts && pnpm run build` - passed.
- `git diff --check` and `git diff --cached --check` - passed.

Also run:

- `cd mem0-ts && pnpm exec tsc --noEmit -p tsconfig.test.json --pretty false` - failed on existing unrelated baseline TypeScript errors in `src/community/src/integrations/langchain/mem0.ts` and `src/oss/tests/memory.validation.test.ts`; no errors were reported in the touched source or new test file.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (`docs/changelog/sdk.mdx` notes the TS Azure AI Search filter behavior change)
