### PR TITLE
docs: use CLI commands for Claude Code plugin install steps

### DIFF
--- a/docs/integrations/claude-code.mdx
+++ b/docs/integrations/claude-code.mdx
@@ -44,14 +44,14 @@ Install the full plugin including MCP server, lifecycle hooks, and SDK skill.
 
 1. Add the Mem0 marketplace:
 
-   ```
-   /plugin marketplace add mem0ai/mem0
+   ```bash
+   claude plugin marketplace add mem0ai/mem0
    ```
 
 2. Install the plugin:
 
-   ```
-   /plugin install mem0@mem0-plugins
+   ```bash
+   claude plugin install mem0@mem0-plugins
    ```
 
 **Claude Cowork desktop app:** Open the Cowork tab, click **Customize** in the sidebar, click **Browse plugins**, and install Mem0.
@@ -86,6 +86,15 @@ Add to your Claude Code MCP config (`.mcp.json`):
     }
   }
 }
+```
+
+### Managing the Plugin
+
+```bash
+claude plugin update mem0@mem0-plugins         # update the plugin to the latest version (restart to apply)
+claude plugin marketplace update mem0-plugins  # refresh the marketplace catalog
+claude plugin uninstall mem0@mem0-plugins      # uninstall the plugin (keeps the marketplace)
+claude plugin marketplace remove mem0-plugins  # unregister the marketplace entirely
 ```
 
 <Info icon="check">


### PR DESCRIPTION
## Linked Issue

N/A — small documentation consistency fix, no issue filed.

## Description

The Claude Code integration page told users to install the Mem0 plugin with in-session slash commands (`/plugin marketplace add`, `/plugin install`). This PR switches the install steps to terminal CLI commands (`claude plugin marketplace add mem0ai/mem0`, `claude plugin install mem0@mem0-plugins`) and adds a "Managing the Plugin" section (update, uninstall, marketplace remove), matching the format of the Codex integration page. All commands were verified against `claude plugin --help`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Rendered locally with `mint dev` and verified the page at /integrations/claude-code displays the new bash blocks and section correctly; `scripts/check-llms-txt-coverage.py` passes.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (docs-only change)
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
