### PR TITLE
Add delete step to Python OSS quickstart

### DIFF
--- a/docs/open-source/python-quickstart.mdx
+++ b/docs/open-source/python-quickstart.mdx
@@ -74,6 +74,15 @@ print(results)
 ```
 
 </Step>
+
+<Step title="Delete a memory">
+```python
+if results["results"]:
+    memory_id = results["results"][0]["id"]
+    m.delete(memory_id=memory_id)
+    print(f"Deleted memory {memory_id}")
+```
+</Step>
 </Steps>
 
 <Snippet file="star-on-github.mdx" />


### PR DESCRIPTION
﻿The Python quickstart ended after search, but internal doc templates require an add-search-delete loop. This adds a short delete step that reuses the search result ID so new users complete the full CRUD verification path.
