### PR TITLE
fix(litellm): route params through the shared reasoning-model gate

### DIFF
--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -60,9 +60,17 @@ class LLMBase(ABC):
         if explicit is not None:
             return explicit
 
+        # The non-dotted GPT-5 originals (gpt-5, gpt-5-mini, gpt-5-nano) are
+        # reasoning models: they reject temperature/top_p and only accept the
+        # default temperature=1. gpt-5-mini is mem0's default-resolved model,
+        # so it must be listed here or the default config 400s (#6241). Dotted
+        # versions (gpt-5.4-mini, gpt-5.5, ...) *do* support temperature and are
+        # deliberately kept out — matched exactly, never by prefix, so #4738
+        # (gpt-5.4-mini incorrectly stripped) can't regress.
         reasoning_models = {
             "o1", "o1-preview", "o3-mini", "o3",
-            "gpt-5", "gpt-5o", "gpt-5o-mini", "gpt-5o-micro",
+            "gpt-5", "gpt-5-mini", "gpt-5-nano",
+            "gpt-5o", "gpt-5o-mini", "gpt-5o-micro",
         }
 
         model_lower = model.lower()

--- a/mem0/llms/litellm.py
+++ b/mem0/llms/litellm.py
@@ -70,16 +70,17 @@ class LiteLLM(LLMBase):
         if tools and not litellm.supports_function_calling(self.config.model):
             raise ValueError(f"Model '{self.config.model}' in litellm does not support function calling.")
 
-        params = {
+        # Route through the shared reasoning-model gate: reasoning models
+        # (o1/o3 and the gpt-5 family, incl. provider-prefixed names like
+        # "openai/gpt-5-mini") reject temperature/top_p, so those params must
+        # be filtered here just like in the OpenAI provider (#6241, #6085).
+        # For regular models this yields the exact same temperature/top_p and
+        # max_tokens/max_completion_tokens params as before.
+        params = self._get_supported_params(messages=messages)
+        params.update({
             "model": self.config.model,
             "messages": messages,
-            "temperature": self.config.temperature,
-            "top_p": self.config.top_p,
-        }
-        if self._uses_max_completion_tokens(self.config.model):
-            params["max_completion_tokens"] = self.config.max_tokens
-        else:
-            params["max_tokens"] = self.config.max_tokens
+        })
         if response_format:
             params["response_format"] = response_format
         if tools:  # TODO: Remove tools if no issues found with new memory addition logic

--- a/tests/llms/test_litellm.py
+++ b/tests/llms/test_litellm.py
@@ -161,6 +161,26 @@ def test_reasoning_model_omits_temperature_and_top_p(mock_litellm):
     assert called["model"] == "o3-mini"
 
 
+def test_default_resolved_gpt5_mini_omits_temperature_and_top_p(mock_litellm):
+    """mem0's default-resolved model is gpt-5-mini, a reasoning model that
+    rejects temperature/top_p. With no model set, the shared gate must still
+    strip them once LiteLLM resolves the default (#6241)."""
+    config = BaseLlmConfig(temperature=0.7, max_tokens=100, top_p=1)
+    llm = litellm.LiteLLM(config)
+    assert llm.config.model == "gpt-5-mini"
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="hi"))]
+    mock_litellm.completion.return_value = mock_response
+
+    llm.generate_response([{"role": "user", "content": "Hello"}])
+
+    called = mock_litellm.completion.call_args.kwargs
+    assert "temperature" not in called
+    assert "top_p" not in called
+    assert called["model"] == "gpt-5-mini"
+
+
 def test_provider_prefixed_reasoning_model_omits_temperature(mock_litellm):
     config = BaseLlmConfig(model="openai/o1-2024-12-17", temperature=0.7, max_tokens=100, top_p=1)
     llm = litellm.LiteLLM(config)

--- a/tests/llms/test_litellm.py
+++ b/tests/llms/test_litellm.py
@@ -141,3 +141,54 @@ def test_generate_response_with_tools(mock_litellm):
     assert len(response["tool_calls"]) == 1
     assert response["tool_calls"][0]["name"] == "add_memory"
     assert response["tool_calls"][0]["arguments"] == {"data": "Today is a sunny day."}
