### PR TITLE
fix(openmemory): validate ollama_base_url to prevent SSRF

### DIFF
--- a/openmemory/api/app/routers/config.py
+++ b/openmemory/api/app/routers/config.py
@@ -3,11 +3,23 @@ from typing import Any, Dict, Optional
 from app.database import get_db
 from app.models import Config as ConfigModel
 from app.utils.memory import reset_memory_client
+from app.utils.url_validation import UnsafeURLError, validate_public_base_url
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from sqlalchemy.orm import Session
 
 router = APIRouter(prefix="/api/v1/config", tags=["config"])
+
+
+def _validate_ollama_base_url(value: Optional[str]) -> Optional[str]:
+    """Reject ollama_base_url values that could enable SSRF (issue #6081)."""
+    if value is None:
+        return value
+    try:
+        return validate_public_base_url(value)
+    except UnsafeURLError as exc:
+        raise ValueError(str(exc)) from exc
+
 
 class LLMConfig(BaseModel):
     model: str = Field(..., description="LLM model name")
@@ -15,6 +27,8 @@ class LLMConfig(BaseModel):
     max_tokens: int = Field(..., description="Maximum tokens to generate")
     api_key: Optional[str] = Field(None, description="API key or 'env:API_KEY' to use environment variable")
     ollama_base_url: Optional[str] = Field(None, description="Base URL for Ollama server (e.g., http://host.docker.internal:11434)")
+
+    _validate_ollama_base_url = field_validator("ollama_base_url")(_validate_ollama_base_url)
 
 class LLMProvider(BaseModel):
     provider: str = Field(..., description="LLM provider name")
@@ -24,6 +38,8 @@ class EmbedderConfig(BaseModel):
     model: str = Field(..., description="Embedder model name")
     api_key: Optional[str] = Field(None, description="API key or 'env:API_KEY' to use environment variable")
     ollama_base_url: Optional[str] = Field(None, description="Base URL for Ollama server (e.g., http://host.docker.internal:11434)")
+
+    _validate_ollama_base_url = field_validator("ollama_base_url")(_validate_ollama_base_url)
 
 class EmbedderProvider(BaseModel):
     provider: str = Field(..., description="Embedder provider name")

