### PR TITLE
Fix/openmemory mcp search acl deny all

### DIFF
--- a/openmemory/api/app/mcp_server.py
+++ b/openmemory/api/app/mcp_server.py
@@ -182,13 +182,13 @@ async def search_memory(query: str) -> str:
                 filters=filters,
             )
 
-            allowed = set(str(mid) for mid in accessible_memory_ids) if accessible_memory_ids else None
+            allowed = set(str(mid) for mid in accessible_memory_ids)
 
             results = []
             for h in hits:
                 # All vector db search functions return OutputData class
                 id, score, payload = h.id, h.score, h.payload
-                if allowed and (h.id is None or h.id not in allowed):
+                if h.id is None or h.id not in allowed:
                     continue
                 
                 results.append({

--- a/openmemory/api/app/mcp_server.py
+++ b/openmemory/api/app/mcp_server.py
@@ -22,7 +22,6 @@ import logging
 import uuid
 
 import anyio
-
 from app.database import SessionLocal
 from app.models import Memory, MemoryAccessLog, MemoryState, MemoryStatusHistory
 from app.utils.db import get_user_and_app
@@ -179,7 +178,7 @@ async def search_memory(query: str) -> str:
             hits = memory_client.vector_store.search(
                 query=query, 
                 vectors=embeddings, 
-                limit=10, 
+                top_k=10,
                 filters=filters,
             )
 
@@ -245,7 +244,7 @@ async def list_memories() -> str:
             user, app = get_user_and_app(db, user_id=uid, app_id=client_name)
 
             # Get all memories
-            memories = memory_client.get_all(user_id=uid)
+            memories = memory_client.get_all(filters={"user_id": uid})
             filtered_memories = []
 
             # Filter memories based on permissions
@@ -464,14 +463,15 @@ async def handle_sse(request: Request):
 
 @mcp_router.post("/messages/")
 async def handle_get_message(request: Request):
-    return await handle_post_message(request)
+    return await _handle_post_message(request)
 
 
 @mcp_router.post("/{client_name}/sse/{user_id}/messages/")
 async def handle_post_message(request: Request):
-    return await handle_post_message(request)
+    return await _handle_post_message(request)
 
-async def handle_post_message(request: Request):
+
+async def _handle_post_message(request: Request):
     """Handle POST messages for SSE"""
     try:
         body = await request.body()

--- a/openmemory/api/tests/test_mcp_server.py
+++ b/openmemory/api/tests/test_mcp_server.py
@@ -291,6 +291,52 @@ class TestStreamableHTTPProtocol:
         )
 
     @pytest.mark.asyncio
+    async def test_search_memory_returns_no_hits_when_acl_denies_all(self, client, monkeypatch):
+        from app import mcp_server
+
+        memory_ids = [uuid4(), uuid4()]
+        user = SimpleNamespace(id=uuid4())
+        app = SimpleNamespace(id=uuid4())
+        user_memories = [SimpleNamespace(id=memory_id) for memory_id in memory_ids]
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.all.return_value = user_memories
+        monkeypatch.setattr(mcp_server, "SessionLocal", MagicMock(return_value=db))
+        monkeypatch.setattr(mcp_server, "get_user_and_app", MagicMock(return_value=(user, app)))
+        check_permissions = MagicMock(return_value=False)
+        monkeypatch.setattr(mcp_server, "check_memory_access_permissions", check_permissions)
+
+        memory_client = MagicMock()
+        memory_client.embedding_model.embed.return_value = [0.1, 0.2, 0.3]
+        memory_client.vector_store.search.return_value = [
+            SimpleNamespace(
+                id=str(memory_id),
+                score=0.9,
+                payload={"data": f"Memory {index}", "hash": f"hash-{index}"},
+            )
+            for index, memory_id in enumerate(memory_ids)
+        ]
+        monkeypatch.setattr(mcp_server, "get_memory_client_safe", MagicMock(return_value=memory_client))
+
+        await client.post(
+            "/mcp/testclient/http/alice",
+            json=_initialize_payload(),
+            headers=MCP_HEADERS,
+        )
+        resp = await client.post(
+            "/mcp/testclient/http/alice",
+            json=_jsonrpc("tools/call", {"name": "search_memory", "arguments": {"query": "private"}}, req_id=2),
+            headers=MCP_HEADERS,
+        )
+
+        assert resp.status_code == 200
+        result = resp.json()["result"]
+        assert result.get("isError") is not True
+        assert json.loads(result["content"][0]["text"]) == {"results": []}
+        assert check_permissions.call_count == 2
+        db.add.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_list_memories_uses_filters(self, client, memory_tool_dependencies):
         memory_client, memory_id = memory_tool_dependencies
         memory_client.get_all.return_value = {

--- a/openmemory/api/tests/test_mcp_server.py
+++ b/openmemory/api/tests/test_mcp_server.py
@@ -5,16 +5,19 @@ transport.  Tests exercise the full JSON-RPC flow — initialize, tools/list,
 tools/call — as well as error handling and context-variable isolation.
 """
 
+import json
 import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from uuid import uuid4
 
 # Set dummy keys before any imports that trigger client initialization
 os.environ.setdefault("OPENAI_API_KEY", "test-key")
 
 import pytest
 import pytest_asyncio
-from httpx import ASGITransport, AsyncClient
-
 from app.mcp_server import client_name_var, mcp, mcp_router, user_id_var
+from httpx import ASGITransport, AsyncClient
 
 # MCP Streamable HTTP requires the Accept header to include application/json.
 # Including text/event-stream as well satisfies GET (SSE) requests.
@@ -43,6 +46,28 @@ async def client(test_app):
         yield ac
 
 
+@pytest.fixture
+def memory_tool_dependencies(monkeypatch):
+    """Mock the database and OSS memory client used by MCP memory tools."""
+    from app import mcp_server
+
+    memory_id = uuid4()
+    user = SimpleNamespace(id=uuid4())
+    app = SimpleNamespace(id=uuid4(), is_active=True)
+    memory = SimpleNamespace(id=memory_id)
+
+    db = MagicMock()
+    db.query.return_value.filter.return_value.all.return_value = [memory]
+    monkeypatch.setattr(mcp_server, "SessionLocal", MagicMock(return_value=db))
+    monkeypatch.setattr(mcp_server, "get_user_and_app", MagicMock(return_value=(user, app)))
+    monkeypatch.setattr(mcp_server, "check_memory_access_permissions", MagicMock(return_value=True))
+
+    memory_client = MagicMock()
+    monkeypatch.setattr(mcp_server, "get_memory_client_safe", MagicMock(return_value=memory_client))
+
+    return memory_client, memory_id
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -67,6 +92,23 @@ def _initialize_payload(req_id: int = 1) -> dict:
         },
         req_id=req_id,
     )
+
+
+def _registered_route_paths(app) -> list[str]:
+    """Return route paths across flattened and nested FastAPI routers."""
+    paths = []
+
+    def collect(routes):
+        for route in routes:
+            path = getattr(route, "path", None)
+            if path:
+                paths.append(path)
+            included_router = getattr(route, "original_router", None)
+            if included_router is not None:
+                collect(included_router.routes)
+
+    collect(app.routes)
+    return paths
 
 
 # ---------------------------------------------------------------------------
@@ -213,6 +255,64 @@ class TestStreamableHTTPProtocol:
         assert "error" in data or (
             "result" in data and data["result"].get("isError")
         )
+
+    @pytest.mark.asyncio
+    async def test_search_memory_uses_vector_store_top_k(self, client, memory_tool_dependencies):
+        memory_client, memory_id = memory_tool_dependencies
+        memory_client.embedding_model.embed.return_value = [0.1, 0.2, 0.3]
+        memory_client.vector_store.search.return_value = [
+            SimpleNamespace(
+                id=str(memory_id),
+                score=0.9,
+                payload={"data": "User likes hiking", "hash": "hash-1"},
+            )
+        ]
+
+        await client.post(
+            "/mcp/testclient/http/alice",
+            json=_initialize_payload(),
+            headers=MCP_HEADERS,
+        )
+        resp = await client.post(
+            "/mcp/testclient/http/alice",
+            json=_jsonrpc("tools/call", {"name": "search_memory", "arguments": {"query": "hiking"}}, req_id=2),
+            headers=MCP_HEADERS,
+        )
+
+        assert resp.status_code == 200
+        result = resp.json()["result"]
+        assert result.get("isError") is not True
+        assert json.loads(result["content"][0]["text"])["results"][0]["id"] == str(memory_id)
+        memory_client.vector_store.search.assert_called_once_with(
+            query="hiking",
+            vectors=[0.1, 0.2, 0.3],
+            top_k=10,
+            filters={"user_id": "alice"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_memories_uses_filters(self, client, memory_tool_dependencies):
+        memory_client, memory_id = memory_tool_dependencies
+        memory_client.get_all.return_value = {
+            "results": [{"id": str(memory_id), "memory": "User likes hiking", "hash": "hash-1"}]
+        }
+
+        await client.post(
+            "/mcp/testclient/http/alice",
+            json=_initialize_payload(),
+            headers=MCP_HEADERS,
+        )
+        resp = await client.post(
+            "/mcp/testclient/http/alice",
+            json=_jsonrpc("tools/call", {"name": "list_memories", "arguments": {}}, req_id=2),
+            headers=MCP_HEADERS,
+        )
+
+        assert resp.status_code == 200
+        result = resp.json()["result"]
+        assert result.get("isError") is not True
+        assert json.loads(result["content"][0]["text"])[0]["id"] == str(memory_id)
+        memory_client.get_all.assert_called_once_with(filters={"user_id": "alice"})
 
     @pytest.mark.asyncio
     async def test_unknown_jsonrpc_method(self, client):
@@ -384,13 +484,13 @@ class TestRouteRegistration:
     """Verify all expected routes are registered in the router."""
 
     def test_sse_route_is_registered(self, test_app):
-        routes = [r.path for r in test_app.routes if hasattr(r, "path")]
+        routes = _registered_route_paths(test_app)
         assert "/mcp/{client_name}/sse/{user_id}" in routes
 
     def test_sse_post_messages_route_is_registered(self, test_app):
-        routes = [r.path for r in test_app.routes if hasattr(r, "path")]
+        routes = _registered_route_paths(test_app)
         assert "/mcp/messages/" in routes or "/mcp/{client_name}/sse/{user_id}/messages/" in routes
 
     def test_streamable_http_route_is_registered(self, test_app):
-        routes = [r.path for r in test_app.routes if hasattr(r, "path")]
+        routes = _registered_route_paths(test_app)
         assert "/mcp/{client_name}/http/{user_id}" in routes


### PR DESCRIPTION
## Description

  This PR fixes a fail-open access-control bug in OpenMemory’s MCP search_memory tool.

  The tool builds a list of memory IDs accessible to the requesting application:

  accessible_memory_ids = [
      memory.id
      for memory in user_memories
      if check_memory_access_permissions(db, memory, app.id)
  ]

  Previously, an empty list was converted to None:

  allowed = set(str(mid) for mid in accessible_memory_ids) if accessible_memory_ids else None

  Search results were then filtered only when allowed was truthy:

  if allowed and (h.id is None or h.id not in allowed):
      continue

  When an application had an explicit deny-all ACL, accessible_memory_ids was empty. That produced allowed = None, disabled the filtering
  condition, and allowed every vector-search hit for the user to be returned.

  This PR changes the logic to always construct a set and always enforce membership:

  allowed = set(str(mid) for mid in accessible_memory_ids)

  if h.id is None or h.id not in allowed:
      continue

  An empty allowed set now correctly rejects every search result.

  ## Security Impact

  Before this change, an application with no permission to access any of a user’s memories could receive those memories through the MCP search
  tool.

  The issue was partly masked by the incompatible vector-store argument fixed in the preceding PR. Once MCP search uses the correct top_k
  argument, the ACL bypass becomes reachable.

  After this change:

  - Explicit deny-all ACLs return no memories.
  - Hits missing an ID are rejected.
  - Only vector hits whose IDs are present in the accessible-memory set are returned.
  - Rejected hits do not create memory access-log entries.

  ## Test Coverage

  Added an end-to-end MCP regression test that:

  1. Creates two user-owned memory records.
  2. Configures permission checks to deny access to both records.
  3. Makes the vector store return both records as search hits.
  4. Invokes search_memory through the MCP Streamable HTTP JSON-RPC flow.
  5. Verifies the response contains an empty results list.
  6. Verifies both permission checks occurred.
  7. Verifies no access-log records were written.

  The regression test failed before the implementation change because both denied memories were returned.

  After the fix:

  24 passed in 1.11s

  Command used:

  pytest openmemory/api/tests -q

  Code-quality checks:

  Ruff: passed
  isort: passed

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Refactor (no functional changes)
  - [ ] Documentation update

  ## Breaking Changes

  N/A. This restores the intended ACL behavior and does not change the public API.

  ## Test Coverage Checklist

  - [x] I added/updated unit tests
  - [ ] I added/updated integration tests
  - [x] I tested manually using the full OpenMemory API test suite
  - [ ] No tests needed

  ## Checklist

  - [x] My code follows the project's style guidelines
  - [x] I have performed a self-review of my code
  - [x] I have added tests that prove the fix works
  - [x] New and existing relevant tests pass locally
  - [x] Documentation is not required because this corrects internal ACL enforcement without changing the public API
