### PR TITLE
fix(memory): don't send text-only list content to the vision LLM

### DIFF
--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -192,17 +192,23 @@ def parse_vision_messages(messages, llm=None, vision_details="auto"):
 
         # Handle message content
         if isinstance(content, list):
-            if llm is None:
+            has_image = any(
+                isinstance(part, dict) and part.get("type") == "image_url" for part in content
+            )
+            # Only route to the vision LLM when an image is actually present; a
+            # text-only list would otherwise be sent to the vision model
+            # (prompted to describe an image), discarding the real text.
+            if llm is not None and has_image:
+                description = get_image_description(msg, llm, vision_details)
+                returned_messages.append({"role": role, "content": description})
+            else:
                 text_parts = [
-                    part["text"] for part in msg["content"]
+                    part["text"] for part in content
                     if isinstance(part, dict) and part.get("type") == "text"
                 ]
                 if not text_parts:
                     continue
                 returned_messages.append({"role": role, "content": " ".join(text_parts)})
-            else:
-                description = get_image_description(msg, llm, vision_details)
-                returned_messages.append({"role": role, "content": description})
         elif isinstance(content, dict) and content.get("type") == "image_url":
             if llm is None:
                 continue

--- a/tests/memory/test_memory_utils.py
+++ b/tests/memory/test_memory_utils.py
@@ -79,6 +79,21 @@ class TestParseVisionMessages:
         assert result[0]["content"] == "A photo of a cat"
         mock_llm.generate_response.assert_called_once()
 
+    def test_text_only_list_with_llm_does_not_call_vision(self):
+        # A list-content message with no image part must not be handed to the
+        # vision LLM (which is prompted to describe an image and would discard
+        # the real text); its text parts are joined instead.
+        mock_llm = Mock()
+        messages = [
+            {"role": "user", "content": [
+                {"type": "text", "text": "I love pizza"},
+                {"type": "text", "text": "and pasta"},
+            ]},
+        ]
+        result = parse_vision_messages(messages, llm=mock_llm, vision_details="auto")
+        assert result == [{"role": "user", "content": "I love pizza and pasta"}]
+        mock_llm.generate_response.assert_not_called()
+
     def test_image_only_list_without_llm_is_skipped(self):
         messages = [
             {"role": "user", "content": [


### PR DESCRIPTION
## Linked Issue

Closes #6129

## Description

When `enable_vision` is on, `parse_vision_messages` routed **every** list-type message content to the vision LLM, even lists with no image. A text-only multimodal message (`content: [{"type": "text", "text": "..."}]`) was handed to `get_image_description`, which prompts the model to describe an image, so the real text was dropped and replaced by a description of a nonexistent image (and a vision call was wasted on every such message).

This routes to the vision model only when the list actually contains an `image_url` part; otherwise it extracts the text parts, exactly as the `enable_vision`-off path already does. Image-only and mixed image+text lists are unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

`test_text_only_list_with_llm_does_not_call_vision` fails on `main` (the real text is replaced by the mock vision response and `generate_response` is called) and passes with the fix. Full `tests/memory/` suite: 352 passed, ruff clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
