### PR TITLE
fix(elasticsearch): set size=top_k on KNN search so results are not capped at 10

### DIFF
--- a/mem0/vector_stores/elasticsearch.py
+++ b/mem0/vector_stores/elasticsearch.py
@@ -163,7 +163,10 @@ class ElasticsearchDB(VectorStoreBase):
             search_query = self.custom_search_query(vectors, top_k, filters)
         else:
             search_query = {
-                "knn": {"field": "vector", "query_vector": vectors, "k": top_k, "num_candidates": top_k * 2}
+                # Without `size`, Elasticsearch caps the response at its default of 10 hits
+                # regardless of `knn.k`, silently truncating results when top_k > 10.
+                "size": top_k,
+                "knn": {"field": "vector", "query_vector": vectors, "k": top_k, "num_candidates": top_k * 2},
             }
             if filters:
                 filter_conditions = []

--- a/tests/vector_stores/test_elasticsearch.py
+++ b/tests/vector_stores/test_elasticsearch.py
@@ -209,12 +209,33 @@ class TestElasticsearchDB(unittest.TestCase):
         self.assertEqual(body["knn"]["query_vector"], vectors)
         self.assertEqual(body["knn"]["k"], 5)
         self.assertEqual(body["knn"]["num_candidates"], 10)
+        # `size` must be set or ES caps the response at its default of 10 hits.
+        self.assertEqual(body["size"], 5)
 
         # Verify results
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].id, "id1")
         self.assertEqual(results[0].score, 0.8)
         self.assertEqual(results[0].payload, {"key1": "value1"})
+
+    def test_search_sets_size_to_top_k(self):
+        """Regression for #5909: KNN search must set `size=top_k` or Elasticsearch caps
+        the response at its default of 10 hits regardless of `knn.k`.
+
+        Memory._search_vector_store over-fetches a scoring pool of `max(limit * 4, 60)`
+        candidates for hybrid re-ranking, so even a default search(top_k=20) reaches this
+        layer with top_k=80. Without `size`, that pool is silently truncated to 10.
+        """
+        self.client_mock.search.return_value = {"hits": {"hits": []}}
+
+        # internal_limit in Memory._search_vector_store for a default search(top_k=20)
+        over_fetch = max(20 * 4, 60)
+        self.es_db.search(query="", vectors=[[0.1] * 1536], top_k=over_fetch)
+
+        body = self.client_mock.search.call_args[1]["body"]
+        self.assertEqual(body["size"], over_fetch)
+        self.assertEqual(body["knn"]["k"], over_fetch)
+        self.assertGreater(body["size"], 10)
 
     def test_custom_search_query(self):
         # Mock custom search query


### PR DESCRIPTION
## Summary

Salvages #5910 by @AnnaSuSu (and the later parallel #5951 by @ly-wang19) onto current `main`.

`ElasticsearchDB.search()` builds a KNN body with `knn.k` / `num_candidates` but without top-level `size`. Elasticsearch defaults `size` to **10**, so `top_k > 10` is silently truncated. `keyword_search()` and `list()` already set `size`.

This still bite on main: Memory's hybrid path over-fetches with `max(limit * 4, 60)`, so default searches only score 10 candidates on Elasticsearch.

Closes #5909

## Motivation

Silent recall/ranking regression only on Elasticsearch — other store backends honor `top_k` fully.

## Root cause

Missing `"size": top_k` on the default KNN request body in `mem0/vector_stores/elasticsearch.py`.

## Fix

Add `"size": top_k` next to the knn clause (same approach as #5910 / #5951).

## Why salvage

#5910 and #5951 are open, mergeable, and CI-green but have not landed; the bug remains on main. This rebased salvage keeps the same minimal fix + regression tests under Bartok9 for recheck against current tip.

## Tests

- Extended `test_search` asserts `body["size"] == top_k`
- New `test_search_sets_size_to_top_k` for over-fetch (`max(20*4, 60)`)

```
uv run pytest tests/vector_stores/test_elasticsearch.py -q
# 21 passed
```

## Verification

- Focused: elasticsearch unit tests above
- Diff scoped to 2 files

## Credits

Original analysis and patch shape: @AnnaSuSu (#5910), also @ly-wang19 (#5951).