### PR TITLE
feat(embeddings): native embed_batch for FastEmbed

### DIFF
--- a/mem0/embeddings/fastembed.py
+++ b/mem0/embeddings/fastembed.py
@@ -30,3 +30,28 @@ class FastEmbedEmbedding(EmbeddingBase):
         text = text.replace("\n", " ")
         embeddings = list(self.dense_model.embed(text))
         return embeddings[0].tolist()
+
+    def embed_batch(self, texts, memory_action: Optional[Literal["add", "search", "update"]] = None):
+        """
+        Embed multiple texts in a single FastEmbed call.
+
+        fastembed's ``TextEmbedding.embed()`` accepts an iterable of strings
+        natively, so the whole batch is embedded in one pass instead of one
+        ``embed()`` call per text (the base-class fallback).
+
+        Args:
+            texts (list[str]): The texts to embed.
+            memory_action (optional): The type of embedding to use. Must be one of "add", "search", or "update". Defaults to None.
+        Returns:
+            list: A list of embedding vectors, one per input text.
+        """
+        if not texts:
+            return []
+        cleaned = [text.replace("\n", " ") for text in texts]
+        embeddings = list(self.dense_model.embed(cleaned))
+        if len(embeddings) != len(cleaned):
+            raise ValueError(
+                f"FastEmbed embed() returned {len(embeddings)} embeddings "
+                f"for {len(cleaned)} texts using model '{self.config.model}'"
+            )
+        return [emb.tolist() for emb in embeddings]

--- a/tests/embeddings/test_fastembed_embeddings.py
+++ b/tests/embeddings/test_fastembed_embeddings.py
@@ -44,3 +44,48 @@ def test_embed_removes_newlines(mock_fastembed_client):
     
     mock_fastembed_client.embed.assert_called_once_with("Hello world")
     assert list(embedding) == [0.7, 0.8, 0.9]
+
+def test_embed_batch_single_call(mock_fastembed_client):
+    """embed_batch should embed all texts in one native call, not N calls."""
+    config = BaseEmbedderConfig(model="jinaai/jina-embeddings-v2-base-en", embedding_dims=768)
+    embedder = FastEmbedEmbedding(config)
+
+    mock_fastembed_client.embed.return_value = iter(
+        [np.array([0.1, 0.2]), np.array([0.3, 0.4]), np.array([0.5, 0.6])]
+    )
+
+    texts = ["first", "second", "third"]
+    embeddings = embedder.embed_batch(texts)
+
+    # A single call carrying the whole (newline-cleaned) batch.
+    mock_fastembed_client.embed.assert_called_once_with(texts)
+    assert [list(e) for e in embeddings] == [[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]
+
+
+def test_embed_batch_cleans_newlines(mock_fastembed_client):
+    config = BaseEmbedderConfig(model="jinaai/jina-embeddings-v2-base-en", embedding_dims=768)
+    embedder = FastEmbedEmbedding(config)
+
+    mock_fastembed_client.embed.return_value = iter([np.array([0.1]), np.array([0.2])])
+
+    embedder.embed_batch(["a\nb", "c\nd"])
+    mock_fastembed_client.embed.assert_called_once_with(["a b", "c d"])
+
+
+def test_embed_batch_empty_list(mock_fastembed_client):
+    config = BaseEmbedderConfig(model="jinaai/jina-embeddings-v2-base-en", embedding_dims=768)
+    embedder = FastEmbedEmbedding(config)
+
+    result = embedder.embed_batch([])
+    assert result == []
+    mock_fastembed_client.embed.assert_not_called()
+
+
+def test_embed_batch_count_mismatch_raises(mock_fastembed_client):
+    config = BaseEmbedderConfig(model="jinaai/jina-embeddings-v2-base-en", embedding_dims=768)
+    embedder = FastEmbedEmbedding(config)
+
+    # Model returns fewer embeddings than inputs -> must raise, not silently drop.
+    mock_fastembed_client.embed.return_value = iter([np.array([0.1, 0.2])])
+    with pytest.raises(ValueError):
+        embedder.embed_batch(["first text", "second text"])


### PR DESCRIPTION
## Summary

- `FastEmbedEmbedding.embed_batch()` now embeds an entire batch in a single native `fastembed` call instead of N sequential `embed()` calls.

## Motivation

Closes #6091.

`FastEmbedEmbedding` inherited the base-class `embed_batch()`, which loops and calls `embed()` once per text — N model invocations for a batch of N. fastembed's `TextEmbedding.embed()` accepts an iterable of strings natively, so the batch can be embedded in one pass. This is the same optimisation already applied to Ollama (#5415) and five other providers (#5609).

## Fix

Override `embed_batch()` in `mem0/embeddings/fastembed.py`:
- single `self.dense_model.embed(texts)` call
- per-text newline cleaning (consistent with `embed()`)
- returns `[]` for empty input (no model call)
- raises `ValueError` when the returned embedding count != input count, so embeddings are never silently dropped

## Verification

- `pytest tests/embeddings/test_fastembed_embeddings.py` — 6 passed.
- Added tests: single-call batching (`embed` called once with the full list), newline cleaning, empty-input short-circuit, and count-mismatch raising. The mismatch test fails without the guard.