### PR TITLE
fix(client): send page/page_size as query params when only one is provided

### DIFF
--- a/mem0/client/main.py
+++ b/mem0/client/main.py
@@ -269,11 +269,15 @@ class MemoryClient:
         kwargs = {**(options.model_dump(exclude_unset=True) if options else {}), **kwargs}
         params = self._prepare_params(kwargs)
 
-        if "page" in params and "page_size" in params:
-            query_params = {
-                "page": params.pop("page"),
-                "page_size": params.pop("page_size"),
-            }
+        # Pagination is read from the query string by the server, so lift page
+        # and page_size out of the JSON body independently. Requiring both to be
+        # present (a caller may pass only page_size and rely on page defaulting
+        # to 1) left the provided value in the body, where it was ignored.
+        query_params = {}
+        for key in ("page", "page_size"):
+            if key in params:
+                query_params[key] = params.pop(key)
+        if query_params:
             response = self.client.post("/v3/memories/", json=params, params=query_params)
         else:
             response = self.client.post("/v3/memories/", json=params)
@@ -1192,11 +1196,15 @@ class AsyncMemoryClient:
         kwargs = {**(options.model_dump(exclude_unset=True) if options else {}), **kwargs}
         params = self._prepare_params(kwargs)
 
-        if "page" in params and "page_size" in params:
-            query_params = {
-                "page": params.pop("page"),
-                "page_size": params.pop("page_size"),
-            }
+        # Pagination is read from the query string by the server, so lift page
+        # and page_size out of the JSON body independently. Requiring both to be
+        # present (a caller may pass only page_size and rely on page defaulting
+        # to 1) left the provided value in the body, where it was ignored.
+        query_params = {}
+        for key in ("page", "page_size"):
+            if key in params:
+                query_params[key] = params.pop(key)
+        if query_params:
             response = await self.async_client.post("/v3/memories/", json=params, params=query_params)
         else:
             response = await self.async_client.post("/v3/memories/", json=params)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -130,6 +130,74 @@ class TestGetAllEntityParamRejection:
         )
 
 
+class TestGetAllPagination:
+    """page/page_size must reach the server as query params, not sit in the JSON body."""
+
+    @staticmethod
+    def _ok_response():
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"results": []}
+        mock_response.raise_for_status.return_value = None
+        return mock_response
+
+    def test_get_all_sends_page_size_only_as_query_param(self, mock_memory_client):
+        """Passing only page_size (relying on page defaulting to 1) still goes to the query string."""
+        mock_memory_client.client.post.return_value = self._ok_response()
+
+        mock_memory_client.get_all(filters={"user_id": "u1"}, page_size=5)
+
+        _, kwargs = mock_memory_client.client.post.call_args
+        assert kwargs["params"] == {"page_size": 5}
+        assert "page_size" not in kwargs["json"]
+
+    def test_get_all_sends_page_only_as_query_param(self, mock_memory_client):
+        """Passing only page goes to the query string, not the body."""
+        mock_memory_client.client.post.return_value = self._ok_response()
+
+        mock_memory_client.get_all(filters={"user_id": "u1"}, page=2)
+
+        _, kwargs = mock_memory_client.client.post.call_args
+        assert kwargs["params"] == {"page": 2}
+        assert "page" not in kwargs["json"]
+
+    def test_get_all_sends_both_pagination_params_as_query(self, mock_memory_client):
+        """Both page and page_size still lift to the query string together."""
+        mock_memory_client.client.post.return_value = self._ok_response()
+
+        mock_memory_client.get_all(filters={"user_id": "u1"}, page=2, page_size=5)
+
+        _, kwargs = mock_memory_client.client.post.call_args
+        assert kwargs["params"] == {"page": 2, "page_size": 5}
+        assert "page" not in kwargs["json"] and "page_size" not in kwargs["json"]
+
+    def test_get_all_without_pagination_sends_no_query_params(self, mock_memory_client):
+        """Without pagination the request carries no query params (unchanged behavior)."""
+        mock_memory_client.client.post.return_value = self._ok_response()
+
+        mock_memory_client.get_all(filters={"user_id": "u1"})
+
+        _, kwargs = mock_memory_client.client.post.call_args
+        assert "params" not in kwargs
+
+    def test_async_get_all_sends_page_size_only_as_query_param(self):
+        """The async client lifts page_size the same way."""
+        asyncio.run(self._assert_async_page_size_query())
+
+    async def _assert_async_page_size_query(self):
+        from mem0.client.main import AsyncMemoryClient
+
+        client = AsyncMemoryClient.__new__(AsyncMemoryClient)
+        client.async_client = MagicMock()
+        client.async_client.post = AsyncMock(return_value=self._ok_response())
+
+        with patch("mem0.client.main.capture_client_event"):
+            await client.get_all(filters={"user_id": "u1"}, page_size=5)
+
+        _, kwargs = client.async_client.post.call_args
+        assert kwargs["params"] == {"page_size": 5}
+        assert "page_size" not in kwargs["json"]
+
+
 class TestUpdateExpirationDate:
     """Tests for update expiration_date payload handling."""
 


### PR DESCRIPTION
## Linked Issue

Closes #6227

## Description

`MemoryClient.get_all()` and `AsyncMemoryClient.get_all()` only lifted pagination into the query string when both `page` and `page_size` were present:

```python
if "page" in params and "page_size" in params:
    query_params = {"page": params.pop("page"), "page_size": params.pop("page_size")}
    response = self.client.post("/v3/memories/", json=params, params=query_params)
else:
    response = self.client.post("/v3/memories/", json=params)
```

A common call passes only `page_size` and relies on `page` defaulting to 1 (or passes only `page`). That falls into the `else` branch, so the value is sent in the JSON body instead. The server reads pagination from the query string, so it is silently ignored and the caller gets a default-sized page. The code already treats pagination as query params when both are present, so the single-param case is inconsistent with its own contract.

This lifts `page` and `page_size` out of the body independently, so either one on its own reaches the query string. When neither is present the request is sent without a `params` kwarg, exactly as before. Applies to both the sync and async clients.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

Added `TestGetAllPagination` in `tests/test_client.py`: page_size-only, page-only, both, and no-pagination for the sync client plus a page_size-only case for the async client. The single-param cases fail on `main` (value ends up in the body / no query params) and pass with this change; the both-present and no-pagination cases are unchanged. Full `tests/test_client.py` passes (34) and `ruff check` is clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
