### PR TITLE
feat(ts-sdk): add Chroma vector store

### DIFF
--- a/docs/components/vectordbs/dbs/chroma.mdx
+++ b/docs/components/vectordbs/dbs/chroma.mdx
@@ -2,6 +2,7 @@
 title: "Chroma"
 description: "Use Chroma as a vector database in Mem0 for local or cloud-hosted vector storage with built-in embedding support."
 ---
+
 [Chroma](https://www.trychroma.com/) is an AI-native open-source vector database that simplifies building LLM apps by providing tools for storing, embedding, and searching embeddings with a focus on simplicity and speed. It supports both local deployment and cloud hosting through ChromaDB Cloud.
 
 ### Usage
@@ -37,16 +38,68 @@ messages = [
 m.add(messages, user_id="alice", metadata={"category": "movies"})
 ```
 
+#### TypeScript OSS
+
+Install Chroma alongside the TypeScript SDK when using the OSS vector store:
+
+```bash
+pnpm add chromadb
+```
+
+```ts
+import { Memory } from "mem0ai/oss";
+
+const memory = new Memory({
+  version: "v1.1",
+  embedder: {
+    provider: "openai",
+    config: {
+      apiKey: process.env.OPENAI_API_KEY,
+      model: "text-embedding-3-small",
+    },
+  },
+  vectorStore: {
+    provider: "chroma",
+    config: {
+      collectionName: "memories",
+      host: "localhost",
+      port: 8000,
+    },
+  },
+  llm: {
+    provider: "openai",
+    config: {
+      apiKey: process.env.OPENAI_API_KEY,
+      model: "gpt-4o-mini",
+    },
+  },
+});
+```
+
 ### Config
 
 Here are the parameters available for configuring Chroma:
 
-| Parameter | Description | Default Value |
-| --- | --- | --- |
-| `collection_name` | The name of the collection | `mem0` |
-| `client` | Custom client for Chroma | `None` |
-| `path` | Path for the Chroma database | `db` |
-| `host` | The host where the Chroma server is running | `None` |
-| `port` | The port where the Chroma server is running | `None` |
-| `api_key` | ChromaDB Cloud API key (for cloud usage) | `None` |
-| `tenant` | ChromaDB Cloud tenant ID (for cloud usage) | `None` |
+| Parameter         | Description                                 | Default Value |
+| ----------------- | ------------------------------------------- | ------------- |
+| `collection_name` | The name of the collection                  | `mem0`        |
+| `client`          | Custom client for Chroma                    | `None`        |
+| `path`            | Path for the Chroma database                | `db`          |
+| `host`            | The host where the Chroma server is running | `None`        |
+| `port`            | The port where the Chroma server is running | `None`        |
+| `api_key`         | ChromaDB Cloud API key (for cloud usage)    | `None`        |
+| `tenant`          | ChromaDB Cloud tenant ID (for cloud usage)  | `None`        |
+
+For the TypeScript OSS SDK, use camelCase config keys where applicable:
+
+| Parameter        | Description                                 | Default Value |
+| ---------------- | ------------------------------------------- | ------------- |
+| `collectionName` | The name of the collection                  | `memories`    |
+| `client`         | Custom Chroma client instance               | `None`        |
+| `host`           | The host where the Chroma server is running | `None`        |
+| `port`           | The port where the Chroma server is running | `None`        |
+| `ssl`            | Whether to connect over HTTPS               | `false`       |
+| `path`           | Deprecated Chroma client path option        | `None`        |
+| `apiKey`         | Chroma Cloud API key                        | `None`        |
+| `tenant`         | Chroma Cloud tenant ID                      | `None`        |
+| `database`       | Chroma Cloud database name                  | `mem0`        |

--- a/mem0-ts/package.json
+++ b/mem0-ts/package.json
@@ -112,6 +112,7 @@
     "@azure/identity": "^4.0.0",
     "@azure/search-documents": "^12.0.0",
     "@cloudflare/workers-types": "^4.20250504.0",
+    "chromadb": "^3.5.0",
     "@google-cloud/aiplatform": "^6.8.0",
     "@google/genai": "^1.40.0",
     "@langchain/core": "^1.1.47",
@@ -140,6 +141,9 @@
     "mysql2": "^3.0.0"
   },
   "peerDependenciesMeta": {
+    "chromadb": {
+      "optional": true
+    },
     "mysql2": {
       "optional": true
     }

--- a/mem0-ts/pnpm-lock.yaml
+++ b/mem0-ts/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       cassandra-driver:
         specifier: 4.8.0
         version: 4.8.0
+      chromadb:
+        specifier: ^3.5.0
+        version: 3.5.0
       cloudflare:
         specifier: ^4.2.0
         version: 4.5.0
@@ -1680,6 +1683,41 @@ packages:
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
+
+  chromadb-js-bindings-darwin-arm64@1.3.4:
+    resolution: {integrity: sha512-pDdWCcR0hCz3pSDiIijBito7YG6FumewfzYE2mIjSwjrO1CKSfQKLwDdTVK4ZNpVGQa16ePoMX+pg7ShSUARJg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  chromadb-js-bindings-darwin-x64@1.3.4:
+    resolution: {integrity: sha512-5vKVFXSFo+S9qC9by/7oofjcXqQK4IGHiUnPrvTfc7B52gNlPSKeyDO1wha556COc3KtXSZjICEH0nYBJ8UXng==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  chromadb-js-bindings-linux-arm64-gnu@1.3.4:
+    resolution: {integrity: sha512-ELiqDZzU5mZd1BvZugGrhoMkVeNyQaa+PGizd06WIpIJVoHY+S+9ZBjdeM6ZkRnL3vTxD79XBrosxNWhzqy/kg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  chromadb-js-bindings-linux-x64-gnu@1.3.4:
+    resolution: {integrity: sha512-HmTUe7PEIaBngCQ70Yyle81z2wYyg9OMgJYyRUNBYCBp4ED6zTmdaOro41Vs/c/h2UyQeBXFIKNmHDeD2Nr2fw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  chromadb-js-bindings-win32-x64-msvc@1.3.4:
+    resolution: {integrity: sha512-punrofQRzKspNMxHmv24qoPeRycV2T3KfedekGV4lOuPPG14i6qggS4x/OWLSAK7ozPfBbrzCejvCa5wfvujhQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  chromadb@3.5.0:
+    resolution: {integrity: sha512-A68f2RQjY3R95Pzy0j3ykOu6fi+WWCN1tjbvzrZXZoYQ1d7ZjgWr1FyzitZCeaz/0qmc8y2LEK7QmlxloOAs9Q==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
@@ -5612,6 +5650,31 @@ snapshots:
   chownr@2.0.0: {}
 
   chownr@3.0.0: {}
+
+  chromadb-js-bindings-darwin-arm64@1.3.4:
+    optional: true
+
+  chromadb-js-bindings-darwin-x64@1.3.4:
+    optional: true
+
+  chromadb-js-bindings-linux-arm64-gnu@1.3.4:
+    optional: true
+
+  chromadb-js-bindings-linux-x64-gnu@1.3.4:
+    optional: true
+
+  chromadb-js-bindings-win32-x64-msvc@1.3.4:
+    optional: true
+
+  chromadb@3.5.0:
+    dependencies:
+      semver: 7.8.4
+    optionalDependencies:
+      chromadb-js-bindings-darwin-arm64: 1.3.4
+      chromadb-js-bindings-darwin-x64: 1.3.4
+      chromadb-js-bindings-linux-arm64-gnu: 1.3.4
+      chromadb-js-bindings-linux-x64-gnu: 1.3.4
+      chromadb-js-bindings-win32-x64-msvc: 1.3.4
 
   ci-info@3.9.0: {}
 

--- a/mem0-ts/src/oss/src/index.ts
+++ b/mem0-ts/src/oss/src/index.ts
@@ -42,4 +42,5 @@ export * from "./vector_stores/pinecone";
 export * from "./vector_stores/turbopuffer";
 export * from "./vector_stores/mongodb";
 export * from "./vector_stores/opensearch";
+export * from "./vector_stores/chroma";
 export * from "./utils/factory";

--- a/mem0-ts/src/oss/src/tests/chroma.test.ts
+++ b/mem0-ts/src/oss/src/tests/chroma.test.ts
@@ -163,6 +163,28 @@ describe("ChromaDB", () => {
     ]);
   });
 
+  it("translates logical filters and skips wildcard filters", async () => {
+    const db = await initDb();
+
+    await db.search([1, 2, 3, 4], 5, {
+      AND: [{ user_id: "alice" }, { tag: "*" }],
+      OR: [{ score: { gte: 0.5 } }, { topic: ["a", "b"] }],
+    });
+
+    expect(__mocks__.query).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          $and: [
+            { user_id: { $eq: "alice" } },
+            {
+              $or: [{ score: { $gte: 0.5 } }, { topic: { $in: ["a", "b"] } }],
+            },
+          ],
+        },
+      }),
+    );
+  });
+
   it("retrieves one vector by id", async () => {
     __mocks__.get.mockResolvedValue({
       ids: ["vec-1"],

--- a/mem0-ts/src/oss/src/tests/chroma.test.ts
+++ b/mem0-ts/src/oss/src/tests/chroma.test.ts
@@ -1,0 +1,234 @@
+const __mocks__: {
+  add: jest.Mock;
+  query: jest.Mock;
+  get: jest.Mock;
+  update: jest.Mock;
+  upsert: jest.Mock;
+  delete: jest.Mock;
+  getOrCreateCollection: jest.Mock;
+  deleteCollection: jest.Mock;
+  ChromaClient: jest.Mock;
+  CloudClient: jest.Mock;
+} = {} as any;
+
+jest.mock(
+  "chromadb",
+  () => {
+    const add = jest.fn().mockResolvedValue(undefined);
+    const query = jest.fn().mockResolvedValue({
+      ids: [[]],
+      distances: [[]],
+      metadatas: [[]],
+    });
+    const get = jest.fn().mockResolvedValue({ ids: [], metadatas: [] });
+    const update = jest.fn().mockResolvedValue(undefined);
+    const upsert = jest.fn().mockResolvedValue(undefined);
+    const deleteMock = jest.fn().mockResolvedValue(undefined);
+
+    const collection = { add, query, get, update, upsert, delete: deleteMock };
+    const getOrCreateCollection = jest.fn().mockResolvedValue(collection);
+    const deleteCollection = jest.fn().mockResolvedValue(undefined);
+
+    const ChromaClient = jest.fn().mockImplementation(() => ({
+      getOrCreateCollection,
+      deleteCollection,
+    }));
+    const CloudClient = jest.fn().mockImplementation(() => ({
+      getOrCreateCollection,
+      deleteCollection,
+    }));
+
+    Object.assign(__mocks__, {
+      add,
+      query,
+      get,
+      update,
+      upsert,
+      delete: deleteMock,
+      getOrCreateCollection,
+      deleteCollection,
+      ChromaClient,
+      CloudClient,
+    });
+
+    return { ChromaClient, CloudClient };
+  },
+  { virtual: true },
+);
+
+import { ChromaDB } from "../vector_stores/chroma";
+import { VectorStoreFactory } from "../utils/factory";
+
+function makeDb(overrides: Record<string, any> = {}): ChromaDB {
+  return new ChromaDB({
+    collectionName: "memories",
+    dimension: 4,
+    ...overrides,
+  } as any);
+}
+
+async function initDb(overrides: Record<string, any> = {}): Promise<ChromaDB> {
+  const db = makeDb(overrides);
+  await db.initialize();
+  return db;
+}
+
+beforeEach(() => {
+  jest.requireMock("chromadb");
+  jest.clearAllMocks();
+  __mocks__.query.mockResolvedValue({
+    ids: [[]],
+    distances: [[]],
+    metadatas: [[]],
+  });
+  __mocks__.get.mockResolvedValue({ ids: [], metadatas: [] });
+});
+
+describe("VectorStoreFactory", () => {
+  it("returns a ChromaDB instance for provider 'chroma'", async () => {
+    const db = VectorStoreFactory.create("chroma", {
+      collectionName: "memories",
+      dimension: 4,
+    } as any);
+    expect(db).toBeInstanceOf(ChromaDB);
+    await db.initialize();
+  });
+});
+
+describe("ChromaDB", () => {
+  it("creates a local Chroma client and collection", async () => {
+    await initDb({ host: "localhost", port: 8000, ssl: false });
+
+    expect(__mocks__.ChromaClient).toHaveBeenCalledWith({
+      host: "localhost",
+      port: 8000,
+      ssl: false,
+    });
+    expect(__mocks__.getOrCreateCollection).toHaveBeenCalledWith({
+      name: "memories",
+      embeddingFunction: null,
+    });
+  });
+
+  it("uses CloudClient when apiKey is configured", async () => {
+    await initDb({ apiKey: "chroma-key", tenant: "tenant-a" });
+
+    expect(__mocks__.CloudClient).toHaveBeenCalledWith({
+      apiKey: "chroma-key",
+      tenant: "tenant-a",
+      database: "mem0",
+    });
+    expect(__mocks__.ChromaClient).not.toHaveBeenCalled();
+  });
+
+  it("adds vectors with metadata payloads", async () => {
+    const db = await initDb();
+    await db.insert([[1, 2, 3, 4]], ["vec-1"], [{ text: "hello" }]);
+
+    expect(__mocks__.add).toHaveBeenCalledWith({
+      ids: ["vec-1"],
+      embeddings: [[1, 2, 3, 4]],
+      metadatas: [{ text: "hello" }],
+    });
+  });
+
+  it("queries by embedding and maps distances to scores", async () => {
+    __mocks__.query.mockResolvedValue({
+      ids: [["vec-1"]],
+      distances: [[0.25]],
+      metadatas: [[{ text: "hello" }]],
+    });
+    const db = await initDb();
+
+    const results = await db.search([1, 2, 3, 4], 3, { user_id: "alice" });
+
+    expect(__mocks__.query).toHaveBeenCalledWith({
+      queryEmbeddings: [[1, 2, 3, 4]],
+      nResults: 3,
+      where: { user_id: { $eq: "alice" } },
+      include: ["metadatas", "distances"],
+    });
+    expect(results).toEqual([
+      { id: "vec-1", payload: { text: "hello" }, score: 0.8 },
+    ]);
+  });
+
+  it("retrieves one vector by id", async () => {
+    __mocks__.get.mockResolvedValue({
+      ids: ["vec-1"],
+      metadatas: [{ text: "hello" }],
+    });
+    const db = await initDb();
+
+    await expect(db.get("vec-1")).resolves.toEqual({
+      id: "vec-1",
+      payload: { text: "hello" },
+    });
+    expect(__mocks__.get).toHaveBeenCalledWith({
+      ids: ["vec-1"],
+      include: ["metadatas"],
+    });
+  });
+
+  it("updates and deletes vectors", async () => {
+    const db = await initDb();
+
+    await db.update("vec-1", [4, 3, 2, 1], { text: "updated" });
+    await db.delete("vec-1");
+
+    expect(__mocks__.update).toHaveBeenCalledWith({
+      ids: ["vec-1"],
+      embeddings: [[4, 3, 2, 1]],
+      metadatas: [{ text: "updated" }],
+    });
+    expect(__mocks__.delete).toHaveBeenCalledWith({ ids: ["vec-1"] });
+  });
+
+  it("lists vectors with filters and returns count", async () => {
+    __mocks__.get.mockResolvedValue({
+      ids: ["a", "b"],
+      metadatas: [{ tag: "x" }, { tag: "x" }],
+    });
+    const db = await initDb();
+
+    const [results, count] = await db.list({ tag: "x" }, 10);
+
+    expect(__mocks__.get).toHaveBeenCalledWith({
+      where: { tag: { $eq: "x" } },
+      limit: 10,
+      include: ["metadatas"],
+    });
+    expect(results).toEqual([
+      { id: "a", payload: { tag: "x" } },
+      { id: "b", payload: { tag: "x" } },
+    ]);
+    expect(count).toBe(2);
+  });
+
+  it("deletes and recreates the collection", async () => {
+    const db = await initDb();
+
+    await db.deleteCol();
+
+    expect(__mocks__.deleteCollection).toHaveBeenCalledWith({
+      name: "memories",
+    });
+    const mainCollectionCalls =
+      __mocks__.getOrCreateCollection.mock.calls.filter(
+        ([args]) => args.name === "memories",
+      );
+    expect(mainCollectionCalls).toHaveLength(2);
+  });
+
+  it("upserts the migrations record when setting user id", async () => {
+    const db = await initDb();
+
+    await db.setUserId("user-123");
+
+    expect(__mocks__.upsert).toHaveBeenCalledWith({
+      ids: ["mem0-user-id"],
+      embeddings: [[0, 0, 0, 0]],
+      metadatas: [{ user_id: "user-123" }],
+    });
+  });
+});

--- a/mem0-ts/src/oss/src/tests/chroma.test.ts
+++ b/mem0-ts/src/oss/src/tests/chroma.test.ts
@@ -110,6 +110,16 @@ describe("ChromaDB", () => {
     });
   });
 
+  it("defaults the collection name when omitted", async () => {
+    const db = new ChromaDB({ dimension: 4 } as any);
+    await db.initialize();
+
+    expect(__mocks__.getOrCreateCollection).toHaveBeenCalledWith({
+      name: "memories",
+      embeddingFunction: null,
+    });
+  });
+
   it("uses CloudClient when apiKey is configured", async () => {
     await initDb({ apiKey: "chroma-key", tenant: "tenant-a" });
 

--- a/mem0-ts/src/oss/src/tests/chroma.test.ts
+++ b/mem0-ts/src/oss/src/tests/chroma.test.ts
@@ -241,4 +241,19 @@ describe("ChromaDB", () => {
       metadatas: [{ user_id: "user-123" }],
     });
   });
+
+  it("upserts a generated user id when migrations record is missing", async () => {
+    __mocks__.get.mockResolvedValue({ ids: [], metadatas: [] });
+    const db = await initDb();
+
+    const userId = await db.getUserId();
+
+    expect(typeof userId).toBe("string");
+    expect(userId.length).toBeGreaterThan(0);
+    expect(__mocks__.upsert).toHaveBeenCalledWith({
+      ids: ["mem0-user-id"],
+      embeddings: [[0, 0, 0, 0]],
+      metadatas: [{ user_id: userId }],
+    });
+  });
 });

--- a/mem0-ts/src/oss/src/utils/factory.ts
+++ b/mem0-ts/src/oss/src/utils/factory.ts
@@ -54,6 +54,7 @@ import { PineconeDB } from "../vector_stores/pinecone";
 import { S3Vectors } from "../vector_stores/s3_vectors";
 import { TurbopufferDB } from "../vector_stores/turbopuffer";
 import { MongoDB } from "../vector_stores/mongodb";
+import { ChromaDB } from "../vector_stores/chroma";
 
 export class EmbedderFactory {
   static create(provider: string, config: EmbeddingConfig): Embedder {
@@ -165,6 +166,8 @@ export class VectorStoreFactory {
         return new TurbopufferDB(config as any);
       case "mongodb":
         return new MongoDB(config as any);
+      case "chroma":
+        return new ChromaDB(config as any);
       default:
         throw new Error(`Unsupported vector store provider: ${provider}`);
     }

--- a/mem0-ts/src/oss/src/vector_stores/chroma.ts
+++ b/mem0-ts/src/oss/src/vector_stores/chroma.ts
@@ -1,0 +1,379 @@
+import type { ChromaClient as ChromaClientType, Collection } from "chromadb";
+import { VectorStore } from "./base";
+import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
+
+const MIGRATIONS_COLLECTION = "__mem0_migrations__";
+const MIGRATIONS_RECORD_ID = "mem0-user-id";
+
+interface ChromaDBConfig extends VectorStoreConfig {
+  collectionName: string;
+  client?: ChromaClientType;
+  host?: string;
+  port?: number;
+  ssl?: boolean;
+  path?: string;
+  apiKey?: string;
+  tenant?: string;
+  database?: string;
+  headers?: Record<string, string>;
+  fetchOptions?: RequestInit;
+  embeddingModelDims?: number;
+}
+
+export class ChromaDB implements VectorStore {
+  private client: ChromaClientType;
+  private collection?: Collection;
+  private migrationsCollection?: Collection;
+  private readonly collectionName: string;
+  private readonly dimension: number;
+  private _initPromise?: Promise<void>;
+
+  constructor(config: ChromaDBConfig) {
+    const { ChromaClient, CloudClient } = this.loadChroma();
+
+    if (config.client) {
+      this.client = config.client;
+    } else if (config.apiKey) {
+      this.client = new CloudClient({
+        apiKey: config.apiKey,
+        tenant: config.tenant,
+        database: config.database || "mem0",
+        ...(config.host ? { host: config.host } : {}),
+        ...(config.port ? { port: config.port } : {}),
+        ...(config.fetchOptions ? { fetchOptions: config.fetchOptions } : {}),
+      });
+    } else {
+      this.client = new ChromaClient({
+        ...(config.host ? { host: config.host } : {}),
+        ...(config.port ? { port: config.port } : {}),
+        ...(config.ssl !== undefined ? { ssl: config.ssl } : {}),
+        ...(config.path ? { path: config.path } : {}),
+        ...(config.tenant ? { tenant: config.tenant } : {}),
+        ...(config.database ? { database: config.database } : {}),
+        ...(config.headers ? { headers: config.headers } : {}),
+        ...(config.fetchOptions ? { fetchOptions: config.fetchOptions } : {}),
+      });
+    }
+
+    this.collectionName = config.collectionName;
+    this.dimension = config.embeddingModelDims || config.dimension || 1536;
+    this.initialize().catch(console.error);
+  }
+
+  private loadChroma(): typeof import("chromadb") {
+    try {
+      return require("chromadb");
+    } catch (error) {
+      throw new Error(
+        "The 'chromadb' package is required for the Chroma vector store. Install it with `pnpm add chromadb`.",
+      );
+    }
+  }
+
+  async initialize(): Promise<void> {
+    if (!this._initPromise) {
+      this._initPromise = this._doInitialize();
+    }
+    return this._initPromise;
+  }
+
+  private async _doInitialize(): Promise<void> {
+    this.collection = await this.client.getOrCreateCollection({
+      name: this.collectionName,
+      embeddingFunction: null,
+    });
+    this.migrationsCollection = await this.client.getOrCreateCollection({
+      name: MIGRATIONS_COLLECTION,
+      embeddingFunction: null,
+    });
+  }
+
+  private async getCollection(): Promise<Collection> {
+    await this.initialize();
+    return this.collection!;
+  }
+
+  private async getMigrationsCollection(): Promise<Collection> {
+    await this.initialize();
+    return this.migrationsCollection!;
+  }
+
+  private createFilter(
+    filters?: SearchFilters,
+  ): Record<string, any> | undefined {
+    if (!filters || Object.keys(filters).length === 0) return undefined;
+
+    const clauses: Record<string, any>[] = [];
+
+    for (const [rawKey, value] of Object.entries(filters)) {
+      if (value === undefined || value === null || value === "*") continue;
+
+      const keyMap: Record<string, string> = {
+        $and: "AND",
+        $or: "OR",
+        $not: "NOT",
+      };
+      const key = keyMap[rawKey] || rawKey;
+
+      if (key === "AND" || key === "OR") {
+        if (!Array.isArray(value)) {
+          throw new Error(
+            `${key} filter value must be a list of filter dicts, got ${typeof value}`,
+          );
+        }
+        const subFilters = value
+          .map((sub) => this.createFilter(sub))
+          .filter(Boolean) as Record<string, any>[];
+        if (subFilters.length === 1) {
+          clauses.push(subFilters[0]);
+        } else if (subFilters.length > 1) {
+          clauses.push({ [key === "AND" ? "$and" : "$or"]: subFilters });
+        }
+        continue;
+      }
+
+      if (key === "NOT") {
+        if (!Array.isArray(value)) {
+          throw new Error(
+            `NOT filter value must be a list of filter dicts, got ${typeof value}`,
+          );
+        }
+        for (const sub of value) {
+          const negated = this.createNegatedFilter(sub);
+          if (negated) clauses.push(negated);
+        }
+        continue;
+      }
+
+      clauses.push(this.createFieldFilter(key, value));
+    }
+
+    if (clauses.length === 0) return undefined;
+    if (clauses.length === 1) return clauses[0];
+    return { $and: clauses };
+  }
+
+  private createFieldFilter(key: string, value: any): Record<string, any> {
+    if (Array.isArray(value)) {
+      return { [key]: { $in: value } };
+    }
+
+    if (typeof value === "object" && value !== null) {
+      const chromaOps: Record<string, any> = {};
+      for (const [op, opValue] of Object.entries(value)) {
+        switch (op) {
+          case "eq":
+            chromaOps.$eq = opValue;
+            break;
+          case "ne":
+            chromaOps.$ne = opValue;
+            break;
+          case "gt":
+            chromaOps.$gt = opValue;
+            break;
+          case "gte":
+            chromaOps.$gte = opValue;
+            break;
+          case "lt":
+            chromaOps.$lt = opValue;
+            break;
+          case "lte":
+            chromaOps.$lte = opValue;
+            break;
+          case "in":
+            chromaOps.$in = opValue;
+            break;
+          case "nin":
+            chromaOps.$nin = opValue;
+            break;
+          case "contains":
+          case "icontains":
+            console.warn(
+              `Filter operator '${op}' is not supported by Chroma metadata filters; using equality.`,
+            );
+            chromaOps.$eq = opValue;
+            break;
+          default:
+            throw new Error(`Unsupported filter operator '${op}' for Chroma`);
+        }
+      }
+      return { [key]: chromaOps };
+    }
+
+    return { [key]: { $eq: value } };
+  }
+
+  private createNegatedFilter(
+    filters: SearchFilters,
+  ): Record<string, any> | undefined {
+    const clauses: Record<string, any>[] = [];
+    const negateOp: Record<string, string> = {
+      eq: "$ne",
+      ne: "$eq",
+      gt: "$lte",
+      gte: "$lt",
+      lt: "$gte",
+      lte: "$gt",
+      in: "$nin",
+      nin: "$in",
+    };
+
+    for (const [key, value] of Object.entries(filters)) {
+      if (value === undefined || value === null || value === "*") continue;
+      if (typeof value === "object" && !Array.isArray(value)) {
+        for (const [op, opValue] of Object.entries(value)) {
+          const negated = negateOp[op];
+          if (negated) {
+            clauses.push({ [key]: { [negated]: opValue } });
+          }
+        }
+      } else {
+        clauses.push({ [key]: { $ne: value } });
+      }
+    }
+
+    if (clauses.length === 0) return undefined;
+    if (clauses.length === 1) return clauses[0];
+    return { $or: clauses };
+  }
+
+  private parseResults(data: Record<string, any>): VectorStoreResult[] {
+    const flatten = (value: any): any[] => {
+      if (!Array.isArray(value)) return [];
+      return Array.isArray(value[0]) ? value[0] : value;
+    };
+
+    const ids = flatten(data.ids);
+    const distances = flatten(data.distances);
+    const metadatas = flatten(data.metadatas);
+
+    return ids.map((id, index) => {
+      const rawDistance = distances[index];
+      return {
+        id: String(id),
+        payload: (metadatas[index] as Record<string, any>) || {},
+        ...(rawDistance !== undefined && rawDistance !== null
+          ? { score: 1 / (1 + rawDistance) }
+          : {}),
+      };
+    });
+  }
+
+  async insert(
+    vectors: number[][],
+    ids: string[],
+    payloads: Record<string, any>[],
+  ): Promise<void> {
+    const collection = await this.getCollection();
+    await collection.add({
+      ids,
+      embeddings: vectors,
+      metadatas: payloads,
+    });
+  }
+
+  async keywordSearch(): Promise<null> {
+    return null;
+  }
+
+  async search(
+    query: number[],
+    topK: number = 5,
+    filters?: SearchFilters,
+  ): Promise<VectorStoreResult[]> {
+    const collection = await this.getCollection();
+    const where = this.createFilter(filters);
+    const response = await collection.query({
+      queryEmbeddings: [query],
+      nResults: topK,
+      ...(where ? { where } : {}),
+      include: ["metadatas", "distances"],
+    });
+    return this.parseResults(response as Record<string, any>);
+  }
+
+  async get(vectorId: string): Promise<VectorStoreResult | null> {
+    const collection = await this.getCollection();
+    const response = await collection.get({
+      ids: [vectorId],
+      include: ["metadatas"],
+    });
+    const results = this.parseResults(response as Record<string, any>);
+    return results[0] || null;
+  }
+
+  async update(
+    vectorId: string,
+    vector: number[],
+    payload: Record<string, any>,
+  ): Promise<void> {
+    const collection = await this.getCollection();
+    await collection.update({
+      ids: [vectorId],
+      embeddings: [vector],
+      metadatas: [payload],
+    });
+  }
+
+  async delete(vectorId: string): Promise<void> {
+    const collection = await this.getCollection();
+    await collection.delete({ ids: [vectorId] });
+  }
+
+  async deleteCol(): Promise<void> {
+    if (this._initPromise) {
+      await this._initPromise.catch(() => {});
+    }
+    await this.client.deleteCollection({ name: this.collectionName });
+    this.collection = await this.client.getOrCreateCollection({
+      name: this.collectionName,
+      embeddingFunction: null,
+    });
+  }
+
+  async list(
+    filters?: SearchFilters,
+    topK: number = 100,
+  ): Promise<[VectorStoreResult[], number]> {
+    const collection = await this.getCollection();
+    const where = this.createFilter(filters);
+    const response = await collection.get({
+      ...(where ? { where } : {}),
+      limit: topK,
+      include: ["metadatas"],
+    });
+    const results = this.parseResults(response as Record<string, any>);
+    return [results, results.length];
+  }
+
+  async getUserId(): Promise<string> {
+    const collection = await this.getMigrationsCollection();
+    const response = await collection.get({
+      ids: [MIGRATIONS_RECORD_ID],
+      include: ["metadatas"],
+    });
+    const existing = this.parseResults(response as Record<string, any>)[0];
+    if (existing?.payload?.user_id) {
+      return existing.payload.user_id as string;
+    }
+
+    const randomUserId =
+      Math.random().toString(36).substring(2, 15) +
+      Math.random().toString(36).substring(2, 15);
+    await collection.add({
+      ids: [MIGRATIONS_RECORD_ID],
+      embeddings: [new Array(this.dimension).fill(0)],
+      metadatas: [{ user_id: randomUserId }],
+    });
+    return randomUserId;
+  }
+
+  async setUserId(userId: string): Promise<void> {
+    const collection = await this.getMigrationsCollection();
+    await collection.upsert({
+      ids: [MIGRATIONS_RECORD_ID],
+      embeddings: [new Array(this.dimension).fill(0)],
+      metadatas: [{ user_id: userId }],
+    });
+  }
+}

--- a/mem0-ts/src/oss/src/vector_stores/chroma.ts
+++ b/mem0-ts/src/oss/src/vector_stores/chroma.ts
@@ -6,7 +6,7 @@ const MIGRATIONS_COLLECTION = "__mem0_migrations__";
 const MIGRATIONS_RECORD_ID = "mem0-user-id";
 
 interface ChromaDBConfig extends VectorStoreConfig {
-  collectionName: string;
+  collectionName?: string;
   client?: ChromaClientType;
   host?: string;
   port?: number;
@@ -55,7 +55,7 @@ export class ChromaDB implements VectorStore {
       });
     }
 
-    this.collectionName = config.collectionName;
+    this.collectionName = config.collectionName || "memories";
     this.dimension = config.embeddingModelDims || config.dimension || 1536;
     this.initialize().catch(console.error);
   }

--- a/mem0-ts/src/oss/src/vector_stores/chroma.ts
+++ b/mem0-ts/src/oss/src/vector_stores/chroma.ts
@@ -360,7 +360,7 @@ export class ChromaDB implements VectorStore {
     const randomUserId =
       Math.random().toString(36).substring(2, 15) +
       Math.random().toString(36).substring(2, 15);
-    await collection.add({
+    await collection.upsert({
       ids: [MIGRATIONS_RECORD_ID],
       embeddings: [new Array(this.dimension).fill(0)],
       metadatas: [{ user_id: randomUserId }],


### PR DESCRIPTION
## Summary

- Adds a TypeScript OSS `ChromaDB` vector store provider backed by `chromadb` v3
- Registers `chroma` in `VectorStoreFactory` and exports it from the OSS entrypoint
- Adds focused unit coverage for factory creation, insert/search/get/update/delete/list, collection recreation, and migration user id upsert
- Updates Chroma vector store docs with TypeScript OSS usage and config keys

Closes #5773

## Notes

I noticed other open Chroma-related PRs while preparing this, so this is opened as a draft for maintainer comparison.

## Validation

- `node_modules/.bin/jest.cmd src/oss/src/tests/chroma.test.ts --runInBand`
- `node_modules/.bin/tsc.cmd --noEmit --skipLibCheck --moduleResolution node --esModuleInterop --target ES2018 --module commonjs --types node src/oss/src/vector_stores/chroma.ts`
- `node_modules/.bin/prettier.cmd --check ..\docs\components\vectordbs\dbs\chroma.mdx src\oss\src\vector_stores\chroma.ts src\oss\src\tests\chroma.test.ts src\oss\src\utils\factory.ts src\oss\src\index.ts package.json`
