### PR TITLE
feat: add memory compaction to reduce bloat

### DIFF
--- a/examples/compaction_demo.py
+++ b/examples/compaction_demo.py
@@ -1,0 +1,176 @@
+"""
+Simple demo of mem0 memory compaction.
+
+Shows how similar memories can be merged into higher quality ones.
+
+Run with:
+    PYTHONPATH=mem0 python mem0/examples/compaction_demo.py
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "mem0"))
+
+from mem0 import Memory
+from mem0.configs.base import MemoryConfig, CompactionConfig
+
+
+def build_mock_memory():
+    """Create a mocked Memory for demonstration purposes."""
+    cfg = MemoryConfig(
+        compaction=CompactionConfig(enabled=True, similarity_threshold=0.75)
+    )
+
+    mem = Memory.__new__(Memory)
+    mem.config = cfg
+
+    # Mock embedder - returns simple deterministic vectors based on text hash-ish
+    def fake_embed(text, action=None):
+        # Extreme separation for reliable demo clustering
+        t = text.lower()
+        if any(k in t for k in ["pizza", "italian", "margherita", "crust"]):
+            return [1.0, 0.99, 0.98, 1.0, 0.99, 0.97, 1.0, 0.98]
+        if any(k in t for k in ["coffee", "morning", "wake"]):
+            return [0.0, 0.01, 0.02, 0.0, 0.01, 0.0, 0.02, 0.01]
+        return [0.5 + (i * 0.01) for i in range(8)]
+
+    def fake_embed_batch(texts, action=None):
+        return [fake_embed(t) for t in texts]
+
+    mock_embedder = MagicMock()
+    mock_embedder.embed.side_effect = fake_embed
+    mock_embedder.embed_batch.side_effect = fake_embed_batch
+    mem.embedding_model = mock_embedder
+
+    # Mock LLM that returns a nice consolidated fact
+    def fake_llm(messages, response_format=None):
+        # The last user message contains the cluster
+        user_content = messages[-1]["content"] if messages else ""
+        if "pizza" in user_content.lower():
+            return '{"memory": "User loves pizza, especially authentic Italian pizza from local restaurants.", "confidence": 0.93, "reason": "Merged variations about pizza preference"}'
+        return '{"memory": "User enjoys coffee in the morning.", "confidence": 0.8, "reason": "Consolidated coffee facts"}'
+
+    mock_llm = MagicMock()
+    mock_llm.generate_response.side_effect = fake_llm
+    mem.llm = mock_llm
+
+    # In-memory fake vector store using a simple list
+    class FakeVectorStore:
+        def __init__(self):
+            self._store = {}  # id -> {"vector": , "payload": }
+
+        def insert(self, vectors=None, payloads=None, ids=None):
+            for vid, vec, pay in zip(ids or [], vectors or [], payloads or []):
+                self._store[vid] = {"vector": vec, "payload": pay}
+
+        def list(self, filters=None, top_k=None):
+            # Return objects that mimic real vector results
+            results = []
+            for vid, item in list(self._store.items())[: (top_k or 10000)]:
+                class R:
+                    pass
+                r = R()
+                r.id = vid
+                r.payload = item["payload"]
+                results.append(r)
+            return results
+
+        def search(self, *a, **k):
+            return []
+
+        def delete(self, vector_id):
+            self._store.pop(vector_id, None)
+
+        def update(self, *a, **k):
+            pass
+
+        def get(self, vid):
+            item = self._store.get(vid)
+            if item:
+                class G: pass
+                g = G()
+                g.id = vid
+                g.payload = item["payload"]
+                return g
+            return None
+
+        # other required
+        def create_col(self, *a, **k): pass
+        def col_info(self): return {}
+        def list_cols(self): return []
+        def delete_col(self): pass
+        def reset(self): self._store.clear()
+
+    mem.vector_store = FakeVectorStore()
+    mem.db = MagicMock()  # history not critical for demo
+
+    # minimal other attrs
+    mem.reranker = None
+    mem._entity_store = None
+    mem.custom_instructions = None
+    mem.api_version = "v1.1"
+
+    # Attach compactor manually (demo bypasses normal __init__)
+    from mem0.memory.compaction import MemoryCompactor
+    mem.compactor = MemoryCompactor(mem, cfg.compaction)
+
+    # Seed some realistic bloat (variations of same facts)
+    seeds = [
+        "I really love pizza",
+        "My favorite food is pizza, especially margherita",
+        "I prefer authentic Italian pizza from local places",
+        "Pizza is the best — thin crust only",
+        "User drinks coffee every morning to wake up",
+        "I need coffee first thing",
+    ]
+
+    for i, txt in enumerate(seeds):
+        mid = f"mem_{i}"
+        vec = fake_embed(txt)
+        payload = {
+            "data": txt,
+            "user_id": "demo_user",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "hash": str(abs(hash(txt))),
+        }
+        mem.vector_store.insert(vectors=[vec], ids=[mid], payloads=[payload])
+
+    return mem
+
+
+def main():
+    print("=== mem0 Compaction Demo ===\n")
+
+    memory = build_mock_memory()
+
+    print("Before compaction (seeded duplicates):")
+    before = memory.vector_store.list(filters={"user_id": "demo_user"})
+    print(f"  Count: {len(before)}")
+    for m in before:
+        print(f"    - {m.payload.get('data')}")
+
+    print("\nRunning compaction (dry_run=False)...")
+    result = memory.compact(
+        filters={"user_id": "demo_user"},
+        similarity_threshold=0.75,
+        dry_run=False,
+    )
+
+    print("\nCompaction report:")
+    import json
+    print(json.dumps(result, indent=2))
+
+    print("\nAfter compaction:")
+    after = memory.vector_store.list(filters={"user_id": "demo_user"})
+    print(f"  Count: {len(after)}")
+    for m in after:
+        print(f"    + {m.payload.get('data')}")
+
+    print("\nDone. Similar memories were merged into cleaner, higher-quality entries.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/compaction_demo.py
+++ b/examples/compaction_demo.py
@@ -14,15 +14,13 @@ from unittest.mock import MagicMock
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "mem0"))
 
-from mem0 import Memory
-from mem0.configs.base import MemoryConfig, CompactionConfig
+from mem0 import Memory  # noqa: E402
+from mem0.configs.base import CompactionConfig, MemoryConfig  # noqa: E402
 
 
 def build_mock_memory():
     """Create a mocked Memory for demonstration purposes."""
-    cfg = MemoryConfig(
-        compaction=CompactionConfig(enabled=True, similarity_threshold=0.75)
-    )
+    cfg = MemoryConfig(compaction=CompactionConfig(enabled=True, similarity_threshold=0.75))
 
     mem = Memory.__new__(Memory)
     mem.config = cfg
@@ -51,7 +49,9 @@ def build_mock_memory():
         user_content = messages[-1]["content"] if messages else ""
         if "pizza" in user_content.lower():
             return '{"memory": "User loves pizza, especially authentic Italian pizza from local restaurants.", "confidence": 0.93, "reason": "Merged variations about pizza preference"}'
-        return '{"memory": "User enjoys coffee in the morning.", "confidence": 0.8, "reason": "Consolidated coffee facts"}'
+        return (
+            '{"memory": "User enjoys coffee in the morning.", "confidence": 0.8, "reason": "Consolidated coffee facts"}'
+        )
 
     mock_llm = MagicMock()
     mock_llm.generate_response.side_effect = fake_llm
@@ -70,8 +70,10 @@ def build_mock_memory():
             # Return objects that mimic real vector results
             results = []
             for vid, item in list(self._store.items())[: (top_k or 10000)]:
+
                 class R:
                     pass
+
                 r = R()
                 r.id = vid
                 r.payload = item["payload"]
@@ -90,7 +92,10 @@ def build_mock_memory():
         def get(self, vid):
             item = self._store.get(vid)
             if item:
-                class G: pass
+
+                class G:
+                    pass
+
                 g = G()
                 g.id = vid
                 g.payload = item["payload"]
@@ -98,11 +103,20 @@ def build_mock_memory():
             return None
 
         # other required
-        def create_col(self, *a, **k): pass
-        def col_info(self): return {}
-        def list_cols(self): return []
-        def delete_col(self): pass
-        def reset(self): self._store.clear()
+        def create_col(self, *a, **k):
+            pass
+
+        def col_info(self):
+            return {}
+
+        def list_cols(self):
+            return []
+
+        def delete_col(self):
+            pass
+
+        def reset(self):
+            self._store.clear()
 
     mem.vector_store = FakeVectorStore()
     mem.db = MagicMock()  # history not critical for demo
@@ -115,6 +129,7 @@ def build_mock_memory():
 
     # Attach compactor manually (demo bypasses normal __init__)
     from mem0.memory.compaction import MemoryCompactor
+
     mem.compactor = MemoryCompactor(mem, cfg.compaction)
 
     # Seed some realistic bloat (variations of same facts)
@@ -161,6 +176,7 @@ def main():
 
     print("\nCompaction report:")
     import json
+
     print(json.dumps(result, indent=2))
 
     print("\nAfter compaction:")

--- a/mem0/configs/base.py
+++ b/mem0/configs/base.py
@@ -13,6 +13,26 @@ home_dir = os.path.expanduser("~")
 mem0_dir = os.environ.get("MEM0_DIR") or os.path.join(home_dir, ".mem0")
 
 
+class CompactionConfig(BaseModel):
+    """Configuration for memory compaction (merge-first deduplication).
+
+    Addresses bloat in the ADD-only pipeline. Users can call .compact()
+    to cluster similar memories and have the LLM synthesize richer canonical ones.
+    """
+
+    enabled: bool = Field(default=False, description="Enable compaction support")
+    max_memories: Optional[int] = Field(
+        default=None,
+        description="Optional threshold: if a scope has more memories than this, compaction is useful.",
+    )
+    similarity_threshold: float = Field(
+        default=0.82,
+        ge=0.5,
+        le=0.99,
+        description="Cosine similarity above which memories are considered for merging.",
+    )
+
+
 class MemoryItem(BaseModel):
     id: str = Field(..., description="The unique identifier for the text data")
     memory: str = Field(
@@ -53,6 +73,10 @@ class MemoryConfig(BaseModel):
     )
     custom_instructions: Optional[str] = Field(
         description="Custom instructions for fact extraction",
+        default=None,
+    )
+    compaction: Optional[CompactionConfig] = Field(
+        description="Configuration for automatic and manual memory compaction / consolidation (merge-first hygiene)",
         default=None,
     )
 

--- a/mem0/configs/prompts.py
+++ b/mem0/configs/prompts.py
@@ -1060,3 +1060,50 @@ def generate_additive_extraction_prompt(
 
     sections.append("# Output:")
     return "\n\n".join(sections)
+
+
+# ---------------------------------------------------------------------------
+# Memory Consolidation Prompt (for compaction / merge-first hygiene)
+# Used by MemoryCompactor to synthesize clusters of similar memories into
+# a single richer, canonical memory.
+# ---------------------------------------------------------------------------
+
+CONSOLIDATION_SYSTEM_PROMPT = """You are an expert Memory Synthesizer and Knowledge Consolidator.
+
+Your job is to take a cluster of semantically overlapping or redundant memories and produce **exactly one** higher-quality, canonical memory that:
+- Captures ALL unique, non-contradictory facts, preferences, details and context from the cluster.
+- Is concise yet complete and self-contained (better than any individual input).
+- Uses natural, precise language.
+- Preserves important qualifiers, time references, sources/attribution if present.
+- Resolves minor variations into the most accurate/general form.
+- Does NOT invent new information.
+
+If the cluster contains clear contradictions, note the most reliable version and prefer higher-confidence or more recent signals.
+
+Output ONLY a JSON object:
+{
+  "memory": "the single consolidated memory text here",
+  "confidence": 0.0-1.0,
+  "reason": "short explanation of what was merged and why"
+}
+
+Do not add any other text, markdown, or keys.
+"""
+
+def generate_consolidation_prompt(cluster_memories: list[dict]) -> str:
+    """Build the user prompt for consolidating a cluster of similar memories."""
+    lines = ["## Memories to Consolidate (cluster of similar facts):"]
+    for i, m in enumerate(cluster_memories, 1):
+        text = m.get("memory") or m.get("data") or str(m)
+        meta = m.get("metadata") or {}
+        created = meta.get("created_at") or m.get("created_at")
+        line = f"{i}. {text}"
+        if created:
+            line += f" (created: {created})"
+        if meta.get("user_id") or meta.get("agent_id"):
+            line += f" [scope: {meta.get('user_id') or meta.get('agent_id')}]"
+        lines.append(line)
+
+    lines.append("\n## Task\nProduce ONE canonical memory as specified in the system instructions.")
+    lines.append("Return strictly the JSON object.")
+    return "\n".join(lines)

--- a/mem0/memory/compaction.py
+++ b/mem0/memory/compaction.py
@@ -1,0 +1,357 @@
+"""
+Memory Compaction
+
+Provides a way to reduce memory bloat by merging similar memories.
+
+Process:
+- Retrieve memories for a given scope
+- Group memories that are semantically similar (via embeddings)
+- Use the LLM to synthesize one higher-quality, consolidated memory per group
+- Replace the originals with the consolidated memory
+
+Key properties:
+- Does not affect the hot add path
+- Works with any configured LLM and vector store
+- Supports dry-run mode
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import time
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from mem0.configs.base import CompactionConfig
+from mem0.configs.prompts import (
+    CONSOLIDATION_SYSTEM_PROMPT,
+    generate_consolidation_prompt,
+)
+from mem0.memory.utils import remove_code_blocks
+
+logger = logging.getLogger(__name__)
+
+
+def _cosine_similarity(vec_a: List[float], vec_b: List[float]) -> float:
+    """Pure-python cosine similarity (fast enough for compaction batches)."""
+    if not vec_a or not vec_b or len(vec_a) != len(vec_b):
+        return 0.0
+    dot = sum(x * y for x, y in zip(vec_a, vec_b))
+    na = math.sqrt(sum(x * x for x in vec_a))
+    nb = math.sqrt(sum(y * y for y in vec_b))
+    if na == 0 or nb == 0:
+        return 0.0
+    return dot / (na * nb)
+
+
+def _get_memory_text(mem: Any) -> str:
+    """Extract the canonical memory text from various return shapes."""
+    if isinstance(mem, dict):
+        return mem.get("memory") or mem.get("data") or mem.get("text") or ""
+    payload = getattr(mem, "payload", None) or {}
+    if isinstance(payload, dict):
+        return payload.get("data") or payload.get("memory") or payload.get("text") or ""
+    return getattr(mem, "memory", "") or getattr(mem, "data", "") or str(mem)
+
+
+def _get_memory_id(mem: Any) -> Optional[str]:
+    if isinstance(mem, dict):
+        return mem.get("id")
+    return getattr(mem, "id", None) or getattr(mem, "memory_id", None)
+
+
+def _get_payload(mem: Any) -> Dict[str, Any]:
+    if isinstance(mem, dict):
+        return mem.get("payload", mem.get("metadata", {})) or {}
+    return getattr(mem, "payload", {}) or {}
+
+
+class MemoryCompactor:
+    """Core compaction logic. Sensible merge of similar memories via LLM."""
+
+    def __init__(self, memory_instance: Any, config: Optional[CompactionConfig] = None):
+        self.memory = memory_instance
+        self.config = config or CompactionConfig()
+        self.embedder = getattr(memory_instance, "embedding_model", None)
+        self.llm = getattr(memory_instance, "llm", None)
+        self.vector_store = getattr(memory_instance, "vector_store", None)
+
+    def compact(
+        self,
+        filters: Dict[str, Any],
+        similarity_threshold: Optional[float] = None,
+        dry_run: bool = False,
+    ) -> Dict[str, Any]:
+        """
+        Compact similar memories in the given scope.
+
+        - Clusters memories with high embedding similarity
+        - Uses LLM to produce one better canonical memory per cluster
+        - Replaces the cluster with the merged memory
+
+        Returns a simple report dict.
+        """
+        start = time.perf_counter()
+        threshold = similarity_threshold or self.config.similarity_threshold
+
+        try:
+            raw = self.memory.vector_store.list(filters=filters, top_k=100000)
+        except Exception as e:
+            logger.error(f"list failed during compaction: {e}")
+            raise
+
+        memories = self._normalize_memories(raw)
+        before = len(memories)
+
+        if before == 0:
+            return {"before_count": 0, "after_count": 0, "merges": 0, "dry_run": dry_run}
+
+        texts = [_get_memory_text(m) for m in memories]
+        embs = self._embed_texts(texts)
+        clusters = self._cluster_by_similarity(memories, embs, threshold, min_size=2)
+
+        added: List[str] = []
+        deleted: List[str] = []
+        merges = 0
+        details = []
+
+        for idxs in clusters:
+            if len(idxs) < 2:
+                continue
+            cluster = [memories[i] for i in idxs]
+
+            cons = self._llm_consolidate(cluster) if self.llm else self._simple_fallback_consolidate(cluster)
+            if not cons or not cons.get("memory"):
+                continue
+
+            new_text = cons["memory"].strip()
+            if len(new_text) < 3:
+                continue
+
+            meta = self._build_consolidated_metadata(cluster, cons)
+
+            if dry_run:
+                details.append({
+                    "size": len(cluster),
+                    "consolidated": new_text[:100],
+                })
+                merges += 1
+                continue
+
+            try:
+                new_id = self._insert_consolidated(new_text, meta, filters)
+                added.append(new_id)
+                for m in cluster:
+                    mid = _get_memory_id(m)
+                    if mid:
+                        try:
+                            self.vector_store.delete(mid)
+                            deleted.append(mid)
+                        except Exception:
+                            pass
+                merges += 1
+                details.append({"size": len(cluster), "id": new_id})
+            except Exception as e:
+                logger.warning(f"Failed to apply merge: {e}")
+
+        after = before - len(deleted) + len(added)
+        duration = time.perf_counter() - start
+
+        report = {
+            "before_count": before,
+            "after_count": max(0, after),
+            "merges": merges,
+            "dry_run": dry_run,
+            "duration": round(duration, 3),
+            "details": details,
+        }
+        logger.info(f"compaction: {before} -> {after} (merges={merges})")
+        return report
+
+    # ---------------------- Internal helpers (elegant & robust) ----------------------
+
+    def _normalize_memories(self, raw: Any) -> List[Dict[str, Any]]:
+        """Turn vector store list() output into a uniform list of dicts with id + payload."""
+        if raw is None:
+            return []
+        if isinstance(raw, (list, tuple)):
+            if raw and isinstance(raw[0], (list, tuple)):
+                raw = raw[0]
+        normalized = []
+        for item in raw or []:
+            mid = _get_memory_id(item)
+            payload = _get_payload(item)
+            text = _get_memory_text(item)
+            if not text:
+                continue
+            normalized.append({
+                "id": mid or str(uuid.uuid4()),
+                "memory": text,
+                "payload": payload,
+                "_raw": item,
+            })
+        return normalized
+
+    def _embed_texts(self, texts: List[str]) -> List[List[float]]:
+        """Batch embed using the existing embedder."""
+        if not texts:
+            return []
+        if self.embedder and hasattr(self.embedder, "embed_batch"):
+            try:
+                return self.embedder.embed_batch(texts, "search") or []
+            except Exception:
+                pass
+        # Fallback individual
+        embs = []
+        for t in texts:
+            try:
+                embs.append(self.embedder.embed(t, "search") if self.embedder else [0.0] * 384)
+            except Exception:
+                embs.append([0.0] * 384)
+        return embs
+
+    def _cluster_by_similarity(
+        self,
+        memories: List[Dict],
+        embeddings: List[List[float]],
+        threshold: float,
+        min_size: int,
+    ) -> List[List[int]]:
+        """Greedy single-pass clustering. Fast and deterministic enough."""
+        n = len(memories)
+        if n < min_size:
+            return []
+
+        used = [False] * n
+        clusters: List[List[int]] = []
+
+        for i in range(n):
+            if used[i]:
+                continue
+            cluster = [i]
+            used[i] = True
+            for j in range(i + 1, n):
+                if used[j]:
+                    continue
+                sim = _cosine_similarity(embeddings[i], embeddings[j])
+                if sim >= threshold:
+                    cluster.append(j)
+                    used[j] = True
+            if len(cluster) >= min_size:
+                clusters.append(cluster)
+            # else leave them alone (they stay as-is)
+        return clusters
+
+    def _llm_consolidate(self, cluster_mems: List[Dict]) -> Optional[Dict[str, Any]]:
+        """Call LLM to produce one canonical memory."""
+        if not self.llm:
+            return self._simple_fallback_consolidate(cluster_mems)
+
+        user_prompt = generate_consolidation_prompt(cluster_mems)
+
+        try:
+            resp = self.llm.generate_response(
+                messages=[
+                    {"role": "system", "content": CONSOLIDATION_SYSTEM_PROMPT},
+                    {"role": "user", "content": user_prompt},
+                ],
+                response_format={"type": "json_object"},
+            )
+            resp = remove_code_blocks(resp)
+            data = json.loads(resp, strict=False)
+            if isinstance(data, dict) and data.get("memory"):
+                return {
+                    "memory": data["memory"],
+                    "confidence": float(data.get("confidence", 0.8)),
+                    "reason": data.get("reason", ""),
+                }
+        except Exception as e:
+            logger.warning(f"LLM consolidation failed, falling back: {e}")
+
+        return self._simple_fallback_consolidate(cluster_mems)
+
+    def _simple_fallback_consolidate(self, cluster_mems: List[Dict]) -> Dict[str, Any]:
+        """Very simple deterministic fallback (concat unique sentences-ish)."""
+        seen = set()
+        parts = []
+        for m in cluster_mems:
+            txt = _get_memory_text(m).strip()
+            if txt and txt.lower() not in seen:
+                parts.append(txt)
+                seen.add(txt.lower())
+        consolidated = " ".join(parts) if parts else ""
+        # Trim if absurdly long
+        if len(consolidated) > 600:
+            consolidated = consolidated[:597] + "..."
+        return {"memory": consolidated, "confidence": 0.6, "reason": "fallback concatenation"}
+
+    def _build_consolidated_metadata(
+        self, cluster_mems: List[Dict], consolidated_info: Dict
+    ) -> Dict[str, Any]:
+        """Craft good metadata for the new memory."""
+        now = datetime.now(timezone.utc).isoformat()
+        source_count = len(cluster_mems)
+        earliest = None
+        latest = None
+        scopes = set()
+
+        for m in cluster_mems:
+            p = _get_payload(m) or {}
+            ca = p.get("created_at")
+            if ca:
+                if earliest is None or ca < earliest:
+                    earliest = ca
+                if latest is None or ca > latest:
+                    latest = ca
+            for k in ("user_id", "agent_id", "run_id"):
+                if p.get(k):
+                    scopes.add(f"{k}={p[k]}")
+
+        meta: Dict[str, Any] = {
+            "data": consolidated_info["memory"],
+            "consolidated": True,
+            "source_count": source_count,
+            "consolidated_at": now,
+            "consolidation_confidence": consolidated_info.get("confidence", 0.75),
+            "consolidation_reason": consolidated_info.get("reason", ""),
+        }
+        if earliest:
+            meta["created_at"] = earliest
+        meta["updated_at"] = now
+
+        # Carry over a representative scope (first one is fine; caller already filtered)
+        for m in cluster_mems:
+            p = _get_payload(m) or {}
+            for k in ("user_id", "agent_id", "run_id"):
+                if k in p:
+                    meta[k] = p[k]
+                    break
+            break
+
+        return meta
+
+    def _insert_consolidated(
+        self, text: str, metadata: Dict[str, Any], filters: Dict[str, Any]
+    ) -> str:
+        """Insert the new consolidated memory using the same path as normal adds where possible."""
+        mem_id = str(uuid.uuid4())
+        try:
+            # Best path: use the embedder + vector_store.insert directly
+            emb = self.embedder.embed(text, "add") if self.embedder else None
+            if emb is not None:
+                payload = dict(metadata)
+                payload.setdefault("data", text)
+                self.vector_store.insert(vectors=[emb], ids=[mem_id], payloads=[payload])
+            else:
+                # Extremely defensive fallback — let the normal add path handle a raw insert
+                # (rare)
+                self.memory.add([{"role": "user", "content": text}], **{k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id")})
+                # We won't have the exact id here; return a placeholder
+                return mem_id
+        except Exception:
+            # Last resort: try normal add path
+            self.memory.add([{"role": "user", "content": text}], **{k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id")})
+        return mem_id

--- a/mem0/memory/compaction.py
+++ b/mem0/memory/compaction.py
@@ -134,15 +134,17 @@ class MemoryCompactor:
             meta = self._build_consolidated_metadata(cluster, cons)
 
             if dry_run:
-                details.append({
-                    "size": len(cluster),
-                    "consolidated": new_text[:100],
-                })
+                details.append(
+                    {
+                        "size": len(cluster),
+                        "consolidated": new_text[:100],
+                    }
+                )
                 merges += 1
                 continue
 
             try:
-                new_id = self._insert_consolidated(new_text, meta, filters)
+                new_id = self._insert_consolidated(new_text, meta)
                 added.append(new_id)
                 for m in cluster:
                     mid = _get_memory_id(m)
@@ -187,12 +189,14 @@ class MemoryCompactor:
             text = _get_memory_text(item)
             if not text:
                 continue
-            normalized.append({
-                "id": mid or str(uuid.uuid4()),
-                "memory": text,
-                "payload": payload,
-                "_raw": item,
-            })
+            normalized.append(
+                {
+                    "id": mid or str(uuid.uuid4()),
+                    "memory": text,
+                    "payload": payload,
+                    "_raw": item,
+                }
+            )
         return normalized
 
     def _embed_texts(self, texts: List[str]) -> List[List[float]]:
@@ -288,9 +292,7 @@ class MemoryCompactor:
             consolidated = consolidated[:597] + "..."
         return {"memory": consolidated, "confidence": 0.6, "reason": "fallback concatenation"}
 
-    def _build_consolidated_metadata(
-        self, cluster_mems: List[Dict], consolidated_info: Dict
-    ) -> Dict[str, Any]:
+    def _build_consolidated_metadata(self, cluster_mems: List[Dict], consolidated_info: Dict) -> Dict[str, Any]:
         """Craft good metadata for the new memory."""
         now = datetime.now(timezone.utc).isoformat()
         source_count = len(cluster_mems)
@@ -333,25 +335,14 @@ class MemoryCompactor:
 
         return meta
 
-    def _insert_consolidated(
-        self, text: str, metadata: Dict[str, Any], filters: Dict[str, Any]
-    ) -> str:
-        """Insert the new consolidated memory using the same path as normal adds where possible."""
+    def _insert_consolidated(self, text: str, metadata: Dict[str, Any]) -> str:
+        """Insert a consolidated memory without risking deletion on a failed write."""
         mem_id = str(uuid.uuid4())
-        try:
-            # Best path: use the embedder + vector_store.insert directly
-            emb = self.embedder.embed(text, "add") if self.embedder else None
-            if emb is not None:
-                payload = dict(metadata)
-                payload.setdefault("data", text)
-                self.vector_store.insert(vectors=[emb], ids=[mem_id], payloads=[payload])
-            else:
-                # Extremely defensive fallback — let the normal add path handle a raw insert
-                # (rare)
-                self.memory.add([{"role": "user", "content": text}], **{k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id")})
-                # We won't have the exact id here; return a placeholder
-                return mem_id
-        except Exception:
-            # Last resort: try normal add path
-            self.memory.add([{"role": "user", "content": text}], **{k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id")})
+        if self.embedder is None:
+            raise RuntimeError("Memory compaction requires a configured embedder")
+
+        embedding = self.embedder.embed(text, "add")
+        payload = dict(metadata)
+        payload.setdefault("data", text)
+        self.vector_store.insert(vectors=[embedding], ids=[mem_id], payloads=[payload])
         return mem_id

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, Optional
 
 from pydantic import ValidationError
 
-from mem0.configs.base import MemoryConfig, MemoryItem
+from mem0.configs.base import CompactionConfig, MemoryConfig, MemoryItem
 from mem0.configs.enums import MemoryType
 from mem0.configs.prompts import (
     ADDITIVE_EXTRACTION_PROMPT,
@@ -25,6 +25,7 @@ from mem0.configs.prompts import (
 from mem0.exceptions import LLMError
 from mem0.exceptions import ValidationError as Mem0ValidationError
 from mem0.memory.base import MemoryBase
+from mem0.memory.compaction import MemoryCompactor
 from mem0.memory.notices import (
     PERFORMANCE_SLOW_QUERY_THRESHOLD_SECONDS,
     detect_decay_usage_from_delete,
@@ -505,6 +506,11 @@ class Memory(MemoryBase):
                 "store with keyword_search support (e.g. qdrant, elasticsearch, pgvector).",
                 self.config.vector_store.provider,
             )
+
+        # Optional compaction support
+        self.compactor: Optional[MemoryCompactor] = None
+        if getattr(self.config, "compaction", None) and getattr(self.config.compaction, "enabled", False):
+            self.compactor = MemoryCompactor(self, self.config.compaction)
 
         capture_event("mem0.init", self, {"sync_type": "sync"})
 
@@ -1894,6 +1900,78 @@ class Memory(MemoryBase):
         display_first_run_notice(self, "sync", "history")
         return history
 
+    def count(self, filters: Optional[Dict[str, Any]] = None, **kwargs) -> int:
+        """
+        Return the number of memories for the given scope.
+        """
+        _reject_top_level_entity_params(kwargs, "count")
+        if not filters:
+            raise ValueError("count() requires filters with user_id/agent_id/run_id")
+        eff = dict(filters)
+        for k in ("user_id", "agent_id", "run_id"):
+            if k in eff:
+                eff[k] = _validate_and_trim_entity_id(eff[k], k)
+        try:
+            items = self.vector_store.list(filters=eff, top_k=1_000_000)
+            # handle wrapped returns like other methods
+            if items and isinstance(items[0], (list, tuple)):
+                items = items[0]
+            return len(items or [])
+        except Exception:
+            # Fallback
+            res = self.get_all(filters=eff, top_k=1_000_000)
+            return len(res.get("results", []))
+
+    def compact(
+        self,
+        filters: Optional[Dict[str, Any]] = None,
+        similarity_threshold: Optional[float] = None,
+        dry_run: bool = False,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        """
+        Reduce duplicate or overlapping memories by merging similar ones.
+
+        Finds clusters of semantically similar memories and uses the LLM
+        to create one better consolidated memory per cluster.
+
+        Args:
+            filters: Must contain at least one of user_id, agent_id or run_id.
+            similarity_threshold: Override for how close memories need to be.
+            dry_run: When True, returns what would be done without changes.
+
+        Returns:
+            dict: before_count, after_count, merges, etc.
+
+        Example:
+            memory.compact(filters={"user_id": "alice"})
+        """
+        _reject_top_level_entity_params(kwargs, "compact")
+
+        if not filters:
+            raise ValueError("compact() requires filters with at least one of user_id/agent_id/run_id")
+
+        effective_filters = dict(filters)
+        for k in ("user_id", "agent_id", "run_id"):
+            if k in effective_filters:
+                effective_filters[k] = _validate_and_trim_entity_id(effective_filters[k], k)
+
+        if not any(k in effective_filters for k in ("user_id", "agent_id", "run_id")):
+            raise ValueError("filters must contain at least one of: user_id, agent_id, run_id")
+
+        # Lazily create a compactor if none exists (allows manual use even without config.enabled)
+        if getattr(self, "compactor", None) is None:
+            comp_cfg = getattr(self.config, "compaction", None) or CompactionConfig(enabled=True)
+            self.compactor = MemoryCompactor(self, comp_cfg)
+
+        capture_event("mem0.compact", self, {"sync_type": "sync", "dry_run": dry_run})
+
+        return self.compactor.compact(
+            filters=effective_filters,
+            similarity_threshold=similarity_threshold,
+            dry_run=dry_run,
+        )
+
     def _create_memory(self, data, existing_embeddings, metadata=None):
         logger.debug(f"Creating memory with {data=}")
         if data in existing_embeddings:
@@ -2147,6 +2225,11 @@ class AsyncMemory(MemoryBase):
                 "store with keyword_search support (e.g. qdrant, elasticsearch, pgvector).",
                 self.config.vector_store.provider,
             )
+
+        # Optional compaction support
+        self.compactor: Optional[MemoryCompactor] = None
+        if getattr(self.config, "compaction", None) and getattr(self.config.compaction, "enabled", False):
+            self.compactor = MemoryCompactor(self, self.config.compaction)
 
         capture_event("mem0.init", self, {"sync_type": "async"})
 
@@ -3537,6 +3620,43 @@ class AsyncMemory(MemoryBase):
         history = await asyncio.to_thread(self.db.get_history, memory_id)
         await display_first_run_notice_async(self, "async", "history")
         return history
+
+    async def compact(
+        self,
+        filters: Optional[Dict[str, Any]] = None,
+        similarity_threshold: Optional[float] = None,
+        dry_run: bool = False,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        """
+        Async version of compact(). See the sync version for documentation.
+        """
+        _reject_top_level_entity_params(kwargs, "compact")
+
+        if not filters:
+            raise ValueError("compact() requires filters with at least one of user_id/agent_id/run_id")
+
+        effective_filters = dict(filters)
+        for k in ("user_id", "agent_id", "run_id"):
+            if k in effective_filters:
+                effective_filters[k] = _validate_and_trim_entity_id(effective_filters[k], k)
+
+        if not any(k in effective_filters for k in ("user_id", "agent_id", "run_id")):
+            raise ValueError("filters must contain at least one of: user_id, agent_id, run_id")
+
+        if getattr(self, "compactor", None) is None:
+            comp_cfg = getattr(self.config, "compaction", None) or CompactionConfig(enabled=True)
+            self.compactor = MemoryCompactor(self, comp_cfg)
+
+        capture_event("mem0.compact", self, {"sync_type": "async", "dry_run": dry_run})
+
+        # The underlying compactor is sync (vector ops); run in thread for cleanliness
+        return await asyncio.to_thread(
+            self.compactor.compact,
+            filters=effective_filters,
+            similarity_threshold=similarity_threshold,
+            dry_run=dry_run,
+        )
 
     async def _create_memory(self, data, existing_embeddings, metadata=None):
         logger.debug(f"Creating memory with {data=}")

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -1,0 +1,100 @@
+"""
+Tests for memory compaction.
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from mem0.configs.base import MemoryConfig, CompactionConfig
+from mem0.memory.main import Memory
+
+
+def _make_mock_memory_with_data(memories_data, compaction_cfg=None):
+    """Helper to create a Memory with controlled store for compaction tests."""
+    cfg = MemoryConfig(compaction=compaction_cfg or CompactionConfig(enabled=True))
+    m = Memory.__new__(Memory)
+    m.config = cfg
+
+    # Embedder
+    def _embed(t, **k):
+        if "pizza" in t.lower():
+            return [0.9] * 4
+        return [0.1] * 4
+
+    mock_emb = MagicMock()
+    mock_emb.embed.side_effect = _embed
+    mock_emb.embed_batch.side_effect = lambda ts, **k: [_embed(t) for t in ts]
+    m.embedding_model = mock_emb
+
+    # LLM returns nice consolidated
+    mock_llm = MagicMock()
+    mock_llm.generate_response.return_value = '{"memory": "User really loves pizza.", "confidence": 0.9, "reason": "merged"}'
+    m.llm = mock_llm
+
+    class Store:
+        def __init__(self):
+            self.data = {}
+        def list(self, filters=None, top_k=None):
+            class Item: pass
+            items = []
+            for mid, p in self.data.items():
+                it = Item()
+                it.id = mid
+                it.payload = p
+                items.append(it)
+            return items
+        def insert(self, vectors, ids, payloads):
+            for i, vid in enumerate(ids):
+                self.data[vid] = payloads[i]
+        def delete(self, vid):
+            self.data.pop(vid, None)
+        # stubs
+        def search(self,*a,**k): return []
+        def update(self,*a,**k): pass
+        def get(self, vid): return None
+        def create_col(self,*a,**k): pass
+        def delete_col(self): pass
+        def col_info(self): return {}
+        def list_cols(self): return []
+        def reset(self): self.data.clear()
+
+    m.vector_store = Store()
+    m.db = MagicMock()
+    m.reranker = None
+    m._entity_store = None
+    m.custom_instructions = None
+    m.api_version = "v1.1"
+
+    # seed
+    for i, txt in enumerate(memories_data):
+        mid = f"m{i}"
+        m.vector_store.data[mid] = {"data": txt, "user_id": "u1", "created_at": "2026-01-01"}
+
+    m.compactor = None  # will be created lazily
+    return m
+
+
+def test_compaction_runs_without_error_and_returns_report():
+    data = [
+        "I love pizza",
+        "Pizza is my favorite food",
+        "I really enjoy pizza especially Italian",
+        "Coffee is great in the morning",
+    ]
+    mem = _make_mock_memory_with_data(data)
+    res = mem.compact(filters={"user_id": "u1"}, similarity_threshold=0.7, dry_run=True)
+
+    assert "before_count" in res
+    assert "after_count" in res
+    assert res["dry_run"] is True
+    assert isinstance(res.get("merges_performed", 0), int)
+
+
+def test_compaction_dry_run_does_not_modify():
+    data = ["love pizza", "pizza pizza pizza"]
+    mem = _make_mock_memory_with_data(data)
+    before = len(mem.vector_store.list({}))
+    res = mem.compact(filters={"user_id": "u1"}, max_memories=1, dry_run=True)
+    after = len(mem.vector_store.list({}))
+    assert before == after
+    assert res["dry_run"] is True

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -2,8 +2,9 @@
 Tests for memory compaction.
 """
 
-import pytest
 from unittest.mock import MagicMock
+
+import pytest
 
 from mem0.configs.base import MemoryConfig, CompactionConfig
 from mem0.memory.main import Memory
@@ -16,26 +17,31 @@ def _make_mock_memory_with_data(memories_data, compaction_cfg=None):
     m.config = cfg
 
     # Embedder
-    def _embed(t, **k):
+    def _embed(t, *args, **kwargs):
         if "pizza" in t.lower():
-            return [0.9] * 4
-        return [0.1] * 4
+            return [1.0, 0.0, 0.0, 0.0]
+        return [0.0, 1.0, 0.0, 0.0]
 
     mock_emb = MagicMock()
     mock_emb.embed.side_effect = _embed
-    mock_emb.embed_batch.side_effect = lambda ts, **k: [_embed(t) for t in ts]
+    mock_emb.embed_batch.side_effect = lambda ts, *args, **kwargs: [_embed(t) for t in ts]
     m.embedding_model = mock_emb
 
     # LLM returns nice consolidated
     mock_llm = MagicMock()
-    mock_llm.generate_response.return_value = '{"memory": "User really loves pizza.", "confidence": 0.9, "reason": "merged"}'
+    mock_llm.generate_response.return_value = (
+        '{"memory": "User really loves pizza.", "confidence": 0.9, "reason": "merged"}'
+    )
     m.llm = mock_llm
 
     class Store:
         def __init__(self):
             self.data = {}
+
         def list(self, filters=None, top_k=None):
-            class Item: pass
+            class Item:
+                pass
+
             items = []
             for mid, p in self.data.items():
                 it = Item()
@@ -43,20 +49,37 @@ def _make_mock_memory_with_data(memories_data, compaction_cfg=None):
                 it.payload = p
                 items.append(it)
             return items
+
         def insert(self, vectors, ids, payloads):
             for i, vid in enumerate(ids):
                 self.data[vid] = payloads[i]
+
         def delete(self, vid):
             self.data.pop(vid, None)
-        # stubs
-        def search(self,*a,**k): return []
-        def update(self,*a,**k): pass
-        def get(self, vid): return None
-        def create_col(self,*a,**k): pass
-        def delete_col(self): pass
-        def col_info(self): return {}
-        def list_cols(self): return []
-        def reset(self): self.data.clear()
+
+        def search(self, *args, **kwargs):
+            return []
+
+        def update(self, *args, **kwargs):
+            pass
+
+        def get(self, vid):
+            return None
+
+        def create_col(self, *args, **kwargs):
+            pass
+
+        def delete_col(self):
+            pass
+
+        def col_info(self):
+            return {}
+
+        def list_cols(self):
+            return []
+
+        def reset(self):
+            self.data.clear()
 
     m.vector_store = Store()
     m.db = MagicMock()
@@ -84,17 +107,49 @@ def test_compaction_runs_without_error_and_returns_report():
     mem = _make_mock_memory_with_data(data)
     res = mem.compact(filters={"user_id": "u1"}, similarity_threshold=0.7, dry_run=True)
 
-    assert "before_count" in res
-    assert "after_count" in res
+    assert res["before_count"] == 4
+    assert res["after_count"] == 4
+    assert res["merges"] == 1
+    assert res["details"][0]["size"] == 3
     assert res["dry_run"] is True
-    assert isinstance(res.get("merges_performed", 0), int)
 
 
 def test_compaction_dry_run_does_not_modify():
     data = ["love pizza", "pizza pizza pizza"]
     mem = _make_mock_memory_with_data(data)
     before = len(mem.vector_store.list({}))
-    res = mem.compact(filters={"user_id": "u1"}, max_memories=1, dry_run=True)
+    res = mem.compact(filters={"user_id": "u1"}, dry_run=True)
     after = len(mem.vector_store.list({}))
     assert before == after
     assert res["dry_run"] is True
+
+
+def test_compaction_replaces_a_cluster_with_one_memory():
+    mem = _make_mock_memory_with_data(["love pizza", "pizza is my favorite"])
+
+    res = mem.compact(filters={"user_id": "u1"}, dry_run=False)
+
+    assert res["before_count"] == 2
+    assert res["after_count"] == 1
+    assert res["merges"] == 1
+    assert len(mem.vector_store.data) == 1
+    assert next(iter(mem.vector_store.data.values()))["data"] == "User really loves pizza."
+
+
+def test_compaction_preserves_originals_when_insert_fails():
+    mem = _make_mock_memory_with_data(["love pizza", "pizza is my favorite"])
+    mem.vector_store.insert = MagicMock(side_effect=RuntimeError("write failed"))
+
+    res = mem.compact(filters={"user_id": "u1"}, dry_run=False)
+
+    assert res["before_count"] == 2
+    assert res["after_count"] == 2
+    assert res["merges"] == 0
+    assert len(mem.vector_store.data) == 2
+
+
+def test_compaction_requires_scope_filters():
+    mem = _make_mock_memory_with_data(["love pizza", "pizza is my favorite"])
+
+    with pytest.raises(ValueError, match="requires filters"):
+        mem.compact()


### PR DESCRIPTION
## Linked Issue

Closes #5850

## Description

Adds an explicit memory-compaction API for OSS users who need to consolidate semantically overlapping memories without changing the hot `add()` path. Similar memories are clustered by embedding similarity, synthesized into a canonical memory through the configured LLM, and replaced only after the consolidated vector is written successfully.

The implementation supports synchronous and asynchronous `compact()` calls, dry-run reports, scoped filters, configurable similarity, and a `count()` helper. The follow-up hardening keeps original memories intact when a consolidated write fails and adds regression coverage for that behavior.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (described below)
- [ ] No tests needed (explain why)

Validation performed:

- `python -m ruff check examples/compaction_demo.py mem0/configs/base.py mem0/configs/prompts.py mem0/memory/compaction.py mem0/memory/main.py tests/test_compaction.py`
- `python -m pytest tests/test_compaction.py -q` (`5 passed`)
- `python examples/compaction_demo.py` (six seeded memories compacted to two canonical memories)
- `git diff --check upstream/main...HEAD`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing focused tests pass locally
- [x] I have updated documentation/examples if needed