### PR TITLE
fix(milvus): fall back to dense-only schema on pre-2.5 servers (salvage of #6184)

### DIFF
--- a/mem0/vector_stores/milvus.py
+++ b/mem0/vector_stores/milvus.py
@@ -135,9 +135,12 @@ class MilvusDB(VectorStoreBase):
                 # clear "unsupported/invalid schema" rejection instead of silently degrading
                 # to a dense-only collection.
                 code = getattr(e, "code", None)
-                # 1100 UnexpectedError / 65535 illegal-argument style codes cover the
-                # "server doesn't support BM25 functions or sparse fields" case.
-                if code not in (0, 1100, 65535):
+                # 1100: unsupported field / BM25 function rejection (issue #6183 traceback).
+                # 0: legacy pymilvus check_status() path can leave code=0 while the real
+                # error lives on error_code — treat as schema rejection for fallback.
+                # Do not allowlist 65535: that value is VARCHAR max_length elsewhere in
+                # this file, not a confirmed merr / ErrorCode for BM25 refusal.
+                if code not in (0, 1100):
                     raise
                 logger.warning(
                     "Failed to create collection with BM25 hybrid search schema (MilvusException "

--- a/mem0/vector_stores/milvus.py
+++ b/mem0/vector_stores/milvus.py
@@ -89,39 +89,72 @@ class MilvusDB(VectorStoreBase):
                     "To enable hybrid search, use a fresh collection."
                 )
         else:
-            fields = [
-                FieldSchema(name="id", dtype=DataType.VARCHAR, is_primary=True, max_length=512),
-                FieldSchema(name="vectors", dtype=DataType.FLOAT_VECTOR, dim=vector_size),
-                FieldSchema(name="metadata", dtype=DataType.JSON),
-                # Text field for BM25 full-text search (auto-tokenized by Milvus analyzer)
-                FieldSchema(name="text", dtype=DataType.VARCHAR, max_length=65535, enable_analyzer=True),
-                # Sparse vector field populated automatically by the BM25 function below
-                FieldSchema(name="sparse", dtype=DataType.SPARSE_FLOAT_VECTOR),
-            ]
+            # Prefer Milvus 2.5+ hybrid schema (dense + BM25 sparse). Older servers reject
+            # BM25 functions/sparse fields — fall back to dense-only so init still works.
+            try:
+                fields = [
+                    FieldSchema(name="id", dtype=DataType.VARCHAR, is_primary=True, max_length=512),
+                    FieldSchema(name="vectors", dtype=DataType.FLOAT_VECTOR, dim=vector_size),
+                    FieldSchema(name="metadata", dtype=DataType.JSON),
+                    # Text field for BM25 full-text search (auto-tokenized by Milvus analyzer)
+                    FieldSchema(name="text", dtype=DataType.VARCHAR, max_length=65535, enable_analyzer=True),
+                    # Sparse vector field populated automatically by the BM25 function below
+                    FieldSchema(name="sparse", dtype=DataType.SPARSE_FLOAT_VECTOR),
+                ]
 
-            schema = CollectionSchema(fields, enable_dynamic_field=True)
+                schema = CollectionSchema(fields, enable_dynamic_field=True)
 
-            # Add BM25 function so Milvus auto-generates sparse vectors from the text field
-            bm25_function = Function(
-                name="bm25",
-                input_field_names=["text"],
-                output_field_names=["sparse"],
-                function_type=FunctionType.BM25,
-            )
-            schema.add_function(bm25_function)
+                # Add BM25 function so Milvus auto-generates sparse vectors from the text field
+                bm25_function = Function(
+                    name="bm25",
+                    input_field_names=["text"],
+                    output_field_names=["sparse"],
+                    function_type=FunctionType.BM25,
+                )
+                schema.add_function(bm25_function)
 
-            index_params = self.client.prepare_index_params()
-            index_params.add_index(
-                field_name="vectors", metric_type=metric_type, index_type="AUTOINDEX", index_name="vector_index"
-            )
-            index_params.add_index(
-                field_name="sparse",
-                index_type="SPARSE_INVERTED_INDEX",
-                metric_type="BM25",
-                index_name="sparse_index",
-            )
-            self.client.create_collection(collection_name=collection_name, schema=schema, index_params=index_params)
-            self._has_bm25_schema = True
+                index_params = self.client.prepare_index_params()
+                index_params.add_index(
+                    field_name="vectors", metric_type=metric_type, index_type="AUTOINDEX", index_name="vector_index"
+                )
+                index_params.add_index(
+                    field_name="sparse",
+                    index_type="SPARSE_INVERTED_INDEX",
+                    metric_type="BM25",
+                    index_name="sparse_index",
+                )
+                self.client.create_collection(
+                    collection_name=collection_name, schema=schema, index_params=index_params
+                )
+                self._has_bm25_schema = True
+            except Exception as e:
+                logger.warning(
+                    "Failed to create collection with BM25 hybrid search schema: %s. "
+                    "Falling back to dense-only collection without sparse vectors "
+                    "(common on Milvus < 2.5).",
+                    e,
+                )
+                if self.client.has_collection(collection_name):
+                    # Partial create may leave a broken collection; replace it.
+                    self.client.drop_collection(collection_name)
+
+                fields = [
+                    FieldSchema(name="id", dtype=DataType.VARCHAR, is_primary=True, max_length=512),
+                    FieldSchema(name="vectors", dtype=DataType.FLOAT_VECTOR, dim=vector_size),
+                    FieldSchema(name="metadata", dtype=DataType.JSON),
+                ]
+                schema = CollectionSchema(fields, enable_dynamic_field=True)
+                index_params = self.client.prepare_index_params()
+                index_params.add_index(
+                    field_name="vectors",
+                    metric_type=metric_type,
+                    index_type="AUTOINDEX",
+                    index_name="vector_index",
+                )
+                self.client.create_collection(
+                    collection_name=collection_name, schema=schema, index_params=index_params
+                )
+                self._has_bm25_schema = False
 
     def insert(self, ids, vectors, payloads, **kwargs: Optional[dict[str, any]]):
         """Insert vectors into a collection.
@@ -298,13 +331,14 @@ class MilvusDB(VectorStoreBase):
             if payload is None:
                 payload = existing[0].get("metadata")
 
-        schema = {"id": vector_id, "vectors": vector, "metadata": payload}
+        record = {"id": vector_id, "vectors": vector, "metadata": payload}
+        # Only write top-level `text` on hybrid collections; dense-only / pre-v3 schemas reject it.
         if self._has_bm25_schema:
             text = ""
             if payload:
                 text = (payload.get("text_lemmatized") or payload.get("data", ""))[:65535]
-            schema["text"] = text
-        self.client.upsert(collection_name=self.collection_name, data=schema)
+            record["text"] = text
+        self.client.upsert(collection_name=self.collection_name, data=record)
 
     def get(self, vector_id) -> Optional[OutputData]:
         """

--- a/mem0/vector_stores/milvus.py
+++ b/mem0/vector_stores/milvus.py
@@ -20,6 +20,7 @@ from pymilvus import (
     FunctionType,
     MilvusClient,
 )
+from pymilvus.exceptions import MilvusException
 
 logger = logging.getLogger(__name__)
 
@@ -127,11 +128,22 @@ class MilvusDB(VectorStoreBase):
                     collection_name=collection_name, schema=schema, index_params=index_params
                 )
                 self._has_bm25_schema = True
