### PR TITLE
fix(server): add google-genai alongside google-generativeai for Gemini SDK

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -10,6 +10,7 @@ psycopg-pool>=3.2.6,<4.0.0
 # here, rebuilding the image, and updating BUNDLED_*_PROVIDERS in main.py.
 anthropic>=0.39,<1.0
 google-generativeai>=0.8,<1.0
+google-genai>=1.0
 
 # Auth & database (Phase 1)
 sqlalchemy>=2.0,<3.0


### PR DESCRIPTION
## Linked Issue

&lt;!-- No existing issue — this is a new bug discovered during self-hosted deployment --&gt;
Related to self-hosted Gemini configuration failures.

## Description

Fixes the `ImportError: cannot import name 'genai' from 'google'` error when using Gemini as LLM or embedder in self-hosted Mem0 deployments.

Mem0's Gemini embedder (`mem0/embeddings/gemini.py`) imports from `google.genai`, which requires the `google-genai` package. However, `server/requirements.txt` only listed the deprecated `google-generativeai` package, causing the server to crash on startup when Gemini is configured.

## Changes

- Kept `google-generativeai&gt;=0.8,&lt;1.0` for backward compatibility
- Added `google-genai&gt;=1.0` for the new Google GenAI SDK

This ensures both legacy and current Gemini integrations work correctly in self-hosted deployments.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

**Manual testing:**
1. Built Docker image with updated `requirements.txt` containing both packages
2. Verified `from google import genai` imports successfully in container
3. Confirmed `/configure` endpoint accepts Gemini provider without ImportError
4. Server starts successfully with Gemini as default LLM/embedder

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed