### PR TITLE
fix(ts-oss/valkey): keep entity ids snake_case in returned payloads

### DIFF
--- a/mem0-ts/src/oss/src/vector_stores/valkey.ts
+++ b/mem0-ts/src/oss/src/vector_stores/valkey.ts
@@ -379,9 +379,6 @@ export class ValkeyDB implements VectorStore {
         this.timezone,
       );
     }
-    if (doc.agent_id) resultPayload.agent_id = doc.agent_id;
-    if (doc.run_id) resultPayload.run_id = doc.run_id;
-    if (doc.user_id) resultPayload.user_id = doc.user_id;
 
     if (doc.metadata) {
       try {
@@ -391,9 +388,20 @@ export class ValkeyDB implements VectorStore {
       }
     }
 
+    // Entity ids are part of the canonical payload contract in snake_case:
+    // index.ts and the other vector stores read payload.user_id, not
+    // payload.userId. Running the whole payload through toCamelCase renamed
+    // them to userId/agentId/runId, which dropped them from search/getAll/get
+    // results and leaked them into metadata. Attach them in snake_case after
+    // the camelCase pass (timestamps stay camelCase as the contract expects).
+    const payload = toCamelCase(resultPayload);
+    if (doc.agent_id) payload.agent_id = doc.agent_id;
+    if (doc.run_id) payload.run_id = doc.run_id;
+    if (doc.user_id) payload.user_id = doc.user_id;
+
     return {
       id: doc.memory_id ?? "",
-      payload: toCamelCase(resultPayload),
+      payload,
       score,
     };
   }

--- a/mem0-ts/src/oss/tests/valkey.test.ts
+++ b/mem0-ts/src/oss/tests/valkey.test.ts
@@ -166,9 +166,41 @@ describe("Valkey – mocked iovalkey client", () => {
     const result = await store.get("mem-1");
     expect(result?.id).toBe("mem-1");
     expect(result?.payload.data).toBe("hello valkey");
-    expect(result?.payload.userId).toBe("alice");
+    // Entity ids follow the canonical snake_case contract (index.ts reads
+    // payload.user_id, not payload.userId); only timestamps are camelCase.
+    expect(result?.payload.user_id).toBe("alice");
+    expect(result?.payload.userId).toBeUndefined();
     // created_at is persisted as unix seconds and rendered back to its ISO instant.
     expect(result?.payload.createdAt).toBe("2024-01-01T00:00:00.000Z");
+  });
+
+  it("returns agent_id and run_id in snake_case, not camelCase", async () => {
+    const store = new ValkeyDB({
+      collectionName: "test",
+      embeddingModelDims: 4,
+      valkeyUrl: "valkey://localhost:6379",
+    });
+    await store.initialize();
+
+    await store.insert(
+      [[0.1, 0.2, 0.3, 0.4]],
+      ["mem-2"],
+      [
+        {
+          data: "scoped",
+          hash: "hash-2",
+          created_at: "2024-01-01T00:00:00.000Z",
+          agent_id: "agent-1",
+          run_id: "run-1",
+        },
+      ],
+    );
+
+    const result = await store.get("mem-2");
+    expect(result?.payload.agent_id).toBe("agent-1");
+    expect(result?.payload.run_id).toBe("run-1");
+    expect(result?.payload.agentId).toBeUndefined();
+    expect(result?.payload.runId).toBeUndefined();
   });
 
   it("uses Cluster client when clusterMode is enabled", async () => {


### PR DESCRIPTION
## Linked Issue

Closes #6266

## Description

`docToResult` (used by `search`, `get` and `list`) ran the whole payload through `toCamelCase`, renaming `user_id`/`agent_id`/`run_id` to `userId`/`agentId`/`runId`.

That breaks the canonical payload contract. `memory/index.ts` and the other stores (memory, qdrant, pgvector) read `payload.user_id`, and the in-memory store keeps entity ids snake_case while leaving timestamps camelCase (`createdAt`). Valkey was an outlier.

For Valkey users this meant:

- `search()`/`getAll()`/`get()` dropped `user_id`/`agent_id`/`run_id` from results, since index.ts reads the snake_case keys which were now camelCase.
- Those camelCase keys were not in index.ts's snake_case `excludedKeys`, so they leaked into `metadata`.
- Entity-store cleanup on delete/update read `payload.user_id` (undefined) and ran unscoped.

The fix attaches the entity ids in snake_case after the camelCase pass (timestamps and metadata keep their casing). This is the same fix already applied to the Redis store.

The existing `get()` test asserted the camelCase output (`payload.userId`), which encoded the bug; it is updated to the snake_case contract, and an `agent_id`/`run_id` case is added.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

Updated the insert/get round-trip test to assert `payload.user_id === "alice"` (and no `userId`), and added a test asserting `agent_id`/`run_id` come back snake_case. Both fail on `main` (ids come back `undefined` under the snake_case keys) and pass with this change. Full `valkey` suite (10 tests) passes; typecheck and prettier are clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
