### PR TITLE
feat(mem0-plugin): make query-driven prefetch top_k configurable

### DIFF
--- a/integrations/mem0-plugin/scripts/_identity.sh
+++ b/integrations/mem0-plugin/scripts/_identity.sh
@@ -68,6 +68,10 @@ if command -v python3 >/dev/null 2>&1; then
   MEM0_AUTO_SAVE=$(echo "$_SETTINGS_JSON" | python3 -c "import sys,json; print(str(json.load(sys.stdin).get('auto_save',True)).lower())" 2>/dev/null || echo "true")
   MEM0_AUTO_SEARCH=$(echo "$_SETTINGS_JSON" | python3 -c "import sys,json; print(str(json.load(sys.stdin).get('auto_search',True)).lower())" 2>/dev/null || echo "true")
   MEM0_SEARCH_LIMIT=$(echo "$_SETTINGS_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin).get('search_limit',10))" 2>/dev/null || echo "10")
+  # Pre-set env var wins over settings.json
+  if [ -z "${MEM0_PREFETCH_TOP_K:-}" ]; then
+    MEM0_PREFETCH_TOP_K=$(echo "$_SETTINGS_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin).get('prefetch_top_k',5))" 2>/dev/null || echo "5")
+  fi
   MEM0_RETENTION_SESSION_DAYS=$(echo "$_SETTINGS_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin).get('retention_session_days',90))" 2>/dev/null || echo "90")
   MEM0_CONFIDENCE_THRESHOLD=$(echo "$_SETTINGS_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin).get('confidence_threshold',0.3))" 2>/dev/null || echo "0.3")
   MEM0_GLOBAL_SEARCH=$(echo "$_SETTINGS_JSON" | python3 -c "import sys,json; print(str(json.load(sys.stdin).get('global_search',False)).lower())" 2>/dev/null || echo "false")
@@ -76,12 +80,13 @@ else
   MEM0_AUTO_SAVE="true"
   MEM0_AUTO_SEARCH="true"
   MEM0_SEARCH_LIMIT="10"
+  MEM0_PREFETCH_TOP_K="${MEM0_PREFETCH_TOP_K:-5}"
   MEM0_RETENTION_SESSION_DAYS="90"
   MEM0_CONFIDENCE_THRESHOLD="0.3"
   MEM0_GLOBAL_SEARCH="false"
   MEM0_DEBUG="false"
 fi
-export MEM0_AUTO_SAVE MEM0_AUTO_SEARCH MEM0_SEARCH_LIMIT MEM0_RETENTION_SESSION_DAYS MEM0_CONFIDENCE_THRESHOLD MEM0_GLOBAL_SEARCH MEM0_DEBUG
+export MEM0_AUTO_SAVE MEM0_AUTO_SEARCH MEM0_SEARCH_LIMIT MEM0_PREFETCH_TOP_K MEM0_RETENTION_SESSION_DAYS MEM0_CONFIDENCE_THRESHOLD MEM0_GLOBAL_SEARCH MEM0_DEBUG
 
 # Also resolve project context
 . "$_SCRIPT_DIR/_project.sh"

--- a/integrations/mem0-plugin/scripts/_search.py
+++ b/integrations/mem0-plugin/scripts/_search.py
@@ -12,6 +12,7 @@ import urllib.request
 
 SEARCH_URL = "https://api.mem0.ai/v3/memories/search/"
 SEARCH_TIMEOUT = 5
+PREFETCH_TOP_K_DEFAULT = 5
 
 
 def should_rerank() -> bool:
@@ -30,6 +31,15 @@ def should_rerank() -> bool:
     if raw is None:
         return True
     return raw.strip().lower() not in ("0", "false", "no", "off", "")
+
+
+def prefetch_top_k() -> int:
+    """Prefetch injection count from MEM0_PREFETCH_TOP_K (settings ``prefetch_top_k``); default 5, min 1."""
+    raw = os.environ.get("MEM0_PREFETCH_TOP_K", "")
+    try:
+        return max(1, int(raw.strip()))
+    except ValueError:
+        return PREFETCH_TOP_K_DEFAULT
 
 
 def _do_search(api_key: str, payload: dict) -> list[dict]:

