### PR TITLE
fix(openmemory): honor LLM/EMBEDDER env vars in the default config and stop dropping openai_base_url

### DIFF
--- a/openmemory/api/app/routers/config.py
+++ b/openmemory/api/app/routers/config.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any, Dict, Optional
 
 from app.database import get_db
@@ -14,6 +15,7 @@ class LLMConfig(BaseModel):
     temperature: float = Field(..., description="Temperature setting for the model")
     max_tokens: int = Field(..., description="Maximum tokens to generate")
     api_key: Optional[str] = Field(None, description="API key or 'env:API_KEY' to use environment variable")
+    openai_base_url: Optional[str] = Field(None, description="Base URL for OpenAI-compatible APIs (e.g., http://localhost:8080/v1)")
     ollama_base_url: Optional[str] = Field(None, description="Base URL for Ollama server (e.g., http://host.docker.internal:11434)")
 
 class LLMProvider(BaseModel):
@@ -23,6 +25,7 @@ class LLMProvider(BaseModel):
 class EmbedderConfig(BaseModel):
     model: str = Field(..., description="Embedder model name")
     api_key: Optional[str] = Field(None, description="API key or 'env:API_KEY' to use environment variable")
+    openai_base_url: Optional[str] = Field(None, description="Base URL for OpenAI-compatible APIs (e.g., http://localhost:8080/v1)")
     ollama_base_url: Optional[str] = Field(None, description="Base URL for Ollama server (e.g., http://host.docker.internal:11434)")
 
 class EmbedderProvider(BaseModel):
@@ -47,27 +50,58 @@ class ConfigSchema(BaseModel):
     mem0: Optional[Mem0Config] = None
 
 def get_default_configuration():
