### PR TITLE
fix(weaviate): don't write OutputData model fields as properties on update

### DIFF
--- a/mem0/vector_stores/weaviate.py
+++ b/mem0/vector_stores/weaviate.py
@@ -1,6 +1,6 @@
 import logging
 import uuid
-from typing import Dict, List, Mapping, Optional
+from typing import Dict, List, Optional
 from urllib.parse import urlparse
 
 from pydantic import BaseModel
@@ -297,13 +297,12 @@ class Weaviate(VectorStoreBase):
             collection.data.update(uuid=vector_id, properties=payload)
 
         if vector:
-            existing_data = self.get(vector_id)
-            if existing_data:
-                existing_data = dict(existing_data)
-                if "id" in existing_data:
-                    del existing_data["id"]
-                existing_payload: Mapping[str, str] = existing_data
-                collection.data.update(uuid=vector_id, properties=existing_payload, vector=vector)
+            # data.update performs a partial (merge) update, so updating the
+            # vector alone leaves the existing properties untouched. The previous
+            # implementation resent dict(OutputData), i.e. the model field names
+            # ("id", "score", "payload"), which overwrote the real properties
+            # with garbage instead of preserving them.
+            collection.data.update(uuid=vector_id, vector=vector)
 
     def get(self, vector_id) -> Optional[OutputData]:
         """

--- a/mem0/vector_stores/weaviate.py
+++ b/mem0/vector_stores/weaviate.py
@@ -297,11 +297,6 @@ class Weaviate(VectorStoreBase):
             collection.data.update(uuid=vector_id, properties=payload)
 
         if vector:
-            # data.update performs a partial (merge) update, so updating the
-            # vector alone leaves the existing properties untouched. The previous
-            # implementation resent dict(OutputData), i.e. the model field names
-            # ("id", "score", "payload"), which overwrote the real properties
-            # with garbage instead of preserving them.
             collection.data.update(uuid=vector_id, vector=vector)
 
     def get(self, vector_id) -> Optional[OutputData]:

--- a/tests/vector_stores/test_weaviate.py
+++ b/tests/vector_stores/test_weaviate.py
@@ -220,6 +220,50 @@ class TestWeaviateDB(unittest.TestCase):
         self.client_mock.collections.delete.assert_called_once_with("test_collection")
         self.client_mock.collections.create.assert_called_once()
 
+    def test_update_preserves_properties_and_does_not_write_model_fields(self):
+        # Regression: the vector branch of update() previously resent
+        # dict(OutputData) as properties, i.e. the model field names
+        # {"id", "score", "payload"}, corrupting the stored object instead of
+        # preserving its real properties.
+        valid_uuid = str(uuid.uuid4())
+        collection = self.client_mock.collections.get.return_value
+
+        # Mock get() so that, on the buggy code path, the vector branch can run
+        # to completion and actually write its (wrong) properties.
+        mock_response = MagicMock()
+        mock_response.properties = {"data": "existing", "hash": "abc123"}
+        mock_response.uuid = valid_uuid
+        collection.query.fetch_object_by_id.return_value = mock_response
+
+        new_payload = {
+            "data": "updated memory",
+            "hash": "def456",
+            "user_id": "user_123",
+        }
+
+        self.weaviate_db.update(
+            vector_id=valid_uuid,
+            vector=[0.1] * 1536,
+            payload=new_payload,
+        )
+
+        update_calls = collection.data.update.call_args_list
+        # The payload branch updates the real properties.
+        property_updates = [c for c in update_calls if "properties" in c.kwargs]
+        self.assertEqual(len(property_updates), 1)
+        self.assertEqual(property_updates[0].kwargs["properties"], new_payload)
+
+        # No update call may write the OutputData model field names as properties.
+        for call in update_calls:
+            props = call.kwargs.get("properties", {})
+            self.assertNotIn("score", props)
+            self.assertNotIn("payload", props)
+
+        # The vector branch updates the vector without touching properties.
+        vector_updates = [c for c in update_calls if "vector" in c.kwargs]
+        self.assertEqual(len(vector_updates), 1)
+        self.assertNotIn("properties", vector_updates[0].kwargs)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Linked Issue

Closes #6148

## Description

`Weaviate.update()` corrupted the stored object whenever it was called with a `vector`. In the vector branch it resent the `OutputData` **model field names** (`id`, `score`, `payload`) as Weaviate properties instead of the object's real properties:

```python
if vector:
    existing_data = self.get(vector_id)      # OutputData(id, score, payload)
    if existing_data:
        existing_data = dict(existing_data)   # {"id": ..., "score": 1.0, "payload": {...}}  <- model fields
        ...
        collection.data.update(uuid=vector_id, properties=existing_payload, vector=vector)
```

`Memory.update(memory_id, data=...)` calls `vector_store.update(vector_id=..., vector=embeddings, payload=new_metadata)` with both `vector` and `payload` set, so the `payload` branch correctly updated the properties and then this `vector` branch injected `score`/`payload` as bogus properties (with auto-schema on) or raised (auto-schema off).

`collection.data.update()` is a partial (merge) update, so the vector branch only needs to update the vector — existing properties are preserved automatically. This removes the faulty property round-trip entirely (and the now-unused `Mapping` import).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added `test_update_preserves_properties_and_does_not_write_model_fields` in `tests/vector_stores/test_weaviate.py`. It asserts the payload branch performs exactly one property update (equal to the given payload), that no `data.update` call writes the `score`/`payload` model field names, and that the vector branch updates the vector without touching properties. The test fails on `main` and passes with this change.

Verified locally: `ruff check` and `ruff format --check` clean, `isort` clean, and the full `tests/vector_stores/test_weaviate.py` suite passes (12 passed).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed (N/A — internal bug fix)
