### PR TITLE
Fix/delete all complete pagination

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -1722,18 +1722,30 @@ export class Memory {
       );
     }
 
-    const [memories] = await this.vectorStore.list(filters);
-    for (const memory of memories) {
-      await this.deleteMemory(memory.id);
+    let deletedCount = 0;
+    const processedMemoryIds = new Set<string>();
+    while (true) {
+      const [listedMemories] = await this.vectorStore.list(filters);
+      const memories = listedMemories.filter(
+        (memory) => !processedMemoryIds.has(String(memory.id)),
+      );
+      if (memories.length === 0) break;
+
+      for (const memory of memories) {
+        const memoryId = String(memory.id);
+        processedMemoryIds.add(memoryId);
+        await this.deleteMemory(memoryId);
+        deletedCount += 1;
+      }
     }
 
     const result = { message: "Memories deleted successfully!" };
-    if (memories.length > 0) {
+    if (deletedCount > 0) {
       await this._displayDecayUsageNotice({
         triggerFunction: "delete_all",
         triggerSource: "delete_all",
         triggerReason: "bulk_delete",
-        deletedCount: memories.length,
+        deletedCount,
       });
     } else {
       await this._displayFirstRunNotice("delete_all");

--- a/mem0-ts/src/oss/tests/memory.crud.test.ts
+++ b/mem0-ts/src/oss/tests/memory.crud.test.ts
@@ -571,6 +571,45 @@ describe("Memory - deleteAll()", () => {
     expect(remaining.results).toHaveLength(0);
   });
 
+  test("deletes memories across multiple vector-store pages", async () => {
+    const pagedMemory = createMemory();
+    const internals = pagedMemory as any;
+    await internals._ensureInitialized();
+
+    const memories = Array.from({ length: 101 }, (_, index) => ({
+      id: String(index),
+      payload: { data: `Memory ${index}`, user_id: userId },
+    }));
+    const listSpy = jest
+      .spyOn(internals.vectorStore, "list")
+      .mockResolvedValueOnce([memories.slice(0, 100), 101])
+      .mockResolvedValueOnce([memories.slice(100), 1])
+      .mockResolvedValueOnce([[], 0]);
+    const deleteSpy = jest
+      .spyOn(internals, "deleteMemory")
+      .mockResolvedValue(undefined);
+    const noticeSpy = jest
+      .spyOn(internals, "_displayDecayUsageNotice")
+      .mockResolvedValue(undefined);
+
+    const result = await pagedMemory.deleteAll({ userId });
+
+    expect(result).toEqual({ message: "Memories deleted successfully!" });
+    expect(listSpy).toHaveBeenCalledTimes(3);
+    expect(deleteSpy).toHaveBeenCalledTimes(101);
+    expect(deleteSpy.mock.calls.map(([memoryId]) => memoryId)).toEqual(
+      memories.map((item) => item.id),
+    );
+    expect(noticeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ deletedCount: 101 }),
+    );
+
+    listSpy.mockRestore();
+    deleteSpy.mockRestore();
+    noticeSpy.mockRestore();
+    await pagedMemory.reset();
+  });
+
   test("throws when no filter is provided", async () => {
     await expect(memory.deleteAll({} as any)).rejects.toThrow(
       "At least one filter is required to delete all memories",

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1869,14 +1869,25 @@ class Memory(MemoryBase):
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "sync"})
-        # delete all vector memories and reset the collections
-        memories = self.vector_store.list(filters=filters)[0]
-        for memory in memories:
-            self._delete_memory(memory.id)
+        deleted_count = 0
+        processed_memory_ids = set()
+        while True:
+            memories = [
+                memory
+                for memory in _vector_store_list_rows(self.vector_store.list(filters=filters))
+                if str(memory.id) not in processed_memory_ids
+            ]
+            if not memories:
+                break
 
-        logger.info(f"Deleted {len(memories)} memories")
+            processed_memory_ids.update(str(memory.id) for memory in memories)
+            for memory in memories:
+                self._delete_memory(memory.id)
+                deleted_count += 1
 
-        decay_usage_notice = detect_decay_usage_from_delete_all(len(memories))
+        logger.info(f"Deleted {deleted_count} memories")
+
+        decay_usage_notice = detect_decay_usage_from_delete_all(deleted_count)
         if decay_usage_notice:
             display_decay_usage_notice(self, "sync", "delete_all", *decay_usage_notice)
         else:
@@ -3501,26 +3512,35 @@ class AsyncMemory(MemoryBase):
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "async"})
-        memories = await asyncio.to_thread(self.vector_store.list, filters=filters)
+        deleted_count = 0
+        processed_memory_ids = set()
+        errors = []
+        while True:
+            listed = await asyncio.to_thread(self.vector_store.list, filters=filters)
+            memories = [
+                memory for memory in _vector_store_list_rows(listed) if str(memory.id) not in processed_memory_ids
+            ]
+            if not memories:
+                break
 
