### PR TITLE
Fix/openmemory store mutation consistency

### DIFF
--- a/openmemory/api/app/mcp_server.py
+++ b/openmemory/api/app/mcp_server.py
@@ -292,6 +292,42 @@ async def list_memories() -> str:
         return f"Error getting memories: {e}"
 
 
+def _delete_memory_from_stores(db, memory_client, memory, user_id, app_id, access_type, operation):
+    memory_id = memory.id
+    try:
+        memory_client.delete(str(memory_id))
+    except Exception as delete_error:
+        raise RuntimeError(f"Failed to delete memory {memory_id} from vector store: {delete_error}") from delete_error
+
+    old_state = memory.state
+    memory.state = MemoryState.deleted
+    memory.deleted_at = datetime.datetime.now(datetime.UTC)
+    db.add(
+        MemoryStatusHistory(
+            memory_id=memory_id,
+            changed_by=user_id,
+            old_state=old_state,
+            new_state=MemoryState.deleted,
+        )
+    )
+    db.add(
+        MemoryAccessLog(
+            memory_id=memory_id,
+            app_id=app_id,
+            access_type=access_type,
+            metadata_={"operation": operation},
+        )
+    )
+
+    try:
+        db.commit()
+    except Exception as db_error:
+        db.rollback()
+        raise RuntimeError(
+            f"Memory {memory_id} was deleted from vector store but its SQL state could not be updated"
+        ) from db_error
+
+
 @mcp.tool(description="Delete specific memories by their IDs")
 async def delete_memories(memory_ids: list[str]) -> str:
     uid = user_id_var.get(None)
@@ -315,50 +351,40 @@ async def delete_memories(memory_ids: list[str]) -> str:
             # Convert string IDs to UUIDs and filter accessible ones
             requested_ids = [uuid.UUID(mid) for mid in memory_ids]
             user_memories = db.query(Memory).filter(Memory.user_id == user.id).all()
-            accessible_memory_ids = [memory.id for memory in user_memories if check_memory_access_permissions(db, memory, app.id)]
+            accessible_memories = [
+                memory for memory in user_memories if check_memory_access_permissions(db, memory, app.id)
+            ]
+            accessible_memories_by_id = {memory.id: memory for memory in accessible_memories}
 
             # Only delete memories that are both requested and accessible
-            ids_to_delete = [mid for mid in requested_ids if mid in accessible_memory_ids]
+            memories_to_delete = [
+                accessible_memories_by_id[mid] for mid in requested_ids if mid in accessible_memories_by_id
+            ]
 
-            if not ids_to_delete:
+            if not memories_to_delete:
                 return "Error: No accessible memories found with provided IDs"
 
-            # Delete from vector store
-            for memory_id in ids_to_delete:
+            # Delete each vector before committing the corresponding SQL state.
+            deleted_count = 0
+            for memory in memories_to_delete:
                 try:
-                    memory_client.delete(str(memory_id))
+                    _delete_memory_from_stores(
+                        db,
+                        memory_client,
+                        memory,
+                        user.id,
+                        app.id,
+                        "delete",
+                        "delete_by_id",
+                    )
                 except Exception as delete_error:
-                    logging.warning(f"Failed to delete memory {memory_id} from vector store: {delete_error}")
+                    raise RuntimeError(
+                        f"Delete stopped after {deleted_count} successful deletions: {delete_error}"
+                    ) from delete_error
 
-            # Update each memory's state and create history entries
-            now = datetime.datetime.now(datetime.UTC)
-            for memory_id in ids_to_delete:
-                memory = db.query(Memory).filter(Memory.id == memory_id).first()
-                if memory:
-                    # Update memory state
-                    memory.state = MemoryState.deleted
-                    memory.deleted_at = now
+                deleted_count += 1
 
-                    # Create history entry
-                    history = MemoryStatusHistory(
-                        memory_id=memory_id,
-                        changed_by=user.id,
-                        old_state=MemoryState.active,
-                        new_state=MemoryState.deleted
-                    )
-                    db.add(history)
-
-                    # Create access log entry
-                    access_log = MemoryAccessLog(
-                        memory_id=memory_id,
-                        app_id=app.id,
-                        access_type="delete",
-                        metadata_={"operation": "delete_by_id"}
-                    )
-                    db.add(access_log)
-
-            db.commit()
-            return f"Successfully deleted {len(ids_to_delete)} memories"
+            return f"Successfully deleted {deleted_count} memories"
         finally:
             db.close()
     except Exception as e:
@@ -387,42 +413,30 @@ async def delete_all_memories() -> str:
             user, app = get_user_and_app(db, user_id=uid, app_id=client_name)
 
             user_memories = db.query(Memory).filter(Memory.user_id == user.id).all()
-            accessible_memory_ids = [memory.id for memory in user_memories if check_memory_access_permissions(db, memory, app.id)]
+            accessible_memories = [
+                memory for memory in user_memories if check_memory_access_permissions(db, memory, app.id)
+            ]
 
-            # delete the accessible memories only
-            for memory_id in accessible_memory_ids:
+            # Delete each vector before committing the corresponding SQL state.
+            deleted_count = 0
+            for memory in accessible_memories:
                 try:
-                    memory_client.delete(str(memory_id))
+                    _delete_memory_from_stores(
+                        db,
+                        memory_client,
+                        memory,
+                        user.id,
+                        app.id,
+                        "delete_all",
+                        "bulk_delete",
+                    )
                 except Exception as delete_error:
-                    logging.warning(f"Failed to delete memory {memory_id} from vector store: {delete_error}")
+                    raise RuntimeError(
+                        f"Delete stopped after {deleted_count} successful deletions: {delete_error}"
+                    ) from delete_error
 
-            # Update each memory's state and create history entries
-            now = datetime.datetime.now(datetime.UTC)
-            for memory_id in accessible_memory_ids:
-                memory = db.query(Memory).filter(Memory.id == memory_id).first()
-                # Update memory state
-                memory.state = MemoryState.deleted
-                memory.deleted_at = now
+                deleted_count += 1
 
-                # Create history entry
-                history = MemoryStatusHistory(
-                    memory_id=memory_id,
-                    changed_by=user.id,
-                    old_state=MemoryState.active,
-                    new_state=MemoryState.deleted
-                )
-                db.add(history)
-
-                # Create access log entry
-                access_log = MemoryAccessLog(
-                    memory_id=memory_id,
-                    app_id=app.id,
-                    access_type="delete_all",
-                    metadata_={"operation": "bulk_delete"}
-                )
-                db.add(access_log)
-
-            db.commit()
             return "Successfully deleted all memories"
         finally:
             db.close()

--- a/openmemory/api/app/mcp_server.py
+++ b/openmemory/api/app/mcp_server.py
@@ -182,13 +182,13 @@ async def search_memory(query: str) -> str:
                 filters=filters,
             )
 
-            allowed = set(str(mid) for mid in accessible_memory_ids) if accessible_memory_ids else None
+            allowed = set(str(mid) for mid in accessible_memory_ids)
 
             results = []
             for h in hits:
                 # All vector db search functions return OutputData class
                 id, score, payload = h.id, h.score, h.payload
-                if allowed and (h.id is None or h.id not in allowed):
+                if h.id is None or h.id not in allowed:
                     continue
                 
                 results.append({

--- a/openmemory/api/app/mcp_server.py
+++ b/openmemory/api/app/mcp_server.py
@@ -22,7 +22,6 @@ import logging
 import uuid
 
 import anyio
-
 from app.database import SessionLocal
 from app.models import Memory, MemoryAccessLog, MemoryState, MemoryStatusHistory
 from app.utils.db import get_user_and_app
@@ -179,7 +178,7 @@ async def search_memory(query: str) -> str:
             hits = memory_client.vector_store.search(
                 query=query, 
                 vectors=embeddings, 
-                limit=10, 
+                top_k=10,
                 filters=filters,
             )
 
@@ -245,7 +244,7 @@ async def list_memories() -> str:
             user, app = get_user_and_app(db, user_id=uid, app_id=client_name)
 
             # Get all memories
-            memories = memory_client.get_all(user_id=uid)
+            memories = memory_client.get_all(filters={"user_id": uid})
             filtered_memories = []
 
             # Filter memories based on permissions
@@ -464,14 +463,15 @@ async def handle_sse(request: Request):
 
 @mcp_router.post("/messages/")
 async def handle_get_message(request: Request):
-    return await handle_post_message(request)
+    return await _handle_post_message(request)
 
 
 @mcp_router.post("/{client_name}/sse/{user_id}/messages/")
 async def handle_post_message(request: Request):
-    return await handle_post_message(request)
+    return await _handle_post_message(request)
 
-async def handle_post_message(request: Request):
+
+async def _handle_post_message(request: Request):
     """Handle POST messages for SSE"""
     try:
         body = await request.body()

--- a/openmemory/api/app/routers/memories.py
+++ b/openmemory/api/app/routers/memories.py
@@ -378,16 +378,38 @@ async def delete_memories(
             detail=f"Memory service unavailable: {str(client_error)}"
         )
 
-    # Delete from vector store then mark as deleted in database
-    for memory_id in request.memory_ids:
+    memories = [get_memory_or_404(db, memory_id) for memory_id in request.memory_ids]
+
+    # Delete each vector before marking the corresponding SQL row as deleted.
+    deleted_count = 0
+    for memory in memories:
         try:
-            memory_client.delete(str(memory_id))
+            memory_client.delete(str(memory.id))
         except Exception as delete_error:
-            logging.warning(f"Failed to delete memory {memory_id} from vector store: {delete_error}")
+            logging.error(f"Failed to delete memory {memory.id} from vector store: {delete_error}")
+            raise HTTPException(
+                status_code=502,
+                detail=(
+                    f"Failed to delete memory {memory.id} from vector store after "
+                    f"{deleted_count} successful deletions: {delete_error}"
+                ),
+            ) from delete_error
 
-        update_memory_state(db, memory_id, MemoryState.deleted, user.id)
+        try:
+            update_memory_state(db, memory.id, MemoryState.deleted, user.id)
+        except HTTPException:
+            raise
+        except Exception as db_error:
+            db.rollback()
+            logging.error(f"Memory {memory.id} was deleted from vector store but SQL update failed: {db_error}")
+            raise HTTPException(
+                status_code=500,
+                detail=f"Memory {memory.id} was deleted from vector store but its SQL state could not be updated",
+            ) from db_error
 
-    return {"message": f"Successfully deleted {len(request.memory_ids)} memories"}
+        deleted_count += 1
+
+    return {"message": f"Successfully deleted {deleted_count} memories"}
 
 
 # Archive memories
@@ -524,8 +546,53 @@ async def update_memory(
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
     memory = get_memory_or_404(db, memory_id)
+
+    try:
+        memory_client = get_memory_client()
+        if not memory_client:
+            raise HTTPException(status_code=503, detail="Memory client is not available")
+    except HTTPException:
+        raise
+    except Exception as client_error:
+        logging.error(f"Memory client initialization failed: {client_error}")
+        raise HTTPException(
+            status_code=503,
+            detail=f"Memory service unavailable: {str(client_error)}",
+        ) from client_error
+
+    old_content = memory.content
+    try:
+        memory_client.update(str(memory_id), text=request.memory_content)
+    except Exception as update_error:
+        logging.error(f"Failed to update memory {memory_id} in vector store: {update_error}")
+        raise HTTPException(
+            status_code=502,
+            detail=f"Failed to update memory {memory_id} in vector store: {update_error}",
+        ) from update_error
+
     memory.content = request.memory_content
-    db.commit()
+    try:
+        db.commit()
+    except Exception as db_error:
+        db.rollback()
+        try:
+            memory_client.update(str(memory_id), text=old_content)
+        except Exception as compensation_error:
+            logging.exception(
+                f"Failed to restore memory {memory_id} in vector store after SQL update failed: {compensation_error}"
+            )
+            raise HTTPException(
+                status_code=500,
+                detail=(
+                    f"SQL update failed for memory {memory_id}, and its vector-store update could not be restored"
+                ),
+            ) from db_error
+
+        raise HTTPException(
+            status_code=500,
+            detail=f"SQL update failed for memory {memory_id}; the vector-store update was restored",
+        ) from db_error
+
     db.refresh(memory)
     return memory
 

--- a/openmemory/api/tests/test_mcp_server.py
+++ b/openmemory/api/tests/test_mcp_server.py
@@ -291,6 +291,52 @@ class TestStreamableHTTPProtocol:
         )
 
     @pytest.mark.asyncio
+    async def test_search_memory_returns_no_hits_when_acl_denies_all(self, client, monkeypatch):
+        from app import mcp_server
+
+        memory_ids = [uuid4(), uuid4()]
+        user = SimpleNamespace(id=uuid4())
+        app = SimpleNamespace(id=uuid4())
+        user_memories = [SimpleNamespace(id=memory_id) for memory_id in memory_ids]
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.all.return_value = user_memories
+        monkeypatch.setattr(mcp_server, "SessionLocal", MagicMock(return_value=db))
+        monkeypatch.setattr(mcp_server, "get_user_and_app", MagicMock(return_value=(user, app)))
+        check_permissions = MagicMock(return_value=False)
+        monkeypatch.setattr(mcp_server, "check_memory_access_permissions", check_permissions)
+
+        memory_client = MagicMock()
+        memory_client.embedding_model.embed.return_value = [0.1, 0.2, 0.3]
+        memory_client.vector_store.search.return_value = [
+            SimpleNamespace(
+                id=str(memory_id),
+                score=0.9,
+                payload={"data": f"Memory {index}", "hash": f"hash-{index}"},
+            )
+            for index, memory_id in enumerate(memory_ids)
+        ]
+        monkeypatch.setattr(mcp_server, "get_memory_client_safe", MagicMock(return_value=memory_client))
+
+        await client.post(
+            "/mcp/testclient/http/alice",
+            json=_initialize_payload(),
+            headers=MCP_HEADERS,
+        )
+        resp = await client.post(
+            "/mcp/testclient/http/alice",
+            json=_jsonrpc("tools/call", {"name": "search_memory", "arguments": {"query": "private"}}, req_id=2),
+            headers=MCP_HEADERS,
+        )
+
+        assert resp.status_code == 200
+        result = resp.json()["result"]
+        assert result.get("isError") is not True
+        assert json.loads(result["content"][0]["text"]) == {"results": []}
+        assert check_permissions.call_count == 2
+        db.add.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_list_memories_uses_filters(self, client, memory_tool_dependencies):
         memory_client, memory_id = memory_tool_dependencies
         memory_client.get_all.return_value = {

--- a/openmemory/api/tests/test_mcp_server.py
+++ b/openmemory/api/tests/test_mcp_server.py
@@ -5,16 +5,19 @@ transport.  Tests exercise the full JSON-RPC flow — initialize, tools/list,
 tools/call — as well as error handling and context-variable isolation.
 """
 
+import json
 import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from uuid import uuid4
 
 # Set dummy keys before any imports that trigger client initialization
 os.environ.setdefault("OPENAI_API_KEY", "test-key")
 
 import pytest
 import pytest_asyncio
-from httpx import ASGITransport, AsyncClient
-
 from app.mcp_server import client_name_var, mcp, mcp_router, user_id_var
+from httpx import ASGITransport, AsyncClient
 
 # MCP Streamable HTTP requires the Accept header to include application/json.
 # Including text/event-stream as well satisfies GET (SSE) requests.
@@ -43,6 +46,28 @@ async def client(test_app):
         yield ac
 
 
+@pytest.fixture
+def memory_tool_dependencies(monkeypatch):
+    """Mock the database and OSS memory client used by MCP memory tools."""
+    from app import mcp_server
+
+    memory_id = uuid4()
+    user = SimpleNamespace(id=uuid4())
+    app = SimpleNamespace(id=uuid4(), is_active=True)
+    memory = SimpleNamespace(id=memory_id)
+
+    db = MagicMock()
+    db.query.return_value.filter.return_value.all.return_value = [memory]
+    monkeypatch.setattr(mcp_server, "SessionLocal", MagicMock(return_value=db))
+    monkeypatch.setattr(mcp_server, "get_user_and_app", MagicMock(return_value=(user, app)))
+    monkeypatch.setattr(mcp_server, "check_memory_access_permissions", MagicMock(return_value=True))
+
+    memory_client = MagicMock()
+    monkeypatch.setattr(mcp_server, "get_memory_client_safe", MagicMock(return_value=memory_client))
+
+    return memory_client, memory_id
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -67,6 +92,23 @@ def _initialize_payload(req_id: int = 1) -> dict:
         },
         req_id=req_id,
     )
+
+
+def _registered_route_paths(app) -> list[str]:
+    """Return route paths across flattened and nested FastAPI routers."""
+    paths = []
+
+    def collect(routes):
+        for route in routes:
+            path = getattr(route, "path", None)
+            if path:
+                paths.append(path)
+            included_router = getattr(route, "original_router", None)
+            if included_router is not None:
+                collect(included_router.routes)
+
+    collect(app.routes)
+    return paths
 
 
 # ---------------------------------------------------------------------------
@@ -213,6 +255,64 @@ class TestStreamableHTTPProtocol:
         assert "error" in data or (
             "result" in data and data["result"].get("isError")
         )
+
+    @pytest.mark.asyncio
+    async def test_search_memory_uses_vector_store_top_k(self, client, memory_tool_dependencies):
+        memory_client, memory_id = memory_tool_dependencies
+        memory_client.embedding_model.embed.return_value = [0.1, 0.2, 0.3]
+        memory_client.vector_store.search.return_value = [
+            SimpleNamespace(
+                id=str(memory_id),
+                score=0.9,
+                payload={"data": "User likes hiking", "hash": "hash-1"},
+            )
+        ]
+
+        await client.post(
+            "/mcp/testclient/http/alice",
+            json=_initialize_payload(),
+            headers=MCP_HEADERS,
+        )
+        resp = await client.post(
+            "/mcp/testclient/http/alice",
+            json=_jsonrpc("tools/call", {"name": "search_memory", "arguments": {"query": "hiking"}}, req_id=2),
+            headers=MCP_HEADERS,
+        )
+
+        assert resp.status_code == 200
+        result = resp.json()["result"]
+        assert result.get("isError") is not True
+        assert json.loads(result["content"][0]["text"])["results"][0]["id"] == str(memory_id)
+        memory_client.vector_store.search.assert_called_once_with(
+            query="hiking",
+            vectors=[0.1, 0.2, 0.3],
+            top_k=10,
+            filters={"user_id": "alice"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_memories_uses_filters(self, client, memory_tool_dependencies):
+        memory_client, memory_id = memory_tool_dependencies
+        memory_client.get_all.return_value = {
+            "results": [{"id": str(memory_id), "memory": "User likes hiking", "hash": "hash-1"}]
+        }
+
+        await client.post(
+            "/mcp/testclient/http/alice",
+            json=_initialize_payload(),
+            headers=MCP_HEADERS,
+        )
+        resp = await client.post(
+            "/mcp/testclient/http/alice",
+            json=_jsonrpc("tools/call", {"name": "list_memories", "arguments": {}}, req_id=2),
+            headers=MCP_HEADERS,
+        )
+
+        assert resp.status_code == 200
+        result = resp.json()["result"]
+        assert result.get("isError") is not True
+        assert json.loads(result["content"][0]["text"])[0]["id"] == str(memory_id)
+        memory_client.get_all.assert_called_once_with(filters={"user_id": "alice"})
 
     @pytest.mark.asyncio
     async def test_unknown_jsonrpc_method(self, client):
@@ -384,13 +484,13 @@ class TestRouteRegistration:
     """Verify all expected routes are registered in the router."""
 
     def test_sse_route_is_registered(self, test_app):
-        routes = [r.path for r in test_app.routes if hasattr(r, "path")]
+        routes = _registered_route_paths(test_app)
         assert "/mcp/{client_name}/sse/{user_id}" in routes
 
     def test_sse_post_messages_route_is_registered(self, test_app):
-        routes = [r.path for r in test_app.routes if hasattr(r, "path")]
+        routes = _registered_route_paths(test_app)
         assert "/mcp/messages/" in routes or "/mcp/{client_name}/sse/{user_id}/messages/" in routes
 
     def test_streamable_http_route_is_registered(self, test_app):
-        routes = [r.path for r in test_app.routes if hasattr(r, "path")]
+        routes = _registered_route_paths(test_app)
         assert "/mcp/{client_name}/http/{user_id}" in routes

--- a/openmemory/api/tests/test_mcp_server.py
+++ b/openmemory/api/tests/test_mcp_server.py
@@ -361,6 +361,57 @@ class TestStreamableHTTPProtocol:
         memory_client.get_all.assert_called_once_with(filters={"user_id": "alice"})
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("tool_name", "arguments"),
+        [
+            ("delete_memories", lambda memory_id: {"memory_ids": [str(memory_id)]}),
+            ("delete_all_memories", lambda _memory_id: {}),
+        ],
+    )
+    async def test_delete_tools_preserve_sql_when_vector_delete_fails(
+        self, client, monkeypatch, tool_name, arguments
+    ):
+        from app import mcp_server
+
+        memory_id = uuid4()
+        user = SimpleNamespace(id=uuid4())
+        app = SimpleNamespace(id=uuid4())
+        memory = SimpleNamespace(id=memory_id, state=mcp_server.MemoryState.active, deleted_at=None)
+        db = MagicMock()
+        db.query.return_value.filter.return_value.all.return_value = [memory]
+        monkeypatch.setattr(mcp_server, "SessionLocal", MagicMock(return_value=db))
+        monkeypatch.setattr(mcp_server, "get_user_and_app", MagicMock(return_value=(user, app)))
+        monkeypatch.setattr(mcp_server, "check_memory_access_permissions", MagicMock(return_value=True))
+
+        memory_client = MagicMock()
+        memory_client.delete.side_effect = RuntimeError("vector unavailable")
+        monkeypatch.setattr(mcp_server, "get_memory_client_safe", MagicMock(return_value=memory_client))
+
+        await client.post(
+            "/mcp/testclient/http/alice",
+            json=_initialize_payload(),
+            headers=MCP_HEADERS,
+        )
+        resp = await client.post(
+            "/mcp/testclient/http/alice",
+            json=_jsonrpc(
+                "tools/call",
+                {"name": tool_name, "arguments": arguments(memory_id)},
+                req_id=2,
+            ),
+            headers=MCP_HEADERS,
+        )
+
+        assert resp.status_code == 200
+        text = resp.json()["result"]["content"][0]["text"]
+        assert text.startswith("Error deleting memories:")
+        assert "vector unavailable" in text
+        assert memory.state == mcp_server.MemoryState.active
+        assert memory.deleted_at is None
+        db.add.assert_not_called()
+        db.commit.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_unknown_jsonrpc_method(self, client):
         """An unknown JSON-RPC method should return an error."""
         resp = await client.post(

--- a/openmemory/api/tests/test_memories_router.py
+++ b/openmemory/api/tests/test_memories_router.py
@@ -1,0 +1,103 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call
+from uuid import uuid4
+
+import pytest
+from app.models import MemoryState
+from app.routers import memories as memories_router
+from fastapi import HTTPException
+
+
+@pytest.mark.asyncio
+async def test_update_memory_updates_vector_store_before_sql(monkeypatch):
+    memory_id = uuid4()
+    user = SimpleNamespace(id=uuid4())
+    memory = SimpleNamespace(id=memory_id, content="Old content")
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = user
+    memory_client = MagicMock()
+
+    monkeypatch.setattr(memories_router, "get_memory_or_404", MagicMock(return_value=memory))
+    monkeypatch.setattr(memories_router, "get_memory_client", MagicMock(return_value=memory_client))
+
+    request = memories_router.UpdateMemoryRequest(memory_content="New content", user_id="alice")
+    result = await memories_router.update_memory(memory_id, request, db)
+
+    memory_client.update.assert_called_once_with(str(memory_id), text="New content")
+    assert memory.content == "New content"
+    db.commit.assert_called_once_with()
+    db.refresh.assert_called_once_with(memory)
+    assert result is memory
+
+
+@pytest.mark.asyncio
+async def test_update_memory_preserves_sql_when_vector_update_fails(monkeypatch):
+    memory_id = uuid4()
+    user = SimpleNamespace(id=uuid4())
+    memory = SimpleNamespace(id=memory_id, content="Old content")
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = user
+    memory_client = MagicMock()
+    memory_client.update.side_effect = RuntimeError("vector unavailable")
+
+    monkeypatch.setattr(memories_router, "get_memory_or_404", MagicMock(return_value=memory))
+    monkeypatch.setattr(memories_router, "get_memory_client", MagicMock(return_value=memory_client))
+
+    request = memories_router.UpdateMemoryRequest(memory_content="New content", user_id="alice")
+    with pytest.raises(HTTPException) as exc_info:
+        await memories_router.update_memory(memory_id, request, db)
+
+    assert exc_info.value.status_code == 502
+    assert "vector store" in exc_info.value.detail
+    assert memory.content == "Old content"
+    db.commit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_update_memory_restores_vector_when_sql_commit_fails(monkeypatch):
+    memory_id = uuid4()
+    user = SimpleNamespace(id=uuid4())
+    memory = SimpleNamespace(id=memory_id, content="Old content")
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = user
+    db.commit.side_effect = RuntimeError("database unavailable")
+    memory_client = MagicMock()
+
+    monkeypatch.setattr(memories_router, "get_memory_or_404", MagicMock(return_value=memory))
+    monkeypatch.setattr(memories_router, "get_memory_client", MagicMock(return_value=memory_client))
+
+    request = memories_router.UpdateMemoryRequest(memory_content="New content", user_id="alice")
+    with pytest.raises(HTTPException) as exc_info:
+        await memories_router.update_memory(memory_id, request, db)
+
+    assert exc_info.value.status_code == 500
+    assert memory_client.update.call_args_list == [
+        call(str(memory_id), text="New content"),
+        call(str(memory_id), text="Old content"),
+    ]
+    db.rollback.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_delete_memories_preserves_sql_when_vector_delete_fails(monkeypatch):
+    memory_id = uuid4()
+    user = SimpleNamespace(id=uuid4())
+    memory = SimpleNamespace(id=memory_id, state=MemoryState.active)
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = user
+    memory_client = MagicMock()
+    memory_client.delete.side_effect = RuntimeError("vector unavailable")
+    update_memory_state = MagicMock()
+
+    monkeypatch.setattr(memories_router, "get_memory_or_404", MagicMock(return_value=memory))
+    monkeypatch.setattr(memories_router, "get_memory_client", MagicMock(return_value=memory_client))
+    monkeypatch.setattr(memories_router, "update_memory_state", update_memory_state)
+
+    request = memories_router.DeleteMemoriesRequest(memory_ids=[memory_id], user_id="alice")
+    with pytest.raises(HTTPException) as exc_info:
+        await memories_router.delete_memories(request, db)
+
+    assert exc_info.value.status_code == 502
+    assert "vector store" in exc_info.value.detail
+    update_memory_state.assert_not_called()
+    assert memory.state == MemoryState.active


### PR DESCRIPTION
## Description

  This PR prevents OpenMemory’s SQL database and Mem0 vector store from silently diverging during memory updates and deletions.

  Previously:

  - Updating a memory changed only Memory.content in SQL.
  - The vector embedding and vector payload retained the previous content.
  - REST and MCP delete paths caught vector-store exceptions and continued.
  - SQL rows were marked as deleted even when their vectors were still present.
  - Delete operations returned success despite incomplete storage mutations.

  This could cause updated memories to remain searchable using their old meaning and deleted memories to continue appearing in semantic search.

  ## Update Behavior

  The REST update_memory endpoint now updates the Mem0 vector store before committing the new SQL content:

  memory_client.update(str(memory_id), text=request.memory_content)

  The operation follows these semantics:

  1. Load the existing SQL memory and retain its old content.
  2. Update the vector store, including the embedding and vector payload.
  3. If the vector update fails:
      - Return HTTP 502.
      - Leave SQL unchanged.

  4. If the vector update succeeds:
      - Update and commit the SQL content.

  5. If the SQL commit fails:
      - Roll back the SQL transaction.
      - Attempt to restore the vector store using the old content.
      - Return HTTP 500 explaining whether compensation succeeded.

  This prevents a reported-success update from changing only one store.

  ## Delete Behavior

  The REST and MCP delete paths now delete each vector before marking its corresponding SQL row as deleted.

  For every memory:

  1. Delete the memory through memory_client.delete().
  2. Stop immediately if vector deletion fails.
  3. Only after successful vector deletion:
      - Mark the SQL memory as deleted.
      - Record the deletion timestamp.
      - Add the state-history record.
      - Add the MCP access-log record where applicable.
      - Commit that memory’s SQL mutation.

  This ordering ensures a vector deletion failure cannot cause the SQL row to be marked deleted.

  ### Batch Failure Semantics

  Batch deletions are processed and committed one memory at a time.

  If a later deletion fails:

  - Earlier successfully completed memories remain consistently deleted from both stores.
  - The failed memory remains active in SQL.
  - Processing stops immediately.
  - The response reports how many deletions completed before the failure.
  - The operation no longer returns a false success response.

  ### SQL Failure After Vector Deletion

  Vector deletion is irreversible through the current public memory-client API while preserving the original memory ID.

  If vector deletion succeeds but the SQL commit fails:

  - The SQL transaction is rolled back.
  - The API returns an explicit HTTP 500 or MCP error message.
  - The error states that the vector was deleted but SQL could not be updated.

  This edge case cannot be compensated safely without an outbox/reconciliation mechanism, but it is no longer hidden behind a success response.

  ## Additional Corrections

  Deletion history records now use the memory’s actual previous state:

  old_state = memory.state

  Previously, MCP deletion always recorded MemoryState.active, even if the memory was paused or archived.

  The MCP delete implementations also share a private helper so specific and delete-all operations use the same ordering, logging, history, and
  rollback behavior.

  ## Error Responses

  The REST API now returns:

  - 502 Bad Gateway when a vector update or deletion fails.
  - 500 Internal Server Error when SQL persistence fails after an external store mutation.
  - 503 Service Unavailable when the memory client cannot be initialized.

  MCP delete tools now return an error string containing:

  - The failed operation.
  - The affected memory.
  - The underlying vector-store failure.
  - The number of memories successfully deleted before a batch failure.

  They no longer return Successfully deleted... after a failed vector operation.

  ## Test Coverage

  Added six regression cases covering the affected behavior.

  ### REST Update Tests

  - Verifies successful updates call memory_client.update() with the new content.
  - Verifies SQL is committed only after the vector update succeeds.
  - Verifies vector-update failure returns 502 and leaves SQL unchanged.
  - Verifies SQL-commit failure rolls SQL back and restores the previous vector content.

  ### REST Delete Test

  - Verifies vector-deletion failure returns 502.
  - Verifies SQL state mutation is not attempted after the failure.
  - Verifies the memory remains active.

  ### MCP Delete Tests

  The test invokes both tools through the real MCP Streamable HTTP JSON-RPC flow:

  - delete_memories
  - delete_all_memories

  For both tools, it verifies:

  - Vector-store failure produces an error response.
  - The error includes the original failure.
  - The SQL memory remains active.
  - No deletion timestamp is written.
  - No history or access-log rows are added.
  - No SQL commit occurs.

  ## Verification

  Full OpenMemory API test suite:

  pytest openmemory/api/tests -q

  Result:

  30 passed in 1.02s

  One existing Pydantic v1-style validator deprecation warning remains unrelated to this change.

  Code-quality checks:

  Ruff: passed
  isort: passed

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Refactor (no functional changes)
  - [ ] Documentation update

  ## Breaking Changes

  N/A.

  The public request and response schemas remain unchanged. Failed mutations now return errors instead of incorrectly reporting success.

  ## Test Coverage Checklist

  - [x] I added/updated unit tests
  - [x] I added MCP tool-call regression coverage
  - [x] I tested manually using the complete OpenMemory API test suite
  - [ ] No tests needed

  ## Checklist

  - [x] My code follows the project's style guidelines
  - [x] I have performed a self-review of the code
  - [x] I have added tests that prove the fix works
  - [x] New and existing relevant tests pass locally
  - [x] Ruff and isort pass
  - [x] Documentation is not required because the public API schema is unchanged
