### PR TITLE
fix(memory): remove_code_blocks must not crash on None or list (salvage of #6152)

### DIFF
--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -112,17 +112,30 @@ def normalize_facts(raw_facts):
     return normalized
 
 
-def remove_code_blocks(content: str) -> str:
+def remove_code_blocks(content: Any) -> str:
     """
     Removes enclosing code block markers ```[language] and ``` from a given string.
 
     Remarks:
+    - If content is None, returns an empty string.
+    - If content is a list of content blocks, extracts string items and dict item "text" values before processing.
     - The function uses a regex pattern to match code blocks that may start with ``` followed by an optional language tag (letters or numbers) and end with ```.
     - If a code block is detected, it returns only the inner content, stripping out the markers.
     - If no code block markers are found, the original content is returned as-is.
     """
     if content is None:
         return ""
+    if isinstance(content, list):
+        content_parts = []
+        for item in content:
+            if isinstance(item, str):
+                content_parts.append(item)
+            elif isinstance(item, dict) and "text" in item:
+                content_parts.append(str(item["text"]))
+        content = "".join(content_parts)
+    elif not isinstance(content, str):
+        content = str(content)
+
     pattern = r"^```[a-zA-Z0-9]*\n([\s\S]*?)\n```$"
     match = re.match(pattern, content.strip())
     match_res=match.group(1).strip() if match else content.strip()

--- a/tests/test_chatty_llm_parsing.py
+++ b/tests/test_chatty_llm_parsing.py
@@ -103,6 +103,23 @@ class TestRemoveCodeBlocks:
         parsed = json.loads(result)
         assert parsed == {"memory": []}
 
+    
+    def test_none_content_returns_empty_string(self):
+        assert remove_code_blocks(None) == ""
+
+    def test_string_list_content_is_joined(self):
+        assert remove_code_blocks(["hello ", "world"]) == "hello world"
+
+    def test_langchain_text_blocks_are_joined(self):
+        content = [{"type": "text", "text": "hello"}, {"type": "text", "text": " world"}]
+        assert remove_code_blocks(content) == "hello world"
+
+    def test_plain_string_code_block_still_strips_markers(self):
+        assert remove_code_blocks("```python\ncode\n```") == "code"
+
+    def test_plain_string_without_code_block_is_stripped(self):
+        assert remove_code_blocks("  hello world  ") == "hello world"
+
     def test_no_code_block(self):
         """Without code blocks, returns content as-is (may not be valid JSON)."""
         text = 'Here is the result: {"memory": []}'


### PR DESCRIPTION
## Summary
Salvage of #6152 by @aloktripathi1, rebased onto current `main`.

`remove_code_blocks` now tolerates `None`, list content-blocks, and non-str values instead of crashing when LLM output is empty/block-shaped.

## Credit
- Original: #6152 (@aloktripathi1)

## Verification
- Cherry-picked original; kept HEAD tests and re-attached the new regression tests after conflict.