### PR TITLE
fix(ts-oss/memory): apply all operators in a compound field filter

### DIFF
--- a/mem0-ts/src/oss/src/vector_stores/memory.ts
+++ b/mem0-ts/src/oss/src/vector_stores/memory.ts
@@ -111,46 +111,63 @@ export class MemoryVectorStore implements VectorStore {
       return value.includes(payloadValue);
     }
 
-    // Handle comparison operators
-    if ("eq" in value) {
-      return payloadValue === value.eq;
-    }
-    if ("ne" in value) {
-      return payloadValue !== value.ne;
-    }
-    if ("gt" in value) {
-      return payloadValue > value.gt;
-    }
-    if ("gte" in value) {
-      return payloadValue >= value.gte;
-    }
-    if ("lt" in value) {
-      return payloadValue < value.lt;
-    }
-    if ("lte" in value) {
-      return payloadValue <= value.lte;
-    }
-    if ("in" in value) {
-      return Array.isArray(value.in) && value.in.includes(payloadValue);
-    }
-    if ("nin" in value) {
-      return !Array.isArray(value.nin) || !value.nin.includes(payloadValue);
-    }
-    if ("contains" in value) {
-      return (
-        typeof payloadValue === "string" &&
-        payloadValue.includes(value.contains)
-      );
-    }
-    if ("icontains" in value) {
-      return (
-        typeof payloadValue === "string" &&
-        payloadValue.toLowerCase().includes(value.icontains.toLowerCase())
-      );
+    // Handle comparison operators. A condition may combine several operators on
+    // the same field (e.g. {gte:10, lte:20} for a range). ALL of them must hold,
+    // so every operator is evaluated instead of returning on the first match —
+    // otherwise the upper bound of a range is silently ignored. This matches how
+    // the other stores (pgvector, qdrant) AND multiple operators together.
+    const knownOperators = [
+      "eq",
+      "ne",
+      "gt",
+      "gte",
+      "lt",
+      "lte",
+      "in",
+      "nin",
+      "contains",
+      "icontains",
+    ];
+    if (!knownOperators.some((op) => op in value)) {
+      // Unknown operator - treat as nested object for equality (shouldn't happen normally)
+      return payloadValue === value;
     }
 
-    // Unknown operator - treat as nested object for equality (shouldn't happen normally)
-    return payloadValue === value;
+    if ("eq" in value && !(payloadValue === value.eq)) return false;
+    if ("ne" in value && !(payloadValue !== value.ne)) return false;
+    if ("gt" in value && !(payloadValue > value.gt)) return false;
+    if ("gte" in value && !(payloadValue >= value.gte)) return false;
+    if ("lt" in value && !(payloadValue < value.lt)) return false;
+    if ("lte" in value && !(payloadValue <= value.lte)) return false;
+    if (
+      "in" in value &&
+      !(Array.isArray(value.in) && value.in.includes(payloadValue))
+    )
+      return false;
+    if (
+      "nin" in value &&
+      Array.isArray(value.nin) &&
+      value.nin.includes(payloadValue)
+    )
+      return false;
+    if (
+      "contains" in value &&
+      !(
+        typeof payloadValue === "string" &&
+        payloadValue.includes(value.contains)
+      )
+    )
+      return false;
+    if (
+      "icontains" in value &&
+      !(
+        typeof payloadValue === "string" &&
+        payloadValue.toLowerCase().includes(value.icontains.toLowerCase())
+      )
+    )
+      return false;
+
+    return true;
   }
 
   /**

--- a/mem0-ts/src/oss/tests/vector-store.unit.test.ts
+++ b/mem0-ts/src/oss/tests/vector-store.unit.test.ts
@@ -182,6 +182,47 @@ describe("MemoryVectorStore - list", () => {
   });
 });
 
+describe("MemoryVectorStore - compound field operators", () => {
+  let store: MemoryVectorStore;
+
+  beforeAll(async () => {
+    store = createStore();
+    await store.insert(
+      [vec([1, 0, 0, 0]), vec([0, 1, 0, 0]), vec([0, 0, 1, 0])],
+      ["c1", "c2", "c3"],
+      [
+        { data: "young", userId: "u1", age: 5 },
+        { data: "mid", userId: "u1", age: 15 },
+        { data: "old", userId: "u1", age: 25 },
+      ],
+    );
+  });
+
+  test("applies BOTH bounds of a range ({gte, lte}) on the same field", async () => {
+    // age in [10, 20] must match only the mid record. A store that stops at the
+    // first operator would apply gte:10 only and wrongly include age=25.
+    const [results, count] = await store.list({
+      user_id: "u1",
+      age: { gte: 10, lte: 20 },
+    });
+    expect(count).toBe(1);
+    expect(results.map((r) => r.payload.data)).toEqual(["mid"]);
+  });
+
+  test("applies an exclusive range ({gt, lt})", async () => {
+    const [results] = await store.list({
+      user_id: "u1",
+      age: { gt: 5, lt: 25 },
+    });
+    expect(results.map((r) => r.payload.data)).toEqual(["mid"]);
+  });
+
+  test("still matches a single-operator condition", async () => {
+    const [, count] = await store.list({ user_id: "u1", age: { gte: 15 } });
+    expect(count).toBe(2); // 15 and 25
+  });
+});
+
 describe("MemoryVectorStore - userId tracking", () => {
   test("getUserId generates and persists a random ID", async () => {
     const store = createStore();


### PR DESCRIPTION
## Linked Issue

Closes #6264

## Description

`MemoryVectorStore.matchFieldCondition` evaluated comparison operators with a chain of early returns:

```ts
if ("gte" in value) return payloadValue >= value.gte;
if ("lte" in value) return payloadValue <= value.lte;
```

So a condition combining more than one operator on the same field only ever applied the first. A range like `{ age: { gte: 10, lte: 20 } }` returned on `gte` and never checked `lte`, so records with `age > 20` wrongly matched. This is the default vector store, and the same compound shape is produced by advanced `AND` filters, so range filtering was silently broken by default. pgvector and qdrant AND all operators together, so this was also a parity gap.

The fix evaluates every operator present in the condition and requires all of them to hold (returning `false` on the first that fails). Single-operator conditions, the `nin` semantics, and the unknown-operator equality fallback are unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

Added a "compound field operators" block to `tests/vector-store.unit.test.ts` (direct `MemoryVectorStore`, real SQLite): with records aged 5/15/25, an inclusive range `{gte:10, lte:20}` and an exclusive range `{gt:5, lt:25}` each return only the age-15 record, and a single-operator condition still returns both matches. The range tests fail on `main` (age 25 leaks in) and pass with this change. Full `vector-store.unit` suite passes; typecheck and prettier are clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
