### PR TITLE
fix: report only successfully persisted memories

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -24,6 +24,7 @@ from mem0.configs.prompts import (
 )
 from mem0.exceptions import LLMError
 from mem0.exceptions import ValidationError as Mem0ValidationError
+from mem0.exceptions import VectorStoreError
 from mem0.memory.base import MemoryBase
 from mem0.memory.notices import (
     PERFORMANCE_SLOW_QUERY_THRESHOLD_SECONDS,
@@ -1003,19 +1004,32 @@ class Memory(MemoryBase):
         all_ids = [r[0] for r in records]
         all_payloads = [r[3] for r in records]
 
+        persisted_records = records
         try:
             self.vector_store.insert(
                 vectors=all_vectors,
                 ids=all_ids,
                 payloads=all_payloads,
             )
-        except Exception:
+        except Exception as batch_error:
             # Fallback: insert one by one
-            for mid, vec, pay in zip(all_ids, all_vectors, all_payloads):
+            persisted_records = []
+            for record in records:
+                mid, _, vec, pay = record
                 try:
                     self.vector_store.insert(vectors=[vec], ids=[mid], payloads=[pay])
                 except Exception as e:
                     logger.error(f"Failed to insert memory {mid}: {e}")
+                else:
+                    persisted_records.append(record)
+
+            if not persisted_records:
+                raise VectorStoreError(
+                    message="Failed to persist extracted memories",
+                    details={"operation": "insert", "failed_count": len(records)},
+                ) from batch_error
+
+        records = persisted_records
 
         # Batch history
         history_records = [
@@ -2637,6 +2651,7 @@ class AsyncMemory(MemoryBase):
         all_ids = [r[0] for r in records]
         all_payloads = [r[3] for r in records]
 
+        persisted_records = records
         try:
             await asyncio.to_thread(
                 self.vector_store.insert,
@@ -2644,12 +2659,24 @@ class AsyncMemory(MemoryBase):
                 ids=all_ids,
                 payloads=all_payloads,
             )
-        except Exception:
-            for mid, vec, pay in zip(all_ids, all_vectors, all_payloads):
+        except Exception as batch_error:
+            persisted_records = []
+            for record in records:
+                mid, _, vec, pay = record
                 try:
                     await asyncio.to_thread(self.vector_store.insert, vectors=[vec], ids=[mid], payloads=[pay])
                 except Exception as e:
                     logger.error(f"Failed to insert memory {mid} (async): {e}")
+                else:
+                    persisted_records.append(record)
+
+            if not persisted_records:
+                raise VectorStoreError(
+                    message="Failed to persist extracted memories",
+                    details={"operation": "insert", "failed_count": len(records)},
+                ) from batch_error
+
+        records = persisted_records
 
         # Batch history
         history_records = [

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -7,6 +7,7 @@ import pytest
 
 from mem0 import Memory
 from mem0.configs.base import MemoryConfig
+from mem0.exceptions import VectorStoreError
 from mem0.memory.main import _entity_collection_name
 from mem0.memory.utils import normalize_facts
 
@@ -812,6 +813,167 @@ def test_update_infer_true_caches_embedding_on_llm_rewrite(mock_sqlite, mock_llm
     mock_vector_store.insert.assert_called_once()
 
 
+def _configure_inferred_add_with_insert_failures(
+    mock_sqlite,
+    mock_llm_factory,
+    mock_vector_factory,
+    mock_embedder_factory,
+    *,
+    failed_texts,
+):
+    embedder = MagicMock()
+    embedder.embed.return_value = [0.1, 0.2, 0.3]
+    embedder.embed_batch.return_value = [[0.4, 0.5, 0.6], [0.7, 0.8, 0.9]]
+    mock_embedder_factory.return_value = embedder
+
+    vector_store = MagicMock()
+    vector_store.search.return_value = []
+
+    def insert(*, vectors, ids, payloads):
+        if len(ids) > 1:
+            raise RuntimeError("batch insert failed")
+        if payloads[0]["data"] in failed_texts:
+            raise RuntimeError(f"insert failed for {payloads[0]['data']}")
+
+    vector_store.insert.side_effect = insert
+    mock_vector_factory.return_value = vector_store
+
+    llm = MagicMock()
+    llm.generate_response.return_value = json.dumps(
+        {"memory": [{"text": "Persisted fact"}, {"text": "Failed fact"}]}
+    )
+    mock_llm_factory.return_value = llm
+
+    database = MagicMock()
+    database.get_last_messages.return_value = []
+    mock_sqlite.return_value = database
+    return vector_store, database
+
+
+@patch("mem0.memory.main.extract_entities_batch", return_value=[[]])
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.main.SQLiteManager")
+def test_add_returns_and_links_only_successfully_persisted_memories(
+    mock_sqlite,
+    mock_llm_factory,
+    mock_vector_factory,
+    mock_embedder_factory,
+    mock_extract_entities_batch,
+):
+    vector_store, database = _configure_inferred_add_with_insert_failures(
+        mock_sqlite,
+        mock_llm_factory,
+        mock_vector_factory,
+        mock_embedder_factory,
+        failed_texts={"Failed fact"},
+    )
+
+    from mem0.memory.main import Memory as MemoryClass
+
+    result = MemoryClass(MemoryConfig()).add("Remember these facts", user_id="test-user")
+
+    assert [item["memory"] for item in result["results"]] == ["Persisted fact"]
+    history_records = database.batch_add_history.call_args.args[0]
+    assert [record["new_memory"] for record in history_records] == ["Persisted fact"]
+    mock_extract_entities_batch.assert_called_once_with(["Persisted fact"])
+    assert vector_store.insert.call_count == 3
+
+
+@patch("mem0.memory.main.extract_entities_batch")
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.main.SQLiteManager")
+def test_add_raises_when_no_extracted_memory_can_be_persisted(
+    mock_sqlite,
+    mock_llm_factory,
+    mock_vector_factory,
+    mock_embedder_factory,
+    mock_extract_entities_batch,
+):
+    _, database = _configure_inferred_add_with_insert_failures(
+        mock_sqlite,
+        mock_llm_factory,
+        mock_vector_factory,
+        mock_embedder_factory,
+        failed_texts={"Persisted fact", "Failed fact"},
+    )
+
+    from mem0.memory.main import Memory as MemoryClass
+
+    with pytest.raises(VectorStoreError, match="Failed to persist extracted memories"):
+        MemoryClass(MemoryConfig()).add("Remember these facts", user_id="test-user")
+
+    database.batch_add_history.assert_not_called()
+    database.save_messages.assert_not_called()
+    mock_extract_entities_batch.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("mem0.memory.main.extract_entities_batch", return_value=[[]])
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.main.SQLiteManager")
+async def test_async_add_returns_and_links_only_successfully_persisted_memories(
+    mock_sqlite,
+    mock_llm_factory,
+    mock_vector_factory,
+    mock_embedder_factory,
+    mock_extract_entities_batch,
+):
+    vector_store, database = _configure_inferred_add_with_insert_failures(
+        mock_sqlite,
+        mock_llm_factory,
+        mock_vector_factory,
+        mock_embedder_factory,
+        failed_texts={"Failed fact"},
+    )
+
+    from mem0.memory.main import AsyncMemory
+
+    result = await AsyncMemory(MemoryConfig()).add("Remember these facts", user_id="test-user")
+
+    assert [item["memory"] for item in result["results"]] == ["Persisted fact"]
+    history_records = database.batch_add_history.call_args.args[0]
+    assert [record["new_memory"] for record in history_records] == ["Persisted fact"]
+    mock_extract_entities_batch.assert_called_once_with(["Persisted fact"])
+    assert vector_store.insert.call_count == 3
+
+
+@pytest.mark.asyncio
+@patch("mem0.memory.main.extract_entities_batch")
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.main.SQLiteManager")
+async def test_async_add_raises_when_no_extracted_memory_can_be_persisted(
+    mock_sqlite,
+    mock_llm_factory,
+    mock_vector_factory,
+    mock_embedder_factory,
+    mock_extract_entities_batch,
+):
+    _, database = _configure_inferred_add_with_insert_failures(
+        mock_sqlite,
+        mock_llm_factory,
+        mock_vector_factory,
+        mock_embedder_factory,
+        failed_texts={"Persisted fact", "Failed fact"},
+    )
+
+    from mem0.memory.main import AsyncMemory
+
+    with pytest.raises(VectorStoreError, match="Failed to persist extracted memories"):
+        await AsyncMemory(MemoryConfig()).add("Remember these facts", user_id="test-user")
+
+    database.batch_add_history.assert_not_called()
+    database.save_messages.assert_not_called()
+    mock_extract_entities_batch.assert_not_called()
+
+
 @patch('mem0.utils.factory.EmbedderFactory.create')
 @patch('mem0.utils.factory.VectorStoreFactory.create')
 @patch('mem0.utils.factory.LlmFactory.create')
@@ -1231,8 +1393,9 @@ class TestHybridSearchWarning:
     def test_warning_for_store_without_keyword_search(
         self, mock_vs_factory, mock_emb, mock_llm, mock_sqlite, _cap, caplog
     ):
-        from mem0.vector_stores.base import VectorStoreBase
         import logging
+
+        from mem0.vector_stores.base import VectorStoreBase
 
         class StoreWithoutKeywordSearch(VectorStoreBase):
             def create_col(self, *a, **kw): pass
@@ -1267,8 +1430,9 @@ class TestHybridSearchWarning:
     def test_no_warning_for_store_with_keyword_search(
         self, mock_vs_factory, mock_emb, mock_llm, mock_sqlite, _cap, caplog
     ):
-        from mem0.vector_stores.base import VectorStoreBase
         import logging
+
+        from mem0.vector_stores.base import VectorStoreBase
 
         class StoreWithKeywordSearch(VectorStoreBase):
             def keyword_search(self, query, top_k=5, filters=None):


### PR DESCRIPTION
## Description

  When inferred memories were persisted, the SDK first attempted a batch vector-store insert. If that failed, it retried each
  memory individually.

  Individual insertion failures were logged but otherwise ignored. The complete original record collection was subsequently used
  for:

  - History creation
  - Entity extraction and linking
  - API response results

  This meant callers could receive successful `ADD` results containing IDs that did not exist in the vector store. History and
  entity records could also reference memories that were never persisted.

  This PR fixes that behavior in both synchronous and asynchronous `Memory` implementations.

  ## Implementation

  The fallback insertion path now tracks each record that was successfully persisted.

  When the batch insert succeeds:

  - All records continue through the existing history, entity-linking, and response pipeline.

  When the batch insert fails but individual retries partially succeed:

  - Only successfully persisted records are included in history.
  - Only successfully persisted records participate in entity extraction and linking.
  - Only successfully persisted records are returned to the caller.
  - Failed records continue to be logged with their generated memory ID.

  When every individual retry fails:

  - The operation raises `VectorStoreError`.
  - No phantom success response is returned.
  - No history entries are created.
  - No entity extraction or linking is attempted.
  - The input messages are not recorded as successfully processed.
  - Error details include the operation and number of failed records.

  ## Why raise on total failure?

  Returning an empty or successful result would make a vector-store outage indistinguishable from a valid extraction that
  produced no memories.

  `Memory.add()` already documents `VectorStoreError` as the expected failure type for vector-store operations, so surfacing
  that error gives callers a reliable signal for retry or fallback behavior.

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Breaking change
  - [ ] Refactor
  - [ ] Documentation update

  ## Breaking Changes

  N/A for successfully persisted operations.

  The only behavioral change is that a total persistence failure now raises the documented `VectorStoreError` instead of
  returning IDs for nonexistent memories.

  ## Test Coverage

  Regression tests cover both synchronous and asynchronous implementations:

  - Partial batch fallback failure returns only the successfully inserted memory.
  - History is written only for the persisted memory.
  - Entity extraction receives only persisted memory text.
  - Total fallback failure raises `VectorStoreError`.
  - Total failure does not create history.
  - Total failure does not run entity extraction.
  - Total failure does not save messages as successfully processed.

  ### Verification performed

  - New sync/async regression selection:
    - 4 passed
  - `pytest tests/test_main.py`
    - 43 passed
  - Ruff on affected files:
    - Passed
  - Pre-commit Ruff and isort hooks:
    - Passed

  A full `tests/test_memory.py` run produced 61 passes and two unrelated existing failures:

  - `test_add_infer_true_caches_embedding_on_llm_rewrite`
  - `test_update_infer_true_caches_embedding_on_llm_rewrite`

  Those tests expect one `embed_batch` call, while the current entity-linking pipeline performs a second batch embedding
  operation. This behavior predates and is unrelated to the persistence-result filtering in this PR.

  ## Checklist

  - [x] Code follows the project's style guidelines
  - [x] Self-review performed
  - [x] Tests added that prove the fix
  - [x] Relevant tests pass locally
  - [x] No public API documentation changes required