### PR TITLE
fix(opensearch): list() without top_k no longer caps at 10 results

### DIFF
--- a/mem0/vector_stores/opensearch.py
+++ b/mem0/vector_stores/opensearch.py
@@ -17,6 +17,11 @@ logger = logging.getLogger(__name__)
 
 _SAFE_FILTER_KEY = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_.]*$")
 
+# OpenSearch's default index.max_result_window — the largest size a single
+# search can return without deep pagination. Used as the fallback when list()
+# is called without an explicit top_k to enumerate everything (#6108).
+DEFAULT_MAX_RESULT_WINDOW = 10000
+
 
 def _validate_filter(key: str, value) -> None:
     if not isinstance(key, str) or not _SAFE_FILTER_KEY.match(key):
@@ -383,9 +388,8 @@ class OpenSearchDB(VectorStoreBase):
 
             # Without an explicit size OpenSearch returns only its default 10
             # hits, silently truncating get_all()/delete_all(), which call
-            # list() with top_k=None to enumerate everything (#6108). 10000
-            # is OpenSearch's default index.max_result_window.
-            query["size"] = top_k if top_k else 10000
+            # list() with top_k=None to enumerate everything (#6108).
+            query["size"] = top_k if top_k else DEFAULT_MAX_RESULT_WINDOW
 
             response = self.client.search(index=self.collection_name, body=query)
             hits = response["hits"]["hits"]

--- a/mem0/vector_stores/opensearch.py
+++ b/mem0/vector_stores/opensearch.py
@@ -381,8 +381,11 @@ class OpenSearchDB(VectorStoreBase):
             if filter_clauses:
                 query["query"] = {"bool": {"filter": filter_clauses}}
 
-            if top_k:
-                query["size"] = top_k
+            # Without an explicit size OpenSearch returns only its default 10
+            # hits, silently truncating get_all()/delete_all(), which call
+            # list() with top_k=None to enumerate everything (#6108). 10000
+            # is OpenSearch's default index.max_result_window.
+            query["size"] = top_k if top_k else 10000
 
             response = self.client.search(index=self.collection_name, body=query)
             hits = response["hits"]["hits"]

--- a/tests/vector_stores/test_opensearch.py
+++ b/tests/vector_stores/test_opensearch.py
@@ -312,6 +312,20 @@ class TestOpenSearchDB(unittest.TestCase):
         self.assertEqual(len(result[0]), 1)
         self.assertEqual(result[0][0].id, "id1")
 
+    def test_list_without_top_k_requests_max_window(self):
+        """list(top_k=None) must not fall back to OpenSearch's default 10-hit
+        page — get_all()/delete_all() rely on it enumerating everything (#6108)."""
+        self.client_mock.search.return_value = {"hits": {"hits": []}}
+        self.os_db.list(filters={"user_id": "alice"})
+        body = self.client_mock.search.call_args.kwargs["body"]
+        self.assertEqual(body["size"], 10000)
+
+    def test_list_with_top_k_requests_top_k(self):
+        self.client_mock.search.return_value = {"hits": {"hits": []}}
+        self.os_db.list(filters={"user_id": "alice"}, top_k=25)
+        body = self.client_mock.search.call_args.kwargs["body"]
+        self.assertEqual(body["size"], 25)
+
     @patch("mem0.vector_stores.opensearch.logger")
     def test_list_error_returns_nested_empty_list(self, mock_logger):
         """list() error path must return [[]] (not bare []) so callers can do


### PR DESCRIPTION
Closes #6108

`OpenSearchDB.list()` only set the query `size` when `top_k` was truthy. `Memory.get_all()` and `Memory.delete_all()` call `list(filters=..., top_k=None)` to enumerate **all** matching memories, so the query fell back to OpenSearch's default of 10 hits — `get_all()` returned at most 10 memories and `delete_all()` left everything past the first 10 behind, both silently.

Fix: request `size=10000` (OpenSearch's default `index.max_result_window`) when no `top_k` is given — same convention as `vertex_ai_vector_search.py`'s `search_limit = top_k if top_k is not None else 10000`. Explicit `top_k` behaviour is unchanged.

Note: the Elasticsearch adapter has the same `if top_k:` shape; per the issue this PR scopes to OpenSearch only, happy to follow up on ES if wanted.

Tests assert the outgoing query body for both cases. `pytest tests/vector_stores/test_opensearch.py`: 31 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)