### PR TITLE
fix(client): send page/page_size as query params even when passed alone

### DIFF
--- a/mem0/client/main.py
+++ b/mem0/client/main.py
@@ -269,11 +269,11 @@ class MemoryClient:
         kwargs = {**(options.model_dump(exclude_unset=True) if options else {}), **kwargs}
         params = self._prepare_params(kwargs)
 
-        if "page" in params and "page_size" in params:
-            query_params = {
-                "page": params.pop("page"),
-                "page_size": params.pop("page_size"),
-            }
+        # Pagination always travels as query params — the server ignores
+        # page/page_size in the JSON body, so passing either one alone must
+        # still move it out of the body (see #6227).
+        query_params = {key: params.pop(key) for key in ("page", "page_size") if key in params}
+        if query_params:
             response = self.client.post("/v3/memories/", json=params, params=query_params)
         else:
             response = self.client.post("/v3/memories/", json=params)
@@ -1192,11 +1192,11 @@ class AsyncMemoryClient:
         kwargs = {**(options.model_dump(exclude_unset=True) if options else {}), **kwargs}
         params = self._prepare_params(kwargs)
 
-        if "page" in params and "page_size" in params:
-            query_params = {
-                "page": params.pop("page"),
-                "page_size": params.pop("page_size"),
-            }
+        # Pagination always travels as query params — the server ignores
+        # page/page_size in the JSON body, so passing either one alone must
+        # still move it out of the body (see #6227).
+        query_params = {key: params.pop(key) for key in ("page", "page_size") if key in params}
+        if query_params:
             response = await self.async_client.post("/v3/memories/", json=params, params=query_params)
         else:
             response = await self.async_client.post("/v3/memories/", json=params)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -389,3 +389,48 @@ class TestValidateApiKeyHttpError:
 
         assert not isinstance(exc_info.value, requests.exceptions.JSONDecodeError)
         assert "Error:" in str(exc_info.value)
+
+
+class TestGetAllPagination:
+    """page/page_size must travel as query params even when passed alone (#6227)."""
+
+    def _mock_post(self, client):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"results": []}
+        mock_response.raise_for_status.return_value = None
+        client.client.post.return_value = mock_response
+
+    def test_page_size_alone_moves_to_query_params(self, mock_memory_client):
+        self._mock_post(mock_memory_client)
+        mock_memory_client.get_all(filters={"user_id": "u1"}, page_size=5)
+        mock_memory_client.client.post.assert_called_once_with(
+            "/v3/memories/",
+            json={"filters": {"user_id": "u1"}},
+            params={"page_size": 5},
+        )
+
+    def test_page_alone_moves_to_query_params(self, mock_memory_client):
+        self._mock_post(mock_memory_client)
+        mock_memory_client.get_all(filters={"user_id": "u1"}, page=2)
+        mock_memory_client.client.post.assert_called_once_with(
+            "/v3/memories/",
+            json={"filters": {"user_id": "u1"}},
+            params={"page": 2},
+        )
+
+    def test_page_and_page_size_move_to_query_params(self, mock_memory_client):
+        self._mock_post(mock_memory_client)
+        mock_memory_client.get_all(filters={"user_id": "u1"}, page=2, page_size=5)
+        mock_memory_client.client.post.assert_called_once_with(
+            "/v3/memories/",
+            json={"filters": {"user_id": "u1"}},
+            params={"page": 2, "page_size": 5},
+        )
+
+    def test_no_pagination_omits_query_params(self, mock_memory_client):
+        self._mock_post(mock_memory_client)
+        mock_memory_client.get_all(filters={"user_id": "u1"})
+        mock_memory_client.client.post.assert_called_once_with(
+            "/v3/memories/",
+            json={"filters": {"user_id": "u1"}},
+        )


### PR DESCRIPTION
Closes #6227

`get_all()` (sync and async) only moved `page`/`page_size` into the query string when **both** were supplied. Passing `page_size` alone (with `page` defaulting) left it in the JSON body, which the server does not read for pagination — the value was silently dropped and a default-sized page came back.

Fix: move whichever of the two keys is present into the query params; body-only requests are unchanged when neither is passed.

Tests cover all four combinations (page_size alone / page alone / both / neither) asserting the exact outgoing request shape. `pytest tests/test_client.py`: 33 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)