### PR TITLE
fix: respect hosted HTTP client ownership

### DIFF
--- a/mem0/client/main.py
+++ b/mem0/client/main.py
@@ -108,7 +108,8 @@ class MemoryClient:
                   "https://api.mem0.ai".
             client: A custom httpx.Client instance. If provided, it will be
                     used instead of creating a new one. Note that base_url and
-                    headers will be set/overridden as needed.
+                    headers will be set/overridden as needed. The caller retains
+                    ownership and is responsible for closing it.
 
         Raises:
             ValueError: If no API key is provided or found in the environment.
@@ -125,6 +126,7 @@ class MemoryClient:
         # Create MD5 hash of API key for user_id
         self.user_id = hashlib.md5(self.api_key.encode()).hexdigest()
 
+        self._owns_client = client is None
         if client is not None:
             self.client = client
             # Ensure the client has the correct base_url and headers
@@ -156,6 +158,17 @@ class MemoryClient:
 
         _maybe_alias_anon_to_email(self.user_email)
         capture_client_event("client.init", self, {"sync_type": "sync"})
+
+    def close(self) -> None:
+        """Close the internally created HTTP client, if any."""
+        if self._owns_client:
+            self.client.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
 
     def _validate_api_key(self):
         """Validate the API key by making a test request."""
@@ -997,7 +1010,8 @@ class AsyncMemoryClient:
                   "https://api.mem0.ai".
             client: A custom httpx.AsyncClient instance. If provided, it will
                     be used instead of creating a new one. Note that base_url
-                    and headers will be set/overridden as needed.
+                    and headers will be set/overridden as needed. The caller
+                    retains ownership and is responsible for closing it.
 
         Raises:
             ValueError: If no API key is provided or found in the environment.
@@ -1014,6 +1028,7 @@ class AsyncMemoryClient:
         # Create MD5 hash of API key for user_id
         self.user_id = hashlib.md5(self.api_key.encode()).hexdigest()
 
+        self._owns_client = client is None
         if client is not None:
             self.async_client = client
             # Ensure the client has the correct base_url and headers
@@ -1114,7 +1129,12 @@ class AsyncMemoryClient:
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        await self.async_client.aclose()
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        """Close the internally created async HTTP client, if any."""
+        if self._owns_client:
+            await self.async_client.aclose()
 
     @api_error_handler
     async def add(self, messages, options: Optional[AddMemoryOptions] = None, **kwargs) -> Dict[str, Any]:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -389,3 +389,88 @@ class TestValidateApiKeyHttpError:
 
         assert not isinstance(exc_info.value, requests.exceptions.JSONDecodeError)
         assert "Error:" in str(exc_info.value)
+
+
+class TestHttpClientLifecycle:
+    @staticmethod
+    def _ping_response():
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {
+            "org_id": "org1",
+            "project_id": "project1",
+            "user_email": "test@example.com",
+        }
+        return response
+
+    def test_sync_client_closes_internally_created_transport(self):
+        transport = MagicMock()
+        transport.get.return_value = self._ping_response()
+
+        with patch("mem0.client.main.httpx.Client", return_value=transport):
+            with patch("mem0.client.main.capture_client_event"):
+                from mem0.client.main import MemoryClient
+
+                client = MemoryClient(api_key="test-api-key")
+                client.close()
+
+        transport.close.assert_called_once_with()
+
+    def test_sync_context_manager_closes_internally_created_transport(self):
+        transport = MagicMock()
+        transport.get.return_value = self._ping_response()
+
+        with patch("mem0.client.main.httpx.Client", return_value=transport):
+            with patch("mem0.client.main.capture_client_event"):
+                from mem0.client.main import MemoryClient
+
+                client = MemoryClient(api_key="test-api-key")
+                with client as entered:
+                    assert entered is client
+
+        transport.close.assert_called_once_with()
+
+    def test_sync_context_manager_does_not_close_borrowed_transport(self):
+        transport = MagicMock()
+        transport.headers = httpx.Headers()
+        transport.get.return_value = self._ping_response()
+
+        with patch("mem0.client.main.capture_client_event"):
+            from mem0.client.main import MemoryClient
+
+            client = MemoryClient(api_key="test-api-key", client=transport)
+            with client as entered:
+                assert entered is client
+
+        transport.close.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_client_closes_internally_created_transport(self):
+        transport = MagicMock()
+        transport.aclose = AsyncMock()
+
+        with patch("mem0.client.main.httpx.AsyncClient", return_value=transport):
+            with patch("mem0.client.main.requests.get", return_value=self._ping_response()):
+                with patch("mem0.client.main.capture_client_event"):
+                    from mem0.client.main import AsyncMemoryClient
+
+                    client = AsyncMemoryClient(api_key="test-api-key")
+                    await client.aclose()
+
+        transport.aclose.assert_awaited_once_with()
+
+    @pytest.mark.asyncio
+    async def test_async_context_manager_does_not_close_borrowed_transport(self):
+        transport = MagicMock()
+        transport.headers = httpx.Headers()
+        transport.aclose = AsyncMock()
+
+        with patch("mem0.client.main.requests.get", return_value=self._ping_response()):
+            with patch("mem0.client.main.capture_client_event"):
+                from mem0.client.main import AsyncMemoryClient
+
+                client = AsyncMemoryClient(api_key="test-api-key", client=transport)
+                async with client as entered:
+                    assert entered is client
+
+        transport.aclose.assert_not_awaited()


