### PR TITLE
ci: add CI and CD workflows for kilo-plugin

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -21,6 +21,7 @@ Package workflows keep their own push-to-main and manual triggers. Their `pull_r
 | Mem0 Plugin | `mem0-plugin-checks.yml` | Push to main (`integrations/mem0-plugin/`, excluding `.opencode-plugin/`), manual | pytest + hook exec bits + JSON manifest validation on Python 3.10, 3.11, 3.12 |
 | OpenCode Plugin | `opencode-plugin-checks.yml` | Push to main (`.opencode-plugin/`), manual | Bun: tsc + build + dist artifact check |
 | Pi Agent Plugin | `pi-agent-plugin-checks.yml` | Push to main (`integrations/pi-agent-plugin/`), manual | tsc + vitest + tsup on Node 20, 22 |
+| Kilo Plugin | `kilo-plugin-checks.yml` | Push to main (`integrations/kilo-plugin/`), manual | Bun: tsc + build + dist artifact check |
 | n8n Node | `n8n-nodes-mem0-checks.yml` | Push to main (`integrations/n8n-nodes-mem0/`), manual | ESLint + tsc build on Node 20 |
 | Zapier App | `zapier-mem0-checks.yml` | Push to main (`integrations/zapier-mem0/`), manual | tsc + `zapier validate` + offline unit tests on Node 22 |
 | docs llms.txt | `docs-llms-txt-check.yml` | Manual | `docs/llms.txt` coverage |
@@ -55,6 +56,7 @@ Requiring `CI Gate` also means fork PRs from first-time contributors cannot merg
 | OpenClaw | `openclaw-cd.yml` | `openclaw-v*` | npm (`@mem0/openclaw-mem0`) |
 | OpenCode Plugin | `opencode-plugin-cd.yml` | `opencode-v*` | npm (`@mem0/opencode-plugin`) |
 | Pi Agent Plugin | `pi-agent-plugin-cd.yml` | `pi-agent-v*` | npm (`@mem0/pi-agent-plugin`) |
+| Kilo Plugin | `kilo-plugin-cd.yml` | `kilo-v*` | npm (`@mem0/kilo-plugin`) |
 | n8n Node | `n8n-nodes-mem0-cd.yml` | `n8n-nodes-mem0-v*` | npm (`@mem0/n8n-nodes-mem0`) |
 
 - Package CD workflows are `workflow_dispatch`-only, with `tag` and `prerelease` inputs. They check out and build the given tag.

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -21,7 +21,7 @@ Package workflows keep their own push-to-main and manual triggers. Their `pull_r
 | Mem0 Plugin | `mem0-plugin-checks.yml` | Push to main (`integrations/mem0-plugin/`, excluding `.opencode-plugin/`), manual | pytest + hook exec bits + JSON manifest validation on Python 3.10, 3.11, 3.12 |
 | OpenCode Plugin | `opencode-plugin-checks.yml` | Push to main (`.opencode-plugin/`), manual | Bun: tsc + build + dist artifact check |
 | Pi Agent Plugin | `pi-agent-plugin-checks.yml` | Push to main (`integrations/pi-agent-plugin/`), manual | tsc + vitest + tsup on Node 20, 22 |
-| Kilo Plugin | `kilo-plugin-checks.yml` | Push to main (`integrations/kilo-plugin/`), manual | Bun: tsc + build + dist artifact check |
+| Kilo Plugin | `kilo-plugin-checks.yml` | Push to main (`integrations/kilo-plugin/`), manual | Bun: test + tsc + build + dist artifact check |
 | n8n Node | `n8n-nodes-mem0-checks.yml` | Push to main (`integrations/n8n-nodes-mem0/`), manual | ESLint + tsc build on Node 20 |
 | Zapier App | `zapier-mem0-checks.yml` | Push to main (`integrations/zapier-mem0/`), manual | tsc + `zapier validate` + offline unit tests on Node 22 |
 | docs llms.txt | `docs-llms-txt-check.yml` | Manual | `docs/llms.txt` coverage |

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -40,6 +40,7 @@ jobs:
       openclaw: ${{ steps.filter.outputs.openclaw }}
       opencode_plugin: ${{ steps.filter.outputs.opencode_plugin }}
       pi_agent_plugin: ${{ steps.filter.outputs.pi_agent_plugin }}
