### PR TITLE
fix(embeddings/huggingface): forward api_key on base_url path

### DIFF
--- a/docs/components/embedders/models/huggingface.mdx
+++ b/docs/components/embedders/models/huggingface.mdx
@@ -99,6 +99,7 @@ Here are the parameters available for configuring the Hugging Face embedder:
 | `embedding_dims` | Dimensions of the embedding model | `selected_model_dimensions` |
 | `model_kwargs` | Additional arguments for the model | `None` |
 | `huggingface_base_url` | URL to connect to Text Embeddings Inference (TEI) API | `None` |
+| `api_key` | API key for the TEI or OpenAI-compatible endpoint; falls back to the `HUGGINGFACE_API_KEY` env var | `"hf"` |
 </Tab>
 <Tab title="TypeScript">
 | Parameter | Description | Default Value |

--- a/mem0/embeddings/huggingface.py
+++ b/mem0/embeddings/huggingface.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import Literal, Optional
 
 from openai import OpenAI
@@ -17,7 +18,8 @@ class HuggingFaceEmbedding(EmbeddingBase):
         super().__init__(config)
 
         if self.config.huggingface_base_url:
-            self.client = OpenAI(base_url=self.config.huggingface_base_url)
+            api_key = self.config.api_key or os.getenv("HUGGINGFACE_API_KEY") or "hf"
+            self.client = OpenAI(base_url=self.config.huggingface_base_url, api_key=api_key)
             self.config.model = self.config.model or "tei"
         else:
             self.config.model = self.config.model or "multi-qa-MiniLM-L6-cos-v1"

--- a/tests/embeddings/test_huggingface_embeddings.py
+++ b/tests/embeddings/test_huggingface_embeddings.py
@@ -94,13 +94,37 @@ def test_embed_with_huggingface_base_url():
         embedder = HuggingFaceEmbedding(config)
         result = embedder.embed("Hello from custom endpoint")
 
-        mock_openai.assert_called_once_with(base_url="http://localhost:8080")
+        mock_openai.assert_called_once_with(base_url="http://localhost:8080", api_key="hf")
         mock_client.embeddings.create.assert_called_once_with(
             input="Hello from custom endpoint",
             model="my-custom-model",
             truncate=True,
         )
         assert result == [0.1, 0.2, 0.3]
+
+
+def test_base_url_forwards_config_api_key(monkeypatch):
+    monkeypatch.delenv("HUGGINGFACE_API_KEY", raising=False)
+    config = BaseEmbedderConfig(huggingface_base_url="http://localhost:8080", api_key="hf_configToken")
+    with patch("mem0.embeddings.huggingface.OpenAI") as mock_openai:
+        HuggingFaceEmbedding(config)
+        assert mock_openai.call_args.kwargs["api_key"] == "hf_configToken"
+
+
+def test_base_url_uses_env_api_key_when_config_unset(monkeypatch):
+    monkeypatch.setenv("HUGGINGFACE_API_KEY", "hf_envToken")
+    config = BaseEmbedderConfig(huggingface_base_url="http://localhost:8080")
+    with patch("mem0.embeddings.huggingface.OpenAI") as mock_openai:
+        HuggingFaceEmbedding(config)
+        assert mock_openai.call_args.kwargs["api_key"] == "hf_envToken"
+
+
+def test_base_url_defaults_api_key_when_unset(monkeypatch):
+    monkeypatch.delenv("HUGGINGFACE_API_KEY", raising=False)
+    config = BaseEmbedderConfig(huggingface_base_url="http://localhost:8080")
+    with patch("mem0.embeddings.huggingface.OpenAI") as mock_openai:
+        HuggingFaceEmbedding(config)
+        assert mock_openai.call_args.kwargs["api_key"] == "hf"
 
 
 def test_embed_batch_sentence_transformer(mock_sentence_transformer):

--- a/tests/embeddings/test_huggingface_embeddings.py
+++ b/tests/embeddings/test_huggingface_embeddings.py
@@ -72,7 +72,8 @@ def test_embed_with_custom_embedding_dims(mock_sentence_transformer):
     assert result == [1.0, 1.1, 1.2]
 
 
-def test_embed_with_huggingface_base_url():
+def test_embed_with_huggingface_base_url(monkeypatch):
+    monkeypatch.delenv("HUGGINGFACE_API_KEY", raising=False)
     config = BaseEmbedderConfig(
         huggingface_base_url="http://localhost:8080",
         model="my-custom-model",


### PR DESCRIPTION
### Summary

On the `huggingface_base_url` path (TEI server / HF Inference Endpoint), `HuggingFaceEmbedding` built the OpenAI-compatible client with only `base_url` and never forwarded `api_key`. A user-supplied `api_key` was silently dropped, and with no `OPENAI_API_KEY` present the client raised `openai.OpenAIError: Missing credentials` at construction. (It could also leak a real `OPENAI_API_KEY` as the bearer token sent to whatever host `huggingface_base_url` points at.)

This forwards the key with `config > env > default` precedence. The exact 3-tier precedence matches the TypeScript SDK (`mem0-ts/src/oss/src/embeddings/huggingface.ts`) and the documented `HUGGINGFACE_API_KEY` / `"hf"` fallback. The sibling `LMStudioEmbedding` follows the same "always pass a non-empty key" shape (though it is 2-tier: config then default, no env fallback).

### Changes

- `mem0/embeddings/huggingface.py`: pass `api_key = self.config.api_key or os.getenv("HUGGINGFACE_API_KEY") or "hf"` to `OpenAI(...)` on the base_url branch.
- `tests/embeddings/test_huggingface_embeddings.py`: add 3 regression tests (config key, env fallback, default `"hf"`). The existing base_url test asserts the key and `delenv`s `HUGGINGFACE_API_KEY` so it is deterministic regardless of the local environment.
- `docs/components/embedders/models/huggingface.mdx`: add the `api_key` row to the Python config table (it was only in the TypeScript tab).

### Verification

- `ruff check` clean on the changed Python files.
- `pytest tests/embeddings/test_huggingface_embeddings.py` -> 14 passed, both with and without `HUGGINGFACE_API_KEY` set.
- `docs/llms.txt` reported in sync after the docs change.
- End-to-end against a real OpenAI client: config key, `HUGGINGFACE_API_KEY`, and the `"hf"` default all resolve correctly, and the no-`OPENAI_API_KEY` construction no longer crashes.

Closes #6301
