### PR TITLE
fix(memory): parse chatty JSON payloads

### DIFF
--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -1,4 +1,5 @@
 import hashlib
+import json
 import logging
 import re
 from typing import Any, Dict, List
@@ -14,11 +15,11 @@ logger = logging.getLogger(__name__)
 
 def get_fact_retrieval_messages(message, is_agent_memory=False):
     """Get fact retrieval messages based on the memory type.
-    
+
     Args:
         message: The message content to extract facts from
         is_agent_memory: If True, use agent memory extraction prompt, else use user memory extraction prompt
-        
+
     Returns:
         tuple: (system_prompt, user_prompt)
     """
@@ -52,8 +53,7 @@ def ensure_json_instruction(system_prompt, user_prompt):
     combined = (system_prompt + user_prompt).lower()
     if "json" not in combined:
         system_prompt += (
-            "\n\nYou must return your response in valid JSON format "
-            "with a 'facts' key containing an array of strings."
+            "\n\nYou must return your response in valid JSON format with a 'facts' key containing an array of strings."
         )
     return system_prompt, user_prompt
 
@@ -86,6 +86,7 @@ def format_entities(entities):
         formatted_lines.append(simplified)
 
     return "\n".join(formatted_lines)
+
 
 def normalize_facts(raw_facts):
     """Normalize LLM-extracted facts to a list of strings.
@@ -123,15 +124,14 @@ def remove_code_blocks(content: str) -> str:
     """
     pattern = r"^```[a-zA-Z0-9]*\n([\s\S]*?)\n```$"
     match = re.match(pattern, content.strip())
-    match_res=match.group(1).strip() if match else content.strip()
+    match_res = match.group(1).strip() if match else content.strip()
     return re.sub(r"<think>.*?</think>", "", match_res, flags=re.DOTALL).strip()
-
 
 
 def extract_json(text):
     """
     Extracts JSON content from a string, removing enclosing triple backticks and optional 'json' tag if present.
-    If no code block is found, attempts to locate JSON by finding the first '{' and last '}'.
+    If no code block is found, attempts to locate the first valid JSON object or array.
     If that also fails, returns the text as-is.
     """
     text = text.strip()
@@ -139,12 +139,23 @@ def extract_json(text):
     if match:
         json_str = match.group(1)
     else:
-        start_idx = text.find("{")
-        end_idx = text.rfind("}")
-        if start_idx != -1 and end_idx != -1 and end_idx > start_idx:
-            json_str = text[start_idx : end_idx + 1]
+        decoder = json.JSONDecoder(strict=False)
+        fallback_json = None
+        json_str = text
+        for candidate in re.finditer(r"[\{\[]", text):
+            start_idx = candidate.start()
+            try:
+                decoded, end_idx = decoder.raw_decode(text[start_idx:])
+            except json.JSONDecodeError:
+                continue
+            candidate_json = text[start_idx : start_idx + end_idx]
+            if isinstance(decoded, dict) and ("memory" in decoded or "facts" in decoded):
+                json_str = candidate_json
+                break
+            if fallback_json is None:
+                fallback_json = candidate_json
         else:
-            json_str = text
+            json_str = fallback_json or text
     return json_str
 
 
@@ -194,8 +205,7 @@ def parse_vision_messages(messages, llm=None, vision_details="auto"):
         if isinstance(content, list):
             if llm is None:
                 text_parts = [
-                    part["text"] for part in msg["content"]
-                    if isinstance(part, dict) and part.get("type") == "text"
+                    part["text"] for part in msg["content"] if isinstance(part, dict) and part.get("type") == "text"
                 ]
                 if not text_parts:
                     continue
