### PR TITLE
fix(vector-stores/s3): don't cap server fetch by top_k when filtering

### DIFF
--- a/mem0/vector_stores/s3_vectors.py
+++ b/mem0/vector_stores/s3_vectors.py
@@ -188,7 +188,12 @@ class S3Vectors(VectorStoreBase):
             "returnData": False,
             "returnMetadata": True,
         }
-        if top_k:
+        # S3 Vectors' list_vectors has no server-side metadata filtering, so filters
+        # are applied client-side below. When filters are present we must NOT cap the
+        # server fetch with maxResults=top_k: doing so limits the *unfiltered* page,
+        # which can yield fewer than top_k matches (or none) even when more exist.
+        # Only push maxResults to the server when there is nothing to filter locally.
+        if top_k and not filters:
             params["maxResults"] = top_k
 
         paginator = self.client.get_paginator("list_vectors")

--- a/tests/vector_stores/test_s3_vectors.py
+++ b/tests/vector_stores/test_s3_vectors.py
@@ -272,3 +272,52 @@ def test_list_filters_metadata_client_side(mock_boto_client):
     [results] = store.list(filters={"user_id": "alice", "category": "work"})
 
     assert [result.id for result in results] == ["id1"]
+
+
+def test_list_with_filters_does_not_cap_server_fetch(mock_boto_client):
+    """When filters are present, top_k must not be pushed to the server as
+    maxResults: S3's list_vectors has no server-side filtering, so capping the
+    unfiltered fetch could drop matching records that appear later in the index.
+    """
+    mock_paginator = mock_boto_client.get_paginator.return_value
+    mock_paginator.paginate.return_value = [
+        {
+            "vectors": [
+                {"key": "id1", "metadata": {"user_id": "bob"}},
+                {"key": "id2", "metadata": {"user_id": "bob"}},
+                {"key": "id3", "metadata": {"user_id": "alice"}},
+            ]
+        }
+    ]
+    store = S3Vectors(
+        vector_bucket_name=BUCKET_NAME,
+        collection_name=INDEX_NAME,
+        embedding_model_dims=EMBEDDING_DIMS,
+    )
+
+    # Ask for a single result matching user_id=alice. The only match is the 3rd
+    # record; a naive maxResults=1 fetch would return only bob and miss it.
+    [results] = store.list(filters={"user_id": "alice"}, top_k=1)
+
+    # maxResults must NOT have been forwarded to the paginator.
+    _, paginate_kwargs = mock_paginator.paginate.call_args
+    assert "maxResults" not in paginate_kwargs
+    assert [result.id for result in results] == ["id3"]
+
+
+def test_list_without_filters_pushes_top_k_to_server(mock_boto_client):
+    """With no filters, top_k can be pushed to the server as maxResults."""
+    mock_paginator = mock_boto_client.get_paginator.return_value
+    mock_paginator.paginate.return_value = [
+        {"vectors": [{"key": "id1", "metadata": {"user_id": "alice"}}]}
+    ]
+    store = S3Vectors(
+        vector_bucket_name=BUCKET_NAME,
+        collection_name=INDEX_NAME,
+        embedding_model_dims=EMBEDDING_DIMS,
+    )
+
+    store.list(top_k=5)
+
+    _, paginate_kwargs = mock_paginator.paginate.call_args
+    assert paginate_kwargs["maxResults"] == 5


### PR DESCRIPTION
## Summary

- `S3Vectors.list()` no longer caps the server-side fetch with `top_k` when metadata filters are supplied.
- A filtered `list(top_k=N)` now reliably returns up to N *matching* records instead of silently dropping matches.

## Motivation

`S3Vectors.list()` applies metadata filters client-side, because S3 Vectors' `list_vectors` API has no server-side metadata filtering. When both `filters` and `top_k` were provided, `top_k` was forwarded to the server as `maxResults`, which caps the **unfiltered** page *before* local filtering runs.

As a result, a filtered `list(top_k=N)` could return fewer than N matches — or none at all — whenever the matching records happened to appear after the `maxResults` cutoff in the index. Since mem0 uses `list()` with scope filters (`user_id`/`agent_id`/`run_id`) for `get_all`, this manifests as memories silently missing from scoped listings on the S3 Vectors backend.

## Fix

Only push `maxResults=top_k` to the server when there are no filters. When filters are present, fetch all pages, filter locally, then apply the `top_k` cap to the *filtered* results. The unfiltered path is unchanged (still efficient).

## Verification

- `python -m pytest tests/vector_stores/test_s3_vectors.py` — 12 passed
- `test_list_with_filters_does_not_cap_server_fetch`: filtered `list(top_k=1)` where the only match is the last record; asserts `maxResults` is not forwarded and the match is returned (fails before the fix).
- `test_list_without_filters_pushes_top_k_to_server`: unfiltered `list` still forwards `maxResults` for server-side efficiency.
- Did NOT change: the `list()` return shape or the client-side filter semantics.
