### PR TITLE
fix(openclaw): honor recall maxMemories for session search

### DIFF
--- a/integrations/openclaw/recall.test.ts
+++ b/integrations/openclaw/recall.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { recall } from "./recall.ts";
+import type { Mem0Provider, SearchOptions } from "./types.ts";
+
+describe("recall", () => {
+  it("uses configured over-fetch limit for session recall search", async () => {
+    const search = vi.fn(async (_query: string, _options: SearchOptions) => []);
+    const provider = { search } as unknown as Mem0Provider;
+
+    await recall(
+      provider,
+      "remember the current project context",
+      "user-1",
+      { recall: { maxMemories: 8 } },
+      "session-1",
+    );
+
+    expect(search).toHaveBeenCalledTimes(2);
+    expect(search.mock.calls[0]?.[1]).toMatchObject({
+      user_id: "user-1",
+      source: "OPENCLAW",
+      top_k: 16,
+    });
+    expect(search.mock.calls[1]?.[1]).toMatchObject({
+      user_id: "user-1",
+      run_id: "session-1",
+      source: "OPENCLAW",
+      top_k: 16,
+    });
+  });
+});

--- a/integrations/openclaw/recall.ts
+++ b/integrations/openclaw/recall.ts
@@ -283,7 +283,7 @@ export async function recall(
       sessionMemories = await provider.search(cleanQuery, {
         ...searchOpts,
         run_id: sessionId,
-        top_k: 5,
+        top_k: searchOpts.top_k,
       });
     } catch {
       // Session search failure is non-critical


### PR DESCRIPTION
## Summary
- use the configured OpenClaw recall over-fetch limit for session-scoped searches
- keep session recall aligned with `skills.recall.maxMemories`
- add a regression test for the session search `top_k` option

Related to #6135

## Tests
- `pnpm test recall.test.ts`
- `pnpm build`
- `git diff --check`

Note: `pnpm test` currently fails in existing `index.test.ts` and `sqlite-resilience.test.ts` suites because `openclaw/plugin-sdk/plugin-entry` is not resolved by the current test alias setup; the targeted regression test and package build pass.