### PR TITLE
fix(mem0-plugin): honor MEM0_AUTO_SEARCH in Cursor file-read hook

### DIFF
--- a/integrations/mem0-plugin/scripts/on_file_read_cursor.sh
+++ b/integrations/mem0-plugin/scripts/on_file_read_cursor.sh
@@ -22,6 +22,14 @@ if [ -z "${MEM0_API_KEY:-}" ]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Re-source identity so settings.json auto_search applies even when
+# MEM0_API_KEY was already present in the environment (the branch above
+# skips identity in that case).
+. "$SCRIPT_DIR/_identity.sh" 2>/dev/null || true
+if [ "${MEM0_AUTO_SEARCH:-true}" = "false" ]; then
+  exit 0
+fi
+
 CWD=$(echo "$INPUT" | jq -r '.cwd // "."' 2>/dev/null || echo ".")
 
 TIMELINE=$(python3 "$SCRIPT_DIR/file_context.py" "$FILE_PATH" "$CWD" 2>/dev/null || echo "")

--- a/integrations/mem0-plugin/tests/test_cursor_file_read_auto_search.py
+++ b/integrations/mem0-plugin/tests/test_cursor_file_read_auto_search.py
@@ -1,0 +1,51 @@
+"""Regression: Cursor on_file_read honors MEM0_AUTO_SEARCH (#6252)."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
+HOOK = os.path.join(SCRIPTS_DIR, "on_file_read_cursor.sh")
+
+
+def _run(env_extra: dict | None = None) -> subprocess.CompletedProcess:
+    env = {
+        **os.environ,
+        "MEM0_API_KEY": "test-key",
+        "MEM0_AUTO_SEARCH": "false",
+        "PATH": os.environ.get("PATH", ""),
+    }
+    if env_extra:
+        env.update(env_extra)
+    payload = json.dumps({"tool_input": {"file_path": "/tmp/example.py"}, "cwd": "/tmp"})
+    return subprocess.run(
+        ["bash", HOOK],
+        input=payload,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=10,
+    )
+
+
+def test_auto_search_false_exits_without_timeline(tmp_path, monkeypatch):
+    """When auto_search is off, hook must not invoke file_context.py work.
+
+    We assert empty stdout (no additionalContext JSON) and success exit.
+    """
+    # Point PYTHON so if file_context were called it would be findable; we still
+    # expect no context emission when auto_search is false.
+    result = _run()
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_auto_search_true_may_emit(tmp_path, monkeypatch):
+    """Control: with auto_search true the hook still exits 0 (file_context may no-op)."""
+    result = _run({"MEM0_AUTO_SEARCH": "true"})
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary

- Make Cursor `on_file_read_cursor.sh` respect `auto_search` / `MEM0_AUTO_SEARCH`
- Always source `_identity.sh` so `~/.mem0/settings.json` applies even when `MEM0_API_KEY` is already set
- Add regression tests

## Motivation

Closes #6252.

#6071 gated Claude Code `on_file_read.sh`, but the Cursor PreToolUse twin never checked `MEM0_AUTO_SEARCH`. Worse, identity (where `auto_search` is loaded) was only sourced when the API key was *missing*, so the common "key already exported" path never loaded settings.json either.

Users who set `auto_search: false` still paid for `file_context.py` searches on every Read tool call under Cursor.

## Verification

- `python3 -m pytest integrations/mem0-plugin/tests/test_cursor_file_read_auto_search.py -v` — **2 passed**
- Did NOT change: Claude Code hooks (covered by #6071 + #6251), auto_save
