### PR TITLE
fix(claude-code-plugin): respect auto_search setting in hooks

### DIFF
--- a/integrations/mem0-plugin/scripts/on_bash_output.sh
+++ b/integrations/mem0-plugin/scripts/on_bash_output.sh
@@ -46,6 +46,10 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 . "$SCRIPT_DIR/_identity.sh" 2>/dev/null || true
 
+if [ "${MEM0_AUTO_SEARCH:-true}" = "false" ]; then
+  exit 0
+fi
+
 # Extract error class/message (first matching line)
 ERROR_LINE=$(echo "$TOOL_RESULT" | grep -iE '(Error:|Exception:|panic:|FAIL:|fatal:)' | head -1 | sed 's/^[[:space:]]*//' | cut -c1-120)
 

--- a/integrations/mem0-plugin/scripts/on_file_read.sh
+++ b/integrations/mem0-plugin/scripts/on_file_read.sh
@@ -30,6 +30,11 @@ fi
 if [ -z "${MEM0_API_KEY:-}" ]; then
   exit 0
 fi
+
+if [ "${MEM0_AUTO_SEARCH:-true}" = "false" ]; then
+  exit 0
+fi
+
 CWD=$(echo "$INPUT" | jq -r '.cwd // "."' 2>/dev/null || echo ".")
 
 # Call the Python worker — it handles gating (file size, existence)


### PR DESCRIPTION
## Description
This PR fixes the issue where the `auto_search: false` setting in `~/.mem0/settings.json` is ignored by hook-driven searches.

The `on_file_read.sh` and `on_bash_output.sh` hooks were not checking the `MEM0_AUTO_SEARCH` environment variable, causing unnecessary API calls even when the user explicitly disabled auto_search.

## Changes
- Added guard in `integrations/mem0-plugin/scripts/on_file_read.sh` to exit early when `auto_search` is false
- Added guard in `integrations/mem0-plugin/scripts/on_bash_output.sh` to exit early when `auto_search` is false

## Related Issue
Closes #6065