### PR TITLE
fix(llms/litellm): strip temperature/top_p for reasoning models

### DIFF
--- a/mem0/llms/litellm.py
+++ b/mem0/llms/litellm.py
@@ -70,21 +70,34 @@ class LiteLLM(LLMBase):
         if tools and not litellm.supports_function_calling(self.config.model):
             raise ValueError(f"Model '{self.config.model}' in litellm does not support function calling.")
 
-        params = {
-            "model": self.config.model,
-            "messages": messages,
-            "temperature": self.config.temperature,
-            "top_p": self.config.top_p,
-        }
-        if self._uses_max_completion_tokens(self.config.model):
-            params["max_completion_tokens"] = self.config.max_tokens
-        else:
-            params["max_tokens"] = self.config.max_tokens
+        # Build provider params through the shared helper so reasoning models
+        # (o1/o3/gpt-5 family) drop temperature/top_p the way OpenAI/xAI do.
+        # LiteLLM previously always forwarded temperature, which is the same
+        # failure mode documented in #6085 for the OpenAI default path.
+        kwargs = {}
         if response_format:
-            params["response_format"] = response_format
+            kwargs["response_format"] = response_format
         if tools:  # TODO: Remove tools if no issues found with new memory addition logic
-            params["tools"] = tools
-            params["tool_choice"] = tool_choice
+            kwargs["tools"] = tools
+            kwargs["tool_choice"] = tool_choice
+
+        params = self._get_supported_params(messages=messages, **kwargs)
+        params.update(
+            {
+                "model": self.config.model,
+                "messages": messages,
+            }
+        )
+        # ``_get_supported_params`` already chose max_tokens vs max_completion_tokens
+        # for non-reasoning models. For reasoning models the shared helper omits the
+        # cap entirely today; re-apply the GPT-5-family max_completion_tokens key so
+        # configured limits still work through LiteLLM.
+        if self._is_reasoning_model(self.config.model) or self._uses_max_completion_tokens(
+            self.config.model
+        ):
+            if self.config.max_tokens is not None and "max_tokens" not in params and "max_completion_tokens" not in params:
+                params["max_completion_tokens"] = self.config.max_tokens
+        params.setdefault("model", self.config.model)
 
         response = litellm.completion(**params)
         return self._parse_response(response, tools)

--- a/tests/llms/test_litellm.py
+++ b/tests/llms/test_litellm.py
@@ -56,9 +56,12 @@ def test_generate_response_without_tools(mock_litellm):
 
     response = llm.generate_response(messages)
 
-    mock_litellm.completion.assert_called_once_with(
-        model="gpt-4.1-nano-2025-04-14", messages=messages, temperature=0.7, max_tokens=100, top_p=1.0
-    )
+    _, kwargs = mock_litellm.completion.call_args
+    assert kwargs["model"] == "gpt-4.1-nano-2025-04-14"
+    assert kwargs["messages"] == messages
+    assert kwargs["temperature"] == 0.7
+    assert kwargs["max_tokens"] == 100
+    assert kwargs["top_p"] == 1.0
     assert response == "I'm doing well, thank you for asking!"
 
 
@@ -133,11 +136,60 @@ def test_generate_response_with_tools(mock_litellm):
 
     response = llm.generate_response(messages, tools=tools)
 
-    mock_litellm.completion.assert_called_once_with(
-        model="gpt-4.1-nano-2025-04-14", messages=messages, temperature=0.7, max_tokens=100, top_p=1, tools=tools, tool_choice="auto"
-    )
+    _, kwargs = mock_litellm.completion.call_args
+    assert kwargs["model"] == "gpt-4.1-nano-2025-04-14"
+    assert kwargs["messages"] == messages
+    assert kwargs["temperature"] == 0.7
+    assert kwargs["max_tokens"] == 100
+    assert kwargs["top_p"] == 1
+    assert kwargs["tools"] == tools
+    assert kwargs["tool_choice"] == "auto"
 
     assert response["content"] == "I've added the memory for you."
     assert len(response["tool_calls"]) == 1
     assert response["tool_calls"][0]["name"] == "add_memory"
     assert response["tool_calls"][0]["arguments"] == {"data": "Today is a sunny day."}
+
+
+def test_generate_response_reasoning_model_omits_temperature(mock_litellm):
+    """Reasoning models reject temperature/top_p; LiteLLM must strip them (#6085 parity)."""
+    config = BaseLlmConfig(model="o3-mini", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = litellm.LiteLLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Hi"))]
+    mock_litellm.completion.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    _, kwargs = mock_litellm.completion.call_args
+    assert "temperature" not in kwargs
+    assert "top_p" not in kwargs
+    assert kwargs["model"] == "o3-mini"
+    assert kwargs["messages"] == messages
+    # Configured max_tokens must still be forwarded as max_completion_tokens
+    assert kwargs.get("max_completion_tokens") == 100
+    assert "max_tokens" not in kwargs
+
+
+def test_generate_response_explicit_is_reasoning_model_flag(mock_litellm):
+    config = BaseLlmConfig(
+        model="custom-router/o3-like",
+        temperature=0.5,
+        max_tokens=50,
+        top_p=0.9,
+        is_reasoning_model=True,
+    )
+    llm = litellm.LiteLLM(config)
+    messages = [{"role": "user", "content": "Hi"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="ok"))]
+    mock_litellm.completion.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    _, kwargs = mock_litellm.completion.call_args
+    assert "temperature" not in kwargs
+    assert "top_p" not in kwargs


### PR DESCRIPTION
## Summary

- Route LiteLLM generate_response params through LLMBase._get_supported_params so reasoning models (o1/o3/gpt-5 family) omit temperature/top_p.
- Keep configured token limits via max_completion_tokens for reasoning/GPT-5 models.
- Add regression tests for o3-mini and explicit is_reasoning_model=True.

## Motivation

Follow-up / adjacency to #6085. OpenAI/Azure/xAI already filter sampling params for reasoning models; mem0/llms/litellm.py still always sent temperature and top_p. With default temperature=0.1 and model names that LiteLLM can map to reasoning families (including the post-#6085 gpt-5-mini default), workflows using the LiteLLM provider crash or fail.

## Verification

- python -m pytest tests/llms/test_litellm.py -q — 8 passed
- Did NOT change OpenAI/xAI providers (already correct)
