### PR TITLE
fix: mount Qdrant volume at /qdrant/storage in OpenMemory docker-compose

### DIFF
--- a/openmemory/docker-compose.yml
+++ b/openmemory/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     ports:
       - "6333:6333"
     volumes:
-      - mem0_storage:/mem0/storage
+      - mem0_storage:/qdrant/storage
   openmemory-mcp:
     image: mem0/openmemory-mcp
     build: api/


### PR DESCRIPTION
## Linked Issue

Closes #6075

## Description

`openmemory/docker-compose.yml` mounts the `mem0_storage` named volume into the Qdrant container at `/mem0/storage`, but Qdrant's default storage path is `/qdrant/storage`. Qdrant therefore writes all collections and vectors into the ephemeral container layer, and every `docker compose down` (or container recreation after an image pull) silently destroys all vector data — the named volume stays empty the whole time.

This PR mounts the volume at `/qdrant/storage`, so vector data actually lands in the named volume and survives container recreation.

Note for existing deployments: any data currently sitting in a running container's layer is not migrated by this change — it was already going to be lost on the next `down`. After this fix, data added going forward persists.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

No unit tests — one-line infrastructure config change. Manually verified on a docker-compose OpenMemory deployment:

1. With the fix applied, `docker compose up -d`, added memories, confirmed Qdrant data appears in the `mem0_storage` volume (`docker run --rm -v openmemory_mem0_storage:/v alpine ls /v` shows `collections/`, `raft_state.json`, ...)
2. `docker compose down && docker compose up -d` — collections and vectors survive

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (N/A — compose config)
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
