### PR TITLE
fix(memory): remove_code_blocks must not crash on None or list content

### DIFF
--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -112,15 +112,30 @@ def normalize_facts(raw_facts):
     return normalized
 
 
-def remove_code_blocks(content: str) -> str:
+def remove_code_blocks(content: Any) -> str:
     """
     Removes enclosing code block markers ```[language] and ``` from a given string.
 
     Remarks:
+    - If content is None, returns an empty string.
+    - If content is a list of content blocks, extracts string items and dict item "text" values before processing.
     - The function uses a regex pattern to match code blocks that may start with ``` followed by an optional language tag (letters or numbers) and end with ```.
     - If a code block is detected, it returns only the inner content, stripping out the markers.
     - If no code block markers are found, the original content is returned as-is.
     """
+    if content is None:
+        return ""
+    if isinstance(content, list):
+        content_parts = []
+        for item in content:
+            if isinstance(item, str):
+                content_parts.append(item)
+            elif isinstance(item, dict) and "text" in item:
+                content_parts.append(str(item["text"]))
+        content = "".join(content_parts)
+    elif not isinstance(content, str):
+        content = str(content)
+
     pattern = r"^```[a-zA-Z0-9]*\n([\s\S]*?)\n```$"
     match = re.match(pattern, content.strip())
     match_res=match.group(1).strip() if match else content.strip()
@@ -317,4 +332,3 @@ def remove_spaces_from_entities(
         item["destination"] = item["destination"].lower().replace(" ", "_")
         cleaned.append(item)
     return cleaned
-

--- a/tests/test_chatty_llm_parsing.py
+++ b/tests/test_chatty_llm_parsing.py
@@ -103,6 +103,22 @@ class TestRemoveCodeBlocks:
         parsed = json.loads(result)
         assert parsed == {"memory": []}
 
+    def test_none_content_returns_empty_string(self):
+        assert remove_code_blocks(None) == ""
+
+    def test_string_list_content_is_joined(self):
+        assert remove_code_blocks(["hello ", "world"]) == "hello world"
+
+    def test_langchain_text_blocks_are_joined(self):
+        content = [{"type": "text", "text": "hello"}, {"type": "text", "text": " world"}]
+        assert remove_code_blocks(content) == "hello world"
+
+    def test_plain_string_code_block_still_strips_markers(self):
+        assert remove_code_blocks("```python\ncode\n```") == "code"
+
+    def test_plain_string_without_code_block_is_stripped(self):
+        assert remove_code_blocks("  hello world  ") == "hello world"
+
     def test_no_code_block(self):
         """Without code blocks, returns content as-is (may not be valid JSON)."""
         text = 'Here is the result: {"memory": []}'

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1529,3 +1529,112 @@ async def test_async_procedural_memory_langchain_strips_code_blocks(mock_llm_fac
     insert_call = memory.vector_store.insert.call_args
     stored_data = insert_call[1]["payloads"][0]["data"]
     assert "```" not in stored_data
+
+
+@pytest.mark.parametrize(
+    ("llm_response", "expected_memory"),
+    [
+        (None, ""),
+        ([{"type": "text", "text": "hello"}, {"type": "text", "text": " world"}], "hello world"),
+    ],
+)
+@patch("mem0.memory.main.VectorStoreFactory")
+@patch("mem0.memory.main.EmbedderFactory")
+@patch("mem0.memory.main.LlmFactory")
+def test_sync_procedural_memory_handles_empty_and_block_content(
+    mock_llm_factory, mock_emb, mock_vs, llm_response, expected_memory
+):
+    mock_vs.create.return_value = MagicMock()
+    mock_emb.create.return_value = MagicMock()
+    mock_emb.create.return_value.embed.return_value = [0.1] * 1536
+    mock_llm_factory.create.return_value = MagicMock()
+    mock_llm_factory.create.return_value.generate_response.return_value = llm_response
+
+    from mem0.memory.main import Memory
+
+    config = MemoryConfig()
+    memory = Memory(config)
+    memory.vector_store = MagicMock()
+    memory.vector_store.insert = MagicMock()
+
+    result = memory._create_procedural_memory(
+        [{"role": "user", "content": "test"}],
+        metadata={"user_id": "test_user"},
+    )
+
+    assert result["results"][0]["memory"] == expected_memory
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("llm_response", "expected_memory"),
+    [
+        (None, ""),
+        (["hello ", {"type": "text", "text": "world"}], "hello world"),
+    ],
+)
+@patch("mem0.memory.main.VectorStoreFactory")
+@patch("mem0.memory.main.EmbedderFactory")
+@patch("mem0.memory.main.LlmFactory")
+async def test_async_procedural_memory_handles_empty_and_block_content(
+    mock_llm_factory, mock_emb, mock_vs, llm_response, expected_memory
+):
+    mock_vs.create.return_value = MagicMock()
+    mock_emb.create.return_value = MagicMock()
+    mock_emb.create.return_value.embed.return_value = [0.1] * 1536
+    mock_llm_factory.create.return_value = MagicMock()
+    mock_llm_factory.create.return_value.generate_response.return_value = llm_response
+
+    from mem0.memory.main import AsyncMemory
+
+    config = MemoryConfig()
+    memory = AsyncMemory(config)
+    memory.vector_store = MagicMock()
+    memory.vector_store.insert = MagicMock()
+
+    result = await memory._create_procedural_memory(
+        [{"role": "user", "content": "test"}],
+        metadata={"user_id": "test_user"},
+    )
+
+    assert result["results"][0]["memory"] == expected_memory
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("response_content", "expected_memory"),
+    [
+        (None, ""),
+        ([{"type": "text", "text": "hello"}, {"type": "text", "text": " world"}], "hello world"),
+    ],
+)
+@patch("mem0.memory.main.VectorStoreFactory")
+@patch("mem0.memory.main.EmbedderFactory")
+@patch("mem0.memory.main.LlmFactory")
+async def test_async_procedural_memory_langchain_handles_empty_and_block_content(
+    mock_llm_factory, mock_emb, mock_vs, response_content, expected_memory
+):
+    mock_vs.create.return_value = MagicMock()
+    mock_emb.create.return_value = MagicMock()
+    mock_emb.create.return_value.embed.return_value = [0.1] * 1536
+    mock_llm_factory.create.return_value = MagicMock()
+
+    from mem0.memory.main import AsyncMemory
+
+    config = MemoryConfig()
+    memory = AsyncMemory(config)
+    memory.vector_store = MagicMock()
+    memory.vector_store.insert = MagicMock()
+
+    mock_langchain_llm = MagicMock()
+    mock_response = MagicMock()
+    mock_response.content = response_content
+    mock_langchain_llm.invoke.return_value = mock_response
+
+    result = await memory._create_procedural_memory(
+        [{"role": "user", "content": "test"}],
+        metadata={"user_id": "test_user"},
+        llm=mock_langchain_llm,
+    )
+
+    assert result["results"][0]["memory"] == expected_memory


### PR DESCRIPTION
Closes #6150

remove_code_blocks(content: str) in mem0/memory/utils.py assumed content is always a string. It's called at 5 sites in main.py. 3 of them (fact extraction, sync and async) already catch this and degrade gracefully to []. The other 2 (_create_procedural_memory, sync and async) catch, log, and re-raise, so a crash here is user-facing.

content can legitimately be None. Per the OpenAI SDK's own type definition, ChatCompletionMessage.content is Union[str, None], populated as None on safety refusals where refusal is set instead. remove_code_blocks(None) then crashed with AttributeError: 'NoneType' object has no attribute 'strip' instead of a clear error.

The async LangChain path has a second trigger: content can be a list of content blocks instead of a plain string.

Fixed at the root, in remove_code_blocks() itself. None returns an empty string (matches how the 3 already-protected callers treat "nothing extracted"). Lists are joined, handling both plain strings and LangChain-style {"text": ...} dict blocks. Any other non-str type is coerced with str(). Existing str behavior is byte-for-byte unchanged.

16 tests pass (9 utility, 7 procedural memory covering sync, async, and async-LangChain paths). Red-green verified. Ruff clean.