### PR TITLE
fix(server): scope auth DB sessions to prevent connection-pool exhaustion

### DIFF
--- a/server/auth.py
+++ b/server/auth.py
@@ -3,7 +3,7 @@ import secrets
 import uuid
 from datetime import datetime, timedelta, timezone
 
-from db import get_db
+from db import SessionLocal
 from fastapi import Depends, HTTPException, Request
 from fastapi.security import APIKeyHeader, HTTPAuthorizationCredentials, HTTPBearer
 from jose import JWTError, jwt
@@ -145,19 +145,24 @@ async def verify_auth(
     request: Request,
     credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
     x_api_key: str | None = Depends(api_key_header),
-    db: Session = Depends(get_db),
 ) -> User | None:
-    """Authenticate via JWT, X-API-Key, or legacy ADMIN_API_KEY. Returns User or None."""
+    """Authenticate via JWT, X-API-Key, or legacy ADMIN_API_KEY. Returns User or None.
+
+    A short-lived session is opened only on the branches that query the DB, so no
+    pooled connection is held for the lifetime of the (possibly long-running) request.
+    """
     if credentials is not None:
         _mark_auth_type(request, "bearer")
-        return _resolve_user_from_jwt(credentials.credentials, db)
+        with SessionLocal() as db:
+            return _resolve_user_from_jwt(credentials.credentials, db)
 
     if x_api_key is not None:
         if ADMIN_API_KEY and secrets.compare_digest(x_api_key, ADMIN_API_KEY):
             _mark_auth_type(request, "admin_api_key")
             return None
         _mark_auth_type(request, "api_key")
-        return _resolve_user_from_api_key(x_api_key, db)
+        with SessionLocal() as db:
+            return _resolve_user_from_api_key(x_api_key, db)
 
     if AUTH_DISABLED:
         _mark_auth_type(request, "disabled")
