### PR TITLE
fix(reranker): don't mutate caller's documents in failure fallback

### DIFF
--- a/mem0/reranker/cohere_reranker.py
+++ b/mem0/reranker/cohere_reranker.py
@@ -84,7 +84,10 @@ class CohereReranker(BaseReranker):
         except Exception as e:
             # Fallback to original order if reranking fails
             logger.warning("Cohere reranking failed, falling back to original order: %s", e)
+            fallback_docs = []
             for doc in documents:
-                doc['rerank_score'] = 0.0
+                fallback_doc = doc.copy()
+                fallback_doc['rerank_score'] = 0.0
+                fallback_docs.append(fallback_doc)
             final_top_k = top_k or self.config.top_k
-            return documents[:final_top_k] if final_top_k else documents
+            return fallback_docs[:final_top_k] if final_top_k else fallback_docs

--- a/mem0/reranker/huggingface_reranker.py
+++ b/mem0/reranker/huggingface_reranker.py
@@ -163,7 +163,10 @@ class HuggingFaceReranker(BaseReranker):
         except Exception as e:
             # Fallback to original order if reranking fails
             logger.warning("HuggingFace reranking failed, falling back to original order: %s", e)
+            fallback_docs = []
             for doc in documents:
-                doc['rerank_score'] = 0.0
+                fallback_doc = doc.copy()
+                fallback_doc['rerank_score'] = 0.0
+                fallback_docs.append(fallback_doc)
             final_top_k = top_k or self.config.top_k
-            return documents[:final_top_k] if final_top_k else documents
+            return fallback_docs[:final_top_k] if final_top_k else fallback_docs

--- a/mem0/reranker/sentence_transformer_reranker.py
+++ b/mem0/reranker/sentence_transformer_reranker.py
@@ -108,7 +108,10 @@ class SentenceTransformerReranker(BaseReranker):
         except Exception as e:
             # Fallback to original order if reranking fails
             logger.warning("SentenceTransformer reranking failed, falling back to original order: %s", e)
+            fallback_docs = []
             for doc in documents:
-                doc['rerank_score'] = 0.0
+                fallback_doc = doc.copy()
+                fallback_doc['rerank_score'] = 0.0
+                fallback_docs.append(fallback_doc)
             final_top_k = top_k or self.config.top_k
-            return documents[:final_top_k] if final_top_k else documents
+            return fallback_docs[:final_top_k] if final_top_k else fallback_docs

--- a/mem0/reranker/zero_entropy_reranker.py
+++ b/mem0/reranker/zero_entropy_reranker.py
@@ -95,7 +95,10 @@ class ZeroEntropyReranker(BaseReranker):
         except Exception as e:
             # Fallback to original order if reranking fails
             logger.warning("Zero Entropy reranking failed, falling back to original order: %s", e)
+            fallback_docs = []
             for doc in documents:
-                doc['rerank_score'] = 0.0
+                fallback_doc = doc.copy()
+                fallback_doc['rerank_score'] = 0.0
+                fallback_docs.append(fallback_doc)
             final_top_k = top_k or self.config.top_k
-            return documents[:final_top_k] if final_top_k else documents
+            return fallback_docs[:final_top_k] if final_top_k else fallback_docs

--- a/tests/rerankers/test_reranker_fallback_no_mutation.py
+++ b/tests/rerankers/test_reranker_fallback_no_mutation.py
@@ -1,0 +1,99 @@
+"""Reranker failure fallback must not mutate the caller's documents.
+
+The success paths of every provider ``doc.copy()`` before attaching
+``rerank_score`` (and ``LLMReranker`` copies even on its per-document failure
+path), but the API/model providers' ``except`` fallback used to write
+``rerank_score = 0.0`` directly onto the input dicts. ``Memory.search`` passes
+its live result list into ``rerank()``, so a transient provider failure
+permanently stamped the caller-visible memories.
+
+Providers are instantiated via ``object.__new__`` with stubbed attributes so
+the tests run without the optional heavy dependencies (cohere, transformers,
+sentence-transformers, zeroentropy) installed.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from mem0.reranker.cohere_reranker import CohereReranker
+from mem0.reranker.huggingface_reranker import HuggingFaceReranker
+from mem0.reranker.sentence_transformer_reranker import SentenceTransformerReranker
+from mem0.reranker.zero_entropy_reranker import ZeroEntropyReranker
+
+
+def _make_cohere():
+    reranker = object.__new__(CohereReranker)
+    reranker.config = SimpleNamespace(top_k=None, return_documents=False, max_chunks_per_doc=10)
+    reranker.model = "rerank-english-v3.0"
+    reranker.client = MagicMock()
+    reranker.client.rerank.side_effect = RuntimeError("upstream 500")
+    return reranker
+
+
+def _make_huggingface():
+    reranker = object.__new__(HuggingFaceReranker)
+    reranker.config = SimpleNamespace(top_k=None, batch_size=32, max_length=512, normalize=False)
+    reranker.tokenizer = MagicMock(side_effect=RuntimeError("tokenizer exploded"))
+    reranker.model = MagicMock()
+    reranker.device = "cpu"
+    return reranker
+
+
+def _make_sentence_transformer():
+    reranker = object.__new__(SentenceTransformerReranker)
+    reranker.config = SimpleNamespace(top_k=None, batch_size=32, show_progress_bar=False)
+    reranker.model = MagicMock()
+    reranker.model.predict.side_effect = RuntimeError("predict exploded")
+    return reranker
+
+
+def _make_zero_entropy():
+    reranker = object.__new__(ZeroEntropyReranker)
+    reranker.config = SimpleNamespace(top_k=None)
+    reranker.model = "zerank-1"
+    reranker.client = MagicMock()
+    reranker.client.models.rerank.side_effect = RuntimeError("upstream 500")
+    return reranker
+
+
+@pytest.mark.parametrize(
+    "make_reranker",
+    [_make_cohere, _make_huggingface, _make_sentence_transformer, _make_zero_entropy],
+    ids=["cohere", "huggingface", "sentence_transformer", "zero_entropy"],
+)
+class TestFallbackDoesNotMutateInput:
+    def test_input_documents_unchanged_on_failure(self, make_reranker):
+        reranker = make_reranker()
+        documents = [{"memory": "alpha", "score": 0.9}, {"memory": "beta", "score": 0.4}]
+        originals = [doc.copy() for doc in documents]
+
+        result = reranker.rerank("query", documents)
+
+        # The caller's dicts must come back exactly as they went in.
+        assert documents == originals
+        assert all("rerank_score" not in doc for doc in documents)
+
+        # Graceful degradation still holds: same docs, original order, neutral score.
+        assert len(result) == 2
+        assert [doc["memory"] for doc in result] == ["alpha", "beta"]
+        assert all(doc["rerank_score"] == 0.0 for doc in result)
+
+    def test_fallback_returns_copies(self, make_reranker):
+        reranker = make_reranker()
+        documents = [{"memory": "alpha", "score": 0.9}]
+
+        result = reranker.rerank("query", documents)
+
+        assert result[0] is not documents[0]
+
+    def test_fallback_respects_config_top_k(self, make_reranker):
+        reranker = make_reranker()
+        reranker.config.top_k = 1
+        documents = [{"memory": "alpha"}, {"memory": "beta"}, {"memory": "gamma"}]
+
+        result = reranker.rerank("query", documents)
+
+        assert len(result) == 1
+        assert documents == [{"memory": "alpha"}, {"memory": "beta"}, {"memory": "gamma"}]


### PR DESCRIPTION
## Linked Issue

Closes #6362

## Description

The failure fallback in four reranker providers (Cohere, HuggingFace, SentenceTransformer, ZeroEntropy) was writing `rerank_score = 0.0` directly onto the input dicts, while every success path copies before attaching the score (LLMReranker even copies on its per-document failure path). Since `Memory.search()` hands its live result list to `rerank()` (`mem0/memory/main.py:1458`, async twin near line 3096), one transient provider failure permanently stamped the caller's memory dicts from a call that looked successful.

This copies each dict in the fallback loop before setting the sentinel, matching the success-path contract. Fallback behavior is otherwise untouched: original order, 0.0 sentinel, config `top_k` slice.

The new test file is parametrized over all four providers and proves the regression both ways: all 12 cases fail on main and pass with the fix. Providers are constructed via `object.__new__` with stubbed attributes so the tests run without the optional heavy deps (cohere, transformers, sentence-transformers, zeroentropy) installed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Ran `make lint` (clean) and `make test-py-3.11` (1687 passed; the two Redis e2e failures are pre-existing on main and only trigger because a local Redis happens to be reachable on my machine, they are skipped in CI). Also verified the new tests fail without the provider changes.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed

---

quick note: I'm a college freshman trying my best to contribute for the greater good :) this fix came out of a session with Claude Code (it did the heavy lifting, I read through the diff and ran the gates locally), so apologies in advance if anything looks off. if there are mistakes I would genuinely love to learn from them.
