### PR TITLE
fix(redis): request updated_at in search/keyword_search return_fields

### DIFF
--- a/mem0/vector_stores/redis.py
+++ b/mem0/vector_stores/redis.py
@@ -155,7 +155,17 @@ class RedisDB(VectorStoreBase):
         v = VectorQuery(
             vector=np.array(vectors, dtype=np.float32).tobytes(),
             vector_field_name="embedding",
-            return_fields=["memory_id", "hash", "agent_id", "run_id", "user_id", "memory", "metadata", "created_at"],
+            return_fields=[
+                "memory_id",
+                "hash",
+                "agent_id",
+                "run_id",
+                "user_id",
+                "memory",
+                "metadata",
+                "created_at",
+                "updated_at",
+            ],
             filter_expression=filter,
             num_results=top_k,
         )
@@ -209,7 +219,17 @@ class RedisDB(VectorStoreBase):
         t = TextQuery(
             text=query,
             text_field_name="memory",
-            return_fields=["memory_id", "hash", "agent_id", "run_id", "user_id", "memory", "metadata", "created_at"],
+            return_fields=[
+                "memory_id",
+                "hash",
+                "agent_id",
+                "run_id",
+                "user_id",
+                "memory",
+                "metadata",
+                "created_at",
+                "updated_at",
+            ],
             filter_expression=filter_expression,
             num_results=top_k,
         )

--- a/tests/vector_stores/test_redis.py
+++ b/tests/vector_stores/test_redis.py
@@ -228,3 +228,39 @@ def test_update_entity_payload_without_hash_and_timestamps():
     assert data_dict["hash"] == ""
     assert data_dict["created_at"] == 0
     assert data_dict["updated_at"] == 0
+
+
+def test_search_requests_updated_at_in_return_fields():
+    """search() must request updated_at so its payload can surface it, matching
+    get() and list().
+
+    Regression: updated_at was missing from the search() return_fields, so the
+    ``if "updated_at" in result`` payload guard was dead code and search results
+    never carried updated_at even though update() persists it and it is a
+    declared index field.
+    """
+    db, mock_index = _make_redis_db()
+    mock_index.query.return_value = []
+
+    with patch("mem0.vector_stores.redis.VectorQuery") as mock_vector_query:
+        db.search("query", [0.1, 0.2, 0.3, 0.4], top_k=5, filters=None)
+
+    return_fields = mock_vector_query.call_args.kwargs["return_fields"]
+    assert "updated_at" in return_fields
+
+
+def test_keyword_search_requests_updated_at_in_return_fields():
+    """keyword_search() must request updated_at so its payload can surface it,
+    matching get(), list() and search().
+
+    Same dead-guard regression as search(): the ``if "updated_at" in result``
+    branch never fired because updated_at was absent from return_fields.
+    """
+    db, mock_index = _make_redis_db()
+    mock_index.query.return_value = []
+
+    with patch("mem0.vector_stores.redis.TextQuery") as mock_text_query:
+        db.keyword_search("query", top_k=5, filters=None)
+
+    return_fields = mock_text_query.call_args.kwargs["return_fields"]
+    assert "updated_at" in return_fields


### PR DESCRIPTION
## Summary

Salvages #6060 by @Krishnachaitanyakc onto current `main`.

Redis `search()` / `keyword_search()` omit `updated_at` from redis-vl `return_fields`, even though:

- `DEFAULT_FIELDS` indexes `updated_at`
- `update()` persists it
- `get()` / `list()` already return it

The `if "updated_at" in result` payload guards were dead code — search paths never surface `updated_at`.

Closes #6059

## Motivation

Metadata parity across read paths. After update, `get`+`list` show `updated_at` while hybrid/search drops it on Redis only.

## Root cause

Incomplete `return_fields` lists on `VectorQuery` and `TextQuery` in `mem0/vector_stores/redis.py`.

## Fix

Include `"updated_at"` in both `return_fields` (same fix as #6060).

## Why salvage

#6060 is open/mergeable/CI-green but not merged; bug still present on main.

## Tests

- `test_search_requests_updated_at_in_return_fields`
- `test_keyword_search_requests_updated_at_in_return_fields`

```
uv run pytest tests/vector_stores/test_redis.py -q
# 13 passed
```

## Verification

- Focused redis vector-store unit tests
- Diff scoped to 2 files

## Credits

Original report + patch: @Krishnachaitanyakc (#6060 / issue #6059).