### PR TITLE
fix(openmemory): bound backup import archive size

### DIFF
--- a/openmemory/api/.env.example
+++ b/openmemory/api/.env.example
@@ -13,3 +13,20 @@ USER=user
 # EMBEDDER_MODEL=nomic-embed-text
 # EMBEDDER_API_KEY=
 # EMBEDDER_BASE_URL=
+
+# Backup import limits (optional, import-only)
+# Values are bytes except *_RECORDS, and are read when the API process starts.
+# Restart the API process/container after changing these values.
+# Oversized restores fail with 413; malformed zip/JSON content fails with 400.
+# Exports are not size-capped, so trusted large exports may need higher import limits before restore.
+# If these backup routes are exposed beyond trusted local/self-hosted use, protect them with auth/proxy controls.
+# OPENMEMORY_BACKUP_READ_CHUNK_BYTES=1048576
+# OPENMEMORY_MAX_BACKUP_UPLOAD_BYTES=104857600
+# OPENMEMORY_MAX_BACKUP_SQLITE_BYTES=10485760
+# OPENMEMORY_MAX_BACKUP_LOGICAL_GZIP_BYTES=104857600
+# OPENMEMORY_MAX_BACKUP_LOGICAL_DECOMPRESSED_BYTES=262144000
+# OPENMEMORY_MAX_BACKUP_LOGICAL_RECORD_BYTES=1048576
+# OPENMEMORY_MAX_BACKUP_LOGICAL_RECORDS=250000
+# OPENMEMORY_MAX_BACKUP_MANIFEST_RECORDS=250000
+# OPENMEMORY_MAX_BACKUP_ZIP_MEMBERS=64
+# OPENMEMORY_MAX_BACKUP_ZIP_CENTRAL_DIRECTORY_BYTES=1048576

--- a/openmemory/api/README.md
+++ b/openmemory/api/README.md
@@ -40,6 +40,33 @@ Once the server is running, you can access the API documentation at:
 - Swagger UI: `http://localhost:8765/docs`
 - ReDoc: `http://localhost:8765/redoc`
 
+## Backup Import Limits
+
+OpenMemory bounds backup imports to avoid excessive memory use from large or highly compressed archives. The defaults are suitable for ordinary local backups:
+
+| Variable | Default | Purpose |
+|---|---:|---|
+| `OPENMEMORY_BACKUP_READ_CHUNK_BYTES` | `1048576` (1 MiB) | Upload read chunk size |
+| `OPENMEMORY_MAX_BACKUP_UPLOAD_BYTES` | `104857600` (100 MiB) | Maximum uploaded `.zip` size |
+| `OPENMEMORY_MAX_BACKUP_SQLITE_BYTES` | `10485760` (10 MiB) | Maximum `memories.json` member size |
+| `OPENMEMORY_MAX_BACKUP_LOGICAL_GZIP_BYTES` | `104857600` (100 MiB) | Maximum compressed `memories.jsonl.gz` member size |
+| `OPENMEMORY_MAX_BACKUP_LOGICAL_DECOMPRESSED_BYTES` | `262144000` (250 MiB) | Maximum decompressed JSONL size |
+| `OPENMEMORY_MAX_BACKUP_LOGICAL_RECORD_BYTES` | `1048576` (1 MiB) | Maximum single JSONL record size |
+| `OPENMEMORY_MAX_BACKUP_LOGICAL_RECORDS` | `250000` | Maximum JSONL record count |
+| `OPENMEMORY_MAX_BACKUP_MANIFEST_RECORDS` | `250000` | Maximum records per `memories.json` list section |
+| `OPENMEMORY_MAX_BACKUP_ZIP_MEMBERS` | `64` | Maximum file entries in the uploaded `.zip` |
+| `OPENMEMORY_MAX_BACKUP_ZIP_CENTRAL_DIRECTORY_BYTES` | `1048576` (1 MiB) | Maximum ZIP central directory size |
+
+For trusted large restores, raise the relevant value in `api/.env` and restart the API process or container.
+These values are read when the API starts.
+Oversized imports fail with `413`; malformed zip or JSON content fails with `400` before any import writes begin.
+
+Exports are not size-capped. If an instance exports a very large dataset, restoring that backup on a default-config API may
+return `413` until the matching import limits are raised.
+
+OpenMemory is intended for trusted local/self-hosted use. The backup endpoints use the submitted `user_id` to select
+export/import data, so do not expose them directly to untrusted networks without an authentication or proxy layer.
+
 ## Project Structure
 
 - `app/`: Main application code

--- a/openmemory/api/app/routers/backup.py
+++ b/openmemory/api/app/routers/backup.py
@@ -2,6 +2,8 @@ from datetime import UTC, datetime
 import io 
 import json 
 import gzip 
+import os
+import struct
 import zipfile
 from typing import Optional, List, Dict, Any
 from uuid import UUID
