### PR TITLE
docs: fix provider overview links in config pages

### DIFF
--- a/docs/components/embedders/config.mdx
+++ b/docs/components/embedders/config.mdx
@@ -97,4 +97,4 @@ Here's a comprehensive list of all parameters that can be used across different 
 
 ## Supported Embedding Models
 
-For detailed information on configuring specific embedders, please visit the [Embedding Models](./models) section. There you'll find information for each supported embedder with provider-specific usage examples and configuration details.
+For detailed information on configuring specific embedders, please visit the [Embedding Models](./overview) section. There you'll find information for each supported embedder with provider-specific usage examples and configuration details.

--- a/docs/components/llms/config.mdx
+++ b/docs/components/llms/config.mdx
@@ -133,4 +133,4 @@ Here's a comprehensive list of all parameters that can be used across different 
 
 ## Supported LLMs
 
-For detailed information on configuring specific LLMs, please visit the [LLMs](./models) section. There you'll find information for each supported LLM with provider-specific usage examples and configuration details.
+For detailed information on configuring specific LLMs, please visit the [LLMs](./overview) section. There you'll find information for each supported LLM with provider-specific usage examples and configuration details.

--- a/docs/components/vectordbs/config.mdx
+++ b/docs/components/vectordbs/config.mdx
@@ -118,10 +118,10 @@ Here's a comprehensive list of all parameters that can be used across different 
 
 Each vector database has its own specific configuration requirements. To customize the config for your chosen vector store:
 
-1. Identify the vector database you want to use from [supported vector databases](./dbs).
+1. Identify the vector database you want to use from [supported vector databases](./overview).
 2. Refer to the `Config` section in the respective vector database's documentation.
 3. Include only the relevant parameters for your chosen database in the `config` dictionary.
 
 ## Supported Vector Databases
 
-For detailed information on configuring specific vector databases, please visit the [Supported Vector Databases](./dbs) section. There you'll find individual pages for each supported vector store with provider-specific usage examples and configuration details.
+For detailed information on configuring specific vector databases, please visit the [Supported Vector Databases](./overview) section. There you'll find individual pages for each supported vector store with provider-specific usage examples and configuration details.


### PR DESCRIPTION
## Linked Issue

Closes #6127

## Description

This PR updates the documentation links on the configuration pages to point to the provider overview pages instead of the provider-specific pages.

### Changes

- Updated Embedders config page to link to `./overview`
- Updated LLMs config page to link to `./overview`
- Updated Vector Databases config page to link to `./overview`

This resolves the issue where the "Supported ..." links redirected users to the first provider page instead of the overview page listing all supported providers.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Verified that the updated links now point to the overview pages (`./overview`).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [x] I have updated documentation if needed