### PR TITLE
docs(components): point config links to provider overviews

### DIFF
--- a/docs/components/embedders/config.mdx
+++ b/docs/components/embedders/config.mdx
@@ -97,4 +97,4 @@ Here's a comprehensive list of all parameters that can be used across different 
 
 ## Supported Embedding Models
 
-For detailed information on configuring specific embedders, please visit the [Embedding Models](./models) section. There you'll find information for each supported embedder with provider-specific usage examples and configuration details.
+For detailed information on configuring specific embedders, please visit the [Embedding Models](./overview) section. There you'll find information for each supported embedder with provider-specific usage examples and configuration details.

--- a/docs/components/llms/config.mdx
+++ b/docs/components/llms/config.mdx
@@ -133,4 +133,4 @@ Here's a comprehensive list of all parameters that can be used across different 
 
 ## Supported LLMs
 
-For detailed information on configuring specific LLMs, please visit the [LLMs](./models) section. There you'll find information for each supported LLM with provider-specific usage examples and configuration details.
+For detailed information on configuring specific LLMs, please visit the [LLMs](./overview) section. There you'll find information for each supported LLM with provider-specific usage examples and configuration details.

--- a/docs/components/vectordbs/config.mdx
+++ b/docs/components/vectordbs/config.mdx
@@ -123,10 +123,10 @@ Here's a comprehensive list of all parameters that can be used across different 
 
 Each vector database has its own specific configuration requirements. To customize the config for your chosen vector store:
 
-1. Identify the vector database you want to use from [supported vector databases](./dbs).
+1. Identify the vector database you want to use from [supported vector databases](./overview).
 2. Refer to the `Config` section in the respective vector database's documentation.
 3. Include only the relevant parameters for your chosen database in the `config` dictionary.
 
 ## Supported Vector Databases
 
-For detailed information on configuring specific vector databases, please visit the [Supported Vector Databases](./dbs) section. There you'll find individual pages for each supported vector store with provider-specific usage examples and configuration details.
+For detailed information on configuring specific vector databases, please visit the [Supported Vector Databases](./overview) section. There you'll find individual pages for each supported vector store with provider-specific usage examples and configuration details.

--- a/docs/components/vectordbs/config.mdx
+++ b/docs/components/vectordbs/config.mdx
@@ -118,10 +118,10 @@ Here's a comprehensive list of all parameters that can be used across different 
 
 Each vector database has its own specific configuration requirements. To customize the config for your chosen vector store:
 
-1. Identify the vector database you want to use from [supported vector databases](./dbs).
+1. Identify the vector database you want to use from [supported vector databases](./overview).
 2. Refer to the `Config` section in the respective vector database's documentation.
 3. Include only the relevant parameters for your chosen database in the `config` dictionary.
 
 ## Supported Vector Databases
 
-For detailed information on configuring specific vector databases, please visit the [Supported Vector Databases](./dbs) section. There you'll find individual pages for each supported vector store with provider-specific usage examples and configuration details.
+For detailed information on configuring specific vector databases, please visit the [Supported Vector Databases](./overview) section. There you'll find individual pages for each supported vector store with provider-specific usage examples and configuration details.


### PR DESCRIPTION
## Linked Issue

Closes #6127

## Description

The embedder, LLM, and vector-store config pages each link users to the section path rather than the provider overview page:

- `docs/components/embedders/config.mdx` links `[Embedding Models](./models)`
- `docs/components/llms/config.mdx` links `[LLMs](./models)`
- `docs/components/vectordbs/config.mdx` links `[supported vector databases](./dbs)` and `[Supported Vector Databases](./dbs)`

On the live docs, those section paths currently redirect to the first provider page, not to a list or overview page:

- `/components/embedders/models` redirects to `/components/embedders/models/openai`
- `/components/llms/models` redirects to `/components/llms/models/openai`
- `/components/vectordbs/dbs` redirects to `/components/vectordbs/dbs/qdrant`

This repoints each link to the section `./overview` page, which exists (`components/{embedders,llms,vectordbs}/overview.mdx`), is registered in the nav in `docs.json`, and lists the supported providers.

## Type of Change

- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] No tests needed (explain why)

Docs-only link fix. Verified the live `./models` / `./dbs` targets redirect to first-provider pages, while the three `overview.mdx` pages exist and are the correct provider-list targets.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
