### PR TITLE
fix(ts-oss/redis): keep entity ids snake_case in returned payloads

### DIFF
--- a/mem0-ts/src/oss/src/vector_stores/redis.ts
+++ b/mem0-ts/src/oss/src/vector_stores/redis.ts
@@ -145,6 +145,24 @@ function toCamelCase(obj: Record<string, any>): Record<string, any> {
   );
 }
 
+// Re-attach entity ids in snake_case after a toCamelCase pass on a stored
+// payload. The entity ids (user_id/agent_id/run_id) are part of the canonical
+// payload contract in snake_case: index.ts and every other vector store read
+// payload.user_id, not payload.userId. Running the whole payload through
+// toCamelCase renamed them to userId/agentId/runId, so they were dropped from
+// search/getAll/get results and leaked into metadata, and delete/update entity
+// cleanup could not read the scope. Timestamps stay camelCase (createdAt) as
+// the contract expects, which is why the camelCase pass is kept for the rest.
+function withEntityIds(
+  payload: Record<string, any>,
+  source: { agent_id?: string; run_id?: string; user_id?: string },
+): Record<string, any> {
+  if (source.agent_id) payload.agent_id = source.agent_id;
+  if (source.run_id) payload.run_id = source.run_id;
+  if (source.user_id) payload.user_id = source.user_id;
+  return payload;
+}
+
 export class RedisDB implements VectorStore {
   private client: RedisClientType<
     RedisDefaultModules & RedisModules & RedisFunctions & RedisScripts
@@ -437,15 +455,12 @@ export class RedisDB implements VectorStore {
           ...(doc.value.updated_at && {
             updated_at: new Date(parseInt(doc.value.updated_at)).toISOString(),
           }),
-          ...(doc.value.agent_id && { agent_id: doc.value.agent_id }),
-          ...(doc.value.run_id && { run_id: doc.value.run_id }),
-          ...(doc.value.user_id && { user_id: doc.value.user_id }),
           ...JSON.parse(doc.value.metadata || "{}"),
         };
 
         return {
           id: doc.value.memory_id,
-          payload: toCamelCase(resultPayload),
+          payload: withEntityIds(toCamelCase(resultPayload), doc.value),
           score: Math.max(0, 1 - (Number(doc.value.__vector_score) ?? 0)),
         };
       });
