### PR TITLE
fix(opensearch): don't cap unbounded list() at OpenSearch's 10-hit default

### DIFF
--- a/mem0/vector_stores/opensearch.py
+++ b/mem0/vector_stores/opensearch.py
@@ -17,6 +17,11 @@ logger = logging.getLogger(__name__)
 
 _SAFE_FILTER_KEY = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_.]*$")
 
+# OpenSearch's own default for `index.max_result_window`. Used as the query
+# size when no top_k is given, so unbounded list() calls (e.g. get_all(),
+# delete_all()) aren't silently capped at OpenSearch's search-API default of 10.
+_DEFAULT_MAX_RESULT_WINDOW = 10000
+
 
 def _validate_filter(key: str, value) -> None:
     if not isinstance(key, str) or not _SAFE_FILTER_KEY.match(key):
@@ -381,8 +386,7 @@ class OpenSearchDB(VectorStoreBase):
             if filter_clauses:
                 query["query"] = {"bool": {"filter": filter_clauses}}
 
-            if top_k:
-                query["size"] = top_k
+            query["size"] = top_k if top_k else _DEFAULT_MAX_RESULT_WINDOW
 
             response = self.client.search(index=self.collection_name, body=query)
             hits = response["hits"]["hits"]

--- a/mem0/vector_stores/opensearch.py
+++ b/mem0/vector_stores/opensearch.py
@@ -20,6 +20,10 @@ _SAFE_FILTER_KEY = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_.]*$")
 # OpenSearch's own default for `index.max_result_window`. Used as the query
 # size when no top_k is given, so unbounded list() calls (e.g. get_all(),
 # delete_all()) aren't silently capped at OpenSearch's search-API default of 10.
+# This is itself a ceiling, not true unboundedness: collections with more than
+# this many matching docs will still be truncated on get_all()/delete_all().
+# Paginating with search_after (or a PIT/scroll) would be needed to remove the
+# cap entirely; 10000 matches mem0's existing "give me everything" convention.
 _DEFAULT_MAX_RESULT_WINDOW = 10000
 
 

--- a/tests/vector_stores/test_opensearch.py
+++ b/tests/vector_stores/test_opensearch.py
@@ -312,6 +312,23 @@ class TestOpenSearchDB(unittest.TestCase):
         self.assertEqual(len(result[0]), 1)
         self.assertEqual(result[0][0].id, "id1")
 
+    def test_list_without_top_k_uses_max_result_window(self):
+        """list() with no top_k (e.g. get_all()/delete_all()) must not be
+        silently capped at OpenSearch's search-API default of 10 hits."""
+        mock_response = {"hits": {"hits": []}}
+        self.client_mock.search.return_value = mock_response
+        self.os_db.list(filters={"user_id": "alice"})
+        search_args = self.client_mock.search.call_args[1]
+        self.assertEqual(search_args["body"]["size"], 10000)
+
+    def test_list_with_top_k_uses_given_size(self):
+        """Passing an explicit top_k should still cap the query at that size."""
+        mock_response = {"hits": {"hits": []}}
+        self.client_mock.search.return_value = mock_response
+        self.os_db.list(filters={"user_id": "alice"}, top_k=25)
+        search_args = self.client_mock.search.call_args[1]
+        self.assertEqual(search_args["body"]["size"], 25)
+
     @patch("mem0.vector_stores.opensearch.logger")
     def test_list_error_returns_nested_empty_list(self, mock_logger):
         """list() error path must return [[]] (not bare []) so callers can do


### PR DESCRIPTION
## Summary

Closes #6108.

`OpenSearchDB.list()` (`mem0/vector_stores/opensearch.py`) only set the query `size` when `top_k` was truthy:

```python
if top_k:
    query["size"] = top_k
```

`Memory.get_all()` and `Memory.delete_all()` call `vector_store.list(filters=...)` with `top_k=None` to enumerate **all** matching memories. With `size` unset, OpenSearch falls back to its search-API default of **10 hits**, so any user/agent/run with more than 10 memories silently loses the rest:

- `get_all()` returns at most 10 memories.
- `delete_all()` deletes at most 10 memories per call, leaving older ones behind.

## Fix

Fall back to `10000` (OpenSearch's own default for `index.max_result_window`) as the query size when `top_k` is `None`/falsy, so unbounded `list()` calls return everything up to that window instead of silently truncating at 10:

```python
query["size"] = top_k if top_k else _DEFAULT_MAX_RESULT_WINDOW
```

The sibling Elasticsearch adapter has the same `if top_k:` shape (noted in the issue) but is out of scope here — this PR only touches the OpenSearch backend per the issue's title.

## Test plan

- [x] Added `test_list_without_top_k_uses_max_result_window` — asserts the query sent to OpenSearch has `size == 10000` when `top_k` is omitted
- [x] Added `test_list_with_top_k_uses_given_size` — regression check that an explicit `top_k` still caps the query at that value
- [x] `pytest tests/vector_stores/test_opensearch.py` — 31 passed (29 existing + 2 new)
- [x] `ruff check` on changed files — clean