### PR TITLE
fix(ts/redis): return updated_at from OSS vector store search()

### DIFF
--- a/mem0-ts/src/oss/src/vector_stores/redis.ts
+++ b/mem0-ts/src/oss/src/vector_stores/redis.ts
@@ -413,6 +413,7 @@ export class RedisDB implements VectorStore {
         "memory",
         "metadata",
         "created_at",
+        "updated_at",
         "__vector_score",
       ],
       SORTBY: "__vector_score",

--- a/mem0-ts/src/oss/tests/redis.unit.test.ts
+++ b/mem0-ts/src/oss/tests/redis.unit.test.ts
@@ -126,3 +126,54 @@ describe("RedisDB – entity payload handling", () => {
     expect(Number.isNaN(entry.created_at)).toBe(false);
   });
 });
+
+describe("RedisDB – search() surfaces updated_at (parity with get()/list())", () => {
+  let store: RedisDB;
+  let mockClient: any;
+
+  beforeAll(async () => {
+    store = createStore();
+    await store.initialize();
+    mockClient = (store as any).client;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("search() requests updated_at in RETURN", async () => {
+    mockClient.ft.search.mockResolvedValue({ total: 0, documents: [] });
+
+    await store.search([0.1, 0.2, 0.3, 0.4], 5);
+
+    const options = mockClient.ft.search.mock.calls[0][2];
+    expect(options.RETURN).toContain("updated_at");
+  });
+
+  test("search() surfaces updated_at in the payload when present", async () => {
+    const now = Date.now();
+    const stored: Record<string, string> = {
+      memory_id: "m1",
+      hash: "h",
+      memory: "hello",
+      created_at: String(now - 1000),
+      updated_at: String(now),
+      metadata: "{}",
+      __vector_score: "0.1",
+    };
+    // Mimic RediSearch: only return the fields the query asked for.
+    mockClient.ft.search.mockImplementation(
+      (_index: string, _query: string, options: { RETURN: string[] }) => {
+        const requested = new Set([...options.RETURN, "memory_id"]);
+        const value = Object.fromEntries(
+          Object.entries(stored).filter(([key]) => requested.has(key)),
+        );
+        return Promise.resolve({ total: 1, documents: [{ id: "m1", value }] });
+      },
+    );
+
+    const results = await store.search([0.1, 0.2, 0.3, 0.4], 1);
+
+    expect((results[0].payload as any).updatedAt).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Linked Issue

Closes #6116

## Description

The OSS TypeScript Redis vector store's `search()` omitted `"updated_at"` from its `RETURN` list, so the `...(doc.value.updated_at && {...})` payload guard was dead code and `search()` never surfaced `updated_at` — even though `update()` persists it, `DEFAULT_FIELDS` declares it, and `get()` and `list()` already return it. Adds `"updated_at"` to the `RETURN` list. Follow-up to #6060 (Python) per the maintainer note on #6059.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A — additive. Payloads gain `updatedAt` for records that have it (matching `get()`/`list()`); records without it are unchanged.

## Test Coverage

- [x] I added/updated unit tests
- [x] I tested manually (describe below)

Added two jest tests: `search()` requests `updated_at` in `RETURN`, and (with a RediSearch-mimicking mock) surfaces it in the payload; both fail before the change and pass after. Verified live against `redis/redis-stack` (RediSearch) with a real `insert -> update -> get -> search` round-trip: on `main`, `get()` returns `updated_at` but `search()` returns `undefined`; on this branch, both return it. Full OSS unit suite stays green.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (N/A — internal read-path parity)
