### PR TITLE
fix(server): parse generated instructions by line markers

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -21,6 +21,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, RedirectResponse
 from mem0.exceptions import ValidationError as Mem0ValidationError
 from models import RequestLog, User
+from parsing import parse_generate_instructions_response
 from pydantic import BaseModel, Field
 from rate_limit import limiter
 from routers import api_keys as api_keys_router
@@ -352,12 +353,7 @@ def generate_instructions(req: GenerateInstructionsRequest, _auth=Depends(verify
             f"TEST_MESSAGE: <your test message>\n\nUse case: {req.use_case}"
         )
         response = llm.generate_response([{"role": "user", "content": prompt}])
-        instructions = response
-        test_message = "I like to hike on weekends."
-        if "INSTRUCTIONS:" in response and "TEST_MESSAGE:" in response:
-            parts = response.split("TEST_MESSAGE:")
-            instructions = parts[0].replace("INSTRUCTIONS:", "").strip()
-            test_message = parts[1].strip()
+        instructions, test_message = parse_generate_instructions_response(response)
         return {"custom_instructions": instructions, "test_message": test_message}
     except Exception:
         raise upstream_error()

--- a/server/parsing.py
+++ b/server/parsing.py
@@ -1,0 +1,16 @@
+import re
+
+DEFAULT_TEST_MESSAGE = "I like to hike on weekends."
+
+GENERATE_INSTRUCTIONS_RE = re.compile(
+    r"^\s*INSTRUCTIONS:\s*(?P<instructions>.*?)(?:\r?\n)\s*TEST_MESSAGE:\s*(?P<test_message>.*)\s*$",
+    re.DOTALL,
+)
+
+
+def parse_generate_instructions_response(response: str) -> tuple[str, str]:
+    match = GENERATE_INSTRUCTIONS_RE.match(response)
+    if not match:
+        return response, DEFAULT_TEST_MESSAGE
+
+    return match.group("instructions").strip(), match.group("test_message").strip()

--- a/tests/test_server_generate_instructions.py
+++ b/tests/test_server_generate_instructions.py
@@ -1,0 +1,13 @@
+from server.parsing import parse_generate_instructions_response
+
+
+def test_parse_generate_instructions_preserves_recurring_markers():
+    response = (
+        "INSTRUCTIONS: Please follow these INSTRUCTIONS: prioritize recent events.\n"
+        "TEST_MESSAGE: This is a TEST_MESSAGE: hello."
+    )
+
+    instructions, test_message = parse_generate_instructions_response(response)
+
+    assert instructions == "Please follow these INSTRUCTIONS: prioritize recent events."
+    assert test_message == "This is a TEST_MESSAGE: hello."


### PR DESCRIPTION
## Summary
- parse generated instruction responses using line-start markers instead of global replacements
- preserve recurring INSTRUCTIONS: and TEST_MESSAGE: text inside generated content
- add focused parser regression coverage

Fixes #5993

## Tests
- UV_CACHE_DIR=/private/tmp/uv-cache-mem0 uv run --python 3.12 --extra test pytest tests/test_server_generate_instructions.py -q
- UV_CACHE_DIR=/private/tmp/uv-cache-mem0 uv run --python 3.12 --extra test python -m py_compile server/main.py server/parsing.py tests/test_server_generate_instructions.py
- UV_CACHE_DIR=/private/tmp/uv-cache-mem0 uv run --python 3.12 --extra test --with ruff ruff check server/main.py server/parsing.py tests/test_server_generate_instructions.py