@@ -541,15 +556,12 @@ export class RedisDB implements VectorStore {
         data: doc.memory,
         created_at: created_at.toISOString(),
         ...(updated_at && { updated_at: updated_at.toISOString() }),
-        ...(doc.agent_id && { agent_id: doc.agent_id }),
-        ...(doc.run_id && { run_id: doc.run_id }),
-        ...(doc.user_id && { user_id: doc.user_id }),
         ...JSON.parse(doc.metadata || "{}"),
       };
 
       return {
         id: vectorId,
-        payload: toCamelCase(payload),
+        payload: withEntityIds(toCamelCase(payload), doc),
       };
     } catch (error) {
       console.error("Error getting vector:", error);
@@ -658,18 +670,18 @@ export class RedisDB implements VectorStore {
 
     const items = results.documents.map((doc) => ({
       id: doc.value.memory_id,
-      payload: toCamelCase({
-        hash: doc.value.hash,
-        data: doc.value.memory,
-        created_at: new Date(parseInt(doc.value.created_at)).toISOString(),
-        ...(doc.value.updated_at && {
-          updated_at: new Date(parseInt(doc.value.updated_at)).toISOString(),
+      payload: withEntityIds(
+        toCamelCase({
+          hash: doc.value.hash,
+          data: doc.value.memory,
+          created_at: new Date(parseInt(doc.value.created_at)).toISOString(),
+          ...(doc.value.updated_at && {
+            updated_at: new Date(parseInt(doc.value.updated_at)).toISOString(),
+          }),
+          ...JSON.parse(doc.value.metadata || "{}"),
         }),
-        ...(doc.value.agent_id && { agent_id: doc.value.agent_id }),
-        ...(doc.value.run_id && { run_id: doc.value.run_id }),
-        ...(doc.value.user_id && { user_id: doc.value.user_id }),
-        ...JSON.parse(doc.value.metadata || "{}"),
-      }),
+        doc.value,
+      ),
     }));
 
     return [items, results.total];

--- a/mem0-ts/src/oss/tests/redis.unit.test.ts
+++ b/mem0-ts/src/oss/tests/redis.unit.test.ts
@@ -125,4 +125,99 @@ describe("RedisDB – entity payload handling", () => {
     expect(entry.created_at).toBeGreaterThan(0);
     expect(Number.isNaN(entry.created_at)).toBe(false);
   });
+
+  // Entity ids are part of the canonical payload contract in snake_case:
+  // index.ts and the other stores read payload.user_id, not payload.userId.
+  // Timestamps stay camelCase (createdAt). Before the fix, the whole payload
+  // was run through toCamelCase, renaming user_id -> userId, which dropped the
+  // ids from results and leaked them into metadata.
+  const CREATED_AT_MS = 1719316800000;
+
+  test("search returns entity ids in snake_case with camelCase timestamps", async () => {
+    mockClient.ft.search.mockResolvedValueOnce({
+      total: 1,
+      documents: [
+        {
+          id: "mem0:test:mem-1",
+          value: {
+            memory_id: "mem-1",
+            hash: "h1",
+            memory: "likes coffee",
+            created_at: String(CREATED_AT_MS),
+            user_id: "test_user",
+            agent_id: "agent_1",
+            metadata: JSON.stringify({ source: "chat" }),
+            __vector_score: "0.1",
+          },
+        },
+      ],
+    });
+
+    const results = await store.search([0.1, 0.2, 0.3, 0.4], 5, {
+      userId: "test_user",
+    });
+
+    expect(results).toHaveLength(1);
+    const payload = results[0].payload;
+    expect(payload.user_id).toBe("test_user");
+    expect(payload.agent_id).toBe("agent_1");
+    expect(payload.userId).toBeUndefined();
+    expect(payload.agentId).toBeUndefined();
+    expect(payload.createdAt).toBe(new Date(CREATED_AT_MS).toISOString());
+    expect(payload.source).toBe("chat");
+  });
+
+  test("list returns entity ids in snake_case with camelCase timestamps", async () => {
+    mockClient.ft.search.mockResolvedValueOnce({
+      total: 1,
+      documents: [
+        {
+          id: "mem0:test:mem-1",
+          value: {
+            memory_id: "mem-1",
+            hash: "h1",
+            memory: "likes coffee",
+            created_at: String(CREATED_AT_MS),
+            user_id: "test_user",
+            run_id: "run_1",
+            metadata: JSON.stringify({ source: "chat" }),
+          },
+        },
+      ],
+    });
+
+    const [items, total] = await store.list({ userId: "test_user" }, 100);
+
+    expect(total).toBe(1);
+    const payload = items[0].payload;
+    expect(payload.user_id).toBe("test_user");
+    expect(payload.run_id).toBe("run_1");
+    expect(payload.userId).toBeUndefined();
+    expect(payload.runId).toBeUndefined();
+    expect(payload.createdAt).toBe(new Date(CREATED_AT_MS).toISOString());
+  });
+
+  test("get returns entity ids in snake_case with camelCase timestamps", async () => {
+    mockClient.exists.mockResolvedValueOnce(1);
+    mockClient.hGetAll.mockResolvedValueOnce({
+      memory_id: "mem-1",
+      hash: "h1",
+      memory: "likes coffee",
+      created_at: String(CREATED_AT_MS),
+      user_id: "test_user",
+      agent_id: "agent_1",
+      metadata: JSON.stringify({ source: "chat" }),
+    });
+
+    const result = await store.get("mem-1");
+
+    expect(result).not.toBeNull();
+    const payload = result!.payload;
+    expect(payload.user_id).toBe("test_user");
+    expect(payload.agent_id).toBe("agent_1");
+    expect(payload.userId).toBeUndefined();
+    expect(payload.agentId).toBeUndefined();
+    expect(payload.createdAt).toBe(new Date(CREATED_AT_MS).toISOString());
+    expect(payload.source).toBe("chat");
+  });
 });


### PR DESCRIPTION
## Linked Issue

Closes #6254

## Description

The Redis vector store ran every returned payload through `toCamelCase` in `search()`, `get()` and `list()`, which renamed `user_id`/`agent_id`/`run_id` to `userId`/`agentId`/`runId`.

That breaks the canonical payload contract. `memory/index.ts` and the other stores (memory, qdrant, pgvector) read `payload.user_id`, and the in-memory store's `normalizePayload` deliberately keeps entity ids snake_case while leaving timestamps camelCase (`createdAt`). Redis was the only store returning camelCase ids.

For Redis users this meant:

- `search()`/`getAll()`/`get()` dropped `user_id`/`agent_id`/`run_id` from results, since index.ts reads the snake_case keys which were now camelCase.
- Those camelCase keys were not in index.ts's snake_case `excludedKeys`, so they leaked into `metadata` instead.
- `_sessionFiltersFromPayload` read `payload.user_id` (undefined), so entity-store cleanup on delete/update ran unscoped.

The fix re-attaches the entity ids in snake_case after the camelCase pass (timestamps and metadata keep their existing casing), through a small `withEntityIds` helper used by all three read paths. This is the minimal change that restores the contract without altering the timestamp/metadata behavior.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

Added three tests to `tests/redis.unit.test.ts` (using the existing mocked redis client) for `search`, `list` and `get`: each asserts the returned payload has snake_case `user_id`/`agent_id`/`run_id`, no camelCase variants, camelCase `createdAt`, and metadata intact. All three fail on `main` (ids come back `undefined`) and pass with this change. `redis.unit`, `valkey` and `vector-store.unit` suites pass; the `vector-stores-compat` failures are a pre-existing missing optional dependency (`@databricks/sql`) unrelated to this change and are identical with and without it.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
