### PR TITLE
fix: persist and return updated config in OpenMemory PUT /api/v1/config

### DIFF
--- a/openmemory/api/app/routers/config.py
+++ b/openmemory/api/app/routers/config.py
@@ -151,10 +151,15 @@ async def update_configuration(config: ConfigSchema, db: Session = Depends(get_d
         if "openmemory" not in updated_config:
             updated_config["openmemory"] = {}
         updated_config["openmemory"].update(config.openmemory.dict(exclude_none=True))
-    
-    # Update mem0 settings
-    updated_config["mem0"] = config.mem0.dict(exclude_none=True)
-    
+
+    # Update mem0 settings if provided
+    if config.mem0 is not None:
+        updated_config["mem0"] = config.mem0.dict(exclude_none=True)
+
+    save_config_to_db(db, updated_config)
+    reset_memory_client()
+    return updated_config
+
 
 @router.patch("/", response_model=ConfigSchema)
 async def patch_configuration(config_update: ConfigSchema, db: Session = Depends(get_db)):

--- a/openmemory/api/tests/test_config_router.py
+++ b/openmemory/api/tests/test_config_router.py
@@ -1,0 +1,129 @@
+"""Tests for the configuration API router.
+
+Covers the PUT /api/v1/config/ handler, which previously built the updated
+configuration but never persisted it, never reset the memory client, and
+returned None (causing a ResponseValidationError / HTTP 500 on every call).
+"""
+
+import os
+
+# Set dummy keys before any imports that trigger client initialization
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.database import Base, get_db
+from app.models import Config as ConfigModel
+from app.routers import config as config_router
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def db_session_factory():
+    """In-memory SQLite database shared across sessions via StaticPool."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    yield sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    engine.dispose()
+
+
+@pytest.fixture
+def reset_calls(monkeypatch):
+    """Stub out reset_memory_client and record invocations."""
+    calls = []
+    monkeypatch.setattr(config_router, "reset_memory_client", lambda: calls.append(1))
+    return calls
+
+
+@pytest.fixture
+def client(db_session_factory, reset_calls):
+    """TestClient wired to the config router with the test database."""
+    app = FastAPI()
+    app.include_router(config_router.router)
+
+    def override_get_db():
+        db = db_session_factory()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    return TestClient(app)
+
+
+def _sample_config():
+    return {
+        "openmemory": {"custom_instructions": "Remember dietary preferences."},
+        "mem0": {
+            "llm": {
+                "provider": "openai",
+                "config": {
+                    "model": "gpt-4o",
+                    "temperature": 0.2,
+                    "max_tokens": 1500,
+                    "api_key": "env:OPENAI_API_KEY",
+                },
+            }
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/v1/config/
+# ---------------------------------------------------------------------------
+
+class TestUpdateConfiguration:
+    def test_put_returns_updated_config(self, client):
+        """PUT should return the updated configuration, not None (500)."""
+        resp = client.put("/api/v1/config/", json=_sample_config())
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["mem0"]["llm"]["config"]["model"] == "gpt-4o"
+        assert data["openmemory"]["custom_instructions"] == "Remember dietary preferences."
+
+    def test_put_persists_config(self, client, db_session_factory):
+        """PUT should save the updated configuration to the database."""
+        client.put("/api/v1/config/", json=_sample_config())
+
+        db = db_session_factory()
+        try:
+            stored = db.query(ConfigModel).filter(ConfigModel.key == "main").first()
+            assert stored is not None
+            assert stored.value["mem0"]["llm"]["config"]["model"] == "gpt-4o"
+        finally:
+            db.close()
+
+        # And a subsequent GET reflects the update
+        resp = client.get("/api/v1/config/")
+        assert resp.status_code == 200
+        assert resp.json()["mem0"]["llm"]["config"]["model"] == "gpt-4o"
+
+    def test_put_resets_memory_client(self, client, reset_calls):
+        """PUT should reset the memory client so the new config takes effect."""
+        client.put("/api/v1/config/", json=_sample_config())
+        assert len(reset_calls) == 1
+
+    def test_put_without_mem0_section(self, client):
+        """PUT with only openmemory settings should not fail on the absent mem0 key."""
+        resp = client.put(
+            "/api/v1/config/",
+            json={"openmemory": {"custom_instructions": "Only openmemory."}},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["openmemory"]["custom_instructions"] == "Only openmemory."
+        # mem0 section keeps its existing (default) values
+        assert data["mem0"]["llm"]["provider"] == "openai"


### PR DESCRIPTION
## Linked Issue

Closes #6074

## Description

`PUT /api/v1/config/` in the OpenMemory API currently 500s on every request. The `update_configuration` handler builds `updated_config` but never calls `save_config_to_db()`, never calls `reset_memory_client()`, and has no `return` — so nothing is persisted and the handler returns `None`, which fails validation against `response_model=ConfigSchema` (`ResponseValidationError` → HTTP 500).

This PR completes the handler following the exact pattern already used by the `PATCH /api/v1/config/` handler directly below it:

- save the merged configuration with `save_config_to_db()`
- call `reset_memory_client()` so the running memory client picks up the new configuration
- return the updated configuration

It also fixes an adjacent defect in the same handler: `config.mem0.dict(...)` was called unconditionally even though `mem0` is `Optional` in `ConfigSchema`, so a PUT containing only `openmemory` settings would have raised `AttributeError`. The `mem0` section is now only replaced when provided, mirroring the existing `openmemory` guard.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added `openmemory/api/tests/test_config_router.py` with regression tests that fail without this fix:

- PUT returns the updated configuration (previously: 500)
- PUT persists the configuration to the database (previously: silently dropped)
- PUT resets the memory client (previously: never called)
- PUT with only `openmemory` settings works and preserves the existing `mem0` section (previously: `AttributeError`)

Manually verified against a docker-compose OpenMemory deployment: with this fix applied, `PUT /api/v1/config/` returns 200 with the updated config and the change persists.

Note: `tests/test_mcp_server.py::TestRouteRegistration` (3 tests) fails identically on an unmodified `main` checkout in my environment — pre-existing and unrelated to this change. All other tests, including the new ones, pass.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
