### PR TITLE
feat(ts-sdk): add OpenSearch vector store provider

### DIFF
--- a/mem0-ts/package.json
+++ b/mem0-ts/package.json
@@ -114,6 +114,7 @@
     "@langchain/core": "^1.1.47",
     "@mistralai/mistralai": "^1.5.2",
     "@qdrant/js-client-rest": "^1.18.0",
+    "@opensearch-project/opensearch": "^3.0.0",
     "@supabase/supabase-js": "^2.49.1",
     "@types/jest": "29.5.14",
     "@types/pg": "8.11.0",

--- a/mem0-ts/pnpm-lock.yaml
+++ b/mem0-ts/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@mistralai/mistralai':
         specifier: ^1.5.2
         version: 1.15.1
+      '@opensearch-project/opensearch':
+        specifier: ^3.0.0
+        version: 3.6.0
       '@qdrant/js-client-rest':
         specifier: ^1.18.0
         version: 1.18.0(typescript@5.5.4)
@@ -662,6 +665,10 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@opensearch-project/opensearch@3.6.0':
+    resolution: {integrity: sha512-ow1A/Z7MBlNL/JZzTY4+M+8psiVh66g0Z7EQSl/qbT0U6zLBsVDYh6nvm8D4e4tIzQtn6ODbA2OsqYGvqZj76g==}
+    engines: {node: '>=14', yarn: ^1.22.10}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -1094,6 +1101,9 @@ packages:
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  aws4@1.13.2:
+    resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
 
   axios@1.17.0:
     resolution: {integrity: sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==}
