### PR TITLE
fix(llms/gemini): forward http_client_proxies in BaseLlmConfig conversion

### DIFF
--- a/mem0/llms/gemini.py
+++ b/mem0/llms/gemini.py
@@ -29,6 +29,7 @@ class GeminiLLM(LLMBase):
                 top_k=config.top_k,
                 enable_vision=config.enable_vision,
                 vision_details=config.vision_details,
+                http_client_proxies=config.http_client_proxies,
             )
 
         super().__init__(config)

--- a/tests/test_http_client_proxies.py
+++ b/tests/test_http_client_proxies.py
@@ -37,3 +37,22 @@ def test_llm_factory_preserves_http_client_proxies():
     llm = LlmFactory.create("openai", base)
     assert llm.config.http_client_proxies == "http://proxy.local:8080"
     assert isinstance(llm.config.http_client, httpx.Client)
+
+
+def test_gemini_llm_preserves_http_client_proxies_from_base_config():
+    """GeminiLLM converts BaseLlmConfig to GeminiConfig; proxies must survive.
+
+    Regression for https://github.com/mem0ai/mem0/issues/6385 — the conversion
+    block omitted http_client_proxies even though GeminiConfig accepts it and
+    every other provider forwards it.
+    """
+    from mem0.llms.gemini import GeminiLLM
+
+    base = BaseLlmConfig(
+        model="gemini-2.0-flash",
+        api_key="sk-test",
+        http_client_proxies="http://proxy.local:8080",
+    )
+    llm = GeminiLLM(base)
+    assert llm.config.http_client_proxies == "http://proxy.local:8080"
+    assert isinstance(llm.config.http_client, httpx.Client)


### PR DESCRIPTION
## Summary

- Forward `http_client_proxies` when `GeminiLLM` converts a plain `BaseLlmConfig` into `GeminiConfig`.
- Add a regression test alongside the other proxy-preservation checks.

## Motivation

Closes #6385.

`GeminiConfig` already accepts `http_client_proxies`, and every other LLM provider that converts from `BaseLlmConfig` forwards that field. Gemini's conversion block dropped it, so proxy settings were silently lost on that construction path.

## Verification

- `python -m pytest tests/test_http_client_proxies.py -q` — 8 passed, 0 failed
- Did NOT change: Gemini client construction / Vertex auth paths (proxies remain on the shared config object for consumers that use `http_client`)

## Differential value

N/A — new issue opened with this fix; no competing open PR on #6385.