### PR TITLE
fix(ts-oss): honor response_format in Anthropic generateResponse

### DIFF
--- a/mem0-ts/src/oss/src/llms/anthropic.ts
+++ b/mem0-ts/src/oss/src/llms/anthropic.ts
@@ -2,6 +2,7 @@ import type Anthropic from "@anthropic-ai/sdk";
 import { LLM, LLMResponse } from "./base";
 import { LLMConfig, Message } from "../types";
 import { loadPeer } from "../utils/load_peer";
+import { extractJson } from "../prompts";
 
 export class AnthropicLLM implements LLM {
   private client!: Anthropic;
@@ -43,7 +44,7 @@ export class AnthropicLLM implements LLM {
 
   async generateResponse(
     messages: Message[],
-    responseFormat?: { type: string },
+    responseFormat?: { type: string; json_schema?: any },
     tools?: any[],
   ): Promise<string | LLMResponse> {
     await this.ensureClient();
@@ -80,6 +81,37 @@ export class AnthropicLLM implements LLM {
       params.tool_choice = { type: "auto" };
     }
 
+    // Anthropic has no native response_format param, so translate the shared
+    // interface here (parity with the Python provider, #5820 / #6203).
+    // response_format is intentionally ignored when tools are active: the
+    // tool_use handling below takes precedence, and the JSON prefill would
+    // otherwise drop tool_use blocks.
+    let wantsJsonPrefill = false;
+    if (responseFormat && !tools) {
+      if (responseFormat.type === "json_schema" && responseFormat.json_schema) {
+        let schema = responseFormat.json_schema;
+        if (schema && typeof schema === "object" && "schema" in schema) {
+          schema = schema.schema;
+        }
+        // output_config is newer than the pinned @anthropic-ai/sdk types.
+        (params as unknown as { output_config: unknown }).output_config = {
+          format: { type: "json_schema", schema },
+        };
+      } else if (responseFormat.type === "json_object") {
+        wantsJsonPrefill = true;
+        params.system =
+          (params.system ?? "") +
+          "\n\nYou must respond with valid JSON only. Do not include any " +
+          "other text, markdown formatting, or code fences.";
+        // Prefill the assistant turn with "{" so the model continues a JSON
+        // object; the leading brace is added back when reconstructing below.
+        params.messages = [
+          ...params.messages,
+          { role: "assistant", content: "{" },
+        ];
+      }
+    }
+
     const response = await this.client.messages.create(params);
 
     if (tools) {
@@ -100,10 +132,25 @@ export class AnthropicLLM implements LLM {
       return { content, role: "assistant", toolCalls };
     }
 
-    // Thinking-enabled responses put a thinking block before the text block,
-    // and a response can carry no text block at all, so find the text block
-    // like the tools branch above instead of indexing content[0]. Mirrors the
-    // Python provider (#6481).
+    if (wantsJsonPrefill) {
+      const text = this.firstTextBlock(response);
+      // No text block means there was nothing to continue the prefill with,
+      // so don't hand back a bare "{" that no parser can use.
+      if (!text) {
+        return "";
+      }
+      // Re-attach the "{" prefill that was sent as the assistant turn.
+      return extractJson("{" + text);
+    }
+
+    return this.firstTextBlock(response);
+  }
+
+  // Thinking-enabled responses put a thinking block before the text block, and
+  // a response can carry no text block at all, so find the text block like the
+  // tools branch does instead of indexing content[0] (#6506, mirroring the
+  // Python provider in #6481).
+  private firstTextBlock(response: Anthropic.Message): string {
     for (const block of response.content) {
       if (block.type === "text") {
         return block.text;

--- a/mem0-ts/src/oss/tests/anthropic-llm.test.ts
+++ b/mem0-ts/src/oss/tests/anthropic-llm.test.ts
@@ -329,4 +329,133 @@ describe("AnthropicLLM (unit)", () => {
     expect(callArgs.temperature).toBe(0.5);
     expect(callArgs.top_p).toBeUndefined();
   });
+
+  // #6203 (TS parity with #5820): Anthropic has no native response_format, so
+  // json_object must be translated into an assistant "{" prefill + a JSON
+  // system instruction, and the leading brace re-attached on the way out.
+  it("prefills '{' and appends a JSON instruction for response_format json_object", async () => {
+    // Model continues the object after the prefilled "{".
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: "text", text: '"facts": ["a"]}' }],
+    });
+
+    const llm = new AnthropicLLM({ apiKey: "test-key" });
+    const result = await llm.generateResponse(
+      [
+        { role: "system", content: "sys" },
+        { role: "user", content: "Hi" },
+      ],
+      { type: "json_object" },
+    );
+
+    const callArgs = mockCreate.mock.calls[0][0];
+    // Assistant turn prefilled with "{"
+    expect(callArgs.messages[callArgs.messages.length - 1]).toEqual({
+      role: "assistant",
+      content: "{",
+    });
+    // JSON-only instruction appended to system
+    expect(callArgs.system).toContain("valid JSON only");
+    // Leading brace re-attached → full, parseable JSON
+    expect(JSON.parse(result as string)).toEqual({ facts: ["a"] });
+  });
+
+  // The prefill path must find the text block rather than index content[0],
+  // otherwise thinking-enabled models break json_object mode (same defect
+  // #6506 fixed for the plain-text path).
+  it("finds the text block for json_object when a thinking block precedes it", async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [
+        { type: "thinking", thinking: "considering" },
+        { type: "text", text: '"facts": ["a"]}' },
+      ],
+    });
+
+    const llm = new AnthropicLLM({ apiKey: "test-key" });
+    const result = await llm.generateResponse(
+      [{ role: "user", content: "Hi" }],
+      { type: "json_object" },
+    );
+
+    expect(JSON.parse(result as string)).toEqual({ facts: ["a"] });
+  });
+
+  it("returns an empty string for json_object when no text block is present", async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: "thinking", thinking: "considering" }],
+    });
+
+    const llm = new AnthropicLLM({ apiKey: "test-key" });
+    const result = await llm.generateResponse(
+      [{ role: "user", content: "Hi" }],
+      { type: "json_object" },
+    );
+
+    // A bare "{" would be worse than nothing — no parser can use it.
+    expect(result).toBe("");
+  });
+
+  // json_schema → the Anthropic structured-outputs output_config.format.
+  it("maps response_format json_schema to output_config.format", async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: "text", text: '{"ok": true}' }],
+    });
+
+    const schema = {
+      type: "object",
+      properties: { ok: { type: "boolean" } },
+    };
+    const llm = new AnthropicLLM({ apiKey: "test-key" });
+    await llm.generateResponse([{ role: "user", content: "Hi" }], {
+      type: "json_schema",
+      json_schema: { schema },
+    });
+
+    const callArgs = mockCreate.mock.calls[0][0];
+    expect(callArgs.output_config).toEqual({
+      format: { type: "json_schema", schema },
+    });
+    // json_schema must not use the prefill path
+    expect(
+      callArgs.messages.some(
+        (m: { role: string; content: string }) =>
+          m.role === "assistant" && m.content === "{",
+      ),
+    ).toBe(false);
+  });
+
+  // response_format is ignored when tools are active (tool_use blocks would be
+  // dropped by the JSON prefill/extract path).
+  it("ignores response_format when tools are provided", async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: "tool_use", id: "t1", name: "add", input: { a: 1 } }],
+    });
+
+    const tools = [
+      {
+        name: "add",
+        description: "add",
+        input_schema: { type: "object", properties: {} },
+      },
+    ];
+    const llm = new AnthropicLLM({ apiKey: "test-key" });
+    const result = await llm.generateResponse(
+      [{ role: "user", content: "Hi" }],
+      { type: "json_object" },
+      tools,
+    );
+
+    const callArgs = mockCreate.mock.calls[0][0];
+    // No prefill injected, no JSON instruction, no output_config
+    expect(
+      callArgs.messages.some(
+        (m: { role: string; content: string }) =>
+          m.role === "assistant" && m.content === "{",
+      ),
+    ).toBe(false);
+    expect(callArgs.system ?? "").not.toContain("valid JSON only");
+    expect(callArgs.output_config).toBeUndefined();
+    // Tools path still returns structured toolCalls
+    expect(result).toHaveProperty("toolCalls");
+  });
 });