-            except Exception as e:
+            except MilvusException as e:
+                # Only a server-side rejection of the BM25 function/sparse field (e.g.
+                # pre-2.5 servers, code=1100 unsupported field) should fall back. Transient
+                # failures surface as MilvusException too, so re-raise anything that isn't a
+                # clear "unsupported/invalid schema" rejection instead of silently degrading
+                # to a dense-only collection.
+                code = getattr(e, "code", None)
+                # 1100 UnexpectedError / 65535 illegal-argument style codes cover the
+                # "server doesn't support BM25 functions or sparse fields" case.
+                if code not in (0, 1100, 65535):
+                    raise
                 logger.warning(
-                    "Failed to create collection with BM25 hybrid search schema: %s. "
-                    "Falling back to dense-only collection without sparse vectors "
-                    "(common on Milvus < 2.5).",
+                    "Failed to create collection with BM25 hybrid search schema (MilvusException "
+                    "code=%s): %s. Falling back to dense-only collection without sparse vectors. "
+                    "This is expected on Milvus servers that predate BM25/sparse support (< 2.5).",
+                    code,
                     e,
                 )
                 if self.client.has_collection(collection_name):

--- a/tests/vector_stores/test_milvus.py
+++ b/tests/vector_stores/test_milvus.py
@@ -396,6 +396,85 @@ class TestMilvusDB:
         mock_milvus_client.create_collection.assert_not_called()
 
 
+    def test_create_col_falls_back_when_bm25_schema_rejected(self, mock_milvus_client):
+        """Milvus < 2.5 rejects BM25 hybrid schema — fall back to dense-only."""
+        mock_milvus_client.has_collection.return_value = False
+
+        def create_collection_side_effect(**kwargs):
+            schema = kwargs.get("schema")
+            field_names = {f.name for f in schema.fields}
+            if "sparse" in field_names or "text" in field_names:
+                # Simulate partial failure after create starts: mark collection present once.
+                mock_milvus_client.has_collection.return_value = True
+                raise RuntimeError("BM25 function not supported on this server")
+            return None
+
+        mock_milvus_client.create_collection.side_effect = create_collection_side_effect
+
+        db = MilvusDB(
+            url="http://localhost:19530",
+            token="test_token",
+            collection_name="legacy_server_collection",
+            embedding_model_dims=1536,
+            metric_type=MetricType.COSINE,
+            db_name="test_db",
+        )
+
+        assert db._has_bm25_schema is False
+        # Hybrid attempt + dense-only fallback
+        assert mock_milvus_client.create_collection.call_count == 2
+        mock_milvus_client.drop_collection.assert_called_once_with("legacy_server_collection")
+
+        # Final create uses dense-only schema (no text/sparse)
+        final_schema = mock_milvus_client.create_collection.call_args_list[-1].kwargs["schema"]
+        final_names = {f.name for f in final_schema.fields}
+        assert final_names == {"id", "vectors", "metadata"}
+
+    def test_create_col_hybrid_success_sets_bm25_flag(self, milvus_db, mock_milvus_client):
+        """Default path still creates hybrid schema and enables BM25."""
+        assert milvus_db._has_bm25_schema is True
+        mock_milvus_client.create_collection.assert_called_once()
+        schema = mock_milvus_client.create_collection.call_args.kwargs["schema"]
+        names = {f.name for f in schema.fields}
+        assert {"id", "vectors", "metadata", "text", "sparse"}.issubset(names)
+
+    def test_update_omits_text_field_without_bm25_schema(self, milvus_db, mock_milvus_client):
+        """Dense-only collections must not upsert a top-level text field."""
+        milvus_db._has_bm25_schema = False
+        milvus_db.update(
+            vector_id="mem1",
+            vector=[0.1] * 1536,
+            payload={"data": "hello world", "user_id": "alice"},
+        )
+        data = mock_milvus_client.upsert.call_args.kwargs["data"]
+        assert "text" not in data
+        assert data["id"] == "mem1"
+        assert data["metadata"]["data"] == "hello world"
+
+    def test_update_includes_text_field_with_bm25_schema(self, milvus_db, mock_milvus_client):
+        """Hybrid collections should still populate text for BM25."""
+        milvus_db._has_bm25_schema = True
+        milvus_db.update(
+            vector_id="mem1",
+            vector=[0.1] * 1536,
+            payload={"data": "hello world", "user_id": "alice"},
+        )
+        data = mock_milvus_client.upsert.call_args.kwargs["data"]
+        assert data["text"] == "hello world"
+
+    def test_insert_omits_text_without_bm25_schema(self, milvus_db, mock_milvus_client):
+        """Insert path already guarded — keep regression coverage for dense-only."""
+        milvus_db._has_bm25_schema = False
+        milvus_db.insert(
+            ids=["id1"],
+            vectors=[[0.1] * 1536],
+            payloads=[{"data": "only dense", "user_id": "alice"}],
+        )
+        inserted = mock_milvus_client.insert.call_args.kwargs["data"]
+        assert "text" not in inserted[0]
+        assert inserted[0]["metadata"]["data"] == "only dense"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
 

--- a/tests/vector_stores/test_milvus.py
+++ b/tests/vector_stores/test_milvus.py
@@ -11,6 +11,7 @@ These tests verify:
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pymilvus.exceptions import MilvusException
 
 from mem0.configs.vector_stores.milvus import MetricType
 from mem0.vector_stores.milvus import MilvusDB
@@ -406,7 +407,9 @@ class TestMilvusDB:
             if "sparse" in field_names or "text" in field_names:
                 # Simulate partial failure after create starts: mark collection present once.
                 mock_milvus_client.has_collection.return_value = True
-                raise RuntimeError("BM25 function not supported on this server")
+                # Real pre-2.5 rejection surfaces as a MilvusException with an
+                # "unsupported field" code (1100), not a bare RuntimeError.
+                raise MilvusException(code=1100, message="BM25 function not supported on this server")
             return None
 
         mock_milvus_client.create_collection.side_effect = create_collection_side_effect
@@ -429,6 +432,30 @@ class TestMilvusDB:
         final_schema = mock_milvus_client.create_collection.call_args_list[-1].kwargs["schema"]
         final_names = {f.name for f in final_schema.fields}
         assert final_names == {"id", "vectors", "metadata"}
+
+    def test_create_col_reraises_transient_failure(self, mock_milvus_client):
+        """A transient error (not a version-incompat rejection) must NOT be silently
+        absorbed into a dense-only collection — it should propagate."""
+        mock_milvus_client.has_collection.return_value = False
+
+        def create_collection_side_effect(**kwargs):
+            # Simulate a dropped connection / momentary failure mid-request.
+            raise MilvusException(code=2, message="connection lost")
+
+        mock_milvus_client.create_collection.side_effect = create_collection_side_effect
+
+        with pytest.raises(MilvusException):
+            MilvusDB(
+                url="http://localhost:19530",
+                token="test_token",
+                collection_name="transient_fail_collection",
+                embedding_model_dims=1536,
+                metric_type=MetricType.COSINE,
+                db_name="test_db",
+            )
+
+        # No dense-only fallback should have been attempted.
+        mock_milvus_client.create_collection.assert_called_once()
 
     def test_create_col_hybrid_success_sets_bm25_flag(self, milvus_db, mock_milvus_client):
         """Default path still creates hybrid schema and enables BM25."""


### PR DESCRIPTION
## Summary

**salvage:** upgrades @QunBB's useful #6184 (credit) with tests + an `update()` dense-only guard.

On Milvus **< 2.5**, creating the hybrid BM25 schema (`text` + `sparse` + BM25 function) fails. Today that aborts `MilvusDB` init entirely even though semantic (dense) search would work.

This PR:

1. Tries hybrid collection creation first (unchanged happy path on 2.5+).
2. On failure, drops any partial collection and creates a **dense-only** schema (`id` / `vectors` / `metadata`), setting `_has_bm25_schema = False`.
3. Guards `update()` so dense-only collections never upsert a top-level `text` field (`insert()` already had this).
4. Leaves `keyword_search()` returning `None` without hybrid fields (existing behavior).

Credit: **@QunBB** in #6184 (Milvus versions below 2.5).

## Motivation

Users still run older Milvus servers. Hard-failing collection creation forces a full upgrade just to store embeddings. Dense-only fallback matches how existing pre-v3 collections already behave at runtime.

## Verification

```bash
python -m pytest tests/vector_stores/test_milvus.py -q
# 31 passed
```

New coverage:

- hybrid create success keeps BM25 flag
- BM25 create failure → dense-only fallback + drop partial collection
- `update()` / `insert()` omit `text` when `_has_bm25_schema` is false
- `update()` still writes `text` on hybrid collections

## Notes for maintainers

- No automatic data migration / no silent drop of **existing** collections that already exist (existing-collection path unchanged).
- Only drops a collection when hybrid **create** fails and `has_collection` is true afterward (partial create cleanup).
- Related original PR: https://github.com/mem0ai/mem0/pull/6184