### PR TITLE
fix(llms/aws_bedrock): iterate Converse content blocks for Anthropic text

### DIFF
--- a/mem0/llms/aws_bedrock.py
+++ b/mem0/llms/aws_bedrock.py
@@ -573,11 +573,20 @@ class AWSBedrockLLM(LLMBase):
             # Use converse API for Anthropic models
             response = self.client.converse(**converse_params)
 
-            # Parse Converse API response
+            # Parse Converse API response. Claude reasoning models can emit a
+            # `reasoningContent` block before the `text` block, so iterate to
+            # find the first block that carries text instead of indexing
+            # content[0] (same approach as the MiniMax branch below).
             if hasattr(response, 'output') and hasattr(response.output, 'message'):
-                return response.output.message.content[0].text
+                for block in response.output.message.content:
+                    if hasattr(block, 'text'):
+                        return block.text
+                return ""
             elif 'output' in response and 'message' in response['output']:
-                return response['output']['message']['content'][0]['text']
+                for block in response['output']['message']['content']:
+                    if 'text' in block:
+                        return block['text']
+                return ""
             else:
                 return str(response)
 

--- a/tests/llms/test_aws_bedrock.py
+++ b/tests/llms/test_aws_bedrock.py
@@ -452,3 +452,51 @@ class TestParseResponseLegacy:
         response = {"body": body}
         result = llm._parse_response(response, tools=None)
         assert result == "hello from ai21"
+
+
+class TestAnthropicConverseContentParsing:
+    """The Anthropic Converse branch must not assume content[0] is the text
+    block: Claude reasoning models emit a reasoningContent block before the
+    text block, and some stop conditions produce an empty content array. The
+    parser iterates for the first block carrying text, like the MiniMax branch.
+    """
+
+    def test_text_after_reasoning_content_block(self, mock_boto3):
+        mock_boto3.converse.return_value = {
+            "output": {
+                "message": {
+                    "content": [
+                        {"reasoningContent": {"reasoningText": {"text": "step by step..."}}},
+                        {"text": "final answer"},
+                    ]
+                }
+            }
+        }
+        llm = _make_llm("anthropic.claude-3-5-sonnet-20240620-v1:0", mock_boto3)
+
+        assert llm.generate_response(MESSAGES) == "final answer"
+
+    def test_empty_content_returns_empty_string(self, mock_boto3):
+        mock_boto3.converse.return_value = {"output": {"message": {"content": []}}}
+        llm = _make_llm("anthropic.claude-3-5-sonnet-20240620-v1:0", mock_boto3)
+
+        assert llm.generate_response(MESSAGES) == ""
+
+    def test_plain_text_content_still_returned(self, mock_boto3):
+        mock_boto3.converse.return_value = _converse_response("plain answer")
+        llm = _make_llm("anthropic.claude-3-5-sonnet-20240620-v1:0", mock_boto3)
+
+        assert llm.generate_response(MESSAGES) == "plain answer"
+
+    def test_object_style_response_iterates_blocks(self, mock_boto3):
+        # Defensive attr-style branch: object wrapper with a reasoning block first.
+        from types import SimpleNamespace
+
+        reasoning_block = SimpleNamespace(reasoningContent={"reasoningText": {"text": "hmm"}})
+        text_block = SimpleNamespace(text="object answer")
+        mock_boto3.converse.return_value = SimpleNamespace(
+            output=SimpleNamespace(message=SimpleNamespace(content=[reasoning_block, text_block]))
+        )
+        llm = _make_llm("anthropic.claude-3-5-sonnet-20240620-v1:0", mock_boto3)
+
+        assert llm.generate_response(MESSAGES) == "object answer"


### PR DESCRIPTION
## Linked Issue

Closes #6368

## Description

The Anthropic branch of `_generate_standard` parsed the Converse API response with `content[0]`, which assumes the first content block is the text block. Reasoning-enabled Claude models emit a `reasoningContent` block first (KeyError), and some stop conditions produce an empty content array (IndexError); both surface as an unhelpful generic `RuntimeError` from `generate_response`. The MiniMax branch in the same function already iterates the content blocks for exactly this reason, with a comment explaining it. This applies the same treatment to the Anthropic branch, in both response shapes, returning an empty string when no text block exists (matching the MiniMax and Gemini provider contracts).

Four new tests cover the reasoning-block-first case, the empty content array, the plain text case (unchanged behavior), and the object-style response shape. The first two fail on main and pass with the fix.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

`make lint` clean, `make test-py-3.11` green (1679 passed; the two Redis e2e failures are pre-existing on main, they only trigger because a local Redis is reachable on my machine and are skipped in CI). Verified the new reasoning/empty-content tests fail without the parser change.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed

---

small disclosure like on my last PR: freshman here doing my best for the greater good :) built this with Claude Code doing the heavy lifting while I sanity-checked the diff and ran the gates locally. if I got something wrong I'd honestly rather hear it and learn than have it slide.
