### PR TITLE
Update MiniMax default model to MiniMax-M3

### DIFF
--- a/docs/components/llms/models/minimax.mdx
+++ b/docs/components/llms/models/minimax.mdx
@@ -3,7 +3,7 @@ title: MiniMax
 description: "Configure MiniMax as an LLM provider in Mem0 with API key setup and optional custom endpoint configuration."
 ---
 
-To use MiniMax LLM models, you have to set the `MINIMAX_API_KEY` environment variable. You can also optionally set `MINIMAX_API_BASE` if you need to use a different API endpoint (defaults to "https://api.minimax.io/v1").
+The `minimax` provider uses MiniMax's OpenAI-compatible API. Set the `MINIMAX_API_KEY` environment variable before using it. You can also set `MINIMAX_API_BASE` to override the API endpoint; it defaults to `https://api.minimax.io/v1`.
 
 ## Usage
 
@@ -19,7 +19,7 @@ config = {
     "llm": {
         "provider": "minimax",
         "config": {
-            "model": "MiniMax-M2.7",  # default model
+            "model": "MiniMax-M3",  # default model
             "temperature": 0.2,
             "max_tokens": 2000,
             "top_p": 1.0
@@ -45,7 +45,7 @@ const config = {
     provider: 'minimax',
     config: {
       apiKey: process.env.MINIMAX_API_KEY || '',
-      model: 'MiniMax-M2.7',
+      model: 'MiniMax-M3',
       temperature: 0.2,
       maxTokens: 2000,
       topP: 1.0,
@@ -64,7 +64,16 @@ await memory.add(messages, { userId: 'alice', metadata: { category: 'movies' } }
 
 </CodeGroup>
 
-You can also configure the API base URL in the config:
+## Endpoint configuration
+
+| Protocol             | Mem0 provider | Global                             | Mainland China                       |
+| :------------------- | :------------ | :--------------------------------- | :----------------------------------- |
+| OpenAI-compatible    | `minimax`     | `https://api.minimax.io/v1`        | `https://api.minimaxi.com/v1`        |
+| Anthropic-compatible | `anthropic`   | `https://api.minimax.io/anthropic` | `https://api.minimaxi.com/anthropic` |
+
+The `anthropic` provider calls the SDK's Messages client, which appends `/v1/messages`. Keep its base URL at `/anthropic` so the final global request URL is `https://api.minimax.io/anthropic/v1/messages`.
+
+Configure an OpenAI-compatible endpoint directly on the `minimax` provider:
 
 <CodeGroup>
 ```python Python
@@ -73,7 +82,7 @@ config = {
         "provider": "minimax",
         "config": {
             "model": "MiniMax-M2.7",
-            "minimax_base_url": "https://your-custom-endpoint.com",
+            "minimax_base_url": "https://api.minimaxi.com/v1",
             "api_key": "your-api-key"  # alternatively to using environment variable
         }
     }
@@ -86,8 +95,38 @@ const config = {
     provider: 'minimax',
     config: {
       model: 'MiniMax-M2.7',
-      baseURL: 'https://your-custom-endpoint.com',
+      baseURL: 'https://api.minimaxi.com/v1',
       apiKey: 'your-api-key', // alternatively to using the environment variable
+    },
+  },
+};
+```
+</CodeGroup>
+
+For the Anthropic-compatible protocol, use the `anthropic` provider with the SDK base URL:
+
+<CodeGroup>
+```python Python
+config = {
+    "llm": {
+        "provider": "anthropic",
+        "config": {
+            "model": "MiniMax-M3",
+            "anthropic_base_url": "https://api.minimax.io/anthropic",
+            "api_key": "your-api-key"
+        }
+    }
+}
+```
+
+```typescript TypeScript
+const config = {
+  llm: {
+    provider: 'anthropic',
+    config: {
+      model: 'MiniMax-M3',
+      baseURL: 'https://api.minimax.io/anthropic',
+      apiKey: 'your-api-key',
     },
   },
 };

--- a/mem0-ts/src/oss/src/llms/minimax.ts
+++ b/mem0-ts/src/oss/src/llms/minimax.ts
@@ -15,7 +15,7 @@ export class MiniMaxLLM extends OpenAILLM {
         config.baseURL ||
         process.env.MINIMAX_API_BASE ||
         "https://api.minimax.io/v1",
-      model: config.model || "MiniMax-M2.7",
+      model: config.model || "MiniMax-M3",
     });
   }
 

--- a/mem0-ts/src/oss/tests/minimax.test.ts
+++ b/mem0-ts/src/oss/tests/minimax.test.ts
@@ -50,20 +50,35 @@ describe("MiniMaxLLM (unit)", () => {
     });
   });
 
-  it("config values take precedence over environment variables", () => {
+  it("config values take precedence over environment variables", async () => {
     process.env.MINIMAX_API_KEY = "env-key";
     process.env.MINIMAX_API_BASE = "https://env.minimax.test/v1";
+    mockCreate.mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            content: "Hello from MiniMax",
+            role: "assistant",
+            tool_calls: null,
+          },
+        },
+      ],
+    });
 
-    new MiniMaxLLM({
+    const llm = new MiniMaxLLM({
       apiKey: "config-key",
       baseURL: "https://config.minimax.test/v1",
-      model: "MiniMax-M1",
+      model: "MiniMax-M2.7",
     });
+    await llm.generateResponse([{ role: "user", content: "Hi" }]);
 
     expect(capturedConstructorArgs).toMatchObject({
       apiKey: "config-key",
       baseURL: "https://config.minimax.test/v1",
     });
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "MiniMax-M2.7" }),
+    );
   });
 
   it("generateResponse() returns a text response", async () => {
@@ -85,7 +100,7 @@ describe("MiniMaxLLM (unit)", () => {
     ]);
 
     expect(mockCreate).toHaveBeenCalledWith(
-      expect.objectContaining({ model: "MiniMax-M2.7" }),
+      expect.objectContaining({ model: "MiniMax-M3" }),
     );
     expect(result).toBe("Hello from MiniMax");
   });

--- a/mem0/llms/minimax.py
+++ b/mem0/llms/minimax.py
@@ -34,7 +34,7 @@ class MiniMaxLLM(LLMBase):
         super().__init__(config)
 
         if not self.config.model:
-            self.config.model = "MiniMax-M2.7"
+            self.config.model = "MiniMax-M3"
 
         api_key = self.config.api_key or os.getenv("MINIMAX_API_KEY")
         base_url = (

--- a/tests/llms/test_minimax.py
+++ b/tests/llms/test_minimax.py
@@ -61,10 +61,10 @@ def test_minimax_llm_config_base_url():
 
 
 def test_minimax_llm_default_model(mock_minimax_client):
-    """Default model is MiniMax-M2.7 when not specified."""
+    """Default model is MiniMax-M3 when not specified."""
     config = MinimaxConfig(temperature=0.7, max_tokens=100, api_key="api_key")
     llm = MiniMaxLLM(config)
-    assert llm.config.model == "MiniMax-M2.7"
+    assert llm.config.model == "MiniMax-M3"
 
 
 def test_minimax_llm_env_api_key():


### PR DESCRIPTION
## Linked Issue

Replacement for #6176.

## Description

- Update the Python and TypeScript MiniMax provider defaults to `MiniMax-M3`.
- Retain explicit `MiniMax-M2.7` model coverage.
- Document the supported global and mainland China OpenAI-compatible and Anthropic-compatible endpoints.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

- `python -m pytest -q tests/llms/test_minimax.py tests/llms/test_anthropic.py`
- `ruff check mem0/llms/minimax.py tests/llms/test_minimax.py`
- `pnpm --dir mem0-ts exec jest src/oss/tests/minimax.test.ts --runInBand`
- `pnpm --dir mem0-ts exec prettier --check src/oss/src/llms/minimax.ts src/oss/tests/minimax.test.ts`
- `pnpm --dir mem0-ts run build`
- `python scripts/check-llms-txt-coverage.py`
- Captured Python and TypeScript SDK request URLs for both regions and both compatible protocols.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing focused tests pass locally
- [x] I have updated documentation if needed
