### PR TITLE
fix(mem0-plugin): Windows compatibility for hooks and metadata size cap

### DIFF
--- a/integrations/mem0-plugin/scripts/_identity.sh
+++ b/integrations/mem0-plugin/scripts/_identity.sh
@@ -71,7 +71,8 @@ if command -v python3 >/dev/null 2>&1; then
   MEM0_RETENTION_SESSION_DAYS=$(echo "$_SETTINGS_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin).get('retention_session_days',90))" 2>/dev/null || echo "90")
   MEM0_CONFIDENCE_THRESHOLD=$(echo "$_SETTINGS_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin).get('confidence_threshold',0.3))" 2>/dev/null || echo "0.3")
   MEM0_GLOBAL_SEARCH=$(echo "$_SETTINGS_JSON" | python3 -c "import sys,json; print(str(json.load(sys.stdin).get('global_search',False)).lower())" 2>/dev/null || echo "false")
-  MEM0_DEBUG=$(echo "$_SETTINGS_JSON" | python3 -c "import sys,json; print(str(json.load(sys.stdin).get('debug',False)).lower())" 2>/dev/null || echo "false")
+  # Export empty (not "false") when disabled — consumers test emptiness/truthiness
+  MEM0_DEBUG=$(echo "$_SETTINGS_JSON" | python3 -c "import sys,json; print('true' if json.load(sys.stdin).get('debug',False) else '')" 2>/dev/null || echo "")
 else
   MEM0_AUTO_SAVE="true"
   MEM0_AUTO_SEARCH="true"
@@ -79,7 +80,7 @@ else
   MEM0_RETENTION_SESSION_DAYS="90"
   MEM0_CONFIDENCE_THRESHOLD="0.3"
   MEM0_GLOBAL_SEARCH="false"
-  MEM0_DEBUG="false"
+  MEM0_DEBUG=""
 fi
 export MEM0_AUTO_SAVE MEM0_AUTO_SEARCH MEM0_SEARCH_LIMIT MEM0_RETENTION_SESSION_DAYS MEM0_CONFIDENCE_THRESHOLD MEM0_GLOBAL_SEARCH MEM0_DEBUG
 

--- a/integrations/mem0-plugin/scripts/auto_capture.py
+++ b/integrations/mem0-plugin/scripts/auto_capture.py
@@ -29,11 +29,11 @@ _handler = logging.StreamHandler(sys.stderr)
 _handler.setFormatter(logging.Formatter("[mem0-auto-capture] %(message)s"))
 log.addHandler(_handler)
 
-if os.environ.get("MEM0_DEBUG"):
+if os.environ.get("MEM0_DEBUG", "").lower() not in ("", "0", "false"):
     _log_dir = os.path.expanduser("~/.mem0")
     try:
         os.makedirs(_log_dir, exist_ok=True)
-        _fh = logging.FileHandler(os.path.join(_log_dir, "hooks.log"))
+        _fh = logging.FileHandler(os.path.join(_log_dir, "hooks.log"), encoding="utf-8")
         _fh.setFormatter(logging.Formatter("[mem0-auto-capture] %(asctime)s %(message)s"))
         log.addHandler(_fh)
     except OSError:

--- a/integrations/mem0-plugin/scripts/auto_import.py
+++ b/integrations/mem0-plugin/scripts/auto_import.py
@@ -31,11 +31,11 @@ _handler = logging.StreamHandler(sys.stderr)
 _handler.setFormatter(logging.Formatter("[mem0-auto-import] %(message)s"))
 log.addHandler(_handler)
 
-if os.environ.get("MEM0_DEBUG"):
+if os.environ.get("MEM0_DEBUG", "").lower() not in ("", "0", "false"):
     _log_dir = os.path.expanduser("~/.mem0")
     try:
         os.makedirs(_log_dir, exist_ok=True)
-        _file_handler = logging.FileHandler(os.path.join(_log_dir, "hooks.log"))
+        _file_handler = logging.FileHandler(os.path.join(_log_dir, "hooks.log"), encoding="utf-8")
         _file_handler.setFormatter(logging.Formatter("[mem0-auto-import] %(asctime)s %(message)s"))
         log.addHandler(_file_handler)
     except OSError:

--- a/integrations/mem0-plugin/scripts/auto_setup_categories.py
+++ b/integrations/mem0-plugin/scripts/auto_setup_categories.py
@@ -47,11 +47,11 @@ _handler = logging.StreamHandler(sys.stderr)
 _handler.setFormatter(logging.Formatter("[mem0-auto-categories] %(message)s"))
 log.addHandler(_handler)
 