@@ -10,7 +12,6 @@ from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Query, 
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy.orm import Session, joinedload
-from sqlalchemy import and_
 
 from app.database import get_db
 from app.models import (
@@ -23,6 +24,46 @@ from uuid import uuid4
 
 router = APIRouter(prefix="/api/v1/backup", tags=["backup"])
 
+
+def _get_positive_int_env(name: str, default: int) -> int:
+    try:
+        value = int(os.getenv(name, str(default)))
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _format_limit(value: int, unit: str = "bytes") -> str:
+    if unit == "records":
+        return f"{value:,} records"
+    if value % (1024 * 1024) == 0:
+        return f"{value // (1024 * 1024)} MiB"
+    if value % 1024 == 0:
+        return f"{value // 1024} KiB"
+    return f"{value:,} bytes"
+
+
+BACKUP_READ_CHUNK_BYTES = _get_positive_int_env("OPENMEMORY_BACKUP_READ_CHUNK_BYTES", 1024 * 1024)
+MAX_BACKUP_UPLOAD_BYTES = _get_positive_int_env("OPENMEMORY_MAX_BACKUP_UPLOAD_BYTES", 100 * 1024 * 1024)
+MAX_BACKUP_SQLITE_BYTES = _get_positive_int_env("OPENMEMORY_MAX_BACKUP_SQLITE_BYTES", 10 * 1024 * 1024)
+MAX_BACKUP_LOGICAL_GZIP_BYTES = _get_positive_int_env("OPENMEMORY_MAX_BACKUP_LOGICAL_GZIP_BYTES", 100 * 1024 * 1024)
+MAX_BACKUP_LOGICAL_DECOMPRESSED_BYTES = _get_positive_int_env(
+    "OPENMEMORY_MAX_BACKUP_LOGICAL_DECOMPRESSED_BYTES",
+    250 * 1024 * 1024,
+)
+MAX_BACKUP_LOGICAL_RECORD_BYTES = _get_positive_int_env(
+    "OPENMEMORY_MAX_BACKUP_LOGICAL_RECORD_BYTES",
+    1024 * 1024,
+)
+MAX_BACKUP_LOGICAL_RECORDS = _get_positive_int_env("OPENMEMORY_MAX_BACKUP_LOGICAL_RECORDS", 250_000)
+MAX_BACKUP_MANIFEST_RECORDS = _get_positive_int_env("OPENMEMORY_MAX_BACKUP_MANIFEST_RECORDS", 250_000)
+MAX_BACKUP_ZIP_MEMBERS = _get_positive_int_env("OPENMEMORY_MAX_BACKUP_ZIP_MEMBERS", 64)
+MAX_BACKUP_ZIP_CENTRAL_DIRECTORY_BYTES = _get_positive_int_env(
+    "OPENMEMORY_MAX_BACKUP_ZIP_CENTRAL_DIRECTORY_BYTES",
+    1024 * 1024,
+)
+
+
 class ExportRequest(BaseModel):
     user_id: str
     app_id: Optional[UUID] = None
@@ -34,7 +75,7 @@ def _iso(dt: Optional[datetime]) -> Optional[str]:
     if isinstance(dt, datetime): 
         try: 
             return dt.astimezone(UTC).isoformat()
-        except: 
+        except Exception:
             return dt.replace(tzinfo=UTC).isoformat()
     return None
 
@@ -48,6 +89,459 @@ def _parse_iso(dt: Optional[str]) -> Optional[datetime]:
             return datetime.fromisoformat(dt.replace("Z", "+00:00"))
         except Exception:
             return None
+
+
+def _validate_optional_iso_timestamp(value: Any, field: str, source: str = "memories.json") -> None:
+    if value is None:
+        return
+    if not isinstance(value, str):
+        raise HTTPException(status_code=400, detail=f"Invalid {source}: {field} must be a string")
+    if _parse_iso(value) is None:
+        raise HTTPException(status_code=400, detail=f"Invalid {source}: {field} must be an ISO timestamp")
+
+
+async def _read_upload_limited(file: UploadFile) -> bytes:
+    data = bytearray()
+    while True:
+        read_size = min(BACKUP_READ_CHUNK_BYTES, MAX_BACKUP_UPLOAD_BYTES - len(data) + 1)
+        chunk = await file.read(read_size)
+        if not chunk:
+            break
+        if len(data) + len(chunk) > MAX_BACKUP_UPLOAD_BYTES:
+            raise HTTPException(
+                status_code=413,
+                detail=f"Backup archive exceeds upload limit of {_format_limit(MAX_BACKUP_UPLOAD_BYTES)}",
+            )
+        data.extend(chunk)
+    return bytes(data)
+
+
+def _find_backup_members(infos: List[zipfile.ZipInfo]) -> tuple[Optional[str], Optional[str]]:
+    sqlite_member = None
+    memories_member = None
+    seen_files = 0
+
+    for info in infos:
+        if info.is_dir():
+            continue
+        seen_files += 1
+        if seen_files > MAX_BACKUP_ZIP_MEMBERS:
+            raise HTTPException(
+                status_code=413,
+                detail=f"Backup archive exceeds file count limit of {_format_limit(MAX_BACKUP_ZIP_MEMBERS, unit='records')}",
+            )
+
+        basename = info.filename.rsplit("/", 1)[-1]
+        if basename == "memories.json":
+            if sqlite_member is not None:
+                raise HTTPException(status_code=400, detail="Duplicate memories.json in zip")
+            sqlite_member = info.filename
+        elif basename == "memories.jsonl.gz":
+            if memories_member is not None:
+                raise HTTPException(status_code=400, detail="Duplicate memories.jsonl.gz in zip")
+            memories_member = info.filename
+
+    return sqlite_member, memories_member
+
+
+def _validate_zip_directory_limits(content: bytes) -> None:
+    eocd_signature = b"PK\x05\x06"
+    zip64_locator_signature = b"PK\x06\x07"
+    zip64_eocd_signature = b"PK\x06\x06"
+    search_start = max(0, len(content) - (65_535 + 22))
+    eocd_offset = content.rfind(eocd_signature, search_start)
+    if eocd_offset < 0 or eocd_offset + 22 > len(content):
+        raise HTTPException(status_code=400, detail="Invalid zip file")
+
+    (
+        _signature,
+        disk_number,
+        central_directory_disk,
+        entries_this_disk,
+        total_entries,
+        central_directory_size,
+        central_directory_offset,
+        comment_length,
+    ) = struct.unpack_from("<4s4H2LH", content, eocd_offset)
+
+    if eocd_offset + 22 + comment_length != len(content):
+        raise HTTPException(status_code=400, detail="Invalid zip file")
+    if disk_number != 0 or central_directory_disk != 0 or entries_this_disk != total_entries:
+        raise HTTPException(status_code=400, detail="Invalid zip file")
+
+    if total_entries == 0xFFFF or central_directory_size == 0xFFFFFFFF or central_directory_offset == 0xFFFFFFFF:
+        locator_offset = eocd_offset - 20
+        if locator_offset < 0 or content[locator_offset : locator_offset + 4] != zip64_locator_signature:
+            raise HTTPException(status_code=400, detail="Invalid zip file")
+        (_locator_signature, _locator_disk, zip64_eocd_offset, total_disks) = struct.unpack_from(
+            "<4sLQL",
+            content,
+            locator_offset,
+        )
+        if total_disks != 1 or zip64_eocd_offset + 56 > len(content):
+            raise HTTPException(status_code=400, detail="Invalid zip file")
+        if content[zip64_eocd_offset : zip64_eocd_offset + 4] != zip64_eocd_signature:
+            raise HTTPException(status_code=400, detail="Invalid zip file")
+        (
+            _zip64_signature,
+            _zip64_record_size,
+            _version_made_by,
+            _version_needed,
+            zip64_disk_number,
+            zip64_directory_disk,
+            zip64_entries_this_disk,
+            zip64_total_entries,
+            zip64_central_directory_size,
+            zip64_central_directory_offset,
+        ) = struct.unpack_from("<4sQ2H2L4Q", content, zip64_eocd_offset)
+        if (
+            zip64_disk_number != 0
+            or zip64_directory_disk != 0
+            or zip64_entries_this_disk != zip64_total_entries
+        ):
+            raise HTTPException(status_code=400, detail="Invalid zip file")
+        total_entries = zip64_total_entries
+        central_directory_size = zip64_central_directory_size
+        central_directory_offset = zip64_central_directory_offset
+
+    if total_entries > MAX_BACKUP_ZIP_MEMBERS:
+        raise HTTPException(
+            status_code=413,
+            detail=f"Backup archive exceeds file count limit of {_format_limit(MAX_BACKUP_ZIP_MEMBERS, unit='records')}",
+        )
+    if central_directory_size > MAX_BACKUP_ZIP_CENTRAL_DIRECTORY_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=(
+                "Backup archive central directory exceeds limit of "
+                f"{_format_limit(MAX_BACKUP_ZIP_CENTRAL_DIRECTORY_BYTES)}"
+            ),
+        )
+    if central_directory_offset + central_directory_size > len(content):
+        raise HTTPException(status_code=400, detail="Invalid zip file")
+
+
+def _read_zip_member_limited(zf: zipfile.ZipFile, member: str, max_bytes: int, label: str) -> bytes:
+    info = zf.getinfo(member)
+    if info.file_size > max_bytes:
+        raise HTTPException(status_code=413, detail=f"{label} exceeds limit of {_format_limit(max_bytes)}")
+
+    data = bytearray()
+    with zf.open(info) as member_file:
+        while True:
+            read_size = min(BACKUP_READ_CHUNK_BYTES, max_bytes - len(data) + 1)
+            chunk = member_file.read(read_size)
+            if not chunk:
+                break
+            if len(data) + len(chunk) > max_bytes:
+                raise HTTPException(status_code=413, detail=f"{label} exceeds limit of {_format_limit(max_bytes)}")
+            data.extend(chunk)
+    return bytes(data)
+
+
+def _load_backup_archive(content: bytes) -> tuple[Dict[str, Any], Optional[bytes]]:
+    try:
+        _validate_zip_directory_limits(content)
+        with zipfile.ZipFile(io.BytesIO(content), "r") as zf:
+            sqlite_member, memories_member = _find_backup_members(zf.infolist())
+            if not sqlite_member:
+                raise HTTPException(status_code=400, detail="memories.json missing in zip")
+
+            sqlite_data = json.loads(
+                _read_zip_member_limited(zf, sqlite_member, MAX_BACKUP_SQLITE_BYTES, "memories.json")
+            )
+            memories_blob = (
+                _read_zip_member_limited(
+                    zf,
+                    memories_member,
+                    MAX_BACKUP_LOGICAL_GZIP_BYTES,
+                    "memories.jsonl.gz",
+                )
+                if memories_member
+                else None
+            )
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid zip file")
+
+    return sqlite_data, memories_blob
+
+
+def _validate_uuid(value: Any, label: str) -> None:
+    try:
+        UUID(str(value))
+    except Exception:
+        raise HTTPException(status_code=400, detail=f"Invalid memories.json: {label} must be a UUID")
+
+
+def _validate_manifest_list(sqlite_data: Dict[str, Any], key: str) -> List[Any]:
+    value = sqlite_data.get(key, [])
+    if not isinstance(value, list):
+        raise HTTPException(status_code=400, detail=f"Invalid memories.json: {key} must be a list")
+    if len(value) > MAX_BACKUP_MANIFEST_RECORDS:
+        raise HTTPException(
+            status_code=413,
+            detail=(
+                f"memories.json {key} exceeds record limit of "
+                f"{_format_limit(MAX_BACKUP_MANIFEST_RECORDS, unit='records')}"
+            ),
+        )
+    return value
+
+
+def _validate_unique_id(value: str, seen: set[str], label: str) -> None:
+    if value in seen:
+        raise HTTPException(status_code=400, detail=f"Invalid memories.json: duplicate {label}")
+    seen.add(value)
+
+
+def _validate_sqlite_backup_manifest(sqlite_data: Dict[str, Any]) -> None:
+    if not isinstance(sqlite_data, dict):
+        raise HTTPException(status_code=400, detail="Invalid memories.json: root must be an object")
+
+    categories = _validate_manifest_list(sqlite_data, "categories")
+    memories = _validate_manifest_list(sqlite_data, "memories")
+    memory_categories_rows = _validate_manifest_list(sqlite_data, "memory_categories")
+    history_rows = _validate_manifest_list(sqlite_data, "status_history")
+    _validate_manifest_list(sqlite_data, "apps")
+    _validate_manifest_list(sqlite_data, "access_controls")
+
+    valid_states = {state.value for state in MemoryState}
+    known_category_ids = set()
+    for index, category in enumerate(categories):
+        if not isinstance(category, dict):
+            raise HTTPException(status_code=400, detail="Invalid memories.json: categories entries must be objects")
+        category_id = str(category.get("id"))
+        _validate_uuid(category_id, f"categories[{index}].id")
+        _validate_unique_id(category_id, known_category_ids, f"categories[{index}].id")
+        if not isinstance(category.get("name"), str):
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid memories.json: categories[{index}].name must be a string",
+            )
+        description = category.get("description")
+        if description is not None and not isinstance(description, str):
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid memories.json: categories[{index}].description must be a string",
+            )
+
+    memory_ids = set()
+    for index, memory in enumerate(memories):
+        if not isinstance(memory, dict):
+            raise HTTPException(status_code=400, detail="Invalid memories.json: memories entries must be objects")
+        memory_id = str(memory.get("id"))
+        _validate_uuid(memory_id, f"memories[{index}].id")
+        _validate_unique_id(memory_id, memory_ids, f"memories[{index}].id")
+        content = memory.get("content")
+        if content is not None and not isinstance(content, str):
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid memories.json: memories[{index}].content must be a string",
+            )
+        metadata = memory.get("metadata")
+        if metadata is not None and not isinstance(metadata, dict):
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid memories.json: memories[{index}].metadata must be an object",
+            )
+        state = memory.get("state", "active")
+        if state not in valid_states:
+            raise HTTPException(status_code=400, detail=f"Invalid memories.json: memories[{index}].state is invalid")
+        for key in ("created_at", "updated_at", "archived_at", "deleted_at"):
+            _validate_optional_iso_timestamp(memory.get(key), f"memories[{index}].{key}")
+        memory_category_ids = memory.get("category_ids", [])
+        if not isinstance(memory_category_ids, list):
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid memories.json: memories[{index}].category_ids must be a list",
+            )
+        for cat_index, category_id in enumerate(memory_category_ids):
+            category_id = str(category_id)
+            _validate_uuid(category_id, f"memories[{index}].category_ids[{cat_index}]")
+            if category_id not in known_category_ids:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Invalid memories.json: memories[{index}].category_ids[{cat_index}] "
+                        "is not present in categories"
+                    ),
+                )
+
+    for index, link in enumerate(memory_categories_rows):
+        if not isinstance(link, dict):
+            raise HTTPException(
+                status_code=400,
+                detail="Invalid memories.json: memory_categories entries must be objects",
+            )
+        memory_id = str(link.get("memory_id"))
+        category_id = str(link.get("category_id"))
+        _validate_uuid(memory_id, f"memory_categories[{index}].memory_id")
+        _validate_uuid(category_id, f"memory_categories[{index}].category_id")
+        if memory_id not in memory_ids:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid memories.json: memory_categories[{index}].memory_id is not present in memories",
+            )
+        if category_id not in known_category_ids:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid memories.json: memory_categories[{index}].category_id is not present in categories",
+            )
+
+    history_ids = set()
+    for index, history in enumerate(history_rows):
+        if not isinstance(history, dict):
+            raise HTTPException(status_code=400, detail="Invalid memories.json: status_history entries must be objects")
+        history_id = str(history.get("id"))
+        _validate_uuid(history_id, f"status_history[{index}].id")
+        _validate_unique_id(history_id, history_ids, f"status_history[{index}].id")
+        memory_id = str(history.get("memory_id"))
+        _validate_uuid(memory_id, f"status_history[{index}].memory_id")
+        if memory_id not in memory_ids:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid memories.json: status_history[{index}].memory_id is not present in memories",
+            )
+        for key in ("old_state", "new_state"):
+            state = history.get(key, "active")
+            if state not in valid_states:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Invalid memories.json: status_history[{index}].{key} is invalid",
+                )
+        _validate_optional_iso_timestamp(history.get("changed_at"), f"status_history[{index}].changed_at")
+
+
+def _validate_logical_record(record: Any, index: int, allowed_memory_ids: Optional[set[str]] = None) -> None:
+    if not isinstance(record, dict):
+        raise HTTPException(status_code=400, detail=f"Invalid memories.jsonl.gz: record {index} must be an object")
+
+    memory_id = record.get("id")
+    _validate_uuid(memory_id, f"memories.jsonl.gz record {index}.id")
+    if allowed_memory_ids is not None and str(memory_id) not in allowed_memory_ids:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid memories.jsonl.gz: record {index}.id is not present in memories.json",
+        )
+
+    content = record.get("content")
+    if content is not None and not isinstance(content, str):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid memories.jsonl.gz: record {index}.content must be a string",
+        )
+
+    metadata = record.get("metadata")
+    if metadata is not None and not isinstance(metadata, dict):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid memories.jsonl.gz: record {index}.metadata must be an object",
+        )
+    for key in ("created_at", "updated_at"):
+        _validate_optional_iso_timestamp(
+            record.get(key),
+            f"record {index}.{key}",
+            source="memories.jsonl.gz",
+        )
+
+
+def _iter_limited_logical_records(memories_blob: bytes):
+    total_bytes = 0
+    total_records = 0
+
+    try:
+        with gzip.GzipFile(fileobj=io.BytesIO(memories_blob), mode="rb") as gz:
+            while True:
+                remaining_total = MAX_BACKUP_LOGICAL_DECOMPRESSED_BYTES - total_bytes
+                if remaining_total < 0:
+                    raise HTTPException(
+                        status_code=413,
+                        detail=(
+                            "memories.jsonl.gz exceeds decompressed limit of "
+                            f"{_format_limit(MAX_BACKUP_LOGICAL_DECOMPRESSED_BYTES)}"
+                        ),
+                    )
+                if remaining_total == 0:
+                    if gz.read(1):
+                        raise HTTPException(
+                            status_code=413,
+                            detail=(
+                                "memories.jsonl.gz exceeds decompressed limit of "
+                                f"{_format_limit(MAX_BACKUP_LOGICAL_DECOMPRESSED_BYTES)}"
+                            ),
+                        )
+                    break
+
+                read_limit = min(MAX_BACKUP_LOGICAL_RECORD_BYTES, remaining_total) + 1
+                raw = gz.readline(read_limit)
+                if not raw:
+                    break
+
+                total_records += 1
+                total_bytes += len(raw)
+
+                if total_records > MAX_BACKUP_LOGICAL_RECORDS:
+                    raise HTTPException(
+                        status_code=413,
+                        detail=(
+                            "memories.jsonl.gz exceeds record count limit of "
+                            f"{_format_limit(MAX_BACKUP_LOGICAL_RECORDS, unit='records')}"
+                        ),
+                    )
+                if total_bytes > MAX_BACKUP_LOGICAL_DECOMPRESSED_BYTES:
+                    raise HTTPException(
+                        status_code=413,
+                        detail=(
+                            "memories.jsonl.gz exceeds decompressed limit of "
+                            f"{_format_limit(MAX_BACKUP_LOGICAL_DECOMPRESSED_BYTES)}"
+                        ),
+                    )
+                if len(raw) > MAX_BACKUP_LOGICAL_RECORD_BYTES:
+                    raise HTTPException(
+                        status_code=413,
+                        detail=(
+                            "memories.jsonl.gz contains a record that exceeds limit of "
+                            f"{_format_limit(MAX_BACKUP_LOGICAL_RECORD_BYTES)}"
+                        ),
+                    )
+
+                yield json.loads(raw.decode("utf-8"))
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid memories.jsonl.gz")
+
+
+def _validate_logical_memories_blob(
+    memories_blob: Optional[bytes],
+    sqlite_data: Optional[Dict[str, Any]] = None,
+) -> None:
+    if memories_blob is None:
+        return
+    if len(memories_blob) == 0:
+        raise HTTPException(status_code=400, detail="Invalid memories.jsonl.gz")
+
+    allowed_memory_ids = None
+    if sqlite_data is not None:
+        allowed_memory_ids = {str(memory.get("id")) for memory in sqlite_data.get("memories", [])}
+
+    record_count = 0
+    seen_memory_ids = set()
+    for index, record in enumerate(_iter_limited_logical_records(memories_blob), start=1):
+        record_count = index
+        _validate_logical_record(record, index, allowed_memory_ids)
+        memory_id = str(record.get("id"))
+        if memory_id in seen_memory_ids:
+            raise HTTPException(status_code=400, detail=f"Invalid memories.jsonl.gz: duplicate record {index}.id")
+        seen_memory_ids.add(memory_id)
+
+    if record_count == 0 and allowed_memory_ids:
+        raise HTTPException(status_code=400, detail="Invalid memories.jsonl.gz: no records found")
+    if allowed_memory_ids is not None and seen_memory_ids != allowed_memory_ids:
+        raise HTTPException(status_code=400, detail="Invalid memories.jsonl.gz: records do not match memories.json")
+
 
 def _export_sqlite(db: Session, req: ExportRequest) -> Dict[str, Any]: 
     user = db.query(User).filter(User.user_id == req.user_id).first()
