### PR TITLE
fix(proxy): pass entity ids via filters and read search results key

### DIFF
--- a/mem0/proxy/main.py
+++ b/mem0/proxy/main.py
@@ -6,8 +6,6 @@ from typing import List, Optional, Union
 
 import httpx
 
-import mem0
-
 try:
     import litellm
 except ImportError:
@@ -169,23 +167,37 @@ class Completions:
         # Currently, only pass the last 6 messages to the search API to prevent long query
         message_input = [f"{message['role']}: {message['content']}" for message in messages][-6:]
         # TODO: Make it better by summarizing the past conversation
+        # Both Memory.search and MemoryClient.search reject top-level entity params and
+        # require them inside `filters` (see #4907).
+        search_filters = dict(filters) if filters else {}
+        if user_id:
+            search_filters["user_id"] = user_id
+        if agent_id:
+            search_filters["agent_id"] = agent_id
+        if run_id:
+            search_filters["run_id"] = run_id
         return self.mem0_client.search(
             query="\n".join(message_input),
-            user_id=user_id,
-            agent_id=agent_id,
-            run_id=run_id,
-            filters=filters,
+            filters=search_filters,
             top_k=top_k,
         )
 
     def _format_query_with_memories(self, messages, relevant_memories):
-        # Check if self.mem0_client is an instance of Memory or MemoryClient
-
-        entities = []
-        if isinstance(self.mem0_client, mem0.memory.main.Memory):
-            memories_text = "\n".join(memory["memory"] for memory in relevant_memories["results"])
-            if relevant_memories.get("relations"):
-                entities = [entity for entity in relevant_memories["relations"]]
-        elif isinstance(self.mem0_client, mem0.client.main.MemoryClient):
-            memories_text = "\n".join(memory["memory"] for memory in relevant_memories)
-        return f"- Relevant Memories/Facts: {memories_text}\n\n- Entities: {entities}\n\n- User Question: {messages[-1]['content']}"
+        # Both Memory and MemoryClient return {"results": [...], "relations": [...]}.
+        # Avoid iterating a raw dict (which yields keys) or requiring a package import for
+        # isinstance checks — use the shared response shape instead.
+        if isinstance(relevant_memories, dict):
+            memories_list = relevant_memories.get("results") or []
+            entities = relevant_memories.get("relations") or []
+        else:
+            memories_list = relevant_memories or []
+            entities = []
+        memories_text = "\n".join(
+            memory.get("memory", "") if isinstance(memory, dict) else str(memory)
+            for memory in memories_list
+        )
+        return (
+            f"- Relevant Memories/Facts: {memories_text}\n\n"
+            f"- Entities: {entities}\n\n"
+            f"- User Question: {messages[-1]['content']}"
+        )

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -65,7 +65,7 @@ def test_completions_create(mock_memory_client, mock_litellm):
     completions = Completions(mock_memory_client)
 
     messages = [{"role": "user", "content": "Hello, how are you?"}]
-    mock_memory_client.search.return_value = [{"memory": "Some relevant memory"}]
+    mock_memory_client.search.return_value = {"results": [{"memory": "Some relevant memory"}]}
     mock_litellm.completion.return_value = {"choices": [{"message": {"content": "I'm doing well, thank you!"}}]}
     mock_litellm.supports_function_calling.return_value = True
 
@@ -90,7 +90,7 @@ def test_completions_create_with_system_message(mock_memory_client, mock_litellm
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "Hello, how are you?"},
     ]
-    mock_memory_client.search.return_value = [{"memory": "Some relevant memory"}]
+    mock_memory_client.search.return_value = {"results": [{"memory": "Some relevant memory"}]}
     mock_litellm.completion.return_value = {"choices": [{"message": {"content": "I'm doing well, thank you!"}}]}
     mock_litellm.supports_function_calling.return_value = True
 
@@ -138,3 +138,65 @@ def test_completions_create_messages_default_does_not_leak_between_calls(mock_me
         f"Completions.create(messages=...) must default to None to avoid the "
         f"B006 shared-default-list bug; got {messages_default!r}."
     )
