### PR TITLE
fix(ts-oss/weaviate): run keyword BM25 over the lemmatized field

### DIFF
--- a/mem0-ts/src/oss/src/vector_stores/weaviate.ts
+++ b/mem0-ts/src/oss/src/vector_stores/weaviate.ts
@@ -165,8 +165,12 @@ export class WeaviateDB implements VectorStore {
     filters?: SearchFilters,
   ): Promise<VectorStoreResult[] | null> {
     await this.initialize();
+    // The memory layer lemmatizes the query before calling keywordSearch, and it
+    // stores the lemmatized text under textLemmatized. Match BM25 against that
+    // field (as pgvector and the in-memory store do); running it over the raw
+    // data field means a stemmed query token never matches the unstemmed text.
     const result = await this._col.query.bm25(query, {
-      queryProperties: ["data"],
+      queryProperties: ["textLemmatized"],
       limit: topK ?? 10,
       filters: this._buildFilters(filters),
       returnMetadata: ["score"],

--- a/mem0-ts/src/oss/tests/weaviate.keyword.unit.test.ts
+++ b/mem0-ts/src/oss/tests/weaviate.keyword.unit.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Weaviate keyword search must run BM25 against the lemmatized field.
+ *
+ * The memory layer lemmatizes the query before calling keywordSearch and stores
+ * the lemmatized text under `textLemmatized`. Matching a stemmed query against
+ * the raw `data` field silently misses hits, so keyword recall degrades.
+ */
+/// <reference types="jest" />
+
+describe("Weaviate keywordSearch – mocked weaviate-client", () => {
+  let WeaviateDB: any;
+  let bm25Mock: jest.Mock;
+
+  beforeEach(() => {
+    jest.resetModules();
+    bm25Mock = jest.fn(async () => ({ objects: [] }));
+
+    jest.doMock("weaviate-client", () => {
+      const col = {
+        data: { insertMany: jest.fn(async () => undefined) },
+        query: {
+          bm25: bm25Mock,
+          fetchObjectById: jest.fn(async () => null),
+          fetchObjects: jest.fn(async () => ({ objects: [] })),
+          nearVector: jest.fn(async () => ({ objects: [] })),
+        },
+        filter: {
+          byProperty: (key: string) => ({
+            equal: (value: any) => ({ key, value }),
+          }),
+        },
+      };
+
+      const client = {
+        collections: {
+          exists: jest.fn(async () => false),
+          create: jest.fn(async () => undefined),
+          get: jest.fn(() => col),
+          delete: jest.fn(async () => undefined),
+        },
+      };
+
+      const weaviateDefault = {
+        configure: {
+          vectorizer: { none: () => ({}) },
+          vectorIndex: { hnsw: () => ({}) },
+        },
+        connectToLocal: jest.fn(async () => client),
+        connectToCustom: jest.fn(async () => client),
+      };
+
+      return {
+        __esModule: true,
+        default: weaviateDefault,
+        Filters: { and: (...conditions: any[]) => conditions },
+      };
+    });
+
+    WeaviateDB = require("../src/vector_stores/weaviate").WeaviateDB;
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it("runs BM25 against the lemmatized field, not the raw data field", async () => {
+    const store = new WeaviateDB({
+      collectionName: "test",
+      embeddingModelDims: 4,
+      clusterUrl: "http://localhost:8080",
+    });
+
+    await store.keywordSearch("studi", 5, { user_id: "alice" });
+
+    expect(bm25Mock).toHaveBeenCalledTimes(1);
+    const [, options] = bm25Mock.mock.calls[0];
+    expect(options.queryProperties).toEqual(["textLemmatized"]);
+    expect(options.queryProperties).not.toContain("data");
+  });
+});


### PR DESCRIPTION
## Linked Issue

Closes #6297

## Description

Weaviate keyword search ran BM25 against the raw `data` field while the memory
layer hands it an already-lemmatized query, so stemmed query tokens missed the
unstemmed stored text and keyword recall degraded silently.

`Memory.search()` lemmatizes the query before calling `keywordSearch` (it passes
`queryLemmatized`) and stores the lemmatized text on each memory under
`textLemmatized`. The other keyword-capable stores match lemmatized-to-lemmatized:
pgvector queries `payload->>'textLemmatized'` and the in-memory store tokenizes
`payload.textLemmatized`. Weaviate was the outlier, querying `data`, whose default
tokenizer lowercases but does not stem, so e.g. a query "studies" (stemmed to
`studi`) would not match stored "studying".

## What changed

- Weaviate `keywordSearch` now targets `textLemmatized` instead of `data`, so the
  lemmatized query matches the lemmatized field, consistent with the other stores.

## Testing

Added a unit test (mocked `weaviate-client`) asserting `keywordSearch` calls BM25
with `queryProperties: ["textLemmatized"]`. It fails against the old code
(`["data"]`) and passes with the fix. Typecheck and prettier clean.
