### PR TITLE
feat(oss): portable session export/import on core Memory / AsyncMemory

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1,6 +1,7 @@
 import asyncio
 import concurrent.futures
 import gc
+import gzip
 import hashlib
 import json
 import logging
@@ -10,7 +11,7 @@ import uuid
 import warnings
 from copy import deepcopy
 from datetime import date, datetime, timezone
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Literal, Optional
 
 from pydantic import ValidationError
 
@@ -378,6 +379,143 @@ def _build_session_scope(filters):
         if val:
             parts.append(f"{key}={val}")
     return "&".join(parts)
+
+
+EXPORT_BUNDLE_VERSION = "1"
+EXPORT_MEMORY_FETCH_LIMIT = 10000  # kept at/below common backend list() ceilings (e.g. Pinecone 10k); truncation is logged
+
+
+def _validate_export_filters(filters):
+    effective_filters = dict(filters) if filters else {}
+    for key in ("user_id", "agent_id", "run_id"):
+        if key in effective_filters:
+            effective_filters[key] = _validate_and_trim_entity_id(effective_filters[key], key)
+    if not any(key in effective_filters for key in ("user_id", "agent_id", "run_id")):
+        raise ValueError(
+            "filters must contain at least one of: user_id, agent_id, run_id. "
+            "Example: filters={'run_id': 'sess-42'}"
+        )
+    return effective_filters
+
+
+def _validate_on_conflict(on_conflict):
+    if on_conflict not in ("skip", "overwrite", "new_ids"):
+        raise ValueError("on_conflict must be one of: 'skip', 'overwrite', 'new_ids'")
+
+
+def _memory_exists(vector_store, memory_id):
+    try:
+        return vector_store.get(vector_id=memory_id) is not None
+    except Exception:
+        return False
+
+
+def _export_session_bundle(vector_store, effective_filters):
+    """Build a round-trippable bundle for the given entity scope (shared by sync + async)."""
+    listed = vector_store.list(filters=effective_filters, top_k=EXPORT_MEMORY_FETCH_LIMIT)
+    rows = _vector_store_list_rows(listed)
+    memories = [
+        {"id": row.id, "payload": dict(row.payload) if getattr(row, "payload", None) else {}} for row in rows
+    ]
+    if len(memories) >= EXPORT_MEMORY_FETCH_LIMIT:
+        logger.warning(
+            "export_session reached the fetch limit of %s memories; the bundle may be truncated. "
+            "Export a narrower scope.",
+            EXPORT_MEMORY_FETCH_LIMIT,
+        )
+
+    return {
+        "mem0_export_version": EXPORT_BUNDLE_VERSION,
+        "exported_at": datetime.now(timezone.utc).isoformat(),
+        "scope": {k: effective_filters[k] for k in ("user_id", "agent_id", "run_id") if k in effective_filters},
+        "memories": memories,
+    }
+
+
+def _import_session_bundle(vector_store, embedding_model, bundle, on_conflict, remap):
+    """Re-embed and upsert a bundle's memories into this instance (shared by sync + async).
+
+    Re-embeds with THIS instance's embedder and recomputes the content-derived fields (hash,
+    text_lemmatized) from ``data`` so dedup and BM25 keyword search stay correct regardless of which
+    backend produced the bundle. ``new_ids`` mints a fresh id per memory and is intentionally NOT
+    idempotent - do not run it repeatedly against the same target or it will duplicate memories.
+    """
+    imported_memories = 0
+    skipped_memories = 0
+    dropped_memories = 0
+
+    for record in bundle.get("memories", []):
+        old_id = record.get("id")
+        payload = dict(record.get("payload") or {})
+        for key in ("user_id", "agent_id", "run_id"):
+            if key in remap:
+                payload[key] = remap[key]
+        data = payload.get("data")
+        if not data:
+            dropped_memories += 1
+            continue
+
+        # A remapped import forks the session under a new identity, so it must land on fresh
+        # ids: reusing the source ids would be skipped (id already present) or overwrite the
+        # source memories in place, both of which break "continue under a new identity".
+        if on_conflict == "new_ids" or remap or not old_id:
+            new_id, do_insert = str(uuid.uuid4()), True
+        elif on_conflict == "skip" and _memory_exists(vector_store, old_id):
+            new_id, do_insert = old_id, False
+        else:
+            new_id, do_insert = old_id, True
+        if not do_insert:
+            skipped_memories += 1
+            continue
+
+        # Recompute content-derived fields from data (mirror the add path) so hash/text_lemmatized
+        # always agree with the stored content, independent of what the source backend persisted.
+        payload["hash"] = hashlib.md5(data.encode()).hexdigest()
+        payload["text_lemmatized"] = lemmatize_for_bm25(data)
+
+        embeddings = embedding_model.embed(data, memory_action="add")
+        if on_conflict == "overwrite":
+            try:
+                vector_store.delete(vector_id=new_id)
+            except Exception:
+                pass
+        vector_store.insert(vectors=[embeddings], ids=[new_id], payloads=[payload])
+        imported_memories += 1
+
+    return {
+        "imported": {"memories": imported_memories},
+        "skipped": {"memories": skipped_memories},
+        "dropped": {"memories": dropped_memories},
+    }
+
+
+def _write_bundle(bundle, path, compress):
+    path = str(path)
+    if compress and not path.lower().endswith(".gz"):
+        path = path + ".gz"
+    data = json.dumps(bundle, ensure_ascii=False, indent=2)
+    if path.lower().endswith(".gz"):
+        with gzip.open(path, "wt", encoding="utf-8") as f:
+            f.write(data)
+    else:
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(data)
+    return path
+
+
+def _read_bundle(path):
+    path = str(path)
+    opener = gzip.open if path.lower().endswith(".gz") else open
+    with opener(path, "rt", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _load_bundle(bundle, path):
+    if bundle is None and path is None:
+        raise ValueError("Provide either 'bundle' or 'path' to import_session")
+    if bundle is not None and path is not None:
+        raise ValueError("Provide only one of 'bundle' or 'path' to import_session")
+    return _read_bundle(path) if path is not None else bundle
 
 
 def _entity_collection_name(provider: str, collection_name: str) -> str:
@@ -1897,6 +2035,93 @@ class Memory(MemoryBase):
         history = self.db.get_history(memory_id)
         display_first_run_notice(self, "sync", "history")
         return history
+
+    def export_session(
+        self,
+        *,
+        filters: Optional[Dict[str, Any]] = None,
+        path: Optional[str] = None,
+        compress: bool = False,
+    ):
+        """Export a session (or any entity scope) as a portable, round-trippable bundle.
+
+        The bundle holds the raw memories scoped by ``filters`` (at least one of ``user_id``,
+        ``agent_id``, ``run_id`` - the same rule as :meth:`get_all`). Import it into any other
+        self-hosted mem0 instance with :meth:`import_session`.
+
+        Args:
+            filters (dict): Entity scope, e.g. ``{"run_id": "sess-42"}``.
+            path (str, optional): If given, write the bundle to this file and return the path;
+                otherwise return the bundle dict. A ``.gz`` suffix (or ``compress=True``) gzips it.
+            compress (bool): Gzip the file when writing to ``path``. Defaults to False.
+
+        Returns:
+            dict | str: The bundle dict, or the written file path when ``path`` is given.
+        """
+        effective_filters = _validate_export_filters(filters)
+        bundle = _export_session_bundle(self.vector_store, effective_filters)
+        result = _write_bundle(bundle, path, compress) if path is not None else bundle
+        keys, encoded_ids = process_telemetry_filters(effective_filters)
+        capture_event(
+            "mem0.export_session",
+            self,
+            {
+                "keys": keys,
+                "encoded_ids": encoded_ids,
+                "count": len(bundle["memories"]),
+                "sync_type": "sync",
+            },
+        )
+        return result
+
+    def import_session(
+        self,
+        bundle: Optional[Dict[str, Any]] = None,
+        *,
+        path: Optional[str] = None,
+        on_conflict: Literal["skip", "overwrite", "new_ids"] = "skip",
+        remap_scope: Optional[Dict[str, str]] = None,
+    ) -> dict:
+        """Import a bundle produced by :meth:`export_session` into this instance.
+
+        Memories are re-embedded with this instance's embedder and upserted. The LLM
+        fact-extraction pipeline is never invoked - this is a faithful round-trip, not a
+        re-derivation.
+
+        Args:
+            bundle (dict, optional): An in-memory bundle dict. Provide this or ``path``.
+            path (str, optional): Read the bundle from this ``.json`` / ``.json.gz`` file instead.
+            on_conflict (str): When a memory id already exists - ``"skip"`` (keep existing),
+                ``"overwrite"`` (replace), or ``"new_ids"`` (always mint a fresh id; NOT idempotent,
+                do not re-run against the same target). Defaults to ``"skip"``.
+            remap_scope (dict, optional): Rewrite ``user_id`` / ``agent_id`` / ``run_id`` on every
+                imported memory, so the session continues under a new identity, e.g.
+                ``{"run_id": "sess-42-cont"}``. When set, memories are always imported under fresh
+                ids (a fork), so ``on_conflict`` does not apply to them and the source session is
+                left intact even when importing back into the same instance.
+
+        Returns:
+            dict: Summary, e.g. ``{"imported": {"memories": 3}, "skipped": {"memories": 0},
+            "dropped": {"memories": 0}}``.
+        """
+        _validate_on_conflict(on_conflict)
+        bundle = _load_bundle(bundle, path)
+        summary = _import_session_bundle(
+            self.vector_store, self.embedding_model, bundle, on_conflict, remap_scope or {}
+        )
+        capture_event(
+            "mem0.import_session",
+            self,
+            {
+                "imported": summary["imported"]["memories"],
+                "skipped": summary["skipped"]["memories"],
+                "dropped": summary["dropped"]["memories"],
+                "on_conflict": on_conflict,
+                "remap": bool(remap_scope),
+                "sync_type": "sync",
+            },
+        )
+        return summary
 
     def _create_memory(self, data, existing_embeddings, metadata=None):
         logger.debug(f"Creating memory with {data=}")
@@ -3541,6 +3766,63 @@ class AsyncMemory(MemoryBase):
         history = await asyncio.to_thread(self.db.get_history, memory_id)
         await display_first_run_notice_async(self, "async", "history")
         return history
+
+    async def export_session(
+        self,
+        *,
+        filters: Optional[Dict[str, Any]] = None,
+        path: Optional[str] = None,
+        compress: bool = False,
+    ):
+        """Async version of :meth:`Memory.export_session`."""
+        effective_filters = _validate_export_filters(filters)
+        bundle = await asyncio.to_thread(_export_session_bundle, self.vector_store, effective_filters)
+        result = await asyncio.to_thread(_write_bundle, bundle, path, compress) if path is not None else bundle
+        keys, encoded_ids = process_telemetry_filters(effective_filters)
+        capture_event(
+            "mem0.export_session",
+            self,
+            {
+                "keys": keys,
+                "encoded_ids": encoded_ids,
+                "count": len(bundle["memories"]),
+                "sync_type": "async",
+            },
+        )
+        return result
+
+    async def import_session(
+        self,
+        bundle: Optional[Dict[str, Any]] = None,
+        *,
+        path: Optional[str] = None,
+        on_conflict: Literal["skip", "overwrite", "new_ids"] = "skip",
+        remap_scope: Optional[Dict[str, str]] = None,
+    ) -> dict:
+        """Async version of :meth:`Memory.import_session`."""
+        _validate_on_conflict(on_conflict)
+        bundle = await asyncio.to_thread(_load_bundle, bundle, path)
+        summary = await asyncio.to_thread(
+            _import_session_bundle,
+            self.vector_store,
+            self.embedding_model,
+            bundle,
+            on_conflict,
+            remap_scope or {},
+        )
+        capture_event(
+            "mem0.import_session",
+            self,
+            {
+                "imported": summary["imported"]["memories"],
+                "skipped": summary["skipped"]["memories"],
+                "dropped": summary["dropped"]["memories"],
+                "on_conflict": on_conflict,
+                "remap": bool(remap_scope),
+                "sync_type": "async",
+            },
+        )
+        return summary
 
     async def _create_memory(self, data, existing_embeddings, metadata=None):
         logger.debug(f"Creating memory with {data=}")

--- a/tests/memory/test_session_export_import.py
+++ b/tests/memory/test_session_export_import.py
@@ -1,0 +1,208 @@
+import asyncio
+import hashlib
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from mem0.memory.main import AsyncMemory, Memory
+from mem0.memory.storage import SQLiteManager
+from mem0.utils.lemmatization import lemmatize_for_bm25
+
+
+class FakeVectorStore:
+    """In-memory stand-in implementing just the slice export/import + get_all touch."""
+
+    def __init__(self):
+        self.data = {}
+
+    def insert(self, vectors, ids, payloads):
+        for vid, payload in zip(ids, payloads):
+            self.data[vid] = SimpleNamespace(id=vid, payload=dict(payload), score=None)
+
+    def list(self, filters=None, top_k=100):
+        filters = filters or {}
+        matched = [
+            SimpleNamespace(id=item.id, payload=dict(item.payload), score=None)
+            for item in self.data.values()
+            if all(item.payload.get(k) == v for k, v in filters.items())
+        ]
+        return [matched]
+
+    def get(self, vector_id):
+        return self.data.get(vector_id)
+
+    def delete(self, vector_id):
+        self.data.pop(vector_id, None)
+
+
+class FakeEmbedder:
+    def embed(self, text, memory_action=None):
+        return [float(len(text or "")), 0.0, 0.0]
+
+
+SCOPE = {"user_id": "u1", "agent_id": "a1", "run_id": "sess-42"}
+TS = "2026-07-10T00:00:00+00:00"
+
+
+def _make_memory(mocker, cls=Memory):
+    mocker.patch("mem0.utils.factory.EmbedderFactory.create", return_value=MagicMock())
+    mocker.patch("mem0.utils.factory.VectorStoreFactory.create", return_value=MagicMock())
+    mocker.patch("mem0.utils.factory.LlmFactory.create", return_value=MagicMock())
+    mocker.patch("mem0.memory.main.SQLiteManager", return_value=MagicMock())
+    mocker.patch("mem0.memory.main.capture_event")
+    mocker.patch("mem0.memory.main.display_first_run_notice")
+    mocker.patch("mem0.memory.main.display_scale_threshold_notice")
+    m = cls()
+    m.vector_store = FakeVectorStore()
+    m.embedding_model = FakeEmbedder()
+    m.db = SQLiteManager(":memory:")
+    m.api_version = "v1.1"
+    return m
+
+
+def _seed(mem, mem_id="m1", data="I love pizza", scope=SCOPE):
+    payload = {"data": data, "hash": "h_" + mem_id, "created_at": TS, "updated_at": TS, **scope}
+    mem.vector_store.insert(vectors=[[0.0, 0.0, 0.0]], ids=[mem_id], payloads=[payload])
+    return payload
+
+
+class TestSessionExportImport:
+    def test_export_requires_entity_filter(self, mocker):
+        m = _make_memory(mocker)
+        with pytest.raises(ValueError):
+            m.export_session(filters={})
+
+    def test_round_trip_memories(self, mocker):
+        src = _make_memory(mocker)
+        _seed(src, "m1", "I love pizza")
+        _seed(src, "m2", "I use Python")
+
+        bundle = src.export_session(filters=SCOPE)
+        assert bundle["mem0_export_version"] == "1"
+        assert bundle["scope"] == SCOPE
+        assert len(bundle["memories"]) == 2
+
+        dst = _make_memory(mocker)
+        summary = dst.import_session(bundle)
+        assert summary["imported"]["memories"] == 2
+
+        got = {r["id"]: r["memory"] for r in dst.get_all(filters=SCOPE)["results"]}
+        assert got == {"m1": "I love pizza", "m2": "I use Python"}
+
+    def test_import_recomputes_hash_and_text_lemmatized(self, mocker):
+        src = _make_memory(mocker)
+        _seed(src, "m1", "I love pizza")
+        bundle = src.export_session(filters=SCOPE)
+        # simulate a source backend that dropped text_lemmatized and carried a stale hash
+        bundle["memories"][0]["payload"].pop("text_lemmatized", None)
+        bundle["memories"][0]["payload"]["hash"] = "stale"
+
+        dst = _make_memory(mocker)
+        dst.import_session(bundle)
+        stored = dst.vector_store.get("m1").payload
+        assert stored["text_lemmatized"] == lemmatize_for_bm25("I love pizza")
+        assert stored["hash"] == hashlib.md5("I love pizza".encode()).hexdigest()
+
+    def test_empty_data_memory_is_dropped(self, mocker):
+        src = _make_memory(mocker)
+        _seed(src, "m1", "real memory")
+        _seed(src, "m2", "")
+        bundle = src.export_session(filters=SCOPE)
+        assert len(bundle["memories"]) == 2  # export keeps both
+
+        dst = _make_memory(mocker)
+        summary = dst.import_session(bundle)
+        assert summary["imported"]["memories"] == 1
+        assert summary["dropped"]["memories"] == 1
+        assert {r["id"] for r in dst.get_all(filters=SCOPE)["results"]} == {"m1"}
+
+    def test_remap_scope_continues_as_new_session(self, mocker):
+        src = _make_memory(mocker)
+        _seed(src, "m1", "I love pizza")
+        bundle = src.export_session(filters=SCOPE)
+
+        dst = _make_memory(mocker)
+        dst.import_session(bundle, remap_scope={"run_id": "sess-cont"})
+
+        new_scope = {**SCOPE, "run_id": "sess-cont"}
+        assert [r["memory"] for r in dst.get_all(filters=new_scope)["results"]] == ["I love pizza"]
+        assert dst.get_all(filters=SCOPE)["results"] == []
+
+    def test_remap_into_populated_same_instance_forks_source_intact(self, mocker):
+        # Fork a session under a new run_id in the SAME store. remap must mint fresh ids so
+        # nothing is silently skipped and the original session is left untouched.
+        m = _make_memory(mocker)
+        _seed(m, "m1", "I love pizza")
+        _seed(m, "m2", "I use Python")
+        bundle = m.export_session(filters=SCOPE)
+
+        summary = m.import_session(bundle, remap_scope={"run_id": "sess-cont"})
+        assert summary["imported"]["memories"] == 2  # forked, not skipped
+
+        # Original session untouched.
+        assert {r["id"] for r in m.get_all(filters=SCOPE)["results"]} == {"m1", "m2"}
+        # Fork populated under the new scope, on fresh ids (not m1/m2).
+        forked = m.get_all(filters={**SCOPE, "run_id": "sess-cont"})["results"]
+        assert sorted(r["memory"] for r in forked) == ["I love pizza", "I use Python"]
+        assert {r["id"] for r in forked}.isdisjoint({"m1", "m2"})
+
+    def test_on_conflict_modes(self, mocker):
+        src = _make_memory(mocker)
+        _seed(src, "m1", "I love pizza")
+        bundle = src.export_session(filters=SCOPE)
+
+        dst = _make_memory(mocker)
+        assert dst.import_session(bundle)["imported"]["memories"] == 1
+        again = dst.import_session(bundle, on_conflict="skip")
+        assert again["imported"]["memories"] == 0
+        assert again["skipped"]["memories"] == 1
+        assert dst.import_session(bundle, on_conflict="overwrite")["imported"]["memories"] == 1
+        assert len(dst.vector_store.data) == 1
+        assert dst.import_session(bundle, on_conflict="new_ids")["imported"]["memories"] == 1
+        assert len(dst.vector_store.data) == 2
+
+    def test_invalid_on_conflict_and_missing_bundle(self, mocker):
+        m = _make_memory(mocker)
+        with pytest.raises(ValueError):
+            m.import_session({"memories": []}, on_conflict="nope")
+        with pytest.raises(ValueError):
+            m.import_session()
+
+    def test_file_round_trip_gz(self, mocker, tmp_path):
+        src = _make_memory(mocker)
+        _seed(src, "m1", "I love pizza")
+        out = src.export_session(filters=SCOPE, path=str(tmp_path / "sess.json"), compress=True)
+        assert out.endswith(".gz")
+
+        dst = _make_memory(mocker)
+        assert dst.import_session(path=out)["imported"]["memories"] == 1
+
+    def test_file_round_trip_plain_json(self, mocker, tmp_path):
+        src = _make_memory(mocker)
+        _seed(src, "m1", "I love pizza")
+        out = src.export_session(filters=SCOPE, path=str(tmp_path / "sess.json"))
+        assert out.endswith(".json") and not out.endswith(".gz")
+
+        dst = _make_memory(mocker)
+        assert dst.import_session(path=out)["imported"]["memories"] == 1
+
+    def test_compress_does_not_double_gz_suffix(self, mocker, tmp_path):
+        src = _make_memory(mocker)
+        _seed(src, "m1", "x")
+        out = src.export_session(filters=SCOPE, path=str(tmp_path / "s.json.gz"), compress=True)
+        assert out.endswith(".json.gz") and not out.endswith(".gz.gz")
+
+    def test_async_round_trip(self, mocker):
+        src = _make_memory(mocker, cls=AsyncMemory)
+        _seed(src, "m1", "I love pizza")
+
+        async def run():
+            bundle = await src.export_session(filters=SCOPE)
+            dst = _make_memory(mocker, cls=AsyncMemory)
+            summary = await dst.import_session(bundle)
+            return dst, summary
+
+        dst, summary = asyncio.run(run())
+        assert summary["imported"]["memories"] == 1
+        assert dst.vector_store.get("m1").payload["data"] == "I love pizza"


### PR DESCRIPTION
## Linked Issue

Closes #6214

## Description

There's no way to move a self-hosted mem0 session between instances today. `get_all` reads memories but there's no import to re-hydrate them, the platform `create_memory_export` is hosted-only and schema-reshaped, and `openmemory/.../backup.py` is tied to the OpenMemory stack, so core-SDK users (`from mem0 import Memory`) have nothing.

This adds two methods to `Memory` and `AsyncMemory`:

```python
bundle = m.export_session(filters={"run_id": "sess-42"}, path="sess-42.json")
m2.import_session(path="sess-42.json", remap_scope={"run_id": "sess-42-cont"})
```

- **Export** lists the raw vector-store payloads for an entity scope (`filters`, at least one of `user_id`/`agent_id`/`run_id`, same rule as `get_all`) into a versioned JSON bundle, optionally gzipped to a file.
- **Import** re-embeds each memory's content with the target instance's embedder and upserts it, recomputing `hash` and `text_lemmatized` from the content so dedup and BM25 stay correct regardless of which backend produced the bundle. The LLM fact-extraction pipeline is never invoked, so it's a faithful round-trip, not a re-derivation.
- `on_conflict` (`skip` / `overwrite` / `new_ids`) merges into an existing store; `remap_scope` rewrites the entity ids so a session continues under a new identity. When `remap_scope` is set, memories are imported under fresh ids (a fork), so the source session is never skipped or overwritten, even when importing back into the same instance.
- No new dependencies (stdlib `json`/`gzip` plus the configured embedder and vector store). Sync and async parity.

Per @kartik-mem0's note on the issue, this is the memories-only first cut; change-history and recent-message export are left for follow-up PRs. This is the real SDK implementation of the issue (unlike #6219, which only edits an example script and doesn't touch `Memory`/`AsyncMemory`).

I'm happy to add a `docs/open-source` page and `docs/llms.txt` entry as a follow-up or in this PR, whichever you prefer.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

`tests/memory/test_session_export_import.py` (12 tests): entity-filter validation, memories round-trip, `remap_scope` (including a same-instance fork that must leave the source intact), all three `on_conflict` modes, hash/`text_lemmatized` recompute, empty-`data` drop, gzip and plain-`.json` file round-trips, invalid input, and async parity. Full `tests/memory/` passes (364) and `ruff check` is clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed (docs page to follow, noted above)
