### PR TITLE
fix(llms/vllm): honor VLLM_BASE_URL when config value is unset

### DIFF
--- a/mem0/configs/llms/vllm.py
+++ b/mem0/configs/llms/vllm.py
@@ -53,4 +53,4 @@ class VllmConfig(BaseLlmConfig):
         )
 
         # vLLM-specific parameters
-        self.vllm_base_url = vllm_base_url or "http://localhost:8000/v1"
+        self.vllm_base_url = vllm_base_url

--- a/mem0/llms/vllm.py
+++ b/mem0/llms/vllm.py
@@ -37,7 +37,7 @@ class VllmLLM(LLMBase):
             self.config.model = "Qwen/Qwen2.5-32B-Instruct"
 
         self.config.api_key = self.config.api_key or os.getenv("VLLM_API_KEY") or "vllm-api-key"
-        base_url = self.config.vllm_base_url or os.getenv("VLLM_BASE_URL")
+        base_url = self.config.vllm_base_url or os.getenv("VLLM_BASE_URL") or "http://localhost:8000/v1"
         self.client = OpenAI(api_key=self.config.api_key, base_url=base_url)
 
     def _parse_response(self, response, tools):

--- a/tests/llms/test_vllm.py
+++ b/tests/llms/test_vllm.py
@@ -4,6 +4,7 @@ import pytest
 
 from mem0 import AsyncMemory, Memory
 from mem0.configs.llms.base import BaseLlmConfig
+from mem0.configs.llms.vllm import VllmConfig
 from mem0.llms.vllm import VllmLLM
 
 
@@ -130,6 +131,27 @@ def test_generate_response_without_response_format(mock_vllm_client):
     call_kwargs = mock_vllm_client.chat.completions.create.call_args[1]
     assert "response_format" not in call_kwargs
     assert response == "Why did the chicken cross the road?"
+
+
+def test_base_url_uses_env_var_when_config_unset(monkeypatch):
+    monkeypatch.setenv("VLLM_BASE_URL", "http://remote-vllm:8000/v1")
+    with patch("mem0.llms.vllm.OpenAI") as mock_openai:
+        VllmLLM(BaseLlmConfig(model="Qwen/Qwen2.5-32B-Instruct"))
+        assert mock_openai.call_args.kwargs["base_url"] == "http://remote-vllm:8000/v1"
+
+
+def test_config_base_url_overrides_env(monkeypatch):
+    monkeypatch.setenv("VLLM_BASE_URL", "http://remote-vllm:8000/v1")
+    with patch("mem0.llms.vllm.OpenAI") as mock_openai:
+        VllmLLM(VllmConfig(model="Qwen/Qwen2.5-32B-Instruct", vllm_base_url="http://explicit:8001/v1"))
+        assert mock_openai.call_args.kwargs["base_url"] == "http://explicit:8001/v1"
+
+
+def test_base_url_defaults_to_localhost_when_unset(monkeypatch):
+    monkeypatch.delenv("VLLM_BASE_URL", raising=False)
+    with patch("mem0.llms.vllm.OpenAI") as mock_openai:
+        VllmLLM(BaseLlmConfig(model="Qwen/Qwen2.5-32B-Instruct"))
+        assert mock_openai.call_args.kwargs["base_url"] == "http://localhost:8000/v1"
 
 
 def create_mocked_memory():


### PR DESCRIPTION
## Linked Issue

Closes #6256

## Description

`VllmConfig.__init__` bakes a localhost default into the config attribute:

```python
self.vllm_base_url = vllm_base_url or "http://localhost:8000/v1"
```

So `self.config.vllm_base_url` is **never** `None`, which makes the `VLLM_BASE_URL` env fallback in `VllmLLM` unreachable dead code:

```python
base_url = self.config.vllm_base_url or os.getenv("VLLM_BASE_URL")  # getenv never runs
```

Users who set `VLLM_BASE_URL` — as the docs and `examples/misc/vllm_example.py` instruct — are silently ignored, and every request goes to `http://localhost:8000/v1` regardless.

This PR drops the default from `VllmConfig` and appends it to the LLM's resolution chain, giving the correct `config > env > default` precedence:

```python
# VllmConfig
self.vllm_base_url = vllm_base_url
# VllmLLM
base_url = self.config.vllm_base_url or os.getenv("VLLM_BASE_URL") or "http://localhost:8000/v1"
```

This mirrors `DeepSeekLLM` (Python) and the TypeScript SDK's vLLM provider, which already resolve base URLs this way.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A — when neither the config value nor `VLLM_BASE_URL` is set, the resolved URL is still `http://localhost:8000/v1`, so existing local setups are unaffected. The only behavior change is that `VLLM_BASE_URL` is now honored (previously ignored).

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added 3 regression tests in `tests/llms/test_vllm.py`:
- `test_base_url_uses_env_var_when_config_unset` — `VLLM_BASE_URL` is honored when the config value is unset.
- `test_config_base_url_overrides_env` — an explicit config value wins over the env var.
- `test_base_url_defaults_to_localhost_when_unset` — falls back to `http://localhost:8000/v1` when nothing is set.

**Red → green proof** (the key test fails on `main`, passes with this fix):

```
# main (pre-fix): config bakes localhost, so the env var is ignored
$ pytest tests/llms/test_vllm.py -k base_url
test_base_url_uses_env_var_when_config_unset      FAILED
test_config_base_url_overrides_env                PASSED
test_base_url_defaults_to_localhost_when_unset    PASSED

    assert mock_openai.call_args.kwargs["base_url"] == "http://remote-vllm:8000/v1"
E   AssertionError: assert 'http://localhost:8000/v1' == 'http://remote-vllm:8000/v1'
1 failed, 2 passed

# with this fix
$ pytest tests/llms/test_vllm.py -k base_url
test_base_url_uses_env_var_when_config_unset      PASSED
test_config_base_url_overrides_env                PASSED
test_base_url_defaults_to_localhost_when_unset    PASSED
3 passed
```

Full `tests/llms/test_vllm.py` suite (9 tests) passes; `ruff check` is clean on the changed source.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
