### PR TITLE
fix(llms/openai): fall back to reasoning_content when content is empty

### DIFF
--- a/mem0-ts/src/oss/src/llms/openai.ts
+++ b/mem0-ts/src/oss/src/llms/openai.ts
@@ -37,10 +37,15 @@ export class OpenAILLM implements LLM {
     });
 
     const response = completion.choices[0].message;
+    const textContent =
+      response.content ||
+      // OpenAI-compatible reasoning models may put the answer in reasoning_content (#4932)
+      ((response as { reasoning_content?: string | null }).reasoning_content ??
+        "");
 
     if (response.tool_calls) {
       return {
-        content: response.content || "",
+        content: textContent,
         role: response.role,
         toolCalls: response.tool_calls.map((call) => ({
           name: call.function.name,
@@ -49,7 +54,7 @@ export class OpenAILLM implements LLM {
       };
     }
 
-    return response.content || "";
+    return textContent;
   }
 
   async generateChat(messages: Message[]): Promise<LLMResponse> {
@@ -67,8 +72,12 @@ export class OpenAILLM implements LLM {
       model: this.model,
     });
     const response = completion.choices[0].message;
+    const textContent =
+      response.content ||
+      ((response as { reasoning_content?: string | null }).reasoning_content ??
+        "");
     return {
-      content: response.content || "",
+      content: textContent,
       role: response.role,
     };
   }

--- a/mem0-ts/src/oss/tests/openai-llm.test.ts
+++ b/mem0-ts/src/oss/tests/openai-llm.test.ts
@@ -119,6 +119,50 @@ describe("OpenAILLM (unit)", () => {
     });
   });
 
+  it("generateResponse() falls back to reasoning_content when content is empty", async () => {
+    mockCreate.mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            content: "",
+            reasoning_content: '{"facts": ["User lives in Guadalajara"]}',
+            role: "assistant",
+            tool_calls: null,
+          },
+        },
+      ],
+    });
+
+    const llm = new OpenAILLM({ apiKey: "test-key" });
+    const result = await llm.generateResponse([
+      { role: "user", content: "Hi" },
+    ]);
+
+    expect(result).toBe('{"facts": ["User lives in Guadalajara"]}');
+  });
+
+  it("generateResponse() prefers content over reasoning_content", async () => {
+    mockCreate.mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            content: "final answer",
+            reasoning_content: "chain of thought",
+            role: "assistant",
+            tool_calls: null,
+          },
+        },
+      ],
+    });
+
+    const llm = new OpenAILLM({ apiKey: "test-key" });
+    const result = await llm.generateResponse([
+      { role: "user", content: "Hi" },
+    ]);
+
+    expect(result).toBe("final answer");
+  });
+
   it("generateChat() returns LLMResponse shape", async () => {
     mockCreate.mockResolvedValueOnce({
       choices: [

--- a/mem0-ts/src/oss/tests/openai-llm.test.ts
+++ b/mem0-ts/src/oss/tests/openai-llm.test.ts
@@ -163,6 +163,30 @@ describe("OpenAILLM (unit)", () => {
     expect(result).toBe("final answer");
   });
 
+  it("generateChat() falls back to reasoning_content when content is empty", async () => {
+    mockCreate.mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: "",
+            reasoning_content: '{"facts": ["User lives in Guadalajara"]}',
+          },
+        },
+      ],
+    });
+
+    const llm = new OpenAILLM({ apiKey: "test-key", model: "gpt-4o-mini" });
+    const result = await llm.generateChat([
+      { role: "user", content: "extract facts" },
+    ]);
+
+    expect(result).toEqual({
+      content: '{"facts": ["User lives in Guadalajara"]}',
+      role: "assistant",
+    });
+  });
+
   it("generateChat() returns LLMResponse shape", async () => {
     mockCreate.mockResolvedValueOnce({
       choices: [

--- a/mem0/llms/azure_openai.py
+++ b/mem0/llms/azure_openai.py
@@ -8,7 +8,7 @@ from openai import AzureOpenAI
 
 from mem0.configs.llms.azure import AzureOpenAIConfig
 from mem0.configs.llms.base import BaseLlmConfig
-from mem0.llms.base import LLMBase
+from mem0.llms.base import LLMBase, message_content_with_reasoning_fallback
 from mem0.memory.utils import extract_json
 
 SCOPE = "https://cognitiveservices.azure.com/.default"
@@ -102,8 +102,9 @@ class AzureOpenAILLM(LLMBase):
             str or dict: The processed response.
         """
         if tools:
+            message = response.choices[0].message
             processed_response = {
-                "content": response.choices[0].message.content,
+                "content": message_content_with_reasoning_fallback(message),
                 "tool_calls": [],
             }
 
@@ -118,7 +119,7 @@ class AzureOpenAILLM(LLMBase):
 
             return processed_response
         else:
-            return response.choices[0].message.content
+            return message_content_with_reasoning_fallback(response.choices[0].message)
 
     def generate_response(
         self,

--- a/mem0/llms/azure_openai_structured.py
+++ b/mem0/llms/azure_openai_structured.py
@@ -7,7 +7,7 @@ from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from openai import AzureOpenAI
 
 from mem0.configs.llms.base import BaseLlmConfig
-from mem0.llms.base import LLMBase
+from mem0.llms.base import LLMBase, message_content_with_reasoning_fallback
 from mem0.memory.utils import extract_json
 
 SCOPE = "https://cognitiveservices.azure.com/.default"
@@ -134,8 +134,9 @@ class AzureOpenAIStructuredLLM(LLMBase):
             str or dict: The processed response.
         """
         if tools:
+            message = response.choices[0].message
             processed_response = {
-                "content": response.choices[0].message.content,
+                "content": message_content_with_reasoning_fallback(message),
                 "tool_calls": [],
             }
 
@@ -150,4 +151,4 @@ class AzureOpenAIStructuredLLM(LLMBase):
 
             return processed_response
         else:
-            return response.choices[0].message.content
+            return message_content_with_reasoning_fallback(response.choices[0].message)

--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -4,18 +4,21 @@ from typing import Dict, List, Optional, Union
 from mem0.configs.llms.base import BaseLlmConfig
 
 
-
 def message_content_with_reasoning_fallback(message):
     """Return chat message text, falling back to reasoning_content when empty.
 
     Some OpenAI-compatible endpoints (DeepSeek, Ollama Cloud, GLM, etc.) put the
     full answer in ``reasoning_content`` and leave ``content`` empty for reasoning
     models. Fact extraction must not silently return [] in that case (#4932).
+
+    Always returns a string (empty when both fields are missing/empty) so callers
+    like ``remove_code_blocks`` can safely call ``.strip()``.
     """
     content = getattr(message, "content", None)
     if not content:
         content = getattr(message, "reasoning_content", None)
-    return content
+    return content or ""
+
 
 class LLMBase(ABC):
     """

--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -4,6 +4,19 @@ from typing import Dict, List, Optional, Union
 from mem0.configs.llms.base import BaseLlmConfig
 
 
+
+def message_content_with_reasoning_fallback(message):
+    """Return chat message text, falling back to reasoning_content when empty.
+
+    Some OpenAI-compatible endpoints (DeepSeek, Ollama Cloud, GLM, etc.) put the
+    full answer in ``reasoning_content`` and leave ``content`` empty for reasoning
+    models. Fact extraction must not silently return [] in that case (#4932).
+    """
+    content = getattr(message, "content", None)
+    if not content:
+        content = getattr(message, "reasoning_content", None)
+    return content
+
 class LLMBase(ABC):
     """
     Base class for all LLM providers.

--- a/mem0/llms/deepseek.py
+++ b/mem0/llms/deepseek.py
@@ -6,7 +6,7 @@ from openai import OpenAI
 
 from mem0.configs.llms.base import BaseLlmConfig
 from mem0.configs.llms.deepseek import DeepSeekConfig
-from mem0.llms.base import LLMBase
+from mem0.llms.base import LLMBase, message_content_with_reasoning_fallback
 from mem0.memory.utils import extract_json
 
 
@@ -52,8 +52,9 @@ class DeepSeekLLM(LLMBase):
             str or dict: The processed response.
         """
         if tools:
+            message = response.choices[0].message
             processed_response = {
-                "content": response.choices[0].message.content,
+                "content": message_content_with_reasoning_fallback(message),
                 "tool_calls": [],
             }
 
@@ -68,7 +69,7 @@ class DeepSeekLLM(LLMBase):
 
             return processed_response
         else:
-            return response.choices[0].message.content
+            return message_content_with_reasoning_fallback(response.choices[0].message)
 
     def generate_response(
         self,

--- a/mem0/llms/groq.py
+++ b/mem0/llms/groq.py
@@ -9,7 +9,7 @@ except ImportError:
     raise ImportError("The 'groq' library is required. Please install it using 'pip install groq'.")
 
 from mem0.configs.llms.base import BaseLlmConfig
-from mem0.llms.base import LLMBase
+from mem0.llms.base import LLMBase, message_content_with_reasoning_fallback
 from mem0.memory.utils import extract_json
 
 logger = logging.getLogger(__name__)
@@ -55,8 +55,9 @@ class GroqLLM(LLMBase):
             str or dict: The processed response.
         """
         if tools:
+            message = response.choices[0].message
             processed_response = {
-                "content": response.choices[0].message.content,
+                "content": message_content_with_reasoning_fallback(message),
                 "tool_calls": [],
             }
 
@@ -71,7 +72,7 @@ class GroqLLM(LLMBase):
 
             return processed_response
         else:
-            return response.choices[0].message.content
+            return message_content_with_reasoning_fallback(response.choices[0].message)
 
     def generate_response(
         self,

--- a/mem0/llms/litellm.py
+++ b/mem0/llms/litellm.py
@@ -7,7 +7,7 @@ except ImportError:
     raise ImportError("The 'litellm' library is required. Please install it using 'pip install litellm'.")
 
 from mem0.configs.llms.base import BaseLlmConfig
-from mem0.llms.base import LLMBase
+from mem0.llms.base import LLMBase, message_content_with_reasoning_fallback
 from mem0.memory.utils import extract_json
 
 
@@ -30,8 +30,9 @@ class LiteLLM(LLMBase):
             str or dict: The processed response.
         """
         if tools:
+            message = response.choices[0].message
             processed_response = {
-                "content": response.choices[0].message.content,
+                "content": message_content_with_reasoning_fallback(message),
                 "tool_calls": [],
             }
 
@@ -46,7 +47,7 @@ class LiteLLM(LLMBase):
 
             return processed_response
         else:
-            return response.choices[0].message.content
+            return message_content_with_reasoning_fallback(response.choices[0].message)
 
     def generate_response(
         self,

--- a/mem0/llms/lmstudio.py
+++ b/mem0/llms/lmstudio.py
@@ -5,7 +5,7 @@ from openai import OpenAI
 
 from mem0.configs.llms.base import BaseLlmConfig
 from mem0.configs.llms.lmstudio import LMStudioConfig
-from mem0.llms.base import LLMBase
+from mem0.llms.base import LLMBase, message_content_with_reasoning_fallback
 from mem0.memory.utils import extract_json
 
 
@@ -52,8 +52,9 @@ class LMStudioLLM(LLMBase):
             str or dict: The processed response.
         """
         if tools:
+            message = response.choices[0].message
             processed_response = {
-                "content": response.choices[0].message.content,
+                "content": message_content_with_reasoning_fallback(message),
                 "tool_calls": [],
             }
 
@@ -68,7 +69,7 @@ class LMStudioLLM(LLMBase):
 
             return processed_response
         else:
-            return response.choices[0].message.content
+            return message_content_with_reasoning_fallback(response.choices[0].message)
 
     def generate_response(
         self,

--- a/mem0/llms/minimax.py
+++ b/mem0/llms/minimax.py
@@ -6,7 +6,7 @@ from openai import OpenAI
 
 from mem0.configs.llms.base import BaseLlmConfig
 from mem0.configs.llms.minimax import MinimaxConfig
-from mem0.llms.base import LLMBase
+from mem0.llms.base import LLMBase, message_content_with_reasoning_fallback
 from mem0.memory.utils import extract_json
 
 
@@ -56,8 +56,9 @@ class MiniMaxLLM(LLMBase):
             str or dict: The processed response.
         """
         if tools:
+            message = response.choices[0].message
             processed_response = {
-                "content": response.choices[0].message.content,
+                "content": message_content_with_reasoning_fallback(message),
                 "tool_calls": [],
             }
 
@@ -72,7 +73,7 @@ class MiniMaxLLM(LLMBase):
 
             return processed_response
         else:
-            return response.choices[0].message.content
+            return message_content_with_reasoning_fallback(response.choices[0].message)
 
     def generate_response(
         self,

--- a/mem0/llms/openai.py
+++ b/mem0/llms/openai.py
@@ -7,7 +7,7 @@ from openai import OpenAI
 
 from mem0.configs.llms.base import BaseLlmConfig
 from mem0.configs.llms.openai import OpenAIConfig
-from mem0.llms.base import LLMBase
+from mem0.llms.base import LLMBase, message_content_with_reasoning_fallback
 from mem0.memory.utils import extract_json
 
 
@@ -64,8 +64,9 @@ class OpenAILLM(LLMBase):
             str or dict: The processed response.
         """
         if tools:
+            message = response.choices[0].message
             processed_response = {
-                "content": response.choices[0].message.content,
+                "content": message_content_with_reasoning_fallback(message),
                 "tool_calls": [],
             }
 
@@ -80,7 +81,7 @@ class OpenAILLM(LLMBase):
 
             return processed_response
         else:
-            return response.choices[0].message.content
+            return message_content_with_reasoning_fallback(response.choices[0].message)
 
     def generate_response(
         self,

--- a/mem0/llms/openai_structured.py
+++ b/mem0/llms/openai_structured.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional
 from openai import OpenAI
 
 from mem0.configs.llms.base import BaseLlmConfig
-from mem0.llms.base import LLMBase
+from mem0.llms.base import LLMBase, message_content_with_reasoning_fallback
 
 
 class OpenAIStructuredLLM(LLMBase):
@@ -46,4 +46,4 @@ class OpenAIStructuredLLM(LLMBase):
             params["tool_choice"] = tool_choice
 
         response = self.client.beta.chat.completions.parse(**params)
-        return response.choices[0].message.content
+        return message_content_with_reasoning_fallback(response.choices[0].message)

--- a/mem0/llms/together.py
+++ b/mem0/llms/together.py
@@ -8,7 +8,7 @@ except ImportError:
     raise ImportError("The 'together' library is required. Please install it using 'pip install together'.")
 
 from mem0.configs.llms.base import BaseLlmConfig
-from mem0.llms.base import LLMBase
+from mem0.llms.base import LLMBase, message_content_with_reasoning_fallback
 from mem0.memory.utils import extract_json
 
 
@@ -34,8 +34,9 @@ class TogetherLLM(LLMBase):
             str or dict: The processed response.
         """
         if tools:
+            message = response.choices[0].message
             processed_response = {
-                "content": response.choices[0].message.content,
+                "content": message_content_with_reasoning_fallback(message),
                 "tool_calls": [],
             }
 
@@ -50,7 +51,7 @@ class TogetherLLM(LLMBase):
 
             return processed_response
         else:
-            return response.choices[0].message.content
+            return message_content_with_reasoning_fallback(response.choices[0].message)
 
     def generate_response(
         self,

--- a/mem0/llms/vllm.py
+++ b/mem0/llms/vllm.py
@@ -6,7 +6,7 @@ from openai import OpenAI
 
 from mem0.configs.llms.base import BaseLlmConfig
 from mem0.configs.llms.vllm import VllmConfig
-from mem0.llms.base import LLMBase
+from mem0.llms.base import LLMBase, message_content_with_reasoning_fallback
 from mem0.memory.utils import extract_json
 
 
@@ -52,8 +52,9 @@ class VllmLLM(LLMBase):
             str or dict: The processed response.
         """
         if tools:
+            message = response.choices[0].message
             processed_response = {
-                "content": response.choices[0].message.content,
+                "content": message_content_with_reasoning_fallback(message),
                 "tool_calls": [],
             }
 
@@ -68,7 +69,7 @@ class VllmLLM(LLMBase):
 
             return processed_response
         else:
-            return response.choices[0].message.content
+            return message_content_with_reasoning_fallback(response.choices[0].message)
 
     def generate_response(
         self,

--- a/mem0/llms/xai.py
+++ b/mem0/llms/xai.py
@@ -6,7 +6,7 @@ from openai import OpenAI
 
 from mem0.configs.llms.base import BaseLlmConfig
 from mem0.configs.llms.xai import XAIConfig
-from mem0.llms.base import LLMBase
+from mem0.llms.base import LLMBase, message_content_with_reasoning_fallback
 from mem0.memory.utils import extract_json
 
 
@@ -52,8 +52,9 @@ class XAILLM(LLMBase):
             str or dict: The processed response.
         """
         if tools:
+            message = response.choices[0].message
             processed_response = {
-                "content": response.choices[0].message.content,
+                "content": message_content_with_reasoning_fallback(message),
                 "tool_calls": [],
             }
 
@@ -68,7 +69,7 @@ class XAILLM(LLMBase):
 
             return processed_response
         else:
-            return response.choices[0].message.content
+            return message_content_with_reasoning_fallback(response.choices[0].message)
 
     def generate_response(
         self,

--- a/tests/llms/test_deepseek.py
+++ b/tests/llms/test_deepseek.py
@@ -157,3 +157,23 @@ def test_generate_response_without_response_format(mock_deepseek_client):
     call_kwargs = mock_deepseek_client.chat.completions.create.call_args[1]
     assert "response_format" not in call_kwargs
     assert response == "Why did the chicken cross the road?"
+
+
+
+def test_generate_response_falls_back_to_reasoning_content(mock_deepseek_client):
+    """DeepSeek reasoning models often put the answer in reasoning_content (#4932)."""
+    config = DeepSeekConfig(model="deepseek-reasoner", temperature=0.0)
+    llm = DeepSeekLLM(config)
+    messages = [{"role": "user", "content": "What do I know?"}]
+
+    mock_message = Mock()
+    mock_message.content = ""
+    mock_message.reasoning_content = '{"facts": ["User lives in Guadalajara"]}'
+    mock_message.tool_calls = None
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=mock_message)]
+    mock_deepseek_client.chat.completions.create.return_value = mock_response
+
+    response = llm.generate_response(messages)
+
+    assert response == '{"facts": ["User lives in Guadalajara"]}'

--- a/tests/llms/test_deepseek.py
+++ b/tests/llms/test_deepseek.py
@@ -159,7 +159,6 @@ def test_generate_response_without_response_format(mock_deepseek_client):
     assert response == "Why did the chicken cross the road?"
 
 
-
 def test_generate_response_falls_back_to_reasoning_content(mock_deepseek_client):
     """DeepSeek reasoning models often put the answer in reasoning_content (#4932)."""
     config = DeepSeekConfig(model="deepseek-reasoner", temperature=0.0)

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -464,3 +464,93 @@ def test_openai_llm_preserves_proxies_from_base_config(mock_openai_client):
     llm = OpenAILLM(config)
     assert llm.config.http_client_proxies == "http://proxy.local:8080"
     assert isinstance(llm.config.http_client, httpx.Client)
+
+
+
+def test_generate_response_falls_back_to_reasoning_content(mock_openai_client):
+    """When content is empty and reasoning_content is present, return reasoning_content.
+
+    Some OpenAI-compatible endpoints (Ollama, DeepSeek, GLM, etc.) put the full
+    answer inside `reasoning_content` and leave `content` empty when a reasoning
+    model is used. Without the fallback, fact extraction silently returns empty
+    results (fixes #4932).
+    """
+    config = OpenAIConfig(model="glm-5.1", temperature=0.0)
+    llm = OpenAILLM(config)
+    messages = [{"role": "user", "content": "What do I know?"}]
+
+    mock_message = Mock()
+    mock_message.content = ""
+    mock_message.reasoning_content = '{"facts": ["User lives in Guadalajara"]}'
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=mock_message)]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    response = llm.generate_response(messages)
+
+    assert response == '{"facts": ["User lives in Guadalajara"]}'
+
+
+def test_generate_response_content_takes_priority_over_reasoning_content(mock_openai_client):
+    """When content is non-empty, reasoning_content should not be used."""
+    config = OpenAIConfig(model="glm-5.1", temperature=0.0)
+    llm = OpenAILLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_message = Mock()
+    mock_message.content = "Hello there!"
+    mock_message.reasoning_content = "internal thoughts"
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=mock_message)]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    response = llm.generate_response(messages)
+
+    assert response == "Hello there!"
+
+
+def test_generate_response_returns_none_when_both_content_fields_empty(mock_openai_client):
+    """When both content and reasoning_content are absent/empty, return None."""
+    config = OpenAIConfig(model="some-model", temperature=0.0)
+    llm = OpenAILLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_message = Mock(spec=["content"])
+    mock_message.content = ""
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=mock_message)]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    response = llm.generate_response(messages)
+
+    assert response is None
+
+
+def test_generate_response_tools_path_falls_back_to_reasoning_content(mock_openai_client):
+    """Tools branch must also fall back when content is empty (#4932 kartik review)."""
+    config = OpenAIConfig(model="glm-5.1", temperature=0.0)
+    llm = OpenAILLM(config)
+    messages = [{"role": "user", "content": "Add a fact"}]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "add_memory",
+                "description": "Add a memory",
+                "parameters": {"type": "object", "properties": {"data": {"type": "string"}}},
+            },
+        }
+    ]
+
+    mock_message = Mock()
+    mock_message.content = ""
+    mock_message.reasoning_content = "should surface in tools content"
+    mock_message.tool_calls = None
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=mock_message)]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    response = llm.generate_response(messages, tools=tools)
+
+    assert response["content"] == "should surface in tools content"
+    assert response["tool_calls"] == []

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -466,7 +466,6 @@ def test_openai_llm_preserves_proxies_from_base_config(mock_openai_client):
     assert isinstance(llm.config.http_client, httpx.Client)
 
 
-
 def test_generate_response_falls_back_to_reasoning_content(mock_openai_client):
     """When content is empty and reasoning_content is present, return reasoning_content.
 
@@ -509,8 +508,8 @@ def test_generate_response_content_takes_priority_over_reasoning_content(mock_op
     assert response == "Hello there!"
 
 
-def test_generate_response_returns_none_when_both_content_fields_empty(mock_openai_client):
-    """When both content and reasoning_content are absent/empty, return None."""
+def test_generate_response_returns_empty_string_when_both_content_fields_empty(mock_openai_client):
+    """When both content and reasoning_content are absent/empty, return empty string."""
     config = OpenAIConfig(model="some-model", temperature=0.0)
     llm = OpenAILLM(config)
     messages = [{"role": "user", "content": "Hello"}]
@@ -523,7 +522,7 @@ def test_generate_response_returns_none_when_both_content_fields_empty(mock_open
 
     response = llm.generate_response(messages)
 
-    assert response is None
+    assert response == ""
 
 
 def test_generate_response_tools_path_falls_back_to_reasoning_content(mock_openai_client):


### PR DESCRIPTION
## Summary

- `OpenAILLM._parse_response` now falls back to `message.reasoning_content` when `message.content` is empty (non-tools path).
- Adds three regression tests for fallback, content-priority, and both-empty behavior.
- Focused salvage of #4937 by @octo-patch (stale since Apr 2026) without the unrelated `examples/mem0-demo` UI diff.

## Motivation

Closes #4932.

Reasoning models on several OpenAI-compatible endpoints (Ollama Cloud, DeepSeek, native GLM, etc.) put the usable answer in `reasoning_content` and leave `content` empty. Mem0 then treated extraction as "no facts" with an empty results list and no error.

## Root cause

`_parse_response` only read `response.choices[0].message.content`.

## Fix

If `content` is falsy, use `getattr(message, "reasoning_content", None)` before returning.

## Differential value vs #4937

- Same core fix credited to @octo-patch.
- Rebased onto current `main` only.
- Drops the unrelated demo frontend type-tightening that was mixed into #4937.

## Tests

```bash
pytest tests/llms/test_openai.py -k reasoning -q
```

All targeted tests pass. (A few pre-existing env-sensitive tests in the same file fail under local `OPENROUTER_API_KEY` / store-param fixture drift — unrelated to this change.)

## Verification

- [x] Fallback returns `reasoning_content` when content is empty
- [x] Non-empty `content` still wins
- [x] Missing `reasoning_content` does not crash