### PR TITLE
fix(ts-oss): mirror entity ids from filters into metadata for infer:false path

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -713,6 +713,12 @@ export class Memory {
     if (agentId) filters.agent_id = metadata.agent_id = agentId;
     if (runId) filters.run_id = metadata.run_id = runId;
 
+    // Ensure entity IDs already in filters (passed directly via config.filters)
+    // are also mirrored into metadata so the infer:false path persists them.
+    if (filters.user_id && !metadata.user_id) metadata.user_id = filters.user_id;
+    if (filters.agent_id && !metadata.agent_id) metadata.agent_id = filters.agent_id;
+    if (filters.run_id && !metadata.run_id) metadata.run_id = filters.run_id;
+
     if (!filters.user_id && !filters.agent_id && !filters.run_id) {
       throw new Error(
         "One of the filters: userId, agentId or runId is required!",

--- a/mem0-ts/src/oss/tests/memory.add.test.ts
+++ b/mem0-ts/src/oss/tests/memory.add.test.ts
@@ -8,6 +8,10 @@ import type { MemoryConfig, MemoryItem, SearchResult } from "../src/types";
 
 jest.setTimeout(15000);
 
+// Mock vector store dependencies that fail in CI
+jest.mock("mysql2/promise", () => ({ createPool: jest.fn() }), { virtual: true });
+jest.mock("weaviate-client", () => ({}), { virtual: true });
+
 // Mock Google modules to prevent @google/genai crash in CI
 jest.mock("../src/embeddings/google", () => ({
   GoogleEmbedder: jest.fn(),
@@ -190,5 +194,38 @@ describe("Memory - add()", () => {
     expect(result.results[0].metadata).toEqual(
       expect.objectContaining({ event: "ADD" }),
     );
+  });
+
+  test("infer=false with filters.user_id stores user_id in payload and is retrievable", async () => {
+    const uid = `infer_false_filters_${Date.now()}`;
+    const result: SearchResult = await memory.add("Filtered entity test", {
+      filters: { user_id: uid },
+      infer: false,
+    });
+    const stored: MemoryItem | null = await memory.get(result.results[0].id);
+    expect(stored).not.toBeNull();
+    expect(stored!.user_id).toBe(uid);
+  });
+
+  test("infer=false with filters.agent_id stores agent_id in payload and is retrievable", async () => {
+    const aid = `agent_infer_false_${Date.now()}`;
+    const result: SearchResult = await memory.add("Agent scoped memory", {
+      filters: { agent_id: aid },
+      infer: false,
+    });
+    const stored: MemoryItem | null = await memory.get(result.results[0].id);
+    expect(stored).not.toBeNull();
+    expect(stored!.agent_id).toBe(aid);
+  });
+
+  test("infer=false with filters.run_id stores run_id in payload and is retrievable", async () => {
+    const rid = `run_infer_false_${Date.now()}`;
+    const result: SearchResult = await memory.add("Run scoped memory", {
+      filters: { run_id: rid },
+      infer: false,
+    });
+    const stored: MemoryItem | null = await memory.get(result.results[0].id);
+    expect(stored).not.toBeNull();
+    expect(stored!.run_id).toBe(rid);
   });
 });


### PR DESCRIPTION
## Description

When `add()` is called with `infer:false`, entity IDs (`user_id`/`agent_id`/`run_id`) passed via the `filters` option were silently dropped. Only the top-level `userId`/`agentId`/`runId` fields were copied into `metadata`. Since the `infer:false` path in `addToVectorStore()` only passes `metadata` to `createMemory()`, the entity IDs were never persisted, making the memory unretrievable via `getAll()`/`search()`.

The `infer:true` path did not have this problem because it writes `filters.user_id`/etc. directly into the memory payload.

## Fix

After copying top-level entity params into both `filters` and `metadata`, also mirror any entity IDs already present in `filters` (from direct `config.filters`) into `metadata` if not already set. This ensures both input paths produce the same stored payload.

## Testing

All 95 existing tests pass (5 pre-existing FAIL suites are due to missing optional dependency `mysql2/promise`).

Fixes #6170