### PR TITLE
docs: update README benchmarks to current temporal-reasoning results

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@
 
 | Benchmark | Old | New  | Tokens  | Latency p50  |
 | --- | --- | --- | --- | --- |
-| **LoCoMo** | 71.4 | **91.6** | 7.0K  | 0.88s  |
-| **LongMemEval** | 67.8 | **94.8** | 6.8K  | 1.09s  |
+| **LoCoMo** | 71.4 | **92.5** | 7.0K  | 0.88s  |
+| **LongMemEval** | 67.8 | **94.4** | 6.8K  | 1.09s  |
 | **BEAM (1M)** | — | **64.1** | 6.7K  | 1.00s  |
 | **BEAM (10M)** | — | **48.6** | 6.9K  | 1.05s  |
 
-All benchmarks run on the same production-representative model stack. Single-pass retrieval (one call, no agentic loops).
+All benchmarks run on the same production-representative model stack. Single-pass retrieval (one call, no agentic loops) at a top_200 retrieval budget. Scores reflect Mem0's managed platform, which includes proprietary optimizations not available in the open-source SDK; open-source users should expect directionally similar gains but not identical numbers.
 
 **What changed:**
 - **Single-pass ADD-only extraction** -- one LLM call, no UPDATE/DELETE. Memories accumulate; nothing is overwritten.
@@ -63,8 +63,8 @@ All benchmarks run on the same production-representative model stack. Single-pas
 See the [migration guide](https://docs.mem0.ai/migration/oss-v2-to-v3) for upgrade instructions. The [evaluation framework](https://github.com/mem0ai/memory-benchmarks) is open-sourced so anyone can reproduce the numbers.
 
 ## Research Highlights
-- **91.6 on LoCoMo** -- +20 points over the previous algorithm
-- **94.8 on LongMemEval** -- +27 points, with +53.6 on assistant memory recall
+- **92.5 on LoCoMo** -- +21 points over the previous algorithm
+- **94.4 on LongMemEval** -- +27 points, with 98.2 on assistant memory recall
 - **64.1 on BEAM (1M)** -- production-scale memory evaluation at 1M tokens
 - [Read the full paper](https://mem0.ai/research)
 


### PR DESCRIPTION
## Linked Issue

N/A — follow-up to #6056, which refreshed the [Memory Evaluation](https://docs.mem0.ai/core-concepts/memory-evaluation) page but left the README carrying the pre-temporal-reasoning numbers.

## Description

The README benchmark table and Research Highlights were out of sync with `docs/core-concepts/memory-evaluation.mdx`. This aligns them.

| Benchmark | README (before) | Docs / this PR |
|---|---|---|
| LoCoMo | 91.6 | **92.5** |
| LongMemEval | 94.8 | **94.4** |
| BEAM (1M) | 64.1 | 64.1 (unchanged) |
| BEAM (10M) | 48.6 | 48.6 (unchanged) |

Note that the README's LongMemEval score of **94.8 was not sourced by any page in `docs/`** — the current value is 94.4 (memory-evaluation) and the v3-launch value was 93.4 (migration guide / changelog). Neither is 94.8.

Also updated:

- **Research Highlights**: `+53.6 on assistant memory recall` was the old-vs-new delta against a since-superseded 100.0 score. Replaced with the current absolute, **98.2**, so it can't drift again. LoCoMo delta corrected `+20` → `+21` (71.4 → 92.5).
- **Caption**: now states the **top_200 retrieval budget** and carries the managed-platform caveat from the docs page — the scores reflect proprietary platform optimizations not in the OSS SDK, which is worth saying plainly on the OSS README.

Token counts (7.0K / 6.8K / 6.7K / 6.9K) already matched the docs (6,956 / 6,787 / 6,719 / 6,914) and are unchanged.

### One thing to confirm

The `Latency p50` column (0.88s / 1.09s / 1.00s / 1.05s) has **no source anywhere in `docs/`**, and #6056 did not touch latency. I left the values as-is rather than guess. If they were measured against the old algorithm they are now stale, and this column should either be refreshed or dropped — flagging for whoever owns the benchmark runs.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [x] No tests needed (README-only copy change; no `docs/**/*.mdx` touched, so the llms.txt coverage check does not apply)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed