### PR TITLE
fix(cli): emit structured JSON envelope for agent-mode init success

### DIFF
--- a/cli/node/src/commands/agent-mode.ts
+++ b/cli/node/src/commands/agent-mode.ts
@@ -5,6 +5,8 @@
 import readline from "node:readline";
 import { colors, printError, printInfo, printSuccess } from "../branding.js";
 import { type Mem0Config, saveConfig } from "../config.js";
+import { formatJsonEnvelope } from "../output.js";
+import { isAgentMode } from "../state.js";
 
 const { brand, dim } = colors;
 
@@ -134,21 +136,54 @@ export async function bootstrapViaBackend(
 	config.defaults.userId = envelope.default_user_id;
 	saveConfig(config);
 
-	printSuccess(
-		`Agent Mode active. Default user_id: ${envelope.default_user_id}`,
-	);
-	if (envelope.mem0_notice) {
-		console.log(`\n\x1b[33m🔔 ${envelope.mem0_notice}\x1b[0m\n`);
+	// Agent/JSON mode: emit exactly ONE structured envelope on stdout so a
+	// machine consumer (an LLM agent parsing this output) doesn't have to deal
+	// with stray plain-text lines mixed into the response. Human mode keeps
+	// the original colored console output unchanged.
+	if (isAgentMode()) {
+		formatJsonEnvelope({
+			command: "init",
+			data: {
+				api_key_saved: true,
+				default_user_id: envelope.default_user_id,
+				// The API key is written to ~/.mem0/config.json, but MCP hosts
+				// (Codex, Cursor, etc.) read the key from the MEM0_API_KEY env
+				// var, not from config.json. If that env var isn't present in
+				// THIS process, MCP tools will fail auth even though the CLI
+				// itself reports "connected" — this reflects that honestly.
+				mcp_ready: !!process.env.MEM0_API_KEY,
+				next_step: process.env.MEM0_API_KEY
+					? "MCP tools are ready to use."
+					: "MEM0_API_KEY is not set in this shell/agent environment. Export it (see ~/.mem0/config.json) and restart your MCP host before using MCP tools.",
+				...(envelope.mem0_notice
+					? { mem0_notice: envelope.mem0_notice }
+					: {}),
+				...(agentCaller
+					? {}
+					: {
+							identify_hint:
+								"If you are an AI agent, identify yourself: `mem0 identify <your-name>` (e.g. claude-code, cursor).",
+						}),
+			},
+		});
 	} else {
-		// Fallback for older backends without the unified notice field.
-		const claimCmd = envelope.claim_command ?? "mem0 init --email <your-email>";
-		console.log(`  ${dim(`To claim this account later: ${claimCmd}`)}`);
-	}
-
-	if (!agentCaller) {
-		console.log(
-			`  ${dim("If you are an AI agent, identify yourself: `mem0 identify <your-name>` (e.g. claude-code, cursor).")}`,
+		printSuccess(
+			`Agent Mode active. Default user_id: ${envelope.default_user_id}`,
 		);
+		if (envelope.mem0_notice) {
+			console.log(`\n\x1b[33m🔔 ${envelope.mem0_notice}\x1b[0m\n`);
+		} else {
+			// Fallback for older backends without the unified notice field.
+			const claimCmd =
+				envelope.claim_command ?? "mem0 init --email <your-email>";
+			console.log(`  ${dim(`To claim this account later: ${claimCmd}`)}`);
+		}
+
+		if (!agentCaller) {
+			console.log(
+				`  ${dim("If you are an AI agent, identify yourself: `mem0 identify <your-name>` (e.g. claude-code, cursor).")}`,
+			);
+		}
 	}
 }
 


### PR DESCRIPTION
## Linked Issue
Relates to #6346 (part 1 of 3 — see issue discussion for scope)

## Description
Agent/JSON mode previously fell through to plain-text console output
in `bootstrapViaBackend()`, so `mem0 init --agent --json` on a clean
home printed styled prose instead of a machine-parseable envelope.

This PR makes `bootstrapViaBackend()` emit a single structured JSON
object in agent/JSON mode, containing `api_key_saved`, `default_user_id`,
`mcp_ready`, and `next_step`. `mcp_ready` reflects whether `MEM0_API_KEY`
is actually present in the current process env, since MCP hosts read
auth from env, not from `config.json` — which was the second half of
the bug in #6346.

Human/non-JSON mode output is unchanged.

cc @victorgulchenko — per your acceptance test in the issue thread,
this exits 0 and prints exactly one JSON object with no styled prose
before or after it on a clean home. Verified output:

​```json
{
  "status": "success",
  "command": "init",
  "data": {
    "api_key_saved": true,
    "default_user_id": "user_xxxxxxxxxxxx",
    "mcp_ready": false,
    "next_step": "MEM0_API_KEY is not set in this shell/agent environment. Export it (see ~/.mem0/config.json) and restart your MCP host before using MCP tools.",
    "mem0_notice": "..."
  }
}
​```

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes
N/A

## Test Coverage
- [x] I tested manually (describe below)

Manually tested with an isolated `$env:HOME`/`$env:USERPROFILE` clean
home directory:
`node dist/index.js init --agent --agent-caller codex --json`
→ exits 0, prints exactly one valid JSON object, no other stdout output.

Not adding a new unit test in this PR since it's scoped to part 1 of 3
per the issue discussion — an integration test covering the full
clean-home JSON path is one of the follow-up items the reporter
suggested for a later PR.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally
- [ ] I have added tests that prove my fix/feature works
- [ ] I have updated documentation if needed