### PR TITLE
fix(pi-agent-plugin): tag global-scope adds so they stay searchable

### DIFF
--- a/integrations/pi-agent-plugin/src/memory/scoping.test.ts
+++ b/integrations/pi-agent-plugin/src/memory/scoping.test.ts
@@ -79,12 +79,21 @@ describe("resolveAddParams", () => {
     expect(resolveAddParams("session", ctx)).toEqual({ userId: "u1", appId: "a1", runId: "r1" });
   });
 
-  it("tags global scope with the reserved GLOBAL_APP_ID instead of leaving appId unset", () => {
+  it("tags global scope with the reserved sentinel appId instead of leaving appId unset", () => {
     // Regression test: resolveSearchFilters("global", ...) filters on app_id: "*",
     // which only matches non-null values. Writing without an appId would persist
     // app_id: null and make the memory permanently unreachable by that search —
     // see resolveSearchFilters's "global" test above for the read-side half.
-    expect(resolveAddParams("global", ctx)).toEqual({ userId: "u1", appId: GLOBAL_APP_ID });
+    //
+    // Assert the literal, not the imported GLOBAL_APP_ID: without the fix that
+    // import resolves to undefined, and toEqual treats an undefined-valued
+    // property as equal to a missing one — so asserting against the constant
+    // would pass against the very code this test exists to catch.
+    expect(resolveAddParams("global", ctx)).toEqual({ userId: "u1", appId: "__global__" });
+  });
+
+  it("exports the sentinel the global add path tags with", () => {
+    expect(GLOBAL_APP_ID).toBe("__global__");
   });
 });
 

--- a/integrations/pi-agent-plugin/src/memory/scoping.test.ts
+++ b/integrations/pi-agent-plugin/src/memory/scoping.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { detectRunId, resolveSearchFilters, resolveAddParams } from "./scoping.ts";
+import { detectRunId, resolveSearchFilters, resolveAddParams, GLOBAL_APP_ID } from "./scoping.ts";
 
 const mockExecFileSync = vi.fn();
 
@@ -79,7 +79,30 @@ describe("resolveAddParams", () => {
     expect(resolveAddParams("session", ctx)).toEqual({ userId: "u1", appId: "a1", runId: "r1" });
   });
 
-  it("only includes userId for global scope", () => {
-    expect(resolveAddParams("global", ctx)).toEqual({ userId: "u1" });
+  it("tags global scope with the reserved GLOBAL_APP_ID instead of leaving appId unset", () => {
+    // Regression test: resolveSearchFilters("global", ...) filters on app_id: "*",
+    // which only matches non-null values. Writing without an appId would persist
+    // app_id: null and make the memory permanently unreachable by that search —
+    // see resolveSearchFilters's "global" test above for the read-side half.
+    expect(resolveAddParams("global", ctx)).toEqual({ userId: "u1", appId: GLOBAL_APP_ID });
   });
+});
+
+describe("resolveAddParams / resolveSearchFilters scoping fields stay in sync", () => {
+  const ctx = { userId: "u1", appId: "a1", runId: "r1" };
+  const scopingFields: Record<string, string> = { userId: "user_id", appId: "app_id", runId: "run_id" };
+
+  for (const scope of ["project", "session", "global"] as const) {
+    it(`add sets every scoping field that search filters on for "${scope}" scope`, () => {
+      // A memory added under a given scope must be findable by a search under that
+      // same scope: search can't require a field (as a non-null match or wildcard)
+      // that the write never sets to a non-null value.
+      const addKeys = new Set(Object.keys(resolveAddParams(scope, ctx)));
+      const searchKeys = new Set(
+        Object.keys(resolveSearchFilters(scope, ctx)).map((k) => scopingFields[k] ?? k),
+      );
+      const addKeysNormalized = new Set([...addKeys].map((k) => scopingFields[k] ?? k));
+      expect(addKeysNormalized).toEqual(searchKeys);
+    });
+  }
 });

--- a/integrations/pi-agent-plugin/src/memory/scoping.ts
+++ b/integrations/pi-agent-plugin/src/memory/scoping.ts
@@ -36,6 +36,15 @@ export function resolveSearchFilters(
   }
 }
 
