### PR TITLE
fix(elasticsearch): don't cap unbounded list() at ES default of 10

### DIFF
--- a/mem0/vector_stores/elasticsearch.py
+++ b/mem0/vector_stores/elasticsearch.py
@@ -15,6 +15,11 @@ from mem0.vector_stores.base import VectorStoreBase
 
 logger = logging.getLogger(__name__)
 
+# Elasticsearch's own default for `index.max_result_window`. Used as the query
+# size when no top_k is given, so unbounded list() calls (e.g. get_all(),
+# delete_all()) aren't silently capped at Elasticsearch's search-API default of 10.
+_DEFAULT_MAX_RESULT_WINDOW = 10000
+
 
 class OutputData(BaseModel):
     id: str
@@ -282,8 +287,7 @@ class ElasticsearchDB(VectorStoreBase):
                 filter_conditions.append({"term": {f"metadata.{key}": value}})
             query["query"] = {"bool": {"must": filter_conditions}}
 
-        if top_k:
-            query["size"] = top_k
+        query["size"] = top_k if top_k else _DEFAULT_MAX_RESULT_WINDOW
 
         response = self.client.search(index=self.collection_name, body=query)
 

--- a/mem0/vector_stores/elasticsearch.py
+++ b/mem0/vector_stores/elasticsearch.py
@@ -18,6 +18,9 @@ logger = logging.getLogger(__name__)
 # Elasticsearch's own default for `index.max_result_window`. Used as the query
 # size when no top_k is given, so unbounded list() calls (e.g. get_all(),
 # delete_all()) aren't silently capped at Elasticsearch's search-API default of 10.
+# NOTE: this is still a ceiling, not true unboundedness — a collection with more
+# than 10k matching docs will truncate here. For genuinely unbounded scans, use
+# search_after / PIT (point-in-time) pagination.
 _DEFAULT_MAX_RESULT_WINDOW = 10000
 
 

--- a/tests/vector_stores/test_elasticsearch.py
+++ b/tests/vector_stores/test_elasticsearch.py
@@ -290,6 +290,21 @@ class TestElasticsearchDB(unittest.TestCase):
         self.assertEqual(results[0][1].id, "id2")
         self.assertEqual(results[0][1].payload, {"key2": "value2"})
 
+    def test_list_without_top_k_uses_max_result_window(self):
+        """list() with no top_k (e.g. get_all()/delete_all()) must not be
+        silently capped at Elasticsearch's search-API default of 10 hits."""
+        self.client_mock.search.return_value = {"hits": {"hits": []}}
+        self.es_db.list(filters={"user_id": "alice"})
+        body = self.client_mock.search.call_args[1]["body"]
+        self.assertEqual(body["size"], 10000)
+
+    def test_list_with_top_k_uses_given_size(self):
+        """Passing an explicit top_k should still cap the query at that size."""
+        self.client_mock.search.return_value = {"hits": {"hits": []}}
+        self.es_db.list(filters={"user_id": "alice"}, top_k=25)
+        body = self.client_mock.search.call_args[1]["body"]
+        self.assertEqual(body["size"], 25)
+
     def test_delete(self):
         # Perform delete
         self.es_db.delete(vector_id="id1")


### PR DESCRIPTION
## Summary

- `ElasticsearchDB.list()` only set the query `size` when `top_k` was truthy, so unbounded calls fell back to Elasticsearch's search-API default of **10 hits**.
- User-facing impact: `get_all()` / `delete_all()` (which call `Memory.list(filters=...)[0]` with no `top_k`) silently returned/operated on at most 10 memories regardless of how many exist.

## Motivation

`mem0/memory/main.py` calls `self.vector_store.list(filters=filters)[0]` with no `top_k`. In the Elasticsearch adapter:

```python
if top_k:
    query["size"] = top_k
# else: no size set -> Elasticsearch defaults to 10
```

Elasticsearch caps the response at the default `size` of 10 when the field is absent, so any store with >10 memories is silently truncated on unbounded reads.

This is the Elasticsearch analogue of the OpenSearch `list()` cap (issue #6108, fix #6121). The existing Elasticsearch PRs #5910/#5951 fix the KNN **`search()`** path only; the unbounded **`list()`** path is untouched.

## Fix

Default the query size to `index.max_result_window` (10000) when no `top_k` is given, mirroring the OpenSearch adapter, while still honouring an explicit `top_k`:

```python
query["size"] = top_k if top_k else _DEFAULT_MAX_RESULT_WINDOW
```

## Verification

- `python -m pytest tests/vector_stores/test_elasticsearch.py` — **22 passed**
- New regression tests:
  - `test_list_without_top_k_uses_max_result_window` — asserts `size == 10000` (fails without the fix: `KeyError: 'size'`)
  - `test_list_with_top_k_uses_given_size` — asserts an explicit `top_k=25` still caps at 25
- Did NOT change: the `search()` / `keyword_search()` paths or the `top_k`-provided behaviour.
