### PR TITLE
Fix/openmemory offload blocking routes

### DIFF
--- a/openmemory/api/app/mcp_server.py
+++ b/openmemory/api/app/mcp_server.py
@@ -62,6 +62,10 @@ sse = SseServerTransport("/mcp/messages/")
 
 @mcp.tool(description="Add a new memory. This method is called everytime the user informs anything about themselves, their preferences, or anything that has any relevant information which can be useful in the future conversation. This can also be called when the user asks you to remember something. Set infer to False to store the memory verbatim without LLM fact extraction.")
 async def add_memories(text: str, infer: bool = True) -> str:
+    return await anyio.to_thread.run_sync(_add_memories, text, infer)
+
+
+def _add_memories(text: str, infer: bool = True) -> str:
     uid = user_id_var.get(None)
     client_name = client_name_var.get(None)
 
@@ -147,6 +151,10 @@ async def add_memories(text: str, infer: bool = True) -> str:
 
 @mcp.tool(description="Search through stored memories. This method is called EVERYTIME the user asks anything.")
 async def search_memory(query: str) -> str:
+    return await anyio.to_thread.run_sync(_search_memory, query)
+
+
+def _search_memory(query: str) -> str:
     uid = user_id_var.get(None)
     client_name = client_name_var.get(None)
     if not uid:
@@ -225,6 +233,10 @@ async def search_memory(query: str) -> str:
 
 @mcp.tool(description="List all memories in the user's memory")
 async def list_memories() -> str:
+    return await anyio.to_thread.run_sync(_list_memories)
+
+
+def _list_memories() -> str:
     uid = user_id_var.get(None)
     client_name = client_name_var.get(None)
     if not uid:
@@ -330,6 +342,10 @@ def _delete_memory_from_stores(db, memory_client, memory, user_id, app_id, acces
 
 @mcp.tool(description="Delete specific memories by their IDs")
 async def delete_memories(memory_ids: list[str]) -> str:
+    return await anyio.to_thread.run_sync(_delete_memories, memory_ids)
+
+
+def _delete_memories(memory_ids: list[str]) -> str:
     uid = user_id_var.get(None)
     client_name = client_name_var.get(None)
     if not uid:
@@ -394,6 +410,10 @@ async def delete_memories(memory_ids: list[str]) -> str:
 
 @mcp.tool(description="Delete all memories in the user's memory")
 async def delete_all_memories() -> str:
+    return await anyio.to_thread.run_sync(_delete_all_memories)
+
+
+def _delete_all_memories() -> str:
     uid = user_id_var.get(None)
     client_name = client_name_var.get(None)
     if not uid:

--- a/openmemory/api/app/mcp_server.py
+++ b/openmemory/api/app/mcp_server.py
@@ -292,6 +292,42 @@ async def list_memories() -> str:
         return f"Error getting memories: {e}"
 
 
+def _delete_memory_from_stores(db, memory_client, memory, user_id, app_id, access_type, operation):
+    memory_id = memory.id
+    try:
+        memory_client.delete(str(memory_id))
+    except Exception as delete_error:
+        raise RuntimeError(f"Failed to delete memory {memory_id} from vector store: {delete_error}") from delete_error
+
+    old_state = memory.state
+    memory.state = MemoryState.deleted
+    memory.deleted_at = datetime.datetime.now(datetime.UTC)
+    db.add(
+        MemoryStatusHistory(
+            memory_id=memory_id,
+            changed_by=user_id,
+            old_state=old_state,
+            new_state=MemoryState.deleted,
+        )
+    )
+    db.add(
+        MemoryAccessLog(
+            memory_id=memory_id,
+            app_id=app_id,
+            access_type=access_type,
+            metadata_={"operation": operation},
+        )
+    )
+
+    try:
+        db.commit()
+    except Exception as db_error:
+        db.rollback()
+        raise RuntimeError(
+            f"Memory {memory_id} was deleted from vector store but its SQL state could not be updated"
+        ) from db_error
+
+
 @mcp.tool(description="Delete specific memories by their IDs")
 async def delete_memories(memory_ids: list[str]) -> str:
     uid = user_id_var.get(None)
@@ -315,50 +351,40 @@ async def delete_memories(memory_ids: list[str]) -> str:
             # Convert string IDs to UUIDs and filter accessible ones
             requested_ids = [uuid.UUID(mid) for mid in memory_ids]
             user_memories = db.query(Memory).filter(Memory.user_id == user.id).all()
-            accessible_memory_ids = [memory.id for memory in user_memories if check_memory_access_permissions(db, memory, app.id)]
+            accessible_memories = [
+                memory for memory in user_memories if check_memory_access_permissions(db, memory, app.id)
+            ]
+            accessible_memories_by_id = {memory.id: memory for memory in accessible_memories}
 
             # Only delete memories that are both requested and accessible
-            ids_to_delete = [mid for mid in requested_ids if mid in accessible_memory_ids]
+            memories_to_delete = [
+                accessible_memories_by_id[mid] for mid in requested_ids if mid in accessible_memories_by_id
+            ]
 
-            if not ids_to_delete:
+            if not memories_to_delete:
                 return "Error: No accessible memories found with provided IDs"
 
-            # Delete from vector store
-            for memory_id in ids_to_delete:
+            # Delete each vector before committing the corresponding SQL state.
+            deleted_count = 0
+            for memory in memories_to_delete:
                 try:
-                    memory_client.delete(str(memory_id))
+                    _delete_memory_from_stores(
+                        db,
+                        memory_client,
+                        memory,
+                        user.id,
+                        app.id,
+                        "delete",
+                        "delete_by_id",
+                    )
                 except Exception as delete_error:
-                    logging.warning(f"Failed to delete memory {memory_id} from vector store: {delete_error}")
+                    raise RuntimeError(
+                        f"Delete stopped after {deleted_count} successful deletions: {delete_error}"
+                    ) from delete_error
 
-            # Update each memory's state and create history entries
-            now = datetime.datetime.now(datetime.UTC)
-            for memory_id in ids_to_delete:
-                memory = db.query(Memory).filter(Memory.id == memory_id).first()
-                if memory:
-                    # Update memory state
-                    memory.state = MemoryState.deleted
-                    memory.deleted_at = now
+                deleted_count += 1
 
-                    # Create history entry
-                    history = MemoryStatusHistory(
-                        memory_id=memory_id,
-                        changed_by=user.id,
-                        old_state=MemoryState.active,
-                        new_state=MemoryState.deleted
-                    )
-                    db.add(history)
-
-                    # Create access log entry
-                    access_log = MemoryAccessLog(
-                        memory_id=memory_id,
-                        app_id=app.id,
-                        access_type="delete",
-                        metadata_={"operation": "delete_by_id"}
-                    )
-                    db.add(access_log)
-
-            db.commit()
-            return f"Successfully deleted {len(ids_to_delete)} memories"
+            return f"Successfully deleted {deleted_count} memories"
         finally:
             db.close()
     except Exception as e:
@@ -387,42 +413,30 @@ async def delete_all_memories() -> str:
             user, app = get_user_and_app(db, user_id=uid, app_id=client_name)
 
             user_memories = db.query(Memory).filter(Memory.user_id == user.id).all()
-            accessible_memory_ids = [memory.id for memory in user_memories if check_memory_access_permissions(db, memory, app.id)]
+            accessible_memories = [
+                memory for memory in user_memories if check_memory_access_permissions(db, memory, app.id)
+            ]
 
-            # delete the accessible memories only
-            for memory_id in accessible_memory_ids:
+            # Delete each vector before committing the corresponding SQL state.
+            deleted_count = 0
+            for memory in accessible_memories:
                 try:
-                    memory_client.delete(str(memory_id))
+                    _delete_memory_from_stores(
+                        db,
+                        memory_client,
+                        memory,
+                        user.id,
+                        app.id,
+                        "delete_all",
+                        "bulk_delete",
+                    )
                 except Exception as delete_error:
-                    logging.warning(f"Failed to delete memory {memory_id} from vector store: {delete_error}")
+                    raise RuntimeError(
+                        f"Delete stopped after {deleted_count} successful deletions: {delete_error}"
+                    ) from delete_error
 
-            # Update each memory's state and create history entries
-            now = datetime.datetime.now(datetime.UTC)
-            for memory_id in accessible_memory_ids:
-                memory = db.query(Memory).filter(Memory.id == memory_id).first()
-                # Update memory state
-                memory.state = MemoryState.deleted
-                memory.deleted_at = now
+                deleted_count += 1
 
-                # Create history entry
-                history = MemoryStatusHistory(
-                    memory_id=memory_id,
-                    changed_by=user.id,
-                    old_state=MemoryState.active,
-                    new_state=MemoryState.deleted
-                )
-                db.add(history)
-
-                # Create access log entry
-                access_log = MemoryAccessLog(
-                    memory_id=memory_id,
-                    app_id=app.id,
-                    access_type="delete_all",
-                    metadata_={"operation": "bulk_delete"}
-                )
-                db.add(access_log)
-
-            db.commit()
             return "Successfully deleted all memories"
         finally:
             db.close()

--- a/openmemory/api/app/mcp_server.py
+++ b/openmemory/api/app/mcp_server.py
@@ -182,13 +182,13 @@ async def search_memory(query: str) -> str:
                 filters=filters,
             )
 
-            allowed = set(str(mid) for mid in accessible_memory_ids) if accessible_memory_ids else None
+            allowed = set(str(mid) for mid in accessible_memory_ids)
 
             results = []
             for h in hits:
                 # All vector db search functions return OutputData class
                 id, score, payload = h.id, h.score, h.payload
-                if allowed and (h.id is None or h.id not in allowed):
+                if h.id is None or h.id not in allowed:
                     continue
                 
                 results.append({

--- a/openmemory/api/app/mcp_server.py
+++ b/openmemory/api/app/mcp_server.py
@@ -22,7 +22,6 @@ import logging
 import uuid
 
 import anyio
-
 from app.database import SessionLocal
 from app.models import Memory, MemoryAccessLog, MemoryState, MemoryStatusHistory
 from app.utils.db import get_user_and_app
@@ -179,7 +178,7 @@ async def search_memory(query: str) -> str:
             hits = memory_client.vector_store.search(
                 query=query, 
                 vectors=embeddings, 
-                limit=10, 
+                top_k=10,
                 filters=filters,
             )
 
@@ -245,7 +244,7 @@ async def list_memories() -> str:
             user, app = get_user_and_app(db, user_id=uid, app_id=client_name)
 
             # Get all memories
-            memories = memory_client.get_all(user_id=uid)
+            memories = memory_client.get_all(filters={"user_id": uid})
             filtered_memories = []
 
             # Filter memories based on permissions
@@ -464,14 +463,15 @@ async def handle_sse(request: Request):
 
 @mcp_router.post("/messages/")
 async def handle_get_message(request: Request):
-    return await handle_post_message(request)
+    return await _handle_post_message(request)
 
 
 @mcp_router.post("/{client_name}/sse/{user_id}/messages/")
 async def handle_post_message(request: Request):
-    return await handle_post_message(request)
+    return await _handle_post_message(request)
 
-async def handle_post_message(request: Request):
+
+async def _handle_post_message(request: Request):
     """Handle POST messages for SSE"""
     try:
         body = await request.body()

--- a/openmemory/api/app/routers/memories.py
+++ b/openmemory/api/app/routers/memories.py
@@ -99,7 +99,7 @@ def get_accessible_memory_ids(db: Session, app_id: UUID) -> Set[UUID]:
 
 # List all memories with filtering
 @router.get("/", response_model=Page[MemoryResponse])
-async def list_memories(
+def list_memories(
     user_id: str,
     app_id: Optional[UUID] = None,
     from_date: Optional[int] = Query(
@@ -187,7 +187,7 @@ async def list_memories(
 
 # Get all categories
 @router.get("/categories")
-async def get_categories(
+def get_categories(
     user_id: str,
     db: Session = Depends(get_db)
 ):
@@ -219,7 +219,7 @@ class CreateMemoryRequest(BaseModel):
 
 # Create new memory
 @router.post("/")
-async def create_memory(
+def create_memory(
     request: CreateMemoryRequest,
     db: Session = Depends(get_db)
 ):
@@ -330,7 +330,7 @@ async def create_memory(
 
 # Get memory by ID
 @router.get("/{memory_id}")
-async def get_memory(
+def get_memory(
     memory_id: UUID,
     db: Session = Depends(get_db)
 ):
@@ -353,7 +353,7 @@ class DeleteMemoriesRequest(BaseModel):
 
 # Delete multiple memories
 @router.delete("/")
-async def delete_memories(
+def delete_memories(
     request: DeleteMemoriesRequest,
     db: Session = Depends(get_db)
 ):
@@ -414,7 +414,7 @@ async def delete_memories(
 
 # Archive memories
 @router.post("/actions/archive")
-async def archive_memories(
+def archive_memories(
     memory_ids: List[UUID],
     user_id: UUID,
     db: Session = Depends(get_db)
@@ -435,7 +435,7 @@ class PauseMemoriesRequest(BaseModel):
 
 # Pause access to memories
 @router.post("/actions/pause")
-async def pause_memories(
+def pause_memories(
     request: PauseMemoriesRequest,
     db: Session = Depends(get_db)
 ):
@@ -508,7 +508,7 @@ async def pause_memories(
 
 # Get memory access logs
 @router.get("/{memory_id}/access-log")
-async def get_memory_access_log(
+def get_memory_access_log(
     memory_id: UUID,
     page: int = Query(1, ge=1),
     page_size: int = Query(10, ge=1, le=100),
@@ -537,7 +537,7 @@ class UpdateMemoryRequest(BaseModel):
 
 # Update a memory
 @router.put("/{memory_id}")
-async def update_memory(
+def update_memory(
     memory_id: UUID,
     request: UpdateMemoryRequest,
     db: Session = Depends(get_db)
@@ -610,7 +610,7 @@ class FilterMemoriesRequest(BaseModel):
     show_archived: Optional[bool] = False
 
 @router.post("/filter", response_model=Page[MemoryResponse])
-async def filter_memories(
+def filter_memories(
     request: FilterMemoriesRequest,
     db: Session = Depends(get_db)
 ):
@@ -704,7 +704,7 @@ async def filter_memories(
 
 
 @router.get("/{memory_id}/related", response_model=Page[MemoryResponse])
-async def get_related_memories(
+def get_related_memories(
     memory_id: UUID,
     user_id: str,
     params: Params = Depends(),

--- a/openmemory/api/app/routers/memories.py
+++ b/openmemory/api/app/routers/memories.py
@@ -378,16 +378,38 @@ async def delete_memories(
             detail=f"Memory service unavailable: {str(client_error)}"
         )
 
-    # Delete from vector store then mark as deleted in database
-    for memory_id in request.memory_ids:
+    memories = [get_memory_or_404(db, memory_id) for memory_id in request.memory_ids]
+
+    # Delete each vector before marking the corresponding SQL row as deleted.
+    deleted_count = 0
+    for memory in memories:
         try:
-            memory_client.delete(str(memory_id))
+            memory_client.delete(str(memory.id))
         except Exception as delete_error:
-            logging.warning(f"Failed to delete memory {memory_id} from vector store: {delete_error}")
+            logging.error(f"Failed to delete memory {memory.id} from vector store: {delete_error}")
+            raise HTTPException(
+                status_code=502,
+                detail=(
+                    f"Failed to delete memory {memory.id} from vector store after "
+                    f"{deleted_count} successful deletions: {delete_error}"
+                ),
+            ) from delete_error
 
-        update_memory_state(db, memory_id, MemoryState.deleted, user.id)
+        try:
+            update_memory_state(db, memory.id, MemoryState.deleted, user.id)
+        except HTTPException:
+            raise
+        except Exception as db_error:
+            db.rollback()
+            logging.error(f"Memory {memory.id} was deleted from vector store but SQL update failed: {db_error}")
+            raise HTTPException(
+                status_code=500,
+                detail=f"Memory {memory.id} was deleted from vector store but its SQL state could not be updated",
+            ) from db_error
 
-    return {"message": f"Successfully deleted {len(request.memory_ids)} memories"}
+        deleted_count += 1
+
+    return {"message": f"Successfully deleted {deleted_count} memories"}
 
 
 # Archive memories
@@ -524,8 +546,53 @@ async def update_memory(
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
     memory = get_memory_or_404(db, memory_id)
+
+    try:
+        memory_client = get_memory_client()
+        if not memory_client:
+            raise HTTPException(status_code=503, detail="Memory client is not available")
+    except HTTPException:
+        raise
+    except Exception as client_error:
+        logging.error(f"Memory client initialization failed: {client_error}")
+        raise HTTPException(
+            status_code=503,
+            detail=f"Memory service unavailable: {str(client_error)}",
+        ) from client_error
+
+    old_content = memory.content
+    try:
+        memory_client.update(str(memory_id), text=request.memory_content)
+    except Exception as update_error:
+        logging.error(f"Failed to update memory {memory_id} in vector store: {update_error}")
+        raise HTTPException(
+            status_code=502,
+            detail=f"Failed to update memory {memory_id} in vector store: {update_error}",
+        ) from update_error
+
     memory.content = request.memory_content
-    db.commit()
+    try:
+        db.commit()
+    except Exception as db_error:
+        db.rollback()
+        try:
+            memory_client.update(str(memory_id), text=old_content)
+        except Exception as compensation_error:
+            logging.exception(
+                f"Failed to restore memory {memory_id} in vector store after SQL update failed: {compensation_error}"
+            )
+            raise HTTPException(
+                status_code=500,
+                detail=(
+                    f"SQL update failed for memory {memory_id}, and its vector-store update could not be restored"
+                ),
+            ) from db_error
+
+        raise HTTPException(
+            status_code=500,
+            detail=f"SQL update failed for memory {memory_id}; the vector-store update was restored",
+        ) from db_error
+
     db.refresh(memory)
     return memory
 

--- a/openmemory/api/tests/test_mcp_server.py
+++ b/openmemory/api/tests/test_mcp_server.py
@@ -5,8 +5,10 @@ transport.  Tests exercise the full JSON-RPC flow — initialize, tools/list,
 tools/call — as well as error handling and context-variable isolation.
 """
 
+import asyncio
 import json
 import os
+import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 from uuid import uuid4
@@ -35,6 +37,11 @@ def test_app():
 
     app = FastAPI()
     app.include_router(mcp_router)
+
+    @app.get("/probe")
+    async def probe():
+        return {"status": "ok"}
+
     return app
 
 
@@ -255,6 +262,64 @@ class TestStreamableHTTPProtocol:
         assert "error" in data or (
             "result" in data and data["result"].get("isError")
         )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("tool_name", "arguments"),
+        [
+            ("add_memories", {"text": "Remember this"}),
+            ("search_memory", {"query": "Remember"}),
+        ],
+    )
+    async def test_blocking_memory_tools_do_not_stall_concurrent_requests(
+        self, client, memory_tool_dependencies, tool_name, arguments
+    ):
+        memory_client, _ = memory_tool_dependencies
+        started = threading.Event()
+        release = threading.Event()
+
+        def slow_call(*args, **kwargs):
+            started.set()
+            release.wait(timeout=3)
+            if tool_name == "add_memories":
+                return {"results": []}
+            return [0.1, 0.2, 0.3]
+
+        if tool_name == "add_memories":
+            memory_client.add.side_effect = slow_call
+        else:
+            memory_client.embedding_model.embed.side_effect = slow_call
+            memory_client.vector_store.search.return_value = []
+
+        await client.post(
+            "/mcp/testclient/http/alice",
+            json=_initialize_payload(),
+            headers=MCP_HEADERS,
+        )
+
+        timer = threading.Timer(2, release.set)
+        timer.start()
+        started_at = asyncio.get_running_loop().time()
+        tool_task = asyncio.create_task(
+            client.post(
+                "/mcp/testclient/http/alice",
+                json=_jsonrpc("tools/call", {"name": tool_name, "arguments": arguments}, req_id=2),
+                headers=MCP_HEADERS,
+            )
+        )
+
+        try:
+            assert await asyncio.to_thread(started.wait, 2)
+            response = await client.get("/probe")
+            elapsed = asyncio.get_running_loop().time() - started_at
+        finally:
+            release.set()
+            tool_response = await tool_task
+            timer.cancel()
+
+        assert response.status_code == 200
+        assert tool_response.status_code == 200
+        assert elapsed < 1.5
 
     @pytest.mark.asyncio
     async def test_search_memory_uses_vector_store_top_k(self, client, memory_tool_dependencies):

--- a/openmemory/api/tests/test_mcp_server.py
+++ b/openmemory/api/tests/test_mcp_server.py
@@ -291,6 +291,52 @@ class TestStreamableHTTPProtocol:
         )
 
     @pytest.mark.asyncio
+    async def test_search_memory_returns_no_hits_when_acl_denies_all(self, client, monkeypatch):
+        from app import mcp_server
+
+        memory_ids = [uuid4(), uuid4()]
+        user = SimpleNamespace(id=uuid4())
+        app = SimpleNamespace(id=uuid4())
+        user_memories = [SimpleNamespace(id=memory_id) for memory_id in memory_ids]
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.all.return_value = user_memories
+        monkeypatch.setattr(mcp_server, "SessionLocal", MagicMock(return_value=db))
+        monkeypatch.setattr(mcp_server, "get_user_and_app", MagicMock(return_value=(user, app)))
+        check_permissions = MagicMock(return_value=False)
+        monkeypatch.setattr(mcp_server, "check_memory_access_permissions", check_permissions)
+
+        memory_client = MagicMock()
+        memory_client.embedding_model.embed.return_value = [0.1, 0.2, 0.3]
+        memory_client.vector_store.search.return_value = [
+            SimpleNamespace(
+                id=str(memory_id),
+                score=0.9,
+                payload={"data": f"Memory {index}", "hash": f"hash-{index}"},
+            )
+            for index, memory_id in enumerate(memory_ids)
+        ]
+        monkeypatch.setattr(mcp_server, "get_memory_client_safe", MagicMock(return_value=memory_client))
+
+        await client.post(
+            "/mcp/testclient/http/alice",
+            json=_initialize_payload(),
+            headers=MCP_HEADERS,
+        )
+        resp = await client.post(
+            "/mcp/testclient/http/alice",
+            json=_jsonrpc("tools/call", {"name": "search_memory", "arguments": {"query": "private"}}, req_id=2),
+            headers=MCP_HEADERS,
+        )
+
+        assert resp.status_code == 200
+        result = resp.json()["result"]
+        assert result.get("isError") is not True
+        assert json.loads(result["content"][0]["text"]) == {"results": []}
+        assert check_permissions.call_count == 2
+        db.add.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_list_memories_uses_filters(self, client, memory_tool_dependencies):
         memory_client, memory_id = memory_tool_dependencies
         memory_client.get_all.return_value = {

--- a/openmemory/api/tests/test_mcp_server.py
+++ b/openmemory/api/tests/test_mcp_server.py
@@ -5,16 +5,19 @@ transport.  Tests exercise the full JSON-RPC flow — initialize, tools/list,
 tools/call — as well as error handling and context-variable isolation.
 """
 
+import json
 import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from uuid import uuid4
 
 # Set dummy keys before any imports that trigger client initialization
 os.environ.setdefault("OPENAI_API_KEY", "test-key")
 
 import pytest
 import pytest_asyncio
-from httpx import ASGITransport, AsyncClient
-
 from app.mcp_server import client_name_var, mcp, mcp_router, user_id_var
+from httpx import ASGITransport, AsyncClient
 
 # MCP Streamable HTTP requires the Accept header to include application/json.
 # Including text/event-stream as well satisfies GET (SSE) requests.
@@ -43,6 +46,28 @@ async def client(test_app):
         yield ac
 
 
+@pytest.fixture
+def memory_tool_dependencies(monkeypatch):
+    """Mock the database and OSS memory client used by MCP memory tools."""
+    from app import mcp_server
+
+    memory_id = uuid4()
+    user = SimpleNamespace(id=uuid4())
+    app = SimpleNamespace(id=uuid4(), is_active=True)
+    memory = SimpleNamespace(id=memory_id)
+
+    db = MagicMock()
+    db.query.return_value.filter.return_value.all.return_value = [memory]
+    monkeypatch.setattr(mcp_server, "SessionLocal", MagicMock(return_value=db))
+    monkeypatch.setattr(mcp_server, "get_user_and_app", MagicMock(return_value=(user, app)))
+    monkeypatch.setattr(mcp_server, "check_memory_access_permissions", MagicMock(return_value=True))
+
+    memory_client = MagicMock()
+    monkeypatch.setattr(mcp_server, "get_memory_client_safe", MagicMock(return_value=memory_client))
+
+    return memory_client, memory_id
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -67,6 +92,23 @@ def _initialize_payload(req_id: int = 1) -> dict:
         },
         req_id=req_id,
     )
+
+
+def _registered_route_paths(app) -> list[str]:
+    """Return route paths across flattened and nested FastAPI routers."""
+    paths = []
+
+    def collect(routes):
+        for route in routes:
+            path = getattr(route, "path", None)
+            if path:
+                paths.append(path)
+            included_router = getattr(route, "original_router", None)
+            if included_router is not None:
+                collect(included_router.routes)
+
+    collect(app.routes)
+    return paths
 
 
 # ---------------------------------------------------------------------------
@@ -213,6 +255,64 @@ class TestStreamableHTTPProtocol:
         assert "error" in data or (
             "result" in data and data["result"].get("isError")
         )
+
+    @pytest.mark.asyncio
+    async def test_search_memory_uses_vector_store_top_k(self, client, memory_tool_dependencies):
+        memory_client, memory_id = memory_tool_dependencies
+        memory_client.embedding_model.embed.return_value = [0.1, 0.2, 0.3]
+        memory_client.vector_store.search.return_value = [
+            SimpleNamespace(
+                id=str(memory_id),
+                score=0.9,
+                payload={"data": "User likes hiking", "hash": "hash-1"},
+            )
+        ]
+
+        await client.post(
+            "/mcp/testclient/http/alice",
+            json=_initialize_payload(),
+            headers=MCP_HEADERS,
+        )
+        resp = await client.post(
+            "/mcp/testclient/http/alice",
+            json=_jsonrpc("tools/call", {"name": "search_memory", "arguments": {"query": "hiking"}}, req_id=2),
+            headers=MCP_HEADERS,
+        )
+
+        assert resp.status_code == 200
+        result = resp.json()["result"]
+        assert result.get("isError") is not True
+        assert json.loads(result["content"][0]["text"])["results"][0]["id"] == str(memory_id)
+        memory_client.vector_store.search.assert_called_once_with(
+            query="hiking",
+            vectors=[0.1, 0.2, 0.3],
+            top_k=10,
+            filters={"user_id": "alice"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_memories_uses_filters(self, client, memory_tool_dependencies):
+        memory_client, memory_id = memory_tool_dependencies
+        memory_client.get_all.return_value = {
+            "results": [{"id": str(memory_id), "memory": "User likes hiking", "hash": "hash-1"}]
+        }
+
+        await client.post(
+            "/mcp/testclient/http/alice",
+            json=_initialize_payload(),
+            headers=MCP_HEADERS,
+        )
+        resp = await client.post(
+            "/mcp/testclient/http/alice",
+            json=_jsonrpc("tools/call", {"name": "list_memories", "arguments": {}}, req_id=2),
+            headers=MCP_HEADERS,
+        )
+
+        assert resp.status_code == 200
+        result = resp.json()["result"]
+        assert result.get("isError") is not True
+        assert json.loads(result["content"][0]["text"])[0]["id"] == str(memory_id)
+        memory_client.get_all.assert_called_once_with(filters={"user_id": "alice"})
 
     @pytest.mark.asyncio
     async def test_unknown_jsonrpc_method(self, client):
@@ -384,13 +484,13 @@ class TestRouteRegistration:
     """Verify all expected routes are registered in the router."""
 
     def test_sse_route_is_registered(self, test_app):
-        routes = [r.path for r in test_app.routes if hasattr(r, "path")]
+        routes = _registered_route_paths(test_app)
         assert "/mcp/{client_name}/sse/{user_id}" in routes
 
     def test_sse_post_messages_route_is_registered(self, test_app):
-        routes = [r.path for r in test_app.routes if hasattr(r, "path")]
+        routes = _registered_route_paths(test_app)
         assert "/mcp/messages/" in routes or "/mcp/{client_name}/sse/{user_id}/messages/" in routes
 
     def test_streamable_http_route_is_registered(self, test_app):
-        routes = [r.path for r in test_app.routes if hasattr(r, "path")]
+        routes = _registered_route_paths(test_app)
         assert "/mcp/{client_name}/http/{user_id}" in routes

--- a/openmemory/api/tests/test_mcp_server.py
+++ b/openmemory/api/tests/test_mcp_server.py
@@ -361,6 +361,57 @@ class TestStreamableHTTPProtocol:
         memory_client.get_all.assert_called_once_with(filters={"user_id": "alice"})
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("tool_name", "arguments"),
+        [
+            ("delete_memories", lambda memory_id: {"memory_ids": [str(memory_id)]}),
+            ("delete_all_memories", lambda _memory_id: {}),
+        ],
+    )
+    async def test_delete_tools_preserve_sql_when_vector_delete_fails(
+        self, client, monkeypatch, tool_name, arguments
+    ):
+        from app import mcp_server
+
+        memory_id = uuid4()
+        user = SimpleNamespace(id=uuid4())
+        app = SimpleNamespace(id=uuid4())
+        memory = SimpleNamespace(id=memory_id, state=mcp_server.MemoryState.active, deleted_at=None)
+        db = MagicMock()
+        db.query.return_value.filter.return_value.all.return_value = [memory]
+        monkeypatch.setattr(mcp_server, "SessionLocal", MagicMock(return_value=db))
+        monkeypatch.setattr(mcp_server, "get_user_and_app", MagicMock(return_value=(user, app)))
+        monkeypatch.setattr(mcp_server, "check_memory_access_permissions", MagicMock(return_value=True))
+
+        memory_client = MagicMock()
+        memory_client.delete.side_effect = RuntimeError("vector unavailable")
+        monkeypatch.setattr(mcp_server, "get_memory_client_safe", MagicMock(return_value=memory_client))
+
+        await client.post(
+            "/mcp/testclient/http/alice",
+            json=_initialize_payload(),
+            headers=MCP_HEADERS,
+        )
+        resp = await client.post(
+            "/mcp/testclient/http/alice",
+            json=_jsonrpc(
+                "tools/call",
+                {"name": tool_name, "arguments": arguments(memory_id)},
+                req_id=2,
+            ),
+            headers=MCP_HEADERS,
+        )
+
+        assert resp.status_code == 200
+        text = resp.json()["result"]["content"][0]["text"]
+        assert text.startswith("Error deleting memories:")
+        assert "vector unavailable" in text
+        assert memory.state == mcp_server.MemoryState.active
+        assert memory.deleted_at is None
+        db.add.assert_not_called()
+        db.commit.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_unknown_jsonrpc_method(self, client):
         """An unknown JSON-RPC method should return an error."""
         resp = await client.post(

--- a/openmemory/api/tests/test_memories_router.py
+++ b/openmemory/api/tests/test_memories_router.py
@@ -1,15 +1,78 @@
+import asyncio
+import os
+import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call
 from uuid import uuid4
 
 import pytest
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
 from app.models import MemoryState
 from app.routers import memories as memories_router
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
+from httpx import ASGITransport, AsyncClient
 
 
 @pytest.mark.asyncio
-async def test_update_memory_updates_vector_store_before_sql(monkeypatch):
+async def test_create_memory_does_not_block_concurrent_requests(monkeypatch):
+    user = SimpleNamespace(id=uuid4())
+    app_record = SimpleNamespace(id=uuid4(), is_active=True)
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.side_effect = [user, app_record]
+
+    started = threading.Event()
+    release = threading.Event()
+
+    def slow_add(*args, **kwargs):
+        started.set()
+        release.wait(timeout=3)
+        return {"results": []}
+
+    memory_client = MagicMock()
+    memory_client.add.side_effect = slow_add
+    monkeypatch.setattr(memories_router, "get_memory_client", MagicMock(return_value=memory_client))
+
+    app = FastAPI()
+    app.include_router(memories_router.router)
+
+    def override_get_db():
+        yield db
+
+    app.dependency_overrides[memories_router.get_db] = override_get_db
+
+    @app.get("/probe")
+    async def probe():
+        return {"status": "ok"}
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        timer = threading.Timer(2, release.set)
+        timer.start()
+        started_at = asyncio.get_running_loop().time()
+        create_task = asyncio.create_task(
+            client.post(
+                "/api/v1/memories/",
+                json={"user_id": "alice", "text": "Remember this", "app": "test-app"},
+            )
+        )
+
+        try:
+            assert await asyncio.to_thread(started.wait, 2)
+            response = await client.get("/probe")
+            elapsed = asyncio.get_running_loop().time() - started_at
+        finally:
+            release.set()
+            create_response = await create_task
+            timer.cancel()
+
+    assert response.status_code == 200
+    assert create_response.status_code == 200
+    assert elapsed < 1.5
+
+
+def test_update_memory_updates_vector_store_before_sql(monkeypatch):
     memory_id = uuid4()
     user = SimpleNamespace(id=uuid4())
     memory = SimpleNamespace(id=memory_id, content="Old content")
@@ -21,7 +84,7 @@ async def test_update_memory_updates_vector_store_before_sql(monkeypatch):
     monkeypatch.setattr(memories_router, "get_memory_client", MagicMock(return_value=memory_client))
 
     request = memories_router.UpdateMemoryRequest(memory_content="New content", user_id="alice")
-    result = await memories_router.update_memory(memory_id, request, db)
+    result = memories_router.update_memory(memory_id, request, db)
 
     memory_client.update.assert_called_once_with(str(memory_id), text="New content")
     assert memory.content == "New content"
@@ -30,8 +93,7 @@ async def test_update_memory_updates_vector_store_before_sql(monkeypatch):
     assert result is memory
 
 
-@pytest.mark.asyncio
-async def test_update_memory_preserves_sql_when_vector_update_fails(monkeypatch):
+def test_update_memory_preserves_sql_when_vector_update_fails(monkeypatch):
     memory_id = uuid4()
     user = SimpleNamespace(id=uuid4())
     memory = SimpleNamespace(id=memory_id, content="Old content")
@@ -45,7 +107,7 @@ async def test_update_memory_preserves_sql_when_vector_update_fails(monkeypatch)
 
     request = memories_router.UpdateMemoryRequest(memory_content="New content", user_id="alice")
     with pytest.raises(HTTPException) as exc_info:
-        await memories_router.update_memory(memory_id, request, db)
+        memories_router.update_memory(memory_id, request, db)
 
     assert exc_info.value.status_code == 502
     assert "vector store" in exc_info.value.detail
@@ -53,8 +115,7 @@ async def test_update_memory_preserves_sql_when_vector_update_fails(monkeypatch)
     db.commit.assert_not_called()
 
 
-@pytest.mark.asyncio
-async def test_update_memory_restores_vector_when_sql_commit_fails(monkeypatch):
+def test_update_memory_restores_vector_when_sql_commit_fails(monkeypatch):
     memory_id = uuid4()
     user = SimpleNamespace(id=uuid4())
     memory = SimpleNamespace(id=memory_id, content="Old content")
@@ -68,7 +129,7 @@ async def test_update_memory_restores_vector_when_sql_commit_fails(monkeypatch):
 
     request = memories_router.UpdateMemoryRequest(memory_content="New content", user_id="alice")
     with pytest.raises(HTTPException) as exc_info:
-        await memories_router.update_memory(memory_id, request, db)
+        memories_router.update_memory(memory_id, request, db)
 
     assert exc_info.value.status_code == 500
     assert memory_client.update.call_args_list == [
@@ -78,8 +139,7 @@ async def test_update_memory_restores_vector_when_sql_commit_fails(monkeypatch):
     db.rollback.assert_called_once_with()
 
 
-@pytest.mark.asyncio
-async def test_delete_memories_preserves_sql_when_vector_delete_fails(monkeypatch):
+def test_delete_memories_preserves_sql_when_vector_delete_fails(monkeypatch):
     memory_id = uuid4()
     user = SimpleNamespace(id=uuid4())
     memory = SimpleNamespace(id=memory_id, state=MemoryState.active)
@@ -95,7 +155,7 @@ async def test_delete_memories_preserves_sql_when_vector_delete_fails(monkeypatc
 
     request = memories_router.DeleteMemoriesRequest(memory_ids=[memory_id], user_id="alice")
     with pytest.raises(HTTPException) as exc_info:
-        await memories_router.delete_memories(request, db)
+        memories_router.delete_memories(request, db)
 
     assert exc_info.value.status_code == 502
     assert "vector store" in exc_info.value.detail

--- a/openmemory/api/tests/test_memories_router.py
+++ b/openmemory/api/tests/test_memories_router.py
@@ -1,0 +1,103 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call
+from uuid import uuid4
+
+import pytest
+from app.models import MemoryState
+from app.routers import memories as memories_router
+from fastapi import HTTPException
+
+
+@pytest.mark.asyncio
+async def test_update_memory_updates_vector_store_before_sql(monkeypatch):
+    memory_id = uuid4()
+    user = SimpleNamespace(id=uuid4())
+    memory = SimpleNamespace(id=memory_id, content="Old content")
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = user
+    memory_client = MagicMock()
+
+    monkeypatch.setattr(memories_router, "get_memory_or_404", MagicMock(return_value=memory))
+    monkeypatch.setattr(memories_router, "get_memory_client", MagicMock(return_value=memory_client))
+
+    request = memories_router.UpdateMemoryRequest(memory_content="New content", user_id="alice")
+    result = await memories_router.update_memory(memory_id, request, db)
+
+    memory_client.update.assert_called_once_with(str(memory_id), text="New content")
+    assert memory.content == "New content"
+    db.commit.assert_called_once_with()
+    db.refresh.assert_called_once_with(memory)
+    assert result is memory
+
+
+@pytest.mark.asyncio
+async def test_update_memory_preserves_sql_when_vector_update_fails(monkeypatch):
+    memory_id = uuid4()
+    user = SimpleNamespace(id=uuid4())
+    memory = SimpleNamespace(id=memory_id, content="Old content")
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = user
+    memory_client = MagicMock()
+    memory_client.update.side_effect = RuntimeError("vector unavailable")
+
+    monkeypatch.setattr(memories_router, "get_memory_or_404", MagicMock(return_value=memory))
+    monkeypatch.setattr(memories_router, "get_memory_client", MagicMock(return_value=memory_client))
+
+    request = memories_router.UpdateMemoryRequest(memory_content="New content", user_id="alice")
+    with pytest.raises(HTTPException) as exc_info:
+        await memories_router.update_memory(memory_id, request, db)
+
+    assert exc_info.value.status_code == 502
+    assert "vector store" in exc_info.value.detail
+    assert memory.content == "Old content"
+    db.commit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_update_memory_restores_vector_when_sql_commit_fails(monkeypatch):
+    memory_id = uuid4()
+    user = SimpleNamespace(id=uuid4())
+    memory = SimpleNamespace(id=memory_id, content="Old content")
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = user
+    db.commit.side_effect = RuntimeError("database unavailable")
+    memory_client = MagicMock()
+
+    monkeypatch.setattr(memories_router, "get_memory_or_404", MagicMock(return_value=memory))
+    monkeypatch.setattr(memories_router, "get_memory_client", MagicMock(return_value=memory_client))
+
+    request = memories_router.UpdateMemoryRequest(memory_content="New content", user_id="alice")
+    with pytest.raises(HTTPException) as exc_info:
+        await memories_router.update_memory(memory_id, request, db)
+
+    assert exc_info.value.status_code == 500
+    assert memory_client.update.call_args_list == [
+        call(str(memory_id), text="New content"),
+        call(str(memory_id), text="Old content"),
+    ]
+    db.rollback.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_delete_memories_preserves_sql_when_vector_delete_fails(monkeypatch):
+    memory_id = uuid4()
+    user = SimpleNamespace(id=uuid4())
+    memory = SimpleNamespace(id=memory_id, state=MemoryState.active)
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = user
+    memory_client = MagicMock()
+    memory_client.delete.side_effect = RuntimeError("vector unavailable")
+    update_memory_state = MagicMock()
+
+    monkeypatch.setattr(memories_router, "get_memory_or_404", MagicMock(return_value=memory))
+    monkeypatch.setattr(memories_router, "get_memory_client", MagicMock(return_value=memory_client))
+    monkeypatch.setattr(memories_router, "update_memory_state", update_memory_state)
+
+    request = memories_router.DeleteMemoriesRequest(memory_ids=[memory_id], user_id="alice")
+    with pytest.raises(HTTPException) as exc_info:
+        await memories_router.delete_memories(request, db)
+
+    assert exc_info.value.status_code == 502
+    assert "vector store" in exc_info.value.detail
+    update_memory_state.assert_not_called()
+    assert memory.state == MemoryState.active


### PR DESCRIPTION
 ## Description

  This PR prevents OpenMemory’s synchronous database, LLM, embedding, and vector-store operations from blocking the application’s asyncio event
  loop.

  Several FastAPI endpoints and FastMCP tools were declared with async def but performed synchronous work directly, including:

  - SQLAlchemy queries and commits using synchronous Session
  - Mem0 SDK calls
  - Embedding generation
  - Vector-store searches and mutations
  - LLM inference
  - Potentially slow Ollama and other network requests

  Because this work ran directly inside async handlers, one slow memory request could stall unrelated HTTP and MCP requests handled by the same
  event loop.

  ## Problem

  FastAPI treats synchronous and asynchronous endpoints differently.

  A normal synchronous endpoint:

  def create_memory(...):
      ...

  is automatically executed in FastAPI’s worker thread pool.

  An asynchronous endpoint:

  async def create_memory(...):
      memory_client.add(...)

  runs on the event-loop thread. FastAPI assumes blocking operations inside it have already been offloaded.

  The affected endpoints used synchronous SQLAlchemy and Mem0 clients from inside async def, so a slow embedding, LLM, vector-store, or database
  operation blocked the event loop.

  FastMCP has a related constraint: its current runtime directly invokes synchronous tool functions instead of automatically moving them into a
  worker thread. Therefore, changing MCP tools from async def to def would still block the event loop.

  ## Solution

  ### FastAPI memory endpoints

  All endpoints in the synchronous SQLAlchemy memory router were converted from async def to normal def.

  This includes:

  - list_memories
  - get_categories
  - create_memory
  - get_memory
  - delete_memories
  - archive_memories
  - pause_memories
  - get_memory_access_log
  - update_memory
  - filter_memories
  - get_related_memories

  FastAPI now executes these handlers in its managed thread pool.

  This keeps the existing synchronous SQLAlchemy session and Mem0 client model without introducing a partial AsyncSession migration.

  ### MCP memory tools

  MCP tools remain asynchronous so their schemas and FastMCP registration behavior remain unchanged.

  Each tool is now a lightweight async wrapper:

  async def search_memory(query: str) -> str:
      return await anyio.to_thread.run_sync(_search_memory, query)

  The complete synchronous operation runs inside the worker thread, including:

  - Reading MCP request context
  - Initializing the memory client
  - Creating and closing the SQLAlchemy session
  - Permission checks
  - Embedding generation
  - Vector-store operations
  - SQL history and access-log commits

  The following MCP tools are covered:

  - add_memories
  - search_memory
  - list_memories
  - delete_memories
  - delete_all_memories

  ## Why the Entire Operation Is Offloaded

  Only offloading individual network calls would still leave synchronous SQLAlchemy operations on the event loop and could move a database
  session between execution contexts.

  Instead, each MCP tool’s complete synchronous body runs in one worker thread. The database session is created, used, committed, and closed
  within that worker execution.

  AnyIO also propagates contextvars into worker threads. Existing MCP regression tests confirm that user_id and client_name remain available and
  that user-scoped filters and ACL checks still receive the correct request context.

  ## Why Not Convert MCP Tools to def

  The installed FastMCP runtime distinguishes sync and async tools but directly calls synchronous tools:

  if fn_is_async:
      return await fn(**arguments)
  else:
      return fn(**arguments)

  It does not automatically offload the synchronous branch.

  Keeping async MCP wrappers and explicitly using anyio.to_thread.run_sync ensures the blocking implementation does not execute on the event-
  loop thread.

  ## Why Not Migrate to AsyncSession

  A complete asynchronous migration would require coordinated changes across:

  - SQLAlchemy engine/session configuration
  - Database dependencies
  - Query syntax
  - Transaction handling
  - Memory and ACL helpers
  - Tests and deployment configuration

  That would substantially increase the scope and risk of this bug fix.

  Thread-pool execution is the established FastAPI approach for synchronous database and SDK integrations and fixes the responsiveness issue
  without changing persistence behavior.

  ## Concurrency Behavior

  Before this change, a slow memory call delayed unrelated requests until the blocking operation completed.

  For example:

  MCP search starts
  └── synchronous embedding call blocks event loop
      └── unrelated HTTP probe cannot run

  After this change:

  MCP search starts
  └── embedding/search work runs in worker thread

  Event loop remains available
  └── unrelated HTTP probe responds immediately

  The same behavior now applies to REST memory creation and all other memory-router endpoints.

  ## Public API Impact

  There are no request-schema, response-schema, route, or MCP tool-schema changes.

  The internal endpoint implementation changes from coroutine functions to synchronous FastAPI handlers, but external clients continue using the
  same HTTP methods and paths.

  MCP tool names, arguments, results, and error behavior remain unchanged.

  ## Test Coverage

  Added concurrent responsiveness tests that deliberately block memory operations using thread synchronization.

  ### REST concurrency test

  The REST regression test:

  1. Creates a FastAPI application with the real memory router.
  2. Mocks memory_client.add() with a blocking synchronous function.
  3. Starts a memory-creation request.
  4. Waits until the blocking SDK operation has started.
  5. Sends an unrelated async probe request before releasing the memory operation.
  6. Verifies the probe responds while memory creation is still blocked.
  7. Verifies the original create request completes successfully after release.

  Before the fix, the probe was delayed until the blocking memory call completed.

  ### MCP add concurrency test

  The MCP test invokes add_memories through the real Streamable HTTP JSON-RPC flow while memory_client.add() is blocked.

  It verifies an unrelated HTTP request remains responsive during the operation.

  ### MCP search concurrency test

  The MCP search test blocks synchronous embedding generation and verifies that:

  - The event loop remains responsive.
  - An unrelated request completes before embedding is released.
  - The MCP tool call subsequently completes successfully.

  ### Existing regression coverage

  The full suite also confirms that offloading does not break:

  - MCP tool registration and schemas
  - Request context isolation
  - SDK argument compatibility
  - Search ACL enforcement
  - Update/delete consistency behavior
  - Vector failure handling
  - MCP route registration
  - Streamable HTTP protocol handling

  ## Verification

  Full OpenMemory API test suite:

  pytest openmemory/api/tests -q

  Result:

  33 passed in 1.07s

  One existing Pydantic v1-style validator deprecation warning remains unrelated to this change.

  Code-quality checks:

  Ruff: passed
  isort: passed
  pre-commit hooks: passed

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature
  - [ ] Breaking change
  - [ ] Refactor
  - [ ] Documentation update

  ## Breaking Changes

  N/A.

  HTTP routes, request/response formats, MCP tool schemas, and persistence behavior remain unchanged.

  ## Test Coverage Checklist

  - [x] Added concurrent REST responsiveness coverage
  - [x] Added concurrent MCP add coverage
  - [x] Added concurrent MCP search coverage
  - [x] Ran the complete OpenMemory API test suite
  - [ ] No tests needed

  ## Checklist

  - [x] My code follows the project’s style guidelines
  - [x] I performed a self-review
  - [x] I added tests that reproduce the event-loop blocking behavior
  - [x] New and existing relevant tests pass locally
  - [x] Ruff and isort pass
  - [x] No public API documentation changes are required
