### PR TITLE
fix(memory): fill top-k after expiration filtering

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -83,11 +83,23 @@ logger = logging.getLogger(__name__)
 
 
 def _vector_store_list_rows(listed):
-    if isinstance(listed, (list, tuple)) and listed and isinstance(listed[0], list):
+    if isinstance(listed, (list, tuple)) and listed and isinstance(listed[0], (list, tuple)):
         return listed[0]
     if isinstance(listed, (list, tuple)):
         return listed
     return []
+
+
+def _should_fetch_more_for_expiration(rows, requested_limit, target_count, previous_count):
+    """Return whether increasing top_k may reveal enough non-expired rows."""
+    active_count = 0
+    for row in rows:
+        payload = row.payload if hasattr(row, "payload") else row.get("payload", {})
+        if not _payload_is_expired(payload):
+            active_count += 1
+
+    row_count = len(rows)
+    return active_count < target_count and row_count >= requested_limit and row_count > previous_count
 
 
 # Fields that hold runtime auth/connection objects and must be preserved.
@@ -1280,20 +1292,20 @@ class Memory(MemoryBase):
         return {"results": all_memories_result}
 
     def _get_all_from_vector_store(self, filters, limit, show_expired=False, output_limit=None):
-        memories_result = self.vector_store.list(filters=filters, top_k=limit)
+        previous_count = 0
+        while True:
+            memories_result = self.vector_store.list(filters=filters, top_k=limit)
+            actual_memories = _vector_store_list_rows(memories_result)
 
-        # Handle different vector store return formats by inspecting first element
-        if isinstance(memories_result, (tuple, list)) and len(memories_result) > 0:
-            first_element = memories_result[0]
+            if (
+                show_expired
+                or output_limit is None
+                or not _should_fetch_more_for_expiration(actual_memories, limit, output_limit, previous_count)
+            ):
+                break
 
-            # If first element is a container, unwrap one level
-            if isinstance(first_element, (list, tuple)):
-                actual_memories = first_element
-            else:
-                # First element is a memory object, structure is already flat
-                actual_memories = memories_result
-        else:
-            actual_memories = memories_result
+            previous_count = len(actual_memories)
+            limit *= 2
 
         promoted_payload_keys = [
             "user_id",
@@ -1595,9 +1607,18 @@ class Memory(MemoryBase):
 
         # Step 3: Semantic search (over-fetch for scoring pool)
         internal_limit = max(limit * 4, 60)
-        semantic_results = self.vector_store.search(
-            query=query, vectors=embeddings, top_k=internal_limit, filters=filters
-        )
+        previous_count = 0
+        while True:
+            semantic_results = self.vector_store.search(
+                query=query, vectors=embeddings, top_k=internal_limit, filters=filters
+            )
+            if show_expired or not _should_fetch_more_for_expiration(
+                semantic_results, internal_limit, limit, previous_count
+            ):
+                break
+
+            previous_count = len(semantic_results)
+            internal_limit *= 2
 
         # Step 4: Keyword search (if store supports it)
         keyword_results = self.vector_store.keyword_search(
@@ -2914,20 +2935,20 @@ class AsyncMemory(MemoryBase):
         return {"results": all_memories_result}
 
     async def _get_all_from_vector_store(self, filters, limit, show_expired=False, output_limit=None):
-        memories_result = await asyncio.to_thread(self.vector_store.list, filters=filters, top_k=limit)
+        previous_count = 0
+        while True:
+            memories_result = await asyncio.to_thread(self.vector_store.list, filters=filters, top_k=limit)
+            actual_memories = _vector_store_list_rows(memories_result)
 
-        # Handle different vector store return formats by inspecting first element
-        if isinstance(memories_result, (tuple, list)) and len(memories_result) > 0:
-            first_element = memories_result[0]
+            if (
+                show_expired
+                or output_limit is None
+                or not _should_fetch_more_for_expiration(actual_memories, limit, output_limit, previous_count)
+            ):
+                break
 
-            # If first element is a container, unwrap one level
-            if isinstance(first_element, (list, tuple)):
-                actual_memories = first_element
-            else:
-                # First element is a memory object, structure is already flat
-                actual_memories = memories_result
-        else:
-            actual_memories = memories_result
+            previous_count = len(actual_memories)
+            limit *= 2
 
         promoted_payload_keys = [
             "user_id",
@@ -3235,9 +3256,18 @@ class AsyncMemory(MemoryBase):
 
         # Step 3: Semantic search (over-fetch)
         internal_limit = max(limit * 4, 60)
-        semantic_results = await asyncio.to_thread(
-            self.vector_store.search, query=query, vectors=embeddings, top_k=internal_limit, filters=filters
-        )
+        previous_count = 0
+        while True:
+            semantic_results = await asyncio.to_thread(
+                self.vector_store.search, query=query, vectors=embeddings, top_k=internal_limit, filters=filters
+            )
+            if show_expired or not _should_fetch_more_for_expiration(
+                semantic_results, internal_limit, limit, previous_count
+            ):
+                break
+
+            previous_count = len(semantic_results)
+            internal_limit *= 2
 
         # Step 4: Keyword search (if store supports it)
         keyword_results = await asyncio.to_thread(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from mem0.configs.base import MemoryConfig
-from mem0.memory.main import Memory, _validate_and_trim_entity_id
+from mem0.memory.main import AsyncMemory, Memory, _validate_and_trim_entity_id
 
 
 @pytest.fixture(autouse=True)
@@ -31,6 +31,51 @@ def memory_instance():
 
         config = MemoryConfig(version="v1.1")
         return Memory(config)
+
+
+@pytest.fixture
+def async_memory_instance():
+    with (
+        patch("mem0.utils.factory.EmbedderFactory") as mock_embedder,
+        patch("mem0.memory.main.VectorStoreFactory") as mock_vector_store,
+        patch("mem0.utils.factory.LlmFactory") as mock_llm,
+        patch("mem0.memory.telemetry.capture_event"),
+    ):
+        mock_embedder.create.return_value = Mock()
+        mock_vector_store.create.return_value = Mock()
+        mock_vector_store.create.return_value.search.return_value = []
+        mock_llm.create.return_value = Mock()
+
+        config = MemoryConfig(version="v1.1")
+        return AsyncMemory(config)
+
+
+def _memories_beyond_expiration_window():
+    expired = [
+        Mock(
+            id=f"expired-{index}",
+            payload={
+                "data": f"Expired memory {index}",
+                "user_id": "test_user",
+                "expiration_date": "2000-01-01",
+            },
+            score=1 - index / 1000,
+        )
+        for index in range(61)
+    ]
+    active = [
+        Mock(
+            id=f"active-{index}",
+            payload={
+                "data": f"Active memory {index}",
+                "user_id": "test_user",
+                "expiration_date": "2999-01-01",
+            },
+            score=0.8 - index / 1000,
+        )
+        for index in range(2)
+    ]
+    return expired + active
 
 
 @pytest.fixture
@@ -151,6 +196,39 @@ def test_search_hides_expired_memories_by_default(memory_instance):
 
     assert [memory["memory"] for memory in result["results"]] == ["Active memory"]
     assert result["results"][0]["expiration_date"] == "2999-01-01"
+
+
+def test_search_expands_window_until_top_k_active_memories(memory_instance):
+    memories = _memories_beyond_expiration_window()
+    memory_instance.vector_store.search = Mock(side_effect=lambda **kwargs: memories[: kwargs["top_k"]])
+    memory_instance.vector_store.keyword_search = Mock(return_value=None)
+    memory_instance.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+
+    with (
+        patch("mem0.memory.main.lemmatize_for_bm25", return_value="test query"),
+        patch("mem0.memory.main.extract_entities", return_value=[]),
+    ):
+        result = memory_instance.search("test query", filters={"user_id": "test_user"}, top_k=2)
+
+    assert [memory["id"] for memory in result["results"]] == ["active-0", "active-1"]
+    assert [call.kwargs["top_k"] for call in memory_instance.vector_store.search.call_args_list] == [60, 120]
+
+
+@pytest.mark.asyncio
+async def test_async_search_expands_window_until_top_k_active_memories(async_memory_instance):
+    memories = _memories_beyond_expiration_window()
+    async_memory_instance.vector_store.search = Mock(side_effect=lambda **kwargs: memories[: kwargs["top_k"]])
+    async_memory_instance.vector_store.keyword_search = Mock(return_value=None)
+    async_memory_instance.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+
+    with (
+        patch("mem0.memory.main.lemmatize_for_bm25", return_value="test query"),
+        patch("mem0.memory.main.extract_entities", return_value=[]),
+    ):
+        result = await async_memory_instance.search("test query", filters={"user_id": "test_user"}, top_k=2)
+
+    assert [memory["id"] for memory in result["results"]] == ["active-0", "active-1"]
+    assert [call.kwargs["top_k"] for call in async_memory_instance.vector_store.search.call_args_list] == [60, 120]
 
 
 def test_search_can_show_expired_memories(memory_instance):
@@ -318,6 +396,41 @@ def test_get_all_hides_expired_memories_by_default(memory_instance):
 
     assert [memory["memory"] for memory in result["results"]] == ["Active memory"]
     assert result["results"][0]["expiration_date"] == "2999-01-01"
+
+
+def test_get_all_expands_window_until_top_k_active_memories(memory_instance):
+    memories = _memories_beyond_expiration_window()
+    memory_instance.vector_store.list = Mock(
+        side_effect=lambda **kwargs: (memories[: kwargs["top_k"]], None)
+    )
+
+    result = memory_instance.get_all(filters={"user_id": "test_user"}, top_k=2)
+
+    assert [memory["id"] for memory in result["results"]] == ["active-0", "active-1"]
+    assert [call.kwargs["top_k"] for call in memory_instance.vector_store.list.call_args_list] == [60, 120]
+
+
+def test_get_all_stops_when_provider_window_does_not_grow(memory_instance):
+    expired_memories = _memories_beyond_expiration_window()[:60]
+    memory_instance.vector_store.list = Mock(return_value=(expired_memories, None))
+
+    result = memory_instance.get_all(filters={"user_id": "test_user"}, top_k=2)
+
+    assert result["results"] == []
+    assert [call.kwargs["top_k"] for call in memory_instance.vector_store.list.call_args_list] == [60, 120]
+
+
+@pytest.mark.asyncio
+async def test_async_get_all_expands_window_until_top_k_active_memories(async_memory_instance):
+    memories = _memories_beyond_expiration_window()
+    async_memory_instance.vector_store.list = Mock(
+        side_effect=lambda **kwargs: (memories[: kwargs["top_k"]], None)
+    )
+
+    result = await async_memory_instance.get_all(filters={"user_id": "test_user"}, top_k=2)
+
+    assert [memory["id"] for memory in result["results"]] == ["active-0", "active-1"]
+    assert [call.kwargs["top_k"] for call in async_memory_instance.vector_store.list.call_args_list] == [60, 120]
 
 
 def test_get_all_can_show_expired_memories(memory_instance):


### PR DESCRIPTION
## Description

  This PR fixes incomplete get_all() and search() results when expired memories occupy most or all of the initial vector-store result window.

  Previously, sync and async memory APIs fetched a fixed over-sized window:

  max(top_k * 4, 60)

  Expired memories were then removed in Python. If that window contained mostly expired records, the method could return fewer than top_k
  results—or even return an empty result—despite active memories existing immediately after the fetched window.

  This made active memories appear forgotten and reduced recall in RAG and agent-memory workflows.

  ## Affected APIs

  The fix covers all four OSS SDK paths:

  - Memory.get_all()
  - Memory.search()
  - AsyncMemory.get_all()
  - AsyncMemory.search()

  ## Previous Behavior

  Given:

  - top_k=2
  - 61 expired memories ranked before two active memories
  - An initial internal fetch size of 60

  The SDK fetched only the first 60 expired records, filtered them out, and returned:

  {
    "results": []
  }

  The two active memories were never requested from the vector store.

  ## New Behavior

  When expiration filtering removes too many results, the SDK progressively increases the requested vector-store window.

  For example:

  Initial request: top_k=60
  Active results: 0

  Second request: top_k=120
  Active results: 2

  Return the requested 2 active memories

  The window doubles on each retry, avoiding a large number of small repeated queries.

  ## Stop Conditions

  The SDK continues expanding only while additional active memories may exist. Fetching stops when any of these conditions is met:

  1. At least the requested top_k non-expired memories have been collected.
  2. The provider returns fewer rows than requested, indicating exhaustion.
  3. The provider result count does not grow, protecting against providers that silently cap top_k.
  4. show_expired=True, because no expiration filtering needs to be compensated for.

  The no-growth condition prevents infinite retries against providers with fixed server-side result limits.

  ## Provider Compatibility

  The vector-store base contract exposes top_k, but it does not provide a universal cursor or offset:

  def search(self, query, vectors, top_k=5, filters=None)
  def list(self, filters=None, top_k=None)

  For that reason, the implementation uses provider-neutral progressive re-querying instead of provider-specific pagination.

  No vector-store provider interface changes are required.

  The existing list-result normalization was also extended to support providers returning either a nested list or nested tuple.

  ## Hybrid Search Behavior

  Semantic search expands until it has enough active candidates or reaches a stop condition.

  Keyword/BM25 search then runs once using the final semantic fetch size. This preserves the existing hybrid scoring pipeline while ensuring
  expired semantic results do not prematurely reduce the candidate pool.

  Entity boosting, threshold filtering, reranking, score explanations, and final result formatting remain unchanged.

  ## Performance Considerations

  Additional vector-store requests occur only when:

  - show_expired=False
  - The current result window contains fewer than top_k active memories
  - The provider indicates that more records may exist

  Normal searches with enough active records still make one semantic-search request.

  The window grows exponentially:

  60 → 120 → 240 → 480

  This bounds the number of additional round trips to logarithmic growth relative to the number of expired records preceding active results.

  ## Test Coverage

  Added five regression tests.

  ### Sync search

  Verifies that Memory.search():

  - Initially requests 60 records.
  - Detects that all 60 are expired.
  - Expands the request to 120.
  - Returns the two active memories beyond the original window.

  ### Async search

  Verifies identical behavior for AsyncMemory.search().

  ### Sync get_all

  Verifies that Memory.get_all() expands its list window and fills the requested active result count.

  ### Async get_all

  Verifies identical behavior for AsyncMemory.get_all().

  ### Capped provider guard

  Verifies that fetching stops when a provider returns the same fixed set of expired records after the requested window increases.

  This protects against infinite retry loops when a provider silently caps its response size.

  ## Verification

  Focused memory API tests:

  pytest tests/test_main.py -q

  Result:

  48 passed

  Complete Python SDK suite:

  pytest tests -q

  Result:

  1680 passed, 48 skipped, 6 warnings

  The six warnings are existing deprecation and serialization warnings unrelated to this change.

  Code-quality checks:

  Ruff lint: passed
  isort: passed
  pre-commit hooks: passed

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature
  - [ ] Breaking change
  - [ ] Refactor
  - [ ] Documentation update

  ## Breaking Changes

  N/A.

  Public method signatures and response formats remain unchanged.

  The only behavioral difference is that expiration-filtered calls may make additional provider requests when necessary to satisfy top_k.

  ## Test Coverage Checklist

  - [x] Added sync regression tests
  - [x] Added async regression tests
  - [x] Added capped-provider termination coverage
  - [x] Ran the complete Python SDK test suite
  - [ ] No tests needed

  ## Checklist

  - [x] My code follows the project’s style guidelines
  - [x] I performed a self-review
  - [x] I added tests proving the bug and fix
  - [x] New and existing tests pass locally
  - [x] Ruff and isort pass
  - [x] No public API documentation changes are required
