### PR TITLE
fix(ts): use match-all Redis query for empty filters

### DIFF
--- a/mem0-ts/src/oss/src/vector_stores/redis.ts
+++ b/mem0-ts/src/oss/src/vector_stores/redis.ts
@@ -133,6 +133,17 @@ function toSnakeCase(obj: Record<string, any>): Record<string, any> {
   );
 }
 
+function buildFilterExpression(filters?: SearchFilters): string {
+  const snakeFilters = filters ? toSnakeCase(filters) : undefined;
+  const clauses = snakeFilters
+    ? Object.entries(snakeFilters)
+        .filter(([_, value]) => value !== null && value !== undefined)
+        .map(([key, value]) => `@${key}:{${escapeRedisTagValue(value)}}`)
+    : [];
+
+  return clauses.length ? clauses.join(" ") : "*";
+}
+
 // Utility function to convert object keys to camelCase
 function toCamelCase(obj: Record<string, any>): Record<string, any> {
   if (typeof obj !== "object" || obj === null) return obj;
@@ -390,13 +401,7 @@ export class RedisDB implements VectorStore {
     topK: number = 5,
     filters?: SearchFilters,
   ): Promise<VectorStoreResult[]> {
-    const snakeFilters = filters ? toSnakeCase(filters) : undefined;
-    const filterExpr = snakeFilters
-      ? Object.entries(snakeFilters)
-          .filter(([_, value]) => value !== null && value !== undefined)
-          .map(([key, value]) => `@${key}:{${escapeRedisTagValue(value)}}`)
-          .join(" ")
-      : "*";
+    const filterExpr = buildFilterExpression(filters);
 
     const queryVector = new Float32Array(query).buffer;
 
@@ -634,13 +639,7 @@ export class RedisDB implements VectorStore {
     filters?: SearchFilters,
     topK: number = 100,
   ): Promise<[VectorStoreResult[], number]> {
-    const snakeFilters = filters ? toSnakeCase(filters) : undefined;
-    const filterExpr = snakeFilters
-      ? Object.entries(snakeFilters)
-          .filter(([_, value]) => value !== null && value !== undefined)
-          .map(([key, value]) => `@${key}:{${escapeRedisTagValue(value)}}`)
-          .join(" ")
-      : "*";
+    const filterExpr = buildFilterExpression(filters);
 
     const searchOptions = {
       SORTBY: "created_at",

--- a/mem0-ts/src/oss/tests/redis.unit.test.ts
+++ b/mem0-ts/src/oss/tests/redis.unit.test.ts
@@ -125,4 +125,29 @@ describe("RedisDB – entity payload handling", () => {
     expect(entry.created_at).toBeGreaterThan(0);
     expect(Number.isNaN(entry.created_at)).toBe(false);
   });
+
+  test("search uses match-all query for empty and all-null filters", async () => {
+    mockClient.ft.search.mockResolvedValue({ total: 0, documents: [] });
+
+    await store.search([0.1, 0.2, 0.3, 0.4], 5, {});
+    await store.search([0.1, 0.2, 0.3, 0.4], 5, {
+      userId: null,
+      agentId: undefined,
+    });
+
+    expect(mockClient.ft.search.mock.calls[0][1]).toBe(
+      "* =>[KNN 5 @embedding $vec AS __vector_score]",
+    );
+    expect(mockClient.ft.search.mock.calls[1][1]).toBe(
+      "* =>[KNN 5 @embedding $vec AS __vector_score]",
+    );
+  });
+
+  test("list uses match-all query for empty filters", async () => {
+    mockClient.ft.search.mockResolvedValue({ total: 0, documents: [] });
+
+    await store.list({});
+
+    expect(mockClient.ft.search.mock.calls[0][1]).toBe("*");
+  });
 });


### PR DESCRIPTION
## Summary
- build Redis filter expressions through a shared helper
- fall back to * when filters are empty or all values are null/undefined
- add Redis unit coverage for search and list empty-filter queries

Fixes #6013

## Tests
- pnpm jest src/oss/tests/redis.unit.test.ts --runInBand
- pnpm exec prettier --check src/oss/src/vector_stores/redis.ts src/oss/tests/redis.unit.test.ts
- pnpm run build