### PR TITLE
docs: add TokenLab OSS configuration example

### DIFF
--- a/docs/open-source/configuration.mdx
+++ b/docs/open-source/configuration.mdx
@@ -93,6 +93,33 @@ export OPENAI_API_KEY="..."
 export COHERE_API_KEY="..."   # Python reranker only
 ```
 
+### OpenAI-compatible providers
+
+For OpenAI-compatible LLM providers, keep the `openai` provider and set
+`openai_base_url` in the LLM config. For example, TokenLab can be used with its
+OpenAI-compatible `/v1` endpoint:
+
+```python
+from mem0 import Memory
+
+config = {
+    "llm": {
+        "provider": "openai",
+        "config": {
+            "model": "claude-sonnet-5",
+            "api_key": "your-tokenlab-api-key",
+            "openai_base_url": "https://api.tokenlab.sh/v1",
+        },
+    },
+    "vector_store": {
+        "provider": "qdrant",
+        "config": {"host": "localhost", "port": 6333},
+    },
+}
+
+memory = Memory.from_config(config)
+```
+
 <Note>
   The TypeScript OSS SDK configures the LLM, embedder, vector store, and history store. Reranker and graph memory are Python-only today.
 </Note>


### PR DESCRIPTION
## Summary
- Document TokenLab as an OpenAI-compatible Mem0 OSS LLM configuration.
- Use TokenLab's OpenAI-compatible base URL: https://api.tokenlab.sh/v1
- No runtime behavior changes; documentation only.

## Verification
- git diff --check


---

Supersedes #6162. The previous PR was closed while fixing contributor commit metadata; this replacement branch preserves the same scoped diff with commits authored by `hedging8563 <45883076+hedging8563@users.noreply.github.com>`.
