### PR TITLE
docs: point config "Supported" links to overview pages

### DIFF
--- a/docs/components/embedders/config.mdx
+++ b/docs/components/embedders/config.mdx
@@ -97,4 +97,4 @@ Here's a comprehensive list of all parameters that can be used across different 
 
 ## Supported Embedding Models
 
-For detailed information on configuring specific embedders, please visit the [Embedding Models](./models) section. There you'll find information for each supported embedder with provider-specific usage examples and configuration details.
+For detailed information on configuring specific embedders, please visit the [Embedding Models](./overview) section. There you'll find information for each supported embedder with provider-specific usage examples and configuration details.

--- a/docs/components/llms/config.mdx
+++ b/docs/components/llms/config.mdx
@@ -133,4 +133,4 @@ Here's a comprehensive list of all parameters that can be used across different 
 
 ## Supported LLMs
 
-For detailed information on configuring specific LLMs, please visit the [LLMs](./models) section. There you'll find information for each supported LLM with provider-specific usage examples and configuration details.
+For detailed information on configuring specific LLMs, please visit the [LLMs](./overview) section. There you'll find information for each supported LLM with provider-specific usage examples and configuration details.

--- a/docs/components/vectordbs/config.mdx
+++ b/docs/components/vectordbs/config.mdx
@@ -118,10 +118,10 @@ Here's a comprehensive list of all parameters that can be used across different 
 
 Each vector database has its own specific configuration requirements. To customize the config for your chosen vector store:
 
-1. Identify the vector database you want to use from [supported vector databases](./dbs).
+1. Identify the vector database you want to use from [supported vector databases](./overview).
 2. Refer to the `Config` section in the respective vector database's documentation.
 3. Include only the relevant parameters for your chosen database in the `config` dictionary.
 
 ## Supported Vector Databases
 
-For detailed information on configuring specific vector databases, please visit the [Supported Vector Databases](./dbs) section. There you'll find individual pages for each supported vector store with provider-specific usage examples and configuration details.
+For detailed information on configuring specific vector databases, please visit the [Supported Vector Databases](./overview) section. There you'll find individual pages for each supported vector store with provider-specific usage examples and configuration details.


### PR DESCRIPTION
## Description

Fixes #6127.

The **"Supported …"** sections on the following config pages linked to `./models` (embedders/LLMs) and `./dbs` (vector DBs):

- `components/embedders/config`
- `components/llms/config`
- `components/vectordbs/config`

Those paths don't resolve to a provider-listing page — they redirect to a single provider page (`.../models/openai`, `.../dbs/qdrant`). A user looking for the full list of supported providers lands on just one provider.

This PR points those links to `./overview` instead, which already exists in the navigation and renders the full `CardGroup` of every supported provider — the intended destination.

## Changes

- `docs/components/embedders/config.mdx`: `./models` → `./overview`
- `docs/components/llms/config.mdx`: `./models` → `./overview`
- `docs/components/vectordbs/config.mdx`: `./dbs` → `./overview` (2 links)

Docs-only change; no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)