### PR TITLE
fix(embeddings): forward api_key to huggingface custom endpoint client

### DIFF
--- a/mem0/embeddings/huggingface.py
+++ b/mem0/embeddings/huggingface.py
@@ -17,7 +17,9 @@ class HuggingFaceEmbedding(EmbeddingBase):
         super().__init__(config)
 
         if self.config.huggingface_base_url:
-            self.client = OpenAI(base_url=self.config.huggingface_base_url)
+            import os
+            api_key = self.config.api_key or os.getenv("HUGGINGFACE_API_KEY") or "hf"
+            self.client = OpenAI(base_url=self.config.huggingface_base_url, api_key=api_key)
             self.config.model = self.config.model or "tei"
         else:
             self.config.model = self.config.model or "multi-qa-MiniLM-L6-cos-v1"

--- a/tests/embeddings/test_huggingface_embeddings.py
+++ b/tests/embeddings/test_huggingface_embeddings.py
@@ -94,7 +94,7 @@ def test_embed_with_huggingface_base_url():
         embedder = HuggingFaceEmbedding(config)
         result = embedder.embed("Hello from custom endpoint")
 
-        mock_openai.assert_called_once_with(base_url="http://localhost:8080")
+        mock_openai.assert_called_once_with(base_url="http://localhost:8080", api_key="hf")
         mock_client.embeddings.create.assert_called_once_with(
             input="Hello from custom endpoint",
             model="my-custom-model",
@@ -140,10 +140,35 @@ def test_embed_batch_base_url():
         texts = ["First text.", "Second text."]
         result = embedder.embed_batch(texts)
 
+        mock_openai.assert_called_once_with(base_url="http://localhost:8080", api_key="hf")
         mock_client.embeddings.create.assert_called_once_with(
             input=texts, model="my-custom-model"
         )
         assert result == [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+
+
+def test_embed_with_huggingface_base_url_and_api_key():
+    config = BaseEmbedderConfig(
+        huggingface_base_url="http://localhost:8080",
+        model="my-custom-model",
+        api_key="hf_customToken",
+    )
+    with patch("mem0.embeddings.huggingface.OpenAI") as mock_openai:
+        mock_client = Mock()
+        mock_openai.return_value = mock_client
+        
+        mock_embedding_response = Mock()
+        mock_embedding_response.embedding = [0.1, 0.2, 0.3]
+        
+        mock_create_response = Mock()
+        mock_create_response.data = [mock_embedding_response]
+        mock_client.embeddings.create.return_value = mock_create_response
+
+        embedder = HuggingFaceEmbedding(config)
+        result = embedder.embed("Hello from custom endpoint")
+
+        mock_openai.assert_called_once_with(base_url="http://localhost:8080", api_key="hf_customToken")
+        assert result == [0.1, 0.2, 0.3]
 
 
 def test_embed_batch_count_mismatch_raises_base_url():


### PR DESCRIPTION
Resolves #6301.

### Description
In `HuggingFaceEmbedding`, if a user provides a custom `huggingface_base_url` (e.g. TEI server or custom Inference Endpoint), the underlying `OpenAI` client was initialized without forwarding the `api_key` configured in the `BaseEmbedderConfig`. This resulted in the client defaulting to `OPENAI_API_KEY` (if set) or raising a missing credentials error (if not set).

### Changes
- Forwarded the `api_key` using a fallback precedence of `config.api_key` -> `HUGGINGFACE_API_KEY` -> default `"hf"` (matching TypeScript client implementation).
- Updated existing test assertions in `test_huggingface_embeddings.py` to match new signature parameters.
- Added a new unit test `test_embed_with_huggingface_base_url_and_api_key` validating that custom api keys are successfully passed through on client initialization.