### PR TITLE
feat(mem0-plugin): bound hosted memory requests

### DIFF
--- a/integrations/mem0-plugin/README.md
+++ b/integrations/mem0-plugin/README.md
@@ -221,10 +221,12 @@ The plugin includes 17 skills accessible via `/mem0:` commands:
 
 ## Hosted-memory cost controls
 
-Automatic hosted retrieval is off by default. Set `"auto_search": true` in
-`~/.mem0/settings.json` to opt in to file-read, resume, error, SessionStart,
-and automatic-import searches. Explicit MCP searches remain available, subject
-to the same hard local budget as all other hosted Mem0 traffic.
+Automatic hosted retrieval is off for fresh installs and whenever the setting
+is missing. Set `"auto_search": true` in `~/.mem0/settings.json` to opt in to
+file-read, resume, error, SessionStart, and automatic-import searches. An
+existing explicit `auto_search: true` is preserved on upgrade; set it to
+`false` to adopt the new posture. Explicit MCP searches remain available,
+subject to the same hard local budget as all other hosted Mem0 traffic.
 
 The Python/shell plugin surface charges each admitted hosted request atomically
 in `${MEM0_STATE_DIR:-~/.mem0}/admission.sqlite3` before transport. Defaults:

--- a/integrations/mem0-plugin/README.md
+++ b/integrations/mem0-plugin/README.md
@@ -275,9 +275,9 @@ Your `MEM0_API_KEY` doesn't need to be re-entered — the auth header is re-read
 
 If reconnection still fails after a restart, check that `MEM0_API_KEY` is reachable in the new shell (`echo $MEM0_API_KEY`) and confirm you're using a key that starts with `m0-` (from https://app.mem0.ai/dashboard/api-keys, not a legacy token).
 
-## Coding-tuned categories (automatic)
+## Coding-tuned categories (automatic when retrieval is enabled)
 
-mem0 auto-tags every memory with one or more `categories` from a project-level list. The default list is consumer-oriented (`food`, `hobbies`, `music` …) — useful for chat assistants, less so for code. **The plugin installs a coding-focused taxonomy automatically in the background on session start** — no prompt, no manual step. New memories then auto-tag against 17 development-oriented categories: `architecture_decisions`, `anti_patterns`, `task_learnings`, `tooling_setup`, `bug_fixes`, `coding_conventions`, `user_preferences`, `dependency_decisions`, `performance_findings`, `security_constraints`, `testing_patterns`, `data_model`, `api_contracts`, `deployment_runbook`, `team_norms`, `domain_glossary`, `experiment_results`.
+mem0 auto-tags every memory with one or more `categories` from a project-level list. The default list is consumer-oriented (`food`, `hobbies`, `music` …) — useful for chat assistants, less so for code. When `auto_search` is explicitly enabled, **the plugin installs a coding-focused taxonomy automatically in the background on session start**. With the default-off setting, no automatic hosted taxonomy get/update occurs; use the explicit command below when desired. New memories then auto-tag against 17 development-oriented categories: `architecture_decisions`, `anti_patterns`, `task_learnings`, `tooling_setup`, `bug_fixes`, `coding_conventions`, `user_preferences`, `dependency_decisions`, `performance_findings`, `security_constraints`, `testing_patterns`, `data_model`, `api_contracts`, `deployment_runbook`, `team_norms`, `domain_glossary`, `experiment_results`.
 
 The background setup is idempotent and runs once per account (cached in `~/.mem0/categories_setup.json`); it re-applies only if the taxonomy itself changes. To preview the taxonomy or force a refresh manually:
 

--- a/integrations/mem0-plugin/README.md
+++ b/integrations/mem0-plugin/README.md
@@ -219,6 +219,36 @@ The plugin includes 17 skills accessible via `/mem0:` commands:
 | `/mem0:memory-reviewer` | Audit memory quality — duplicates, contradictions, stale |
 | `/mem0:context-loader` | Pre-load relevant memories for current task |
 
+## Hosted-memory cost controls
+
+Automatic hosted retrieval is off by default. Set `"auto_search": true` in
+`~/.mem0/settings.json` to opt in to file-read, resume, error, SessionStart,
+and automatic-import searches. Explicit MCP searches remain available, subject
+to the same hard local budget as all other hosted Mem0 traffic.
+
+The Python/shell plugin surface charges each admitted hosted request atomically
+in `${MEM0_STATE_DIR:-~/.mem0}/admission.sqlite3` before transport. Defaults:
+
+| Environment variable | Default |
+|---|---:|
+| `MEM0_BUDGET_SESSION_REQUESTS` | 12 |
+| `MEM0_BUDGET_DAILY_REQUESTS` | 50 |
+| `MEM0_BUDGET_SESSION_AUTO_REQUESTS` | 6 |
+| `MEM0_BUDGET_DAILY_AUTO_REQUESTS` | 20 |
+| `MEM0_BUDGET_SESSION_WEIGHT` | 30 |
+| `MEM0_BUDGET_DAILY_WEIGHT` | 120 |
+
+`0` denies that dimension. Invalid or unavailable accounting fails closed for
+remote memory calls only; file reads and local work continue. Request weights
+are conservative tuning heuristics, not provider billing units, tokens, or
+dollar estimates. Charges are monotonic admitted attempts and are not refunded.
+
+Claude Code's PreToolUse deny path is protected by the tested hook contract.
+Codex, Cursor, and Antigravity remain best-effort until equivalent
+host-executed deny smokes pass. **P0 cost admission: unprotected for the
+separately published OpenCode TypeScript plugin**, which needs a future
+language-neutral adapter.
+
 ## What's included
 
 | Component | Claude Code / Cowork | Cursor (MCP) | Codex (Sideload) | Codex (Direct MCP) | OpenCode (Full) | OpenCode (MCP) | Antigravity |

--- a/integrations/mem0-plugin/hooks/codex-hooks.json
+++ b/integrations/mem0-plugin/hooks/codex-hooks.json
@@ -12,7 +12,7 @@
         ]
       },
       {
-        "matcher": "mcp__mem0__add_memory|mcp__plugin_mem0_mem0__add_memory|mcp__mem0__search_memories|mcp__plugin_mem0_mem0__search_memories|mcp__mem0__get_memories|mcp__plugin_mem0_mem0__get_memories|mcp__mem0__delete_all_memories|mcp__plugin_mem0_mem0__delete_all_memories",
+        "matcher": "mcp__mem0__.*|mcp__plugin_mem0_mem0__.*",
         "hooks": [
           {
             "type": "command",

--- a/integrations/mem0-plugin/hooks/cursor-hooks.json
+++ b/integrations/mem0-plugin/hooks/cursor-hooks.json
@@ -14,7 +14,7 @@
       },
       {
         "command": "${CURSOR_PLUGIN_ROOT}/scripts/enforce_metadata_defaults.sh",
-        "matcher": "mcp__mem0__add_memory|mcp__plugin_mem0_mem0__add_memory|mcp__mem0__search_memories|mcp__plugin_mem0_mem0__search_memories|mcp__mem0__get_memories|mcp__plugin_mem0_mem0__get_memories|mcp__mem0__delete_all_memories|mcp__plugin_mem0_mem0__delete_all_memories",
+        "matcher": "mcp__mem0__.*|mcp__plugin_mem0_mem0__.*",
         "timeout": 3
       },
       {

--- a/integrations/mem0-plugin/hooks/hooks.json
+++ b/integrations/mem0-plugin/hooks/hooks.json
@@ -46,7 +46,7 @@
         ]
       },
       {
-        "matcher": "mcp__mem0__add_memory|mcp__plugin_mem0_mem0__add_memory|mcp__mem0__search_memories|mcp__plugin_mem0_mem0__search_memories|mcp__mem0__get_memories|mcp__plugin_mem0_mem0__get_memories|mcp__mem0__delete_all_memories|mcp__plugin_mem0_mem0__delete_all_memories",
+        "matcher": "mcp__mem0__.*|mcp__plugin_mem0_mem0__.*",
         "hooks": [
           {
             "type": "command",

--- a/integrations/mem0-plugin/scripts/_identity.py
+++ b/integrations/mem0-plugin/scripts/_identity.py
@@ -83,7 +83,7 @@ def resolve_config() -> dict:
     except ImportError:
         return {
             "auto_save": True,
-            "auto_search": True,
+            "auto_search": False,
             "search_limit": 10,
             "retention_session_days": 90,
             "confidence_threshold": 0.3,

--- a/integrations/mem0-plugin/scripts/_identity.sh
+++ b/integrations/mem0-plugin/scripts/_identity.sh
@@ -56,6 +56,17 @@ _mem0_resolve_identity() {
 MEM0_RESOLVED_USER_ID="$(_mem0_resolve_identity)"
 export MEM0_RESOLVED_USER_ID
 
+# Hooks do not all inherit the SessionStart environment on every host. Reuse
+# the session marker rather than collapsing their budgets into a permanent
+# "default" bucket.
+if [ -z "${MEM0_SESSION_ID:-}" ]; then
+  _MEM0_SESSION_FILE="/tmp/mem0_session_id_${USER:-default}"
+  if [ -f "$_MEM0_SESSION_FILE" ]; then
+    MEM0_SESSION_ID=$(cat "$_MEM0_SESSION_FILE" 2>/dev/null || echo "")
+    export MEM0_SESSION_ID
+  fi
+fi
+
 _MEM0_IDENTITY_ANNOTATION=""
 if [ -n "${MEM0_USER_ID:-}" ] && [ "$MEM0_USER_ID" != "${USER:-default}" ]; then
   _MEM0_IDENTITY_ANNOTATION=" (override; default: ${USER:-default})"
@@ -66,7 +77,7 @@ export _MEM0_IDENTITY_ANNOTATION
 if command -v python3 >/dev/null 2>&1; then
   _SETTINGS_JSON=$(PYTHONPATH="$_SCRIPT_DIR" python3 -c "from load_settings import load_settings; import json; print(json.dumps(load_settings()))" 2>/dev/null || echo "{}")
   MEM0_AUTO_SAVE=$(echo "$_SETTINGS_JSON" | python3 -c "import sys,json; print(str(json.load(sys.stdin).get('auto_save',True)).lower())" 2>/dev/null || echo "true")
-  MEM0_AUTO_SEARCH=$(echo "$_SETTINGS_JSON" | python3 -c "import sys,json; print(str(json.load(sys.stdin).get('auto_search',True)).lower())" 2>/dev/null || echo "true")
+  MEM0_AUTO_SEARCH=$(echo "$_SETTINGS_JSON" | python3 -c "import sys,json; print(str(json.load(sys.stdin).get('auto_search',False)).lower())" 2>/dev/null || echo "false")
   MEM0_SEARCH_LIMIT=$(echo "$_SETTINGS_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin).get('search_limit',10))" 2>/dev/null || echo "10")
   MEM0_RETENTION_SESSION_DAYS=$(echo "$_SETTINGS_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin).get('retention_session_days',90))" 2>/dev/null || echo "90")
   MEM0_CONFIDENCE_THRESHOLD=$(echo "$_SETTINGS_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin).get('confidence_threshold',0.3))" 2>/dev/null || echo "0.3")
@@ -74,7 +85,7 @@ if command -v python3 >/dev/null 2>&1; then
   MEM0_DEBUG=$(echo "$_SETTINGS_JSON" | python3 -c "import sys,json; print(str(json.load(sys.stdin).get('debug',False)).lower())" 2>/dev/null || echo "false")
 else
   MEM0_AUTO_SAVE="true"
-  MEM0_AUTO_SEARCH="true"
+  MEM0_AUTO_SEARCH="false"
   MEM0_SEARCH_LIMIT="10"
   MEM0_RETENTION_SESSION_DAYS="90"
   MEM0_CONFIDENCE_THRESHOLD="0.3"

--- a/integrations/mem0-plugin/scripts/_search.py
+++ b/integrations/mem0-plugin/scripts/_search.py
@@ -6,9 +6,12 @@ All pre-fetch hooks use this instead of duplicating urllib boilerplate.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import urllib.request
+
+from hosted_request import open_hosted_request
 
 SEARCH_URL = "https://api.mem0.ai/v3/memories/search/"
 SEARCH_TIMEOUT = 5
@@ -32,7 +35,13 @@ def should_rerank() -> bool:
     return raw.strip().lower() not in ("0", "false", "no", "off", "")
 
 
-def _do_search(api_key: str, payload: dict) -> list[dict]:
+def _do_search(
+    api_key: str,
+    payload: dict,
+    *,
+    ingress: str,
+    automatic: bool,
+) -> list[dict]:
     body = json.dumps(payload).encode()
     req = urllib.request.Request(
         SEARCH_URL,
@@ -40,7 +49,22 @@ def _do_search(api_key: str, payload: dict) -> list[dict]:
         headers={"Authorization": f"Token {api_key}", "Content-Type": "application/json"},
         method="POST",
     )
-    with urllib.request.urlopen(req, timeout=SEARCH_TIMEOUT) as r:
+    coalesce_key = None
+    if automatic:
+        coalesce_key = hashlib.sha256(
+            json.dumps(
+                {"ingress": ingress, "query": payload.get("query"), "filters": payload.get("filters")},
+                sort_keys=True,
+            ).encode()
+        ).hexdigest()
+    with open_hosted_request(
+        req,
+        timeout=SEARCH_TIMEOUT,
+        ingress=ingress,
+        automatic=automatic,
+        operation="search",
+        coalesce_key=coalesce_key,
+    ) as r:
         data = json.loads(r.read())
         return data if isinstance(data, list) else data.get("results", [])
 
@@ -57,9 +81,19 @@ def search_memories(
     rerank: bool = False,
     threshold: float = 0.3,
     global_search: bool = False,
+    ingress: str = "explicit-search",
+    automatic: bool = False,
 ) -> list[dict]:
     if not api_key:
         return []
+    if automatic:
+        try:
+            from load_settings import load_settings
+
+            if not load_settings().get("auto_search", False):
+                return []
+        except Exception:
+            return []
 
     if global_search:
         filters: dict = {"OR": [{"user_id": "*"}]}
@@ -78,7 +112,9 @@ def search_memories(
 
     try:
         payload = {**base_payload, "filters": filters}
-        results = _do_search(api_key, payload)[:top_k]
+        results = _do_search(
+            api_key, payload, ingress=ingress, automatic=automatic
+        )[:top_k]
 
         if min_score > 0:
             results = [m for m in results if m.get("score", 0) >= min_score]

--- a/integrations/mem0-plugin/scripts/admission.py
+++ b/integrations/mem0-plugin/scripts/admission.py
@@ -1,0 +1,226 @@
+"""Atomic, local admission control for hosted Mem0 requests.
+
+Charges are monotonic attempts. They are committed before transport and are
+never refunded, so the configured ceilings remain hard even when a process
+dies or the provider result is unavailable.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import sqlite3
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+DEFAULT_LIMITS = {
+    "session_requests": 12,
+    "daily_requests": 50,
+    "session_auto_requests": 6,
+    "daily_auto_requests": 20,
+    "session_weight": 30,
+    "daily_weight": 120,
+}
+
+ENV_LIMITS = {
+    "session_requests": "MEM0_BUDGET_SESSION_REQUESTS",
+    "daily_requests": "MEM0_BUDGET_DAILY_REQUESTS",
+    "session_auto_requests": "MEM0_BUDGET_SESSION_AUTO_REQUESTS",
+    "daily_auto_requests": "MEM0_BUDGET_DAILY_AUTO_REQUESTS",
+    "session_weight": "MEM0_BUDGET_SESSION_WEIGHT",
+    "daily_weight": "MEM0_BUDGET_DAILY_WEIGHT",
+}
+
+SEARCH_OPERATIONS = {"search", "list", "get", "search_memories", "get_memories", "get_memory", "list_entities"}
+WRITE_OPERATIONS = {"add", "update", "import", "add_memory", "update_memory"}
+
+
+@dataclass(frozen=True)
+class AdmissionResult:
+    admitted: bool
+    reason: str | None
+    charge_id: str
+    weight: int
+    idempotent: bool = False
+
+
+def operation_weight(operation: str, payload_bytes: int = 0) -> int:
+    normalized = operation.lower()
+    if normalized in SEARCH_OPERATIONS:
+        return 1
+    if normalized in WRITE_OPERATIONS:
+        return 2 + math.ceil(max(0, payload_bytes) / 4096)
+    if normalized.startswith("delete") or normalized.endswith("entities"):
+        return 1
+    return 3
+
+
+def _limits() -> dict[str, int] | None:
+    values: dict[str, int] = {}
+    for key, default in DEFAULT_LIMITS.items():
+        raw = os.environ.get(ENV_LIMITS[key], str(default))
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            return None
+        if value < 0 or str(value) != str(raw).strip():
+            return None
+        values[key] = value
+    return values
+
+
+def _database_path() -> Path:
+    root = Path(os.environ.get("MEM0_STATE_DIR", "~/.mem0")).expanduser()
+    root.mkdir(parents=True, exist_ok=True)
+    return root / "admission.sqlite3"
+
+
+def _connect() -> sqlite3.Connection:
+    connection = sqlite3.connect(_database_path(), timeout=0.5, isolation_level=None)
+    connection.execute("PRAGMA busy_timeout = 500")
+    connection.execute("PRAGMA journal_mode = WAL")
+    connection.execute(
+        """
+        CREATE TABLE IF NOT EXISTS charges (
+            charge_id TEXT PRIMARY KEY,
+            operation TEXT NOT NULL,
+            ingress TEXT NOT NULL,
+            automatic INTEGER NOT NULL,
+            session_id TEXT NOT NULL,
+            day_bucket TEXT NOT NULL,
+            weight INTEGER NOT NULL,
+            status TEXT NOT NULL,
+            created_at REAL NOT NULL,
+            coalesce_key TEXT
+        )
+        """
+    )
+    connection.execute(
+        "CREATE INDEX IF NOT EXISTS charges_session_idx ON charges(session_id, created_at)"
+    )
+    connection.execute(
+        "CREATE INDEX IF NOT EXISTS charges_day_idx ON charges(day_bucket, created_at)"
+    )
+    connection.execute(
+        "CREATE INDEX IF NOT EXISTS charges_coalesce_idx ON charges(coalesce_key, created_at)"
+    )
+    return connection
+
+
+def _totals(connection: sqlite3.Connection, where: str, params: tuple) -> tuple[int, int]:
+    row = connection.execute(
+        f"SELECT COUNT(*), COALESCE(SUM(weight), 0) FROM charges WHERE {where}", params
+    ).fetchone()
+    return int(row[0]), int(row[1])
+
+
+def admit(
+    operation: str,
+    ingress: str,
+    automatic: bool,
+    session_id: str,
+    *,
+    payload_bytes: int = 0,
+    charge_id: str | None = None,
+    coalesce_key: str | None = None,
+    now: float | None = None,
+) -> AdmissionResult:
+    """Atomically admit and charge one hosted-memory attempt."""
+    identifier = charge_id or str(uuid.uuid4())
+    weight = operation_weight(operation, payload_bytes)
+    limits = _limits()
+    if limits is None:
+        return AdmissionResult(False, "remote-invalid-budget-config", identifier, weight)
+
+    timestamp = time.time() if now is None else now
+    day_bucket = datetime.fromtimestamp(timestamp, tz=timezone.utc).date().isoformat()
+    session = session_id or os.environ.get("MEM0_SESSION_ID", "default") or "default"
+
+    connection = None
+    try:
+        connection = _connect()
+        connection.execute("BEGIN IMMEDIATE")
+
+        existing = connection.execute(
+            "SELECT weight FROM charges WHERE charge_id = ?", (identifier,)
+        ).fetchone()
+        if existing:
+            connection.execute("COMMIT")
+            return AdmissionResult(True, None, identifier, int(existing[0]), idempotent=True)
+
+        if automatic and coalesce_key:
+            duplicate = connection.execute(
+                "SELECT 1 FROM charges WHERE coalesce_key = ? AND created_at >= ? LIMIT 1",
+                (coalesce_key, timestamp - 30),
+            ).fetchone()
+            if duplicate:
+                connection.execute("COMMIT")
+                return AdmissionResult(False, "remote-coalesced", identifier, weight)
+
+        session_count, session_weight = _totals(connection, "session_id = ?", (session,))
+        day_count, day_weight = _totals(connection, "day_bucket = ?", (day_bucket,))
+
+        if session_count + 1 > limits["session_requests"]:
+            reason = "remote-session-budget-exhausted"
+        elif day_count + 1 > limits["daily_requests"]:
+            reason = "remote-daily-budget-exhausted"
+        elif session_weight + weight > limits["session_weight"]:
+            reason = "remote-session-weight-exhausted"
+        elif day_weight + weight > limits["daily_weight"]:
+            reason = "remote-daily-weight-exhausted"
+        elif automatic:
+            session_auto, _ = _totals(
+                connection, "session_id = ? AND automatic = 1", (session,)
+            )
+            day_auto, _ = _totals(
+                connection, "day_bucket = ? AND automatic = 1", (day_bucket,)
+            )
+            reason = (
+                "remote-automatic-budget-exhausted"
+                if session_auto + 1 > limits["session_auto_requests"]
+                or day_auto + 1 > limits["daily_auto_requests"]
+                else None
+            )
+        else:
+            reason = None
+
+        if reason:
+            connection.execute("ROLLBACK")
+            return AdmissionResult(False, reason, identifier, weight)
+
+        connection.execute(
+            """
+            INSERT INTO charges (
+                charge_id, operation, ingress, automatic, session_id,
+                day_bucket, weight, status, created_at, coalesce_key
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, 'charged', ?, ?)
+            """,
+            (
+                identifier,
+                operation,
+                ingress,
+                int(automatic),
+                session,
+                day_bucket,
+                weight,
+                timestamp,
+                coalesce_key,
+            ),
+        )
+        connection.execute("COMMIT")
+        return AdmissionResult(True, None, identifier, weight)
+    except (OSError, sqlite3.Error):
+        if connection is not None:
+            try:
+                connection.execute("ROLLBACK")
+            except sqlite3.Error:
+                pass
+        return AdmissionResult(False, "remote-accounting-unavailable", identifier, weight)
+    finally:
+        if connection is not None:
+            connection.close()
+

--- a/integrations/mem0-plugin/scripts/admission.py
+++ b/integrations/mem0-plugin/scripts/admission.py
@@ -223,4 +223,3 @@ def admit(
     finally:
         if connection is not None:
             connection.close()
-

--- a/integrations/mem0-plugin/scripts/admission_cli.py
+++ b/integrations/mem0-plugin/scripts/admission_cli.py
@@ -38,4 +38,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/integrations/mem0-plugin/scripts/admission_cli.py
+++ b/integrations/mem0-plugin/scripts/admission_cli.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""JSON CLI bridge for shell and MCP admission hooks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+
+from admission import admit
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    charge = subparsers.add_parser("charge")
+    charge.add_argument("--operation", required=True)
+    charge.add_argument("--ingress", required=True)
+    charge.add_argument("--automatic", action="store_true")
+    charge.add_argument("--session-id", default=os.environ.get("MEM0_SESSION_ID", "default"))
+    charge.add_argument("--payload-bytes", type=int, default=0)
+    charge.add_argument("--charge-id")
+    charge.add_argument("--coalesce-key")
+    args = parser.parse_args()
+
+    result = admit(
+        args.operation,
+        args.ingress,
+        args.automatic,
+        args.session_id,
+        payload_bytes=args.payload_bytes,
+        charge_id=args.charge_id,
+        coalesce_key=args.coalesce_key,
+    )
+    print(json.dumps(result.__dict__, sort_keys=True))
+    return 0 if result.admitted else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/integrations/mem0-plugin/scripts/auto_capture.py
+++ b/integrations/mem0-plugin/scripts/auto_capture.py
@@ -22,6 +22,7 @@ import urllib.request
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _identity import resolve_api_key, resolve_user_id
 from _project import resolve_branch, resolve_project_id
+from hosted_request import HostedRequestDenied, open_hosted_request
 
 log = logging.getLogger("mem0-auto-capture")
 log.setLevel(logging.DEBUG)
@@ -138,7 +139,7 @@ def store_exchange(api_key: str, messages: list[dict], user_id: str,
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=15) as resp:
+        with open_hosted_request(req, timeout=15, ingress="auto-capture", automatic=True, operation="add") as resp:
             if resp.status in (200, 201):
                 result = json.loads(resp.read())
                 log.info("Auto-captured: event_id=%s status=%s",
@@ -146,7 +147,7 @@ def store_exchange(api_key: str, messages: list[dict], user_id: str,
                 return True
             log.warning("API returned status %d", resp.status)
             return False
-    except urllib.error.URLError as e:
+    except (urllib.error.URLError, HostedRequestDenied) as e:
         log.warning("API call failed: %s", e)
         return False
 

--- a/integrations/mem0-plugin/scripts/auto_import.py
+++ b/integrations/mem0-plugin/scripts/auto_import.py
@@ -22,8 +22,9 @@ import urllib.request
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _chunking import filter_and_truncate, split_by_headers
-from _identity import resolve_api_key, resolve_user_id
+from _identity import resolve_api_key, resolve_config, resolve_user_id
 from _project import resolve_branch, resolve_project_id, save_project_mapping
+from hosted_request import HostedRequestDenied, open_hosted_request
 
 log = logging.getLogger("mem0-auto-import")
 log.setLevel(logging.DEBUG)
@@ -46,6 +47,11 @@ MAX_FILE_SIZE = 100_000  # skip files over 100 KB
 TARGET_FILES = ["CLAUDE.md", "AGENTS.md", ".cursorrules", ".windsurfrules", "mem0.md"]
 HASH_STORE = os.path.expanduser("~/.mem0/file_hashes.json")
 LOCK_FILE = os.path.expanduser("~/.mem0/auto_import.lock")
+
+
+def _automatic_mode() -> bool:
+    """Manual onboarding can opt into an explicit, separately reserved import."""
+    return os.environ.get("MEM0_IMPORT_EXPLICIT", "") != "1"
 
 
 def _acquire_lock() -> bool:
@@ -141,7 +147,7 @@ def already_imported(api_key: str, user_id: str, project_id: str, filename: str)
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=5) as r:
+        with open_hosted_request(req, timeout=5, ingress="auto-import-dedupe", automatic=_automatic_mode(), operation="search") as r:
             data = json.loads(r.read())
             results = data if isinstance(data, list) else data.get("results", [])
             for result in results:
@@ -176,7 +182,7 @@ def _delete_stale_chunks(api_key: str, user_id: str, project_id: str, filename: 
     )
     ids_to_delete = []
     try:
-        with urllib.request.urlopen(req, timeout=10) as r:
+        with open_hosted_request(req, timeout=10, ingress="auto-import-stale-search", automatic=_automatic_mode(), operation="search") as r:
             data = json.loads(r.read())
             results = data if isinstance(data, list) else data.get("results", [])
             for result in results:
@@ -200,7 +206,7 @@ def _delete_stale_chunks(api_key: str, user_id: str, project_id: str, filename: 
                 headers={"Authorization": f"Token {api_key}"},
                 method="DELETE",
             )
-            with urllib.request.urlopen(del_req, timeout=10):
+            with open_hosted_request(del_req, timeout=10, ingress="auto-import-delete", automatic=_automatic_mode(), operation="delete"):
                 deleted += 1
         except Exception as e:
             log.warning("Failed to delete stale chunk %s: %s", mid, e)
@@ -244,18 +250,21 @@ def post_memory(api_key: str, content: str, user_id: str, filename: str, project
     )
 
     try:
-        with urllib.request.urlopen(req, timeout=15) as resp:
+        with open_hosted_request(req, timeout=15, ingress="auto-import-add", automatic=_automatic_mode(), operation="import") as resp:
             if resp.status in (200, 201):
                 log.info("Imported %s (project=%s)", filename, project_id)
                 return True
             log.warning("API returned status %d for %s", resp.status, filename)
             return False
-    except urllib.error.URLError as e:
+    except (urllib.error.URLError, HostedRequestDenied) as e:
         log.warning("API call failed for %s: %s", filename, e)
         return False
 
 
 def main() -> None:
+    if _automatic_mode() and not resolve_config().get("auto_search", False):
+        log.debug("auto_search is disabled; skipping automatic import because dedup requires search")
+        return
     api_key = resolve_api_key()
     if not api_key:
         log.debug("MEM0_API_KEY not set, skipping auto-import")

--- a/integrations/mem0-plugin/scripts/auto_setup_categories.py
+++ b/integrations/mem0-plugin/scripts/auto_setup_categories.py
@@ -38,7 +38,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 # Importing setup_coding_categories also injects the plugin venv's site-packages
 # onto sys.path (its module-level bootstrap), so ``from mem0 import MemoryClient``
 # works even when this script is run with the system python3.
-from _identity import resolve_api_key  # noqa: E402
+from _identity import resolve_api_key, resolve_config  # noqa: E402
 from setup_coding_categories import CODING_CATEGORIES, _categories_match  # noqa: E402
 from hosted_request import require_admission  # noqa: E402
 
@@ -192,6 +192,9 @@ def _release_lock() -> None:
 # Entry point                                                                  #
 # --------------------------------------------------------------------------- #
 def main() -> None:
+    if not resolve_config().get("auto_search", False):
+        log.debug("auto_search is disabled; skipping automatic coding-category setup")
+        return
     api_key = resolve_api_key()
     if not api_key:
         log.debug("MEM0_API_KEY not set, skipping coding-categories setup")

--- a/integrations/mem0-plugin/scripts/auto_setup_categories.py
+++ b/integrations/mem0-plugin/scripts/auto_setup_categories.py
@@ -40,6 +40,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 # works even when this script is run with the system python3.
 from _identity import resolve_api_key  # noqa: E402
 from setup_coding_categories import CODING_CATEGORIES, _categories_match  # noqa: E402
+from hosted_request import require_admission  # noqa: E402
 
 log = logging.getLogger("mem0-auto-categories")
 log.setLevel(logging.DEBUG)
@@ -133,6 +134,7 @@ def make_client():
 
 def fetch_current_categories(client) -> list | None:
     """Return the project's current custom_categories, or None if unavailable."""
+    require_admission("get", "auto-categories-get", True)
     current = client.project.get(fields=["custom_categories"])
     if isinstance(current, dict):
         return current.get("custom_categories")
@@ -148,6 +150,12 @@ def apply_categories(client, proposed: list = CODING_CATEGORIES) -> str:
     current = fetch_current_categories(client)
     if _categories_match(current, proposed):
         return "already-configured"
+    require_admission(
+        "update",
+        "auto-categories-update",
+        True,
+        payload_bytes=len(json.dumps(proposed).encode()),
+    )
     client.project.update(custom_categories=proposed)
     return "applied"
 

--- a/integrations/mem0-plugin/scripts/capture_compact_summary.py
+++ b/integrations/mem0-plugin/scripts/capture_compact_summary.py
@@ -27,6 +27,7 @@ from datetime import date, timedelta
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _identity import resolve_api_key, resolve_user_id
 from _project import resolve_branch, resolve_project_id
+from hosted_request import HostedRequestDenied, open_hosted_request
 
 log = logging.getLogger("mem0-compact-summary")
 log.setLevel(logging.DEBUG)
@@ -124,13 +125,13 @@ def store_summary(api_key: str, summary: str, user_id: str, session_id: str, pro
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=15) as resp:
+        with open_hosted_request(req, timeout=15, ingress="compact-summary", automatic=True, operation="add") as resp:
             if resp.status in (200, 201):
                 log.info("Compact summary stored")
                 return True
             log.warning("API returned status %d", resp.status)
             return False
-    except urllib.error.URLError as e:
+    except (urllib.error.URLError, HostedRequestDenied) as e:
         log.warning("API call failed: %s", e)
         return False
 

--- a/integrations/mem0-plugin/scripts/capture_session_summary.py
+++ b/integrations/mem0-plugin/scripts/capture_session_summary.py
@@ -25,6 +25,7 @@ from datetime import date, timedelta
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _identity import resolve_api_key, resolve_user_id
 from _project import resolve_branch, resolve_project_id
+from hosted_request import HostedRequestDenied, open_hosted_request
 
 log = logging.getLogger("mem0-session-summary")
 log.setLevel(logging.DEBUG)
@@ -196,13 +197,13 @@ def store_summary(
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=15) as resp:
+        with open_hosted_request(req, timeout=15, ingress="session-summary", automatic=True, operation="add") as resp:
             if resp.status in (200, 201):
                 log.info("Session summary stored")
                 return True
             log.warning("API returned status %d", resp.status)
             return False
-    except urllib.error.URLError as e:
+    except (urllib.error.URLError, HostedRequestDenied) as e:
         log.warning("API call failed: %s", e)
         return False
 

--- a/integrations/mem0-plugin/scripts/count_memories.py
+++ b/integrations/mem0-plugin/scripts/count_memories.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Budgeted SessionStart memory count helper."""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.request
+
+from hosted_request import open_hosted_request
+from load_settings import load_settings
+
+
+def main() -> None:
+    if not load_settings().get("auto_search", False):
+        print("not-loaded")
+        return
+    api_key = os.environ.get("MEM0_API_KEY", "")
+    user_id = os.environ.get("MEM0_RESOLVED_USER_ID", "default")
+    app_id = os.environ.get("MEM0_PROJECT_ID", "")
+    if not api_key:
+        print("?")
+        return
+    if os.environ.get("MEM0_GLOBAL_SEARCH", "false") == "true":
+        filters = {"OR": [{"user_id": "*"}]}
+    else:
+        filters = {"AND": [{"user_id": user_id}, {"app_id": app_id}]}
+    body = json.dumps({"filters": filters}).encode()
+    request = urllib.request.Request(
+        "https://api.mem0.ai/v3/memories/?page=1&page_size=1",
+        headers={"Authorization": f"Token {api_key}", "Content-Type": "application/json"},
+        data=body,
+        method="POST",
+    )
+    try:
+        with open_hosted_request(
+            request,
+            timeout=5,
+            ingress="session-count",
+            automatic=True,
+            operation="list",
+            coalesce_key=f"session-count:{user_id}:{app_id}",
+        ) as response:
+            data = json.loads(response.read())
+        if isinstance(data, dict) and "count" in data:
+            print(data["count"])
+        elif isinstance(data, list):
+            print(len(data))
+        else:
+            print(0)
+    except Exception:
+        print("?")
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/mem0-plugin/scripts/enforce_metadata_defaults.sh
+++ b/integrations/mem0-plugin/scripts/enforce_metadata_defaults.sh
@@ -4,11 +4,9 @@
 # omits them. Uses the hookSpecificOutput.updatedInput contract to modify
 # tool call parameters before execution.
 #
-# Handles:
-#   add_memory         — top-level user_id, app_id, metadata defaults
-#   search_memories    — user_id/app_id into filters.AND[]
-#   get_memories       — user_id/app_id into filters.AND[]
-#   delete_all_memories — top-level user_id, app_id
+# Classifies and budgets every advertised Mem0 MCP operation. Identity defaults
+# are injected only where the tool contract accepts them. Record-scoped and
+# entity-management operations are admission-only passthroughs.
 #
 # Hook contract:
 #   exit 0 = allow. If stdout contains {"hookSpecificOutput": {"updatedInput": ...}},
@@ -33,12 +31,40 @@ case "$TOOL_NAME" in
     HANDLER="search_memories" ;;
   mcp__mem0__get_memories|mcp__plugin_mem0_mem0__get_memories)
     HANDLER="get_memories" ;;
+  mcp__mem0__get_memory|mcp__plugin_mem0_mem0__get_memory)
+    HANDLER="get_memory" ;;
+  mcp__mem0__update_memory|mcp__plugin_mem0_mem0__update_memory)
+    HANDLER="update_memory" ;;
+  mcp__mem0__delete_memory|mcp__plugin_mem0_mem0__delete_memory)
+    HANDLER="delete_memory" ;;
   mcp__mem0__delete_all_memories|mcp__plugin_mem0_mem0__delete_all_memories)
-    HANDLER="delete_all" ;;
-  *) exit 0 ;;
+    HANDLER="delete_all_memories" ;;
+  mcp__mem0__delete_entities|mcp__plugin_mem0_mem0__delete_entities)
+    HANDLER="delete_entities" ;;
+  mcp__mem0__list_entities|mcp__plugin_mem0_mem0__list_entities)
+    HANDLER="list_entities" ;;
+  *)
+    echo "remote-unknown-operation: unclassified Mem0 MCP tool $TOOL_NAME" >&2
+    exit 2 ;;
 esac
 
 TOOL_INPUT=$(echo "$INPUT" | jq -r '.tool_input // "{}"' 2>/dev/null)
+
+# Admission is synchronous: no MCP request is allowed until the monotonic
+# charge is committed. Explicit MCP calls are intentionally not coalesced.
+_PAYLOAD_BYTES=$(printf '%s' "$TOOL_INPUT" | wc -c | tr -d '[:space:]')
+_ADMISSION_SESSION_ID="${MEM0_SESSION_ID:-default}"
+_ADMISSION_OUT=$(python3 "$SCRIPT_DIR/admission_cli.py" charge \
+  --operation "$HANDLER" \
+  --ingress "mcp-pretooluse" \
+  --session-id "$_ADMISSION_SESSION_ID" \
+  --payload-bytes "${_PAYLOAD_BYTES:-0}" 2>/dev/null)
+_ADMISSION_STATUS=$?
+if [ "$_ADMISSION_STATUS" -ne 0 ]; then
+  _REASON=$(printf '%s' "$_ADMISSION_OUT" | jq -r '.reason // "remote-accounting-unavailable"' 2>/dev/null || echo "remote-accounting-unavailable")
+  echo "${_REASON}: hosted Mem0 request denied" >&2
+  exit 2
+fi
 
 _PATCH_OUT="/tmp/mem0_enforce_$$"
 trap 'rm -f "$_PATCH_OUT"' EXIT
@@ -185,8 +211,12 @@ elif handler in ("search_memories", "get_memories"):
     else:
         changed = inject_filter_identity(inp, resolved_uid, resolved_aid)
 
-elif handler == "delete_all":
+elif handler == "delete_all_memories":
     changed = inject_top_level_identity(inp, resolved_uid, resolved_aid)
+
+# get_memory/update_memory/delete_memory are record-scoped. delete_entities
+# and list_entities have operation-specific entity parameters. None accepts
+# the generic identity defaults above, so those five are admission-only.
 
 if changed:
     print(json.dumps(inp))
@@ -202,6 +232,13 @@ if [ -n "$PATCHED" ] && echo "$PATCHED" | jq empty 2>/dev/null; then
       "updatedInput": $updated
     }
   }' 2>/dev/null || true
+else
+  jq -n '{
+    "hookSpecificOutput": {
+      "hookEventName": "PreToolUse",
+      "permissionDecision": "allow"
+    }
+  }' 2>/dev/null || true
 fi
 
 # Track session stats here because PostToolUse hooks don't fire for plugin MCP tools.
@@ -210,7 +247,7 @@ case "$HANDLER" in
     _CAT=$(echo "$TOOL_INPUT" | jq -r '.metadata.type // .metadata.category // ""' 2>/dev/null || echo "")
     python3 "$SCRIPT_DIR/session_stats.py" add "$_CAT" 2>/dev/null &
     ;;
-  search_memories|get_memories)
+  search_memories|get_memories|get_memory|list_entities)
     python3 "$SCRIPT_DIR/session_stats.py" search 2>/dev/null &
     ;;
 esac

--- a/integrations/mem0-plugin/scripts/enforce_metadata_defaults.sh
+++ b/integrations/mem0-plugin/scripts/enforce_metadata_defaults.sh
@@ -54,7 +54,9 @@ TOOL_INPUT=$(echo "$INPUT" | jq -r '.tool_input // "{}"' 2>/dev/null)
 # charge is committed. Explicit MCP calls are intentionally not coalesced.
 _PAYLOAD_BYTES=$(printf '%s' "$TOOL_INPUT" | wc -c | tr -d '[:space:]')
 _ADMISSION_SESSION_ID="${MEM0_SESSION_ID:-default}"
-_ADMISSION_OUT=$(python3 "$SCRIPT_DIR/admission_cli.py" charge \
+# Bound accounting below the host's 3s hook deadline. Timeout or missing Perl
+# returns non-zero and therefore follows the same fail-closed denial path.
+_ADMISSION_OUT=$(perl -e 'alarm 2; exec @ARGV' python3 "$SCRIPT_DIR/admission_cli.py" charge \
   --operation "$HANDLER" \
   --ingress "mcp-pretooluse" \
   --session-id "$_ADMISSION_SESSION_ID" \

--- a/integrations/mem0-plugin/scripts/file_context.py
+++ b/integrations/mem0-plugin/scripts/file_context.py
@@ -94,6 +94,8 @@ def search_file_context(
         top_k=MAX_RESULTS, threshold=0.3,
         global_search=global_search,
         rerank=should_rerank(),
+        ingress="file-read",
+        automatic=True,
     )
 
     results = results[:MAX_RESULTS]

--- a/integrations/mem0-plugin/scripts/hosted_request.py
+++ b/integrations/mem0-plugin/scripts/hosted_request.py
@@ -1,0 +1,75 @@
+"""Single transport owner for direct hosted Mem0 HTTP requests."""
+
+from __future__ import annotations
+
+import os
+import urllib.request
+
+from admission import AdmissionResult, admit
+
+
+class HostedRequestDenied(RuntimeError):
+    def __init__(self, result: AdmissionResult):
+        self.result = result
+        super().__init__(result.reason or "remote-request-denied")
+
+
+def require_admission(
+    operation: str,
+    ingress: str,
+    automatic: bool,
+    *,
+    payload_bytes: int = 0,
+) -> AdmissionResult:
+    """Admission bridge for hosted SDK calls that do not expose HTTP requests."""
+    result = admit(
+        operation,
+        ingress,
+        automatic,
+        os.environ.get("MEM0_SESSION_ID", "default"),
+        payload_bytes=payload_bytes,
+    )
+    if not result.admitted:
+        raise HostedRequestDenied(result)
+    return result
+
+
+def _operation_for(request: urllib.request.Request) -> str:
+    url = request.full_url.lower()
+    method = request.get_method().upper()
+    if "/search" in url:
+        return "search"
+    if method == "DELETE":
+        return "delete"
+    if "/add" in url or method == "POST":
+        return "add" if "/add" in url else "list"
+    if method in {"PUT", "PATCH"}:
+        return "update"
+    return "get"
+
+
+def open_hosted_request(
+    request: urllib.request.Request,
+    *,
+    timeout: float,
+    ingress: str,
+    automatic: bool,
+    operation: str | None = None,
+    session_id: str | None = None,
+    charge_id: str | None = None,
+    coalesce_key: str | None = None,
+):
+    """Charge atomically, then open a hosted HTTP request.
+
+    The returned object is the ordinary ``urlopen`` response and can be used as
+    a context manager. A denied request never reaches the network.
+    """
+    payload = request.data or b""
+    result = admit(
+        operation or _operation_for(request), ingress, automatic,
+        session_id or os.environ.get("MEM0_SESSION_ID", "default"),
+        payload_bytes=len(payload), charge_id=charge_id, coalesce_key=coalesce_key,
+    )
+    if not result.admitted:
+        raise HostedRequestDenied(result)
+    return urllib.request.urlopen(request, timeout=timeout)

--- a/integrations/mem0-plugin/scripts/import_competing_tools.py
+++ b/integrations/mem0-plugin/scripts/import_competing_tools.py
@@ -32,6 +32,7 @@ from _chunking import (
 )
 from _identity import resolve_api_key, resolve_user_id
 from _project import resolve_branch, resolve_project_id
+from hosted_request import HostedRequestDenied, open_hosted_request
 
 API_URL = "https://api.mem0.ai"
 HASH_STORE = os.path.expanduser("~/.mem0/import_hashes.json")
@@ -92,9 +93,9 @@ def post_memory(api_key: str, content: str, user_id: str, project_id: str, branc
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=20) as resp:
+        with open_hosted_request(req, timeout=20, ingress="explicit-import", automatic=False, operation="import") as resp:
             return resp.status in (200, 201)
-    except urllib.error.URLError as e:
+    except (urllib.error.URLError, HostedRequestDenied) as e:
         print(f"  [warn] API call failed: {e}", file=sys.stderr)
         return False
 

--- a/integrations/mem0-plugin/scripts/load_settings.py
+++ b/integrations/mem0-plugin/scripts/load_settings.py
@@ -12,7 +12,7 @@ SETTINGS_PATH = Path.home() / ".mem0" / "settings.json"
 
 DEFAULTS = {
     "auto_save": True,
-    "auto_search": True,
+    "auto_search": False,
     "search_limit": 10,
     "retention_session_days": 90,
     "confidence_threshold": 0.3,

--- a/integrations/mem0-plugin/scripts/on_bash_output.sh
+++ b/integrations/mem0-plugin/scripts/on_bash_output.sh
@@ -70,6 +70,9 @@ python3 "$SCRIPT_DIR/telemetry.py" bash_error --error_detected 2>/dev/null &
 if [ -z "${MEM0_API_KEY:-}" ]; then
   exit 0
 fi
+if [ "${MEM0_AUTO_SEARCH:-false}" != "true" ]; then
+  exit 0
+fi
 
 # Pre-fetch memories: anti_pattern and bug_fix searches
 RESULTS=$(PYTHONPATH="$SCRIPT_DIR" MEM0_SEARCH_QUERY="$ERROR_QUERY" MEM0_SEARCH_USER="$USER_ID" \
@@ -85,8 +88,8 @@ project_id = os.environ.get('MEM0_PROJECT_ID', 'unknown')
 query = os.environ.get('MEM0_SEARCH_QUERY', '')
 rerank = should_rerank()
 
-r1 = search_memories(api_key, user_id, project_id, query, metadata_type='anti_pattern', top_k=3, rerank=rerank)
-r2 = search_memories(api_key, user_id, project_id, query, metadata_type='bug_fix', top_k=3, rerank=rerank)
+r1 = search_memories(api_key, user_id, project_id, query, metadata_type='anti_pattern', top_k=3, rerank=rerank, ingress='bash-error-anti-pattern', automatic=True)
+r2 = search_memories(api_key, user_id, project_id, query, metadata_type='bug_fix', top_k=3, rerank=rerank, ingress='bash-error-bug-fix', automatic=True)
 
 seen = set()
 combined = []

--- a/integrations/mem0-plugin/scripts/on_file_read.sh
+++ b/integrations/mem0-plugin/scripts/on_file_read.sh
@@ -23,9 +23,10 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# Resolve API key (covers Desktop app users who set it in shell profile)
-if [ -z "${MEM0_API_KEY:-}" ]; then
-  . "$SCRIPT_DIR/_identity.sh" 2>/dev/null || true
+# Resolve settings and API key (covers Desktop users and default-off search).
+. "$SCRIPT_DIR/_identity.sh" 2>/dev/null || true
+if [ "${MEM0_AUTO_SEARCH:-false}" != "true" ]; then
+  exit 0
 fi
 if [ -z "${MEM0_API_KEY:-}" ]; then
   exit 0

--- a/integrations/mem0-plugin/scripts/on_file_read_cursor.sh
+++ b/integrations/mem0-plugin/scripts/on_file_read_cursor.sh
@@ -13,15 +13,15 @@ if [ -z "$FILE_PATH" ]; then
   exit 0
 fi
 
-if [ -z "${MEM0_API_KEY:-}" ]; then
-  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-  . "$SCRIPT_DIR/_identity.sh" 2>/dev/null || true
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/_identity.sh" 2>/dev/null || true
+if [ "${MEM0_AUTO_SEARCH:-false}" != "true" ]; then
+  exit 0
 fi
 if [ -z "${MEM0_API_KEY:-}" ]; then
   exit 0
 fi
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CWD=$(echo "$INPUT" | jq -r '.cwd // "."' 2>/dev/null || echo ".")
 
 TIMELINE=$(python3 "$SCRIPT_DIR/file_context.py" "$FILE_PATH" "$CWD" 2>/dev/null || echo "")

--- a/integrations/mem0-plugin/scripts/on_pre_compact.py
+++ b/integrations/mem0-plugin/scripts/on_pre_compact.py
@@ -25,6 +25,7 @@ from datetime import date, timedelta
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _identity import resolve_api_key, resolve_user_id
 from _project import resolve_branch, resolve_project_id
+from hosted_request import HostedRequestDenied, open_hosted_request
 
 log = logging.getLogger("mem0-capture")
 log.setLevel(logging.DEBUG)
@@ -191,13 +192,13 @@ def store_memory(api_key: str, content: str, user_id: str, source: str, session_
     )
 
     try:
-        with urllib.request.urlopen(req, timeout=15) as resp:
+        with open_hosted_request(req, timeout=15, ingress="pre-compact", automatic=True, operation="add") as resp:
             if resp.status in (200, 201):
                 log.info("Session state stored successfully")
                 return True
             log.warning("API returned status %d", resp.status)
             return False
-    except urllib.error.URLError as e:
+    except (urllib.error.URLError, HostedRequestDenied) as e:
         log.warning("API call failed: %s", e)
         return False
 

--- a/integrations/mem0-plugin/scripts/on_session_start.sh
+++ b/integrations/mem0-plugin/scripts/on_session_start.sh
@@ -150,13 +150,15 @@ if [ "$SOURCE" = "startup" ]; then
       python3 "$SCRIPT_DIR/auto_import.py" 2>/dev/null &
   fi
 
-  # Configure the coding-category taxonomy in the background (idempotent, never blocks).
-  # Prefer the venv python since this path needs the mem0ai SDK.
-  _VENV_PY="${CLAUDE_PLUGIN_DATA:-$HOME/.mem0/plugin-data}/venv/bin/python3"
-  if [ -x "$_VENV_PY" ]; then
-    MEM0_CWD="$MEM0_CWD_RESOLVED" "$_VENV_PY" "$SCRIPT_DIR/auto_setup_categories.py" 2>/dev/null &
-  else
-    MEM0_CWD="$MEM0_CWD_RESOLVED" python3 "$SCRIPT_DIR/auto_setup_categories.py" 2>/dev/null &
+  # Taxonomy setup performs hosted get/update calls, so it shares the same
+  # explicit automatic-retrieval opt-in as the other SessionStart helpers.
+  if [ "${MEM0_AUTO_SEARCH:-false}" = "true" ]; then
+    _VENV_PY="${CLAUDE_PLUGIN_DATA:-$HOME/.mem0/plugin-data}/venv/bin/python3"
+    if [ -x "$_VENV_PY" ]; then
+      MEM0_CWD="$MEM0_CWD_RESOLVED" "$_VENV_PY" "$SCRIPT_DIR/auto_setup_categories.py" 2>/dev/null &
+    else
+      MEM0_CWD="$MEM0_CWD_RESOLVED" python3 "$SCRIPT_DIR/auto_setup_categories.py" 2>/dev/null &
+    fi
   fi
 
 elif [ "$SOURCE" = "resume" ]; then

--- a/integrations/mem0-plugin/scripts/on_session_start.sh
+++ b/integrations/mem0-plugin/scripts/on_session_start.sh
@@ -70,39 +70,10 @@ if [ -f "${_DATA_DIR}/.install-failed" ]; then
 fi
 
 MEM0_COUNT="?"
-if command -v python3 >/dev/null 2>&1; then
-  MEM0_COUNT=$(python3 -c "
-import json, os, urllib.request, urllib.error
-api_key = os.environ.get('MEM0_API_KEY', '')
-user_id = os.environ.get('MEM0_RESOLVED_USER_ID', 'default')
-app_id = os.environ.get('MEM0_PROJECT_ID', '')
-global_search = os.environ.get('MEM0_GLOBAL_SEARCH', 'false') == 'true'
-
-def get_count(filters):
-    body = json.dumps({'filters': filters}).encode()
-    req = urllib.request.Request(
-        'https://api.mem0.ai/v3/memories/?page=1&page_size=1',
-        headers={'Authorization': f'Token {api_key}', 'Content-Type': 'application/json'},
-        data=body, method='POST',
-    )
-    with urllib.request.urlopen(req, timeout=5) as r:
-        data = json.loads(r.read())
-        if isinstance(data, dict) and 'count' in data:
-            return data['count']
-        if isinstance(data, list):
-            return len(data)
-    return 0
-
-try:
-    if global_search:
-        filters = {'OR': [{'user_id': '*'}]}
-    else:
-        filters = {'AND': [{'user_id': user_id}, {'app_id': app_id}]}
-    total = get_count(filters)
-    print(total)
-except Exception:
-    print('?')
-" 2>/dev/null || echo "?")
+if command -v python3 >/dev/null 2>&1 && [ "${MEM0_AUTO_SEARCH:-false}" = "true" ]; then
+  MEM0_COUNT=$(python3 "$SCRIPT_DIR/count_memories.py" 2>/dev/null || echo "?")
+elif [ "${MEM0_AUTO_SEARCH:-false}" != "true" ]; then
+  MEM0_COUNT="not-loaded"
 fi
 
 _UID="${MEM0_RESOLVED_USER_ID:-${USER:-default}}"
@@ -152,7 +123,9 @@ if command -v python3 >/dev/null 2>&1; then
 fi
 
 if [ "$SOURCE" = "startup" ]; then
-  if [ "$MEM0_COUNT" = "0" ]; then
+  if [ "${MEM0_AUTO_SEARCH:-false}" != "true" ]; then
+    echo "Automatic hosted retrieval is off. Use explicit Mem0 search only when it is high value."
+  elif [ "$MEM0_COUNT" = "0" ]; then
     echo "New project with 0 memories. Invoke the mem0:onboard skill to import project files. Coding categories install automatically in the background."
   else
     echo "Search mem0 for recent decisions and task learnings before responding. Run 2 parallel searches: one for decision type, one for task_learning type."
@@ -172,8 +145,10 @@ if [ "$SOURCE" = "startup" ]; then
     echo "Native MEMORY.md detected at ${_MEMORY_MD}. Add autoMemoryEnabled:false to settings.json or run /mem0:import."
   fi
 
-  MEM0_CWD="$MEM0_CWD_RESOLVED" \
-    python3 "$SCRIPT_DIR/auto_import.py" 2>/dev/null &
+  if [ "${MEM0_AUTO_SEARCH:-false}" = "true" ]; then
+    MEM0_CWD="$MEM0_CWD_RESOLVED" \
+      python3 "$SCRIPT_DIR/auto_import.py" 2>/dev/null &
+  fi
 
   # Configure the coding-category taxonomy in the background (idempotent, never blocks).
   # Prefer the venv python since this path needs the mem0ai SDK.

--- a/integrations/mem0-plugin/scripts/on_user_prompt.sh
+++ b/integrations/mem0-plugin/scripts/on_user_prompt.sh
@@ -117,7 +117,7 @@ USER_ID="$MEM0_RESOLVED_USER_ID"
 
 _PROMPT_CTX=""
 
-if [ -n "$HAS_RESUME" ]; then
+if [ -n "$HAS_RESUME" ] && [ "${MEM0_AUTO_SEARCH:-false}" = "true" ]; then
   RESUME_RESULTS=$(PYTHONPATH="$SCRIPT_DIR" MEM0_SEARCH_USER="$USER_ID" python3 -c "
 import os, sys
 sys.path.insert(0, os.environ.get('PYTHONPATH', '.'))
@@ -128,8 +128,8 @@ user_id = os.environ.get('MEM0_SEARCH_USER', 'default')
 project_id = os.environ.get('MEM0_PROJECT_ID', 'unknown')
 rerank = should_rerank()
 
-state = search_memories(api_key, user_id, project_id, 'session state current task', metadata_type='session_state', top_k=3, rerank=rerank)
-decisions = search_memories(api_key, user_id, project_id, 'recent decisions and learnings', metadata_type='decision', top_k=3, rerank=rerank)
+state = search_memories(api_key, user_id, project_id, 'session state current task', metadata_type='session_state', top_k=3, rerank=rerank, ingress='prompt-resume-state', automatic=True)
+decisions = search_memories(api_key, user_id, project_id, 'recent decisions and learnings', metadata_type='decision', top_k=3, rerank=rerank, ingress='prompt-resume-decisions', automatic=True)
 
 all_r = state + decisions
 seen = set()
@@ -157,7 +157,7 @@ fi
 # matches so relevant memories are guaranteed in context, not left for the agent
 # to fetch. Skipped on resume (handled above with targeted queries) and when
 # MEM0_PREFETCH=false.
-if [ -z "$HAS_RESUME" ] && [ "${MEM0_PREFETCH:-true}" != "false" ]; then
+if [ -z "$HAS_RESUME" ] && [ "${MEM0_PREFETCH:-true}" != "false" ] && [ "${MEM0_AUTO_SEARCH:-false}" = "true" ]; then
   PREFETCH_RESULTS=$(PYTHONPATH="$SCRIPT_DIR" MEM0_SEARCH_USER="$USER_ID" MEM0_SEARCH_QUERY="$PROMPT" python3 -c "
 import os, sys
 sys.path.insert(0, os.environ.get('PYTHONPATH', '.'))
@@ -168,7 +168,7 @@ user_id = os.environ.get('MEM0_SEARCH_USER', 'default')
 project_id = os.environ.get('MEM0_PROJECT_ID', 'unknown')
 query = os.environ.get('MEM0_SEARCH_QUERY', '')
 
-results = search_memories(api_key, user_id, project_id, query, top_k=5, rerank=should_rerank())
+results = search_memories(api_key, user_id, project_id, query, top_k=5, rerank=should_rerank(), ingress='prompt-prefetch', automatic=True)
 if results:
     print(format_results_for_context(results, heading='Relevant memories (auto-retrieved for this request)'))
 " 2>/dev/null || echo "")

--- a/integrations/mem0-plugin/scripts/session_timeline.py
+++ b/integrations/mem0-plugin/scripts/session_timeline.py
@@ -20,6 +20,8 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _formatting import TYPE_ICONS, format_age
 from _identity import resolve_api_key, resolve_user_id
 from _project import resolve_project_id
+from hosted_request import open_hosted_request
+from load_settings import load_settings
 
 API_URL = "https://api.mem0.ai"
 MAX_RECENT = 10
@@ -29,6 +31,8 @@ FETCH_TIMEOUT = 5
 
 def fetch_recent_memories(api_key: str, user_id: str, project_id: str) -> list[dict]:
     """Fetch the most recent memories for this project via GET list endpoint."""
+    if not load_settings().get("auto_search", False):
+        return []
     global_search = os.environ.get("MEM0_GLOBAL_SEARCH", "false") == "true"
 
     if global_search:
@@ -47,7 +51,14 @@ def fetch_recent_memories(api_key: str, user_id: str, project_id: str) -> list[d
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=FETCH_TIMEOUT) as r:
+        with open_hosted_request(
+            req,
+            timeout=FETCH_TIMEOUT,
+            ingress="session-timeline",
+            automatic=True,
+            operation="list",
+            coalesce_key=f"session-timeline:{user_id}:{project_id}",
+        ) as r:
             result = json.loads(r.read())
             if isinstance(result, dict) and "results" in result:
                 return result["results"][:MAX_RECENT]

--- a/integrations/mem0-plugin/scripts/setup_coding_categories.py
+++ b/integrations/mem0-plugin/scripts/setup_coding_categories.py
@@ -25,6 +25,7 @@ import sys
 _script_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, _script_dir)
 from _identity import resolve_api_key  # noqa: E402
+from hosted_request import require_admission  # noqa: E402
 
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT", os.path.join(_script_dir, ".."))
 _data_dir = os.environ.get("CLAUDE_PLUGIN_DATA", os.path.join(os.path.expanduser("~"), ".mem0", "plugin-data"))
@@ -204,6 +205,7 @@ def main() -> int:
         return 1
 
     try:
+        require_admission("get", "explicit-categories-get", False)
         current = client.project.get(fields=["custom_categories"])
         current_cats = current.get("custom_categories") if isinstance(current, dict) else None
     except Exception as e:
@@ -223,6 +225,12 @@ def main() -> int:
 
     print("Applying coding categories...")
     try:
+        require_admission(
+            "update",
+            "explicit-categories-update",
+            False,
+            payload_bytes=len(json.dumps(CODING_CATEGORIES).encode()),
+        )
         response = client.project.update(custom_categories=CODING_CATEGORIES)
     except Exception as e:
         print(f"ERROR applying update: {e}", file=sys.stderr)

--- a/integrations/mem0-plugin/skills/onboard/SKILL.md
+++ b/integrations/mem0-plugin/skills/onboard/SKILL.md
@@ -116,7 +116,7 @@ If no files found, print `- No project files found. Skipping import.` and procee
 Run auto_import in foreground to check status and import if needed:
 
 ```bash
-MEM0_DEBUG=1 MEM0_CWD="$PWD" python3 "${CLAUDE_PLUGIN_ROOT}/scripts/auto_import.py"
+MEM0_DEBUG=1 MEM0_IMPORT_EXPLICIT=1 MEM0_CWD="$PWD" python3 "${CLAUDE_PLUGIN_ROOT}/scripts/auto_import.py"
 ```
 
 ### 4c: Report to user

--- a/integrations/mem0-plugin/tests/conftest.py
+++ b/integrations/mem0-plugin/tests/conftest.py
@@ -34,6 +34,21 @@ def _clean_project_map(monkeypatch):
         os.remove(map_path)
 
 
+@pytest.fixture(autouse=True)
+def _isolated_admission_state(monkeypatch, tmp_path):
+    """Tests must never consume the operator's real hosted-memory budget."""
+    monkeypatch.setenv("MEM0_STATE_DIR", str(tmp_path / "mem0-state"))
+    for name in (
+        "MEM0_BUDGET_SESSION_REQUESTS",
+        "MEM0_BUDGET_DAILY_REQUESTS",
+        "MEM0_BUDGET_SESSION_AUTO_REQUESTS",
+        "MEM0_BUDGET_DAILY_AUTO_REQUESTS",
+        "MEM0_BUDGET_SESSION_WEIGHT",
+        "MEM0_BUDGET_DAILY_WEIGHT",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
 @pytest.fixture()
 def tmp_git_repo(tmp_path):
     """Create a temp dir with a git repo and HTTPS remote."""

--- a/integrations/mem0-plugin/tests/test_admission.py
+++ b/integrations/mem0-plugin/tests/test_admission.py
@@ -299,3 +299,39 @@ def test_session_start_launcher_does_not_spawn_automatic_hosted_helpers_by_defau
     assert result.returncode == 0
     assert not marker.exists()
     assert not (state / "admission.sqlite3").exists()
+
+
+@pytest.mark.parametrize("opted_in", [False, True])
+def test_prompt_prefetch_respects_auto_search_and_budget(tmp_path, opted_in):
+    if opted_in:
+        settings = tmp_path / ".mem0" / "settings.json"
+        settings.parent.mkdir()
+        settings.write_text(json.dumps({"auto_search": True}))
+    state = tmp_path / "state"
+    hook = os.path.join(os.path.dirname(__file__), "..", "scripts", "on_user_prompt.sh")
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(tmp_path),
+            "USER": f"prefetch-{tmp_path.name}",
+            "MEM0_API_KEY": "sentinel-no-network",
+            "MEM0_STATE_DIR": str(state),
+            "MEM0_BUDGET_SESSION_REQUESTS": "0",
+            "MEM0_RUBRIC_DIR": str(tmp_path),
+        }
+    )
+    result = subprocess.run(
+        [hook],
+        input=json.dumps(
+            {
+                "prompt": "Explain the current architecture decision and its tradeoffs.",
+                "session_id": "prefetch-test",
+                "cwd": str(tmp_path),
+            }
+        ),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert (state / "admission.sqlite3").exists() is opted_in

--- a/integrations/mem0-plugin/tests/test_admission.py
+++ b/integrations/mem0-plugin/tests/test_admission.py
@@ -1,0 +1,265 @@
+"""Cost-admission contracts for hosted Mem0 traffic."""
+
+from __future__ import annotations
+
+import concurrent.futures
+import importlib
+import os
+import subprocess
+import sys
+import urllib.request
+import uuid
+import json
+from unittest.mock import patch
+
+import pytest
+
+
+def _reset_budget_env(monkeypatch):
+    for name in (
+        "MEM0_BUDGET_SESSION_REQUESTS",
+        "MEM0_BUDGET_DAILY_REQUESTS",
+        "MEM0_BUDGET_SESSION_AUTO_REQUESTS",
+        "MEM0_BUDGET_DAILY_AUTO_REQUESTS",
+        "MEM0_BUDGET_SESSION_WEIGHT",
+        "MEM0_BUDGET_DAILY_WEIGHT",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_default_auto_search_is_off_in_python_resolution(monkeypatch, tmp_path):
+    monkeypatch.setattr("load_settings.SETTINGS_PATH", tmp_path / "missing.json")
+    import load_settings
+    import _identity
+
+    importlib.reload(load_settings)
+    importlib.reload(_identity)
+    monkeypatch.setattr(load_settings, "SETTINGS_PATH", tmp_path / "missing.json")
+    assert load_settings.load_settings()["auto_search"] is False
+    assert _identity.resolve_config()["auto_search"] is False
+
+
+def test_atomic_session_limit_across_processes(monkeypatch, tmp_path):
+    _reset_budget_env(monkeypatch)
+    monkeypatch.setenv("MEM0_STATE_DIR", str(tmp_path))
+    monkeypatch.setenv("MEM0_BUDGET_SESSION_REQUESTS", "1")
+    env = os.environ.copy()
+    script = os.path.join(os.path.dirname(__file__), "..", "scripts", "admission_cli.py")
+
+    def charge_once():
+        return subprocess.run(
+            [
+                sys.executable,
+                script,
+                "charge",
+                "--operation",
+                "search",
+                "--ingress",
+                "test",
+                "--session-id",
+                "one-session",
+                "--charge-id",
+                str(uuid.uuid4()),
+            ],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(lambda _: charge_once(), range(8)))
+
+    assert sum(result.returncode == 0 for result in results) == 1
+    assert sum(result.returncode == 2 for result in results) == 7
+
+
+def test_duplicate_charge_id_is_idempotent(monkeypatch, tmp_path):
+    _reset_budget_env(monkeypatch)
+    monkeypatch.setenv("MEM0_STATE_DIR", str(tmp_path))
+    monkeypatch.setenv("MEM0_BUDGET_SESSION_REQUESTS", "1")
+    from admission import admit
+
+    first = admit("search", "test", False, "session", charge_id="same")
+    second = admit("search", "test", False, "session", charge_id="same")
+
+    assert first.admitted is True
+    assert second.admitted is True
+    assert second.idempotent is True
+
+
+def test_automatic_ceiling_preserves_explicit_reserve(monkeypatch, tmp_path):
+    _reset_budget_env(monkeypatch)
+    monkeypatch.setenv("MEM0_STATE_DIR", str(tmp_path))
+    monkeypatch.setenv("MEM0_BUDGET_SESSION_REQUESTS", "2")
+    monkeypatch.setenv("MEM0_BUDGET_SESSION_AUTO_REQUESTS", "1")
+    from admission import admit
+
+    assert admit("search", "hook", True, "session").admitted
+    denied = admit("search", "hook", True, "session")
+    assert denied.admitted is False
+    assert denied.reason == "remote-automatic-budget-exhausted"
+    assert admit("search", "explicit", False, "session").admitted
+
+
+def test_daily_request_ceiling_spans_sessions(monkeypatch, tmp_path):
+    _reset_budget_env(monkeypatch)
+    monkeypatch.setenv("MEM0_STATE_DIR", str(tmp_path))
+    monkeypatch.setenv("MEM0_BUDGET_DAILY_REQUESTS", "1")
+    from admission import admit
+
+    assert admit("search", "test", False, "session-a").admitted
+    denied = admit("search", "test", False, "session-b")
+    assert denied.admitted is False
+    assert denied.reason == "remote-daily-budget-exhausted"
+
+
+def test_daily_weight_ceiling_spans_sessions(monkeypatch, tmp_path):
+    _reset_budget_env(monkeypatch)
+    monkeypatch.setenv("MEM0_STATE_DIR", str(tmp_path))
+    monkeypatch.setenv("MEM0_BUDGET_DAILY_WEIGHT", "3")
+    from admission import admit
+
+    assert admit("add", "test", False, "session-a", payload_bytes=1).admitted
+    denied = admit("search", "test", False, "session-b")
+    assert denied.admitted is False
+    assert denied.reason == "remote-daily-weight-exhausted"
+
+
+@pytest.mark.parametrize("value", ["-1", "garbage", "1.5"])
+def test_invalid_budget_configuration_fails_closed(monkeypatch, tmp_path, value):
+    _reset_budget_env(monkeypatch)
+    monkeypatch.setenv("MEM0_STATE_DIR", str(tmp_path))
+    monkeypatch.setenv("MEM0_BUDGET_DAILY_REQUESTS", value)
+    from admission import admit
+
+    result = admit("search", "test", False, "session")
+    assert result.admitted is False
+    assert result.reason == "remote-invalid-budget-config"
+
+
+def test_unwritable_accounting_fails_closed(monkeypatch, tmp_path):
+    _reset_budget_env(monkeypatch)
+    state_file = tmp_path / "not-a-directory"
+    state_file.write_text("x")
+    monkeypatch.setenv("MEM0_STATE_DIR", str(state_file))
+    from admission import admit
+
+    result = admit("search", "test", False, "session")
+    assert result.admitted is False
+    assert result.reason == "remote-accounting-unavailable"
+
+
+def test_weight_ceiling_is_monotonic(monkeypatch, tmp_path):
+    _reset_budget_env(monkeypatch)
+    monkeypatch.setenv("MEM0_STATE_DIR", str(tmp_path))
+    monkeypatch.setenv("MEM0_BUDGET_SESSION_WEIGHT", "3")
+    from admission import admit
+
+    assert admit("add", "test", False, "session", payload_bytes=1).admitted
+    denied = admit("search", "test", False, "session")
+    assert denied.admitted is False
+    assert denied.reason == "remote-session-weight-exhausted"
+
+
+def test_automatic_search_coalesces_before_charge(monkeypatch, tmp_path):
+    _reset_budget_env(monkeypatch)
+    monkeypatch.setenv("MEM0_STATE_DIR", str(tmp_path))
+    from admission import admit
+
+    first = admit("search", "read", True, "session", coalesce_key="same-scope-query")
+    duplicate = admit("search", "read", True, "session", coalesce_key="same-scope-query")
+    assert first.admitted is True
+    assert duplicate.admitted is False
+    assert duplicate.reason == "remote-coalesced"
+
+
+def test_denied_hosted_request_never_reaches_network(monkeypatch, tmp_path):
+    _reset_budget_env(monkeypatch)
+    monkeypatch.setenv("MEM0_STATE_DIR", str(tmp_path))
+    monkeypatch.setenv("MEM0_BUDGET_SESSION_REQUESTS", "0")
+    from hosted_request import HostedRequestDenied, open_hosted_request
+
+    request = urllib.request.Request("https://api.mem0.ai/v3/memories/search/")
+    with patch("urllib.request.urlopen") as network:
+        with pytest.raises(HostedRequestDenied):
+            open_hosted_request(
+                request,
+                timeout=1,
+                ingress="test",
+                automatic=False,
+                operation="search",
+            )
+    network.assert_not_called()
+
+
+def test_file_read_hook_default_off_never_enters_admission(tmp_path):
+    target = tmp_path / "large.py"
+    target.write_text("x" * 2000)
+    state = tmp_path / "state"
+    hook = os.path.join(os.path.dirname(__file__), "..", "scripts", "on_file_read.sh")
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(tmp_path),
+            "MEM0_API_KEY": "sentinel-no-network",
+            "MEM0_STATE_DIR": str(state),
+            "MEM0_BUDGET_SESSION_REQUESTS": "0",
+        }
+    )
+    result = subprocess.run(
+        [hook],
+        input=json.dumps({"tool_input": {"file_path": str(target)}, "cwd": str(tmp_path)}),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert not (state / "admission.sqlite3").exists()
+
+
+def test_file_read_hook_explicit_opt_in_reaches_admission_not_network(tmp_path):
+    target = tmp_path / "large.py"
+    target.write_text("x" * 2000)
+    settings = tmp_path / ".mem0" / "settings.json"
+    settings.parent.mkdir()
+    settings.write_text(json.dumps({"auto_search": True}))
+    state = tmp_path / "state"
+    hook = os.path.join(os.path.dirname(__file__), "..", "scripts", "on_file_read.sh")
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(tmp_path),
+            "MEM0_API_KEY": "sentinel-no-network",
+            "MEM0_STATE_DIR": str(state),
+            "MEM0_BUDGET_SESSION_REQUESTS": "0",
+        }
+    )
+    result = subprocess.run(
+        [hook],
+        input=json.dumps({"tool_input": {"file_path": str(target)}, "cwd": str(tmp_path)}),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert (state / "admission.sqlite3").exists()
+
+
+@pytest.mark.parametrize("helper", ["count_memories.py", "session_timeline.py"])
+def test_session_start_helpers_default_off_never_enter_admission(tmp_path, helper):
+    state = tmp_path / "state"
+    script = os.path.join(os.path.dirname(__file__), "..", "scripts", helper)
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(tmp_path),
+            "MEM0_API_KEY": "sentinel-no-network",
+            "MEM0_STATE_DIR": str(state),
+            "MEM0_BUDGET_SESSION_REQUESTS": "0",
+        }
+    )
+    result = subprocess.run(
+        [sys.executable, script], env=env, capture_output=True, text=True
+    )
+    assert result.returncode == 0
+    assert not (state / "admission.sqlite3").exists()

--- a/integrations/mem0-plugin/tests/test_admission.py
+++ b/integrations/mem0-plugin/tests/test_admission.py
@@ -10,6 +10,8 @@ import sys
 import urllib.request
 import uuid
 import json
+import shutil
+import time
 from unittest.mock import patch
 
 import pytest
@@ -262,4 +264,38 @@ def test_session_start_helpers_default_off_never_enter_admission(tmp_path, helpe
         [sys.executable, script], env=env, capture_output=True, text=True
     )
     assert result.returncode == 0
+    assert not (state / "admission.sqlite3").exists()
+
+
+def test_session_start_launcher_does_not_spawn_automatic_hosted_helpers_by_default(tmp_path):
+    source_scripts = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "scripts"))
+    scripts = tmp_path / "scripts"
+    shutil.copytree(source_scripts, scripts)
+    marker = tmp_path / "automatic-helper-ran"
+    sentinel = f"#!/bin/sh\necho ran >> {marker}\n"
+    for name in ("auto_import.py", "auto_setup_categories.py"):
+        helper = scripts / name
+        helper.write_text(sentinel)
+        helper.chmod(0o755)
+
+    state = tmp_path / "state"
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(tmp_path / "home"),
+            "MEM0_API_KEY": "sentinel-no-network",
+            "MEM0_STATE_DIR": str(state),
+            "CLAUDE_PLUGIN_DATA": str(tmp_path / "plugin-data"),
+        }
+    )
+    result = subprocess.run(
+        [scripts / "on_session_start.sh"],
+        input=json.dumps({"source": "startup", "session_id": "test-session", "cwd": str(tmp_path)}),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    time.sleep(0.1)
+    assert result.returncode == 0
+    assert not marker.exists()
     assert not (state / "admission.sqlite3").exists()

--- a/integrations/mem0-plugin/tests/test_auto_setup_categories.py
+++ b/integrations/mem0-plugin/tests/test_auto_setup_categories.py
@@ -151,3 +151,15 @@ def test_fetch_current_categories_handles_non_dict():
         project = type("P", (), {"get": staticmethod(lambda fields=None: "unexpected")})()
 
     assert asc.fetch_current_categories(Weird()) is None
+
+
+def test_main_skips_all_hosted_setup_when_auto_search_is_off(monkeypatch):
+    """Default-off automatic retrieval must include taxonomy get/update calls."""
+    monkeypatch.setattr(asc, "resolve_config", lambda: {"auto_search": False})
+    monkeypatch.setattr(asc, "resolve_api_key", lambda: "sentinel-key")
+    called = []
+    monkeypatch.setattr(asc, "make_client", lambda: called.append(True))
+
+    asc.main()
+
+    assert called == []

--- a/integrations/mem0-plugin/tests/test_ingress_inventory.py
+++ b/integrations/mem0-plugin/tests/test_ingress_inventory.py
@@ -1,0 +1,48 @@
+"""Keep every executable hosted-memory ingress behind a named adapter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+PLUGIN = Path(__file__).resolve().parents[1]
+SCRIPTS = PLUGIN / "scripts"
+
+
+def test_direct_urlopen_has_one_memory_transport_owner():
+    offenders = []
+    for path in SCRIPTS.glob("*"):
+        if path.suffix not in {".py", ".sh"}:
+            continue
+        text = path.read_text(errors="replace")
+        if "urllib.request.urlopen" not in text:
+            continue
+        if path.name not in {"hosted_request.py", "telemetry.py"}:
+            offenders.append(path.name)
+    assert offenders == []
+
+
+def test_every_api_url_builder_imports_transport_adapter():
+    exclusions = {"hosted_request.py", "telemetry.py"}
+    offenders = []
+    for path in SCRIPTS.glob("*.py"):
+        text = path.read_text(errors="replace")
+        if "api.mem0.ai" in text and path.name not in exclusions:
+            if "open_hosted_request" not in text:
+                offenders.append(path.name)
+    assert offenders == []
+
+
+def test_every_sdk_call_site_has_admission_bridge():
+    offenders = []
+    for path in SCRIPTS.glob("*.py"):
+        text = path.read_text(errors="replace")
+        if "MemoryClient" in text and "require_admission" not in text:
+            offenders.append(path.name)
+    assert offenders == []
+
+
+def test_opencode_surface_is_explicitly_excluded_from_p0():
+    opencode = PLUGIN / ".opencode-plugin" / "opencode-mem0.ts"
+    assert opencode.exists()
+    assert "P0 cost admission: unprotected" in (PLUGIN / "README.md").read_text()

--- a/integrations/mem0-plugin/tests/test_mcp_admission.py
+++ b/integrations/mem0-plugin/tests/test_mcp_admission.py
@@ -1,0 +1,109 @@
+"""MCP manifest and PreToolUse admission contracts."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+
+import pytest
+
+
+PLUGIN_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+SCRIPT = os.path.join(PLUGIN_ROOT, "scripts", "enforce_metadata_defaults.sh")
+
+
+def _manifest_matchers(path):
+    with open(path) as handle:
+        data = json.load(handle)
+    hooks = data["hooks"]
+    entries = hooks.get("PreToolUse", hooks.get("preToolUse", []))
+    return [entry.get("matcher", "") for entry in entries]
+
+
+@pytest.mark.parametrize(
+    "relative",
+    ["hooks/hooks.json", "hooks/codex-hooks.json", "hooks/cursor-hooks.json", "hooks.json"],
+)
+def test_every_manifest_uses_broad_mem0_matcher(relative):
+    matchers = _manifest_matchers(os.path.join(PLUGIN_ROOT, relative))
+    assert "mcp__mem0__.*|mcp__plugin_mem0_mem0__.*" in matchers
+
+
+def _run_hook(tmp_path, tool_name, extra_env=None):
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(tmp_path),
+            "MEM0_STATE_DIR": str(tmp_path / "state"),
+            "MEM0_PROJECT_ID": "project",
+            "MEM0_USER_ID": "user",
+            "MEM0_BUDGET_SESSION_REQUESTS": "20",
+            "MEM0_BUDGET_DAILY_REQUESTS": "20",
+            "MEM0_BUDGET_SESSION_AUTO_REQUESTS": "20",
+            "MEM0_BUDGET_DAILY_AUTO_REQUESTS": "20",
+            "MEM0_BUDGET_SESSION_WEIGHT": "100",
+            "MEM0_BUDGET_DAILY_WEIGHT": "100",
+        }
+    )
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [SCRIPT],
+        input=json.dumps({"tool_name": tool_name, "tool_input": {}}),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        "add_memory",
+        "search_memories",
+        "get_memories",
+        "get_memory",
+        "update_memory",
+        "delete_memory",
+        "delete_all_memories",
+        "delete_entities",
+        "list_entities",
+    ],
+)
+def test_all_advertised_mcp_operations_are_classified_and_admitted(tmp_path, operation):
+    result = _run_hook(tmp_path, f"mcp__mem0__{operation}")
+    assert result.returncode == 0, result.stderr
+    output = json.loads(result.stdout)
+    assert output["hookSpecificOutput"]["permissionDecision"] == "allow"
+
+
+def test_unknown_mem0_operation_is_typed_deny_without_charge(tmp_path):
+    result = _run_hook(tmp_path, "mcp__mem0__future_operation")
+    assert result.returncode == 2
+    assert "remote-unknown-operation" in result.stderr
+    assert not (tmp_path / "state" / "admission.sqlite3").exists()
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        "add_memory",
+        "search_memories",
+        "get_memories",
+        "get_memory",
+        "update_memory",
+        "delete_memory",
+        "delete_all_memories",
+        "delete_entities",
+        "list_entities",
+    ],
+)
+def test_budget_denial_returns_pretooluse_deny_for_every_operation(tmp_path, operation):
+    result = _run_hook(
+        tmp_path,
+        f"mcp__mem0__{operation}",
+        {"MEM0_BUDGET_SESSION_REQUESTS": "0"},
+    )
+    assert result.returncode == 2
+    assert "remote-session-budget-exhausted" in result.stderr

--- a/integrations/mem0-plugin/tests/test_mcp_admission.py
+++ b/integrations/mem0-plugin/tests/test_mcp_admission.py
@@ -107,3 +107,15 @@ def test_budget_denial_returns_pretooluse_deny_for_every_operation(tmp_path, ope
     )
     assert result.returncode == 2
     assert "remote-session-budget-exhausted" in result.stderr
+
+
+def test_accounting_has_fail_closed_deadline_before_host_timeout():
+    script = open(SCRIPT).read()
+    assert "alarm 2; exec @ARGV" in script
+    for relative in ("hooks/hooks.json", "hooks/codex-hooks.json", "hooks/cursor-hooks.json"):
+        with open(os.path.join(PLUGIN_ROOT, relative)) as handle:
+            manifest = json.load(handle)
+        entries = manifest["hooks"].get("PreToolUse", manifest["hooks"].get("preToolUse", []))
+        mem0 = next(entry for entry in entries if entry.get("matcher", "").startswith("mcp__mem0__"))
+        hooks = mem0.get("hooks", [mem0])
+        assert hooks[0]["timeout"] >= 3


### PR DESCRIPTION
## Linked Issue

Closes #6283

## Description

Adds a local, atomic admission authority for every hosted-memory ingress in the Python/shell editor plugin surface. It bounds Mem0 request amplification while preserving explicit admitted memory use and keeping local/file operations independent of the accounting database.

Key behavior:

- Fresh or missing settings default `auto_search` to false; existing explicit `auto_search: true` is preserved and budgeted.
- SQLite `BEGIN IMMEDIATE` admission enforces session/day request, automatic-request, and heuristic-weight ceilings before transport.
- Direct REST and SDK calls share one transport/admission owner.
- All nine advertised MCP operations are classified and charged synchronously; unknown Mem0 MCP tools deny until classified.
- Remote accounting failures deny remote memory traffic only.
- OpenCode TypeScript remains explicitly outside this first P0 boundary. Codex, Cursor, and Antigravity remain best-effort protection labels pending host-executed deny smokes.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A. Existing explicit `auto_search: true` settings remain authoritative. New installs and missing settings default automatic hosted retrieval off.

## Test Coverage

- [x] I added/updated unit tests
- [x] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Local verification:

- `uv run --no-project --with pytest pytest integrations/mem0-plugin/tests -q` — 204 passed
- `uvx ruff check integrations/mem0-plugin/scripts integrations/mem0-plugin/tests` — passed
- `python3 -m compileall -q integrations/mem0-plugin/scripts` — passed
- 30 cold end-to-end MCP-hook runs: p95 693.98 ms, max 882.24 ms
- 10 locked-database end-to-end MCP-hook runs: all typed-denied fail-closed, max 876.1 ms
- Independent high-risk review-loop Execution Gate approved canonical patch `5aa4607a95a88ea185bfcdb29632913b546a0a1b0d3b6d5d1d6549f4de290fd3` with no blocking findings

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove the fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed

## Follow-ups

The Python/shell plugin test suite is not currently wired into `ci-gate.yml`. This PR does not modify CI workflows because the repository guidance requires explicit approval for CI changes; a separate follow-up should add pytest/Ruff/compileall coverage for `integrations/mem0-plugin/**`.