### PR TITLE
fix(openmemory): persist PUT /api/v1/config/ updates (salvage of #6356)

### DIFF
--- a/openmemory/api/app/routers/config.py
+++ b/openmemory/api/app/routers/config.py
@@ -142,19 +142,24 @@ async def get_configuration(db: Session = Depends(get_db)):
 async def update_configuration(config: ConfigSchema, db: Session = Depends(get_db)):
     """Update the configuration."""
     current_config = get_config_from_db(db)
-    
+
     # Convert to dict for processing
     updated_config = current_config.copy()
-    
+
     # Update openmemory settings if provided
     if config.openmemory is not None:
         if "openmemory" not in updated_config:
             updated_config["openmemory"] = {}
         updated_config["openmemory"].update(config.openmemory.dict(exclude_none=True))
-    
-    # Update mem0 settings
-    updated_config["mem0"] = config.mem0.dict(exclude_none=True)
-    
+
+    # Update mem0 settings (full replace semantics for PUT)
+    if config.mem0 is not None:
+        updated_config["mem0"] = config.mem0.dict(exclude_none=True)
+
+    save_config_to_db(db, updated_config)
+    reset_memory_client()
+    return updated_config
+
 
 @router.patch("/", response_model=ConfigSchema)
 async def patch_configuration(config_update: ConfigSchema, db: Session = Depends(get_db)):

--- a/openmemory/api/tests/test_config_put_persist.py
+++ b/openmemory/api/tests/test_config_put_persist.py
@@ -1,0 +1,148 @@
+"""Regression: PUT /api/v1/config/ must persist and return the updated config.
+
+Closes mem0ai/mem0#6353. Builds on salvage of @okyashgajjar #6356.
+
+Loads the router module directly (avoids package__init__ dependency chain)
+so CI/dev can run these without full openmemory stack install.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _load_config_router():
+    """Import app.routers.config without importing app.routers package side effects."""
+    api_root = Path(__file__).resolve().parents[1]
+    # Ensure `app` package path for relative absolute imports inside the module
+    if str(api_root) not in sys.path:
+        sys.path.insert(0, str(api_root))
+
+    # Stub only heavy transitive deps if missing (will work with real installs too)
+    for modname in (
+        "app.database",
+        "app.models",
+        "app.utils.memory",
+    ):
+        if modname not in sys.modules:
+            stub = types.ModuleType(modname)
+            if modname == "app.database":
+                stub.get_db = MagicMock()
+            if modname == "app.models":
+                class Config:  # minimal stand-in
+                    pass
+                stub.Config = Config
+            if modname == "app.utils.memory":
+                stub.reset_memory_client = MagicMock()
+            # parent packages
+            parts = modname.split(".")
+            for i in range(1, len(parts)):
+                parent = ".".join(parts[:i])
+                if parent not in sys.modules:
+                    sys.modules[parent] = types.ModuleType(parent)
+            sys.modules[modname] = stub
+
+    path = api_root / "app" / "routers" / "config.py"
+    spec = importlib.util.spec_from_file_location("app.routers.config_under_test", path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.mark.asyncio
+async def test_put_configuration_saves_and_resets_client():
+    """PUT must call save_config_to_db + reset_memory_client and return body."""
+    config_router = _load_config_router()
+
+    current = {
+        "openmemory": {"custom_instructions": None},
+        "mem0": {
+            "llm": {
+                "provider": "openai",
+                "config": {
+                    "model": "gpt-4o-mini",
+                    "temperature": 0.1,
+                    "max_tokens": 2000,
+                    "api_key": "env:OPENAI_API_KEY",
+                },
+            },
+            "embedder": {
+                "provider": "openai",
+                "config": {
+                    "model": "text-embedding-3-small",
+                    "api_key": "env:OPENAI_API_KEY",
+                },
+            },
+            "vector_store": None,
+        },
+    }
+
+    openmemory_payload = config_router.OpenMemoryConfig(
+        custom_instructions="Test instructions"
+    )
+    llm = config_router.LLMProvider(
+        provider="openai",
+        config=config_router.LLMConfig(
+            model="gpt-4o",
+            temperature=0.5,
+            max_tokens=4000,
+        ),
+    )
+    body = config_router.ConfigSchema(
+        openmemory=openmemory_payload,
+        mem0=config_router.Mem0Config(llm=llm, embedder=None, vector_store=None),
+    )
+    db = MagicMock()
+
+    with (
+        patch.object(config_router, "get_config_from_db", return_value=current.copy()) as get_cfg,
+        patch.object(config_router, "save_config_to_db", side_effect=lambda db, cfg: cfg) as save_cfg,
+        patch.object(config_router, "reset_memory_client") as reset_client,
+    ):
+        result = await config_router.update_configuration(body, db)
+
+    get_cfg.assert_called_once_with(db)
+    save_cfg.assert_called_once()
+    saved = save_cfg.call_args.args[1]
+    assert saved["openmemory"]["custom_instructions"] == "Test instructions"
+    assert saved["mem0"]["llm"]["provider"] == "openai"
+    assert saved["mem0"]["llm"]["config"]["model"] == "gpt-4o"
+    reset_client.assert_called_once()
+    assert result is saved
+    assert result["openmemory"]["custom_instructions"] == "Test instructions"
+
+
+@pytest.mark.asyncio
+async def test_put_configuration_allows_omitted_mem0():
+    """If mem0 is omitted, PUT should keep prior mem0 and still persist openmemory."""
+    config_router = _load_config_router()
+
+    current = {
+        "openmemory": {"custom_instructions": "old"},
+        "mem0": {"llm": {"provider": "openai", "config": {"model": "keep-me"}}},
+    }
+    body = config_router.ConfigSchema(
+        openmemory=config_router.OpenMemoryConfig(custom_instructions="new"),
+        mem0=None,
+    )
+    db = MagicMock()
+
+    with (
+        patch.object(config_router, "get_config_from_db", return_value=current.copy()),
+        patch.object(config_router, "save_config_to_db", side_effect=lambda db, cfg: cfg) as save_cfg,
+        patch.object(config_router, "reset_memory_client") as reset_client,
+    ):
+        result = await config_router.update_configuration(body, db)
+
+    saved = save_cfg.call_args.args[1]
+    assert saved["openmemory"]["custom_instructions"] == "new"
+    assert saved["mem0"]["llm"]["config"]["model"] == "keep-me"
+    reset_client.assert_called_once()
+    assert result["mem0"]["llm"]["config"]["model"] == "keep-me"


### PR DESCRIPTION
## Summary

OpenMemory `PUT /api/v1/config/` built `updated_config` but never wrote it.

- Call `save_config_to_db` + `reset_memory_client` (same as PATCH/reset).
- Return the persisted body (not an implicit `None` 200).
- Skip wiping `mem0` when the client omits that field.
- Unit tests for persist/reset and omitted-`mem0`.

## Salvage credit

Rebases/extends **@okyashgajjar** work in #6356 (`fix(api): persist configuration updates in PUT config endpoint`). Original diagnosis + core fix direction. This salvage adds None-safe `mem0` handling and regression tests. Human-reviewed.

Closes #6353

## Verification

```
cd openmemory/api && PYTHONPATH=. pytest tests/test_config_put_persist.py -q
# 2 passed
```

Manual: PUT then GET show new config (issue repro).

## Notes

- AI-assisted; human-reviewed
- Touch surface limited to OpenMemory config router + tests