### PR TITLE
fix(sdk): delete all matching memories across batches

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1869,14 +1869,25 @@ class Memory(MemoryBase):
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "sync"})
-        # delete all vector memories and reset the collections
-        memories = self.vector_store.list(filters=filters)[0]
-        for memory in memories:
-            self._delete_memory(memory.id)
+        deleted_count = 0
+        processed_memory_ids = set()
+        while True:
+            memories = [
+                memory
+                for memory in _vector_store_list_rows(self.vector_store.list(filters=filters))
+                if str(memory.id) not in processed_memory_ids
+            ]
+            if not memories:
+                break
 
-        logger.info(f"Deleted {len(memories)} memories")
+            processed_memory_ids.update(str(memory.id) for memory in memories)
+            for memory in memories:
+                self._delete_memory(memory.id)
+                deleted_count += 1
 
-        decay_usage_notice = detect_decay_usage_from_delete_all(len(memories))
+        logger.info(f"Deleted {deleted_count} memories")
+
+        decay_usage_notice = detect_decay_usage_from_delete_all(deleted_count)
         if decay_usage_notice:
             display_decay_usage_notice(self, "sync", "delete_all", *decay_usage_notice)
         else:
@@ -3501,26 +3512,35 @@ class AsyncMemory(MemoryBase):
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "async"})
-        memories = await asyncio.to_thread(self.vector_store.list, filters=filters)
+        deleted_count = 0
+        processed_memory_ids = set()
+        errors = []
+        while True:
+            listed = await asyncio.to_thread(self.vector_store.list, filters=filters)
+            memories = [
+                memory for memory in _vector_store_list_rows(listed) if str(memory.id) not in processed_memory_ids
+            ]
+            if not memories:
+                break
 
-        delete_tasks = []
-        for memory in memories[0]:
-            delete_tasks.append(self._delete_memory(memory.id, skip_entity_cleanup=True))
-
-        results = await asyncio.gather(*delete_tasks, return_exceptions=True)
+            processed_memory_ids.update(str(memory.id) for memory in memories)
+            delete_tasks = [self._delete_memory(memory.id, skip_entity_cleanup=True) for memory in memories]
+            results = await asyncio.gather(*delete_tasks, return_exceptions=True)
+            batch_errors = [result for result in results if isinstance(result, BaseException)]
+            errors.extend(batch_errors)
+            deleted_count += len(results) - len(batch_errors)
 
         if self._entity_store is not None:
             await self._bulk_clear_entity_store(filters)
 
-        errors = [r for r in results if isinstance(r, BaseException)]
         if errors:
-            logger.warning("Failed to delete %d out of %d memories", len(errors), len(results))
+            logger.warning("Failed to delete %d out of %d memories", len(errors), len(processed_memory_ids))
             for err in errors:
                 logger.warning("Delete error: %s", err)
 
-        logger.info(f"Deleted {len(results) - len(errors)} memories")
+        logger.info(f"Deleted {deleted_count} memories")
 
-        decay_usage_notice = detect_decay_usage_from_delete_all(len(memories[0]))
+        decay_usage_notice = detect_decay_usage_from_delete_all(deleted_count)
         if decay_usage_notice:
             await display_decay_usage_notice_async(self, "async", "delete_all", *decay_usage_notice)
         else:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -280,7 +280,7 @@ def test_delete(memory_instance):
 
 def test_delete_all(memory_instance):
     mock_memories = [Mock(id="1"), Mock(id="2")]
-    memory_instance.vector_store.list = Mock(return_value=(mock_memories, None))
+    memory_instance.vector_store.list = Mock(side_effect=[(mock_memories, None), ([], None)])
     memory_instance.vector_store.reset = Mock()
     memory_instance._delete_memory = Mock()
 
@@ -291,6 +291,22 @@ def test_delete_all(memory_instance):
     memory_instance.vector_store.reset.assert_not_called()
 
     assert result["message"] == "Memories deleted successfully!"
+
+
+def test_delete_all_deletes_more_than_one_vector_store_page(memory_instance):
+    mock_memories = [Mock(id=str(index)) for index in range(101)]
+    memory_instance.vector_store.list = Mock(
+        side_effect=[(mock_memories[:100], "next-page"), (mock_memories[100:], None), ([], None)]
+    )
+    memory_instance._delete_memory = Mock()
+
+    result = memory_instance.delete_all(user_id="test_user")
+
+    assert result == {"message": "Memories deleted successfully!"}
+    assert memory_instance.vector_store.list.call_count == 3
+    assert [call.args[0] for call in memory_instance._delete_memory.call_args_list] == [
+        memory.id for memory in mock_memories
+    ]
 
 
 def test_get_all(memory_instance):

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,7 +1,7 @@
 import json
 import sys
 from datetime import datetime
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
@@ -1001,6 +1001,36 @@ async def test_async_delete_all_continues_on_partial_failure(mock_sqlite, mock_l
     assert mock_vector_store.delete.call_count == 2
 
 
+@pytest.mark.asyncio
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.main.SQLiteManager')
+async def test_async_delete_all_deletes_more_than_one_vector_store_page(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_store = MagicMock()
+    mock_vector_factory.return_value = mock_vector_store
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import AsyncMemory
+
+    memory = AsyncMemory(MemoryConfig())
+    mock_memories = [MagicMock(id=str(index)) for index in range(101)]
+    mock_vector_store.list.side_effect = [[mock_memories[:100]], [mock_memories[100:]], [[]]]
+    memory._delete_memory = AsyncMock()
+
+    result = await memory.delete_all(user_id="test-user")
+
+    assert result == {"message": "Memories deleted successfully!"}
+    assert mock_vector_store.list.call_count == 3
+    assert [call.args[0] for call in memory._delete_memory.await_args_list] == [
+        memory.id for memory in mock_memories
+    ]
+
+
 @patch('mem0.utils.factory.EmbedderFactory.create')
 @patch('mem0.utils.factory.VectorStoreFactory.create')
 @patch('mem0.utils.factory.LlmFactory.create')
@@ -1231,8 +1261,9 @@ class TestHybridSearchWarning:
     def test_warning_for_store_without_keyword_search(
         self, mock_vs_factory, mock_emb, mock_llm, mock_sqlite, _cap, caplog
     ):
-        from mem0.vector_stores.base import VectorStoreBase
         import logging
+
+        from mem0.vector_stores.base import VectorStoreBase
 
         class StoreWithoutKeywordSearch(VectorStoreBase):
             def create_col(self, *a, **kw): pass
@@ -1267,8 +1298,9 @@ class TestHybridSearchWarning:
     def test_no_warning_for_store_with_keyword_search(
         self, mock_vs_factory, mock_emb, mock_llm, mock_sqlite, _cap, caplog
     ):
-        from mem0.vector_stores.base import VectorStoreBase
         import logging
+
+        from mem0.vector_stores.base import VectorStoreBase
 
         class StoreWithKeywordSearch(VectorStoreBase):
             def keyword_search(self, query, top_k=5, filters=None):


### PR DESCRIPTION
  ## Description

  Fixes `Memory.delete_all()` and `AsyncMemory.delete_all()` deleting only the first page of matching memories.

  Vector store providers such as Qdrant and pgvector return at most 100 records by default. The previous implementation called `list()` once and
  returned a success response, leaving any additional matching memories undeleted.

  This change repeatedly lists and deletes batches until no unprocessed memories remain. It also tracks processed IDs to prevent infinite loops
  if a provider returns stale or repeated results.

  Async partial-failure handling and bulk entity cleanup behavior are preserved.

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Breaking change
  - [ ] Refactor
  - [ ] Documentation update

  ## Breaking Changes

  N/A

  ## Test Coverage

  - [x] Added sync regression coverage with 101 memories
  - [x] Added async regression coverage with 101 memories
  - [x] Verified existing async partial-failure and entity-cleanup behavior
  - [x] Ran the complete Python SDK test suite

  Full suite result:

  - 1,677 passed
  - 48 skipped
  - 0 failed

  ## Checklist

  - [x] My code follows the project's style guidelines
  - [x] I have performed a self-review of my code
  - [x] I have added tests that prove the fix
  - [x] New and existing tests pass locally
  - [x] Ruff and isort checks pass
  - [x] Documentation is not required because this does not change the public API
