### PR TITLE
fix(core): drop null entity ids from filters before scope validation

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -145,6 +145,22 @@ def _reject_top_level_entity_params(kwargs: Dict[str, Any], method_name: str) ->
         )
 
 
+def _drop_null_entity_ids(filters: Dict[str, Any]) -> None:
+    """Remove entity id keys whose value is None from a filters dict (in place).
+
+    A caller often builds filters from optional params, e.g.
+    ``filters={"agent_id": agent_id, "user_id": user_id}`` where some ids are
+    None. Left in place, a None id scopes the query to ``<key> IS NULL`` and
+    silently returns nothing, even when another id in the same dict is a valid
+    scope. Dropping the None keys mirrors add()'s truthiness handling and lets
+    the "at least one entity id" guard reject a filters dict that has no usable
+    scope instead of running an unintended query.
+    """
+    for key in ENTITY_PARAMS:
+        if key in filters and filters[key] is None:
+            del filters[key]
+
+
 def _validate_and_trim_entity_id(value: Optional[Any], name: str) -> Optional[str]:
     """
     Validates and normalizes an entity ID.
@@ -1258,6 +1274,7 @@ class Memory(MemoryBase):
             )
 
         # Validate filters contains at least one entity ID
+        _drop_null_entity_ids(effective_filters)
         if not any(key in effective_filters for key in ("user_id", "agent_id", "run_id")):
             raise ValueError(
                 "filters must contain at least one of: user_id, agent_id, run_id. "
@@ -1412,6 +1429,7 @@ class Memory(MemoryBase):
             effective_filters["run_id"] = _validate_and_trim_entity_id(
                 effective_filters["run_id"], "run_id"
             )
+        _drop_null_entity_ids(effective_filters)
         if not any(key in effective_filters for key in ("user_id", "agent_id", "run_id")):
             raise ValueError(
                 "filters must contain at least one of: user_id, agent_id, run_id. "
@@ -2892,6 +2910,7 @@ class AsyncMemory(MemoryBase):
             )
 
         # Validate filters contains at least one entity ID
+        _drop_null_entity_ids(effective_filters)
         if not any(key in effective_filters for key in ("user_id", "agent_id", "run_id")):
             raise ValueError(
                 "filters must contain at least one of: user_id, agent_id, run_id. "
@@ -3050,6 +3069,7 @@ class AsyncMemory(MemoryBase):
             )
 
         # Validate filters contains at least one entity ID
+        _drop_null_entity_ids(effective_filters)
         if not any(key in effective_filters for key in ("user_id", "agent_id", "run_id")):
             raise ValueError(
                 "filters must contain at least one of: user_id, agent_id, run_id. "

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -455,6 +455,40 @@ class TestEntityIdValidation:
         _, kwargs = memory_instance.vector_store.list.call_args
         assert kwargs["filters"]["user_id"] == "42"
 
+    def test_get_all_rejects_filters_with_only_none_entity_ids(self, memory_instance):
+        """A filters dict whose only entity ids are None has no usable scope and must be rejected."""
+        with pytest.raises(ValueError, match="at least one of: user_id, agent_id, run_id"):
+            memory_instance.get_all(filters={"user_id": None, "agent_id": None})
+
+    def test_get_all_drops_none_entity_id_but_keeps_valid_scope(self, memory_instance):
+        """A None id alongside a real id must be dropped, not scope the query to <id> IS NULL."""
+        memory_instance.vector_store.list = Mock(return_value=([], None))
+
+        memory_instance.get_all(filters={"user_id": None, "agent_id": "a1"})
+
+        _, kwargs = memory_instance.vector_store.list.call_args
+        assert "user_id" not in kwargs["filters"]
+        assert kwargs["filters"]["agent_id"] == "a1"
+
+    def test_search_rejects_filters_with_only_none_entity_ids(self, memory_instance):
+        """search should reject a filters dict whose only entity ids are None."""
+        with pytest.raises(ValueError, match="at least one of: user_id, agent_id, run_id"):
+            memory_instance.search("test query", filters={"user_id": None})
+
+    def test_search_drops_none_entity_id_but_keeps_valid_scope(self, memory_instance):
+        """search must drop a None id and scope by the remaining valid id."""
+        memory_instance.vector_store.search = Mock(return_value=[])
+        memory_instance.vector_store.keyword_search = Mock(return_value=None)
+        memory_instance.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+
+        with patch("mem0.memory.main.lemmatize_for_bm25", return_value="test query"), \
+             patch("mem0.memory.main.extract_entities", return_value=[]):
+            memory_instance.search("test query", filters={"user_id": None, "agent_id": "a1"})
+
+        _, kwargs = memory_instance.vector_store.search.call_args
+        assert "user_id" not in kwargs["filters"]
+        assert kwargs["filters"]["agent_id"] == "a1"
+
 
 class TestSearchParamValidation:
     """Tests for search parameter validation (threshold and top_k)."""


### PR DESCRIPTION
## Linked Issue

Closes #6225

## Description

`get_all()` and `search()` validate each entity id in `filters` with `_validate_and_trim_entity_id`, which returns `None` (no error) when the input is `None` and leaves the key in the dict. The "at least one entity id" guard then checks whether the *key* is present, not whether the value is usable, so a filters dict such as `{"user_id": None, "agent_id": "a1"}` passes validation and the stray `None` id flows downstream. It either scopes the query to `user_id IS NULL` (returning nothing despite a valid `agent_id`) or crashes in `process_telemetry_filters`, which calls `.encode()` on the `None`.

This differs from `add()`, which builds its filters with a truthiness check and already ignores `None` ids. Building filters from optional params and leaving some as `None` is a common caller pattern, so the read path should treat them the same way.

The fix adds a small `_drop_null_entity_ids` helper and calls it right before the existing guard, on `get_all` and `search` for both `Memory` and `AsyncMemory`. A dict with no usable scope now raises the normal `ValueError`, and a `None` id sitting next to a real one is simply ignored.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)

Added four tests to `TestEntityIdValidation` in `tests/test_main.py` covering `get_all` and `search`: an all-`None` filters dict now raises the standard "at least one of" error, and a `None` id next to a real id is dropped so the query is scoped by the remaining id. All four fail on `main` (AttributeError / wrong scope) and pass with this change. Full `tests/test_main.py` passes (47) and `ruff check` is clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
