### PR TITLE
fix(ts-oss): preserve filter entity ids without inference

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -748,6 +748,23 @@ export class Memory {
       metadata.expiration_date = normalizeExpirationDate(config.expirationDate);
     }
 
+    const filterUserId = validateAndTrimEntityId(
+      filters.user_id,
+      "filters.user_id",
+    );
+    const filterAgentId = validateAndTrimEntityId(
+      filters.agent_id,
+      "filters.agent_id",
+    );
+    const filterRunId = validateAndTrimEntityId(
+      filters.run_id,
+      "filters.run_id",
+    );
+
+    if (filterUserId) filters.user_id = metadata.user_id = filterUserId;
+    if (filterAgentId) filters.agent_id = metadata.agent_id = filterAgentId;
+    if (filterRunId) filters.run_id = metadata.run_id = filterRunId;
+
     if (!filters.user_id && !filters.agent_id && !filters.run_id) {
       throw new Error(
         "One of the filters: userId, agentId or runId is required!",

--- a/mem0-ts/src/oss/tests/memory.add.test.ts
+++ b/mem0-ts/src/oss/tests/memory.add.test.ts
@@ -182,6 +182,76 @@ describe("Memory - add()", () => {
     expect(result.results[0].memory).toBe("Direct storage content");
   });
 
+  test("with infer=false stores and trims user_id passed through filters", async () => {
+    const filteredUserId = `filter_user_${Date.now()}`;
+    const result: SearchResult = await memory.add(
+      "User filter scoped content",
+      {
+        filters: { user_id: `  ${filteredUserId}  ` },
+        infer: false,
+      },
+    );
+
+    const stored: MemoryItem | null = await memory.get(result.results[0].id);
+    expect(stored).not.toBeNull();
+    expect(stored!.metadata).toEqual(
+      expect.objectContaining({ user_id: filteredUserId }),
+    );
+
+    const scopedResults = await memory.getAll({
+      filters: { user_id: filteredUserId },
+    });
+    expect(scopedResults.results.map((item) => item.id)).toContain(
+      result.results[0].id,
+    );
+  });
+
+  test("with infer=false stores agent_id passed through filters", async () => {
+    const filteredAgentId = `filter_agent_${Date.now()}`;
+    const result: SearchResult = await memory.add(
+      "Agent filter scoped content",
+      {
+        filters: { agent_id: filteredAgentId },
+        infer: false,
+      },
+    );
+
+    const stored: MemoryItem | null = await memory.get(result.results[0].id);
+    expect(stored!.metadata).toEqual(
+      expect.objectContaining({ agent_id: filteredAgentId }),
+    );
+  });
+
+  test("with infer=false stores run_id passed through filters", async () => {
+    const filteredRunId = `filter_run_${Date.now()}`;
+    const result: SearchResult = await memory.add("Run filter scoped content", {
+      filters: { run_id: filteredRunId },
+      infer: false,
+    });
+
+    const stored: MemoryItem | null = await memory.get(result.results[0].id);
+    expect(stored!.metadata).toEqual(
+      expect.objectContaining({ run_id: filteredRunId }),
+    );
+  });
+
+  test("top-level userId takes precedence over filters.user_id", async () => {
+    const explicitUserId = `explicit_user_${Date.now()}`;
+    const result: SearchResult = await memory.add(
+      "Explicit user scoped content",
+      {
+        userId: explicitUserId,
+        filters: { user_id: `filter_user_${Date.now()}` },
+        infer: false,
+      },
+    );
+
+    const stored: MemoryItem | null = await memory.get(result.results[0].id);
+    expect(stored!.metadata).toEqual(
+      expect.objectContaining({ user_id: explicitUserId }),
+    );
+  });
+
   test("with infer=false marks event as ADD in metadata", async () => {
     const result: SearchResult = await memory.add("Direct fact", {
       userId,


### PR DESCRIPTION
## Linked Issue

Closes #6170

## Description

When `Memory.add()` receives entity IDs through `filters`, the IDs scope the operation but were not copied into stored metadata. This was especially visible with `infer: false`: the memory was created without the entity metadata expected by subsequent filtered retrieval.

This change validates and trims `filters.user_id`, `filters.agent_id`, and `filters.run_id`, then stores the normalized IDs in metadata consistently with the existing top-level `userId`, `agentId`, and `runId` options.

Top-level entity ID options continue to take precedence when both forms are provided.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] Added regression coverage for `user_id`, `agent_id`, and `run_id` supplied through filters
- [x] Verified leading/trailing whitespace is trimmed
- [x] Verified top-level `userId` takes precedence over `filters.user_id`

Commands run locally:

- `pnpm exec prettier --check src/oss/src/memory/index.ts src/oss/tests/memory.add.test.ts` - passed
- `pnpm exec jest src/oss/tests/memory.add.test.ts --runInBand` - passed, 15/15 tests
- `pnpm run build` - passed, including Prettier, CJS/ESM builds, and declaration generation
- `pnpm exec tsc --noEmit` - blocked by existing project-wide Jest global and community LangChain type-resolution errors; no errors referenced the changed files

## Checklist

- [x] My code follows the project style guidelines
- [x] I performed a self-review
- [x] I added tests that prove the fix works
- [x] The targeted tests and package build pass locally
- [x] Documentation is not required for this consistency fix