### PR TITLE
fix(ts): default Redis filterExpr to * for empty filters

### DIFF
--- a/mem0-ts/src/oss/src/vector_stores/redis.ts
+++ b/mem0-ts/src/oss/src/vector_stores/redis.ts
@@ -22,6 +22,18 @@ function escapeRedisTagValue(value: unknown): string {
   );
 }
 
+function buildRedisFilterExpr(
+  snakeFilters?: Record<string, unknown>,
+): string {
+  if (!snakeFilters) {
+    return "*";
+  }
+  const clauses = Object.entries(snakeFilters)
+    .filter(([_, value]) => value !== null && value !== undefined)
+    .map(([key, value]) => `@${key}:{${escapeRedisTagValue(value)}}`);
+  return clauses.length > 0 ? clauses.join(" ") : "*";
+}
+
 interface RedisConfig extends VectorStoreConfig {
   redisUrl: string;
   collectionName: string;
@@ -389,13 +401,7 @@ export class RedisDB implements VectorStore {
     topK: number = 5,
     filters?: SearchFilters,
   ): Promise<VectorStoreResult[]> {
-    const snakeFilters = filters ? toSnakeCase(filters) : undefined;
-    const filterExpr = snakeFilters
-      ? Object.entries(snakeFilters)
-          .filter(([_, value]) => value !== null && value !== undefined)
-          .map(([key, value]) => `@${key}:{${escapeRedisTagValue(value)}}`)
-          .join(" ")
-      : "*";
+    const filterExpr = buildRedisFilterExpr(filters ? toSnakeCase(filters) : undefined);
 
     const queryVector = new Float32Array(query).buffer;
 
@@ -633,13 +639,7 @@ export class RedisDB implements VectorStore {
     filters?: SearchFilters,
     topK: number = 100,
   ): Promise<[VectorStoreResult[], number]> {
-    const snakeFilters = filters ? toSnakeCase(filters) : undefined;
-    const filterExpr = snakeFilters
-      ? Object.entries(snakeFilters)
-          .filter(([_, value]) => value !== null && value !== undefined)
-          .map(([key, value]) => `@${key}:{${escapeRedisTagValue(value)}}`)
-          .join(" ")
-      : "*";
+    const filterExpr = buildRedisFilterExpr(filters ? toSnakeCase(filters) : undefined);
 
     const searchOptions = {
       SORTBY: "created_at",


### PR DESCRIPTION
## Summary
- Extract buildRedisFilterExpr helper
- Return * when filter clauses would otherwise be empty

Fixes #6013

## Test plan
- [x] Search/list with {} filters no longer builds blank filter expression

Made with [Cursor](https://cursor.com)