### PR TITLE
fix: fall back when keyword search fails

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1600,9 +1600,13 @@ class Memory(MemoryBase):
         )
 
         # Step 4: Keyword search (if store supports it)
-        keyword_results = self.vector_store.keyword_search(
-            query=query_lemmatized, top_k=internal_limit, filters=filters
-        )
+        try:
+            keyword_results = self.vector_store.keyword_search(
+                query=query_lemmatized, top_k=internal_limit, filters=filters
+            )
+        except Exception as e:
+            logger.warning("Keyword search failed; continuing with semantic search: %s", e)
+            keyword_results = None
 
         # Step 5: Compute BM25 scores from keyword results
         bm25_scores = {}
@@ -3240,9 +3244,13 @@ class AsyncMemory(MemoryBase):
         )
 
         # Step 4: Keyword search (if store supports it)
-        keyword_results = await asyncio.to_thread(
-            self.vector_store.keyword_search, query=query_lemmatized, top_k=internal_limit, filters=filters
-        )
+        try:
+            keyword_results = await asyncio.to_thread(
+                self.vector_store.keyword_search, query=query_lemmatized, top_k=internal_limit, filters=filters
+            )
+        except Exception as e:
+            logger.warning("Keyword search failed; continuing with semantic search: %s", e)
+            keyword_results = None
 
         # Step 5: Compute BM25 scores
         bm25_scores = {}

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -240,6 +240,79 @@ def test_search_explain_includes_score_details(
     assert details["threshold"] == 0.1
 
 
+@patch("mem0.memory.main.extract_entities", return_value=[])
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.main.SQLiteManager")
+def test_search_falls_back_to_semantic_results_when_keyword_search_fails(
+    mock_sqlite,
+    mock_llm_factory,
+    mock_vector_factory,
+    mock_embedder_factory,
+    _mock_extract_entities,
+    caplog,
+):
+    mock_embedder = MagicMock()
+    mock_embedder.embed.return_value = [0.1, 0.2, 0.3]
+    mock_embedder_factory.return_value = mock_embedder
+
+    mock_vector_store = MagicMock()
+    mock_vector_store.search.return_value = [
+        MockVectorMemory("semantic", {"data": "Semantic result", "user_id": "test"}, score=0.8)
+    ]
+    mock_vector_store.keyword_search.side_effect = RuntimeError("keyword backend unavailable")
+    mock_vector_factory.return_value = mock_vector_store
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+
+    with caplog.at_level("WARNING", logger="mem0.memory.main"):
+        result = MemoryClass(MemoryConfig()).search("test query", filters={"user_id": "test"})
+
+    assert [item["id"] for item in result["results"]] == ["semantic"]
+    assert result["results"][0]["score"] == pytest.approx(0.8)
+    assert "Keyword search failed; continuing with semantic search" in caplog.text
+
+
+@pytest.mark.asyncio
+@patch("mem0.memory.main.extract_entities", return_value=[])
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.main.SQLiteManager")
+async def test_async_search_falls_back_to_semantic_results_when_keyword_search_fails(
+    mock_sqlite,
+    mock_llm_factory,
+    mock_vector_factory,
+    mock_embedder_factory,
+    _mock_extract_entities,
+    caplog,
+):
+    mock_embedder = MagicMock()
+    mock_embedder.embed.return_value = [0.1, 0.2, 0.3]
+    mock_embedder_factory.return_value = mock_embedder
+
+    mock_vector_store = MagicMock()
+    mock_vector_store.search.return_value = [
+        MockVectorMemory("semantic", {"data": "Semantic result", "user_id": "test"}, score=0.8)
+    ]
+    mock_vector_store.keyword_search.side_effect = RuntimeError("keyword backend unavailable")
+    mock_vector_factory.return_value = mock_vector_store
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import AsyncMemory
+
+    with caplog.at_level("WARNING", logger="mem0.memory.main"):
+        result = await AsyncMemory(MemoryConfig()).search("test query", filters={"user_id": "test"})
+
+    assert [item["id"] for item in result["results"]] == ["semantic"]
+    assert result["results"][0]["score"] == pytest.approx(0.8)
+    assert "Keyword search failed; continuing with semantic search" in caplog.text
+
+
 @patch('mem0.utils.factory.EmbedderFactory.create')
 @patch('mem0.utils.factory.VectorStoreFactory.create')
 @patch('mem0.utils.factory.LlmFactory.create')
@@ -1231,8 +1304,9 @@ class TestHybridSearchWarning:
     def test_warning_for_store_without_keyword_search(
         self, mock_vs_factory, mock_emb, mock_llm, mock_sqlite, _cap, caplog
     ):
-        from mem0.vector_stores.base import VectorStoreBase
         import logging
+
+        from mem0.vector_stores.base import VectorStoreBase
 
         class StoreWithoutKeywordSearch(VectorStoreBase):
             def create_col(self, *a, **kw): pass
@@ -1267,8 +1341,9 @@ class TestHybridSearchWarning:
     def test_no_warning_for_store_with_keyword_search(
         self, mock_vs_factory, mock_emb, mock_llm, mock_sqlite, _cap, caplog
     ):
-        from mem0.vector_stores.base import VectorStoreBase
         import logging
+
+        from mem0.vector_stores.base import VectorStoreBase
 
         class StoreWithKeywordSearch(VectorStoreBase):
             def keyword_search(self, query, top_k=5, filters=None):


### PR DESCRIPTION
## Description

  Python hybrid search performs semantic retrieval first and then optionally enriches those results using keyword/BM25
  retrieval.

  Previously, an exception from `vector_store.keyword_search()` aborted the entire request. This discarded semantic results that
  had already been retrieved successfully.

  Keyword search may fail independently because of:

  - An unavailable lexical-search backend
  - A missing or uninitialized BM25 index
  - An optional provider dependency
  - A provider-specific query error
  - A transient backend failure

  Because lexical retrieval is an optional enrichment signal, its failure should not make semantic retrieval unavailable.

  This PR updates both:

  - Python `Memory`
  - Python `AsyncMemory`

  The TypeScript OSS implementation already follows this fallback behavior.

  ## Implementation

  The keyword-search operation is now isolated in its own exception boundary.

  When keyword search succeeds:

  - Existing BM25 normalization and hybrid scoring behavior is unchanged.

  When keyword search fails:

  - A warning is logged with the underlying error.
  - Keyword results are treated as unavailable.
  - BM25 scores remain empty for that request.
  - Existing semantic results continue through filtering, entity boosting, scoring, and response formatting.
  - Semantic-only scores retain their existing values.

  The exception boundary covers only keyword retrieval. Failures from semantic search, embedding generation, or the rest of the
  core retrieval pipeline continue to propagate normally.

  ## Why degrade gracefully?

  Keyword retrieval is an optional enhancement to the primary semantic-search path. Allowing it to abort the complete request
  turns an auxiliary backend into a single point of failure for RAG and agent-memory retrieval.

  The TypeScript OSS implementation already handles keyword-search failures this way, so this change also restores behavioral
  consistency between the Python and TypeScript SDKs.

  ## Logging

  Failures produce a warning in the following form:

  ```text
  Keyword search failed; continuing with semantic search: <provider error>

  This keeps the request available while preserving enough information for operators to detect and investigate lexical-backend
  problems.

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Breaking change
  - [ ] Refactor
  - [ ] Documentation update

  ## Breaking Changes

  N/A.

  Successful hybrid-search behavior is unchanged. The only behavioral difference is that keyword-backend failures now return
  available semantic results instead of failing the entire search request.

  ## Test Coverage

  Regression tests cover synchronous and asynchronous search behavior.

  Each test verifies that when keyword search raises:

  - The search request still succeeds.
  - The semantic result remains in the response.
  - The semantic-only score is preserved.
  - A warning is emitted describing the fallback.

  ### Verification performed

  - Focused fallback and existing explain-scoring tests:
      - 3 passed

  - Broader search-related tests from tests/test_memory.py:
      - 7 passed

  - pytest tests/test_main.py:
      - 43 passed

  - Ruff on affected files:
      - Passed

  - Pre-commit Ruff and isort hooks:
      - Passed

  ## Checklist

  - [x] Code follows the project's style guidelines
  - [x] Self-review performed
  - [x] Tests added that prove the fix
  - [x] Relevant new and existing tests pass locally
  - [x] No public API documentation changes required