-if os.environ.get("MEM0_DEBUG"):
+if os.environ.get("MEM0_DEBUG", "").lower() not in ("", "0", "false"):
     _log_dir = os.path.expanduser("~/.mem0")
     try:
         os.makedirs(_log_dir, exist_ok=True)
-        _file_handler = logging.FileHandler(os.path.join(_log_dir, "hooks.log"))
+        _file_handler = logging.FileHandler(os.path.join(_log_dir, "hooks.log"), encoding="utf-8")
         _file_handler.setFormatter(logging.Formatter("[mem0-auto-categories] %(asctime)s %(message)s"))
         log.addHandler(_file_handler)
     except OSError:

--- a/integrations/mem0-plugin/scripts/block_memory_write.sh
+++ b/integrations/mem0-plugin/scripts/block_memory_write.sh
@@ -25,6 +25,9 @@ if [ -z "$FILE_PATH" ]; then
   exit 0
 fi
 
+# Normalize Windows backslashes so the glob patterns below match
+FILE_PATH="${FILE_PATH//\\//}"
+
 case "$FILE_PATH" in
   */.claude/*/MEMORY.md|*/.claude/memory/*)
     echo "BLOCKED: Do not write to $FILE_PATH. Use the mem0 MCP \`add_memory\` tool instead to persist memories. This project uses mem0 for all memory storage." >&2

--- a/integrations/mem0-plugin/scripts/block_memory_write_cursor.sh
+++ b/integrations/mem0-plugin/scripts/block_memory_write_cursor.sh
@@ -20,6 +20,9 @@ if [ -z "$FILE_PATH" ]; then
   exit 0
 fi
 
+# Normalize Windows backslashes so the glob patterns below match
+FILE_PATH="${FILE_PATH//\\//}"
+
 case "$FILE_PATH" in
   */MEMORY.md|*/.claude/memory/*|*/.cursor/memory/*)
     jq -cn --arg msg "Do not write to $FILE_PATH. Use the mem0 MCP add_memory tool instead to persist memories." \

--- a/integrations/mem0-plugin/scripts/capture_compact_summary.py
+++ b/integrations/mem0-plugin/scripts/capture_compact_summary.py
@@ -34,11 +34,11 @@ _handler = logging.StreamHandler(sys.stderr)
 _handler.setFormatter(logging.Formatter("[mem0-compact-summary] %(message)s"))
 log.addHandler(_handler)
 
-if os.environ.get("MEM0_DEBUG"):
+if os.environ.get("MEM0_DEBUG", "").lower() not in ("", "0", "false"):
     _log_dir = os.path.expanduser("~/.mem0")
     try:
         os.makedirs(_log_dir, exist_ok=True)
-        _file_handler = logging.FileHandler(os.path.join(_log_dir, "hooks.log"))
+        _file_handler = logging.FileHandler(os.path.join(_log_dir, "hooks.log"), encoding="utf-8")
         _file_handler.setFormatter(logging.Formatter("[mem0-compact-summary] %(asctime)s %(message)s"))
         log.addHandler(_file_handler)
     except OSError:

--- a/integrations/mem0-plugin/scripts/capture_session_summary.py
+++ b/integrations/mem0-plugin/scripts/capture_session_summary.py
@@ -32,11 +32,11 @@ _handler = logging.StreamHandler(sys.stderr)
 _handler.setFormatter(logging.Formatter("[mem0-session-summary] %(message)s"))
 log.addHandler(_handler)
 
-if os.environ.get("MEM0_DEBUG"):
+if os.environ.get("MEM0_DEBUG", "").lower() not in ("", "0", "false"):
     _log_dir = os.path.expanduser("~/.mem0")
     try:
         os.makedirs(_log_dir, exist_ok=True)
-        _fh = logging.FileHandler(os.path.join(_log_dir, "hooks.log"))
+        _fh = logging.FileHandler(os.path.join(_log_dir, "hooks.log"), encoding="utf-8")
         _fh.setFormatter(logging.Formatter("[mem0-session-summary] %(asctime)s %(message)s"))
         log.addHandler(_fh)
     except OSError:
@@ -46,6 +46,8 @@ API_URL = "https://api.mem0.ai"
 MAX_TAIL_LINES = 3000
 MAX_SUMMARY_CHARS = 50000
 SUMMARY_EXPIRY_DAYS = 90
+# The mem0 API rejects metadata whose serialized size exceeds 2000 chars
+METADATA_MAX_CHARS = 2000
 
 SYSTEM_TAG_RE = re.compile(
     r"<(?:system-reminder|private|claude-mem-context|persisted-output|system_instruction)>"
@@ -174,6 +176,10 @@ def store_summary(
         metadata["branch"] = branch
     if files:
         metadata["files_touched"] = files[:20]
+    while metadata.get("files_touched") and len(json.dumps(metadata)) > METADATA_MAX_CHARS:
+        metadata["files_touched"].pop()
+    if "files_touched" in metadata and not metadata["files_touched"]:
+        del metadata["files_touched"]
 
     body = {
         "messages": [{"role": "user", "content": summary_prompt}],

--- a/integrations/mem0-plugin/scripts/ensure_deps.sh
+++ b/integrations/mem0-plugin/scripts/ensure_deps.sh
@@ -13,9 +13,22 @@ mkdir -p "${DATA_DIR}"
 
 LOCKDIR="${DATA_DIR}/.install-lock"
 
+# Venv layout differs by platform: POSIX puts interpreters in bin/,
+# Windows in Scripts/. Probe both instead of assuming bin/.
+find_venv_python() {
+  for _p in "${VENV_DIR}/bin/python3" "${VENV_DIR}/bin/python" \
+            "${VENV_DIR}/Scripts/python.exe" "${VENV_DIR}/Scripts/python"; do
+    if [ -x "${_p}" ]; then
+      printf '%s' "${_p}"
+      return 0
+    fi
+  done
+  return 1
+}
+
 needs_install=false
 
-if [ ! -f "${VENV_DIR}/bin/python3" ]; then
+if ! VENV_PY=$(find_venv_python); then
   needs_install=true
 elif ! diff -q "${REQ_SRC}" "${REQ_STAMP}" >/dev/null 2>&1; then
   needs_install=true
@@ -25,9 +38,14 @@ if [ "${needs_install}" = "true" ]; then
   if mkdir "${LOCKDIR}" 2>/dev/null; then
     # We acquired the lock — proceed with installation
     trap 'rmdir "${LOCKDIR}" 2>/dev/null || true' EXIT
-    python3 -m venv "${VENV_DIR}" 2>/dev/null || python -m venv "${VENV_DIR}"
-    "${VENV_DIR}/bin/pip" install --quiet --upgrade pip >/dev/null 2>&1 || true
-    if "${VENV_DIR}/bin/pip" install --quiet -r "${REQ_SRC}" 2>/dev/null; then
+    if ! VENV_PY=$(find_venv_python); then
+      python3 -m venv "${VENV_DIR}" 2>/dev/null || python -m venv "${VENV_DIR}"
+      VENV_PY=$(find_venv_python) || VENV_PY=""
+    fi
+    if [ -n "${VENV_PY}" ]; then
+      "${VENV_PY}" -m pip install --quiet --upgrade pip >/dev/null 2>&1 || true
+    fi
+    if [ -n "${VENV_PY}" ] && "${VENV_PY}" -m pip install --quiet -r "${REQ_SRC}" 2>/dev/null; then
       cp "${REQ_SRC}" "${REQ_STAMP}"
       rm -f "${DATA_DIR}/.install-failed"
     else

--- a/integrations/mem0-plugin/scripts/on_pre_compact.py
+++ b/integrations/mem0-plugin/scripts/on_pre_compact.py
@@ -32,11 +32,11 @@ _handler = logging.StreamHandler(sys.stderr)
 _handler.setFormatter(logging.Formatter("[mem0-capture] %(message)s"))
 log.addHandler(_handler)
 
-if os.environ.get("MEM0_DEBUG"):
+if os.environ.get("MEM0_DEBUG", "").lower() not in ("", "0", "false"):
     _log_dir = os.path.expanduser("~/.mem0")
     try:
         os.makedirs(_log_dir, exist_ok=True)
-        _file_handler = logging.FileHandler(os.path.join(_log_dir, "hooks.log"))
+        _file_handler = logging.FileHandler(os.path.join(_log_dir, "hooks.log"), encoding="utf-8")
         _file_handler.setFormatter(logging.Formatter("[mem0-capture] %(asctime)s %(message)s"))
         log.addHandler(_file_handler)
     except OSError:

--- a/integrations/mem0-plugin/scripts/on_session_start.sh
+++ b/integrations/mem0-plugin/scripts/on_session_start.sh
@@ -177,8 +177,16 @@ if [ "$SOURCE" = "startup" ]; then
 
   # Configure the coding-category taxonomy in the background (idempotent, never blocks).
   # Prefer the venv python since this path needs the mem0ai SDK.
-  _VENV_PY="${CLAUDE_PLUGIN_DATA:-$HOME/.mem0/plugin-data}/venv/bin/python3"
-  if [ -x "$_VENV_PY" ]; then
+  # Venv layout differs by platform: bin/ on POSIX, Scripts/ on Windows.
+  _VENV_ROOT="${CLAUDE_PLUGIN_DATA:-$HOME/.mem0/plugin-data}/venv"
+  _VENV_PY=""
+  for _p in "$_VENV_ROOT/bin/python3" "$_VENV_ROOT/Scripts/python.exe"; do
+    if [ -x "$_p" ]; then
+      _VENV_PY="$_p"
+      break
+    fi
+  done
+  if [ -n "$_VENV_PY" ]; then
     MEM0_CWD="$MEM0_CWD_RESOLVED" "$_VENV_PY" "$SCRIPT_DIR/auto_setup_categories.py" 2>/dev/null &
   else
     MEM0_CWD="$MEM0_CWD_RESOLVED" python3 "$SCRIPT_DIR/auto_setup_categories.py" 2>/dev/null &


### PR DESCRIPTION
## Linked Issue

N/A — found while running the plugin on Windows; happy to open an issue if preferred.

## Description

Four bug fixes for the Claude Code plugin (`integrations/mem0-plugin`), all reproduced on Windows 11 with Claude Code running under Git Bash:

**1. `ensure_deps.sh` assumed the POSIX venv layout (`venv/bin/`)**

Windows venvs put interpreters in `venv/Scripts/`, so `[ ! -f "${VENV_DIR}/bin/python3" ]` was always true. Every SessionStart re-detected "not installed", recreated the venv, failed at the nonexistent `bin/pip`, and left a `.install-failed` marker — producing a false *"mem0 SDK installation failed"* warning on every session, even when the SDK was actually importable via `Scripts/python.exe`. Because the requirements stamp was never written, the `diff -q` gate in `hooks.json` also re-ran the installer on every session start.

Fixed by probing both `bin/` and `Scripts/` layouts and installing via `"$VENV_PY" -m pip` instead of a hardcoded pip path. The same layout probe is applied to the venv-python lookup in `on_session_start.sh` (used for `auto_setup_categories.py`).

**2. Stop-hook session summaries failed with HTTP 400 on busy sessions**

`capture_session_summary.py` puts up to 20 full file paths into `metadata.files_touched`. The v3 add API rejects metadata over 2000 serialized chars:

```
{"error":"{'metadata': [ErrorDetail(string='Metadata size (2166 chars) exceeds the limit of 2000 chars.', code='invalid')]}"}
```

Windows paths are long, so any session touching many files never got its summary stored (`hooks.log` showed a consistent pattern: 7–8 file summaries stored, 20-file summaries → 400). Fixed by trimming `files_touched` from the end until the serialized metadata fits.

**3. `block_memory_write.sh` didn't block Windows backslash paths**

The `case` globs (`*/.claude/*/MEMORY.md` etc.) only match `/`-separated paths, so writes to `C:\Users\...\memory\MEMORY.md` slipped through. Fixed by normalizing `\` → `/` before matching, in both the Claude and Cursor variants.

**4. `debug: false` in settings enabled debug logging**

`_identity.sh` exported the setting as the literal string `"false"`, which is truthy for both bash `[ -n ]` and Python `os.environ.get()` — so hook debug logging was unconditionally on. Now exports an empty string when disabled, and the Python checks treat `"false"`/`"0"` as off. The `hooks.log` `FileHandler`s also get `encoding="utf-8"`, fixing mojibake on systems whose locale encoding isn't UTF-8.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I tested manually (describe below)
- [x] No tests needed (explain why) — the plugin scripts have no test harness in the repo; verified manually as below.

- `bash -n` / `py_compile` pass on all changed scripts.
- Fixed `ensure_deps.sh` run against a real Windows `CLAUDE_PLUGIN_DATA` dir: finds `Scripts/python.exe`, installs, writes the requirements stamp, clears `.install-failed`; subsequent SessionStarts skip via the existing `diff -q` gate. The false warning no longer appears in SessionStart output.
- Metadata trim: a 20-path payload that previously serialized to 2166 chars (rejected by the API) now trims to 18 paths / 1962 chars.
- `block_memory_write.sh`: `C:\Users\...\memory\MEMORY.md` (JSON-escaped) now exits 2 (blocked); forward-slash memory paths still exit 2; normal project files still exit 0.
- `_identity.sh` with `debug: false` now exports `MEM0_DEBUG=''`; with `debug: true`, `'true'`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaqWz33KCPCXuVVfBFyS2P