### PR TITLE
fix: change VectorStoreConfig.config from Optional[Dict] to Optional[Any]

### DIFF
--- a/mem0/vector_stores/configs.py
+++ b/mem0/vector_stores/configs.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -8,7 +8,7 @@ class VectorStoreConfig(BaseModel):
         description="Provider of the vector store (e.g., 'qdrant', 'chroma', 'upstash_vector')",
         default="qdrant",
     )
-    config: Optional[Dict] = Field(description="Configuration for the specific vector store", default=None)
+    config: Optional[Any] = Field(description="Configuration for the specific vector store", default=None)
 
     _provider_configs: Dict[str, str] = {
         "qdrant": "QdrantConfig",


### PR DESCRIPTION
## Description

`VectorStoreConfig.config` is declared as `Optional[Dict]`, but the `@model_validator(mode="after")` in `validate_and_create_config` reassigns it to a provider-specific config object (e.g. `QdrantConfig`, `ChromaDbConfig`, etc.). 

Pydantic v2 rejects this type mismatch on any code path that re-validates the field — serialization, `.model_dump()`, or any library method that triggers internal pydantic validation — raising:

```
1 validation error for VectorStoreConfig
config
  Input should be a valid dictionary [type=dict_type, input_value=QdrantConfig(...), input_type=QdrantConfig]
```

This breaks every vector store operation (search, add, update) when the config has been constructed with a typed config object instead of a raw dict.

## Fix

Change the field type from `Optional[Dict]` to `Optional[Any]` in `mem0/vector_stores/configs.py`. The `@model_validator` already handles construction of the correct typed config class — this just makes the field annotation match reality.

## Impact

All vector store providers are affected (Qdrant, Chroma, PGVector, Pinecone, MongoDB, Milvus, etc.). This is a runtime-visible regression for any consumer using `MemoryConfig(vector_store=VectorStoreConfig(provider="qdrant", config=QdrantConfig(...)))` — including the mem0-oss memory plugin in Hermes Agent, LangChain integrations, and any direct library user.

## Testing

- ✅ `VectorStoreConfig(provider="qdrant", config=QdrantConfig(path="/tmp/qdrant", collection_name="test"))` now validates cleanly
- ✅ Search, add, and list operations work end-to-end after the fix
- ✅ No change to the public API — `Dict`/`QdrantConfig` inputs both continue to work via the model_validator
