### PR TITLE
fix(core): don't require langchain-core for default async procedural memory

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -3563,16 +3563,6 @@ class AsyncMemory(MemoryBase):
             llm (llm, optional): LLM to use for the procedural memory creation. Defaults to None.
             prompt (str, optional): Prompt to use for the procedural memory creation. Defaults to None.
         """
-        try:
-            from langchain_core.messages.utils import (
-                convert_to_messages,  # type: ignore
-            )
-        except Exception:
-            logger.error(
-                "Import error while loading langchain-core. Please install 'langchain-core' to use procedural memory."
-            )
-            raise
-
         logger.info("Creating procedural memory")
 
         parsed_messages = [
@@ -3583,6 +3573,19 @@ class AsyncMemory(MemoryBase):
 
         try:
             if llm is not None:
+                # langchain-core is only needed to adapt messages for a custom
+                # LangChain LLM. The default path uses self.llm and must not
+                # require the optional dependency, mirroring the sync version.
+                try:
+                    from langchain_core.messages.utils import (
+                        convert_to_messages,  # type: ignore
+                    )
+                except ImportError as e:
+                    raise ImportError(
+                        "langchain-core is required to pass a custom LLM to procedural memory. "
+                        "Install it with 'pip install langchain-core'."
+                    ) from e
+
                 parsed_messages = convert_to_messages(parsed_messages)
                 response = await asyncio.to_thread(llm.invoke, input=parsed_messages)
                 procedural_memory = remove_code_blocks(response.content)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,6 +1,7 @@
 import json
+import sys
 from datetime import datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
@@ -1529,3 +1530,43 @@ async def test_async_procedural_memory_langchain_strips_code_blocks(mock_llm_fac
     insert_call = memory.vector_store.insert.call_args
     stored_data = insert_call[1]["payloads"][0]["data"]
     assert "```" not in stored_data
+
+
+@pytest.mark.asyncio
+@patch("mem0.memory.main.VectorStoreFactory")
+@patch("mem0.memory.main.EmbedderFactory")
+@patch("mem0.memory.main.LlmFactory")
+async def test_async_procedural_memory_default_path_without_langchain(mock_llm_factory, mock_emb, mock_vs):
+    """Async procedural memory must not require langchain-core on the default
+    (llm=None) path, which uses self.llm and never calls convert_to_messages.
+    The sync path already works without it; this keeps the async path in parity.
+    """
+    mock_vs.return_value = MagicMock()
+    mock_emb.return_value = MagicMock()
+    mock_emb.return_value.embed.return_value = [0.1] * 1536
+    mock_llm_factory.return_value = MagicMock()
+
+    from mem0.memory.main import AsyncMemory
+
+    config = MemoryConfig()
+    memory = AsyncMemory(config)
+    memory.vector_store = MagicMock()
+    memory.vector_store.insert = MagicMock()
+    memory.embedding_model.embed = Mock(return_value=[0.1] * 1536)
+    memory.llm.generate_response = Mock(return_value="- deploy with the release script")
+
+    messages = [{"role": "user", "content": "how do we deploy"}]
+
+    # Simulate langchain-core being unavailable; the default path must still work.
+    with patch.dict(
+        sys.modules,
+        {
+            "langchain_core": None,
+            "langchain_core.messages": None,
+            "langchain_core.messages.utils": None,
+        },
+    ):
+        result = await memory._create_procedural_memory(messages, metadata={"agent_id": "agent_1"})
+
+    assert result["results"][0]["event"] == "ADD"
+    memory.llm.generate_response.assert_called_once()


### PR DESCRIPTION
## Linked Issue

Closes #6208

## Description

`AsyncMemory._create_procedural_memory` imported `langchain-core` at the top of the method and re-raised if it was missing, even though the default (`llm=None`) path never uses it. Async procedural memory therefore failed on a base install, while the sync `Memory._create_procedural_memory` works fine without the package — an async/sync asymmetry.

`langchain-core` is optional (`[extras]` in `pyproject.toml`) and is only needed to adapt messages for a custom LangChain `llm` via `convert_to_messages`. This moves the import into the `llm is not None` branch where it is actually used, and raises a clear `ImportError` if the package is missing in that specific case. The default path now runs without `langchain-core`, matching the sync implementation.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

Added `test_async_procedural_memory_default_path_without_langchain`, which runs the default async path with `langchain-core` simulated absent (patched out of `sys.modules`) and asserts the memory is created via `self.llm`. It fails on the current code with `ModuleNotFoundError` and passes with the fix. The existing custom-LLM test (`test_async_procedural_memory_langchain_strips_code_blocks`) is unaffected — that path still imports and uses `convert_to_messages`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
