### PR TITLE
fix(databricks): don't KeyError in list() when row lacks 'memory' column

### DIFF
--- a/mem0/vector_stores/databricks.py
+++ b/mem0/vector_stores/databricks.py
@@ -828,7 +828,7 @@ class Databricks(VectorStoreBase):
                     except Exception:
                         pass
                 memory_id = row_dict.get("memory_id") or row_dict.get("id")
-                payload['data'] = payload['memory']
+                payload["data"] = payload.get("memory", "")
                 memory_results.append(MemoryResult(id=memory_id, payload=payload))
             return [memory_results]
         except Exception as e:

--- a/tests/vector_stores/test_databricks.py
+++ b/tests/vector_stores/test_databricks.py
@@ -538,6 +538,23 @@ def test_list_memories_default_limit(db_instance_delta, mock_workspace_client):
     assert call_kwargs["num_results"] == 100
 
 
+def test_list_memories_row_without_memory_column(db_instance_delta, mock_workspace_client):
+    """list() must not KeyError when a row lacks the 'memory' column.
+
+    search() and get() already guard this with payload.get("memory", ""),
+    but list() previously did payload['memory'] and crashed on any index
+    whose schema/row omits that column.
+    """
+    # Simulate an index whose returned columns do not include 'memory'.
+    db_instance_delta.column_names = ["memory_id", "hash", "metadata"]
+    mock_workspace_client.vector_search_indexes.query_index.return_value = SimpleNamespace(
+        result=SimpleNamespace(data_array=[["id-1", "h", None]])
+    )
+    res = db_instance_delta.list(top_k=1)
+    assert res[0][0].id == "id-1"
+    assert res[0][0].payload["data"] == ""
+
+
 # ---------------------- Table Creation Tests ---------------------- #
 
 


### PR DESCRIPTION
## Summary

- `DatabricksDB.list()` built `payload["data"] = payload["memory"]` with a hard key access, which raises `KeyError` on any index whose schema/row omits the `memory` column.
- User-facing impact: the `KeyError` is swallowed by the surrounding `try/except` and `list()` returns a bare `[]`, so callers doing `list(...)[0]` (e.g. `Memory.delete_all`) then crash with `IndexError`.

## Motivation

In `mem0/vector_stores/databricks.py`, `search()` (line 515) and `get()` (line 564) already guard this safely:

```python
payload["data"] = payload.get("memory", "")
```

But `list()` did:

```python
payload['data'] = payload['memory']   # KeyError if 'memory' absent
```

`payload` is built from `self.column_names`, so an index whose schema doesn't include a `memory` column (legacy/custom tables) makes every `list()` call fail. Because the failure is caught and returns `[]`, `Memory.delete_all()` (`memories = self.vector_store.list(filters=filters)[0]`) then raises `IndexError: list index out of range`.

## Fix

Align `list()` with the safe accessor already used by `search()` and `get()`:

```python
payload["data"] = payload.get("memory", "")
```

One-line change; no behaviour change when the column is present.

## Verification

- `python -m pytest tests/vector_stores/test_databricks.py` — **64 passed**
- New regression test `test_list_memories_row_without_memory_column`:
  - Without the fix: `KeyError: 'memory'` is swallowed → `list()` returns `[]` → `res[0]` raises `IndexError`.
  - With the fix: `list()` returns the row with `payload["data"] == ""`.
- Did NOT change: `search()` / `get()` (already correct) or the happy path when `memory` is present.
