### PR TITLE
test(server): add regression tests for empty-string entity id filtering

### DIFF
--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Shared pytest setup for the self-hosted server tests.
+
+Importing ``main`` runs module-level initialization (auth check, DB engine,
+Mem0 runtime). Set safe defaults here so the import works without a live
+Postgres/provider; individual tests stub ``get_memory_instance`` as needed.
+"""
+
+import os
+import tempfile
+
+os.environ.setdefault("AUTH_DISABLED", "true")
+os.environ.setdefault("MEM0_TELEMETRY", "false")
+os.environ.setdefault("OPENAI_API_KEY", "sk-test")
+os.environ.setdefault(
+    "HISTORY_DB_PATH", os.path.join(tempfile.gettempdir(), "mem0_server_test_history.db")
+)

--- a/server/tests/test_get_memories_filters.py
+++ b/server/tests/test_get_memories_filters.py
@@ -1,0 +1,69 @@
+"""Regression tests for entity-id filter scoping in server/main.py.
+
+Empty-string entity ids (e.g. `?agent_id=`) must be dropped when building the
+downstream filter/params, consistent with the `any([...])` "list all" / "id
+required" guards. Otherwise they are forwarded as real (empty) filter values
+and silently over-scope the query. Covers GET /memories, /search, and
+DELETE /memories, which all shared the same `is not None` pattern.
+"""
+
+import main
+from main import SearchRequest, delete_all_memories, get_all_memories, search_memories
+
+
+class _StubMemory:
+    def __init__(self):
+        self.get_all_calls = []
+        self.search_calls = []
+        self.delete_all_calls = []
+
+    def get_all(self, **params):
+        self.get_all_calls.append(params)
+        return {"results": []}
+
+    def search(self, query, filters=None, **params):
+        self.search_calls.append(filters)
+        return {"results": []}
+
+    def delete_all(self, **params):
+        self.delete_all_calls.append(params)
+
+
+def test_get_all_drops_empty_string_ids(monkeypatch):
+    stub = _StubMemory()
+    monkeypatch.setattr(main, "get_memory_instance", lambda: stub)
+
+    get_all_memories(
+        request=None,
+        user_id="alice",
+        run_id="",
+        agent_id="",
+        top_k=None,
+        show_expired=False,
+        _auth=None,
+    )
+
+    assert stub.get_all_calls, "get_all should have been called"
+    assert stub.get_all_calls[0]["filters"] == {"user_id": "alice"}
+
+
+def test_search_drops_empty_string_ids(monkeypatch):
+    stub = _StubMemory()
+    monkeypatch.setattr(main, "get_memory_instance", lambda: stub)
+
+    search_memories(
+        SearchRequest(query="hi", user_id="alice", agent_id="", run_id=""),
+        _auth=None,
+    )
+
+    # Only the real id ends up in the deprecated-param -> filters promotion.
+    assert stub.search_calls == [{"user_id": "alice"}]
+
+
+def test_delete_all_drops_empty_string_ids(monkeypatch):
+    stub = _StubMemory()
+    monkeypatch.setattr(main, "get_memory_instance", lambda: stub)
+
+    delete_all_memories(user_id="alice", run_id="", agent_id="", _auth=None)
+
+    assert stub.delete_all_calls == [{"user_id": "alice"}]


### PR DESCRIPTION
## Description

#5992 fixed the empty-string entity-id handling in `GET /memories`, `/search`, and `DELETE /memories` (dropping empty ids instead of forwarding them as real filters). That fix landed without tests, and `server/` had no test coverage at all, so this adds the first `server/tests/` package to guard the behavior:

- `conftest.py` sets safe import-time env defaults (`AUTH_DISABLED`, dummy `OPENAI_API_KEY`, a temp `HISTORY_DB_PATH`, telemetry off) so `main` imports without a live Postgres/provider.
- Three cases (one per endpoint) call the handler with a real `user_id` plus empty-string `agent_id`/`run_id` and assert only the real id reaches the downstream filter/params. `get_memory_instance` is stubbed, so no network.

Each test would fail on the pre-#5992 behavior, so they lock in the fix.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Tests (no functional/source changes)

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually
- [ ] No tests needed

Test-only change; the three tests pass against current `main` and fail against the pre-#5992 logic.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove the fix works
- [x] New and existing tests pass locally
- [x] No source changes; nothing to document