+      kilo_plugin: ${{ steps.filter.outputs.kilo_plugin }}
       docs_llms_txt: ${{ steps.filter.outputs.docs_llms_txt }}
     steps:
       - uses: dorny/paths-filter@v3
@@ -78,6 +79,10 @@ jobs:
             pi_agent_plugin:
               - 'integrations/pi-agent-plugin/**'
               - '.github/workflows/pi-agent-plugin-checks.yml'
+              - '.github/workflows/ci-gate.yml'
+            kilo_plugin:
+              - 'integrations/kilo-plugin/**'
+              - '.github/workflows/kilo-plugin-checks.yml'
               - '.github/workflows/ci-gate.yml'
             docs_llms_txt:
               - 'docs/**/*.mdx'
@@ -136,6 +141,13 @@ jobs:
     uses: ./.github/workflows/pi-agent-plugin-checks.yml
     secrets: inherit
 
+  kilo-plugin:
+    name: Kilo Plugin
+    needs: changes
+    if: needs.changes.outputs.kilo_plugin == 'true'
+    uses: ./.github/workflows/kilo-plugin-checks.yml
+    secrets: inherit
+
   docs-llms-txt:
     name: docs llms.txt
     needs: changes
@@ -154,6 +166,7 @@ jobs:
       - openclaw
       - opencode-plugin
       - pi-agent-plugin
+      - kilo-plugin
       - docs-llms-txt
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -41,6 +41,7 @@ jobs:
       mem0_plugin: ${{ steps.filter.outputs.mem0_plugin }}
       opencode_plugin: ${{ steps.filter.outputs.opencode_plugin }}
       pi_agent_plugin: ${{ steps.filter.outputs.pi_agent_plugin }}
+      kilo_plugin: ${{ steps.filter.outputs.kilo_plugin }}
       n8n_nodes_mem0: ${{ steps.filter.outputs.n8n_nodes_mem0 }}
       zapier_mem0: ${{ steps.filter.outputs.zapier_mem0 }}
       docs_llms_txt: ${{ steps.filter.outputs.docs_llms_txt }}
@@ -86,6 +87,10 @@ jobs:
             pi_agent_plugin:
               - 'integrations/pi-agent-plugin/**'
               - '.github/workflows/pi-agent-plugin-checks.yml'
+              - '.github/workflows/ci-gate.yml'
+            kilo_plugin:
+              - 'integrations/kilo-plugin/**'
+              - '.github/workflows/kilo-plugin-checks.yml'
               - '.github/workflows/ci-gate.yml'
             n8n_nodes_mem0:
               - 'integrations/n8n-nodes-mem0/**'
@@ -158,6 +163,13 @@ jobs:
     uses: ./.github/workflows/pi-agent-plugin-checks.yml
     secrets: inherit
 
+  kilo-plugin:
+    name: Kilo Plugin
+    needs: changes
+    if: needs.changes.outputs.kilo_plugin == 'true'
+    uses: ./.github/workflows/kilo-plugin-checks.yml
+    secrets: inherit
+
   n8n-nodes-mem0:
     name: n8n Node
     needs: changes
@@ -189,6 +201,7 @@ jobs:
       - mem0-plugin
       - opencode-plugin
       - pi-agent-plugin
+      - kilo-plugin
       - n8n-nodes-mem0
       - zapier-mem0
       - docs-llms-txt

--- a/.github/workflows/kilo-plugin-cd.yml
+++ b/.github/workflows/kilo-plugin-cd.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   build-n-publish:
     name: Build and publish @mem0/kilo-plugin 📦 to npm