+
+
+def test_reasoning_model_omits_temperature_and_top_p(mock_litellm):
+    """Reasoning models reject temperature/top_p; the shared gate must filter
+    them out for LiteLLM just like the OpenAI provider (#6241, #6085)."""
+    config = BaseLlmConfig(model="o3-mini", temperature=0.7, max_tokens=100, top_p=1)
+    llm = litellm.LiteLLM(config)
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="hi"))]
+    mock_litellm.completion.return_value = mock_response
+
+    llm.generate_response([{"role": "user", "content": "Hello"}])
+
+    called = mock_litellm.completion.call_args.kwargs
+    assert "temperature" not in called
+    assert "top_p" not in called
+    assert called["model"] == "o3-mini"
+
+
+def test_provider_prefixed_reasoning_model_omits_temperature(mock_litellm):
+    config = BaseLlmConfig(model="openai/o1-2024-12-17", temperature=0.7, max_tokens=100, top_p=1)
+    llm = litellm.LiteLLM(config)
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="hi"))]
+    mock_litellm.completion.return_value = mock_response
+
+    llm.generate_response([{"role": "user", "content": "Hello"}])
+
+    called = mock_litellm.completion.call_args.kwargs
+    assert "temperature" not in called
+    assert "top_p" not in called
+
+
+def test_regular_model_keeps_temperature_and_max_tokens(mock_litellm):
+    """Non-reasoning models must send the exact same params as before."""
+    config = BaseLlmConfig(model="gpt-4.1-mini", temperature=0.7, max_tokens=100, top_p=1)
+    llm = litellm.LiteLLM(config)
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="hi"))]
+    mock_litellm.completion.return_value = mock_response
+
+    llm.generate_response([{"role": "user", "content": "Hello"}])
+
+    called = mock_litellm.completion.call_args.kwargs
+    assert called["temperature"] == 0.7
+    assert called["top_p"] == 1
+    assert called["max_tokens"] == 100
+    assert "max_completion_tokens" not in called

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -319,12 +319,18 @@ def test_is_reasoning_model_classification(mock_openai_client):
     assert llm._is_reasoning_model("o3-mini") is True
     assert llm._is_reasoning_model("o3") is True
     assert llm._is_reasoning_model("gpt-5") is True
+    # Non-dotted GPT-5 originals reject temperature/top_p (#6241). gpt-5-mini is
+    # the default-resolved model, so it must classify as reasoning.
+    assert llm._is_reasoning_model("gpt-5-mini") is True
+    assert llm._is_reasoning_model("gpt-5-nano") is True
     assert llm._is_reasoning_model("o1-preview") is True
     assert llm._is_reasoning_model("o1-2024-12-17") is True
     assert llm._is_reasoning_model("openai/o3-mini") is True
 
-    # Non-reasoning models — should return False
+    # Non-reasoning models — should return False. Dotted gpt-5.x versions support
+    # temperature and must not be caught by the gpt-5-mini/nano additions (#4738).
     assert llm._is_reasoning_model("gpt-5.4-mini") is False
+    assert llm._is_reasoning_model("gpt-5.4-nano") is False
     assert llm._is_reasoning_model("gpt-5.4") is False
     assert llm._is_reasoning_model("gpt-4.1") is False
     assert llm._is_reasoning_model("gpt-4.1-nano-2025-04-14") is False


### PR DESCRIPTION
Closes #6241 (the LiteLLM follow-up invited in #6085's triage notes)

The LiteLLM provider built its request params by hand and always sent `temperature`/`top_p`, never consulting `LLMBase._is_reasoning_model` / `_get_supported_params`. Reasoning models routed through LiteLLM — the o1/o3 family, the gpt-5 family including the default-resolved `gpt-5-mini`, and provider-prefixed names like `openai/o1-2024-12-17` — reject those params with a 400. Same failure mode as #6085, but unaffected by #6090's heuristic fix because this provider bypassed the gate entirely.

Fix: build params via the shared `self._get_supported_params(messages=messages)`, exactly like the OpenAI provider. For regular models this yields byte-identical params to before (`_get_common_params` covers the temperature/top_p and `max_tokens` vs `max_completion_tokens` split that was previously inlined here).

Tests: reasoning model omits temperature/top_p; provider-prefixed reasoning name also filtered; regular model keeps the exact previous params. `pytest tests/llms/test_litellm.py`: 9 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)