+// Reserved app_id for scope="global" adds. A memory written without an appId
+// gets app_id: null, but resolveSearchFilters("global") uses a "*" wildcard,
+// which only matches non-null values — so a null-tagged memory would never
+// surface in a global search. Tagging it with this sentinel instead keeps it
+// inside the wildcard's match set without widening what counts as "global"
+// on the read side (which already correctly covers every real project's
+// memories via the wildcard).
+export const GLOBAL_APP_ID = "__global__";
+
 export function resolveAddParams(
   scope: Scope,
   ctx: ScopeContext,
@@ -46,6 +55,6 @@ export function resolveAddParams(
     case "session":
       return { userId: ctx.userId, appId: ctx.appId, runId: ctx.runId };
     case "global":
-      return { userId: ctx.userId };
+      return { userId: ctx.userId, appId: GLOBAL_APP_ID };
   }
 }

--- a/integrations/pi-agent-plugin/tests/scoping.test.ts
+++ b/integrations/pi-agent-plugin/tests/scoping.test.ts
@@ -41,7 +41,13 @@ describe("resolveAddParams", () => {
     });
   });
 
-  it("global scope tags appId with the reserved GLOBAL_APP_ID sentinel", () => {
-    expect(resolveAddParams("global", ctx)).toEqual({ userId: "kartik", appId: GLOBAL_APP_ID });
+  it("global scope tags appId with the reserved sentinel", () => {
+    // Literal, not the imported GLOBAL_APP_ID — see src/memory/scoping.test.ts
+    // for why asserting against the constant would pass on the unfixed code.
+    expect(resolveAddParams("global", ctx)).toEqual({ userId: "kartik", appId: "__global__" });
+  });
+
+  it("exports the sentinel the global add path tags with", () => {
+    expect(GLOBAL_APP_ID).toBe("__global__");
   });
 });

--- a/integrations/pi-agent-plugin/tests/scoping.test.ts
+++ b/integrations/pi-agent-plugin/tests/scoping.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveAddParams, resolveSearchFilters } from "../src/memory/scoping.ts";
+import { resolveAddParams, resolveSearchFilters, GLOBAL_APP_ID } from "../src/memory/scoping.ts";
 import type { ScopeContext } from "../src/types.ts";
 
 const ctx: ScopeContext = {
@@ -41,7 +41,7 @@ describe("resolveAddParams", () => {
     });
   });
 
-  it("global scope returns userId only", () => {
-    expect(resolveAddParams("global", ctx)).toEqual({ userId: "kartik" });
+  it("global scope tags appId with the reserved GLOBAL_APP_ID sentinel", () => {
+    expect(resolveAddParams("global", ctx)).toEqual({ userId: "kartik", appId: GLOBAL_APP_ID });
   });
 });

