### PR TITLE
fix(cli-node): align delete-all agent envelope

### DIFF
--- a/cli/node/src/commands/memory.ts
+++ b/cli/node/src/commands/memory.ts
@@ -537,6 +537,18 @@ export async function cmdDelete(
 	}
 }
 
+function deleteAllAgentData(
+	result: Record<string, unknown>,
+): Record<string, unknown> {
+	if (typeof result.message === "string") {
+		return {
+			deletion_started: true,
+			message: result.message,
+		};
+	}
+	return { deleted: true };
+}
+
 export async function cmdDeleteAll(
 	backend: Backend,
 	opts: {
@@ -603,7 +615,13 @@ export async function cmdDeleteAll(
 		if (opts.output === "agent") {
 			formatAgentEnvelope({
 				command: "delete-all",
-				data: result,
+				data: deleteAllAgentData(result),
+				scope: {
+					user_id: "*",
+					agent_id: "*",
+					app_id: "*",
+					run_id: "*",
+				},
 				durationMs: Math.round(elapsed * 1000),
 			});
 		} else if (opts.output === "json") {
@@ -684,9 +702,16 @@ export async function cmdDeleteAll(
 	const elapsed = (performance.now() - start) / 1000;
 
 	if (opts.output === "agent") {
+		const scope: Record<string, string | undefined> = {
+			user_id: opts.userId,
+			agent_id: opts.agentId,
+			app_id: opts.appId,
+			run_id: opts.runId,
+		};
 		formatAgentEnvelope({
 			command: "delete-all",
-			data: result,
+			data: deleteAllAgentData(result),
+			scope,
 			durationMs: Math.round(elapsed * 1000),
 		});
 	} else if (opts.output === "json") {

--- a/cli/node/tests/commands.test.ts
+++ b/cli/node/tests/commands.test.ts
@@ -436,6 +436,65 @@ describe("agent mode", () => {
     expect(parsed.data).toBeDefined();
   });
 
+  it("cmdDeleteAll outputs scoped JSON envelope", async () => {
+    setAgentMode(true);
+    const { cmdDeleteAll } = await import("../src/commands/memory.js");
+    await cmdDeleteAll(mockBackend, {
+      force: true,
+      userId: "alice",
+      agentId: "agent-1",
+      output: "agent",
+    });
+    const parsed = JSON.parse(output.trim());
+    expect(parsed.status).toBe("success");
+    expect(parsed.command).toBe("delete-all");
+    expect(parsed.data).toEqual({ deleted: true });
+    expect(parsed.scope).toEqual({ user_id: "alice", agent_id: "agent-1" });
+    expect(parsed.duration_ms).toEqual(expect.any(Number));
+  });
+
+  it("cmdDeleteAll outputs project JSON envelope", async () => {
+    setAgentMode(true);
+    const { cmdDeleteAll } = await import("../src/commands/memory.js");
+    await cmdDeleteAll(mockBackend, {
+      force: true,
+      all: true,
+      output: "agent",
+    });
+    const parsed = JSON.parse(output.trim());
+    expect(parsed.status).toBe("success");
+    expect(parsed.command).toBe("delete-all");
+    expect(parsed.data).toEqual({ deleted: true });
+    expect(parsed.scope).toEqual({
+      user_id: "*",
+      agent_id: "*",
+      app_id: "*",
+      run_id: "*",
+    });
+    expect(parsed.duration_ms).toEqual(expect.any(Number));
+  });
+
+  it("cmdDeleteAll preserves background deletion state in agent output", async () => {
+    (mockBackend.delete as ReturnType<typeof vi.fn>).mockResolvedValue({
+      message: "Memories deletion started...",
+    });
+    setAgentMode(true);
+    const { cmdDeleteAll } = await import("../src/commands/memory.js");
+    await cmdDeleteAll(mockBackend, {
+      force: true,
+      userId: "alice",
+      output: "agent",
+    });
+    const parsed = JSON.parse(output.trim());
+    expect(parsed.status).toBe("success");
+    expect(parsed.command).toBe("delete-all");
+    expect(parsed.data).toEqual({
+      deletion_started: true,
+      message: "Memories deletion started...",
+    });
+    expect(parsed.scope).toEqual({ user_id: "alice" });
+  });
+
   it("cmdEventList outputs JSON envelope", async () => {
     setAgentMode(true);
     const { cmdEventList } = await import("../src/commands/events.js");


### PR DESCRIPTION
## Linked Issue

No existing issue. Discovered during the contribution campaign's Node/Python CLI parity review.

## Description

This aligns the Node CLI's `delete-all` Agent Mode JSON envelope with the rest of the CLI's machine-readable output contract. Previously `cmdDeleteAll(..., output: "agent")` passed the backend delete response through as `data`, unlike other destructive command envelopes that return stable command-level data.

The Node CLI now emits a stable delete-all result, includes the requested scope at the envelope level, and preserves background deletion state when the backend reports that deletion was started asynchronously.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Commands run:

- `cd cli/node && pnpm install` — passed
- `cd cli/node && pnpm run test -- tests/commands.test.ts` — passed, 9 files / 122 tests
- `cd cli/node && pnpm run typecheck` — passed
- `cd cli/node && pnpm run lint` — passed
- `cd cli/node && pnpm run build` — passed
- `git diff --check` — passed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed

## Risk

Risk level: low.

This only changes Node CLI Agent Mode JSON output for `delete-all`; the backend delete calls, confirmation behavior, scope selection, text output, and JSON output remain unchanged. Rollback is a small revert of one command helper and its tests.

## Notes for maintainers

The tests cover scoped delete-all, project-wide delete-all, and backend responses that indicate background deletion has started.