--- a/openmemory/api/app/utils/url_validation.py
+++ b/openmemory/api/app/utils/url_validation.py
@@ -1,0 +1,88 @@
+"""URL validation helpers to mitigate SSRF via attacker-controlled provider URLs.
+
+The OpenMemory config API accepts an ``ollama_base_url`` that the server later
+dials when the memory client is used. Without validation, a caller can point it
+at internal-only addresses (e.g. the cloud metadata endpoint
+``http://169.254.169.254/``) and turn the server into an SSRF proxy. See
+https://github.com/mem0ai/mem0/issues/6081.
+
+These helpers enforce a scheme allowlist and reject hostnames that resolve to
+private, loopback, link-local, or otherwise non-public IP ranges.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+# Only plain HTTP(S) provider URLs are meaningful for Ollama-style endpoints.
+ALLOWED_SCHEMES = ("http", "https")
+
+
+class UnsafeURLError(ValueError):
+    """Raised when a provided URL is malformed or points at a non-public host."""
+
+
+def _is_disallowed_ip(ip: ipaddress._BaseAddress) -> bool:
+    """Return True when the address is not a routable public address."""
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
+
+
+def validate_public_base_url(url: str) -> str:
+    """Validate that ``url`` is an http(s) URL pointing at a public host.
+
+    Returns the URL unchanged when it is safe. Raises :class:`UnsafeURLError`
+    when the scheme is not allowed, the host is missing, or the host resolves
+    to a private/loopback/link-local/reserved address (SSRF guard).
+    """
+    if not isinstance(url, str) or not url.strip():
+        raise UnsafeURLError("URL must be a non-empty string")
+
+    parsed = urlparse(url)
+
+    if parsed.scheme.lower() not in ALLOWED_SCHEMES:
+        raise UnsafeURLError(
+            f"URL scheme '{parsed.scheme}' is not allowed; "
+            f"use one of {ALLOWED_SCHEMES}"
+        )
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise UnsafeURLError("URL must include a host")
+
+    # If the host is a literal IP, validate it directly.
+    try:
+        ip = ipaddress.ip_address(hostname)
+    except ValueError:
+        ip = None
+
+    if ip is not None:
+        if _is_disallowed_ip(ip):
+            raise UnsafeURLError(
+                f"URL host '{hostname}' resolves to a non-public address range"
+            )
+        return url
+
+    # Otherwise resolve the hostname and check every returned address.
+    try:
+        addr_infos = socket.getaddrinfo(hostname, parsed.port or None)
+    except socket.gaierror as exc:
+        raise UnsafeURLError(f"URL host '{hostname}' could not be resolved") from exc
+
+    for family, _type, _proto, _canonname, sockaddr in addr_infos:
+        resolved = ipaddress.ip_address(sockaddr[0])
+        if _is_disallowed_ip(resolved):
+            raise UnsafeURLError(
+                f"URL host '{hostname}' resolves to a non-public address "
+                f"({resolved})"
+            )
+
+    return url

--- a/openmemory/api/tests/test_config_url_validation.py
+++ b/openmemory/api/tests/test_config_url_validation.py
@@ -1,0 +1,80 @@
+"""Tests for the SSRF guard on ollama_base_url in the OpenMemory config API.
+
+Regression coverage for https://github.com/mem0ai/mem0/issues/6081: the
+config endpoints accepted an arbitrary ``ollama_base_url`` with no scheme or
+IP-range validation, allowing an unauthenticated caller to point the server at
+internal addresses (e.g. the cloud metadata endpoint).
+"""
+
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+import pytest
+from pydantic import ValidationError
+
+from app.routers.config import EmbedderConfig, LLMConfig
+from app.utils.url_validation import UnsafeURLError, validate_public_base_url
+
+
+# ---------------------------------------------------------------------------
+# validate_public_base_url unit tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://169.254.169.254/latest/meta-data/",  # AWS IMDS (the reported PoC)
+        "http://127.0.0.1:11434",  # loopback
+        "http://localhost:11434",  # loopback by name
+        "http://10.0.0.5:11434",  # private RFC1918
+        "http://192.168.1.10:11434",  # private RFC1918
+        "http://172.16.0.1:11434",  # private RFC1918
+        "http://[::1]:11434",  # IPv6 loopback
+        "file:///etc/passwd",  # disallowed scheme
+        "ftp://example.com",  # disallowed scheme
+        "not-a-url",  # no scheme/host
+        "",  # empty
+    ],
+)
+def test_validate_public_base_url_rejects_unsafe(url):
+    with pytest.raises(UnsafeURLError):
+        validate_public_base_url(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://8.8.8.8:11434",  # public IP literal
+        "https://1.1.1.1",  # public IP literal (no DNS needed)
+    ],
+)
+def test_validate_public_base_url_allows_public(url):
+    assert validate_public_base_url(url) == url
+
+
+# ---------------------------------------------------------------------------
+# pydantic model integration
+# ---------------------------------------------------------------------------
+
+def test_llm_config_rejects_ssrf_ollama_url():
+    with pytest.raises(ValidationError):
+        LLMConfig(
+            model="llama3.1",
+            temperature=0.1,
+            max_tokens=2000,
+            ollama_base_url="http://169.254.169.254/latest/meta-data/",
+        )
+
+
+def test_embedder_config_rejects_ssrf_ollama_url():
+    with pytest.raises(ValidationError):
+        EmbedderConfig(
+            model="nomic-embed-text",
+            ollama_base_url="http://127.0.0.1:11434",
+        )
+
+
+def test_llm_config_allows_none_ollama_url():
+    cfg = LLMConfig(model="gpt-4o-mini", temperature=0.1, max_tokens=2000)
+    assert cfg.ollama_base_url is None


### PR DESCRIPTION
## Summary

- Adds scheme + IP-range validation for `ollama_base_url` in the OpenMemory config API.
- Blocks unauthenticated SSRF against internal addresses (e.g. cloud metadata endpoint).

## Motivation

Closes #6081.

The config endpoints (`PUT /api/v1/config/mem0/llm`, `.../embedder`) accepted an arbitrary `ollama_base_url` with **no scheme allowlist and no IP-range validation**. A caller could set it to an internal address — the reported PoC used `http://169.254.169.254/latest/meta-data/` — and the server would issue an outbound HTTP request there on the next memory operation, turning it into an SSRF proxy.

## Fix

- New `app/utils/url_validation.py` with `validate_public_base_url()`:
  - Enforces an `http`/`https` scheme allowlist.
  - Rejects hosts (literal IPs *and* resolved hostnames) that fall in private, loopback, link-local, reserved, multicast, or unspecified ranges.
- Wired into `LLMConfig` and `EmbedderConfig` via a pydantic `field_validator`, so unsafe values are rejected at the API boundary (422) instead of being stored and later dialed.

`None` remains valid (the field is optional), so existing configs that don't set an Ollama URL are unaffected.

## Verification

- `python -m pytest tests/test_config_url_validation.py` — **16 passed**
  - Covers the reported IMDS PoC, loopback (v4/v6), RFC1918 private ranges, disallowed schemes (`file://`, `ftp://`), malformed input, and acceptance of public IP literals.
- Model-level integration tests confirm `LLMConfig`/`EmbedderConfig` raise `ValidationError` for unsafe URLs.

## Scope note

This PR addresses the **SSRF** portion of #6081. The broader missing-authentication concern (and API-key exposure) is tracked separately in #6080 and is intentionally out of scope here to keep the diff focused.