### PR TITLE
fix(xai): forward http_client_proxies instead of the built client in config conversion

### DIFF
--- a/mem0/llms/xai.py
+++ b/mem0/llms/xai.py
@@ -28,7 +28,7 @@ class XAILLM(LLMBase):
                 top_k=config.top_k,
                 enable_vision=config.enable_vision,
                 vision_details=config.vision_details,
-                http_client_proxies=config.http_client,
+                http_client_proxies=config.http_client_proxies,
             )
 
         super().__init__(config)

--- a/tests/test_http_client_proxies.py
+++ b/tests/test_http_client_proxies.py
@@ -37,3 +37,22 @@ def test_llm_factory_preserves_http_client_proxies():
     llm = LlmFactory.create("openai", base)
     assert llm.config.http_client_proxies == "http://proxy.local:8080"
     assert isinstance(llm.config.http_client, httpx.Client)
+
+
+def test_xai_llm_preserves_http_client_proxies_from_base_config():
+    """XAILLM converts a BaseLlmConfig to XAIConfig directly; the proxy setting must survive.
+
+    Every other provider forwards config.http_client_proxies in this conversion. xAI
+    forwarded the already-built config.http_client instead, which build_http_client then
+    tried to treat as a proxy, crashing whenever a proxy was configured.
+    """
+    from mem0.llms.xai import XAILLM
+
+    base = BaseLlmConfig(
+        model="grok-4",
+        api_key="sk-test",
+        http_client_proxies="http://proxy.local:8080",
+    )
+    llm = XAILLM(base)
+    assert llm.config.http_client_proxies == "http://proxy.local:8080"
+    assert isinstance(llm.config.http_client, httpx.Client)


### PR DESCRIPTION
## Linked Issue

Closes #6230

## Description

When `XAILLM` is constructed with a plain `BaseLlmConfig` (not an `XAIConfig`), it converts the config so `xai_base_url` is available. That conversion forwarded `config.http_client` into the `http_client_proxies` argument:

```python
config = XAIConfig(
    ...
    http_client_proxies=config.http_client,
)
```

`config.http_client` is the `httpx.Client` that `BaseLlmConfig` already built from the proxy setting, whereas `config.http_client_proxies` is the raw proxy dict/str. `XAIConfig` then runs `build_http_client()` on it, which expects a proxy dict/str; given a `Client` object it falls through to `httpx.Client(proxy=<client>)` and crashes. This only bites when a proxy is configured (otherwise both values are `None`).

Every other provider (openai, anthropic, azure_openai, deepseek, lmstudio, minimax, ollama, vllm) forwards `config.http_client_proxies` in this conversion. xAI was the only outlier. Going through `LlmFactory` already converts the config correctly, so this specifically affects direct `XAILLM(base_config)` construction.

The fix forwards `config.http_client_proxies`, matching the other providers.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

Added `test_xai_llm_preserves_http_client_proxies_from_base_config` to `tests/test_http_client_proxies.py`, alongside the existing openai equivalent: it builds `XAILLM` from a `BaseLlmConfig` carrying a proxy and asserts the proxy survives into `XAIConfig`. It crashes on `main` and passes with this change. Full `tests/test_http_client_proxies.py` passes (8) and `ruff check` is clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
