### PR TITLE
fix(llms/together): strip temperature/top_p for reasoning models

### DIFF
--- a/mem0/llms/together.py
+++ b/mem0/llms/together.py
@@ -74,19 +74,29 @@ class TogetherLLM(LLMBase):
         Returns:
             str: The generated response.
         """
-        params = {
-            "model": self.config.model,
-            "messages": messages,
-            "temperature": self.config.temperature,
-            "max_tokens": self.config.max_tokens,
-            "top_p": self.config.top_p,
-        }
-        params.update(kwargs)
+        # Use the shared parameter filter so o1/o3/gpt-5-style models drop
+        # temperature/top_p (parity with OpenAI/xAI and the LiteLLM fix).
+        call_kwargs = dict(kwargs)
         if response_format:
-            params["response_format"] = response_format
+            call_kwargs["response_format"] = response_format
         if tools:  # TODO: Remove tools if no issues found with new memory addition logic
-            params["tools"] = tools
-            params["tool_choice"] = tool_choice
+            call_kwargs["tools"] = tools
+            call_kwargs["tool_choice"] = tool_choice
+
+        params = self._get_supported_params(messages=messages, **call_kwargs)
+        params.update(
+            {
+                "model": self.config.model,
+                "messages": messages,
+            }
+        )
+        if (
+            (self._is_reasoning_model(self.config.model) or self._uses_max_completion_tokens(self.config.model))
+            and self.config.max_tokens is not None
+            and "max_tokens" not in params
+            and "max_completion_tokens" not in params
+        ):
+            params["max_completion_tokens"] = self.config.max_tokens
 
         response = self.client.chat.completions.create(**params)
         return self._parse_response(response, tools)

--- a/tests/llms/test_together.py
+++ b/tests/llms/test_together.py
@@ -28,9 +28,12 @@ def test_generate_response_without_tools(mock_together_client):
 
     response = llm.generate_response(messages)
 
-    mock_together_client.chat.completions.create.assert_called_once_with(
-        model="mistralai/Mixtral-8x7B-Instruct-v0.1", messages=messages, temperature=0.7, max_tokens=100, top_p=1.0
-    )
+    _, kwargs = mock_together_client.chat.completions.create.call_args
+    assert kwargs["model"] == "mistralai/Mixtral-8x7B-Instruct-v0.1"
+    assert kwargs["messages"] == messages
+    assert kwargs["temperature"] == 0.7
+    assert kwargs["max_tokens"] == 100
+    assert kwargs["top_p"] == 1.0
     assert response == "I'm doing well, thank you for asking!"
 
 
@@ -70,15 +73,14 @@ def test_generate_response_with_tools(mock_together_client):
 
     response = llm.generate_response(messages, tools=tools)
 
-    mock_together_client.chat.completions.create.assert_called_once_with(
-        model="mistralai/Mixtral-8x7B-Instruct-v0.1",
-        messages=messages,
-        temperature=0.7,
-        max_tokens=100,
-        top_p=1.0,
-        tools=tools,
-        tool_choice="auto",
-    )
+    _, kwargs = mock_together_client.chat.completions.create.call_args
+    assert kwargs["model"] == "mistralai/Mixtral-8x7B-Instruct-v0.1"
+    assert kwargs["messages"] == messages
+    assert kwargs["temperature"] == 0.7
+    assert kwargs["max_tokens"] == 100
+    assert kwargs["top_p"] == 1.0
+    assert kwargs["tools"] == tools
+    assert kwargs["tool_choice"] == "auto"
 
     assert response["content"] == "I've added the memory for you."
     assert len(response["tool_calls"]) == 1
@@ -102,3 +104,22 @@ def test_generate_response_forwards_extra_kwargs(mock_together_client):
     assert response == "Hi"
     call_kwargs = mock_together_client.chat.completions.create.call_args.kwargs
     assert call_kwargs["frequency_penalty"] == 0.5
+
+
+def test_generate_response_reasoning_model_omits_temperature(mock_together_client):
+    config = BaseLlmConfig(model="o3-mini", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = TogetherLLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Hi"))]
+    mock_together_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    _, kwargs = mock_together_client.chat.completions.create.call_args
+    assert "temperature" not in kwargs
+    assert "top_p" not in kwargs
+    assert kwargs["model"] == "o3-mini"
+    assert kwargs.get("max_completion_tokens") == 100
+    assert "max_tokens" not in kwargs


### PR DESCRIPTION
## Summary

- Route TogetherLLM generate_response through LLMBase._get_supported_params so reasoning models omit temperature/top_p.
- Preserve configured token limits as max_completion_tokens for reasoning/GPT-5 models.
- Add o3-mini regression test.

## Motivation

Same class of bug as #6085 / LiteLLM follow-up: TogetherAI OpenAI-compatible models in the reasoning family reject temperature, but the provider always forwarded it. One-liner class fix with shared helper parity.

## Verification

- python -m pytest tests/llms/test_together.py -q — 4 passed
- Focused diff: together.py + tests only
