### PR TITLE
fix(ts-oss): don't let update() metadata overwrite user_id/agent_id/run_id

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -101,12 +101,8 @@ const ENTITY_PARAMS = [
   "runId",
 ];
 
-// Identity fields that scope every search()/getAll()/deleteAll() call and are
-// immutable after creation. Derived from ENTITY_PARAMS (which already covers
-// user_id/agent_id/run_id in both snake_case and camelCase — the default vector
-// store promotes the camelCase aliases to snake_case on read) plus actor_id,
-// which has no camelCase alias. update() strips these from caller metadata so it
-// can neither overwrite an existing scope nor inject a new one.
+// Identity keys stripped from update() metadata: ENTITY_PARAMS covers user_id/agent_id/run_id
+// in both casings (the default store promotes camelCase on read); actor_id has no camelCase alias.
 const IDENTITY_KEYS = [...ENTITY_PARAMS, "actor_id"];
 
 /**
@@ -1949,16 +1945,10 @@ export class Memory {
       existingEmbeddings[newData] ||
       (await this.embedder.embed(newData, "update"));
 
-    // Strip identity keys from the incoming metadata before the spread so
-    // caller-supplied metadata can neither overwrite an existing scope nor
-    // inject a brand-new one on a memory that never had it — either would
-    // silently move the memory across tenants or grant it a scope it never had.
-    // Mirrors the Python fix (issues #6277 / #6278, TS twin #6342 / #6367).
-    const sanitizedMetadata = metadata
-      ? Object.fromEntries(
-          Object.entries(metadata).filter(([k]) => !IDENTITY_KEYS.includes(k)),
-        )
-      : metadata;
+    // Caller metadata must not overwrite or inject an identity scope (#6342 / #6367).
+    const sanitizedMetadata = Object.fromEntries(
+      Object.entries(metadata).filter(([k]) => !IDENTITY_KEYS.includes(k)),
+    );
 
     const newMetadata = {
       ...existingMemory.payload,

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -1941,27 +1941,27 @@ export class Memory {
       existingEmbeddings[newData] ||
       (await this.embedder.embed(newData, "update"));
 
+    // Identity fields scope every search()/getAll()/deleteAll() call and are
+    // immutable after creation. Strip them from the incoming metadata before the
+    // spread so caller-supplied metadata can neither overwrite an existing scope
+    // nor inject a brand-new one on a memory that never had it — either would
+    // silently move the memory across tenants or grant it a scope it never had.
+    // Mirrors the Python fix (issues #6277 / #6278, TS twin #6342 / #6367).
+    const IDENTITY_KEYS = ["actor_id", "user_id", "agent_id", "run_id"];
+    const sanitizedMetadata = metadata
+      ? Object.fromEntries(
+          Object.entries(metadata).filter(([k]) => !IDENTITY_KEYS.includes(k)),
+        )
+      : metadata;
+
     const newMetadata = {
       ...existingMemory.payload,
-      ...metadata,
+      ...sanitizedMetadata,
       data: newData,
       hash: createHash("md5").update(newData).digest("hex"),
       textLemmatized: lemmatizeForBm25(newData),
       createdAt: existingMemory.payload.createdAt,
       updatedAt: new Date().toISOString(),
-      // Identity fields scope every search()/getAll()/deleteAll() call and are
-      // immutable after creation. Re-pin them after the spread so caller-supplied
-      // metadata can never silently move a memory into another tenant's scope
-      // (mirror of the Python P0 fix, issues #6277 / #6278).
-      ...(existingMemory.payload.user_id !== undefined && {
-        user_id: existingMemory.payload.user_id,
-      }),
-      ...(existingMemory.payload.agent_id !== undefined && {
-        agent_id: existingMemory.payload.agent_id,
-      }),
-      ...(existingMemory.payload.run_id !== undefined && {
-        run_id: existingMemory.payload.run_id,
-      }),
     };
 
     await this.vectorStore.update(memoryId, embedding, newMetadata);

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -101,6 +101,14 @@ const ENTITY_PARAMS = [
   "runId",
 ];
 
+// Identity fields that scope every search()/getAll()/deleteAll() call and are
+// immutable after creation. Derived from ENTITY_PARAMS (which already covers
+// user_id/agent_id/run_id in both snake_case and camelCase — the default vector
+// store promotes the camelCase aliases to snake_case on read) plus actor_id,
+// which has no camelCase alias. update() strips these from caller metadata so it
+// can neither overwrite an existing scope nor inject a new one.
+const IDENTITY_KEYS = [...ENTITY_PARAMS, "actor_id"];
+
 /**
  * Validates that no top-level entity parameters are passed in config.
  * @throws Error if entity params are found at top level
@@ -1941,13 +1949,11 @@ export class Memory {
       existingEmbeddings[newData] ||
       (await this.embedder.embed(newData, "update"));
 
-    // Identity fields scope every search()/getAll()/deleteAll() call and are
-    // immutable after creation. Strip them from the incoming metadata before the
-    // spread so caller-supplied metadata can neither overwrite an existing scope
-    // nor inject a brand-new one on a memory that never had it — either would
+    // Strip identity keys from the incoming metadata before the spread so
+    // caller-supplied metadata can neither overwrite an existing scope nor
+    // inject a brand-new one on a memory that never had it — either would
     // silently move the memory across tenants or grant it a scope it never had.
     // Mirrors the Python fix (issues #6277 / #6278, TS twin #6342 / #6367).
-    const IDENTITY_KEYS = ["actor_id", "user_id", "agent_id", "run_id"];
     const sanitizedMetadata = metadata
       ? Object.fromEntries(
           Object.entries(metadata).filter(([k]) => !IDENTITY_KEYS.includes(k)),

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -1949,6 +1949,19 @@ export class Memory {
       textLemmatized: lemmatizeForBm25(newData),
       createdAt: existingMemory.payload.createdAt,
       updatedAt: new Date().toISOString(),
+      // Identity fields scope every search()/getAll()/deleteAll() call and are
+      // immutable after creation. Re-pin them after the spread so caller-supplied
+      // metadata can never silently move a memory into another tenant's scope
+      // (mirror of the Python P0 fix, issues #6277 / #6278).
+      ...(existingMemory.payload.user_id !== undefined && {
+        user_id: existingMemory.payload.user_id,
+      }),
+      ...(existingMemory.payload.agent_id !== undefined && {
+        agent_id: existingMemory.payload.agent_id,
+      }),
+      ...(existingMemory.payload.run_id !== undefined && {
+        run_id: existingMemory.payload.run_id,
+      }),
     };
 
     await this.vectorStore.update(memoryId, embedding, newMetadata);

--- a/mem0-ts/src/oss/tests/memory.crud.test.ts
+++ b/mem0-ts/src/oss/tests/memory.crud.test.ts
@@ -240,6 +240,48 @@ describe("Memory - update()", () => {
     });
     expect(bList.results.map((m) => m.id)).not.toContain(id);
   });
+
+  // A memory created with only some identity fields (e.g. run_id only — allowed,
+  // since add()/getAll() require just one of user_id/agent_id/run_id) must not
+  // let update() metadata *inject* a brand-new identity key, granting the memory
+  // a scope it never had. Covers the injection case (not just overwrite) and
+  // actor_id, matching #6367 / the Python fix in #6278.
+  test("metadata cannot inject a new identity field on update", async () => {
+    const runId = `run_only_${Date.now()}`;
+    const attacker = `attacker_${Date.now()}`;
+    const addResult: SearchResult = await memory.add("Run-scoped secret", {
+      runId,
+      infer: false,
+    });
+    const id = addResult.results[0].id;
+
+    // Memory has no user_id/agent_id/actor_id — metadata tries to inject them.
+    await memory.update(id, {
+      text: "Updated text",
+      metadata: {
+        user_id: attacker,
+        agent_id: attacker,
+        actor_id: attacker,
+      },
+    });
+
+    // Still reachable under its original run_id scope...
+    const runList: SearchResult = await memory.getAll({
+      filters: { run_id: runId },
+    });
+    expect(runList.results.map((m) => m.id)).toContain(id);
+
+    // ...and the injected identity scopes must not resolve to it.
+    const userList: SearchResult = await memory.getAll({
+      filters: { user_id: attacker },
+    });
+    expect(userList.results.map((m) => m.id)).not.toContain(id);
+
+    const agentList: SearchResult = await memory.getAll({
+      filters: { agent_id: attacker },
+    });
+    expect(agentList.results.map((m) => m.id)).not.toContain(id);
+  });
 });
 
 // ─── update() options: text / data / metadata / expirationDate ───

--- a/mem0-ts/src/oss/tests/memory.crud.test.ts
+++ b/mem0-ts/src/oss/tests/memory.crud.test.ts
@@ -282,6 +282,43 @@ describe("Memory - update()", () => {
     });
     expect(agentList.results.map((m) => m.id)).not.toContain(id);
   });
+
+  // The default vector store promotes camelCase aliases (userId/agentId/runId)
+  // to their snake_case identity keys on read (normalizePayload). So stripping
+  // only snake_case keys leaves an injection path open via the camelCase alias.
+  // Metadata must not inject an identity scope through either casing.
+  test("metadata cannot inject an identity field via camelCase alias", async () => {
+    const runId = `run_camel_${Date.now()}`;
+    const attacker = `attacker_camel_${Date.now()}`;
+    const addResult: SearchResult = await memory.add("Run-scoped secret", {
+      runId,
+      infer: false,
+    });
+    const id = addResult.results[0].id;
+
+    // camelCase aliases attempt to inject new scopes.
+    await memory.update(id, {
+      text: "Updated text",
+      metadata: { userId: attacker, agentId: attacker },
+    });
+
+    // Still reachable under its original run_id scope...
+    const runList: SearchResult = await memory.getAll({
+      filters: { run_id: runId },
+    });
+    expect(runList.results.map((m) => m.id)).toContain(id);
+
+    // ...and the injected scopes must not resolve to it, through either casing.
+    const userList: SearchResult = await memory.getAll({
+      filters: { user_id: attacker },
+    });
+    expect(userList.results.map((m) => m.id)).not.toContain(id);
+
+    const agentList: SearchResult = await memory.getAll({
+      filters: { agent_id: attacker },
+    });
+    expect(agentList.results.map((m) => m.id)).not.toContain(id);
+  });
 });
 
 // ─── update() options: text / data / metadata / expirationDate ───

--- a/mem0-ts/src/oss/tests/memory.crud.test.ts
+++ b/mem0-ts/src/oss/tests/memory.crud.test.ts
@@ -209,10 +209,7 @@ describe("Memory - update()", () => {
   });
 
   // Regression: metadata passed to update() must never overwrite a memory's
-  // user_id/agent_id/run_id. These fields scope every search()/getAll()/
-  // deleteAll() call, so letting caller metadata overwrite them would silently
-  // move a memory into another tenant's scope and make it unreachable via the
-  // original tenant. Mirrors the Python P0 fix (issues #6277 / #6278).
+  // identity fields (issues #6277 / #6278).
   test("metadata cannot overwrite identity fields (tenant isolation)", async () => {
     const tenantA = `tenant_a_${Date.now()}`;
     const tenantB = `tenant_b_${Date.now()}`;
@@ -241,12 +238,10 @@ describe("Memory - update()", () => {
     expect(bList.results.map((m) => m.id)).not.toContain(id);
   });
 
-  // A memory created with only some identity fields (e.g. run_id only — allowed,
-  // since add()/getAll() require just one of user_id/agent_id/run_id) must not
-  // let update() metadata *inject* a brand-new identity key, granting the memory
-  // a scope it never had. Covers the injection case (not just overwrite) and
-  // actor_id, matching #6367 / the Python fix in #6278.
-  test("metadata cannot inject a new identity field on update", async () => {
+  // A memory created with only some identity fields (e.g. run_id only) must not
+  // let update() metadata inject a brand-new identity key. The default vector
+  // store promotes camelCase aliases to snake_case on read, so both casings must be covered.
+  test("metadata cannot inject an identity field on update (snake_case or camelCase)", async () => {
     const runId = `run_only_${Date.now()}`;
     const attacker = `attacker_${Date.now()}`;
     const addResult: SearchResult = await memory.add("Run-scoped secret", {
@@ -255,13 +250,16 @@ describe("Memory - update()", () => {
     });
     const id = addResult.results[0].id;
 
-    // Memory has no user_id/agent_id/actor_id — metadata tries to inject them.
+    // Memory has no user_id/agent_id/actor_id — metadata tries to inject them,
+    // in both snake_case and camelCase.
     await memory.update(id, {
       text: "Updated text",
       metadata: {
         user_id: attacker,
         agent_id: attacker,
         actor_id: attacker,
+        userId: attacker,
+        agentId: attacker,
       },
     });
 
@@ -272,43 +270,6 @@ describe("Memory - update()", () => {
     expect(runList.results.map((m) => m.id)).toContain(id);
 
     // ...and the injected identity scopes must not resolve to it.
-    const userList: SearchResult = await memory.getAll({
-      filters: { user_id: attacker },
-    });
-    expect(userList.results.map((m) => m.id)).not.toContain(id);
-
-    const agentList: SearchResult = await memory.getAll({
-      filters: { agent_id: attacker },
-    });
-    expect(agentList.results.map((m) => m.id)).not.toContain(id);
-  });
-
-  // The default vector store promotes camelCase aliases (userId/agentId/runId)
-  // to their snake_case identity keys on read (normalizePayload). So stripping
-  // only snake_case keys leaves an injection path open via the camelCase alias.
-  // Metadata must not inject an identity scope through either casing.
-  test("metadata cannot inject an identity field via camelCase alias", async () => {
-    const runId = `run_camel_${Date.now()}`;
-    const attacker = `attacker_camel_${Date.now()}`;
-    const addResult: SearchResult = await memory.add("Run-scoped secret", {
-      runId,
-      infer: false,
-    });
-    const id = addResult.results[0].id;
-
-    // camelCase aliases attempt to inject new scopes.
-    await memory.update(id, {
-      text: "Updated text",
-      metadata: { userId: attacker, agentId: attacker },
-    });
-
-    // Still reachable under its original run_id scope...
-    const runList: SearchResult = await memory.getAll({
-      filters: { run_id: runId },
-    });
-    expect(runList.results.map((m) => m.id)).toContain(id);
-
-    // ...and the injected scopes must not resolve to it, through either casing.
     const userList: SearchResult = await memory.getAll({
       filters: { user_id: attacker },
     });

--- a/mem0-ts/src/oss/tests/memory.crud.test.ts
+++ b/mem0-ts/src/oss/tests/memory.crud.test.ts
@@ -207,6 +207,39 @@ describe("Memory - update()", () => {
       expect.objectContaining({ category: "hobbies", priority: "high" }),
     );
   });
+
+  // Regression: metadata passed to update() must never overwrite a memory's
+  // user_id/agent_id/run_id. These fields scope every search()/getAll()/
+  // deleteAll() call, so letting caller metadata overwrite them would silently
+  // move a memory into another tenant's scope and make it unreachable via the
+  // original tenant. Mirrors the Python P0 fix (issues #6277 / #6278).
+  test("metadata cannot overwrite identity fields (tenant isolation)", async () => {
+    const tenantA = `tenant_a_${Date.now()}`;
+    const tenantB = `tenant_b_${Date.now()}`;
+    const addResult: SearchResult = await memory.add("Tenant A secret", {
+      userId: tenantA,
+      infer: false,
+    });
+    const id = addResult.results[0].id;
+
+    // Caller metadata attempts to re-scope the memory to tenant B.
+    await memory.update(id, {
+      text: "Updated text",
+      metadata: { user_id: tenantB, agent_id: "attacker", run_id: "attacker" },
+    });
+
+    // The memory must remain in tenant A's scope...
+    const aList: SearchResult = await memory.getAll({
+      filters: { user_id: tenantA },
+    });
+    expect(aList.results.map((m) => m.id)).toContain(id);
+
+    // ...and must never leak into tenant B's scope.
+    const bList: SearchResult = await memory.getAll({
+      filters: { user_id: tenantB },
+    });
+    expect(bList.results.map((m) => m.id)).not.toContain(id);
+  });
 });
 
 // ─── update() options: text / data / metadata / expirationDate ───


### PR DESCRIPTION
## Linked Issue

Closes #6342
Closes #6367

## Description

In the TypeScript OSS SDK, `memory.update()` merges caller-supplied `metadata` into a memory's stored payload without protecting its identity fields (`actor_id` / `user_id` / `agent_id` / `run_id`). `updateMemory()` builds the new payload as:

```ts
const newMetadata = {
  ...existingMemory.payload,
  ...metadata,          // caller keys win — clobbers / injects identity fields
  ...
  createdAt: existingMemory.payload.createdAt,
  updatedAt: new Date().toISOString(),
};
```

Only `createdAt`/`updatedAt` are re-asserted after the spread, so caller `metadata` can:

- **Overwrite** an existing scope — `update(id, { metadata: { user_id: "tenant_b" } })` silently moves a memory into another tenant's scope: it disappears from the owning tenant (unreadable, undeletable) and surfaces for another.
- **Inject** a brand-new scope — a memory created with only a subset of identity fields (e.g. `run_id` only, which `add()`/`getAll()` allow) can have a fresh `user_id`/`agent_id`/`actor_id` injected via `update()` metadata, granting it a reachable scope it never had.

Those fields scope every `search()` / `getAll()` / `deleteAll()` call, so both cases silently break tenant isolation. No error is raised.

This is the TypeScript twin of #6277 (`P0-critical`), fixed for Python in #6278. The TS SDK had **zero** protection here — it never received the original `actor_id` fix from #4490 either. #6367 tracks the TS side and describes the correct fix.

This PR strips the identity keys (`actor_id` / `user_id` / `agent_id` / `run_id`) from a copy of the incoming `metadata` before the spread, mirroring the strip-before-merge approach the Python fix landed in #6278. Existing scopes on the memory survive (they come from `...existingMemory.payload`), caller metadata can neither overwrite nor inject an identity field, and benign metadata keys still pass through normally.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A — the affected behavior (caller metadata re-scoping or scope-injecting a memory across tenants) was never intended and matches the Python SDK's post-#6278 semantics.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added two regression tests in `mem0-ts/src/oss/tests/memory.crud.test.ts`:

1. **Overwrite** — adds a memory under `tenant_a`, calls `update()` with `metadata.user_id = tenant_b`, asserts the memory stays in `tenant_a`'s scope and never appears in `tenant_b`'s.
2. **Injection** — adds a `run_id`-only memory, calls `update()` with injected `user_id`/`agent_id`/`actor_id`, asserts it stays reachable under its original `run_id` and never resolves under the injected scopes.

Both fail without the fix (memory leaks / scope injected) and pass with it. Full `memory.crud.test.ts` suite (52 tests) passes; `tsc`, `prettier --check`, and the `tsup` build are all clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
