### PR TITLE
fix(memory): skip vision LLM for text-only multimodal content

### DIFF
--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -192,7 +192,16 @@ def parse_vision_messages(messages, llm=None, vision_details="auto"):
 
         # Handle message content
         if isinstance(content, list):
-            if llm is None:
+            has_image = any(
+                isinstance(part, dict) and part.get("type") == "image_url"
+                for part in content
+            )
+            if llm is None or not has_image:
+                # No vision model available, or the list carries no image part:
+                # extract the text parts instead of routing to the vision LLM.
+                # Routing a text-only list to get_image_description would prompt
+                # the model for an image that does not exist and discard the
+                # user's real text (see issue #6129).
                 text_parts = [
                     part["text"] for part in msg["content"]
                     if isinstance(part, dict) and part.get("type") == "text"

--- a/tests/memory/test_memory_utils.py
+++ b/tests/memory/test_memory_utils.py
@@ -79,6 +79,32 @@ class TestParseVisionMessages:
         assert result[0]["content"] == "A photo of a cat"
         mock_llm.generate_response.assert_called_once()
 
+    def test_text_only_list_with_llm_extracts_text_and_skips_vision(self):
+        # Regression for #6129: a list content with no image_url part must not
+        # be routed to the vision model. Doing so prompts for a nonexistent
+        # image and discards the user's real text.
+        mock_llm = Mock()
+        mock_llm.generate_response.return_value = "A photo of ..."
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "I love pizza"}]},
+        ]
+        result = parse_vision_messages(messages, llm=mock_llm, vision_details="auto")
+        assert result == [{"role": "user", "content": "I love pizza"}]
+        mock_llm.generate_response.assert_not_called()
+
+    def test_text_only_multi_part_list_with_llm_joins_text(self):
+        # Multiple text parts and no image: join them, still no vision call.
+        mock_llm = Mock()
+        messages = [
+            {"role": "user", "content": [
+                {"type": "text", "text": "I love"},
+                {"type": "text", "text": "pizza"},
+            ]},
+        ]
+        result = parse_vision_messages(messages, llm=mock_llm, vision_details="auto")
+        assert result == [{"role": "user", "content": "I love pizza"}]
+        mock_llm.generate_response.assert_not_called()
+
     def test_image_only_list_without_llm_is_skipped(self):
         messages = [
             {"role": "user", "content": [


### PR DESCRIPTION
## Summary

- `parse_vision_messages` no longer routes text-only list content to the vision LLM.
- Text is preserved (instead of being replaced by a hallucinated image description), and a wasteful vision call is avoided on every text-only multimodal message.

## Motivation

Closes #6129.

When `enable_vision` is on, `parse_vision_messages` (`mem0/memory/utils.py`) passed **every** list-type message content to `get_image_description`, even when the list contained no image. That prompts the model with *"A user is providing an image..."* with no image attached, so it returns a confused guess — and that guess **replaces the user's actual text** before fact extraction. The `llm is None` branch already handled this correctly by extracting text parts; only the vision-enabled branch was affected.

## Fix

Detect whether the list actually contains an `image_url` part. Only route to the vision model when it does; otherwise extract and join the text parts (mirroring the `llm is None` path).

## Verification

- Added two regression tests in `tests/memory/test_memory_utils.py`:
  - `test_text_only_list_with_llm_extracts_text_and_skips_vision`
  - `test_text_only_multi_part_list_with_llm_joins_text`
- Both **fail on current main** (real text replaced by the mock's return value) and **pass with the fix**.
- Full suite: `pytest tests/memory/test_memory_utils.py` → **21 passed**.
- Did NOT change the image-bearing path or the `llm is None` behavior.