-    """Get the default configuration with sensible defaults for LLM and embedder."""
+    """Get the default configuration with sensible defaults for LLM and embedder.
+
+    Honors the same LLM_* / EMBEDDER_* environment variables that
+    app.utils.memory.get_default_memory_config() supports, so the config row
+    this function seeds matches an env-configured deployment instead of
+    silently switching it to hardcoded OpenAI defaults. Values are stored as
+    'env:VAR' references so secret material is never persisted in the
+    database. With none of these variables set, the result is identical to
+    the previous hardcoded defaults.
+    """
+    llm_provider = os.environ.get("LLM_PROVIDER", "openai").lower()
+    llm_config = {
+        "model": os.environ.get("LLM_MODEL", "gpt-4o-mini"),
+        "temperature": 0.1,
+        "max_tokens": 2000,
+    }
+    if llm_provider == "ollama":
+        if os.environ.get("OLLAMA_BASE_URL"):
+            llm_config["ollama_base_url"] = "env:OLLAMA_BASE_URL"
+        elif os.environ.get("LLM_BASE_URL"):
+            llm_config["ollama_base_url"] = "env:LLM_BASE_URL"
+    else:
+        llm_config["api_key"] = "env:LLM_API_KEY" if os.environ.get("LLM_API_KEY") else "env:OPENAI_API_KEY"
+        if os.environ.get("LLM_BASE_URL"):
+            llm_config["openai_base_url"] = "env:LLM_BASE_URL"
+
+    embedder_provider = os.environ.get("EMBEDDER_PROVIDER", "openai").lower()
+    embedder_config = {
+        "model": os.environ.get("EMBEDDER_MODEL", "text-embedding-3-small"),
+    }
+    if embedder_provider == "ollama":
+        if os.environ.get("EMBEDDER_BASE_URL"):
+            embedder_config["ollama_base_url"] = "env:EMBEDDER_BASE_URL"
+        elif os.environ.get("OLLAMA_BASE_URL"):
+            embedder_config["ollama_base_url"] = "env:OLLAMA_BASE_URL"
+    else:
+        embedder_config["api_key"] = "env:EMBEDDER_API_KEY" if os.environ.get("EMBEDDER_API_KEY") else "env:OPENAI_API_KEY"
+        if os.environ.get("EMBEDDER_BASE_URL"):
+            embedder_config["openai_base_url"] = "env:EMBEDDER_BASE_URL"
+
     return {
         "openmemory": {
             "custom_instructions": None
         },
         "mem0": {
             "llm": {
-                "provider": "openai",
-                "config": {
-                    "model": "gpt-4o-mini",
-                    "temperature": 0.1,
-                    "max_tokens": 2000,
-                    "api_key": "env:OPENAI_API_KEY"
-                }
+                "provider": llm_provider,
+                "config": llm_config
             },
             "embedder": {
-                "provider": "openai",
-                "config": {
-                    "model": "text-embedding-3-small",
-                    "api_key": "env:OPENAI_API_KEY"
-                }
+                "provider": embedder_provider,
+                "config": embedder_config
             },
             "vector_store": None
         }

--- a/openmemory/api/tests/test_config_router.py
+++ b/openmemory/api/tests/test_config_router.py
@@ -1,0 +1,140 @@
+"""Tests for the config router's default configuration and schema round-trips.
+
+The default configuration seeds the persistent DB config row via
+get-or-create on every /api/v1/config GET, and the DB row overrides
+environment configuration in get_memory_client() — so these defaults must
+honor the documented LLM_* / EMBEDDER_* environment variables, and the
+pydantic schemas must not silently drop fields on PUT round-trips.
+"""
+
+import os
+
+# Set dummy keys before any imports that trigger client initialization
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+from unittest import mock
+
+from app.routers.config import ConfigSchema, get_default_configuration
+
+# ---------------------------------------------------------------------------
+# get_default_configuration
+# ---------------------------------------------------------------------------
+
+def test_defaults_unchanged_without_env_vars():
+    """With no LLM_*/EMBEDDER_* env vars set, output matches the legacy hardcoded defaults."""
+    with mock.patch.dict(os.environ, {}, clear=True):
+        config = get_default_configuration()
+
+    assert config["mem0"]["llm"] == {
+        "provider": "openai",
+        "config": {
+            "model": "gpt-4o-mini",
+            "temperature": 0.1,
+            "max_tokens": 2000,
+            "api_key": "env:OPENAI_API_KEY",
+        },
+    }
+    assert config["mem0"]["embedder"] == {
+        "provider": "openai",
+        "config": {
+            "model": "text-embedding-3-small",
+            "api_key": "env:OPENAI_API_KEY",
+        },
+    }
+    assert config["mem0"]["vector_store"] is None
+    assert config["openmemory"] == {"custom_instructions": None}
+
+
+def test_defaults_honor_openai_compatible_env_vars():
+    env = {
+        "LLM_PROVIDER": "openai",
+        "LLM_MODEL": "my-model",
+        "LLM_API_KEY": "sk-secret-llm",
+        "LLM_BASE_URL": "http://localhost:8080/v1",
+        "EMBEDDER_MODEL": "my-embedder",
+        "EMBEDDER_API_KEY": "sk-secret-embed",
+        "EMBEDDER_BASE_URL": "http://localhost:8081/v1",
+    }
+    with mock.patch.dict(os.environ, env, clear=True):
+        config = get_default_configuration()
+
+    llm = config["mem0"]["llm"]["config"]
+    assert llm["model"] == "my-model"
+    assert llm["openai_base_url"] == "env:LLM_BASE_URL"
+    embedder = config["mem0"]["embedder"]["config"]
+    assert embedder["model"] == "my-embedder"
+    assert embedder["openai_base_url"] == "env:EMBEDDER_BASE_URL"
+
+
+def test_defaults_store_env_references_not_secrets():
+    """Secret material must never be written into the persisted default config."""
+    env = {
+        "LLM_MODEL": "my-model",
+        "LLM_API_KEY": "sk-secret-llm",
+        "EMBEDDER_API_KEY": "sk-secret-embed",
+    }
+    with mock.patch.dict(os.environ, env, clear=True):
+        config = get_default_configuration()
+
+    assert config["mem0"]["llm"]["config"]["api_key"] == "env:LLM_API_KEY"
+    assert config["mem0"]["embedder"]["config"]["api_key"] == "env:EMBEDDER_API_KEY"
+    assert "sk-secret-llm" not in str(config)
+    assert "sk-secret-embed" not in str(config)
+
+
+def test_defaults_honor_ollama_env_vars():
+    env = {
+        "LLM_PROVIDER": "ollama",
+        "LLM_MODEL": "llama3.1:latest",
+        "OLLAMA_BASE_URL": "http://host.docker.internal:11434",
+        "EMBEDDER_PROVIDER": "ollama",
+        "EMBEDDER_MODEL": "nomic-embed-text",
+    }
+    with mock.patch.dict(os.environ, env, clear=True):
+        config = get_default_configuration()
+
+    llm = config["mem0"]["llm"]
+    assert llm["provider"] == "ollama"
+    assert llm["config"]["ollama_base_url"] == "env:OLLAMA_BASE_URL"
+    assert "api_key" not in llm["config"]
+    embedder = config["mem0"]["embedder"]
+    assert embedder["provider"] == "ollama"
+    assert embedder["config"]["ollama_base_url"] == "env:OLLAMA_BASE_URL"
+
+
+# ---------------------------------------------------------------------------
+# Schema round-trips
+# ---------------------------------------------------------------------------
+
+def test_config_schema_preserves_openai_base_url():
+    """PUT payloads with openai_base_url must round-trip instead of being dropped."""
+    payload = {
+        "mem0": {
+            "llm": {
+                "provider": "openai",
+                "config": {
+                    "model": "my-model",
+                    "temperature": 0.1,
+                    "max_tokens": 2000,
+                    "api_key": "env:OPENAI_API_KEY",
+                    "openai_base_url": "http://localhost:8080/v1",
+                },
+            },
+            "embedder": {
+                "provider": "openai",
+                "config": {
+                    "model": "my-embedder",
+                    "api_key": "env:OPENAI_API_KEY",
+                    "openai_base_url": "http://localhost:8081/v1",
+                },
+            },
+        }
+    }
+
+    parsed = ConfigSchema(**payload)
+
+    assert parsed.mem0.llm.config.openai_base_url == "http://localhost:8080/v1"
+    assert parsed.mem0.embedder.config.openai_base_url == "http://localhost:8081/v1"
+    dumped = parsed.model_dump()
+    assert dumped["mem0"]["llm"]["config"]["openai_base_url"] == "http://localhost:8080/v1"
+    assert dumped["mem0"]["embedder"]["config"]["openai_base_url"] == "http://localhost:8081/v1"


### PR DESCRIPTION
## Problem

Deployments that configure OpenMemory through the documented `LLM_*` / `EMBEDDER_*` environment variables (any OpenAI-compatible endpoint — Ollama's OpenAI mode, vLLM, LM Studio, OpenRouter, hosted gateways) get silently broken by the config API:

1. **`get_default_configuration()` ignores environment configuration.** Every `GET /api/v1/config/*` endpoint get-or-creates the persistent `main` config row using hardcoded defaults (`gpt-4o-mini` / `text-embedding-3-small` / `env:OPENAI_API_KEY`), and `get_memory_client()` gives the DB row precedence over env config. So merely opening the dashboard settings page permanently switches a working env-configured deployment onto the hardcoded OpenAI defaults — every subsequent memory add then fails (e.g. 401s, because a non-OpenAI key gets sent to `api.openai.com`).

2. **The config schemas cannot express OpenAI-compatible endpoints.** `LLMConfig` / `EmbedderConfig` accept `ollama_base_url` but not `openai_base_url`, even though `app/utils/memory.py` writes that field and mem0's own OpenAI LLM/embedder configs support it. Any `PUT /api/v1/config/...` round-trip silently strips it, so a custom base URL can't be persisted through the API — and a dashboard save destroys one written by other means.

**Reproduction:** deploy with `LLM_PROVIDER`/`LLM_MODEL`/`LLM_BASE_URL` etc. set (adds work) → `curl` any `GET /api/v1/config/` endpoint or open dashboard settings → adds now fail; inspect the `configs` DB row to see the hardcoded defaults that were seeded.

## Fix

- `get_default_configuration()` now builds its defaults from the same environment variables `get_default_memory_config()` documents, storing **`env:` references** (`env:LLM_API_KEY`, `env:LLM_BASE_URL`, …) so no secret material is ever persisted in the database. With none of these variables set, the output is identical to the previous hardcoded defaults — no behavior change for plain-OpenAI deployments.
- Added `openai_base_url` to `LLMConfig` and `EmbedderConfig` so the field round-trips through GET/PUT.

## Tests

New `tests/test_config_router.py`: legacy-default equivalence with no env vars, env-var honoring (OpenAI-compatible and Ollama), secrets-stay-out-of-the-DB, and schema round-trip of `openai_base_url`. All 5 pass; the 3 pre-existing failures in `test_mcp_server.py::TestRouteRegistration` are unrelated and fail identically on `main`.

Addresses the failure mode reported in #4194 and part of #3238.