### PR TITLE
fix(openmemory): use top_k for MCP memory search

### DIFF
--- a/openmemory/api/app/mcp_server.py
+++ b/openmemory/api/app/mcp_server.py
@@ -177,9 +177,9 @@ async def search_memory(query: str) -> str:
             embeddings = memory_client.embedding_model.embed(query, "search")
 
             hits = memory_client.vector_store.search(
-                query=query, 
-                vectors=embeddings, 
-                limit=10, 
+                query=query,
+                vectors=embeddings,
+                top_k=10,
                 filters=filters,
             )
 

--- a/openmemory/api/tests/test_mcp_server.py
+++ b/openmemory/api/tests/test_mcp_server.py
@@ -14,6 +14,7 @@ import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
+from app import mcp_server
 from app.mcp_server import client_name_var, mcp, mcp_router, user_id_var
 
 # MCP Streamable HTTP requires the Accept header to include application/json.
@@ -234,6 +235,80 @@ class TestStreamableHTTPProtocol:
         )
         ct = resp.headers.get("content-type", "")
         assert "application/json" in ct
+
+
+# ---------------------------------------------------------------------------
+# MCP tools — memory search behavior
+# ---------------------------------------------------------------------------
+
+class TestMCPMemorySearch:
+    """Verify search_memory calls the vector store through the project contract."""
+
+    @pytest.mark.asyncio
+    async def test_search_memory_uses_top_k_for_vector_store(self, monkeypatch):
+        """search_memory should pass top_k, not the unsupported limit keyword."""
+        captured = {}
+
+        class FakeQuery:
+            def filter(self, *_args, **_kwargs):
+                return self
+
+            def all(self):
+                return []
+
+        class FakeSession:
+            def query(self, *_args, **_kwargs):
+                return FakeQuery()
+
+            def commit(self):
+                pass
+
+            def close(self):
+                pass
+
+        class FakeEmbeddingModel:
+            def embed(self, query, mode):
+                captured["embedding"] = (query, mode)
+                return [0.1, 0.2, 0.3]
+
+        class FakeVectorStore:
+            def search(self, **kwargs):
+                captured["search_kwargs"] = kwargs
+                return []
+
+        fake_memory_client = type(
+            "FakeMemoryClient",
+            (),
+            {
+                "embedding_model": FakeEmbeddingModel(),
+                "vector_store": FakeVectorStore(),
+            },
+        )()
+
+        user = type("User", (), {"id": "user-db-id"})()
+        app = type("App", (), {"id": "app-db-id"})()
+
+        monkeypatch.setattr(mcp_server, "get_memory_client_safe", lambda: fake_memory_client)
+        monkeypatch.setattr(mcp_server, "SessionLocal", FakeSession)
+        monkeypatch.setattr(mcp_server, "get_user_and_app", lambda *_args, **_kwargs: (user, app))
+
+        user_token = user_id_var.set("alice")
+        client_token = client_name_var.set("test-client")
+        try:
+            result = await mcp_server.search_memory("pizza")
+        finally:
+            user_id_var.reset(user_token)
+            client_name_var.reset(client_token)
+
+        assert result == '{\n  "results": []\n}'
+        assert captured["embedding"] == ("pizza", "search")
+        assert captured["search_kwargs"] == {
+            "query": "pizza",
+            "vectors": [0.1, 0.2, 0.3],
+            "top_k": 10,
+            "filters": {"user_id": "alice"},
+        }
+        assert "limit" not in captured["search_kwargs"]
 
 
 # ---------------------------------------------------------------------------

--- a/openmemory/api/tests/test_mcp_server.py
+++ b/openmemory/api/tests/test_mcp_server.py
@@ -244,11 +244,8 @@ class TestStreamableHTTPProtocol:
 class TestMCPMemorySearch:
     """Verify search_memory calls the vector store through the project contract."""
 
-    @pytest.mark.asyncio
-    async def test_search_memory_uses_top_k_for_vector_store(self, monkeypatch):
-        """search_memory should pass top_k, not the unsupported limit keyword."""
-        captured = {}
-
+    @staticmethod
+    def _patch_search_dependencies(monkeypatch, captured):
         class FakeQuery:
             def filter(self, *_args, **_kwargs):
                 return self
