### PR TITLE
fix(ts-oss): handle prototype-named embedding cache keys

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -1893,8 +1893,12 @@ export class Memory {
     metadata: Record<string, any>,
   ): Promise<string> {
     const memoryId = uuidv4();
-    const embedding =
-      existingEmbeddings[data] || (await this.embedder.embed(data, "add"));
+    const embedding = Object.prototype.hasOwnProperty.call(
+      existingEmbeddings,
+      data,
+    )
+      ? existingEmbeddings[data]
+      : await this.embedder.embed(data, "add");
 
     const memoryMetadata = {
       ...metadata,
@@ -1937,9 +1941,12 @@ export class Memory {
     }
     const textChanged = newData !== prevValue;
 
-    const embedding =
-      existingEmbeddings[newData] ||
-      (await this.embedder.embed(newData, "update"));
+    const embedding = Object.prototype.hasOwnProperty.call(
+      existingEmbeddings,
+      newData,
+    )
+      ? existingEmbeddings[newData]
+      : await this.embedder.embed(newData, "update");
 
     const newMetadata = {
       ...existingMemory.payload,

--- a/mem0-ts/src/oss/tests/memory.add.test.ts
+++ b/mem0-ts/src/oss/tests/memory.add.test.ts
@@ -191,4 +191,18 @@ describe("Memory - add()", () => {
       expect.objectContaining({ event: "ADD" }),
     );
   });
+
+  test.each(["toString", "constructor", "__proto__"])(
+    "with infer=false stores Object.prototype-named text %s",
+    async (text) => {
+      const result: SearchResult = await memory.add(text, {
+        userId,
+        infer: false,
+      });
+
+      expect(result.results[0].memory).toBe(text);
+      const stored: MemoryItem | null = await memory.get(result.results[0].id);
+      expect(stored!.memory).toBe(text);
+    },
+  );
 });

--- a/mem0-ts/src/oss/tests/memory.crud.test.ts
+++ b/mem0-ts/src/oss/tests/memory.crud.test.ts
@@ -207,6 +207,23 @@ describe("Memory - update()", () => {
       expect.objectContaining({ category: "hobbies", priority: "high" }),
     );
   });
+
+  test("supports metadata-only updates for Object.prototype-named text", async () => {
+    const addResult: SearchResult = await memory.add("Before collision", {
+      userId,
+      infer: false,
+    });
+    const id = addResult.results[0].id;
+    await memory.update(id, { text: "toString" });
+
+    await memory.update(id, { metadata: { source: "prototype-key-test" } });
+
+    const after: MemoryItem | null = await memory.get(id);
+    expect(after!.memory).toBe("toString");
+    expect(after!.metadata).toEqual(
+      expect.objectContaining({ source: "prototype-key-test" }),
+    );
+  });
 });
 
 // ─── update() options: text / data / metadata / expirationDate ───


### PR DESCRIPTION
## Linked Issue

Closes #6323

## Description

The TypeScript OSS memory implementation used direct property access when looking up cached embeddings:

```ts
existingEmbeddings[data] || await this.embedder.embed(...)
```

Because the cache is a plain object, memory text such as `toString`, `constructor`, or `__proto__` can resolve to inherited `Object.prototype` values. Those truthy non-vector values were treated as cached embeddings, causing `infer: false` adds and metadata-only updates to fail with vector dimension errors.

This change only reuses a cached embedding when the requested key is an own property of the cache. Otherwise it calls the embedder normally. The guard is applied to both `createMemory` and `updateMemory`.

Regression coverage includes:

- parameterized `infer: false` adds for `toString`, `constructor`, and `__proto__`
- a metadata-only update after changing a memory's text to `toString`

This is a property-name collision fix, not a prototype-pollution or security change.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Focused validation:

```text
pnpm exec jest src/oss/tests/memory.add.test.ts src/oss/tests/memory.crud.test.ts --runInBand
Test Suites: 2 passed, 2 total
Tests:       65 passed, 65 total

pnpm exec prettier --check src/oss/src/memory/index.ts src/oss/tests/memory.add.test.ts src/oss/tests/memory.crud.test.ts
All matched files use Prettier code style!

pnpm exec tsup
CJS, ESM, and DTS builds succeeded
```

The full `pnpm run test:unit` suite was also attempted on Windows: 81 suites and 1,290 tests passed; 5 suites / 44 tests failed in unrelated SQLite temporary-file cleanup (`EPERM` / `EBUSY`) and an existing Databricks endpoint-readiness timeout. The focused suites above pass completely, and CI can validate the full suite on Linux.

The repository-level `pnpm run build` Prettier pre-step also reports CRLF differences in 217 untouched files on this Windows checkout. The three changed files pass the targeted Prettier check, and direct `tsup` compilation succeeds.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove the fix/feature works
- [x] New and existing tests pass locally (focused tests pass; unrelated Windows-only full-suite failures are documented above)
- [x] I have updated documentation if needed (N/A: no public API or configuration change)
