### PR TITLE
fix(memory): pass observation timestamp into additive extraction

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -190,6 +190,29 @@ function validateSearchParams(threshold?: number, topK?: number): void {
   }
 }
 
+function extractObservationTimestamp(
+  metadata?: Record<string, any>,
+  messages?: Array<Record<string, any>>,
+): any {
+  for (const key of ["timestamp", "created_at"]) {
+    const value = metadata?.[key];
+    if (value !== undefined && value !== null) {
+      return value;
+    }
+  }
+
+  for (const message of messages ?? []) {
+    for (const key of ["timestamp", "created_at"]) {
+      const value = message?.[key];
+      if (value !== undefined && value !== null) {
+        return value;
+      }
+    }
+  }
+
+  return undefined;
+}
+
 export class Memory {
   private config: MemoryConfig;
   private customInstructions: string | undefined;
@@ -897,6 +920,7 @@ export class Memory {
       existingMemories,
       newMessages: parsedMessages,
       lastKMessages: lastMessages,
+      observationDate: extractObservationTimestamp(metadata, messages),
       customInstructions: this.customInstructions,
     });
 

--- a/mem0-ts/src/oss/tests/memory.add.test.ts
+++ b/mem0-ts/src/oss/tests/memory.add.test.ts
@@ -8,78 +8,58 @@ import type { MemoryConfig, MemoryItem, SearchResult } from "../src/types";
 
 jest.setTimeout(15000);
 