@@ -1685,6 +1695,10 @@ packages:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
+  hpagent@1.2.0:
+    resolution: {integrity: sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==}
+    engines: {node: '>=14'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -1975,6 +1989,10 @@ packages:
   json-parse-even-better-errors@3.0.2:
     resolution: {integrity: sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  json11@2.0.2:
+    resolution: {integrity: sha512-HIrd50UPYmP6sqLuLbFVm75g16o0oZrVfxrsY0EEys22klz8mRoWlX9KAEDOSOR9Q34rcxsyC8oDveGrCz5uLQ==}
+    hasBin: true
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -2619,6 +2637,9 @@ packages:
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
+
+  secure-json-parse@2.7.0:
+    resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -3719,6 +3740,17 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@opensearch-project/opensearch@3.6.0':
+    dependencies:
+      aws4: 1.13.2
+      debug: 4.4.3(supports-color@5.5.0)
+      hpagent: 1.2.0
+      json11: 2.0.2
+      ms: 2.1.3
+      secure-json-parse: 2.7.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -4076,6 +4108,8 @@ snapshots:
   argparse@2.0.1: {}
 
   asynckit@0.4.0: {}
+
+  aws4@1.13.2: {}
 
   axios@1.17.0:
     dependencies:
@@ -4717,6 +4751,8 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
 
+  hpagent@1.2.0: {}
+
   html-escaper@2.0.2: {}
 
   http-proxy-agent@7.0.2:
@@ -5183,6 +5219,8 @@ snapshots:
   json-parse-even-better-errors@2.3.1: {}
 
   json-parse-even-better-errors@3.0.2: {}
+
+  json11@2.0.2: {}
 
   json5@2.2.3: {}
 
@@ -5832,6 +5870,8 @@ snapshots:
   safe-buffer@5.2.1: {}
 
   safe-stable-stringify@2.5.0: {}
+
+  secure-json-parse@2.7.0: {}
 
   semver@6.3.1: {}
 

--- a/mem0-ts/src/oss/src/utils/factory.ts
+++ b/mem0-ts/src/oss/src/utils/factory.ts
@@ -38,6 +38,7 @@ import { LangchainEmbedder } from "../embeddings/langchain";
 import { LangchainVectorStore } from "../vector_stores/langchain";
 import { AzureAISearch } from "../vector_stores/azure_ai_search";
 import { PGVector } from "../vector_stores/pgvector";
+import { OpenSearch } from "../vector_stores/opensearch";
 
 export class EmbedderFactory {
   static create(provider: string, config: EmbeddingConfig): Embedder {
@@ -116,6 +117,8 @@ export class VectorStoreFactory {
         return new AzureAISearch(config as any);
       case "pgvector":
         return new PGVector(config as any);
+      case "opensearch":
+        return new OpenSearch(config as any);
       default:
         throw new Error(`Unsupported vector store provider: ${provider}`);
     }

--- a/mem0-ts/src/oss/src/vector_stores/opensearch.ts
+++ b/mem0-ts/src/oss/src/vector_stores/opensearch.ts
@@ -1,0 +1,383 @@
+import { Client as OpenSearchClient } from "@opensearch-project/opensearch";
+import { AwsSigv4Signer } from "@opensearch-project/opensearch/aws";
+import { VectorStore } from "./base";
+import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
+
+interface OpenSearchConfig extends VectorStoreConfig {
+  /** OpenSearch host (default: "localhost"). */
+  host?: string;
+  /** OpenSearch port (default: 9200). */
+  port?: number;
+  /** Full connection URL (overrides host/port). */
+  url?: string;
+  /** HTTP auth credentials `[username, password]`. */
+  httpAuth?: [string, string];
+  /** AWS region — when set, requests are signed with Sigv4. */
+  awsRegion?: string;
+  /** AWS service name for Sigv4 signing (default: "es"). */
+  awsService?: string;
+  /** Whether to use SSL (default: true). */
+  useSSL?: boolean;
+  /** Whether to verify SSL certificates (default: true). */
+  verifyCerts?: boolean;
+  /** Index / collection name. */
+  collectionName: string;
+  /** Dimension of embedding vectors. */
+  embeddingModelDims: number;
+  /** Refresh after insert (default: false — see Python impl for why). */
+  autoRefresh?: boolean;
+}
+
+interface OpenSearchHit {
+  _id: string;
+  _score: number;
+  _source: {
+    id: string;
+    vector_field: number[];
+    payload: Record<string, any>;
+  };
+}
+
+const SAFE_FILTER_KEY = /^[a-zA-Z_][a-zA-Z0-9_.]*$/;
+
+function validateFilter(key: string, value: unknown): void {
+  if (typeof key !== "string" || !SAFE_FILTER_KEY.test(key)) {
+    throw new Error(`Invalid filter key: ${JSON.stringify(key)}`);
+  }
+  if (
+    typeof value !== "string" &&
+    typeof value !== "number" &&
+    typeof value !== "boolean"
+  ) {
+    throw new Error(
+      `Filter value for ${JSON.stringify(key)} must be string, number, or boolean, ` +
+        `got ${typeof value}`,
+    );
+  }
+}
+
+export class OpenSearch implements VectorStore {
+  private client: OpenSearchClient;
+  private readonly collectionName: string;
+  private readonly embeddingModelDims: number;
+  private readonly autoRefresh: boolean;
+
+  constructor(config: OpenSearchConfig) {
+    this.collectionName = config.collectionName;
+    this.embeddingModelDims = config.embeddingModelDims;
+    this.autoRefresh = config.autoRefresh ?? false;
+
+    const host = config.host ?? "localhost";
+    const port = config.port ?? 9200;
+    const useSSL = config.useSSL ?? true;
+    const verifyCerts = config.verifyCerts ?? true;
+
+    // Build connection node
+    const node: Record<string, any> = {
+      url: config.url ?? `${useSSL ? "https" : "http"}://${host}:${port}`,
+    };
+
+    // AWS Sigv4 signing
+    if (config.awsRegion) {
+      const region = config.awsRegion;
+      const service = config.awsService ?? "es";
+      const signer = AwsSigv4Signer({
+        region,
+        service,
+        // Access credentials are picked up from the environment
+        // (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN)
+        // or from the default credential provider chain.
+      });
+      Object.assign(node, signer);
+    }
+
+    const clientOptions: Record<string, any> = {
+      node,
+      ssl: {
+        rejectUnauthorized: verifyCerts,
+      },
+    };
+
+    if (config.httpAuth) {
+      clientOptions.auth = {
+        username: config.httpAuth[0],
+        password: config.httpAuth[1],
+      };
+    }
+
+    this.client = new OpenSearchClient(clientOptions);
+  }
+
+  /** Ensure the index exists with the correct k-NN mapping. */
+  async initialize(): Promise<void> {
+    const { body: exists } = await this.client.indices.exists({
+      index: this.collectionName,
+    });
+
+    if (!exists) {
+      await this.client.indices.create({
+        index: this.collectionName,
+        body: {
+          settings: {
+            index: { knn: true },
+          },
+          mappings: {
+            properties: {
+              vector_field: {
+                type: "knn_vector",
+                dimension: this.embeddingModelDims,
+                method: {
+                  engine: "nmslib",
+                  name: "hnsw",
+                  space_type: "cosinesimil",
+                },
+              },
+              id: { type: "keyword" },
+              payload: { type: "object" },
+            },
+          },
+        },
+      });
+    }
+  }
+
+  // ── VectorStore interface ─────────────────────────────────────────────
+
+  async insert(
+    vectors: number[][],
+    ids: string[],
+    payloads: Record<string, any>[],
+  ): Promise<void> {
+    for (let i = 0; i < vectors.length; i++) {
+      const vec = vectors[i];
+      if (!vec || vec.length === 0) {
+        throw new Error(
+          `Vector at index ${i} is empty. Expected dimension ${this.embeddingModelDims}.`,
+        );
+      }
+      if (vec.length !== this.embeddingModelDims) {
+        throw new Error(
+          `Vector at index ${i} has dimension ${vec.length}, ` +
+            `but expected ${this.embeddingModelDims}.`,
+        );
+      }
+
+      await this.client.index({
+        index: this.collectionName,
+        body: {
+          vector_field: vec,
+          id: ids[i],
+          payload: payloads[i] ?? {},
+        },
+      });
+    }
+
+    if (this.autoRefresh) {
+      await this.client.indices.refresh({ index: this.collectionName });
+    }
+  }
+
+  async search(
+    query: number[],
+    topK: number = 5,
+    filters?: SearchFilters,
+  ): Promise<VectorStoreResult[]> {
+    const knnQuery: Record<string, any> = {
+      knn: {
+        vector_field: {
+          vector: query,
+          k: topK * 2,
+        },
+      },
+    };
+
+    const filterClauses = this.buildFilterClauses(filters);
+    const body: Record<string, any> = { size: topK * 2 };
+
+    if (filterClauses.length > 0) {
+      body.query = { bool: { must: knnQuery, filter: filterClauses } };
+    } else {
+      body.query = knnQuery;
+    }
+
+    try {
+      const { body: response } = await this.client.search({
+        index: this.collectionName,
+        body,
+      });
+
+      const hits: OpenSearchHit[] = response.hits?.hits ?? [];
+      return hits.slice(0, topK).map((hit) => ({
+        id: hit._source.id,
+        score: hit._score,
+        payload: hit._source.payload ?? {},
+      }));
+    } catch {
+      return [];
+    }
+  }
+
+  async keywordSearch?(
+    query: string,
+    topK: number = 5,
+    filters?: SearchFilters,
+  ): Promise<VectorStoreResult[] | null> {
+    const boolQuery: Record<string, any> = {
+      should: [
+        { match: { "payload.data": query } },
+        { match: { "payload.text_lemmatized": query } },
+      ],
+      minimum_should_match: 1,
+    };
+
+    const filterClauses = this.buildFilterClauses(filters);
+    if (filterClauses.length > 0) {
+      boolQuery.filter = filterClauses;
+    }
+
+    try {
+      const { body: response } = await this.client.search({
+        index: this.collectionName,
+        body: { size: topK, query: { bool: boolQuery } },
+      });
+
+      const hits: OpenSearchHit[] = response.hits?.hits ?? [];
+      return hits.slice(0, topK).map((hit) => ({
+        id: hit._source.id,
+        score: hit._score,
+        payload: hit._source.payload ?? {},
+      }));
+    } catch {
+      return null;
+    }
+  }
+
+  async get(vectorId: string): Promise<VectorStoreResult | null> {
+    try {
+      const { body: response } = await this.client.search({
+        index: this.collectionName,
+        body: { query: { term: { id: vectorId } } },
+      });
+
+      const hits: OpenSearchHit[] = response.hits?.hits ?? [];
+      if (hits.length === 0) return null;
+
+      return {
+        id: hits[0]._source.id,
+        score: 1.0,
+        payload: hits[0]._source.payload ?? {},
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  async update(
+    vectorId: string,
+    vector: number[],
+    payload: Record<string, any>,
+  ): Promise<void> {
+    if (vector.length !== this.embeddingModelDims) {
+      throw new Error(
+        `Update vector has dimension ${vector.length}, ` +
+          `but expected ${this.embeddingModelDims}.`,
+      );
+    }
+
+    // Find document by custom ID
+    const { body: response } = await this.client.search({
+      index: this.collectionName,
+      body: { query: { term: { id: vectorId } } },
+    });
+
+    const hits: OpenSearchHit[] = response.hits?.hits ?? [];
+    if (hits.length === 0) return;
+
+    await this.client.update({
+      index: this.collectionName,
+      id: hits[0]._id,
+      body: {
+        doc: {
+          vector_field: vector,
+          payload,
+        },
+      },
+    });
+  }
+
+  async delete(vectorId: string): Promise<void> {
+    const { body: response } = await this.client.search({
+      index: this.collectionName,
+      body: { query: { term: { id: vectorId } } },
+    });
+
+    const hits: OpenSearchHit[] = response.hits?.hits ?? [];
+    if (hits.length === 0) return;
+
+    await this.client.delete({
+      index: this.collectionName,
+      id: hits[0]._id,
+    });
+  }
+
+  async deleteCol(): Promise<void> {
+    await this.client.indices.delete({ index: this.collectionName });
+  }
+
+  async list(
+    filters?: SearchFilters,
+    topK?: number,
+  ): Promise<[VectorStoreResult[], number]> {
+    const body: Record<string, any> = { query: { match_all: {} } };
+
+    const filterClauses = this.buildFilterClauses(filters);
+    if (filterClauses.length > 0) {
+      body.query = { bool: { filter: filterClauses } };
+    }
+
+    if (topK) {
+      body.size = topK;
+    }
+
+    try {
+      const { body: response } = await this.client.search({
+        index: this.collectionName,
+        body,
+      });
+
+      const hits: OpenSearchHit[] = response.hits?.hits ?? [];
+      const results: VectorStoreResult[] = hits.map((hit) => ({
+        id: hit._source.id,
+        score: 1.0,
+        payload: hit._source.payload ?? {},
+      }));
+
+      return [results, results.length];
+    } catch {
+      return [[], 0];
+    }
+  }
+
+  async getUserId(): Promise<string> {
+    throw new Error("getUserId is not supported by OpenSearch vector store");
+  }
+
+  async setUserId(_userId: string): Promise<void> {
+    throw new Error("setUserId is not supported by OpenSearch vector store");
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────
+
+  private buildFilterClauses(filters?: SearchFilters): any[] {
+    if (!filters) return [];
+
+    const clauses: any[] = [];
+    for (const [key, value] of Object.entries(filters)) {
+      if (value !== undefined && value !== null) {
+        validateFilter(key, value);
+        clauses.push({ term: { [`payload.${key}.keyword`]: value } });
+      }
+    }
+    return clauses;
+  }
+}

--- a/mem0-ts/src/oss/src/vector_stores/opensearch.ts
+++ b/mem0-ts/src/oss/src/vector_stores/opensearch.ts
@@ -80,7 +80,7 @@ export class OpenSearch implements VectorStore {
     // AWS Sigv4 signing
     if (config.awsRegion) {
       const region = config.awsRegion;
-      const service = config.awsService ?? "es";
+      const service = (config.awsService ?? "es") as "es" | "aoss";
       const signer = AwsSigv4Signer({
         region,
         service,
@@ -206,7 +206,7 @@ export class OpenSearch implements VectorStore {
         body,
       });
 
-      const hits: OpenSearchHit[] = response.hits?.hits ?? [];
+      const hits = (response.hits?.hits ?? []) as unknown as OpenSearchHit[];
       return hits.slice(0, topK).map((hit) => ({
         id: hit._source.id,
         score: hit._score,
@@ -241,7 +241,7 @@ export class OpenSearch implements VectorStore {
         body: { size: topK, query: { bool: boolQuery } },
       });
 
-      const hits: OpenSearchHit[] = response.hits?.hits ?? [];
+      const hits = (response.hits?.hits ?? []) as unknown as OpenSearchHit[];
       return hits.slice(0, topK).map((hit) => ({
         id: hit._source.id,
         score: hit._score,
@@ -259,7 +259,7 @@ export class OpenSearch implements VectorStore {
         body: { query: { term: { id: vectorId } } },
       });
 
-      const hits: OpenSearchHit[] = response.hits?.hits ?? [];
+      const hits = (response.hits?.hits ?? []) as unknown as OpenSearchHit[];
       if (hits.length === 0) return null;
 
       return {
@@ -290,7 +290,7 @@ export class OpenSearch implements VectorStore {
       body: { query: { term: { id: vectorId } } },
     });
 
-    const hits: OpenSearchHit[] = response.hits?.hits ?? [];
+    const hits = (response.hits?.hits ?? []) as unknown as OpenSearchHit[];
     if (hits.length === 0) return;
 
     await this.client.update({
@@ -311,7 +311,7 @@ export class OpenSearch implements VectorStore {
       body: { query: { term: { id: vectorId } } },
     });
 
-    const hits: OpenSearchHit[] = response.hits?.hits ?? [];
+    const hits = (response.hits?.hits ?? []) as unknown as OpenSearchHit[];
     if (hits.length === 0) return;
 
     await this.client.delete({
@@ -345,7 +345,7 @@ export class OpenSearch implements VectorStore {
         body,
       });
 
-      const hits: OpenSearchHit[] = response.hits?.hits ?? [];
+      const hits = (response.hits?.hits ?? []) as unknown as OpenSearchHit[];
       const results: VectorStoreResult[] = hits.map((hit) => ({
         id: hit._source.id,
         score: 1.0,


### PR DESCRIPTION
## Summary

The Python SDK supports **OpenSearch** as a vector store provider, but the TypeScript OSS SDK (`mem0ai/oss`) does not. Add it to bring the TS SDK to parity.

## Changes

- **`mem0-ts/src/oss/src/vector_stores/opensearch.ts`** — Full `VectorStore` implementation using `@opensearch-project/opensearch` (v3) with the k-NN plugin
- **`mem0-ts/src/oss/src/utils/factory.ts`** — Register `"opensearch"` provider in `VectorStoreFactory`
- **`mem0-ts/package.json`** — Add `@opensearch-project/opensearch` as a peer dependency

## Features

| Method | Description |
|--------|-------------|
| `insert` | Index vectors with custom IDs and payloads |
| `search` | k-NN cosine similarity search with optional filters |
| `keywordSearch` | BM25 keyword matching across `payload.data` and `payload.text_lemmatized` |
| `get` | Retrieve a vector by custom ID |
| `update` | Update vector and/or payload |
| `delete` | Delete by custom ID |
| `deleteCol` | Delete the entire index |
| `list` | List all vectors with optional filters |
| `initialize` | Create index with k-NN mapping if it doesn't exist |

Also supports:
- **AWS Sigv4 signing** for managed OpenSearch (via `awsRegion` config)
- **Optional auto-refresh** (disabled by default — see Python impl for Serverless compatibility notes)

## Usage

```typescript
import { Memory } from "mem0ai/oss";

const memory = new Memory({
  vectorStore: {
    provider: "opensearch",
    config: {
      collectionName: "mem0",
      embeddingModelDims: 1536,
      host: "localhost",
      port: 9200,
    },
  },
  // ... llm, embedder config
});
```

## Test plan

- [ ] Build succeeds (`pnpm run build`)
- [ ] Existing tests pass (`pnpm run test`)
- [ ] Manual integration test with a local OpenSearch instance

Closes #5776
