### PR TITLE
fix(qdrant): validate existing collection dimensions

### DIFF
--- a/mem0/vector_stores/qdrant.py
+++ b/mem0/vector_stores/qdrant.py
@@ -140,6 +140,16 @@ class Qdrant(VectorStoreBase):
             if collection.name == self.collection_name:
                 logger.debug(f"Collection {self.collection_name} already exists. Skipping creation.")
                 info = self.client.get_collection(self.collection_name)
+
+                dense_vector_config = info.config.params.vectors
+                existing_vector_size = getattr(dense_vector_config, "size", None)
+                if existing_vector_size is not None and existing_vector_size != vector_size:
+                    raise ValueError(
+                        f"Collection '{self.collection_name}' has vector dimension {existing_vector_size}, "
+                        f"but embedding_model_dims is configured as {vector_size}. "
+                        "Use a different collection_name or recreate the collection with matching dimensions."
+                    )
+
                 sparse_cfg = info.config.params.sparse_vectors
                 self._has_bm25_slot = bool(sparse_cfg and "bm25" in sparse_cfg)
                 if not self._has_bm25_slot:

--- a/tests/vector_stores/test_qdrant.py
+++ b/tests/vector_stores/test_qdrant.py
@@ -71,6 +71,30 @@ class TestQdrant(unittest.TestCase):
             sparse_vectors_config=expected_sparse_config,
         )
 
+    def test_existing_collection_dimension_mismatch_raises_clear_error(self):
+        client_mock = MagicMock(spec=QdrantClient)
+        existing_collection = MagicMock()
+        existing_collection.name = "test_collection"
+        client_mock.get_collections.return_value = MagicMock(collections=[existing_collection])
+
+        collection_info = MagicMock()
+        collection_info.config.params.vectors = VectorParams(size=1536, distance=Distance.COSINE)
+        collection_info.config.params.sparse_vectors = None
+        client_mock.get_collection.return_value = collection_info
+
+        with self.assertRaises(ValueError) as ctx:
+            Qdrant(
+                collection_name="test_collection",
+                embedding_model_dims=1024,
+                client=client_mock,
+            )
+
+        error_message = str(ctx.exception)
+        self.assertIn("test_collection", error_message)
+        self.assertIn("1536", error_message)
+        self.assertIn("1024", error_message)
+        client_mock.create_collection.assert_not_called()
+
     def test_insert(self):
         vectors = [[0.1, 0.2], [0.3, 0.4]]
         payloads = [{"key": "value1"}, {"key": "value2"}]


### PR DESCRIPTION
## Description

Qdrant currently reuses an existing collection without validating its dense vector dimension. If the collection was created with 1536 dimensions and `embedding_model_dims` is later configured as 1024, initialization succeeds but search fails later with a low-level NumPy shape mismatch.

This change validates the existing collection dimension during Qdrant initialization and raises a clear `ValueError` when the dimensions do not match. The error includes the collection name, the existing dimension, the configured dimension, and guidance to use a new collection name or recreate the collection with matching dimensions.

The implementation does not automatically delete or recreate collections, so existing user data is preserved.

Fixes #6318 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Test Coverage

- [x] I added/updated unit tests

Validation performed:

```bash
hatch run dev_py_3_11:pytest -p no:cacheprovider -q tests/vector_stores/test_qdrant.py
uvx --from ruff==0.6.9 ruff check mem0/vector_stores/qdrant.py tests/vector_stores/test_qdrant.py
uvx --from ruff==0.6.9 ruff format --check --range=140-155 mem0/vector_stores/qdrant.py
uvx --from ruff==0.6.9 ruff format --check --range=74-97 tests/vector_stores/test_qdrant.py
```

The Qdrant test suite passes with 96 tests.