### PR TITLE
fix(mem0-plugin): honor MEM0_AUTO_SEARCH in on_user_prompt.sh

### DIFF
--- a/integrations/mem0-plugin/scripts/on_user_prompt.sh
+++ b/integrations/mem0-plugin/scripts/on_user_prompt.sh
@@ -30,6 +30,14 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=_identity.sh
 . "$SCRIPT_DIR/_identity.sh" 2>/dev/null || true
 
+# auto_search: false disables automatic search API calls while still allowing
+# static detection + rubric injection (those make no mem0 requests).
+# Mirrors the MEM0_AUTO_SEARCH guards in on_file_read.sh / on_bash_output.sh (#6065/#6071).
+MEM0_AUTO_SEARCH_ENABLED=true
+if [ "${MEM0_AUTO_SEARCH:-true}" = "false" ]; then
+  MEM0_AUTO_SEARCH_ENABLED=false
+fi
+
 # Rubric dedup: only inject full rubric once per session.
 # Key on session ID to avoid cross-session interference.
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // ""' 2>/dev/null || echo "")
@@ -117,7 +125,7 @@ USER_ID="$MEM0_RESOLVED_USER_ID"
 
 _PROMPT_CTX=""
 
-if [ -n "$HAS_RESUME" ]; then
+if [ -n "$HAS_RESUME" ] && [ "$MEM0_AUTO_SEARCH_ENABLED" = "true" ]; then
   RESUME_RESULTS=$(PYTHONPATH="$SCRIPT_DIR" MEM0_SEARCH_USER="$USER_ID" python3 -c "
 import os, sys
 sys.path.insert(0, os.environ.get('PYTHONPATH', '.'))
@@ -157,7 +165,7 @@ fi
 # matches so relevant memories are guaranteed in context, not left for the agent
 # to fetch. Skipped on resume (handled above with targeted queries) and when
 # MEM0_PREFETCH=false.
-if [ -z "$HAS_RESUME" ] && [ "${MEM0_PREFETCH:-true}" != "false" ]; then
+if [ -z "$HAS_RESUME" ] && [ "${MEM0_PREFETCH:-true}" != "false" ] && [ "$MEM0_AUTO_SEARCH_ENABLED" = "true" ]; then
   PREFETCH_RESULTS=$(PYTHONPATH="$SCRIPT_DIR" MEM0_SEARCH_USER="$USER_ID" MEM0_SEARCH_QUERY="$PROMPT" python3 -c "
 import os, sys
 sys.path.insert(0, os.environ.get('PYTHONPATH', '.'))

--- a/integrations/mem0-plugin/tests/test_rubric_dedup.py
+++ b/integrations/mem0-plugin/tests/test_rubric_dedup.py
@@ -59,3 +59,33 @@ def test_second_prompt_gets_no_rubric():
     _run_hook("How should we refactor the auth module?")
     output = _run_hook("What about the database layer?")
     assert output.strip() == ""
+
+def test_auto_search_false_skips_resume_api_search():
+    """MEM0_AUTO_SEARCH=false must not run resume search_memories (#6250)."""
+    output = _run_hook(
+        "Where did we leave off on the auth module refactor?",
+        env_overrides={
+            "MEM0_AUTO_SEARCH": "false",
+            "MEM0_PREFETCH": "true",
+            "MEM0_API_KEY": "test-key-123",
+        },
+        session_id="test-sess-auto-search-resume",
+    )
+    assert "Session context recovered from mem0" not in output
+    assert "Relevant memories (auto-retrieved for this request)" not in output
+
+
+def test_auto_search_false_skips_prefetch_header():
+    """Prefetch search header must not appear when auto_search is off (#6250)."""
+    output = _run_hook(
+        "How should we design the memory scoring pipeline carefully?",
+        env_overrides={
+            "MEM0_AUTO_SEARCH": "false",
+            "MEM0_PREFETCH": "true",
+            "MEM0_API_KEY": "test-key-123",
+        },
+        session_id="test-sess-auto-search-prefetch",
+    )
+    assert "Relevant memories (auto-retrieved for this request)" not in output
+    # First prompt of a session may still inject the non-API rubric.
+    assert "Mem0 searches apply" in output


### PR DESCRIPTION
## Summary

- Gate `on_user_prompt.sh` resume + prefetch `search_memories` calls on `MEM0_AUTO_SEARCH`
- Keep static detections / decision rubric (no API) when auto_search is off
- Add regression tests in `test_rubric_dedup.py`

## Motivation

Closes #6250.

Follow-up to #6065 / #6071: those PRs only guarded `on_file_read.sh` and `on_bash_output.sh`. `on_user_prompt.sh` still left session-resume and prompt-prefetch search paths unblocked, so `auto_search: false` in `~/.mem0/settings.json` continued to burn Platform API quota on every UserPromptSubmit with a substantial prompt.

Root cause: identity exports `MEM0_AUTO_SEARCH`, but the two `python -c` blocks that call `_search.search_memories` never read it.

Fix: after sourcing `_identity.sh`, set `MEM0_AUTO_SEARCH_ENABLED` and require it for both search blocks. Early static detections (error/file/resume/remember flags) and the rubric injection remain — they make no network calls.

## Verification

- `python3 -m pytest integrations/mem0-plugin/tests/test_rubric_dedup.py -v` — **4 passed**
- Did NOT change: source of `MEM0_AUTO_SEARCH` in `_identity.sh`; auto_save path; `MEM0_PREFETCH` semantics when auto_search is true
