### PR TITLE
feat(llms): add optional retry with backoff for LLM provider calls

### DIFF
--- a/mem0/configs/llms/base.py
+++ b/mem0/configs/llms/base.py
@@ -26,6 +26,7 @@ class BaseLlmConfig(ABC):
         reasoning_effort: Optional[str] = None,
         http_client_proxies: Optional[Union[Dict, str]] = None,
         is_reasoning_model: Optional[bool] = None,
+        max_retries: int = 0,
     ):
         """
         Initialize a base configuration class instance for the LLM.
@@ -63,6 +64,11 @@ class BaseLlmConfig(ABC):
                 deployments with custom/versioned model names (e.g. Azure
                 "gpt-5.4-nano-2026-03-17") that the name-based heuristic cannot
                 recognize. Defaults to None
+            max_retries: Number of retries on transient provider errors
+                (rate-limit / network / timeout / 5xx) using exponential
+                backoff with jitter. 0 (default) disables mem0-level retries and
+                preserves existing behavior. Only applied by providers wired for
+                retries. Defaults to 0
         """
         self.model = model
         self.temperature = temperature
@@ -74,5 +80,8 @@ class BaseLlmConfig(ABC):
         self.vision_details = vision_details
         self.reasoning_effort = reasoning_effort
         self.is_reasoning_model = is_reasoning_model
+        if isinstance(max_retries, bool) or not isinstance(max_retries, int) or max_retries < 0:
+            raise ValueError(f"max_retries must be a non-negative int, got {max_retries!r}")
+        self.max_retries = max_retries
         self.http_client_proxies = http_client_proxies
         self.http_client = build_http_client(http_client_proxies)

--- a/mem0/configs/llms/openai.py
+++ b/mem0/configs/llms/openai.py
@@ -33,6 +33,7 @@ class OpenAIConfig(BaseLlmConfig):
         store: Optional[bool] = None,
         # Response monitoring callback
         response_callback: Optional[Callable[[Any, dict, dict], None]] = None,