@@ -279,30 +773,10 @@ async def import_backup(
     if not user: 
         raise HTTPException(status_code=404, detail="User not found")
 
-    content = await file.read()
-    try:
-        with zipfile.ZipFile(io.BytesIO(content), "r") as zf:
-            names = zf.namelist()
-
-            def find_member(filename: str) -> Optional[str]:
-                for name in names:
-                    # Skip directory entries
-                    if name.endswith('/'):
-                        continue
-                    if name.rsplit('/', 1)[-1] == filename:
-                        return name
-                return None
-
-            sqlite_member = find_member("memories.json")
-            if not sqlite_member:
-                raise HTTPException(status_code=400, detail="memories.json missing in zip")
-
-            memories_member = find_member("memories.jsonl.gz")
-
-            sqlite_data = json.loads(zf.read(sqlite_member))
-            memories_blob = zf.read(memories_member) if memories_member else None
-    except Exception:
-        raise HTTPException(status_code=400, detail="Invalid zip file")
+    content = await _read_upload_limited(file)
+    sqlite_data, memories_blob = _load_backup_archive(content)
+    _validate_sqlite_backup_manifest(sqlite_data)
+    _validate_logical_memories_blob(memories_blob, sqlite_data)
 
     default_app = db.query(App).filter(App.owner_id == user.id, App.name == "openmemory").first()
     if not default_app: 
@@ -412,11 +886,8 @@ async def import_backup(
 
     if vector_store and memory_client and hasattr(memory_client, "embedding_model"):
         def iter_logical_records():
-            if memories_blob:
-                gz_buf = io.BytesIO(memories_blob)
-                with gzip.GzipFile(fileobj=gz_buf, mode="rb") as gz:
-                    for raw in gz:
-                        yield json.loads(raw.decode("utf-8"))
+            if memories_blob is not None:
+                yield from _iter_limited_logical_records(memories_blob)
             else:
                 for m in sqlite_data.get("memories", []):
                     yield {
@@ -493,7 +964,3 @@ async def import_backup(
 
 
  
-
-
-
-

--- a/openmemory/api/tests/test_backup_import_limits.py
+++ b/openmemory/api/tests/test_backup_import_limits.py
@@ -1,0 +1,871 @@
+import gzip
+import io
+import json
+import os
+import zipfile
+from types import SimpleNamespace
+from uuid import uuid4
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+import pytest
+from fastapi import FastAPI, HTTPException, UploadFile
+from httpx import ASGITransport, AsyncClient
+
+from app.routers import backup
+
+
+def _build_zip(files: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for name, content in files.items():
+            zf.writestr(name, content)
+    return buf.getvalue()
+
+
+def _sqlite_payload(
+    memories: list[dict] | None = None,
+    categories: list[dict] | None = None,
+    memory_categories: list[dict] | None = None,
+    status_history: list[dict] | None = None,
+) -> bytes:
+    return json.dumps(
+        {
+            "categories": categories or [],
+            "memories": memories or [],
+            "memory_categories": memory_categories or [],
+            "status_history": status_history or [],
+        }
+    ).encode("utf-8")
+
+
+def _gzip_jsonl(lines: list[dict]) -> bytes:
+    return gzip.compress(b"".join((json.dumps(line) + "\n").encode("utf-8") for line in lines))
+
+
+def _gzip_bytes(content: bytes) -> bytes:
+    return gzip.compress(content)
+
+
+class _FakeQuery:
+    def __init__(self, result):
+        self.result = result
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def first(self):
+        return self.result
+
+
+class _FakeDb:
+    def __init__(self):
+        self.user = SimpleNamespace(id=uuid4(), user_id="user-1")
+        self.query_count = 0
+        self.add_count = 0
+        self.commit_count = 0
+
+    def query(self, model):
+        self.query_count += 1
+        if model is backup.User:
+            return _FakeQuery(self.user)
+        return _FakeQuery(None)
+
+    def add(self, item):
+        self.add_count += 1
+
+    def commit(self):
+        self.commit_count += 1
+
+
+class _FakeZipFile:
+    def __init__(self, file_size: int, content: bytes):
+        self.info = SimpleNamespace(file_size=file_size)
+        self.content = content
+
+    def getinfo(self, member):
+        return self.info
+
+    def open(self, info):
+        return io.BytesIO(self.content)
+
+
+@pytest.mark.asyncio
+async def test_read_upload_limited_rejects_oversized_archive(monkeypatch):
+    monkeypatch.setattr(backup, "BACKUP_READ_CHUNK_BYTES", 4)
+    monkeypatch.setattr(backup, "MAX_BACKUP_UPLOAD_BYTES", 5)
+    upload = UploadFile(filename="backup.zip", file=io.BytesIO(b"123456"))
+
+    with pytest.raises(HTTPException) as exc:
+        await backup._read_upload_limited(upload)
+
+    assert exc.value.status_code == 413
+    assert exc.value.detail == "Backup archive exceeds upload limit of 5 bytes"
+
+
+def test_read_zip_member_limited_rejects_underreported_member(monkeypatch):
+    monkeypatch.setattr(backup, "BACKUP_READ_CHUNK_BYTES", 4)
+    zf = _FakeZipFile(file_size=4, content=b"123456")
+
+    with pytest.raises(HTTPException) as exc:
+        backup._read_zip_member_limited(zf, "memories.json", 5, "memories.json")
+
+    assert exc.value.status_code == 413
+    assert exc.value.detail == "memories.json exceeds limit of 5 bytes"
+
+
+def test_load_backup_archive_rejects_too_many_zip_members(monkeypatch):
+    monkeypatch.setattr(backup, "MAX_BACKUP_ZIP_MEMBERS", 1)
+    content = _build_zip(
+        {
+            "memories.json": _sqlite_payload(),
+            "memories.jsonl.gz": _gzip_bytes(b""),
+        }
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        backup._load_backup_archive(content)
+
+    assert exc.value.status_code == 413
+    assert exc.value.detail == "Backup archive exceeds file count limit of 1 records"
+
+
+def test_load_backup_archive_rejects_large_central_directory(monkeypatch):
+    monkeypatch.setattr(backup, "MAX_BACKUP_ZIP_CENTRAL_DIRECTORY_BYTES", 8)
+    content = _build_zip({"memories.json": _sqlite_payload()})
+
+    with pytest.raises(HTTPException) as exc:
+        backup._load_backup_archive(content)
+
+    assert exc.value.status_code == 413
+    assert exc.value.detail == "Backup archive central directory exceeds limit of 8 bytes"
+
+
+def test_load_backup_archive_rejects_duplicate_required_members():
+    content = _build_zip(
+        {
+            "one/memories.json": _sqlite_payload(),
+            "two/memories.json": _sqlite_payload(),
+        }
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        backup._load_backup_archive(content)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Duplicate memories.json in zip"
+
+
+def test_load_backup_archive_accepts_valid_small_archive():
+    memory_id = str(uuid4())
+    logical_records = [{"id": memory_id, "content": "remember this", "metadata": {}}]
+    content = _build_zip(
+        {
+            "nested/memories.json": _sqlite_payload(),
+            "nested/memories.jsonl.gz": _gzip_jsonl(logical_records),
+        }
+    )
+
+    sqlite_data, memories_blob = backup._load_backup_archive(content)
+
+    assert sqlite_data["memories"] == []
+    assert list(backup._iter_limited_logical_records(memories_blob)) == logical_records
+
+
+def test_load_backup_archive_rejects_oversized_sqlite_member(monkeypatch):
+    monkeypatch.setattr(backup, "MAX_BACKUP_SQLITE_BYTES", 8)
+    content = _build_zip({"memories.json": _sqlite_payload()})
+
+    with pytest.raises(HTTPException) as exc:
+        backup._load_backup_archive(content)
+
+    assert exc.value.status_code == 413
+    assert exc.value.detail == "memories.json exceeds limit of 8 bytes"
+
+
+def test_load_backup_archive_rejects_oversized_logical_member(monkeypatch):
+    monkeypatch.setattr(backup, "MAX_BACKUP_LOGICAL_GZIP_BYTES", 8)
+    content = _build_zip(
+        {
+            "memories.json": _sqlite_payload(),
+            "memories.jsonl.gz": _gzip_jsonl([{"id": str(uuid4()), "content": "remember this"}]),
+        }
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        backup._load_backup_archive(content)
+
+    assert exc.value.status_code == 413
+    assert exc.value.detail == "memories.jsonl.gz exceeds limit of 8 bytes"
+
+
+def test_validate_logical_memories_blob_rejects_oversized_decompressed_data(monkeypatch):
+    monkeypatch.setattr(backup, "MAX_BACKUP_LOGICAL_DECOMPRESSED_BYTES", 16)
+    blob = _gzip_jsonl([{"id": str(uuid4()), "content": "x" * 32}])
+
+    with pytest.raises(HTTPException) as exc:
+        backup._validate_logical_memories_blob(blob)
+
+    assert exc.value.status_code == 413
+    assert exc.value.detail == "memories.jsonl.gz exceeds decompressed limit of 16 bytes"
+
+
+def test_validate_logical_memories_blob_accepts_exact_decompressed_limit(monkeypatch):
+    record = {"id": str(uuid4()), "content": "ok", "metadata": {}}
+    raw = (json.dumps(record) + "\n").encode("utf-8")
+    monkeypatch.setattr(backup, "MAX_BACKUP_LOGICAL_DECOMPRESSED_BYTES", len(raw))
+    monkeypatch.setattr(backup, "MAX_BACKUP_LOGICAL_RECORD_BYTES", len(raw))
+
+    backup._validate_logical_memories_blob(_gzip_bytes(raw))
+
+
+def test_validate_logical_memories_blob_rejects_oversized_record(monkeypatch):
+    monkeypatch.setattr(backup, "MAX_BACKUP_LOGICAL_RECORD_BYTES", 16)
+    blob = _gzip_jsonl([{"id": str(uuid4()), "content": "x" * 32}])
+
+    with pytest.raises(HTTPException) as exc:
+        backup._validate_logical_memories_blob(blob)
+
+    assert exc.value.status_code == 413
+    assert exc.value.detail == "memories.jsonl.gz contains a record that exceeds limit of 16 bytes"
+
+
+def test_validate_logical_memories_blob_rejects_no_newline_oversized_record(monkeypatch):
+    monkeypatch.setattr(backup, "MAX_BACKUP_LOGICAL_RECORD_BYTES", 16)
+    blob = _gzip_bytes(b'{"id":"' + str(uuid4()).encode("utf-8") + b'","content":"' + (b"x" * 32) + b'"}')
+
+    with pytest.raises(HTTPException) as exc:
+        backup._validate_logical_memories_blob(blob)
+
+    assert exc.value.status_code == 413
+    assert exc.value.detail == "memories.jsonl.gz contains a record that exceeds limit of 16 bytes"
+
+
+def test_validate_logical_memories_blob_rejects_too_many_records(monkeypatch):
+    monkeypatch.setattr(backup, "MAX_BACKUP_LOGICAL_RECORDS", 1)
+    blob = _gzip_jsonl(
+        [
+            {"id": str(uuid4()), "content": "one"},
+            {"id": str(uuid4()), "content": "two"},
+        ]
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        backup._validate_logical_memories_blob(blob)
+
+    assert exc.value.status_code == 413
+    assert exc.value.detail == "memories.jsonl.gz exceeds record count limit of 1 records"
+
+
+def test_validate_logical_memories_blob_rejects_invalid_gzip():
+    with pytest.raises(HTTPException) as exc:
+        backup._validate_logical_memories_blob(b"not gzip")
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid memories.jsonl.gz"
+
+
+def test_validate_logical_memories_blob_rejects_empty_gzip_member():
+    with pytest.raises(HTTPException) as exc:
+        backup._validate_logical_memories_blob(b"")
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid memories.jsonl.gz"
+
+
+def test_validate_logical_memories_blob_accepts_zero_record_gzip_stream():
+    backup._validate_logical_memories_blob(_gzip_bytes(b""))
+
+
+def test_validate_logical_memories_blob_rejects_zero_records_with_manifest_memories():
+    memory_id = str(uuid4())
+    sqlite_data = {"memories": [{"id": memory_id}]}
+
+    with pytest.raises(HTTPException) as exc:
+        backup._validate_logical_memories_blob(_gzip_bytes(b""), sqlite_data)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid memories.jsonl.gz: no records found"
+
+
+def test_validate_logical_memories_blob_rejects_missing_manifest_records():
+    included_id = str(uuid4())
+    missing_id = str(uuid4())
+    sqlite_data = {"memories": [{"id": included_id}, {"id": missing_id}]}
+
+    with pytest.raises(HTTPException) as exc:
+        backup._validate_logical_memories_blob(
+            _gzip_jsonl([{"id": included_id, "content": "included"}]),
+            sqlite_data,
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid memories.jsonl.gz: records do not match memories.json"
+
+
+def test_validate_logical_memories_blob_rejects_duplicate_record_ids():
+    memory_id = str(uuid4())
+    sqlite_data = {"memories": [{"id": memory_id}]}
+
+    with pytest.raises(HTTPException) as exc:
+        backup._validate_logical_memories_blob(
+            _gzip_jsonl(
+                [
+                    {"id": memory_id, "content": "one"},
+                    {"id": memory_id, "content": "two"},
+                ]
+            ),
+            sqlite_data,
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid memories.jsonl.gz: duplicate record 2.id"
+
+
+def test_validate_logical_memories_blob_rejects_malformed_jsonl():
+    with pytest.raises(HTTPException) as exc:
+        backup._validate_logical_memories_blob(_gzip_bytes(b"{not-json}\n"))
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid memories.jsonl.gz"
+
+
+def test_validate_logical_memories_blob_rejects_non_object_record():
+    with pytest.raises(HTTPException) as exc:
+        backup._validate_logical_memories_blob(_gzip_bytes(b"[]\n"))
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid memories.jsonl.gz: record 1 must be an object"
+
+
+def test_validate_logical_memories_blob_rejects_missing_record_id():
+    with pytest.raises(HTTPException) as exc:
+        backup._validate_logical_memories_blob(_gzip_jsonl([{}]))
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid memories.json: memories.jsonl.gz record 1.id must be a UUID"
+
+
+def test_validate_logical_memories_blob_rejects_bad_record_uuid():
+    with pytest.raises(HTTPException) as exc:
+        backup._validate_logical_memories_blob(_gzip_jsonl([{"id": "not-a-uuid"}]))
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid memories.json: memories.jsonl.gz record 1.id must be a UUID"
+
+
+def test_validate_logical_memories_blob_rejects_record_missing_from_manifest():
+    manifest_memory_id = str(uuid4())
+    logical_memory_id = str(uuid4())
+    sqlite_data = {
+        "memories": [{"id": manifest_memory_id}],
+    }
+
+    with pytest.raises(HTTPException) as exc:
+        backup._validate_logical_memories_blob(
+            _gzip_jsonl([{"id": logical_memory_id, "content": "remember this"}]),
+            sqlite_data,
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid memories.jsonl.gz: record 1.id is not present in memories.json"
+
+
+@pytest.mark.parametrize(
+    ("section", "record"),
+    [
+        ("categories", {"id": str(uuid4()), "name": "work"}),
+        ("memories", {"id": str(uuid4())}),
+        ("memory_categories", {"memory_id": str(uuid4()), "category_id": str(uuid4())}),
+        ("status_history", {"id": str(uuid4()), "memory_id": str(uuid4())}),
+        ("apps", {}),
+        ("access_controls", {}),
+    ],
+)
+def test_validate_sqlite_manifest_rejects_too_many_manifest_records(monkeypatch, section, record):
+    monkeypatch.setattr(backup, "MAX_BACKUP_MANIFEST_RECORDS", 1)
+    payload = {
+        "categories": [],
+        "memories": [],
+        "memory_categories": [],
+        "status_history": [],
+        "apps": [],
+        "access_controls": [],
+    }
+    payload[section] = [record, record]
+
+    with pytest.raises(HTTPException) as exc:
+        backup._validate_sqlite_backup_manifest(payload)
+
+    assert exc.value.status_code == 413
+    assert exc.value.detail == f"memories.json {section} exceeds record limit of 1 records"
+
+
+def test_validate_sqlite_manifest_rejects_invalid_memory_id():
+    payload = {
+        "categories": [],
+        "memories": [{"id": "not-a-uuid"}],
+        "memory_categories": [],
+        "status_history": [],
+    }
+
+    with pytest.raises(HTTPException) as exc:
+        backup._validate_sqlite_backup_manifest(payload)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid memories.json: memories[0].id must be a UUID"
+
+
+def test_validate_sqlite_manifest_rejects_non_string_memory_content():
+    payload = {
+        "categories": [],
+        "memories": [{"id": str(uuid4()), "content": {"text": "not a string"}}],
+        "memory_categories": [],
+        "status_history": [],
+    }
+
+    with pytest.raises(HTTPException) as exc:
+        backup._validate_sqlite_backup_manifest(payload)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid memories.json: memories[0].content must be a string"
+
+
+def test_validate_sqlite_manifest_rejects_non_object_memory_metadata():
+    payload = {
+        "categories": [],
+        "memories": [{"id": str(uuid4()), "metadata": ["not", "an", "object"]}],
+        "memory_categories": [],
+        "status_history": [],
+    }
+
+    with pytest.raises(HTTPException) as exc:
+        backup._validate_sqlite_backup_manifest(payload)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid memories.json: memories[0].metadata must be an object"
+
+
+def test_validate_sqlite_manifest_rejects_non_string_category_description():
+    payload = {
+        "categories": [{"id": str(uuid4()), "name": "work", "description": ["not", "a", "string"]}],
+        "memories": [],
+        "memory_categories": [],
+        "status_history": [],
+    }
+
+    with pytest.raises(HTTPException) as exc:
+        backup._validate_sqlite_backup_manifest(payload)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid memories.json: categories[0].description must be a string"
+
+
+@pytest.mark.parametrize(
+    ("section", "rows", "detail"),
+    [
+        (
+            "categories",
+            lambda item_id: [{"id": item_id, "name": "one"}, {"id": item_id, "name": "two"}],
+            "Invalid memories.json: duplicate categories[1].id",
+        ),
+        (
+            "memories",
+            lambda item_id: [{"id": item_id, "content": "one"}, {"id": item_id, "content": "two"}],
+            "Invalid memories.json: duplicate memories[1].id",
+        ),
+        (
+            "status_history",
+            lambda item_id: [
+                {"id": item_id, "memory_id": str(uuid4())},
+                {"id": item_id, "memory_id": str(uuid4())},
+            ],
+            "Invalid memories.json: duplicate status_history[1].id",
+        ),
+    ],
+)
+def test_validate_sqlite_manifest_rejects_duplicate_ids(section, rows, detail):
+    item_id = str(uuid4())
+    memory_id = str(uuid4())
+    payload = {
+        "categories": [],
+        "memories": [{"id": memory_id}],
+        "memory_categories": [],
+        "status_history": [],
+    }
+    payload[section] = rows(item_id)
+    if section == "status_history":
+        payload["memories"] = [{"id": payload[section][0]["memory_id"]}]
+        payload[section][1]["memory_id"] = payload[section][0]["memory_id"]
+
+    with pytest.raises(HTTPException) as exc:
+        backup._validate_sqlite_backup_manifest(payload)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == detail
+
+
+@pytest.mark.parametrize("timestamp_field", ["created_at", "updated_at", "archived_at", "deleted_at"])
+def test_validate_sqlite_manifest_rejects_invalid_memory_timestamps(timestamp_field):
+    payload = {
+        "categories": [],
+        "memories": [{"id": str(uuid4()), timestamp_field: "not-an-iso-timestamp"}],
+        "memory_categories": [],
+        "status_history": [],
+    }
+
+    with pytest.raises(HTTPException) as exc:
+        backup._validate_sqlite_backup_manifest(payload)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == f"Invalid memories.json: memories[0].{timestamp_field} must be an ISO timestamp"
+
+
+@pytest.mark.parametrize("timestamp_field", ["created_at", "updated_at"])
+def test_validate_logical_memories_blob_rejects_invalid_timestamps(timestamp_field):
+    with pytest.raises(HTTPException) as exc:
+        backup._validate_logical_memories_blob(
+            _gzip_jsonl([{"id": str(uuid4()), timestamp_field: "not-an-iso-timestamp"}])
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == f"Invalid memories.jsonl.gz: record 1.{timestamp_field} must be an ISO timestamp"
+
+
+def test_validate_sqlite_manifest_rejects_dangling_memory_category_link():
+    category_id = str(uuid4())
+    payload = {
+        "categories": [{"id": category_id, "name": "work"}],
+        "memories": [{"id": str(uuid4())}],
+        "memory_categories": [{"memory_id": str(uuid4()), "category_id": category_id}],
+        "status_history": [],
+    }
+
+    with pytest.raises(HTTPException) as exc:
+        backup._validate_sqlite_backup_manifest(payload)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid memories.json: memory_categories[0].memory_id is not present in memories"
+
+
+def test_validate_sqlite_manifest_rejects_dangling_status_history():
+    payload = {
+        "categories": [],
+        "memories": [{"id": str(uuid4())}],
+        "memory_categories": [],
+        "status_history": [{"id": str(uuid4()), "memory_id": str(uuid4())}],
+    }
+
+    with pytest.raises(HTTPException) as exc:
+        backup._validate_sqlite_backup_manifest(payload)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid memories.json: status_history[0].memory_id is not present in memories"
+
+
+def test_validate_sqlite_manifest_rejects_invalid_status_history_timestamp():
+    memory_id = str(uuid4())
+    payload = {
+        "categories": [],
+        "memories": [{"id": memory_id}],
+        "memory_categories": [],
+        "status_history": [{"id": str(uuid4()), "memory_id": memory_id, "changed_at": "bad-ts"}],
+    }
+
+    with pytest.raises(HTTPException) as exc:
+        backup._validate_sqlite_backup_manifest(payload)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid memories.json: status_history[0].changed_at must be an ISO timestamp"
+
+
+@pytest.mark.asyncio
+async def test_import_backup_rejects_invalid_gzip_before_db_writes():
+    db = _FakeDb()
+    content = _build_zip(
+        {
+            "memories.json": _sqlite_payload(),
+            "memories.jsonl.gz": b"not gzip",
+        }
+    )
+    upload = UploadFile(filename="backup.zip", file=io.BytesIO(content))
+
+    with pytest.raises(HTTPException) as exc:
+        await backup.import_backup(file=upload, user_id="user-1", mode="overwrite", db=db)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid memories.jsonl.gz"
+    assert db.add_count == 0
+    assert db.commit_count == 0
+    assert db.query_count == 1
+
+
+@pytest.mark.asyncio
+async def test_import_backup_rejects_empty_gzip_member_before_db_writes():
+    db = _FakeDb()
+    content = _build_zip(
+        {
+            "memories.json": _sqlite_payload(),
+            "memories.jsonl.gz": b"",
+        }
+    )
+    upload = UploadFile(filename="backup.zip", file=io.BytesIO(content))
+
+    with pytest.raises(HTTPException) as exc:
+        await backup.import_backup(file=upload, user_id="user-1", mode="overwrite", db=db)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid memories.jsonl.gz"
+    assert db.add_count == 0
+    assert db.commit_count == 0
+    assert db.query_count == 1
+
+
+@pytest.mark.asyncio
+async def test_import_backup_rejects_empty_logical_records_before_db_writes():
+    db = _FakeDb()
+    memory_id = str(uuid4())
+    content = _build_zip(
+        {
+            "memories.json": _sqlite_payload(memories=[{"id": memory_id}]),
+            "memories.jsonl.gz": _gzip_bytes(b""),
+        }
+    )
+    upload = UploadFile(filename="backup.zip", file=io.BytesIO(content))
+
+    with pytest.raises(HTTPException) as exc:
+        await backup.import_backup(file=upload, user_id="user-1", mode="overwrite", db=db)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid memories.jsonl.gz: no records found"
+    assert db.add_count == 0
+    assert db.commit_count == 0
+    assert db.query_count == 1
+
+
+@pytest.mark.asyncio
+async def test_import_backup_rejects_incomplete_logical_records_before_db_writes():
+    db = _FakeDb()
+    included_id = str(uuid4())
+    missing_id = str(uuid4())
+    content = _build_zip(
+        {
+            "memories.json": _sqlite_payload(memories=[{"id": included_id}, {"id": missing_id}]),
+            "memories.jsonl.gz": _gzip_jsonl([{"id": included_id, "content": "included"}]),
+        }
+    )
+    upload = UploadFile(filename="backup.zip", file=io.BytesIO(content))
+
+    with pytest.raises(HTTPException) as exc:
+        await backup.import_backup(file=upload, user_id="user-1", mode="overwrite", db=db)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid memories.jsonl.gz: records do not match memories.json"
+    assert db.add_count == 0
+    assert db.commit_count == 0
+    assert db.query_count == 1
+
+
+@pytest.mark.asyncio
+async def test_import_backup_rejects_bad_category_description_before_db_writes():
+    db = _FakeDb()
+    content = _build_zip(
+        {
+            "memories.json": _sqlite_payload(
+                categories=[{"id": str(uuid4()), "name": "work", "description": ["bad"]}]
+            ),
+        }
+    )
+    upload = UploadFile(filename="backup.zip", file=io.BytesIO(content))
+
+    with pytest.raises(HTTPException) as exc:
+        await backup.import_backup(file=upload, user_id="user-1", mode="overwrite", db=db)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid memories.json: categories[0].description must be a string"
+    assert db.add_count == 0
+    assert db.commit_count == 0
+    assert db.query_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("timestamp_field", ["created_at", "updated_at", "archived_at", "deleted_at"])
+async def test_import_backup_rejects_bad_manifest_timestamp_before_db_writes(timestamp_field):
+    db = _FakeDb()
+    content = _build_zip(
+        {
+            "memories.json": _sqlite_payload(
+                memories=[{"id": str(uuid4()), timestamp_field: "not-an-iso-timestamp"}]
+            ),
+        }
+    )
+    upload = UploadFile(filename="backup.zip", file=io.BytesIO(content))
+
+    with pytest.raises(HTTPException) as exc:
+        await backup.import_backup(file=upload, user_id="user-1", mode="overwrite", db=db)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == f"Invalid memories.json: memories[0].{timestamp_field} must be an ISO timestamp"
+    assert db.add_count == 0
+    assert db.commit_count == 0
+    assert db.query_count == 1
+
+
+@pytest.mark.asyncio
+async def test_import_backup_rejects_bad_logical_timestamp_before_db_writes():
+    db = _FakeDb()
+    memory_id = str(uuid4())
+    content = _build_zip(
+        {
+            "memories.json": _sqlite_payload(memories=[{"id": memory_id}]),
+            "memories.jsonl.gz": _gzip_jsonl([{"id": memory_id, "created_at": "bad-ts"}]),
+        }
+    )
+    upload = UploadFile(filename="backup.zip", file=io.BytesIO(content))
+
+    with pytest.raises(HTTPException) as exc:
+        await backup.import_backup(file=upload, user_id="user-1", mode="overwrite", db=db)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid memories.jsonl.gz: record 1.created_at must be an ISO timestamp"
+    assert db.add_count == 0
+    assert db.commit_count == 0
+    assert db.query_count == 1
+
+
+@pytest.mark.asyncio
+async def test_import_backup_rejects_bad_history_timestamp_before_db_writes():
+    db = _FakeDb()
+    memory_id = str(uuid4())
+    content = _build_zip(
+        {
+            "memories.json": _sqlite_payload(
+                memories=[{"id": memory_id}],
+                status_history=[{"id": str(uuid4()), "memory_id": memory_id, "changed_at": "bad-ts"}],
+            ),
+        }
+    )
+    upload = UploadFile(filename="backup.zip", file=io.BytesIO(content))
+
+    with pytest.raises(HTTPException) as exc:
+        await backup.import_backup(file=upload, user_id="user-1", mode="overwrite", db=db)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid memories.json: status_history[0].changed_at must be an ISO timestamp"
+    assert db.add_count == 0
+    assert db.commit_count == 0
+    assert db.query_count == 1
+
+
+@pytest.mark.asyncio
+async def test_import_backup_rejects_bad_logical_record_before_db_writes():
+    db = _FakeDb()
+    memory_id = str(uuid4())
+    content = _build_zip(
+        {
+            "memories.json": _sqlite_payload(memories=[{"id": memory_id}]),
+            "memories.jsonl.gz": _gzip_jsonl([{}]),
+        }
+    )
+    upload = UploadFile(filename="backup.zip", file=io.BytesIO(content))
+
+    with pytest.raises(HTTPException) as exc:
+        await backup.import_backup(file=upload, user_id="user-1", mode="overwrite", db=db)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid memories.json: memories.jsonl.gz record 1.id must be a UUID"
+    assert db.add_count == 0
+    assert db.commit_count == 0
+    assert db.query_count == 1
+
+
+@pytest.mark.asyncio
+async def test_import_backup_rejects_bad_manifest_content_before_db_writes():
+    db = _FakeDb()
+    content = _build_zip(
+        {
+            "memories.json": _sqlite_payload(memories=[{"id": str(uuid4()), "content": {"bad": "shape"}}]),
+        }
+    )
+    upload = UploadFile(filename="backup.zip", file=io.BytesIO(content))
+
+    with pytest.raises(HTTPException) as exc:
+        await backup.import_backup(file=upload, user_id="user-1", mode="overwrite", db=db)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid memories.json: memories[0].content must be a string"
+    assert db.add_count == 0
+    assert db.commit_count == 0
+    assert db.query_count == 1
+
+
+def test_load_backup_archive_preserves_missing_memories_json_status():
+    content = _build_zip({"memories.jsonl.gz": _gzip_jsonl([])})
+
+    with pytest.raises(HTTPException) as exc:
+        backup._load_backup_archive(content)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "memories.json missing in zip"
+
+
+def test_load_backup_archive_rejects_malformed_memories_json():
+    content = _build_zip({"memories.json": b"{not-json}"})
+
+    with pytest.raises(HTTPException) as exc:
+        backup._load_backup_archive(content)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid zip file"
+
+
+@pytest.mark.asyncio
+async def test_import_backup_route_rejects_invalid_gzip_before_db_writes():
+    db = _FakeDb()
+    content = _build_zip(
+        {
+            "memories.json": _sqlite_payload(),
+            "memories.jsonl.gz": b"not gzip",
+        }
+    )
+    app = FastAPI()
+    app.include_router(backup.router)
+    app.dependency_overrides[backup.get_db] = lambda: db
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/api/v1/backup/import?mode=overwrite",
+            data={"user_id": "user-1"},
+            files={"file": ("backup.zip", content, "application/zip")},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid memories.jsonl.gz"
+    assert db.add_count == 0
+    assert db.commit_count == 0
+    assert db.query_count == 1
+
+
+@pytest.mark.asyncio
+async def test_import_backup_route_rejects_oversized_upload_before_db_writes(monkeypatch):
+    monkeypatch.setattr(backup, "BACKUP_READ_CHUNK_BYTES", 4)
+    monkeypatch.setattr(backup, "MAX_BACKUP_UPLOAD_BYTES", 5)
+    db = _FakeDb()
+    app = FastAPI()
+    app.include_router(backup.router)
+    app.dependency_overrides[backup.get_db] = lambda: db
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/api/v1/backup/import?mode=overwrite",
+            data={"user_id": "user-1"},
+            files={"file": ("backup.zip", b"123456", "application/zip")},
+        )
+
+    assert response.status_code == 413
+    assert response.json()["detail"] == "Backup archive exceeds upload limit of 5 bytes"
+    assert db.add_count == 0
+    assert db.commit_count == 0
+    assert db.query_count == 1


### PR DESCRIPTION
## Linked Issue

No existing issue. This was discovered during repository security/reliability review.

## Description

OpenMemory backup import previously read the uploaded zip, `memories.json`, and optional `memories.jsonl.gz` into memory without upload, zip-member, manifest-record, or decompressed-stream limits. This PR adds configurable bounded reads for the archive and its members, validates `memories.json` structure/counts/timestamps, and validates the optional gzip JSONL stream before any import database writes begin.

The backup format is unchanged. Small valid exports continue to load, while oversized archives, manifest sections, or gzip streams now return `413` instead of consuming unbounded memory/CPU. Malformed zip, JSON, manifest, or JSONL content returns `400` before import writes begin.

This hardens import resource limits only. It does not add authentication or authorization to the backup routes, so deployments should continue to rely on trusted local/self-hosted usage or an external auth/proxy layer when exposing the API.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

This does not change the backup file format, but it is a user-visible import behavior change: imports that exceed the configured limits now fail with `413`.

Default limits:

- `OPENMEMORY_BACKUP_READ_CHUNK_BYTES`: `1 MiB`
- `OPENMEMORY_MAX_BACKUP_UPLOAD_BYTES`: `100 MiB`
- `OPENMEMORY_MAX_BACKUP_SQLITE_BYTES`: `10 MiB`
- `OPENMEMORY_MAX_BACKUP_LOGICAL_GZIP_BYTES`: `100 MiB`
- `OPENMEMORY_MAX_BACKUP_LOGICAL_DECOMPRESSED_BYTES`: `250 MiB`
- `OPENMEMORY_MAX_BACKUP_LOGICAL_RECORD_BYTES`: `1 MiB`
- `OPENMEMORY_MAX_BACKUP_LOGICAL_RECORDS`: `250,000 records`
- `OPENMEMORY_MAX_BACKUP_MANIFEST_RECORDS`: `250,000 records` per manifest list section
- `OPENMEMORY_MAX_BACKUP_ZIP_MEMBERS`: `64 files`
- `OPENMEMORY_MAX_BACKUP_ZIP_CENTRAL_DIRECTORY_BYTES`: `1 MiB`

Self-hosted operators with larger trusted backups can raise these environment variables.
Limit changes are read when the OpenMemory API process starts, so the API process/container must be restarted before retries use updated values.

Exports are not size-capped. A very large backup produced by OpenMemory may require raising the matching import limits before restore on a default-config API.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Commands run:

- `cd openmemory/api && ../../.agent-notes/venv-openmemory-pr8/bin/python -m pytest tests/test_backup_import_limits.py` — passed, 63 tests.
- `.agent-notes/venv-openmemory-pr8/bin/python -m py_compile openmemory/api/app/routers/backup.py openmemory/api/tests/test_backup_import_limits.py` — passed.
- `git diff --check` — passed.
- `cd openmemory/api && uvx ruff check app/routers/backup.py tests/test_backup_import_limits.py` — passed.
- `rg -n "from sqlalchemy import and_|except:" openmemory/api/app/routers/backup.py openmemory/api/tests/test_backup_import_limits.py` — no matches for the touched lint issues.
- `cd openmemory/api && ../../.agent-notes/venv-openmemory-pr8/bin/python -m pytest tests` — failed with 81 passed / 3 failed. The failures are existing MCP route-registration tests under freshly installed latest dependencies and are unrelated to this backup router change.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [x] I have updated documentation if needed

Updated `openmemory/api/.env.example` and `openmemory/api/README.md` with the new backup import limit environment variables, defaults, trusted-local backup route assumption, and large-export restore caveat.

## Risk

Risk level: low to medium.

The compatibility risk is that extremely large backup archives now fail fast with `413`. The limits are configurable for self-hosted deployments, and defaults are set to bound attacker-controlled input while allowing ordinary backups. This PR does not change backup-route authentication or authorization behavior; trusted-local or external auth/proxy deployment assumptions still apply. Rollback is isolated to the helper functions and the import path call sites in `openmemory/api/app/routers/backup.py`.

## Notes for maintainers

This intentionally does not address backup authorization policy. OpenMemory's backup routes currently do not have an auth dependency, but adding one would require a broader product/security decision. This PR is limited to resource-exhaustion hardening at the file-import boundary.
