### PR TITLE
fix(vector-stores/vertex): size list() zero-vector to configured embedding dims

### DIFF
--- a/mem0/configs/vector_stores/vertex_ai_vector_search.py
+++ b/mem0/configs/vector_stores/vertex_ai_vector_search.py
@@ -14,6 +14,7 @@ class GoogleMatchingEngineConfig(BaseModel):
     credentials_path: Optional[str] = Field(None, description="Path to service account credentials JSON file")
     service_account_json: Optional[Dict] = Field(None, description="Service account credentials as dictionary (alternative to credentials_path)")
     vector_search_api_endpoint: Optional[str] = Field(None, description="Vector search API endpoint")
+    embedding_model_dims: int = Field(768, description="Dimension of the embedding vectors")
 
     model_config = ConfigDict(extra="forbid")
 

--- a/mem0/vector_stores/vertex_ai_vector_search.py
+++ b/mem0/vector_stores/vertex_ai_vector_search.py
@@ -61,6 +61,7 @@ class GoogleMatchingEngine(VectorStoreBase):
         self.deployment_index_id = config.deployment_index_id  # The deployment-specific ID
         self.collection_name = config.collection_name
         self.vector_search_api_endpoint = config.vector_search_api_endpoint
+        self.embedding_model_dims = config.embedding_model_dims
 
         logger.debug("Using project=%s, location=%s", self.project_id, self.region)
 
@@ -480,9 +481,10 @@ class GoogleMatchingEngine(VectorStoreBase):
         logger.debug("Limit: %s", top_k)
 
         try:
-            # Use a zero vector for the search
-            dimension = 768  # This should be configurable based on the model
-            zero_vector = [0.0] * dimension
+            # Use a zero vector for the search, sized to the configured embedding
+            # dimension. Hardcoding 768 broke any model with a different dimension
+            # (e.g. text-embedding-3-large at 3072), producing a shape mismatch.
+            zero_vector = [0.0] * self.embedding_model_dims
 
             # Use a large top_k if none specified
             search_limit = top_k if top_k is not None else 10000

--- a/tests/vector_stores/test_vertex_ai_vector_search.py
+++ b/tests/vector_stores/test_vertex_ai_vector_search.py
@@ -128,6 +128,31 @@ def test_list_does_not_raise_type_error(vector_store, mock_vertex_ai):
     assert results == [[]]
 
 
+def test_list_uses_configured_embedding_dims(mock_vertex_ai):
+    """list() must size its zero-vector to the configured embedding dimension,
+    not a hardcoded 768 (which broke models like text-embedding-3-large @ 3072)."""
+    mock_vertex_ai["index_class"].return_value = mock_vertex_ai["index"]
+    mock_vertex_ai["endpoint_class"].return_value = mock_vertex_ai["endpoint"]
+    config = GoogleMatchingEngineConfig(
+        project_id="test-project",
+        project_number="123456789",
+        region="us-central1",
+        endpoint_id="test-endpoint",
+        index_id="test-index",
+        deployment_index_id="test-deployment",
+        collection_name="test-collection",
+        vector_search_api_endpoint="test.vertexai.goog",
+        embedding_model_dims=3072,
+    )
+    store = GoogleMatchingEngine(**config.model_dump())
+    mock_vertex_ai["endpoint"].find_neighbors.return_value = [[]]
+
+    store.list(filters={"user_id": "test_user"}, top_k=5)
+
+    queries = mock_vertex_ai["endpoint"].find_neighbors.call_args[1]["queries"]
+    assert queries == [[0.0] * 3072]
+
+
 def test_similarity_search_with_score_passes_embedding(vector_store, mock_vertex_ai):
     """similarity_search_with_score() must pass the embedding as `vectors`."""
     embedding = [0.1, 0.2, 0.3]


### PR DESCRIPTION
## Summary

- `GoogleMatchingEngine.list()` now sizes its zero query-vector to the configured embedding dimension instead of a hardcoded 768.
- Fixes `list()` / `get_all()` on the Vertex AI Vector Search backend for any embedding model whose dimension is not 768.

## Motivation

`GoogleMatchingEngine.list()` built its dummy query vector as `[0.0] * 768` (with an explicit `# This should be configurable based on the model` comment). Vertex AI Vector Search rejects queries whose vector dimension does not match the index, so any deployment using an embedding model with a different dimension — e.g. OpenAI `text-embedding-3-large` (3072), `text-embedding-3-small` (1536), or Vertex `text-embedding-004` variants — hits a shape mismatch on every `list()` call. Since mem0's `get_all()` is backed by `list()`, scoped memory listings fail entirely on those configurations.

## Fix

Add `embedding_model_dims` to `GoogleMatchingEngineConfig` (default `768`, matching the field name already used by other vector-store configs such as `s3_vectors`, `milvus`, `pinecone`, `opensearch`) and use it to size the zero-vector in `list()`. The default is unchanged, so existing 768-dim deployments are unaffected.

## Verification

- `python -m pytest tests/vector_stores/test_vertex_ai_vector_search.py` — 8 passed
- `test_list_uses_configured_embedding_dims`: `list()` with `embedding_model_dims=3072` asserts the zero-vector is sized 3072 (fails before the fix).
- Existing `test_list_does_not_raise_type_error` still asserts the 768 default is used when unset.
- Did NOT change: the `list()` return shape, filter handling, or the `search()` path.
