### PR TITLE
fix(ts-oss/weaviate): return full payload from get() and list()

### DIFF
--- a/mem0-ts/src/oss/src/vector_stores/weaviate.ts
+++ b/mem0-ts/src/oss/src/vector_stores/weaviate.ts
@@ -14,18 +14,11 @@ interface WeaviateConfig extends VectorStoreConfig {
   embeddingModelDims: number;
 }
 
-const RETURN_PROPERTIES = [
-  "ids",
-  "hash",
-  "metadata",
-  "data",
-  "created_at",
-  "category",
-  "updated_at",
-  "user_id",
-  "agent_id",
-  "run_id",
-];
+// Seeds the collection schema on first create. Weaviate auto-schema extends it
+// with whatever the memory layer actually writes (camelCase timestamps, the
+// lemmatized text, and any custom metadata keys), so reads must not be pinned
+// to this list.
+const BASE_PROPERTIES = ["hash", "data", "user_id", "agent_id", "run_id"];
 
 export class WeaviateDB implements VectorStore {
   private _config: WeaviateConfig;
@@ -107,7 +100,7 @@ export class WeaviateDB implements VectorStore {
     if (!exists) {
       await this._client.collections.create({
         name: collectionName,
-        properties: RETURN_PROPERTIES.map((name) => ({
+        properties: BASE_PROPERTIES.map((name) => ({
           name,
           dataType: "text" as const,
         })),
@@ -180,9 +173,11 @@ export class WeaviateDB implements VectorStore {
 
   async get(vectorId: string): Promise<VectorStoreResult | null> {
     await this.initialize();
-    const obj = await this._col.query.fetchObjectById(vectorId, {
-      returnProperties: RETURN_PROPERTIES,
-    });
+    // Return every stored property. Restricting to a fixed property list drops
+    // the camelCase timestamps (createdAt/updatedAt) and any custom metadata key
+    // the memory layer writes but the list does not name. search() already omits
+    // returnProperties for the same reason.
+    const obj = await this._col.query.fetchObjectById(vectorId);
     if (!obj) return null;
     return { id: obj.uuid, payload: obj.properties };
   }
@@ -218,7 +213,6 @@ export class WeaviateDB implements VectorStore {
     const result = await this._col.query.fetchObjects({
       limit: topK ?? 100,
       filters: this._buildFilters(filters),
-      returnProperties: RETURN_PROPERTIES,
     });
     const results = result.objects.map((obj: any) => ({
       id: obj.uuid,

--- a/mem0-ts/src/oss/tests/weaviate.unit.test.ts
+++ b/mem0-ts/src/oss/tests/weaviate.unit.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Weaviate vector store unit tests with a mocked weaviate-client.
+ *
+ * The mock reproduces Weaviate's real behavior that `returnProperties`, when
+ * supplied, restricts which fields come back on a read. That is exactly what
+ * made get()/list() silently drop the camelCase timestamps and custom metadata.
+ */
+/// <reference types="jest" />
+
+describe("Weaviate – mocked weaviate-client", () => {
+  let WeaviateDB: any;
+
+  const project = (
+    props: Record<string, any>,
+    returnProperties?: string[],
+  ): Record<string, any> => {
+    if (!returnProperties) return { ...props };
+    const out: Record<string, any> = {};
+    for (const key of returnProperties) {
+      if (key in props) out[key] = props[key];
+    }
+    return out;
+  };
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    jest.doMock("weaviate-client", () => {
+      const store = new Map<string, Record<string, any>>();
+
+      const col = {
+        data: {
+          insertMany: jest.fn(async (objects: any[]) => {
+            for (const o of objects) store.set(o.id, { ...o.properties });
+          }),
+          update: jest.fn(async ({ id, properties }: any) => {
+            store.set(id, { ...(store.get(id) ?? {}), ...properties });
+          }),
+          deleteById: jest.fn(async (id: string) => {
+            store.delete(id);
+          }),
+        },
+        query: {
+          fetchObjectById: jest.fn(async (id: string, opts?: any) => {
+            const props = store.get(id);
+            if (!props) return null;
+            return {
+              uuid: id,
+              properties: project(props, opts?.returnProperties),
+            };
+          }),
+          fetchObjects: jest.fn(async (opts?: any) => ({
+            objects: [...store.entries()].map(([id, props]) => ({
+              uuid: id,
+              properties: project(props, opts?.returnProperties),
+            })),
+          })),
+          nearVector: jest.fn(async (_v: number[], opts?: any) => ({
+            objects: [...store.entries()].map(([id, props]) => ({
+              uuid: id,
+              properties: project(props, opts?.returnProperties),
+              metadata: { distance: 0 },
+            })),
+          })),
+        },
+        filter: {
+          byProperty: (key: string) => ({
+            equal: (value: any) => ({ key, value }),
+          }),
+        },
+      };
+
+      const client = {
+        collections: {
+          exists: jest.fn(async () => false),
+          create: jest.fn(async () => undefined),
+          get: jest.fn(() => col),
+          delete: jest.fn(async () => undefined),
+        },
+      };
+
+      const weaviateDefault = {
+        configure: {
+          vectorizer: { none: () => ({}) },
+          vectorIndex: { hnsw: () => ({}) },
+        },
+        connectToLocal: jest.fn(async () => client),
+        connectToCustom: jest.fn(async () => client),
+        connectToWeaviateCloud: jest.fn(async () => client),
+        ApiKey: class {},
+      };
+
+      return {
+        __esModule: true,
+        default: weaviateDefault,
+        Filters: { and: (...conditions: any[]) => conditions },
+        __store: store,
+      };
+    });
+
+    WeaviateDB = require("../src/vector_stores/weaviate").WeaviateDB;
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  const newStore = () =>
+    new WeaviateDB({
+      collectionName: "test",
+      embeddingModelDims: 4,
+      clusterUrl: "http://localhost:8080",
+    });
+
+  it("get() returns camelCase timestamps and custom metadata, not just the seed fields", async () => {
+    const store = newStore();
+
+    await store.insert(
+      [[0.1, 0.2, 0.3, 0.4]],
+      ["mem-1"],
+      [
+        {
+          data: "hello weaviate",
+          hash: "hash-1",
+          user_id: "alice",
+          createdAt: "2024-01-01T00:00:00.000Z",
+          updatedAt: "2024-01-02T00:00:00.000Z",
+          priority: "high",
+        },
+      ],
+    );
+
+    const result = await store.get("mem-1");
+    expect(result?.id).toBe("mem-1");
+    expect(result?.payload.data).toBe("hello weaviate");
+    // entity ids were part of the seed list and always survived
+    expect(result?.payload.user_id).toBe("alice");
+    // these were dropped before the fix (not named in the restricted return list)
+    expect(result?.payload.createdAt).toBe("2024-01-01T00:00:00.000Z");
+    expect(result?.payload.updatedAt).toBe("2024-01-02T00:00:00.000Z");
+    expect(result?.payload.priority).toBe("high");
+  });
+
+  it("list() returns camelCase timestamps and custom metadata for every row", async () => {
+    const store = newStore();
+
+    await store.insert(
+      [[0.1, 0.2, 0.3, 0.4]],
+      ["mem-1"],
+      [
+        {
+          data: "row one",
+          hash: "h1",
+          user_id: "alice",
+          createdAt: "2024-01-01T00:00:00.000Z",
+          updatedAt: "2024-01-01T00:00:00.000Z",
+          priority: "low",
+        },
+      ],
+    );
+
+    const [rows] = await store.list({ user_id: "alice" }, 10);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].payload.createdAt).toBe("2024-01-01T00:00:00.000Z");
+    expect(rows[0].payload.updatedAt).toBe("2024-01-01T00:00:00.000Z");
+    expect(rows[0].payload.priority).toBe("low");
+  });
+});


### PR DESCRIPTION
## Linked Issue

Closes #6289

## Description

The Weaviate adapter pins its reads to a fixed property list, which drops
timestamps and custom metadata from `get()` and `getAll()`.

`get()` and `list()` passed a hardcoded `returnProperties` list to
`fetchObjectById`/`fetchObjects`. When `returnProperties` is set, Weaviate only
returns the named fields. That list named the timestamps in snake_case
(`created_at`/`updated_at`), but the memory layer writes them in camelCase
(`createdAt`/`updatedAt`), and it obviously cannot name the arbitrary custom
metadata keys a caller stores. So both were silently discarded on read, and
`payload.createdAt`/`payload.updatedAt` came back `undefined`.

`search()` never set `returnProperties`, so it returned the full payload and was
unaffected. That left `get`/`list` inconsistent with `search` for the very same
record, and out of line with the other providers (pgvector, qdrant, redis) that
all return the whole payload.

## What changed

- `get()` and `list()` no longer restrict `returnProperties`, so every stored
  property comes back (matching `search()`).
- The property constant is kept only to seed the collection schema on create;
  Weaviate auto-schema extends it with the real payload fields, so it no longer
  needs to enumerate timestamps or metadata.

## Testing

Added `weaviate.unit.test.ts` with a mocked `weaviate-client` whose reads honor
`returnProperties` the way the real client does. The tests assert that `get()`
and `list()` return `createdAt`, `updatedAt`, and a custom metadata key. Both
fail against the old code (timestamps `undefined`) and pass with the fix. Ran
the OSS suite and typecheck locally.