-    if: startsWith(inputs.tag, 'kilo-v')
+    if: startsWith(inputs.tag, 'kilo-v') && github.ref == format('refs/tags/{0}', inputs.tag)
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag }}
+          ref: refs/tags/${{ inputs.tag }}
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
@@ -47,6 +47,17 @@ jobs:
 
       - name: Build
         run: bun run build
+
+      - name: Verify package version matches release tag
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          TAG_VERSION=${RELEASE_TAG#kilo-v}
+          if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error file=integrations/kilo-plugin/package.json::Tag version $TAG_VERSION does not match package version $PACKAGE_VERSION"
+            exit 1
+          fi
 
       - name: Publish to npm
         run: |

--- a/.github/workflows/kilo-plugin-cd.yml
+++ b/.github/workflows/kilo-plugin-cd.yml
@@ -1,0 +1,58 @@
+name: Publish @mem0/kilo-plugin 📦 to npm
+
+# Dispatched by release.yml (Release Router) when a release tagged
+# kilo-v* is published. Can also be dispatched manually to re-publish
+# a tag.
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to build and publish (e.g. kilo-v0.1.0)'
+        required: true
+        type: string
+      prerelease:
+        description: 'Publish under the version preid dist-tag instead of latest'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  build-n-publish:
+    name: Build and publish @mem0/kilo-plugin 📦 to npm
+    if: startsWith(inputs.tag, 'kilo-v')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    defaults:
+      run:
+        working-directory: integrations/kilo-plugin
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build
+
+      - name: Publish to npm
+        run: |
+          if [ "${{ inputs.prerelease }}" = "true" ]; then
+            PREID=$(node -p "require('./package.json').version.split('-')[1].split('.')[0]")
+            npx npm@latest publish --provenance --access public --tag "$PREID"
+          else
+            npx npm@latest publish --provenance --access public
+          fi

--- a/.github/workflows/kilo-plugin-checks.yml
+++ b/.github/workflows/kilo-plugin-checks.yml
@@ -1,0 +1,39 @@
+name: kilo-plugin checks
+
+# On PRs this is invoked by ci-gate.yml (the single required check);
+# push-to-main and manual runs remain standalone.
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'integrations/kilo-plugin/**'
+      - '.github/workflows/kilo-plugin-checks.yml'
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: integrations/kilo-plugin
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Type check
+        run: bun run type-check
+
+      - name: Build
+        run: bun run build
+
+      - name: Verify dist output exists
+        run: |
+          test -f dist/index.js || (echo "Build output missing: dist/index.js" && exit 1)

--- a/.github/workflows/kilo-plugin-checks.yml
+++ b/.github/workflows/kilo-plugin-checks.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Test
+        run: bun test
+
       - name: Type check
         run: bun run type-check
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
             opencode-v*)  workflow="opencode-plugin-cd.yml" ;;
             pi-agent-v*)  workflow="pi-agent-plugin-cd.yml" ;;
             n8n-nodes-mem0-v*) workflow="n8n-nodes-mem0-cd.yml" ;;
+            kilo-v*)      workflow="kilo-plugin-cd.yml" ;;
             v*)           workflow="cd.yml" ;;
             *)
               echo "::error::Release tag '$TAG' does not match any known package prefix — nothing will be published. See the tag prefix table in AGENTS.md."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
             openclaw-v*)  workflow="openclaw-cd.yml" ;;
             opencode-v*)  workflow="opencode-plugin-cd.yml" ;;
             pi-agent-v*)  workflow="pi-agent-plugin-cd.yml" ;;
