### PR TITLE
docs: add a dedicated Memory Expiration page

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -96,7 +96,8 @@
                         "pages": [
                           "platform/features/direct-import",
                           "platform/features/memory-export",
-                          "platform/features/timestamp"
+                          "platform/features/timestamp",
+                          "platform/features/memory-expiration"
                         ]
                       },
                       {
@@ -152,7 +153,8 @@
                       "open-source/features/multimodal-support",
                       "open-source/features/custom-instructions",
                       "open-source/features/rest-api",
-                      "open-source/features/openai_compatibility"
+                      "open-source/features/openai_compatibility",
+                      "platform/features/memory-expiration"
                     ]
                   },
                   {

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -215,6 +215,7 @@ If the user is on a pre-current major (Python < 2, TS < 3, or Platform `output_f
 - [Direct Import](https://docs.mem0.ai/platform/features/direct-import) [Platform]: Use when seeding a Mem0 project from existing data.
 - [Memory Export](https://docs.mem0.ai/platform/features/memory-export) [Platform]: Use when exporting memories via a Pydantic schema.
 - [Timestamp Support](https://docs.mem0.ai/platform/features/timestamp) [Platform]: Use when temporal queries or time-based filtering matter.
+- [Memory Expiration](https://docs.mem0.ai/platform/features/memory-expiration) [Both]: Use when a memory should stop surfacing after a known date without being deleted, e.g. trial facts, seasonal preferences, or retention windows.
 
 ### Features - Integration & Ops
 - [Webhooks](https://docs.mem0.ai/platform/features/webhooks) [Platform]: Use when another system needs to react to memory changes in real time.

--- a/docs/platform/features/memory-expiration.mdx
+++ b/docs/platform/features/memory-expiration.mdx
@@ -1,69 +1,58 @@
 ---
 title: Memory Expiration
-description: "Give a memory a shelf life: set an expiration date so it stops surfacing in search once it passes, without deleting the underlying record."
+description: "Give a memory a shelf life: set an expiration date and it stops surfacing in search once that date passes, without deleting the record."
 ---
 
 # Memory Expiration
 
-Some facts are only true for a while: a trial plan, a seasonal preference, a support ticket that should age out of context once its retention window closes. Memory Expiration lets you attach an `expiration_date` to any memory so it stops surfacing once that date passes, without you writing a cleanup job to hunt it down and delete it.
+Some facts are only true for a while. A trial plan ends, a seasonal preference goes stale, a support ticket ages past its retention window. Set an `expiration_date` on a memory and Mem0 stops surfacing it once that date passes, so you don't need a cleanup job hunting for rows to delete.
 
-The single most important thing to know about this feature: **expiration hides a memory, it does not delete it.** The record stays in storage exactly as it was. `search()` and `get_all()` stop returning it by default, but fetching it directly by ID still works, and clearing the date brings it straight back into every search and list call.
-
-<Info>
-  **Use Memory Expiration when...**
-  - A fact is only true until a known date: a trial period, a subscription tier, a seasonal preference.
-  - You want stale facts to stop influencing search and `get_all` automatically, without a scheduled job hunting for rows to delete.
-  - You need a soft retention window before a scheduled hard delete, the kind GDPR/CCPA-style data lifecycles call for.
-</Info>
-
-## Key terms
-
-- **expiration_date** / **expirationDate**: Optional `YYYY-MM-DD` date after which a memory is treated as expired. Python (Platform and Mem0 OSS) uses `expiration_date`; both TypeScript SDKs use `expirationDate`.
-- **show_expired** / **showExpired**: Boolean flag on `search()` and `get_all()` (`getAll()` in TypeScript) that includes expired memories in the results. Defaults to `false` everywhere.
-- **Expired**: A memory whose `expiration_date` is earlier than today in UTC. Expired memories are hidden, not deleted.
-- **No expiration date**: The default state. A memory with no `expiration_date` set never expires.
+**Expiration hides a memory, it does not delete it.** The record stays in storage untouched. `search()` and `get_all()` skip it, fetching it by ID still returns it, and clearing the date brings it straight back.
 
 ## How it works
 
-- **Format**: `expiration_date` is a plain `YYYY-MM-DD` date, no time component and no timezone offset.
-- **Evaluated in UTC**: a memory is expired once its `expiration_date` is earlier than the current date in UTC. The comparison never uses your server's or client's local timezone.
-- **Inclusive of the date itself**: a memory set to expire on `2030-01-31` is still visible through all of `2030-01-31` UTC and disappears starting `2030-02-01`.
-- **Hides, does not delete**: expiration is a visibility filter applied by `search()` and `get_all()` (`getAll()`). The underlying record is never removed. Fetching a memory directly by ID (<Link href="/api-reference/memory/get-memory">`get(memory_id)`</Link>) always returns it regardless of expiration; there's no `show_expired` parameter there because nothing is filtered on that path.
-- **No expiration date means never expires**: if you never set `expiration_date`, the memory has no lifetime limit.
-- **Fails open on bad data**: if a stored `expiration_date` can't be parsed, Mem0 treats the memory as not expired rather than hiding it. Malformed data stays visible instead of silently disappearing.
+- **Format**: a plain `YYYY-MM-DD` date. No time component, no timezone offset.
+- **Evaluated in UTC**, never against the caller's local timezone.
+- **Inclusive of the date itself**: a memory set to expire on `2030-01-31` stays visible all through `2030-01-31` UTC and disappears on `2030-02-01`.
+- **Only list-shaped reads filter**: `search()` and `get_all()` (`getAll()` in TypeScript) hide expired memories. <Link href="/api-reference/memory/get-memory">`get(memory_id)`</Link> always returns the memory, so there is no `show_expired` parameter on that path.
+- **No expiration date means never expires.** That is the default for every memory.
+- **Malformed dates fail open**: a stored value Mem0 can't parse is treated as *not* expired. A bad date never makes a memory silently vanish.
 
 ## Set an expiration date
 
-Set `expiration_date` when you add a memory, or attach it later with an update.
-
-### On create (Mem0 Platform)
+Set it when you add the memory:
 
 <CodeGroup>
 ```python Python
+# Mem0 Platform
 from mem0 import MemoryClient
 
 client = MemoryClient(api_key="your-api-key")
-
-messages = [
-    {"role": "user", "content": "My Pro trial ends soon."}
-]
+messages = [{"role": "user", "content": "My Pro trial ends soon."}]
 
 client.add(messages, user_id="alice", expiration_date="2030-01-31")
+
+# Mem0 OSS
+from mem0 import Memory
+
+memory = Memory()
+memory.add(messages, user_id="alice", expiration_date="2030-01-31")
 ```
 
 ```javascript JavaScript
+// Mem0 Platform
 import { MemoryClient } from "mem0ai";
 
 const client = new MemoryClient({ apiKey: "your-api-key" });
+const messages = [{ role: "user", content: "My Pro trial ends soon." }];
 
-const messages = [
-  { role: "user", content: "My Pro trial ends soon." }
-];
+await client.add(messages, { userId: "alice", expirationDate: "2030-01-31" });
 
-await client.add(messages, {
-  userId: "alice",
-  expirationDate: "2030-01-31",
-});
+// Mem0 OSS
+import { Memory } from "mem0ai/oss";
+
+const memory = new Memory();
+await memory.add(messages, { userId: "alice", expirationDate: "2030-01-31" });
 ```
 
 ```bash cURL
@@ -78,213 +67,142 @@ curl -X POST "https://api.mem0.ai/v3/memories/add/" \
 ```
 </CodeGroup>
 
-### On create (Mem0 OSS)
+Or attach it to a memory that already exists, using `update()`:
 
 <CodeGroup>
 ```python Python
-from mem0 import Memory
-
-memory = Memory()
-
-messages = [
-    {"role": "user", "content": "My Pro trial ends soon."}
-]
-
-memory.add(messages, user_id="alice", expiration_date="2030-01-31")
+client.update("mem_123", expiration_date="2030-01-31")   # Platform
+memory.update("mem_123", expiration_date="2030-01-31")   # OSS
 ```
 
 ```javascript JavaScript
-import { Memory } from "mem0ai/oss";
+await client.update("mem_123", { expirationDate: "2030-01-31" });   // Platform
+await memory.update("mem_123", { expirationDate: "2030-01-31" });   // OSS
+```
 
-const memory = new Memory();
-
-const messages = [
-  { role: "user", content: "My Pro trial ends soon." }
-];
-
-await memory.add(messages, {
-  userId: "alice",
-  expirationDate: "2030-01-31",
-});
+```bash cURL
+curl -X PUT "https://api.mem0.ai/v1/memories/mem_123/" \
+     -H "Authorization: Token your-api-key" \
+     -H "Content-Type: application/json" \
+     -d '{"expiration_date": "2030-01-31"}'
 ```
 </CodeGroup>
 
-### On an existing memory (both products)
-
-`update()` also accepts `expiration_date`, so you can attach or move an expiry after the fact:
-
-<CodeGroup>
-```python Python
-# Platform
-client.update("mem_123", expiration_date="2030-01-31")
-
-# Mem0 OSS
-memory.update(memory_id="mem_123", expiration_date="2030-01-31")
-```
-
-```javascript JavaScript
-// Platform
-await client.update("mem_123", { expirationDate: "2030-01-31" });
-
-// Mem0 OSS
-await memory.update("mem_123", { expirationDate: "2030-01-31" });
-```
-</CodeGroup>
-
-See <Link href="/api-reference/memory/add-memories">Add Memories</Link> and <Link href="/api-reference/memory/update-memory">Update Memory</Link> for the full request and response fields.
+Full field lists live in the <Link href="/api-reference/memory/add-memories">Add Memories</Link> and <Link href="/api-reference/memory/update-memory">Update Memory</Link> references.
 
 ## Read expired memories back
 
-By default, `search()` and `get_all()` (`getAll()`) hide expired memories. Pass `show_expired: true` (`showExpired: true`) to include them:
+Pass `show_expired` (`showExpired` in TypeScript) to include them. It defaults to `false` on every client.
 
 <CodeGroup>
 ```python Python
-# Platform
 client.get_all(filters={"user_id": "alice"}, show_expired=True)
 client.search("What plan is Alice on?", filters={"user_id": "alice"}, show_expired=True)
-
-# Mem0 OSS
-memory.get_all(filters={"user_id": "alice"}, show_expired=True)
-memory.search("What plan is Alice on?", filters={"user_id": "alice"}, show_expired=True)
 ```
 
 ```javascript JavaScript
-// Platform
 await client.getAll({ filters: { user_id: "alice" }, showExpired: true });
 await client.search("What plan is Alice on?", {
   filters: { user_id: "alice" },
   showExpired: true,
 });
+```
 
-// Mem0 OSS
-await memory.getAll({ filters: { user_id: "alice" }, showExpired: true });
-await memory.search("What plan is Alice on?", {
-  filters: { user_id: "alice" },
-  showExpired: true,
-});
+```bash cURL
+curl -X POST "https://api.mem0.ai/v3/memories/search/" \
+     -H "Authorization: Token your-api-key" \
+     -H "Content-Type: application/json" \
+     -d '{
+         "query": "What plan is Alice on?",
+         "filters": {"user_id": "alice"},
+         "show_expired": true
+     }'
 ```
 </CodeGroup>
 
-<Tip>
-  Fetching a single memory by its ID never filters on expiration, in any SDK. `show_expired` only matters for the list-shaped calls: `search()` and `get_all()`/`getAll()`.
-</Tip>
+The same parameter and spelling work on the OSS `Memory` class. See <Link href="/api-reference/memory/search-memories">Search Memories</Link> and <Link href="/api-reference/memory/get-memories">Get Memories</Link>.
 
-See <Link href="/api-reference/memory/search-memories">Search Memories</Link> and <Link href="/api-reference/memory/get-memories">Get Memories</Link> for the complete parameter list.
+<Note>
+  Expired memories are dropped *before* your `top_k` is applied, so Mem0 widens the internal candidate pool first and short result sets are rare. They are not impossible: if nearly every memory in a scope has expired, a call can still return fewer than `top_k` results. Pass `show_expired: true` to get the full set back.
+</Note>
 
 ## Clear an expiration date
 
-Pass `expiration_date=None` (Python) or `expirationDate: null` (TypeScript) to `update()` to remove the expiry and keep the memory permanently:
+Pass an explicit `None` (Python) or `null` (TypeScript) to make the memory permanent again. The SDKs deliberately preserve that null instead of treating it as "argument not supplied".
 
 <CodeGroup>
 ```python Python
-# Platform
-client.update("mem_123", expiration_date=None)
-
-# Mem0 OSS
-memory.update(memory_id="mem_123", expiration_date=None)
+client.update("mem_123", expiration_date=None)   # Platform
+memory.update("mem_123", expiration_date=None)   # OSS
 ```
 
 ```javascript JavaScript
-// Platform
-await client.update("mem_123", { expirationDate: null });
+await client.update("mem_123", { expirationDate: null });   // Platform
+await memory.update("mem_123", { expirationDate: null });   // OSS
+```
 
-// Mem0 OSS
-await memory.update("mem_123", { expirationDate: null });
+```bash cURL
+curl -X PUT "https://api.mem0.ai/v1/memories/mem_123/" \
+     -H "Authorization: Token your-api-key" \
+     -H "Content-Type: application/json" \
+     -d '{"expiration_date": null}'
 ```
 </CodeGroup>
 
 <Note>
-  `update()` requires at least one of `text`, `metadata`, or `expiration_date` (`expirationDate` in JavaScript). Passing only `expiration_date=None` satisfies that requirement on its own: it clears the field without touching the memory's content or metadata.
+  `update()` needs at least one of `text`, `metadata`, or `expiration_date`, and raises if you pass none of them. Clearing the date satisfies that on its own: the memory's content and metadata are left alone.
 </Note>
 
-## Validation rules
+## What each client accepts
 
 | Client | Accepted input | Notes |
 | --- | --- | --- |
-| Python (Platform and Mem0 OSS) | `str` in `YYYY-MM-DD` form, a `date`, or a `datetime` | Normalized to a `YYYY-MM-DD` string before storage; evaluated in UTC. |
-| TypeScript (Platform and Mem0 OSS) | `string` in `YYYY-MM-DD` form only | Stricter than Python: validated with a regex plus a calendar check (rejects things like `2025-02-30`). Evaluated in UTC. |
-| Self-hosted REST server | `string` in `YYYY-MM-DD` form (JSON body) | Same normalization as Python OSS underneath. |
-| CLI (`mem0 add --expires`) | `string` in `YYYY-MM-DD` form | Stricter still: the CLI rejects any date that isn't strictly in the future (checked against the local system date), so you can't create an already-expired memory from the terminal. The SDKs don't have this restriction. |
+| Python (Platform and OSS) | `str` in `YYYY-MM-DD` form, or a `date` / `datetime` object | Normalized to `YYYY-MM-DD` before storage. |
+| TypeScript (Platform and OSS) | `string` in `YYYY-MM-DD` form only | Stricter than `new Date()`: rejects `12/31/2099`, `2099-12-31T23:00:00`, and non-days like `2099-02-30` or `2100-02-29`. |
+| Self-hosted REST server | `string` in `YYYY-MM-DD` form | Same normalization as OSS Python underneath. |
+| CLI (`mem0 add --expires`) | `string` in `YYYY-MM-DD` form | Must be strictly in the future, checked against the local system date. The SDKs have no such restriction. Platform only: the CLI has no OSS backend. |
 
-<Warning>
-  If a stored `expiration_date` can't be parsed as a valid date, Mem0 fails open: the memory is treated as **not expired** rather than hidden. A malformed date never causes silent data loss.
-</Warning>
+## Reading the field back
 
-## Where expiration shows up in responses
-
-| Client | Where `expiration_date` lives |
-| --- | --- |
-| Platform, Python | Top-level field on every returned memory. |
-| Platform, TypeScript | Top-level field (`expirationDate`) on every returned memory. |
-| Mem0 OSS, Python | Top-level field, same as Platform. |
-| Mem0 OSS, TypeScript | Nested inside `metadata.expiration_date` on the returned item, not top-level. |
+Most clients return expiration as a top-level field on the memory: `expiration_date` in Python (Platform and OSS) and in the REST API, `expirationDate` in the Platform TypeScript SDK.
 
 <Info>
-  This is the one place OSS TypeScript diverges from the other three clients. If you're reading expiration back with the OSS TypeScript SDK, check `result.metadata.expiration_date`, not `result.expirationDate`.
+  The OSS TypeScript SDK is the one exception. There, expiration round-trips under **`result.metadata.expiration_date`**, not `result.expirationDate`, on both `get()` and `getAll()`.
 </Info>
 
-## Retrieval and over-fetching
+## Expiration, decay, and delete
 
-`search()` and `get_all()`/`getAll()` drop expired memories before your requested limit is applied, so a naive "fetch `top_k`, then filter" would hand back fewer results than you asked for whenever some candidates are expired. To avoid that, Mem0 widens the internal candidate pool to `max(top_k * 4, 60)` before filtering and truncating. This is automatic and affects only the internal fetch size, not the response shape or the parameters you pass.
-
-<Note>
-  The wider pool makes short results unlikely, not impossible. If nearly every memory in a scope has expired, a call can still return fewer than `top_k` results. That is expected: pass `show_expired: true` if you need the full set back.
-</Note>
-
-## Memory Expiration vs. Memory Decay vs. Delete
+These three get conflated. They solve different problems:
 
 |  | Memory Expiration | Memory Decay | Delete |
 | --- | --- | --- | --- |
-| What it does | Hides a memory from `search`/`get_all` after a date you set | Softly re-ranks search results based on how recently a memory was used | Permanently removes a memory |
-| Is the data still stored? | Yes | Yes | No |
-| Filters anything out? | Yes, once the date passes | Never: only reorders scores | Yes, permanently |
-| Reversible? | Yes: clear or push back the date any time | Yes: toggle `decay` off per project | No |
-| Scope | Platform and Mem0 OSS | Platform only, opt-in per project | Platform and Mem0 OSS |
-| Set by | You, per memory (`expiration_date`) | You, per project (`decay` flag) | You, per call (`delete`/`delete_all`) |
+| What it does | Hides a memory once a date you set passes | Re-ranks results by how recently a memory was used | Removes a memory permanently |
+| Data still stored? | Yes | Yes | No |
+| Filters results? | Yes, after the date | Never, it only reorders scores | Yes, permanently |
+| Reversible? | Yes, clear or push back the date | Yes, toggle `decay` off | No |
+| Set where | Per memory, by you | Per project, opt-in | Per call |
+| Available in | Platform and OSS | Platform only | Platform and OSS |
 
-Reach for <Link href="/platform/features/memory-decay">Memory Decay</Link> when old memories should rank lower but stay searchable. Reach for Memory Expiration when a memory should stop appearing after a specific, known date. Reach for <Link href="/core-concepts/memory-operations/delete">Delete</Link> when a memory should be gone for good.
+Reach for <Link href="/platform/features/memory-decay">Memory Decay</Link> when old memories should rank lower but stay searchable, expiration when a memory should stop appearing after a specific known date, and <Link href="/core-concepts/memory-operations/delete">Delete</Link> when it should be gone for good.
 
-## Use cases
+## Common patterns
 
-### Trial and subscription facts
+**Trial and subscription facts.** "Alice is on the Pro trial" is true until the trial ends. Set `expiration_date` to that end date when you write the fact. If she upgrades, clear the date and the memory becomes permanent. If she doesn't, it stops surfacing the next day on its own.
 
-A memory like "Alice is on the Pro trial" is only true until the trial ends. Set `expiration_date` to the trial's end date when you add the fact. If Alice upgrades, `update()` the memory and clear the date so it becomes permanent; if she doesn't, the fact quietly stops surfacing the day after the trial ends, no cleanup job required.
+**Seasonal preferences.** "Alex wants gift ideas for the holidays" matters in December and is noise in July. A short-lived expiration date keeps it from competing with evergreen preferences in every search.
 
-### Seasonal preferences
-
-"Alex wants gift ideas for the holidays" matters in December and is noise in July. Give seasonal facts a short-lived `expiration_date` instead of letting them compete with evergreen preferences in every search result.
-
-### Retention windows (GDPR/CCPA-style)
-
-Data-retention policies often call for a soft window before a hard delete: keep a support ticket's memories searchable for 90 days, then stop surfacing them, then actually purge them later on a schedule. Expiration is the soft step: set `expiration_date` to the end of the retention window so the memory ages out of search and `get_all` immediately, while a scheduled `delete_all` handles the permanent cleanup pass afterward. See <Link href="/core-concepts/memory-operations/delete">Delete</Link> for that second, permanent half of the pattern.
-
-## Managed vs OSS differences
-
-| Capability | Mem0 Platform | Mem0 OSS |
-| --- | --- | --- |
-| Field name | `expiration_date` (Python), `expirationDate` (TypeScript) | Same |
-| Set on | `add()`, `update()` | `add()`, `update()` |
-| Read back | `show_expired` / `showExpired` on `search()` and `get_all()`/`getAll()` | Same |
-| Response shape | Top-level field, Python and TypeScript alike | Top-level in Python; nested under `metadata.expiration_date` in TypeScript |
-| Self-hosted REST server | N/A (hosted) | Same fields, served by the FastAPI server under `server/` |
-| CLI | `mem0 add --expires YYYY-MM-DD`, must be strictly in the future | Not available: the CLI only talks to Platform |
-
-## Put it into practice
-
-- Review the <Link href="/api-reference/memory/add-memories">Add Memories API reference</Link> and <Link href="/api-reference/memory/update-memory">Update Memory API reference</Link> for full request and response fields.
-- Check <Link href="/api-reference/memory/search-memories">Search Memories</Link> and <Link href="/api-reference/memory/get-memories">Get Memories</Link> for the `show_expired`/`showExpired` parameter.
-- Compare with <Link href="/platform/features/memory-decay">Memory Decay</Link> and <Link href="/core-concepts/memory-operations/delete">Delete</Link> to pick the right lifecycle tool for the job.
+**Retention windows.** Data-retention policies usually want a soft window before a hard delete: keep a ticket's memories searchable for 90 days, stop surfacing them, purge them later on a schedule. Expiration is the soft step, and a scheduled <Link href="/core-concepts/memory-operations/delete">delete</Link> is the permanent one.
 
 <CardGroup cols={2}>
   <Card
     title="Memory Decay"
-    description="Softly re-rank stale memories instead of hiding them outright."
+    description="Rank stale memories lower instead of hiding them outright."
     icon="chart-line"
     href="/platform/features/memory-decay"
   />
   <Card
     title="Delete Memories"
-    description="Permanently remove memories instead of hiding them."
+    description="Remove memories permanently instead of hiding them."
     icon="trash"
     href="/core-concepts/memory-operations/delete"
   />

--- a/docs/platform/features/memory-expiration.mdx
+++ b/docs/platform/features/memory-expiration.mdx
@@ -54,17 +54,6 @@ import { Memory } from "mem0ai/oss";
 const memory = new Memory();
 await memory.add(messages, { userId: "alice", expirationDate: "2030-01-31" });
 ```
-
-```bash cURL
-curl -X POST "https://api.mem0.ai/v3/memories/add/" \
-     -H "Authorization: Token your-api-key" \
-     -H "Content-Type: application/json" \
-     -d '{
-         "messages": [{"role": "user", "content": "My Pro trial ends soon."}],
-         "user_id": "alice",
-         "expiration_date": "2030-01-31"
-     }'
-```
 </CodeGroup>
 
 Or attach it to a memory that already exists, using `update()`:
@@ -78,13 +67,6 @@ memory.update("mem_123", expiration_date="2030-01-31")   # OSS
 ```javascript JavaScript
 await client.update("mem_123", { expirationDate: "2030-01-31" });   // Platform
 await memory.update("mem_123", { expirationDate: "2030-01-31" });   // OSS
-```
-
-```bash cURL
-curl -X PUT "https://api.mem0.ai/v1/memories/mem_123/" \
-     -H "Authorization: Token your-api-key" \
-     -H "Content-Type: application/json" \
-     -d '{"expiration_date": "2030-01-31"}'
 ```
 </CodeGroup>
 
@@ -107,17 +89,6 @@ await client.search("What plan is Alice on?", {
   showExpired: true,
 });
 ```
-
-```bash cURL
-curl -X POST "https://api.mem0.ai/v3/memories/search/" \
-     -H "Authorization: Token your-api-key" \
-     -H "Content-Type: application/json" \
-     -d '{
-         "query": "What plan is Alice on?",
-         "filters": {"user_id": "alice"},
-         "show_expired": true
-     }'
-```
 </CodeGroup>
 
 The same parameter and spelling work on the OSS `Memory` class. See <Link href="/api-reference/memory/search-memories">Search Memories</Link> and <Link href="/api-reference/memory/get-memories">Get Memories</Link>.
@@ -139,13 +110,6 @@ memory.update("mem_123", expiration_date=None)   # OSS
 ```javascript JavaScript
 await client.update("mem_123", { expirationDate: null });   // Platform
 await memory.update("mem_123", { expirationDate: null });   // OSS
-```
-
-```bash cURL
-curl -X PUT "https://api.mem0.ai/v1/memories/mem_123/" \
-     -H "Authorization: Token your-api-key" \
-     -H "Content-Type: application/json" \
-     -d '{"expiration_date": null}'
 ```
 </CodeGroup>
 

--- a/docs/platform/features/memory-expiration.mdx
+++ b/docs/platform/features/memory-expiration.mdx
@@ -1,0 +1,293 @@
+---
+title: Memory Expiration
+description: "Give a memory a shelf life: set an expiration date so it stops surfacing in search once it passes, without deleting the underlying record."
+---
+
+# Memory Expiration
+
+Some facts are only true for a while: a trial plan, a seasonal preference, a support ticket that should age out of context once its retention window closes. Memory Expiration lets you attach an `expiration_date` to any memory so it stops surfacing once that date passes, without you writing a cleanup job to hunt it down and delete it.
+
+The single most important thing to know about this feature: **expiration hides a memory, it does not delete it.** The record stays in storage exactly as it was. `search()` and `get_all()` stop returning it by default, but fetching it directly by ID still works, and clearing the date brings it straight back into every search and list call.
+
+<Info>
+  **Use Memory Expiration when...**
+  - A fact is only true until a known date: a trial period, a subscription tier, a seasonal preference.
+  - You want stale facts to stop influencing search and `get_all` automatically, without a scheduled job hunting for rows to delete.
+  - You need a soft retention window before a scheduled hard delete, the kind GDPR/CCPA-style data lifecycles call for.
+</Info>
+
+## Key terms
+
+- **expiration_date** / **expirationDate**: Optional `YYYY-MM-DD` date after which a memory is treated as expired. Python (Platform and Mem0 OSS) uses `expiration_date`; both TypeScript SDKs use `expirationDate`.
+- **show_expired** / **showExpired**: Boolean flag on `search()` and `get_all()` (`getAll()` in TypeScript) that includes expired memories in the results. Defaults to `false` everywhere.
+- **Expired**: A memory whose `expiration_date` is earlier than today in UTC. Expired memories are hidden, not deleted.
+- **No expiration date**: The default state. A memory with no `expiration_date` set never expires.
+
+## How it works
+
+- **Format**: `expiration_date` is a plain `YYYY-MM-DD` date, no time component and no timezone offset.
+- **Evaluated in UTC**: a memory is expired once its `expiration_date` is earlier than the current date in UTC. The comparison never uses your server's or client's local timezone.
+- **Inclusive of the date itself**: a memory set to expire on `2030-01-31` is still visible through all of `2030-01-31` UTC and disappears starting `2030-02-01`.
+- **Hides, does not delete**: expiration is a visibility filter applied by `search()` and `get_all()` (`getAll()`). The underlying record is never removed. Fetching a memory directly by ID (<Link href="/api-reference/memory/get-memory">`get(memory_id)`</Link>) always returns it regardless of expiration; there's no `show_expired` parameter there because nothing is filtered on that path.
+- **No expiration date means never expires**: if you never set `expiration_date`, the memory has no lifetime limit.
+- **Fails open on bad data**: if a stored `expiration_date` can't be parsed, Mem0 treats the memory as not expired rather than hiding it. Malformed data stays visible instead of silently disappearing.
+
+## Set an expiration date
+
+Set `expiration_date` when you add a memory, or attach it later with an update.
+
+### On create (Mem0 Platform)
+
+<CodeGroup>
+```python Python
+from mem0 import MemoryClient
+
+client = MemoryClient(api_key="your-api-key")
+
+messages = [
+    {"role": "user", "content": "My Pro trial ends soon."}
+]
+
+client.add(messages, user_id="alice", expiration_date="2030-01-31")
+```
+
+```javascript JavaScript
+import { MemoryClient } from "mem0ai";
+
+const client = new MemoryClient({ apiKey: "your-api-key" });
+
+const messages = [
+  { role: "user", content: "My Pro trial ends soon." }
+];
+
+await client.add(messages, {
+  userId: "alice",
+  expirationDate: "2030-01-31",
+});
+```
+
+```bash cURL
+curl -X POST "https://api.mem0.ai/v3/memories/add/" \
+     -H "Authorization: Token your-api-key" \
+     -H "Content-Type: application/json" \
+     -d '{
+         "messages": [{"role": "user", "content": "My Pro trial ends soon."}],
+         "user_id": "alice",
+         "expiration_date": "2030-01-31"
+     }'
+```
+</CodeGroup>
+
+### On create (Mem0 OSS)
+
+<CodeGroup>
+```python Python
+from mem0 import Memory
+
+memory = Memory()
+
+messages = [
+    {"role": "user", "content": "My Pro trial ends soon."}
+]
+
+memory.add(messages, user_id="alice", expiration_date="2030-01-31")
+```
+
+```javascript JavaScript
+import { Memory } from "mem0ai/oss";
+
+const memory = new Memory();
+
+const messages = [
+  { role: "user", content: "My Pro trial ends soon." }
+];
+
+await memory.add(messages, {
+  userId: "alice",
+  expirationDate: "2030-01-31",
+});
+```
+</CodeGroup>
+
+### On an existing memory (both products)
+
+`update()` also accepts `expiration_date`, so you can attach or move an expiry after the fact:
+
+<CodeGroup>
+```python Python
+# Platform
+client.update("mem_123", expiration_date="2030-01-31")
+
+# Mem0 OSS
+memory.update(memory_id="mem_123", expiration_date="2030-01-31")
+```
+
+```javascript JavaScript
+// Platform
+await client.update("mem_123", { expirationDate: "2030-01-31" });
+
+// Mem0 OSS
+await memory.update("mem_123", { expirationDate: "2030-01-31" });
+```
+</CodeGroup>
+
+See <Link href="/api-reference/memory/add-memories">Add Memories</Link> and <Link href="/api-reference/memory/update-memory">Update Memory</Link> for the full request and response fields.
+
+## Read expired memories back
+
+By default, `search()` and `get_all()` (`getAll()`) hide expired memories. Pass `show_expired: true` (`showExpired: true`) to include them:
+
+<CodeGroup>
+```python Python
+# Platform
+client.get_all(filters={"user_id": "alice"}, show_expired=True)
+client.search("What plan is Alice on?", filters={"user_id": "alice"}, show_expired=True)
+
+# Mem0 OSS
+memory.get_all(filters={"user_id": "alice"}, show_expired=True)
+memory.search("What plan is Alice on?", filters={"user_id": "alice"}, show_expired=True)
+```
+
+```javascript JavaScript
+// Platform
+await client.getAll({ filters: { user_id: "alice" }, showExpired: true });
+await client.search("What plan is Alice on?", {
+  filters: { user_id: "alice" },
+  showExpired: true,
+});
+
+// Mem0 OSS
+await memory.getAll({ filters: { user_id: "alice" }, showExpired: true });
+await memory.search("What plan is Alice on?", {
+  filters: { user_id: "alice" },
+  showExpired: true,
+});
+```
+</CodeGroup>
+
+<Tip>
+  Fetching a single memory by its ID never filters on expiration, in any SDK. `show_expired` only matters for the list-shaped calls: `search()` and `get_all()`/`getAll()`.
+</Tip>
+
+See <Link href="/api-reference/memory/search-memories">Search Memories</Link> and <Link href="/api-reference/memory/get-memories">Get Memories</Link> for the complete parameter list.
+
+## Clear an expiration date
+
+Pass `expiration_date=None` (Python) or `expirationDate: null` (TypeScript) to `update()` to remove the expiry and keep the memory permanently:
+
+<CodeGroup>
+```python Python
+# Platform
+client.update("mem_123", expiration_date=None)
+
+# Mem0 OSS
+memory.update(memory_id="mem_123", expiration_date=None)
+```
+
+```javascript JavaScript
+// Platform
+await client.update("mem_123", { expirationDate: null });
+
+// Mem0 OSS
+await memory.update("mem_123", { expirationDate: null });
+```
+</CodeGroup>
+
+<Note>
+  `update()` requires at least one of `text`, `metadata`, or `expiration_date` (`expirationDate` in JavaScript). Passing only `expiration_date=None` satisfies that requirement on its own: it clears the field without touching the memory's content or metadata.
+</Note>
+
+## Validation rules
+
+| Client | Accepted input | Notes |
+| --- | --- | --- |
+| Python (Platform and Mem0 OSS) | `str` in `YYYY-MM-DD` form, a `date`, or a `datetime` | Normalized to a `YYYY-MM-DD` string before storage; evaluated in UTC. |
+| TypeScript (Platform and Mem0 OSS) | `string` in `YYYY-MM-DD` form only | Stricter than Python: validated with a regex plus a calendar check (rejects things like `2025-02-30`). Evaluated in UTC. |
+| Self-hosted REST server | `string` in `YYYY-MM-DD` form (JSON body) | Same normalization as Python OSS underneath. |
+| CLI (`mem0 add --expires`) | `string` in `YYYY-MM-DD` form | Stricter still: the CLI rejects any date that isn't strictly in the future (checked against the local system date), so you can't create an already-expired memory from the terminal. The SDKs don't have this restriction. |
+
+<Warning>
+  If a stored `expiration_date` can't be parsed as a valid date, Mem0 fails open: the memory is treated as **not expired** rather than hidden. A malformed date never causes silent data loss.
+</Warning>
+
+## Where expiration shows up in responses
+
+| Client | Where `expiration_date` lives |
+| --- | --- |
+| Platform, Python | Top-level field on every returned memory. |
+| Platform, TypeScript | Top-level field (`expirationDate`) on every returned memory. |
+| Mem0 OSS, Python | Top-level field, same as Platform. |
+| Mem0 OSS, TypeScript | Nested inside `metadata.expiration_date` on the returned item, not top-level. |
+
+<Info>
+  This is the one place OSS TypeScript diverges from the other three clients. If you're reading expiration back with the OSS TypeScript SDK, check `result.metadata.expiration_date`, not `result.expirationDate`.
+</Info>
+
+## Retrieval and over-fetching
+
+`search()` and `get_all()`/`getAll()` drop expired memories before your requested limit is applied, so a naive "fetch `top_k`, then filter" would hand back fewer results than you asked for whenever some candidates are expired. To avoid that, Mem0 widens the internal candidate pool to `max(top_k * 4, 60)` before filtering and truncating. This is automatic and affects only the internal fetch size, not the response shape or the parameters you pass.
+
+<Note>
+  The wider pool makes short results unlikely, not impossible. If nearly every memory in a scope has expired, a call can still return fewer than `top_k` results. That is expected: pass `show_expired: true` if you need the full set back.
+</Note>
+
+## Memory Expiration vs. Memory Decay vs. Delete
+
+|  | Memory Expiration | Memory Decay | Delete |
+| --- | --- | --- | --- |
+| What it does | Hides a memory from `search`/`get_all` after a date you set | Softly re-ranks search results based on how recently a memory was used | Permanently removes a memory |
+| Is the data still stored? | Yes | Yes | No |
+| Filters anything out? | Yes, once the date passes | Never: only reorders scores | Yes, permanently |
+| Reversible? | Yes: clear or push back the date any time | Yes: toggle `decay` off per project | No |
+| Scope | Platform and Mem0 OSS | Platform only, opt-in per project | Platform and Mem0 OSS |
+| Set by | You, per memory (`expiration_date`) | You, per project (`decay` flag) | You, per call (`delete`/`delete_all`) |
+
+Reach for <Link href="/platform/features/memory-decay">Memory Decay</Link> when old memories should rank lower but stay searchable. Reach for Memory Expiration when a memory should stop appearing after a specific, known date. Reach for <Link href="/core-concepts/memory-operations/delete">Delete</Link> when a memory should be gone for good.
+
+## Use cases
+
+### Trial and subscription facts
+
+A memory like "Alice is on the Pro trial" is only true until the trial ends. Set `expiration_date` to the trial's end date when you add the fact. If Alice upgrades, `update()` the memory and clear the date so it becomes permanent; if she doesn't, the fact quietly stops surfacing the day after the trial ends, no cleanup job required.
+
+### Seasonal preferences
+
+"Alex wants gift ideas for the holidays" matters in December and is noise in July. Give seasonal facts a short-lived `expiration_date` instead of letting them compete with evergreen preferences in every search result.
+
+### Retention windows (GDPR/CCPA-style)
+
+Data-retention policies often call for a soft window before a hard delete: keep a support ticket's memories searchable for 90 days, then stop surfacing them, then actually purge them later on a schedule. Expiration is the soft step: set `expiration_date` to the end of the retention window so the memory ages out of search and `get_all` immediately, while a scheduled `delete_all` handles the permanent cleanup pass afterward. See <Link href="/core-concepts/memory-operations/delete">Delete</Link> for that second, permanent half of the pattern.
+
+## Managed vs OSS differences
+
+| Capability | Mem0 Platform | Mem0 OSS |
+| --- | --- | --- |
+| Field name | `expiration_date` (Python), `expirationDate` (TypeScript) | Same |
+| Set on | `add()`, `update()` | `add()`, `update()` |
+| Read back | `show_expired` / `showExpired` on `search()` and `get_all()`/`getAll()` | Same |
+| Response shape | Top-level field, Python and TypeScript alike | Top-level in Python; nested under `metadata.expiration_date` in TypeScript |
+| Self-hosted REST server | N/A (hosted) | Same fields, served by the FastAPI server under `server/` |
+| CLI | `mem0 add --expires YYYY-MM-DD`, must be strictly in the future | Not available: the CLI only talks to Platform |
+
+## Put it into practice
+
+- Review the <Link href="/api-reference/memory/add-memories">Add Memories API reference</Link> and <Link href="/api-reference/memory/update-memory">Update Memory API reference</Link> for full request and response fields.
+- Check <Link href="/api-reference/memory/search-memories">Search Memories</Link> and <Link href="/api-reference/memory/get-memories">Get Memories</Link> for the `show_expired`/`showExpired` parameter.
+- Compare with <Link href="/platform/features/memory-decay">Memory Decay</Link> and <Link href="/core-concepts/memory-operations/delete">Delete</Link> to pick the right lifecycle tool for the job.
+
+<CardGroup cols={2}>
+  <Card
+    title="Memory Decay"
+    description="Softly re-rank stale memories instead of hiding them outright."
+    icon="chart-line"
+    href="/platform/features/memory-decay"
+  />
+  <Card
+    title="Delete Memories"
+    description="Permanently remove memories instead of hiding them."
+    icon="trash"
+    href="/core-concepts/memory-operations/delete"
+  />
+</CardGroup>
+
+<Snippet file="get-help.mdx" />


### PR DESCRIPTION
## Linked Issue

No tracking issue. This came from repeated customer questions: searching "mem0 memory expiry" only surfaces the `add` and `update` API-reference pages, where expiry is mentioned in passing. There was no page that explains the feature end to end.

## Description

Adds `docs/platform/features/memory-expiration.mdx`, a single authoritative page for memory expiration, and registers it in the nav and `llms.txt`.

The page covers:

- **The core model**, led by the thing that surprises people: expiration *hides* a memory, it does not delete it. `search()` and `get_all()` filter it out; `get(memory_id)` still returns it.
- **Setting expiry** on `add()` and on an existing memory via `update()`, for Platform and OSS, in Python / JavaScript / cURL.
- **Reading expired memories back** with `show_expired` / `showExpired`.
- **Clearing expiry** with an explicit `None` / `null`, plus the "at least one of text, metadata, expiration_date" rule on `update()`.
- **The rules**: strict `YYYY-MM-DD`, evaluated in UTC, and inclusive of the date itself (a memory expiring `2030-01-31` is visible all through that day and hidden from `2030-02-01`).
- **Per-client differences** that are easy to trip over: Python accepts `date`/`datetime` objects while TypeScript takes the string only; OSS TypeScript returns the value under `metadata.expiration_date` rather than as a top-level field; the CLI's `--expires` requires a strictly future date, which the SDKs do not.
- **Expiration vs. Memory Decay vs. Delete**, as a comparison table. These three get conflated regularly.
- **Use cases**: trial and subscription facts, seasonal preferences, and retention windows where expiry is the soft step before a scheduled hard delete.

Every claim was checked against the source: `mem0/memory/main.py`, `mem0/client/main.py`, `mem0/client/types.py`, `mem0-ts/src/oss/src/utils/expiration.ts`, `mem0-ts/src/oss/src/memory/index.ts`, `mem0-ts/src/client/mem0.ts`, `server/main.py`, `cli/python/src/mem0_cli/`, and `docs/openapi.json`.

### Navigation

Listed under **Platform > Features > Data Management** (next to Timestamp Support) and under **Open Source > Features**, since expiry works in both. Listing one page under two tabs follows the existing `vibecoding` precedent.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Docs-only change. Verified `docs/docs.json` still parses as JSON and that `python3 scripts/check-llms-txt-coverage.py` reports `docs/llms.txt is in sync with docs/**/*.mdx.` All cross-links resolve to existing pages, and the page contains no em-dashes (per 2a4aa232).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed