### PR TITLE
fix(opensearch): set explicit size on unbounded list() calls

### DIFF
--- a/mem0/vector_stores/opensearch.py
+++ b/mem0/vector_stores/opensearch.py
@@ -15,6 +15,10 @@ from mem0.vector_stores.base import VectorStoreBase
 
 logger = logging.getLogger(__name__)
 
+# OpenSearch's default index.max_result_window. Used as the fallback "size" for
+# unbounded list() calls so they do not silently cap at the default of 10 hits.
+MAX_RESULT_WINDOW = 10000
+
 _SAFE_FILTER_KEY = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_.]*$")
 
 
@@ -381,8 +385,12 @@ class OpenSearchDB(VectorStoreBase):
             if filter_clauses:
                 query["query"] = {"bool": {"filter": filter_clauses}}
 
-            if top_k:
-                query["size"] = top_k
+            # OpenSearch defaults to returning only 10 hits when "size" is
+            # unset. list() is used by get_all()/delete_all() with top_k=None to
+            # enumerate *all* matching memories, so an unset size silently caps
+            # the result at 10 and drops the rest. Fall back to the max result
+            # window so unbounded listings behave as callers expect.
+            query["size"] = top_k if top_k else MAX_RESULT_WINDOW
 
             response = self.client.search(index=self.collection_name, body=query)
             hits = response["hits"]["hits"]

--- a/tests/vector_stores/test_opensearch.py
+++ b/tests/vector_stores/test_opensearch.py
@@ -312,6 +312,24 @@ class TestOpenSearchDB(unittest.TestCase):
         self.assertEqual(len(result[0]), 1)
         self.assertEqual(result[0][0].id, "id1")
 
+    def test_list_without_top_k_sets_max_result_window_size(self):
+        """list() with top_k=None (as used by get_all()/delete_all()) must set an
+        explicit size, otherwise OpenSearch caps the response at 10 hits and
+        silently drops the rest."""
+        from mem0.vector_stores.opensearch import MAX_RESULT_WINDOW
+
+        self.client_mock.search.return_value = {"hits": {"hits": []}}
+        self.os_db.list(filters={"user_id": "alice"})
+        body = self.client_mock.search.call_args[1]["body"]
+        self.assertEqual(body["size"], MAX_RESULT_WINDOW)
+
+    def test_list_with_top_k_sets_requested_size(self):
+        """An explicit top_k must be honored as the query size."""
+        self.client_mock.search.return_value = {"hits": {"hits": []}}
+        self.os_db.list(filters={"user_id": "alice"}, top_k=25)
+        body = self.client_mock.search.call_args[1]["body"]
+        self.assertEqual(body["size"], 25)
+
     @patch("mem0.vector_stores.opensearch.logger")
     def test_list_error_returns_nested_empty_list(self, mock_logger):
         """list() error path must return [[]] (not bare []) so callers can do


### PR DESCRIPTION
## Summary

- `OpenSearchDB.list()` now sets an explicit query `size` (falling back to `index.max_result_window`) even when `top_k` is `None`.
- Fixes silent truncation of `get_all()` / `delete_all()` on the OpenSearch backend for users with more than 10 memories.

## Motivation

Closes #6108.

`OpenSearchDB.list()` only set `query["size"]` when `top_k` was truthy:

```python
if top_k:
    query["size"] = top_k
```

`Memory.get_all()` and `Memory.delete_all()` call `list(filters=...)` with `top_k=None` to enumerate **all** matching memories. With `size` unset, OpenSearch defaults to returning only **10 hits**, so `get_all()` returns at most 10 and `delete_all()` deletes at most 10, silently leaving the rest behind.

The fix falls back to `index.max_result_window` (10000) when `top_k` is `None`, so unbounded listings behave as callers expect. An explicit `top_k` is still honored unchanged.

## Verification

- `python -m pytest tests/vector_stores/test_opensearch.py` — 31 passed (2 new regression tests: `test_list_without_top_k_sets_max_result_window_size`, `test_list_with_top_k_sets_requested_size`).
- Diff is 2 files: the fix + tests.