### PR TITLE
fix(vector-stores/redis): return updated_at from search() and keyword_search()

### DIFF
--- a/mem0/vector_stores/redis.py
+++ b/mem0/vector_stores/redis.py
@@ -155,7 +155,17 @@ class RedisDB(VectorStoreBase):
         v = VectorQuery(
             vector=np.array(vectors, dtype=np.float32).tobytes(),
             vector_field_name="embedding",
-            return_fields=["memory_id", "hash", "agent_id", "run_id", "user_id", "memory", "metadata", "created_at"],
+            return_fields=[
+                "memory_id",
+                "hash",
+                "agent_id",
+                "run_id",
+                "user_id",
+                "memory",
+                "metadata",
+                "created_at",
+                "updated_at",
+            ],
             filter_expression=filter,
             num_results=top_k,
         )
@@ -209,7 +219,17 @@ class RedisDB(VectorStoreBase):
         t = TextQuery(
             text=query,
             text_field_name="memory",
-            return_fields=["memory_id", "hash", "agent_id", "run_id", "user_id", "memory", "metadata", "created_at"],
+            return_fields=[
+                "memory_id",
+                "hash",
+                "agent_id",
+                "run_id",
+                "user_id",
+                "memory",
+                "metadata",
+                "created_at",
+                "updated_at",
+            ],
             filter_expression=filter_expression,
             num_results=top_k,
         )

--- a/tests/vector_stores/test_redis.py
+++ b/tests/vector_stores/test_redis.py
@@ -228,3 +228,39 @@ def test_update_entity_payload_without_hash_and_timestamps():
     assert data_dict["hash"] == ""
     assert data_dict["created_at"] == 0
     assert data_dict["updated_at"] == 0
+
+
+def test_search_requests_updated_at_in_return_fields():
+    """search() must request updated_at so its payload can surface it, matching
+    get() and list().
+
+    Regression: updated_at was missing from the search() return_fields, so the
+    ``if "updated_at" in result`` payload guard was dead code and search results
+    never carried updated_at even though update() persists it and it is a
+    declared index field.
+    """
+    db, mock_index = _make_redis_db()
+    mock_index.query.return_value = []
+
+    with patch("mem0.vector_stores.redis.VectorQuery") as mock_vector_query:
+        db.search("query", [0.1, 0.2, 0.3, 0.4], top_k=5, filters=None)
+
+    return_fields = mock_vector_query.call_args.kwargs["return_fields"]
+    assert "updated_at" in return_fields
+
+
+def test_keyword_search_requests_updated_at_in_return_fields():
+    """keyword_search() must request updated_at so its payload can surface it,
+    matching get(), list() and search().
+
+    Same dead-guard regression as search(): the ``if "updated_at" in result``
+    branch never fired because updated_at was absent from return_fields.
+    """
+    db, mock_index = _make_redis_db()
+    mock_index.query.return_value = []
+
+    with patch("mem0.vector_stores.redis.TextQuery") as mock_text_query:
+        db.keyword_search("query", top_k=5, filters=None)
+
+    return_fields = mock_text_query.call_args.kwargs["return_fields"]
+    assert "updated_at" in return_fields


### PR DESCRIPTION
## Linked Issue

Closes #6059

## Description

`search()` and `keyword_search()` on the Redis vector store omitted `updated_at` from their `return_fields`, so the existing `if "updated_at" in result` payload guards were dead code and neither read path surfaced `updated_at` — even though `update()` persists it, it is a declared numeric index field in `DEFAULT_FIELDS`, and both `get()` and `list()` already return it. This restores metadata round-trip parity across the Redis vector store's read paths.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A — additive only. Payloads gain `updated_at` for records that have it (matching `get()`/`list()`); records without it are unchanged.

## Test Coverage

- [x] I added/updated unit tests
- [x] I tested manually (describe below)

Added `test_search_requests_updated_at_in_return_fields` and `test_keyword_search_requests_updated_at_in_return_fields` — both fail before the change and pass after.

Real behavior proof:
- Unit: before the fix both new tests FAIL (`AssertionError: 'updated_at' not in [...]`); after the fix `pytest tests/vector_stores/test_redis.py` → 13 passed.
- Live end-to-end against `redis/redis-stack` (RediSearch), real `insert -> update -> get -> search` round-trip:
  - On `main`: `get()` returns `updated_at` (`2023-11-14T22:14:10+00:00`), `search()` returns `None` (bug reproduced).
  - On this branch: both `get()` and `search()` return `updated_at` (fixed).
- `make lint` (ruff check) clean; isort clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (N/A — internal read-path parity)
