### PR TITLE
fix(ts-oss): set updatedAt on infer:false memories

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -1896,12 +1896,17 @@ export class Memory {
     const embedding =
       existingEmbeddings[data] || (await this.embedder.embed(data, "add"));
 
+    const now = new Date().toISOString();
     const memoryMetadata = {
       ...metadata,
       data,
       hash: createHash("md5").update(data).digest("hex"),
       textLemmatized: lemmatizeForBm25(data),
-      createdAt: new Date().toISOString(),
+      createdAt: now,
+      // A freshly created memory has updatedAt == createdAt. The batch pipeline
+      // and updateMemory both set it; without it here, infer:false memories come
+      // back from get()/getAll()/search() with updatedAt undefined.
+      updatedAt: now,
     };
 
     await this.vectorStore.insert([embedding], [memoryId], [memoryMetadata]);
@@ -1911,6 +1916,7 @@ export class Memory {
       data,
       "ADD",
       memoryMetadata.createdAt,
+      memoryMetadata.updatedAt,
     );
 
     return memoryId;

--- a/mem0-ts/src/oss/tests/memory.infer-false-timestamp.test.ts
+++ b/mem0-ts/src/oss/tests/memory.infer-false-timestamp.test.ts
@@ -1,0 +1,94 @@
+/**
+ * infer:false add() must persist updatedAt on the stored payload, matching the
+ * infer:true batch pipeline and updateMemory. Without it, get()/getAll()/search()
+ * return updatedAt as undefined for every infer:false memory.
+ */
+/// <reference types="jest" />
+import { Memory } from "../src/memory";
+import type { SearchResult } from "../src/types";
+
+jest.setTimeout(30000);
+
+// Keep the optional native providers out of CI.
+jest.mock("../src/embeddings/google", () => ({ GoogleEmbedder: jest.fn() }));
+jest.mock("../src/llms/google", () => ({ GoogleLLM: jest.fn() }));
+
+const mockEmbedding = new Array(1536).fill(0.1);
+jest.mock("../src/embeddings/openai", () => ({
+  OpenAIEmbedder: jest.fn().mockImplementation(() => ({
+    embed: jest.fn().mockResolvedValue(mockEmbedding),
+    embedBatch: jest
+      .fn()
+      .mockImplementation((texts: string[]) =>
+        Promise.resolve(texts.map(() => mockEmbedding)),
+      ),
+    embeddingDims: 1536,
+  })),
+}));
+// infer:false never calls the LLM, but the factory still constructs one.
+jest.mock("../src/llms/openai", () => ({
+  OpenAILLM: jest.fn().mockImplementation(() => ({
+    generateResponse: jest.fn().mockResolvedValue("{}"),
+  })),
+}));
+
+function createMemory(): Memory {
+  return new Memory({
+    version: "v1.1",
+    embedder: {
+      provider: "openai",
+      config: { apiKey: "test-key", model: "text-embedding-3-small" },
+    },
+    vectorStore: {
+      provider: "memory",
+      config: {
+        collectionName: `test-infer-false-${Date.now()}-${Math.random()}`,
+        dimension: 1536,
+        dbPath: ":memory:",
+      },
+    },
+    llm: {
+      provider: "openai",
+      config: { apiKey: "test-key", model: "gpt-5-mini" },
+    },
+    historyDbPath: ":memory:",
+  });
+}
+
+describe("Memory - infer:false timestamps", () => {
+  let memory: Memory;
+  const userId = `infer_false_${Date.now()}`;
+
+  beforeAll(() => {
+    memory = createMemory();
+  });
+
+  afterAll(async () => {
+    await memory.reset();
+  });
+
+  test("get() returns updatedAt equal to createdAt for an infer:false memory", async () => {
+    const addResult: SearchResult = await memory.add("I like tea", {
+      userId,
+      infer: false,
+    });
+    const id = addResult.results[0].id;
+
+    const item = await memory.get(id);
+    expect(item).not.toBeNull();
+    expect(item!.createdAt).toBeDefined();
+    expect(item!.updatedAt).toBeDefined();
+    expect(item!.updatedAt).toBe(item!.createdAt);
+  });
+
+  test("getAll() returns updatedAt for infer:false memories", async () => {
+    await memory.add("I like coffee", { userId, infer: false });
+
+    const all = await memory.getAll({ filters: { user_id: userId } });
+    expect(all.results.length).toBeGreaterThan(0);
+    for (const item of all.results) {
+      expect(item.updatedAt).toBeDefined();
+      expect(item.createdAt).toBeDefined();
+    }
+  });
+});


### PR DESCRIPTION
## Linked Issue

Closes #6295

## Description

Memories added with `infer: false` were stored without `updatedAt`, so reading
them back through `get()`, `getAll()`, or `search()` returned
`updatedAt: undefined`.

The `infer: false` path calls `createMemory`, which built the payload with
`createdAt` but never set `updatedAt`. Every other write path sets it:

- the `infer: true` batch pipeline writes both `createdAt` and `updatedAt`,
- `updateMemory` sets `updatedAt` on edits,
- and Python's `_create_memory` sets `updated_at = created_at` for a new memory.

So `infer: false` memories were the only ones missing it, violating the contract
that `updatedAt` is always populated.

## What changed

- `createMemory` now sets `updatedAt` equal to `createdAt` on the stored payload
  and passes it to `addHistory`, so the ADD event carries it too.

## Testing

Added `memory.infer-false-timestamp.test.ts` asserting `get()` and `getAll()`
return `updatedAt` (equal to `createdAt`) for `infer: false` memories. Both fail
against the old code (undefined) and pass with the fix. `memory.crud` suite
(50 tests) still passes; prettier clean.
