### PR TITLE
fix(memory): return ([], {}) from process_telemetry_filters for None filters

### DIFF
--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -227,7 +227,9 @@ def process_telemetry_filters(filters):
     Process the telemetry filters
     """
     if filters is None:
-        return {}
+        # Callers unpack the result as `keys, encoded_ids` — keep the
+        # return type a 2-tuple for the None case too.
+        return [], {}
 
     encoded_ids = {}
     if "user_id" in filters:

--- a/tests/memory/test_memory_utils.py
+++ b/tests/memory/test_memory_utils.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 from mem0.memory.utils import (
     parse_messages,
     parse_vision_messages,
+    process_telemetry_filters,
     remove_spaces_from_entities,
     sanitize_relationship_for_cypher,
 )
@@ -168,3 +169,18 @@ class TestRemoveSpacesFromEntities:
         f = remove_spaces_from_entities([dict(base)], sanitize_relationship=False)[0]["relationship"]
         assert t == sanitize_relationship_for_cypher("a/b")
         assert f == "a/b"
+
+
+class TestProcessTelemetryFilters:
+    def test_none_returns_empty_tuple_pair(self):
+        """All callers unpack the result as `keys, encoded_ids` — None input
+        must yield a 2-tuple, not a bare dict (issue #6171)."""
+        keys, encoded_ids = process_telemetry_filters(None)
+        assert keys == []
+        assert encoded_ids == {}
+
+    def test_filters_return_keys_and_hashed_ids(self):
+        keys, encoded_ids = process_telemetry_filters({"user_id": "alice", "topic": "x"})
+        assert keys == ["user_id", "topic"]
+        assert set(encoded_ids) == {"user_id"}
+        assert encoded_ids["user_id"] != "alice"  # md5-hashed, never raw


### PR DESCRIPTION
Closes #6171

`process_telemetry_filters` returned a bare `{}` when `filters is None`, but all 8 call sites in `main.py` unpack the result as a 2-tuple (`keys, encoded_ids`), so a None input raises `ValueError: not enough values to unpack`. This keeps the return type a consistent `([], {})`.

Added regression tests for both the None branch and the normal branch (keys list + md5-hashed ids, raw ids never leaked).

`pytest tests/memory/test_memory_utils.py`: 21 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)