--- a/integrations/mem0-plugin/scripts/load_settings.py
+++ b/integrations/mem0-plugin/scripts/load_settings.py
@@ -14,6 +14,7 @@ DEFAULTS = {
     "auto_save": True,
     "auto_search": True,
     "search_limit": 10,
+    "prefetch_top_k": 5,
     "retention_session_days": 90,
     "confidence_threshold": 0.3,
     "global_search": False,

--- a/integrations/mem0-plugin/scripts/on_user_prompt.sh
+++ b/integrations/mem0-plugin/scripts/on_user_prompt.sh
@@ -156,19 +156,19 @@ fi
 # Query-driven prefetch: search mem0 with the current prompt and inject the top
 # matches so relevant memories are guaranteed in context, not left for the agent
 # to fetch. Skipped on resume (handled above with targeted queries) and when
-# MEM0_PREFETCH=false.
+# MEM0_PREFETCH=false. Match count: prefetch_top_k setting (default 5).
 if [ -z "$HAS_RESUME" ] && [ "${MEM0_PREFETCH:-true}" != "false" ]; then
   PREFETCH_RESULTS=$(PYTHONPATH="$SCRIPT_DIR" MEM0_SEARCH_USER="$USER_ID" MEM0_SEARCH_QUERY="$PROMPT" python3 -c "
 import os, sys
 sys.path.insert(0, os.environ.get('PYTHONPATH', '.'))
-from _search import search_memories, format_results_for_context, should_rerank
+from _search import search_memories, format_results_for_context, should_rerank, prefetch_top_k
 
 api_key = os.environ.get('MEM0_API_KEY', '')
 user_id = os.environ.get('MEM0_SEARCH_USER', 'default')
 project_id = os.environ.get('MEM0_PROJECT_ID', 'unknown')
 query = os.environ.get('MEM0_SEARCH_QUERY', '')
 
-results = search_memories(api_key, user_id, project_id, query, top_k=5, rerank=should_rerank())
+results = search_memories(api_key, user_id, project_id, query, top_k=prefetch_top_k(), rerank=should_rerank())
 if results:
     print(format_results_for_context(results, heading='Relevant memories (auto-retrieved for this request)'))
 " 2>/dev/null || echo "")

--- a/integrations/mem0-plugin/tests/test_load_settings.py
+++ b/integrations/mem0-plugin/tests/test_load_settings.py
@@ -1,0 +1,37 @@
+"""Tests for load_settings.py — plugin settings loader."""
+
+from __future__ import annotations
+
+import json
+
+
+def test_defaults_include_prefetch_top_k():
+    """Regression for #6135: prefetch_top_k is a first-class setting."""
+    from load_settings import DEFAULTS
+
+    assert DEFAULTS["prefetch_top_k"] == 5
+
+
+def test_user_settings_override_prefetch_top_k(tmp_path, monkeypatch):
+    import load_settings
+
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text(json.dumps({"prefetch_top_k": 20}))
+    monkeypatch.setattr(load_settings, "SETTINGS_PATH", settings_file)
+
+    assert load_settings.load_settings()["prefetch_top_k"] == 20
+
+
+def test_unknown_keys_ignored_and_missing_file_falls_back(tmp_path, monkeypatch):
+    import load_settings
+
+    monkeypatch.setattr(load_settings, "SETTINGS_PATH", tmp_path / "missing.json")
+    settings = load_settings.load_settings()
+    assert settings == load_settings.DEFAULTS
+
+    bad_file = tmp_path / "settings.json"
+    bad_file.write_text(json.dumps({"prefetch_top_k": 7, "not_a_setting": True}))
+    monkeypatch.setattr(load_settings, "SETTINGS_PATH", bad_file)
+    settings = load_settings.load_settings()
+    assert settings["prefetch_top_k"] == 7
+    assert "not_a_setting" not in settings

--- a/integrations/mem0-plugin/tests/test_search.py
+++ b/integrations/mem0-plugin/tests/test_search.py
@@ -175,3 +175,35 @@ def test_format_results_for_context():
     assert "[decision]" in output
     assert "Use Postgres for auth" in output
     assert "abc12345" in output
+
+
+def test_prefetch_top_k_defaults_to_five(monkeypatch):
+    """Regression for #6135: default preserves the previous hardcoded value."""
+    from _search import prefetch_top_k
+
+    monkeypatch.delenv("MEM0_PREFETCH_TOP_K", raising=False)
+    assert prefetch_top_k() == 5
+
+
+def test_prefetch_top_k_reads_env(monkeypatch):
+    """Regression for #6135: prefetch window is configurable via settings."""
+    from _search import prefetch_top_k
+
+    monkeypatch.setenv("MEM0_PREFETCH_TOP_K", "25")
+    assert prefetch_top_k() == 25
+
+
+def test_prefetch_top_k_invalid_values_fall_back(monkeypatch):
+    from _search import prefetch_top_k
+
+    for garbage in ("", "abc", "5.5", "  "):
+        monkeypatch.setenv("MEM0_PREFETCH_TOP_K", garbage)
+        assert prefetch_top_k() == 5, garbage
+
+
+def test_prefetch_top_k_clamps_to_at_least_one(monkeypatch):
+    from _search import prefetch_top_k
+
+    for low in ("0", "-3"):
+        monkeypatch.setenv("MEM0_PREFETCH_TOP_K", low)
+        assert prefetch_top_k() == 1, low

--- a/integrations/openclaw/recall.ts
+++ b/integrations/openclaw/recall.ts
@@ -283,7 +283,7 @@ export async function recall(
       sessionMemories = await provider.search(cleanQuery, {
         ...searchOpts,
         run_id: sessionId,
-        top_k: 5,
+        top_k: maxMemories,
       });
     } catch {
       // Session search failure is non-critical

--- a/integrations/openclaw/tests/recall.test.ts
+++ b/integrations/openclaw/tests/recall.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from "vitest";
+import { recall } from "../recall.ts";
+import type { Mem0Provider, SearchOptions } from "../types.ts";
+
+function mockProvider(): { provider: Mem0Provider; calls: SearchOptions[] } {
+  const calls: SearchOptions[] = [];
+  const provider = {
+    search: vi.fn(async (_query: string, opts: SearchOptions) => {
+      calls.push(opts);
+      return [];
+    }),
+  } as unknown as Mem0Provider;
+  return { provider, calls };
+}
+
+describe("recall session search top_k", () => {
+  it("uses the default maxMemories (15) instead of a hardcoded 5", async () => {
+    const { provider, calls } = mockProvider();
+    await recall(provider, "what did we decide?", "user1", {}, "sess-1");
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0].top_k).toBe(30); // long-term: maxMemories * 2 over-fetch
+    expect(calls[1].top_k).toBe(15); // session: maxMemories
+  });
+
+  it("honors recall.maxMemories from config", async () => {
+    const { provider, calls } = mockProvider();
+    await recall(
+      provider,
+      "what did we decide?",
+      "user1",
+      { recall: { maxMemories: 40 } },
+      "sess-1",
+    );
+
+    expect(calls[0].top_k).toBe(80);
+    expect(calls[1].top_k).toBe(40);
+  });
+
+  it("skips session search without a sessionId", async () => {
+    const { provider, calls } = mockProvider();
+    await recall(provider, "what did we decide?", "user1", {});
+
+    expect(calls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Linked Issue

Closes #6135

## Description

The Claude Code plugin's query-driven prefetch (`UserPromptSubmit` hook) hardcoded `top_k=5`, capping auto-injected memories at 5 per turn regardless of the model's context budget. This makes the prefetch window configurable while keeping 5 as the default, so existing installs see no behavior change.

Resolution order: `MEM0_PREFETCH_TOP_K` env var > `prefetch_top_k` in `~/.mem0/settings.json` > default 5.

- `scripts/load_settings.py` — add `"prefetch_top_k": 5` to `DEFAULTS`
- `scripts/_identity.sh` — export `MEM0_PREFETCH_TOP_K` from settings; a pre-set env var wins (mirrors the `MEM0_API_KEY` precedence in the same file)
- `scripts/_search.py` — new `prefetch_top_k()` helper (same pattern as `should_rerank()`): invalid values fall back to 5, values below 1 clamp to 1
- `scripts/on_user_prompt.sh` — prefetch call uses the helper instead of the literal `5`

`MEM0_PREFETCH=false` still disables prefetch entirely.

Note: the issue's component label says "Core / Python SDK", but the hardcoded value lives in `integrations/mem0-plugin` — the core SDK has no `prefetch_top_k`.

Also fixes the OpenClaw skills-mode recall reported in the issue thread: the session-scoped search in `integrations/openclaw/recall.ts` ignored `skills.recall.maxMemories` and always fetched 5 — both search legs now scale with the configured recall window. (OpenClaw's auto-recall was already configurable via `topK`.)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A — default remains 5; existing settings files and env setups keep working unchanged.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Unit tests (7 new; `pytest tests/` → 162 passed):
- `test_search.py`: default is 5, env value respected, garbage values fall back to 5, sub-1 values clamp to 1
- `test_load_settings.py` (new file): `DEFAULTS` includes the key, user settings override it, unknown keys ignored / missing file falls back
- `integrations/openclaw/tests/recall.test.ts` (new): session search uses default 15, honors `maxMemories` override, skipped without session — 449 vitest pass, tsc clean, tsup build ok

Manual verification:
- `bash -n` on both modified shell scripts
- Sourced `_identity.sh` under a temp `$HOME` for all three tiers: env preset → `99`, settings file `{"prefetch_top_k": 42}` → `42`, nothing → `5`
- Headless hook invocation (piped `UserPromptSubmit` JSON into `on_user_prompt.sh`) exits 0 and emits valid `hookSpecificOutput`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
