### PR TITLE
feat(litellm): add reasoning_effort passthrough

### DIFF
--- a/docs/components/llms/models/litellm.mdx
+++ b/docs/components/llms/models/litellm.mdx
@@ -63,6 +63,50 @@ await memory.add(messages, { userId: 'alice', metadata: { category: 'movies' } }
 ```
 </CodeGroup>
 
+### Model-specific parameters
+
+Python users can pass model-specific LiteLLM parameters directly in the LLM config. For Gemini models, set a Gemini API key and use `reasoning_effort` to control thinking token usage:
+
+```python
+import os
+
+os.environ["GEMINI_API_KEY"] = "your-gemini-api-key"
+
+config = {
+    "llm": {
+        "provider": "litellm",
+        "config": {
+            "model": "gemini/gemini-3-flash-preview",
+            "reasoning_effort": "low",
+            "temperature": 0.0,
+            "max_tokens": 8192,
+        },
+    }
+}
+```
+
+You can also keep model-specific parameters with the model name:
+
+```python
+import os
+
+os.environ["GEMINI_API_KEY"] = "your-gemini-api-key"
+
+config = {
+    "llm": {
+        "provider": "litellm",
+        "config": {
+            "model": {
+                "name": "gemini/gemini-3-flash-preview",
+                "reasoning_effort": "low",
+            },
+            "temperature": 0.0,
+            "max_tokens": 8192,
+        },
+    }
+}
+```
+
 ## Config
 
 All available parameters for the `litellm` config are present in [Master List of All Params in Config](../config).

--- a/mem0/llms/litellm.py
+++ b/mem0/llms/litellm.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 try:
     import litellm
@@ -17,6 +17,28 @@ class LiteLLM(LLMBase):
 
         if not self.config.model:
             self.config.model = "gpt-5-mini"
+        elif isinstance(self.config.model, dict) and not self.config.model.get("name"):
+            self.config.model["name"] = "gpt-5-mini"
+
+    def _get_model_name(self) -> str:
+        """Return the LiteLLM model name from string or dict model config."""
+        if isinstance(self.config.model, dict):
+            return self.config.model.get("name", "gpt-5-mini")
+        return self.config.model
+
+    def _get_model_params(self) -> Dict[str, Union[str, float, int, List[str]]]:
+        params = {}
+
+        reasoning_effort = getattr(self.config, "reasoning_effort", None)
+        if reasoning_effort is not None:
+            params["reasoning_effort"] = reasoning_effort
+
+        if isinstance(self.config.model, dict):
+            for param in ["reasoning_effort", "frequency_penalty", "presence_penalty", "seed", "stop"]:
+                if self.config.model.get(param) is not None:
+                    params[param] = self.config.model[param]
+
+        return params
 
     def _parse_response(self, response, tools):
         """
@@ -67,19 +89,22 @@ class LiteLLM(LLMBase):
         Returns:
             str: The generated response.
         """
-        if tools and not litellm.supports_function_calling(self.config.model):
-            raise ValueError(f"Model '{self.config.model}' in litellm does not support function calling.")
+        model_name = self._get_model_name()
+
+        if tools and not litellm.supports_function_calling(model_name):
+            raise ValueError(f"Model '{model_name}' in litellm does not support function calling.")
 
         params = {
-            "model": self.config.model,
+            "model": model_name,
             "messages": messages,
             "temperature": self.config.temperature,
             "top_p": self.config.top_p,
         }
-        if self._uses_max_completion_tokens(self.config.model):
+        if self._uses_max_completion_tokens(model_name):
             params["max_completion_tokens"] = self.config.max_tokens
         else:
             params["max_tokens"] = self.config.max_tokens
+        params.update(self._get_model_params())
         if response_format:
             params["response_format"] = response_format
         if tools:  # TODO: Remove tools if no issues found with new memory addition logic

--- a/tests/llms/test_litellm.py
+++ b/tests/llms/test_litellm.py
@@ -96,6 +96,89 @@ def test_generate_response_legacy_model_uses_max_tokens(mock_litellm):
     assert "max_completion_tokens" not in kwargs
 
 
+def test_generate_response_passes_reasoning_effort_from_config(mock_litellm):
+    config = BaseLlmConfig(
+        model="gemini/gemini-3-flash-preview",
+        temperature=0.2,
+        max_tokens=4000,
+        top_p=0.9,
+        reasoning_effort="low",
+    )
+    llm = litellm.LiteLLM(config)
+    messages = [{"role": "user", "content": "Solve this"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Done"))]
+    mock_litellm.completion.return_value = mock_response
+
+    response = llm.generate_response(messages)
+
+    _, kwargs = mock_litellm.completion.call_args
+    assert kwargs["model"] == "gemini/gemini-3-flash-preview"
+    assert kwargs["reasoning_effort"] == "low"
+    assert response == "Done"
+
+
+def test_generate_response_passes_model_dict_params(mock_litellm):
+    config = BaseLlmConfig(
+        model={
+            "name": "gemini/gemini-3-flash-preview",
+            "reasoning_effort": "medium",
+            "frequency_penalty": 0.5,
+            "presence_penalty": 0.1,
+            "seed": 42,
+            "stop": ["END"],
+        },
+        temperature=0.5,
+        max_tokens=2000,
+        top_p=0.95,
+    )
+    llm = litellm.LiteLLM(config)
+    messages = [{"role": "user", "content": "Generate text"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Generated text."))]
+    mock_litellm.completion.return_value = mock_response
+
+    response = llm.generate_response(messages)
+
+    _, kwargs = mock_litellm.completion.call_args
+    assert kwargs["model"] == "gemini/gemini-3-flash-preview"
+    assert kwargs["max_tokens"] == 2000
+    assert kwargs["reasoning_effort"] == "medium"
+    assert kwargs["frequency_penalty"] == 0.5
+    assert kwargs["presence_penalty"] == 0.1
+    assert kwargs["seed"] == 42
+    assert kwargs["stop"] == ["END"]
+    assert response == "Generated text."
+
+
+def test_generate_response_model_dict_uses_name_for_max_completion_tokens(mock_litellm):
+    config = BaseLlmConfig(model={"name": "openai/gpt-5.4-mini", "reasoning_effort": "high"}, max_tokens=100)
+    llm = litellm.LiteLLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Hi"))]
+    mock_litellm.completion.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    _, kwargs = mock_litellm.completion.call_args
+    assert kwargs["model"] == "openai/gpt-5.4-mini"
+    assert kwargs["max_completion_tokens"] == 100
+    assert "max_tokens" not in kwargs
+    assert kwargs["reasoning_effort"] == "high"
+
+
+def test_get_model_name_with_dict_without_name_uses_default(mock_litellm):
+    config = BaseLlmConfig(model={"reasoning_effort": "low"})
+    llm = litellm.LiteLLM(config)
+
+    assert llm._get_model_name() == "gpt-5-mini"
+    assert llm.config.model["reasoning_effort"] == "low"
+
+
 def test_generate_response_with_tools(mock_litellm):
     config = BaseLlmConfig(model="gpt-4.1-nano-2025-04-14", temperature=0.7, max_tokens=100, top_p=1)
     llm = litellm.LiteLLM(config)
@@ -134,7 +217,13 @@ def test_generate_response_with_tools(mock_litellm):
     response = llm.generate_response(messages, tools=tools)
 
     mock_litellm.completion.assert_called_once_with(
-        model="gpt-4.1-nano-2025-04-14", messages=messages, temperature=0.7, max_tokens=100, top_p=1, tools=tools, tool_choice="auto"
+        model="gpt-4.1-nano-2025-04-14",
+        messages=messages,
+        temperature=0.7,
+        max_tokens=100,
+        top_p=1,
+        tools=tools,
+        tool_choice="auto",
     )
 
     assert response["content"] == "I've added the memory for you."


### PR DESCRIPTION
## Linked Issue

Follow-up to closed PR #3889.

## Description

Adds LiteLLM passthrough support for `reasoning_effort`, including Gemini model configs where callers need to control thinking token usage. Also supports a dict-shaped `model` config with `name` plus model-specific LiteLLM parameters while preserving the current GPT-5 `max_completion_tokens` behavior.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Manual verification:

- `python -m hatch run dev_py_3_11:pytest tests/llms/test_litellm.py -q`
- `python -m ruff check mem0/llms/litellm.py tests/llms/test_litellm.py`
- `python -m ruff format --check mem0/llms/litellm.py tests/llms/test_litellm.py`
- `python scripts/check-llms-txt-coverage.py`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
