### PR TITLE
fix(memory): tokenize mixed-script text for BM25

### DIFF
--- a/mem0/utils/lemmatization.py
+++ b/mem0/utils/lemmatization.py
@@ -7,29 +7,79 @@ Uses spaCy's lemmatizer for better handling of:
 - Plurals: memories -> memory
 - Avoids over-stemming: organization != organize
 
-Also includes original -ing forms alongside lemmas to handle cases
-where spaCy's context-dependent lemmatization produces inconsistent
-results (e.g., "meeting" as noun vs verb -> different lemmas).
+Also includes script-aware preprocessing for mixed Chinese-English text:
+- Han spans use character bigrams so queries overlap longer memories.
+- Latin spans continue through spaCy's lemmatizer.
+- Technical identifiers are preserved as exact normalized tokens.
 """
 
 from __future__ import annotations
 
 import logging
+import re
+import unicodedata
 
 logger = logging.getLogger(__name__)
 
+_HAN_RANGES = (
+    (0x3400, 0x4DBF),
+    (0x4E00, 0x9FFF),
+    (0xF900, 0xFAFF),
+    (0x20000, 0x2FA1F),
+    (0x30000, 0x323AF),
+)
 
-def lemmatize_for_bm25(text: str) -> str:
-    """Lemmatize text for BM25 matching.
+# Preserve connector-based technical identifiers while leaving ordinary
+# hyphenated words to spaCy. A hyphen-only token must contain a digit;
+# stronger technical separators such as '/', '_', '.', ':', and '#' are
+# sufficient on their own.
+_IDENTIFIER_RE = re.compile(
+    r"(?<![A-Za-z0-9])"
+    r"(?=[A-Za-z0-9._/:#-]*(?:\d|[._/:#]))"
+    r"[A-Za-z0-9]+(?:[-_./:#][A-Za-z0-9]+)+"
+    r"(?![A-Za-z0-9])"
+)
+_SIMPLE_WORD_RE = re.compile(r"[^\W_]+(?:['’][^\W_]+)?", re.UNICODE)
 
