### PR TITLE
docs: add Unstructured Transform MCP + Mem0 cookbook and notebook

### DIFF
--- a/docs/cookbooks/integrations/unstructured-transform-mcp.mdx
+++ b/docs/cookbooks/integrations/unstructured-transform-mcp.mdx
@@ -7,7 +7,7 @@ Real-world documents (PDFs with columns, tables, scans) are hard to hand to a mo
 [Unstructured](https://unstructured.io) solves this with **Unstructured Transform**, a hosted MCP server that turns
 60+ file types into clean content. Since it is a remote
 [MCP](https://modelcontextprotocol.io) server, you can plug it into the OpenAI **Responses API**
-as a tool. Your agent gets document processing as a tool it can call on demand. For more information, check out the [docs](https://docs.unstructured.io/transform/overview). 15,000 free pages a month, 3 cents a page after.
+as a tool. Your agent gets document processing as a tool it can call on demand. For more information, check out the [docs](https://docs.unstructured.io/transform/overview). 10,000 free pages to start, then $0.015 a page.
 
 This cookbook then lets an agent work over the document the same way a coding agent works over a repository. Instead of chopping the document into pieces and embedding them into a vector database, we parse the PDF to markdown and save it to a local file, then give the agent two simple tools, `search_document` and `read_lines`, to find and read only the parts it needs. Mem0 remembers only **hints** about where common questions are answered, so repeat questions route faster and improve with feedback. The document stays on disk; only the small slices the agent reads enter its context; Mem0 never stores the document.
 

--- a/docs/cookbooks/integrations/unstructured-transform-mcp.mdx
+++ b/docs/cookbooks/integrations/unstructured-transform-mcp.mdx
@@ -1,0 +1,188 @@
+---
+title: Document Processing as a Tool, with Memory
+description: "Give an agent document processing via the Unstructured Transform MCP server, let it search a local markdown copy with simple tools (no vector DB), and use Mem0 to remember navigation hints."
+---
+
+Real-world documents (PDFs with columns, tables, scans) are hard to hand to a model directly.
+[Unstructured](https://unstructured.io) solves this with **Unstructured Transform**, a hosted MCP server that turns
+60+ file types into clean content. Since it is a remote
+[MCP](https://modelcontextprotocol.io) server, you can plug it into the OpenAI **Responses API**
+as a tool. Your agent gets document processing as a tool it can call on demand. For more information, check out the [docs](https://docs.unstructured.io/transform/overview). 15,000 free pages a month, 3 cents a page after.
+
+This cookbook then lets an agent work over the document the same way a coding agent works over a repository. Instead of chopping the document into pieces and embedding them into a vector database, we parse the PDF to markdown and save it to a local file, then give the agent two simple tools, `search_document` and `read_lines`, to find and read only the parts it needs. Mem0 remembers only **hints** about where common questions are answered, so repeat questions route faster and improve with feedback. The document stays on disk; only the small slices the agent reads enter its context; Mem0 never stores the document.
+
+A runnable notebook is at [`examples/notebooks/unstructured-transform-mcp.ipynb`](https://github.com/mem0ai/mem0/blob/main/examples/notebooks/unstructured-transform-mcp.ipynb).
+
+
+## Prerequisites
+
+```bash
+pip install openai mem0ai requests
+```
+```bash
+export UNSTRUCTURED_API_KEY=your-unstructured-key   # https://platform.unstructured.io
+export MEM0_API_KEY=your-mem0-key                   # https://app.mem0.ai
+export OPENAI_API_KEY=your-openai-key
+```
+
+## Code Walkthrough
+
+### 1. Parse to markdown and save it locally
+
+Parsing runs as an asynchronous job. We let the model drive the Transform tools and give it a `wait_seconds` tool it can call between status checks. Because `wait_seconds` really sleeps, the agent can patiently wait for a slow job, then we fetch the markdown and save it locally. This needs only the `openai` client.
+
+```python
+import json, os, re, time, requests
+from openai import OpenAI
+
+client, MODEL = OpenAI(), "gpt-5"
+TRANSFORM_MCP_URL = "https://mcp.transform.unstructured.io/"
+PDF_URL = "https://arxiv.org/pdf/1706.03762"  # Attention Is All You Need
+DOC_PATH = "attention.md"
+
+def transform_mcp_tool():
+    return {
+        "type": "mcp",
+        "server_label": "unstructured_transform",
+        "server_url": TRANSFORM_MCP_URL,
+        "require_approval": "never",
+        "headers": {"Authorization": f"Bearer {os.environ['UNSTRUCTURED_API_KEY']}"},
+    }
+
+def wait_seconds(seconds):
+    time.sleep(seconds)
+    return f"Waited {seconds} seconds."
+
+WAIT_TOOL = {
+    "type": "function", "name": "wait_seconds",
+    "description": "Wait the given number of seconds before checking the job status again.",
+    "parameters": {"type": "object", "properties": {"seconds": {"type": "integer"}},
+                   "required": ["seconds"], "additionalProperties": False},
+}
+
+MD_URL = re.compile(r"https://mcp\.transform\.unstructured\.io/output/\S+?\.md[^\"\\ ]*")
+
+def parse_to_markdown(url):
+    tools = [transform_mcp_tool(), WAIT_TOOL]
+    instruction = (
+        f"Parse the PDF at {url} into markdown using the Unstructured Transform tools. "
+        "Call transform_files with the URL, then poll check_transform_status, calling "
+        "wait_seconds(10) between each check, until the status is COMPLETED. Then call "
+        "get_transform_results with output_format 'md' and report the markdown download URL."
+    )
+    resp = client.responses.create(model=MODEL, tools=tools, input=instruction)
+    seen = json.dumps(resp.model_dump())
+    for _ in range(40):
+        calls = [o for o in resp.output if o.type == "function_call"]
+        if not calls:
+            break
+        outputs = [{"type": "function_call_output", "call_id": c.call_id,
+                    "output": wait_seconds(**json.loads(c.arguments))}
+                   for c in calls if c.name == "wait_seconds"]
+        resp = client.responses.create(model=MODEL, tools=tools,
+                                       previous_response_id=resp.id, input=outputs)
+        seen += "\n" + json.dumps(resp.model_dump())
+    urls = MD_URL.findall(seen)
+    if not urls:
+        raise RuntimeError("Transform did not return a markdown URL; check the job status.")
+    return requests.get(urls[0], timeout=120).text
+
+markdown = parse_to_markdown(PDF_URL)
+open(DOC_PATH, "w", encoding="utf-8").write(markdown)
+```
+
+### 2. Give the agent search and read tools
+
+Two small tools over the local file. The agent decides what to search for and how much to read.
+
+```python
+def search_document(query):
+    lines = open(DOC_PATH, encoding="utf-8").read().splitlines()
+    hits = [f"L{i + 1}: {ln}" for i, ln in enumerate(lines) if query.lower() in ln.lower()]
+    return "\n".join(hits[:25]) if hits else "No matches."
+
+def read_lines(start, end):
+    lines = open(DOC_PATH, encoding="utf-8").read().splitlines()
+    start, end = max(1, start), min(len(lines), end)
+    return "\n".join(f"L{i}: {lines[i - 1]}" for i in range(start, end + 1))
+
+TOOL_FUNCS = {"search_document": search_document, "read_lines": read_lines}
+TOOLS = [
+    {"type": "function", "name": "search_document",
+     "description": "Case-insensitive search; returns matching lines with line numbers.",
+     "parameters": {"type": "object", "properties": {"query": {"type": "string"}},
+                    "required": ["query"], "additionalProperties": False}},
+    {"type": "function", "name": "read_lines",
+     "description": "Read a range of lines (1-indexed, inclusive).",
+     "parameters": {"type": "object",
+                    "properties": {"start": {"type": "integer"}, "end": {"type": "integer"}},
+                    "required": ["start", "end"], "additionalProperties": False}},
+]
+
+SYSTEM = ("You answer questions about a document you can only access through the search_document and "
+          "read_lines tools. Search, read, then answer from the document only. End with a line: "
+          "'Source: <the section heading you used>'.")
+
+def run_agent(question, hint_heading=None):
+    system = SYSTEM
+    if hint_heading:
+        system += f"\n\nMemory hint: a similar question was answered from '{hint_heading}'. Search there first."
+    resp = client.responses.create(model=MODEL, tools=TOOLS,
+        input=[{"role": "system", "content": system}, {"role": "user", "content": question}])
+    for _ in range(6):
+        calls = [o for o in resp.output if o.type == "function_call"]
+        if not calls:
+            return resp.output_text
+        outputs = []
+        for c in calls:
+            args = json.loads(c.arguments)
+            print(f"  tool call: {c.name}  args: {args}")
+            result = TOOL_FUNCS[c.name](**args)
+            print(f"    -> {(result.splitlines()[0] if result else '')[:90]}")
+            outputs.append({"type": "function_call_output", "call_id": c.call_id, "output": result})
+        resp = client.responses.create(model=MODEL, tools=TOOLS,
+            previous_response_id=resp.id, input=outputs)
+    return resp.output_text
+```
+
+### 3. Remember hints with Mem0
+
+Mem0 stores only hints about where a kind of question was answered. `answer()` looks for a matching hint first, passes it to the agent, answers, then saves a hint. Positive feedback reinforces good hints.
+
+```python
+from mem0 import MemoryClient
+mem = MemoryClient()
+HINTS = "attention_hints"
+
+def rows(res):
+    return res.get("results", res) if isinstance(res, dict) else res
+
+def get_hint(question):
+    hits = rows(mem.search(question, version="v2", filters={"agent_id": HINTS}, limit=1))
+    return hits[0] if hits else None
+
+def answer(question):
+    hint = get_hint(question)
+    hint_heading = (hint.get("metadata") or {}).get("heading") if hint else None
+    reply = run_agent(question, hint_heading=hint_heading)
+    match = re.search(r"Source:\s*(.+)", reply)
+    heading = match.group(1).strip() if match else None
+    mem.add(messages=[{"role": "user", "content": question}],
+            agent_id=HINTS, metadata={"heading": heading}, infer=False)
+    return reply
+
+# reinforce a hint that guided a question
+hit = get_hint("How many attention heads does the model use?")
+if hit:
+    mem.feedback(memory_id=hit["id"], feedback="POSITIVE")
+```
+
+## Where to go next
+
+- Add a tool that reads a whole section by heading, or have `search_document` return the nearest heading with each match, so the agent navigates with less reading.
+- Serve many documents at once by giving each its own `agent_id` for hints, so one assistant can cover several manuals.
+- Swap in any file type Transform supports (PDF, DOCX, PPTX, images, and more). See the [Transform docs](https://docs.unstructured.io/transform/overview).
+
+## Resources
+
+- [Unstructured Transform](https://docs.unstructured.io/transform/overview)

--- a/docs/cookbooks/integrations/unstructured-transform-mcp.mdx
+++ b/docs/cookbooks/integrations/unstructured-transform-mcp.mdx
@@ -66,9 +66,9 @@ def parse_to_markdown(url):
     tools = [transform_mcp_tool(), WAIT_TOOL]
     instruction = (
         f"Parse the PDF at {url} into markdown using the Unstructured Transform tools. "
-        "Call transform_files with the URL, then poll check_transform_status, calling "
+        "Call start_transform_job with the URL, then poll check_job_status, calling "
         "wait_seconds(10) between each check, until the status is COMPLETED. Then call "
-        "get_transform_results with output_format 'md' and report the markdown download URL."
+        "get_job_results with output_format 'md' and report the markdown download URL."
     )
     resp = client.responses.create(model=MODEL, tools=tools, input=instruction)
     seen = json.dumps(resp.model_dump())

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -437,7 +437,8 @@
                       "cookbooks/integrations/mastra-agent",
                       "cookbooks/integrations/healthcare-google-adk",
                       "cookbooks/integrations/aws-bedrock",
-                      "cookbooks/integrations/tavily-search"
+                      "cookbooks/integrations/tavily-search",
+                      "cookbooks/integrations/unstructured-transform-mcp"
                     ]
                   },
                   {

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -321,6 +321,7 @@ If the user is on a pre-current major (Python < 2, TS < 3, or Platform `output_f
 - [Healthcare Google ADK](https://docs.mem0.ai/cookbooks/integrations/healthcare-google-adk) [Both]: Use when the domain is medical and the framework is Google ADK.
 - [AWS Bedrock](https://docs.mem0.ai/cookbooks/integrations/aws-bedrock) [Both]: Use when deploying with AWS managed model services.
 - [Tavily Search](https://docs.mem0.ai/cookbooks/integrations/tavily-search) [Both]: Use when the agent layers web search on memory.
+- [Document Processing as a Tool, with Memory](https://docs.mem0.ai/cookbooks/integrations/unstructured-transform-mcp) [Platform]: Use when parsing a document with Unstructured Transform and letting an agent search a local markdown copy with simple tools (no vector DB), while Mem0 remembers navigation hints.
 
 ### Framework Examples
 - [LlamaIndex React](https://docs.mem0.ai/cookbooks/frameworks/llamaindex-react) [Both]: Use when building a React UI with LlamaIndex and memory.

--- a/examples/notebooks/unstructured-transform-mcp.ipynb
+++ b/examples/notebooks/unstructured-transform-mcp.ipynb
@@ -11,7 +11,7 @@
     "[Unstructured](https://unstructured.io) solves this with **Unstructured Transform**, a hosted MCP server that turns\n",
     "60+ file types into clean content. Since it is a remote\n",
     "[MCP](https://modelcontextprotocol.io) server, you can plug it into the OpenAI **Responses API**\n",
-    "as a tool. Your agent gets document processing as a tool it can call on demand. For more information, check out the [docs](https://docs.unstructured.io/transform/overview). 15,000 free pages a month, 3 cents a page after.\n",
+    "as a tool. Your agent gets document processing as a tool it can call on demand. For more information, check out the [docs](https://docs.unstructured.io/transform/overview). 10,000 free pages to start, then $0.015 a page.\n",
     "\n",
     "Here is the idea, and it is the same way a coding agent works over a repository. Instead of chopping\n",
     "the document into pieces and embedding them into a vector database, we:\n",

--- a/examples/notebooks/unstructured-transform-mcp.ipynb
+++ b/examples/notebooks/unstructured-transform-mcp.ipynb
@@ -1,0 +1,399 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Give your agent a document to search, plus a memory: Unstructured Transform MCP + mem0\n",
+    "\n",
+    "Real-world documents (PDFs with columns, tables, scans) are hard to hand to a model directly.\n",
+    "[Unstructured](https://unstructured.io) solves this with **Unstructured Transform**, a hosted MCP server that turns\n",
+    "60+ file types into clean content. Since it is a remote\n",
+    "[MCP](https://modelcontextprotocol.io) server, you can plug it into the OpenAI **Responses API**\n",
+    "as a tool. Your agent gets document processing as a tool it can call on demand. For more information, check out the [docs](https://docs.unstructured.io/transform/overview). 15,000 free pages a month, 3 cents a page after.\n",
+    "\n",
+    "Here is the idea, and it is the same way a coding agent works over a repository. Instead of chopping\n",
+    "the document into pieces and embedding them into a vector database, we:\n",
+    "\n",
+    "1. Let the agent call the Transform tool to parse the PDF into **markdown**, and save that markdown\n",
+    "   to a local file.\n",
+    "2. Give the agent two simple tools over that file, `search_document` and `read_lines`, and let it\n",
+    "   search and read only the parts it needs. No embeddings, no vector database.\n",
+    "3. Use [mem0](https://mem0.ai) to remember **hints** about where common questions are answered, so\n",
+    "   the agent jumps to the right place faster next time. Feedback reinforces good hints.\n",
+    "\n",
+    "The document stays on disk. Only the small slices the agent reads enter its context. mem0 stores\n",
+    "only hints, never the document. The demo document is the \"Attention Is All You Need\" paper."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Prerequisites\n",
+    "\n",
+    "Three keys, read from environment variables (do not hard-code secrets):\n",
+    "\n",
+    "- `UNSTRUCTURED_API_KEY` from https://platform.unstructured.io\n",
+    "- `MEM0_API_KEY` from https://app.mem0.ai\n",
+    "- `OPENAI_API_KEY` from https://platform.openai.com/api-keys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f8e83d5a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install --upgrade openai mem0ai requests"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b5096d38",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import os\n",
+    "import re\n",
+    "import time\n",
+    "from getpass import getpass\n",
+    "\n",
+    "import requests\n",
+    "from mem0 import MemoryClient\n",
+    "from openai import OpenAI\n",
+    "\n",
+    "for key in (\"UNSTRUCTURED_API_KEY\", \"MEM0_API_KEY\", \"OPENAI_API_KEY\"):\n",
+    "    if key not in os.environ:\n",
+    "        os.environ[key] = getpass(f\"{key}: \")\n",
+    "\n",
+    "client = OpenAI()       # reads OPENAI_API_KEY\n",
+    "mem = MemoryClient()    # reads MEM0_API_KEY\n",
+    "\n",
+    "TRANSFORM_MCP_URL = \"https://mcp.transform.unstructured.io/\"\n",
+    "PDF_URL = \"https://arxiv.org/pdf/1706.03762\"  # Attention Is All You Need\n",
+    "DOC_PATH = \"attention.md\"\n",
+    "MODEL = \"gpt-5\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c91ee939",
+   "metadata": {},
+   "source": [
+    "## 2. Parse to markdown and save it locally\n",
+    "\n",
+    "Parsing runs as an asynchronous job. We let the model drive the Transform tools, and we give it a\n",
+    "`wait_seconds` tool it can call between status checks. The model submits the job with\n",
+    "`transform_files`, calls `wait_seconds(10)` between each `check_transform_status` until the job is\n",
+    "COMPLETED, then calls `get_transform_results`. Because `wait_seconds` really sleeps, the agent can\n",
+    "patiently wait for a slow job. We then fetch the markdown and save it to a local file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0971e297",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def transform_mcp_tool():\n",
+    "    \"\"\"Return a Responses API MCP tool block for the Unstructured Transform server.\"\"\"\n",
+    "    return {\n",
+    "        \"type\": \"mcp\",\n",
+    "        \"server_label\": \"unstructured_transform\",\n",
+    "        \"server_url\": TRANSFORM_MCP_URL,\n",
+    "        \"require_approval\": \"never\",\n",
+    "        \"headers\": {\"Authorization\": f\"Bearer {os.environ['UNSTRUCTURED_API_KEY']}\"},\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "def wait_seconds(seconds):\n",
+    "    \"\"\"Wait before checking the job status again. The agent calls this so it can truly wait.\"\"\"\n",
+    "    time.sleep(seconds)\n",
+    "    return f\"Waited {seconds} seconds.\"\n",
+    "\n",
+    "\n",
+    "WAIT_TOOL = {\n",
+    "    \"type\": \"function\", \"name\": \"wait_seconds\",\n",
+    "    \"description\": \"Wait the given number of seconds before checking the job status again.\",\n",
+    "    \"parameters\": {\"type\": \"object\", \"properties\": {\"seconds\": {\"type\": \"integer\"}},\n",
+    "                   \"required\": [\"seconds\"], \"additionalProperties\": False},\n",
+    "}\n",
+    "\n",
+    "MD_URL = re.compile(r\"https://mcp\\.transform\\.unstructured\\.io/output/\\S+?\\.md[^\\\"\\\\ ]*\")\n",
+    "\n",
+    "\n",
+    "def parse_to_markdown(url):\n",
+    "    \"\"\"Let the model drive Transform, with a real wait tool, and return the parsed markdown.\"\"\"\n",
+    "    tools = [transform_mcp_tool(), WAIT_TOOL]\n",
+    "    instruction = (\n",
+    "        f\"Parse the PDF at {url} into markdown using the Unstructured Transform tools. \"\n",
+    "        \"Call transform_files with the URL, then poll check_transform_status, calling \"\n",
+    "        \"wait_seconds(10) between each check, until the status is COMPLETED. Then call \"\n",
+    "        \"get_transform_results with output_format 'md' and report the markdown download URL.\"\n",
+    "    )\n",
+    "    resp = client.responses.create(model=MODEL, tools=tools, input=instruction)\n",
+    "    seen = json.dumps(resp.model_dump())\n",
+    "    for _ in range(40):\n",
+    "        calls = [o for o in resp.output if o.type == \"function_call\"]\n",
+    "        if not calls:\n",
+    "            break\n",
+    "        outputs = []\n",
+    "        for call in calls:\n",
+    "            args = json.loads(call.arguments)\n",
+    "            result = wait_seconds(**args) if call.name == \"wait_seconds\" else \"unknown tool\"\n",
+    "            outputs.append({\"type\": \"function_call_output\", \"call_id\": call.call_id, \"output\": result})\n",
+    "        resp = client.responses.create(model=MODEL, tools=tools,\n",
+    "                                       previous_response_id=resp.id, input=outputs)\n",
+    "        seen += \"\\n\" + json.dumps(resp.model_dump())\n",
+    "    urls = MD_URL.findall(seen)\n",
+    "    if not urls:\n",
+    "        raise RuntimeError(\"Transform did not return a markdown URL; check the job status.\")\n",
+    "    return requests.get(urls[0], timeout=120).text\n",
+    "\n",
+    "\n",
+    "markdown = parse_to_markdown(PDF_URL)\n",
+    "with open(DOC_PATH, \"w\", encoding=\"utf-8\") as f:\n",
+    "    f.write(markdown)\n",
+    "\n",
+    "print(f\"Saved {len(markdown):,} characters to {DOC_PATH}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0b78210",
+   "metadata": {},
+   "source": [
+    "## 3. Give the agent tools to search and read the file\n",
+    "\n",
+    "Two small tools over the local markdown file. `search_document` returns matching lines with their\n",
+    "line numbers, and `read_lines` returns a range of lines. The agent decides what to search for and how\n",
+    "much to read, the same way a coding agent explores a repository. `run_agent` runs the short tool loop\n",
+    "and returns the final answer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0b1630a0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def search_document(query):\n",
+    "    \"\"\"Case-insensitive search of the local document. Returns matching lines with line numbers.\"\"\"\n",
+    "    lines = open(DOC_PATH, encoding=\"utf-8\").read().splitlines()\n",
+    "    hits = [f\"L{i + 1}: {ln}\" for i, ln in enumerate(lines) if query.lower() in ln.lower()]\n",
+    "    return \"\\n\".join(hits[:25]) if hits else \"No matches.\"\n",
+    "\n",
+    "\n",
+    "def read_lines(start, end):\n",
+    "    \"\"\"Read a range of lines (1-indexed, inclusive) from the local document.\"\"\"\n",
+    "    lines = open(DOC_PATH, encoding=\"utf-8\").read().splitlines()\n",
+    "    start, end = max(1, start), min(len(lines), end)\n",
+    "    return \"\\n\".join(f\"L{i}: {lines[i - 1]}\" for i in range(start, end + 1))\n",
+    "\n",
+    "\n",
+    "TOOL_FUNCS = {\"search_document\": search_document, \"read_lines\": read_lines}\n",
+    "\n",
+    "TOOLS = [\n",
+    "    {\"type\": \"function\", \"name\": \"search_document\",\n",
+    "     \"description\": \"Case-insensitive search of the document; returns matching lines with line numbers.\",\n",
+    "     \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\"}},\n",
+    "                    \"required\": [\"query\"], \"additionalProperties\": False}},\n",
+    "    {\"type\": \"function\", \"name\": \"read_lines\",\n",
+    "     \"description\": \"Read a range of lines (1-indexed, inclusive) from the document.\",\n",
+    "     \"parameters\": {\"type\": \"object\",\n",
+    "                    \"properties\": {\"start\": {\"type\": \"integer\"}, \"end\": {\"type\": \"integer\"}},\n",
+    "                    \"required\": [\"start\", \"end\"], \"additionalProperties\": False}},\n",
+    "]\n",
+    "\n",
+    "SYSTEM = (\n",
+    "    \"You answer questions about a document you can only access through the search_document and \"\n",
+    "    \"read_lines tools. Search to locate the relevant part, read it, then answer from it only \"\n",
+    "    \"(no prior knowledge). End your answer with a line: 'Source: <the section heading you used>'.\"\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def run_agent(question, hint_heading=None):\n",
+    "    system = SYSTEM\n",
+    "    if hint_heading:\n",
+    "        system += (f\"\\n\\nMemory hint: a similar question was answered from the section titled \"\n",
+    "                   f\"'{hint_heading}'. Search there first.\")\n",
+    "    resp = client.responses.create(\n",
+    "        model=MODEL, tools=TOOLS,\n",
+    "        input=[{\"role\": \"system\", \"content\": system}, {\"role\": \"user\", \"content\": question}],\n",
+    "    )\n",
+    "    for _ in range(6):\n",
+    "        calls = [o for o in resp.output if o.type == \"function_call\"]\n",
+    "        if not calls:\n",
+    "            return resp.output_text\n",
+    "        outputs = []\n",
+    "        for c in calls:\n",
+    "            args = json.loads(c.arguments)\n",
+    "            print(f\"  tool call: {c.name}  args: {args}\")\n",
+    "            result = TOOL_FUNCS[c.name](**args)\n",
+    "            preview = result.splitlines()[0] if result else \"\"\n",
+    "            print(f\"    -> {preview[:90]}\")\n",
+    "            outputs.append({\"type\": \"function_call_output\", \"call_id\": c.call_id, \"output\": result})\n",
+    "        resp = client.responses.create(\n",
+    "            model=MODEL, tools=TOOLS, previous_response_id=resp.id, input=outputs)\n",
+    "    return resp.output_text"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bc73f4c3",
+   "metadata": {},
+   "source": [
+    "## 4. Add memory: hints that make the agent faster\n",
+    "\n",
+    "mem0 stores only hints: which section a kind of question was answered from. `answer()` looks for a\n",
+    "matching hint first (and passes it to the agent), answers, then saves a hint for next time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ffe9aa60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "HINTS = \"attention_hints\"\n",
+    "\n",
+    "\n",
+    "def rows(res):\n",
+    "    return res.get(\"results\", res) if isinstance(res, dict) else res\n",
+    "\n",
+    "\n",
+    "def get_hint(question):\n",
+    "    hits = rows(mem.search(question, version=\"v2\", filters={\"agent_id\": HINTS}, limit=1))\n",
+    "    if hits:\n",
+    "        return hits[0]\n",
+    "    return None\n",
+    "\n",
+    "\n",
+    "def answer(question):\n",
+    "    hint = get_hint(question)\n",
+    "    hint_heading = (hint.get(\"metadata\") or {}).get(\"heading\") if hint else None\n",
+    "    reply = run_agent(question, hint_heading=hint_heading)\n",
+    "\n",
+    "    heading = None\n",
+    "    match = re.search(r\"Source:\\s*(.+)\", reply)\n",
+    "    if match:\n",
+    "        heading = match.group(1).strip()\n",
+    "    mem.add(messages=[{\"role\": \"user\", \"content\": question}],\n",
+    "            agent_id=HINTS, metadata={\"heading\": heading}, infer=False)\n",
+    "\n",
+    "    print(f\"[answered{' using a memory hint' if hint_heading else ''}; stored hint -> {heading}]\")\n",
+    "    return reply"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da401587",
+   "metadata": {},
+   "source": [
+    "## 5. First question (nothing learned yet)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6aa0f291",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(answer(\"How does multi-head attention work?\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5db33f61",
+   "metadata": {},
+   "source": [
+    "## 6. A related question routes via memory\n",
+    "\n",
+    "A differently worded question on the same topic finds the hint we just saved, which points the agent\n",
+    "at the right section. We then send positive feedback so mem0 favors that hint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d9af5af8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "question = \"How many attention heads does the model use?\"\n",
+    "used = get_hint(question)\n",
+    "print(answer(question))\n",
+    "\n",
+    "if used:\n",
+    "    \n",
+    "    mem.feedback(memory_id=used[\"id\"], feedback=\"POSITIVE\")\n",
+    "    print(\"\\nReinforced hint ->\", (used.get(\"metadata\") or {}).get(\"heading\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74b76078",
+   "metadata": {},
+   "source": [
+    "## 7. Inspect what mem0 stored\n",
+    "\n",
+    "Only hints. The document itself never went into mem0."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6af7f30b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for m in rows(mem.get_all(version=\"v2\", filters={\"agent_id\": HINTS})):\n",
+    "    print(f\"- {m.get('memory')}  (heading: {(m.get('metadata') or {}).get('heading')})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Unstructured Transform gives your agent document processing as a tool, so it can parse any document\n",
+    "on demand. Saving the result as markdown and handing the agent simple search and read tools lets it\n",
+    "navigate the document like a coding agent navigates a repository, pulling only what it needs into\n",
+    "context, with no vector database. mem0 adds a small memory of hints, so the agent gets faster on the\n",
+    "questions it sees often.\n",
+    "\n",
+    "Next steps:\n",
+    "- Add a tool to read whole sections by heading, or return the nearest heading with each match.\n",
+    "- Bring in thresholds to prevent using unambiguous hints.\n",
+    "- Play around with what gets stored in memory, sometimes this works, sometimes you might need something else ;) \n",
+    "- Swap in any file type Transform supports (PDF, DOCX, PPTX, images, and more). \n",
+    "\n",
+    "Resources:\n",
+    "- [Unstructured Transform](https://docs.unstructured.io/transform/overview)\n",
+    "- [mem0 docs](https://docs.mem0.ai) and [feedback](https://docs.mem0.ai/platform/features/feedback-mechanism)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/unstructured-transform-mcp.ipynb
+++ b/examples/notebooks/unstructured-transform-mcp.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "5e7f338d",
    "metadata": {},
    "source": [
     "# Give your agent a document to search, plus a memory: Unstructured Transform MCP + mem0\n",
@@ -28,13 +29,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "faaf989f",
    "metadata": {},
    "source": [
     "## 1. Prerequisites\n",
     "\n",
     "Three keys, read from environment variables (do not hard-code secrets):\n",
     "\n",
-    "- `UNSTRUCTURED_API_KEY` from https://platform.unstructured.io\n",
+    "- `UNSTRUCTURED_API_KEY` from https://unstructured.io/?modal=try-for-free (log in, then copy your API key)\n",
     "- `MEM0_API_KEY` from https://app.mem0.ai\n",
     "- `OPENAI_API_KEY` from https://platform.openai.com/api-keys"
    ]
@@ -87,10 +89,10 @@
     "## 2. Parse to markdown and save it locally\n",
     "\n",
     "Parsing runs as an asynchronous job. We let the model drive the Transform tools, and we give it a\n",
-    "`wait_seconds` tool it can call between status checks. The model submits the job with\n",
-    "`transform_files`, calls `wait_seconds(10)` between each `check_transform_status` until the job is\n",
-    "COMPLETED, then calls `get_transform_results`. Because `wait_seconds` really sleeps, the agent can\n",
-    "patiently wait for a slow job. We then fetch the markdown and save it to a local file."
+    "`wait_seconds` tool it can call between status checks. We describe the outcome we want rather than\n",
+    "naming tools, so the model reads what the server offers and picks for itself. Because `wait_seconds`\n",
+    "really sleeps, the agent can patiently wait for a slow job. We then fetch the markdown and save it to a\n",
+    "local file."
    ]
   },
   {
@@ -132,9 +134,9 @@
     "    tools = [transform_mcp_tool(), WAIT_TOOL]\n",
     "    instruction = (\n",
     "        f\"Parse the PDF at {url} into markdown using the Unstructured Transform tools. \"\n",
-    "        \"Call transform_files with the URL, then poll check_transform_status, calling \"\n",
-    "        \"wait_seconds(10) between each check, until the status is COMPLETED. Then call \"\n",
-    "        \"get_transform_results with output_format 'md' and report the markdown download URL.\"\n",
+    "        \"Submit the job with the URL, then poll its status, calling wait_seconds(10) \"\n",
+    "        \"between each check, until it is COMPLETED. Then fetch the results as markdown \"\n",
+    "        \"and report the download URL.\"\n",
     "    )\n",
     "    resp = client.responses.create(model=MODEL, tools=tools, input=instruction)\n",
     "    seen = json.dumps(resp.model_dump())\n",
@@ -361,6 +363,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a324000f",
    "metadata": {},
    "source": [
     "## Conclusion\n",


### PR DESCRIPTION
## Linked Issue

N/A (happy to open a tracking issue if the maintainers prefer one).

## Description

Adds a cookbook and a runnable notebook showing how to pair Unstructured Transform (a hosted MCP server) with Mem0.

An agent uses the Transform MCP tools to parse a PDF into markdown and saves it locally, then answers questions by searching that markdown with two small tools (`search_document`, `read_lines`) instead of embedding chunks into a vector database. Mem0 stores only lightweight navigation hints (which section answered a kind of question), so repeat questions route faster and are reinforced with feedback. The document itself never goes into Mem0.

Files:
- `examples/notebooks/unstructured-transform-mcp.ipynb`
- `docs/cookbooks/integrations/unstructured-transform-mcp.mdx` (registered in `docs/docs.json` and `docs/llms.txt`)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (described below)
- [x] No tests needed (documentation cookbook plus example notebook)

Ran the notebook top to bottom with `UNSTRUCTURED_API_KEY`, `MEM0_API_KEY`, and `OPENAI_API_KEY` set. The `docs/llms.txt` coverage check (`python scripts/check-llms-txt-coverage.py`) passes locally.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (N/A, documentation only)
- [x] New and existing tests pass locally (docs `llms.txt` coverage check passes)
- [x] I have updated documentation if needed
