### PR TITLE
Stop evaluating Memory's default MemoryConfig at import time

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -442,7 +442,9 @@ class _AsyncOSSProject:
 
 
 class Memory(MemoryBase):
-    def __init__(self, config: MemoryConfig = MemoryConfig()):
+    def __init__(self, config: Optional[MemoryConfig] = None):
+        if config is None:
+            config = MemoryConfig()
         self.config = config
 
         self.embedding_model = EmbedderFactory.create(
@@ -2093,7 +2095,9 @@ class Memory(MemoryBase):
 
 
 class AsyncMemory(MemoryBase):
-    def __init__(self, config: MemoryConfig = MemoryConfig()):
+    def __init__(self, config: Optional[MemoryConfig] = None):
+        if config is None:
+            config = MemoryConfig()
         self.config = config
 
         self.embedding_model = EmbedderFactory.create(

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -1,0 +1,26 @@
+import json
+import subprocess
+import sys
+
+
+def test_import_mem0_does_not_import_qdrant_client():
+    """Importing mem0 must not construct the default MemoryConfig.
+
+    Memory.__init__'s config default used to be evaluated at import time,
+    which pulled in the default vector store's SDK (qdrant_client) for every
+    consumer, whatever their configured provider. The probe runs in a
+    subprocess so it sees exactly what `import mem0` loads.
+    """
+    probe = (
+        "import json, sys\n"
+        "import mem0\n"
+        "print(json.dumps(sorted(m for m in sys.modules if m.startswith('qdrant'))))\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=120,
+    )
+    assert json.loads(result.stdout) == []


### PR DESCRIPTION
## Linked Issue

N/A — small self-contained fix; happy to open an issue if preferred.

## Description

`Memory.__init__` and `AsyncMemory.__init__` declare `config: MemoryConfig = MemoryConfig()`, so the default config is constructed **when `mem0.memory.main` is imported**. That default `MemoryConfig` builds a default `VectorStoreConfig` (provider `"qdrant"`), whose `model_validator` imports `mem0.configs.vector_stores.qdrant`, which imports `qdrant_client` in its class body. Net effect: every `import mem0` pays the `qdrant_client` import — ~0.3 s of pydantic model construction (`qdrant_client.http` alone is ~0.2 s) — even for consumers configured with a completely different vector store. The existing lazy `__import__` in `VectorStoreConfig.validate_and_create_config` is defeated by the import-time default.

It is also the classic shared-mutable-default pitfall: every `Memory()` constructed without an explicit config shared one `MemoryConfig` instance, so mutations leaked between instances.

This PR changes the default to `None`, resolved to a fresh `MemoryConfig()` per call — behavior is otherwise identical.

Measured (M1 Mac, warm, best of 2): `import mem0` goes from **0.48 s (86 qdrant modules loaded)** to **0.20 s (0 qdrant modules)**. Configured-qdrant users load qdrant exactly as before, at config validation time.

Found while profiling import time in [MindRoom](https://github.com/mindroom-ai/mindroom), where mem0 (with chroma configured) was the largest remaining contributor to startup import cost.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A — `Memory()` / `AsyncMemory()` without arguments behave as before, except each instance now gets its own `MemoryConfig` instead of a shared one (which is the expected semantics).

## Test Coverage

- [x] I added/updated unit tests
- [x] I tested manually (describe below)

Added `tests/test_lazy_imports.py`: a subprocess probe asserting `import mem0` loads no `qdrant*` module. Ran `pytest tests/memory tests/configs` locally: 354 passed before and after (the new probe fails on `main`, passes here).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed