### PR TITLE
feat(embeddings): add native embed_batch to FastEmbed provider

### DIFF
--- a/mem0/embeddings/fastembed.py
+++ b/mem0/embeddings/fastembed.py
@@ -18,6 +18,17 @@ class FastEmbedEmbedding(EmbeddingBase):
         if not self.config.embedding_dims:
             self.config.embedding_dims = self.dense_model.embedding_size
 
+    def embed_batch(self, texts, memory_action="add"):
+        if not texts:
+            return []
+        embeddings = list(self.dense_model.embed(texts))
+        if len(embeddings) != len(texts):
+            raise ValueError(
+                f"FastEmbed embed_batch() returned {len(embeddings)} embeddings for {len(texts)} texts"
+                f" using model '{self.config.model}'"
+            )
+        return embeddings
+
     def embed(self, text, memory_action: Optional[Literal["add", "search", "update"]] = None):
         """
         Convert the text to embeddings using FastEmbed running in the Onnx runtime

--- a/tests/embeddings/test_fastembed_embeddings.py
+++ b/tests/embeddings/test_fastembed_embeddings.py
@@ -35,12 +35,49 @@ def test_embed_with_jina_model(mock_fastembed_client):
 def test_embed_removes_newlines(mock_fastembed_client):
     config = BaseEmbedderConfig(model="jinaai/jina-embeddings-v2-base-en", embedding_dims=768)
     embedder = FastEmbedEmbedding(config)
-    
+
     mock_embedding = np.array([0.7, 0.8, 0.9])
     mock_fastembed_client.embed.return_value = iter([mock_embedding])
-    
+
     text_with_newlines = "Hello\nworld"
     embedding = embedder.embed(text_with_newlines)
-    
+
     mock_fastembed_client.embed.assert_called_once_with("Hello world")
     assert list(embedding) == [0.7, 0.8, 0.9]
+
+
+def test_embed_batch_single_call(mock_fastembed_client):
+    config = BaseEmbedderConfig(model="jinaai/jina-embeddings-v2-base-en", embedding_dims=768)
+    embedder = FastEmbedEmbedding(config)
+
+    emb0 = np.array([0.1, 0.2, 0.3])
+    emb1 = np.array([0.4, 0.5, 0.6])
+    mock_fastembed_client.embed.return_value = iter([emb0, emb1])
+
+    texts = ["First text.", "Second text."]
+    result = embedder.embed_batch(texts)
+
+    mock_fastembed_client.embed.assert_called_once_with(texts)
+    assert len(result) == 2
+    assert list(result[0]) == [0.1, 0.2, 0.3]
+    assert list(result[1]) == [0.4, 0.5, 0.6]
+
+
+def test_embed_batch_empty_list(mock_fastembed_client):
+    config = BaseEmbedderConfig(model="jinaai/jina-embeddings-v2-base-en", embedding_dims=768)
+    embedder = FastEmbedEmbedding(config)
+
+    result = embedder.embed_batch([])
+
+    assert result == []
+    mock_fastembed_client.embed.assert_not_called()
+
+
+def test_embed_batch_count_mismatch_raises(mock_fastembed_client):
+    config = BaseEmbedderConfig(model="jinaai/jina-embeddings-v2-base-en", embedding_dims=768)
+    embedder = FastEmbedEmbedding(config)
+
+    mock_fastembed_client.embed.return_value = iter([np.array([0.1, 0.2, 0.3])])
+
+    with pytest.raises(ValueError, match="returned 1 embeddings for 2 texts"):
+        embedder.embed_batch(["first text", "second text"])


### PR DESCRIPTION
FastEmbedEmbedding fell back to the base class embed_batch(), calling embed() once per text. TextEmbedding.embed() accepts a list natively, so this is one call instead of N.

5 tests pass, ruff clean.