### PR TITLE
feat(otel): first-party OpenTelemetry tracing for add and search

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -25,6 +25,7 @@ from mem0.configs.prompts import (
 from mem0.exceptions import LLMError
 from mem0.exceptions import ValidationError as Mem0ValidationError
 from mem0.memory.base import MemoryBase
+from mem0.memory import otel
 from mem0.memory.notices import (
     PERFORMANCE_SLOW_QUERY_THRESHOLD_SECONDS,
     detect_decay_usage_from_delete,
@@ -447,6 +448,17 @@ class _AsyncOSSProject:
         raise ValueError(_PROJECT_UPDATE_UNSUPPORTED_ERROR)
 
 
+def _otel_records(items, content_key):
+    """Shape mem0 memory items into the gen_ai.memory.records schema."""
+    records = []
+    for item in items or []:
+        record = {"content": item.get(content_key), "id": item.get("id")}
+        if item.get("score") is not None:
+            record["score"] = item.get("score")
+        records.append(record)
+    return records
+
+
 class Memory(MemoryBase):
     def __init__(self, config: MemoryConfig = MemoryConfig()):
         self.config = config
@@ -720,6 +732,7 @@ class Memory(MemoryBase):
         # Use agent memory extraction if agent_id is present and there are assistant messages
         return has_agent_id and has_assistant_messages
 
+    @otel.trace_memory_operation(otel.OP_ADD)
     def add(
         self,
         messages,
@@ -817,6 +830,11 @@ class Memory(MemoryBase):
                 display_scale_threshold_notice(self, "sync", "add", *scale_threshold_notice)
             else:
                 display_first_run_notice(self, "sync", "add")
+            otel.annotate_operation(
+                otel.current_span(),
+                record_count=len(results["results"]),
+                records_factory=lambda: _otel_records(results["results"], "memory"),
+            )
             return results
 
         if self.config.llm.config.get("enable_vision"):
@@ -832,6 +850,11 @@ class Memory(MemoryBase):
             display_scale_threshold_notice(self, "sync", "add", *scale_threshold_notice)
         else:
             display_first_run_notice(self, "sync", "add")
+        otel.annotate_operation(
+            otel.current_span(),
+            record_count=len(vector_store_result),
+            records_factory=lambda: _otel_records(vector_store_result, "memory"),
+        )
         return {"results": vector_store_result}
 
     def _add_to_vector_store(self, messages, metadata, filters, infer, prompt=None):
@@ -880,13 +903,14 @@ class Memory(MemoryBase):
 
         # Phase 1: Existing memory retrieval
         search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
-        query_embedding = self.embedding_model.embed(parsed_messages, "search")
-        existing_results = self.vector_store.search(
-            query=parsed_messages,
-            vectors=query_embedding,
-            top_k=10,
-            filters=search_filters,
-        )
+        with otel.memory_phase_span("mem0.add.retrieve_existing"):
+            query_embedding = self.embedding_model.embed(parsed_messages, "search")
+            existing_results = self.vector_store.search(
+                query=parsed_messages,
+                vectors=query_embedding,
+                top_k=10,
+                filters=search_filters,
+            )
 
         # Map UUIDs to integers (anti-hallucination)
         existing_memories = []
@@ -911,13 +935,14 @@ class Memory(MemoryBase):
         )
 
         try:
-            response = self.llm.generate_response(
-                messages=[
-                    {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": user_prompt},
-                ],
-                response_format={"type": "json_object"},
-            )
+            with otel.memory_phase_span("mem0.add.llm_extract"):
+                response = self.llm.generate_response(
+                    messages=[
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": user_prompt},
+                    ],
+                    response_format={"type": "json_object"},
+                )
         except Exception as e:
             # Re-raise so callers can implement provider fallback / retry.
             # The original silent ``return []`` made upstream callers unable to
@@ -948,17 +973,18 @@ class Memory(MemoryBase):
 
         # Phase 3: Batch embed all extracted memory texts
         mem_texts = [m.get("text", "") for m in extracted_memories if m.get("text")]
-        try:
-            mem_embeddings_list = self.embedding_model.embed_batch(mem_texts, "add")
-            embed_map = dict(zip(mem_texts, mem_embeddings_list))
-        except Exception:
-            # Fallback: embed individually
-            embed_map = {}
-            for text in mem_texts:
-                try:
-                    embed_map[text] = self.embedding_model.embed(text, "add")
-                except Exception as e:
-                    logger.warning(f"Failed to embed memory text: {e}")
+        with otel.memory_phase_span("mem0.add.embed_memories"):
+            try:
+                mem_embeddings_list = self.embedding_model.embed_batch(mem_texts, "add")
+                embed_map = dict(zip(mem_texts, mem_embeddings_list))
+            except Exception:
+                # Fallback: embed individually
+                embed_map = {}
+                for text in mem_texts:
+                    try:
+                        embed_map[text] = self.embedding_model.embed(text, "add")
+                    except Exception as e:
+                        logger.warning(f"Failed to embed memory text: {e}")
 
         # Phase 4: Per-memory CPU processing + Phase 5: Hash dedup
         # Build set of existing hashes for dedup
@@ -1005,19 +1031,20 @@ class Memory(MemoryBase):
         all_ids = [r[0] for r in records]
         all_payloads = [r[3] for r in records]
 
-        try:
-            self.vector_store.insert(
-                vectors=all_vectors,
-                ids=all_ids,
-                payloads=all_payloads,
-            )
-        except Exception:
-            # Fallback: insert one by one
-            for mid, vec, pay in zip(all_ids, all_vectors, all_payloads):
-                try:
-                    self.vector_store.insert(vectors=[vec], ids=[mid], payloads=[pay])
-                except Exception as e:
-                    logger.error(f"Failed to insert memory {mid}: {e}")
+        with otel.memory_phase_span("mem0.add.vector_write"):
+            try:
+                self.vector_store.insert(
+                    vectors=all_vectors,
+                    ids=all_ids,
+                    payloads=all_payloads,
+                )
+            except Exception:
+                # Fallback: insert one by one
+                for mid, vec, pay in zip(all_ids, all_vectors, all_payloads):
+                    try:
+                        self.vector_store.insert(vectors=[vec], ids=[mid], payloads=[pay])
+                    except Exception as e:
+                        logger.error(f"Failed to insert memory {mid}: {e}")
 
         # Batch history
         history_records = [
@@ -1334,6 +1361,7 @@ class Memory(MemoryBase):
 
         return formatted_memories
 
+    @otel.trace_memory_operation(otel.OP_SEARCH)
     def search(
         self,
         query: str,
@@ -1457,7 +1485,8 @@ class Memory(MemoryBase):
         # Apply reranking if enabled and reranker is available
         if rerank and self.reranker and original_memories:
             try:
-                reranked_memories = self.reranker.rerank(query, original_memories, limit)
+                with otel.memory_phase_span("mem0.search.rerank"):
+                    reranked_memories = self.reranker.rerank(query, original_memories, limit)
                 original_memories = reranked_memories
             except Exception as e:
                 logger.warning(f"Reranking failed, using original results: {e}")
@@ -1477,6 +1506,12 @@ class Memory(MemoryBase):
             )
         else:
             display_first_run_notice(self, "sync", "search")
+        otel.annotate_operation(
+            otel.current_span(),
+            record_count=len(original_memories),
+            query_text=query,
+            records_factory=lambda: _otel_records(original_memories, "memory"),
+        )
         return {"results": original_memories}
 
     def _process_metadata_filters(self, metadata_filters: Dict[str, Any]) -> Dict[str, Any]:
@@ -1593,18 +1628,21 @@ class Memory(MemoryBase):
         query_entities = extract_entities(query)
 
         # Step 2: Embed query
-        embeddings = self.embedding_model.embed(query, "search")
+        with otel.memory_phase_span("mem0.search.embed_query"):
+            embeddings = self.embedding_model.embed(query, "search")
 
         # Step 3: Semantic search (over-fetch for scoring pool)
         internal_limit = max(limit * 4, 60)
-        semantic_results = self.vector_store.search(
-            query=query, vectors=embeddings, top_k=internal_limit, filters=filters
-        )
+        with otel.memory_phase_span("mem0.search.vector_search"):
+            semantic_results = self.vector_store.search(
+                query=query, vectors=embeddings, top_k=internal_limit, filters=filters
+            )
 
         # Step 4: Keyword search (if store supports it)
-        keyword_results = self.vector_store.keyword_search(
-            query=query_lemmatized, top_k=internal_limit, filters=filters
-        )
+        with otel.memory_phase_span("mem0.search.keyword_search"):
+            keyword_results = self.vector_store.keyword_search(
+                query=query_lemmatized, top_k=internal_limit, filters=filters
+            )
 
         # Step 5: Compute BM25 scores from keyword results
         bm25_scores = {}
@@ -1619,7 +1657,8 @@ class Memory(MemoryBase):
         # Step 6: Compute entity boosts
         entity_boosts = {}
         if query_entities:
-            entity_boosts = self._compute_entity_boosts(query_entities, filters)
+            with otel.memory_phase_span("mem0.search.entity_boost"):
+                entity_boosts = self._compute_entity_boosts(query_entities, filters)
 
         # Step 7: Build candidate set from semantic results
         candidates = []
@@ -2371,6 +2410,7 @@ class AsyncMemory(MemoryBase):
         # Use agent memory extraction if agent_id is present and there are assistant messages
         return has_agent_id and has_assistant_messages
 
+    @otel.trace_memory_operation(otel.OP_ADD)
     async def add(
         self,
         messages,
@@ -2447,6 +2487,11 @@ class AsyncMemory(MemoryBase):
                 await display_scale_threshold_notice_async(self, "async", "add", *scale_threshold_notice)
             else:
                 await display_first_run_notice_async(self, "async", "add")
+            otel.annotate_operation(
+                otel.current_span(),
+                record_count=len(results["results"]),
+                records_factory=lambda: _otel_records(results["results"], "memory"),
+            )
             return results
 
         if self.config.llm.config.get("enable_vision"):
@@ -2462,6 +2507,11 @@ class AsyncMemory(MemoryBase):
             await display_scale_threshold_notice_async(self, "async", "add", *scale_threshold_notice)
         else:
             await display_first_run_notice_async(self, "async", "add")
+        otel.annotate_operation(
+            otel.current_span(),
+            record_count=len(vector_store_result),
+            records_factory=lambda: _otel_records(vector_store_result, "memory"),
+        )
         return {"results": vector_store_result}
 
     async def _add_to_vector_store(
@@ -2517,14 +2567,15 @@ class AsyncMemory(MemoryBase):
 
         # Phase 1: Existing memory retrieval
         search_filters = {k: v for k, v in effective_filters.items() if k in ("user_id", "agent_id", "run_id") and v}
-        query_embedding = await asyncio.to_thread(self.embedding_model.embed, parsed_messages, "search")
-        existing_results = await asyncio.to_thread(
-            self.vector_store.search,
-            query=parsed_messages,
-            vectors=query_embedding,
-            top_k=10,
-            filters=search_filters,
-        )
+        with otel.memory_phase_span("mem0.add.retrieve_existing"):
+            query_embedding = await asyncio.to_thread(self.embedding_model.embed, parsed_messages, "search")
+            existing_results = await asyncio.to_thread(
+                self.vector_store.search,
+                query=parsed_messages,
+                vectors=query_embedding,
+                top_k=10,
+                filters=search_filters,
+            )
 
         # Map UUIDs to integers (anti-hallucination)
         existing_memories = []
@@ -2549,14 +2600,15 @@ class AsyncMemory(MemoryBase):
         )
 
         try:
-            response = await asyncio.to_thread(
-                self.llm.generate_response,
-                messages=[
-                    {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": user_prompt},
-                ],
-                response_format={"type": "json_object"},
-            )
+            with otel.memory_phase_span("mem0.add.llm_extract"):
+                response = await asyncio.to_thread(
+                    self.llm.generate_response,
+                    messages=[
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": user_prompt},
+                    ],
+                    response_format={"type": "json_object"},
+                )
         except Exception as e:
             # Re-raise so callers can implement provider fallback / retry
             # (see sync counterpart for rationale).
@@ -2584,16 +2636,17 @@ class AsyncMemory(MemoryBase):
 
         # Phase 3: Batch embed all extracted memory texts
         mem_texts = [m.get("text", "") for m in extracted_memories if m.get("text")]
-        try:
-            mem_embeddings_list = await asyncio.to_thread(self.embedding_model.embed_batch, mem_texts, "add")
-            embed_map = dict(zip(mem_texts, mem_embeddings_list))
-        except Exception:
-            embed_map = {}
-            for text in mem_texts:
-                try:
-                    embed_map[text] = await asyncio.to_thread(self.embedding_model.embed, text, "add")
-                except Exception as e:
-                    logger.warning(f"Failed to embed memory text (async): {e}")
+        with otel.memory_phase_span("mem0.add.embed_memories"):
+            try:
+                mem_embeddings_list = await asyncio.to_thread(self.embedding_model.embed_batch, mem_texts, "add")
+                embed_map = dict(zip(mem_texts, mem_embeddings_list))
+            except Exception:
+                embed_map = {}
+                for text in mem_texts:
+                    try:
+                        embed_map[text] = await asyncio.to_thread(self.embedding_model.embed, text, "add")
+                    except Exception as e:
+                        logger.warning(f"Failed to embed memory text (async): {e}")
 
         # Phase 4: Per-memory CPU processing + Phase 5: Hash dedup
         existing_hashes = set()
@@ -2639,19 +2692,20 @@ class AsyncMemory(MemoryBase):
         all_ids = [r[0] for r in records]
         all_payloads = [r[3] for r in records]
 
-        try:
-            await asyncio.to_thread(
-                self.vector_store.insert,
-                vectors=all_vectors,
-                ids=all_ids,
-                payloads=all_payloads,
-            )
-        except Exception:
-            for mid, vec, pay in zip(all_ids, all_vectors, all_payloads):
-                try:
-                    await asyncio.to_thread(self.vector_store.insert, vectors=[vec], ids=[mid], payloads=[pay])
-                except Exception as e:
-                    logger.error(f"Failed to insert memory {mid} (async): {e}")
+        with otel.memory_phase_span("mem0.add.vector_write"):
+            try:
+                await asyncio.to_thread(
+                    self.vector_store.insert,
+                    vectors=all_vectors,
+                    ids=all_ids,
+                    payloads=all_payloads,
+                )
+            except Exception:
+                for mid, vec, pay in zip(all_ids, all_vectors, all_payloads):
+                    try:
+                        await asyncio.to_thread(self.vector_store.insert, vectors=[vec], ids=[mid], payloads=[pay])
+                    except Exception as e:
+                        logger.error(f"Failed to insert memory {mid} (async): {e}")
 
         # Batch history
         history_records = [
@@ -2968,6 +3022,7 @@ class AsyncMemory(MemoryBase):
 
         return formatted_memories
 
+    @otel.trace_memory_operation(otel.OP_SEARCH)
     async def search(
         self,
         query: str,
@@ -3096,9 +3151,8 @@ class AsyncMemory(MemoryBase):
         if rerank and self.reranker and original_memories:
             try:
                 # Run reranking in thread pool to avoid blocking async loop
-                reranked_memories = await asyncio.to_thread(
-                    self.reranker.rerank, query, original_memories, limit
-                )
+                with otel.memory_phase_span("mem0.search.rerank"):
+                    reranked_memories = await asyncio.to_thread(self.reranker.rerank, query, original_memories, limit)
                 original_memories = reranked_memories
             except Exception as e:
                 logger.warning(f"Reranking failed, using original results: {e}")
@@ -3118,6 +3172,12 @@ class AsyncMemory(MemoryBase):
             )
         else:
             await display_first_run_notice_async(self, "async", "search")
+        otel.annotate_operation(
+            otel.current_span(),
+            record_count=len(original_memories),
+            query_text=query,
+            records_factory=lambda: _otel_records(original_memories, "memory"),
+        )
         return {"results": original_memories}
 
     def _process_metadata_filters(self, metadata_filters: Dict[str, Any]) -> Dict[str, Any]:
@@ -3233,18 +3293,21 @@ class AsyncMemory(MemoryBase):
         query_entities = await asyncio.to_thread(extract_entities, query)
 
         # Step 2: Embed query
-        embeddings = await asyncio.to_thread(self.embedding_model.embed, query, "search")
+        with otel.memory_phase_span("mem0.search.embed_query"):
+            embeddings = await asyncio.to_thread(self.embedding_model.embed, query, "search")
 
         # Step 3: Semantic search (over-fetch)
         internal_limit = max(limit * 4, 60)
-        semantic_results = await asyncio.to_thread(
-            self.vector_store.search, query=query, vectors=embeddings, top_k=internal_limit, filters=filters
-        )
+        with otel.memory_phase_span("mem0.search.vector_search"):
+            semantic_results = await asyncio.to_thread(
+                self.vector_store.search, query=query, vectors=embeddings, top_k=internal_limit, filters=filters
+            )
 
         # Step 4: Keyword search (if store supports it)
-        keyword_results = await asyncio.to_thread(
-            self.vector_store.keyword_search, query=query_lemmatized, top_k=internal_limit, filters=filters
-        )
+        with otel.memory_phase_span("mem0.search.keyword_search"):
+            keyword_results = await asyncio.to_thread(
+                self.vector_store.keyword_search, query=query_lemmatized, top_k=internal_limit, filters=filters
+            )
 
         # Step 5: Compute BM25 scores
         bm25_scores = {}
@@ -3259,7 +3322,8 @@ class AsyncMemory(MemoryBase):
         # Step 6: Compute entity boosts
         entity_boosts = {}
         if query_entities:
-            entity_boosts = await self._compute_entity_boosts_async(query_entities, filters)
+            with otel.memory_phase_span("mem0.search.entity_boost"):
+                entity_boosts = await self._compute_entity_boosts_async(query_entities, filters)
 
         # Step 7: Build candidate set from semantic results
         candidates = []

--- a/mem0/memory/otel.py
+++ b/mem0/memory/otel.py
@@ -1,0 +1,193 @@
+"""Optional OpenTelemetry tracing for memory operations.
+
+This module is a thin, dependency-optional layer. It emits spans for the
+public ``add`` and ``search`` operations (following the GenAI memory
+semantic conventions) plus internal child spans for the LLM-extraction,
+embedding and vector-store phases underneath them.
+
+Nothing here changes behavior unless the caller has both installed
+``opentelemetry-api`` (the ``otel`` optional dependency) and configured a
+``TracerProvider``. When OpenTelemetry is not importable, every helper
+degrades to a no-op with negligible overhead, so the hot path is unchanged
+for the default install.
+
+Memory content (the query text and the stored/retrieved records) is
+sensitive and is only recorded when the caller opts in via
+``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true``; ids and counts
+are always safe to record.
+"""
+
+from __future__ import annotations
+
+import functools
+import importlib.metadata
+import inspect
+import json
+import os
+from contextlib import contextmanager
+
+try:
+    from opentelemetry import trace
+    from opentelemetry.trace import SpanKind
+
+    _OTEL_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised only when the extra is absent
+    _OTEL_AVAILABLE = False
+
+
+# --- Semantic-convention attribute keys (gen_ai.memory.*, development stability) ---
+# Source: open-telemetry/semantic-conventions-genai, `gen_ai.memory.client` span.
+GEN_AI_OPERATION_NAME = "gen_ai.operation.name"
+GEN_AI_MEMORY_RECORD_COUNT = "gen_ai.memory.record.count"
+GEN_AI_MEMORY_QUERY_TEXT = "gen_ai.memory.query.text"
+GEN_AI_MEMORY_RECORDS = "gen_ai.memory.records"
+ERROR_TYPE = "error.type"
+
+# `gen_ai.operation.name` enum values that describe mem0's public operations.
+# `add` may create/update/consolidate records (the LLM decides), which is the
+# spec's definition of `upsert_memory`; `search` maps to `search_memory`.
+OP_ADD = "upsert_memory"
+OP_SEARCH = "search_memory"
+
+# Standard GenAI content-capture opt-in. Off unless explicitly set to "true".
+CONTENT_CAPTURE_ENV = "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"
+
+_INSTRUMENTING_MODULE = "mem0"
+
+
+class _NoopSpan:
+    """Stand-in returned when OpenTelemetry is not installed."""
+
+    def is_recording(self):
+        return False
+
+    def set_attribute(self, *args, **kwargs):
+        return None
+
+    def set_status(self, *args, **kwargs):
+        return None
+
+    def record_exception(self, *args, **kwargs):
+        return None
+
+
+_NOOP_SPAN = _NoopSpan()
+
+
+def _mem0_version():
+    try:
+        return importlib.metadata.version("mem0ai")
+    except Exception:  # pragma: no cover - version metadata should always resolve
+        return ""
+
+
+def _get_tracer():
+    # Cheap: the provider caches tracers per (name, version), and returns a
+    # proxy that resolves lazily once a real TracerProvider is configured.
+    return trace.get_tracer(_INSTRUMENTING_MODULE, _mem0_version())
+
+
+def is_content_capture_enabled():
+    """True only when the operator opts in to capturing memory content."""
+    return os.environ.get(CONTENT_CAPTURE_ENV, "false").strip().lower() == "true"
+
+
+def _is_recording(span):
+    return bool(span) and span.is_recording()
+
+
+def current_span():
+    """The active span, or a no-op stand-in when tracing is unavailable."""
+    if not _OTEL_AVAILABLE:
+        return _NOOP_SPAN
+    return trace.get_current_span()
+
+
+def trace_memory_operation(operation_name):
+    """Decorate a public memory method with a ``gen_ai.memory.client`` span.
+
+    The wrapped method's body runs inside the span, so any child spans it
+    opens (via :func:`memory_phase_span`) nest underneath automatically.
+    Async methods are detected and wrapped with an async wrapper. When
+    OpenTelemetry is absent the method is returned unchanged.
+    """
+
+    def decorator(func):
+        if not _OTEL_AVAILABLE:
+            return func
+
+        if inspect.iscoroutinefunction(func):
+
+            @functools.wraps(func)
+            async def async_wrapper(*args, **kwargs):
+                with _get_tracer().start_as_current_span(operation_name, kind=SpanKind.CLIENT) as span:
+                    if span.is_recording():
+                        span.set_attribute(GEN_AI_OPERATION_NAME, operation_name)
+                    try:
+                        return await func(*args, **kwargs)
+                    except BaseException as exc:
+                        if span.is_recording():
+                            span.set_attribute(ERROR_TYPE, type(exc).__qualname__)
+                        raise
+
+            return async_wrapper
+
+        @functools.wraps(func)
+        def sync_wrapper(*args, **kwargs):
+            with _get_tracer().start_as_current_span(operation_name, kind=SpanKind.CLIENT) as span:
+                if span.is_recording():
+                    span.set_attribute(GEN_AI_OPERATION_NAME, operation_name)
+                try:
+                    return func(*args, **kwargs)
+                except BaseException as exc:
+                    if span.is_recording():
+                        span.set_attribute(ERROR_TYPE, type(exc).__qualname__)
+                    raise
+
+        return sync_wrapper
+
+    return decorator
+
+
+@contextmanager
+def memory_phase_span(name):
+    """Open an internal child span around one phase of an operation.
+
+    No-op (yields a stand-in) when OpenTelemetry is not installed.
+    """
+    if not _OTEL_AVAILABLE:
+        yield _NOOP_SPAN
+        return
+    with _get_tracer().start_as_current_span(name, kind=SpanKind.INTERNAL) as span:
+        try:
+            yield span
+        except BaseException as exc:
+            if span.is_recording():
+                span.set_attribute(ERROR_TYPE, type(exc).__qualname__)
+            raise
+
+
+def _encode_records(records):
+    try:
+        return json.dumps(records, default=str, ensure_ascii=False)
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        return "[]"
+
+
+def annotate_operation(span, *, record_count=None, query_text=None, records_factory=None):
+    """Attach result attributes to an operation span.
+
+    ``record_count`` (a safe count) is always recorded. ``query_text`` and
+    the records payload are sensitive and only recorded when content capture
+    is opted in; ``records_factory`` is a zero-arg callable so the payload is
+    only built when it will actually be recorded.
+    """
+    if not _is_recording(span):
+        return
+    if record_count is not None:
+        span.set_attribute(GEN_AI_MEMORY_RECORD_COUNT, record_count)
+    if is_content_capture_enabled():
+        if query_text is not None:
+            span.set_attribute(GEN_AI_MEMORY_QUERY_TEXT, query_text)
+        if records_factory is not None:
+            span.set_attribute(GEN_AI_MEMORY_RECORDS, _encode_records(records_factory()))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,10 +74,14 @@ extras = [
     "opensearch-py>=2.0.0",
     "fastembed>=0.3.1",
 ]
+otel = [
+    "opentelemetry-api>=1.20.0",
+]
 test = [
     "pytest>=8.2.2",
     "pytest-mock>=3.14.0",
     "pytest-asyncio>=0.23.7",
+    "opentelemetry-sdk>=1.20.0",
 ]
 dev = [
     "ruff>=0.6.5",

--- a/tests/memory/test_otel_tracing.py
+++ b/tests/memory/test_otel_tracing.py
@@ -1,0 +1,256 @@
+"""Tests for the optional OpenTelemetry tracing layer (``mem0.memory.otel``).
+
+These exercise the spans emitted by the public ``add`` / ``search`` methods on
+both ``Memory`` and ``AsyncMemory``: the ``gen_ai.memory.client`` operation
+span, the internal phase child spans nested underneath it, content gating, the
+error path, and the no-op behavior when tracing is unavailable.
+"""
+
+import pytest
+
+pytest.importorskip("opentelemetry.sdk")
+
+from unittest.mock import MagicMock, Mock  # noqa: E402
+
+from opentelemetry.sdk.trace import TracerProvider  # noqa: E402
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor  # noqa: E402
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter  # noqa: E402
+from opentelemetry.trace import SpanKind  # noqa: E402
+
+from mem0.exceptions import LLMError  # noqa: E402
+from mem0.memory import otel  # noqa: E402
+from mem0.memory.main import AsyncMemory, Memory  # noqa: E402
+
+_EXPORTER = InMemorySpanExporter()
+_PROVIDER = TracerProvider()
+_PROVIDER.add_span_processor(SimpleSpanProcessor(_EXPORTER))
+
+_EXTRACTION = '{"memory": [{"text": "Alice met Bob"}, {"text": "Bob called Alice"}]}'
+
+
+def _setup_mocks(mocker):
+    mock_embedder = mocker.MagicMock()
+    mock_embedder.return_value.embed.return_value = [0.1, 0.2, 0.3]
+    mocker.patch("mem0.utils.factory.EmbedderFactory.create", mock_embedder)
+
+    mock_vector_store = mocker.MagicMock()
+    mock_vector_store.return_value.search.return_value = []
+    mocker.patch(
+        "mem0.utils.factory.VectorStoreFactory.create",
+        side_effect=[mock_vector_store.return_value, mocker.MagicMock()],
+    )
+
+    mock_llm = mocker.MagicMock()
+    mocker.patch("mem0.utils.factory.LlmFactory.create", mock_llm)
+    mocker.patch("mem0.memory.storage.SQLiteManager", mocker.MagicMock())
+    return mock_llm, mock_vector_store
+
+
+def _spans():
+    return {s.name: s for s in _EXPORTER.get_finished_spans()}
+
+
+@pytest.fixture(autouse=True)
+def _otel_env(mocker, monkeypatch):
+    # Route mem0's tracer at an in-memory provider, independent of any global one.
+    monkeypatch.setattr(otel, "_get_tracer", lambda: _PROVIDER.get_tracer("mem0-test"))
+    # Silence unrelated side effects (telemetry, notices) and heavy NLP so the
+    # tests exercise only the instrumentation.
+    mocker.patch("mem0.memory.main.capture_event")
+    mocker.patch("mem0.memory.main.extract_entities", return_value=[])
+    mocker.patch("mem0.memory.main.extract_entities_batch", return_value=[])
+    mocker.patch("mem0.memory.main.lemmatize_for_bm25", side_effect=lambda q: q)
+    mocker.patch("mem0.memory.main.detect_temporal_usage_from_metadata", return_value=None)
+    mocker.patch("mem0.memory.main.detect_temporal_usage_from_search", return_value=None)
+    mocker.patch("mem0.memory.main.detect_scale_threshold_from_add_result", return_value=None)
+    mocker.patch("mem0.memory.main.detect_scale_threshold_from_top_k", return_value=None)
+    for name in (
+        "display_first_run_notice",
+        "display_first_run_notice_async",
+        "display_scale_threshold_notice",
+        "display_scale_threshold_notice_async",
+        "display_temporal_usage_notice",
+        "display_temporal_usage_notice_async",
+        "display_performance_slow_query_notice",
+        "display_performance_slow_query_notice_async",
+    ):
+        mocker.patch(f"mem0.memory.main.{name}")
+    _EXPORTER.clear()
+    yield
+    _EXPORTER.clear()
+
+
+def _wire(memory):
+    memory.custom_instructions = None
+    memory.api_version = "v1.1"
+    memory.llm.generate_response.return_value = _EXTRACTION
+    memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+    memory.embedding_model.embed_batch = Mock(side_effect=lambda texts, action="add": [[0.1, 0.2, 0.3] for _ in texts])
+    memory.vector_store.search = Mock(return_value=[])
+    memory.vector_store.keyword_search = Mock(return_value=None)
+    memory.vector_store.insert = Mock()
+    memory.db.get_last_messages = MagicMock(return_value=[])
+    memory.db.save_messages = MagicMock()
+    memory.db.batch_add_history = MagicMock()
+    memory.db.add_history = MagicMock()
+    return memory
+
+
+def _memory(mocker):
+    _setup_mocks(mocker)
+    return _wire(Memory())
+
+
+def _async_memory(mocker):
+    _setup_mocks(mocker)
+    return _wire(AsyncMemory())
+
+
+class TestAddTracing:
+    def test_add_emits_operation_span(self, mocker):
+        result = _memory(mocker).add("Alice met Bob; Bob called Alice", user_id="u1")
+        parent = _spans()[otel.OP_ADD]
+        assert parent.kind == SpanKind.CLIENT
+        assert parent.attributes[otel.GEN_AI_OPERATION_NAME] == "upsert_memory"
+        assert parent.attributes[otel.GEN_AI_MEMORY_RECORD_COUNT] == len(result["results"])
+
+    def test_add_emits_phase_children_nested_under_parent(self, mocker):
+        _memory(mocker).add("Alice met Bob", user_id="u1")
+        spans = _spans()
+        parent = spans[otel.OP_ADD]
+        for child_name in (
+            "mem0.add.retrieve_existing",
+            "mem0.add.llm_extract",
+            "mem0.add.embed_memories",
+            "mem0.add.vector_write",
+        ):
+            assert child_name in spans, child_name
+            child = spans[child_name]
+            assert child.kind == SpanKind.INTERNAL
+            assert child.parent is not None
+            assert child.parent.span_id == parent.context.span_id
+            assert child.context.trace_id == parent.context.trace_id
+
+    def test_add_error_records_error_type_and_reraises(self, mocker):
+        memory = _memory(mocker)
+        memory.llm.generate_response.side_effect = RuntimeError("boom")
+        with pytest.raises(LLMError):
+            memory.add("x", user_id="u1")
+        parent = _spans()[otel.OP_ADD]
+        assert parent.attributes[otel.ERROR_TYPE] == "LLMError"
+        assert parent.status.status_code.name == "ERROR"
+
+    def test_procedural_add_annotates_record_count(self, mocker):
+        memory = _memory(mocker)
+        mocker.patch.object(memory, "_create_memory", return_value="mem-1")
+        result = memory.add("summarize this workflow", agent_id="a1", memory_type="procedural_memory")
+        parent = _spans()[otel.OP_ADD]
+        assert parent.attributes[otel.GEN_AI_OPERATION_NAME] == "upsert_memory"
+        assert parent.attributes[otel.GEN_AI_MEMORY_RECORD_COUNT] == len(result["results"])
+
+
+class TestSearchTracing:
+    def test_search_emits_operation_span(self, mocker):
+        result = _memory(mocker).search("coffee", filters={"user_id": "u1"})
+        parent = _spans()[otel.OP_SEARCH]
+        assert parent.kind == SpanKind.CLIENT
+        assert parent.attributes[otel.GEN_AI_OPERATION_NAME] == "search_memory"
+        assert parent.attributes[otel.GEN_AI_MEMORY_RECORD_COUNT] == len(result["results"])
+
+    def test_search_emits_phase_children(self, mocker):
+        _memory(mocker).search("coffee", filters={"user_id": "u1"})
+        spans = _spans()
+        for child_name in ("mem0.search.embed_query", "mem0.search.vector_search", "mem0.search.keyword_search"):
+            assert child_name in spans, child_name
+            assert spans[child_name].kind == SpanKind.INTERNAL
+
+    def test_content_not_captured_by_default(self, mocker):
+        _memory(mocker).search("secret query", filters={"user_id": "u1"})
+        parent = _spans()[otel.OP_SEARCH]
+        assert otel.GEN_AI_MEMORY_QUERY_TEXT not in parent.attributes
+        assert otel.GEN_AI_MEMORY_RECORDS not in parent.attributes
+
+    def test_content_captured_when_enabled(self, mocker, monkeypatch):
+        monkeypatch.setenv("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "true")
+        _memory(mocker).search("secret query", filters={"user_id": "u1"})
+        parent = _spans()[otel.OP_SEARCH]
+        assert parent.attributes[otel.GEN_AI_MEMORY_QUERY_TEXT] == "secret query"
+        assert otel.GEN_AI_MEMORY_RECORDS in parent.attributes
+
+    def test_entity_boost_span_when_entities_present(self, mocker):
+        mocker.patch("mem0.memory.main.extract_entities", return_value=["Alice"])
+        memory = _memory(mocker)
+        memory._compute_entity_boosts = MagicMock(return_value={})
+        memory.search("Alice", filters={"user_id": "u1"})
+        assert "mem0.search.entity_boost" in _spans()
+
+
+class TestAsyncTracing:
+    @pytest.mark.asyncio
+    async def test_async_add_emits_span(self, mocker):
+        result = await _async_memory(mocker).add("Alice met Bob", user_id="u1")
+        parent = _spans()[otel.OP_ADD]
+        assert parent.attributes[otel.GEN_AI_OPERATION_NAME] == "upsert_memory"
+        assert parent.attributes[otel.GEN_AI_MEMORY_RECORD_COUNT] == len(result["results"])
+        assert "mem0.add.llm_extract" in _spans()
+
+    @pytest.mark.asyncio
+    async def test_async_search_emits_span(self, mocker):
+        await _async_memory(mocker).search("coffee", filters={"user_id": "u1"})
+        spans = _spans()
+        assert spans[otel.OP_SEARCH].attributes[otel.GEN_AI_OPERATION_NAME] == "search_memory"
+        assert "mem0.search.vector_search" in spans
+
+
+class TestPhaseSpanErrors:
+    def test_phase_span_records_error_type_and_reraises(self):
+        with pytest.raises(ValueError):
+            with otel.memory_phase_span("mem0.test.phase"):
+                raise ValueError("boom")
+        span = {s.name: s for s in _EXPORTER.get_finished_spans()}["mem0.test.phase"]
+        assert span.attributes[otel.ERROR_TYPE] == "ValueError"
+        assert span.status.status_code.name == "ERROR"
+
+
+class TestNoopSafety:
+    def test_phase_span_noop_when_unavailable(self, monkeypatch):
+        monkeypatch.setattr(otel, "_OTEL_AVAILABLE", False)
+        with otel.memory_phase_span("x") as span:
+            assert span.is_recording() is False
+        assert not _EXPORTER.get_finished_spans()
+
+    def test_current_span_noop_when_unavailable(self, monkeypatch):
+        monkeypatch.setattr(otel, "_OTEL_AVAILABLE", False)
+        assert otel.current_span() is otel._NOOP_SPAN
+
+    def test_annotate_noop_on_nonrecording_span(self):
+        # Must not raise, and the records factory must not even be invoked.
+        called = []
+        otel.annotate_operation(
+            otel._NOOP_SPAN,
+            record_count=5,
+            query_text="q",
+            records_factory=lambda: called.append(True) or [{"content": "x"}],
+        )
+        assert called == []
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("true", True),
+            ("True", True),
+            ("TRUE", True),
+            (" true ", True),
+            ("false", False),
+            ("", False),
+            ("1", False),
+            ("yes", False),
+        ],
+    )
+    def test_content_capture_env_parsing(self, monkeypatch, value, expected):
+        monkeypatch.setenv("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", value)
+        assert otel.is_content_capture_enabled() is expected
+
+    def test_content_capture_off_when_unset(self, monkeypatch):
+        monkeypatch.delenv("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", raising=False)
+        assert otel.is_content_capture_enabled() is False


### PR DESCRIPTION
## Linked Issue

Closes #6291

## Description

Adds first-party, opt-in OpenTelemetry tracing for the two hot public operations, `add` and `search`, on both `Memory` and `AsyncMemory`. This lands the design agreed in #6291: the phase-level breakdown (LLM extraction, embedding, vector reads and writes) needs hooks that are internal to `Memory`/`AsyncMemory` and are not public, so a wrapper package cannot produce it. It has to be first-party.

Instrumentation lives in a new, dependency-optional module `mem0/memory/otel.py`:

- Each public `add`/`search` emits one `gen_ai.memory.client` span (CLIENT kind, span name = the operation) following the GenAI memory semantic conventions (`gen_ai.memory.*`, open-telemetry/semantic-conventions-genai#140): `add` maps to `gen_ai.operation.name = upsert_memory` (the LLM may add, update, or delete records, which is the spec definition of upsert), `search` maps to `search_memory`.
- Internal child spans give the phase breakdown: `retrieve_existing`, `llm_extract`, `embed_memories`, `vector_write` under `add`; `embed_query`, `vector_search`, `keyword_search`, `entity_boost`, `rerank` under `search`. Both sync and async paths are instrumented.
- Attributes: `gen_ai.memory.record.count` is safe and always recorded. `gen_ai.memory.query.text` and `gen_ai.memory.records` are sensitive and recorded only when the operator opts in via `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true` (default off). `error.type` and span status are set on failure.

Zero behavior change unless opted in: if `opentelemetry-api` is not installed, or is installed with no `TracerProvider` configured, every helper is a no-op with negligible overhead and never raises. This mirrors the default-off precedent set by `max_retries` in #6271.

## Packaging

New optional extra: `pip install "mem0ai[otel]"` pulls only `opentelemetry-api`. The SDK stays a test and application dependency and is never a runtime dependency. Content capture is off by default.

## Note on graph and entity spans

In this version the `add`/`search` path has no separate graph store; entity linking runs against a second vector-store collection (the entity store), which is instrumented as the `entity_*` phase. If a standalone graph-memory store lands on its own config flag, graph spans are a natural follow-up. Similarly the `llm_extract` and `embed_*` child spans mark phase latency; adopting the full `gen_ai` inference and embedding span conventions on them, or deferring to a user's existing OpenAI/embedding instrumentation, can be a follow-up.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Test Coverage

- [x] I added/updated unit tests

`tests/memory/test_otel_tracing.py` (24 tests): operation and phase span emission and nesting, sync/async parity, content gating on and off, the error path (`error.type` and status on both operation and phase spans), procedural-add annotation, and the no-op paths when tracing is unavailable. The full existing suite passes unchanged (1699 passed, 48 skipped).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my feature works
- [x] New and existing tests pass locally
