### PR TITLE
fix(server): show all visible request-log auth modes

### DIFF
--- a/server/routers/requests.py
+++ b/server/routers/requests.py
@@ -24,7 +24,7 @@ class RequestLogItem(BaseModel):
     model_config = {"from_attributes": True}
 
 
-API_KEY_AUTH_TYPES = ("api_key", "admin_api_key")
+VISIBLE_REQUEST_LOG_AUTH_TYPES = ("bearer", "api_key", "admin_api_key", "disabled")
 
 
 @router.get("", response_model=list[RequestLogItem])
@@ -36,7 +36,7 @@ def list_requests(
     logs = (
         db.execute(
             select(RequestLog)
-            .where(RequestLog.auth_type.in_(API_KEY_AUTH_TYPES))
+            .where(RequestLog.auth_type.in_(VISIBLE_REQUEST_LOG_AUTH_TYPES))
             .order_by(RequestLog.created_at.desc())
             .limit(limit)
         )

--- a/tests/server/test_requests_router.py
+++ b/tests/server/test_requests_router.py
@@ -1,0 +1,128 @@
+import importlib
+import inspect
+import sys
+import types
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import DeclarativeBase, Session
+
+
+SERVER_ROOT = Path(__file__).resolve().parents[2] / "server"
+
+
+def _load_requests_router(monkeypatch, request):
+    class TestBase(DeclarativeBase):
+        pass
+
+    class FakeRouter:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def get(self, *args, **kwargs):
+            return lambda endpoint: endpoint
+
+    fake_auth = types.ModuleType("auth")
+    fake_auth.require_admin = lambda: None
+    fake_auth.verify_auth = lambda: None
+
+    fake_db = types.ModuleType("db")
+    fake_db.Base = TestBase
+    fake_db.get_db = lambda: None
+
+    fake_fastapi = types.ModuleType("fastapi")
+    fake_fastapi.APIRouter = FakeRouter
+    fake_fastapi.Depends = lambda dependency=None, *args, **kwargs: dependency
+    fake_fastapi.Query = lambda default=None, *args, **kwargs: default
+
+    module_names = ("auth", "db", "fastapi", "models", "routers.requests")
+    original_modules = {name: sys.modules.get(name) for name in module_names}
+
+    def restore_modules():
+        for name in module_names:
+            sys.modules.pop(name, None)
+            if original_modules[name] is not None:
+                sys.modules[name] = original_modules[name]
+
+    request.addfinalizer(restore_modules)
+
+    monkeypatch.syspath_prepend(str(SERVER_ROOT))
+    monkeypatch.setitem(sys.modules, "auth", fake_auth)
+    monkeypatch.setitem(sys.modules, "db", fake_db)
+    monkeypatch.setitem(sys.modules, "fastapi", fake_fastapi)
+    monkeypatch.delitem(sys.modules, "models", raising=False)
+    monkeypatch.delitem(sys.modules, "routers.requests", raising=False)
+    return importlib.import_module("routers.requests"), TestBase, fake_auth.require_admin
+
+
+def _build_db(requests_router, test_base):
+    engine = create_engine("sqlite:///:memory:")
+    test_base.metadata.create_all(engine)
+    return engine
+
+
+def _add_request_log(db, requests_router, *, path, auth_type, created_at):
+    db.add(
+        requests_router.RequestLog(
+            method="GET",
+            path=path,
+            status_code=200,
+            latency_ms=1,
+            auth_type=auth_type,
+            created_at=created_at,
+        )
+    )
+
+
+def test_list_requests_returns_visible_auth_logs(monkeypatch, request):
+    requests_router, test_base, _require_admin = _load_requests_router(monkeypatch, request)
+    engine = _build_db(requests_router, test_base)
+    now = datetime.now(timezone.utc)
+
+    with Session(engine) as db:
+        _add_request_log(db, requests_router, path="/none", auth_type="none", created_at=now + timedelta(seconds=5))
+        _add_request_log(db, requests_router, path="/bearer", auth_type="bearer", created_at=now + timedelta(seconds=1))
+        _add_request_log(db, requests_router, path="/api-key", auth_type="api_key", created_at=now + timedelta(seconds=2))
+        _add_request_log(
+            db, requests_router, path="/admin-key", auth_type="admin_api_key", created_at=now + timedelta(seconds=3)
+        )
+        _add_request_log(
+            db, requests_router, path="/disabled", auth_type="disabled", created_at=now + timedelta(seconds=4)
+        )
+        db.commit()
+
+        logs = requests_router.list_requests(_auth=object(), db=db, limit=10)
+
+    assert [log.auth_type for log in logs] == ["disabled", "admin_api_key", "api_key", "bearer"]
+    assert [log.path for log in logs] == ["/disabled", "/admin-key", "/api-key", "/bearer"]
+
+
+def test_list_requests_applies_limit_after_filtering_visible_logs(monkeypatch, request):
+    requests_router, test_base, _require_admin = _load_requests_router(monkeypatch, request)
+    engine = _build_db(requests_router, test_base)
+    now = datetime.now(timezone.utc)
+
+    with Session(engine) as db:
+        _add_request_log(db, requests_router, path="/none", auth_type="none", created_at=now + timedelta(seconds=5))
+        _add_request_log(db, requests_router, path="/bearer", auth_type="bearer", created_at=now + timedelta(seconds=1))
+        _add_request_log(db, requests_router, path="/api-key", auth_type="api_key", created_at=now + timedelta(seconds=2))
+        _add_request_log(
+            db, requests_router, path="/admin-key", auth_type="admin_api_key", created_at=now + timedelta(seconds=3)
+        )
+        _add_request_log(
+            db, requests_router, path="/disabled", auth_type="disabled", created_at=now + timedelta(seconds=4)
+        )
+        db.commit()
+
+        logs = requests_router.list_requests(_auth=object(), db=db, limit=2)
+
+    assert [log.path for log in logs] == ["/disabled", "/admin-key"]
+
+
+def test_list_requests_requires_admin_dependency(monkeypatch, request):
+    requests_router, _test_base, require_admin = _load_requests_router(monkeypatch, request)
+
+    signature = inspect.signature(requests_router.list_requests)
+
+    assert signature.parameters["_auth"].default is require_admin


### PR DESCRIPTION
## Linked Issue

No existing issue. This was discovered during repository analysis.

## Description

The self-hosted server persists request logs with auth modes such as `bearer`, `api_key`, `admin_api_key`, `disabled`, and `none`, but the `/requests` admin endpoint only returned API-key entries. That meant normal dashboard/API traffic authenticated with JWT bearer tokens, plus local `AUTH_DISABLED` traffic, was invisible in the Requests audit view even though it was being stored.

This PR expands the visible request-log auth modes to include bearer/JWT, API key, admin API key, and `AUTH_DISABLED` traffic while continuing to exclude unauthenticated `none` entries. The route remains admin-only via `require_admin`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Commands run:

- `.agent-notes/venv-server-pr9/bin/python -m pytest tests/server/test_requests_router.py` — passed, 3 tests
- `.agent-notes/venv-root-pr9/bin/python -m pytest tests/server/test_requests_router.py` — passed, 3 tests in a minimal root-style env without server-only FastAPI installed
- `.agent-notes/venv-server-pr9/bin/ruff check server/routers/requests.py tests/server/test_requests_router.py` — passed
- `.agent-notes/venv-server-pr9/bin/python -m py_compile server/routers/requests.py tests/server/test_requests_router.py` — passed
- `git diff --check` — passed

Not run:

- Full server Docker/Postgres stack; this is a narrow router query change covered with in-memory SQLAlchemy tests.
- Full root test suite; scoped tests were run for the changed server router behavior.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
