### PR TITLE
docs: clarify Platform and OSS REST API surfaces

### DIFF
--- a/docs/open-source/features/rest-api.mdx
+++ b/docs/open-source/features/rest-api.mdx
@@ -1,6 +1,6 @@
 ---
 title: REST API Server
-description: Reach every Mem0 OSS capability through a FastAPI-powered REST layer.
+description: Reach self-hosted Mem0 memory operations through a FastAPI-powered REST layer.
 icon: "code"
 ---
 
@@ -18,7 +18,7 @@ The Mem0 REST API server exposes every OSS memory operation over HTTP. Run it al
 </Warning>
 
 <Warning>
-  **OSS vs Platform API paths:** The self-hosted OSS server does **not** use the `/v1/` prefix. For example, the endpoint is `POST /memories`, not `POST /v1/memories/`. The [API Reference](/api-reference) documents the hosted platform at `api.mem0.ai` which uses `/v1/` paths: those do not apply to the OSS server.
+  **OSS vs Platform API paths:** The self-hosted OSS server does **not** use the hosted Platform memory API's `/v1` or `/v3` route families. For example, the OSS endpoints are `POST /memories` and `POST /search`, not `POST /v3/memories/add/` or `POST /v3/memories/search/`. The [API Reference](/api-reference) documents the hosted Platform API at `api.mem0.ai`; use this page or your server's `/docs` page for the OSS REST surface. Do not use a Platform API key against the OSS server; use the OSS auth modes described below.
 </Warning>
 
 <Warning>
@@ -202,9 +202,12 @@ ADMIN_API_KEY=your-long-admin-key
 
 ### Create and search memories via HTTP
 
+These examples use a per-user API key. Protected endpoints also accept a bearer JWT from `POST /auth/login`.
+
 ```bash
 curl -X POST http://localhost:8888/memories \
   -H "Content-Type: application/json" \
+  -H "X-API-Key: m0sk_your_key_here" \
   -d '{
     "messages": [
       {"role": "user", "content": "I love fresh vegetable pizza."}
@@ -220,6 +223,7 @@ curl -X POST http://localhost:8888/memories \
 ```bash
 curl -X POST http://localhost:8888/search \
   -H "Content-Type: application/json" \
+  -H "X-API-Key: m0sk_your_key_here" \
   -d '{
     "query": "vegetable",
     "user_id": "alice"
@@ -231,6 +235,7 @@ Set `explain` to inspect the scoring signals used by OSS hybrid search:
 ```bash
 curl -X POST http://localhost:8888/search \
   -H "Content-Type: application/json" \
+  -H "X-API-Key: m0sk_your_key_here" \
   -d '{
     "query": "vegetable pizza",
     "user_id": "alice",
@@ -254,7 +259,7 @@ Each returned memory includes `score_details` only when explanation mode is enab
 
 ## Endpoint reference
 
-The OSS REST server exposes the following endpoints. None use the `/v1/` prefix.
+The OSS REST server exposes the following endpoints. None use the hosted Platform memory API's `/v1` or `/v3` route families.
 
 ### Memory operations
 
@@ -281,13 +286,13 @@ The OSS REST server exposes the following endpoints. None use the `/v1/` prefix.
 | `POST` | `/auth/register` | Register the first admin. Registration closes after the first admin is created; additional accounts are provisioned by the existing admin. |
 | `POST` | `/auth/login` | Exchange email and password for access and refresh JWTs |
 | `POST` | `/auth/refresh` | Exchange a refresh token for a new access token |
-| `GET` | `/auth/me` | Get the current authenticated user (JWT required) |
+| `GET` | `/auth/me` | Get the current authenticated user |
 | `PATCH` | `/auth/me` | Update the caller's name or email. 409 if the new email is already in use |
 | `POST` | `/auth/change-password` | Change the caller's password. 401 if the current password is wrong; new password must be at least 8 characters |
 
 ### API keys
 
-All `/api-keys` endpoints require a JWT.
+All `/api-keys` endpoints require an authenticated user. Dashboard JWTs are the intended flow for managing keys, and the server also accepts per-user `X-API-Key` auth.
 
 | Method | Path | Description |
 |--------|------|-------------|

--- a/docs/open-source/overview.mdx
+++ b/docs/open-source/overview.mdx
@@ -11,6 +11,10 @@ Run it two ways:
 - **As a library** in your app. `pip install mem0ai` (or `npm install mem0ai`), call `Memory()`, and you have memory in a few lines.
 - **As a self-hosted server.** A Docker stack with a dashboard, per-user API keys, and a request audit log.
 
+<Note>
+  Use the OSS SDK entry points when you self-host: `Memory` / `AsyncMemory` in Python, or `Memory` from `mem0ai/oss` in TypeScript. `MemoryClient` is the Platform API client; even with a custom `host`, its memory methods expect Platform-compatible `/v1` and `/v3` routes, so it is not a drop-in client for the self-hosted OSS FastAPI server.
+</Note>
+
 ## Get started
 
 <CardGroup cols={3}>

--- a/docs/platform/platform-vs-oss.mdx
+++ b/docs/platform/platform-vs-oss.mdx
@@ -91,14 +91,18 @@ Mem0 offers two powerful ways to add memory to your AI applications. Choose base
   <Accordion title="Development & Integration" icon="code">
     | Feature | Platform | Open Source |
     |---------|----------|-------------|
-    | **REST API** | ✅ | ✅ (self-hosted server) |
-    | **Python SDK** | ✅ | ✅ |
-    | **JavaScript SDK** | ✅ | ✅ |
+    | **REST API** | ✅ Hosted Platform API (`api.mem0.ai`) | ✅ Self-hosted FastAPI server |
+    | **Python SDK** | ✅ `MemoryClient` / `AsyncMemoryClient` | ✅ `Memory` / `AsyncMemory` |
+    | **JavaScript SDK** | ✅ `MemoryClient` | ✅ `Memory` from `mem0ai/oss` |
     | **Framework integrations** | LangChain, CrewAI, LlamaIndex, and 20+ more | Same |
     | **Dashboard** | ✅ Web-based | ❌ |
     | **Analytics** | ✅ Built-in | DIY |
   </Accordion>
 </AccordionGroup>
+
+<Note>
+  The Platform and self-hosted REST APIs are different surfaces. `MemoryClient` targets the hosted Platform API, and its memory methods use Platform-compatible `/v1` and `/v3` routes. The OSS self-hosted server exposes its own FastAPI endpoints such as `/memories` and `/search`; use the server's `/docs` page or the <Link href="/open-source/features/rest-api">OSS REST API Server</Link> guide for that reference.
+</Note>
 
 ---
 


### PR DESCRIPTION
## Linked Issue

Closes #5863

## Description

This PR clarifies that Mem0 Platform and self-hosted OSS both expose REST/API workflows, but they are different surfaces. The hosted `MemoryClient` targets Platform-compatible memory routes, while the OSS server exposes its own FastAPI endpoints such as `/memories` and `/search`.

The goal is to prevent self-hosted users from trying Platform API paths or Platform API keys against the OSS server, and to point them to the OSS SDK entry points or the server's `/docs` page instead.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [x] No tests needed (explain why)

Docs-only change. Commands run:

- `python3 scripts/check-llms-txt-coverage.py` - passed
- `git diff --check` - passed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
