### PR TITLE
docs(ts-sdk): use dimension config option instead of embeddingModelDims in qdrant

### DIFF
--- a/docs/components/vectordbs/dbs/qdrant.mdx
+++ b/docs/components/vectordbs/dbs/qdrant.mdx
@@ -42,7 +42,7 @@ const config = {
     provider: 'qdrant',
     config: {
       collectionName: 'memories',
-      embeddingModelDims: 1536,
+      dimension: 1536,
       host: 'localhost',
       port: 6333,
     },
@@ -83,7 +83,7 @@ Let's see the available parameters for the `qdrant` config:
 | Parameter | Description | Default Value |
 | --- | --- | --- |
 | `collectionName` | The name of the collection to store the vectors | `mem0` |
-| `embeddingModelDims` | Dimensions of the embedding model | `1536` |
+| `dimension` | Dimensions of the embedding model | `1536` |
 | `host` | The host where the Qdrant server is running | `None` |
 | `port` | The port where the Qdrant server is running | `None` |
 | `path` | Path for the Qdrant database | `/tmp/qdrant` |


### PR DESCRIPTION
## Linked Issue

Closes #6191

## Description

This PR replaces `embeddingModelDims` with `dimension` config option for TypeScript examples on Qdrant page.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

No breaking changes.

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [x] No tests needed (explain why)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
