### PR TITLE
feat(vector-stores): add TypeScript FAISS provider

### DIFF
--- a/docs/components/vectordbs/config.mdx
+++ b/docs/components/vectordbs/config.mdx
@@ -102,11 +102,13 @@ Here's a comprehensive list of all parameters that can be used across different 
 | `collectionName` | Name of the collection |
 | `embeddingModelDims` | Dimensions of the embedding model |
 | `dimension` | Dimensions of the embedding model (for memory provider) |
+| `distanceStrategy` | Distance strategy for FAISS (`euclidean`, `inner_product`, `cosine`) |
+| `normalizeL2` | Enable L2 normalization for FAISS euclidean search |
 | `host` | Host where the server is running |
 | `port` | Port where the server is running |
 | `url` | URL for the server |
 | `apiKey` | API key for the server |
-| `path` | Path for the database |
+| `path` | Path for the database or FAISS directory that stores index and metadata files |
 | `onDisk` | Enable persistent storage |
 | `redisUrl` | URL for the Redis server |
 | `username` | Username for database connection |

--- a/docs/components/vectordbs/dbs/faiss.mdx
+++ b/docs/components/vectordbs/dbs/faiss.mdx
@@ -2,9 +2,10 @@
 title: "FAISS"
 description: "Use Facebook FAISS as a high-performance vector store in Mem0, optimized for memory usage and fast similarity search."
 ---
