### PR TITLE
fix(llms): rewrite assistant as whole word for Azure

### DIFF
--- a/mem0/llms/azure_openai.py
+++ b/mem0/llms/azure_openai.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import os
+import re
 from typing import Dict, List, Optional, Union
 
 from azure.identity import DefaultAzureCredential, get_bearer_token_provider
@@ -32,9 +33,9 @@ class AzureOpenAILLM(LLMBase):
                 top_k=config.top_k,
                 enable_vision=config.enable_vision,
                 vision_details=config.vision_details,
-                reasoning_effort=getattr(config, 'reasoning_effort', None),
+                reasoning_effort=getattr(config, "reasoning_effort", None),
                 http_client_proxies=config.http_client_proxies,
-                is_reasoning_model=getattr(config, 'is_reasoning_model', None),
+                is_reasoning_model=getattr(config, "is_reasoning_model", None),
             )
 
         super().__init__(config)
@@ -87,7 +88,7 @@ class AzureOpenAILLM(LLMBase):
         messages = copy.deepcopy(messages)
         last_content = messages[-1].get("content")
         if isinstance(last_content, str):
-            messages[-1]["content"] = last_content.replace("assistant", "ai")
+            messages[-1]["content"] = re.sub(r"\bassistant\b", "ai", last_content)
         return messages
 
     def _parse_response(self, response, tools):
@@ -151,10 +152,12 @@ class AzureOpenAILLM(LLMBase):
         params = self._get_supported_params(messages=messages, **kwargs)
 
         # Add model and messages
-        params.update({
-            "model": self.config.model,
-            "messages": messages,
-        })
+        params.update(
+            {
+                "model": self.config.model,
+                "messages": messages,
+            }
+        )
 
         if response_format:
             params["response_format"] = response_format

--- a/mem0/llms/azure_openai_structured.py
+++ b/mem0/llms/azure_openai_structured.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import os
+import re
 from typing import Dict, List, Optional
 
 from azure.identity import DefaultAzureCredential, get_bearer_token_provider
@@ -119,7 +120,7 @@ class AzureOpenAIStructuredLLM(LLMBase):
         messages = copy.deepcopy(messages)
         last_content = messages[-1].get("content")
         if isinstance(last_content, str):
-            messages[-1]["content"] = last_content.replace("assistant", "ai")
+            messages[-1]["content"] = re.sub(r"\bassistant\b", "ai", last_content)
         return messages
 
     def _parse_response(self, response, tools):

--- a/tests/llms/test_azure_openai.py
+++ b/tests/llms/test_azure_openai.py
@@ -165,6 +165,21 @@ def test_generate_response_rewrites_assistant_keyword_for_model_only(mock_openai
     assert messages[-1]["content"] == "my assistant helps me"
 
 
+def test_generate_response_rewrites_assistant_as_whole_word_only(mock_openai_client):
+    config = AzureOpenAIConfig(model=MODEL, temperature=TEMPERATURE, max_tokens=MAX_TOKENS, top_p=TOP_P)
+    llm = AzureOpenAILLM(config)
+    messages = [{"role": "user", "content": "assistant support improved the assistantship program"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="ok"))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    sent_messages = mock_openai_client.chat.completions.create.call_args[1]["messages"]
+    assert sent_messages[-1]["content"] == "ai support improved the assistantship program"
+
+
 def test_generate_response_handles_multimodal_content(mock_openai_client):
     config = AzureOpenAIConfig(model=MODEL, temperature=TEMPERATURE, max_tokens=MAX_TOKENS, top_p=TOP_P)
     llm = AzureOpenAILLM(config)

--- a/tests/llms/test_azure_openai_structured.py
+++ b/tests/llms/test_azure_openai_structured.py
@@ -305,6 +305,25 @@ def test_generate_response_rewrites_assistant_keyword_for_model_only(mock_azure_
 
 
 @mock.patch("mem0.llms.azure_openai_structured.AzureOpenAI")
+def test_generate_response_rewrites_assistant_as_whole_word_only(mock_azure_openai):
+    mock_client = Mock()
+    mock_azure_openai.return_value = mock_client
+
+    config = DummyConfig(model="test-model", azure_kwargs=DummyAzureKwargs(api_key="real-key"))
+    llm = AzureOpenAIStructuredLLM(config)
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="ok"))]
+    mock_client.chat.completions.create.return_value = mock_response
+
+    messages = [{"role": "user", "content": "assistant support improved the assistantship program"}]
+    llm.generate_response(messages)
+
+    sent_messages = mock_client.chat.completions.create.call_args[1]["messages"]
+    assert sent_messages[-1]["content"] == "ai support improved the assistantship program"
+
+
+@mock.patch("mem0.llms.azure_openai_structured.AzureOpenAI")
 def test_generate_response_handles_multimodal_content(mock_azure_openai):
     mock_client = Mock()
     mock_azure_openai.return_value = mock_client


### PR DESCRIPTION
## Summary
- rewrite only standalone assistant tokens in Azure OpenAI prompts
- preserve words that contain assistant as a substring, such as assistantship
- add regression coverage for both Azure OpenAI LLM implementations

Fixes #6036

## Tests
- UV_CACHE_DIR=/private/tmp/uv-cache-mem0 uv run --python 3.12 --extra test --extra vector-stores pytest tests/llms/test_azure_openai.py tests/llms/test_azure_openai_structured.py -q
- UV_CACHE_DIR=/private/tmp/uv-cache-mem0 uv run --python 3.12 --extra test --with ruff ruff check mem0/llms/azure_openai.py mem0/llms/azure_openai_structured.py tests/llms/test_azure_openai.py tests/llms/test_azure_openai_structured.py
- UV_CACHE_DIR=/private/tmp/uv-cache-mem0 uv run --python 3.12 --extra test --with ruff ruff format --check mem0/llms/azure_openai.py mem0/llms/azure_openai_structured.py tests/llms/test_azure_openai.py tests/llms/test_azure_openai_structured.py