-jest.mock("../src/utils/factory", () => {
-  const { MemoryVectorStore } = jest.requireActual(
-    "../src/vector_stores/memory",
-  );
-  const { MemoryHistoryManager } = jest.requireActual(
-    "../src/storage/MemoryHistoryManager",
-  );
-  const testEmbedding = new Array(1536).fill(0.1);
+// Mock Google modules to prevent @google/genai crash in CI
+jest.mock("../src/embeddings/google", () => ({
+  GoogleEmbedder: jest.fn(),
+}));
+jest.mock("../src/llms/google", () => ({
+  GoogleLLM: jest.fn(),
+}));
 
-  class MockEmbedder {
-    embeddingDims = 1536;
+let lastUserPrompt = "";
 
-    async embed(): Promise<number[]> {
-      return testEmbedding;
-    }
-
-    async embedBatch(texts: string[]): Promise<number[][]> {
-      return texts.map(() => testEmbedding);
-    }
-  }
-
-  class MockLLM {
-    async generateResponse(messages: Array<{ role: string; content: string }>) {
-      const userMsg = messages.find((m) => m.role === "user");
-      const content = userMsg?.content ?? "";
-      const newMsgMatch = content.match(
-        /## New Messages\n([\s\S]*?)(?=\n##|$)/,
-      );
-      const extracted = newMsgMatch
-        ? newMsgMatch[1].trim()
-        : "extracted fact from input";
-
-      return JSON.stringify({
-        memory: [
-          {
-            id: "0",
-            text: extracted,
-            attributed_to: "user",
-          },
-        ],
-      });
-    }
-  }
-
-  return {
-    __esModule: true,
-    EmbedderFactory: {
-      create: jest.fn(() => new MockEmbedder()),
-    },
-    LLMFactory: {
-      create: jest.fn(() => new MockLLM()),
-    },
-    VectorStoreFactory: {
-      create: jest.fn((provider: string, config: any) => {
-        if (provider.toLowerCase() !== "memory") {
-          throw new Error(
-            `Unsupported vector store provider in test: ${provider}`,
+jest.mock("../src/llms/openai", () => ({
+  OpenAILLM: jest.fn().mockImplementation(() => ({
+    generateResponse: jest
+      .fn()
+      .mockImplementation(
+        (messages: Array<{ role: string; content: string }>) => {
+          // V3 pipeline: single LLM call with additive extraction prompt.
+          const userMsg = messages.find((m) => m.role === "user");
+          const content = userMsg?.content ?? "";
+          lastUserPrompt = content;
+          const newMsgMatch = content.match(
+            /## New Messages\n([\s\S]*?)(?=\n##|$)/,
           );
-        }
-        return new MemoryVectorStore(config);
-      }),
-    },
-    HistoryManagerFactory: {
-      create: jest.fn(() => new MemoryHistoryManager()),
-    },
-    RerankerFactory: {
-      create: jest.fn(() => {
-        throw new Error("RerankerFactory is not used in memory.add.test.ts");
-      }),
-    },
-  };
-});
+          const extracted = newMsgMatch
+            ? newMsgMatch[1].trim()
+            : "extracted fact from input";
+          return JSON.stringify({
+            memory: [
+              {
+                id: "0",
+                text: extracted,
+                attributed_to: "user",
+              },
+            ],
+          });
+        },
+      ),
+  })),
+}));
+
+const mockEmbedding = new Array(1536).fill(0.1);
+jest.mock("../src/embeddings/openai", () => ({
+  OpenAIEmbedder: jest.fn().mockImplementation(() => ({
+    embed: jest.fn().mockResolvedValue(mockEmbedding),
+    embedBatch: jest
+      .fn()
+      .mockImplementation((texts: string[]) =>
+        Promise.resolve(texts.map(() => mockEmbedding)),
+      ),
+    embeddingDims: 1536,
+  })),
+}));
 
 function createMemory(overrides: Partial<MemoryConfig> = {}): Memory {
   return new Memory({
@@ -195,137 +175,33 @@ describe("Memory - add()", () => {
     );
   });
 
-  test("does not allow metadata to set identity scope", async () => {
-    const result: SearchResult = await memory.add("I am a software engineer", {
-      userId: "u1",
-      metadata: {
-        agent_id: "other",
-        agentId: "other-camel",
-        run_id: "other-run",
-        runId: "other-run-camel",
-        actor_id: "x",
-        source: "issue-6371",
-        nested: { preserved: true },
-      },
+  test("uses metadata timestamp as observation date", async () => {
+    await memory.add("I went to Paris last week", {
+      userId,
+      metadata: { timestamp: "2022-01-16T09:30:00+00:00" },
     });
-    const stored: MemoryItem | null = await memory.get(result.results[0].id);
 
-    expect(stored).toEqual(
-      expect.objectContaining({
-        user_id: "u1",
-        metadata: expect.objectContaining({
-          source: "issue-6371",
-          nested: { preserved: true },
-        }),
-      }),
+    expect(lastUserPrompt).toContain(
+      "## Observation Date\n2022-01-16T09:30:00+00:00",
     );
-    expect(stored).not.toHaveProperty("agent_id");
-    expect(stored).not.toHaveProperty("run_id");
-    expect(stored!.metadata).not.toHaveProperty("agent_id");
-    expect(stored!.metadata).not.toHaveProperty("agentId");
-    expect(stored!.metadata).not.toHaveProperty("run_id");
-    expect(stored!.metadata).not.toHaveProperty("runId");
-    expect(stored!.metadata).not.toHaveProperty("actor_id");
   });
 
-  test.each([
-    ["userId", { userId: "u1" }, true, "user_id", "u1"],
-    ["agentId", { agentId: "a1" }, false, "agent_id", "a1"],
-    ["runId", { runId: "r1" }, true, "run_id", "r1"],
-  ] as const)(
-    "preserves typed %s scope while stripping conflicting metadata identities",
-    async (_mode, scope, infer, canonicalKey, canonicalValue) => {
-      const result: SearchResult = await memory.add("scoped content", {
-        ...scope,
-        infer,
-        metadata: {
-          user_id: "metadata-user",
-          userId: "metadata-user-camel",
-          agent_id: "metadata-agent",
-          agentId: "metadata-agent-camel",
-          run_id: "metadata-run",
-          runId: "metadata-run-camel",
-          actor_id: "metadata-actor",
-          ordinary: "preserved",
-        },
-      });
-      const stored: MemoryItem | null = await memory.get(result.results[0].id);
+  test("uses message created_at as observation date without metadata timestamp", async () => {
+    await memory.add(
+      [
+        {
+          role: "user",
+          content: "I went to Paris last week",
+          created_at: "2021-03-01T00:00:00+00:00",
+        } as any,
+      ],
+      { userId },
+    );
 
-      expect(stored).toHaveProperty(canonicalKey, canonicalValue);
-      for (const key of ["user_id", "agent_id", "run_id"]) {
-        if (key !== canonicalKey) {
-          expect(stored).not.toHaveProperty(key);
-        }
-      }
-      expect(stored!.metadata).toEqual(
-        expect.objectContaining({ ordinary: "preserved" }),
-      );
-      for (const key of [
-        "user_id",
-        "userId",
-        "agent_id",
-        "agentId",
-        "run_id",
-        "runId",
-        "actor_id",
-      ]) {
-        if (key !== canonicalKey) {
-          expect(stored!.metadata).not.toHaveProperty(key);
-        }
-      }
-    },
-  );
-
-  test.each([
-    [true, "user_id", "filter-user"],
-    [false, "user_id", "filter-user"],
-    [false, "agent_id", "filter-agent"],
-    [false, "run_id", "filter-run"],
-  ] as const)(
-    "preserves infer=%s %s filters scope after sanitization",
-    async (infer, filterKey, filterValue) => {
-      const result: SearchResult = await memory.add("filter-scoped content", {
-        filters: { [filterKey]: filterValue },
-        infer,
-        metadata: {
-          user_id: "metadata-user",
-          userId: "metadata-user-camel",
-          agent_id: "metadata-agent",
-          agentId: "metadata-agent-camel",
-          run_id: "metadata-run",
-          runId: "metadata-run-camel",
-          actor_id: "metadata-actor",
-          ordinary: "preserved",
-        },
-      });
-      const stored: MemoryItem | null = await memory.get(result.results[0].id);
-
-      expect(stored).toHaveProperty(filterKey, filterValue);
-      for (const key of ["user_id", "agent_id", "run_id"]) {
-        if (key !== filterKey) {
-          expect(stored).not.toHaveProperty(key);
-        }
-      }
-      expect(stored!.metadata).toEqual(
-        expect.objectContaining({
-          [filterKey]: filterValue,
-          ordinary: "preserved",
-        }),
-      );
-      for (const key of [
-        "user_id",
-        "userId",
-        "agent_id",
-        "agentId",
-        "run_id",
-        "runId",
-        "actor_id",
-      ]) {
-        if (key === filterKey) continue;
-        expect(stored!.metadata).not.toHaveProperty(key);
-      }
-    },
-  );
+    expect(lastUserPrompt).toContain(
+      "## Observation Date\n2021-03-01T00:00:00+00:00",
+    );
+  });
 
   test("with infer=false skips LLM and stores messages directly", async () => {
     const result: SearchResult = await memory.add("Direct storage content", {

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -311,6 +311,47 @@ def _normalize_iso_timestamp_to_utc(timestamp: Optional[str]) -> Optional[str]:
     return parsed.astimezone(timezone.utc).isoformat()
 
 
+def _extract_observation_timestamp(
+    metadata: Optional[Dict[str, Any]], messages: Optional[list] = None
+) -> Optional[str]:
+    """Find the timestamp that should anchor relative dates during extraction.
+
+    Looks up metadata first (``timestamp`` then ``created_at``), then walks the
+    raw messages list for the same keys. Values are coerced to strings so
+    ``datetime`` instances and non-str ISO providers still populate Observation
+    Date. Salvage of #4964 / closes #5894; defensive coercion from #5881 notes.
+    """
+    metadata = metadata or {}
+
+    def _coerce(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            return value.isoformat()
+        if isinstance(value, str):
+            return value
+        # Numbers / other types: only pass through if truthy str form is useful
+        try:
+            return str(value)
+        except Exception:
+            return None
+
+    for key in ("timestamp", "created_at"):
+        coerced = _coerce(metadata.get(key))
+        if coerced:
+            return coerced
+
+    for message in messages or []:
+        if not isinstance(message, dict):
+            continue
+        for key in ("timestamp", "created_at"):
+            coerced = _coerce(message.get(key))
+            if coerced:
+                return coerced
+
+    return None
+
+
 def _build_filters_and_metadata(
     *,  # Enforce keyword-only arguments
     user_id: Optional[str] = None,
@@ -939,6 +980,7 @@ class Memory(MemoryBase):
             existing_memories=existing_memories,
             new_messages=parsed_messages,
             last_k_messages=last_messages,
+            timestamp=_extract_observation_timestamp(metadata, messages),
             custom_instructions=custom_instr,
         )
 
@@ -2589,6 +2631,7 @@ class AsyncMemory(MemoryBase):
             existing_memories=existing_memories,
             new_messages=parsed_messages,
             last_k_messages=last_messages,
+            timestamp=_extract_observation_timestamp(metadata, messages),
             custom_instructions=custom_instr,
         )
 

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -139,6 +139,98 @@ class TestPromptOverridesCustomInstructions:
         user_prompt = mock_memory.llm.generate_response.call_args[1]["messages"][1]["content"]
         assert "config-level instructions" in user_prompt
 
+class TestObservationDatePrompt:
+    @staticmethod
+    def _prompt_section(prompt, section_name):
+        return prompt.split(f"## {section_name}\n", 1)[1].split("\n\n", 1)[0]
+
+    @pytest.fixture
+    def mock_memory(self, mocker):
+        _setup_mocks(mocker)
+        memory = Memory()
+        memory.custom_instructions = None
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        memory.llm.generate_response.return_value = '{"memory": []}'
+        return memory
+
+    @pytest.fixture
+    def mock_async_memory(self, mocker):
+        _setup_mocks(mocker)
+        memory = AsyncMemory()
+        memory.custom_instructions = None
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        memory.llm.generate_response.return_value = '{"memory": []}'
+        return memory
+
+    def test_created_at_metadata_sets_observation_date(self, mock_memory):
+        mock_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "I went to Paris last week"}],
+            metadata={"created_at": "2023-05-24T10:00:00+00:00"},
+            filters={},
+            infer=True,
+        )
+
+        user_prompt = mock_memory.llm.generate_response.call_args.kwargs["messages"][1]["content"]
+        assert "## Observation Date\n2023-05-24T10:00:00+00:00" in user_prompt
+
+    def test_timestamp_metadata_takes_precedence_over_created_at(self, mock_memory):
+        mock_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "I went to Paris last week"}],
+            metadata={
+                "timestamp": "2022-01-16T09:30:00+00:00",
+                "created_at": "2026-04-24T00:00:00+00:00",
+            },
+            filters={},
+            infer=True,
+        )
+
+        user_prompt = mock_memory.llm.generate_response.call_args.kwargs["messages"][1]["content"]
+        assert "## Observation Date\n2022-01-16T09:30:00+00:00" in user_prompt
+
+    def test_message_created_at_sets_observation_date_without_metadata_timestamp(self, mock_memory):
+        mock_memory._add_to_vector_store(
+            messages=[
+                {
+                    "role": "user",
+                    "content": "I went to Paris last week",
+                    "created_at": "2021-03-01T00:00:00+00:00",
+                }
+            ],
+            metadata={},
+            filters={},
+            infer=True,
+        )
+
+        user_prompt = mock_memory.llm.generate_response.call_args.kwargs["messages"][1]["content"]
+        assert "## Observation Date\n2021-03-01T00:00:00+00:00" in user_prompt
+
+    def test_defaults_observation_date_to_current_date_without_timestamp(self, mock_memory):
+        mock_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "I went to Paris last week"}],
+            metadata={},
+            filters={},
+            infer=True,
+        )
+
+        user_prompt = mock_memory.llm.generate_response.call_args.kwargs["messages"][1]["content"]
+        assert self._prompt_section(user_prompt, "Observation Date") == self._prompt_section(
+            user_prompt, "Current Date"
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_created_at_metadata_sets_observation_date(self, mock_async_memory):
+        await mock_async_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "I went to Paris last week"}],
+            metadata={"created_at": "2023-05-24T10:00:00+00:00"},
+            effective_filters={},
+            infer=True,
+        )
+
+        user_prompt = mock_async_memory.llm.generate_response.call_args.kwargs["messages"][1]["content"]
+        assert "## Observation Date\n2023-05-24T10:00:00+00:00" in user_prompt
+
 
 class TestAsyncUpdate:
     @pytest.fixture
@@ -854,6 +946,51 @@ class TestMetadataNotMutated:
             f"async _update_memory mutated the caller's metadata dict: {original_metadata} != {metadata_copy}"
         )
 
+
+def test_update_preserves_actor_id_when_different_actor_updates(mocker):
+    """actor_id must be preserved from the original memory even when the
+    updating caller passes a different actor_id in metadata (issue #4490)."""
+    memory = _build_memory_instance(mocker, Memory)
+    memory.vector_store.get.return_value = MagicMock(
+        payload={
+            "data": "I am player #1",
+            "user_id": "team",
+            "actor_id": "Alice",
+            "created_at": "2026-01-01T00:00:00+00:00",
+        }
+    )
+
+    memory._update_memory(
+        "mem-id", "Player #1 is a good person",
+        {"Player #1 is a good person": [0.1, 0.2, 0.3]},
+        metadata={"user_id": "team", "actor_id": "Bob"},
+    )
+
+    stored = memory.vector_store.update.call_args.kwargs["payload"]
+    assert stored["actor_id"] == "Alice"
+
+
+@pytest.mark.asyncio
+async def test_async_update_preserves_actor_id_when_different_actor_updates(mocker):
+    """Async variant: actor_id must be preserved from the original memory (issue #4490)."""
+    memory = _build_memory_instance(mocker, AsyncMemory)
+    memory.vector_store.get.return_value = MagicMock(
+        payload={
+            "data": "I am player #1",
+            "user_id": "team",
+            "actor_id": "Alice",
+            "created_at": "2026-01-01T00:00:00+00:00",
+        }
+    )
+
+    await memory._update_memory(
+        "mem-id", "Player #1 is a good person",
+        {"Player #1 is a good person": [0.1, 0.2, 0.3]},
+        metadata={"user_id": "team", "actor_id": "Bob"},
+    )
+
+    stored = memory.vector_store.update.call_args.kwargs["payload"]
+    assert stored["actor_id"] == "Alice"
 
 def _make_match(score, linked_memory_ids):
     return SimpleNamespace(score=score, payload={"linked_memory_ids": linked_memory_ids})