+        max_retries: int = 0,
     ):
         """
         Initialize OpenAI configuration.
@@ -77,6 +78,7 @@ class OpenAIConfig(BaseLlmConfig):
             reasoning_effort=reasoning_effort,
             http_client_proxies=http_client_proxies,
             is_reasoning_model=is_reasoning_model,
+            max_retries=max_retries,
         )
 
         # OpenAI-specific parameters

--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -1,7 +1,8 @@
 from abc import ABC, abstractmethod
-from typing import Dict, List, Optional, Union
+from typing import Callable, Dict, List, Optional, Sequence, Type, Union
 
 from mem0.configs.llms.base import BaseLlmConfig
+from mem0.utils.retry import retry_call
 
 
 class LLMBase(ABC):
@@ -173,3 +174,30 @@ class LLMBase(ABC):
         params.update(kwargs)
 
         return params
+
+    def _retry(
+        self,
+        func: Callable[[], object],
+        *,
+        retry_on: Sequence[Type[BaseException]],
+        on_giveup: Optional[Callable[[BaseException], BaseException]] = None,
+        retry_after: Optional[Callable[[BaseException], Optional[float]]] = None,
+    ):
+        """Run ``func`` under the retry policy configured on ``self.config``.
+
+        When ``config.max_retries`` is 0 (default), ``func`` is called once and
+        its exceptions propagate unchanged (no behavior change). Otherwise
+        transient errors in ``retry_on`` are retried with exponential backoff
+        and jitter, and ``on_giveup`` / ``retry_after`` are forwarded to
+        :func:`mem0.utils.retry.retry_call`.
+        """
+        max_retries = getattr(self.config, "max_retries", 0) or 0
+        if max_retries <= 0:
+            return func()
+        return retry_call(
+            func,
+            max_retries=max_retries,
+            retry_on=retry_on,
+            retry_after=retry_after,
+            on_giveup=on_giveup,
+        )

--- a/mem0/llms/openai.py
+++ b/mem0/llms/openai.py
@@ -1,14 +1,70 @@
+import email.utils
 import json
 import logging
 import os
+from datetime import datetime, timezone
 from typing import Dict, List, Optional, Union
 
+import openai
 from openai import OpenAI
 
 from mem0.configs.llms.base import BaseLlmConfig
 from mem0.configs.llms.openai import OpenAIConfig
+from mem0.exceptions import LLMError, NetworkError, RateLimitError
 from mem0.llms.base import LLMBase
 from mem0.memory.utils import extract_json
+
+_OPENAI_RETRYABLE_ERRORS = (
+    openai.RateLimitError,
+    openai.APIConnectionError,  # base class of APITimeoutError
+    openai.InternalServerError,
+)
+
+
+def _openai_retry_after(exc):
+    """Server-directed Retry-After (seconds) from an OpenAI error, or None if absent/unparseable.
+
+    Mirrors the OpenAI SDK precedence: ``retry-after-ms`` (milliseconds) first, then
+    ``retry-after`` as either numeric seconds or an HTTP-date. A None/unparseable result
+    makes the caller fall back to computed backoff; the retry layer also ignores
+    negative/non-finite values, so a past HTTP-date is safe.
+    """
+    response = getattr(exc, "response", None)
+    if response is None:
+        return None
+    headers = response.headers
+
+    ms = headers.get("retry-after-ms")
+    if ms:
+        try:
+            return float(ms) / 1000.0
+        except (TypeError, ValueError):
+            pass
+
+    value = headers.get("retry-after")
+    if value:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            pass
+        try:
+            retry_dt = email.utils.parsedate_to_datetime(value)
+        except (TypeError, ValueError):
+            retry_dt = None
+        if retry_dt is not None:
+            if retry_dt.tzinfo is None:
+                retry_dt = retry_dt.replace(tzinfo=timezone.utc)
+            return (retry_dt - datetime.now(timezone.utc)).total_seconds()
+    return None
+
+
+def _to_mem0_llm_error(exc):
+    """Translate an exhausted OpenAI transient error into a mem0 typed exception."""
+    if isinstance(exc, openai.RateLimitError):
+        return RateLimitError(message=str(exc), error_code="LLM_RATE_LIMIT", debug_info={"provider": "openai"})
+    if isinstance(exc, (openai.APITimeoutError, openai.APIConnectionError)):
+        return NetworkError(message=str(exc), error_code="LLM_NETWORK", debug_info={"provider": "openai"})
+    return LLMError(message=str(exc), debug_info={"provider": "openai"})
 
 
 class OpenAILLM(LLMBase):
@@ -32,6 +88,7 @@ class OpenAILLM(LLMBase):
                 reasoning_effort=getattr(config, 'reasoning_effort', None),
                 http_client_proxies=config.http_client_proxies,
                 is_reasoning_model=getattr(config, 'is_reasoning_model', None),
+                max_retries=getattr(config, 'max_retries', 0),
             )
 
         super().__init__(config)
@@ -138,7 +195,12 @@ class OpenAILLM(LLMBase):
         if tools:  # TODO: Remove tools if no issues found with new memory addition logic
             params["tools"] = tools
             params["tool_choice"] = tool_choice
-        response = self.client.chat.completions.create(**params)
+        response = self._retry(
+            lambda: self.client.chat.completions.create(**params),
+            retry_on=_OPENAI_RETRYABLE_ERRORS,
+            on_giveup=_to_mem0_llm_error,
+            retry_after=_openai_retry_after,
+        )
         parsed_response = self._parse_response(response, tools)
         if self.config.response_callback:
             try:

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -111,6 +111,8 @@ class LlmFactory:
                     config_dict["reasoning_effort"] = config.reasoning_effort
                 if accepts_kwargs or "is_reasoning_model" in params:
                     config_dict["is_reasoning_model"] = config.is_reasoning_model
+                if accepts_kwargs or "max_retries" in params:
+                    config_dict["max_retries"] = config.max_retries
                 config_dict.update(kwargs)
                 config = config_class(**config_dict)
             else:

--- a/mem0/utils/retry.py
+++ b/mem0/utils/retry.py
@@ -1,0 +1,122 @@
+"""Dependency-free retry helper for provider call paths.
+
+``retry_call`` wraps a zero-argument callable with bounded exponential backoff
+and full jitter. It is intentionally free of third-party dependencies (no
+``tenacity``/``backoff``) so it can live in the core SDK without adding to the
+dependency surface.
+
+Design notes:
+    * Only exceptions listed in ``retry_on`` are retried; anything else
+      propagates immediately (so auth/validation errors are never retried).
+    * A server-directed ``Retry-After`` value (via the ``retry_after`` hook)
+      takes precedence over the computed backoff.
+    * When all retries are exhausted, ``on_giveup`` (if provided) may translate
+      the final exception — e.g. into a typed :mod:`mem0.exceptions` error.
+
+Example:
+    from mem0.exceptions import RateLimitError
+    from mem0.utils.retry import retry_call
+
+    response = retry_call(
+        lambda: client.chat.completions.create(**params),
+        max_retries=2,
+        retry_on=(TransientProviderError,),
+        on_giveup=lambda exc: RateLimitError(message=str(exc), error_code="LLM_429"),
+    )
+"""
+
+import math
+import random
+import time
+from typing import Callable, Optional, Sequence, Type, TypeVar
+
+T = TypeVar("T")
+
+
+def retry_call(
+    func: Callable[[], T],
+    *,
+    max_retries: int = 2,
+    retry_on: Sequence[Type[BaseException]] = (Exception,),
+    base_delay: float = 0.5,
+    max_delay: float = 20.0,
+    jitter: bool = True,
+    sleep: Optional[Callable[[float], None]] = None,
+    rng: Optional[Callable[[], float]] = None,
+    retry_after: Optional[Callable[[BaseException], Optional[float]]] = None,
+    on_giveup: Optional[Callable[[BaseException], BaseException]] = None,
+) -> T:
+    """Call ``func`` with retries on transient failures.
+
+    Args:
+        func: Zero-argument callable to invoke.
+        max_retries: Maximum number of retries after the first attempt
+            (total attempts = ``max_retries + 1``).
+        retry_on: Exception types that are considered transient and retried.
+            Any exception not matching these propagates immediately.
+        base_delay: Base delay (seconds) for exponential backoff.
+        max_delay: Upper bound (seconds) on any single backoff wait.
+        jitter: When True, apply full jitter (multiply backoff by a random
+            factor in ``[0, 1)``) to avoid thundering-herd retries.
+        sleep: Sleep function, injectable for testing.
+        rng: Zero-argument random generator returning a float in ``[0, 1)``,
+            injectable for testing.
+        retry_after: Optional hook mapping the caught exception to a
+            server-directed delay (seconds). When it returns a value, that
+            delay is used instead of the computed backoff.
+        on_giveup: Optional hook mapping the final exception to a replacement
+            exception raised when all retries are exhausted.
+
+    Returns:
+        The return value of ``func`` on the first successful attempt.
+
+    Raises:
+        BaseException: The last exception raised by ``func`` (or the exception
+            returned by ``on_giveup``) once retries are exhausted, and any
+            non-retryable exception immediately.
+    """
+    if isinstance(max_retries, bool) or not isinstance(max_retries, int) or max_retries < 0:
+        raise ValueError(f"max_retries must be a non-negative int, got {max_retries!r}")
+    retry_on = tuple(retry_on)
+    _sleep = sleep if sleep is not None else time.sleep
+    _rng = rng if rng is not None else random.random
+    attempt = 0
+    while True:
+        try:
+            return func()
+        except retry_on as exc:
+            if attempt >= max_retries:
+                if on_giveup is not None:
+                    raise on_giveup(exc) from exc
+                raise
+            _sleep(_compute_delay(exc, attempt, base_delay, max_delay, jitter, _rng, retry_after))
+            attempt += 1
+
+
+def _compute_delay(
+    exc: BaseException,
+    attempt: int,
+    base_delay: float,
+    max_delay: float,
+    jitter: bool,
+    rng: Callable[[], float],
+    retry_after: Optional[Callable[[BaseException], Optional[float]]],
+) -> float:
+    """Compute the wait (seconds) before the next retry."""
+    if retry_after is not None:
+        server_delay = retry_after(exc)
+        # Only trust a finite, non-negative server delay; otherwise fall back to
+        # the computed backoff (a negative value would crash time.sleep and a
+        # non-finite one would sleep unbounded / crash). Cap it to max_delay so a
+        # large Retry-After can't drive an unbounded wait.
+        if server_delay is not None and math.isfinite(server_delay) and server_delay >= 0:
+            return max(0.0, min(server_delay, max_delay))
+    # Cap the exponent so a very large ``attempt`` can't overflow float
+    # (``2**attempt`` exceeds float max near attempt ~1024); the cap sits far
+    # above any realistic ``max_delay``, so the min() still governs the result.
+    backoff = min(max_delay, base_delay * (2 ** min(attempt, 32)))
+    if jitter:
+        backoff = backoff * rng()
+    # Floor at 0 so a misconfigured negative base_delay/max_delay never reaches
+    # time.sleep() as a negative value.
+    return max(0.0, backoff)

--- a/tests/llms/test_openai_retry.py
+++ b/tests/llms/test_openai_retry.py
@@ -1,0 +1,211 @@
+"""Tests for opt-in retry/backoff on the OpenAI LLM provider call path.
+
+Retries are opt-in (``max_retries`` defaults to 0 → current behavior). When
+enabled, transient OpenAI SDK errors are retried with backoff; on final failure
+they are surfaced as mem0 typed exceptions. Non-transient errors (auth) are
+never retried. ``time.sleep`` is patched so tests are fast and deterministic.
+"""
+
+from unittest.mock import Mock, patch
+
+import httpx
+import openai
+import pytest
+
+from mem0.configs.llms.base import BaseLlmConfig
+from mem0.configs.llms.openai import OpenAIConfig
+from mem0.exceptions import LLMError, NetworkError, RateLimitError
+from mem0.llms.openai import OpenAILLM, _openai_retry_after
+
+
+@pytest.fixture
+def mock_openai_client():
+    with patch("mem0.llms.openai.OpenAI") as mock_openai:
+        client = Mock()
+        mock_openai.return_value = client
+        yield client
+
+
+def _req():
+    return httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+
+
+def _ok():
+    response = Mock()
+    response.choices = [Mock(message=Mock(content="ok"))]
+    return response
+
+
+def _rate_limit_error(retry_after=None):
+    headers = {"retry-after": str(retry_after)} if retry_after is not None else {}
+    resp = httpx.Response(429, request=_req(), headers=headers)
+    return openai.RateLimitError("rate limited", response=resp, body=None)
+
+
+def _timeout_error():
+    return openai.APITimeoutError(request=_req())
+
+
+def _auth_error():
+    resp = httpx.Response(401, request=_req())
+    return openai.AuthenticationError("bad key", response=resp, body=None)
+
+
+def test_max_retries_defaults_to_zero_opt_in():
+    assert BaseLlmConfig().max_retries == 0
+    assert OpenAIConfig().max_retries == 0
+
+
+def test_openai_base_url_positional_slot_preserved():
+    """Regression: adding ``max_retries`` must not shift the historical positional
+    slots of OpenAI-specific parameters.
+
+    Before retries were introduced, ``openai_base_url`` was the 12th positional
+    argument. A pre-existing positional call that passed the base URL in that slot
+    must still bind it to ``openai_base_url`` (and leave ``max_retries`` at its
+    default 0), not silently rebind the URL string to ``max_retries``.
+    """
+    base_url = "https://proxy.internal/v1"
+    config = OpenAIConfig(
+        "gpt-4.1-nano-2025-04-14",  # model
+        0.1,  # temperature
+        "api_key",  # api_key
+        2000,  # max_tokens
+        0.1,  # top_p
+        1,  # top_k
+        False,  # enable_vision
+        "auto",  # vision_details
+        None,  # reasoning_effort
+        None,  # http_client_proxies
+        None,  # is_reasoning_model
+        base_url,  # openai_base_url (historical 12th positional slot)
+    )
+    assert config.openai_base_url == base_url
+    assert config.max_retries == 0
+
+
+def test_no_retry_by_default_propagates_original_error(mock_openai_client):
+    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14")  # max_retries defaults to 0
+    llm = OpenAILLM(config)
+    mock_openai_client.chat.completions.create.side_effect = _timeout_error()
+
+    with patch("time.sleep") as sleep:
+        with pytest.raises(openai.APITimeoutError):
+            llm.generate_response([{"role": "user", "content": "hi"}])
+
+    assert mock_openai_client.chat.completions.create.call_count == 1
+    sleep.assert_not_called()
+
+
+def test_retries_transient_error_then_succeeds(mock_openai_client):
+    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", max_retries=2)
+    llm = OpenAILLM(config)
+    mock_openai_client.chat.completions.create.side_effect = [_timeout_error(), _ok()]
+
+    with patch("time.sleep"):
+        response = llm.generate_response([{"role": "user", "content": "hi"}])
+
+    assert response == "ok"
+    assert mock_openai_client.chat.completions.create.call_count == 2
+
+
+def test_raises_mem0_rate_limit_error_after_exhaustion(mock_openai_client):
+    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", max_retries=1)
+    llm = OpenAILLM(config)
+    mock_openai_client.chat.completions.create.side_effect = _rate_limit_error(retry_after=0)
+
+    with patch("time.sleep"):
+        with pytest.raises(RateLimitError):
+            llm.generate_response([{"role": "user", "content": "hi"}])
+
+    assert mock_openai_client.chat.completions.create.call_count == 2  # 1 initial + 1 retry
+
+
+def test_does_not_retry_authentication_error(mock_openai_client):
+    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", max_retries=3)
+    llm = OpenAILLM(config)
+    mock_openai_client.chat.completions.create.side_effect = _auth_error()
+
+    with patch("time.sleep") as sleep:
+        with pytest.raises(openai.AuthenticationError):
+            llm.generate_response([{"role": "user", "content": "hi"}])
+
+    assert mock_openai_client.chat.completions.create.call_count == 1
+    sleep.assert_not_called()
+
+
+class _HeaderError(Exception):
+    """Minimal stand-in for an OpenAI error carrying a response with headers."""
+
+    def __init__(self, headers):
+        self.response = type("_Resp", (), {"headers": headers})()
+
+
+def test_retry_after_ms_header_takes_precedence():
+    # retry-after-ms (milliseconds) wins over retry-after (seconds), matching the OpenAI SDK.
+    assert _openai_retry_after(_HeaderError({"retry-after-ms": "2000", "retry-after": "9"})) == 2.0
+
+
+def test_retry_after_numeric_seconds():
+    assert _openai_retry_after(_HeaderError({"retry-after": "5"})) == 5.0
+
+
+def test_retry_after_http_date_is_parsed():
+    # A past HTTP-date parses to a negative delay (retry_call then ignores it and falls
+    # back to backoff); a far-future date parses to a positive delay.
+    past = _openai_retry_after(_HeaderError({"retry-after": "Wed, 21 Oct 2015 07:28:00 GMT"}))
+    future = _openai_retry_after(_HeaderError({"retry-after": "Wed, 21 Oct 2099 07:28:00 GMT"}))
+    assert past is not None and past < 0
+    assert future is not None and future > 0
+
+
+def test_retry_after_malformed_returns_none():
+    assert _openai_retry_after(_HeaderError({"retry-after": "soon"})) is None
+
+
+def test_retry_after_absent_returns_none():
+    assert _openai_retry_after(_HeaderError({})) is None
+    assert _openai_retry_after(Exception("no response attribute")) is None
+
+
+def _internal_server_error():
+    resp = httpx.Response(500, request=_req())
+    return openai.InternalServerError("server boom", response=resp, body=None)
+
+
+def test_timeout_exhaustion_raises_network_error_chained(mock_openai_client):
+    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", max_retries=1)
+    llm = OpenAILLM(config)
+    mock_openai_client.chat.completions.create.side_effect = _timeout_error()
+
+    with patch("time.sleep"):
+        with pytest.raises(NetworkError) as excinfo:
+            llm.generate_response([{"role": "user", "content": "hi"}])
+
+    assert isinstance(excinfo.value.__cause__, openai.APITimeoutError)
+
+
+def test_internal_server_error_exhaustion_raises_llm_error_chained(mock_openai_client):
+    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", max_retries=1)
+    llm = OpenAILLM(config)
+    mock_openai_client.chat.completions.create.side_effect = _internal_server_error()
+
+    with patch("time.sleep"):
+        with pytest.raises(LLMError) as excinfo:
+            llm.generate_response([{"role": "user", "content": "hi"}])
+
+    assert isinstance(excinfo.value.__cause__, openai.InternalServerError)
+
+
+@pytest.mark.parametrize("bad", ["1", 0.5, -1, True])
+def test_config_rejects_invalid_max_retries(bad):
+    # max_retries is an integer retry-count knob: reject non-int / negative / bool so a
+    # misconfig fails fast at construction instead of crashing later at `max_retries <= 0`
+    # (e.g. a dict config {"max_retries": "1"}).
+    with pytest.raises(ValueError):
+        OpenAIConfig(model="gpt-4.1-nano-2025-04-14", max_retries=bad)
+
+
+def test_dict_config_invalid_max_retries_raises_valueerror():
+    with pytest.raises(ValueError):
+        OpenAILLM({"model": "gpt-4.1-nano-2025-04-14", "max_retries": "1"})

--- a/tests/utils/test_factory.py
+++ b/tests/utils/test_factory.py
@@ -31,6 +31,17 @@ def test_base_to_openai_preserves_reasoning_fields():
     assert built.is_reasoning_model is True
 
 
+def test_base_to_openai_preserves_max_retries():
+    # max_retries opts into the retry layer; it must survive the base->provider
+    # conversion so LlmFactory.create("openai", BaseLlmConfig(max_retries=...)) stays enabled.
+    base_config = BaseLlmConfig(model="gpt-4.1-nano-2025-04-14", max_retries=5)
+
+    built = _capture_config("openai", base_config)
+
+    assert isinstance(built, OpenAIConfig)
+    assert built.max_retries == 5
+
+
 def test_base_to_kwargs_provider_preserves_reasoning_fields():
     # AWSBedrockConfig accepts the reasoning fields via **kwargs, so they must survive.
     base_config = BaseLlmConfig(model="amazon.nova", reasoning_effort="medium", is_reasoning_model=True)

--- a/tests/utils/test_retry.py
+++ b/tests/utils/test_retry.py
@@ -1,0 +1,234 @@
+"""Unit tests for the dependency-free retry helper (``mem0.utils.retry``).
+
+These tests inject ``sleep`` and ``rng`` so backoff/jitter timing is
+deterministic and no real waiting happens. The callable under test is a real
+flaky function (not a mock) so we exercise the actual control flow rather than
+mock bookkeeping.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from mem0.exceptions import LLMError, RateLimitError
+from mem0.utils.retry import retry_call
+
+
+class _Transient(Exception):
+    """Stand-in for a retryable provider error (429/5xx/network/timeout)."""
+
+
+class _Fatal(Exception):
+    """Stand-in for a non-retryable error (auth/validation)."""
+
+
+def _flaky(failures, exc=_Transient, result="ok"):
+    """Return a callable that raises ``exc`` the first ``failures`` calls, then returns ``result``."""
+
+    state = {"calls": 0}
+
+    def _call():
+        state["calls"] += 1
+        if state["calls"] <= failures:
+            raise exc("transient failure")
+        return result
+
+    _call.state = state
+    return _call
+
+
+def test_returns_result_when_func_succeeds_first_try():
+    sleep = Mock()
+    func = _flaky(failures=0)
+
+    result = retry_call(func, max_retries=3, retry_on=(_Transient,), sleep=sleep)
+
+    assert result == "ok"
+    assert func.state["calls"] == 1
+    sleep.assert_not_called()
+
+
+def test_retries_transient_error_then_succeeds():
+    sleep = Mock()
+    func = _flaky(failures=2)
+
+    result = retry_call(func, max_retries=3, retry_on=(_Transient,), sleep=sleep)
+
+    assert result == "ok"
+    assert func.state["calls"] == 3  # 1 initial + 2 retries
+    assert sleep.call_count == 2
+
+
+def test_gives_up_after_max_retries_and_reraises():
+    sleep = Mock()
+    func = _flaky(failures=99)  # always fails
+
+    with pytest.raises(_Transient):
+        retry_call(func, max_retries=2, retry_on=(_Transient,), sleep=sleep)
+
+    assert func.state["calls"] == 3  # 1 initial + 2 retries
+    assert sleep.call_count == 2
+
+
+def test_does_not_retry_non_retryable_error():
+    sleep = Mock()
+    func = _flaky(failures=99, exc=_Fatal)
+
+    with pytest.raises(_Fatal):
+        retry_call(func, max_retries=3, retry_on=(_Transient,), sleep=sleep)
+
+    assert func.state["calls"] == 1
+    sleep.assert_not_called()
+
+
+def test_exponential_backoff_delays_without_jitter():
+    sleep = Mock()
+    func = _flaky(failures=99)
+
+    with pytest.raises(_Transient):
+        retry_call(
+            func, max_retries=3, retry_on=(_Transient,), base_delay=1.0, max_delay=100.0, jitter=False, sleep=sleep
+        )
+
+    # 3 retries → delays 1, 2, 4 (base_delay * 2**i)
+    assert [c.args[0] for c in sleep.call_args_list] == [1.0, 2.0, 4.0]
+
+
+def test_backoff_is_capped_at_max_delay():
+    sleep = Mock()
+    func = _flaky(failures=99)
+
+    with pytest.raises(_Transient):
+        retry_call(
+            func, max_retries=4, retry_on=(_Transient,), base_delay=10.0, max_delay=15.0, jitter=False, sleep=sleep
+        )
+
+    # 10, then capped at 15 for all subsequent retries
+    assert [c.args[0] for c in sleep.call_args_list] == [10.0, 15.0, 15.0, 15.0]
+
+
+def test_full_jitter_scales_backoff_by_rng():
+    sleep = Mock()
+    func = _flaky(failures=1)
+
+    retry_call(func, max_retries=3, retry_on=(_Transient,), base_delay=4.0, jitter=True, sleep=sleep, rng=lambda: 0.5)
+
+    # single retry: backoff = 4.0 * 2**0 = 4.0; full jitter → 4.0 * 0.5 = 2.0
+    assert sleep.call_args_list[0].args[0] == 2.0
+
+
+def test_honors_retry_after_over_backoff():
+    sleep = Mock()
+    func = _flaky(failures=1)
+
+    retry_call(
+        func,
+        max_retries=3,
+        retry_on=(_Transient,),
+        base_delay=1.0,
+        jitter=True,
+        sleep=sleep,
+        rng=lambda: 0.5,
+        retry_after=lambda exc: 7.0,
+    )
+
+    # server-directed Retry-After takes precedence over computed backoff/jitter
+    assert sleep.call_args_list[0].args[0] == 7.0
+
+
+@pytest.mark.parametrize("bad_delay", [-5.0, float("inf"), float("-inf"), float("nan")])
+def test_invalid_retry_after_is_ignored_and_falls_back_to_backoff(bad_delay):
+    sleep = Mock()
+    func = _flaky(failures=1)
+
+    retry_call(
+        func,
+        max_retries=3,
+        retry_on=(_Transient,),
+        base_delay=1.0,
+        jitter=False,
+        sleep=sleep,
+        retry_after=lambda exc: bad_delay,
+    )
+
+    # invalid server delays (negative / non-finite) are ignored so time.sleep never
+    # sees a bad value; the computed backoff is used instead.
+    assert sleep.call_args_list[0].args[0] == 1.0
+
+
+def test_retry_after_is_capped_at_max_delay():
+    sleep = Mock()
+    func = _flaky(failures=1)
+
+    retry_call(
+        func,
+        max_retries=3,
+        retry_on=(_Transient,),
+        base_delay=1.0,
+        max_delay=20.0,
+        jitter=False,
+        sleep=sleep,
+        retry_after=lambda exc: 3600.0,
+    )
+
+    # an oversized server-directed delay is capped to max_delay to avoid unbounded sleeps
+    assert sleep.call_args_list[0].args[0] == 20.0
+
+
+def test_translates_final_error_via_on_giveup():
+    sleep = Mock()
+    func = _flaky(failures=99)
+
+    def translate(exc):
+        return RateLimitError(message=str(exc), error_code="TEST_429", debug_info={"orig": type(exc).__name__})
+
+    with pytest.raises(RateLimitError):
+        retry_call(func, max_retries=1, retry_on=(_Transient,), sleep=sleep, on_giveup=translate)
+
+    assert func.state["calls"] == 2  # 1 initial + 1 retry
+
+
+def test_on_giveup_not_called_on_success():
+    sleep = Mock()
+    func = _flaky(failures=1)
+    translate = Mock(side_effect=lambda exc: LLMError(message="unexpected"))
+
+    result = retry_call(func, max_retries=3, retry_on=(_Transient,), sleep=sleep, on_giveup=translate)
+
+    assert result == "ok"
+    translate.assert_not_called()
+
+
+def test_no_overflow_with_very_large_max_retries():
+    # base_delay * 2**attempt overflows float around attempt ~1024; the exponent
+    # must be capped so a large max_retries surfaces the real provider error, not
+    # OverflowError. sleep is a no-op Mock so this stays fast.
+    sleep = Mock()
+    func = _flaky(failures=10**9)  # always fails
+
+    with pytest.raises(_Transient):
+        retry_call(
+            func, max_retries=1100, retry_on=(_Transient,), base_delay=1.0, max_delay=20.0, jitter=False, sleep=sleep
+        )
+
+    assert sleep.call_count == 1100
+    assert all(call.args[0] <= 20.0 for call in sleep.call_args_list)
+
+
+@pytest.mark.parametrize("bad", [float("inf"), float("nan"), -1, "3"])
+def test_invalid_max_retries_raises(bad):
+    # A non-finite / negative / non-numeric max_retries makes `attempt >= max_retries`
+    # unreliable (inf → unbounded retry loop / hang); reject it up front.
+    with pytest.raises(ValueError):
+        retry_call(lambda: "unused", max_retries=bad, retry_on=(_Transient,), sleep=Mock())
+
+
+def test_negative_delay_config_is_clamped_to_zero():
+    # Negative base_delay/max_delay must never reach time.sleep() as a negative value
+    # (which would raise and mask the provider error); the wait is floored at 0.
+    sleep = Mock()
+    func = _flaky(failures=2)
+
+    retry_call(func, max_retries=3, retry_on=(_Transient,), base_delay=-5.0, max_delay=-1.0, jitter=False, sleep=sleep)
+
+    assert all(call.args[0] >= 0.0 for call in sleep.call_args_list)


### PR DESCRIPTION
## Linked Issue

Closes #6270

## Description

Adds an optional retry layer for provider calls. A dependency free `retry_call` (exponential backoff, full jitter, honors `Retry-After` including `retry-after-ms` and HTTP-date) plus a `max_retries` config (default `0`, no behavior change) wired through a small `LLMBase._retry`, with OpenAI as the reference provider. Transient errors (rate limit, timeout, connection, 5xx) retry and surface as the typed `mem0.exceptions` errors on final failure, the first use of that taxonomy. Remaining providers and embeddings follow in a later PR. Docs will follow once the config surface here is confirmed.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A. `max_retries` defaults to `0`, so provider behavior is unchanged unless enabled.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