### PR DESCRIPTION
## Linked Issue

Closes #6203

## Description

The OSS TypeScript Anthropic provider (`mem0-ts/src/oss/src/llms/anthropic.ts`) accepted a `responseFormat` argument but never acted on it, so requesting JSON output was silently ignored. This is the TypeScript counterpart of the Python fix in #5820, and the follow-up @kartik-mem0 requested in that review.

Anthropic has no native `response_format`, so this translates the shared interface the same way the Python provider does:

- **`json_object`** → append a JSON-only system instruction and prefill the assistant turn with `{`, then reconstruct the object via `extractJson("{" + text)`.
- **`json_schema`** → map to `output_config.format` (Anthropic structured-outputs API).
- Short-circuits when `responseFormat` is undefined, so the existing path is untouched.
- **`response_format` is ignored when `tools` are active** (guarded + commented) — tool_use handling takes precedence and the JSON prefill would otherwise drop tool_use blocks. This addresses the minor point kartik flagged on #5820.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test Coverage

- [x] I added/updated unit tests

Added three tests to `anthropic-llm.test.ts` (mocked SDK): json_object prefill + reconstruction, json_schema → `output_config.format`, and response_format ignored when tools are present. All 14 tests in the file pass; `anthropic.ts` typechecks clean; prettier clean.

Also verified against the **live Anthropic API**: with `response_format={"type":"json_object"}` the provider returns directly `JSON.parse`-able output (e.g. `{"facts":["the sky is blue"]}`), whereas the same prompt with no format comes back ```-fenced (` ```json ... ``` `) — the exact behavior this fix removes.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally