### PR TITLE
test(ts-oss): lock entity substring dedup regression

### DIFF
--- a/mem0-ts/src/oss/tests/entity-extraction.test.ts
+++ b/mem0-ts/src/oss/tests/entity-extraction.test.ts
@@ -1,6 +1,28 @@
 import { extractEntities } from "../src/utils/entity_extraction";
 
 describe("extractEntities", () => {
+  it("keeps distinct entities that only share a substring prefix", () => {
+    const entityTexts = new Set(
+      extractEntities("The team mentioned Sam and Samsung together.").map(
+        (entity) => entity.text,
+      ),
+    );
+
+    expect(entityTexts.has("Sam")).toBe(true);
+    expect(entityTexts.has("Samsung")).toBe(true);
+  });
+
+  it("still removes true whole-word subsets of longer entities", () => {
+    const entityTexts = new Set(
+      extractEntities(
+        '"machine learning" and "learning" were both mentioned.',
+      ).map((entity) => entity.text.toLowerCase()),
+    );
+
+    expect(entityTexts.has("machine learning")).toBe(true);
+    expect(entityTexts.has("learning")).toBe(false);
+  });
+
   it("handles product lists, coordinated names, and identifiers", () => {
     const text =
       "User reported top inbound integration pages: OpenClaw 25,443, " +


### PR DESCRIPTION
## Linked Issue

Related to #5646

## Description

Adds focused TypeScript OSS regression coverage for the entity deduplication case from #5646. Current `main` already preserves distinct substring-prefix entities after the broader extraction alignment in #5829, so this PR intentionally does not change production code.

This does not close #5646 by itself; it backfills regression coverage for behavior that is already correct on current `main`.

The new tests lock both sides of the intended behavior: `Sam` must survive alongside `Samsung`, while a true whole-word subset such as `learning` is still deduplicated when `machine learning` is present.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Commands run:

- `cd mem0-ts && pnpm exec jest --runInBand src/oss/tests/entity-extraction.test.ts` - passed
- `cd mem0-ts && pnpm exec prettier --check src/oss/tests/entity-extraction.test.ts` - passed
- `cd mem0-ts && pnpm run build` - passed
- `git diff --check` - passed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