-        delete_tasks = []
-        for memory in memories[0]:
-            delete_tasks.append(self._delete_memory(memory.id, skip_entity_cleanup=True))
-
-        results = await asyncio.gather(*delete_tasks, return_exceptions=True)
+            processed_memory_ids.update(str(memory.id) for memory in memories)
+            delete_tasks = [self._delete_memory(memory.id, skip_entity_cleanup=True) for memory in memories]
+            results = await asyncio.gather(*delete_tasks, return_exceptions=True)
+            batch_errors = [result for result in results if isinstance(result, BaseException)]
+            errors.extend(batch_errors)
+            deleted_count += len(results) - len(batch_errors)
 
         if self._entity_store is not None:
             await self._bulk_clear_entity_store(filters)
 
-        errors = [r for r in results if isinstance(r, BaseException)]
         if errors:
-            logger.warning("Failed to delete %d out of %d memories", len(errors), len(results))
+            logger.warning("Failed to delete %d out of %d memories", len(errors), len(processed_memory_ids))
             for err in errors:
                 logger.warning("Delete error: %s", err)
 
-        logger.info(f"Deleted {len(results) - len(errors)} memories")
+        logger.info(f"Deleted {deleted_count} memories")
 
-        decay_usage_notice = detect_decay_usage_from_delete_all(len(memories[0]))
+        decay_usage_notice = detect_decay_usage_from_delete_all(deleted_count)
         if decay_usage_notice:
             await display_decay_usage_notice_async(self, "async", "delete_all", *decay_usage_notice)
         else:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -280,7 +280,7 @@ def test_delete(memory_instance):
 
 def test_delete_all(memory_instance):
     mock_memories = [Mock(id="1"), Mock(id="2")]
-    memory_instance.vector_store.list = Mock(return_value=(mock_memories, None))
+    memory_instance.vector_store.list = Mock(side_effect=[(mock_memories, None), ([], None)])
     memory_instance.vector_store.reset = Mock()
     memory_instance._delete_memory = Mock()
 
@@ -291,6 +291,22 @@ def test_delete_all(memory_instance):
     memory_instance.vector_store.reset.assert_not_called()
 
     assert result["message"] == "Memories deleted successfully!"
+
+
+def test_delete_all_deletes_more_than_one_vector_store_page(memory_instance):
+    mock_memories = [Mock(id=str(index)) for index in range(101)]
+    memory_instance.vector_store.list = Mock(
+        side_effect=[(mock_memories[:100], "next-page"), (mock_memories[100:], None), ([], None)]
+    )
+    memory_instance._delete_memory = Mock()
+
+    result = memory_instance.delete_all(user_id="test_user")
+
+    assert result == {"message": "Memories deleted successfully!"}
+    assert memory_instance.vector_store.list.call_count == 3
+    assert [call.args[0] for call in memory_instance._delete_memory.call_args_list] == [
+        memory.id for memory in mock_memories
+    ]
 
 
 def test_get_all(memory_instance):

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,7 +1,7 @@
 import json
 import sys
 from datetime import datetime
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
@@ -1001,6 +1001,36 @@ async def test_async_delete_all_continues_on_partial_failure(mock_sqlite, mock_l
     assert mock_vector_store.delete.call_count == 2
 
 
+@pytest.mark.asyncio
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.main.SQLiteManager')
+async def test_async_delete_all_deletes_more_than_one_vector_store_page(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_store = MagicMock()
+    mock_vector_factory.return_value = mock_vector_store
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import AsyncMemory
+
+    memory = AsyncMemory(MemoryConfig())
+    mock_memories = [MagicMock(id=str(index)) for index in range(101)]
+    mock_vector_store.list.side_effect = [[mock_memories[:100]], [mock_memories[100:]], [[]]]
+    memory._delete_memory = AsyncMock()
+
+    result = await memory.delete_all(user_id="test-user")
+
+    assert result == {"message": "Memories deleted successfully!"}
+    assert mock_vector_store.list.call_count == 3
+    assert [call.args[0] for call in memory._delete_memory.await_args_list] == [
+        memory.id for memory in mock_memories
+    ]
+
+
 @patch('mem0.utils.factory.EmbedderFactory.create')
 @patch('mem0.utils.factory.VectorStoreFactory.create')
 @patch('mem0.utils.factory.LlmFactory.create')
@@ -1231,8 +1261,9 @@ class TestHybridSearchWarning:
     def test_warning_for_store_without_keyword_search(
         self, mock_vs_factory, mock_emb, mock_llm, mock_sqlite, _cap, caplog
     ):
-        from mem0.vector_stores.base import VectorStoreBase
         import logging
+
+        from mem0.vector_stores.base import VectorStoreBase
 
         class StoreWithoutKeywordSearch(VectorStoreBase):
             def create_col(self, *a, **kw): pass
@@ -1267,8 +1298,9 @@ class TestHybridSearchWarning:
     def test_no_warning_for_store_with_keyword_search(
         self, mock_vs_factory, mock_emb, mock_llm, mock_sqlite, _cap, caplog
     ):
-        from mem0.vector_stores.base import VectorStoreBase
         import logging
+
+        from mem0.vector_stores.base import VectorStoreBase
 
         class StoreWithKeywordSearch(VectorStoreBase):
             def keyword_search(self, query, top_k=5, filters=None):


### PR DESCRIPTION
## Description

  `delete_all()` previously called `vector_store.list()` only once and deleted the memories returned by that single call.

  Many vector-store providers limit `list()` to a default page size, commonly 100 records. When more matching memories existed,
  `delete_all()` deleted only the first page but still returned:

  > Memories deleted successfully!

  This could leave older memories behind in privacy, account-deletion, and data-retention workflows.

  This PR updates bulk deletion across:

  - Python `Memory`
  - Python `AsyncMemory`
  - TypeScript OSS `Memory`

  ## Implementation

  Bulk deletion now repeatedly lists the currently matching first page and deletes each returned memory until the vector store returns no
  unseen matches.

  ### Python sync

  - Re-lists matching memories after each deletion batch.
  - Handles the different list result shapes used by vector-store providers.
  - Tracks processed IDs to prevent repeated or stale results from causing an infinite loop.
  - Reports the total number of deleted memories to logging and decay-usage notices.

  ### Python async

  - Processes every available page rather than only the first.
  - Preserves concurrent deletion within each page.
  - Preserves the existing partial-failure behavior using `asyncio.gather(..., return_exceptions=True)`.
  - Attempts each returned memory only once, preventing persistent failures from causing an infinite loop.
  - Aggregates deletion failures and successful deletion counts across all pages.
  - Performs entity-store cleanup after all deletion batches.
  - Uses the total successful deletion count for notices and logging.

  ### TypeScript OSS

  - Re-lists after each page is deleted.
  - Tracks processed memory IDs to avoid repeated processing.
  - Preserves the existing fail-fast behavior if an individual deletion throws.
  - Uses the total deletion count across all pages for the bulk-delete notice.

  ## Why repeated first-page deletion?

  The vector-store interface does not expose a consistent pagination contract:

  - Providers use different pagination mechanisms.
  - The second `list()` return value is not consistently a cursor.
  - Some providers return a count while others expose provider-specific pagination data.

  Deleting the current first page and listing again provides provider-neutral traversal without introducing provider-specific branching or
  changing the public vector-store interface.

  ## Regression Coverage

  Tests simulate 101 matching memories delivered as:

  1. First page: 100 memories
  2. Second page: 1 memory
  3. Final page: empty

  Coverage verifies that:

  - All 101 memory IDs are deleted.
  - The vector store is listed until it returns no further matches.
  - Python synchronous deletion crosses the page boundary.
  - Python asynchronous deletion crosses the page boundary.
  - Async deletion continues when one memory fails.
  - TypeScript deletion crosses the page boundary.
  - The TypeScript decay-usage notice receives the complete deletion count of 101.

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Breaking change
  - [ ] Refactor
  - [ ] Documentation update

  ## Breaking Changes

  N/A.

  The public API and success response remain unchanged. The method now fulfills its documented behavior by deleting every matching memory
  rather than only the first provider page.

  ## Test Coverage

  - [x] Added/updated Python unit tests
  - [x] Added/updated TypeScript unit tests
  - [ ] Added/updated integration tests
  - [x] Tested the affected paths locally

  ### Verification performed

  - `pytest tests/test_main.py -k delete_all`
    - 6 passed
  - Async `delete_all` regression selection from `tests/test_memory.py`
    - 3 passed
  - Ruff on the affected Python files
    - Passed
  - Pre-commit Ruff and isort hooks
    - Passed
  - `pnpm exec jest --runInBand src/oss/tests/memory.crud.test.ts`
    - 51 passed
  - `pnpm run build`
    - Prettier passed
    - CJS and ESM builds passed
    - TypeScript declaration builds passed

  ## Checklist

  - [x] Code follows the project's style guidelines
  - [x] Self-review performed
  - [x] Tests added that prove the fix
  - [x] Relevant new and existing tests pass locally
  - [x] No public API documentation changes required