### PR TITLE
fix(openmemory): gate sqlite connect args by database URL

### DIFF
--- a/openmemory/api/app/database.py
+++ b/openmemory/api/app/database.py
@@ -2,6 +2,7 @@ import os
 
 from dotenv import load_dotenv
 from sqlalchemy import create_engine
+from sqlalchemy.engine import make_url
 from sqlalchemy.orm import declarative_base, sessionmaker
 
 # load .env file (make sure you have DATABASE_URL set)
@@ -11,11 +12,16 @@ DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./openmemory.db")
 if not DATABASE_URL:
     raise RuntimeError("DATABASE_URL is not set in environment")
 
+
+def get_engine_kwargs(database_url: str):
+    """Return engine kwargs for the configured database backend."""
+    if make_url(database_url).get_backend_name() == "sqlite":
+        return {"connect_args": {"check_same_thread": False}}
+    return {}
+
+
 # SQLAlchemy engine & session
-engine = create_engine(
-    DATABASE_URL,
-    connect_args={"check_same_thread": False}  # Needed for SQLite
-)
+engine = create_engine(DATABASE_URL, **get_engine_kwargs(DATABASE_URL))
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 # Base class for models

--- a/openmemory/api/tests/test_database.py
+++ b/openmemory/api/tests/test_database.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock
 
 import pytest
 import sqlalchemy
+from sqlalchemy import text
 
 
 API_ROOT = Path(__file__).resolve().parents[1]
@@ -53,3 +54,20 @@ def test_non_sqlite_database_url_does_not_get_sqlite_connect_arg(monkeypatch):
 
     assert captured["url"] == "postgresql+psycopg2://user:pass@localhost:5432/openmemory"
     assert "connect_args" not in captured["kwargs"]
+
+
+def test_sqlite_database_url_creates_working_engine_and_session(monkeypatch, tmp_path):
+    sys.modules.pop("app.database", None)
+    database_url = f"sqlite:///{tmp_path / 'openmemory.db'}"
+    monkeypatch.setenv("DATABASE_URL", database_url)
+
+    database = importlib.import_module("app.database")
+    try:
+        with database.SessionLocal() as session:
+            assert session.execute(text("SELECT 1")).scalar_one() == 1
+
+        assert database.engine.url.drivername == "sqlite"
+        assert database.get_engine_kwargs(database_url) == {"connect_args": {"check_same_thread": False}}
+    finally:
+        database.engine.dispose()
+        sys.modules.pop("app.database", None)

--- a/openmemory/api/tests/test_database.py
+++ b/openmemory/api/tests/test_database.py
@@ -1,0 +1,55 @@
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+import sqlalchemy
+
+
+API_ROOT = Path(__file__).resolve().parents[1]
+if str(API_ROOT) not in sys.path:
+    sys.path.insert(0, str(API_ROOT))
+
+
+def _import_database_with_url(monkeypatch, database_url):
+    sys.modules.pop("app.database", None)
+    captured = {}
+
+    def fake_create_engine(url, **kwargs):
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return Mock(name="engine")
+
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    monkeypatch.setattr(sqlalchemy, "create_engine", fake_create_engine)
+
+    try:
+        importlib.import_module("app.database")
+    finally:
+        sys.modules.pop("app.database", None)
+    return captured
+
+
+@pytest.mark.parametrize(
+    "database_url",
+    [
+        "sqlite:///./openmemory.db",
+        "sqlite+pysqlite:///./openmemory.db",
+    ],
+)
+def test_sqlite_database_urls_keep_sqlite_thread_connect_arg(monkeypatch, database_url):
+    captured = _import_database_with_url(monkeypatch, database_url)
+
+    assert captured["url"] == database_url
+    assert captured["kwargs"]["connect_args"] == {"check_same_thread": False}
+
+
+def test_non_sqlite_database_url_does_not_get_sqlite_connect_arg(monkeypatch):
+    captured = _import_database_with_url(
+        monkeypatch,
+        "postgresql+psycopg2://user:pass@localhost:5432/openmemory",
+    )
+
+    assert captured["url"] == "postgresql+psycopg2://user:pass@localhost:5432/openmemory"
+    assert "connect_args" not in captured["kwargs"]


