### PR TITLE
fix(memory): add lock to prevent entity store TOCTOU race condition

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1,5 +1,6 @@
 import asyncio
 import concurrent.futures
+import threading
 import gc
 import hashlib
 import json
@@ -475,6 +476,7 @@ class Memory(MemoryBase):
 
         # Entity store is initialized lazily on first use
         self._entity_store = None
+        self._entity_lock = threading.Lock()
 
         if MEM0_TELEMETRY:
             # Create telemetry config manually to avoid deepcopy issues with thread locks
@@ -567,50 +569,51 @@ class Memory(MemoryBase):
 
     def _upsert_entity(self, entity_text, entity_type, memory_id, filters):
         """Upsert an entity into the entity store, linking it to a memory."""
-        try:
-            entity_embedding = self.embedding_model.embed(entity_text, "add")
-            search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
-            exact_match = self._existing_entities_by_text(search_filters).get(self._normalize_entity_text(entity_text))
+        with self._entity_lock:
+            try:
+                entity_embedding = self.embedding_model.embed(entity_text, "add")
+                search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
+                exact_match = self._existing_entities_by_text(search_filters).get(self._normalize_entity_text(entity_text))
 
-            existing = []
-            if exact_match is None:
-                existing = self.entity_store.search(
-                    query=entity_text,
-                    vectors=entity_embedding,
-                    top_k=1,
-                    filters=search_filters,
-                )
-
-            semantic_match = existing[0] if existing and existing[0].score >= 0.95 else None
-            match = exact_match or semantic_match
-            if match:
-                # Update existing entity's linked_memory_ids
-                payload = match.payload or {}
-                linked_ids = payload.get("linked_memory_ids", [])
-                if memory_id not in linked_ids:
-                    linked_ids.append(memory_id)
-                    payload["linked_memory_ids"] = linked_ids
-                    self.entity_store.update(
-                        vector_id=match.id,
-                        vector=None,
-                        payload=payload,
+                existing = []
+                if exact_match is None:
+                    existing = self.entity_store.search(
+                        query=entity_text,
+                        vectors=entity_embedding,
+                        top_k=1,
+                        filters=search_filters,
                     )
-            else:
-                # Create new entity
-                entity_id = str(uuid.uuid4())
-                entity_payload = {
-                    "data": entity_text,
-                    "entity_type": entity_type,
-                    "linked_memory_ids": [memory_id],
-                    **{k: v for k, v in search_filters.items()},
-                }
-                self.entity_store.insert(
-                    vectors=[entity_embedding],
-                    ids=[entity_id],
-                    payloads=[entity_payload],
-                )
-        except Exception as e:
-            logger.warning(f"Entity upsert failed for '{entity_text}': {e}")
+
+                semantic_match = existing[0] if existing and existing[0].score >= 0.95 else None
+                match = exact_match or semantic_match
+                if match:
+                    # Update existing entity's linked_memory_ids
+                    payload = match.payload or {}
+                    linked_ids = payload.get("linked_memory_ids", [])
+                    if memory_id not in linked_ids:
+                        linked_ids.append(memory_id)
+                        payload["linked_memory_ids"] = linked_ids
+                        self.entity_store.update(
+                            vector_id=match.id,
+                            vector=None,
+                            payload=payload,
+                        )
+                else:
+                    # Create new entity
+                    entity_id = str(uuid.uuid4())
+                    entity_payload = {
+                        "data": entity_text,
+                        "entity_type": entity_type,
+                        "linked_memory_ids": [memory_id],
+                        **{k: v for k, v in search_filters.items()},
+                    }
+                    self.entity_store.insert(
+                        vectors=[entity_embedding],
+                        ids=[entity_id],
+                        payloads=[entity_payload],
+                    )
+            except Exception as e:
+                logger.warning(f"Entity upsert failed for '{entity_text}': {e}")
 
     def _remove_memory_from_entity_store(self, memory_id, filters):
         """Strip `memory_id` from every entity record scoped to `filters`.
@@ -627,45 +630,46 @@ class Memory(MemoryBase):
         """
         if self._entity_store is None:
             return
-        search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
-        try:
-            listed = self.entity_store.list(filters=search_filters, top_k=10000)
-            rows = listed[0] if isinstance(listed, (list, tuple)) and listed and isinstance(listed[0], list) else listed
-            for row in rows or []:
-                try:
-                    payload = getattr(row, "payload", None) or {}
-                    linked = payload.get("linked_memory_ids", [])
-                    if not isinstance(linked, list) or memory_id not in linked:
-                        continue
-                    remaining = [mid for mid in linked if mid != memory_id]
-                    if not remaining:
-                        try:
-                            self.entity_store.delete(vector_id=row.id)
-                        except Exception as e:
-                            logger.debug(f"Entity delete failed for id={row.id}: {e}")
-                    else:
-                        entity_text = payload.get("data")
-                        if not isinstance(entity_text, str) or not entity_text:
-                            logger.debug(f"Entity id={row.id} missing 'data'; skipping update during cleanup")
+        with self._entity_lock:
+            search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
+            try:
+                listed = self.entity_store.list(filters=search_filters, top_k=10000)
+                rows = listed[0] if isinstance(listed, (list, tuple)) and listed and isinstance(listed[0], list) else listed
+                for row in rows or []:
+                    try:
+                        payload = getattr(row, "payload", None) or {}
+                        linked = payload.get("linked_memory_ids", [])
+                        if not isinstance(linked, list) or memory_id not in linked:
                             continue
-                        try:
-                            vec = self.embedding_model.embed(entity_text, "update")
-                        except Exception as e:
-                            logger.debug(f"Entity re-embed failed for '{entity_text}': {e}")
-                            continue
-                        new_payload = {**payload, "linked_memory_ids": remaining}
-                        try:
-                            self.entity_store.update(
-                                vector_id=row.id,
-                                vector=vec,
-                                payload=new_payload,
-                            )
-                        except Exception as e:
-                            logger.debug(f"Entity update failed for id={row.id}: {e}")
-                except Exception as e:
-                    logger.debug(f"Entity cleanup error: {e}")
-        except Exception as e:
-            logger.warning(f"Entity store cleanup failed for memory_id={memory_id}: {e}")
+                        remaining = [mid for mid in linked if mid != memory_id]
+                        if not remaining:
+                            try:
+                                self.entity_store.delete(vector_id=row.id)
+                            except Exception as e:
+                                logger.debug(f"Entity delete failed for id={row.id}: {e}")
+                        else:
+                            entity_text = payload.get("data")
+                            if not isinstance(entity_text, str) or not entity_text:
+                                logger.debug(f"Entity id={row.id} missing 'data'; skipping update during cleanup")
+                                continue
+                            try:
+                                vec = self.embedding_model.embed(entity_text, "update")
+                            except Exception as e:
+                                logger.debug(f"Entity re-embed failed for '{entity_text}': {e}")
+                                continue
+                            new_payload = {**payload, "linked_memory_ids": remaining}
+                            try:
+                                self.entity_store.update(
+                                    vector_id=row.id,
+                                    vector=vec,
+                                    payload=new_payload,
+                                )
+                            except Exception as e:
+                                logger.debug(f"Entity update failed for id={row.id}: {e}")
+                    except Exception as e:
+                        logger.debug(f"Entity cleanup error: {e}")
+            except Exception as e:
+                logger.warning(f"Entity store cleanup failed for memory_id={memory_id}: {e}")
 
     def _link_entities_for_memory(self, memory_id, text, filters):
         """Extract entities from `text` and link them to `memory_id` in the
@@ -2127,6 +2131,7 @@ class AsyncMemory(MemoryBase):
         self.api_version = self.config.version
         self.custom_instructions = self.config.custom_instructions
         self._entity_store = None
+        self._entity_lock = asyncio.Lock()
 
         # Initialize reranker if configured
         self.reranker = None
@@ -2208,53 +2213,54 @@ class AsyncMemory(MemoryBase):
 
     async def _upsert_entity_async(self, entity_text, entity_type, memory_id, filters):
         """Async variant of `_upsert_entity` — per-entity search-then-update-or-insert."""
-        try:
-            entity_embedding = await asyncio.to_thread(self.embedding_model.embed, entity_text, "add")
-            search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
-            exact_match = (
-                await asyncio.to_thread(self._existing_entities_by_text, search_filters)
-            ).get(self._normalize_entity_text(entity_text))
+        async with self._entity_lock:
+            try:
+                entity_embedding = await asyncio.to_thread(self.embedding_model.embed, entity_text, "add")
+                search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
+                exact_match = (
+                    await asyncio.to_thread(self._existing_entities_by_text, search_filters)
+                ).get(self._normalize_entity_text(entity_text))
 
-            existing = []
-            if exact_match is None:
-                existing = await asyncio.to_thread(
-                    self.entity_store.search,
-                    query=entity_text,
-                    vectors=entity_embedding,
-                    top_k=1,
-                    filters=search_filters,
-                )
-
-            semantic_match = existing[0] if existing and existing[0].score >= 0.95 else None
-            match = exact_match or semantic_match
-            if match:
-                payload = match.payload or {}
-                linked_ids = payload.get("linked_memory_ids", [])
-                if memory_id not in linked_ids:
-                    linked_ids.append(memory_id)
-                    payload["linked_memory_ids"] = linked_ids
-                    await asyncio.to_thread(
-                        self.entity_store.update,
-                        vector_id=match.id,
-                        vector=None,
-                        payload=payload,
+                existing = []
+                if exact_match is None:
+                    existing = await asyncio.to_thread(
+                        self.entity_store.search,
+                        query=entity_text,
+                        vectors=entity_embedding,
+                        top_k=1,
+                        filters=search_filters,
                     )
-            else:
-                entity_id = str(uuid.uuid4())
-                entity_payload = {
-                    "data": entity_text,
-                    "entity_type": entity_type,
-                    "linked_memory_ids": [memory_id],
-                    **{k: v for k, v in search_filters.items()},
-                }
-                await asyncio.to_thread(
-                    self.entity_store.insert,
-                    vectors=[entity_embedding],
-                    ids=[entity_id],
-                    payloads=[entity_payload],
-                )
-        except Exception as e:
-            logger.warning(f"Entity upsert failed for '{entity_text}' (async): {e}")
+
+                semantic_match = existing[0] if existing and existing[0].score >= 0.95 else None
+                match = exact_match or semantic_match
+                if match:
+                    payload = match.payload or {}
+                    linked_ids = payload.get("linked_memory_ids", [])
+                    if memory_id not in linked_ids:
+                        linked_ids.append(memory_id)
+                        payload["linked_memory_ids"] = linked_ids
+                        await asyncio.to_thread(
+                            self.entity_store.update,
+                            vector_id=match.id,
+                            vector=None,
+                            payload=payload,
+                        )
+                else:
+                    entity_id = str(uuid.uuid4())
+                    entity_payload = {
+                        "data": entity_text,
+                        "entity_type": entity_type,
+                        "linked_memory_ids": [memory_id],
+                        **{k: v for k, v in search_filters.items()},
+                    }
+                    await asyncio.to_thread(
+                        self.entity_store.insert,
+                        vectors=[entity_embedding],
+                        ids=[entity_id],
+                        payloads=[entity_payload],
+                    )
+            except Exception as e:
+                logger.warning(f"Entity upsert failed for '{entity_text}' (async): {e}")
 
     async def _bulk_clear_entity_store(self, filters):
         """Delete all entity records matching the given scope filters.
@@ -2281,46 +2287,47 @@ class AsyncMemory(MemoryBase):
         """Async variant of `Memory._remove_memory_from_entity_store`."""
         if self._entity_store is None:
             return
-        search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
-        try:
-            listed = await asyncio.to_thread(self.entity_store.list, filters=search_filters, top_k=10000)
-            rows = listed[0] if isinstance(listed, (list, tuple)) and listed and isinstance(listed[0], list) else listed
-            for row in rows or []:
-                try:
-                    payload = getattr(row, "payload", None) or {}
-                    linked = payload.get("linked_memory_ids", [])
-                    if not isinstance(linked, list) or memory_id not in linked:
-                        continue
-                    remaining = [mid for mid in linked if mid != memory_id]
-                    if not remaining:
-                        try:
-                            await asyncio.to_thread(self.entity_store.delete, vector_id=row.id)
-                        except Exception as e:
-                            logger.debug(f"Entity delete failed for id={row.id} (async): {e}")
-                    else:
-                        entity_text = payload.get("data")
-                        if not isinstance(entity_text, str) or not entity_text:
-                            logger.debug(f"Entity id={row.id} missing 'data'; skipping update during cleanup (async)")
+        async with self._entity_lock:
+            search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
+            try:
+                listed = await asyncio.to_thread(self.entity_store.list, filters=search_filters, top_k=10000)
+                rows = listed[0] if isinstance(listed, (list, tuple)) and listed and isinstance(listed[0], list) else listed
+                for row in rows or []:
+                    try:
+                        payload = getattr(row, "payload", None) or {}
+                        linked = payload.get("linked_memory_ids", [])
+                        if not isinstance(linked, list) or memory_id not in linked:
                             continue
-                        try:
-                            vec = await asyncio.to_thread(self.embedding_model.embed, entity_text, "update")
-                        except Exception as e:
-                            logger.debug(f"Entity re-embed failed for '{entity_text}' (async): {e}")
-                            continue
-                        new_payload = {**payload, "linked_memory_ids": remaining}
-                        try:
-                            await asyncio.to_thread(
-                                self.entity_store.update,
-                                vector_id=row.id,
-                                vector=vec,
-                                payload=new_payload,
-                            )
-                        except Exception as e:
-                            logger.debug(f"Entity update failed for id={row.id} (async): {e}")
-                except Exception as e:
-                    logger.debug(f"Entity cleanup error (async): {e}")
-        except Exception as e:
-            logger.warning(f"Entity store cleanup failed for memory_id={memory_id} (async): {e}")
+                        remaining = [mid for mid in linked if mid != memory_id]
+                        if not remaining:
+                            try:
+                                await asyncio.to_thread(self.entity_store.delete, vector_id=row.id)
+                            except Exception as e:
+                                logger.debug(f"Entity delete failed for id={row.id} (async): {e}")
+                        else:
+                            entity_text = payload.get("data")
+                            if not isinstance(entity_text, str) or not entity_text:
+                                logger.debug(f"Entity id={row.id} missing 'data'; skipping update during cleanup (async)")
+                                continue
+                            try:
+                                vec = await asyncio.to_thread(self.embedding_model.embed, entity_text, "update")
+                            except Exception as e:
+                                logger.debug(f"Entity re-embed failed for '{entity_text}' (async): {e}")
+                                continue
+                            new_payload = {**payload, "linked_memory_ids": remaining}
+                            try:
+                                await asyncio.to_thread(
+                                    self.entity_store.update,
+                                    vector_id=row.id,
+                                    vector=vec,
+                                    payload=new_payload,
+                                )
+                            except Exception as e:
+                                logger.debug(f"Entity update failed for id={row.id} (async): {e}")
+                    except Exception as e:
+                        logger.debug(f"Entity cleanup error (async): {e}")
+            except Exception as e:
+                logger.warning(f"Entity store cleanup failed for memory_id={memory_id} (async): {e}")
 
     async def _link_entities_for_memory(self, memory_id, text, filters):
         """Async variant of `Memory._link_entities_for_memory`."""

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -1,4 +1,6 @@
+import asyncio
 import logging
+import threading
 import time
 from datetime import datetime, timezone
 from types import SimpleNamespace
@@ -1083,3 +1085,175 @@ class TestAddPipelineEntityEmbeddingCountGuard:
         assert any("padding/truncating" in r.message for r in caplog.records), (
             "expected count-mismatch warning was not emitted"
         )
+
+
+def _make_entity_store_mock():
+    """Return an in-memory dict-based mock for the entity store."""
+    store = {"rows": {}}
+
+    def _list(*, filters, top_k):
+        return [[SimpleNamespace(id=k, payload=v) for k, v in store["rows"].items()]]
+
+    def _search(*, query, vectors, top_k, filters):
+        for k, v in store["rows"].items():
+            data = (v or {}).get("data", "")
+            if data and data.lower() in query.lower():
+                return [_make_match(0.97, v.get("linked_memory_ids", []), row_id=k)]
+        return []
+
+    def _insert(*, vectors, ids, payloads):
+        for i, row_id in enumerate(ids):
+            store["rows"][row_id] = payloads[i]
+
+    def _update(*, vector_id, vector, payload):
+        store["rows"][vector_id] = payload
+
+    def _delete(*, vector_id):
+        store["rows"].pop(vector_id, None)
+
+    mock = Mock()
+    mock.list = Mock(side_effect=_list)
+    mock.search = Mock(side_effect=_search)
+    mock.insert = Mock(side_effect=_insert)
+    mock.update = Mock(side_effect=_update)
+    mock.delete = Mock(side_effect=_delete)
+    return store, mock
+
+
+def _make_match(score, linked_memory_ids, row_id="ent-1"):
+    return SimpleNamespace(id=row_id, score=score, payload={"data": "test", "linked_memory_ids": list(linked_memory_ids)})
+
+
+class TestEntityStoreConcurrency:
+    """Verify that the entity-store lock prevents lost updates under concurrency."""
+
+    @pytest.fixture
+    def sync_entity_memory(self, mocker):
+        _setup_mocks(mocker)
+        memory = Memory()
+        memory.config = mocker.MagicMock()
+        memory.config.custom_instructions = None
+        memory.config.custom_update_memory_prompt = None
+        memory.custom_instructions = None
+        memory.api_version = "v1.1"
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+        memory._entity_lock = threading.Lock()
+        return memory
+
+    @pytest.fixture
+    def async_entity_memory(self, mocker):
+        _setup_mocks(mocker)
+        memory = AsyncMemory()
+        memory.config = mocker.MagicMock()
+        memory.config.custom_instructions = None
+        memory.config.custom_update_memory_prompt = None
+        memory.custom_instructions = None
+        memory.api_version = "v1.1"
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+        memory._entity_lock = asyncio.Lock()
+        return memory
+
+    def test_concurrent_upsert_preserves_all_memory_ids(self, sync_entity_memory):
+        store, mock_store = _make_entity_store_mock()
+        sync_entity_memory._entity_store = mock_store
+        filters = {"user_id": "u1"}
+        errors = []
+
+        def _upsert(memory_id):
+            try:
+                sync_entity_memory._upsert_entity("Alice", "person", memory_id, filters)
+            except Exception as exc:
+                errors.append(exc)
+
+        t1 = threading.Thread(target=_upsert, args=("mem-a",))
+        t2 = threading.Thread(target=_upsert, args=("mem-b",))
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        assert not errors, f"Unexpected errors: {errors}"
+        rows = store["rows"]
+        assert len(rows) == 1
+        linked = next(iter(rows.values())).get("linked_memory_ids", [])
+        assert "mem-a" in linked
+        assert "mem-b" in linked
+
+    def test_concurrent_upsert_and_remove_no_corruption(self, sync_entity_memory):
+        store, mock_store = _make_entity_store_mock()
+        sync_entity_memory._entity_store = mock_store
+        filters = {"user_id": "u1"}
+
+        sync_entity_memory._upsert_entity("Alice", "person", "mem-a", filters)
+        assert len(store["rows"]) == 1
+
+        errors = []
+
+        def _upsert():
+            try:
+                sync_entity_memory._upsert_entity("Alice", "person", "mem-b", filters)
+            except Exception as exc:
+                errors.append(exc)
+
+        def _remove():
+            try:
+                sync_entity_memory._remove_memory_from_entity_store("mem-a", filters)
+            except Exception as exc:
+                errors.append(exc)
+
+        t1 = threading.Thread(target=_upsert)
+        t2 = threading.Thread(target=_remove)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        assert not errors
+        rows = store["rows"]
+        if rows:
+            linked = next(iter(rows.values())).get("linked_memory_ids", [])
+            assert "mem-a" not in linked
+            if linked:
+                assert linked == ["mem-b"]
+
+    @pytest.mark.asyncio
+    async def test_async_concurrent_upsert_preserves_all_memory_ids(self, async_entity_memory):
+        store, mock_store = _make_entity_store_mock()
+        async_entity_memory._entity_store = mock_store
+        filters = {"user_id": "u1"}
+
+        async def _upsert(memory_id):
+            await async_entity_memory._upsert_entity_async("Alice", "person", memory_id, filters)
+
+        await asyncio.gather(_upsert("mem-a"), _upsert("mem-b"))
+
+        rows = store["rows"]
+        assert len(rows) == 1
+        linked = next(iter(rows.values())).get("linked_memory_ids", [])
+        assert "mem-a" in linked
+        assert "mem-b" in linked
+
+    @pytest.mark.asyncio
+    async def test_async_concurrent_upsert_and_remove_no_corruption(self, async_entity_memory):
+        store, mock_store = _make_entity_store_mock()
+        async_entity_memory._entity_store = mock_store
+        filters = {"user_id": "u1"}
+
+        await async_entity_memory._upsert_entity_async("Alice", "person", "mem-a", filters)
+        assert len(store["rows"]) == 1
+
+        await asyncio.gather(
+            async_entity_memory._upsert_entity_async("Alice", "person", "mem-b", filters),
+            async_entity_memory._remove_memory_from_entity_store("mem-a", filters),
+        )
+
+        rows = store["rows"]
+        if rows:
+            linked = next(iter(rows.values())).get("linked_memory_ids", [])
+            assert "mem-a" not in linked
+            if linked:
+                assert linked == ["mem-b"]


### PR DESCRIPTION
## Linked Issue

Closes #6243

## Description

`_upsert_entity` and `_remove_memory_from_entity_store` (sync + async) perform a read-modify-write cycle on entity records without synchronization. Under concurrent operations within the same scope, two threads/coroutines can read the same snapshot, each modify `linked_memory_ids`, and the second write silently overwrites the first.

**Fix:** Add `threading.Lock` to `Memory` and `asyncio.Lock` to `AsyncMemory`, serializing entity store mutations.

## Type of Change

- [x] Bug fix

## Test Coverage

- [x] I added/updated unit tests — `TestEntityStoreConcurrency` class with 4 tests:
  - Sync concurrent upsert preserves all memory_ids
  - Sync concurrent upsert + remove leaves no corruption
  - Async concurrent upsert preserves all memory_ids
  - Async concurrent upsert + remove leaves no corruption
- [x] All 52 tests in `tests/memory/test_main.py` pass
- [x] Ruff clean on both changed files

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally