### PR TITLE
fix(openclaw): make auto-recall timeout configurable

### DIFF
--- a/docs/integrations/openclaw.mdx
+++ b/docs/integrations/openclaw.mdx
@@ -345,6 +345,7 @@ openclaw mem0 status --json
 | `autoCapture` | `boolean` | `true` | Store facts after each turn. Ignored when `skills` is configured. |
 | `topK` | `number` | `5` | Max memories per recall |
 | `searchThreshold` | `number` | `0.3` | Min similarity (0–1) |
+| `recallTimeoutMs` | `integer` or ASCII digit string | `8000` | Legacy-only recall deadline in milliseconds; allowed range is `1000` to `120000`. Ignored in skills mode. |
 
 ### Platform Mode Options
 

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -303,6 +303,7 @@ openclaw mem0 help --json                                   # discover all comma
 | `autoCapture` | `boolean` | `true` | Extract and store facts after each turn. Ignored when `skills` is set. |
 | `topK` | `number` | `5` | Max memories returned per recall |
 | `searchThreshold` | `number` | `0.1` | Minimum similarity score (0-1) |
+| `recallTimeoutMs` | `integer` or ASCII digit string | `8000` | Legacy-only recall deadline in milliseconds; allowed range is `1000` to `120000`. Ignored in skills mode. |
 
 ### Skills Mode (Recommended)
 
@@ -320,6 +321,8 @@ Enabled by default during `openclaw mem0 init`. `autoRecall` and `autoCapture` a
 | `skills.domain` | `string` | `"companion"` | Domain overlay for triage rules |
 
 ### Platform Mode
+
+Set `recallTimeoutMs` directly or with OpenClaw interpolation, for example `"recallTimeoutMs": "${RECALL_TIMEOUT_MS}"`. The parser validates the resolved value.
 
 | Key | Type | Default | Description |
 | --- | ---- | ------- | ----------- |

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -303,7 +303,7 @@ openclaw mem0 help --json                                   # discover all comma
 | `autoCapture` | `boolean` | `true` | Extract and store facts after each turn. Ignored when `skills` is set. |
 | `topK` | `number` | `5` | Max memories returned per recall |
 | `searchThreshold` | `number` | `0.1` | Minimum similarity score (0-1) |
-| `recallTimeoutMs` | `integer` or ASCII digit string | `8000` | Legacy-only recall deadline in milliseconds; allowed range is `1000` to `120000`. Ignored in skills mode. |
+| `recallTimeoutMs` | `integer` or ASCII digit string | `8000` | Auto-recall deadline in milliseconds for **legacy and skills mode**; allowed range is `1000` to `120000`. |
 
 ### Skills Mode (Recommended)
 

--- a/integrations/openclaw/cli/commands.ts
+++ b/integrations/openclaw/cli/commands.ts
@@ -47,6 +47,7 @@ import {
   OPENCLAW_CONFIG_FILE,
 } from "./config-file.ts";
 import { jsonOut, jsonErr, redactSecrets } from "./json-helpers.ts";
+import { parseRecallTimeoutMs } from "../config.ts";
 import {
   LLM_PROVIDERS, EMBEDDER_PROVIDERS, VECTOR_PROVIDERS,
   buildOssLlmConfig, buildOssEmbedderConfig, buildOssVectorConfig,
@@ -1278,6 +1279,7 @@ export function registerCliCommands(
         auto_recall: "autoRecall",
         auto_capture: "autoCapture",
         top_k: "topK",
+        recall_timeout_ms: "recallTimeoutMs",
         mode: "mode",
         embedder_provider: "oss.embedder.provider",
         embedder_model: "oss.embedder.config.model",
@@ -1307,7 +1309,7 @@ export function registerCliCommands(
       ]);
 
       // Integer config fields — coerce to number on set
-      const INTEGER_KEYS = new Set(["topK", "oss.vectorStore.config.port"]);
+      const INTEGER_KEYS = new Set(["topK", "recallTimeoutMs", "oss.vectorStore.config.port"]);
 
       /** Resolve a user-facing key to the internal camelCase field name. */
       function resolveConfigKey(key: string): string | null {
@@ -1335,6 +1337,7 @@ export function registerCliCommands(
           autoRecall: cfg.autoRecall,
           autoCapture: cfg.autoCapture,
           topK: cfg.topK,
+          recallTimeoutMs: auth.recallTimeoutMs ?? cfg.recallTimeoutMs,
         };
         return values[field];
       }
@@ -1363,6 +1366,7 @@ export function registerCliCommands(
               ["auto_recall", "autoRecall"],
               ["auto_capture", "autoCapture"],
               ["top_k", "topK"],
+              ["recall_timeout_ms", "recallTimeoutMs"],
             ];
             if (cfg.mode === "platform") {
               showEntries.push(["api_key", "apiKey"], ["email", "userEmail"]);
@@ -1396,6 +1400,7 @@ export function registerCliCommands(
             ["auto_recall", "autoRecall"],
             ["auto_capture", "autoCapture"],
             ["top_k", "topK"],
+            ["recall_timeout_ms", "recallTimeoutMs"],
           ];
 
           if (cfg.mode === "platform") {
@@ -1498,13 +1503,19 @@ export function registerCliCommands(
               rawValue === "1" ||
               rawValue.toLowerCase() === "yes";
           } else if (INTEGER_KEYS.has(field)) {
-            const parsed = parseInt(rawValue, 10);
-            if (isNaN(parsed)) {
-              if (jsonErr(opts, `Invalid integer value: ${rawValue}`)) return;
-              console.error(`Invalid integer value: ${rawValue}`);
+            try {
+              value = field === "recallTimeoutMs"
+                ? parseRecallTimeoutMs(rawValue)
+                : Number.parseInt(rawValue, 10);
+              if (!Number.isInteger(value)) throw new Error();
+            } catch {
+              const message = field === "recallTimeoutMs"
+                ? `Invalid recall timeout value: ${rawValue}`
+                : `Invalid integer value: ${rawValue}`;
+              if (jsonErr(opts, message)) return;
+              console.error(message);
               return;
             }
-            value = parsed;
           }
 
           // Nested OSS fields use dot-path writer; flat fields use auth writer

--- a/integrations/openclaw/cli/config-file.ts
+++ b/integrations/openclaw/cli/config-file.ts
@@ -34,6 +34,7 @@ export interface PluginAuthConfig {
   autoRecall?: boolean;
   autoCapture?: boolean;
   topK?: number;
+  recallTimeoutMs?: number;
   anonymousTelemetryId?: string;
 }
 
@@ -134,6 +135,7 @@ export function readPluginAuth(): PluginAuthConfig {
     autoRecall: cfg.autoRecall as boolean | undefined,
     autoCapture: cfg.autoCapture as boolean | undefined,
     topK: cfg.topK as number | undefined,
+    recallTimeoutMs: cfg.recallTimeoutMs as number | undefined,
     anonymousTelemetryId: cfg.anonymousTelemetryId as string | undefined,
   };
 }

--- a/integrations/openclaw/config.ts
+++ b/integrations/openclaw/config.ts
@@ -21,6 +21,30 @@ export interface FileConfig {
   baseUrl?: string;
 }
 
+export const DEFAULT_RECALL_TIMEOUT_MS = 8_000;
+export const MIN_RECALL_TIMEOUT_MS = 1_000;
+export const MAX_RECALL_TIMEOUT_MS = 120_000;
+
+export function parseRecallTimeoutMs(value: unknown): number {
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && /^[0-9]+$/.test(value)
+        ? Number(value)
+        : undefined;
+  if (
+    parsed === undefined ||
+    !Number.isSafeInteger(parsed) ||
+    parsed < MIN_RECALL_TIMEOUT_MS ||
+    parsed > MAX_RECALL_TIMEOUT_MS
+  ) {
+    throw new Error(
+      `recallTimeoutMs must be an integer from ${MIN_RECALL_TIMEOUT_MS} to ${MAX_RECALL_TIMEOUT_MS}`,
+    );
+  }
+  return parsed;
+}
+
 // ============================================================================
 // Default Custom Instructions & Categories
 // ============================================================================
@@ -158,6 +182,7 @@ const ALLOWED_KEYS = [
   "customPrompt",
   "searchThreshold",
   "topK",
+  "recallTimeoutMs",
   "oss",
   "skills",
 ];
@@ -249,6 +274,10 @@ export const mem0ConfigSchema = {
       searchThreshold:
         typeof cfg.searchThreshold === "number" ? cfg.searchThreshold : 0.1,
       topK: typeof cfg.topK === "number" ? cfg.topK : 5,
+      recallTimeoutMs:
+        cfg.recallTimeoutMs === undefined
+          ? DEFAULT_RECALL_TIMEOUT_MS
+          : parseRecallTimeoutMs(cfg.recallTimeoutMs),
       needsSetup,
       oss: ossConfig,
       skills:

--- a/integrations/openclaw/index.test.ts
+++ b/integrations/openclaw/index.test.ts
@@ -14,7 +14,10 @@ import memoryPlugin, {
   isGenericAssistantMessage,
   stripNoiseFromContent,
   filterMessagesForExtraction,
+  registerHooks,
+  formatRegistrationLog,
 } from "./index.ts";
+import type { Mem0Config, Mem0Provider } from "./types.ts";
 
 function createPluginApi(registrationMode?: string) {
   return {
@@ -54,6 +57,125 @@ describe("plugin registration modes", () => {
     expect(api.logger.info).not.toHaveBeenCalledWith(
       expect.stringContaining("openclaw-mem0: registered"),
     );
+  });
+});
+
+describe("startup log", () => {
+  it("logs the effective legacy recall timeout once", () => {
+    expect(formatRegistrationLog(hookConfig(120000), false)).toContain(
+      "legacyRecallTimeoutMs: 120000",
+    );
+  });
+});
+
+function hookConfig(recallTimeoutMs: number): Mem0Config {
+  return {
+    mode: "platform",
+    apiKey: "test-api-key",
+    userId: "alice",
+    customInstructions: "",
+    customCategories: {},
+    autoCapture: false,
+    autoRecall: true,
+    searchThreshold: 0.1,
+    topK: 5,
+    recallTimeoutMs,
+  };
+}
+
+function registerRecallTest(
+  cfg: Mem0Config,
+  provider: Partial<Mem0Provider>,
+  skillsActive = false,
+) {
+  const hooks = new Map<string, (...args: any[]) => Promise<unknown>>();
+  const captureEvent = vi.fn();
+  const api = {
+    on: vi.fn((name: string, callback: (...args: any[]) => Promise<unknown>) => hooks.set(name, callback)),
+    logger: { info: vi.fn(), warn: vi.fn() },
+  } as any;
+  registerHooks(
+    api,
+    provider as Mem0Provider,
+    cfg,
+    () => cfg.userId,
+    () => ({ user_id: cfg.userId }),
+    () => ({ user_id: cfg.userId, top_k: cfg.topK }),
+    { setCurrentSessionId: vi.fn(), getStateDir: () => undefined },
+    skillsActive,
+    captureEvent,
+  );
+  return { api, callback: hooks.get("before_prompt_build")!, captureEvent };
+}
+
+describe("legacy recall timeout ownership", () => {
+  it("uses recallTimeoutMs 9000 for a provider delayed 8500ms", async () => {
+    vi.useFakeTimers();
+    const provider = {
+      search: vi.fn(() => new Promise((resolve) => setTimeout(() => resolve([
+        { id: "m1", memory: "fact", score: 0.9 },
+      ]), 8500))),
+    };
+    const { api, callback } = registerRecallTest(hookConfig(9000), provider);
+    const resultPromise = callback({ prompt: "remember this" }, {});
+    await vi.advanceTimersByTimeAsync(8500);
+    expect((await resultPromise) as object).toHaveProperty("prependContext");
+    expect(api.logger.info).toHaveBeenCalledWith(expect.stringContaining("injecting 1 memories"));
+    vi.useRealTimers();
+  });
+
+  it("uses the 8000ms default when recallTimeoutMs is unset", async () => {
+    vi.useFakeTimers();
+    const provider = {
+      search: vi.fn(() => new Promise((resolve) => setTimeout(() => resolve([
+        { id: "m1", memory: "fact", score: 0.9 },
+      ]), 8500))),
+    };
+    const { api, callback } = registerRecallTest(hookConfig(8000), provider);
+    const resultPromise = callback({ prompt: "remember this" }, {});
+    await vi.advanceTimersByTimeAsync(8000);
+    expect(await resultPromise).toBeUndefined();
+    await vi.advanceTimersByTimeAsync(500);
+    expect(api.logger.warn).toHaveBeenCalledWith(expect.stringContaining("after 8000ms"));
+    expect(api.logger.info).not.toHaveBeenCalledWith(expect.stringContaining("injecting"));
+    vi.useRealTimers();
+  });
+
+  it("skills-mode recall ignores recallTimeoutMs", async () => {
+    const provider = { search: vi.fn().mockResolvedValue([]) };
+    const { callback } = registerRecallTest({
+      ...hookConfig(1000),
+      skills: { recall: { enabled: true } },
+    }, provider, true);
+    await expect(callback({ prompt: "remember this" }, { sessionKey: "agent:main:main" })).resolves.toBeDefined();
+    expect(provider.search).toHaveBeenCalled();
+  });
+
+  it("records one terminal legacy recall outcome", async () => {
+    const provider = {
+      search: vi.fn().mockRejectedValue(new Error("provider unavailable")),
+    };
+    const { api, callback, captureEvent } = registerRecallTest(hookConfig(8000), provider);
+
+    await expect(callback({ prompt: "remember this" }, {})).resolves.toBeUndefined();
+    expect(api.logger.warn).toHaveBeenCalledWith(
+      "openclaw-mem0: recall failed: Error: provider unavailable",
+    );
+    expect(captureEvent).toHaveBeenCalledTimes(1);
+    expect(captureEvent).toHaveBeenCalledWith(
+      "openclaw.hook.recall",
+      expect.objectContaining({ outcome: "provider_error" }),
+    );
+    expect(captureEvent).not.toHaveBeenCalledWith(
+      "openclaw.hook.recall",
+      expect.objectContaining({ outcome: "timeout" }),
+    );
+    expect(captureEvent).not.toHaveBeenCalledWith(
+      "openclaw.hook.recall",
+      expect.objectContaining({ outcome: "success" }),
+    );
+    expect(api.logger.warn).not.toHaveBeenCalledWith(expect.stringContaining("timed out"));
+    expect(api.logger.info).not.toHaveBeenCalledWith(expect.stringContaining("injecting"));
   });
 });
 

--- a/integrations/openclaw/index.test.ts
+++ b/integrations/openclaw/index.test.ts
@@ -75,9 +75,29 @@ describe("startup log", () => {
         (message: string) =>
           message.includes("openclaw-mem0: registered") &&
           message.includes("legacyRecallTimeoutMs: 120000"),
-      );
+    );
     expect(matches).toHaveLength(1);
     expect(matches[0]?.match(/legacyRecallTimeoutMs/g)).toHaveLength(1);
+  });
+
+  it("falls back to the default legacy recall timeout when registration sees an invalid value", () => {
+    const api = createPluginApi(undefined, {
+      recallTimeoutMs: "${RECALL_TIMEOUT_MS}",
+    });
+
+    memoryPlugin.register(api as any);
+
+    expect(api.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('invalid recallTimeoutMs "${RECALL_TIMEOUT_MS}"'),
+    );
+    const matches = api.logger.info.mock.calls
+      .map(([message]: [unknown]) => String(message))
+      .filter(
+        (message: string) =>
+          message.includes("openclaw-mem0: registered") &&
+          message.includes("legacyRecallTimeoutMs: 8000"),
+      );
+    expect(matches).toHaveLength(1);
   });
 });
 