-    Returns space-joined lemmas for full-text search. Falls back to
-    the original text if spaCy is unavailable.
-    """
-    from mem0.utils.spacy_models import get_nlp_lemma
 
-    nlp = get_nlp_lemma()
+def _is_han(character: str) -> bool:
+    codepoint = ord(character)
+    return codepoint == 0x3007 or any(start <= codepoint <= end for start, end in _HAN_RANGES)
+
+
+def _tokenize_han(span: str) -> list[str]:
+    if len(span) < 2:
+        return [span]
+    return [span[index : index + 2] for index in range(len(span) - 1)]
+
+
+def _split_han_spans(text: str):
+    if not text:
+        return
+
+    start = 0
+    is_han = _is_han(text[0])
+    for index, character in enumerate(text[1:], start=1):
+        character_is_han = _is_han(character)
+        if character_is_han != is_han:
+            yield ("han" if is_han else "text"), text[start:index]
+            start = index
+            is_han = character_is_han
+    yield ("han" if is_han else "text"), text[start:]
+
+
+def _split_bm25_spans(text: str):
+    cursor = 0
+    for match in _IDENTIFIER_RE.finditer(text):
+        yield from _split_han_spans(text[cursor : match.start()])
+        yield "identifier", match.group()
+        cursor = match.end()
+    yield from _split_han_spans(text[cursor:])
+
+
+def _lemmatize_text_span(text: str, nlp) -> list[str]:
     if nlp is None:
-        return text
+        return _SIMPLE_WORD_RE.findall(text.lower())
 
     doc = nlp(text.lower())
     tokens = []
@@ -46,5 +96,31 @@ def lemmatize_for_bm25(text: str) -> str:
         # This handles noun/verb ambiguity (meeting/meet, attending/attend).
         if token.text.endswith("ing") and token.text != lemma and token.text.isalnum():
             tokens.append(token.text)
+
+    return tokens
+
+
+def lemmatize_for_bm25(text: str) -> str:
+    """Normalize and tokenize text for BM25 matching.
+
+    Han spans use character bigrams, connector-based identifiers remain
+    intact, and other text uses spaCy lemmatization. If spaCy is unavailable,
+    non-Han text falls back to lightweight Unicode word tokenization.
+    """
+    from mem0.utils.spacy_models import get_nlp_lemma
+
+    normalized = unicodedata.normalize("NFKC", text)
+    spans = list(_split_bm25_spans(normalized))
+    needs_nlp = any(kind == "text" and any(character.isalnum() for character in span) for kind, span in spans)
+    nlp = get_nlp_lemma() if needs_nlp else None
+    tokens = []
+
+    for kind, span in spans:
+        if kind == "han":
+            tokens.extend(_tokenize_han(span))
+        elif kind == "identifier":
+            tokens.append(span.lower())
+        else:
+            tokens.extend(_lemmatize_text_span(span, nlp))
 
     return " ".join(tokens)

--- a/tests/utils/test_lemmatization.py
+++ b/tests/utils/test_lemmatization.py
@@ -1,16 +1,46 @@
+import re
+
 import pytest
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def _ensure_spacy():
     """Skip tests if spaCy model is not available."""
     try:
         import spacy
+
         spacy.load("en_core_web_sm")
     except Exception:
         pytest.skip("spaCy en_core_web_sm model not available")
 
 
+class _FakeToken:
+    def __init__(self, text, lemma):
+        self.text = text
+        self.lemma_ = lemma
+        self.is_punct = False
+        self.is_stop = text in {"a", "an", "are", "in", "is", "the"}
+
+
+class _FakeEnglishNlp:
+    """Small deterministic stand-in for the English spaCy pipeline."""
+
+    _LEMMAS = {
+        "employees": "employee",
+        "manages": "manage",
+    }
+
+    def __call__(self, text):
+        words = re.findall(r"[^\W_]+", text.lower())
+        return [_FakeToken(word, self._LEMMAS.get(word, word)) for word in words]
+
+
+@pytest.fixture
+def fake_english_nlp(monkeypatch):
+    monkeypatch.setattr("mem0.utils.spacy_models.get_nlp_lemma", lambda: _FakeEnglishNlp())
+
+
+@pytest.mark.usefixtures("_ensure_spacy")
 class TestLemmatizeForBm25:
     def test_basic_lemmatization(self):
         from mem0.utils.lemmatization import lemmatize_for_bm25
@@ -65,3 +95,77 @@ class TestLemmatizeForBm25:
         tokens = result.split()
         for stop in ["this", "is", "a", "very", "of", "the"]:
             assert stop not in tokens
+
+
+@pytest.mark.usefixtures("fake_english_nlp")
+class TestMixedScriptLemmatization:
+    def test_han_bigrams_overlap_between_memory_and_query(self):
+        from mem0.utils.lemmatization import lemmatize_for_bm25
+
+        memory_tokens = set(lemmatize_for_bm25("用户喜欢北京烤鸭").split())
+        query_tokens = set(lemmatize_for_bm25("北京烤鸭").split())
+
+        assert {"北京", "京烤", "烤鸭"} <= memory_tokens & query_tokens
+
+    def test_mixed_text_routes_latin_and_han_spans_separately(self):
+        from mem0.utils.lemmatization import lemmatize_for_bm25
+
+        tokens = lemmatize_for_bm25("Alice喜欢北京烤鸭employees").split()
+
+        assert "alice" in tokens
+        assert "employee" in tokens
+        assert {"喜欢", "北京", "烤鸭"} <= set(tokens)
+
+    def test_identifier_is_preserved_as_one_exact_token(self):
+        from mem0.utils.lemmatization import lemmatize_for_bm25
+
+        tokens = lemmatize_for_bm25("张伟的员工编号是 CN-A10293").split()
+
+        assert "cn-a10293" in tokens
+        assert "cn" not in tokens
+        assert "a10293" not in tokens
+
+    def test_plain_hyphenated_word_is_not_treated_as_identifier(self):
+        from mem0.utils.lemmatization import lemmatize_for_bm25
+
+        tokens = lemmatize_for_bm25("state-of-the-art").split()
+
+        assert "state-of-the-art" not in tokens
+        assert {"state", "art"} <= set(tokens)
+
+    def test_fullwidth_identifier_normalizes_to_ascii(self):
+        from mem0.utils.lemmatization import lemmatize_for_bm25
+
+        fullwidth = lemmatize_for_bm25("ＣＮ－Ａ１０２９３")
+        ascii_text = lemmatize_for_bm25("CN-A10293")
+
+        assert fullwidth == ascii_text == "cn-a10293"
+
+    def test_accented_latin_text_is_not_routed_as_han(self):
+        from mem0.utils.lemmatization import lemmatize_for_bm25
+
+        assert lemmatize_for_bm25("café München") == "café münchen"
+
+    def test_english_lemmatization_does_not_regress(self):
+        from mem0.utils.lemmatization import lemmatize_for_bm25
+
+        assert lemmatize_for_bm25("Alice manages employees") == "alice manage employee"
+
+    def test_falls_back_without_spacy_for_mixed_text(self, monkeypatch):
+        from mem0.utils.lemmatization import lemmatize_for_bm25
+
+        monkeypatch.setattr("mem0.utils.spacy_models.get_nlp_lemma", lambda: None)
+
+        tokens = lemmatize_for_bm25("Alice喜欢北京烤鸭 CN-A10293").split()
+        assert {"alice", "喜欢", "北京", "烤鸭", "cn-a10293"} <= set(tokens)
+
+    def test_pure_han_text_does_not_load_spacy(self, monkeypatch):
+        from mem0.utils.lemmatization import lemmatize_for_bm25
+
+        def fail_if_called():
+            pytest.fail("pure Han text should not load spaCy")
+
+        monkeypatch.setattr("mem0.utils.spacy_models.get_nlp_lemma", fail_if_called)
+
+        assert lemmatize_for_bm25("北京烤鸭") == "北京 京烤 烤鸭"
+        assert lemmatize_for_bm25("癌") == "癌"


### PR DESCRIPTION
## Linked Issue

Refs #4884

Related: #5755

This PR intentionally does not close #4884 because multilingual entity extraction remains out of scope. It focuses only on mixed-script BM25 preprocessing.

## Description

The existing BM25 preprocessing sends the entire input through the English spaCy pipeline. For mixed Chinese-English text without whitespace, this can produce a single token and prevent English lemmatization and Chinese lexical matching from working correctly.

For example:

```text
Alice喜欢北京烤鸭employees
```

may be treated as one token instead of independently processing the English and Han spans. Technical identifiers such as `CN-A10293` can also be split at punctuation, while full-width forms such as `ＣＮ－Ａ１０２９３` do not match their ASCII equivalents.

This PR adds lightweight, dependency-free script-aware preprocessing to `lemmatize_for_bm25`:

- Applies Unicode NFKC normalization before tokenization.
- Splits mixed text into Han, non-Han, and technical-identifier spans.
- Tokenizes consecutive Han text using character bigrams.
- Preserves a single Han character as a unigram.
- Continues to use the existing spaCy lemmatizer for English and other non-Han text.
- Preserves connector-based technical identifiers such as `CN-A10293` as normalized exact tokens.
- Uses lightweight Unicode word tokenization when spaCy is unavailable.
- Avoids loading spaCy for pure Han text.
- Conservatively distinguishes technical identifiers from ordinary hyphenated English words such as `state-of-the-art`.

For example:

```text
Alice喜欢北京烤鸭employees CN-A10293
```

is normalized into BM25 terms equivalent to:

```text
alice 喜欢 欢北 北京 京烤 烤鸭 employee cn-a10293
```

The change is limited to the shared Python BM25 preprocessing utility and its unit tests. It introduces no new dependencies, configuration fields, public APIs, or entity-extraction changes.

Existing memories are not automatically backfilled. Memories whose stored `text_lemmatized` payload was generated by the previous implementation need to be re-created or re-indexed to receive the full benefit of the new preprocessing.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added regression coverage for:

- Pure Han memory/query bigram overlap.
- Single-character Han queries.
- Chinese-English text without whitespace.
- English lemmatization inside mixed text.
- Exact technical-identifier preservation.
- Full-width identifier normalization.
- spaCy-unavailable fallback behavior.
- Pure Han processing without loading spaCy.
- Accented Latin text.
- Prevention of false-positive identifier classification for ordinary hyphenated words.

Verification performed:

```text
pytest tests/utils/test_lemmatization.py -q
16 passed

pytest tests/test_memory.py -q
59 passed

ruff check mem0/utils/lemmatization.py tests/utils/test_lemmatization.py
All checks passed

ruff format --check mem0/utils/lemmatization.py tests/utils/test_lemmatization.py
2 files already formatted

pre-commit run --files mem0/utils/lemmatization.py tests/utils/test_lemmatization.py
Ruff  Passed
isort Passed
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed