### PR TITLE
fix(opensearch): list() without top_k returns all matches, not 10

### DIFF
--- a/mem0/vector_stores/opensearch.py
+++ b/mem0/vector_stores/opensearch.py
@@ -17,6 +17,11 @@ logger = logging.getLogger(__name__)
 
 _SAFE_FILTER_KEY = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_.]*$")
 
+# OpenSearch's default query size is 10 hits. When list() is called with no
+# top_k (e.g. from get_all()/delete_all() to enumerate ALL matches), fall back
+# to index.max_result_window (default 10000) so results are not silently capped.
+_MAX_RESULT_WINDOW = 10000
+
 
 def _validate_filter(key: str, value) -> None:
     if not isinstance(key, str) or not _SAFE_FILTER_KEY.match(key):
@@ -381,8 +386,10 @@ class OpenSearchDB(VectorStoreBase):
             if filter_clauses:
                 query["query"] = {"bool": {"filter": filter_clauses}}
 
-            if top_k:
-                query["size"] = top_k
+            # top_k=None means "list everything" (get_all()/delete_all()). Without
+            # an explicit size, OpenSearch caps the response at its default of 10
+            # hits, silently truncating results. Fall back to max_result_window.
+            query["size"] = top_k if top_k else _MAX_RESULT_WINDOW
 
             response = self.client.search(index=self.collection_name, body=query)
             hits = response["hits"]["hits"]

--- a/tests/vector_stores/test_opensearch.py
+++ b/tests/vector_stores/test_opensearch.py
@@ -312,6 +312,24 @@ class TestOpenSearchDB(unittest.TestCase):
         self.assertEqual(len(result[0]), 1)
         self.assertEqual(result[0][0].id, "id1")
 
+    def test_list_without_top_k_uses_max_result_window(self):
+        """Regression for #6108: list(top_k=None) must set an explicit size so
+        get_all()/delete_all() are not silently capped at OpenSearch's default
+        of 10 hits."""
+        from mem0.vector_stores.opensearch import _MAX_RESULT_WINDOW
+
+        self.client_mock.search.return_value = {"hits": {"hits": []}}
+        self.os_db.list(filters={"user_id": "alice"})
+        body = self.client_mock.search.call_args[1]["body"]
+        self.assertEqual(body["size"], _MAX_RESULT_WINDOW)
+
+    def test_list_with_top_k_uses_top_k_as_size(self):
+        """An explicit top_k must still be honored as the query size."""
+        self.client_mock.search.return_value = {"hits": {"hits": []}}
+        self.os_db.list(filters={"user_id": "alice"}, top_k=42)
+        body = self.client_mock.search.call_args[1]["body"]
+        self.assertEqual(body["size"], 42)
+
     @patch("mem0.vector_stores.opensearch.logger")
     def test_list_error_returns_nested_empty_list(self, mock_logger):
         """list() error path must return [[]] (not bare []) so callers can do


### PR DESCRIPTION
## Summary

- `OpenSearchDB.list()` now sets an explicit query size when `top_k` is `None`, so `get_all()` and `delete_all()` operate on the full result set instead of the first 10.

## Motivation

Closes #6108.

`OpenSearchDB.list()` only set the query `size` when `top_k` was truthy:

```python
if top_k:
    query["size"] = top_k
```

`Memory.get_all()` and `Memory.delete_all()` call `list(filters=..., top_k=None)` to enumerate **all** matching memories. With `size` unset, OpenSearch falls back to its default of **10 hits**, so any user with more than 10 memories has the rest silently dropped — `get_all()` returns at most 10, and `delete_all()` deletes at most 10 per call, leaving older memories behind.

## Fix

Fall back to `index.max_result_window` (10000) as the query size when `top_k` is `None`; an explicit `top_k` is still honored as the size.

## Verification

- Added two tests in `tests/vector_stores/test_opensearch.py`:
  - `test_list_without_top_k_uses_max_result_window` — asserts size == max_result_window when top_k is None (**fails on main**, passes with fix).
  - `test_list_with_top_k_uses_top_k_as_size` — asserts an explicit top_k is still used as the size.
- Full suite: `pytest tests/vector_stores/test_opensearch.py` → **31 passed**.
- Scope: only the `list()` size fallback changed; query/filter construction is untouched.