### PR TITLE
docs: fix search result access in oss-v2-to-v3 migration guide

### DIFF
--- a/docs/migration/oss-v2-to-v3.mdx
+++ b/docs/migration/oss-v2-to-v3.mdx
@@ -182,7 +182,7 @@ pip install fastembed
         threshold=0.1,      # New default (pass 0.0 to disable)
         rerank=False         # New default (pass True to restore)
     )
-    for r in results:
+    for r in results["results"]:
         print(r["score"])
     ```
 


### PR DESCRIPTION
## Summary

Fixed incorrect iteration pattern in the OSS v2-to-v3 migration guide (`docs/migration/oss-v2-to-v3.mdx`).

### Problem

The "After" code example for `search()` was iterating over the returned dict directly:

\`\`\`python
results = m.search(...)
for r in results:        # iterates dict keys, not memory entries
    print(r["score"])
\`\`\`

Since `search()` returns \`{"results": [...]}\`, this would iterate over the key \`"results"\` instead of the actual memory entries.

### Fix

\`\`\`python
results = m.search(...)
for r in results["results"]:   # correctly accesses the results list
    print(r["score"])
\`\`\`

### Related

- Related issue: #3309 (docs inconsistency on search return type)