@@ -163,16 +183,6 @@ describe("legacy recall timeout ownership", () => {
     expect(api.logger.warn).toHaveBeenCalledWith(expect.stringContaining("after 8000ms"));
     expect(api.logger.info).not.toHaveBeenCalledWith(expect.stringContaining("injecting"));
     vi.useRealTimers();
-  });
-
-  it("skills-mode recall ignores recallTimeoutMs", async () => {
-    const provider = { search: vi.fn().mockResolvedValue([]) };
-    const { callback } = registerRecallTest({
-      ...hookConfig(1000),
-      skills: { recall: { enabled: true } },
-    }, provider, true);
-    await expect(callback({ prompt: "remember this" }, { sessionKey: "agent:main:main" })).resolves.toBeDefined();
-    expect(provider.search).toHaveBeenCalled();
   });
 
   it("records one terminal legacy recall outcome", async () => {

--- a/integrations/openclaw/index.test.ts
+++ b/integrations/openclaw/index.test.ts
@@ -15,16 +15,19 @@ import memoryPlugin, {
   stripNoiseFromContent,
   filterMessagesForExtraction,
   registerHooks,
-  formatRegistrationLog,
 } from "./index.ts";
 import type { Mem0Config, Mem0Provider } from "./types.ts";
 
-function createPluginApi(registrationMode?: string) {
+function createPluginApi(
+  registrationMode?: string,
+  pluginConfigOverrides: Record<string, unknown> = {},
+) {
   return {
     pluginConfig: {
       mode: "platform",
       apiKey: "test-api-key",
       userId: "alice",
+      ...pluginConfigOverrides,
     },
     registrationMode,
     logger: {
@@ -62,9 +65,19 @@ describe("plugin registration modes", () => {
 
 describe("startup log", () => {
   it("logs the effective legacy recall timeout once", () => {
-    expect(formatRegistrationLog(hookConfig(120000), false)).toContain(
-      "legacyRecallTimeoutMs: 120000",
-    );
+    const api = createPluginApi(undefined, { recallTimeoutMs: 120000 });
+
+    memoryPlugin.register(api as any);
+
+    const matches = api.logger.info.mock.calls
+      .map(([message]: [unknown]) => String(message))
+      .filter(
+        (message: string) =>
+          message.includes("openclaw-mem0: registered") &&
+          message.includes("legacyRecallTimeoutMs: 120000"),
+      );
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.match(/legacyRecallTimeoutMs/g)).toHaveLength(1);
   });
 });
 
@@ -116,11 +129,22 @@ describe("legacy recall timeout ownership", () => {
         { id: "m1", memory: "fact", score: 0.9 },
       ]), 8500))),
     };
-    const { api, callback } = registerRecallTest(hookConfig(9000), provider);
+    const { api, callback, captureEvent } = registerRecallTest(hookConfig(9000), provider);
     const resultPromise = callback({ prompt: "remember this" }, {});
     await vi.advanceTimersByTimeAsync(8500);
     expect((await resultPromise) as object).toHaveProperty("prependContext");
+    await vi.advanceTimersByTimeAsync(1000);
     expect(api.logger.info).toHaveBeenCalledWith(expect.stringContaining("injecting 1 memories"));
+    expect(api.logger.warn).not.toHaveBeenCalledWith(expect.stringContaining("timed out"));
+    expect(captureEvent).toHaveBeenCalledTimes(1);
+    expect(captureEvent).toHaveBeenCalledWith(
+      "openclaw.hook.recall",
+      expect.objectContaining({ outcome: "success" }),
+    );
+    expect(captureEvent).not.toHaveBeenCalledWith(
+      "openclaw.hook.recall",
+      expect.objectContaining({ outcome: "timeout" }),
+    );
     vi.useRealTimers();
   });
 
@@ -152,12 +176,21 @@ describe("legacy recall timeout ownership", () => {
   });
 
   it("records one terminal legacy recall outcome", async () => {
+    vi.useFakeTimers();
     const provider = {
-      search: vi.fn().mockRejectedValue(new Error("provider unavailable")),
+      search: vi.fn(
+        () =>
+          new Promise((_, reject) =>
+            setTimeout(() => reject(new Error("provider unavailable")), 1000),
+          ),
+      ),
     };
     const { api, callback, captureEvent } = registerRecallTest(hookConfig(8000), provider);
 
-    await expect(callback({ prompt: "remember this" }, {})).resolves.toBeUndefined();
+    const resultPromise = callback({ prompt: "remember this" }, {});
+    await vi.advanceTimersByTimeAsync(1000);
+    await expect(resultPromise).resolves.toBeUndefined();
+    await vi.advanceTimersByTimeAsync(8000);
     expect(api.logger.warn).toHaveBeenCalledWith(
       "openclaw-mem0: recall failed: Error: provider unavailable",
     );
@@ -176,6 +209,30 @@ describe("legacy recall timeout ownership", () => {
     );
     expect(api.logger.warn).not.toHaveBeenCalledWith(expect.stringContaining("timed out"));
     expect(api.logger.info).not.toHaveBeenCalledWith(expect.stringContaining("injecting"));
+
+    const emptyProvider = {
+      search: vi.fn(
+        () =>
+          new Promise((resolve) => setTimeout(() => resolve([]), 1000)),
+      ),
+    };
+    const {
+      api: emptyApi,
+      callback: emptyCallback,
+      captureEvent: emptyCaptureEvent,
+    } = registerRecallTest(hookConfig(8000), emptyProvider);
+
+    const emptyResultPromise = emptyCallback({ prompt: "remember this" }, {});
+    await vi.advanceTimersByTimeAsync(1000);
+    await expect(emptyResultPromise).resolves.toBeUndefined();
+    await vi.advanceTimersByTimeAsync(8000);
+    expect(emptyCaptureEvent).not.toHaveBeenCalled();
+    expect(emptyApi.logger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("timed out"),
+    );
+    expect(emptyApi.logger.info).not.toHaveBeenCalledWith(
+      expect.stringContaining("injecting"),
+    );
   });
 });
 

