### PR TITLE
fix(ts-oss): strip identity scope from add() metadata

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -100,6 +100,12 @@ const ENTITY_PARAMS = [
   "agentId",
   "runId",
 ];
+const IDENTITY_METADATA_KEYS = [
+  "user_id",
+  "agent_id",
+  "run_id",
+  "actor_id",
+] as const;
 
 // Identity keys stripped from update() metadata: ENTITY_PARAMS covers user_id/agent_id/run_id
 // in both casings (the default store promotes camelCase on read); actor_id has no camelCase alias.
@@ -736,7 +742,9 @@ export class Memory {
       has_filters: !!config.filters,
       infer: config.infer,
     });
-    const { metadata = {}, filters = {}, infer = true } = config;
+    const { filters = {}, infer = true } = config;
+    const metadata = { ...config.metadata };
+    for (const key of IDENTITY_METADATA_KEYS) delete metadata[key];
 
     // Validate and trim entity IDs
     const userId = validateAndTrimEntityId(config.userId, "userId");
@@ -747,6 +755,9 @@ export class Memory {
     if (userId) filters.user_id = metadata.user_id = userId;
     if (agentId) filters.agent_id = metadata.agent_id = agentId;
     if (runId) filters.run_id = metadata.run_id = runId;
+    if (filters.user_id) metadata.user_id = filters.user_id;
+    if (filters.agent_id) metadata.agent_id = filters.agent_id;
+    if (filters.run_id) metadata.run_id = filters.run_id;
 
     // Normalize expiration date into the stored metadata (round-trips via get()).
     if (config.expirationDate != null) {

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -100,9 +100,19 @@ const ENTITY_PARAMS = [
   "agentId",
   "runId",
 ];
-// Identity keys stripped from update() metadata: ENTITY_PARAMS covers user_id/agent_id/run_id
-// in both casings (the default store promotes camelCase on read); actor_id has no camelCase alias.
+// Identity keys stripped from caller metadata in add() and update(): ENTITY_PARAMS covers
+// user_id/agent_id/run_id in both casings (the default store promotes camelCase on read);
+// actor_id has no camelCase alias.
 const IDENTITY_KEYS = [...ENTITY_PARAMS, "actor_id"];
+
+// Caller metadata must not overwrite or inject an identity scope (#6342 / #6367 / #6371).
+function stripIdentityKeys(
+  metadata: Record<string, any> = {},
+): Record<string, any> {
+  return Object.fromEntries(
+    Object.entries(metadata).filter(([key]) => !IDENTITY_KEYS.includes(key)),
+  );
+}
 
 /**
  * Validates that no top-level entity parameters are passed in config.
@@ -736,8 +746,7 @@ export class Memory {
       infer: config.infer,
     });
     const { filters = {}, infer = true } = config;
-    const metadata = { ...config.metadata };
-    for (const key of IDENTITY_KEYS) delete metadata[key];
+    const metadata = stripIdentityKeys(config.metadata);
 
     // Validate and trim entity IDs
     const userId = validateAndTrimEntityId(config.userId, "userId");
@@ -1950,10 +1959,7 @@ export class Memory {
       existingEmbeddings[newData] ||
       (await this.embedder.embed(newData, "update"));
 
-    // Caller metadata must not overwrite or inject an identity scope (#6342 / #6367).
-    const sanitizedMetadata = Object.fromEntries(
-      Object.entries(metadata).filter(([k]) => !IDENTITY_KEYS.includes(k)),
-    );
+    const sanitizedMetadata = stripIdentityKeys(metadata);
 
     const newMetadata = {
       ...existingMemory.payload,

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -100,12 +100,7 @@ const ENTITY_PARAMS = [
   "agentId",
   "runId",
 ];
-const IDENTITY_METADATA_KEYS = [
-  "user_id",
-  "agent_id",
-  "run_id",
-  "actor_id",
-] as const;
+const IDENTITY_KEYS = [...ENTITY_PARAMS, "actor_id"] as const;
 
 // Identity keys stripped from update() metadata: ENTITY_PARAMS covers user_id/agent_id/run_id
 // in both casings (the default store promotes camelCase on read); actor_id has no camelCase alias.
@@ -744,7 +739,7 @@ export class Memory {
     });
     const { filters = {}, infer = true } = config;
     const metadata = { ...config.metadata };
-    for (const key of IDENTITY_METADATA_KEYS) delete metadata[key];
+    for (const key of IDENTITY_KEYS) delete metadata[key];
 
     // Validate and trim entity IDs
     const userId = validateAndTrimEntityId(config.userId, "userId");

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -100,8 +100,6 @@ const ENTITY_PARAMS = [
   "agentId",
   "runId",
 ];
-const IDENTITY_KEYS = [...ENTITY_PARAMS, "actor_id"] as const;
-
 // Identity keys stripped from update() metadata: ENTITY_PARAMS covers user_id/agent_id/run_id
 // in both casings (the default store promotes camelCase on read); actor_id has no camelCase alias.
 const IDENTITY_KEYS = [...ENTITY_PARAMS, "actor_id"];

--- a/mem0-ts/src/oss/tests/memory.add.test.ts
+++ b/mem0-ts/src/oss/tests/memory.add.test.ts
@@ -172,6 +172,102 @@ describe("Memory - add()", () => {
     );
   });
 
+  test("does not allow metadata to set identity scope", async () => {
+    const result: SearchResult = await memory.add("I am a software engineer", {
+      userId: "u1",
+      metadata: {
+        agent_id: "other",
+        run_id: "other-run",
+        actor_id: "x",
+        source: "issue-6371",
+        nested: { preserved: true },
+      },
+    });
+    const stored: MemoryItem | null = await memory.get(result.results[0].id);
+
+    expect(stored).toEqual(
+      expect.objectContaining({
+        user_id: "u1",
+        metadata: expect.objectContaining({
+          source: "issue-6371",
+          nested: { preserved: true },
+        }),
+      }),
+    );
+    expect(stored).not.toHaveProperty("agent_id");
+    expect(stored).not.toHaveProperty("run_id");
+    expect(stored!.metadata).not.toHaveProperty("agent_id");
+    expect(stored!.metadata).not.toHaveProperty("run_id");
+    expect(stored!.metadata).not.toHaveProperty("actor_id");
+  });
+
+  test.each([
+    ["userId", { userId: "u1" }, true, "user_id", "u1"],
+    ["agentId", { agentId: "a1" }, false, "agent_id", "a1"],
+    ["runId", { runId: "r1" }, true, "run_id", "r1"],
+  ] as const)(
+    "preserves typed %s scope while stripping conflicting metadata identities",
+    async (_mode, scope, infer, canonicalKey, canonicalValue) => {
+      const result: SearchResult = await memory.add("scoped content", {
+        ...scope,
+        infer,
+        metadata: {
+          user_id: "metadata-user",
+          agent_id: "metadata-agent",
+          run_id: "metadata-run",
+          actor_id: "metadata-actor",
+          ordinary: "preserved",
+        },
+      });
+      const stored: MemoryItem | null = await memory.get(result.results[0].id);
+
+      expect(stored).toHaveProperty(canonicalKey, canonicalValue);
+      expect(stored!.metadata).toEqual(
+        expect.objectContaining({ ordinary: "preserved" }),
+      );
+      for (const key of ["user_id", "agent_id", "run_id", "actor_id"]) {
+        if (key !== canonicalKey) {
+          expect(stored!.metadata).not.toHaveProperty(key);
+        }
+      }
+    },
+  );
+
+  test.each([
+    [true, "user_id", "filter-user"],
+    [false, "user_id", "filter-user"],
+    [false, "agent_id", "filter-agent"],
+    [false, "run_id", "filter-run"],
+  ] as const)(
+    "preserves %s filters scope after sanitization",
+    async (infer, filterKey, filterValue) => {
+      const result: SearchResult = await memory.add("filter-scoped content", {
+        filters: { [filterKey]: filterValue },
+        infer,
+        metadata: {
+          user_id: "metadata-user",
+          agent_id: "metadata-agent",
+          run_id: "metadata-run",
+          actor_id: "metadata-actor",
+          ordinary: "preserved",
+        },
+      });
+      const stored: MemoryItem | null = await memory.get(result.results[0].id);
+
+      expect(stored).toHaveProperty(filterKey, filterValue);
+      expect(stored!.metadata).toEqual(
+        expect.objectContaining({
+          [filterKey]: filterValue,
+          ordinary: "preserved",
+        }),
+      );
+      for (const key of ["user_id", "agent_id", "run_id", "actor_id"]) {
+        if (key === filterKey) continue;
+        expect(stored!.metadata).not.toHaveProperty(key);
+      }
+    },
+  );
+
   test("with infer=false skips LLM and stores messages directly", async () => {
     const result: SearchResult = await memory.add("Direct storage content", {
       userId,

--- a/mem0-ts/src/oss/tests/memory.add.test.ts
+++ b/mem0-ts/src/oss/tests/memory.add.test.ts
@@ -8,6 +8,118 @@ import type { MemoryConfig, MemoryItem, SearchResult } from "../src/types";
 
 jest.setTimeout(15000);
 
+jest.mock("../src/utils/factory", () => {
+  const { MemoryVectorStore } = jest.requireActual(
+    "../src/vector_stores/memory",
+  );
+  const { MemoryHistoryManager } = jest.requireActual(
+    "../src/storage/MemoryHistoryManager",
+  );
+  const testEmbedding = new Array(1536).fill(0.1);
+
+  class MockEmbedder {
+    embeddingDims = 1536;
+
+    async embed(): Promise<number[]> {
+      return testEmbedding;
+    }
+
+    async embedBatch(texts: string[]): Promise<number[][]> {
+      return texts.map(() => testEmbedding);
+    }
+  }
+
+  class MockLLM {
+    async generateResponse(messages: Array<{ role: string; content: string }>) {
+      const userMsg = messages.find((m) => m.role === "user");
+      const content = userMsg?.content ?? "";
+      const newMsgMatch = content.match(
+        /## New Messages\n([\s\S]*?)(?=\n##|$)/,
+      );
+      const extracted = newMsgMatch
+        ? newMsgMatch[1].trim()
+        : "extracted fact from input";
+
+      return JSON.stringify({
+        memory: [
+          {
+            id: "0",
+            text: extracted,
+            attributed_to: "user",
+          },
+        ],
+      });
+    }
+  }
+
+  return {
+    __esModule: true,
+    EmbedderFactory: {
+      create: jest.fn(() => new MockEmbedder()),
+    },
+    LLMFactory: {
+      create: jest.fn(() => new MockLLM()),
+    },
+    VectorStoreFactory: {
+      create: jest.fn((provider: string, config: any) => {
+        if (provider.toLowerCase() !== "memory") {
+          throw new Error(
+            `Unsupported vector store provider in test: ${provider}`,
+          );
+        }
+        return new MemoryVectorStore(config);
+      }),
+    },
+    HistoryManagerFactory: {
+      create: jest.fn(() => new MemoryHistoryManager()),
+    },
+    RerankerFactory: {
+      create: jest.fn(() => {
+        throw new Error("RerankerFactory is not used in memory.add.test.ts");
+      }),
+    },
+  };
+});
+
+jest.mock("openai", () => {
+  class MockOpenAI {
+    embeddings = { create: jest.fn() };
+    chat = { completions: { create: jest.fn() } };
+    responses = { create: jest.fn() };
+    beta = { chat: { completions: { parse: jest.fn() } } };
+  }
+
+  return {
+    __esModule: true,
+    default: MockOpenAI,
+    AzureOpenAI: MockOpenAI,
+  };
+});
+
+jest.mock(
+  "node-fetch",
+  () => ({
+    __esModule: true,
+    default: jest.fn(),
+    Headers: class {},
+    Request: class {},
+    Response: class {},
+  }),
+  { virtual: true },
+);
+
+jest.mock("@anthropic-ai/sdk", () => {
+  class MockAnthropic {
+    messages = { create: jest.fn() };
+    beta = { messages: { create: jest.fn() } };
+  }
+
+  return {
+    __esModule: true,
+    default: MockAnthropic,
+  };
+});
+
 // Mock Google modules to prevent @google/genai crash in CI
 jest.mock("../src/embeddings/google", () => ({
   GoogleEmbedder: jest.fn(),
@@ -177,7 +289,9 @@ describe("Memory - add()", () => {
       userId: "u1",
       metadata: {
         agent_id: "other",
+        agentId: "other-camel",
         run_id: "other-run",
+        runId: "other-run-camel",
         actor_id: "x",
         source: "issue-6371",
         nested: { preserved: true },
@@ -197,7 +311,9 @@ describe("Memory - add()", () => {
     expect(stored).not.toHaveProperty("agent_id");
     expect(stored).not.toHaveProperty("run_id");
     expect(stored!.metadata).not.toHaveProperty("agent_id");
+    expect(stored!.metadata).not.toHaveProperty("agentId");
     expect(stored!.metadata).not.toHaveProperty("run_id");
+    expect(stored!.metadata).not.toHaveProperty("runId");
     expect(stored!.metadata).not.toHaveProperty("actor_id");
   });
 
@@ -213,8 +329,11 @@ describe("Memory - add()", () => {
         infer,
         metadata: {
           user_id: "metadata-user",
+          userId: "metadata-user-camel",
           agent_id: "metadata-agent",
+          agentId: "metadata-agent-camel",
           run_id: "metadata-run",
+          runId: "metadata-run-camel",
           actor_id: "metadata-actor",
           ordinary: "preserved",
         },
@@ -222,10 +341,23 @@ describe("Memory - add()", () => {
       const stored: MemoryItem | null = await memory.get(result.results[0].id);
 
       expect(stored).toHaveProperty(canonicalKey, canonicalValue);
+      for (const key of ["user_id", "agent_id", "run_id"]) {
+        if (key !== canonicalKey) {
+          expect(stored).not.toHaveProperty(key);
+        }
+      }
       expect(stored!.metadata).toEqual(
         expect.objectContaining({ ordinary: "preserved" }),
       );
-      for (const key of ["user_id", "agent_id", "run_id", "actor_id"]) {
+      for (const key of [
+        "user_id",
+        "userId",
+        "agent_id",
+        "agentId",
+        "run_id",
+        "runId",
+        "actor_id",
+      ]) {
         if (key !== canonicalKey) {
           expect(stored!.metadata).not.toHaveProperty(key);
         }
@@ -246,8 +378,11 @@ describe("Memory - add()", () => {
         infer,
         metadata: {
           user_id: "metadata-user",
+          userId: "metadata-user-camel",
           agent_id: "metadata-agent",
+          agentId: "metadata-agent-camel",
           run_id: "metadata-run",
+          runId: "metadata-run-camel",
           actor_id: "metadata-actor",
           ordinary: "preserved",
         },
@@ -255,13 +390,26 @@ describe("Memory - add()", () => {
       const stored: MemoryItem | null = await memory.get(result.results[0].id);
 
       expect(stored).toHaveProperty(filterKey, filterValue);
+      for (const key of ["user_id", "agent_id", "run_id"]) {
+        if (key !== filterKey) {
+          expect(stored).not.toHaveProperty(key);
+        }
+      }
       expect(stored!.metadata).toEqual(
         expect.objectContaining({
           [filterKey]: filterValue,
           ordinary: "preserved",
         }),
       );
-      for (const key of ["user_id", "agent_id", "run_id", "actor_id"]) {
+      for (const key of [
+        "user_id",
+        "userId",
+        "agent_id",
+        "agentId",
+        "run_id",
+        "runId",
+        "actor_id",
+      ]) {
         if (key === filterKey) continue;
         expect(stored!.metadata).not.toHaveProperty(key);
       }

--- a/mem0-ts/src/oss/tests/memory.add.test.ts
+++ b/mem0-ts/src/oss/tests/memory.add.test.ts
@@ -81,45 +81,6 @@ jest.mock("../src/utils/factory", () => {
   };
 });
 
-jest.mock("openai", () => {
-  class MockOpenAI {
-    embeddings = { create: jest.fn() };
-    chat = { completions: { create: jest.fn() } };
-    responses = { create: jest.fn() };
-    beta = { chat: { completions: { parse: jest.fn() } } };
-  }
-
-  return {
-    __esModule: true,
-    default: MockOpenAI,
-    AzureOpenAI: MockOpenAI,
-  };
-});
-
-jest.mock(
-  "node-fetch",
-  () => ({
-    __esModule: true,
-    default: jest.fn(),
-    Headers: class {},
-    Request: class {},
-    Response: class {},
-  }),
-  { virtual: true },
-);
-
-jest.mock("@anthropic-ai/sdk", () => {
-  class MockAnthropic {
-    messages = { create: jest.fn() };
-    beta = { messages: { create: jest.fn() } };
-  }
-
-  return {
-    __esModule: true,
-    default: MockAnthropic,
-  };
-});
-
 // Mock Google modules to prevent @google/genai crash in CI
 jest.mock("../src/embeddings/google", () => ({
   GoogleEmbedder: jest.fn(),

--- a/mem0-ts/src/oss/tests/memory.add.test.ts
+++ b/mem0-ts/src/oss/tests/memory.add.test.ts
@@ -81,56 +81,6 @@ jest.mock("../src/utils/factory", () => {
   };
 });
 
-// Mock Google modules to prevent @google/genai crash in CI
-jest.mock("../src/embeddings/google", () => ({
-  GoogleEmbedder: jest.fn(),
-}));
-jest.mock("../src/llms/google", () => ({
-  GoogleLLM: jest.fn(),
-}));
-
-jest.mock("../src/llms/openai", () => ({
-  OpenAILLM: jest.fn().mockImplementation(() => ({
-    generateResponse: jest
-      .fn()
-      .mockImplementation(
-        (messages: Array<{ role: string; content: string }>) => {
-          // V3 pipeline: single LLM call with additive extraction prompt.
-          const userMsg = messages.find((m) => m.role === "user");
-          const content = userMsg?.content ?? "";
-          const newMsgMatch = content.match(
-            /## New Messages\n([\s\S]*?)(?=\n##|$)/,
-          );
-          const extracted = newMsgMatch
-            ? newMsgMatch[1].trim()
-            : "extracted fact from input";
-          return JSON.stringify({
-            memory: [
-              {
-                id: "0",
-                text: extracted,
-                attributed_to: "user",
-              },
-            ],
-          });
-        },
-      ),
-  })),
-}));
-
-const mockEmbedding = new Array(1536).fill(0.1);
-jest.mock("../src/embeddings/openai", () => ({
-  OpenAIEmbedder: jest.fn().mockImplementation(() => ({
-    embed: jest.fn().mockResolvedValue(mockEmbedding),
-    embedBatch: jest
-      .fn()
-      .mockImplementation((texts: string[]) =>
-        Promise.resolve(texts.map(() => mockEmbedding)),
-      ),
-    embeddingDims: 1536,
-  })),
-}));
-
 function createMemory(overrides: Partial<MemoryConfig> = {}): Memory {
   return new Memory({
     version: "v1.1",
@@ -332,7 +282,7 @@ describe("Memory - add()", () => {
     [false, "agent_id", "filter-agent"],
     [false, "run_id", "filter-run"],
   ] as const)(
-    "preserves %s filters scope after sanitization",
+    "preserves infer=%s %s filters scope after sanitization",
     async (infer, filterKey, filterValue) => {
       const result: SearchResult = await memory.add("filter-scoped content", {
         filters: { [filterKey]: filterValue },


### PR DESCRIPTION
## Linked Issue

Closes #6371

## Description

In the TypeScript OSS SDK, `Memory.add()` should only take identity scope from the typed `userId` / `agentId` / `runId` params. Before this change, callers could still smuggle scope through freeform `metadata`, and the default memory store could promote `userId` / `agentId` / `runId` back to canonical snake_case keys on read.

This change strips both the canonical identity keys and their camelCase aliases from `metadata` before typed or filter scope is pinned into the payload. Ordinary metadata still passes through, and typed scope remains authoritative.

## Root cause

`Memory.add()` passed caller-supplied metadata through to the stored payload, so freeform identity keys could establish scope. The default memory store's `normalizePayload()` also promotes `userId` / `agentId` / `runId` to `user_id` / `agent_id` / `run_id` on read, making camelCase aliases an injection path. The add path now removes all recognized identity spellings before typed or filter scope is pinned.

## Scope

- changes the TypeScript OSS `add()` path only
- keeps `update()` separate
- does not change the public API shape

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually
- [ ] No tests needed

Observed verification:

- [x] `cd mem0-ts && pnpm run test:unit -- --runTestsByPath src/oss/tests/memory.add.test.ts --coverage=false`
- [x] `cd mem0-ts && npx prettier --check .\src\oss\src\memory\index.ts .\src\oss\tests\memory.add.test.ts`
- [ ] `cd mem0-ts && pnpm install --frozen-lockfile && pnpm run build && pnpm run test:unit`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [x] I have updated documentation if needed
