### PR TITLE
fix: replace interactive input and sys.exit with ImportError (fixes #6118)

### DIFF
--- a/mem0/embeddings/ollama.py
+++ b/mem0/embeddings/ollama.py
@@ -1,5 +1,3 @@
-import subprocess
-import sys
 from typing import Literal, Optional
 
 from mem0.configs.embeddings.base import BaseEmbedderConfig
@@ -8,17 +6,7 @@ from mem0.embeddings.base import EmbeddingBase
 try:
     from ollama import Client
 except ImportError:
-    user_input = input("The 'ollama' library is required. Install it now? [y/N]: ")
-    if user_input.lower() == "y":
-        try:
-            subprocess.check_call([sys.executable, "-m", "pip", "install", "ollama"])
-            from ollama import Client
-        except subprocess.CalledProcessError:
-            print("Failed to install 'ollama'. Please install it manually using 'pip install ollama'.")
-            sys.exit(1)
-    else:
-        print("The required 'ollama' library is not installed.")
-        sys.exit(1)
+    raise ImportError("The 'ollama' library is required. Please install it using 'pip install ollama'.")
 
 
 class OllamaEmbedding(EmbeddingBase):

--- a/mem0/proxy/main.py
+++ b/mem0/proxy/main.py
@@ -1,6 +1,4 @@
 import logging
-import subprocess
-import sys
 import threading
 from typing import List, Optional, Union
 
@@ -11,12 +9,7 @@ import mem0
 try:
     import litellm
 except ImportError:
-    try:
-        subprocess.check_call([sys.executable, "-m", "pip", "install", "litellm"])
-        import litellm
-    except subprocess.CalledProcessError:
-        print("Failed to install 'litellm'. Please install it manually using 'pip install litellm'.")
-        sys.exit(1)
+    raise ImportError("The 'litellm' library is required. Please install it using 'pip install litellm'.")
 
 from mem0 import Memory, MemoryClient
 from mem0.configs.prompts import MEMORY_ANSWER_PROMPT


### PR DESCRIPTION
## Linked Issue

Closes #6118

## Description

This PR fixes a critical anti-pattern in the library code where missing optional dependencies (`ollama` and `litellm`) would trigger an interactive `input()` prompt or a hard `sys.exit(1)`. 

These anti-patterns blocked execution in non-interactive environments (such as CI pipelines, automated tests, or API servers) and would abruptly crash the host application. The code has been refactored to simply raise a standard `ImportError` with clear installation instructions, allowing the host application to handle the missing dependency gracefully. Unused `sys` and `subprocess` imports were also cleaned up.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [x] No tests needed (explain why)

No new tests are strictly required because this is a standard exception-handling fix. However, this change inherently fixes existing issues in the `pytest` suite, where `test_ollama_embeddings.py` previously caused `OSError: pytest: reading from stdin while output is captured` due to the `input()` call.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
