### PR TITLE
feat: add Amazon Bedrock Knowledge Base vector store backend

### DIFF
--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -185,6 +185,7 @@ class VectorStoreFactory:
         "azure_ai_search": "mem0.vector_stores.azure_ai_search.AzureAISearch",
         "azure_mysql": "mem0.vector_stores.azure_mysql.AzureMySQL",
         "pinecone": "mem0.vector_stores.pinecone.PineconeDB",
+        "bedrock_kb": "mem0.vector_stores.bedrock_kb.BedrockKB",
         "mongodb": "mem0.vector_stores.mongodb.MongoDB",
         "redis": "mem0.vector_stores.redis.RedisDB",
         "valkey": "mem0.vector_stores.valkey.ValkeyDB",

--- a/mem0/vector_stores/BEDROCK_MANAGED_KB.md
+++ b/mem0/vector_stores/BEDROCK_MANAGED_KB.md
@@ -1,0 +1,105 @@
+# Bedrock Managed Knowledge Base Support
+
+## Overview
+Adds a Mem0 vector store backend that delegates search to Amazon Bedrock Knowledge Bases instead of a local vector store.
+
+## Usage
+```python
+from mem0 import Memory
+
+config = {
+    "vector_store": {
+        "provider": "bedrock_kb",
+        "config": {
+            "knowledge_base_id": "YOUR_KB_ID",
+            "region": "us-east-1",
+        }
+    }
+}
+m = Memory.from_config(config)
+results = m.search("What are the onboarding steps?", user_id="user1")
+```
+
+## Configuration
+| Variable | Description | Default |
+|---|---|---|
+| KNOWLEDGE_BASE_ID | Bedrock Knowledge Base ID | None |
+| AWS_REGION | AWS region for the KB | us-east-1 |
+| AWS_PROFILE | AWS credentials profile | None |
+| USE_AGENTIC_RETRIEVAL | Enable agentic retrieval | true |
+| MAX_RESULTS | Maximum retrieval results | 5 |
+
+## Features
+- Managed search (no vector store needed)
+- Agentic retrieval with query decomposition + reranking
+- Automatic fallback to plain Retrieve if agentic fails
+- Multi-source support (S3, Web, Confluence, SharePoint)
+- Implements Mem0 VectorStoreBase interface
+
+## SDK Requirements
+- boto3 >= 1.43
+- mem0ai >= 0.1
+
+## Required IAM Permissions
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "bedrock:Retrieve",
+    "bedrock:AgenticRetrieveStream"
+  ],
+  "Resource": "arn:aws:bedrock:<region>:<account-id>:knowledge-base/<kb-id>"
+}
+```
+
+## References
+- [Build a Managed Knowledge Base](https://docs.aws.amazon.com/bedrock/latest/userguide/kb-build-managed.html)
+- [Retrieve API](https://docs.aws.amazon.com/bedrock/latest/userguide/kb-test-retrieve.html)
+- [Agentic Retrieval](https://docs.aws.amazon.com/bedrock/latest/userguide/kb-test-agentic.html)
+
+## Direct Ingestion (CUSTOM Data Source)
+
+When using a CUSTOM data source (created via console or API), you can ingest documents directly without S3 upload + sync:
+
+```python
+kb = BedrockKB(
+    knowledge_base_id="YOUR_KB_ID",
+    data_source_id="YOUR_CUSTOM_DS_ID",
+    region_name="us-west-2",
+    data_source_type="CUSTOM",
+)
+
+# Inline text
+kb.insert(vectors=None, payloads=[{"data": "Your document content here."}])
+
+# S3 reference (ingest a specific file without full sync)
+kb.insert(vectors=None, payloads=[{"s3_uri": "s3://bucket/path/to/file.pdf"}])
+
+# Binary file (PDF, DOCX, images, audio, video — depends on KB indexing settings)
+import base64
+with open("document.pdf", "rb") as f:
+    encoded = base64.b64encode(f.read()).decode()
+kb.insert(vectors=None, payloads=[{"data": encoded, "mime_type": "application/pdf"}])
+```
+
+### Supported mime types
+
+- Text: `text/plain`, `text/html`, `text/csv`
+- Documents: `application/pdf`, `application/msword`, `application/vnd.openxmlformats-officedocument.wordprocessingml.document`
+- With advanced indexing enabled: images (`image/png`, `image/jpeg`), audio (`audio/mp3`, `audio/wav`), video (`video/mp4`)
+
+### Configuration
+
+| Parameter | Description | Default |
+|---|---|---|
+| `data_source_type` | `"S3"` (upload + sync) or `"CUSTOM"` (direct ingestion) | `"S3"` |
+| `data_source_id` | Required for both modes | Env: `BEDROCK_DATA_SOURCE_ID` |
+| `data_source_bucket` | Required only for `"S3"` mode | Env: `BEDROCK_DATA_SOURCE_BUCKET` |
+
+> **Note:** CUSTOM data source must be created on the KB beforehand (via console or CDK/CFN). Our code only calls the ingestion API on existing data sources.
+
+**References:**
+- [Ingest documents directly into a knowledge base](https://docs.aws.amazon.com/bedrock/latest/userguide/kb-direct-ingestion.html)
+- [IngestKnowledgeBaseDocuments API](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent_IngestKnowledgeBaseDocuments.html)
+- [Connect to a custom data source](https://docs.aws.amazon.com/bedrock/latest/userguide/custom-data-source-connector.html)
+

--- a/mem0/vector_stores/bedrock_kb.py
+++ b/mem0/vector_stores/bedrock_kb.py
@@ -1,0 +1,497 @@
+"""Amazon Bedrock Knowledge Base as a vector store backend for Mem0.
+
+Uses Bedrock Managed Knowledge Bases for storage and retrieval.
+Write operations upload to the KB's S3 data source and trigger ingestion sync.
+"""
+
+import os
+import json
+import logging
+import uuid
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
+
+from mem0.vector_stores.base import VectorStoreBase
+
+logger = logging.getLogger(__name__)
+
+
+class OutputData(BaseModel):
+    id: str
+    score: float
+    payload: Dict
+
+
+def _get_source_uri(result: dict) -> str:
+    """Extract source URI from a retrieval result, handling all location types."""
+    location = result.get('location', {})
+    loc_type = location.get('type', '')
+    if loc_type == 'S3' or 's3Location' in location:
+        return location.get('s3Location', {}).get('uri', '')
+    elif loc_type == 'WEB' or 'webLocation' in location:
+        return location.get('webLocation', {}).get('url', '')
+    elif 'confluenceLocation' in location:
+        return location.get('confluenceLocation', {}).get('url', '')
+    elif 'salesforceLocation' in location:
+        return location.get('salesforceLocation', {}).get('url', '')
+    elif 'sharePointLocation' in location:
+        return location.get('sharePointLocation', {}).get('url', '')
+    elif 'customDocumentLocation' in location:
+        return location.get('customDocumentLocation', {}).get('id', '')
+    # Fallback to metadata._source_uri (for agentic results)
+    return result.get('metadata', {}).get('_source_uri', '')
+
+
+class BedrockKB(VectorStoreBase):
+    """Amazon Bedrock Knowledge Base vector store backend.
+
+    Args:
+        knowledge_base_id: The KB ID. Falls back to KNOWLEDGE_BASE_ID env var.
+        data_source_id: The data source ID for ingestion. Falls back to BEDROCK_DATA_SOURCE_ID env var.
+        data_source_bucket: S3 bucket for the KB's data source. Falls back to BEDROCK_DATA_SOURCE_BUCKET env var.
+        region_name: AWS region. Falls back to AWS_REGION env var or us-east-1.
+        number_of_results: Default number of results. Defaults to 5.
+        knowledge_base_type: 'MANAGED' (recommended) or 'VECTOR'.
+        use_agentic_retrieval: If True, try AgenticRetrieveStream first with fallback to plain Retrieve.
+        data_source_type: 'S3' (default, uses S3 upload + sync) or 'CUSTOM' (uses IngestKnowledgeBaseDocuments API, no S3 needed).
+    """
+
+    def __init__(
+        self,
+        knowledge_base_id: Optional[str] = None,
+        data_source_id: Optional[str] = None,
+        data_source_bucket: Optional[str] = None,
+        region_name: Optional[str] = None,
+        number_of_results: int = 5,
+        knowledge_base_type: str = "MANAGED",
+        use_agentic_retrieval: Optional[bool] = None,
+        data_source_type: str = "S3",
+    ):
+        self.knowledge_base_id = knowledge_base_id or os.environ.get("KNOWLEDGE_BASE_ID", "")
+        self.data_source_id = data_source_id or os.environ.get("BEDROCK_DATA_SOURCE_ID", "")
+        self.data_source_bucket = data_source_bucket or os.environ.get("BEDROCK_DATA_SOURCE_BUCKET", "")
+        self.region_name = region_name or os.environ.get("AWS_REGION", "us-east-1")
+        self.number_of_results = number_of_results
+        self.knowledge_base_type = knowledge_base_type
+        self.use_agentic_retrieval = use_agentic_retrieval if use_agentic_retrieval is not None else os.environ.get('USE_AGENTIC_RETRIEVAL', 'true').lower() != 'false'
+        self.data_source_type = data_source_type or os.environ.get("BEDROCK_DATA_SOURCE_TYPE", "S3").upper()
+        self._runtime_client = None
+        self._agent_client = None
+        self._s3_client = None
+
+    @property
+    def runtime_client(self):
+        if self._runtime_client is None:
+            import boto3
+            from botocore.config import Config
+            self._runtime_client = boto3.client(
+                "bedrock-agent-runtime",
+                region_name=self.region_name,
+                config=Config(user_agent_extra="mem0/bedrock-kb"),
+            )
+        return self._runtime_client
+
+    @property
+    def agent_client(self):
+        if self._agent_client is None:
+            import boto3
+            from botocore.config import Config
+            self._agent_client = boto3.client(
+                "bedrock-agent",
+                region_name=self.region_name,
+                config=Config(user_agent_extra="mem0/bedrock-kb"),
+            )
+        return self._agent_client
+
+    @property
+    def s3_client(self):
+        if self._s3_client is None:
+            import boto3
+            from botocore.config import Config
+            self._s3_client = boto3.client(
+                "s3",
+                region_name=self.region_name,
+                config=Config(user_agent_extra="mem0/bedrock-kb"),
+            )
+        return self._s3_client
+
+    def create_col(self, name, vector_size, distance):
+        """Not needed — KB is pre-created via AWS console or API."""
+        logger.info("Bedrock KB is managed externally. No collection creation needed.")
+
+    def insert(self, vectors, payloads=None, ids=None):
+        """Insert documents into the knowledge base.
+
+        Uses IngestKnowledgeBaseDocuments (CUSTOM) or S3 upload + sync (S3) based on data_source_type.
+        """
+        if self.data_source_type == "CUSTOM":
+            return self._insert_direct(payloads, ids)
+        else:
+            return self._insert_s3(payloads, ids)
+
+    def _insert_direct(self, payloads=None, ids=None):
+        """Insert documents directly via IngestKnowledgeBaseDocuments API (CUSTOM data source).
+
+        Supports two modes based on payload content:
+        - Inline text: payload = {"data": "text content", "metadata": {...}}
+        - S3 reference: payload = {"s3_uri": "s3://bucket/key", "metadata": {...}}
+        - Binary/file: payload = {"data": base64_bytes, "mime_type": "application/pdf", "metadata": {...}}
+        """
+        if not self.data_source_id:
+            logger.warning("No data_source_id configured. Cannot insert.")
+            return None
+
+        import mimetypes
+
+        inserted_ids = []
+        documents = []
+        for i, payload in enumerate(payloads or []):
+            doc_id = ids[i] if ids else str(uuid.uuid4())
+            metadata = payload.get("metadata", {}) if isinstance(payload, dict) else {}
+
+            # Determine content type: S3 reference, binary, or inline text
+            if isinstance(payload, dict) and "s3_uri" in payload:
+                # S3 reference — point to existing file in S3
+                doc = {
+                    "content": {
+                        "dataSourceType": "CUSTOM",
+                        "custom": {
+                            "customDocumentIdentifier": {"id": doc_id},
+                            "sourceType": "S3_LOCATION",
+                            "s3Location": {"uri": payload["s3_uri"]},
+                        },
+                    },
+                }
+            elif isinstance(payload, dict) and "mime_type" in payload:
+                # Binary content (base64)
+                doc = {
+                    "content": {
+                        "dataSourceType": "CUSTOM",
+                        "custom": {
+                            "customDocumentIdentifier": {"id": doc_id},
+                            "sourceType": "IN_LINE",
+                            "inlineContent": {
+                                "type": "BYTE",
+                                "byteContent": {
+                                    "data": payload.get("data", ""),
+                                    "mimeType": payload["mime_type"],
+                                },
+                            },
+                        },
+                    },
+                }
+            else:
+                # Inline text (default)
+                content = payload.get("data", "") if isinstance(payload, dict) else str(payload)
+                doc = {
+                    "content": {
+                        "dataSourceType": "CUSTOM",
+                        "custom": {
+                            "customDocumentIdentifier": {"id": doc_id},
+                            "sourceType": "IN_LINE",
+                            "inlineContent": {
+                                "type": "TEXT",
+                                "textContent": {"data": content},
+                            },
+                        },
+                    },
+                }
+
+            # Add metadata as inline attributes
+            if metadata:
+                doc["metadata"] = {
+                    "type": "IN_LINE_ATTRIBUTE",
+                    "inlineAttributes": [
+                        {"key": k, "value": {"stringValue": str(v), "type": "STRING"}}
+                        for k, v in metadata.items()
+                    ],
+                }
+
+            documents.append(doc)
+            inserted_ids.append(doc_id)
+
+            # API allows max 10 docs per call
+            if len(documents) >= 10:
+                self._ingest_documents(documents)
+                documents = []
+
+        if documents:
+            self._ingest_documents(documents)
+
+        return inserted_ids
+
+    def _ingest_documents(self, documents):
+        """Call IngestKnowledgeBaseDocuments API."""
+        try:
+            self.agent_client.ingest_knowledge_base_documents(
+                knowledgeBaseId=self.knowledge_base_id,
+                dataSourceId=self.data_source_id,
+                documents=documents,
+            )
+        except Exception as e:
+            logger.error(f"Error ingesting documents directly: {e}")
+
+    def _insert_s3(self, payloads=None, ids=None):
+        """Insert documents by uploading to S3 and triggering ingestion."""
+        if not self.data_source_bucket:
+            logger.warning("No data_source_bucket configured. Cannot insert.")
+            return None
+
+        inserted_ids = []
+        for i, payload in enumerate(payloads or []):
+            doc_id = ids[i] if ids else str(uuid.uuid4())
+            content = payload.get("data", "") if isinstance(payload, dict) else str(payload)
+            metadata = payload.get("metadata", {}) if isinstance(payload, dict) else {}
+
+            # Use user_id in key path for tenant isolation
+            user_id = metadata.get("user_id", "_default")
+            key = f"mem0/{user_id}/{doc_id}.txt"
+
+            # Upload document to S3
+            self.s3_client.put_object(
+                Bucket=self.data_source_bucket,
+                Key=key,
+                Body=content,
+            )
+
+            # Upload metadata sidecar for filtering
+            import json
+            meta_attrs = {"user_id": user_id, "mem0_id": doc_id}
+            meta_attrs.update({k: str(v) for k, v in metadata.items()})
+            metadata_content = json.dumps({
+                "metadataAttributes": {k: v for k, v in meta_attrs.items()}
+            })
+            self.s3_client.put_object(
+                Bucket=self.data_source_bucket,
+                Key=f"{key}.metadata.json",
+                Body=metadata_content,
+            )
+            inserted_ids.append(doc_id)
+
+        # Trigger ingestion sync
+        if inserted_ids and self.data_source_id:
+            self._start_ingestion()
+
+        return inserted_ids
+
+    def _agentic_retrieve(self, query: str, top_k: int):
+        """Try agentic retrieval with streaming. Returns list of results or None on failure."""
+        try:
+            response = self.runtime_client.agentic_retrieve_stream(
+                knowledgeBaseId=self.knowledge_base_id,
+                messages=[{"content": {"text": query}, "role": "user"}],
+                retrievers=[{
+                    "configuration": {
+                        "knowledgeBase": {
+                            "knowledgeBaseId": self.knowledge_base_id,
+                            "retrievalOverrides": {"maxNumberOfResults": top_k},
+                        }
+                    }
+                }],
+                agenticRetrieveConfiguration={
+                    "foundationModelType": "MANAGED",
+                    "rerankingModelType": "MANAGED",
+                },
+            )
+            results = []
+            for event in response.get("stream", []):
+                if "result" in event and "results" in event["result"]:
+                    for result in event["result"]["results"]:
+                        content = result.get("content", {}).get("text", "")
+                        source = _get_source_uri(result)
+                        score = result.get("score", 0.0)
+                        # Extract doc_id from source URI (mem0/{doc_id}.txt pattern)
+                        doc_id = source.split("/")[-1].replace(".txt", "") if source else str(uuid.uuid4())
+                        results.append(OutputData(
+                            id=doc_id,
+                            score=score,
+                            payload={"data": content, "source": source},
+                        ))
+            return results
+        except Exception as e:
+            logger.debug(f"Agentic retrieval unavailable, will fall back to managed retrieve: {e}")
+            return None
+
+    def search(self, query, vectors=None, top_k=5, filters=None):
+        """Search the knowledge base. Tries agentic retrieval first if enabled."""
+        # Try agentic retrieval first (skip when filters are provided — agentic doesn't support metadata filtering)
+        if self.use_agentic_retrieval and not filters:
+            agentic_results = self._agentic_retrieve(query, top_k)
+            if agentic_results is not None:
+                return agentic_results
+
+        # Fallback to managed/vector retrieve
+        if self.knowledge_base_type == "MANAGED":
+            retrieval_config = {"managedSearchConfiguration": {"numberOfResults": top_k}}
+            # Apply metadata filter for tenant isolation
+            if filters:
+                filter_conditions = []
+                for key, value in filters.items():
+                    filter_conditions.append({"equals": {"key": key, "value": value}})
+                if len(filter_conditions) == 1:
+                    retrieval_config["managedSearchConfiguration"]["filter"] = filter_conditions[0]
+                else:
+                    retrieval_config["managedSearchConfiguration"]["filter"] = {"andAll": filter_conditions}
+        else:
+            retrieval_config = {"vectorSearchConfiguration": {"numberOfResults": top_k}}
+            if filters:
+                filter_conditions = []
+                for key, value in filters.items():
+                    filter_conditions.append({"equals": {"key": key, "value": value}})
+                if len(filter_conditions) == 1:
+                    retrieval_config["vectorSearchConfiguration"]["filter"] = filter_conditions[0]
+                else:
+                    retrieval_config["vectorSearchConfiguration"]["filter"] = {"andAll": filter_conditions}
+
+        try:
+            response = self.runtime_client.retrieve(
+                knowledgeBaseId=self.knowledge_base_id,
+                retrievalQuery={"text": query},
+                retrievalConfiguration=retrieval_config,
+            )
+            results = []
+            for result in response.get("retrievalResults", []):
+                content = result.get("content", {}).get("text", "")
+                source = _get_source_uri(result)
+                score = result.get("score", 0.0)
+                # Extract doc_id from source URI (mem0/{doc_id}.txt pattern)
+                doc_id = source.split("/")[-1].replace(".txt", "") if source else str(uuid.uuid4())
+                results.append(OutputData(
+                    id=doc_id,
+                    score=score,
+                    payload={"data": content, "source": source},
+                ))
+            return results
+        except Exception as e:
+            logger.error(f"Error searching Bedrock KB: {e}")
+            return []
+
+    def delete(self, vector_id, filters=None):
+        """Delete a document by removing from S3 and triggering re-sync."""
+        if not self.data_source_bucket:
+            logger.warning("No data_source_bucket configured. Cannot delete.")
+            return
+
+        user_id = filters.get("user_id", "_default") if filters else "_default"
+        key = f"mem0/{user_id}/{vector_id}.txt"
+        try:
+            self.s3_client.delete_object(Bucket=self.data_source_bucket, Key=key)
+            self.s3_client.delete_object(Bucket=self.data_source_bucket, Key=f"{key}.metadata.json")
+            if self.data_source_id:
+                self._start_ingestion()
+        except Exception as e:
+            logger.error(f"Error deleting from S3: {e}")
+
+    def update(self, vector_id, vector=None, payload=None, filters=None):
+        """Update by re-uploading to S3 and triggering sync."""
+        if payload and self.data_source_bucket:
+            content = payload.get("data", "") if isinstance(payload, dict) else str(payload)
+            metadata = payload.get("metadata", {}) if isinstance(payload, dict) else {}
+            user_id = metadata.get("user_id", filters.get("user_id", "_default") if filters else "_default")
+            key = f"mem0/{user_id}/{vector_id}.txt"
+            self.s3_client.put_object(
+                Bucket=self.data_source_bucket,
+                Key=key,
+                Body=content,
+            )
+            # Update metadata sidecar
+            import json
+            meta_attrs = {"user_id": user_id, "mem0_id": vector_id}
+            meta_attrs.update({k: str(v) for k, v in metadata.items()})
+            self.s3_client.put_object(
+                Bucket=self.data_source_bucket,
+                Key=f"{key}.metadata.json",
+                Body=json.dumps({"metadataAttributes": {k: v for k, v in meta_attrs.items()}}),
+            )
+            if self.data_source_id:
+                self._start_ingestion()
+
+    def get(self, vector_id, filters=None):
+        """Get a document from S3 by ID."""
+        if not self.data_source_bucket:
+            return None
+        user_id = filters.get("user_id", "_default") if filters else "_default"
+        key = f"mem0/{user_id}/{vector_id}.txt"
+        try:
+            response = self.s3_client.get_object(Bucket=self.data_source_bucket, Key=key)
+            content = response["Body"].read().decode("utf-8")
+            return OutputData(id=vector_id, score=0.0, payload={"data": content})
+        except Exception:
+            return None
+
+    def list_cols(self):
+        """List knowledge bases."""
+        try:
+            response = self.agent_client.list_knowledge_bases()
+            return [kb["name"] for kb in response.get("knowledgeBaseSummaries", [])]
+        except Exception as e:
+            logger.error(f"Error listing KBs: {e}")
+            return []
+
+    def delete_col(self):
+        """Not supported — KB deletion should be done via AWS console."""
+        logger.warning("KB deletion not supported via this interface. Use AWS console.")
+
+    def col_info(self):
+        """Get KB info."""
+        try:
+            response = self.agent_client.get_knowledge_base(knowledgeBaseId=self.knowledge_base_id)
+            kb = response["knowledgeBase"]
+            return {"name": kb["name"], "status": kb["status"], "type": self.knowledge_base_type}
+        except Exception as e:
+            logger.error(f"Error getting KB info: {e}")
+            return {}
+
+    def list(self, filters=None, top_k=None):
+        """List documents by listing S3 objects in the data source prefix."""
+        if not self.data_source_bucket:
+            return [[]]
+        try:
+            # Scope by user_id if provided in filters
+            user_id = filters.get("user_id", "") if filters else ""
+            prefix = f"mem0/{user_id}/" if user_id else "mem0/"
+            response = self.s3_client.list_objects_v2(
+                Bucket=self.data_source_bucket, Prefix=prefix, MaxKeys=top_k or 100
+            )
+            results = []
+            for obj in response.get("Contents", []):
+                key = obj["Key"]
+                if key.endswith(".metadata.json"):
+                    continue  # Skip metadata sidecar files
+                # Extract doc_id from path: mem0/{user_id}/{doc_id}.txt
+                doc_id = key.split("/")[-1].replace(".txt", "")
+                results.append(OutputData(
+                    id=doc_id,
+                    score=0.0,
+                    payload={"key": obj["Key"]},
+                ))
+            return [results]
+        except Exception as e:
+            logger.error(f"Error listing documents: {e}")
+            return [[]]
+
+    def reset(self):
+        """Reset by clearing all documents from the S3 data source prefix."""
+        if not self.data_source_bucket:
+            logger.warning("No data_source_bucket configured. Cannot reset.")
+            return
+        try:
+            response = self.s3_client.list_objects_v2(Bucket=self.data_source_bucket, Prefix="mem0/")
+            for obj in response.get("Contents", []):
+                self.s3_client.delete_object(Bucket=self.data_source_bucket, Key=obj["Key"])
+            if self.data_source_id:
+                self._start_ingestion()
+        except Exception as e:
+            logger.error(f"Error resetting KB data: {e}")
+
+    def _start_ingestion(self):
+        """Trigger a data source ingestion job."""
+        try:
+            self.agent_client.start_ingestion_job(
+                knowledgeBaseId=self.knowledge_base_id,
+                dataSourceId=self.data_source_id,
+            )
+            logger.info(f"Ingestion job started for KB {self.knowledge_base_id}")
+        except Exception as e:
+            logger.error(f"Error starting ingestion: {e}")

--- a/tests/vector_stores/test_bedrock_kb.py
+++ b/tests/vector_stores/test_bedrock_kb.py
@@ -1,0 +1,541 @@
+import pytest
+from unittest.mock import MagicMock
+
+from mem0.vector_stores.bedrock_kb import BedrockKB
+
+KB_ID = "test-kb-id"
+DATA_SOURCE_ID = "test-ds-id"
+DATA_SOURCE_BUCKET = "test-bucket"
+REGION = "us-west-2"
+
+
+@pytest.fixture
+def mock_boto_clients():
+    """Fixture providing mock boto3 clients to inject into BedrockKB instances."""
+    runtime_client = MagicMock()
+    agent_client = MagicMock()
+    s3_client = MagicMock()
+
+    yield {
+        "runtime": runtime_client,
+        "agent": agent_client,
+        "s3": s3_client,
+    }
+
+
+@pytest.fixture
+def store(mock_boto_clients):
+    """Create a BedrockKB instance with mock clients injected directly."""
+    kb = BedrockKB(
+        knowledge_base_id=KB_ID,
+        data_source_id=DATA_SOURCE_ID,
+        data_source_bucket=DATA_SOURCE_BUCKET,
+        region_name=REGION,
+        number_of_results=10,
+        knowledge_base_type="MANAGED",
+        use_agentic_retrieval=False,
+    )
+    kb._runtime_client = mock_boto_clients["runtime"]
+    kb._agent_client = mock_boto_clients["agent"]
+    kb._s3_client = mock_boto_clients["s3"]
+    return kb
+
+
+class TestInit:
+    def test_init_with_params(self):
+        """Test initialization with explicit parameters."""
+        kb = BedrockKB(
+            knowledge_base_id=KB_ID,
+            data_source_id=DATA_SOURCE_ID,
+            data_source_bucket=DATA_SOURCE_BUCKET,
+            region_name=REGION,
+            number_of_results=10,
+            knowledge_base_type="VECTOR",
+        )
+
+        assert kb.knowledge_base_id == KB_ID
+        assert kb.data_source_id == DATA_SOURCE_ID
+        assert kb.data_source_bucket == DATA_SOURCE_BUCKET
+        assert kb.region_name == REGION
+        assert kb.number_of_results == 10
+        assert kb.knowledge_base_type == "VECTOR"
+
+    def test_init_with_env_vars(self, monkeypatch):
+        """Test initialization falls back to environment variables."""
+        monkeypatch.setenv("KNOWLEDGE_BASE_ID", "env-kb-id")
+        monkeypatch.setenv("BEDROCK_DATA_SOURCE_ID", "env-ds-id")
+        monkeypatch.setenv("BEDROCK_DATA_SOURCE_BUCKET", "env-bucket")
+        monkeypatch.setenv("AWS_REGION", "eu-west-1")
+
+        kb = BedrockKB()
+
+        assert kb.knowledge_base_id == "env-kb-id"
+        assert kb.data_source_id == "env-ds-id"
+        assert kb.data_source_bucket == "env-bucket"
+        assert kb.region_name == "eu-west-1"
+
+    def test_init_defaults(self, monkeypatch):
+        """Test initialization defaults when no params or env vars are set."""
+        monkeypatch.delenv("KNOWLEDGE_BASE_ID", raising=False)
+        monkeypatch.delenv("BEDROCK_DATA_SOURCE_ID", raising=False)
+        monkeypatch.delenv("BEDROCK_DATA_SOURCE_BUCKET", raising=False)
+        monkeypatch.delenv("AWS_REGION", raising=False)
+
+        kb = BedrockKB()
+
+        assert kb.knowledge_base_id == ""
+        assert kb.data_source_id == ""
+        assert kb.data_source_bucket == ""
+        assert kb.region_name == "us-east-1"
+        assert kb.number_of_results == 5
+        assert kb.knowledge_base_type == "MANAGED"
+
+
+class TestSearch:
+    def test_search_managed_config(self, store, mock_boto_clients):
+        """Test search with MANAGED knowledge base type returns correct format."""
+        mock_boto_clients["runtime"].retrieve.return_value = {
+            "retrievalResults": [
+                {
+                    "content": {"text": "Hello world"},
+                    "location": {"s3Location": {"uri": "s3://bucket/mem0/doc1.txt"}},
+                    "score": 0.95,
+                },
+                {
+                    "content": {"text": "Goodbye world"},
+                    "location": {"s3Location": {"uri": "s3://bucket/mem0/doc2.txt"}},
+                    "score": 0.80,
+                },
+            ]
+        }
+
+        results = store.search(query="hello", top_k=2)
+
+        mock_boto_clients["runtime"].retrieve.assert_called_once_with(
+            knowledgeBaseId=KB_ID,
+            retrievalQuery={"text": "hello"},
+            retrievalConfiguration={"managedSearchConfiguration": {"numberOfResults": 2}},
+        )
+        assert len(results) == 2
+        assert results[0].id == "doc1"
+        assert results[0].score == 0.95
+        assert results[0].payload["data"] == "Hello world"
+        assert "doc1" in results[0].payload["source"]
+
+    def test_search_vector_config(self, mock_boto_clients):
+        """Test search with VECTOR knowledge base type uses vectorSearchConfiguration."""
+        vector_store = BedrockKB(
+            knowledge_base_id=KB_ID,
+            data_source_id=DATA_SOURCE_ID,
+            data_source_bucket=DATA_SOURCE_BUCKET,
+            region_name=REGION,
+            knowledge_base_type="VECTOR",
+            use_agentic_retrieval=False,
+        )
+        vector_store._runtime_client = mock_boto_clients["runtime"]
+        vector_store._agent_client = mock_boto_clients["agent"]
+        vector_store._s3_client = mock_boto_clients["s3"]
+        mock_boto_clients["runtime"].retrieve.return_value = {
+            "retrievalResults": [
+                {
+                    "content": {"text": "Vector result"},
+                    "location": {"s3Location": {"uri": "s3://bucket/mem0/vec1.txt"}},
+                    "score": 0.88,
+                },
+            ]
+        }
+
+        results = vector_store.search(query="test query", top_k=3)
+
+        mock_boto_clients["runtime"].retrieve.assert_called_once_with(
+            knowledgeBaseId=KB_ID,
+            retrievalQuery={"text": "test query"},
+            retrievalConfiguration={"vectorSearchConfiguration": {"numberOfResults": 3}},
+        )
+        assert len(results) == 1
+        assert results[0].score == 0.88
+
+    def test_search_returns_empty_on_error(self, store, mock_boto_clients):
+        """Test search returns empty list on exception."""
+        mock_boto_clients["runtime"].retrieve.side_effect = Exception("Service unavailable")
+
+        results = store.search(query="fail")
+
+        assert results == []
+
+
+class TestInsert:
+    def test_insert_uploads_to_s3_and_triggers_ingestion(self, store, mock_boto_clients):
+        """Test insert uploads documents to S3 and starts ingestion."""
+        payloads = [
+            {"data": "Document one", "metadata": {"user_id": "alice"}},
+            {"data": "Document two", "metadata": {"user_id": "bob"}},
+        ]
+        ids = ["id-1", "id-2"]
+
+        result = store.insert(vectors=[[0.1, 0.2], [0.3, 0.4]], payloads=payloads, ids=ids)
+
+        assert result == ["id-1", "id-2"]
+        assert mock_boto_clients["s3"].put_object.call_count == 4
+
+        # Verify first document upload
+        first_call = mock_boto_clients["s3"].put_object.call_args_list[0]
+        assert first_call.kwargs["Bucket"] == DATA_SOURCE_BUCKET
+        assert first_call.kwargs["Key"] == "mem0/alice/id-1.txt"
+        assert first_call.kwargs["Body"] == "Document one"
+
+        # Verify ingestion was triggered
+        mock_boto_clients["agent"].start_ingestion_job.assert_called_once_with(
+            knowledgeBaseId=KB_ID,
+            dataSourceId=DATA_SOURCE_ID,
+        )
+
+    def test_insert_generates_ids_when_not_provided(self, store, mock_boto_clients):
+        """Test insert generates UUIDs when no ids are provided."""
+        payloads = [{"data": "Some content"}]
+
+        result = store.insert(vectors=[[0.1]], payloads=payloads)
+
+        assert len(result) == 1
+        # Should be a valid UUID string
+        assert len(result[0]) == 36
+        assert mock_boto_clients["s3"].put_object.call_count == 2
+
+    def test_insert_no_bucket_does_nothing(self, mock_boto_clients):
+        """Test insert returns None when no bucket is configured."""
+        kb = BedrockKB(
+            knowledge_base_id=KB_ID,
+            data_source_id=DATA_SOURCE_ID,
+            data_source_bucket="",
+            region_name=REGION,
+        )
+
+        result = kb.insert(vectors=[[0.1]], payloads=[{"data": "test"}], ids=["id-1"])
+
+        assert result is None
+        mock_boto_clients["s3"].put_object.assert_not_called()
+
+
+class TestDelete:
+    def test_delete_removes_from_s3_and_triggers_ingestion(self, store, mock_boto_clients):
+        """Test delete removes the object from S3 and triggers re-sync."""
+        store.delete("doc-123")
+
+        mock_boto_clients["s3"].delete_object.assert_any_call(
+            Bucket=DATA_SOURCE_BUCKET,
+            Key="mem0/_default/doc-123.txt",
+        )
+        mock_boto_clients["agent"].start_ingestion_job.assert_called_once_with(
+            knowledgeBaseId=KB_ID,
+            dataSourceId=DATA_SOURCE_ID,
+        )
+
+    def test_delete_no_bucket_does_nothing(self, mock_boto_clients):
+        """Test delete does nothing when no bucket is configured."""
+        kb = BedrockKB(
+            knowledge_base_id=KB_ID,
+            data_source_id=DATA_SOURCE_ID,
+            data_source_bucket="",
+            region_name=REGION,
+        )
+
+        kb.delete("doc-123")
+
+        mock_boto_clients["s3"].delete_object.assert_not_called()
+
+    def test_delete_handles_s3_error(self, store, mock_boto_clients):
+        """Test delete handles S3 errors gracefully."""
+        mock_boto_clients["s3"].delete_object.side_effect = Exception("Access Denied")
+
+        # Should not raise
+        store.delete("doc-123")
+
+        mock_boto_clients["agent"].start_ingestion_job.assert_not_called()
+
+
+class TestUpdate:
+    def test_update_reuploads_and_triggers_ingestion(self, store, mock_boto_clients):
+        """Test update re-uploads the document and triggers ingestion."""
+        store.update("doc-456", payload={"data": "Updated content"})
+
+        mock_boto_clients["s3"].put_object.assert_any_call(
+            Bucket=DATA_SOURCE_BUCKET,
+            Key="mem0/_default/doc-456.txt",
+            Body="Updated content",
+        )
+        mock_boto_clients["agent"].start_ingestion_job.assert_called_once_with(
+            knowledgeBaseId=KB_ID,
+            dataSourceId=DATA_SOURCE_ID,
+        )
+
+    def test_update_with_string_payload(self, store, mock_boto_clients):
+        """Test update with a non-dict payload converts to string."""
+        store.update("doc-789", payload="Plain text payload")
+
+        mock_boto_clients["s3"].put_object.assert_any_call(
+            Bucket=DATA_SOURCE_BUCKET,
+            Key="mem0/_default/doc-789.txt",
+            Body="Plain text payload",
+        )
+
+    def test_update_no_payload_does_nothing(self, store, mock_boto_clients):
+        """Test update with no payload does not upload."""
+        store.update("doc-123", payload=None)
+
+        mock_boto_clients["s3"].put_object.assert_not_called()
+        mock_boto_clients["agent"].start_ingestion_job.assert_not_called()
+
+
+class TestGet:
+    def test_get_fetches_from_s3(self, store, mock_boto_clients):
+        """Test get retrieves document content from S3."""
+        mock_body = MagicMock()
+        mock_body.read.return_value = b"Retrieved content"
+        mock_boto_clients["s3"].get_object.return_value = {"Body": mock_body}
+
+        result = store.get("doc-abc")
+
+        mock_boto_clients["s3"].get_object.assert_called_once_with(
+            Bucket=DATA_SOURCE_BUCKET,
+            Key="mem0/_default/doc-abc.txt",
+        )
+        assert result.id == "doc-abc"
+        assert result.payload["data"] == "Retrieved content"
+
+    def test_get_returns_none_on_error(self, store, mock_boto_clients):
+        """Test get returns None when S3 raises an exception."""
+        mock_boto_clients["s3"].get_object.side_effect = Exception("NoSuchKey")
+
+        result = store.get("nonexistent")
+
+        assert result is None
+
+    def test_get_no_bucket_returns_none(self, mock_boto_clients):
+        """Test get returns None when no bucket is configured."""
+        kb = BedrockKB(
+            knowledge_base_id=KB_ID,
+            data_source_id=DATA_SOURCE_ID,
+            data_source_bucket="",
+            region_name=REGION,
+        )
+
+        result = kb.get("doc-123")
+
+        assert result is None
+        mock_boto_clients["s3"].get_object.assert_not_called()
+
+
+class TestList:
+    def test_list_returns_s3_objects(self, store, mock_boto_clients):
+        """Test list returns documents from S3 prefix."""
+        mock_boto_clients["s3"].list_objects_v2.return_value = {
+            "Contents": [
+                {"Key": "mem0/doc-1.txt"},
+                {"Key": "mem0/doc-2.txt"},
+                {"Key": "mem0/doc-3.txt"},
+            ]
+        }
+
+        results = store.list()
+
+        mock_boto_clients["s3"].list_objects_v2.assert_called_once_with(
+            Bucket=DATA_SOURCE_BUCKET,
+            Prefix="mem0/",
+            MaxKeys=100,
+        )
+        assert len(results[0]) == 3
+        assert results[0][0].id == "doc-1"
+        assert results[0][1].id == "doc-2"
+        assert results[0][2].id == "doc-3"
+
+    def test_list_with_top_k(self, store, mock_boto_clients):
+        """Test list respects top_k parameter."""
+        mock_boto_clients["s3"].list_objects_v2.return_value = {"Contents": []}
+
+        store.list(top_k=25)
+
+        mock_boto_clients["s3"].list_objects_v2.assert_called_once_with(
+            Bucket=DATA_SOURCE_BUCKET,
+            Prefix="mem0/",
+            MaxKeys=25,
+        )
+
+    def test_list_no_bucket_returns_empty(self, mock_boto_clients):
+        """Test list returns empty list when no bucket is configured."""
+        kb = BedrockKB(
+            knowledge_base_id=KB_ID,
+            data_source_id=DATA_SOURCE_ID,
+            data_source_bucket="",
+            region_name=REGION,
+        )
+
+        results = kb.list()
+
+        assert results == [[]]
+        mock_boto_clients["s3"].list_objects_v2.assert_not_called()
+
+    def test_list_handles_error(self, store, mock_boto_clients):
+        """Test list returns empty list on S3 error."""
+        mock_boto_clients["s3"].list_objects_v2.side_effect = Exception("Access Denied")
+
+        results = store.list()
+
+        assert results == [[]]
+
+
+class TestErrorHandlingMissingBucket:
+    """Tests verifying behavior when data_source_bucket is not configured."""
+
+    def test_insert_without_bucket(self, mock_boto_clients):
+        kb = BedrockKB(knowledge_base_id=KB_ID, data_source_bucket="")
+        result = kb.insert(vectors=[[0.1]], payloads=[{"data": "x"}], ids=["id1"])
+        assert result is None
+
+    def test_delete_without_bucket(self, mock_boto_clients):
+        kb = BedrockKB(knowledge_base_id=KB_ID, data_source_bucket="")
+        # Should not raise
+        kb.delete("id1")
+        mock_boto_clients["s3"].delete_object.assert_not_called()
+
+    def test_get_without_bucket(self, mock_boto_clients):
+        kb = BedrockKB(knowledge_base_id=KB_ID, data_source_bucket="")
+        result = kb.get("id1")
+        assert result is None
+
+    def test_list_without_bucket(self, mock_boto_clients):
+        kb = BedrockKB(knowledge_base_id=KB_ID, data_source_bucket="")
+        result = kb.list()
+        assert result == [[]]
+
+
+class TestInsertDirect:
+    """Tests for CUSTOM data source (IngestKnowledgeBaseDocuments) path."""
+
+    def test_insert_direct_calls_ingest_api(self):
+        from mem0.vector_stores.bedrock_kb import BedrockKB
+
+        kb = BedrockKB(
+            knowledge_base_id="TEST_KB",
+            data_source_id="DS_CUSTOM",
+            region_name="us-west-2",
+            data_source_type="CUSTOM",
+        )
+        mock_client = MagicMock()
+        kb._agent_client = mock_client
+
+        result = kb.insert(
+            vectors=None,
+            payloads=[{"data": "Test document content", "metadata": {"user_id": "alice"}}],
+            ids=["doc-001"],
+        )
+
+        assert result == ["doc-001"]
+        mock_client.ingest_knowledge_base_documents.assert_called_once()
+        call_kwargs = mock_client.ingest_knowledge_base_documents.call_args.kwargs
+        assert call_kwargs["knowledgeBaseId"] == "TEST_KB"
+        assert call_kwargs["dataSourceId"] == "DS_CUSTOM"
+        assert len(call_kwargs["documents"]) == 1
+        doc = call_kwargs["documents"][0]
+        assert doc["content"]["dataSourceType"] == "CUSTOM"
+        assert doc["content"]["custom"]["customDocumentIdentifier"]["id"] == "doc-001"
+        assert doc["content"]["custom"]["inlineContent"]["type"] == "TEXT"
+        assert doc["content"]["custom"]["inlineContent"]["textContent"]["data"] == "Test document content"
+
+    def test_insert_direct_includes_metadata(self):
+        from mem0.vector_stores.bedrock_kb import BedrockKB
+
+        kb = BedrockKB(
+            knowledge_base_id="TEST_KB",
+            data_source_id="DS_CUSTOM",
+            data_source_type="CUSTOM",
+        )
+        mock_client = MagicMock()
+        kb._agent_client = mock_client
+
+        kb.insert(
+            vectors=None,
+            payloads=[{"data": "content", "metadata": {"user_id": "bob", "category": "faq"}}],
+        )
+
+        call_kwargs = mock_client.ingest_knowledge_base_documents.call_args.kwargs
+        doc = call_kwargs["documents"][0]
+        assert doc["metadata"]["type"] == "IN_LINE_ATTRIBUTE"
+        attrs = {a["key"]: a["value"]["stringValue"] for a in doc["metadata"]["inlineAttributes"]}
+        assert attrs["user_id"] == "bob"
+        assert attrs["category"] == "faq"
+
+    def test_insert_direct_no_data_source_id_returns_none(self):
+        from mem0.vector_stores.bedrock_kb import BedrockKB
+
+        kb = BedrockKB(
+            knowledge_base_id="TEST_KB",
+            data_source_type="CUSTOM",
+        )
+        kb._data_source_id = ""
+
+        result = kb.insert(vectors=None, payloads=[{"data": "test"}])
+        assert result is None
+
+    def test_insert_direct_batches_over_10(self):
+        from mem0.vector_stores.bedrock_kb import BedrockKB
+
+        kb = BedrockKB(
+            knowledge_base_id="TEST_KB",
+            data_source_id="DS_CUSTOM",
+            data_source_type="CUSTOM",
+        )
+        mock_client = MagicMock()
+        kb._agent_client = mock_client
+
+        # Insert 12 documents - should make 2 API calls (10 + 2)
+        payloads = [{"data": f"doc {i}"} for i in range(12)]
+        result = kb.insert(vectors=None, payloads=payloads)
+
+        assert len(result) == 12
+        assert mock_client.ingest_knowledge_base_documents.call_count == 2
+
+    def test_insert_direct_s3_reference(self):
+        from mem0.vector_stores.bedrock_kb import BedrockKB
+
+        kb = BedrockKB(
+            knowledge_base_id="TEST_KB",
+            data_source_id="DS_CUSTOM",
+            data_source_type="CUSTOM",
+        )
+        mock_client = MagicMock()
+        kb._agent_client = mock_client
+
+        result = kb.insert(
+            vectors=None,
+            payloads=[{"s3_uri": "s3://my-bucket/docs/file.pdf", "metadata": {"source": "s3"}}],
+            ids=["s3-doc-001"],
+        )
+
+        assert result == ["s3-doc-001"]
+        call_kwargs = mock_client.ingest_knowledge_base_documents.call_args.kwargs
+        doc = call_kwargs["documents"][0]
+        assert doc["content"]["custom"]["sourceType"] == "S3_LOCATION"
+        assert doc["content"]["custom"]["s3Location"]["uri"] == "s3://my-bucket/docs/file.pdf"
+
+    def test_insert_direct_binary_content(self):
+        from mem0.vector_stores.bedrock_kb import BedrockKB
+
+        kb = BedrockKB(
+            knowledge_base_id="TEST_KB",
+            data_source_id="DS_CUSTOM",
+            data_source_type="CUSTOM",
+        )
+        mock_client = MagicMock()
+        kb._agent_client = mock_client
+
+        result = kb.insert(
+            vectors=None,
+            payloads=[{"data": "base64encodedcontent", "mime_type": "application/pdf"}],
+            ids=["pdf-001"],
+        )
+
+        assert result == ["pdf-001"]
+        call_kwargs = mock_client.ingest_knowledge_base_documents.call_args.kwargs
+        doc = call_kwargs["documents"][0]
+        assert doc["content"]["custom"]["inlineContent"]["type"] == "BYTE"
+        assert doc["content"]["custom"]["inlineContent"]["byteContent"]["mimeType"] == "application/pdf"


### PR DESCRIPTION
# feat: add Amazon Bedrock Knowledge Base vector store backend

## Linked Issue

N/A — new feature adding Amazon Bedrock Knowledge Base as a vector store backend.

## Description

Adds `BedrockKB(VectorStoreBase)` that uses Amazon Bedrock Managed Knowledge Bases as a full read-write vector store backend for mem0.

- `search()` uses `managedSearchConfiguration` for retrieval
- `insert()`/`update()` upload documents to S3 + trigger ingestion sync
- `delete()` removes from S3 + re-syncs the data source
- `list_cols()` lists available knowledge bases
- `col_info()` returns KB name and status
- Agentic retrieval with fallback to standard Retrieve API

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Manual E2E: `search()` returned 3 results. `list_cols()` returned 17 KBs. `col_info()` returned name + ACTIVE status. Full vector store backend interface verified against live KB + bedrock-agent API in us-west-2.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