### PR DESCRIPTION
## Description

  The hosted Python clients did not consistently manage their
  underlying HTTP transports.

  `MemoryClient` created an internal `httpx.Client` but exposed
  neither:

  - A `close()` method
  - Synchronous context-manager support

  This could leave connection pools and other transport resources
  open unless callers reached into internal attributes.

  `AsyncMemoryClient` had the opposite ownership problem. Its async
  context-manager exit always closed `self.async_client`, including
  when the caller had supplied a shared `httpx.AsyncClient`.

  That could unexpectedly shut down a transport used by other
  application components.

  This PR introduces an explicit ownership contract for both hosted
  clients.

## Ownership Contract

### Internally created clients

  When Mem0 creates the HTTP transport:

  - `MemoryClient.close()` closes the internal `httpx.Client`.
  - Exiting `with MemoryClient(...)` closes the internal client.
  - `AsyncMemoryClient.aclose()` closes the internal
  `httpx.AsyncClient`.
  - Exiting `async with AsyncMemoryClient(...)` closes the internal
  async client.

### Caller-supplied clients

  When the caller passes `client=`:

  - Mem0 uses the supplied client but does not own it.
  - `close()` and `aclose()` do not close the borrowed transport.
  - Sync and async context-manager exit do not close the borrowed
  transport.
  - The caller remains responsible for closing it.

  Existing behavior that configures the supplied client's base URL
  and authentication headers is unchanged and remains documented.

## Implementation

  Both clients now record whether their HTTP transport was created
  internally:

  ```python
  self._owns_client = client is None

  MemoryClient now exposes:

  close()
  __enter__()
  __exit__()

  AsyncMemoryClient now exposes:

  aclose()

  Its existing async context manager delegates cleanup to aclose()
  instead of closing the transport unconditionally.

  Constructor documentation now explicitly states that caller-
  supplied transports remain caller-owned.

## Why this matters

  HTTPX clients maintain reusable connection pools and may hold
  sockets and other resources.

  Without deterministic cleanup:

  - Internally created synchronous clients can leak resources in
    long-running applications.

  - Shared asynchronous clients can be closed unexpectedly, causing
    failures in unrelated requests.

  - Applications cannot safely use consistent dependency-injection
    or application-lifespan patterns.

  The new ownership behavior supports both standalone use and
  shared-client patterns commonly used by FastAPI and other async
  applications.

## Usage

  Internally managed synchronous client:

  with MemoryClient(api_key="...") as client:
      client.get_all(filters={"user_id": "user-1"})

  Internally managed asynchronous client:

  async with AsyncMemoryClient(api_key="...") as client:
      await client.get_all(filters={"user_id": "user-1"})

  Caller-managed shared client:

  async with httpx.AsyncClient() as http_client:
      mem0_client = AsyncMemoryClient(
          api_key="...",
          client=http_client,
      )

      # Mem0 will not close http_client.
      await mem0_client.get_all(filters={"user_id": "user-1"})

## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Breaking change
  - [ ] Refactor
  - [ ] Documentation update

## Breaking Changes

  N/A.

  The change prevents borrowed async clients from being closed
  unexpectedly. Internally created async clients continue to be
  closed on async context-manager exit.

  MemoryClient gains lifecycle APIs without changing existing
  request behavior.

## Test Coverage

  Tests verify that:

  - MemoryClient.close() closes an internally created transport.
  - The synchronous context manager returns the client instance.
  - Synchronous context-manager exit closes an internally created
    transport.

  - Synchronous context-manager exit does not close a caller-
    supplied transport.

  - AsyncMemoryClient.aclose() closes an internally created
    transport.

  - The asynchronous context manager returns the client instance.
  - Asynchronous context-manager exit does not close a caller-
    supplied transport.

  - Existing API-key validation error behavior remains intact.

### Verification performed

  - pytest tests/test_client.py
      - 34 passed

  - Ruff on affected files
      - Passed

  - Pre-commit Ruff and isort hooks
      - Passed

## Checklist

  - [x] Code follows the project's style guidelines
  - [x] Self-review performed
  - [x] Tests added that prove the fix
  - [x] New and existing hosted-client tests pass locally
  - [x] Constructor documentation updated
  - [x] No public API documentation page changes required