@@ -173,12 +178,12 @@ async def verify_auth(
 async def require_auth(
     request: Request,
     user: User | None = Depends(verify_auth),
-    db: Session = Depends(get_db),
 ) -> User:
     """Like verify_auth but guarantees a non-None User. Use for endpoints that require auth."""
     if user is None:
         if getattr(request.state, "auth_type", "none") in {"admin_api_key", "disabled"}:
-            default_user = _get_default_user(db)
+            with SessionLocal() as db:
+                default_user = _get_default_user(db)
             if default_user is not None:
                 return default_user
         raise HTTPException(status_code=401, detail="Authentication required.")
@@ -193,7 +198,6 @@ _BOOTSTRAP_ADMIN = User(
 async def require_admin(
     request: Request,
     user: User | None = Depends(verify_auth),
-    db: Session = Depends(get_db),
 ) -> User:
     """Like require_auth but also enforces admin role.
 
@@ -203,7 +207,8 @@ async def require_admin(
     auth_type = getattr(request.state, "auth_type", "none")
     if user is None:
         if auth_type in {"admin_api_key", "disabled"}:
-            default_user = _get_default_user(db)
+            with SessionLocal() as db:
+                default_user = _get_default_user(db)
             if default_user is not None:
                 if default_user.role != "admin":
                     raise HTTPException(status_code=403, detail="Admin role required.")

--- a/server/routers/auth.py
+++ b/server/routers/auth.py
@@ -175,18 +175,23 @@ def update_me(
     user: User = Depends(require_auth),
     db: Session = Depends(get_db),
 ):
-    if body.name is not None and body.name.strip():
-        user.name = body.name.strip()
+    # require_auth resolves the user in its own short-lived session, so `user` is
+    # detached from this request's `db`. Load a session-managed copy to mutate.
+    db_user = db.get(User, user.id)
+    if db_user is None:
+        raise HTTPException(status_code=404, detail="User not found.")
 
-    if body.email is not None and body.email != user.email:
-        collision = db.scalar(select(User).where(User.email == body.email, User.id != user.id))
+    if body.name is not None and body.name.strip():
+        db_user.name = body.name.strip()
+
+    if body.email is not None and body.email != db_user.email:
+        collision = db.scalar(select(User).where(User.email == body.email, User.id != db_user.id))
         if collision is not None:
             raise HTTPException(status_code=409, detail="Email is already in use.")
-        user.email = body.email
+        db_user.email = body.email
 
     db.commit()
-    db.refresh(user)
-    return user
+    return db_user
 
 
 @router.post("/change-password", response_model=MessageResponse)
@@ -195,12 +200,15 @@ def change_password(
     user: User = Depends(require_auth),
     db: Session = Depends(get_db),
 ):
-    if not verify_password(body.current_password, user.password_hash):
+    # require_auth resolves the user in its own short-lived session, so `user` is
+    # detached from this request's `db`. Load a session-managed copy to mutate.
+    db_user = db.get(User, user.id)
+    if db_user is None or not verify_password(body.current_password, db_user.password_hash):
         raise HTTPException(status_code=401, detail="Current password is incorrect.")
 
     _require_password_length(body.new_password)
 
-    user.password_hash = hash_password(body.new_password)
+    db_user.password_hash = hash_password(body.new_password)
     db.commit()
     return MessageResponse(message="Password updated.")
 


### PR DESCRIPTION
## Linked Issue

Closes #6236

## Description

The self-hosted server's auth dependencies in `server/auth.py` declare
`db: Session = Depends(get_db)`. As a FastAPI `yield` dependency, `get_db`
checks out a pooled SQLAlchemy connection at **request start** and holds it
until the response is sent. The auth query is ~1ms, but the connection stays
pinned for the **entire** request — including the long-running LLM endpoints
(`POST /memories` ≈ 20–40s, `POST /search`, `POST /generate-instructions`).

Under concurrency, in-flight requests each hold a connection for the whole LLM
call, so the default engine pool (`create_engine(..., pool_pre_ping=True)` →
SQLAlchemy default `pool_size=5, max_overflow=10` = 15) is exhausted. New
requests then fail on pool-timeout, and because auth itself needs the pool, the
API and dashboard wedge even though the process stays "up". This is the
well-known FastAPI `Depends(get_db)` + slow-endpoint antipattern — a
request-scoped session pins a connection for the duration of a slow request.

## Change

**`server/auth.py`** — scope the auth DB session to just the auth query: open a
short-lived `with SessionLocal() as db:` only on the branches that actually
query, in all three auth dependencies (`verify_auth`, `require_auth`,
`require_admin`), instead of injecting it via `Depends(get_db)` for the whole
request. The auth query releases its connection immediately, so the endpoint
body no longer holds one.

**`server/routers/auth.py`** — because auth now resolves the user in its own
short-lived session, the `User` returned by `require_auth` is detached from the
endpoint's own `db`. The two endpoints that *write* to that user
(`PATCH /auth/me`, `POST /auth/change-password`) now load a session-managed copy
via `db.get(User, user.id)`, mutate that, and commit — so the writes actually
persist. Read-only endpoints are unaffected (they only read scalar columns; a
sweep confirmed these two are the only sites that mutate the injected user).

`server/db.py` sets `sessionmaker(..., expire_on_commit=False)`, so a `User`
loaded inside a `with` block (or the managed copy above) stays readable after
the session closes. Behavior is unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Pool fix: reproduced against a local server — ~40 concurrent `POST /memories`
pinned `mem0_app` connections at 15 (`SELECT count(*) FROM pg_stat_activity
WHERE datname='mem0_app'`) and hung `/search`. With this change, connections
stay in single digits and `/search` stays 200 under the same load.

Write endpoints: the `update_me` / `change_password` detachment surfaced in
review is fixed by mutating a session-managed `db.get(User, user.id)`; verified
by inspection against the model/schema (`User` has no server-computed columns
and `UserResponse` only exposes columns already populated on the managed
instance).

`server/` has no pytest harness (the suite under `tests/` covers the SDK, not
the FastAPI server), so no automated regression test is added here to avoid
introducing a new framework. Happy to add one as a follow-up if you'd like.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
