### PR TITLE
fix(vector-stores): improve milvus wildcard search

### DIFF
--- a/mem0/vector_stores/milvus.py
+++ b/mem0/vector_stores/milvus.py
@@ -159,7 +159,9 @@ class MilvusDB(VectorStoreBase):
         for key, value in filters.items():
             if not self._SAFE_FILTER_KEY.match(key):
                 raise ValueError(f"Invalid filter key: {key!r}")
-            if isinstance(value, str):
+            if value == "*":
+                continue
+            elif isinstance(value, str):
                 escaped = value.replace("\\", "\\\\").replace('"', '\\"')
                 operands.append(f'(metadata["{key}"] == "{escaped}")')
             elif isinstance(value, (int, float, bool)):

--- a/mem0/vector_stores/milvus.py
+++ b/mem0/vector_stores/milvus.py
@@ -160,6 +160,7 @@ class MilvusDB(VectorStoreBase):
             if not self._SAFE_FILTER_KEY.match(key):
                 raise ValueError(f"Invalid filter key: {key!r}")
             if value == "*":
+                # Wildcard - match any value (MilvusDB doesn't have direct wildcard, so we skip this filter)
                 continue
             elif isinstance(value, str):
                 escaped = value.replace("\\", "\\\\").replace('"', '\\"')

--- a/tests/vector_stores/test_milvus.py
+++ b/tests/vector_stores/test_milvus.py
@@ -107,12 +107,11 @@ class TestMilvusDB:
         assert 'metadata["category"] == "work"' in filter_str
         assert ' and ' in filter_str
 
-    def test_create_filter_asterisk_conditions(self, milvus_db):
-        """Test filter creation with asterisk conditions."""
+    def test_create_filter_wildcard_conditions(self, milvus_db):
+        """Test filter creation with wildcard conditions."""
         filters = {"user_id": "alice", "run_id": "*"}
         filter_str = milvus_db._create_filter(filters)
 
-        # Should join with 'and'
         assert 'metadata["user_id"] == "alice"' in filter_str
         assert 'metadata["run_id"] == "*"' not in filter_str
 

--- a/tests/vector_stores/test_milvus.py
+++ b/tests/vector_stores/test_milvus.py
@@ -107,6 +107,15 @@ class TestMilvusDB:
         assert 'metadata["category"] == "work"' in filter_str
         assert ' and ' in filter_str
 
+    def test_create_filter_asterisk_conditions(self, milvus_db):
+        """Test filter creation with asterisk conditions."""
+        filters = {"user_id": "alice", "run_id": "*"}
+        filter_str = milvus_db._create_filter(filters)
+
+        # Should join with 'and'
+        assert 'metadata["user_id"] == "alice"' in filter_str
+        assert 'metadata["run_id"] == "*"' not in filter_str
+
     def test_search_with_filters(self, milvus_db, mock_milvus_client):
         """Test search with metadata filters (reproduces user's bug scenario)."""
         # Setup mock return value


### PR DESCRIPTION
## Linked Issue

Closes #6186

## Description

When filter contains `*`，Milvus will always recall nothing.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update


## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
