### PR TITLE
feat(memory): use native async OpenAI model calls

### DIFF
--- a/mem0/embeddings/base.py
+++ b/mem0/embeddings/base.py
@@ -47,7 +47,7 @@ class EmbeddingBase(ABC):
         """
         return [self.embed(text, memory_action) for text in texts]
 
-    async def aembed(self, text, memory_action: Optional[Literal["add", "search", "update"]]):
+    async def aembed(self, text, memory_action: Optional[Literal["add", "search", "update"]] = None):
         return await asyncio.to_thread(self.embed, text, memory_action)
 
     async def aembed_batch(self, texts, memory_action="add"):

--- a/mem0/embeddings/base.py
+++ b/mem0/embeddings/base.py
@@ -1,3 +1,4 @@
+import asyncio
 from abc import ABC, abstractmethod
 from typing import Literal, Optional
 
@@ -45,3 +46,9 @@ class EmbeddingBase(ABC):
             List of embedding vectors (list of floats), one per input text.
         """
         return [self.embed(text, memory_action) for text in texts]
+
+    async def aembed(self, text, memory_action: Optional[Literal["add", "search", "update"]]):
+        return await asyncio.to_thread(self.embed, text, memory_action)
+
+    async def aembed_batch(self, texts, memory_action="add"):
+        return await asyncio.to_thread(self.embed_batch, texts, memory_action)

--- a/mem0/embeddings/openai.py
+++ b/mem0/embeddings/openai.py
@@ -2,7 +2,7 @@ import os
 import warnings
 from typing import Literal, Optional
 
-from openai import OpenAI
+from openai import AsyncOpenAI, OpenAI
 
 from mem0.configs.embeddings.base import BaseEmbedderConfig
 from mem0.embeddings.base import EmbeddingBase
@@ -33,6 +33,17 @@ class OpenAIEmbedding(EmbeddingBase):
             )
 
         self.client = OpenAI(api_key=api_key, base_url=base_url)
+        self.async_client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+
+    def _build_embedding_kwargs(self, texts):
+        kwargs = {
+            "input": texts,
+            "model": self.config.model,
+            "encoding_format": "float",
+        }
+        if self._pass_dimensions_to_api:
+            kwargs["dimensions"] = self.config.embedding_dims
+        return kwargs
 
     def embed(self, text, memory_action: Optional[Literal["add", "search", "update"]] = None):
         """
@@ -45,14 +56,12 @@ class OpenAIEmbedding(EmbeddingBase):
             list: The embedding vector.
         """
         text = text.replace("\n", " ")
-        kwargs = {
-            "input": [text],
-            "model": self.config.model,
-            "encoding_format": "float",
-        }
-        if self._pass_dimensions_to_api:
-            kwargs["dimensions"] = self.config.embedding_dims
-        return self.client.embeddings.create(**kwargs).data[0].embedding
+        return self.client.embeddings.create(**self._build_embedding_kwargs([text])).data[0].embedding
+
+    async def aembed(self, text, memory_action: Optional[Literal["add", "search", "update"]] = None):
+        text = text.replace("\n", " ")
+        response = await self.async_client.embeddings.create(**self._build_embedding_kwargs([text]))
+        return response.data[0].embedding
 
     def embed_batch(self, texts, memory_action="add"):
         """Embed multiple texts in a single OpenAI API call.
@@ -64,14 +73,26 @@ class OpenAIEmbedding(EmbeddingBase):
         all_embeddings = []
         for i in range(0, len(texts), MAX_BATCH):
             chunk = texts[i : i + MAX_BATCH]
-            kwargs = {
-                "input": chunk,
-                "model": self.config.model,
-                "encoding_format": "float",
-            }
-            if self._pass_dimensions_to_api:
-                kwargs["dimensions"] = self.config.embedding_dims
-            response = self.client.embeddings.create(**kwargs)
+            response = self.client.embeddings.create(**self._build_embedding_kwargs(chunk))
+            all_embeddings.extend(item.embedding for item in sorted(response.data, key=lambda x: x.index))
+        if len(all_embeddings) != len(texts):
+            raise ValueError(
+                f"OpenAI embed_batch() returned {len(all_embeddings)} embeddings for {len(texts)} texts"
+                f" using model '{self.config.model}'"
+            )
+        return all_embeddings
+
+    async def aembed_batch(self, texts, memory_action="add"):
+        """Embed multiple texts in a single OpenAI API call.
+
+        Automatically chunks into batches of 100 to stay within API limits.
+        """
+        MAX_BATCH = 100
+        texts = [text.replace("\n", " ") for text in texts]
+        all_embeddings = []
+        for i in range(0, len(texts), MAX_BATCH):
+            chunk = texts[i : i + MAX_BATCH]
+            response = await self.async_client.embeddings.create(**self._build_embedding_kwargs(chunk))
             all_embeddings.extend(item.embedding for item in sorted(response.data, key=lambda x: x.index))
         if len(all_embeddings) != len(texts):
             raise ValueError(

--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -1,3 +1,4 @@
+import asyncio
 from abc import ABC, abstractmethod
 from typing import Dict, List, Optional, Union
 
@@ -56,8 +57,14 @@ class LLMBase(ABC):
             return explicit
 
         reasoning_models = {
-            "o1", "o1-preview", "o3-mini", "o3",
-            "gpt-5", "gpt-5o", "gpt-5o-mini", "gpt-5o-micro",
+            "o1",
+            "o1-preview",
+            "o3-mini",
+            "o3",
+            "gpt-5",
+            "gpt-5o",
+            "gpt-5o-mini",
+            "gpt-5o-micro",
         }
 
         model_lower = model.lower()
@@ -97,18 +104,18 @@ class LLMBase(ABC):
         """
         Get parameters that are supported by the current model.
         Filters out unsupported parameters for reasoning models and GPT-5 series.
-        
+
         Args:
             **kwargs: Additional parameters to include
-            
+
         Returns:
             Dict: Filtered parameters dictionary
         """
-        model = getattr(self.config, 'model', '')
-        
+        model = getattr(self.config, "model", "")
+
         if self._is_reasoning_model(model):
             supported_params = {}
-            
+
             if "messages" in kwargs:
                 supported_params["messages"] = kwargs["messages"]
             if "response_format" in kwargs:
@@ -119,7 +126,7 @@ class LLMBase(ABC):
                 supported_params["tool_choice"] = kwargs["tool_choice"]
 
             # Add reasoning_effort if configured
-            reasoning_effort = getattr(self.config, 'reasoning_effort', None)
+            reasoning_effort = getattr(self.config, "reasoning_effort", None)
             if reasoning_effort:
                 supported_params["reasoning_effort"] = reasoning_effort
 
@@ -145,6 +152,17 @@ class LLMBase(ABC):
             str or dict: The generated response.
         """
         pass
+
+    async def agenerate_response(
+        self, messages: List[Dict[str, str]], tools: Optional[List[Dict]] = None, tool_choice: str = "auto", **kwargs
+    ):
+        return await asyncio.to_thread(
+            self.generate_response,
+            messages=messages,
+            tools=tools,
+            tool_choice=tool_choice,
+            **kwargs,
+        )
 
     def _get_common_params(self, **kwargs) -> Dict:
         """

--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -156,12 +156,16 @@ class LLMBase(ABC):
     async def agenerate_response(
         self, messages: List[Dict[str, str]], tools: Optional[List[Dict]] = None, tool_choice: str = "auto", **kwargs
     ):
+        call_kwargs = dict(kwargs)
+        if tools is not None:
+            call_kwargs["tools"] = tools
+            call_kwargs["tool_choice"] = tool_choice
+        elif tool_choice != "auto":
+            call_kwargs["tool_choice"] = tool_choice
         return await asyncio.to_thread(
             self.generate_response,
             messages=messages,
-            tools=tools,
-            tool_choice=tool_choice,
-            **kwargs,
+            **call_kwargs,
         )
 
     def _get_common_params(self, **kwargs) -> Dict:

--- a/mem0/llms/openai.py
+++ b/mem0/llms/openai.py
@@ -3,7 +3,7 @@ import logging
 import os
 from typing import Dict, List, Optional, Union
 
-from openai import OpenAI
+from openai import AsyncOpenAI, OpenAI
 
 from mem0.configs.llms.base import BaseLlmConfig
 from mem0.configs.llms.openai import OpenAIConfig
@@ -29,9 +29,9 @@ class OpenAILLM(LLMBase):
                 top_k=config.top_k,
                 enable_vision=config.enable_vision,
                 vision_details=config.vision_details,
-                reasoning_effort=getattr(config, 'reasoning_effort', None),
+                reasoning_effort=getattr(config, "reasoning_effort", None),
                 http_client_proxies=config.http_client_proxies,
-                is_reasoning_model=getattr(config, 'is_reasoning_model', None),
+                is_reasoning_model=getattr(config, "is_reasoning_model", None),
             )
 
         super().__init__(config)
@@ -40,17 +40,16 @@ class OpenAILLM(LLMBase):
             self.config.model = "gpt-5-mini"
 
         if os.environ.get("OPENROUTER_API_KEY"):  # Use OpenRouter
-            self.client = OpenAI(
-                api_key=os.environ.get("OPENROUTER_API_KEY"),
-                base_url=self.config.openrouter_base_url
-                or os.getenv("OPENROUTER_API_BASE")
-                or "https://openrouter.ai/api/v1",
+            api_key = os.environ.get("OPENROUTER_API_KEY")
+            base_url = (
+                self.config.openrouter_base_url or os.getenv("OPENROUTER_API_BASE") or "https://openrouter.ai/api/v1"
             )
         else:
             api_key = self.config.api_key or os.getenv("OPENAI_API_KEY")
             base_url = self.config.openai_base_url or os.getenv("OPENAI_BASE_URL") or "https://api.openai.com/v1"
 
-            self.client = OpenAI(api_key=api_key, base_url=base_url)
+        self.client = OpenAI(api_key=api_key, base_url=base_url)
+        self.async_client = AsyncOpenAI(api_key=api_key, base_url=base_url)
 
     def _parse_response(self, response, tools):
         """
@@ -82,6 +81,54 @@ class OpenAILLM(LLMBase):
         else:
             return response.choices[0].message.content
 
+    def _build_request_params(self, messages, response_format=None, tools=None, tool_choice="auto", **kwargs):
+        params = self._get_supported_params(messages=messages, **kwargs)
+
+        params.update(
+            {
+                "model": self.config.model,
+                "messages": messages,
+            }
+        )
+
+        if os.getenv("OPENROUTER_API_KEY"):
+            openrouter_params = {}
+            if self.config.models:
+                openrouter_params["models"] = self.config.models
+                openrouter_params["route"] = self.config.route
+                params.pop("model")
+
+            if self.config.site_url and self.config.app_name:
+                extra_headers = {
+                    "HTTP-Referer": self.config.site_url,
+                    "X-Title": self.config.app_name,
+                }
+                openrouter_params["extra_headers"] = extra_headers
+
+            params.update(**openrouter_params)
+        else:
+            # Only send OpenAI-specific parameters when the user has explicitly
+            # configured them. OpenAI-compatible backends (Gemini, Groq, vLLM, etc.)
+            # reject unknown fields, so `store` must be opt-in, not opt-out.
+            if self.config.store is not None:
+                params["store"] = self.config.store
+
+        if response_format:
+            params["response_format"] = response_format
+        if tools:  # TODO: Remove tools if no issues found with new memory addition logic
+            params["tools"] = tools
+            params["tool_choice"] = tool_choice
+
+        return params
+
+    def _handle_response_callback(self, response, params):
+        if self.config.response_callback:
+            try:
+                self.config.response_callback(self, response, params)
+            except Exception as e:
+                # Log error but don't propagate
+                logging.error(f"Error due to callback: {e}")
+
     def generate_response(
         self,
         messages: List[Dict[str, str]],
@@ -103,48 +150,34 @@ class OpenAILLM(LLMBase):
         Returns:
             json: The generated response.
         """
-        params = self._get_supported_params(messages=messages, **kwargs)
-        
-        params.update({
-            "model": self.config.model,
-            "messages": messages,
-        })
-
-        if os.getenv("OPENROUTER_API_KEY"):
-            openrouter_params = {}
-            if self.config.models:
-                openrouter_params["models"] = self.config.models
-                openrouter_params["route"] = self.config.route
-                params.pop("model")
-
-            if self.config.site_url and self.config.app_name:
-                extra_headers = {
-                    "HTTP-Referer": self.config.site_url,
-                    "X-Title": self.config.app_name,
-                }
-                openrouter_params["extra_headers"] = extra_headers
-
-            params.update(**openrouter_params)
-        
-        else:
-            # Only send OpenAI-specific parameters when the user has explicitly
-            # configured them. OpenAI-compatible backends (Gemini, Groq, vLLM, etc.)
-            # reject unknown fields, so `store` must be opt-in, not opt-out.
-            if self.config.store is not None:
-                params["store"] = self.config.store
-
-        if response_format:
-            params["response_format"] = response_format
-        if tools:  # TODO: Remove tools if no issues found with new memory addition logic
-            params["tools"] = tools
-            params["tool_choice"] = tool_choice
+        params = self._build_request_params(
+            messages,
+            response_format=response_format,
+            tools=tools,
+            tool_choice=tool_choice,
+            **kwargs,
+        )
         response = self.client.chat.completions.create(**params)
         parsed_response = self._parse_response(response, tools)
-        if self.config.response_callback:
-            try:
-                self.config.response_callback(self, response, params)
-            except Exception as e:
-                # Log error but don't propagate
-                logging.error(f"Error due to callback: {e}")
-                pass
+        self._handle_response_callback(response, params)
+        return parsed_response
+
+    async def agenerate_response(
+        self,
+        messages: List[Dict[str, str]],
+        response_format=None,
+        tools: Optional[List[Dict]] = None,
+        tool_choice: str = "auto",
+        **kwargs,
+    ):
+        params = self._build_request_params(
+            messages,
+            response_format=response_format,
+            tools=tools,
+            tool_choice=tool_choice,
+            **kwargs,
+        )
+        response = await self.async_client.chat.completions.create(**params)
+        parsed_response = self._parse_response(response, tools)
+        self._handle_response_callback(response, params)
         return parsed_response

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -2234,7 +2234,7 @@ class AsyncMemory(MemoryBase):
     async def _upsert_entity_async(self, entity_text, entity_type, memory_id, filters):
         """Async variant of `_upsert_entity` — per-entity search-then-update-or-insert."""
         try:
-            entity_embedding = await asyncio.to_thread(self.embedding_model.embed, entity_text, "add")
+            entity_embedding = await self.embedding_model.aembed(entity_text, "add")
             search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
             exact_match = (
                 await asyncio.to_thread(self._existing_entities_by_text, search_filters)
@@ -2328,7 +2328,7 @@ class AsyncMemory(MemoryBase):
                             logger.debug(f"Entity id={row.id} missing 'data'; skipping update during cleanup (async)")
                             continue
                         try:
-                            vec = await asyncio.to_thread(self.embedding_model.embed, entity_text, "update")
+                            vec = await self.embedding_model.aembed(entity_text, "update")
                         except Exception as e:
                             logger.debug(f"Entity re-embed failed for '{entity_text}' (async): {e}")
                             continue
@@ -2519,7 +2519,7 @@ class AsyncMemory(MemoryBase):
                     per_msg_meta["actor_id"] = actor_name
 
                 msg_content = message_dict["content"]
-                msg_embeddings = await asyncio.to_thread(self.embedding_model.embed, msg_content, "add")
+                msg_embeddings = await self.embedding_model.aembed(msg_content, "add")
                 mem_id = await self._create_memory(msg_content, {msg_content: msg_embeddings}, per_msg_meta)
 
                 returned_memories.append(
@@ -2542,7 +2542,7 @@ class AsyncMemory(MemoryBase):
 
         # Phase 1: Existing memory retrieval
         search_filters = {k: v for k, v in effective_filters.items() if k in ("user_id", "agent_id", "run_id") and v}
-        query_embedding = await asyncio.to_thread(self.embedding_model.embed, parsed_messages, "search")
+        query_embedding = await self.embedding_model.aembed(parsed_messages, "search")
         existing_results = await asyncio.to_thread(
             self.vector_store.search,
             query=parsed_messages,
@@ -2574,8 +2574,7 @@ class AsyncMemory(MemoryBase):
         )
 
         try:
-            response = await asyncio.to_thread(
-                self.llm.generate_response,
+            response = await self.llm.agenerate_response(
                 messages=[
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_prompt},
@@ -2610,13 +2609,13 @@ class AsyncMemory(MemoryBase):
         # Phase 3: Batch embed all extracted memory texts
         mem_texts = [m.get("text", "") for m in extracted_memories if m.get("text")]
         try:
-            mem_embeddings_list = await asyncio.to_thread(self.embedding_model.embed_batch, mem_texts, "add")
+            mem_embeddings_list = await self.embedding_model.aembed_batch(mem_texts, "add")
             embed_map = dict(zip(mem_texts, mem_embeddings_list))
         except Exception:
             embed_map = {}
             for text in mem_texts:
                 try:
-                    embed_map[text] = await asyncio.to_thread(self.embedding_model.embed, text, "add")
+                    embed_map[text] = await self.embedding_model.aembed(text, "add")
                 except Exception as e:
                     logger.warning(f"Failed to embed memory text (async): {e}")
 
@@ -2724,12 +2723,12 @@ class AsyncMemory(MemoryBase):
 
                 # 7b: Batch embed entities
                 try:
-                    entity_embeddings = await asyncio.to_thread(self.embedding_model.embed_batch, entity_texts, "add")
+                    entity_embeddings = await self.embedding_model.aembed_batch(entity_texts, "add")
                 except Exception:
                     entity_embeddings = []
                     for t in entity_texts:
                         try:
-                            entity_embeddings.append(await asyncio.to_thread(self.embedding_model.embed, t, "add"))
+                            entity_embeddings.append(await self.embedding_model.aembed(t, "add"))
                         except Exception:
                             entity_embeddings.append(None)
 
@@ -3258,7 +3257,7 @@ class AsyncMemory(MemoryBase):
         query_entities = await asyncio.to_thread(extract_entities, query)
 
         # Step 2: Embed query
-        embeddings = await asyncio.to_thread(self.embedding_model.embed, query, "search")
+        embeddings = await self.embedding_model.aembed(query, "search")
 
         # Step 3: Semantic search (over-fetch)
         internal_limit = max(limit * 4, 60)
@@ -3370,7 +3369,7 @@ class AsyncMemory(MemoryBase):
 
         try:
             entity_texts = [text for _, text in deduped]
-            embeddings = await asyncio.to_thread(self.embedding_model.embed_batch, entity_texts, "search")
+            embeddings = await self.embedding_model.aembed_batch(entity_texts, "search")
 
             if len(embeddings) != len(entity_texts):
                 logger.warning(
@@ -3474,7 +3473,7 @@ class AsyncMemory(MemoryBase):
 
         existing_embeddings = {}
         if text is not None:
-            embeddings = await asyncio.to_thread(self.embedding_model.embed, text, "update")
+            embeddings = await self.embedding_model.aembed(text, "update")
             existing_embeddings[text] = embeddings
 
         await self._update_memory(memory_id, text, existing_embeddings, update_metadata)
@@ -3595,7 +3594,7 @@ class AsyncMemory(MemoryBase):
         if data in existing_embeddings:
             embeddings = existing_embeddings[data]
         else:
-            embeddings = await asyncio.to_thread(self.embedding_model.embed, data, memory_action="add")
+            embeddings = await self.embedding_model.aembed(data, memory_action="add")
 
         memory_id = str(uuid.uuid4())
         new_metadata = deepcopy(metadata) if metadata is not None else {}
@@ -3664,7 +3663,7 @@ class AsyncMemory(MemoryBase):
                 response = await asyncio.to_thread(llm.invoke, input=parsed_messages)
                 procedural_memory = remove_code_blocks(response.content)
             else:
-                procedural_memory = await asyncio.to_thread(self.llm.generate_response, messages=parsed_messages)
+                procedural_memory = await self.llm.agenerate_response(messages=parsed_messages)
                 procedural_memory = remove_code_blocks(procedural_memory)
         
         except Exception as e:
@@ -3675,7 +3674,7 @@ class AsyncMemory(MemoryBase):
             raise ValueError("Metadata cannot be done for procedural memory.")
 
         metadata = {**metadata, "memory_type": MemoryType.PROCEDURAL.value}
-        embeddings = await asyncio.to_thread(self.embedding_model.embed, procedural_memory, memory_action="add")
+        embeddings = await self.embedding_model.aembed(procedural_memory, memory_action="add")
         memory_id = await self._create_memory(procedural_memory, {procedural_memory: embeddings}, metadata=metadata)
         capture_event("mem0._create_procedural_memory", self, {"memory_id": memory_id, "sync_type": "async"})
 
@@ -3716,7 +3715,7 @@ class AsyncMemory(MemoryBase):
         if data in existing_embeddings:
             embeddings = existing_embeddings[data]
         else:
-            embeddings = await asyncio.to_thread(self.embedding_model.embed, data, "update")
+            embeddings = await self.embedding_model.aembed(data, "update")
 
         await asyncio.to_thread(
             self.vector_store.update,

--- a/tests/embeddings/test_embedding_base_async.py
+++ b/tests/embeddings/test_embedding_base_async.py
@@ -1,0 +1,34 @@
+import asyncio
+
+from mem0.configs.embeddings.base import BaseEmbedderConfig
+from mem0.embeddings.base import EmbeddingBase
+
+
+class EchoEmbedder(EmbeddingBase):
+    def __init__(self):
+        super().__init__(BaseEmbedderConfig(model="demo-model"))
+        self.embed_calls = []
+        self.batch_calls = []
+
+    def embed(self, text, memory_action=None):
+        self.embed_calls.append((text, memory_action))
+        return {"text": text, "memory_action": memory_action}
+
+    def embed_batch(self, texts, memory_action="add"):
+        self.batch_calls.append((texts, memory_action))
+        return [{"text": text, "memory_action": memory_action} for text in texts]
+
+
+def test_aembed_and_aembed_batch_fall_back_to_sync_provider():
+    embedder = EchoEmbedder()
+
+    single = asyncio.run(embedder.aembed("hello", "search"))
+    batch = asyncio.run(embedder.aembed_batch(["alpha", "beta"], "update"))
+
+    assert single == {"text": "hello", "memory_action": "search"}
+    assert batch == [
+        {"text": "alpha", "memory_action": "update"},
+        {"text": "beta", "memory_action": "update"},
+    ]
+    assert embedder.embed_calls == [("hello", "search")]
+    assert embedder.batch_calls == [(["alpha", "beta"], "update")]

--- a/tests/embeddings/test_embedding_base_async.py
+++ b/tests/embeddings/test_embedding_base_async.py
@@ -22,13 +22,15 @@ class EchoEmbedder(EmbeddingBase):
 def test_aembed_and_aembed_batch_fall_back_to_sync_provider():
     embedder = EchoEmbedder()
 
+    default_single = asyncio.run(embedder.aembed("default"))
     single = asyncio.run(embedder.aembed("hello", "search"))
     batch = asyncio.run(embedder.aembed_batch(["alpha", "beta"], "update"))
 
+    assert default_single == {"text": "default", "memory_action": None}
     assert single == {"text": "hello", "memory_action": "search"}
     assert batch == [
         {"text": "alpha", "memory_action": "update"},
         {"text": "beta", "memory_action": "update"},
     ]
-    assert embedder.embed_calls == [("hello", "search")]
+    assert embedder.embed_calls == [("default", None), ("hello", "search")]
     assert embedder.batch_calls == [(["alpha", "beta"], "update")]

--- a/tests/embeddings/test_openai_embedding_async.py
+++ b/tests/embeddings/test_openai_embedding_async.py
@@ -1,0 +1,120 @@
+import asyncio
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from mem0.configs.embeddings.base import BaseEmbedderConfig
+from mem0.embeddings.openai import OpenAIEmbedding
+
+
+def _make_embedding_response(start, count):
+    response = Mock()
+    response.data = [Mock(index=index, embedding=[start + index]) for index in range(count)]
+    return response
+
+
+@pytest.fixture
+def openai_clients(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+    with (
+        patch("mem0.embeddings.openai.OpenAI") as mock_sync_ctor,
+        patch("mem0.embeddings.openai.AsyncOpenAI") as mock_async_ctor,
+    ):
+        sync_client = Mock()
+        async_client = Mock()
+        sync_client.embeddings = Mock(create=Mock())
+        async_client.embeddings = Mock(create=Mock())
+        mock_sync_ctor.return_value = sync_client
+        mock_async_ctor.return_value = async_client
+        yield sync_client, async_client, mock_sync_ctor, mock_async_ctor
+
+
+def test_openai_embedding_clients_share_constructor_args(openai_clients):
+    sync_client, async_client, sync_ctor, async_ctor = openai_clients
+
+    embedder = OpenAIEmbedding(
+        BaseEmbedderConfig(
+            model="text-embedding-3-small", api_key="config-key", openai_base_url="https://api.example/v1"
+        )
+    )
+
+    assert sync_ctor.call_args.kwargs == {"api_key": "config-key", "base_url": "https://api.example/v1"}
+    assert async_ctor.call_args.kwargs == {"api_key": "config-key", "base_url": "https://api.example/v1"}
+    assert embedder.client is sync_client
+    assert embedder.async_client is async_client
+
+
+def test_openai_embedding_async_embed_matches_sync_and_normalizes_text(openai_clients):
+    sync_client, async_client, _, _ = openai_clients
+    embedder = OpenAIEmbedding(
+        BaseEmbedderConfig(model="text-embedding-3-small", api_key="config-key", embedding_dims=256)
+    )
+    sync_response = Mock(data=[Mock(embedding=[1.0, 2.0])])
+    async_response = Mock(data=[Mock(embedding=[1.0, 2.0])])
+    sync_client.embeddings.create = Mock(return_value=sync_response)
+    async_client.embeddings.create = AsyncMock(return_value=async_response)
+
+    sync_result = embedder.embed("hello\nworld")
+    async_result = asyncio.run(embedder.aembed("hello\nworld"))
+
+    expected = {
+        "input": ["hello world"],
+        "model": "text-embedding-3-small",
+        "encoding_format": "float",
+        "dimensions": 256,
+    }
+    assert sync_client.embeddings.create.call_args.kwargs == expected
+    assert async_client.embeddings.create.call_args.kwargs == expected
+    assert sync_result == async_result == [1.0, 2.0]
+
+
+def test_openai_embedding_async_batch_matches_sync_and_chunks(openai_clients):
+    sync_client, async_client, _, _ = openai_clients
+    embedder = OpenAIEmbedding(
+        BaseEmbedderConfig(model="text-embedding-3-small", api_key="config-key", embedding_dims=256)
+    )
+    texts = [f"text {index}\nline" for index in range(101)]
+    sync_client.embeddings.create = Mock(
+        side_effect=[
+            _make_embedding_response(0, 100),
+            _make_embedding_response(100, 1),
+        ]
+    )
+    async_client.embeddings.create = AsyncMock(
+        side_effect=[
+            _make_embedding_response(0, 100),
+            _make_embedding_response(100, 1),
+        ]
+    )
+
+    sync_result = embedder.embed_batch(texts)
+    async_result = asyncio.run(embedder.aembed_batch(texts))
+
+    expected_first_call = {
+        "input": [f"text {index} line" for index in range(100)],
+        "model": "text-embedding-3-small",
+        "encoding_format": "float",
+        "dimensions": 256,
+    }
+    expected_second_call = {
+        "input": ["text 100 line"],
+        "model": "text-embedding-3-small",
+        "encoding_format": "float",
+        "dimensions": 256,
+    }
+    assert sync_client.embeddings.create.call_args_list[0].kwargs == expected_first_call
+    assert async_client.embeddings.create.call_args_list[0].kwargs == expected_first_call
+    assert sync_client.embeddings.create.call_args_list[1].kwargs == expected_second_call
+    assert async_client.embeddings.create.call_args_list[1].kwargs == expected_second_call
+    assert sync_result == async_result == [[index] for index in range(101)]
+
+
+def test_openai_embedding_async_batch_count_mismatch_raises(openai_clients):
+    _, async_client, _, _ = openai_clients
+    embedder = OpenAIEmbedding(BaseEmbedderConfig(model="text-embedding-3-small", api_key="config-key"))
+    async_client.embeddings.create = AsyncMock(return_value=_make_embedding_response(0, 1))
+
+    with pytest.raises(ValueError, match="returned 1 embeddings for 2 texts"):
+        asyncio.run(embedder.aembed_batch(["first text", "second text"]))

--- a/tests/embeddings/test_openai_embeddings.py
+++ b/tests/embeddings/test_openai_embeddings.py
@@ -8,7 +8,7 @@ from mem0.embeddings.openai import OpenAIEmbedding
 
 @pytest.fixture
 def mock_openai_client():
-    with patch("mem0.embeddings.openai.OpenAI") as mock_openai:
+    with patch("mem0.embeddings.openai.OpenAI") as mock_openai, patch("mem0.embeddings.openai.AsyncOpenAI"):
         mock_client = Mock()
         mock_openai.return_value = mock_client
         yield mock_client

--- a/tests/llms/test_llm_base_async.py
+++ b/tests/llms/test_llm_base_async.py
@@ -24,6 +24,16 @@ class BoomLLM(LLMBase):
         raise RuntimeError("sync boom")
 
 
+class KwargsOnlyLLM(LLMBase):
+    def __init__(self):
+        super().__init__(BaseLlmConfig(model="demo-model"))
+        self.kwargs = None
+
+    def generate_response(self, messages, **kwargs):
+        self.kwargs = kwargs
+        return "ok"
+
+
 def test_agenerate_response_falls_back_to_sync_provider():
     llm = EchoLLM()
     messages = [{"role": "user", "content": "hello"}]
@@ -44,6 +54,16 @@ def test_agenerate_response_falls_back_to_sync_provider():
     assert result["tool_choice"] == "required"
     assert result["kwargs"] == {"response_format": {"type": "json_object"}, "retry": 1}
     assert llm.calls == [(messages, tools, "required", {"response_format": {"type": "json_object"}, "retry": 1})]
+
+
+def test_agenerate_response_does_not_inject_default_tool_kwargs():
+    llm = KwargsOnlyLLM()
+    messages = [{"role": "user", "content": "hello"}]
+
+    result = asyncio.run(llm.agenerate_response(messages, response_format={"type": "json_object"}))
+
+    assert result == "ok"
+    assert llm.kwargs == {"response_format": {"type": "json_object"}}
 
 
 def test_agenerate_response_propagates_sync_provider_errors():

--- a/tests/llms/test_llm_base_async.py
+++ b/tests/llms/test_llm_base_async.py
@@ -1,0 +1,51 @@
+import asyncio
+
+import pytest
+
+from mem0.configs.llms.base import BaseLlmConfig
+from mem0.llms.base import LLMBase
+
+
+class EchoLLM(LLMBase):
+    def __init__(self):
+        super().__init__(BaseLlmConfig(model="demo-model"))
+        self.calls = []
+
+    def generate_response(self, messages, tools=None, tool_choice="auto", **kwargs):
+        self.calls.append((messages, tools, tool_choice, kwargs))
+        return {"messages": messages, "tools": tools, "tool_choice": tool_choice, "kwargs": kwargs}
+
+
+class BoomLLM(LLMBase):
+    def __init__(self):
+        super().__init__(BaseLlmConfig(model="demo-model"))
+
+    def generate_response(self, messages, tools=None, tool_choice="auto", **kwargs):
+        raise RuntimeError("sync boom")
+
+
+def test_agenerate_response_falls_back_to_sync_provider():
+    llm = EchoLLM()
+    messages = [{"role": "user", "content": "hello"}]
+    tools = [{"type": "function"}]
+
+    result = asyncio.run(
+        llm.agenerate_response(
+            messages,
+            tools=tools,
+            tool_choice="required",
+            response_format={"type": "json_object"},
+            retry=1,
+        )
+    )
+
+    assert result["messages"] == messages
+    assert result["tools"] == tools
+    assert result["tool_choice"] == "required"
+    assert result["kwargs"] == {"response_format": {"type": "json_object"}, "retry": 1}
+    assert llm.calls == [(messages, tools, "required", {"response_format": {"type": "json_object"}, "retry": 1})]
+
+
+def test_agenerate_response_propagates_sync_provider_errors():
+    with pytest.raises(RuntimeError, match="sync boom"):
+        asyncio.run(BoomLLM().agenerate_response([{"role": "user", "content": "hello"}]))

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -11,7 +11,7 @@ from mem0.llms.openai import OpenAILLM
 
 @pytest.fixture
 def mock_openai_client():
-    with patch("mem0.llms.openai.OpenAI") as mock_openai:
+    with patch("mem0.llms.openai.OpenAI") as mock_openai, patch("mem0.llms.openai.AsyncOpenAI"):
         mock_client = Mock()
         mock_openai.return_value = mock_client
         yield mock_client

--- a/tests/llms/test_openai_llm_async.py
+++ b/tests/llms/test_openai_llm_async.py
@@ -1,0 +1,144 @@
+import asyncio
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from mem0.configs.llms.openai import OpenAIConfig
+from mem0.llms.openai import OpenAILLM
+
+
+def _make_response(content, tool_calls=None):
+    message = Mock(content=content)
+    message.tool_calls = tool_calls or []
+    response = Mock()
+    response.choices = [Mock(message=message)]
+    return response
+
+
+@pytest.fixture
+def openai_clients(monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_BASE", raising=False)
+    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+    with patch("mem0.llms.openai.OpenAI") as mock_sync_ctor, patch("mem0.llms.openai.AsyncOpenAI") as mock_async_ctor:
+        sync_client = Mock()
+        async_client = Mock()
+        sync_client.chat = Mock(completions=Mock())
+        async_client.chat = Mock(completions=Mock())
+        mock_sync_ctor.return_value = sync_client
+        mock_async_ctor.return_value = async_client
+        yield sync_client, async_client, mock_sync_ctor, mock_async_ctor
+
+
+def test_openai_clients_share_constructor_args(openai_clients):
+    sync_client, async_client, sync_ctor, async_ctor = openai_clients
+
+    llm = OpenAILLM(
+        OpenAIConfig(model="gpt-4.1-nano-2025-04-14", api_key="config-key", openai_base_url="https://api.example/v1")
+    )
+
+    assert sync_ctor.call_args.kwargs == {"api_key": "config-key", "base_url": "https://api.example/v1"}
+    assert async_ctor.call_args.kwargs == {"api_key": "config-key", "base_url": "https://api.example/v1"}
+    assert llm.client is sync_client
+    assert llm.async_client is async_client
+
+
+def test_openai_async_payload_matches_sync_and_preserves_store_callback(openai_clients):
+    sync_client, async_client, _, _ = openai_clients
+    callback = Mock()
+    llm = OpenAILLM(
+        OpenAIConfig(
+            model="gpt-4.1-nano-2025-04-14",
+            temperature=0.7,
+            max_tokens=100,
+            top_p=1.0,
+            store=True,
+            response_callback=callback,
+        )
+    )
+    messages = [{"role": "user", "content": "Hello"}]
+    tools = [{"type": "function", "function": {"name": "noop", "parameters": {"type": "object", "properties": {}}}}]
+    response_format = {"type": "json_object"}
+    sync_response = _make_response("sync content")
+    async_response = _make_response("sync content")
+    sync_client.chat.completions.create = Mock(return_value=sync_response)
+    async_client.chat.completions.create = AsyncMock(return_value=async_response)
+
+    sync_result = llm.generate_response(
+        messages,
+        response_format=response_format,
+        tools=tools,
+        tool_choice="required",
+        seed=7,
+    )
+    async_result = asyncio.run(
+        llm.agenerate_response(
+            messages,
+            response_format=response_format,
+            tools=tools,
+            tool_choice="required",
+            seed=7,
+        )
+    )
+
+    expected = {
+        "model": "gpt-4.1-nano-2025-04-14",
+        "messages": messages,
+        "temperature": 0.7,
+        "max_tokens": 100,
+        "top_p": 1.0,
+        "response_format": response_format,
+        "tools": tools,
+        "tool_choice": "required",
+        "store": True,
+        "seed": 7,
+    }
+    assert sync_client.chat.completions.create.call_args.kwargs == expected
+    assert async_client.chat.completions.create.call_args.kwargs == expected
+    assert sync_result == async_result == {"content": "sync content", "tool_calls": []}
+    assert callback.call_count == 2
+    assert callback.call_args_list[0].args[1] is sync_response
+    assert callback.call_args_list[1].args[1] is async_response
+
+
+def test_openrouter_async_payload_matches_sync_and_uses_route_fields(openai_clients, monkeypatch):
+    sync_client, async_client, _, _ = openai_clients
+    monkeypatch.setenv("OPENROUTER_API_KEY", "router-key")
+    monkeypatch.setenv("OPENROUTER_API_BASE", "https://router.example/v1")
+
+    llm = OpenAILLM(
+        OpenAIConfig(
+            model="gpt-4.1-nano-2025-04-14",
+            openrouter_base_url="https://router.config/v1",
+            models=["openrouter/model-a", "openrouter/model-b"],
+            route="fallback",
+            site_url="https://site.example",
+            app_name="Mem0",
+            store=True,
+        )
+    )
+    messages = [{"role": "user", "content": "Hello"}]
+    sync_response = _make_response("router content")
+    async_response = _make_response("router content")
+    sync_client.chat.completions.create = Mock(return_value=sync_response)
+    async_client.chat.completions.create = AsyncMock(return_value=async_response)
+
+    sync_result = llm.generate_response(messages)
+    async_result = asyncio.run(llm.agenerate_response(messages))
+
+    expected = {
+        "temperature": 0.1,
+        "max_tokens": 2000,
+        "top_p": 0.1,
+        "messages": messages,
+        "models": ["openrouter/model-a", "openrouter/model-b"],
+        "route": "fallback",
+        "extra_headers": {"HTTP-Referer": "https://site.example", "X-Title": "Mem0"},
+    }
+    assert sync_client.chat.completions.create.call_args.kwargs == expected
+    assert async_client.chat.completions.create.call_args.kwargs == expected
+    assert "model" not in sync_client.chat.completions.create.call_args.kwargs
+    assert "store" not in sync_client.chat.completions.create.call_args.kwargs
+    assert sync_result == async_result == "router content"

--- a/tests/llms/test_vllm.py
+++ b/tests/llms/test_vllm.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
@@ -140,11 +140,14 @@ def create_mocked_memory():
          patch('mem0.memory.storage.SQLiteManager') as mock_sqlite:
 
         mock_llm = MagicMock()
+        mock_llm.agenerate_response = AsyncMock(side_effect=lambda *args, **kwargs: mock_llm.generate_response(*args, **kwargs))
         mock_llm_factory.return_value = mock_llm
 
         mock_embedder = MagicMock()
         mock_embedder.embed.return_value = [0.1, 0.2, 0.3]
         mock_embedder.embed_batch.return_value = [[0.1, 0.2, 0.3]]
+        mock_embedder.aembed = AsyncMock(side_effect=lambda *args, **kwargs: mock_embedder.embed(*args, **kwargs))
+        mock_embedder.aembed_batch = AsyncMock(side_effect=lambda *args, **kwargs: mock_embedder.embed_batch(*args, **kwargs))
         mock_embedder_factory.return_value = mock_embedder
 
         mock_vector_store = MagicMock()
@@ -170,11 +173,14 @@ def create_mocked_async_memory():
          patch('mem0.memory.storage.SQLiteManager') as mock_sqlite:
 
         mock_llm = MagicMock()
+        mock_llm.agenerate_response = AsyncMock(side_effect=lambda *args, **kwargs: mock_llm.generate_response(*args, **kwargs))
         mock_llm_factory.return_value = mock_llm
 
         mock_embedder = MagicMock()
         mock_embedder.embed.return_value = [0.1, 0.2, 0.3]
         mock_embedder.embed_batch.return_value = [[0.1, 0.2, 0.3]]
+        mock_embedder.aembed = AsyncMock(side_effect=lambda *args, **kwargs: mock_embedder.embed(*args, **kwargs))
+        mock_embedder.aembed_batch = AsyncMock(side_effect=lambda *args, **kwargs: mock_embedder.embed_batch(*args, **kwargs))
         mock_embedder_factory.return_value = mock_embedder
 
         mock_vector_store = MagicMock()

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -221,7 +221,7 @@ class TestAsyncUpdate:
 
     @pytest.mark.asyncio
     async def test_async_update_data_is_deprecated_alias_for_text(self, mock_async_memory, mocker, caplog):
-        mock_async_memory.embedding_model = Mock()
+        mock_async_memory.embedding_model = _asyncify_embedding_model(Mock())
         mock_async_memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
         mock_async_memory._update_memory = mocker.AsyncMock()
 

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -1,13 +1,32 @@
+import asyncio
 import logging
 import time
+from contextlib import ExitStack
 from datetime import datetime, timezone
 from types import SimpleNamespace
-from unittest.mock import MagicMock, Mock
+from unittest.mock import AsyncMock, MagicMock, Mock, call, patch as mock_patch
 
 import pytest
 
 from mem0.exceptions import LLMError
 from mem0.memory.main import AsyncMemory, Memory
+from mem0.memory.utils import parse_messages
+
+
+@pytest.fixture
+def mocker():
+    stack = ExitStack()
+
+    class _Mocker:
+        MagicMock = MagicMock
+        AsyncMock = AsyncMock
+        Mock = Mock
+
+        def patch(self, target, *args, **kwargs):
+            return stack.enter_context(mock_patch(target, *args, **kwargs))
+
+    yield _Mocker()
+    stack.close()
 
 
 def _setup_mocks(mocker):
@@ -28,6 +47,17 @@ def _setup_mocks(mocker):
     mocker.patch("mem0.memory.storage.SQLiteManager", mocker.MagicMock())
 
     return mock_llm, mock_vector_store
+
+
+def _asyncify_embedding_model(model):
+    model.aembed = AsyncMock(side_effect=lambda *args, **kwargs: model.embed(*args, **kwargs))
+    model.aembed_batch = AsyncMock(side_effect=lambda *args, **kwargs: model.embed_batch(*args, **kwargs))
+    return model
+
+
+def _asyncify_llm(model):
+    model.agenerate_response = AsyncMock(side_effect=lambda *args, **kwargs: model.generate_response(*args, **kwargs))
+    return model
 
 
 class TestAddToVectorStoreErrors:
@@ -63,7 +93,9 @@ class TestAddToVectorStoreErrors:
         # Verify — v3 single-pass pipeline makes 1 LLM call, returns [] on parse error
         assert mock_memory.llm.generate_response.call_count == 1
         assert result == []
-        assert any("Error parsing extraction response" in record.message for record in caplog.records), "Expected error message not found in logs"
+        assert any("Error parsing extraction response" in record.message for record in caplog.records), (
+            "Expected error message not found in logs"
+        )
 
     def test_empty_llm_response_memory_actions(self, mock_memory, caplog):
         """Test empty response from LLM during memory actions (v3: single-pass, 1 LLM call)"""
@@ -148,43 +180,40 @@ class TestAsyncUpdate:
         memory = AsyncMemory()
         return memory
 
-    @pytest.mark.asyncio
-    async def test_async_update_without_metadata(self, mock_async_memory, mocker):
+    def test_async_update_without_metadata(self, mock_async_memory, mocker):
         """Test async update passes None metadata by default"""
-        mock_async_memory.embedding_model = Mock()
+        mock_async_memory.embedding_model = _asyncify_embedding_model(Mock())
         mock_async_memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
         mock_async_memory._update_memory = mocker.AsyncMock()
 
-        result = await mock_async_memory.update("test_id", "Updated memory")
+        result = asyncio.run(mock_async_memory.update("test_id", "Updated memory"))
 
         mock_async_memory._update_memory.assert_called_once_with(
             "test_id", "Updated memory", {"Updated memory": [0.1, 0.2, 0.3]}, None
         )
         assert result["message"] == "Memory updated successfully!"
 
-    @pytest.mark.asyncio
-    async def test_async_update_with_metadata(self, mock_async_memory, mocker):
+    def test_async_update_with_metadata(self, mock_async_memory, mocker):
         """Test async update correctly forwards metadata"""
-        mock_async_memory.embedding_model = Mock()
+        mock_async_memory.embedding_model = _asyncify_embedding_model(Mock())
         mock_async_memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
         mock_async_memory._update_memory = mocker.AsyncMock()
         metadata = {"category": "sports", "priority": "high"}
 
-        result = await mock_async_memory.update("test_id", "Updated memory", metadata=metadata)
+        result = asyncio.run(mock_async_memory.update("test_id", "Updated memory", metadata=metadata))
 
         mock_async_memory._update_memory.assert_called_once_with(
             "test_id", "Updated memory", {"Updated memory": [0.1, 0.2, 0.3]}, metadata
         )
         assert result["message"] == "Memory updated successfully!"
 
-    @pytest.mark.asyncio
-    async def test_async_update_with_empty_metadata(self, mock_async_memory, mocker):
+    def test_async_update_with_empty_metadata(self, mock_async_memory, mocker):
         """Test async update with empty metadata dict"""
-        mock_async_memory.embedding_model = Mock()
+        mock_async_memory.embedding_model = _asyncify_embedding_model(Mock())
         mock_async_memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
         mock_async_memory._update_memory = mocker.AsyncMock()
 
-        await mock_async_memory.update("test_id", "Updated memory", metadata={})
+        asyncio.run(mock_async_memory.update("test_id", "Updated memory", metadata={}))
 
         mock_async_memory._update_memory.assert_called_once_with(
             "test_id", "Updated memory", {"Updated memory": [0.1, 0.2, 0.3]}, {}
@@ -272,7 +301,9 @@ class TestAsyncAddToVectorStoreErrors:
             )
         assert mock_async_memory.llm.generate_response.call_count == 1
         assert result == []
-        assert any("Error parsing extraction response" in record.message for record in caplog.records), "Expected error message not found in logs"
+        assert any("Error parsing extraction response" in record.message for record in caplog.records), (
+            "Expected error message not found in logs"
+        )
 
     @pytest.mark.asyncio
     async def test_async_empty_llm_response_memory_actions(self, mock_async_memory, caplog, mocker):
@@ -325,6 +356,9 @@ def _build_memory_instance(mocker, memory_cls):
     memory.api_version = "v1.1"
     memory.vector_store = mocker.MagicMock()
     memory.db = mocker.MagicMock()
+    if memory_cls is AsyncMemory:
+        memory.llm = _asyncify_llm(memory.llm)
+        memory.embedding_model = _asyncify_embedding_model(memory.embedding_model)
     return memory
 
 
@@ -650,6 +684,7 @@ class TestMetadataNotMutated:
         memory = _build_memory_instance(mocker, Memory)
         metadata = {"user_id": "test_user", "tags": ["important", "urgent"], "config": {"key": "val"}}
         import copy
+
         metadata_snapshot = copy.deepcopy(metadata)
 
         memory._create_memory("test data", {"test data": [0.1, 0.2, 0.3]}, metadata=metadata)
@@ -823,11 +858,10 @@ class TestEntityBoostParallelism:
 
         mock_memory.embedding_model.embed_batch.assert_called_once_with(["alice", "bob", "carol"], "search")
 
-    @pytest.mark.asyncio
-    async def test_async_boosts_preserve_scoring(self, mock_async_memory):
+    def test_async_boosts_preserve_scoring(self, mock_async_memory):
         from mem0.utils.scoring import ENTITY_BOOST_WEIGHT
 
-        mock_async_memory.embedding_model = Mock()
+        mock_async_memory.embedding_model = _asyncify_embedding_model(Mock())
         mock_async_memory.embedding_model.embed_batch = Mock(return_value=[[0.1, 0.2, 0.3], [0.1, 0.2, 0.3]])
 
         results_by_query = {
@@ -841,9 +875,11 @@ class TestEntityBoostParallelism:
         mock_async_memory._entity_store = Mock()
         mock_async_memory._entity_store.search = Mock(side_effect=fake_search)
 
-        boosts = await mock_async_memory._compute_entity_boosts_async(
-            [("person", "alice"), ("person", "bob")],
-            {"user_id": "u1"},
+        boosts = asyncio.run(
+            mock_async_memory._compute_entity_boosts_async(
+                [("person", "alice"), ("person", "bob")],
+                {"user_id": "u1"},
+            )
         )
 
         boost_alice = 0.9 * ENTITY_BOOST_WEIGHT * (1.0 / (1.0 + 0.001 * (0**2)))
@@ -851,16 +887,17 @@ class TestEntityBoostParallelism:
         assert boosts["mem-1"] == pytest.approx(max(boost_alice, boost_bob))
         assert boosts["mem-2"] == pytest.approx(boost_bob)
 
-    @pytest.mark.asyncio
-    async def test_async_embed_batch_called_once(self, mock_async_memory):
-        mock_async_memory.embedding_model = Mock()
+    def test_async_embed_batch_called_once(self, mock_async_memory):
+        mock_async_memory.embedding_model = _asyncify_embedding_model(Mock())
         mock_async_memory.embedding_model.embed_batch = Mock(return_value=[[0.1], [0.1], [0.1]])
         mock_async_memory._entity_store = Mock()
         mock_async_memory._entity_store.search = Mock(return_value=[_make_match(0.7, ["mem-1"])])
 
-        await mock_async_memory._compute_entity_boosts_async(
-            [("person", "alice"), ("person", "bob"), ("person", "carol")],
-            {"user_id": "u1"},
+        asyncio.run(
+            mock_async_memory._compute_entity_boosts_async(
+                [("person", "alice"), ("person", "bob"), ("person", "carol")],
+                {"user_id": "u1"},
+            )
         )
 
         mock_async_memory.embedding_model.embed_batch.assert_called_once_with(["alice", "bob", "carol"], "search")
@@ -886,9 +923,8 @@ class TestEntityBoostParallelism:
         assert "mem-9" in boosts
         assert any("Entity boost search failed" in r.message for r in caplog.records)
 
-    @pytest.mark.asyncio
-    async def test_async_one_entity_failure_does_not_abort_others(self, mock_async_memory, caplog):
-        mock_async_memory.embedding_model = Mock()
+    def test_async_one_entity_failure_does_not_abort_others(self, mock_async_memory, caplog):
+        mock_async_memory.embedding_model = _asyncify_embedding_model(Mock())
         mock_async_memory.embedding_model.embed_batch = Mock(return_value=[[0.1, 0.2, 0.3], [0.1, 0.2, 0.3]])
 
         def fake_search(query, vectors, top_k, filters):
@@ -900,9 +936,11 @@ class TestEntityBoostParallelism:
         mock_async_memory._entity_store.search = Mock(side_effect=fake_search)
 
         with caplog.at_level(logging.WARNING):
-            boosts = await mock_async_memory._compute_entity_boosts_async(
-                [("person", "boom"), ("person", "ok")],
-                {"user_id": "u1"},
+            boosts = asyncio.run(
+                mock_async_memory._compute_entity_boosts_async(
+                    [("person", "boom"), ("person", "ok")],
+                    {"user_id": "u1"},
+                )
             )
 
         assert "mem-9" in boosts
@@ -933,9 +971,8 @@ class TestEntityBoostParallelism:
         assert concurrent_count["peak"] >= 2, "no overlap observed between entity searches"
         assert len(boosts) == 4
 
-    @pytest.mark.asyncio
-    async def test_async_searches_run_concurrently(self, mock_async_memory):
-        mock_async_memory.embedding_model = Mock()
+    def test_async_searches_run_concurrently(self, mock_async_memory):
+        mock_async_memory.embedding_model = _asyncify_embedding_model(Mock())
         mock_async_memory.embedding_model.embed_batch = Mock(return_value=[[0.1]] * 4)
 
         concurrent_count = {"current": 0, "peak": 0}
@@ -952,7 +989,7 @@ class TestEntityBoostParallelism:
 
         entities = [("person", f"e{i}") for i in range(4)]
         start = time.perf_counter()
-        boosts = await mock_async_memory._compute_entity_boosts_async(entities, {"user_id": "u1"})
+        boosts = asyncio.run(mock_async_memory._compute_entity_boosts_async(entities, {"user_id": "u1"}))
         elapsed = time.perf_counter() - start
 
         assert elapsed < 0.75, f"searches did not run concurrently (took {elapsed:.2f}s)"
@@ -1049,12 +1086,12 @@ class TestAddPipelineEntityEmbeddingCountGuard:
             "expected count-mismatch warning was not emitted"
         )
 
-    @pytest.mark.asyncio
-    async def test_async_short_entity_embeddings_still_link_valid_entity(self, mock_async_memory, mocker, caplog):
+    def test_async_short_entity_embeddings_still_link_valid_entity(self, mock_async_memory, mocker, caplog):
+        mock_async_memory.llm = _asyncify_llm(mock_async_memory.llm)
         mock_async_memory.llm.generate_response.return_value = (
             '{"memory": [{"text": "Alice met Bob"}, {"text": "Bob called Alice"}]}'
         )
-        mock_async_memory.embedding_model = Mock()
+        mock_async_memory.embedding_model = _asyncify_embedding_model(Mock())
         mock_async_memory.embedding_model.embed_batch = Mock(side_effect=self._short_entity_embed_batch)
         mock_async_memory.embedding_model.embed = Mock(return_value=[0.1] * 10)
 
@@ -1073,11 +1110,13 @@ class TestAddPipelineEntityEmbeddingCountGuard:
         mocker.patch("mem0.memory.main.capture_event")
 
         with caplog.at_level(logging.WARNING):
-            result = await mock_async_memory._add_to_vector_store(
-                messages=[{"role": "user", "content": "Alice met Bob; Bob called Alice"}],
-                metadata={},
-                effective_filters={"user_id": "u1"},
-                infer=True,
+            result = asyncio.run(
+                mock_async_memory._add_to_vector_store(
+                    messages=[{"role": "user", "content": "Alice met Bob; Bob called Alice"}],
+                    metadata={},
+                    effective_filters={"user_id": "u1"},
+                    infer=True,
+                )
             )
 
         assert len(result) == 2
@@ -1089,3 +1128,115 @@ class TestAddPipelineEntityEmbeddingCountGuard:
         assert any("padding/truncating" in r.message for r in caplog.records), (
             "expected count-mismatch warning was not emitted"
         )
+
+
+def test_async_add_without_inference_uses_aembed(mocker):
+    memory = _build_memory_instance(mocker, AsyncMemory)
+    memory.embedding_model = _asyncify_embedding_model(Mock())
+    memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+    memory._create_memory = mocker.AsyncMock(return_value="memory-1")
+
+    result = asyncio.run(
+        memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "Hello"}],
+            metadata={"user_id": "u1"},
+            effective_filters={"user_id": "u1"},
+            infer=False,
+        )
+    )
+
+    assert result == [{"id": "memory-1", "memory": "Hello", "event": "ADD", "actor_id": None, "role": "user"}]
+    memory.embedding_model.aembed.assert_awaited_once_with("Hello", "add")
+    memory._create_memory.assert_awaited_once_with(
+        "Hello",
+        {"Hello": [0.1, 0.2, 0.3]},
+        {"user_id": "u1", "role": "user"},
+    )
+
+
+def test_async_add_inference_uses_aembed_batch_and_fallback(mocker):
+    memory = _build_memory_instance(mocker, AsyncMemory)
+    memory.embedding_model = _asyncify_embedding_model(Mock())
+    memory.embedding_model.embed = Mock(return_value=[0.9, 0.8, 0.7])
+    memory.embedding_model.embed_batch = Mock(side_effect=RuntimeError("batch failed"))
+    memory.llm.generate_response.return_value = '{"memory": [{"text": "Alpha"}, {"text": "Beta"}]}'
+    memory.db.get_last_messages = Mock(return_value=[])
+    memory.vector_store.search = Mock(return_value=[])
+    memory.vector_store.insert = Mock()
+    memory.db.batch_add_history = Mock()
+    memory.db.save_messages = Mock()
+    mocker.patch("mem0.memory.main.capture_event")
+    mocker.patch("mem0.memory.main.extract_entities_batch", return_value=[])
+
+    result = asyncio.run(
+        memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "Hello"}],
+            metadata={"user_id": "u1"},
+            effective_filters={"user_id": "u1"},
+            infer=True,
+        )
+    )
+
+    assert [item["memory"] for item in result] == ["Alpha", "Beta"]
+    assert memory.llm.generate_response.call_count == 1
+    memory.embedding_model.aembed.assert_any_await(parse_messages([{"role": "user", "content": "Hello"}]), "search")
+    memory.embedding_model.aembed_batch.assert_awaited_once_with(["Alpha", "Beta"], "add")
+    assert memory.embedding_model.embed.call_args_list == [
+        call(parse_messages([{"role": "user", "content": "Hello"}]), "search"),
+        call("Alpha", "add"),
+        call("Beta", "add"),
+    ]
+
+
+def test_async_search_vector_store_uses_aembed(mocker):
+    memory = _build_memory_instance(mocker, AsyncMemory)
+    memory.embedding_model = _asyncify_embedding_model(Mock())
+    memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+    memory.vector_store.search = Mock(return_value=[])
+    memory.vector_store.keyword_search = Mock(return_value=[])
+    mocker.patch("mem0.memory.main.extract_entities", return_value=[])
+
+    result = asyncio.run(memory._search_vector_store("tea", filters={}, limit=5))
+
+    assert result == []
+    memory.embedding_model.aembed.assert_awaited_once_with("tea", "search")
+
+
+def test_async_update_uses_aembed(mocker):
+    memory = _build_memory_instance(mocker, AsyncMemory)
+    memory.embedding_model = _asyncify_embedding_model(Mock())
+    memory.embedding_model.embed = Mock(return_value=[0.2, 0.3, 0.4])
+    memory._update_memory = mocker.AsyncMock(return_value=None)
+    mocker.patch("mem0.memory.main.display_first_run_notice_async", new=AsyncMock())
+    mocker.patch("mem0.memory.main.capture_event")
+
+    result = asyncio.run(memory.update("memory-id", data="Updated memory"))
+
+    assert result == {"message": "Memory updated successfully!"}
+    memory.embedding_model.aembed.assert_awaited_once_with("Updated memory", "update")
+    memory._update_memory.assert_awaited_once_with(
+        "memory-id",
+        "Updated memory",
+        {"Updated memory": [0.2, 0.3, 0.4]},
+        None,
+    )
+
+
+def test_async_create_procedural_memory_uses_async_provider_methods(mocker):
+    memory = _build_memory_instance(mocker, AsyncMemory)
+    memory.llm.generate_response.return_value = "Procedural summary"
+    memory.embedding_model = _asyncify_embedding_model(Mock())
+    memory.embedding_model.embed = Mock(return_value=[0.5, 0.6, 0.7])
+    memory._create_memory = mocker.AsyncMock(return_value="memory-id")
+    mocker.patch("mem0.memory.main.capture_event")
+
+    result = asyncio.run(
+        memory._create_procedural_memory(
+            [{"role": "user", "content": "Remember this"}],
+            metadata={"user_id": "u1"},
+        )
+    )
+
+    assert result == {"results": [{"id": "memory-id", "memory": "Procedural summary", "event": "ADD"}]}
+    memory.llm.agenerate_response.assert_awaited_once()
+    memory.embedding_model.aembed.assert_awaited_once_with("Procedural summary", memory_action="add")

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, call, patch as mock_patch
 import pytest
 
 from mem0.exceptions import LLMError
-from mem0.memory.main import AsyncMemory, Memory
+from mem0.memory.main import ADDITIVE_EXTRACTION_PROMPT, AsyncMemory, Memory, generate_additive_extraction_prompt
 from mem0.memory.utils import parse_messages
 
 
@@ -1181,7 +1181,21 @@ def test_async_add_inference_uses_aembed_batch_and_fallback(mocker):
     )
 
     assert [item["memory"] for item in result] == ["Alpha", "Beta"]
-    assert memory.llm.generate_response.call_count == 1
+    memory.llm.agenerate_response.assert_awaited_once_with(
+        messages=[
+            {"role": "system", "content": ADDITIVE_EXTRACTION_PROMPT},
+            {
+                "role": "user",
+                "content": generate_additive_extraction_prompt(
+                    existing_memories=[],
+                    new_messages=parse_messages([{"role": "user", "content": "Hello"}]),
+                    last_k_messages=[],
+                    custom_instructions=None,
+                ),
+            },
+        ],
+        response_format={"type": "json_object"},
+    )
     memory.embedding_model.aembed.assert_any_await(parse_messages([{"role": "user", "content": "Hello"}]), "search")
     memory.embedding_model.aembed_batch.assert_awaited_once_with(["Alpha", "Beta"], "add")
     assert memory.embedding_model.embed.call_args_list == [

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -243,6 +243,7 @@ class TestAsyncUpdate:
 
     @pytest.mark.asyncio
     async def test_async_update_can_change_expiration_date_without_changing_text(self, mock_async_memory, mocker):
+        mock_async_memory.embedding_model = _asyncify_embedding_model(mock_async_memory.embedding_model)
         mock_async_memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
         mock_async_memory.vector_store.get = Mock(
             return_value=Mock(
@@ -277,6 +278,8 @@ class TestAsyncAddToVectorStoreErrors:
         mock_llm, _ = _setup_mocks(mocker)
 
         memory = AsyncMemory()
+        memory.llm = _asyncify_llm(memory.llm)
+        memory.embedding_model = _asyncify_embedding_model(memory.embedding_model)
         memory.config = mocker.MagicMock()
         memory.config.custom_instructions = None
         memory.config.custom_update_memory_prompt = None

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1565,7 +1565,9 @@ async def test_async_procedural_memory_default_path_without_langchain(mock_llm_f
     memory.vector_store = MagicMock()
     memory.vector_store.insert = MagicMock()
     memory.embedding_model.embed = Mock(return_value=[0.1] * 1536)
+    memory.embedding_model.aembed = AsyncMock(side_effect=lambda *args, **kwargs: memory.embedding_model.embed(*args, **kwargs))
     memory.llm.generate_response = Mock(return_value="- deploy with the release script")
+    memory.llm.agenerate_response = AsyncMock(side_effect=lambda *args, **kwargs: memory.llm.generate_response(*args, **kwargs))
 
     messages = [{"role": "user", "content": "how do we deploy"}]
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,7 +1,7 @@
 import json
 import sys
 from datetime import datetime
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
@@ -9,6 +9,12 @@ from mem0 import Memory
 from mem0.configs.base import MemoryConfig
 from mem0.memory.main import _entity_collection_name
 from mem0.memory.utils import normalize_facts
+
+
+def _asyncify_embedding_model(model):
+    model.aembed = AsyncMock(side_effect=lambda *args, **kwargs: model.embed(*args, **kwargs))
+    model.aembed_batch = AsyncMock(side_effect=lambda *args, **kwargs: model.embed_batch(*args, **kwargs))
+    return model
 
 
 class MockVectorMemory:
@@ -194,7 +200,7 @@ def test_search_handles_incomplete_payloads(mock_sqlite, mock_llm_factory, mock_
 
     mock_embedder = MagicMock()
     mock_embedder.embed.return_value = [0.1, 0.2, 0.3]
-    memory.embedding_model = mock_embedder
+    memory.embedding_model = _asyncify_embedding_model(mock_embedder)
 
     result = memory._search_vector_store("test", {"user_id": "test"}, 10)
 
@@ -366,7 +372,7 @@ def test_read_apis_surface_attributed_to(mock_sqlite, mock_llm_factory, mock_vec
 
     from mem0.memory.main import Memory as MemoryClass
     memory = MemoryClass(MemoryConfig())
-    memory.embedding_model = mock_embedder
+    memory.embedding_model = _asyncify_embedding_model(mock_embedder)
 
     payload = {"data": "User likes Python", "attributed_to": "user", "user_id": "u1"}
 
@@ -407,7 +413,7 @@ async def test_async_read_apis_surface_attributed_to(mock_sqlite, mock_llm_facto
 
     from mem0.memory.main import AsyncMemory
     memory = AsyncMemory(MemoryConfig())
-    memory.embedding_model = mock_embedder
+    memory.embedding_model = _asyncify_embedding_model(mock_embedder)
 
     payload = {"data": "User likes Python", "attributed_to": "user", "user_id": "u1"}
 
@@ -1510,7 +1516,7 @@ class TestAsyncDeleteAllEntityRace:
 async def test_async_procedural_memory_langchain_strips_code_blocks(mock_llm_factory, mock_emb, mock_vs):
     """Regression #5710: async LangChain path must call remove_code_blocks()."""
     mock_vs.return_value = MagicMock()
-    mock_emb.return_value = MagicMock()
+    mock_emb.return_value = _asyncify_embedding_model(MagicMock())
     mock_emb.return_value.embed.return_value = [0.1] * 1536
     mock_llm_factory.return_value = MagicMock()
 
@@ -1518,6 +1524,8 @@ async def test_async_procedural_memory_langchain_strips_code_blocks(mock_llm_fac
 
     config = MemoryConfig()
     memory = AsyncMemory(config)
+    memory.embedding_model = _asyncify_embedding_model(MagicMock())
+    memory.embedding_model.embed.return_value = [0.1] * 1536
     memory.vector_store = MagicMock()
     memory.vector_store.insert = MagicMock()
 


### PR DESCRIPTION
## Linked Issue

Closes #6070

## Summary

`AsyncMemory` exposes async methods, but OpenAI-compatible LLM and embedding requests still run through executor threads. This adds native `AsyncOpenAI` paths to the OpenAI LLM and embedding adapters, then routes `AsyncMemory` model calls through provider-base async methods with sync fallbacks for providers without native async clients.

## Scope

The change is limited to OpenAI-compatible LLM and embedding model calls. Vector stores, history DB, entity-store operations, rerankers, graph storage, OpenMemory, the TypeScript SDK, and a full end-to-end async conversion remain unchanged.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update

## Breaking Changes

N/A. Providers without native async clients retain the existing sync fallback behavior.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested the focused provider and memory paths
- [ ] No tests needed

Verification:

- [x] Focused async and provider suite: 159 passed
- [x] `ruff check` passed for all fourteen changed files
- [x] `git diff --check` passed
- [ ] `ruff format --check`, current-main formatting differences remain in four touched files
- [ ] `make test`, not run in this final pass because the broad optional dependency matrix is unavailable locally

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of the code
- [x] I have added tests that prove the fix works
- [x] Focused tests pass locally
- [x] I have updated documentation if needed
