### PR TITLE
fix(ts-oss): deep-merge same-field operators in advanced metadata filters

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -2107,6 +2107,33 @@ export class Memory {
       return result;
     };
 
+    // Merge source into target, deep-merging nested operator dicts for the same
+    // key so multiple conditions on one field combine (e.g. {gte:10} and
+    // {lte:20} -> {gte:10, lte:20}) instead of the later one overwriting the
+    // earlier. A plain Object.assign shallow-overwrites, silently dropping the
+    // first bound of a range expressed via AND. Mirrors merge_filters in the
+    // Python SDK's Memory._process_metadata_filters.
+    const mergeFilters = (
+      target: Record<string, any>,
+      source: Record<string, any>,
+    ): void => {
+      for (const [key, value] of Object.entries(source)) {
+        const existing = target[key];
+        if (
+          existing !== null &&
+          typeof existing === "object" &&
+          !Array.isArray(existing) &&
+          value !== null &&
+          typeof value === "object" &&
+          !Array.isArray(value)
+        ) {
+          Object.assign(existing, value);
+        } else {
+          target[key] = value;
+        }
+      }
+    };
+
     for (const [key, value] of Object.entries(metadataFilters)) {
       if (key === "AND") {
         // Logical AND: combine multiple conditions
@@ -2115,7 +2142,7 @@ export class Memory {
         }
         for (const condition of value) {
           for (const [subKey, subValue] of Object.entries(condition)) {
-            Object.assign(processedFilters, processCondition(subKey, subValue));
+            mergeFilters(processedFilters, processCondition(subKey, subValue));
           }
         }
       } else if (key === "OR") {
@@ -2131,7 +2158,7 @@ export class Memory {
           for (const [subKey, subValue] of Object.entries(
             condition as Record<string, any>,
           )) {
-            Object.assign(orCondition, processCondition(subKey, subValue));
+            mergeFilters(orCondition, processCondition(subKey, subValue));
           }
           processedFilters["$or"].push(orCondition);
         }
@@ -2148,12 +2175,12 @@ export class Memory {
           for (const [subKey, subValue] of Object.entries(
             condition as Record<string, any>,
           )) {
-            Object.assign(notCondition, processCondition(subKey, subValue));
+            mergeFilters(notCondition, processCondition(subKey, subValue));
           }
           processedFilters["$not"].push(notCondition);
         }
       } else {
-        Object.assign(processedFilters, processCondition(key, value));
+        mergeFilters(processedFilters, processCondition(key, value));
       }
     }
 

