### PR TITLE
fix(ts-oss): mirror entity ids from filters into metadata for infer:false (salvage of #6177)

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -741,6 +741,12 @@ export class Memory {
       metadata.expiration_date = normalizeExpirationDate(config.expirationDate);
     }
 
+    // Ensure entity IDs already in filters (passed directly via config.filters)
+    // are also mirrored into metadata so the infer:false path persists them.
+    if (filters.user_id && !metadata.user_id) metadata.user_id = filters.user_id;
+    if (filters.agent_id && !metadata.agent_id) metadata.agent_id = filters.agent_id;
+    if (filters.run_id && !metadata.run_id) metadata.run_id = filters.run_id;
+
     if (!filters.user_id && !filters.agent_id && !filters.run_id) {
       throw new Error(
         "One of the filters: userId, agentId or runId is required!",

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -743,8 +743,10 @@ export class Memory {
 
     // Ensure entity IDs already in filters (passed directly via config.filters)
     // are also mirrored into metadata so the infer:false path persists them.
-    if (filters.user_id && !metadata.user_id) metadata.user_id = filters.user_id;
-    if (filters.agent_id && !metadata.agent_id) metadata.agent_id = filters.agent_id;
+    if (filters.user_id && !metadata.user_id)
+      metadata.user_id = filters.user_id;
+    if (filters.agent_id && !metadata.agent_id)
+      metadata.agent_id = filters.agent_id;
     if (filters.run_id && !metadata.run_id) metadata.run_id = filters.run_id;
 
     if (!filters.user_id && !filters.agent_id && !filters.run_id) {

--- a/mem0-ts/src/oss/tests/memory.add.test.ts
+++ b/mem0-ts/src/oss/tests/memory.add.test.ts
@@ -8,6 +8,10 @@ import type { MemoryConfig, MemoryItem, SearchResult } from "../src/types";
 
 jest.setTimeout(15000);
 
+// Mock vector store dependencies that fail in CI
+jest.mock("mysql2/promise", () => ({ createPool: jest.fn() }), { virtual: true });
+jest.mock("weaviate-client", () => ({}), { virtual: true });
+
 // Mock Google modules to prevent @google/genai crash in CI
 jest.mock("../src/embeddings/google", () => ({
   GoogleEmbedder: jest.fn(),
@@ -190,5 +194,38 @@ describe("Memory - add()", () => {
     expect(result.results[0].metadata).toEqual(
       expect.objectContaining({ event: "ADD" }),
     );
+  });
+
+  test("infer=false with filters.user_id stores user_id in payload and is retrievable", async () => {
+    const uid = `infer_false_filters_${Date.now()}`;
+    const result: SearchResult = await memory.add("Filtered entity test", {
+      filters: { user_id: uid },
+      infer: false,
+    });
+    const stored: MemoryItem | null = await memory.get(result.results[0].id);
+    expect(stored).not.toBeNull();
+    expect(stored!.user_id).toBe(uid);
+  });
+
+  test("infer=false with filters.agent_id stores agent_id in payload and is retrievable", async () => {
+    const aid = `agent_infer_false_${Date.now()}`;
+    const result: SearchResult = await memory.add("Agent scoped memory", {
+      filters: { agent_id: aid },
+      infer: false,
+    });
+    const stored: MemoryItem | null = await memory.get(result.results[0].id);
+    expect(stored).not.toBeNull();
+    expect(stored!.agent_id).toBe(aid);
+  });
+
+  test("infer=false with filters.run_id stores run_id in payload and is retrievable", async () => {
+    const rid = `run_infer_false_${Date.now()}`;
+    const result: SearchResult = await memory.add("Run scoped memory", {
+      filters: { run_id: rid },
+      infer: false,
+    });
+    const stored: MemoryItem | null = await memory.get(result.results[0].id);
+    expect(stored).not.toBeNull();
+    expect(stored!.run_id).toBe(rid);
   });
 });

--- a/mem0-ts/src/oss/tests/memory.add.test.ts
+++ b/mem0-ts/src/oss/tests/memory.add.test.ts
@@ -9,7 +9,9 @@ import type { MemoryConfig, MemoryItem, SearchResult } from "../src/types";
 jest.setTimeout(15000);
 
 // Mock vector store dependencies that fail in CI
-jest.mock("mysql2/promise", () => ({ createPool: jest.fn() }), { virtual: true });
+jest.mock("mysql2/promise", () => ({ createPool: jest.fn() }), {
+  virtual: true,
+});
 jest.mock("weaviate-client", () => ({}), { virtual: true });
 
 // Mock Google modules to prevent @google/genai crash in CI


### PR DESCRIPTION
## Summary
Salvage of #6177 by @nandanadileep, rebased onto current `main`.

When `add()` is called with `infer: false`, entity IDs only present on `filters` were not mirrored into `metadata` and were never persisted, making memories unretrievable via `getAll()`/`search()`.

Also retains the existing main-tip expiration-date metadata normalization next to this fix.

## Credit
- Original work: #6177 (@nandanadileep)

## Motivation
Closes the gap described in #6170 / #6177 without leaving a CONFLICTING PR stranded.

## Verification
- Cherry-picked both original commits; resolved conflict with modern expiration metadata path.
- Diff limited to ts-oss memory path + regression tests from upstream PR.