### PR TITLE
feat(ts-sdk): add AWS Bedrock LLM provider

### DIFF
--- a/docs/components/llms/models/aws_bedrock.mdx
+++ b/docs/components/llms/models/aws_bedrock.mdx
@@ -5,12 +5,14 @@ description: "Configure AWS Bedrock as an LLM provider in Mem0 with IAM authenti
 
 ### Setup
 - Before using the AWS Bedrock LLM, make sure you have the appropriate model access from [Bedrock Console](https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/modelaccess).
-- You will also need to authenticate the `boto3` client by using a method in the [AWS documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials)
+- The Python SDK authenticates the `boto3` client and the TypeScript SDK authenticates the AWS SDK for JavaScript. Both use the standard [AWS credential provider chain](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html).
 - You will have to export `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY` to set environment variables.
+- The TypeScript SDK uses `@aws-sdk/client-bedrock-runtime`, which is an optional peer dependency. Install it with `npm install @aws-sdk/client-bedrock-runtime` when using this provider.
 
 ### Usage
 
-```python
+<CodeGroup>
+```python Python
 import os
 from mem0 import Memory
 
@@ -38,6 +40,34 @@ messages = [
 ]
 m.add(messages, user_id="alice", metadata={"category": "movies"})
 ```
+
+```typescript TypeScript
+import { Memory } from 'mem0ai/oss';
+
+// Credentials are read from the standard AWS credential chain
+// (AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY), or you can
+// pass awsRegion / awsAccessKeyId / awsSecretAccessKey in config.
+const config = {
+  llm: {
+    provider: 'aws_bedrock',
+    config: {
+      model: 'anthropic.claude-3-5-haiku-20241022-v1:0',
+      temperature: 0.2,
+      maxTokens: 2000,
+    },
+  },
+};
+
+const memory = new Memory(config);
+const messages = [
+    {"role": "user", "content": "I'm planning to watch a movie tonight. Any recommendations?"},
+    {"role": "assistant", "content": "How about thriller movies? They can be quite engaging."},
+    {"role": "user", "content": "I’m not a big fan of thriller movies but I love sci-fi movies."},
+    {"role": "assistant", "content": "Got it! I'll avoid thriller recommendations and suggest sci-fi movies in the future."}
+]
+await memory.add(messages, { userId: "alice", metadata: { category: "movies" } });
+```
+</CodeGroup>
 
 ### Config
 

--- a/mem0-ts/package.json
+++ b/mem0-ts/package.json
@@ -109,6 +109,7 @@
   },
   "peerDependencies": {
     "@anthropic-ai/sdk": "^0.40.1",
+    "@aws-sdk/client-bedrock-runtime": "3.967.0",
     "@aws-sdk/client-s3vectors": "3.967.0",
     "@mochow/mochow-sdk-node": "^2.1.5",
     "@azure/identity": "^4.0.0",
@@ -148,6 +149,9 @@
     "@zilliz/milvus2-sdk-node": "^2.4.0 || ^3.0.0"
   },
   "peerDependenciesMeta": {
+    "@aws-sdk/client-bedrock-runtime": {
+      "optional": true
+    },
     "mysql2": {
       "optional": true
     },

--- a/mem0-ts/pnpm-lock.yaml
+++ b/mem0-ts/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.40.1
         version: 0.40.1
+      '@aws-sdk/client-bedrock-runtime':
+        specifier: 3.967.0
+        version: 3.967.0
       '@aws-sdk/client-s3vectors':
         specifier: 3.967.0
         version: 3.967.0
@@ -246,6 +249,10 @@ packages:
     resolution: {integrity: sha512-USI1N1d+NbCcfjeiYLKIl94PSYykl5IIjj4X3WqdL33Ln5qktA6sjXYct0o/gG2Cte7cuzbXKkDBkzUA4VPHrg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-bedrock-runtime@3.967.0':
+    resolution: {integrity: sha512-pFID1Lb/54u413HTpnqQYLJjX+voEKLZyqlpdVHDbxcw8MfalmmSg5PR/uJWGO3kku0LkB+H/Ca5ftL11PTL9w==}
+    engines: {node: '>=18.0.0'}
+
   '@aws-sdk/client-s3@3.1080.0':
     resolution: {integrity: sha512-erKuxbwhYLKs0ZviBeTDvXxC0E4AtugHXLbt5kFk8u9/rQMglh/QJNK5f9KuLjlMrbFSJgkBmjNSY5O03YoK4A==}
     engines: {node: '>=20.0.0'}
@@ -330,6 +337,14 @@ packages:
     resolution: {integrity: sha512-q2rJSQ/AMjemUS18OtQqczqSo2R6VjOCLmLVmLVcdrP5/AKoj632lGCrMUWQ6EgnaLMEHbq0UO4mWh/u6gjPhA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/eventstream-handler-node@3.965.0':
+    resolution: {integrity: sha512-QriACiXP+/x2xXw8u849BxID+zSUbh/7Gt0Zfaxeye0mIKVeSTid5776rXfrM8wcYhbVXWWZhKd1Du7oPuFwsg==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/middleware-eventstream@3.965.0':
+    resolution: {integrity: sha512-YVNOPbc3r+gETUY6ufnJYsgIRMaBfoGRM9GzPb+gwtidCPd0BEpLjmZNIVGYawMrGc2kAdlV1kjBzAvmYaMINw==}
+    engines: {node: '>=18.0.0'}
+
   '@aws-sdk/middleware-host-header@3.965.0':
     resolution: {integrity: sha512-SfpSYqoPOAmdb3DBsnNsZ0vix+1VAtkUkzXM79JL3R5IfacpyKE2zytOgVAQx/FjhhlpSTwuXd+LRhUEVb3MaA==}
     engines: {node: '>=18.0.0'}
@@ -349,6 +364,11 @@ packages:
   '@aws-sdk/middleware-user-agent@3.967.0':
     resolution: {integrity: sha512-2qzJzZj5u+cZiG7kz3XJPaTH4ssUY/aet1kwJsUTFKrWeHUf7mZZkDFfkXP5cOffgiOyR5ZkrmJoLKAde9hshg==}
     engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/middleware-websocket@3.965.0':
+    resolution: {integrity: sha512-BGU92StrWF0EJj8jX5EFvRkX9z4/CVIZfON0nWow8gb5ouKwz47o1rO9CP/k2b3F6g134/0XqwXvrUgIWfjJeA==}
+    engines: {node: '>= 14.0.0'}
+    deprecated: Please update your @aws-sdk client to a more recent version, such as https://github.com/aws/aws-sdk-js-v3/releases/tag/v3.982.0, if using browser-based WebSocket bidirectional streaming.
 
   '@aws-sdk/nested-clients@3.967.0':
     resolution: {integrity: sha512-PYa7V8w0gaNux6Sz/Z7zrHmPloEE+EKpRxQIOG/D0askTr5Yd4oO2KGgcInf65uHK3f0Z9U4CTUGHZvQvABypA==}
@@ -388,6 +408,10 @@ packages:
 
   '@aws-sdk/util-endpoints@3.965.0':
     resolution: {integrity: sha512-WqSCB0XIsGUwZWvrYkuoofi2vzoVHqyeJ2kN+WyoOsxPLTiQSBIoqm/01R/qJvoxwK/gOOF7su9i84Vw2NQQpQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/util-format-url@3.965.0':
+    resolution: {integrity: sha512-KiplV4xYGXdNCcz5eRP8WfAejT5EkE2gQxC4IY6WsuxYprzQKsnGaAzEQ+giR5GgQLIRBkPaWT0xHEYkMiCQ1Q==}
     engines: {node: '>=18.0.0'}
 
   '@aws-sdk/util-locate-window@3.965.8':
@@ -1445,12 +1469,32 @@ packages:
     resolution: {integrity: sha512-qoiY4nrk5OCu1+eIR1VB8l5DmON/oKiqrd5zZFAhXJXjJlLWQusKEW/SkBDAtGDcPaz86m9kfcE1lngU0GlM6A==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.29.2':
+    resolution: {integrity: sha512-DXUk6yU0C1Q1tYvJh1VCtl8QOBcSoZpKwjTPkxT6A4MUQYHvgeKGByL8mrEdxnvhdf9nq5GyzmRb5n/vPgu3Lw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.4.2':
     resolution: {integrity: sha512-18UMDMyrAbDcpmL1gLUA7ww0fRTcdCrSjSJOi2Sbld+tVjwD/pW+OAwjlScFLR7vvBnhZrIPQ7kVuTf1mnJLug==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/credential-provider-imds@4.4.6':
     resolution: {integrity: sha512-B2WQ/PV/H6Jeg3lrIq6bKUfa6Hy01mtK7CGs6lhjzHA6k4aagldH6T6eEjnzKl4HI0cJnAsxfJ19pgb5PV+CVQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-codec@4.4.7':
+    resolution: {integrity: sha512-YNodWVjMFOMAyjQgpHBBCz62DbYu4xwhpt+z5HRf7OZPwrfHgNDCyUZxaC0fy9/2TWcO+niOMHSl8aMgfbWZTQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-browser@4.4.7':
+    resolution: {integrity: sha512-l9UbuFbEeKItYk+PXl/mkXiWlXOCTIarbYVnd+9X7mKCWIMlZJ83UETq+mo7TVY7unISFkLSldViX5LdCiwhhQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-config-resolver@4.5.7':
+    resolution: {integrity: sha512-Q6wNRG7+zaMZEIKRYyYFnJqpC42mSN+F8ijX/61G7YHun+RGiRp0Cw2kuHmvXlIk0mxGAxCcgDWSTgUyfkunjw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-node@4.4.7':
+    resolution: {integrity: sha512-A22v/VJNKr/9aCiLu2c2F2lljK5Bhr5FQr87cfUHednLvlLSw61dlmI7WB1YXy3XH8zOkebPw885U+qCZKVfYg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/fetch-http-handler@5.5.2':
@@ -1513,12 +1557,12 @@ packages:
     resolution: {integrity: sha512-ZCQGk/UNS+YF5D+Jmhr8+PQX2PJKe4QzR6zuOR5sUinxO/ZiKNA7nyrbeO/Ds2hXLts3fZAtgLPKLJgvjCX9uQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/shared-ini-file-loader@4.6.2':
-    resolution: {integrity: sha512-9Xti1yhj7Em9t4ZQ1E8YRA6wbhAqx1nfLu0XSAqv82HED43TMUvn3nOO2xBISxZc0hcOg7wvuHEypUy4L4XF2w==}
+  '@smithy/querystring-builder@4.4.7':
+    resolution: {integrity: sha512-mj5EKTusnmJUQ1SxUxealNG8mlkwPPeKdUzGlOLy1CMor7qS19FW67HS0T7daUwHvyoXJo3hh4LLy97taJDNBA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/signature-v4@5.5.2':
-    resolution: {integrity: sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA==}
+  '@smithy/shared-ini-file-loader@4.6.2':
+    resolution: {integrity: sha512-9Xti1yhj7Em9t4ZQ1E8YRA6wbhAqx1nfLu0XSAqv82HED43TMUvn3nOO2xBISxZc0hcOg7wvuHEypUy4L4XF2w==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/signature-v4@5.6.2':
@@ -1535,6 +1579,10 @@ packages:
 
   '@smithy/types@4.15.1':
     resolution: {integrity: sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.16.0':
+    resolution: {integrity: sha512-aVUabzlBBmY0PfvVgLKQSOGFIL5/7R54JE3uD9a5Ay/jSED61SkuAcCYENNXJzYUvJ1NPrWO0P+rAXHCkbBUKw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/url-parser@4.4.2':
@@ -1567,6 +1615,10 @@ packages:
 
   '@smithy/util-endpoints@3.6.2':
     resolution: {integrity: sha512-K50/sbl8HRnBJt5+UYvIG8HCdEDNA9rhCmkWTDftzGMlJ4XlPgtqI1V6jTSi9tmK7MLfgw7CfGvzSKFSWOteOQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-hex-encoding@4.4.7':
+    resolution: {integrity: sha512-Wetc72mlwBkgGXIm/qpsc8uHxRdweMwc0LM5WUkGnCOxfcmbRvHN6R0EFCKU6hGMPVmTe6E0A8fQrLA+UP5Nsg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-middleware@4.4.2':
@@ -4384,7 +4436,7 @@ snapshots:
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/types': 3.973.15
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
@@ -4395,6 +4447,58 @@ snapshots:
       '@smithy/core': 3.29.1
       '@smithy/types': 4.15.1
       tslib: 2.8.1
+
+  '@aws-sdk/client-bedrock-runtime@3.967.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.967.0
+      '@aws-sdk/credential-provider-node': 3.967.0
+      '@aws-sdk/eventstream-handler-node': 3.965.0
+      '@aws-sdk/middleware-eventstream': 3.965.0
+      '@aws-sdk/middleware-host-header': 3.965.0
+      '@aws-sdk/middleware-logger': 3.965.0
+      '@aws-sdk/middleware-recursion-detection': 3.965.0
+      '@aws-sdk/middleware-user-agent': 3.967.0
+      '@aws-sdk/middleware-websocket': 3.965.0
+      '@aws-sdk/region-config-resolver': 3.965.0
+      '@aws-sdk/token-providers': 3.967.0
+      '@aws-sdk/types': 3.965.0
+      '@aws-sdk/util-endpoints': 3.965.0
+      '@aws-sdk/util-user-agent-browser': 3.965.0
+      '@aws-sdk/util-user-agent-node': 3.967.0
+      '@smithy/config-resolver': 4.6.2
+      '@smithy/core': 3.29.1
+      '@smithy/eventstream-serde-browser': 4.4.7
+      '@smithy/eventstream-serde-config-resolver': 4.5.7
+      '@smithy/eventstream-serde-node': 4.4.7
+      '@smithy/fetch-http-handler': 5.6.3
+      '@smithy/hash-node': 4.4.2
+      '@smithy/invalid-dependency': 4.4.2
+      '@smithy/middleware-content-length': 4.4.2
+      '@smithy/middleware-endpoint': 4.6.2
+      '@smithy/middleware-retry': 4.7.2
+      '@smithy/middleware-serde': 4.4.2
+      '@smithy/middleware-stack': 4.4.2
+      '@smithy/node-config-provider': 4.5.2
+      '@smithy/node-http-handler': 4.9.3
+      '@smithy/protocol-http': 5.5.2
+      '@smithy/smithy-client': 4.14.2
+      '@smithy/types': 4.15.1
+      '@smithy/url-parser': 4.4.2
+      '@smithy/util-base64': 4.5.2
+      '@smithy/util-body-length-browser': 4.4.2
+      '@smithy/util-body-length-node': 4.4.2
+      '@smithy/util-defaults-mode-browser': 4.5.2
+      '@smithy/util-defaults-mode-node': 4.4.2
+      '@smithy/util-endpoints': 3.6.2
+      '@smithy/util-middleware': 4.4.2
+      '@smithy/util-retry': 4.5.2
+      '@smithy/util-stream': 4.7.2
+      '@smithy/util-utf8': 4.4.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
 
   '@aws-sdk/client-s3@3.1080.0':
     dependencies:
@@ -4469,8 +4573,8 @@ snapshots:
       '@aws-sdk/util-user-agent-browser': 3.965.0
       '@aws-sdk/util-user-agent-node': 3.967.0
       '@smithy/config-resolver': 4.6.2
-      '@smithy/core': 3.26.0
-      '@smithy/fetch-http-handler': 5.5.2
+      '@smithy/core': 3.29.1
+      '@smithy/fetch-http-handler': 5.6.3
       '@smithy/hash-node': 4.4.2
       '@smithy/invalid-dependency': 4.4.2
       '@smithy/middleware-content-length': 4.4.2
@@ -4479,10 +4583,10 @@ snapshots:
       '@smithy/middleware-serde': 4.4.2
       '@smithy/middleware-stack': 4.4.2
       '@smithy/node-config-provider': 4.5.2
-      '@smithy/node-http-handler': 4.8.2
+      '@smithy/node-http-handler': 4.9.3
       '@smithy/protocol-http': 5.5.2
       '@smithy/smithy-client': 4.14.2
-      '@smithy/types': 4.15.0
+      '@smithy/types': 4.15.1
       '@smithy/url-parser': 4.4.2
       '@smithy/util-base64': 4.5.2
       '@smithy/util-body-length-browser': 4.4.2
@@ -4501,13 +4605,13 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.965.0
       '@aws-sdk/xml-builder': 3.965.0
-      '@smithy/core': 3.26.0
+      '@smithy/core': 3.29.1
       '@smithy/node-config-provider': 4.5.2
       '@smithy/property-provider': 4.4.2
       '@smithy/protocol-http': 5.5.2
-      '@smithy/signature-v4': 5.5.2
+      '@smithy/signature-v4': 5.6.2
       '@smithy/smithy-client': 4.14.2
-      '@smithy/types': 4.15.0
+      '@smithy/types': 4.15.1
       '@smithy/util-base64': 4.5.2
       '@smithy/util-middleware': 4.4.2
       '@smithy/util-utf8': 4.4.2
@@ -4606,7 +4710,7 @@ snapshots:
       '@smithy/property-provider': 4.4.2
       '@smithy/protocol-http': 5.5.2
       '@smithy/shared-ini-file-loader': 4.6.2
-      '@smithy/types': 4.15.0
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -4712,6 +4816,20 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@aws-sdk/eventstream-handler-node@3.965.0':
+    dependencies:
+      '@aws-sdk/types': 3.965.0
+      '@smithy/eventstream-codec': 4.4.7
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-eventstream@3.965.0':
+    dependencies:
+      '@aws-sdk/types': 3.965.0
+      '@smithy/protocol-http': 5.5.2
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-host-header@3.965.0':
     dependencies:
       '@aws-sdk/types': 3.965.0
@@ -4752,6 +4870,19 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-websocket@3.965.0':
+    dependencies:
+      '@aws-sdk/types': 3.965.0
+      '@aws-sdk/util-format-url': 3.965.0
+      '@smithy/eventstream-codec': 4.4.7
+      '@smithy/eventstream-serde-browser': 4.4.7
+      '@smithy/fetch-http-handler': 5.6.3
+      '@smithy/protocol-http': 5.5.2
+      '@smithy/signature-v4': 5.6.2
+      '@smithy/types': 4.15.1
+      '@smithy/util-hex-encoding': 4.4.7
+      tslib: 2.8.1
+
   '@aws-sdk/nested-clients@3.967.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -4767,8 +4898,8 @@ snapshots:
       '@aws-sdk/util-user-agent-browser': 3.965.0
       '@aws-sdk/util-user-agent-node': 3.967.0
       '@smithy/config-resolver': 4.6.2
-      '@smithy/core': 3.26.0
-      '@smithy/fetch-http-handler': 5.5.2
+      '@smithy/core': 3.29.1
+      '@smithy/fetch-http-handler': 5.6.3
       '@smithy/hash-node': 4.4.2
       '@smithy/invalid-dependency': 4.4.2
       '@smithy/middleware-content-length': 4.4.2
@@ -4777,10 +4908,10 @@ snapshots:
       '@smithy/middleware-serde': 4.4.2
       '@smithy/middleware-stack': 4.4.2
       '@smithy/node-config-provider': 4.5.2
-      '@smithy/node-http-handler': 4.8.2
+      '@smithy/node-http-handler': 4.9.3
       '@smithy/protocol-http': 5.5.2
       '@smithy/smithy-client': 4.14.2
-      '@smithy/types': 4.15.0
+      '@smithy/types': 4.15.1
       '@smithy/url-parser': 4.4.2
       '@smithy/util-base64': 4.5.2
       '@smithy/util-body-length-browser': 4.4.2
@@ -4837,19 +4968,19 @@ snapshots:
       '@aws-sdk/types': 3.965.0
       '@smithy/property-provider': 4.4.2
       '@smithy/shared-ini-file-loader': 4.6.2
-      '@smithy/types': 4.15.0
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
   '@aws-sdk/types@3.965.0':
     dependencies:
-      '@smithy/types': 4.15.0
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@aws-sdk/types@3.973.13':
     dependencies:
-      '@smithy/types': 4.15.0
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@aws-sdk/types@3.973.15':
@@ -4863,6 +4994,13 @@ snapshots:
       '@smithy/types': 4.15.0
       '@smithy/url-parser': 4.4.2
       '@smithy/util-endpoints': 3.6.2
+      tslib: 2.8.1
+
+  '@aws-sdk/util-format-url@3.965.0':
+    dependencies:
+      '@aws-sdk/types': 3.965.0
+      '@smithy/querystring-builder': 4.4.7
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@aws-sdk/util-locate-window@3.965.8':
@@ -4886,7 +5024,7 @@ snapshots:
 
   '@aws-sdk/xml-builder@3.965.0':
     dependencies:
-      '@smithy/types': 4.15.0
+      '@smithy/types': 4.15.1
       fast-xml-parser: 5.9.3
       tslib: 2.8.1
 
@@ -5959,6 +6097,11 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@smithy/core@3.29.2':
+    dependencies:
+      '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.4.2':
     dependencies:
       '@smithy/core': 3.26.0
@@ -5969,6 +6112,26 @@ snapshots:
     dependencies:
       '@smithy/core': 3.29.1
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/eventstream-codec@4.4.7':
+    dependencies:
+      '@smithy/core': 3.29.2
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-browser@4.4.7':
+    dependencies:
+      '@smithy/core': 3.29.2
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-config-resolver@4.5.7':
+    dependencies:
+      '@smithy/core': 3.29.2
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-node@4.4.7':
+    dependencies:
+      '@smithy/core': 3.29.2
       tslib: 2.8.1
 
   '@smithy/fetch-http-handler@5.5.2':
@@ -6049,15 +6212,14 @@ snapshots:
       '@smithy/core': 3.26.0
       tslib: 2.8.1
 
+  '@smithy/querystring-builder@4.4.7':
+    dependencies:
+      '@smithy/core': 3.29.2
+      tslib: 2.8.1
+
   '@smithy/shared-ini-file-loader@4.6.2':
     dependencies:
       '@smithy/core': 3.26.0
-      tslib: 2.8.1
-
-  '@smithy/signature-v4@5.5.2':
-    dependencies:
-      '@smithy/core': 3.26.0
-      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@smithy/signature-v4@5.6.2':
@@ -6077,6 +6239,10 @@ snapshots:
       tslib: 2.8.1
 
   '@smithy/types@4.15.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/types@4.16.0':
     dependencies:
       tslib: 2.8.1
 
@@ -6120,6 +6286,11 @@ snapshots:
       '@smithy/core': 3.26.0
       tslib: 2.8.1
 
+  '@smithy/util-hex-encoding@4.4.7':
+    dependencies:
+      '@smithy/core': 3.29.2
+      tslib: 2.8.1
+
   '@smithy/util-middleware@4.4.2':
     dependencies:
       '@smithy/core': 3.26.0
@@ -6132,7 +6303,7 @@ snapshots:
 
   '@smithy/util-stream@4.7.2':
     dependencies:
-      '@smithy/core': 3.26.0
+      '@smithy/core': 3.29.1
       tslib: 2.8.1
 
   '@smithy/util-utf8@2.3.0':

--- a/mem0-ts/src/oss/src/llms/aws_bedrock.ts
+++ b/mem0-ts/src/oss/src/llms/aws_bedrock.ts
@@ -1,0 +1,248 @@
+import type {
+  BedrockRuntimeClient,
+  ContentBlock,
+  ConverseCommandInput,
+  Message as BedrockMessage,
+  Tool as BedrockTool,
+} from "@aws-sdk/client-bedrock-runtime";
+import { LLM, LLMResponse } from "./base";
+import { AWSBedrockConfig, Message } from "../types";
+
+type BedrockSDK = typeof import("@aws-sdk/client-bedrock-runtime");
+
+// Providers that reject requests including both `temperature` and `topP` in
+// `inferenceConfig`. Mirrors the Python provider's `_build_inference_config`.
+const TOP_P_INCOMPATIBLE_PROVIDERS = new Set(["anthropic", "minimax"]);
+
+// Cross-region inference profile prefixes that precede the real provider
+// segment in a model id (e.g. `us.anthropic.claude-...`).
+const REGION_PREFIXES = new Set(["us", "eu", "apac", "global"]);
+
+function extractProvider(model: string): string {
+  const parts = model.split(".");
+  if (parts.length >= 2 && REGION_PREFIXES.has(parts[0])) {
+    return parts[1];
+  }
+  return parts[0];
+}
+
+export class AWSBedrockLLM implements LLM {
+  private clientArgs: NonNullable<
+    ConstructorParameters<typeof BedrockRuntimeClient>[0]
+  >;
+  private client?: BedrockRuntimeClient;
+  private model: string;
+  private provider: string;
+  private maxTokens: number;
+  private temperature?: number;
+  private topP?: number;
+
+  constructor(config: AWSBedrockConfig = {}) {
+    // Support both top-level fields and a nested `config` record (used by the
+    // Python SDK / OpenClaw config shape).
+    const nested = (config.config || {}) as Record<string, any>;
+    const region =
+      config.awsRegion ??
+      nested.awsRegion ??
+      nested.region ??
+      process.env.AWS_REGION ??
+      process.env.AWS_DEFAULT_REGION;
+
+    const clientArgs: NonNullable<
+      ConstructorParameters<typeof BedrockRuntimeClient>[0]
+    > = {};
+    if (region) {
+      clientArgs.region = region;
+    }
+    // Explicit credentials are optional. When omitted, the AWS SDK falls back
+    // to its default credential provider chain (env vars, shared config,
+    // instance/role credentials).
+    const accessKeyId =
+      config.awsAccessKeyId ??
+      nested.awsAccessKeyId ??
+      process.env.AWS_ACCESS_KEY_ID;
+    const secretAccessKey =
+      config.awsSecretAccessKey ??
+      nested.awsSecretAccessKey ??
+      process.env.AWS_SECRET_ACCESS_KEY;
+    if (accessKeyId && secretAccessKey) {
+      clientArgs.credentials = {
+        accessKeyId,
+        secretAccessKey,
+        sessionToken:
+          config.awsSessionToken ??
+          nested.awsSessionToken ??
+          process.env.AWS_SESSION_TOKEN,
+      };
+    }
+    this.clientArgs = clientArgs;
+
+    this.model =
+      (typeof config.model === "string" ? config.model : undefined) ||
+      "anthropic.claude-3-5-sonnet-20240620-v1:0";
+    this.provider = extractProvider(this.model);
+    // Defaults mirror the Python provider's AWSBedrockConfig
+    // (max_tokens=2000, temperature=0.1, top_p omitted).
+    this.maxTokens = config.maxTokens ?? 2000;
+    this.temperature = config.temperature ?? 0.1;
+    this.topP = config.topP;
+  }
+
+  // The AWS SDK is an optional peer dependency; import it lazily so users who
+  // don't use Bedrock aren't forced to install it (parity with the Vertex AI
+  // and Valkey providers).
+  private async getSDK(): Promise<BedrockSDK> {
+    try {
+      return await import("@aws-sdk/client-bedrock-runtime");
+    } catch (error) {
+      throw new Error(
+        "Failed to import '@aws-sdk/client-bedrock-runtime'. Please install it to use the AWS Bedrock provider: " +
+          (error as Error).message,
+      );
+    }
+  }
+
+  private async getClient(): Promise<BedrockRuntimeClient> {
+    if (!this.client) {
+      const sdk = await this.getSDK();
+      this.client = new sdk.BedrockRuntimeClient(this.clientArgs);
+    }
+    return this.client;
+  }
+
+  private buildInferenceConfig(): ConverseCommandInput["inferenceConfig"] {
+    const inferenceConfig: NonNullable<
+      ConverseCommandInput["inferenceConfig"]
+    > = {
+      maxTokens: this.maxTokens,
+    };
+    if (this.temperature !== undefined) {
+      inferenceConfig.temperature = this.temperature;
+    }
+    // Anthropic and MiniMax reasoning models raise a ValidationException when
+    // both temperature and topP are present. Prefer temperature for those.
+    if (
+      this.topP !== undefined &&
+      !(
+        TOP_P_INCOMPATIBLE_PROVIDERS.has(this.provider) &&
+        this.temperature !== undefined
+      )
+    ) {
+      inferenceConfig.topP = this.topP;
+    }
+    return inferenceConfig;
+  }
+
+  private toBedrockMessages(messages: Message[]): {
+    system?: { text: string }[];
+    messages: BedrockMessage[];
+  } {
+    const system: { text: string }[] = [];
+    const converseMessages: BedrockMessage[] = [];
+
+    for (const msg of messages) {
+      const content =
+        typeof msg.content === "string"
+          ? msg.content
+          : JSON.stringify(msg.content);
+      if (msg.role === "system") {
+        system.push({ text: content });
+      } else {
+        converseMessages.push({
+          role: msg.role === "assistant" ? "assistant" : "user",
+          content: [{ text: content }],
+        });
+      }
+    }
+
+    if (converseMessages.length === 0) {
+      converseMessages.push({ role: "user", content: [{ text: "" }] });
+    }
+
+    return {
+      system: system.length > 0 ? system : undefined,
+      messages: converseMessages,
+    };
+  }
+
+  private toToolConfig(
+    tools?: any[],
+  ): ConverseCommandInput["toolConfig"] | undefined {
+    if (!tools || tools.length === 0) {
+      return undefined;
+    }
+    const converseTools: BedrockTool[] = [];
+    for (const tool of tools) {
+      if (tool.type === "function" && tool.function) {
+        const fn = tool.function;
+        converseTools.push({
+          toolSpec: {
+            name: fn.name,
+            description: fn.description || "",
+            inputSchema: { json: fn.parameters || {} },
+          },
+        });
+      }
+    }
+    return converseTools.length > 0 ? { tools: converseTools } : undefined;
+  }
+
+  async generateResponse(
+    messages: Message[],
+    _responseFormat?: { type: string },
+    tools?: any[],
+  ): Promise<string | LLMResponse> {
+    const sdk = await this.getSDK();
+    const client = await this.getClient();
+
+    const { system, messages: converseMessages } =
+      this.toBedrockMessages(messages);
+    const toolConfig = this.toToolConfig(tools);
+
+    const input: ConverseCommandInput = {
+      modelId: this.model,
+      messages: converseMessages,
+      inferenceConfig: this.buildInferenceConfig(),
+    };
+    if (system) {
+      input.system = system;
+    }
+    if (toolConfig) {
+      input.toolConfig = toolConfig;
+    }
+
+    const response = await client.send(new sdk.ConverseCommand(input));
+    const blocks: ContentBlock[] = response.output?.message?.content ?? [];
+
+    if (toolConfig) {
+      let content = "";
+      const toolCalls: Array<{ name: string; arguments: string }> = [];
+      for (const block of blocks) {
+        if ("text" in block && block.text !== undefined) {
+          content = block.text;
+        } else if ("toolUse" in block && block.toolUse) {
+          toolCalls.push({
+            name: block.toolUse.name ?? "",
+            arguments: JSON.stringify(block.toolUse.input ?? {}),
+          });
+        }
+      }
+      return { content, role: "assistant", toolCalls };
+    }
+
+    for (const block of blocks) {
+      if ("text" in block && block.text !== undefined) {
+        return block.text;
+      }
+    }
+    return "";
+  }
+
+  async generateChat(messages: Message[]): Promise<LLMResponse> {
+    const response = await this.generateResponse(messages);
+    if (typeof response === "string") {
+      return { content: response, role: "assistant" };
+    }
+    return response;
+  }
+}

--- a/mem0-ts/src/oss/src/llms/aws_bedrock.ts
+++ b/mem0-ts/src/oss/src/llms/aws_bedrock.ts
@@ -14,16 +14,51 @@ type BedrockSDK = typeof import("@aws-sdk/client-bedrock-runtime");
 // `inferenceConfig`. Mirrors the Python provider's `_build_inference_config`.
 const TOP_P_INCOMPATIBLE_PROVIDERS = new Set(["anthropic", "minimax"]);
 
-// Cross-region inference profile prefixes that precede the real provider
-// segment in a model id (e.g. `us.anthropic.claude-...`).
-const REGION_PREFIXES = new Set(["us", "eu", "apac", "global"]);
+// Known Bedrock model providers. Mirrors the Python provider's PROVIDERS list
+// and is used to validate the provider segment of a model id.
+const PROVIDERS = [
+  "ai21",
+  "amazon",
+  "anthropic",
+  "cohere",
+  "meta",
+  "mistral",
+  "stability",
+  "writer",
+  "deepseek",
+  "gpt-oss",
+  "perplexity",
+  "snowflake",
+  "titan",
+  "command",
+  "j2",
+  "llama",
+  "minimax",
+];
 
+// Providers whose models support the Converse tool-use API. Requests that
+// attach a toolConfig for other families raise an AWS ValidationException, so
+// tools are silently dropped for them (parity with the Python provider's
+// `supports_tools` gate).
+const SUPPORTS_TOOLS_PROVIDERS = new Set(["anthropic", "cohere", "amazon"]);
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// Resolve the provider family from a model id by word-boundary matching against
+// the known PROVIDERS list. Mirrors the Python provider's regex search and
+// raises on an unrecognized model id rather than silently guessing.
 function extractProvider(model: string): string {
-  const parts = model.split(".");
-  if (parts.length >= 2 && REGION_PREFIXES.has(parts[0])) {
-    return parts[1];
+  for (const provider of PROVIDERS) {
+    const pattern = new RegExp(`\\b${escapeRegExp(provider)}\\b`);
+    if (pattern.test(model)) {
+      return provider;
+    }
   }
-  return parts[0];
+  throw new Error(
+    `Unknown AWS Bedrock provider for model '${model}'. Expected the model id to reference one of: ${PROVIDERS.join(", ")}.`,
+  );
 }
 
 export class AWSBedrockLLM implements LLM {
@@ -33,6 +68,7 @@ export class AWSBedrockLLM implements LLM {
   private client?: BedrockRuntimeClient;
   private model: string;
   private provider: string;
+  private supportsTools: boolean;
   private maxTokens: number;
   private temperature?: number;
   private topP?: number;
@@ -81,6 +117,7 @@ export class AWSBedrockLLM implements LLM {
       (typeof config.model === "string" ? config.model : undefined) ||
       "anthropic.claude-3-5-sonnet-20240620-v1:0";
     this.provider = extractProvider(this.model);
+    this.supportsTools = SUPPORTS_TOOLS_PROVIDERS.has(this.provider);
     // Defaults mirror the Python provider's AWSBedrockConfig
     // (max_tokens=2000, temperature=0.1, top_p omitted).
     this.maxTokens = config.maxTokens ?? 2000;
@@ -197,7 +234,12 @@ export class AWSBedrockLLM implements LLM {
 
     const { system, messages: converseMessages } =
       this.toBedrockMessages(messages);
-    const toolConfig = this.toToolConfig(tools);
+    // Only attach tools for provider families that support the tool-use API.
+    // For others the tools are silently dropped rather than triggering an AWS
+    // ValidationException, matching the Python provider's fallback.
+    const toolConfig = this.supportsTools
+      ? this.toToolConfig(tools)
+      : undefined;
 
     const input: ConverseCommandInput = {
       modelId: this.model,

--- a/mem0-ts/src/oss/src/tests/aws_bedrock.test.ts
+++ b/mem0-ts/src/oss/src/tests/aws_bedrock.test.ts
@@ -130,6 +130,78 @@ describe("AWSBedrockLLM", () => {
     });
   });
 
+  it("drops tools for providers that do not support the tool-use API", async () => {
+    const llm = new AWSBedrockLLM({
+      awsRegion: "us-west-2",
+      model: "meta.llama3-70b-instruct-v1:0",
+    });
+    const tools = [
+      {
+        type: "function",
+        function: {
+          name: "add_memory",
+          description: "store a memory",
+          parameters: { type: "object", properties: {} },
+        },
+      },
+    ];
+
+    const result = await llm.generateResponse(
+      [{ role: "user", content: "Hi" }],
+      undefined,
+      tools,
+    );
+
+    // No toolConfig is sent for unsupported families; the plain text response
+    // is returned instead of a toolCalls payload.
+    const input = converseCtor.mock.calls[0][0];
+    expect(input.toolConfig).toBeUndefined();
+    expect(result).toBe("hello");
+  });
+
+  it("keeps tools for supported providers", async () => {
+    const llm = new AWSBedrockLLM({
+      awsRegion: "us-west-2",
+      model: "cohere.command-r-plus-v1:0",
+    });
+    const tools = [
+      {
+        type: "function",
+        function: {
+          name: "add_memory",
+          description: "store a memory",
+          parameters: { type: "object", properties: {} },
+        },
+      },
+    ];
+
+    await llm.generateResponse(
+      [{ role: "user", content: "Hi" }],
+      undefined,
+      tools,
+    );
+
+    const input = converseCtor.mock.calls[0][0];
+    expect(input.toolConfig.tools[0].toolSpec.name).toBe("add_memory");
+  });
+
+  it("resolves the provider for region-prefixed model ids", () => {
+    // A cross-region inference profile id still resolves to the underlying
+    // provider family, so tool support is gated correctly.
+    expect(
+      () =>
+        new AWSBedrockLLM({
+          model: "us.anthropic.claude-3-5-sonnet-20240620-v1:0",
+        }),
+    ).not.toThrow();
+  });
+
+  it("throws on an unknown provider in the model id", () => {
+    expect(() => new AWSBedrockLLM({ model: "acme.super-model-v1:0" })).toThrow(
+      /Unknown AWS Bedrock provider/,
+    );
+  });
+
   it("reads region and credentials from the environment", async () => {
     process.env.AWS_REGION = "eu-central-1";
     process.env.AWS_ACCESS_KEY_ID = "AKIA_TEST";

--- a/mem0-ts/src/oss/src/tests/aws_bedrock.test.ts
+++ b/mem0-ts/src/oss/src/tests/aws_bedrock.test.ts
@@ -1,0 +1,150 @@
+import { AWSBedrockLLM } from "../llms/aws_bedrock";
+import { LLMFactory } from "../utils/factory";
+
+const sendMock = jest.fn();
+const clientCtor = jest.fn();
+const converseCtor = jest.fn().mockImplementation((input) => ({ input }));
+
+jest.mock("@aws-sdk/client-bedrock-runtime", () => ({
+  BedrockRuntimeClient: jest.fn().mockImplementation((args) => {
+    clientCtor(args);
+    return { send: sendMock };
+  }),
+  ConverseCommand: jest.fn().mockImplementation((input) => converseCtor(input)),
+}));
+
+function mockText(text: string) {
+  sendMock.mockResolvedValue({
+    output: { message: { content: [{ text }] } },
+  });
+}
+
+describe("AWSBedrockLLM", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.AWS_REGION;
+    delete process.env.AWS_DEFAULT_REGION;
+    delete process.env.AWS_ACCESS_KEY_ID;
+    delete process.env.AWS_SECRET_ACCESS_KEY;
+    mockText("hello");
+  });
+
+  it("registers the aws_bedrock and bedrock providers with LLMFactory", () => {
+    expect(LLMFactory.create("aws_bedrock", {})).toBeInstanceOf(AWSBedrockLLM);
+    expect(LLMFactory.create("bedrock", {})).toBeInstanceOf(AWSBedrockLLM);
+  });
+
+  it("does not import the AWS SDK at construction time", () => {
+    // Constructing must not instantiate the client (lazy loading), so users
+    // without the SDK installed can still import the module.
+    new AWSBedrockLLM({ awsRegion: "us-east-1" });
+    expect(clientCtor).not.toHaveBeenCalled();
+  });
+
+  it("returns text and passes system + inferenceConfig to Converse", async () => {
+    const llm = new AWSBedrockLLM({
+      awsRegion: "us-west-2",
+      model: "anthropic.claude-3-5-sonnet-20240620-v1:0",
+    });
+
+    const result = await llm.generateResponse([
+      { role: "system", content: "be terse" },
+      { role: "user", content: "Hi" },
+    ]);
+
+    expect(result).toBe("hello");
+    expect(clientCtor).toHaveBeenCalledWith({ region: "us-west-2" });
+
+    const input = converseCtor.mock.calls[0][0];
+    expect(input.modelId).toBe("anthropic.claude-3-5-sonnet-20240620-v1:0");
+    expect(input.system).toEqual([{ text: "be terse" }]);
+    expect(input.messages).toEqual([
+      { role: "user", content: [{ text: "Hi" }] },
+    ]);
+    // Anthropic must not receive topP alongside temperature.
+    expect(input.inferenceConfig).toEqual({
+      maxTokens: 2000,
+      temperature: 0.1,
+    });
+  });
+
+  it("keeps topP for non-anthropic providers", async () => {
+    const llm = new AWSBedrockLLM({
+      awsRegion: "us-west-2",
+      model: "meta.llama3-70b-instruct-v1:0",
+      topP: 0.9,
+    });
+
+    await llm.generateResponse([{ role: "user", content: "Hi" }]);
+
+    const input = converseCtor.mock.calls[0][0];
+    expect(input.inferenceConfig.topP).toBe(0.9);
+  });
+
+  it("maps tool definitions and toolUse responses to toolCalls", async () => {
+    sendMock.mockResolvedValue({
+      output: {
+        message: {
+          content: [
+            { text: "calling" },
+            {
+              toolUse: {
+                name: "add_memory",
+                input: { data: "likes coffee" },
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    const llm = new AWSBedrockLLM({ awsRegion: "us-west-2" });
+    const tools = [
+      {
+        type: "function",
+        function: {
+          name: "add_memory",
+          description: "store a memory",
+          parameters: { type: "object", properties: {} },
+        },
+      },
+    ];
+
+    const result = await llm.generateResponse(
+      [{ role: "user", content: "remember I like coffee" }],
+      undefined,
+      tools,
+    );
+
+    const input = converseCtor.mock.calls[0][0];
+    expect(input.toolConfig.tools[0].toolSpec.name).toBe("add_memory");
+    expect(result).toEqual({
+      content: "calling",
+      role: "assistant",
+      toolCalls: [
+        {
+          name: "add_memory",
+          arguments: JSON.stringify({ data: "likes coffee" }),
+        },
+      ],
+    });
+  });
+
+  it("reads region and credentials from the environment", async () => {
+    process.env.AWS_REGION = "eu-central-1";
+    process.env.AWS_ACCESS_KEY_ID = "AKIA_TEST";
+    process.env.AWS_SECRET_ACCESS_KEY = "secret";
+
+    const llm = new AWSBedrockLLM({});
+    await llm.generateChat([{ role: "user", content: "Hi" }]);
+
+    expect(clientCtor).toHaveBeenCalledWith({
+      region: "eu-central-1",
+      credentials: {
+        accessKeyId: "AKIA_TEST",
+        secretAccessKey: "secret",
+        sessionToken: undefined,
+      },
+    });
+  });
+});

--- a/mem0-ts/src/oss/src/types/index.ts
+++ b/mem0-ts/src/oss/src/types/index.ts
@@ -69,6 +69,17 @@ export interface LLMConfig {
   maxTokens?: number;
 }
 
+export interface AWSBedrockConfig extends LLMConfig {
+  /** AWS region for the Bedrock runtime endpoint. Falls back to `AWS_REGION`. */
+  awsRegion?: string;
+  /** Optional explicit access key. Falls back to the AWS credential chain. */
+  awsAccessKeyId?: string;
+  /** Optional explicit secret key. Falls back to the AWS credential chain. */
+  awsSecretAccessKey?: string;
+  /** Optional session token for temporary credentials. */
+  awsSessionToken?: string;
+}
+
 export interface RerankerConfig {
   apiKey?: string;
   /** The reranker model to use. Default varies by provider. */
@@ -217,6 +228,10 @@ export const MemoryConfigSchema = z.object({
       temperature: z.number().optional(),
       topP: z.number().optional(),
       maxTokens: z.number().optional(),
+      awsRegion: z.string().optional(),
+      awsAccessKeyId: z.string().optional(),
+      awsSecretAccessKey: z.string().optional(),
+      awsSessionToken: z.string().optional(),
     }),
   }),
   historyDbPath: z.string().optional(),

--- a/mem0-ts/src/oss/src/utils/factory.ts
+++ b/mem0-ts/src/oss/src/utils/factory.ts
@@ -38,6 +38,7 @@ import { LiteLLM } from "../llms/litellm";
 import { MiniMaxLLM } from "../llms/minimax";
 import { TogetherLLM } from "../llms/together";
 import { VllmLLM } from "../llms/vllm";
+import { AWSBedrockLLM } from "../llms/aws_bedrock";
 import { SupabaseDB } from "../vector_stores/supabase";
 import { SQLiteManager } from "../storage/SQLiteManager";
 import { MemoryHistoryManager } from "../storage/MemoryHistoryManager";
@@ -136,6 +137,9 @@ export class LLMFactory {
         return new TogetherLLM(config);
       case "vllm":
         return new VllmLLM(config);
+      case "aws_bedrock":
+      case "bedrock":
+        return new AWSBedrockLLM(config);
       default:
         throw new Error(`Unsupported LLM provider: ${provider}`);
     }


### PR DESCRIPTION
## Summary

Closes #5765.

Brings the TypeScript OSS SDK to parity with the Python SDK by adding an **AWS Bedrock** LLM provider.

## Changes

- **`llms/aws_bedrock.ts`**: New `AWSBedrockLLM` implementing the `LLM` interface (`generateResponse` / `generateChat`). Uses `@aws-sdk/client-bedrock-runtime` with the Converse API so a single code path works across Bedrock model families (Anthropic, Amazon Nova, Meta, Mistral, Cohere, etc.). Mirrors the Python provider's behavior:
  - System messages are lifted into the Converse `system` parameter.
  - OpenAI-style tool definitions are converted to `toolConfig.tools[].toolSpec`, and `toolUse` responses are mapped back into the existing `toolCalls` shape.
  - `inferenceConfig` omits `topP` for Anthropic and MiniMax when `temperature` is set (both reject the two together), matching `_build_inference_config` in Python.
  - Defaults match the Python provider (`maxTokens=2000`, `temperature=0.1`).
- **`utils/factory.ts`**: Register the `aws_bedrock` provider (plus a `bedrock` alias).
- **`types/index.ts`**: Add `AWSBedrockConfig` (`awsRegion`, `awsAccessKeyId`, `awsSecretAccessKey`, `awsSessionToken`) and the matching zod schema fields.
- **`package.json`**: Add `@aws-sdk/client-bedrock-runtime` as an optional peer dependency. The SDK is **lazy-loaded**, so users who don't use Bedrock aren't forced to install it (parity with the Vertex AI / Valkey providers).
- **`tests/aws_bedrock.test.ts`**: Unit tests for factory registration, lazy loading (no client construction at init), Converse request formatting, `topP` handling, tool-call mapping, and credential resolution from the environment.
- **docs**: Add a TypeScript usage example to the AWS Bedrock LLM page.

Auth uses the standard AWS credential provider chain (`AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`), with optional explicit credentials via config.

## Testing

- `pnpm run test:unit` (new `aws_bedrock.test.ts` passes, 6/6)
- `tsc --noEmit` clean
- `prettier --check` clean
- `pnpm install --frozen-lockfile` verified

## Notes

Followed the standalone-provider approach discussed on the issue rather than extending `OpenAILLM`, since Bedrock has provider-specific payloads and Converse-specific formatting. `aws_profile` support (which would require an extra credential-provider package) is intentionally left out in favor of the standard AWS SDK credential chain; happy to add it if maintainers prefer.