### PR TITLE
fix(plugin): read telemetry manifest as utf-8

### DIFF
--- a/integrations/mem0-plugin/scripts/telemetry.py
+++ b/integrations/mem0-plugin/scripts/telemetry.py
@@ -42,7 +42,7 @@ def _load_plugin_version(platform_name: str = "") -> str:
     parts = _PLATFORM_MANIFESTS.get(platform_name, _DEFAULT_MANIFEST)
     try:
         plugin_json = os.path.join(os.path.dirname(__file__), *parts)
-        with open(plugin_json) as f:
+        with open(plugin_json, encoding="utf-8") as f:
             return json.load(f).get("version", "unknown")
     except (OSError, json.JSONDecodeError, KeyError):
         return "unknown"

--- a/integrations/mem0-plugin/tests/test_telemetry.py
+++ b/integrations/mem0-plugin/tests/test_telemetry.py
@@ -199,6 +199,30 @@ def test_plugin_version_is_per_editor(monkeypatch):
         assert payload["properties"]["plugin_version"] == expected, f"{plat} should report {expected} from {rel}"
 
 
+def test_plugin_version_reads_utf8_manifest_content(monkeypatch, tmp_path):
+    """Regression coverage for manifests containing non-ASCII metadata."""
+    import telemetry
+
+    plugin_dir = tmp_path / "mem0-plugin"
+    scripts_dir = plugin_dir / "scripts"
+    manifest_dir = plugin_dir / ".codex-plugin"
+    scripts_dir.mkdir(parents=True)
+    manifest_dir.mkdir()
+    (manifest_dir / "plugin.json").write_text(
+        json.dumps({"name": "Mem0 🧠", "version": "0.2.3"}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(telemetry, "__file__", str(scripts_dir / "telemetry.py"))
+    monkeypatch.setitem(
+        telemetry._PLATFORM_MANIFESTS,
+        "codex",
+        ("..", ".codex-plugin", "plugin.json"),
+    )
+
+    assert telemetry._load_plugin_version("codex") == "0.2.3"
+
+
 def test_send_fails_silently(monkeypatch):
     import telemetry
 


### PR DESCRIPTION
## Summary
- read the plugin telemetry manifest with explicit UTF-8 encoding

## Problem
The telemetry helper loads platform-specific `plugin.json` files without an explicit text encoding. On Windows or other non-UTF-8 locales, that can make manifest parsing depend on the process locale if the metadata ever contains non-ASCII text.

## Before / after
Before, `_load_plugin_version()` used the platform default encoding when opening `plugin.json`.

After, it reads the manifest as UTF-8, matching JSON's expected encoding and the rest of the plugin metadata handling.

## Verification
- `python -m py_compile integrations\mem0-plugin\scripts\telemetry.py`
- `git diff --check`