### PR TITLE
fix(qdrant): support offline BM25 via bm25_specific_model_path

### DIFF
--- a/mem0/configs/vector_stores/qdrant.py
+++ b/mem0/configs/vector_stores/qdrant.py
@@ -21,6 +21,17 @@ class QdrantConfig(BaseModel):
         description="Whether to force HTTPS on or off. Explicit schemes in url take precedence.",
     )
     on_disk: Optional[bool] = Field(False,description="Enables persistent storage. Vectors are kept on disk (True) or in memory (False). Does not delete the local database path.")
+    bm25_model_name: Optional[str] = Field(
+        "Qdrant/bm25",
+        description="fastembed SparseTextEmbedding model name for BM25 hybrid search",
+    )
+    bm25_specific_model_path: Optional[str] = Field(
+        None,
+        description=(
+            "Local directory for a pre-downloaded BM25 sparse model. When set, fastembed "
+            "loads from this path (cache_dir) so hybrid BM25 works offline."
+        ),
+    )
 
     @model_validator(mode="before")
     @classmethod

--- a/mem0/vector_stores/qdrant.py
+++ b/mem0/vector_stores/qdrant.py
@@ -39,6 +39,8 @@ class Qdrant(VectorStoreBase):
         api_key: str = None,
         https: bool | None = None,
         on_disk: bool = False,
+        bm25_model_name: str = "Qdrant/bm25",
+        bm25_specific_model_path: str | None = None,
     ):
         """
         Initialize the Qdrant vector store.
@@ -56,6 +58,9 @@ class Qdrant(VectorStoreBase):
                 Defaults to None.
             on_disk (bool, optional): Enables persistent storage. Vectors are stored on disk (True) or in memory (False).
                 Does not delete the local database path. Defaults to False.
+            bm25_model_name (str, optional): fastembed SparseTextEmbedding model name. Defaults to "Qdrant/bm25".
+            bm25_specific_model_path (str, optional): Local cache directory for a pre-downloaded BM25 model so
+                hybrid search works without network access. Passed to SparseTextEmbedding as cache_dir.
         """
         if client:
             self.client = client
@@ -83,6 +88,8 @@ class Qdrant(VectorStoreBase):
         self.collection_name = collection_name
         self.embedding_model_dims = embedding_model_dims
         self.on_disk = on_disk
+        self.bm25_model_name = bm25_model_name or "Qdrant/bm25"
+        self.bm25_specific_model_path = bm25_specific_model_path
         self._bm25_encoder = None
         # Whether this collection has the `bm25` named sparse vector slot.
         # Pre-v3 collections lack it; writing a `bm25` sparse vector into such a
@@ -95,8 +102,20 @@ class Qdrant(VectorStoreBase):
         if self._bm25_encoder is None:
             try:
                 from fastembed import SparseTextEmbedding
-                self._bm25_encoder = SparseTextEmbedding(model_name="Qdrant/bm25")
-                logger.info("BM25 encoder loaded (fastembed Qdrant/bm25)")
+
+                kwargs = {"model_name": self.bm25_model_name}
+                if self.bm25_specific_model_path:
+                    # Offline / air-gapped: load weights from a pre-populated cache dir.
+                    kwargs["cache_dir"] = self.bm25_specific_model_path
+                self._bm25_encoder = SparseTextEmbedding(**kwargs)
+                if self.bm25_specific_model_path:
+                    logger.info(
+                        "BM25 encoder loaded (fastembed %s, cache_dir=%s)",
+                        self.bm25_model_name,
+                        self.bm25_specific_model_path,
+                    )
+                else:
+                    logger.info("BM25 encoder loaded (fastembed %s)", self.bm25_model_name)
             except ImportError:
                 logger.warning(
                     "fastembed not installed - BM25 keyword search disabled. "

--- a/tests/vector_stores/test_qdrant.py
+++ b/tests/vector_stores/test_qdrant.py
@@ -1041,3 +1041,57 @@ class TestQdrantDatetimeRangeFilters(unittest.TestCase):
         self.assertIn("mem0ai[extras]", joined)  # points at the right install
         self.assertNotIn("pip install fastembed", joined)  # not the bare package
         self.assertNotIn("\u2014", joined)  # no em-dash
+
+
+
+    def test_get_bm25_encoder_passes_specific_model_path_as_cache_dir(self):
+        """#6361: offline BM25 via bm25_specific_model_path -> SparseTextEmbedding(cache_dir=...)."""
+        import types
+
+        self.qdrant._bm25_encoder = None
+        self.qdrant.bm25_model_name = "Qdrant/bm25"
+        self.qdrant.bm25_specific_model_path = "/opt/models/fastembed-cache"
+
+        mock_encoder = MagicMock(name="SparseTextEmbedding")
+        mod = types.ModuleType("fastembed")
+        mod.SparseTextEmbedding = MagicMock(return_value=mock_encoder)
+
+        with patch.dict("sys.modules", {"fastembed": mod}):
+            result = self.qdrant._get_bm25_encoder()
+
+        self.assertIs(result, mock_encoder)
+        mod.SparseTextEmbedding.assert_called_once_with(
+            model_name="Qdrant/bm25",
+            cache_dir="/opt/models/fastembed-cache",
+        )
+
+    def test_get_bm25_encoder_without_path_keeps_default_constructor(self):
+        """Without bm25_specific_model_path, only model_name is forwarded."""
+        import types
+
+        self.qdrant._bm25_encoder = None
+        self.qdrant.bm25_model_name = "Qdrant/bm25"
+        self.qdrant.bm25_specific_model_path = None
+
+        mock_encoder = MagicMock(name="SparseTextEmbedding")
+        mod = types.ModuleType("fastembed")
+        mod.SparseTextEmbedding = MagicMock(return_value=mock_encoder)
+
+        with patch.dict("sys.modules", {"fastembed": mod}):
+            result = self.qdrant._get_bm25_encoder()
+
+        self.assertIs(result, mock_encoder)
+        mod.SparseTextEmbedding.assert_called_once_with(model_name="Qdrant/bm25")
+
+
+def test_qdrant_init_stores_bm25_path_options():
+    client_mock = MagicMock(spec=QdrantClient)
+    q = Qdrant(
+        collection_name="c",
+        embedding_model_dims=8,
+        client=client_mock,
+        bm25_model_name="Custom/bm25",
+        bm25_specific_model_path="/var/cache/bm25",
+    )
+    assert q.bm25_model_name == "Custom/bm25"
+    assert q.bm25_specific_model_path == "/var/cache/bm25"

--- a/tests/vector_stores/test_qdrant_config.py
+++ b/tests/vector_stores/test_qdrant_config.py
@@ -35,3 +35,15 @@ def test_qdrant_passes_explicit_https_to_client(monkeypatch):
         port=6333,
         https=False,
     )
+
+
+def test_qdrant_config_accepts_bm25_offline_options():
+    config = QdrantConfig(
+        host="127.0.0.1",
+        port=6333,
+        api_key="test-key",
+        bm25_model_name="Qdrant/bm25",
+        bm25_specific_model_path="/models/cache",
+    )
+    assert config.bm25_model_name == "Qdrant/bm25"
+    assert config.bm25_specific_model_path == "/models/cache"


### PR DESCRIPTION
## Summary

- Forward optional `bm25_specific_model_path` / `bm25_model_name` into Qdrant BM25 fastembed loading.
- When set, passes `cache_dir` to `SparseTextEmbedding` so hybrid BM25 works offline from a pre-downloaded model tree.

## Motivation

Closes #6361.

Hybrid search always did `SparseTextEmbedding(model_name="Qdrant/bm25")`, which downloads model weights on first use. Air-gapped / no-network hosts could not enable BM25 even with a local cache already populated. This exposes the path as config and stores it on the vector store constructor (consistent with other Qdrant options).

## Verification

- `pytest tests/vector_stores/test_qdrant.py tests/vector_stores/test_qdrant_config.py` — 101 passed
- Did NOT change: dense-only create_col path when bm25 slot missing; default model name remains `Qdrant/bm25` when unset
