### PR TITLE
fix: include keyword-only hybrid search matches

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -1517,14 +1517,33 @@ export class Memory {
       }
     }
 
-    // Step 7: Build candidate set from semantic results
-    const candidates = semanticResults
-      .filter((mem) => showExpired || !payloadIsExpired(mem.payload))
-      .map((mem) => ({
-        id: String(mem.id),
+    // Step 7: Build candidate set from the union of semantic and keyword results
+    const candidatesById = new Map<
+      string,
+      { id: string; score?: number; payload: Record<string, any> }
+    >();
+    for (const mem of semanticResults) {
+      const payload = mem.payload || {};
+      if (!showExpired && payloadIsExpired(payload)) continue;
+      const id = String(mem.id);
+      candidatesById.set(id, {
+        id,
         score: mem.score ?? 0,
-        payload: mem.payload || {},
-      }));
+        payload,
+      });
+    }
+
+    if (keywordResults) {
+      for (const mem of keywordResults) {
+        const id = String(mem.id);
+        if (candidatesById.has(id) || bm25Scores[id] == null) continue;
+        const payload = mem.payload || {};
+        if (!showExpired && payloadIsExpired(payload)) continue;
+        candidatesById.set(id, { id, payload });
+      }
+    }
+
+    const candidates = Array.from(candidatesById.values());
 
     // Step 8: Score and rank
     const scoredResults = scoreAndRank(

--- a/mem0-ts/src/oss/src/utils/scoring.ts
+++ b/mem0-ts/src/oss/src/utils/scoring.ts
@@ -79,8 +79,9 @@ export interface ScoredResult {
  * For each candidate:
  *   combined = (semantic + bm25 + entity_boost) / max_possible
  *
- * Threshold gates the semantic score BEFORE combining -- candidates
- * below the threshold are excluded even if BM25/entity would boost them.
+ * Threshold gates semantic candidates before combining. Keyword-only
+ * candidates, represented by a missing semantic score, are allowed through
+ * when they have a BM25 score.
  *
  * The divisor adapts based on which signals are active:
  *   - Semantic only: max_possible = 1.0
@@ -88,7 +89,8 @@ export interface ScoredResult {
  *   - Semantic + BM25 + entity: max_possible = 2.5
  *   - Semantic + entity (no BM25): max_possible = 1.5
  *
- * @param semanticResults - Candidate results with id, score, and payload.
+ * @param semanticResults - Candidate results from semantic and keyword search.
+ *   Keyword-only candidates omit score.
  * @param bm25Scores - Map of memory ID to normalized BM25 score.
  * @param entityBoosts - Map of memory ID to entity boost score.
  * @param threshold - Minimum semantic score to include a candidate.
@@ -99,7 +101,7 @@ export interface ScoredResult {
 export function scoreAndRank(
   semanticResults: Array<{
     id: string;
-    score: number;
+    score?: number;
     payload: Record<string, any>;
   }>,
   bm25Scores: Record<string, number>,
@@ -127,14 +129,15 @@ export function scoreAndRank(
       continue;
     }
 
-    const semanticScore = result.score ?? 0.0;
-    if (semanticScore < threshold) {
-      continue;
-    }
-
     const memIdStr = String(memId);
     const bm25Score = bm25Scores[memIdStr] ?? 0.0;
     const entityBoost = entityBoosts[memIdStr] ?? 0.0;
+
+    const semanticScore = result.score ?? 0.0;
+    const isKeywordOnly = result.score == null && bm25Score > 0;
+    if (!isKeywordOnly && semanticScore < threshold) {
+      continue;
+    }
 
     const rawCombined = semanticScore + bm25Score + entityBoost;
     const combined = Math.min(rawCombined / maxPossible, 1.0);

--- a/mem0-ts/src/oss/tests/memory.hybrid-search.test.ts
+++ b/mem0-ts/src/oss/tests/memory.hybrid-search.test.ts
@@ -1,0 +1,80 @@
+/// <reference types="jest" />
+import { Memory } from "../src/memory";
+
+jest.setTimeout(15000);
+
+jest.mock("../src/embeddings/google", () => ({
+  GoogleEmbedder: jest.fn(),
+}));
+jest.mock("../src/llms/google", () => ({
+  GoogleLLM: jest.fn(),
+}));
+jest.mock("../src/llms/openai", () => ({
+  OpenAILLM: jest.fn().mockImplementation(() => ({
+    generateResponse: jest
+      .fn()
+      .mockResolvedValue(JSON.stringify({ memory: [] })),
+  })),
+}));
+
+const mockEmbedding = new Array(1536).fill(0.1);
+jest.mock("../src/embeddings/openai", () => ({
+  OpenAIEmbedder: jest.fn().mockImplementation(() => ({
+    embed: jest.fn().mockResolvedValue(mockEmbedding),
+    embedBatch: jest
+      .fn()
+      .mockImplementation((texts: string[]) =>
+        Promise.resolve(texts.map(() => mockEmbedding)),
+      ),
+    embeddingDims: 1536,
+  })),
+}));
+
+function createMemory(): Memory {
+  return new Memory({
+    version: "v1.1",
+    embedder: {
+      provider: "openai",
+      config: { apiKey: "test-key", model: "text-embedding-3-small" },
+    },
+    vectorStore: {
+      provider: "memory",
+      config: {
+        collectionName: `test-hybrid-${Date.now()}-${Math.random()}`,
+        dimension: 1536,
+        dbPath: ":memory:",
+      },
+    },
+    llm: {
+      provider: "openai",
+      config: { apiKey: "test-key", model: "gpt-5-mini" },
+    },
+    historyDbPath: ":memory:",
+  });
+}
+
+describe("Memory.search hybrid candidates", () => {
+  it("returns a keyword-only match outside the semantic result pool", async () => {
+    const memory = createMemory();
+    const internals = memory as any;
+    await internals._ensureInitialized();
+
+    internals.vectorStore.search = jest.fn().mockResolvedValue([]);
+    internals.vectorStore.keywordSearch = jest.fn().mockResolvedValue([
+      {
+        id: "keyword-only",
+        score: 20,
+        payload: { data: "Error code ERR_AUTH_0042", user_id: "test" },
+      },
+    ]);
+
+    const result = await memory.search("ERR_AUTH_0042", {
+      filters: { user_id: "test" },
+    });
+
+    expect(result.results.map((item) => item.id)).toEqual(["keyword-only"]);
+    expect(result.results[0].memory).toBe("Error code ERR_AUTH_0042");
+
+    await memory.reset();
+  });
+});

--- a/mem0-ts/src/oss/tests/scoring.test.ts
+++ b/mem0-ts/src/oss/tests/scoring.test.ts
@@ -46,4 +46,18 @@ describe("scoreAndRank", () => {
     expect(details.maxPossibleScore).toBe(1.0);
     expect(details.finalScore).toBe(0.8);
   });
+
+  it("does not gate keyword-only candidates on semantic threshold", () => {
+    const scored = scoreAndRank(
+      [{ id: "keyword", payload: { data: "exact match" } }],
+      { keyword: 0.9 },
+      {},
+      0.1,
+      10,
+    );
+
+    expect(scored).toHaveLength(1);
+    expect(scored[0].id).toBe("keyword");
+    expect(scored[0].score).toBeCloseTo(0.45);
+  });
 });

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1619,18 +1619,36 @@ class Memory(MemoryBase):
         if query_entities:
             entity_boosts = self._compute_entity_boosts(query_entities, filters)
 
-        # Step 7: Build candidate set from semantic results
-        candidates = []
+        # Step 7: Build candidate set from the union of semantic and keyword results
+        candidates_by_id = {}
         for mem in semantic_results:
-            payload = mem.payload if hasattr(mem, 'payload') else {}
+            payload = mem.payload if hasattr(mem, "payload") else mem.get("payload", {})
             if not show_expired and _payload_is_expired(payload):
                 continue
-            mem_id = str(mem.id)
-            candidates.append({
+            mem_id = str(mem.id) if hasattr(mem, "id") else str(mem.get("id", ""))
+            if not mem_id:
+                continue
+            candidates_by_id[mem_id] = {
                 "id": mem_id,
-                "score": mem.score,
+                "score": mem.score if hasattr(mem, "score") else mem.get("score"),
                 "payload": payload,
-            })
+            }
+
+        if keyword_results is not None:
+            for mem in keyword_results:
+                mem_id = str(mem.id) if hasattr(mem, "id") else str(mem.get("id", ""))
+                if not mem_id or mem_id in candidates_by_id or mem_id not in bm25_scores:
+                    continue
+                payload = mem.payload if hasattr(mem, "payload") else mem.get("payload", {})
+                if not show_expired and _payload_is_expired(payload):
+                    continue
+                candidates_by_id[mem_id] = {
+                    "id": mem_id,
+                    "score": None,
+                    "payload": payload,
+                }
+
+        candidates = list(candidates_by_id.values())
 
         # Step 8: Score and rank
         scored_results = score_and_rank(
@@ -3259,18 +3277,36 @@ class AsyncMemory(MemoryBase):
         if query_entities:
             entity_boosts = await self._compute_entity_boosts_async(query_entities, filters)
 
-        # Step 7: Build candidate set from semantic results
-        candidates = []
+        # Step 7: Build candidate set from the union of semantic and keyword results
+        candidates_by_id = {}
         for mem in semantic_results:
-            payload = mem.payload if hasattr(mem, 'payload') else {}
+            payload = mem.payload if hasattr(mem, "payload") else mem.get("payload", {})
             if not show_expired and _payload_is_expired(payload):
                 continue
-            mem_id = str(mem.id)
-            candidates.append({
+            mem_id = str(mem.id) if hasattr(mem, "id") else str(mem.get("id", ""))
+            if not mem_id:
+                continue
+            candidates_by_id[mem_id] = {
                 "id": mem_id,
-                "score": mem.score,
+                "score": mem.score if hasattr(mem, "score") else mem.get("score"),
                 "payload": payload,
-            })
+            }
+
+        if keyword_results is not None:
+            for mem in keyword_results:
+                mem_id = str(mem.id) if hasattr(mem, "id") else str(mem.get("id", ""))
+                if not mem_id or mem_id in candidates_by_id or mem_id not in bm25_scores:
+                    continue
+                payload = mem.payload if hasattr(mem, "payload") else mem.get("payload", {})
+                if not show_expired and _payload_is_expired(payload):
+                    continue
+                candidates_by_id[mem_id] = {
+                    "id": mem_id,
+                    "score": None,
+                    "payload": payload,
+                }
+
+        candidates = list(candidates_by_id.values())
 
         # Step 8: Score and rank
         scored_results = score_and_rank(

--- a/mem0/utils/scoring.py
+++ b/mem0/utils/scoring.py
@@ -71,8 +71,9 @@ def score_and_rank(
         semantic_score is taken from the result's score field.
         combined = (semantic + bm25 + entity_boost) / max_possible
 
-    Threshold gates the semantic score BEFORE combining -- candidates
-    below the threshold are excluded even if BM25/entity would boost them.
+    Threshold gates semantic candidates BEFORE combining. Keyword-only
+    candidates, represented by a missing semantic score, are allowed through
+    when they have a BM25 score.
 
     The divisor adapts based on which signals are active:
         - Semantic only: max_possible = 1.0
@@ -81,7 +82,8 @@ def score_and_rank(
         - Semantic + entity (no BM25): max_possible = 1.5
 
     Args:
-        semantic_results: Candidate memories from vector search.
+        semantic_results: Candidate memories from semantic and keyword search.
+            Keyword-only candidates have a ``None`` score.
         bm25_scores: Normalized keyword scores keyed by memory ID.
         entity_boosts: Entity-link boosts keyed by memory ID.
         threshold: Minimum semantic score required before hybrid scoring.
@@ -107,13 +109,15 @@ def score_and_rank(
         if mem_id is None:
             continue
 
-        semantic_score = result.get("score") or 0.0
-        if semantic_score < threshold:
-            continue
-
         mem_id_str = str(mem_id)
         bm25_score = bm25_scores.get(mem_id_str, 0.0)
         entity_boost = entity_boosts.get(mem_id_str, 0.0)
+
+        raw_semantic_score = result.get("score")
+        semantic_score = raw_semantic_score or 0.0
+        is_keyword_only = raw_semantic_score is None and bm25_score > 0
+        if not is_keyword_only and semantic_score < threshold:
+            continue
 
         raw_combined = semantic_score + bm25_score + entity_boost
         combined = min(raw_combined / max_possible, 1.0)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -240,6 +240,67 @@ def test_search_explain_includes_score_details(
     assert details["threshold"] == 0.1
 
 
+@patch("mem0.memory.main.extract_entities", return_value=[])
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.storage.SQLiteManager")
+def test_search_returns_keyword_only_matches(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory, _mock_extract_entities
+):
+    mock_embedder = MagicMock()
+    mock_embedder.embed.return_value = [0.1, 0.2, 0.3]
+    mock_embedder_factory.return_value = mock_embedder
+
+    mock_vector_store = MagicMock()
+    mock_vector_store.search.return_value = []
+    mock_vector_store.keyword_search.return_value = [
+        MockVectorMemory("keyword_only", {"data": "Error code ERR_AUTH_0042", "user_id": "test"}, score=20.0)
+    ]
+    mock_vector_factory.return_value = mock_vector_store
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+
+    memory = MemoryClass(MemoryConfig())
+    result = memory.search("ERR_AUTH_0042", filters={"user_id": "test"})
+
+    assert [item["id"] for item in result["results"]] == ["keyword_only"]
+    assert result["results"][0]["memory"] == "Error code ERR_AUTH_0042"
+
+
+@pytest.mark.asyncio
+@patch("mem0.memory.main.extract_entities", return_value=[])
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.storage.SQLiteManager")
+async def test_async_search_returns_keyword_only_matches(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory, _mock_extract_entities
+):
+    mock_embedder = MagicMock()
+    mock_embedder.embed.return_value = [0.1, 0.2, 0.3]
+    mock_embedder_factory.return_value = mock_embedder
+
+    mock_vector_store = MagicMock()
+    mock_vector_store.search.return_value = []
+    mock_vector_store.keyword_search.return_value = [
+        MockVectorMemory("keyword_only", {"data": "Error code ERR_AUTH_0042", "user_id": "test"}, score=20.0)
+    ]
+    mock_vector_factory.return_value = mock_vector_store
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import AsyncMemory
+
+    memory = AsyncMemory(MemoryConfig())
+    result = await memory.search("ERR_AUTH_0042", filters={"user_id": "test"})
+
+    assert [item["id"] for item in result["results"]] == ["keyword_only"]
+    assert result["results"][0]["memory"] == "Error code ERR_AUTH_0042"
+
+
 @patch('mem0.utils.factory.EmbedderFactory.create')
 @patch('mem0.utils.factory.VectorStoreFactory.create')
 @patch('mem0.utils.factory.LlmFactory.create')
@@ -1231,8 +1292,9 @@ class TestHybridSearchWarning:
     def test_warning_for_store_without_keyword_search(
         self, mock_vs_factory, mock_emb, mock_llm, mock_sqlite, _cap, caplog
     ):
-        from mem0.vector_stores.base import VectorStoreBase
         import logging
+
+        from mem0.vector_stores.base import VectorStoreBase
 
         class StoreWithoutKeywordSearch(VectorStoreBase):
             def create_col(self, *a, **kw): pass
@@ -1267,8 +1329,9 @@ class TestHybridSearchWarning:
     def test_no_warning_for_store_with_keyword_search(
         self, mock_vs_factory, mock_emb, mock_llm, mock_sqlite, _cap, caplog
     ):
-        from mem0.vector_stores.base import VectorStoreBase
         import logging
+
+        from mem0.vector_stores.base import VectorStoreBase
 
         class StoreWithKeywordSearch(VectorStoreBase):
             def keyword_search(self, query, top_k=5, filters=None):

--- a/tests/utils/test_scoring.py
+++ b/tests/utils/test_scoring.py
@@ -1,10 +1,10 @@
 import pytest
 
 from mem0.utils.scoring import (
+    ENTITY_BOOST_WEIGHT,
     get_bm25_params,
     normalize_bm25,
     score_and_rank,
-    ENTITY_BOOST_WEIGHT,
 )
 
 
@@ -95,6 +95,14 @@ class TestScoreAndRank:
         scored = score_and_rank(results, bm25, {}, threshold=0.1, top_k=10)
         assert len(scored) == 1
         assert scored[0]["id"] == "b"
+
+    def test_keyword_only_candidate_is_not_gated_by_semantic_threshold(self):
+        results = [{"id": "a", "score": None, "payload": {"data": "exact match"}}]
+        scored = score_and_rank(results, {"a": 0.9}, {}, threshold=0.1, top_k=10)
+
+        assert len(scored) == 1
+        assert scored[0]["id"] == "a"
+        assert scored[0]["score"] == pytest.approx(0.45)
 
     def test_top_k_limit(self):
         results = [{"id": str(i), "score": 0.5, "payload": {}} for i in range(20)]


### PR DESCRIPTION
 ## Description

  Hybrid search calculated BM25 scores for keyword-search results but constructed its final candidate set exclusively from semantic-search
  results.

  Consequently, a memory returned only by keyword search could never reach the scoring stage. This particularly affected exact lexical
  queries such as identifiers, error codes, uncommon names, and other terms for which keyword retrieval may succeed while semantic
  retrieval does not include the memory in its candidate pool.

  This PR fixes the issue consistently across:

  - Python `Memory`
  - Python `AsyncMemory`
  - TypeScript OSS `Memory`

  ### Implementation

  The search pipeline now constructs candidates from the union of semantic and keyword results.

  - Semantic results remain the canonical candidate when the same memory appears in both result sets.
  - Keyword-only candidates retain their keyword-search payload and enter scoring without an artificial semantic score.
  - Duplicate memory IDs are removed.
  - Expired-memory filtering is applied equally to semantic and keyword-only candidates.
  - Keyword results without a valid positive BM25 score are not promoted into the candidate set.

  The scoring utilities now distinguish keyword-only candidates from low-scoring semantic candidates.

  - Existing semantic threshold behavior is preserved.
  - A genuine semantic result below the configured threshold remains excluded, even if it has a high BM25 score.
  - A candidate with no semantic result may still be ranked when it has a valid BM25 score.
  - Keyword-only candidates use a semantic contribution of zero, avoiding fabricated similarity scores.

  ### Why this matters

  Previously, hybrid search could miss the exact category of results lexical retrieval is intended to recover. For example, a memory
  containing `ERR_AUTH_0042` could be returned by BM25 but silently discarded when it was absent from the semantic top-K results.

  After this change, such keyword-only matches are included and ranked using their normalized BM25 contribution.

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Breaking change
  - [ ] Refactor
  - [ ] Documentation update

  ## Breaking Changes

  N/A. Existing semantic-result scoring and threshold behavior remain unchanged.

  ## Test Coverage

  - [x] Added Python scorer regression coverage
  - [x] Added synchronous Python search regression coverage
  - [x] Added asynchronous Python search regression coverage
  - [x] Added TypeScript scorer regression coverage
  - [x] Added TypeScript OSS search regression coverage
  - [x] Verified Python lint and import sorting
  - [x] Verified the TypeScript package build

  ### Verification performed

  - `pytest tests/utils/test_scoring.py tests/test_memory.py -k 'keyword_only or search_explain_includes_score_details or
  threshold_gates_on_semantic'`
    - 5 passed
  - `ruff check mem0/memory/main.py mem0/utils/scoring.py tests/test_memory.py tests/utils/test_scoring.py`
    - Passed
  - `pnpm exec jest --runInBand src/oss/tests/scoring.test.ts src/oss/tests/memory.hybrid-search.test.ts`
    - 6 passed
  - `pnpm run build`
    - Prettier, CJS/ESM builds, and declaration builds passed
  - Pre-commit Ruff and isort hooks
    - Passed

  A broader Python run produced two unrelated existing failures in embedding call-count tests:

  - `test_add_infer_true_caches_embedding_on_llm_rewrite`
  - `test_update_infer_true_caches_embedding_on_llm_rewrite`

  Both concern entity-link embedding calls in the add pipeline and are unrelated to search candidate construction or hybrid scoring.

  A raw repository-wide `tsc --noEmit` also reports existing errors in unrelated client test configuration and community integration
  imports. The package's supported `pnpm run build`, including declaration generation, passes.

  ## Checklist

  - [x] Code follows the project's style guidelines
  - [x] Self-review performed
  - [x] Tests added that prove the fix
  - [x] Relevant existing tests pass locally
  - [x] No public API documentation changes required