--- a/mem0-ts/src/oss/tests/memory.filter-merge.test.ts
+++ b/mem0-ts/src/oss/tests/memory.filter-merge.test.ts
@@ -1,0 +1,107 @@
+/**
+ * OSS Memory unit tests — advanced metadata filter merging in search().
+ *
+ * When multiple conditions target the same field (a range expressed with AND,
+ * or a top-level operator plus an AND on the same field), the processed filter
+ * must combine the operators ({gte:10} + {lte:20} -> {gte:10, lte:20}) instead
+ * of the later condition shallow-overwriting the earlier one. This mirrors the
+ * Python SDK's Memory._process_metadata_filters.merge_filters.
+ */
+/// <reference types="jest" />
+import { Memory } from "../src/memory";
+
+jest.setTimeout(15000);
+
+jest.mock("../src/embeddings/google", () => ({
+  GoogleEmbedder: jest.fn(),
+}));
+jest.mock("../src/llms/google", () => ({
+  GoogleLLM: jest.fn(),
+}));
+jest.mock("../src/llms/openai", () => ({
+  OpenAILLM: jest.fn().mockImplementation(() => ({
+    generateResponse: jest
+      .fn()
+      .mockResolvedValue(JSON.stringify({ memory: [] })),
+  })),
+}));
+
+const mockEmbedding = new Array(1536).fill(0.1);
+jest.mock("../src/embeddings/openai", () => ({
+  OpenAIEmbedder: jest.fn().mockImplementation(() => ({
+    embed: jest.fn().mockResolvedValue(mockEmbedding),
+    embedBatch: jest.fn().mockResolvedValue([mockEmbedding]),
+  })),
+}));
+
+describe("Memory - search() metadata filter merge", () => {
+  let memory: Memory;
+
+  beforeAll(async () => {
+    memory = new Memory({
+      version: "v1.1",
+      embedder: {
+        provider: "openai",
+        config: { apiKey: "test-key", model: "text-embedding-3-small" },
+      },
+      llm: {
+        provider: "openai",
+        config: { apiKey: "test-key", model: "gpt-5-mini" },
+      },
+      vectorStore: {
+        provider: "memory",
+        config: { collectionName: "filter-merge-test" },
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  });
+
+  afterAll(async () => {
+    try {
+      await memory.reset();
+    } catch (e) {
+      // ignore cleanup errors
+    }
+  });
+
+  it("combines two AND conditions on the same field into one operator dict", async () => {
+    const searchSpy = jest
+      .spyOn((memory as any).vectorStore, "search")
+      .mockResolvedValue([]);
+
+    await memory.search("q", {
+      filters: {
+        user_id: "u1",
+        AND: [{ age: { gte: 10 } }, { age: { lte: 20 } }],
+      },
+    });
+
+    expect(searchSpy).toHaveBeenCalled();
+    const passedFilters = searchSpy.mock.calls[0][2] as Record<string, any>;
+    // Both bounds must survive. A shallow overwrite drops the gte bound and
+    // the query becomes age <= 20 only (over-inclusive).
+    expect(passedFilters.age).toEqual({ gte: 10, lte: 20 });
+    expect(passedFilters.user_id).toBe("u1");
+
+    searchSpy.mockRestore();
+  });
+
+  it("combines a top-level operator with an AND on the same field", async () => {
+    const searchSpy = jest
+      .spyOn((memory as any).vectorStore, "search")
+      .mockResolvedValue([]);
+
+    await memory.search("q", {
+      filters: {
+        user_id: "u1",
+        age: { gte: 10 },
+        AND: [{ age: { lte: 20 } }],
+      },
+    });
+
+    const passedFilters = searchSpy.mock.calls[0][2] as Record<string, any>;
+    expect(passedFilters.age).toEqual({ gte: 10, lte: 20 });
+
+    searchSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Linked Issue

Closes #6260

## Description

`search()` processes advanced metadata filters (`AND`/`OR`/`NOT`) in `_processMetadataFilters`. When two conditions target the same field, it combined them with `Object.assign`, a shallow overwrite, so a range expressed with `AND` lost one bound:

```ts
// filters: { AND: [ { age: { gte: 10 } }, { age: { lte: 20 } } ] }
Object.assign(processedFilters, { age: { gte: 10 } });  // age = {gte:10}
Object.assign(processedFilters, { age: { lte: 20 } });  // age = {lte:20}  <-- gte lost
```

The Python SDK does this correctly: `Memory._process_metadata_filters` uses a `merge_filters` helper that deep-merges nested operator dicts for the same key (`target[key].update(value)`). So the TS SDK silently returned over-inclusive results (`age <= 20` only) where Python returned `10 <= age <= 20`.

This adds a `mergeFilters` helper mirroring Python's one-level deep merge and uses it in place of every `Object.assign` in `_processMetadataFilters` (AND, OR sub-conditions, NOT sub-conditions, and the top-level pass), so multiple operators on one field combine instead of overwriting.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

Added `tests/memory.filter-merge.test.ts`: it spies on the vector store's `search` and asserts the processed filters. Two cases (two AND conditions on the same field; a top-level operator plus an AND on the same field) assert `age` becomes `{ gte: 10, lte: 20 }`. Both fail on `main` (the `gte` bound is dropped) and pass with this change. Existing `memory.validation` (84 tests) and `redis.unit` suites pass; typecheck and prettier are clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