@@ -292,6 +289,24 @@ class TestMCPMemorySearch:
         monkeypatch.setattr(mcp_server, "SessionLocal", FakeSession)
         monkeypatch.setattr(mcp_server, "get_user_and_app", lambda *_args, **_kwargs: (user, app))
 
+    @staticmethod
+    def _assert_search_uses_top_k(captured):
+        assert captured["embedding"] == ("pizza", "search")
+        assert captured["search_kwargs"] == {
+            "query": "pizza",
+            "vectors": [0.1, 0.2, 0.3],
+            "top_k": 10,
+            "filters": {"user_id": "alice"},
+        }
+        assert "limit" not in captured["search_kwargs"]
+
+    @pytest.mark.asyncio
+    async def test_search_memory_uses_top_k_for_vector_store(self, monkeypatch):
+        """search_memory should pass top_k, not the unsupported limit keyword."""
+        captured = {}
+
+        self._patch_search_dependencies(monkeypatch, captured)
+
         user_token = user_id_var.set("alice")
         client_token = client_name_var.set("test-client")
         try:
@@ -301,14 +316,33 @@ class TestMCPMemorySearch:
             client_name_var.reset(client_token)
 
         assert result == '{\n  "results": []\n}'
-        assert captured["embedding"] == ("pizza", "search")
-        assert captured["search_kwargs"] == {
-            "query": "pizza",
-            "vectors": [0.1, 0.2, 0.3],
-            "top_k": 10,
-            "filters": {"user_id": "alice"},
-        }
-        assert "limit" not in captured["search_kwargs"]
+        self._assert_search_uses_top_k(captured)
+
+    @pytest.mark.asyncio
+    async def test_search_memory_uses_top_k_through_streamable_http(self, client, monkeypatch):
+        """tools/call for search_memory should forward top_k through the HTTP MCP transport."""
+        captured = {}
+        self._patch_search_dependencies(monkeypatch, captured)
+
+        init_resp = await client.post(
+            "/mcp/test-client/http/alice",
+            json=_initialize_payload(),
+            headers=MCP_HEADERS,
+        )
+        assert init_resp.status_code == 200
+
+        resp = await client.post(
+            "/mcp/test-client/http/alice",
+            json=_jsonrpc("tools/call", {"name": "search_memory", "arguments": {"query": "pizza"}}, req_id=2),
+            headers=MCP_HEADERS,
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["jsonrpc"] == "2.0"
+        assert data["id"] == 2
+        assert "result" in data
+        self._assert_search_uses_top_k(captured)
 
 
 # ---------------------------------------------------------------------------

--- a/openmemory/api/tests/test_mcp_server.py
+++ b/openmemory/api/tests/test_mcp_server.py
@@ -458,14 +458,14 @@ class TestStreamableHTTPResponses:
 class TestRouteRegistration:
     """Verify all expected routes are registered in the router."""
 
-    def test_sse_route_is_registered(self, test_app):
-        routes = [r.path for r in test_app.routes if hasattr(r, "path")]
+    def test_sse_route_is_registered(self):
+        routes = [r.path for r in mcp_router.routes if hasattr(r, "path")]
         assert "/mcp/{client_name}/sse/{user_id}" in routes
 
-    def test_sse_post_messages_route_is_registered(self, test_app):
-        routes = [r.path for r in test_app.routes if hasattr(r, "path")]
+    def test_sse_post_messages_route_is_registered(self):
+        routes = [r.path for r in mcp_router.routes if hasattr(r, "path")]
         assert "/mcp/messages/" in routes or "/mcp/{client_name}/sse/{user_id}/messages/" in routes
 
-    def test_streamable_http_route_is_registered(self, test_app):
-        routes = [r.path for r in test_app.routes if hasattr(r, "path")]
+    def test_streamable_http_route_is_registered(self):
+        routes = [r.path for r in mcp_router.routes if hasattr(r, "path")]
         assert "/mcp/{client_name}/http/{user_id}" in routes


### PR DESCRIPTION
## Linked Issue

Refs #6078

This PR fixes the `search_memory` part of #6078. It intentionally does not close the issue because #6078 also tracks a separate `list_memories` signature mismatch.

## Description

This PR fixes the `search_memory` portion of #6078 by aligning the OpenMemory MCP server with the vector store search contract. The MCP search path now passes `top_k=10` instead of the unsupported `limit=10` keyword when calling `memory_client.vector_store.search(...)`.

### What Problem This Solves

`search_memory` builds an embedding for the incoming MCP query, then calls the vector store directly through `memory_client.vector_store.search(...)`. The shared vector store interface expects the result-count parameter to be named `top_k`:

```python
search(query, vectors, top_k=5, filters=None)
```

Before this change, the OpenMemory MCP call site passed `limit=10` instead. As reported in #6078, this can fail at runtime against vector store implementations such as Qdrant with:

```text
TypeError: Qdrant.search() got an unexpected keyword argument 'limit'
```

That makes this an API contract mismatch between the OpenMemory MCP layer and the vector store layer: the MCP tool was forwarding a keyword that the vector store implementations do not accept.

This PR intentionally fixes only the `search_memory` failure. It does not close #6078 because that issue also tracks a separate `list_memories` / `get_all()` signature mismatch.
### Changes

- Change the OpenMemory MCP `search_memory` vector-store call from `limit=10` to `top_k=10`.
- Keep the existing query text, embedding generation, ACL-derived filtering, result formatting, and access-log behavior unchanged.
- Add a focused unit regression test for `search_memory` that verifies the MCP path forwards `top_k=10` and does not send `limit`.
- Add an ASGI-level MCP integration regression test that calls `search_memory` through the Streamable HTTP `tools/call` flow and verifies the vector-store call still receives `top_k=10`.
- Update the route-registration tests to inspect `mcp_router.routes` directly, matching where the MCP routes are registered before they are wrapped by the FastAPI test app.

### Evidence

The fixed call site now uses the vector store contract directly:

```python
hits = memory_client.vector_store.search(
    query=query,
    vectors=embeddings,
    top_k=10,
    filters=filters,
)
```

The focused regression test patches `search_memory` with a fake memory client, calls it with `"pizza"`, and asserts the vector store receives:

```python
{
    "query": "pizza",
    "vectors": [0.1, 0.2, 0.3],
    "top_k": 10,
    "filters": {"user_id": "alice"},
}
```

It also asserts:

```python
assert "limit" not in captured["search_kwargs"]
```

The integration regression test exercises the MCP Streamable HTTP transport with:

```text
initialize -> tools/call(search_memory, {"query": "pizza"})
```

and then verifies the same `top_k=10` vector-store call is made through the JSON-RPC tool path.

Local validation:

```bash
conda run -n prw-mem0-py312 python -m pytest openmemory/api/tests -q
```

Result:

```text
23 passed
```

Focused integration regression validation:

```bash
conda run -n prw-mem0-py312 python -m pytest openmemory/api/tests/test_mcp_server.py -k search_memory_uses_top_k_through_streamable_http -q
```

Result:

```text
1 passed, 22 deselected
```

Also checked:

```bash
git diff --check
```

Result: passed.

Docker-level validation was not run because the local Docker daemon is not running:

```text
failed to connect to the docker API at npipe:////./pipe/dockerDesktopLinuxEngine
```

### Possible call chain / impact

```text
MCP client search request
  -> Streamable HTTP /mcp/{client_name}/http/{user_id}
  -> JSON-RPC tools/call(search_memory)
  -> openmemory/api/app/mcp_server.py
  -> search_memory(query)
  -> memory_client.embedding_model.embed(query, "search")
  -> memory_client.vector_store.search(query=..., vectors=..., top_k=10, filters=...)
  -> vector store implementation such as Qdrant.search(...)
```

The affected path is OpenMemory MCP memory search. The practical impact is that MCP `search_memory` now uses the same keyword expected by `VectorStoreBase.search` and vector store implementations such as Qdrant.

This PR does not change `list_memories`, `memory_client.get_all(...)`, memory creation/update/delete behavior, ACL checks, embedding generation, or vector-store result ranking semantics.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [x] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Validation run locally:

```bash
conda run -n prw-mem0-py312 python -m pytest openmemory/api/tests -q
conda run -n prw-mem0-py312 python -m pytest openmemory/api/tests/test_mcp_server.py -k search_memory_uses_top_k_through_streamable_http -q
git diff --check
```

Results:

```text
openmemory/api/tests: 23 passed
Streamable HTTP search_memory integration regression: 1 passed, 22 deselected
git diff --check: passed
```

Docker-level validation was not run because Docker Desktop / the local Docker daemon is not currently available on this machine.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed