### PR TITLE
fix(core): carry updated_at into batch add history records

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1027,7 +1027,10 @@ class Memory(MemoryBase):
                 "new_memory": r[1],
                 "event": "ADD",
                 "created_at": r[3].get("created_at"),
+                "updated_at": r[3].get("updated_at"),
                 "is_deleted": 0,
+                "actor_id": r[3].get("actor_id"),
+                "role": r[3].get("role"),
             }
             for r in records
         ]
@@ -1037,7 +1040,16 @@ class Memory(MemoryBase):
             # Fallback: add one by one
             for hr in history_records:
                 try:
-                    self.db.add_history(hr["memory_id"], None, hr["new_memory"], "ADD", created_at=hr.get("created_at"))
+                    self.db.add_history(
+                        hr["memory_id"],
+                        None,
+                        hr["new_memory"],
+                        "ADD",
+                        created_at=hr.get("created_at"),
+                        updated_at=hr.get("updated_at"),
+                        actor_id=hr.get("actor_id"),
+                        role=hr.get("role"),
+                    )
                 except Exception as e:
                     logger.error(f"Failed to add history for {hr['memory_id']}: {e}")
 
@@ -2661,7 +2673,10 @@ class AsyncMemory(MemoryBase):
                 "new_memory": r[1],
                 "event": "ADD",
                 "created_at": r[3].get("created_at"),
+                "updated_at": r[3].get("updated_at"),
                 "is_deleted": 0,
+                "actor_id": r[3].get("actor_id"),
+                "role": r[3].get("role"),
             }
             for r in records
         ]
@@ -2672,7 +2687,10 @@ class AsyncMemory(MemoryBase):
                 try:
                     await asyncio.to_thread(
                         self.db.add_history, hr["memory_id"], None, hr["new_memory"], "ADD",
-                        created_at=hr.get("created_at")
+                        created_at=hr.get("created_at"),
+                        updated_at=hr.get("updated_at"),
+                        actor_id=hr.get("actor_id"),
+                        role=hr.get("role"),
                     )
                 except Exception as e:
                     logger.error(f"Failed to add history for {hr['memory_id']} (async): {e}")

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import time
 from datetime import datetime, timezone
@@ -461,6 +462,59 @@ def test_create_then_search_and_get_all_return_same_timestamps(mocker):
     assert search_item["updated_at"] is not None
     assert get_all_item["created_at"] is not None
     assert get_all_item["updated_at"] is not None
+
+
+def test_batch_add_history_carries_updated_at(mocker):
+    """The V3 batch add pipeline (the default infer=True path) must record the
+    ADD history event with updated_at set, matching the single-memory
+    _create_memory path where updated_at == created_at."""
+    memory = _build_memory_instance(mocker, Memory)
+    memory.db.get_last_messages.return_value = []
+    memory.vector_store.search.return_value = []
+    memory.embedding_model.embed.return_value = [0.1, 0.2, 0.3]
+    memory.embedding_model.embed_batch.return_value = [[0.1, 0.2, 0.3]]
+    memory.llm.generate_response.return_value = json.dumps({"memory": [{"text": "Likes pizza"}]})
+
+    memory._add_to_vector_store(
+        messages=[{"role": "user", "content": "I like pizza"}],
+        metadata={"user_id": "alice"},
+        filters={"user_id": "alice"},
+        infer=True,
+    )
+
+    memory.db.batch_add_history.assert_called_once()
+    records = memory.db.batch_add_history.call_args.args[0]
+    assert len(records) == 1
+    record = records[0]
+    assert record["event"] == "ADD"
+    assert record["created_at"] is not None
+    assert record["updated_at"] == record["created_at"]
+
+
+@pytest.mark.asyncio
+async def test_async_batch_add_history_carries_updated_at(mocker):
+    """Async twin of test_batch_add_history_carries_updated_at."""
+    memory = _build_memory_instance(mocker, AsyncMemory)
+    memory.db.get_last_messages.return_value = []
+    memory.vector_store.search.return_value = []
+    memory.embedding_model.embed.return_value = [0.1, 0.2, 0.3]
+    memory.embedding_model.embed_batch.return_value = [[0.1, 0.2, 0.3]]
+    memory.llm.generate_response.return_value = json.dumps({"memory": [{"text": "Likes pizza"}]})
+
+    await memory._add_to_vector_store(
+        messages=[{"role": "user", "content": "I like pizza"}],
+        metadata={"user_id": "alice"},
+        effective_filters={"user_id": "alice"},
+        infer=True,
+    )
+
+    memory.db.batch_add_history.assert_called_once()
+    records = memory.db.batch_add_history.call_args.args[0]
+    assert len(records) == 1
+    record = records[0]
+    assert record["event"] == "ADD"
+    assert record["created_at"] is not None
+    assert record["updated_at"] == record["created_at"]
 
 
 def test_update_preserves_created_at_and_updates_updated_at(mocker):


### PR DESCRIPTION
## Linked Issue

Closes #6293

## Description

Memories created through the default `add()` pipeline ended up with an ADD
history row whose `updated_at`, `actor_id`, and `role` were NULL, while the
single-add path recorded `updated_at == created_at`. Same event type, two
different results depending on which internal path ran.

The default `add(infer=True)` flow goes through the V3 batch pipeline in
`_add_to_vector_store`. When it assembled the batch history records it only
carried `created_at`, so `batch_add_history` inserted the rest as NULL. That is
inconsistent with:

- the vector payload written for the same memory, which sets
  `updated_at = created_at`, and
- `_create_memory` (the single/`infer=False` path), which explicitly passes
  `updated_at`, `actor_id`, and `role` into `add_history`.

So the intent is clearly that an ADD event carries `updated_at == created_at`;
the batch path just dropped it. Anyone reading `history()` saw
`updated_at: null` for the ADD event of essentially every normally-created
memory.

## What changed

- The batch history records (and the one-by-one fallback) now include
  `updated_at`, `actor_id`, and `role`, read from the same payload that was
  persisted to the vector store.
- Applied to both `Memory` and `AsyncMemory`, which had the identical omission.

## Testing

Added sync and async tests that drive the batch pipeline and assert the ADD
history record carries `updated_at == created_at`. Both fail against the old
code (the key is absent) and pass with the fix. Full `tests/memory/test_main.py`
passes (50 tests); ruff clean.