-[FAISS](https://github.com/facebookresearch/faiss) is a library for efficient similarity search and clustering of dense vectors. It is designed to work with large-scale datasets and provides a high-performance search engine for vector data. FAISS is optimized for memory usage and search speed, making it an excellent choice for production environments.
 
-### Usage
+[FAISS](https://github.com/facebookresearch/faiss) is a library for efficient similarity search and clustering of dense vectors. It is designed for large-scale vector retrieval and exact flat search stays fast for small and medium collections.
+
+### Python Usage
 
 ```python
 import os
@@ -18,24 +19,69 @@ config = {
         "config": {
             "collection_name": "test",
             "path": "/tmp/faiss_memories",
-            "distance_strategy": "euclidean"
-        }
+            "distance_strategy": "euclidean",
+        },
     }
 }
 
-m = Memory.from_config(config)
+memory = Memory.from_config(config)
 messages = [
     {"role": "user", "content": "I'm planning to watch a movie tonight. Any recommendations?"},
     {"role": "assistant", "content": "How about thriller movies? They can be quite engaging."},
     {"role": "user", "content": "I'm not a big fan of thriller movies but I love sci-fi movies."},
-    {"role": "assistant", "content": "Got it! I'll avoid thriller recommendations and suggest sci-fi movies in the future."}
+    {"role": "assistant", "content": "Got it! I'll avoid thriller recommendations and suggest sci-fi movies in the future."},
 ]
-m.add(messages, user_id="alice", metadata={"category": "movies"})
+memory.add(messages, user_id="alice", metadata={"category": "movies"})
+```
+
+### TypeScript Usage
+
+```ts
+import { Memory } from "mem0ai/oss";
+
+const memory = new Memory({
+  llm: {
+    provider: "openai",
+    config: {
+      apiKey: process.env.OPENAI_API_KEY || "",
+      model: "gpt-5-mini",
+    },
+  },
+  embedder: {
+    provider: "openai",
+    config: {
+      apiKey: process.env.OPENAI_API_KEY || "",
+      model: "text-embedding-3-small",
+    },
+  },
+  vectorStore: {
+    provider: "faiss",
+    config: {
+      collectionName: "test",
+      path: "/tmp/faiss_memories",
+      distanceStrategy: "cosine",
+      normalizeL2: false,
+      embeddingModelDims: 1536,
+    },
+  },
+});
 ```
 
 ### Installation
 
-To use FAISS in your mem0 project, you need to install the appropriate FAISS package for your environment:
+Install the optional native addon in Node.js:
+
+```bash
+pnpm add faiss-node
+```
+
+If you publish a wrapper around Mem0 OSS, keep `faiss-node` as an optional peer dependency. Mem0 loads it lazily when the FAISS provider is constructed.
+
+<Warning>
+  FAISS is a Node-native provider. It does not run in browsers, Cloudflare Workers, or serverless runtimes that block native addons.
+</Warning>
+
+For Python, install the appropriate FAISS package for your environment:
 
 ```bash
 # For CPU version
@@ -49,29 +95,29 @@ pip install faiss-gpu
 
 Here are the parameters available for configuring FAISS:
 
-| Parameter | Description | Default Value |
-| --- | --- | --- |
-| `collection_name` | The name of the collection | `mem0` |
-| `path` | Path to store FAISS index and metadata | `/tmp/faiss/<collection_name>` |
-| `distance_strategy` | Distance metric strategy to use (options: 'euclidean', 'inner_product', 'cosine') | `euclidean` |
-| `normalize_L2` | Whether to normalize L2 vectors (only applicable for euclidean distance) | `False` |
-| `embedding_model_dims` | Dimensions of the embedding model | `1536` |
+| Parameter              | TypeScript key       | Description                                                                                | Default value                 |
+| ---------------------- | -------------------- | ------------------------------------------------------------------------------------------ | ----------------------------- |
+| `collection_name`      | `collectionName`     | The collection name. Use this to isolate separate memory stores.                           | `mem0`                        |
+| `path`                 | `path`               | Directory that holds `collectionName.faiss` and `collectionName.json`.                     | `/tmp/faiss/<collectionName>` |
+| `distance_strategy`    | `distanceStrategy`   | Distance metric strategy. Supported values are `euclidean`, `inner_product`, and `cosine`. | `euclidean`                   |
+| `normalize_L2`         | `normalizeL2`        | Whether to normalize vectors before euclidean indexing. `cosine` always normalizes.        | `false`                       |
+| `embedding_model_dims` | `embeddingModelDims` | Dimensions of the embedding model.                                                         | `1536`                        |
 
 ### Performance Considerations
 
 FAISS offers several advantages for vector search:
 
-1. **Efficiency**: FAISS is optimized for memory usage and speed, making it suitable for large-scale applications.
-2. **Offline Support**: FAISS works entirely locally, with no need for external servers or API calls.
-3. **Storage Options**: Vectors can be stored in-memory for maximum speed or persisted to disk.
-4. **Multiple Index Types**: FAISS supports different index types optimized for various use cases (though mem0 currently uses the basic flat index).
+1. Efficiency: FAISS is optimized for memory usage and speed, making it suitable for large-scale applications.
+2. Offline support: FAISS works entirely locally, with no need for external servers or API calls.
+3. Storage options: Vectors and JSON metadata are stored on disk so collections can be rebuilt or reopened later.
+4. Flat indexes: Mem0 currently uses flat FAISS indexes, which keep the provider exact and predictable.
 
 ### Distance Strategies
 
-FAISS in mem0 supports three distance strategies:
+FAISS in Mem0 supports three distance strategies:
 
-- **euclidean**: L2 distance, suitable for most embedding models
-- **inner_product**: Dot product similarity, useful for some specialized embeddings
-- **cosine**: Cosine similarity, best for comparing semantic similarity regardless of vector magnitude
+- `euclidean`: L2 distance, suitable for most embedding models
+- `inner_product`: Dot product similarity, useful for specialized embeddings
+- `cosine`: Cosine similarity, best for semantic similarity regardless of vector magnitude
 
-When using `cosine` or `inner_product` with normalized vectors, you may want to set `normalize_L2=True` for better results.
+When using `cosine`, vectors are normalized before indexing and searching. For `euclidean`, set `normalizeL2` when you want the same normalization behavior.

--- a/docs/components/vectordbs/overview.mdx
+++ b/docs/components/vectordbs/overview.mdx
@@ -10,7 +10,7 @@ Mem0 includes built-in support for various popular databases. Memory can utilize
 See the list of supported vector databases below.
 
 <Note>
-  The following vector databases are supported in the Python implementation. The TypeScript implementation currently supports Qdrant, Redis, PGVector, Supabase, LangChain, Azure AI Search, Vectorize, Amazon S3 Vectors, Milvus, Neptune Analytics, and an in-memory store.
+  The following vector databases are supported in the Python implementation. The TypeScript implementation currently supports Qdrant, Redis, PGVector, Supabase, LangChain, Azure AI Search, Vectorize, Amazon S3 Vectors, Milvus, Neptune Analytics, FAISS, and an in-memory store.
 </Note>
 
 <CardGroup cols={3}>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -486,7 +486,7 @@ Everything below is OSS-only provider configuration. Skip this entire section wh
 - [Vectorize](https://docs.mem0.ai/components/vectordbs/dbs/vectorize) [OSS]: Use when the store is Cloudflare Vectorize.
 - [Vertex AI Vector Search](https://docs.mem0.ai/components/vectordbs/dbs/vertex_ai) [OSS]: Use when the store is Google Cloud Vertex Vector Search.
 - [Weaviate](https://docs.mem0.ai/components/vectordbs/dbs/weaviate) [OSS]: Use when Weaviate is the backing store.
-- [FAISS](https://docs.mem0.ai/components/vectordbs/dbs/faiss) [OSS]: Use for local FAISS-based similarity search.
+- [FAISS](https://docs.mem0.ai/components/vectordbs/dbs/faiss) [OSS]: Use for local FAISS-based similarity search in Python or TypeScript OSS. Install the optional `faiss-node` native addon for Node.js.
 - [LangChain Vector Store](https://docs.mem0.ai/components/vectordbs/dbs/langchain) [OSS]: Use when the vector store is wrapped behind LangChain.
 - [Baidu](https://docs.mem0.ai/components/vectordbs/dbs/baidu) [OSS]: Use when the user is on Baidu Cloud vector service.
 - [Cassandra](https://docs.mem0.ai/components/vectordbs/dbs/cassandra) [OSS]: Use when Cassandra is the backing store.

--- a/docs/open-source/configuration.mdx
+++ b/docs/open-source/configuration.mdx
@@ -121,7 +121,7 @@ Change the `provider` string to switch backends. The most common options:
 | --- | --- | --- |
 | LLM | `openai`, `anthropic`, `gemini`, `groq`, `ollama`, `aws_bedrock`, `azure_openai`, `litellm` | `openai`, `anthropic`, `gemini`, `groq`, `ollama`, `aws_bedrock`, `azure_openai`, `mistral`, `deepseek` |
 | Embedder | `openai`, `gemini`, `azure_openai`, `ollama`, `huggingface`, `vertexai`, `aws_bedrock` | `openai`, `gemini`, `azure_openai`, `ollama` |
-| Vector store | `qdrant`, `pgvector`, `chroma`, `pinecone`, `redis`, `weaviate`, `milvus`, `elasticsearch` | `memory`, `qdrant`, `pgvector`, `redis`, `supabase`, `azure-ai-search`, `vectorize`, `milvus` |
+| Vector store | `qdrant`, `pgvector`, `chroma`, `pinecone`, `redis`, `weaviate`, `milvus`, `elasticsearch`, `faiss` | `memory`, `qdrant`, `pgvector`, `redis`, `supabase`, `azure-ai-search`, `vectorize`, `milvus`, `faiss` |
 
 See the full catalog in <Link href="/components/llms/overview">Components</Link>.
 

--- a/mem0-ts/package.json
+++ b/mem0-ts/package.json
@@ -216,10 +216,9 @@
       "optional": true
     },
     "faiss-node": {
-    "iovalkey": {
       "optional": true
     },
-    "faiss-node": {
+    "iovalkey": {
       "optional": true
     }
   },

--- a/mem0-ts/package.json
+++ b/mem0-ts/package.json
@@ -136,6 +136,7 @@
     "cohere-ai": "^7.17.0 || ^8.0.0",
     "fastembed": "^2.1.0",
     "groq-sdk": "0.3.0",
+    "faiss-node": "^0.5.1",
     "mongodb": "^7.0.0",
     "weaviate-client": "^3.0.0",
     "ollama": "^0.5.14",
@@ -214,7 +215,11 @@
     "@huggingface/transformers": {
       "optional": true
     },
+    "faiss-node": {
     "iovalkey": {
+      "optional": true
+    },
+    "faiss-node": {
       "optional": true
     }
   },

--- a/mem0-ts/pnpm-lock.yaml
+++ b/mem0-ts/pnpm-lock.yaml
@@ -124,6 +124,9 @@ importers:
       compromise:
         specifier: ^14.0.0
         version: 14.15.1
+      faiss-node:
+        specifier: ^0.5.1
+        version: 0.5.1
       fastembed:
         specifier: ^2.1.0
         version: 2.1.0
@@ -2671,6 +2674,10 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  faiss-node@0.5.1:
+    resolution: {integrity: sha512-zD8wobJn8C6OLWo68Unho+Ih8l6nSRB2w3Amj01a+xc4bsEvd2mBDLklAn7VocA9XO3WDvQL/bLpi5flkCn/XQ==}
+    engines: {node: '>= 14.0.0'}
+
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
@@ -3617,6 +3624,9 @@ packages:
   node-abi@3.92.0:
     resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
     engines: {node: '>=10'}
+
+  node-addon-api@6.1.0:
+    resolution: {integrity: sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==}
 
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
@@ -7956,6 +7966,12 @@ snapshots:
 
   extend@3.0.2: {}
 
+  faiss-node@0.5.1:
+    dependencies:
+      bindings: 1.5.0
+      node-addon-api: 6.1.0
+      prebuild-install: 7.1.3
+
   fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -9123,6 +9139,8 @@ snapshots:
   node-abi@3.92.0:
     dependencies:
       semver: 7.8.4
+
+  node-addon-api@6.1.0: {}
 
   node-domexception@1.0.0: {}
 

--- a/mem0-ts/src/oss/src/tests/faiss.test.ts
+++ b/mem0-ts/src/oss/src/tests/faiss.test.ts
@@ -1,0 +1,439 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import Module from "module";
+
+import { FAISSDB, FAISSConfig, FaissBinding } from "../vector_stores/faiss";
+import { VectorStoreFactory } from "../utils/factory";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "mem0-faiss-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  while (tempDirs.length > 0) {
+    fs.rmSync(tempDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+function squaredL2Distance(a: number[], b: number[]): number {
+  let total = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    const delta = a[i] - b[i];
+    total += delta * delta;
+  }
+  return total;
+}
+
+function dotProduct(a: number[], b: number[]): number {
+  let total = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    total += a[i] * b[i];
+  }
+  return total;
+}
+
+class FakeFaissIndexBase {
+  protected vectors: number[][] = [];
+
+  constructor(
+    protected readonly dimension: number,
+    private readonly metric: "l2" | "ip",
+  ) {}
+
+  private toVector(vector: number[] | Float32Array): number[] {
+    return Array.from(vector, (value) => Number(value));
+  }
+
+  private assertDimension(vector: number[]): void {
+    if (vector.length !== this.dimension) {
+      throw new Error(
+        `Expected vector dimension ${this.dimension}, got ${vector.length}`,
+      );
+    }
+  }
+
+  add(vector: number[] | Float32Array): void {
+    const values = this.toVector(vector);
+    this.assertDimension(values);
+    this.vectors.push([...values]);
+  }
+
+  search(
+    vector: number[] | Float32Array,
+    topK: number,
+  ): { labels: number[]; distances: number[] } {
+    const query = this.toVector(vector);
+    this.assertDimension(query);
+
+    const scored = this.vectors.map((candidate, label) => {
+      const distance =
+        this.metric === "l2"
+          ? squaredL2Distance(query, candidate)
+          : dotProduct(query, candidate);
+      return { label, distance };
+    });
+
+    scored.sort((a, b) =>
+      this.metric === "l2" ? a.distance - b.distance : b.distance - a.distance,
+    );
+
+    const slice = scored.slice(0, topK);
+    return {
+      labels: slice.map((item) => item.label),
+      distances: slice.map((item) => item.distance),
+    };
+  }
+
+  reconstruct(label: number): number[] {
+    const vector = this.vectors[label];
+    if (!vector) {
+      throw new Error(`Missing label ${label}`);
+    }
+    return [...vector];
+  }
+
+  ntotal(): number {
+    return this.vectors.length;
+  }
+
+  write(filePath: string): void {
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify(
+        {
+          dimension: this.dimension,
+          metric: this.metric,
+          vectors: this.vectors,
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+  }
+}
+
+class FakeIndexFlatL2 extends FakeFaissIndexBase {
+  constructor(dimension: number) {
+    super(dimension, "l2");
+  }
+
+  static read(filePath: string): FakeIndexFlatL2 {
+    const parsed = JSON.parse(fs.readFileSync(filePath, "utf8")) as {
+      dimension: number;
+      vectors: number[][];
+    };
+    const index = new FakeIndexFlatL2(parsed.dimension);
+    index.vectors = parsed.vectors.map((vector) => [...vector]);
+    return index;
+  }
+}
+
+class FakeIndexFlatIP extends FakeFaissIndexBase {
+  constructor(dimension: number) {
+    super(dimension, "ip");
+  }
+
+  static read(filePath: string): FakeIndexFlatIP {
+    const parsed = JSON.parse(fs.readFileSync(filePath, "utf8")) as {
+      dimension: number;
+      vectors: number[][];
+    };
+    const index = new FakeIndexFlatIP(parsed.dimension);
+    index.vectors = parsed.vectors.map((vector) => [...vector]);
+    return index;
+  }
+}
+
+function createFakeFaissBinding(): FaissBinding {
+  return {
+    IndexFlatL2: FakeIndexFlatL2 as any,
+    IndexFlatIP: FakeIndexFlatIP as any,
+  };
+}
+
+function makeConfig(overrides: Partial<FAISSConfig> = {}): FAISSConfig {
+  const pathDir = overrides.path || makeTempDir();
+  if (!overrides.path) {
+    overrides.path = pathDir;
+  }
+
+  return {
+    collectionName: "memories",
+    embeddingModelDims: 2,
+    distanceStrategy: "euclidean",
+    normalizeL2: false,
+    binding: createFakeFaissBinding(),
+    ...overrides,
+    path: overrides.path || pathDir,
+  } as FAISSConfig;
+}
+
+async function initStore(
+  overrides: Partial<FAISSConfig> = {},
+): Promise<FAISSDB> {
+  const store = new FAISSDB(makeConfig(overrides));
+  await store.initialize();
+  return store;
+}
+
+describe("VectorStoreFactory", () => {
+  it("returns a FAISS provider and remains case-insensitive", async () => {
+    const store = VectorStoreFactory.create("FAISS", makeConfig());
+    expect(store).toBeInstanceOf(FAISSDB);
+    await store.initialize();
+  });
+});
+
+describe("FAISSDB", () => {
+  it("returns [] for an empty search", async () => {
+    const store = await initStore();
+    expect(await store.search([1, 0], 5)).toEqual([]);
+  });
+
+  it("round-trips ids and payloads through insert, get, search, and list", async () => {
+    const store = await initStore();
+
+    await store.insert(
+      [
+        [1, 0],
+        [0, 1],
+      ],
+      ["vec-a", "vec-b"],
+      [
+        { userId: "alice", topic: "alpha" },
+        { userId: "bob", topic: "beta" },
+      ],
+    );
+
+    expect(await store.get("vec-a")).toEqual({
+      id: "vec-a",
+      payload: { user_id: "alice", topic: "alpha" },
+    });
+
+    const searchResults = await store.search([1, 0], 2);
+    expect(searchResults.map((result) => result.id)).toEqual([
+      "vec-a",
+      "vec-b",
+    ]);
+
+    const [listed, count] = await store.list();
+    expect(listed).toEqual([
+      { id: "vec-a", payload: { user_id: "alice", topic: "alpha" } },
+      { id: "vec-b", payload: { user_id: "bob", topic: "beta" } },
+    ]);
+    expect(count).toBe(2);
+  });
+
+  it("returns euclidean scores as 1 / (1 + distance)", async () => {
+    const store = await initStore();
+
+    await store.insert(
+      [
+        [1, 0],
+        [0, 0],
+      ],
+      ["exact", "near"],
+      [{ kind: "exact" }, { kind: "near" }],
+    );
+
+    const results = await store.search([1, 0], 2);
+    expect(results).toEqual([
+      { id: "exact", payload: { kind: "exact" }, score: 1 },
+      { id: "near", payload: { kind: "near" }, score: 0.5 },
+    ]);
+  });
+
+  it("normalizes cosine vectors before scoring", async () => {
+    const store = await initStore({
+      distanceStrategy: "cosine",
+      normalizeL2: false,
+    });
+
+    await store.insert(
+      [
+        [2, 0],
+        [0, 5],
+      ],
+      ["aligned", "orthogonal"],
+      [{ kind: "aligned" }, { kind: "orthogonal" }],
+    );
+
+    const results = await store.search([10, 0], 2);
+    expect(results[0]).toEqual({
+      id: "aligned",
+      payload: { kind: "aligned" },
+      score: 1,
+    });
+    expect(results[1].score).toBe(0);
+  });
+
+  it("applies filters after over-fetching and supports boolean and string operators", async () => {
+    const store = await initStore();
+
+    await store.insert(
+      [
+        [0.99, 0],
+        [0.8, 0],
+        [0.2, 1],
+      ],
+      ["wrong-top-hit", "filtered-hit", "ignored"],
+      [
+        {
+          category: "music",
+          title: "Solar noise",
+          archived: false,
+          tags: ["draft", "noise"],
+        },
+        {
+          category: "science",
+          title: "Solar Arrays",
+          archived: false,
+          tags: ["featured", "solar"],
+        },
+        {
+          category: "science",
+          title: "galaxy note",
+          archived: true,
+          tags: ["archived"],
+        },
+      ],
+    );
+
+    const results = await store.search([1, 0], 1, {
+      AND: [
+        { category: ["science", "astronomy"] },
+        {
+          OR: [
+            { title: { contains: "Solar" } },
+            { title: { icontains: "galaxy" } },
+          ],
+        },
+        { NOT: [{ archived: true }] },
+      ],
+    });
+
+    expect(results).toEqual([
+      {
+        id: "filtered-hit",
+        payload: {
+          category: "science",
+          title: "Solar Arrays",
+          archived: false,
+          tags: ["featured", "solar"],
+        },
+        score: expect.any(Number),
+      },
+    ]);
+  });
+
+  it("throws on dimension mismatches", async () => {
+    const store = await initStore();
+
+    await expect(
+      store.insert([[1, 0, 0]], ["bad"], [{ kind: "bad" }]),
+    ).rejects.toThrow("Vector dimension mismatch");
+    await expect(store.search([1, 0, 0])).rejects.toThrow(
+      "Query dimension mismatch",
+    );
+  });
+
+  it("updates records in place and rebuilds the index", async () => {
+    const store = await initStore();
+
+    await store.insert(
+      [
+        [1, 0],
+        [0, 1],
+      ],
+      ["vec-a", "vec-b"],
+      [{ state: "old" }, { state: "stay" }],
+    );
+    await store.update("vec-a", [0, 2], { state: "new", userId: "alice" });
+
+    const results = await store.search([0, 2], 2);
+    expect(results[0]).toEqual({
+      id: "vec-a",
+      payload: { state: "new", user_id: "alice" },
+      score: 1,
+    });
+    expect(await store.get("vec-a")).toEqual({
+      id: "vec-a",
+      payload: { state: "new", user_id: "alice" },
+    });
+  });
+
+  it("rebuilds after delete and deleteCol without breaking remaining ids", async () => {
+    const store = await initStore();
+
+    await store.insert(
+      [
+        [1, 0],
+        [0, 1],
+        [0, 2],
+      ],
+      ["vec-a", "vec-b", "vec-c"],
+      [{ label: "a" }, { label: "b" }, { label: "c" }],
+    );
+
+    await store.delete("vec-b");
+    expect(await store.get("vec-b")).toBeNull();
+    expect((await store.search([0, 2], 3)).map((result) => result.id)).toEqual([
+      "vec-c",
+      "vec-a",
+    ]);
+
+    await store.deleteCol();
+    expect(await store.list()).toEqual([[], 0]);
+    expect(await store.search([0, 2], 3)).toEqual([]);
+  });
+
+  it("persists user ids through JSON metadata", async () => {
+    const dir = makeTempDir();
+    const first = await initStore({ path: dir });
+    await first.setUserId("user-123");
+
+    const second = await initStore({ path: dir });
+    expect(await second.getUserId()).toBe("user-123");
+  });
+
+  it("avoids requiring faiss-node when a binding is injected", async () => {
+    const requireSpy = jest.spyOn(Module.prototype as any, "require");
+    const store = await initStore();
+    await store.search([1, 0], 1);
+
+    expect(
+      requireSpy.mock.calls.some(([moduleName]) => moduleName === "faiss-node"),
+    ).toBe(false);
+  });
+
+  it("throws an actionable install error when faiss-node is missing", () => {
+    const originalRequire = Module.prototype.require;
+    const requireSpy = jest.spyOn(Module.prototype as any, "require");
+    requireSpy.mockImplementation(function (
+      this: NodeModule,
+      moduleName: string,
+    ) {
+      if (moduleName === "faiss-node") {
+        const error = new Error("Cannot find module 'faiss-node'");
+        (error as NodeJS.ErrnoException).code = "MODULE_NOT_FOUND";
+        throw error;
+      }
+      return originalRequire.call(this, moduleName);
+    });
+
+    expect(() => {
+      new FAISSDB({
+        collectionName: "memories",
+        embeddingModelDims: 2,
+        path: makeTempDir(),
+      } as any);
+    }).toThrow("faiss-node");
+  });
+});

--- a/mem0-ts/src/oss/src/types/index.ts
+++ b/mem0-ts/src/oss/src/types/index.ts
@@ -37,7 +37,13 @@ export type { ValkeyConfig } from "./valkey";
 export interface VectorStoreConfig {
   collectionName?: string;
   dimension?: number;
+  embeddingModelDims?: number;
   dbPath?: string;
+  path?: string;
+  distanceStrategy?: string;
+  normalizeL2?: boolean;
+  binding?: any;
+  faissLib?: any;
   client?: any;
   instance?: any;
   [key: string]: any;

--- a/mem0-ts/src/oss/src/utils/factory.ts
+++ b/mem0-ts/src/oss/src/utils/factory.ts
@@ -70,6 +70,7 @@ import { TurbopufferDB } from "../vector_stores/turbopuffer";
 import { Milvus } from "../vector_stores/milvus";
 import { MongoDB } from "../vector_stores/mongodb";
 import { WeaviateDB } from "../vector_stores/weaviate";
+import { FAISSDB } from "../vector_stores/faiss";
 
 export class EmbedderFactory {
   static create(provider: string, config: EmbeddingConfig): Embedder {
@@ -202,6 +203,8 @@ export class VectorStoreFactory {
         return new MongoDB(config as any);
       case "weaviate":
         return new WeaviateDB(config as any);
+      case "faiss":
+        return new FAISSDB(config as any);
       default:
         throw new Error(`Unsupported vector store provider: ${provider}`);
     }

--- a/mem0-ts/src/oss/src/vector_stores/faiss.ts
+++ b/mem0-ts/src/oss/src/vector_stores/faiss.ts
@@ -1,0 +1,607 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { randomUUID } from "crypto";
+import { VectorStore } from "./base";
+import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
+
+type DistanceStrategy = "euclidean" | "inner_product" | "cosine";
+
+interface FaissSearchResult {
+  labels: ArrayLike<number | bigint>;
+  distances: ArrayLike<number>;
+}
+
+export interface FaissIndexLike {
+  add(vector: number[] | Float32Array): void | Promise<void>;
+  search(
+    vector: number[] | Float32Array,
+    topK: number,
+  ): FaissSearchResult | Promise<FaissSearchResult>;
+  write?(filePath: string): void | Promise<void>;
+  toBuffer?(): Buffer | Uint8Array | ArrayBuffer;
+}
+
+export interface FaissIndexConstructor {
+  new (dimension: number): FaissIndexLike;
+}
+
+export interface FaissBinding {
+  IndexFlatL2: FaissIndexConstructor;
+  IndexFlatIP: FaissIndexConstructor;
+}
+
+export interface FAISSConfig extends VectorStoreConfig {
+  collectionName?: string;
+  path?: string;
+  distanceStrategy?: DistanceStrategy;
+  normalizeL2?: boolean;
+  embeddingModelDims?: number;
+  binding?: FaissBinding;
+  faissLib?: FaissBinding;
+}
+
+interface StoredRecord {
+  id: string;
+  vector: number[];
+  payload: Record<string, any>;
+}
+
+interface PersistedState {
+  collectionName: string;
+  distanceStrategy: DistanceStrategy;
+  normalizeL2: boolean;
+  embeddingModelDims: number;
+  userId: string;
+  records: StoredRecord[];
+}
+
+const CAMEL_TO_SNAKE: Record<string, string> = {
+  userId: "user_id",
+  agentId: "agent_id",
+  runId: "run_id",
+};
+
+const LOGICAL_KEYS = new Set(["AND", "OR", "NOT", "$and", "$or", "$not"]);
+const FILTER_OPERATORS = new Set([
+  "eq",
+  "ne",
+  "gt",
+  "gte",
+  "lt",
+  "lte",
+  "in",
+  "nin",
+  "contains",
+  "icontains",
+]);
+
+function cloneValue<T>(value: T): T {
+  if (typeof structuredClone === "function") {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value));
+}
+
+function l2Normalize(vector: number[]): number[] {
+  const norm = Math.sqrt(vector.reduce((sum, value) => sum + value * value, 0));
+  if (norm === 0) return [...vector];
+  return vector.map((value) => value / norm);
+}
+
+function normalizePayload(payload: Record<string, any>): Record<string, any> {
+  const normalized = cloneValue(payload);
+  for (const [camel, snake] of Object.entries(CAMEL_TO_SNAKE)) {
+    if (camel in normalized && !(snake in normalized)) {
+      normalized[snake] = normalized[camel];
+      delete normalized[camel];
+    }
+  }
+  return normalized;
+}
+
+function normalizeFieldKey(key: string): string {
+  return CAMEL_TO_SNAKE[key] || key;
+}
+
+function cloneRecord(record: StoredRecord): StoredRecord {
+  return {
+    id: record.id,
+    vector: [...record.vector],
+    payload: normalizePayload(record.payload),
+  };
+}
+
+export class FAISSDB implements VectorStore {
+  private readonly collectionName: string;
+  private readonly distanceStrategy: DistanceStrategy;
+  private readonly normalizeL2: boolean;
+  private readonly dimension: number;
+  private readonly basePath: string;
+  private readonly indexPath: string;
+  private readonly metadataPath: string;
+  private readonly binding: FaissBinding;
+  private readonly indexCtor: FaissIndexConstructor;
+  private index: FaissIndexLike;
+  private records: StoredRecord[] = [];
+  private userId = "";
+  private initPromise?: Promise<void>;
+
+  constructor(config: FAISSConfig) {
+    this.collectionName = config.collectionName || "mem0";
+    this.distanceStrategy = this.normalizeDistanceStrategy(
+      config.distanceStrategy || "euclidean",
+    );
+    this.normalizeL2 = config.normalizeL2 ?? false;
+    this.dimension = Math.floor(
+      config.embeddingModelDims ?? config.dimension ?? 1536,
+    );
+    if (this.dimension <= 0) {
+      throw new Error("FAISS embeddingModelDims must be a positive integer");
+    }
+
+    this.basePath = path.resolve(
+      config.path ||
+        config.dbPath ||
+        path.join(os.tmpdir(), "faiss", this.collectionName),
+    );
+    this.indexPath = path.join(this.basePath, `${this.collectionName}.faiss`);
+    this.metadataPath = path.join(this.basePath, `${this.collectionName}.json`);
+    this.binding = config.binding || config.faissLib || this.loadFaissBinding();
+    this.indexCtor = this.resolveIndexCtor();
+    this.index = this.createIndex();
+
+    this.initialize().catch(console.error);
+  }
+
+  private normalizeDistanceStrategy(strategy: string): DistanceStrategy {
+    const value = strategy.toLowerCase();
+    if (
+      value !== "euclidean" &&
+      value !== "inner_product" &&
+      value !== "cosine"
+    ) {
+      throw new Error(
+        `Unsupported FAISS distance strategy: ${strategy}. Use euclidean, inner_product, or cosine.`,
+      );
+    }
+    return value;
+  }
+
+  private loadFaissBinding(): FaissBinding {
+    try {
+      // Lazy native resolution keeps the package importable without faiss-node.
+      return require("faiss-node") as FaissBinding;
+    } catch {
+      throw new Error(
+        "FAISS provider requires the optional faiss-node dependency. Install it with `pnpm add faiss-node` and try again.",
+      );
+    }
+  }
+
+  private resolveIndexCtor(): FaissIndexConstructor {
+    return this.distanceStrategy === "inner_product" ||
+      this.distanceStrategy === "cosine"
+      ? this.binding.IndexFlatIP
+      : this.binding.IndexFlatL2;
+  }
+
+  private createIndex(): FaissIndexLike {
+    return new this.indexCtor(this.dimension);
+  }
+
+  private prepareVector(vector: number[]): number[] {
+    if (this.distanceStrategy === "cosine") {
+      return l2Normalize(vector);
+    }
+    if (this.distanceStrategy === "euclidean" && this.normalizeL2) {
+      return l2Normalize(vector);
+    }
+    return [...vector];
+  }
+
+  private validateVector(vector: number[], context: string): void {
+    if (vector.length !== this.dimension) {
+      throw new Error(
+        `${context} dimension mismatch. Expected ${this.dimension}, got ${vector.length}`,
+      );
+    }
+  }
+
+  private recordIndex(vectorId: string): number {
+    return this.records.findIndex((record) => record.id === vectorId);
+  }
+
+  private normalizeFilters(
+    filters?: SearchFilters,
+  ): Record<string, any> | undefined {
+    if (!filters || Object.keys(filters).length === 0) {
+      return undefined;
+    }
+
+    const normalized: Record<string, any> = {};
+    for (const [key, value] of Object.entries(filters)) {
+      const normalizedKey = normalizeFieldKey(key);
+      if (!(normalizedKey in normalized)) {
+        normalized[normalizedKey] = value;
+      }
+    }
+    return normalized;
+  }
+
+  private matchesFieldCondition(payloadValue: any, value: any): boolean {
+    if (value === "*") return true;
+    if (Array.isArray(value)) {
+      return value.some((entry) => entry === payloadValue);
+    }
+    if (typeof value !== "object" || value === null) {
+      return payloadValue === value;
+    }
+
+    const operators = Object.entries(value);
+    if (operators.length === 0) return true;
+    return operators.every(([operator, operand]) =>
+      this.matchesOperator(payloadValue, operator, operand),
+    );
+  }
+
+  private matchesOperator(
+    payloadValue: any,
+    operator: string,
+    operand: any,
+  ): boolean {
+    if (!FILTER_OPERATORS.has(operator)) {
+      throw new Error(`Unsupported filter operator: ${operator}`);
+    }
+
+    switch (operator) {
+      case "eq":
+        return payloadValue === operand;
+      case "ne":
+        return payloadValue !== operand;
+      case "gt":
+        return payloadValue > operand;
+      case "gte":
+        return payloadValue >= operand;
+      case "lt":
+        return payloadValue < operand;
+      case "lte":
+        return payloadValue <= operand;
+      case "in":
+        return (
+          Array.isArray(operand) &&
+          operand.some((entry) => entry === payloadValue)
+        );
+      case "nin":
+        return (
+          !Array.isArray(operand) ||
+          !operand.some((entry) => entry === payloadValue)
+        );
+      case "contains":
+        return (
+          typeof payloadValue === "string" &&
+          payloadValue.includes(String(operand))
+        );
+      case "icontains":
+        return (
+          typeof payloadValue === "string" &&
+          payloadValue.toLowerCase().includes(String(operand).toLowerCase())
+        );
+      default:
+        return false;
+    }
+  }
+
+  private matchesFilters(
+    payload: Record<string, any>,
+    filters?: SearchFilters,
+  ): boolean {
+    const normalized = this.normalizeFilters(filters);
+    if (!normalized) return true;
+
+    for (const [key, value] of Object.entries(normalized)) {
+      if (LOGICAL_KEYS.has(key)) {
+        if (!Array.isArray(value)) {
+          throw new Error(`${key} filter value must be an array.`);
+        }
+
+        if (key === "AND" || key === "$and") {
+          if (
+            !value.every((subFilter) => this.matchesFilters(payload, subFilter))
+          ) {
+            return false;
+          }
+          continue;
+        }
+
+        if (key === "OR" || key === "$or") {
+          if (
+            !value.some((subFilter) => this.matchesFilters(payload, subFilter))
+          ) {
+            return false;
+          }
+          continue;
+        }
+
+        if (key === "NOT" || key === "$not") {
+          if (
+            !value.every(
+              (subFilter) => !this.matchesFilters(payload, subFilter),
+            )
+          ) {
+            return false;
+          }
+          continue;
+        }
+      }
+
+      if (!this.matchesFieldCondition(payload[key], value)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private buildPersistedState(): PersistedState {
+    return {
+      collectionName: this.collectionName,
+      distanceStrategy: this.distanceStrategy,
+      normalizeL2: this.normalizeL2,
+      embeddingModelDims: this.dimension,
+      userId: this.userId,
+      records: this.records.map(cloneRecord),
+    };
+  }
+
+  private readPersistedState(): PersistedState | null {
+    if (!fs.existsSync(this.metadataPath)) {
+      return null;
+    }
+
+    const parsed = JSON.parse(fs.readFileSync(this.metadataPath, "utf8")) as
+      | Partial<PersistedState>
+      | undefined;
+
+    return {
+      collectionName: parsed?.collectionName || this.collectionName,
+      distanceStrategy: this.distanceStrategy,
+      normalizeL2: this.normalizeL2,
+      embeddingModelDims: this.dimension,
+      userId: parsed?.userId || "",
+      records: Array.isArray(parsed?.records)
+        ? parsed!.records.map((record: any) => ({
+            id: String(record.id),
+            vector: Array.isArray(record.vector)
+              ? record.vector.map((value: any) => Number(value))
+              : [],
+            payload: normalizePayload(record.payload || {}),
+          }))
+        : [],
+    };
+  }
+
+  private async persistState(): Promise<void> {
+    fs.mkdirSync(this.basePath, { recursive: true });
+    fs.writeFileSync(
+      this.metadataPath,
+      JSON.stringify(this.buildPersistedState(), null, 2),
+      "utf8",
+    );
+
+    if (typeof this.index.write === "function") {
+      await Promise.resolve(this.index.write(this.indexPath));
+      return;
+    }
+
+    if (typeof this.index.toBuffer === "function") {
+      const buffer = this.index.toBuffer();
+      fs.writeFileSync(this.indexPath, Buffer.from(buffer));
+    }
+  }
+
+  private async rebuildIndexFromRecords(): Promise<void> {
+    this.index = this.createIndex();
+
+    for (const record of this.records) {
+      await Promise.resolve(this.index.add(this.prepareVector(record.vector)));
+    }
+
+    await this.persistState();
+  }
+
+  async initialize(): Promise<void> {
+    if (!this.initPromise) {
+      this.initPromise = this.doInitialize();
+    }
+    return this.initPromise;
+  }
+
+  private async doInitialize(): Promise<void> {
+    fs.mkdirSync(this.basePath, { recursive: true });
+    const persisted = this.readPersistedState();
+
+    if (!persisted) {
+      this.records = [];
+      this.userId = "";
+      this.index = this.createIndex();
+      await this.persistState();
+      return;
+    }
+
+    this.records = persisted.records.map(cloneRecord);
+    this.userId = persisted.userId;
+    await this.rebuildIndexFromRecords();
+  }
+
+  async insert(
+    vectors: number[][],
+    ids: string[],
+    payloads: Record<string, any>[],
+  ): Promise<void> {
+    await this.initialize();
+
+    if (vectors.length !== ids.length || vectors.length !== payloads.length) {
+      throw new Error("Vectors, ids, and payloads must have the same length");
+    }
+
+    for (let i = 0; i < vectors.length; i += 1) {
+      this.validateVector(vectors[i], "Vector");
+      const record = {
+        id: ids[i],
+        vector: [...vectors[i]],
+        payload: normalizePayload(payloads[i] || {}),
+      };
+      const existingIndex = this.recordIndex(record.id);
+      if (existingIndex >= 0) {
+        this.records[existingIndex] = record;
+      } else {
+        this.records.push(record);
+      }
+    }
+
+    await this.rebuildIndexFromRecords();
+  }
+
+  async search(
+    query: number[],
+    topK: number = 10,
+    filters?: SearchFilters,
+  ): Promise<VectorStoreResult[]> {
+    await this.initialize();
+    this.validateVector(query, "Query");
+
+    if (this.records.length === 0) {
+      return [];
+    }
+
+    const searchVector = this.prepareVector(query);
+    const searchTopK = filters
+      ? this.records.length
+      : Math.min(topK, this.records.length);
+    const rawResults = await Promise.resolve(
+      this.index.search(searchVector, Math.max(searchTopK, 1)),
+    );
+
+    const results: VectorStoreResult[] = [];
+    for (let i = 0; i < rawResults.labels.length; i += 1) {
+      const rawLabel = rawResults.labels[i];
+      const label =
+        typeof rawLabel === "bigint" ? Number(rawLabel) : Number(rawLabel);
+      if (label < 0) continue;
+      const record = this.records[label];
+      if (!record) continue;
+      if (!this.matchesFilters(record.payload, filters)) continue;
+
+      const rawScore = Number(rawResults.distances[i]);
+      const score =
+        this.distanceStrategy === "euclidean" ? 1 / (1 + rawScore) : rawScore;
+
+      results.push({
+        id: record.id,
+        payload: normalizePayload(record.payload),
+        score,
+      });
+
+      if (results.length >= topK) {
+        break;
+      }
+    }
+
+    return results;
+  }
+
+  async keywordSearch(): Promise<null> {
+    return null;
+  }
+
+  async get(vectorId: string): Promise<VectorStoreResult | null> {
+    await this.initialize();
+    const record = this.records[this.recordIndex(vectorId)];
+    if (!record) return null;
+
+    return {
+      id: record.id,
+      payload: normalizePayload(record.payload),
+    };
+  }
+
+  async update(
+    vectorId: string,
+    vector: number[],
+    payload: Record<string, any>,
+  ): Promise<void> {
+    await this.initialize();
+    this.validateVector(vector, "Vector");
+
+    const existingIndex = this.recordIndex(vectorId);
+    if (existingIndex < 0) {
+      throw new Error(`Vector ${vectorId} not found`);
+    }
+
+    this.records[existingIndex] = {
+      id: vectorId,
+      vector: [...vector],
+      payload: normalizePayload(payload || {}),
+    };
+
+    await this.rebuildIndexFromRecords();
+  }
+
+  async delete(vectorId: string): Promise<void> {
+    await this.initialize();
+    const nextRecords = this.records.filter((record) => record.id !== vectorId);
+    if (nextRecords.length === this.records.length) {
+      return;
+    }
+
+    this.records = nextRecords;
+    await this.rebuildIndexFromRecords();
+  }
+
+  async deleteCol(): Promise<void> {
+    await this.initialize();
+    this.records = [];
+    this.userId = "";
+    this.index = this.createIndex();
+
+    if (fs.existsSync(this.metadataPath)) {
+      fs.rmSync(this.metadataPath, { force: true });
+    }
+    if (fs.existsSync(this.indexPath)) {
+      fs.rmSync(this.indexPath, { force: true });
+    }
+    await this.persistState();
+  }
+
+  async list(
+    filters?: SearchFilters,
+    topK: number = 100,
+  ): Promise<[VectorStoreResult[], number]> {
+    await this.initialize();
+
+    const matches = this.records
+      .filter((record) => this.matchesFilters(record.payload, filters))
+      .map((record) => ({
+        id: record.id,
+        payload: normalizePayload(record.payload),
+      }));
+
+    return [matches.slice(0, topK), matches.length];
+  }
+
+  async getUserId(): Promise<string> {
+    await this.initialize();
+    if (!this.userId) {
+      this.userId = randomUUID();
+      await this.persistState();
+    }
+    return this.userId;
+  }
+
+  async setUserId(userId: string): Promise<void> {
+    await this.initialize();
+    this.userId = userId;
+    await this.persistState();
+  }
+}

--- a/mem0-ts/tsup.config.ts
+++ b/mem0-ts/tsup.config.ts
@@ -44,6 +44,7 @@ const external = [
   "@elastic/elasticsearch",
   "chromadb",
   "weaviate-client",
+  "faiss-node",
 ];
 
 const define = {


### PR DESCRIPTION
## Linked Issue

Closes #6161

## Summary

This implements @Real5K's request in #6161.

TypeScript OSS now supports FAISS as a vector store. The provider loads `faiss-node` lazily, registers through `VectorStoreFactory`, persists Mem0 metadata in JSON beside the FAISS index, and keeps the native addon optional for consumers that inject their own binding in tests or other controlled environments.

## Root Cause

`mem0-ts` had no FAISS adapter, no factory branch, no peer metadata for the native addon, and no docs or tests covering the provider path.

## Fix

- Added `FAISSDB` in `mem0-ts/src/oss/src/vector_stores/faiss.ts`
- Registered `provider: "faiss"` in `VectorStoreFactory`
- Added optional `faiss-node` peer metadata and tsup externalization
- Added unit coverage with an injected fake binding
- Updated the FAISS, config, overview, and OSS configuration docs

## Scope

- TypeScript FAISS only
- No Python FAISS changes
- No GPU, HNSW, or approximate index work
- Native addon loading stays lazy and optional

## Test Coverage

- `pnpm exec jest --coverage --ci --runTestsByPath src/oss/src/tests/faiss.test.ts` - 12 passed
- `pnpm exec tsup` - CJS, ESM, and DTS builds passed
- `pnpm exec prettier --check package.json pnpm-lock.yaml tsup.config.ts src/oss/src/types/index.ts src/oss/src/utils/factory.ts src/oss/src/vector_stores/faiss.ts src/oss/src/tests/faiss.test.ts`
- `python scripts/check-llms-txt-coverage.py --write` - `docs/llms.txt` is in sync
- `pnpm run build` is blocked locally by the existing repo-wide Prettier baseline before bundling: `Code style issues found in 192 files.`
- `pnpm run test:unit -- src/oss/src/tests/faiss.test.ts` invokes the broader configured Jest set locally on Windows and hits unrelated SQLite temp cleanup `EBUSY`/`EPERM` failures after the focused FAISS suite passes.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [x] I have updated documentation if needed
