### PR TITLE
fix(core): coerce non-string entity ids instead of crashing on .strip()

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -145,9 +145,10 @@ def _reject_top_level_entity_params(kwargs: Dict[str, Any], method_name: str) ->
         )
 
 
-def _validate_and_trim_entity_id(value: Optional[str], name: str) -> Optional[str]:
+def _validate_and_trim_entity_id(value: Optional[Any], name: str) -> Optional[str]:
     """
     Validates and normalizes an entity ID.
+    - Coerces non-string values (e.g. integer ids) to str
     - Trims leading/trailing whitespace
     - Rejects empty or whitespace-only strings
     - Rejects strings containing internal whitespace
@@ -164,6 +165,11 @@ def _validate_and_trim_entity_id(value: Optional[str], name: str) -> Optional[st
     """
     if value is None:
         return None
+    # Callers commonly pass integer ids (e.g. a database primary key). Coerce
+    # to str at this single validation point so scoping stays consistent across
+    # add/search/get_all/delete_all instead of crashing on `.strip()`.
+    if not isinstance(value, str):
+        value = str(value)
     trimmed = value.strip()
     if trimmed == "":
         raise ValueError(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from mem0.configs.base import MemoryConfig
-from mem0.memory.main import Memory
+from mem0.memory.main import Memory, _validate_and_trim_entity_id
 
 
 @pytest.fixture(autouse=True)
@@ -413,6 +413,28 @@ class TestEntityIdValidation:
         memory_instance.delete_all(user_id="  alice  ")
 
         memory_instance.vector_store.list.assert_called_once_with(filters={"user_id": "alice"})
+
+    def test_validate_coerces_non_string_entity_id(self):
+        """Integer (and other non-string) ids are coerced to str, not crashed on."""
+        assert _validate_and_trim_entity_id(42, "user_id") == "42"
+        assert _validate_and_trim_entity_id(0, "user_id") == "0"
+
+    def test_delete_all_coerces_integer_user_id_before_list(self, memory_instance):
+        """delete_all should accept an integer user_id and scope by its str form."""
+        memory_instance.vector_store.list = Mock(return_value=([], None))
+
+        memory_instance.delete_all(user_id=42)
+
+        memory_instance.vector_store.list.assert_called_once_with(filters={"user_id": "42"})
+
+    def test_get_all_coerces_integer_user_id(self, memory_instance):
+        """get_all should accept an integer user_id in filters and scope by its str form."""
+        memory_instance.vector_store.list = Mock(return_value=([], None))
+
+        memory_instance.get_all(filters={"user_id": 42})
+
+        _, kwargs = memory_instance.vector_store.list.call_args
+        assert kwargs["filters"]["user_id"] == "42"
 
 
 class TestSearchParamValidation:


### PR DESCRIPTION
## Linked Issue

Closes #6204

## Description

`_validate_and_trim_entity_id` assumed the entity id was always a `str` and called `value.strip()`:

```python
if value is None:
    return None
trimmed = value.strip()   # AttributeError if value is an int
```

Passing a non-string id (e.g. an integer `user_id`, which is common when the id is a database primary key) crashed with `AttributeError: 'int' object has no attribute 'strip'` deep in the call stack, with no hint about the cause. Every public entry point routes entity ids through this one function, so `add`, `search`, `get_all`, and `delete_all` (sync and async) were all affected.

This coerces non-string values to `str` at the single validation point, so the id "just works" and scoping stays consistent across every entry point (they all normalize the same way). The alternative would be to raise a clear `ValueError`; coercion was chosen because integer ids are a common, reasonable input and nothing currently succeeds with them. Happy to switch to an explicit error if you'd prefer that.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

Added tests under `TestEntityIdValidation` covering the helper directly (`42 -> "42"`, `0 -> "0"`) and the `delete_all`/`get_all` integer-id paths (asserting the store is scoped by the str form). They fail on the current code with the `AttributeError` and pass with the fix.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
