### PR TITLE
fix(llms): classify gpt-5 dash family (gpt-5-mini) as reasoning model

### DIFF
--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -77,6 +77,18 @@ class LLMBase(ABC):
         if any(base_model.startswith(prefix) for prefix in ["o1-", "o1.", "o3-", "o3."]):
             return True
 
+        # Match the original GPT-5 dash family (gpt-5-mini, gpt-5-nano and their
+        # dated variants like gpt-5-mini-2025-08-07). These are reasoning models
+        # that reject a non-default temperature. This must NOT match the newer
+        # dot-versioned models (gpt-5.4-mini) which support temperature, hence
+        # the explicit "gpt-5-" (dash) prefix rather than a bare "gpt-5" substring.
+        #
+        # Exclude the "gpt-5-chat" family (gpt-5-chat, gpt-5-chat-latest): these
+        # are the non-reasoning chat variants that DO accept a custom temperature,
+        # so they must stay on the temperature path.
+        if base_model.startswith("gpt-5-") and not base_model.startswith("gpt-5-chat"):
+            return True
+
         return False
 
     def _uses_max_completion_tokens(self, model: str) -> bool:

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -323,11 +323,48 @@ def test_is_reasoning_model_classification(mock_openai_client):
     assert llm._is_reasoning_model("o1-2024-12-17") is True
     assert llm._is_reasoning_model("openai/o3-mini") is True
 
+    # GPT-5 dash family — reasoning models that reject non-default temperature
+    # (regression for https://github.com/mem0ai/mem0/issues/6085)
+    assert llm._is_reasoning_model("gpt-5-mini") is True
+    assert llm._is_reasoning_model("gpt-5-nano") is True
+    assert llm._is_reasoning_model("gpt-5-mini-2025-08-07") is True
+    assert llm._is_reasoning_model("openai/gpt-5-mini") is True
+
     # Non-reasoning models — should return False
     assert llm._is_reasoning_model("gpt-5.4-mini") is False
     assert llm._is_reasoning_model("gpt-5.4") is False
+    # gpt-5-chat family is the non-reasoning chat variant and DOES accept a
+    # custom temperature, so the gpt-5- dash rule must not strip it.
+    assert llm._is_reasoning_model("gpt-5-chat") is False
+    assert llm._is_reasoning_model("gpt-5-chat-latest") is False
+    assert llm._is_reasoning_model("openai/gpt-5-chat") is False
     assert llm._is_reasoning_model("gpt-4.1") is False
     assert llm._is_reasoning_model("gpt-4.1-nano-2025-04-14") is False
+
+
+def test_default_gpt5_mini_omits_temperature(mock_openai_client):
+    """Default OSS config must not send temperature for the resolved gpt-5-mini.
+
+    Regression test for https://github.com/mem0ai/mem0/issues/6085: with all
+    defaults, ``model`` resolves to ``gpt-5-mini`` (a reasoning model that
+    rejects any non-default temperature). Previously the default temperature
+    0.1 was still sent, so every add() failed LLM extraction and silently
+    stored nothing. The dash family must now be classified as reasoning so
+    temperature is stripped.
+    """
+    config = OpenAIConfig(temperature=0.1)  # model=None -> resolves to gpt-5-mini
+    llm = OpenAILLM(config)
+    assert llm.config.model == "gpt-5-mini"
+
+    messages = [{"role": "user", "content": "Hello"}]
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Response"))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    call_kwargs = mock_openai_client.chat.completions.create.call_args
+    assert "temperature" not in call_kwargs[1]
 
 
 def test_is_reasoning_model_explicit_override(mock_openai_client):


### PR DESCRIPTION
## Summary

- Treat the `gpt-5-mini` / `gpt-5-nano` dash family as reasoning models so temperature is stripped.
- Fixes the default OSS config silently storing nothing on every `add()`.

## Motivation

Closes #6085.

The default OSS config leaves `model=None`, which resolves to `gpt-5-mini` inside `mem0/llms/openai.py`. `gpt-5-mini` is a reasoning model that rejects any non-default `temperature`, but `_is_reasoning_model` only matched the bare `"gpt-5"` name and the `o1-`/`o3-` prefixes — **not** the `gpt-5-mini`/`gpt-5-nano` dash family. So the default `temperature=0.1` was still sent, the OpenAI API returned:

```
400 - Unsupported value: 'temperature' does not support 0.1 with this model. Only the default (1) value is supported.
```

The error was caught and logged as `LLM extraction failed`, and `add()` returned without storing anything — a silent failure that looks like a retrieval-quality problem. A brand-new user following the quickstart gets empty search results with no visible error.

## Fix

Add a `"gpt-5-"` (dash) prefix check in `_is_reasoning_model`. This classifies `gpt-5-mini`, `gpt-5-nano`, and their dated variants (e.g. `gpt-5-mini-2025-08-07`) as reasoning models, so `temperature` is dropped.

Crucially, it uses an explicit `gpt-5-` **dash** prefix rather than a bare `gpt-5` substring, so it does **not** match the newer dot-versioned `gpt-5.4-mini`, which supports temperature (behavior preserved from #4738).

## Verification

- `python -m pytest tests/llms/test_openai.py -k "reasoning or gpt5 or default_gpt5"` — **10 passed**
  - Extended `test_is_reasoning_model_classification` with the dash family (True) and dot-versioned models (still False).
  - Added `test_default_gpt5_mini_omits_temperature` proving the all-defaults config resolves to `gpt-5-mini` and no longer sends `temperature`.

## Scope note

3 pre-existing failures in `test_openai.py` (`test_openai_llm_base_url`, `test_store_sent_when_explicitly_*`) reproduce on clean `main` without this change and are unrelated (installed `openai` SDK `store`-param behavior). They are intentionally not touched here.