@@ -317,4 +327,3 @@ def remove_spaces_from_entities(
         item["destination"] = item["destination"].lower().replace(" ", "_")
         cleaned.append(item)
     return cleaned
-

--- a/tests/test_chatty_llm_parsing.py
+++ b/tests/test_chatty_llm_parsing.py
@@ -14,6 +14,7 @@ from mem0.memory.utils import extract_json, remove_code_blocks
 
 # --- Test extract_json ---
 
+
 class TestExtractJson:
     """Tests for extract_json utility."""
 
@@ -55,6 +56,26 @@ That's the result."""
         parsed = json.loads(result)
         assert parsed["memory"][0]["text"] == "likes gaming"
 
+    def test_chatty_with_braces_before_json(self):
+        """extract_json skips non-JSON prose braces before the payload."""
+        text = (
+            "Based on the conversation {about travel}, here is the update: "
+            '{"memory": [{"id": "0", "text": "likes travel", "event": "ADD"}]}'
+        )
+        result = extract_json(text)
+        parsed = json.loads(result)
+        assert parsed["memory"][0]["text"] == "likes travel"
+
+    def test_chatty_with_valid_non_payload_json_before_memory(self):
+        """extract_json prefers a later memory payload over earlier valid JSON prose."""
+        text = (
+            'Example: {"note": "not the memory payload"}. Final answer: '
+            '{"memory": [{"id": "0", "text": "likes hiking", "event": "ADD"}]}'
+        )
+        result = extract_json(text)
+        parsed = json.loads(result)
+        assert parsed["memory"][0]["text"] == "likes hiking"
+
     def test_chatty_multiline_json_without_markdown(self):
         """extract_json finds multi-line JSON by {/} boundaries."""
         text = """Here is the memory update:
@@ -93,6 +114,7 @@ That's the result."""
 
 
 # --- Test remove_code_blocks ---
+
 
 class TestRemoveCodeBlocks:
     """Tests for remove_code_blocks — verify it does NOT handle chatty text."""
@@ -133,6 +155,7 @@ class TestRemoveCodeBlocks:
 
 
 # --- Test the full fallback chain (remove_code_blocks -> extract_json) ---
+
 
 class TestFallbackChain:
     """Tests the actual fallback pattern used in _add_to_vector_store:
@@ -189,6 +212,15 @@ I hope this helps!"""
         result = self._parse_with_fallback(response)
         assert len(result["memory"]) == 2
 
+    def test_chatty_no_markdown_with_braces_before_json(self):
+        """Issue #5998: prose braces before JSON do not poison fallback parsing."""
+        response = (
+            "Based on the conversation {about travel}, here is the update: "
+            '{"memory": [{"id": "0", "text": "likes travel", "event": "ADD"}]}'
+        )
+        result = self._parse_with_fallback(response)
+        assert result["memory"][0]["text"] == "likes travel"
+
     def test_think_tags_with_json(self):
         """Reasoning model with <think> tags."""
         response = '<think>Let me process this...</think>\n```json\n{"memory": [{"id": "0", "text": "test", "event": "ADD"}]}\n```'
@@ -230,3 +262,9 @@ I hope this helps!"""
         response = 'Sure! Here are the facts:\n{"facts": ["Name is Alex", "Loves basketball"]}\nHope that helps!'
         result = self._parse_with_fallback(response)
         assert result["facts"] == ["Name is Alex", "Loves basketball"]
+
+    def test_facts_extraction_prefers_payload_over_prior_json(self):
+        """Earlier valid JSON should not hide a later facts payload."""
+        response = 'Example: {"note": "ignore me"}\nFacts:\n{"facts": ["Name is Alex"]}'
+        result = self._parse_with_fallback(response)
+        assert result["facts"] == ["Name is Alex"]


### PR DESCRIPTION
Summary
- parse chatty fallback JSON by trying valid JSON candidates instead of slicing from the first brace to the last brace
- prefer later `memory` / `facts` payload objects over earlier valid non-payload JSON snippets
- keep a generic first-valid-JSON fallback for other callers

Refs #5998.

Tests
- `uv run --extra test pytest tests/test_chatty_llm_parsing.py tests/memory/test_memory_utils.py -q` (44 passed)
- `uv run --with ruff ruff format --check mem0/memory/utils.py tests/test_chatty_llm_parsing.py`
- `uv run --with ruff ruff check mem0/memory/utils.py tests/test_chatty_llm_parsing.py`
- `git diff --check`