### PR TITLE
fix(ts-sdk): re-raise LLM extraction transport failures instead of returning []

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -74,6 +74,25 @@ import {
 import { getDefaultVectorStoreDbPath } from "../utils/sqlite";
 import { getOrCreateMem0UserId } from "../../../client/config";
 
+/**
+ * Raised when the LLM extraction call itself fails (provider/transport
+ * errors: rate limits, timeouts, connection errors), as opposed to the LLM
+ * responding successfully with an empty or unparseable result. Callers can
+ * catch this to distinguish "LLM unavailable" from "no facts extracted" and
+ * implement retry/fallback logic. Mirrors the Python SDK `LLMError` (see
+ * #5903 / #5878).
+ */
+export class LLMError extends Error {
+  readonly cause?: unknown;
+
+  constructor(message: string, options: { cause?: unknown } = {}) {
+    super(message);
+    this.name = "LLMError";
+    this.cause = options.cause;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
 // Entity params that must be passed via filters - check both snake_case and camelCase
 const ENTITY_PARAMS = [
   "user_id",
@@ -854,7 +873,7 @@ export class Memory {
       )) as string;
     } catch (e) {
       console.error("LLM extraction failed:", e);
-      return [];
+      throw new LLMError(`LLM extraction failed: ${e}`, { cause: e });
     }
 
     // Parse response

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -74,14 +74,6 @@ import {
 import { getDefaultVectorStoreDbPath } from "../utils/sqlite";
 import { getOrCreateMem0UserId } from "../../../client/config";
 
-/**
- * Raised when the LLM extraction call itself fails (provider/transport
- * errors: rate limits, timeouts, connection errors), as opposed to the LLM
- * responding successfully with an empty or unparseable result. Callers can
- * catch this to distinguish "LLM unavailable" from "no facts extracted" and
- * implement retry/fallback logic. Mirrors the Python SDK `LLMError` (see
- * #5903 / #5878).
- */
 export class LLMError extends Error {
   readonly cause?: unknown;
 
@@ -93,7 +85,7 @@ export class LLMError extends Error {
   }
 }
 
-// Entity params that must be passed via filters - check both snake_case and camelCase
+// Entity params that must be passed via filters check both snake_case and camelCase
 const ENTITY_PARAMS = [
   "user_id",
   "agent_id",

--- a/mem0-ts/src/oss/tests/memory.llm-error.test.ts
+++ b/mem0-ts/src/oss/tests/memory.llm-error.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Regression test for #6101 / #5903: LLM extraction transport failures
+ * (rate limits, timeouts, connection errors) must propagate as a typed
+ * `LLMError`, not be silently swallowed into an empty result. Mirrors the
+ * Python SDK regression test added in #5878
+ * (`test_llm_extraction_exception_is_reraised`).
+ */
+/// <reference types="jest" />
+import { Memory, LLMError } from "../src/memory";
+import type { SearchResult } from "../src/types";
+
+jest.setTimeout(15000);
+
+// Mock Google modules to prevent @google/genai crash in CI
+jest.mock("../src/embeddings/google", () => ({
+  GoogleEmbedder: jest.fn(),
+}));
+jest.mock("../src/llms/google", () => ({
+  GoogleLLM: jest.fn(),
+}));
+
+class _ProviderError extends Error {}
+
+jest.mock("../src/llms/openai", () => ({
+  OpenAILLM: jest.fn().mockImplementation(() => ({
+    generateResponse: jest
+      .fn()
+      .mockRejectedValue(new _ProviderError("429 rate limit")),
+  })),
+}));
+
+const mockEmbedding = new Array(1536).fill(0.1);
+jest.mock("../src/embeddings/openai", () => ({
+  OpenAIEmbedder: jest.fn().mockImplementation(() => ({
+    embed: jest.fn().mockResolvedValue(mockEmbedding),
+    embedBatch: jest
+      .fn()
+      .mockImplementation((texts: string[]) =>
+        Promise.resolve(texts.map(() => mockEmbedding)),
+      ),
+    embeddingDims: 1536,
+  })),
+}));
+
+function createMemory(): Memory {
+  return new Memory({
+    version: "v1.1",
+    embedder: {
+      provider: "openai",
+      config: { apiKey: "test-key", model: "text-embedding-3-small" },
+    },
+    vectorStore: {
+      provider: "memory",
+      config: {
+        collectionName: `test-llm-error-${Date.now()}`,
+        dimension: 1536,
+        dbPath: ":memory:",
+      },
+    },
+    llm: {
+      provider: "openai",
+      config: { apiKey: "test-key", model: "gpt-5-mini" },
+    },
+    historyDbPath: ":memory:",
+  });
+}
+
+describe("Memory - LLM extraction transport failures", () => {
+  let memory: Memory;
+  const userId = `llm_error_test_${Date.now()}`;
+
+  beforeAll(async () => {
+    memory = createMemory();
+  });
+
+  afterAll(async () => {
+    await memory.reset();
+  });
+
+  test("add() rejects with LLMError instead of returning an empty result", async () => {
+    await expect(
+      memory.add("this should trigger a provider failure", { userId }),
+    ).rejects.toBeInstanceOf(LLMError);
+  });
+
+  test("thrown LLMError preserves the original error as its cause", async () => {
+    let caught: unknown;
+    try {
+      const result: SearchResult = await memory.add("trigger failure again", {
+        userId,
+      });
+      // Should never reach here — fail loudly if the call resolves.
+      throw new Error(
+        `Expected add() to reject, but it resolved with: ${JSON.stringify(result)}`,
+      );
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(LLMError);
+    expect((caught as LLMError).cause).toBeInstanceOf(_ProviderError);
+    expect((caught as LLMError).message).toContain("429 rate limit");
+  });
+});


### PR DESCRIPTION
## Linked Issue

Closes #6101

## Description

`Memory.add()`'s LLM extraction step in the TypeScript OSS SDK caught *all* errors from `generateResponse` , including provider/transport failures (rate limits, timeouts, connection errors)  and swallowed them
by returning `[]`. This made "the LLM is unreachable" indistinguishable from "the LLM ran and extracted nothing," and callers had no way to detect or retry the former.

This mirrors the Python SDK bug already fixed by #5878 (tracked in #5903, which explicitly flagged this TS-side follow-up).

**Before** (`mem0-ts/src/oss/src/memory/index.ts:855-858`):

```ts
} catch (e) {
  console.error("LLM extraction failed:", e);
  return [];
}
```

**After:**

```ts
} catch (e) {
  console.error("LLM extraction failed:", e);
  throw new LLMError(`LLM extraction failed: ${e}`, { cause: e });
}
```

Adds a typed `LLMError` class (alongside the existing error-handling patterns in this file) so callers can distinguish a transport failure from a genuinely empty/invalid LLM response. The downstream JSON-parse failure path is untouched and still returns `[]`, since that case really is "no facts extracted," not a transport error.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added `mem0-ts/src/oss/tests/memory.llm-error.test.ts` with two regression tests mirroring the Python regression test added in #5878 (`test_llm_extraction_exception_is_reraised`):

- `add()` rejects with `LLMError` instead of resolving with an empty result
- the thrown `LLMError` preserves the original error as `.cause`

```
PASS src/oss/tests/memory.llm-error.test.ts
  Memory - LLM extraction transport failures
    ✓ add() rejects with LLMError instead of returning an empty result
    ✓ thrown LLMError preserves the original error as its cause
```

Also ran the full related suite with zero regressions (`memory.add`, `memory.validation`, `memory.crud`, `memory.init`,
`memory.entity-boost` — 80/80 passing), the full OSS suite (580/623 passing, the 43 failures are pre-existing Windows `EPERM` temp-dir issues in unrelated sqlite/vector-store tests, verified identical on unmodified `main`), `tsc --noEmit` (no new errors), and a `tsup` build (confirmed `LLMError` is correctly exported from the public `dist/oss/index.d.ts` surface).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed