### PR TITLE
fix(ts-oss): persist entity ids from filters in infer:false add()

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -767,6 +767,14 @@ export class Memory {
   ): Promise<MemoryItem[]> {
     if (!infer) {
       const returnedMemories: MemoryItem[] = [];
+      // Fold the session scope into the stored payload so infer:false memories
+      // remain retrievable via scoped getAll/search. This mirrors the infer:true
+      // path (which writes filters.user_id/agent_id/run_id into memPayload) and
+      // covers scope passed via the `filters` option, not just userId/agentId/runId.
+      const baseMetadata: Record<string, any> = { ...metadata };
+      if (filters.user_id) baseMetadata.user_id = filters.user_id;
+      if (filters.agent_id) baseMetadata.agent_id = filters.agent_id;
+      if (filters.run_id) baseMetadata.run_id = filters.run_id;
       for (const message of messages) {
         if (message.role === "system") {
           continue;
@@ -774,7 +782,7 @@ export class Memory {
         const memoryId = await this.createMemory(
           message.content as string,
           {},
-          metadata,
+          baseMetadata,
         );
         returnedMemories.push({
           id: memoryId,

--- a/mem0-ts/src/oss/tests/memory.add.test.ts
+++ b/mem0-ts/src/oss/tests/memory.add.test.ts
@@ -191,4 +191,23 @@ describe("Memory - add()", () => {
       expect.objectContaining({ event: "ADD" }),
     );
   });
+
+  test("with infer=false, scope passed via filters is stored and retrievable", async () => {
+    const scopedUser = `infer_filters_${Date.now()}`;
+    await memory.add("Pizza is my favorite food", {
+      filters: { user_id: scopedUser },
+      infer: false,
+    });
+
+    // The memory must be reachable by a scoped getAll — i.e. its payload
+    // carries user_id. Without folding filters into the stored payload the
+    // memory is orphaned and this returns empty.
+    const all: SearchResult = await memory.getAll({
+      filters: { user_id: scopedUser },
+    });
+    expect(all.results.length).toBeGreaterThan(0);
+    expect(
+      all.results.some((r) => r.memory === "Pizza is my favorite food"),
+    ).toBe(true);
+  });
 });


### PR DESCRIPTION
## Linked Issue

Closes #6170

## Description

`add()` with `infer: false` only folded the session scope into the stored payload when it came from the `userId`/`agentId`/`runId` options:

```ts
if (userId) filters.user_id = metadata.user_id = userId;
```

When the same scope was passed via the `filters` option (a public field on `AddMemoryOptions`), it never reached `metadata`, and the `infer: false` branch of `addToVectorStore()` persists only `metadata`. The memory was therefore stored with no `user_id`/`agent_id`/`run_id` and could never be returned by a scoped `getAll`/`search`, even though `add()` reported success.

The `infer: true` path doesn't have this problem — it writes `filters.user_id`/`agent_id`/`run_id` into the payload directly. This change makes the `infer: false` branch fold the same values into the payload before calling `createMemory()`, so both paths agree. It also matches the Python SDK, whose `infer=false` path stores the session scope in the memory payload.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

Added a regression test in `memory.add.test.ts` that stores a memory with `{ filters: { user_id }, infer: false }` and asserts a scoped `getAll` returns it. It fails on the current code (0 results — the memory is orphaned) and passes with the fix. The full `add()` suite passes locally.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