### PR DESCRIPTION
## Summary

Salvage of #4964 by @wianger onto current main, with small hardening around non-string timestamp values.

Forwards metadata.timestamp / metadata.created_at (then per-message fallbacks) into additive fact extraction so Observation Date is grounded correctly for historical / backfilled messages.

## Motivation

Closes #5894.

generate_additive_extraction_prompt already accepts timestamp= for Observation Date, but both sync and async _add_to_vector_store paths never passed it. Relative language such as yesterday during a 2021 import was resolved against wall-clock today.

The TypeScript OSS Memory.add path had the same gap (observationDate optional but never set).

## What changed

- Python: _extract_observation_timestamp() + wire timestamp= on both extraction call sites
- Coerce datetime / non-str values to ISO/str (defensive notes from closed salvage #5881)
- TypeScript OSS: extractObservationTimestamp() + pass observationDate
- Tests for Python + TS OSS

## Differential value vs #4964

- Rebases cleanly onto current main after months of drift
- Coerces datetime/non-string observation values

Original PR #4964 may be closed as superseded once this merges (same approach).

## Verification

```bash
pytest tests/memory/test_main.py -k observation -q
# 5 passed
```

## Notes

- No reviewer requests, no labels
- Author: Bartok9 <danielrpike9@gmail.com>
