### PR TITLE
fix(ts-oss): avoid redundant reads during deleteAll

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -7,6 +7,7 @@ import {
   Message,
   SearchFilters,
   SearchResult,
+  VectorStoreResult,
 } from "../types";
 import {
   EmbedderFactory,
@@ -1619,7 +1620,7 @@ export class Memory {
 
     const [memories] = await this.vectorStore.list(filters);
     for (const memory of memories) {
-      await this.deleteMemory(memory.id);
+      await this.deleteMemory(memory.id, memory);
     }
 
     const result = { message: "Memories deleted successfully!" };
@@ -1853,8 +1854,11 @@ export class Memory {
     return memoryId;
   }
 
-  private async deleteMemory(memoryId: string): Promise<string> {
-    const existingMemory = await this.vectorStore.get(memoryId);
+  private async deleteMemory(
+    memoryId: string,
+    existingMemory?: VectorStoreResult | null,
+  ): Promise<string> {
+    existingMemory ??= await this.vectorStore.get(memoryId);
     if (!existingMemory) {
       throw new Error(`Memory with ID ${memoryId} not found`);
     }

--- a/mem0-ts/src/oss/tests/memory.crud.test.ts
+++ b/mem0-ts/src/oss/tests/memory.crud.test.ts
@@ -267,6 +267,21 @@ describe("Memory - deleteAll()", () => {
     expect(remaining.results).toHaveLength(0);
   });
 
+  test("does not re-fetch memories already returned by list", async () => {
+    const scopedUserId = `deleteall_no_refetch_${Date.now()}`;
+    await memory.add("No refetch fact A", { userId: scopedUserId });
+    await memory.add("No refetch fact B", { userId: scopedUserId });
+    const vectorStore = (memory as any).vectorStore;
+    const getSpy = jest.spyOn(vectorStore, "get");
+
+    try {
+      await memory.deleteAll({ userId: scopedUserId });
+      expect(getSpy).not.toHaveBeenCalled();
+    } finally {
+      getSpy.mockRestore();
+    }
+  });
+
   test("throws when no filter is provided", async () => {
     await expect(memory.deleteAll({} as any)).rejects.toThrow(
       "At least one filter is required to delete all memories",


### PR DESCRIPTION
## Linked Issue

No standalone issue. This was discovered during repository review after Python issue #5869 / PR #5870 highlighted the same redundant-read pattern, and maintainer review noted the TypeScript OSS path had the matching issue.

## Description

`Memory.deleteAll()` already receives the memory rows it needs from `vectorStore.list(filters)`, but it previously passed only each memory ID into the private delete helper. That forced an extra `vectorStore.get(memoryId)` call for every listed row before deleting it.

This change lets the bulk-delete path pass the listed row into the private helper while leaving single-memory `delete(memoryId)` behavior unchanged. The helper still falls back to fetching by ID when no row is supplied.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Commands run:

- `cd mem0-ts && pnpm exec jest --runInBand src/oss/tests/memory.crud.test.ts` — passed; 27 tests.
- `cd mem0-ts && pnpm exec jest --runInBand src/oss/tests/memory.crud.test.ts src/oss/tests/memory.entity-boost.test.ts` — passed; 2 suites, 31 tests.
- `cd mem0-ts && pnpm exec prettier --check src/oss/src/memory/index.ts src/oss/tests/memory.crud.test.ts` — passed.
- `cd mem0-ts && pnpm run build` — passed.
- `cd mem0-ts && pnpm test --runInBand` — passed; 56 suites passed, 5 skipped, 812 tests passed, 42 skipped.
- `git diff --check` — passed.
- `cd mem0-ts && pnpm exec tsc --noEmit -p tsconfig.test.json --pretty false` — failed on existing unrelated baseline errors in `src/community/src/integrations/langchain/mem0.ts` and `src/oss/tests/memory.validation.test.ts`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed

## Notes for maintainers

Risk level: low. This is a private helper change that avoids redundant reads in the bulk-delete path while preserving the public single-delete flow and the existing not-found behavior.

The focused regression spies on the OSS vector store after creating memories and verifies `deleteAll()` does not call `get()` for rows already returned by `list()`.