+            kilo-v*)      workflow="kilo-plugin-cd.yml" ;;
             v*)           workflow="cd.yml" ;;
             *)
               echo "::error::Release tag '$TAG' does not match any known package prefix — nothing will be published. See the tag prefix table in AGENTS.md."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ This is a **polyglot monorepo** containing Python and TypeScript packages, CLIs,
 | `integrations/mem0-plugin/` | AI editor plugins (Claude Code, Cursor, Codex) — MCP server connection, lifecycle hooks, skills. Contains nested `.opencode-plugin/` (`@mem0/opencode-plugin`) |
 | `integrations/openclaw/` | `@mem0/openclaw-mem0` — OpenClaw plugin for Claude Code / AI editors |
 | `integrations/pi-agent-plugin/` | `@mem0/pi-agent-plugin` — Pi Agent plugin |
+| `integrations/kilo-plugin/` | `@mem0/kilo-plugin` — Kilo Code plugin (Bun; ported from the OpenCode plugin) |
 | `integrations/vercel-ai-sdk/` | `@mem0/vercel-ai-provider` — Vercel AI SDK memory provider |
 | `server/` | FastAPI REST server for self-hosted Mem0 (Docker: FastAPI + PostgreSQL/pgvector + Neo4j) |
 | `openmemory/` | Self-hosted memory platform — `api/` (FastAPI + Alembic + MCP server) and `ui/` (Next.js 15 + React 19) |
@@ -431,6 +432,7 @@ PR testing is orchestrated by a single entry point: **`ci-gate.yml` (CI Gate)** 
 | OpenClaw | `openclaw-checks.yml` | Push to main (on `integrations/openclaw/`), manual | tsc + vitest (with Codecov) + tsup build on Node 20, 22 |
 | OpenCode Plugin | `opencode-plugin-checks.yml` | Push to main (on `integrations/mem0-plugin/.opencode-plugin/`), manual | Bun: tsc type-check + build + dist artifact check |
 | Pi Agent Plugin | `pi-agent-plugin-checks.yml` | Push to main (on `integrations/pi-agent-plugin/`), manual | tsc + vitest + tsup build (dist artifact check) on Node 20, 22 |
+| Kilo Plugin | `kilo-plugin-checks.yml` | Push to main (on `integrations/kilo-plugin/`), manual | Bun: tsc type-check + build + dist artifact check |
 | docs llms.txt | `docs-llms-txt-check.yml` | Manual | `docs/llms.txt` coverage check |
 
 When adding a new package CI workflow: give it `workflow_call` (plus `push`/`workflow_dispatch` as needed, but no `pull_request` trigger), then register it in `ci-gate.yml` — a path filter under the `changes` job, a call job, and an entry in the gate job's `needs` list.
