### PR TITLE
fix(vector-stores): prevent unhandled promise rejection in Supabase & Redis constructors

### DIFF
--- a/mem0-ts/src/oss/src/vector_stores/redis.ts
+++ b/mem0-ts/src/oss/src/vector_stores/redis.ts
@@ -197,7 +197,6 @@ export class RedisDB implements VectorStore {
 
     this.initialize().catch((err) => {
       console.error("Failed to initialize Redis:", err);
-      throw err;
     });
   }
 

--- a/mem0-ts/src/oss/src/vector_stores/supabase.ts
+++ b/mem0-ts/src/oss/src/vector_stores/supabase.ts
@@ -96,7 +96,6 @@ export class SupabaseDB implements VectorStore {
 
     this.initialize().catch((err) => {
       console.error("Failed to initialize Supabase:", err);
-      throw err;
     });
   }
 

--- a/mem0-ts/src/oss/tests/vector-stores-compat.test.ts
+++ b/mem0-ts/src/oss/tests/vector-stores-compat.test.ts
@@ -600,6 +600,45 @@ describe("Supabase – backward compat with mocked client", () => {
     await Promise.all([p1, p2]);
     // No crash = idempotent (Supabase init runs test insert only once)
   });
+
+  it("constructor does not emit an unhandled rejection when init fails", async () => {
+    jest.resetModules();
+    jest.doMock("@supabase/supabase-js", () => {
+      const failing = {
+        from: jest.fn().mockReturnValue({
+          insert: jest.fn().mockReturnValue({
+            select: jest.fn().mockResolvedValue({
+              error: { code: "42P01", message: "no table" },
+            }),
+          }),
+          delete: jest.fn().mockReturnValue({
+            eq: jest.fn().mockResolvedValue({ error: null }),
+          }),
+        }),
+      };
+      return { createClient: jest.fn().mockReturnValue(failing) };
+    });
+    const FailingSupabaseDB =
+      require("../src/vector_stores/supabase").SupabaseDB;
+
+    const rejections: unknown[] = [];
+    const onUnhandled = (reason: unknown) => rejections.push(reason);
+    process.on("unhandledRejection", onUnhandled);
+    try {
+      const store = new FailingSupabaseDB({
+        supabaseUrl: "https://example.supabase.co",
+        supabaseKey: "fake-key",
+        tableName: "memories",
+        collectionName: "test",
+      });
+      expect(store).toBeDefined();
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    } finally {
+      process.removeListener("unhandledRejection", onUnhandled);
+    }
+
+    expect(rejections).toEqual([]);
+  });
 });
 
 // ───────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Linked Issue

No linked issue — found during a self-review/audit of the OSS TypeScript vector stores.

## Description

The `SupabaseDB` and `RedisDB` vector-store constructors kick off background initialization and attach a floating `.catch` handler that **re-threw** the error:

```ts
this.initialize().catch((err) => {
  console.error("Failed to initialize <store>:", err);
  throw err; // ← re-thrown inside a floating .catch
});
```

Nothing awaits this particular promise chain, so the re-thrown error becomes an **unhandled promise rejection**. On Node ≥ 15 the default behavior is to terminate the process — so a transient init failure (missing table/schema, unreachable Redis) could crash the host application instead of surfacing a recoverable error.

This PR removes the `throw err` from both floating catches (keeping the `console.error`). Init errors are still surfaced to callers through the awaited path:

- `initialize()` is idempotent (memoized via `_initPromise`), and
- `Memory._autoInitialize()` explicitly `await`s `vectorStore.initialize()` before any operation, with `_ensureInitialized()` gating every public method.

So a real init failure still propagates to the caller — only the process-crashing floating rejection is removed. No factory/API change is needed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added a regression test in `vector-stores-compat.test.ts` that installs an `unhandledRejection` listener, constructs a `SupabaseDB` whose initialization fails, and asserts no unhandled rejection is emitted. Verified it **fails** with the old `throw err` in place and **passes** with the fix. Supabase + Redis compat suites pass locally.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (N/A — internal robustness fix)