### PR DESCRIPTION
## Linked Issue

Related to #4749 and #5275

## Description

This PR fixes a narrow OpenMemory database compatibility issue in `openmemory/api/app/database.py`.

Before this change, OpenMemory always passed the SQLite-specific DBAPI option `check_same_thread=False` into `sqlalchemy.create_engine(...)`, regardless of which database backend was configured through `DATABASE_URL`:

```python
create_engine(
    DATABASE_URL,
    connect_args={"check_same_thread": False},
)
```

That option is valid for SQLite / `pysqlite`, where it controls whether a SQLite connection can be used across threads. However, `DATABASE_URL` is a SQLAlchemy URL entry point, not a SQLite-only setting. When users configure a non-SQLite backend such as PostgreSQL, SQLAlchemy still forwards `connect_args` to the underlying DBAPI connection layer.

For PostgreSQL via `psycopg2`, the old unconditional argument can fail on the first real database connection with:

```text
psycopg2.ProgrammingError: invalid dsn: invalid connection option "check_same_thread"
```

This is an API contract mismatch between the database URL abstraction and the backend-specific connection options: the caller was applying a SQLite-only DBAPI option to every SQLAlchemy engine, including engines whose drivers do not understand that option.

This PR keeps the existing SQLite behavior unchanged, but gates the SQLite-only `connect_args` behind the parsed SQLAlchemy backend name. In practice:

- SQLite URLs such as `sqlite:///./openmemory.db` still receive `connect_args={"check_same_thread": False}`.
- Non-SQLite URLs such as `postgresql+psycopg2://...` no longer receive that SQLite-only argument.
- Engine construction for non-SQLite backends now follows the normal SQLAlchemy path.

The affected call chain is:

```text
OpenMemory API import/startup
  -> app.database
  -> create_engine(DATABASE_URL, **engine_kwargs)
  -> first SessionLocal()/engine connection
  -> DBAPI connect options
```

The scope is intentionally small. This PR only changes how OpenMemory builds SQLAlchemy engine keyword arguments. It does not change database models, Alembic migrations, session behavior, SQLite defaults, vector-store configuration, or claim complete PostgreSQL/MySQL support for every OpenMemory feature. It only prevents a SQLite-only connection option from being passed to non-SQLite database drivers.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [x] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Validation performed locally:

- `D:\ZXY\Dev\Miniforge3\envs\prw-mem0-py312\python.exe -m pytest openmemory/api/tests/test_database.py -q` - passed, 4 tests
- `D:\ZXY\Dev\Miniforge3\envs\prw-mem0-py312\python.exe -m compileall openmemory/api/app/database.py openmemory/api/tests/test_database.py` - passed
- `git diff --check` - passed

Integration coverage added:

- Imports `app.database` with a temporary SQLite `DATABASE_URL`.
- Creates a real SQLAlchemy engine/session through `SessionLocal`.
- Executes `SELECT 1` through the session to verify the default SQLite engine path still works with the gated connect args.

Additional manual contract check:

- SQLite URL with `connect_args={"check_same_thread": False}` connected successfully.
- PostgreSQL URL with the old unconditional `connect_args={"check_same_thread": False}` reproduced `psycopg2.ProgrammingError: invalid dsn: invalid connection option "check_same_thread"` on first connection.

Adjacent-suite note:

- `D:\ZXY\Dev\Miniforge3\envs\prw-mem0-py312\python.exe -m pytest openmemory/api/tests/test_mcp_server.py -q` currently reports 18 passed / 3 failed on fresh `origin/main`; the failing route-registration assertions are reproducible without this PR's new test and appear unrelated to the database engine-args change.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed