### PR TITLE
fix(cli): structured JSON on agent init; honest mcp_ready=false

### DIFF
--- a/cli/python/src/mem0_cli/commands/agent_mode_cmd.py
+++ b/cli/python/src/mem0_cli/commands/agent_mode_cmd.py
@@ -54,7 +54,8 @@ def bootstrap_via_backend(
     *,
     source: str | None = None,
     agent_caller: str | None = None,
-) -> None:
+    quiet: bool = False,
+) -> dict[str, Any]:
     """POST /api/v1/auth/agent_mode/ and mutate config in place.
 
     Args:
@@ -65,6 +66,11 @@ def bootstrap_via_backend(
             omitted the flag; the agent can backfill later via
             ``mem0 identify <name>``. Sent to the backend in the request body
             and saved into ``platform.agent_caller`` for local introspection.
+        quiet: When True, skip Rich human-facing banners so callers can emit a
+            single structured JSON success envelope (``mem0 init --agent --json``).
+
+    Returns:
+        The validated backend envelope (at least ``api_key`` and ``default_user_id``).
 
     Raises typer.Exit(1) on failure.
     """
@@ -124,20 +130,35 @@ def bootstrap_via_backend(
     config.defaults.user_id = envelope["default_user_id"]
     save_config(config)
 
-    print_success(console, f"Agent Mode active. Default user_id: {envelope['default_user_id']}")
-    notice = envelope.get("mem0_notice")
-    if notice:
-        console.print(f"\n[yellow]🔔 {notice}[/yellow]\n")
-    else:
-        # Fallback if the backend hasn't deployed the unified notice yet.
-        claim_cmd = envelope.get("claim_command", "mem0 init --email <your-email>")
-        console.print(f"  [{DIM_COLOR}]To claim this account later: {claim_cmd}[/]")
-
-    if not agent_caller:
-        console.print(
-            f"  [{DIM_COLOR}]If you are an AI agent, identify yourself: "
-            f"`mem0 identify <your-name>` (e.g. claude-code, cursor).[/]"
+    if not quiet:
+        print_success(
+            console,
+            f"Agent Mode active. Default user_id: {envelope['default_user_id']}",
         )
+        notice = envelope.get("mem0_notice")
+        if notice:
+            console.print(f"\n[yellow]🔔 {notice}[/yellow]\n")
+        else:
+            # Fallback if the backend hasn't deployed the unified notice yet.
+            claim_cmd = envelope.get("claim_command", "mem0 init --email <your-email>")
+            console.print(f"  [{DIM_COLOR}]To claim this account later: {claim_cmd}[/]")
+
+        # MCP hosts (Codex/Cursor/etc.) read MEM0_API_KEY from the environment,
+        # not from ~/.mem0/config.json. Be explicit so exit 0 is not mistaken for
+        # "plugin MCP is authenticated" after a clean-home bootstrap.
+        console.print(
+            f"  [{DIM_COLOR}]CLI credential saved to ~/.mem0/config.json. "
+            f"MCP transports that require MEM0_API_KEY still need that env var "
+            f"exported (or a host restart after you set it) before they are ready.[/]"
+        )
+
+        if not agent_caller:
+            console.print(
+                f"  [{DIM_COLOR}]If you are an AI agent, identify yourself: "
+                f"`mem0 identify <your-name>` (e.g. claude-code, cursor).[/]"
+            )
+
+    return envelope
 
 
 def claim_via_otp(config: Mem0Config, *, email: str, code: str | None = None) -> None:

--- a/cli/python/src/mem0_cli/commands/init_cmd.py
+++ b/cli/python/src/mem0_cli/commands/init_cmd.py
@@ -334,7 +334,38 @@ def run_init(
         # agent_caller is the agent's self-declared identity from --agent-caller
         # (Proof Editor-style). Env-var auto-detect is still used above to
         # decide we're in an agent context, but never to fill identity.
-        bootstrap_via_backend(config, source=source, agent_caller=agent_caller)
+        json_mode = _is_json_mode()
+        envelope = bootstrap_via_backend(
+            config,
+            source=source,
+            agent_caller=agent_caller,
+            quiet=json_mode,
+        )
+        if json_mode:
+            # Scientists and agents must not treat exit 0 + plain text as
+            # MCP-ready: save_config writes config.json only; plugin_sync
+            # only updates EXISTING env/rc entries (none on a clean home).
+            format_json_envelope(
+                console,
+                command="init",
+                data={
+                    "api_key_saved": True,
+                    "api_key_source": "agent_mode_bootstrap",
+                    "default_user_id": envelope["default_user_id"],
+                    "agent_mode": True,
+                    "config_path": str(CONFIG_FILE),
+                    "mcp_ready": False,
+                    "mcp_credential_source": "config_only",
+                    "next_step": (
+                        "API key is in ~/.mem0/config.json for CLI use. "
+                        "Set MEM0_API_KEY (and restart Codex/Cursor MCP if needed) "
+                        "before plugin MCP auth will succeed."
+                    ),
+                    "claim_hint": envelope.get(
+                        "claim_command", "mem0 init --email <your-email>"
+                    ),
+                },
+            )
         _fire_init("agent")
         return
 

--- a/cli/python/src/mem0_cli/commands/init_cmd.py
+++ b/cli/python/src/mem0_cli/commands/init_cmd.py
@@ -361,9 +361,7 @@ def run_init(
                         "Set MEM0_API_KEY (and restart Codex/Cursor MCP if needed) "
                         "before plugin MCP auth will succeed."
                     ),
-                    "claim_hint": envelope.get(
-                        "claim_command", "mem0 init --email <your-email>"
-                    ),
+                    "claim_hint": envelope.get("claim_command", "mem0 init --email <your-email>"),
                 },
             )
         _fire_init("agent")

--- a/cli/python/tests/test_init_internals.py
+++ b/cli/python/tests/test_init_internals.py
@@ -204,3 +204,52 @@ def test_bootstrap_403_permission_surfaces_ratelimit(monkeypatch, capsys) -> Non
     combined = captured.out + captured.err
     assert "Daily Agent Mode signup limit reached" in combined
     assert "permission to perform this action" not in combined
+
+
+def test_bootstrap_quiet_returns_envelope_without_rich_banners(monkeypatch, tmp_path):
+    """#6346: mem0 init --agent --json needs a machine envelope, not claim prose."""
+    from mem0_cli.commands import agent_mode_cmd
+    from mem0_cli.config import Mem0Config
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # Point CONFIG under the clean home
+    import mem0_cli.config as config_mod
+
+    monkeypatch.setattr(config_mod, "CONFIG_DIR", tmp_path / ".mem0")
+    monkeypatch.setattr(config_mod, "CONFIG_FILE", tmp_path / ".mem0" / "config.json")
+    (tmp_path / ".mem0").mkdir(parents=True, exist_ok=True)
+
+    class FakeResp:
+        status_code = 200
+
+        def json(self):
+            return {"api_key": "m0-test-key-abcdef", "default_user_id": "agent-u1"}
+
+    class FakeClient:
+        def __init__(self, *a, **k):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def post(self, *a, **k):
+            return FakeResp()
+
+    monkeypatch.setattr(agent_mode_cmd.httpx, "Client", FakeClient)
+
+    printed: list[str] = []
+
+    def _fake_print_success(console, msg):
+        printed.append(msg)
+
+    monkeypatch.setattr(agent_mode_cmd, "print_success", _fake_print_success)
+
+    cfg = Mem0Config()
+    env = agent_mode_cmd.bootstrap_via_backend(cfg, agent_caller="codex", quiet=True)
+    assert env["api_key"] == "m0-test-key-abcdef"
+    assert env["default_user_id"] == "agent-u1"
+    assert printed == []
+    assert cfg.platform.agent_mode is True


### PR DESCRIPTION
## Summary

- `mem0 init --agent --json` returns a structured success envelope after bootstrap (not claim/prose banners).
- Envelope sets `mcp_ready: false` on clean home and documents that MCP hosts still need `MEM0_API_KEY`.
- Human path adds an explicit note that config.json success ≠ authenticated MCP.

## Motivation

Closes #6346.

On a clean home, `mem0 init --agent --json` exited 0, saved the key to `~/.mem0/config.json`, but printed plain-text claim reminders and implied a ready plugin path. `plugin_sync` only updates *existing* env/rc entries, so Codex MCP (`bearer_token_env_var = MEM0_API_KEY`) still 401s. Agents and scripts need a machine-readable truth signal.

## Verification

- `PYTHONPATH=src pytest cli/python/tests/test_init_internals.py cli/python/tests/test_agent_mode.py` — 25 passed
- Did NOT create new shell/Claude env entries on clean home (still best-effort sync of existing targets only)
