### PR TITLE
fix(llms): honor OPENAI_BASE_URL in structured provider

### DIFF
--- a/mem0/llms/openai_structured.py
+++ b/mem0/llms/openai_structured.py
@@ -15,7 +15,12 @@ class OpenAIStructuredLLM(LLMBase):
             self.config.model = "gpt-5-mini"
 
         api_key = self.config.api_key or os.getenv("OPENAI_API_KEY")
-        base_url = self.config.openai_base_url or os.getenv("OPENAI_API_BASE") or "https://api.openai.com/v1"
+        base_url = (
+            self.config.openai_base_url
+            or os.getenv("OPENAI_API_BASE")
+            or os.getenv("OPENAI_BASE_URL")
+            or "https://api.openai.com/v1"
+        )
         self.client = OpenAI(api_key=api_key, base_url=base_url)
 
     def generate_response(

--- a/mem0/llms/openai_structured.py
+++ b/mem0/llms/openai_structured.py
@@ -15,12 +15,7 @@ class OpenAIStructuredLLM(LLMBase):
             self.config.model = "gpt-5-mini"
 
         api_key = self.config.api_key or os.getenv("OPENAI_API_KEY")
-        base_url = (
-            self.config.openai_base_url
-            or os.getenv("OPENAI_API_BASE")
-            or os.getenv("OPENAI_BASE_URL")
-            or "https://api.openai.com/v1"
-        )
+        base_url = self.config.openai_base_url or os.getenv("OPENAI_BASE_URL") or "https://api.openai.com/v1"
         self.client = OpenAI(api_key=api_key, base_url=base_url)
 
     def generate_response(

--- a/tests/llms/test_openai_structured.py
+++ b/tests/llms/test_openai_structured.py
@@ -53,7 +53,7 @@ def test_regular_model_sends_sampling_params(mock_openai_client):
 
 def test_uses_openai_base_url_environment_variable(monkeypatch):
     base_url = "https://gateway.example/v1"
-    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+    monkeypatch.setenv("OPENAI_API_BASE", "https://legacy.example/v1")
     monkeypatch.setenv("OPENAI_BASE_URL", base_url)
 
     with patch("mem0.llms.openai_structured.OpenAI") as mock_openai:

--- a/tests/llms/test_openai_structured.py
+++ b/tests/llms/test_openai_structured.py
@@ -49,3 +49,14 @@ def test_regular_model_sends_sampling_params(mock_openai_client):
     assert "max_tokens" in call_kwargs  # standard sampling params still forwarded
     assert "top_p" in call_kwargs
     assert call_kwargs["model"] == "gpt-4o"
+
+
+def test_uses_openai_base_url_environment_variable(monkeypatch):
+    base_url = "https://gateway.example/v1"
+    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+    monkeypatch.setenv("OPENAI_BASE_URL", base_url)
+
+    with patch("mem0.llms.openai_structured.OpenAI") as mock_openai:
+        OpenAIStructuredLLM(OpenAIConfig(api_key="test-api-key"))
+
+    mock_openai.assert_called_once_with(api_key="test-api-key", base_url=base_url)


### PR DESCRIPTION
## Linked Issue

Closes #6321

## Description

`OpenAIStructuredLLM` only checked the deprecated `OPENAI_API_BASE` environment variable before falling back to the default OpenAI endpoint. As a result, users who configured the standard `OPENAI_BASE_URL` variable still sent structured-output requests to `https://api.openai.com/v1`.

This change replaces the legacy lookup with `OPENAI_BASE_URL`, matching the current `OpenAILLM` behavior and the direction established in #2384. Explicit `openai_base_url` config still has highest precedence, followed by `OPENAI_BASE_URL`, then the default endpoint.

The mocked regression test sets both the legacy and standard variables and verifies that the standard URL reaches the OpenAI SDK constructor without making a network request.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

The deprecated `OPENAI_API_BASE` fallback is removed from `OpenAIStructuredLLM`. It was scheduled for removal in mem0 0.1.80 in #2384. Users still relying on it should rename the variable to `OPENAI_BASE_URL`.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Validation completed locally:

```text
python -m pytest tests/llms/test_openai.py tests/llms/test_openai_structured.py -q
24 passed

ruff check mem0/llms/openai_structured.py tests/llms/test_openai_structured.py
All checks passed!

ruff format --check mem0/llms/openai_structured.py tests/llms/test_openai_structured.py
2 files already formatted
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove the fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (N/A: [`OPENAI_BASE_URL`](https://docs.mem0.ai/components/llms/config#config-values-precedence) and [`openai_base_url`](https://docs.mem0.ai/components/llms/config#master-list-of-all-params-in-config) are already documented.)