+
+
+def test_fetch_relevant_memories_puts_entity_ids_in_filters(mock_memory_client):
+    """Proxy search must pass entity ids inside `filters`, not as top-level kwargs (#4907)."""
+    completions = Completions(mock_memory_client)
+    messages = [{"role": "user", "content": "Hello"}]
+    mock_memory_client.search.return_value = {"results": [{"memory": "User likes pizza"}]}
+
+    completions._fetch_relevant_memories(
+        messages=messages,
+        user_id="alice",
+        agent_id="bot_1",
+        run_id="run_9",
+        filters={"environment": "prod"},
+        top_k=5,
+    )
+
+    kwargs = mock_memory_client.search.call_args.kwargs
+    assert kwargs["filters"]["user_id"] == "alice"
+    assert kwargs["filters"]["agent_id"] == "bot_1"
+    assert kwargs["filters"]["run_id"] == "run_9"
+    assert kwargs["filters"]["environment"] == "prod"
+    assert "user_id" not in kwargs
+    assert "agent_id" not in kwargs
+    assert "run_id" not in kwargs
+    assert kwargs["top_k"] == 5
+
+
+def test_format_query_with_memories_reads_results_key(mock_memory_client):
+    """MemoryClient-shaped dict responses must iterate `results`, not dict keys (#4907)."""
+    completions = Completions(mock_memory_client)
+    messages = [{"role": "user", "content": "What do I like?"}]
+    response = {
+        "results": [
+            {"memory": "User likes pizza", "id": "1"},
+            {"memory": "User is vegetarian", "id": "2"},
+        ],
+        "relations": [{"source": "User", "relationship": "likes", "target": "pizza"}],
+    }
+
+    result = completions._format_query_with_memories(messages, response)
+
+    assert "User likes pizza" in result
+    assert "User is vegetarian" in result
+    assert "results" not in result  # would appear if we iterated dict keys
+    assert "Entities:" in result
+    assert "What do I like?" in result
+
+
+def test_completions_create_passes_filters_not_top_level_entities(mock_memory_client, mock_litellm):
+    """End-to-end: chat.completions.create must not crash on MemoryClient.search contract."""
+    completions = Completions(mock_memory_client)
+    messages = [{"role": "user", "content": "Hello, how are you?"}]
+    mock_memory_client.search.return_value = {"results": {"results": [{"memory": "Some relevant memory"}]}}
+    mock_litellm.completion.return_value = {"choices": [{"message": {"content": "I'm doing well, thank you!"}}]}
+    mock_litellm.supports_function_calling.return_value = True
+
+    completions.create(model="gpt-4o-mini", messages=messages, user_id="test_user", top_k=3)
+
+    search_kwargs = mock_memory_client.search.call_args.kwargs
+    assert search_kwargs["filters"]["user_id"] == "test_user"
+    assert "user_id" not in search_kwargs


### PR DESCRIPTION
## Summary

- Fold `user_id` / `agent_id` / `run_id` into the `filters` dict before `search()` on the proxy chat path.
- Parse the shared `{results, relations}` response shape for both OSS Memory and MemoryClient.

## Motivation

Closes #4907.

`_fetch_relevant_memories` still passed entity IDs as top-level kwargs, which both `Memory.search` and `MemoryClient.search` reject. Separately, the MemoryClient branch of `_format_query_with_memories` iterated the response dict itself (keys like `"results"`) instead of `response["results"]`, raising `TypeError` and never injecting memories into the prompt.

This salvages the long-stale #4908 approach onto current main with cleaned-up formatting and expanded tests. Prior closed attempts: #4920, #4940, #5038.

## Verification

- `pytest tests/test_proxy.py` — 10 passed
- Did NOT change: `add()` kwargs path (still accepts top-level entity params), litellm install-on-import behavior

## Differential value

#4908 by @shafdev addresses the same issue but is CONFLICTING vs main. This PR is a clean single commit on current main with the same root-cause fix plus regression tests covering filter folding and results-key parsing.