### PR TITLE
fix: raise ImportError instead of blocking on input()/sys.exit() for optional deps

### DIFF
--- a/mem0/embeddings/ollama.py
+++ b/mem0/embeddings/ollama.py
@@ -1,5 +1,3 @@
-import subprocess
-import sys
 from typing import Literal, Optional
 
 from mem0.configs.embeddings.base import BaseEmbedderConfig
@@ -8,17 +6,7 @@ from mem0.embeddings.base import EmbeddingBase
 try:
     from ollama import Client
 except ImportError:
-    user_input = input("The 'ollama' library is required. Install it now? [y/N]: ")
-    if user_input.lower() == "y":
-        try:
-            subprocess.check_call([sys.executable, "-m", "pip", "install", "ollama"])
-            from ollama import Client
-        except subprocess.CalledProcessError:
-            print("Failed to install 'ollama'. Please install it manually using 'pip install ollama'.")
-            sys.exit(1)
-    else:
-        print("The required 'ollama' library is not installed.")
-        sys.exit(1)
+    raise ImportError("The 'ollama' library is required. Please install it using 'pip install ollama'.") from None
 
 
 class OllamaEmbedding(EmbeddingBase):

--- a/mem0/proxy/main.py
+++ b/mem0/proxy/main.py
@@ -1,6 +1,4 @@
 import logging
-import subprocess
-import sys
 import threading
 from typing import List, Optional, Union
 
@@ -11,12 +9,7 @@ import mem0
 try:
     import litellm
 except ImportError:
-    try:
-        subprocess.check_call([sys.executable, "-m", "pip", "install", "litellm"])
-        import litellm
-    except subprocess.CalledProcessError:
-        print("Failed to install 'litellm'. Please install it manually using 'pip install litellm'.")
-        sys.exit(1)
+    raise ImportError("The 'litellm' library is required. Please install it using 'pip install litellm'.") from None
 
 from mem0 import Memory, MemoryClient
 from mem0.configs.prompts import MEMORY_ANSWER_PROMPT

--- a/tests/embeddings/test_ollama_embeddings.py
+++ b/tests/embeddings/test_ollama_embeddings.py
@@ -1,3 +1,5 @@
+import subprocess
+import sys
 from unittest.mock import Mock, patch
 
 import pytest
@@ -94,3 +96,32 @@ def test_embed_batch_count_mismatch_raises(mock_ollama_client):
 
     with pytest.raises(ValueError, match="returned 1 embeddings for 2 texts"):
         embedder.embed_batch(["first text", "second text"])
+
+
+def test_missing_ollama_raises_import_error_without_prompting():
+    """Missing the optional 'ollama' dependency must raise ImportError, not
+    block on input() or kill the process with sys.exit().
+
+    Regression test for https://github.com/mem0ai/mem0/issues/6118: input()
+    hangs any non-interactive host (pytest, a FastAPI server), and sys.exit(1)
+    takes the whole process down instead of letting the caller handle it.
+
+    Runs the import in a fresh subprocess (rather than reloading the module
+    in-process) so a real missing dependency is simulated without leaving
+    mem0.embeddings.ollama's classes in an inconsistent state for other tests.
+    """
+    code = "import sys; sys.modules['ollama'] = None; import mem0.embeddings.ollama"
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        stdin=subprocess.DEVNULL,
+    )
+    assert result.returncode != 0
+    # EOFError would mean input() was actually invoked (stdin is closed);
+    # SystemExit would mean sys.exit() ran. Neither should appear.
+    assert "EOFError" not in result.stderr
+    assert "SystemExit" not in result.stderr
+    assert "ImportError" in result.stderr
+    assert "pip install ollama" in result.stderr

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,4 +1,6 @@
 import inspect
+import subprocess
+import sys
 from unittest.mock import Mock, patch
 
 import pytest
@@ -34,6 +36,32 @@ def mock_openai_llm_client():
 def mock_litellm():
     with patch("mem0.proxy.main.litellm") as mock:
         yield mock
+
+
+def test_missing_litellm_raises_import_error_without_exiting():
+    """Missing the optional 'litellm' dependency must raise ImportError, not
+    silently pip-install it or kill the process with sys.exit().
+
+    Regression test for https://github.com/mem0ai/mem0/issues/6118: sys.exit(1)
+    takes down the whole host process (e.g. a FastAPI server) instead of
+    letting the caller handle a missing optional dependency.
+
+    Runs the import in a fresh subprocess (rather than reloading the module
+    in-process) so a real missing dependency is simulated without leaving
+    mem0.proxy.main's classes in an inconsistent state for other tests.
+    """
+    code = "import sys; sys.modules['litellm'] = None; import mem0.proxy.main"
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        stdin=subprocess.DEVNULL,
+    )
+    assert result.returncode != 0
+    assert "SystemExit" not in result.stderr
+    assert "ImportError" in result.stderr
+    assert "pip install litellm" in result.stderr
 
 
 def test_mem0_initialization_with_api_key(mock_openai_embedding_client, mock_openai_llm_client):


### PR DESCRIPTION
## Summary

Closes #6118.

`mem0/embeddings/ollama.py` and `mem0/proxy/main.py` caught `ImportError` for their optional dependencies (`ollama`, `litellm`) by prompting interactively with `input()` and/or calling `sys.exit(1)`:

- `ollama.py` asked `input("The 'ollama' library is required. Install it now? [y/N]: ")`, which blocks forever on any non-interactive host (pytest, a FastAPI server) — under pytest specifically this raises `OSError: pytest: reading from stdin while output is captured`.
- Both modules called `sys.exit(1)` on failure, which kills the entire host process instead of letting the caller catch and handle a missing optional dependency.

## Fix

Replace both with a plain `raise ImportError(...) from None`, matching the convention already used by every other optional-dependency import in the codebase (e.g. `mem0/llms/litellm.py`, `mem0/embeddings/aws_bedrock.py`, `mem0/embeddings/fastembed.py`):

```python
try:
    from ollama import Client
except ImportError:
    raise ImportError("The 'ollama' library is required. Please install it using 'pip install ollama'.") from None
```

Also removed the now-unused `subprocess`/`sys` imports in both files.

## Test plan

- [x] Added `test_missing_ollama_raises_import_error_without_prompting` (`tests/embeddings/test_ollama_embeddings.py`) and `test_missing_litellm_raises_import_error_without_exiting` (`tests/test_proxy.py`) — both simulate the missing dependency in a fresh subprocess (rather than reloading the module in-process, which would leave the module's classes in an inconsistent state for other tests) and assert: non-zero exit, no `EOFError`/`SystemExit` in stderr (proving `input()`/`sys.exit()` were never invoked), and a clean `ImportError` with the expected install hint.
- [x] `pytest tests/embeddings/test_ollama_embeddings.py tests/test_proxy.py` — 16 passed
- [x] `ruff check` on changed files — clean