### PR TITLE
feat(memory): restore custom_fact_extraction_prompt as a full override of the extraction prompt

### DIFF
--- a/docs/open-source/features/custom-instructions.mdx
+++ b/docs/open-source/features/custom-instructions.mdx
@@ -18,7 +18,10 @@ Custom instructions let you decide exactly which facts Mem0 records from a conve
 </Warning>
 
 <Note>
-  The `custom_fact_extraction_prompt` parameter has been renamed to `custom_instructions`. If you are upgrading from an older version, update your configuration accordingly.
+  `custom_instructions` and `custom_fact_extraction_prompt` are two separate levers. Pick the one that matches how much control you need.
+
+  - **`custom_instructions`** (recommended for most cases): a short guidance string appended to the **user** prompt of the extraction call. The built-in extraction system prompt still runs, so the JSON output contract is preserved automatically.
+  - **`custom_fact_extraction_prompt`**: fully overrides the extraction **system** prompt (the built-in prompt is not sent). Use it only to dial recall down or replace the default extractor. When you set it, you own the JSON output contract: the model must return `{"memory": [{"text": "..."}, ...]}` (each item needs a `text` field, which is what the extractor reads), or the batch is dropped. Leave it unset (`None` or blank) to preserve default behavior byte for byte.
 </Note>
 
 ---
@@ -27,7 +30,7 @@ Custom instructions let you decide exactly which facts Mem0 records from a conve
 
 - **Prompt instructions:** Describe which entities or phrases to keep. Specific guidance keeps the extractor focused.
 - **Few-shot examples:** Show positive and negative cases so the model copies the right format.
-- **Structured output:** Responses return JSON with a `facts` array that Mem0 converts into individual memories.
+- **Structured output:** Responses return JSON with a `memory` array (each item a `{"text": "..."}` object) that Mem0 converts into individual memories.
 - **LLM configuration:** `custom_instructions` (Python) or `customInstructions` (TypeScript) lives alongside your model settings.
 
 <AccordionGroup>
@@ -35,7 +38,7 @@ Custom instructions let you decide exactly which facts Mem0 records from a conve
     1. State the allowed fact types.
     2. Include short examples that mirror production messages.
     3. Show both empty (`[]`) and populated outputs.
-    4. Remind the model to return JSON with a `facts` key only.
+    4. Remind the model to return JSON with a `memory` key only, where each item has a `text` field.
   </Accordion>
 </AccordionGroup>
 
@@ -52,21 +55,21 @@ Please only extract entities containing customer support information, order deta
 Here are some few shot examples:
 
 Input: Hi.
-Output: {"facts" : []}
+Output: {"memory": []}
 
 Input: The weather is nice today.
-Output: {"facts" : []}
+Output: {"memory": []}
 
 Input: My order #12345 hasn't arrived yet.
-Output: {"facts" : ["Order #12345 not received"]}
+Output: {"memory": [{"text": "Order #12345 not received"}]}
 
 Input: I'm John Doe, and I'd like to return the shoes I bought last week.
-Output: {"facts" : ["Customer name: John Doe", "Wants to return shoes", "Purchase made last week"]}
+Output: {"memory": [{"text": "Customer name: John Doe"}, {"text": "Wants to return shoes"}, {"text": "Purchase made last week"}]}
 
 Input: I ordered a red shirt, size medium, but received a blue one instead.
-Output: {"facts" : ["Ordered red shirt, size medium", "Received blue shirt instead"]}
+Output: {"memory": [{"text": "Ordered red shirt, size medium"}, {"text": "Received blue shirt instead"}]}
 
-Return the facts and customer information in a json format as shown above.
+Return the customer information as JSON with a "memory" array whose items each have a "text" field, as shown above.
 """
 ```
 
@@ -76,21 +79,21 @@ Please only extract entities containing customer support information, order deta
 Here are some few shot examples:
 
 Input: Hi.
-Output: {"facts" : []}
+Output: {"memory": []}
 
 Input: The weather is nice today.
-Output: {"facts" : []}
+Output: {"memory": []}
 
 Input: My order #12345 hasn't arrived yet.
-Output: {"facts" : ["Order #12345 not received"]}
+Output: {"memory": [{"text": "Order #12345 not received"}]}
 
 Input: I am John Doe, and I would like to return the shoes I bought last week.
-Output: {"facts" : ["Customer name: John Doe", "Wants to return shoes", "Purchase made last week"]}
+Output: {"memory": [{"text": "Customer name: John Doe"}, {"text": "Wants to return shoes"}, {"text": "Purchase made last week"}]}
 
 Input: I ordered a red shirt, size medium, but received a blue one instead.
-Output: {"facts" : ["Ordered red shirt, size medium", "Received blue shirt instead"]}
+Output: {"memory": [{"text": "Ordered red shirt, size medium"}, {"text": "Received blue shirt instead"}]}
 
-Return the facts and customer information in a json format as shown above.
+Return the customer information as JSON with a "memory" array whose items each have a "text" field, as shown above.
 `;
 ```
 </CodeGroup>
@@ -200,7 +203,7 @@ await memory.add("I like going to hikes", { userId: "user123" });
 
 ## Verify the feature is working
 
-- Log every call during rollout and confirm the `facts` array matches your schema.
+- Log every call during rollout and confirm the `memory` array matches your schema.
 - Check that unrelated messages return an empty `results` array.
 - Run regression samples whenever you edit the prompt to ensure previously accepted facts still pass.
 
@@ -210,7 +213,7 @@ await memory.add("I like going to hikes", { userId: "user123" });
 
 1. **Be precise:** Call out the exact categories or fields you want to capture.
 2. **Show negative cases:** Include examples that should produce `[]` so the model learns to skip them.
-3. **Keep JSON strict:** Avoid extra keys; only return `facts` to simplify downstream parsing.
+3. **Keep JSON strict:** Avoid extra keys; only return a JSON object with a `memory` key to simplify downstream parsing.
 4. **Version prompts:** Track prompt changes with a version number so you can roll back quickly.
 5. **Review outputs regularly:** Spot-check stored memories to catch drift early.
 

--- a/mem0/configs/base.py
+++ b/mem0/configs/base.py
@@ -55,6 +55,20 @@ class MemoryConfig(BaseModel):
         description="Custom instructions for fact extraction",
         default=None,
     )
+    custom_fact_extraction_prompt: Optional[str] = Field(
+        description=(
+            "Optional full override of the extraction system prompt. When set, "
+            "this string replaces the built-in high-recall extraction prompt "
+            "(``ADDITIVE_EXTRACTION_PROMPT``) so self-hosted callers can dial "
+            "extraction recall down. Defaults to ``None``, which preserves "
+            "current behaviour byte-for-byte (a blank value is treated the same "
+            "as ``None``). When set, the caller is "
+            "responsible for preserving the JSON output contract "
+            '(``{"memory": [{"text": ...}, ...]}``); see '
+            "https://github.com/mem0ai/mem0/issues/5730."
+        ),
+        default=None,
+    )
 
 
 class AzureConfig(BaseModel):

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -462,6 +462,9 @@ class Memory(MemoryBase):
         self.collection_name = self.config.vector_store.config.collection_name
         self.api_version = self.config.version
         self.custom_instructions = self.config.custom_instructions
+        # Optional full override of the extraction system prompt (see #5730).
+        # ``None`` preserves current behaviour byte-for-byte.
+        self.custom_fact_extraction_prompt = self.config.custom_fact_extraction_prompt
 
         # Initialize reranker if configured
         self.reranker = None
@@ -895,7 +898,12 @@ class Memory(MemoryBase):
 
         # Phase 2: LLM extraction (single call)
         is_agent_scoped = bool(filters.get("agent_id")) and not filters.get("user_id")
-        system_prompt = ADDITIVE_EXTRACTION_PROMPT
+        # Self-hosted callers can supply ``custom_fact_extraction_prompt`` (see
+        # #5730) to fully replace the built-in high-recall extraction system
+        # prompt and dial recall down. A blank value is treated as unset, so
+        # behaviour is unchanged. The caller owns the JSON output contract.
+        override_prompt = self.custom_fact_extraction_prompt
+        system_prompt = override_prompt if override_prompt and override_prompt.strip() else ADDITIVE_EXTRACTION_PROMPT
         if is_agent_scoped:
             system_prompt += AGENT_CONTEXT_SUFFIX
 
@@ -2124,6 +2132,9 @@ class AsyncMemory(MemoryBase):
         self.collection_name = self.config.vector_store.config.collection_name
         self.api_version = self.config.version
         self.custom_instructions = self.config.custom_instructions
+        # Optional full override of the extraction system prompt (see #5730).
+        # ``None`` preserves current behaviour byte-for-byte.
+        self.custom_fact_extraction_prompt = self.config.custom_fact_extraction_prompt
         self._entity_store = None
 
         # Initialize reranker if configured
@@ -2533,7 +2544,12 @@ class AsyncMemory(MemoryBase):
 
         # Phase 2: LLM extraction (single call)
         is_agent_scoped = bool(effective_filters.get("agent_id")) and not effective_filters.get("user_id")
-        system_prompt = ADDITIVE_EXTRACTION_PROMPT
+        # Self-hosted callers can supply ``custom_fact_extraction_prompt`` (see
+        # #5730) to fully replace the built-in high-recall extraction system
+        # prompt and dial recall down. A blank value is treated as unset, so
+        # behaviour is unchanged. The caller owns the JSON output contract.
+        override_prompt = self.custom_fact_extraction_prompt
+        system_prompt = override_prompt if override_prompt and override_prompt.strip() else ADDITIVE_EXTRACTION_PROMPT
         if is_agent_scoped:
             system_prompt += AGENT_CONTEXT_SUFFIX
 

--- a/openmemory/api/app/utils/memory.py
+++ b/openmemory/api/app/utils/memory.py
@@ -459,10 +459,16 @@ def get_memory_client(custom_instructions: str = None):
             print("Using default configuration")
             # Continue with default configuration if database config can't be loaded
 
-        # Use custom_instructions parameter first, then fall back to database value
+        # Use custom_instructions parameter first, then fall back to database value.
+        # NOTE: route into ``custom_instructions`` (append-only guidance for the
+        # user prompt), NOT ``custom_fact_extraction_prompt`` (which fully
+        # OVERRIDES the extraction system prompt and shifts JSON-contract
+        # ownership to the caller). OpenMemory's UI copy and DB key are both
+        # named ``custom_instructions``; sending short freeform text into the
+        # full-override slot silently breaks the extraction JSON contract.
         instructions_to_use = custom_instructions or db_custom_instructions
         if instructions_to_use:
-            config["custom_fact_extraction_prompt"] = instructions_to_use
+            config["custom_instructions"] = instructions_to_use
 
         # Fix Ollama URLs for Docker environment (applies to both env-var defaults and DB overrides)
         if config.get("llm", {}).get("provider") == "ollama":

--- a/openmemory/api/tests/test_get_memory_client_routes_custom_instructions.py
+++ b/openmemory/api/tests/test_get_memory_client_routes_custom_instructions.py
@@ -1,0 +1,251 @@
+"""Regression test for openmemory's ``get_memory_client`` routing.
+
+Guards against re-routing the openmemory "Custom Instructions" text (which the
+UI + the ``ConfigModel.value["openmemory"]["custom_instructions"]`` DB key both
+name ``custom_instructions``) into mem0's ``custom_fact_extraction_prompt``
+slot. That slot is a FULL override of the extraction system prompt and shifts
+JSON-contract ownership to the caller — silently sending short freeform text
+into it breaks the extraction pipeline. openmemory's short instructions must
+land in ``custom_instructions`` instead, which appends guidance to the user
+prompt while leaving the built-in system prompt (and its JSON contract)
+untouched.
+
+See mem0 PR #6288 / issue #5730.
+
+This test stubs the heavy ``app.database`` and ``app.models`` imports through
+``sys.modules`` so it can exercise ``app.utils.memory.get_memory_client`` in
+isolation — no database, no FastAPI, no real LLM required.
+"""
+
+import importlib
+import os
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub heavy imports BEFORE ``app.utils.memory`` is loaded.
+# ``app.utils.memory`` does ``from app.database import SessionLocal`` and
+# ``from app.models import Config as ConfigModel`` at import time; both pull in
+# SQLAlchemy + declarative_base + dotenv, which we don't need for this test.
+# ---------------------------------------------------------------------------
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+_API_ROOT = Path(__file__).resolve().parents[1]
+if str(_API_ROOT) not in sys.path:
+    sys.path.insert(0, str(_API_ROOT))
+
+
+def _install_app_stubs() -> None:
+    """Register minimal ``app.database`` + ``app.models`` stubs in sys.modules."""
+    # Real ``app`` package — reuse it if already imported so we don't clobber
+    # anything a sibling test set up.
+    app_pkg = sys.modules.get("app")
+    if app_pkg is None:
+        app_pkg = types.ModuleType("app")
+        app_pkg.__path__ = [str(_API_ROOT / "app")]  # mark as a package
+        sys.modules["app"] = app_pkg
+
+    # Stub app.database
+    database_stub = types.ModuleType("app.database")
+    database_stub.SessionLocal = MagicMock(name="SessionLocalStub")
+    sys.modules["app.database"] = database_stub
+    app_pkg.database = database_stub  # type: ignore[attr-defined]
+
+    # Stub app.models with a ``Config`` class the module imports as ``ConfigModel``.
+    models_stub = types.ModuleType("app.models")
+
+    class _ConfigStub:  # noqa: D401 — plain stub
+        """Stand-in for the real SQLAlchemy ``Config`` model."""
+        key = None
+        value = None
+
+    models_stub.Config = _ConfigStub
+    sys.modules["app.models"] = models_stub
+    app_pkg.models = models_stub  # type: ignore[attr-defined]
+
+
+# ``om_memory`` is populated by the module-scoped ``_stubbed_app_module``
+# fixture below, which installs the stubs, imports the target module against
+# them, and then restores ``sys.modules``. Doing the stubbing at import time
+# would leave the partial ``app.database`` / ``app.models`` stubs in the global
+# ``sys.modules`` forever, breaking any sibling module (e.g. ``test_mcp_server``)
+# that later imports the *real* ``app.models`` (``Memory``, ``MemoryAccessLog``).
+om_memory = None
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _stubbed_app_module():
+    """Import ``app.utils.memory`` against the stubs, then restore ``sys.modules``.
+
+    Snapshots every ``app`` entry we touch (and the ``app`` package attributes
+    the stubber mutates), installs the stubs, imports the target module, and on
+    teardown restores the snapshot so the stubs never leak past this module.
+    """
+    global om_memory
+
+    _MISSING = object()
+    tracked = ("app", "app.database", "app.models", "app.utils", "app.utils.memory")
+    saved_modules = {name: sys.modules.get(name) for name in tracked}
+    app_pkg = saved_modules["app"]
+    saved_attrs = (
+        {name: getattr(app_pkg, name, _MISSING) for name in ("database", "models")}
+        if app_pkg is not None
+        else {}
+    )
+
+    _install_app_stubs()
+    try:
+        om_memory = importlib.import_module("app.utils.memory")
+        yield om_memory
+    finally:
+        om_memory = None
+        for name in tracked:
+            original = saved_modules[name]
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+        for name, value in saved_attrs.items():
+            if value is _MISSING:
+                if hasattr(app_pkg, name):
+                    delattr(app_pkg, name)
+            else:
+                setattr(app_pkg, name, value)
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state():
+    """Reset ``get_memory_client`` module-level cache before each test."""
+    om_memory._memory_client = None
+    om_memory._config_hash = None
+    yield
+    om_memory._memory_client = None
+    om_memory._config_hash = None
+
+
+@pytest.fixture
+def empty_db():
+    """Wire ``SessionLocal`` so the DB-config lookup returns ``None``.
+
+    ``get_memory_client`` calls ``db.query(ConfigModel).filter(...).first()``.
+    Returning ``None`` from ``.first()`` forces the "no DB config" branch, so
+    the ONLY source of custom instructions is the function argument.
+    """
+    session = MagicMock(name="Session")
+    session.query.return_value.filter.return_value.first.return_value = None
+    om_memory.SessionLocal = MagicMock(return_value=session)
+    yield session
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def _capture_from_config_calls():
+    """Patch ``Memory.from_config`` to record the config dict it was called with.
+
+    ``get_memory_client`` calls ``Memory.from_config(config_dict=config)``; the
+    patched version returns a sentinel client so the rest of the function's
+    success path executes.
+    """
+    captured: dict = {}
+
+    def _fake_from_config(config_dict):
+        captured["config"] = config_dict
+        return MagicMock(name="MemoryClientStub")
+
+    return captured, _fake_from_config
+
+
+class TestGetMemoryClientRoutesCustomInstructions:
+    def test_custom_instructions_arg_routes_to_custom_instructions_key(self, empty_db):
+        """The ``custom_instructions`` arg must land in ``config['custom_instructions']``.
+
+        It must NOT be written to ``custom_fact_extraction_prompt`` (which is
+        mem0's full-override slot and would silently break the JSON contract).
+        """
+        captured, fake_from_config = _capture_from_config_calls()
+
+        with patch.object(om_memory.Memory, "from_config", side_effect=fake_from_config):
+            client = om_memory.get_memory_client("be concise")
+
+        assert client is not None, "expected a memory client stub, not None"
+
+        cfg = captured.get("config")
+        assert cfg is not None, "Memory.from_config was never called"
+
+        # The core assertion — routes to the append-only slot, not the full-override slot.
+        assert cfg.get("custom_instructions") == "be concise", (
+            "expected openmemory instructions to land in config['custom_instructions'] "
+            f"(append-only), got: {cfg.get('custom_instructions')!r}"
+        )
+        assert "custom_fact_extraction_prompt" not in cfg, (
+            "openmemory's short instructions text must NOT be routed into "
+            "config['custom_fact_extraction_prompt'] — that slot fully overrides "
+            "the extraction system prompt and would break the JSON output contract"
+        )
+
+    def test_no_instructions_writes_neither_key(self, empty_db):
+        """When no instructions are provided, neither key should be set."""
+        captured, fake_from_config = _capture_from_config_calls()
+
+        with patch.object(om_memory.Memory, "from_config", side_effect=fake_from_config):
+            om_memory.get_memory_client(None)
+
+        cfg = captured["config"]
+        assert "custom_instructions" not in cfg
+        assert "custom_fact_extraction_prompt" not in cfg
+
+    def test_db_instructions_also_route_to_custom_instructions_key(self):
+        """The DB-supplied instructions must follow the same routing.
+
+        ``ConfigModel.value["openmemory"]["custom_instructions"]`` is the DB
+        source of the same short freeform text; it must land in the same
+        append-only slot as the function-arg path.
+        """
+        db_config = MagicMock(name="DBConfig")
+        db_config.value = {
+            "openmemory": {"custom_instructions": "prefer bullet points"},
+        }
+        session = MagicMock(name="Session")
+        session.query.return_value.filter.return_value.first.return_value = db_config
+        om_memory.SessionLocal = MagicMock(return_value=session)
+
+        captured, fake_from_config = _capture_from_config_calls()
+
+        with patch.object(om_memory.Memory, "from_config", side_effect=fake_from_config):
+            om_memory.get_memory_client(None)
+
+        cfg = captured["config"]
+        assert cfg.get("custom_instructions") == "prefer bullet points"
+        assert "custom_fact_extraction_prompt" not in cfg
+
+    def test_arg_takes_precedence_over_db(self):
+        """Function-arg wins over DB value, and still lands in the correct slot."""
+        db_config = MagicMock(name="DBConfig")
+        db_config.value = {
+            "openmemory": {"custom_instructions": "from db"},
+        }
+        session = MagicMock(name="Session")
+        session.query.return_value.filter.return_value.first.return_value = db_config
+        om_memory.SessionLocal = MagicMock(return_value=session)
+
+        captured, fake_from_config = _capture_from_config_calls()
+
+        with patch.object(om_memory.Memory, "from_config", side_effect=fake_from_config):
+            om_memory.get_memory_client("from arg")
+
+        cfg = captured["config"]
+        assert cfg.get("custom_instructions") == "from arg"
+        assert "custom_fact_extraction_prompt" not in cfg

--- a/tests/memory/test_custom_fact_extraction_prompt.py
+++ b/tests/memory/test_custom_fact_extraction_prompt.py
@@ -234,6 +234,18 @@ class TestCustomFactExtractionPromptAsync:
         system_prompt = _extract_system_prompt(mock_async_memory)
         assert system_prompt == override + AGENT_CONTEXT_SUFFIX
 
+    @pytest.mark.parametrize("blank", ["", "   ", "\n\t"])
+    async def test_blank_override_falls_back_to_default(self, mock_async_memory, blank):
+        """Async parity: a blank / whitespace-only override is treated as unset."""
+        mock_async_memory.custom_fact_extraction_prompt = blank
+        await mock_async_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "hello"}],
+            metadata={},
+            effective_filters={"user_id": "u1"},
+            infer=True,
+        )
+        assert _extract_system_prompt(mock_async_memory) == ADDITIVE_EXTRACTION_PROMPT
+
 
 # ---------------------------------------------------------------------------
 # ``MemoryConfig`` plumbing

--- a/tests/memory/test_custom_fact_extraction_prompt.py
+++ b/tests/memory/test_custom_fact_extraction_prompt.py
@@ -1,0 +1,269 @@
+"""Tests for the ``custom_fact_extraction_prompt`` full-override lever.
+
+Restores the pre-#4805 capability that let self-hosted callers replace the
+extraction system prompt entirely so recall can be dialled down (see
+https://github.com/mem0ai/mem0/issues/5730). The default (``None``) is
+byte-for-byte identical to current behaviour; when set, the value replaces
+``ADDITIVE_EXTRACTION_PROMPT`` as the extraction system prompt. Caller owns
+the JSON output contract when overriding.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from mem0.configs.base import MemoryConfig
+from mem0.configs.prompts import ADDITIVE_EXTRACTION_PROMPT, AGENT_CONTEXT_SUFFIX
+from mem0.memory.main import AsyncMemory, Memory
+
+
+def _setup_mocks(mocker):
+    """Mirror of the fixture helper in tests/memory/test_main.py."""
+    mock_embedder = mocker.MagicMock()
+    mock_embedder.return_value.embed.return_value = [0.1, 0.2, 0.3]
+    mocker.patch("mem0.utils.factory.EmbedderFactory.create", mock_embedder)
+
+    mock_vector_store = mocker.MagicMock()
+    mock_vector_store.return_value.search.return_value = []
+    mocker.patch(
+        "mem0.utils.factory.VectorStoreFactory.create",
+        side_effect=[mock_vector_store.return_value, mocker.MagicMock()],
+    )
+
+    mock_llm = mocker.MagicMock()
+    mocker.patch("mem0.utils.factory.LlmFactory.create", mock_llm)
+
+    mocker.patch("mem0.memory.storage.SQLiteManager", mocker.MagicMock())
+
+    return mock_llm, mock_vector_store
+
+
+def _extract_system_prompt(mock_memory):
+    """Return the system-message content passed to the mocked LLM."""
+    call_args = mock_memory.llm.generate_response.call_args
+    messages = call_args[1]["messages"] if "messages" in call_args[1] else call_args[0][0]
+    system_messages = [m["content"] for m in messages if m["role"] == "system"]
+    assert len(system_messages) == 1, f"expected exactly one system message, got {len(system_messages)}"
+    return system_messages[0]
+
+
+def _extract_user_prompt(mock_memory):
+    """Return the user-message content passed to the mocked LLM."""
+    call_args = mock_memory.llm.generate_response.call_args
+    messages = call_args[1]["messages"] if "messages" in call_args[1] else call_args[0][0]
+    user_messages = [m["content"] for m in messages if m["role"] == "user"]
+    assert len(user_messages) == 1
+    return user_messages[0]
+
+
+# ---------------------------------------------------------------------------
+# Sync ``Memory`` — full-override behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestCustomFactExtractionPromptSync:
+    @pytest.fixture
+    def mock_memory(self, mocker):
+        mock_llm, _ = _setup_mocks(mocker)
+        mock_llm.return_value.generate_response.return_value = '{"memory": []}'
+
+        memory = Memory()
+        memory.custom_instructions = None
+        memory.custom_fact_extraction_prompt = None
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        return memory
+
+    def test_default_behavior_unchanged(self, mock_memory):
+        """Characterization: with the override unset, the extraction system
+        prompt is exactly ``ADDITIVE_EXTRACTION_PROMPT`` (no regression)."""
+        mock_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "hello"}],
+            metadata={},
+            filters={"user_id": "u1"},
+            infer=True,
+        )
+        assert _extract_system_prompt(mock_memory) == ADDITIVE_EXTRACTION_PROMPT
+
+    def test_override_replaces_system_prompt(self, mock_memory):
+        """When set, the override string replaces the extraction system prompt.
+
+        This is the recall-knob for #5730 — the caller can now dial recall
+        DOWN by supplying a stricter extraction prompt.
+        """
+        override = (
+            "You are a strict fact extractor. Only extract explicit, durable "
+            'user facts. Return JSON: {"memory": [{"text": <str>}, ...]}.'
+        )
+        mock_memory.custom_fact_extraction_prompt = override
+
+        mock_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "hello"}],
+            metadata={},
+            filters={"user_id": "u1"},
+            infer=True,
+        )
+
+        system_prompt = _extract_system_prompt(mock_memory)
+        assert system_prompt == override
+        # And critically: the high-recall additive prompt must not leak in.
+        assert "Memory Extractor" not in system_prompt
+
+    def test_override_coexists_with_custom_instructions(self, mock_memory):
+        """The two levers are orthogonal: ``custom_fact_extraction_prompt``
+        replaces the SYSTEM prompt, while ``custom_instructions`` still
+        appends to the USER prompt. Users can (and typically will) use both."""
+        override = "You are a strict fact extractor."
+        mock_memory.custom_fact_extraction_prompt = override
+        mock_memory.custom_instructions = "Never extract sports scores."
+
+        mock_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "hello"}],
+            metadata={},
+            filters={"user_id": "u1"},
+            infer=True,
+        )
+
+        assert _extract_system_prompt(mock_memory) == override
+        user_prompt = _extract_user_prompt(mock_memory)
+        assert "## Custom Instructions" in user_prompt
+        assert "Never extract sports scores." in user_prompt
+
+    def test_override_preserves_agent_context_suffix(self, mock_memory):
+        """Agent-scoping is orthogonal to which base prompt is chosen: when
+        the caller overrides AND the extraction is agent-scoped, the
+        ``AGENT_CONTEXT_SUFFIX`` still appends to the override."""
+        override = "You are a strict fact extractor."
+        mock_memory.custom_fact_extraction_prompt = override
+
+        mock_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "hello"}],
+            metadata={},
+            filters={"agent_id": "a1"},  # agent-scoped, no user_id
+            infer=True,
+        )
+
+        system_prompt = _extract_system_prompt(mock_memory)
+        assert system_prompt == override + AGENT_CONTEXT_SUFFIX
+
+    @pytest.mark.parametrize("blank", ["", "   ", "\n\t"])
+    def test_blank_override_falls_back_to_default(self, mock_memory, blank):
+        """A blank / whitespace-only override is treated as unset, so a stray
+        empty value can't wipe the extraction system prompt."""
+        mock_memory.custom_fact_extraction_prompt = blank
+        mock_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "hello"}],
+            metadata={},
+            filters={"user_id": "u1"},
+            infer=True,
+        )
+        assert _extract_system_prompt(mock_memory) == ADDITIVE_EXTRACTION_PROMPT
+
+
+# ---------------------------------------------------------------------------
+# Async ``AsyncMemory`` — same contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestCustomFactExtractionPromptAsync:
+    @pytest.fixture
+    def mock_async_memory(self, mocker):
+        mock_llm, _ = _setup_mocks(mocker)
+        mock_llm.return_value.generate_response.return_value = '{"memory": []}'
+
+        memory = AsyncMemory()
+        memory.custom_instructions = None
+        memory.custom_fact_extraction_prompt = None
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        return memory
+
+    async def test_default_behavior_unchanged(self, mock_async_memory):
+        await mock_async_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "hello"}],
+            metadata={},
+            effective_filters={"user_id": "u1"},
+            infer=True,
+        )
+        assert _extract_system_prompt(mock_async_memory) == ADDITIVE_EXTRACTION_PROMPT
+
+    async def test_override_replaces_system_prompt(self, mock_async_memory):
+        override = "You are a strict fact extractor."
+        mock_async_memory.custom_fact_extraction_prompt = override
+
+        await mock_async_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "hello"}],
+            metadata={},
+            effective_filters={"user_id": "u1"},
+            infer=True,
+        )
+
+        system_prompt = _extract_system_prompt(mock_async_memory)
+        assert system_prompt == override
+        assert "Memory Extractor" not in system_prompt
+
+    async def test_override_coexists_with_custom_instructions(self, mock_async_memory):
+        override = "You are a strict fact extractor."
+        mock_async_memory.custom_fact_extraction_prompt = override
+        mock_async_memory.custom_instructions = "Never extract sports scores."
+
+        await mock_async_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "hello"}],
+            metadata={},
+            effective_filters={"user_id": "u1"},
+            infer=True,
+        )
+
+        assert _extract_system_prompt(mock_async_memory) == override
+        user_prompt = _extract_user_prompt(mock_async_memory)
+        assert "## Custom Instructions" in user_prompt
+        assert "Never extract sports scores." in user_prompt
+
+    async def test_override_preserves_agent_context_suffix(self, mock_async_memory):
+        override = "You are a strict fact extractor."
+        mock_async_memory.custom_fact_extraction_prompt = override
+
+        await mock_async_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "hello"}],
+            metadata={},
+            effective_filters={"agent_id": "a1"},
+            infer=True,
+        )
+
+        system_prompt = _extract_system_prompt(mock_async_memory)
+        assert system_prompt == override + AGENT_CONTEXT_SUFFIX
+
+
+# ---------------------------------------------------------------------------
+# ``MemoryConfig`` plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryConfigCustomFactExtractionPrompt:
+    def test_default_is_none(self):
+        """Backwards-compat: default MemoryConfig has the field as None."""
+        cfg = MemoryConfig()
+        assert cfg.custom_fact_extraction_prompt is None
+
+    def test_field_accepts_string(self):
+        """The field is a real pydantic field, not silently dropped as
+        ``extra`` (which was the bug the openmemory sub-project has been
+        hitting since #4805 landed)."""
+        override = "You are a strict fact extractor."
+        cfg = MemoryConfig(custom_fact_extraction_prompt=override)
+        assert cfg.custom_fact_extraction_prompt == override
+
+    def test_memory_init_wires_field_from_config(self, mocker):
+        """``Memory.__init__`` copies the field off MemoryConfig onto the
+        instance, mirroring the existing ``custom_instructions`` wiring."""
+        _setup_mocks(mocker)
+        override = "You are a strict fact extractor."
+        memory = Memory(MemoryConfig(custom_fact_extraction_prompt=override))
+        assert memory.custom_fact_extraction_prompt == override
+
+    def test_async_memory_init_wires_field_from_config(self, mocker):
+        _setup_mocks(mocker)
+        override = "You are a strict fact extractor."
+        memory = AsyncMemory(MemoryConfig(custom_fact_extraction_prompt=override))
+        assert memory.custom_fact_extraction_prompt == override


### PR DESCRIPTION
## Linked Issue

Closes #5730

## Description

Restores `custom_fact_extraction_prompt` as a `MemoryConfig` field that fully overrides the extraction system prompt, so self hosted callers can replace the high recall `ADDITIVE_EXTRACTION_PROMPT` and dial recall down. Default `None` (or blank) keeps current behavior; when set, the string becomes the extraction system prompt in `Memory` and `AsyncMemory`, and the caller owns the JSON output contract.

Per the review on #5730, this also:

- Routes `openmemory` (`openmemory/api/app/utils/memory.py`) to `custom_instructions` instead of the full override, so a short openmemory "Custom Instructions" string keeps the built in extraction system prompt and its JSON contract rather than silently replacing it. Regression test added.
- Adds a Custom Instructions docs page that distinguishes the two levers (`custom_instructions` = user prompt append, contract preserved; `custom_fact_extraction_prompt` = full system prompt override, caller owns the `{"memory": [{"text": "..."}]}` contract), and corrects the example output to that contract.

## Follow up (out of scope for this PR)

The TypeScript SDK has the same recall ceiling but no equivalent lever: `mem0-ts/src/oss/src/memory/index.ts` hardcodes `let systemPrompt = ADDITIVE_EXTRACTION_PROMPT` and exposes only `customInstructions` (user prompt append), with no `custom_fact_extraction_prompt` full override. Happy to open a follow up to bring the TS SDK to parity if that is wanted.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A. `custom_fact_extraction_prompt` defaults to `None`, so extraction behavior is unchanged unless it is set.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