@@ -450,6 +452,7 @@ Publishing is routed through a single entry point: **`release.yml` (Release Rout
 | OpenClaw | `openclaw-cd.yml` | `openclaw-v*` | npm (`@mem0/openclaw-mem0`) |
 | OpenCode Plugin | `opencode-plugin-cd.yml` | `opencode-v*` | npm (`@mem0/opencode-plugin`) |
 | Pi Agent Plugin | `pi-agent-plugin-cd.yml` | `pi-agent-v*` | npm (`@mem0/pi-agent-plugin`) |
+| Kilo Plugin | `kilo-plugin-cd.yml` | `kilo-v*` | npm (`@mem0/kilo-plugin`) |
 
 - Package CD workflows are `workflow_dispatch`-only (inputs: `tag`, `prerelease`); they check out and build the given tag. Registry trusted-publisher settings stay pinned to each package's own workflow filename.
 - All publishing uses **OIDC trusted publishing** — no tokens or secrets required.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ This is a polyglot monorepo and **every package sets its own rules**. Read the `
 - Modify anything in `.github/workflows/` without explicit maintainer approval. Publishing credentials are pinned to workflow filenames.
 - Commit `.env` files, API keys, or credentials.
 - Skip pre-commit hooks.
-- Use npm or yarn in TypeScript packages. This repo is pnpm-only (Bun in `.opencode-plugin/`).
+- Use npm or yarn in TypeScript packages. This repo uses pnpm except for the Bun-based `.opencode-plugin/` and `integrations/kilo-plugin/` packages.
 - Use `require()` in TypeScript. ES module `import` syntax only.
 - Mix up linter configs. Root Python is ruff at line length **120**, `cli/python/` is ruff at **100**, `cli/node/` is Biome, `mem0-ts/` is Prettier, `integrations/vercel-ai-sdk/` is ESLint.
 - Add Python dependencies to the core `dependencies` list in `pyproject.toml`. Use an optional group.

--- a/integrations/AGENTS.md
+++ b/integrations/AGENTS.md
@@ -9,10 +9,11 @@ Agent and editor integrations. Each subdirectory is self-contained: its own `pac
 | `mem0-plugin/` | Claude Code / Cursor / Codex plugin | none | none | pytest |
 | `mem0-plugin/.opencode-plugin/` | `@mem0/opencode-plugin` | Bun | none | tsc type-check |
 | `pi-agent-plugin/` | `@mem0/pi-agent-plugin` | tsup | none | vitest |
+| `kilo-plugin/` | `@mem0/kilo-plugin` | Bun | none | bun test |
 | `n8n-nodes-mem0/` | `@mem0/n8n-nodes-mem0` | tsc | ESLint (n8n-nodes-base) | none |
 | `zapier-mem0/` | `@mem0/zapier` | tsc | none | offline unit tests + `zapier validate` |
 
-pnpm everywhere except `.opencode-plugin/`, which uses Bun. Never npm, never yarn.
+pnpm everywhere except `.opencode-plugin/` and `kilo-plugin/`, which use Bun. Never npm, never yarn.
 
 ## Commands
 


### PR DESCRIPTION
## Linked Issue

Follow-up to #5606 / #5617.

## Description

This is the deliberate, separate CI/CD step for the Kilo plugin requested by @kartik-mem0. It registers `integrations/kilo-plugin` (added by #5617) in the existing CI/CD architecture while keeping workflow changes out of the feature PR.

### What it adds

- `kilo-plugin-checks.yml`: reusable/manual/push checks using Bun, frozen install, typecheck, build, and `dist/index.js` verification. Its shape mirrors the Bun-based OpenCode plugin workflow.
- `kilo-plugin-cd.yml`: manual release workflow guarded on `kilo-v*`, with OIDC provenance publishing for `@mem0/kilo-plugin`.
- `ci-gate.yml`: Kilo is registered in all four required places: changes output, path filter, reusable call job, and gate `needs`.
- `release.yml`: a `kilo-v*)` arm before the bare `v*)` Python arm.
- `.github/AGENTS.md`: Kilo CI, CD tag-prefix, and key-directory entries.

`cache-dependency-path` does not apply: it is an `actions/setup-node` input used by the pnpm workflows. Kilo uses `oven-sh/setup-bun`, matching the existing OpenCode plugin workflow.

## Hard dependency / merge order

This PR must land **after #5617**. It is not safe to merge or approve independently: changing `kilo-plugin-checks.yml` makes this PR's own `ci-gate.yml` path filter select the Kilo job, whose working directory does not exist until #5617 lands.

Required order:

1. Merge #5617.
2. Refresh/rebase this branch onto the resulting `main`.
3. Approve and rerun the workflow checks.
4. Merge this CI/CD PR only after those checks pass.

## Verification

I built a temporary combined tree from this PR (`e1522d6b`) and the current #5617 head (`c8ee9e55`). The branches merge cleanly, and the combined tree passes:

```text
bun install --frozen-lockfile  -> no changes
bun test                       -> 70 pass / 0 fail / 166 assertions (6 files)
bun run type-check             -> exit 0
bun run build                  -> dist/index.js present
dist loader smoke              -> pass
```

All four workflow files parse as YAML. The Kilo changes output, path filter, reusable job, gate dependency, and `kilo-v` router order were also checked directly. The temporary worktree was removed after verification.

The first `@mem0/kilo-plugin` npm publish still requires the repository's one-time OIDC trusted-publisher setup; later releases route through `release.yml`.