--- a/integrations/openclaw/index.test.ts
+++ b/integrations/openclaw/index.test.ts
@@ -185,6 +185,47 @@ describe("legacy recall timeout ownership", () => {
     vi.useRealTimers();
   });
 
+  it("skills-mode recall honors recallTimeoutMs via Promise.race", async () => {
+    vi.useFakeTimers();
+    // skillRecall uses provider.search; hang it past the deadline
+    const provider = {
+      search: vi.fn(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(
+              () => resolve([{ id: "m1", memory: "late fact", score: 0.9 }]),
+              5000,
+            ),
+          ),
+      ),
+      getAll: vi.fn().mockResolvedValue([]),
+    };
+    const { api, callback } = registerRecallTest(
+      {
+        ...hookConfig(1000),
+        skills: { recall: { enabled: true, strategy: "smart" } },
+      },
+      provider,
+      true,
+    );
+    const resultPromise = callback(
+      { prompt: "remember this long enough query" },
+      { sessionKey: "agent:main:main" },
+    );
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await resultPromise;
+    // timeout skips injection; prependSystemContext may still be present
+    expect(api.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("skills-mode recall timed out after 1000ms"),
+    );
+    expect(api.logger.info).not.toHaveBeenCalledWith(
+      expect.stringContaining("injecting"),
+    );
+    // should not hang
+    expect(result).toBeDefined();
+    vi.useRealTimers();
+  });
+
   it("records one terminal legacy recall outcome", async () => {
     vi.useFakeTimers();
     const provider = {

--- a/integrations/openclaw/index.ts
+++ b/integrations/openclaw/index.ts
@@ -83,7 +83,7 @@ export {
   stripNoiseFromContent,
   filterMessagesForExtraction,
 } from "./filtering.ts";
-export { mem0ConfigSchema } from "./config.ts";
+export { mem0ConfigSchema, parseRecallTimeoutMs } from "./config.ts";
 export type { FileConfig } from "./config.ts";
 export { createProvider } from "./providers.ts";
 
@@ -94,6 +94,10 @@ export { createProvider } from "./providers.ts";
 // ============================================================================
 // Plugin Definition
 // ============================================================================
+
+export function formatRegistrationLog(cfg: Mem0Config, skillsActive: boolean): string {
+  return `openclaw-mem0: registered (mode: ${cfg.mode}, user: ${cfg.userId}, autoRecall: ${cfg.autoRecall}, autoCapture: ${cfg.autoCapture}, skills: ${skillsActive}, legacyRecallTimeoutMs: ${cfg.recallTimeoutMs})`;
+}
 
 const memoryPlugin = definePluginEntry({
   id: "openclaw-mem0",
@@ -207,10 +211,11 @@ const memoryPlugin = definePluginEntry({
     _captureEvent("openclaw.plugin.registered", {
       auto_recall: cfg.autoRecall,
       auto_capture: cfg.autoCapture,
+      legacy_recall_timeout_ms: cfg.recallTimeoutMs,
     });
 
     api.logger.info(
-      `openclaw-mem0: registered (mode: ${cfg.mode}, user: ${cfg.userId}, autoRecall: ${cfg.autoRecall}, autoCapture: ${cfg.autoCapture}, skills: ${skillsActive})`,
+      formatRegistrationLog(cfg, skillsActive),
     );
 
     // ========================================================================
@@ -402,7 +407,7 @@ const memoryPlugin = definePluginEntry({
 // Lifecycle Hook Registration
 // ============================================================================
 
-function registerHooks(
+export function registerHooks(
   api: OpenClawPluginApi,
   provider: Mem0Provider,
   cfg: Mem0Config,
@@ -684,8 +689,6 @@ function registerHooks(
 
   // Auto-recall: inject relevant memories before prompt is built
   if (cfg.autoRecall) {
-    const RECALL_TIMEOUT_MS = 8_000;
-
     api.on("before_prompt_build", async (event: any, ctx: any) => {
       if (!event.prompt || event.prompt.length < 5) return;
 
@@ -800,40 +803,52 @@ function registerHooks(
           )
           .join("\n");
 
-        _captureEvent("openclaw.hook.recall", {
-          strategy: "legacy",
-          memory_count: longTermResults.length,
-          latency_ms: Date.now() - recallStart,
-        });
-
-        api.logger.info(
-          `openclaw-mem0: injecting ${longTermResults.length} memories into context`,
-        );
-
         const preamble = isSubagent
           ? `The following are stored memories for user "${cfg.userId}". You are a subagent — use these memories for context but do not assume you are this user.`
           : `The following are stored memories for user "${cfg.userId}". Use them to personalize your response:`;
 
         return {
           prependContext: `<relevant-memories>\n${preamble}\n${memoryContext}\n</relevant-memories>`,
+          memoryCount: longTermResults.length,
         };
       };
 
       try {
         const timeout = new Promise<undefined>((resolve) => {
-          setTimeout(() => resolve(undefined), RECALL_TIMEOUT_MS);
+          setTimeout(() => resolve(undefined), cfg.recallTimeoutMs);
         });
         const result = await Promise.race([
           recallWork(),
           timeout.then(() => {
             api.logger.warn(
-              `openclaw-mem0: recall timed out after ${RECALL_TIMEOUT_MS}ms, skipping`,
+              `openclaw-mem0: recall timed out after ${cfg.recallTimeoutMs}ms, skipping`,
             );
+            _captureEvent("openclaw.hook.recall", {
+              strategy: "legacy",
+              outcome: "timeout",
+              timeout_ms: cfg.recallTimeoutMs,
+              latency_ms: Date.now() - recallStart,
+            });
             return undefined;
           }),
         ]);
-        return result;
+        if (!result) return undefined;
+        _captureEvent("openclaw.hook.recall", {
+          strategy: "legacy",
+          outcome: "success",
+          memory_count: result.memoryCount,
+          latency_ms: Date.now() - recallStart,
+        });
+        api.logger.info(
+          `openclaw-mem0: injecting ${result.memoryCount} memories into context`,
+        );
+        return { prependContext: result.prependContext };
       } catch (err) {
+        _captureEvent("openclaw.hook.recall", {
+          strategy: "legacy",
+          outcome: "provider_error",
+          latency_ms: Date.now() - recallStart,
+        });
         api.logger.warn(`openclaw-mem0: recall failed: ${String(err)}`);
       }
     });

--- a/integrations/openclaw/index.ts
+++ b/integrations/openclaw/index.ts
@@ -534,6 +534,7 @@ export function registerHooks(
 
       if (recallEnabled && recallStrategy !== "manual") {
         const recallStart = Date.now();
+        const recallTimeoutMs = cfg.recallTimeoutMs;
         try {
           const query = sanitizeQuery(event.prompt);
 
@@ -545,25 +546,36 @@ export function registerHooks(
                 : sessionId
               : undefined; // smart: long-term only
 
-          const recallResult = await skillRecall(
+          const skillRecallWork = skillRecall(
             provider,
             query,
             userId,
             cfg.skills ?? {},
             sessionIdForRecall,
           );
-
-          api.logger.info(
-            `openclaw-mem0: skills-mode recall (strategy=${recallStrategy}) injecting ${recallResult.memories.length} memories (~${recallResult.tokenEstimate} tokens)`,
-          );
-
-          _captureEvent("openclaw.hook.recall", {
-            strategy: recallStrategy,
-            memory_count: recallResult.memories.length,
-            latency_ms: Date.now() - recallStart,
+          const skillTimeout = new Promise<"__timeout__">((resolve) => {
+            setTimeout(() => resolve("__timeout__"), recallTimeoutMs);
           });
+          const raced = await Promise.race([skillRecallWork, skillTimeout]);
+          if (raced === "__timeout__") {
+            api.logger.warn(
+              `openclaw-mem0: skills-mode recall timed out after ${recallTimeoutMs}ms, skipping`,
+            );
+          } else {
+            const recallResult = raced;
 
-          recallContext = recallResult.context;
+            api.logger.info(
+              `openclaw-mem0: skills-mode recall (strategy=${recallStrategy}) injecting ${recallResult.memories.length} memories (~${recallResult.tokenEstimate} tokens)`,
+            );
+
+            _captureEvent("openclaw.hook.recall", {
+              strategy: recallStrategy,
+              memory_count: recallResult.memories.length,
+              latency_ms: Date.now() - recallStart,
+            });
+
+            recallContext = recallResult.context;
+          }
         } catch (err) {
           api.logger.warn(
             `openclaw-mem0: skills-mode recall failed: ${String(err)}`,

--- a/integrations/openclaw/index.ts
+++ b/integrations/openclaw/index.ts
@@ -813,25 +813,35 @@ export function registerHooks(
         };
       };
 
+      const RECALL_TIMEOUT = Symbol("recall-timeout");
+      let recallSettled = false;
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
       try {
-        const timeout = new Promise<undefined>((resolve) => {
-          setTimeout(() => resolve(undefined), cfg.recallTimeoutMs);
+        const timeout = new Promise<typeof RECALL_TIMEOUT>((resolve) => {
+          timeoutId = setTimeout(() => {
+            if (recallSettled) return;
+            resolve(RECALL_TIMEOUT);
+          }, cfg.recallTimeoutMs);
         });
         const result = await Promise.race([
           recallWork(),
-          timeout.then(() => {
-            api.logger.warn(
-              `openclaw-mem0: recall timed out after ${cfg.recallTimeoutMs}ms, skipping`,
-            );
-            _captureEvent("openclaw.hook.recall", {
-              strategy: "legacy",
-              outcome: "timeout",
-              timeout_ms: cfg.recallTimeoutMs,
-              latency_ms: Date.now() - recallStart,
-            });
-            return undefined;
-          }),
+          timeout,
         ]);
+        recallSettled = true;
+        if (timeoutId) clearTimeout(timeoutId);
+        if (result === RECALL_TIMEOUT) {
+          api.logger.warn(
+            `openclaw-mem0: recall timed out after ${cfg.recallTimeoutMs}ms, skipping`,
+          );
+          _captureEvent("openclaw.hook.recall", {
+            strategy: "legacy",
+            outcome: "timeout",
+            timeout_ms: cfg.recallTimeoutMs,
+            latency_ms: Date.now() - recallStart,
+          });
+          return undefined;
+        }
         if (!result) return undefined;
         _captureEvent("openclaw.hook.recall", {
           strategy: "legacy",
@@ -844,6 +854,8 @@ export function registerHooks(
         );
         return { prependContext: result.prependContext };
       } catch (err) {
+        recallSettled = true;
+        if (timeoutId) clearTimeout(timeoutId);
         _captureEvent("openclaw.hook.recall", {
           strategy: "legacy",
           outcome: "provider_error",

--- a/integrations/openclaw/index.ts
+++ b/integrations/openclaw/index.ts
@@ -30,7 +30,11 @@ import {
   customCategoryMapToList,
   providerToBackend,
 } from "./providers.ts";
-import { mem0ConfigSchema } from "./config.ts";
+import {
+  DEFAULT_RECALL_TIMEOUT_MS,
+  mem0ConfigSchema,
+  parseRecallTimeoutMs,
+} from "./config.ts";
 import type { FileConfig } from "./config.ts";
 import { createPublicArtifactsProvider } from "./public-artifacts.ts";
 import { filterMessagesForExtraction } from "./filtering.ts";
@@ -99,6 +103,39 @@ export function formatRegistrationLog(cfg: Mem0Config, skillsActive: boolean): s
   return `openclaw-mem0: registered (mode: ${cfg.mode}, user: ${cfg.userId}, autoRecall: ${cfg.autoRecall}, autoCapture: ${cfg.autoCapture}, skills: ${skillsActive}, legacyRecallTimeoutMs: ${cfg.recallTimeoutMs})`;
 }
 
+function parseRegistrationConfig(
+  pluginConfig: unknown,
+  fileConfig: FileConfig,
+  logger: Pick<OpenClawPluginApi["logger"], "warn">,
+): Mem0Config {
+  if (
+    pluginConfig &&
+    typeof pluginConfig === "object" &&
+    !Array.isArray(pluginConfig) &&
+    Object.prototype.hasOwnProperty.call(pluginConfig, "recallTimeoutMs")
+  ) {
+    const rawConfig = pluginConfig as Record<string, unknown>;
+    try {
+      parseRecallTimeoutMs(rawConfig.recallTimeoutMs);
+    } catch {
+      const fallbackConfig = { ...rawConfig };
+      const invalidValue = fallbackConfig.recallTimeoutMs;
+      delete fallbackConfig.recallTimeoutMs;
+      const cfg = mem0ConfigSchema.parse(fallbackConfig, fileConfig);
+      const renderedValue =
+        typeof invalidValue === "string"
+          ? JSON.stringify(invalidValue)
+          : String(invalidValue);
+      logger.warn(
+        `openclaw-mem0: invalid recallTimeoutMs ${renderedValue}, falling back to default ${DEFAULT_RECALL_TIMEOUT_MS}ms`,
+      );
+      return cfg;
+    }
+  }
+
+  return mem0ConfigSchema.parse(pluginConfig, fileConfig);
+}
+
 const memoryPlugin = definePluginEntry({
   id: "openclaw-mem0",
   name: "Memory (Mem0)",
@@ -114,7 +151,7 @@ const memoryPlugin = definePluginEntry({
       apiKey: pluginAuth.apiKey,
       baseUrl: pluginAuth.baseUrl,
     };
-    const cfg = mem0ConfigSchema.parse(api.pluginConfig, fileConfig);
+    const cfg = parseRegistrationConfig(api.pluginConfig, fileConfig, api.logger);
     const isMetadataRegistration = api.registrationMode === "cli-metadata";
 
     // Telemetry context bound to this plugin instance's config

--- a/integrations/openclaw/openclaw.plugin.json
+++ b/integrations/openclaw/openclaw.plugin.json
@@ -97,7 +97,7 @@
     "recallTimeoutMs": {
       "label": "Legacy Recall Timeout (ms)",
       "advanced": true,
-      "help": "Legacy auto-recall deadline. Default: 8000 ms; allowed range: 1000-120000 ms. Ignored in skills mode. Supports ${RECALL_TIMEOUT_MS}."
+      "help": "Auto-recall deadline for legacy + skills mode. Default: 8000 ms; allowed range: 1000-120000 ms. Supports ${RECALL_TIMEOUT_MS}."
     },
     "customInstructions": {
       "label": "Custom Instructions",
@@ -198,7 +198,7 @@
           { "type": "string", "pattern": "^0*(?:[1-9][0-9]{3,4}|1[01][0-9]{4}|120000)$" }
         ],
         "default": 8000,
-        "description": "Legacy auto-recall timeout in milliseconds. Valid range: 1000-120000. Ignored in skills mode. Supports ${RECALL_TIMEOUT_MS}."
+        "description": "Auto-recall timeout in milliseconds (legacy + skills mode). Valid range: 1000-120000. Supports ${RECALL_TIMEOUT_MS}."
       },
       "customInstructions": {
         "type": "string"

--- a/integrations/openclaw/openclaw.plugin.json
+++ b/integrations/openclaw/openclaw.plugin.json
@@ -195,7 +195,7 @@
       "recallTimeoutMs": {
         "anyOf": [
           { "type": "integer", "minimum": 1000, "maximum": 120000 },
-          { "type": "string", "pattern": "^[0-9]+$" }
+          { "type": "string", "pattern": "^(?:[1-9][0-9]{3,4}|1[01][0-9]{4}|120000)$" }
         ],
         "default": 8000,
         "description": "Legacy auto-recall timeout in milliseconds. Valid range: 1000-120000. Ignored in skills mode. Supports ${RECALL_TIMEOUT_MS}."

--- a/integrations/openclaw/openclaw.plugin.json
+++ b/integrations/openclaw/openclaw.plugin.json
@@ -195,7 +195,7 @@
       "recallTimeoutMs": {
         "anyOf": [
           { "type": "integer", "minimum": 1000, "maximum": 120000 },
-          { "type": "string", "pattern": "^(?:[1-9][0-9]{3,4}|1[01][0-9]{4}|120000)$" }
+          { "type": "string", "pattern": "^0*(?:[1-9][0-9]{3,4}|1[01][0-9]{4}|120000)$" }
         ],
         "default": 8000,
         "description": "Legacy auto-recall timeout in milliseconds. Valid range: 1000-120000. Ignored in skills mode. Supports ${RECALL_TIMEOUT_MS}."

--- a/integrations/openclaw/openclaw.plugin.json
+++ b/integrations/openclaw/openclaw.plugin.json
@@ -94,6 +94,11 @@
       "label": "Auto-Recall",
       "help": "Automatically inject relevant memories before each agent turn"
     },
+    "recallTimeoutMs": {
+      "label": "Legacy Recall Timeout (ms)",
+      "advanced": true,
+      "help": "Legacy auto-recall deadline. Default: 8000 ms; allowed range: 1000-120000 ms. Ignored in skills mode. Supports ${RECALL_TIMEOUT_MS}."
+    },
     "customInstructions": {
       "label": "Custom Instructions",
       "placeholder": "Only store user preferences and important facts...",
@@ -186,6 +191,14 @@
         "type": "boolean",
         "default": true,
         "description": "When true, injects relevant memories before each agent turn. Enabled by default. Ignored in skills mode."
+      },
+      "recallTimeoutMs": {
+        "anyOf": [
+          { "type": "integer", "minimum": 1000, "maximum": 120000 },
+          { "type": "string", "pattern": "^[0-9]+$" }
+        ],
+        "default": 8000,
+        "description": "Legacy auto-recall timeout in milliseconds. Valid range: 1000-120000. Ignored in skills mode. Supports ${RECALL_TIMEOUT_MS}."
       },
       "customInstructions": {
         "type": "string"

--- a/integrations/openclaw/tests/cli-commands.test.ts
+++ b/integrations/openclaw/tests/cli-commands.test.ts
@@ -1226,6 +1226,27 @@ describe("registerCliCommands", () => {
       );
     });
 
+    it("handles recall_timeout_ms", () => {
+      const { mem0 } = setup();
+      const configCmd = findCommand(mem0, "config")!;
+      const setCmd = findCommand(configCmd, "set")!;
+
+      setCmd._action!("recall_timeout_ms", "120000");
+      expect(writePluginAuth).toHaveBeenCalledWith({ recallTimeoutMs: 120000 });
+
+      vi.mocked(readPluginAuth).mockReturnValue({ recallTimeoutMs: 120000 });
+      const showCmd = findCommand(configCmd, "show")!;
+      showCmd._action!({ json: true });
+      expect(process.stdout.write).toHaveBeenCalledWith(
+        expect.stringContaining('"recall_timeout_ms": 120000'),
+      );
+
+      setCmd._action!("recall_timeout_ms", "120001");
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid recall timeout value: 120001"),
+      );
+    });
+
     it("errors on invalid integer value for integer keys", () => {
       const { mem0 } = setup();
       const configCmd = findCommand(mem0, "config")!;

--- a/integrations/openclaw/tests/config-file.test.ts
+++ b/integrations/openclaw/tests/config-file.test.ts
@@ -73,6 +73,7 @@ describe("readPluginAuth", () => {
               autoRecall: true,
               autoCapture: false,
               topK: 10,
+              recallTimeoutMs: 120000,
             },
           },
         },
@@ -88,6 +89,7 @@ describe("readPluginAuth", () => {
       autoRecall: true,
       autoCapture: false,
       topK: 10,
+      recallTimeoutMs: 120000,
     });
   });
 
@@ -209,6 +211,21 @@ describe("writePluginAuth", () => {
     expect(cfg.apiKey).toBe("sk-set");
     expect(cfg).not.toHaveProperty("baseUrl");
     expect(cfg).not.toHaveProperty("userId");
+  });
+
+  it("CLI/config surface: recall_timeout_ms round-trip and bounds", () => {
+    setNoFile();
+    mockExists.mockReturnValue(false);
+
+    writePluginAuth({ recallTimeoutMs: 120000 });
+
+    const written = JSON.parse(mockWriteText.mock.calls[0][1]);
+    expect(written.plugins.entries["openclaw-mem0"].config.recallTimeoutMs).toBe(
+      120000,
+    );
+
+    setConfigFile(written);
+    expect(readPluginAuth().recallTimeoutMs).toBe(120000);
   });
 });
 

--- a/integrations/openclaw/tests/config.test.ts
+++ b/integrations/openclaw/tests/config.test.ts
@@ -6,6 +6,9 @@ import {
   mem0ConfigSchema,
   DEFAULT_CUSTOM_INSTRUCTIONS,
   DEFAULT_CUSTOM_CATEGORIES,
+  DEFAULT_RECALL_TIMEOUT_MS,
+  MIN_RECALL_TIMEOUT_MS,
+  MAX_RECALL_TIMEOUT_MS,
 } from "../config.ts";
 
 // ---------------------------------------------------------------------------
@@ -93,6 +96,31 @@ describe("mem0ConfigSchema.parse() — defaults", () => {
   it("allows anonymousTelemetryId", () => {
     const cfg = mem0ConfigSchema.parse({ apiKey: "test-key", anonymousTelemetryId: "123" });
     expect(cfg.anonymousTelemetryId).toBe("123");
+  });
+
+  it("uses the 8000ms default when recallTimeoutMs is unset", () => {
+    expect(mem0ConfigSchema.parse({ apiKey: "test-key" }).recallTimeoutMs).toBe(8000);
+    expect(DEFAULT_RECALL_TIMEOUT_MS).toBe(8000);
+  });
+});
+
+describe("mem0ConfigSchema.parse() — recall timeout", () => {
+  it("accepts bounded recallTimeoutMs values", () => {
+    for (const [input, expected] of [
+      [1000, MIN_RECALL_TIMEOUT_MS],
+      [120000, MAX_RECALL_TIMEOUT_MS],
+      ["1000", 1000],
+      ["120000", 120000],
+    ] as const) {
+    expect(mem0ConfigSchema.parse({ recallTimeoutMs: input }).recallTimeoutMs).toBe(expected);
+    }
+
+    for (const input of [
+      null, true, {}, [], "", " 1000", "1000 ", "1e3", Infinity, NaN,
+      1000.5, 999, 120001,
+    ]) {
+      expect(() => mem0ConfigSchema.parse({ recallTimeoutMs: input })).toThrow();
+    }
   });
 });
 

--- a/integrations/openclaw/tests/recall-timeout-regression.test.ts
+++ b/integrations/openclaw/tests/recall-timeout-regression.test.ts
@@ -10,6 +10,7 @@ vi.mock("../cli/config-file.ts", () => ({
 }));
 
 vi.mock("../fs-safe.ts", () => ({
+  bootstrapTelemetryFlag: vi.fn(),
   readText: vi.fn().mockReturnValue("{}"),
   exists: vi.fn().mockReturnValue(true),
   writeText: vi.fn(),
@@ -20,6 +21,7 @@ vi.mock("../fs-safe.ts", () => ({
 vi.mock("../skill-loader.ts", () => ({
   loadCompactTriagePrompt: vi.fn().mockReturnValue("triage prompt"),
   loadDreamPrompt: vi.fn().mockReturnValue("dream prompt"),
+  isSkillsMode: vi.fn().mockReturnValue(false),
 }));
 
 import { registerCliCommands } from "../cli/commands.ts";
@@ -30,7 +32,7 @@ import {
   mem0ConfigSchema,
   MIN_RECALL_TIMEOUT_MS,
 } from "../config.ts";
-import { formatRegistrationLog, registerHooks } from "../index.ts";
+import memoryPlugin, { registerHooks } from "../index.ts";
 import type { Mem0Config, Mem0Provider } from "../types.ts";
 
 interface MockCommand {
@@ -181,6 +183,30 @@ function setupCli() {
   };
 }
 
+function createPluginApi(pluginConfigOverrides: Record<string, unknown> = {}) {
+  return {
+    pluginConfig: {
+      mode: "platform",
+      apiKey: "test-api-key",
+      userId: "alice",
+      ...pluginConfigOverrides,
+    },
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+    resolvePath: vi.fn((p: string) => p),
+    registerTool: vi.fn(),
+    on: vi.fn(),
+    registerCli: vi.fn(),
+    registerCommand: vi.fn(),
+    registerService: vi.fn(),
+    registerMemoryCapability: vi.fn(),
+  };
+}
+
 let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 let stdoutWriteSpy: ReturnType<typeof vi.spyOn>;
 
@@ -221,15 +247,21 @@ it("reproduction: configurable legacy recall deadline", async () => {
   await vi.advanceTimersByTimeAsync(8500);
 
   await expect(resultPromise).resolves.toHaveProperty("prependContext");
+  await vi.advanceTimersByTimeAsync(1000);
   expect(api.logger.info).toHaveBeenCalledWith(
     expect.stringContaining("injecting 1 memories"),
   );
   expect(api.logger.warn).not.toHaveBeenCalledWith(
     expect.stringContaining("timed out"),
   );
+  expect(captureEvent).toHaveBeenCalledTimes(1);
   expect(captureEvent).toHaveBeenCalledWith(
     "openclaw.hook.recall",
     expect.objectContaining({ outcome: "success" }),
+  );
+  expect(captureEvent).not.toHaveBeenCalledWith(
+    "openclaw.hook.recall",
+    expect.objectContaining({ outcome: "timeout" }),
   );
 });
 
@@ -337,15 +369,24 @@ it("negative-space: skills-mode recall ignores legacy deadline", async () => {
 });
 
 it("terminal outcome ownership", async () => {
+  vi.useFakeTimers();
   const provider = {
-    search: vi.fn().mockRejectedValue(new Error("provider unavailable")),
+    search: vi.fn(
+      () =>
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error("provider unavailable")), 1000),
+        ),
+    ),
   };
   const { api, callback, captureEvent } = registerRecallTest(
     parseHookConfig({ recallTimeoutMs: 8000 }),
     provider,
   );
 
-  await expect(callback({ prompt: "remember this" }, {})).resolves.toBeUndefined();
+  const resultPromise = callback({ prompt: "remember this" }, {});
+  await vi.advanceTimersByTimeAsync(1000);
+  await expect(resultPromise).resolves.toBeUndefined();
+  await vi.advanceTimersByTimeAsync(8000);
   expect(api.logger.warn).toHaveBeenCalledWith(
     "openclaw-mem0: recall failed: Error: provider unavailable",
   );
@@ -368,13 +409,44 @@ it("terminal outcome ownership", async () => {
   expect(api.logger.info).not.toHaveBeenCalledWith(
     expect.stringContaining("injecting"),
   );
+
+  const emptyProvider = {
+    search: vi.fn(
+      () =>
+        new Promise((resolve) => setTimeout(() => resolve([]), 1000)),
+    ),
+  };
+  const {
+    api: emptyApi,
+    callback: emptyCallback,
+    captureEvent: emptyCaptureEvent,
+  } = registerRecallTest(parseHookConfig({ recallTimeoutMs: 8000 }), emptyProvider);
+
+  const emptyResultPromise = emptyCallback({ prompt: "remember this" }, {});
+  await vi.advanceTimersByTimeAsync(1000);
+  await expect(emptyResultPromise).resolves.toBeUndefined();
+  await vi.advanceTimersByTimeAsync(8000);
+  expect(emptyCaptureEvent).not.toHaveBeenCalled();
+  expect(emptyApi.logger.warn).not.toHaveBeenCalledWith(
+    expect.stringContaining("timed out"),
+  );
+  expect(emptyApi.logger.info).not.toHaveBeenCalledWith(
+    expect.stringContaining("injecting"),
+  );
 });
 
 it("startup log: effective legacy timeout", () => {
-  const logLine = formatRegistrationLog(
-    parseHookConfig({ recallTimeoutMs: 120000 }),
-    false,
-  );
-  expect(logLine).toContain("legacyRecallTimeoutMs: 120000");
-  expect(logLine.match(/legacyRecallTimeoutMs/g)).toHaveLength(1);
+  const api = createPluginApi({ recallTimeoutMs: 120000 });
+
+  memoryPlugin.register(api as any);
+
+  const matches = api.logger.info.mock.calls
+    .map(([message]: [unknown]) => String(message))
+    .filter(
+      (message: string) =>
+        message.includes("openclaw-mem0: registered") &&
+        message.includes("legacyRecallTimeoutMs: 120000"),
+    );
+  expect(matches).toHaveLength(1);
+  expect(matches[0]?.match(/legacyRecallTimeoutMs/g)).toHaveLength(1);
 });

--- a/integrations/openclaw/tests/recall-timeout-regression.test.ts
+++ b/integrations/openclaw/tests/recall-timeout-regression.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { afterEach, expect, it, vi } from "vitest";
 
 vi.mock("../cli/config-file.ts", () => ({
   readPluginAuth: vi.fn().mockReturnValue({}),
@@ -24,91 +24,23 @@ vi.mock("../skill-loader.ts", () => ({
   isSkillsMode: vi.fn().mockReturnValue(false),
 }));
 
-import { registerCliCommands } from "../cli/commands.ts";
-import { readPluginAuth, writePluginAuth } from "../cli/config-file.ts";
-import {
-  DEFAULT_RECALL_TIMEOUT_MS,
-  MAX_RECALL_TIMEOUT_MS,
-  mem0ConfigSchema,
-  MIN_RECALL_TIMEOUT_MS,
-} from "../config.ts";
-import memoryPlugin, { registerHooks } from "../index.ts";
+import { registerHooks } from "../index.ts";
 import type { Mem0Config, Mem0Provider } from "../types.ts";
 
-interface MockCommand {
-  _name: string;
-  _subcommands: MockCommand[];
-  _options: Array<{ flags: string; desc: string; defaultVal?: string }>;
-  _action: ((...args: any[]) => any) | null;
-  command(name: string): MockCommand;
-  description(desc: string): MockCommand;
-  configureHelp(opts: any): MockCommand;
-  hook(event: string, fn: (...args: any[]) => any): MockCommand;
-  option(flags: string, desc: string, defaultVal?: string): MockCommand;
-  argument(name: string, desc: string): MockCommand;
-  action(fn: (...args: any[]) => any): MockCommand;
-}
-
-function createMockCommand(name: string): MockCommand {
-  const command: MockCommand = {
-    _name: name,
-    _subcommands: [],
-    _options: [],
-    _action: null,
-    command(subcommandName: string) {
-      const subcommand = createMockCommand(subcommandName);
-      command._subcommands.push(subcommand);
-      return subcommand;
-    },
-    description() {
-      return command;
-    },
-    configureHelp() {
-      return command;
-    },
-    hook() {
-      return command;
-    },
-    option(flags: string, desc: string, defaultVal?: string) {
-      command._options.push({ flags, desc, defaultVal });
-      return command;
-    },
-    argument() {
-      return command;
-    },
-    action(fn: (...args: any[]) => any) {
-      command._action = fn;
-      return command;
-    },
-  };
-  return command;
-}
-
-function findCommand(root: MockCommand, name: string): MockCommand | undefined {
-  for (const subcommand of root._subcommands) {
-    if (subcommand._name === name) {
-      return subcommand;
-    }
-    const nested = findCommand(subcommand, name);
-    if (nested) {
-      return nested;
-    }
-  }
-  return undefined;
-}
-
-function parseHookConfig(overrides: Record<string, unknown> = {}): Mem0Config {
-  return mem0ConfigSchema.parse({
+function hookConfig(): Mem0Config {
+  return {
+    mode: "platform",
     apiKey: "test-api-key",
     userId: "alice",
+    customInstructions: "",
+    customCategories: {},
     autoCapture: false,
     autoRecall: true,
     searchThreshold: 0.1,
     topK: 5,
-    customInstructions: "",
-    customCategories: {},
-    ...overrides,
-  });
+    recallTimeoutMs: 1000,
+    skills: { recall: { enabled: true } },
+  };
 }
 
 function registerRecallTest(
@@ -117,7 +49,6 @@ function registerRecallTest(
   skillsActive = false,
 ) {
   const hooks = new Map<string, (...args: any[]) => Promise<unknown>>();
-  const captureEvent = vi.fn();
   const api = {
     on: vi.fn((name: string, callback: (...args: any[]) => Promise<unknown>) =>
       hooks.set(name, callback)),
@@ -136,201 +67,15 @@ function registerRecallTest(
     () => ({ user_id: cfg.userId, top_k: cfg.topK }),
     { setCurrentSessionId: vi.fn(), getStateDir: () => undefined },
     skillsActive,
-    captureEvent,
+    vi.fn(),
   );
 
-  return { api, callback: hooks.get("before_prompt_build")!, captureEvent };
+  return { api, callback: hooks.get("before_prompt_build")! };
 }
-
-function setupCli() {
-  const effectiveUserId = vi.fn().mockReturnValue("testuser");
-  const agentUserId = vi.fn((id: string) => `testuser:agent:${id}`);
-  const buildSearchOptions = vi.fn().mockReturnValue({
-    user_id: "testuser",
-    top_k: 5,
-    source: "OPENCLAW",
-  });
-  const getCurrentSessionId = vi.fn().mockReturnValue(undefined);
-
-  let registerCliCallback: ((args: { program: MockCommand }) => void) | undefined;
-  const api = {
-    registerCli: vi.fn((callback: (args: { program: MockCommand }) => void) => {
-      registerCliCallback = callback;
-    }),
-    logger: { info: vi.fn(), warn: vi.fn() },
-  } as any;
-
-  registerCliCommands(
-    api,
-    null as any,
-    {} as any,
-    {
-      ...parseHookConfig(),
-      baseUrl: "https://api.mem0.ai",
-      skills: {},
-    },
-    effectiveUserId,
-    agentUserId,
-    buildSearchOptions,
-    getCurrentSessionId,
-  );
-
-  const root = createMockCommand("root");
-  registerCliCallback!({ program: root });
-
-  return {
-    config: findCommand(findCommand(root, "mem0")!, "config")!,
-  };
-}
-
-function createPluginApi(pluginConfigOverrides: Record<string, unknown> = {}) {
-  return {
-    pluginConfig: {
-      mode: "platform",
-      apiKey: "test-api-key",
-      userId: "alice",
-      ...pluginConfigOverrides,
-    },
-    logger: {
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-      debug: vi.fn(),
-    },
-    resolvePath: vi.fn((p: string) => p),
-    registerTool: vi.fn(),
-    on: vi.fn(),
-    registerCli: vi.fn(),
-    registerCommand: vi.fn(),
-    registerService: vi.fn(),
-    registerMemoryCapability: vi.fn(),
-  };
-}
-
-let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
-let stdoutWriteSpy: ReturnType<typeof vi.spyOn>;
-
-beforeEach(() => {
-  vi.resetAllMocks();
-  vi.mocked(readPluginAuth).mockReturnValue({});
-  consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-  stdoutWriteSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-});
 
 afterEach(() => {
-  consoleErrorSpy.mockRestore();
-  stdoutWriteSpy.mockRestore();
   vi.useRealTimers();
   vi.restoreAllMocks();
-});
-
-it("reproduction: configurable legacy recall deadline", async () => {
-  vi.useFakeTimers();
-  const provider = {
-    search: vi.fn(
-      () =>
-        new Promise((resolve) =>
-          setTimeout(
-            () =>
-              resolve([{ id: "m1", memory: "fact", score: 0.9 }]),
-            8500,
-          ),
-        ),
-    ),
-  };
-  const { api, callback, captureEvent } = registerRecallTest(
-    parseHookConfig({ recallTimeoutMs: 9000 }),
-    provider,
-  );
-
-  const resultPromise = callback({ prompt: "remember this" }, {});
-  await vi.advanceTimersByTimeAsync(8500);
-
-  await expect(resultPromise).resolves.toHaveProperty("prependContext");
-  await vi.advanceTimersByTimeAsync(1000);
-  expect(api.logger.info).toHaveBeenCalledWith(
-    expect.stringContaining("injecting 1 memories"),
-  );
-  expect(api.logger.warn).not.toHaveBeenCalledWith(
-    expect.stringContaining("timed out"),
-  );
-  expect(captureEvent).toHaveBeenCalledTimes(1);
-  expect(captureEvent).toHaveBeenCalledWith(
-    "openclaw.hook.recall",
-    expect.objectContaining({ outcome: "success" }),
-  );
-  expect(captureEvent).not.toHaveBeenCalledWith(
-    "openclaw.hook.recall",
-    expect.objectContaining({ outcome: "timeout" }),
-  );
-});
-
-it("preservation: unset legacy timeout", async () => {
-  vi.useFakeTimers();
-  const provider = {
-    search: vi.fn(
-      () =>
-        new Promise((resolve) =>
-          setTimeout(
-            () =>
-              resolve([{ id: "m1", memory: "fact", score: 0.9 }]),
-            8500,
-          ),
-        ),
-    ),
-  };
-  const cfg = parseHookConfig();
-  const { api, callback, captureEvent } = registerRecallTest(cfg, provider);
-
-  expect(cfg.recallTimeoutMs).toBe(DEFAULT_RECALL_TIMEOUT_MS);
-  const resultPromise = callback({ prompt: "remember this" }, {});
-  await vi.advanceTimersByTimeAsync(DEFAULT_RECALL_TIMEOUT_MS);
-
-  await expect(resultPromise).resolves.toBeUndefined();
-  await vi.advanceTimersByTimeAsync(500);
-  expect(api.logger.warn).toHaveBeenCalledWith(
-    expect.stringContaining(`after ${DEFAULT_RECALL_TIMEOUT_MS}ms`),
-  );
-  expect(api.logger.info).not.toHaveBeenCalledWith(
-    expect.stringContaining("injecting"),
-  );
-  expect(captureEvent).toHaveBeenCalledWith(
-    "openclaw.hook.recall",
-    expect.objectContaining({ outcome: "timeout" }),
-  );
-});
-
-it("boundary values 1000 and 120000: parser-owned timeout validation", () => {
-  expect(DEFAULT_RECALL_TIMEOUT_MS).toBe(8000);
-  expect(
-    mem0ConfigSchema.parse({ recallTimeoutMs: 1000 }).recallTimeoutMs,
-  ).toBe(MIN_RECALL_TIMEOUT_MS);
-  expect(
-    mem0ConfigSchema.parse({ recallTimeoutMs: "120000" }).recallTimeoutMs,
-  ).toBe(MAX_RECALL_TIMEOUT_MS);
-  expect(() => mem0ConfigSchema.parse({ recallTimeoutMs: 120001 })).toThrow(
-    `recallTimeoutMs must be an integer from ${MIN_RECALL_TIMEOUT_MS} to ${MAX_RECALL_TIMEOUT_MS}`,
-  );
-});
-
-it("CLI/config surface: recall_timeout_ms round-trip and bounds", async () => {
-  const { config } = setupCli();
-  const setCommand = findCommand(config, "set")!;
-  const showCommand = findCommand(config, "show")!;
-
-  await setCommand._action!("recall_timeout_ms", "120000");
-  expect(writePluginAuth).toHaveBeenCalledWith({ recallTimeoutMs: 120000 });
-
-  vi.mocked(readPluginAuth).mockReturnValue({ recallTimeoutMs: 120000 });
-  await showCommand._action!({ json: true });
-  expect(stdoutWriteSpy).toHaveBeenCalledWith(
-    expect.stringContaining('"recall_timeout_ms": 120000'),
-  );
-
-  await setCommand._action!("recall_timeout_ms", "120001");
-  expect(consoleErrorSpy).toHaveBeenCalledWith(
-    expect.stringContaining("Invalid recall timeout value: 120001"),
-  );
 });
 
 it("negative-space: skills-mode recall ignores legacy deadline", async () => {
@@ -347,14 +92,7 @@ it("negative-space: skills-mode recall ignores legacy deadline", async () => {
         ),
     ),
   };
-  const { api, callback } = registerRecallTest(
-    parseHookConfig({
-      recallTimeoutMs: 1000,
-      skills: { recall: { enabled: true } },
-    }),
-    provider,
-    true,
-  );
+  const { api, callback } = registerRecallTest(hookConfig(), provider, true);
 
   const resultPromise = callback(
     { prompt: "remember this" },
@@ -366,87 +104,4 @@ it("negative-space: skills-mode recall ignores legacy deadline", async () => {
   expect(api.logger.warn).not.toHaveBeenCalledWith(
     expect.stringContaining("timed out"),
   );
-});
-
-it("terminal outcome ownership", async () => {
-  vi.useFakeTimers();
-  const provider = {
-    search: vi.fn(
-      () =>
-        new Promise((_, reject) =>
-          setTimeout(() => reject(new Error("provider unavailable")), 1000),
-        ),
-    ),
-  };
-  const { api, callback, captureEvent } = registerRecallTest(
-    parseHookConfig({ recallTimeoutMs: 8000 }),
-    provider,
-  );
-
-  const resultPromise = callback({ prompt: "remember this" }, {});
-  await vi.advanceTimersByTimeAsync(1000);
-  await expect(resultPromise).resolves.toBeUndefined();
-  await vi.advanceTimersByTimeAsync(8000);
-  expect(api.logger.warn).toHaveBeenCalledWith(
-    "openclaw-mem0: recall failed: Error: provider unavailable",
-  );
-  expect(captureEvent).toHaveBeenCalledTimes(1);
-  expect(captureEvent).toHaveBeenCalledWith(
-    "openclaw.hook.recall",
-    expect.objectContaining({ outcome: "provider_error" }),
-  );
-  expect(captureEvent).not.toHaveBeenCalledWith(
-    "openclaw.hook.recall",
-    expect.objectContaining({ outcome: "timeout" }),
-  );
-  expect(captureEvent).not.toHaveBeenCalledWith(
-    "openclaw.hook.recall",
-    expect.objectContaining({ outcome: "success" }),
-  );
-  expect(api.logger.warn).not.toHaveBeenCalledWith(
-    expect.stringContaining("timed out"),
-  );
-  expect(api.logger.info).not.toHaveBeenCalledWith(
-    expect.stringContaining("injecting"),
-  );
-
-  const emptyProvider = {
-    search: vi.fn(
-      () =>
-        new Promise((resolve) => setTimeout(() => resolve([]), 1000)),
-    ),
-  };
-  const {
-    api: emptyApi,
-    callback: emptyCallback,
-    captureEvent: emptyCaptureEvent,
-  } = registerRecallTest(parseHookConfig({ recallTimeoutMs: 8000 }), emptyProvider);
-
-  const emptyResultPromise = emptyCallback({ prompt: "remember this" }, {});
-  await vi.advanceTimersByTimeAsync(1000);
-  await expect(emptyResultPromise).resolves.toBeUndefined();
-  await vi.advanceTimersByTimeAsync(8000);
-  expect(emptyCaptureEvent).not.toHaveBeenCalled();
-  expect(emptyApi.logger.warn).not.toHaveBeenCalledWith(
-    expect.stringContaining("timed out"),
-  );
-  expect(emptyApi.logger.info).not.toHaveBeenCalledWith(
-    expect.stringContaining("injecting"),
-  );
-});
-
-it("startup log: effective legacy timeout", () => {
-  const api = createPluginApi({ recallTimeoutMs: 120000 });
-
-  memoryPlugin.register(api as any);
-
-  const matches = api.logger.info.mock.calls
-    .map(([message]: [unknown]) => String(message))
-    .filter(
-      (message: string) =>
-        message.includes("openclaw-mem0: registered") &&
-        message.includes("legacyRecallTimeoutMs: 120000"),
-    );
-  expect(matches).toHaveLength(1);
-  expect(matches[0]?.match(/legacyRecallTimeoutMs/g)).toHaveLength(1);
 });

--- a/integrations/openclaw/tests/recall-timeout-regression.test.ts
+++ b/integrations/openclaw/tests/recall-timeout-regression.test.ts
@@ -1,0 +1,380 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+
+vi.mock("../cli/config-file.ts", () => ({
+  readPluginAuth: vi.fn().mockReturnValue({}),
+  writePluginAuth: vi.fn(),
+  writePluginConfigField: vi.fn(),
+  enableSkillsConfig: vi.fn(),
+  getBaseUrl: vi.fn().mockReturnValue("https://api.mem0.ai"),
+  OPENCLAW_CONFIG_FILE: "/mock/.openclaw/openclaw.json",
+}));
+
+vi.mock("../fs-safe.ts", () => ({
+  readText: vi.fn().mockReturnValue("{}"),
+  exists: vi.fn().mockReturnValue(true),
+  writeText: vi.fn(),
+  mkdirp: vi.fn(),
+  unlink: vi.fn(),
+}));
+
+vi.mock("../skill-loader.ts", () => ({
+  loadCompactTriagePrompt: vi.fn().mockReturnValue("triage prompt"),
+  loadDreamPrompt: vi.fn().mockReturnValue("dream prompt"),
+}));
+
+import { registerCliCommands } from "../cli/commands.ts";
+import { readPluginAuth, writePluginAuth } from "../cli/config-file.ts";
+import {
+  DEFAULT_RECALL_TIMEOUT_MS,
+  MAX_RECALL_TIMEOUT_MS,
+  mem0ConfigSchema,
+  MIN_RECALL_TIMEOUT_MS,
+} from "../config.ts";
+import { formatRegistrationLog, registerHooks } from "../index.ts";
+import type { Mem0Config, Mem0Provider } from "../types.ts";
+
+interface MockCommand {
+  _name: string;
+  _subcommands: MockCommand[];
+  _options: Array<{ flags: string; desc: string; defaultVal?: string }>;
+  _action: ((...args: any[]) => any) | null;
+  command(name: string): MockCommand;
+  description(desc: string): MockCommand;
+  configureHelp(opts: any): MockCommand;
+  hook(event: string, fn: (...args: any[]) => any): MockCommand;
+  option(flags: string, desc: string, defaultVal?: string): MockCommand;
+  argument(name: string, desc: string): MockCommand;
+  action(fn: (...args: any[]) => any): MockCommand;
+}
+
+function createMockCommand(name: string): MockCommand {
+  const command: MockCommand = {
+    _name: name,
+    _subcommands: [],
+    _options: [],
+    _action: null,
+    command(subcommandName: string) {
+      const subcommand = createMockCommand(subcommandName);
+      command._subcommands.push(subcommand);
+      return subcommand;
+    },
+    description() {
+      return command;
+    },
+    configureHelp() {
+      return command;
+    },
+    hook() {
+      return command;
+    },
+    option(flags: string, desc: string, defaultVal?: string) {
+      command._options.push({ flags, desc, defaultVal });
+      return command;
+    },
+    argument() {
+      return command;
+    },
+    action(fn: (...args: any[]) => any) {
+      command._action = fn;
+      return command;
+    },
+  };
+  return command;
+}
+
+function findCommand(root: MockCommand, name: string): MockCommand | undefined {
+  for (const subcommand of root._subcommands) {
+    if (subcommand._name === name) {
+      return subcommand;
+    }
+    const nested = findCommand(subcommand, name);
+    if (nested) {
+      return nested;
+    }
+  }
+  return undefined;
+}
+
+function parseHookConfig(overrides: Record<string, unknown> = {}): Mem0Config {
+  return mem0ConfigSchema.parse({
+    apiKey: "test-api-key",
+    userId: "alice",
+    autoCapture: false,
+    autoRecall: true,
+    searchThreshold: 0.1,
+    topK: 5,
+    customInstructions: "",
+    customCategories: {},
+    ...overrides,
+  });
+}
+
+function registerRecallTest(
+  cfg: Mem0Config,
+  provider: Partial<Mem0Provider>,
+  skillsActive = false,
+) {
+  const hooks = new Map<string, (...args: any[]) => Promise<unknown>>();
+  const captureEvent = vi.fn();
+  const api = {
+    on: vi.fn((name: string, callback: (...args: any[]) => Promise<unknown>) =>
+      hooks.set(name, callback)),
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+    },
+  } as any;
+
+  registerHooks(
+    api,
+    provider as Mem0Provider,
+    cfg,
+    () => cfg.userId,
+    () => ({ user_id: cfg.userId }),
+    () => ({ user_id: cfg.userId, top_k: cfg.topK }),
+    { setCurrentSessionId: vi.fn(), getStateDir: () => undefined },
+    skillsActive,
+    captureEvent,
+  );
+
+  return { api, callback: hooks.get("before_prompt_build")!, captureEvent };
+}
+
+function setupCli() {
+  const effectiveUserId = vi.fn().mockReturnValue("testuser");
+  const agentUserId = vi.fn((id: string) => `testuser:agent:${id}`);
+  const buildSearchOptions = vi.fn().mockReturnValue({
+    user_id: "testuser",
+    top_k: 5,
+    source: "OPENCLAW",
+  });
+  const getCurrentSessionId = vi.fn().mockReturnValue(undefined);
+
+  let registerCliCallback: ((args: { program: MockCommand }) => void) | undefined;
+  const api = {
+    registerCli: vi.fn((callback: (args: { program: MockCommand }) => void) => {
+      registerCliCallback = callback;
+    }),
+    logger: { info: vi.fn(), warn: vi.fn() },
+  } as any;
+
+  registerCliCommands(
+    api,
+    null as any,
+    {} as any,
+    {
+      ...parseHookConfig(),
+      baseUrl: "https://api.mem0.ai",
+      skills: {},
+    },
+    effectiveUserId,
+    agentUserId,
+    buildSearchOptions,
+    getCurrentSessionId,
+  );
+
+  const root = createMockCommand("root");
+  registerCliCallback!({ program: root });
+
+  return {
+    config: findCommand(findCommand(root, "mem0")!, "config")!,
+  };
+}
+
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+let stdoutWriteSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(readPluginAuth).mockReturnValue({});
+  consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  stdoutWriteSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+});
+
+afterEach(() => {
+  consoleErrorSpy.mockRestore();
+  stdoutWriteSpy.mockRestore();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+it("reproduction: configurable legacy recall deadline", async () => {
+  vi.useFakeTimers();
+  const provider = {
+    search: vi.fn(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(
+            () =>
+              resolve([{ id: "m1", memory: "fact", score: 0.9 }]),
+            8500,
+          ),
+        ),
+    ),
+  };
+  const { api, callback, captureEvent } = registerRecallTest(
+    parseHookConfig({ recallTimeoutMs: 9000 }),
+    provider,
+  );
+
+  const resultPromise = callback({ prompt: "remember this" }, {});
+  await vi.advanceTimersByTimeAsync(8500);
+
+  await expect(resultPromise).resolves.toHaveProperty("prependContext");
+  expect(api.logger.info).toHaveBeenCalledWith(
+    expect.stringContaining("injecting 1 memories"),
+  );
+  expect(api.logger.warn).not.toHaveBeenCalledWith(
+    expect.stringContaining("timed out"),
+  );
+  expect(captureEvent).toHaveBeenCalledWith(
+    "openclaw.hook.recall",
+    expect.objectContaining({ outcome: "success" }),
+  );
+});
+
+it("preservation: unset legacy timeout", async () => {
+  vi.useFakeTimers();
+  const provider = {
+    search: vi.fn(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(
+            () =>
+              resolve([{ id: "m1", memory: "fact", score: 0.9 }]),
+            8500,
+          ),
+        ),
+    ),
+  };
+  const cfg = parseHookConfig();
+  const { api, callback, captureEvent } = registerRecallTest(cfg, provider);
+
+  expect(cfg.recallTimeoutMs).toBe(DEFAULT_RECALL_TIMEOUT_MS);
+  const resultPromise = callback({ prompt: "remember this" }, {});
+  await vi.advanceTimersByTimeAsync(DEFAULT_RECALL_TIMEOUT_MS);
+
+  await expect(resultPromise).resolves.toBeUndefined();
+  await vi.advanceTimersByTimeAsync(500);
+  expect(api.logger.warn).toHaveBeenCalledWith(
+    expect.stringContaining(`after ${DEFAULT_RECALL_TIMEOUT_MS}ms`),
+  );
+  expect(api.logger.info).not.toHaveBeenCalledWith(
+    expect.stringContaining("injecting"),
+  );
+  expect(captureEvent).toHaveBeenCalledWith(
+    "openclaw.hook.recall",
+    expect.objectContaining({ outcome: "timeout" }),
+  );
+});
+
+it("boundary values 1000 and 120000: parser-owned timeout validation", () => {
+  expect(DEFAULT_RECALL_TIMEOUT_MS).toBe(8000);
+  expect(
+    mem0ConfigSchema.parse({ recallTimeoutMs: 1000 }).recallTimeoutMs,
+  ).toBe(MIN_RECALL_TIMEOUT_MS);
+  expect(
+    mem0ConfigSchema.parse({ recallTimeoutMs: "120000" }).recallTimeoutMs,
+  ).toBe(MAX_RECALL_TIMEOUT_MS);
+  expect(() => mem0ConfigSchema.parse({ recallTimeoutMs: 120001 })).toThrow(
+    `recallTimeoutMs must be an integer from ${MIN_RECALL_TIMEOUT_MS} to ${MAX_RECALL_TIMEOUT_MS}`,
+  );
+});
+
+it("CLI/config surface: recall_timeout_ms round-trip and bounds", async () => {
+  const { config } = setupCli();
+  const setCommand = findCommand(config, "set")!;
+  const showCommand = findCommand(config, "show")!;
+
+  await setCommand._action!("recall_timeout_ms", "120000");
+  expect(writePluginAuth).toHaveBeenCalledWith({ recallTimeoutMs: 120000 });
+
+  vi.mocked(readPluginAuth).mockReturnValue({ recallTimeoutMs: 120000 });
+  await showCommand._action!({ json: true });
+  expect(stdoutWriteSpy).toHaveBeenCalledWith(
+    expect.stringContaining('"recall_timeout_ms": 120000'),
+  );
+
+  await setCommand._action!("recall_timeout_ms", "120001");
+  expect(consoleErrorSpy).toHaveBeenCalledWith(
+    expect.stringContaining("Invalid recall timeout value: 120001"),
+  );
+});
+
+it("negative-space: skills-mode recall ignores legacy deadline", async () => {
+  vi.useFakeTimers();
+  const provider = {
+    search: vi.fn(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(
+            () =>
+              resolve([{ id: "m1", memory: "fact", score: 0.9 }]),
+            1500,
+          ),
+        ),
+    ),
+  };
+  const { api, callback } = registerRecallTest(
+    parseHookConfig({
+      recallTimeoutMs: 1000,
+      skills: { recall: { enabled: true } },
+    }),
+    provider,
+    true,
+  );
+
+  const resultPromise = callback(
+    { prompt: "remember this" },
+    { sessionKey: "agent:main:main" },
+  );
+  await vi.advanceTimersByTimeAsync(1500);
+
+  await expect(resultPromise).resolves.toBeDefined();
+  expect(api.logger.warn).not.toHaveBeenCalledWith(
+    expect.stringContaining("timed out"),
+  );
+});
+
+it("terminal outcome ownership", async () => {
+  const provider = {
+    search: vi.fn().mockRejectedValue(new Error("provider unavailable")),
+  };
+  const { api, callback, captureEvent } = registerRecallTest(
+    parseHookConfig({ recallTimeoutMs: 8000 }),
+    provider,
+  );
+
+  await expect(callback({ prompt: "remember this" }, {})).resolves.toBeUndefined();
+  expect(api.logger.warn).toHaveBeenCalledWith(
+    "openclaw-mem0: recall failed: Error: provider unavailable",
+  );
+  expect(captureEvent).toHaveBeenCalledTimes(1);
+  expect(captureEvent).toHaveBeenCalledWith(
+    "openclaw.hook.recall",
+    expect.objectContaining({ outcome: "provider_error" }),
+  );
+  expect(captureEvent).not.toHaveBeenCalledWith(
+    "openclaw.hook.recall",
+    expect.objectContaining({ outcome: "timeout" }),
+  );
+  expect(captureEvent).not.toHaveBeenCalledWith(
+    "openclaw.hook.recall",
+    expect.objectContaining({ outcome: "success" }),
+  );
+  expect(api.logger.warn).not.toHaveBeenCalledWith(
+    expect.stringContaining("timed out"),
+  );
+  expect(api.logger.info).not.toHaveBeenCalledWith(
+    expect.stringContaining("injecting"),
+  );
+});
+
+it("startup log: effective legacy timeout", () => {
+  const logLine = formatRegistrationLog(
+    parseHookConfig({ recallTimeoutMs: 120000 }),
+    false,
+  );
+  expect(logLine).toContain("legacyRecallTimeoutMs: 120000");
+  expect(logLine.match(/legacyRecallTimeoutMs/g)).toHaveLength(1);
+});

--- a/integrations/openclaw/tests/recall-timeout-regression.test.ts
+++ b/integrations/openclaw/tests/recall-timeout-regression.test.ts
@@ -78,7 +78,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-it("negative-space: skills-mode recall ignores legacy deadline", async () => {
+it("skills-mode recall is bounded by recallTimeoutMs", async () => {
   vi.useFakeTimers();
   const provider = {
     search: vi.fn(
@@ -98,10 +98,15 @@ it("negative-space: skills-mode recall ignores legacy deadline", async () => {
     { prompt: "remember this" },
     { sessionKey: "agent:main:main" },
   );
-  await vi.advanceTimersByTimeAsync(1500);
+  // Deadline fires before provider resolves.
+  await vi.advanceTimersByTimeAsync(1000);
 
   await expect(resultPromise).resolves.toBeDefined();
-  expect(api.logger.warn).not.toHaveBeenCalledWith(
-    expect.stringContaining("timed out"),
+  expect(api.logger.warn).toHaveBeenCalledWith(
+    expect.stringContaining("skills-mode recall timed out after 1000ms"),
   );
+  expect(api.logger.info).not.toHaveBeenCalledWith(
+    expect.stringContaining("injecting"),
+  );
+  vi.useRealTimers();
 });

--- a/integrations/openclaw/types.ts
+++ b/integrations/openclaw/types.ts
@@ -26,6 +26,7 @@ export type Mem0Config = {
   autoRecall: boolean;
   searchThreshold: number;
   topK: number;
+  recallTimeoutMs: number;
   // Setup state
   needsSetup?: boolean;
   // Agentic harness skills


### PR DESCRIPTION
## Summary

- Makes the openclaw-mem0 auto-recall deadline configurable via `recallTimeoutMs` / `RECALL_TIMEOUT_MS` (default still 8000ms).
- Applies the same deadline to skills-mode auto-recall (previously unbounded).

## Motivation

Closes #6307.

Legacy mode raced automatic recall against a hard-coded 8s timer, so local/network‑slower installs degraded even when the provider would succeed shortly after. Operators need a knobs without losing a safe default. Skills mode previously had no deadline, which is worse under provider hangs.

## Fix

- `resolveRecallTimeoutMs()`: config → env → default, clamped to `[500, 120_000]`.
- Wire `Mem0Config.recallTimeoutMs`, schema allowlist, and plugin UI/JSON schema.
- Use the value in legacy `Promise.race` and skills-mode recall.
- Log the effective timeout in the register banner; timeout logs stay distinct from provider errors.

## Verification

- `pnpm exec vitest run tests/config.test.ts` — **69 passed**, 0 failed
- Default remains 8000ms when unset; invalid values fall back safely

## Tests added

- `resolveRecallTimeoutMs` unit coverage (default, config prefer over env, bounds, flooring)
- `mem0ConfigSchema.parse` for default / custom / invalid / env-driven values