### PR TITLE
Update MiniMax default model to MiniMax-M3

### DIFF
--- a/docs/components/llms/models/minimax.mdx
+++ b/docs/components/llms/models/minimax.mdx
@@ -3,7 +3,7 @@ title: MiniMax
 description: "Configure MiniMax as an LLM provider in Mem0 with API key setup and optional custom endpoint configuration."
 ---
 
-To use MiniMax LLM models, you have to set the `MINIMAX_API_KEY` environment variable. You can also optionally set `MINIMAX_API_BASE` if you need to use a different API endpoint (defaults to "https://api.minimax.io/v1").
+The `minimax` provider uses MiniMax's OpenAI-compatible API. Set the `MINIMAX_API_KEY` environment variable before using it. You can also set `MINIMAX_API_BASE` to override the API endpoint; it defaults to `https://api.minimax.io/v1`.
 
 ## Usage
 
@@ -19,7 +19,7 @@ config = {
     "llm": {
         "provider": "minimax",
         "config": {
-            "model": "MiniMax-M2.7",  # default model
+            "model": "MiniMax-M3",  # default model
             "temperature": 0.2,
             "max_tokens": 2000,
             "top_p": 1.0
@@ -45,7 +45,7 @@ const config = {
     provider: 'minimax',
     config: {
       apiKey: process.env.MINIMAX_API_KEY || '',
-      model: 'MiniMax-M2.7',
+      model: 'MiniMax-M3',
       temperature: 0.2,
       maxTokens: 2000,
       topP: 1.0,
@@ -64,7 +64,16 @@ await memory.add(messages, { userId: 'alice', metadata: { category: 'movies' } }
 
 </CodeGroup>
 
-You can also configure the API base URL in the config:
+## Endpoint configuration
+
+| Protocol | Mem0 provider | Global | Mainland China |
+| :-- | :-- | :-- | :-- |
+| OpenAI-compatible | `minimax` | `https://api.minimax.io/v1` | `https://api.minimaxi.com/v1` |
+| Anthropic-compatible | `anthropic` | `https://api.minimax.io/anthropic` | `https://api.minimaxi.com/anthropic` |
+
+The `anthropic` provider calls the SDK's Messages client, which appends `/v1/messages`. Keep its base URL at `/anthropic` so the final global request URL is `https://api.minimax.io/anthropic/v1/messages`.
+
+Configure an OpenAI-compatible endpoint directly on the `minimax` provider:
 
 <CodeGroup>
 ```python Python
@@ -73,7 +82,7 @@ config = {
         "provider": "minimax",
         "config": {
             "model": "MiniMax-M2.7",
-            "minimax_base_url": "https://your-custom-endpoint.com",
+            "minimax_base_url": "https://api.minimaxi.com/v1",
             "api_key": "your-api-key"  # alternatively to using environment variable
         }
     }
@@ -86,8 +95,38 @@ const config = {
     provider: 'minimax',
     config: {
       model: 'MiniMax-M2.7',
-      baseURL: 'https://your-custom-endpoint.com',
+      baseURL: 'https://api.minimaxi.com/v1',
       apiKey: 'your-api-key', // alternatively to using the environment variable
+    },
+  },
+};
+```
+</CodeGroup>
+
+For the Anthropic-compatible protocol, use the `anthropic` provider with the SDK base URL:
+
+<CodeGroup>
+```python Python
+config = {
+    "llm": {
+        "provider": "anthropic",
+        "config": {
+            "model": "MiniMax-M3",
+            "anthropic_base_url": "https://api.minimax.io/anthropic",
+            "api_key": "your-api-key"
+        }
+    }
+}
+```
+
+```typescript TypeScript
+const config = {
+  llm: {
+    provider: 'anthropic',
+    config: {
+      model: 'MiniMax-M3',
+      baseURL: 'https://api.minimax.io/anthropic',
+      apiKey: 'your-api-key',
     },
   },
 };

--- a/mem0-ts/src/oss/src/llms/minimax.ts
+++ b/mem0-ts/src/oss/src/llms/minimax.ts
@@ -15,7 +15,7 @@ export class MiniMaxLLM extends OpenAILLM {
         config.baseURL ||
         process.env.MINIMAX_API_BASE ||
         "https://api.minimax.io/v1",
-      model: config.model || "MiniMax-M2.7",
+      model: config.model || "MiniMax-M3",
     });
   }
 

--- a/mem0-ts/src/oss/tests/minimax.test.ts
+++ b/mem0-ts/src/oss/tests/minimax.test.ts
@@ -57,13 +57,37 @@ describe("MiniMaxLLM (unit)", () => {
     new MiniMaxLLM({
       apiKey: "config-key",
       baseURL: "https://config.minimax.test/v1",
-      model: "MiniMax-M1",
+      model: "MiniMax-M2.7",
     });
 
     expect(capturedConstructorArgs).toMatchObject({
       apiKey: "config-key",
       baseURL: "https://config.minimax.test/v1",
     });
+  });
+
+  it("preserves an explicit MiniMax-M2.7 model", async () => {
+    mockCreate.mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            content: "Hello from MiniMax",
+            role: "assistant",
+            tool_calls: null,
+          },
+        },
+      ],
+    });
+
+    const llm = new MiniMaxLLM({
+      apiKey: "test-key",
+      model: "MiniMax-M2.7",
+    });
+    await llm.generateResponse([{ role: "user", content: "Hi" }]);
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "MiniMax-M2.7" }),
+    );
   });
 
   it("generateResponse() returns a text response", async () => {

--- a/mem0-ts/src/oss/tests/minimax.test.ts
+++ b/mem0-ts/src/oss/tests/minimax.test.ts
@@ -85,7 +85,7 @@ describe("MiniMaxLLM (unit)", () => {
     ]);
 
     expect(mockCreate).toHaveBeenCalledWith(
-      expect.objectContaining({ model: "MiniMax-M2.7" }),
+      expect.objectContaining({ model: "MiniMax-M3" }),
     );
     expect(result).toBe("Hello from MiniMax");
   });

--- a/mem0/llms/minimax.py
+++ b/mem0/llms/minimax.py
@@ -34,7 +34,7 @@ class MiniMaxLLM(LLMBase):
         super().__init__(config)
 
         if not self.config.model:
-            self.config.model = "MiniMax-M2.7"
+            self.config.model = "MiniMax-M3"
 
         api_key = self.config.api_key or os.getenv("MINIMAX_API_KEY")
         base_url = (

--- a/tests/llms/test_minimax.py
+++ b/tests/llms/test_minimax.py
@@ -20,7 +20,7 @@ def mock_minimax_client():
 def test_minimax_llm_default_base_url():
     """Default config uses MiniMax official base URL."""
     config = BaseLlmConfig(
-        model="MiniMax-M3", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key"
+        model="MiniMax-M2.7", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key"
     )
     llm = MiniMaxLLM(config)
     # OpenAI client may normalize URL with trailing slash
@@ -33,7 +33,7 @@ def test_minimax_llm_env_base_url():
     os.environ["MINIMAX_API_BASE"] = provider_base_url
     try:
         config = MinimaxConfig(
-            model="MiniMax-M3",
+            model="MiniMax-M2.7",
             temperature=0.7,
             max_tokens=100,
             top_p=1.0,
@@ -49,7 +49,7 @@ def test_minimax_llm_config_base_url():
     """Config uses minimax_base_url when provided."""
     config_base_url = "https://api.config.com/v1/"
     config = MinimaxConfig(
-        model="MiniMax-M3",
+        model="MiniMax-M2.7",
         temperature=0.7,
         max_tokens=100,
         top_p=1.0,
@@ -74,7 +74,7 @@ def test_minimax_llm_env_api_key():
         with patch("mem0.llms.minimax.OpenAI") as mock_openai:
             mock_client = Mock()
             mock_openai.return_value = mock_client
-            config = MinimaxConfig(model="MiniMax-M3", api_key=None)
+            config = MinimaxConfig(model="MiniMax-M2.7", api_key=None)
             MiniMaxLLM(config)
             mock_openai.assert_called_once_with(
                 api_key="env-api-key",
@@ -87,7 +87,7 @@ def test_minimax_llm_env_api_key():
 def test_generate_response_without_tools(mock_minimax_client):
     """generate_response returns text when no tools provided."""
     config = BaseLlmConfig(
-        model="MiniMax-M3", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key"
+        model="MiniMax-M2.7", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key"
     )
     llm = MiniMaxLLM(config)
     messages = [
@@ -102,7 +102,7 @@ def test_generate_response_without_tools(mock_minimax_client):
     response = llm.generate_response(messages)
 
     mock_minimax_client.chat.completions.create.assert_called_once_with(
-        model="MiniMax-M3", messages=messages, temperature=0.7, max_tokens=100, top_p=1.0
+        model="MiniMax-M2.7", messages=messages, temperature=0.7, max_tokens=100, top_p=1.0
     )
     assert response == "I'm doing well, thank you for asking!"
 
@@ -110,7 +110,7 @@ def test_generate_response_without_tools(mock_minimax_client):
 def test_generate_response_with_tools(mock_minimax_client):
     """generate_response returns tool_calls when tools provided."""
     config = BaseLlmConfig(
-        model="MiniMax-M3", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key"
+        model="MiniMax-M2.7", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key"
     )
     llm = MiniMaxLLM(config)
     messages = [
@@ -147,7 +147,7 @@ def test_generate_response_with_tools(mock_minimax_client):
     response = llm.generate_response(messages, tools=tools)
 
     mock_minimax_client.chat.completions.create.assert_called_once_with(
-        model="MiniMax-M3",
+        model="MiniMax-M2.7",
         messages=messages,
         temperature=0.7,
         max_tokens=100,
@@ -165,7 +165,7 @@ def test_generate_response_with_tools(mock_minimax_client):
 def test_generate_response_with_response_format(mock_minimax_client):
     """generate_response passes response_format to the API."""
     config = BaseLlmConfig(
-        model="MiniMax-M3", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key"
+        model="MiniMax-M2.7", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key"
     )
     llm = MiniMaxLLM(config)
     messages = [{"role": "user", "content": "Return JSON."}]
@@ -178,7 +178,7 @@ def test_generate_response_with_response_format(mock_minimax_client):
     llm.generate_response(messages, response_format=response_format)
 
     mock_minimax_client.chat.completions.create.assert_called_once_with(
-        model="MiniMax-M3",
+        model="MiniMax-M2.7",
         messages=messages,
         temperature=0.7,
         max_tokens=100,
@@ -189,6 +189,6 @@ def test_generate_response_with_response_format(mock_minimax_client):
 
 def test_factory_creates_minimax_llm(mock_minimax_client):
     """LlmFactory.create returns MiniMaxLLM for provider 'minimax'."""
-    llm = LlmFactory.create("minimax", {"model": "MiniMax-M3", "api_key": "test-key"})
+    llm = LlmFactory.create("minimax", {"model": "MiniMax-M2.7", "api_key": "test-key"})
     assert isinstance(llm, MiniMaxLLM)
-    assert llm.config.model == "MiniMax-M3"
+    assert llm.config.model == "MiniMax-M2.7"

--- a/tests/llms/test_minimax.py
+++ b/tests/llms/test_minimax.py
@@ -20,7 +20,7 @@ def mock_minimax_client():
 def test_minimax_llm_default_base_url():
     """Default config uses MiniMax official base URL."""
     config = BaseLlmConfig(
-        model="MiniMax-M2.7", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key"
+        model="MiniMax-M3", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key"
     )
     llm = MiniMaxLLM(config)
     # OpenAI client may normalize URL with trailing slash
@@ -33,7 +33,7 @@ def test_minimax_llm_env_base_url():
     os.environ["MINIMAX_API_BASE"] = provider_base_url
     try:
         config = MinimaxConfig(
-            model="MiniMax-M2.7",
+            model="MiniMax-M3",
             temperature=0.7,
             max_tokens=100,
             top_p=1.0,
@@ -49,7 +49,7 @@ def test_minimax_llm_config_base_url():
     """Config uses minimax_base_url when provided."""
     config_base_url = "https://api.config.com/v1/"
     config = MinimaxConfig(
-        model="MiniMax-M2.7",
+        model="MiniMax-M3",
         temperature=0.7,
         max_tokens=100,
         top_p=1.0,
@@ -61,10 +61,10 @@ def test_minimax_llm_config_base_url():
 
 
 def test_minimax_llm_default_model(mock_minimax_client):
-    """Default model is MiniMax-M2.7 when not specified."""
+    """Default model is MiniMax-M3 when not specified."""
     config = MinimaxConfig(temperature=0.7, max_tokens=100, api_key="api_key")
     llm = MiniMaxLLM(config)
-    assert llm.config.model == "MiniMax-M2.7"
+    assert llm.config.model == "MiniMax-M3"
 
 
 def test_minimax_llm_env_api_key():
@@ -74,7 +74,7 @@ def test_minimax_llm_env_api_key():
         with patch("mem0.llms.minimax.OpenAI") as mock_openai:
             mock_client = Mock()
             mock_openai.return_value = mock_client
-            config = MinimaxConfig(model="MiniMax-M2.7", api_key=None)
+            config = MinimaxConfig(model="MiniMax-M3", api_key=None)
             MiniMaxLLM(config)
             mock_openai.assert_called_once_with(
                 api_key="env-api-key",
@@ -87,7 +87,7 @@ def test_minimax_llm_env_api_key():
 def test_generate_response_without_tools(mock_minimax_client):
     """generate_response returns text when no tools provided."""
     config = BaseLlmConfig(
-        model="MiniMax-M2.7", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key"
+        model="MiniMax-M3", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key"
     )
     llm = MiniMaxLLM(config)
     messages = [
@@ -102,7 +102,7 @@ def test_generate_response_without_tools(mock_minimax_client):
     response = llm.generate_response(messages)
 
     mock_minimax_client.chat.completions.create.assert_called_once_with(
-        model="MiniMax-M2.7", messages=messages, temperature=0.7, max_tokens=100, top_p=1.0
+        model="MiniMax-M3", messages=messages, temperature=0.7, max_tokens=100, top_p=1.0
     )
     assert response == "I'm doing well, thank you for asking!"
 
@@ -110,7 +110,7 @@ def test_generate_response_without_tools(mock_minimax_client):
 def test_generate_response_with_tools(mock_minimax_client):
     """generate_response returns tool_calls when tools provided."""
     config = BaseLlmConfig(
-        model="MiniMax-M2.7", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key"
+        model="MiniMax-M3", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key"
     )
     llm = MiniMaxLLM(config)
     messages = [
@@ -147,7 +147,7 @@ def test_generate_response_with_tools(mock_minimax_client):
     response = llm.generate_response(messages, tools=tools)
 
     mock_minimax_client.chat.completions.create.assert_called_once_with(
-        model="MiniMax-M2.7",
+        model="MiniMax-M3",
         messages=messages,
         temperature=0.7,
         max_tokens=100,
@@ -165,7 +165,7 @@ def test_generate_response_with_tools(mock_minimax_client):
 def test_generate_response_with_response_format(mock_minimax_client):
     """generate_response passes response_format to the API."""
     config = BaseLlmConfig(
-        model="MiniMax-M2.7", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key"
+        model="MiniMax-M3", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key"
     )
     llm = MiniMaxLLM(config)
     messages = [{"role": "user", "content": "Return JSON."}]
@@ -178,7 +178,7 @@ def test_generate_response_with_response_format(mock_minimax_client):
     llm.generate_response(messages, response_format=response_format)
 
     mock_minimax_client.chat.completions.create.assert_called_once_with(
-        model="MiniMax-M2.7",
+        model="MiniMax-M3",
         messages=messages,
         temperature=0.7,
         max_tokens=100,
@@ -189,6 +189,6 @@ def test_generate_response_with_response_format(mock_minimax_client):
 
 def test_factory_creates_minimax_llm(mock_minimax_client):
     """LlmFactory.create returns MiniMaxLLM for provider 'minimax'."""
-    llm = LlmFactory.create("minimax", {"model": "MiniMax-M2.7", "api_key": "test-key"})
+    llm = LlmFactory.create("minimax", {"model": "MiniMax-M3", "api_key": "test-key"})
     assert isinstance(llm, MiniMaxLLM)
-    assert llm.config.model == "MiniMax-M2.7"
+    assert llm.config.model == "MiniMax-M3"


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

## Summary
- Update the Python MiniMax LLM default model to `MiniMax-M3`.
- Update the TypeScript MiniMax LLM default model to `MiniMax-M3`.
- Refresh MiniMax unit test expectations for the new default model.

## Test plan
- `python3 -m pytest /root/octopatch-4/work/repos/mem0ai_mem0/tests/llms/test_minimax.py` (fails: pytest is not installed in the environment)
- `cd /root/octopatch-4/work/repos/mem0ai_mem0/mem0-ts && npm test -- minimax.test.ts` (fails: jest is not installed in the environment)
- `git diff --check`
- Secret scan on changed diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)