--- a/integrations/pi-agent-plugin/tests/tools.test.ts
+++ b/integrations/pi-agent-plugin/tests/tools.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { buildToolExecute } from "../src/memory/tools.ts";
+import { GLOBAL_APP_ID } from "../src/memory/scoping.ts";
 import type { ScopeContext } from "../src/types.ts";
 
 const mockMem0 = {
@@ -44,6 +45,14 @@ describe("buildToolExecute", () => {
     expect(mockMem0.search).toHaveBeenCalledWith("preferences", {
       filters: { user_id: "testuser", app_id: "*" },
     });
+  });
+
+  it("add with scope=global tags appId with GLOBAL_APP_ID so it stays reachable by the global search wildcard", async () => {
+    mockMem0.add.mockResolvedValue([{ id: "new-id", memory: "test" }]);
+    await execute({ action: "add", content: "Cross-project preference", scope: "global" });
+    const call = mockMem0.add.mock.calls[mockMem0.add.mock.calls.length - 1];
+    expect(call[1].userId).toBe("testuser");
+    expect(call[1].appId).toBe(GLOBAL_APP_ID);
   });
 
   it("delete calls mem0.delete with full memory_id", async () => {

--- a/integrations/pi-agent-plugin/tests/tools.test.ts
+++ b/integrations/pi-agent-plugin/tests/tools.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
 import { buildToolExecute } from "../src/memory/tools.ts";
-import { GLOBAL_APP_ID } from "../src/memory/scoping.ts";
 import type { ScopeContext } from "../src/types.ts";
 
 const mockMem0 = {
@@ -47,12 +46,32 @@ describe("buildToolExecute", () => {
     });
   });
 
-  it("add with scope=global tags appId with GLOBAL_APP_ID so it stays reachable by the global search wildcard", async () => {
+  it("add with scope=global tags appId with the sentinel so it stays reachable by the global search wildcard", async () => {
     mockMem0.add.mockResolvedValue([{ id: "new-id", memory: "test" }]);
     await execute({ action: "add", content: "Cross-project preference", scope: "global" });
     const call = mockMem0.add.mock.calls[mockMem0.add.mock.calls.length - 1];
     expect(call[1].userId).toBe("testuser");
-    expect(call[1].appId).toBe(GLOBAL_APP_ID);
+    // Literal, not the imported GLOBAL_APP_ID: without the fix the import is
+    // undefined and so is call[1].appId, so toBe(GLOBAL_APP_ID) would pass on
+    // exactly the code this test guards against.
+    expect(call[1].appId).toBe("__global__");
+  });
+
+  it("delete_all with scope=global scopes the delete to the sentinel, not the user's whole memory set", async () => {
+    // The more severe half of the same bug: delete_all reuses resolveAddParams
+    // as its filter, and deleteAll() hits DELETE /v1/memories/ with raw query
+    // params — no implicit null-scoping. Untagged, the filter degrades to
+    // { userId } alone, which wipes every memory the user has in every project
+    // and session, not just the global-scoped ones.
+    mockMem0.deleteAll.mockResolvedValue({ message: "deleted" });
+    await execute({ action: "delete_all", scope: "global" });
+    expect(mockMem0.deleteAll).toHaveBeenCalledWith({ userId: "testuser", appId: "__global__" });
+  });
+
+  it("delete_all with scope=project stays scoped to the current project", async () => {
+    mockMem0.deleteAll.mockResolvedValue({ message: "deleted" });
+    await execute({ action: "delete_all", scope: "project" });
+    expect(mockMem0.deleteAll).toHaveBeenCalledWith({ userId: "testuser", appId: "testproject" });
   });
 
   it("delete calls mem0.delete with full memory_id", async () => {


### PR DESCRIPTION
## Linked Issue

Closes #6168

## Description

`resolveAddParams("global", ctx)` in `integrations/pi-agent-plugin/src/memory/scoping.ts` wrote memories with no `appId`, persisting `app_id: null`. `resolveSearchFilters("global", ctx)` searches with `app_id: "*"`, which per mem0's documented wildcard semantics only matches non-null values. So any memory added under `scope: "global"` was permanently unreachable by `search`/`get_all`, in any scope — a silent, no-error data-loss-equivalent bug.

`delete_all` under global scope reuses the same `resolveAddParams` output as its filter. Since `deleteAll()` hits the plain `DELETE /v1/memories/` REST endpoint (raw query params, no implicit-null-scoping — that behavior only exists in the `/v3/memories/search/` filter engine), the pre-fix `{ userId }`-only filter would delete **every memory the user has, across all projects and sessions**, not just global-scoped ones, whenever a user cleared memories while in global scope.

## Fix

Tag `scope: "global"` adds with a reserved sentinel `appId` (`GLOBAL_APP_ID = "__global__"`) instead of leaving it unset:

```ts
case "global":
  return { userId: ctx.userId, appId: GLOBAL_APP_ID };
```

This keeps the memory inside the *existing* global-search wildcard's match set. I deliberately left `resolveSearchFilters("global", ...)` untouched — it already correctly returns every real project's memories via the `"*"` wildcard (matches the README's documented "All memories across all your projects" behavior for project/session-scoped data), so narrowing it to drop the wildcard would have broken that working case just to fix the global-add case. Tagging the write side was the narrower, non-regressive fix.

As a side effect, `delete_all(global)` now filters on `{ userId, appId: GLOBAL_APP_ID }`, correctly scoping it to just the memories added under global scope instead of the previous unconstrained delete.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A — `GLOBAL_APP_ID` is a new internal sentinel value; no public API changes. Existing global-scope memories already written with `app_id: null` before this fix won't retroactively pick up the tag (pre-existing null-tagged records stay unreachable, same as today); only new adds after this fix benefit.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Updated `src/memory/scoping.test.ts` and the (pre-existing, duplicate) `tests/scoping.test.ts` / `tests/tools.test.ts` to assert the new sentinel-tagged behavior, and added a symmetry check (`resolveAddParams` / `resolveSearchFilters` scoping fields stay in sync`) across all three scopes so this asymmetry class can't silently regress again. Full suite: 104/104 passing. `tsc --noEmit` clean. `tsup` build succeeds.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (n/a — internal sentinel, no public-facing docs to update)