### PR TITLE
fix(memory): guard remove_code_blocks against None content

### DIFF
--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -120,7 +120,10 @@ def remove_code_blocks(content: str) -> str:
     - The function uses a regex pattern to match code blocks that may start with ``` followed by an optional language tag (letters or numbers) and end with ```.
     - If a code block is detected, it returns only the inner content, stripping out the markers.
     - If no code block markers are found, the original content is returned as-is.
+    - Returns None unchanged when content is None (e.g. safety-refusal responses).
     """
+    if content is None:
+        return content
     pattern = r"^```[a-zA-Z0-9]*\n([\s\S]*?)\n```$"
     match = re.match(pattern, content.strip())
     match_res=match.group(1).strip() if match else content.strip()


### PR DESCRIPTION
## Summary
- `remove_code_blocks` called `content.strip()` unconditionally, raising `AttributeError` when `content` is `None`.
- This is reachable via `Memory.add(messages, memory_type="procedural_memory")` when the model returns a safety-refusal (None) response.
- Early-return `None` unchanged when `content is None`.

## Test plan
- [ ] `pytest tests/` passes
- [ ] Manual: `Memory.add([...], memory_type="procedural_memory")` with a None content does not raise

Closes #6150