### PR TITLE
fix(chroma): raise on unknown filter operator instead of silent equality

### DIFF
--- a/mem0/vector_stores/chroma.py
+++ b/mem0/vector_stores/chroma.py
@@ -293,8 +293,14 @@ class ChromaDB(VectorStoreBase):
                         # ChromaDB doesn't support contains, fallback to equality
                         chroma_condition[key] = {"$eq": val}
                     else:
-                        # Unknown operator, treat as equality
-                        chroma_condition[key] = {"$eq": val}
+                        # Fail fast on unknown operators instead of silently
+                        # downgrading to equality, which returns wrong results
+                        # without any signal to the caller.
+                        raise ValueError(
+                            f"Unsupported filter operator {op!r} for field {key!r}. "
+                            "Supported operators: eq, ne, gt, gte, lt, lte, in, nin, "
+                            "contains, icontains."
+                        )
                 return chroma_condition
             else:
                 # Simple equality

--- a/tests/vector_stores/test_chroma.py
+++ b/tests/vector_stores/test_chroma.py
@@ -286,10 +286,20 @@ def test_generate_where_clause_non_string_values():
     """Test _generate_where_clause with non-string values."""
     filters = {"user_id": "alice", "count": 5, "active": True}
     result = ChromaDB._generate_where_clause(filters)
-    
+
     # ChromaDB accepts non-string values in filters
     expected = {"$and": [{"user_id": {"$eq": "alice"}}, {"count": {"$eq": 5}}, {"active": {"$eq": True}}]}
     assert result == expected
+
+
+def test_generate_where_clause_unknown_operator_raises():
+    """An unsupported operator must raise instead of silently becoming equality.
+
+    Previously an unknown operator (e.g. a typo like ``betwen``) was downgraded
+    to ``$eq``, returning wrong results with no signal to the caller.
+    """
+    with pytest.raises(ValueError, match="Unsupported filter operator"):
+        ChromaDB._generate_where_clause({"age": {"betwen": [10, 20]}})
 
 
 def test_generate_where_clause_not_single_equality():


### PR DESCRIPTION
### Description

`ChromaDB._generate_where_clause` downgraded any unrecognized filter operator to `$eq`:

```python
else:
    # Unknown operator, treat as equality
    chroma_condition[key] = {"$eq": val}
```

So `{"age": {"betwen": [10, 20]}}` (a typo, or an unsupported operator) silently became `{"age": {"$eq": [10, 20]}}` — returning wrong results with no signal to the caller.

This changes the `else` branch to raise a `ValueError` naming the operator and field, matching the fail-fast behavior other stores already have (e.g. the Qdrant store raises on invalid operator usage).

Fixes #6258

### Changes

- `mem0/vector_stores/chroma.py`: raise `ValueError` for unsupported operators instead of silently mapping to `$eq`.
- `tests/vector_stores/test_chroma.py`: add a regression test asserting an unknown operator raises.

### Testing

- `pytest tests/vector_stores/test_chroma.py` → 28 passed
- `ruff check` clean on both files