### PR TITLE
fix(ts-sdk): lazy-load optional provider SDKs in mem0ai/oss

### DIFF
--- a/docs/open-source/configuration.mdx
+++ b/docs/open-source/configuration.mdx
@@ -148,7 +148,7 @@ See the full catalog in <Link href="/components/llms/overview">Components</Link>
 - Qdrant connection errors: confirm port `6333` is exposed and the API key (if set) matches.
 - Empty search results: verify the embedder model name. A mismatch causes dimension errors.
 - `Unknown reranker` (Python): upgrade the SDK with `pip install --upgrade mem0ai` to load the latest provider registry.
-- `Cannot find module` (Node): import from the OSS entry point, `import { Memory } from "mem0ai/oss"`, not `"mem0ai"`.
+- `Cannot find module` (Node): two common causes. First, import from the OSS entry point, `import { Memory } from "mem0ai/oss"`, not `"mem0ai"`. Second, provider SDKs are optional peer dependencies loaded on demand, so install the one for the provider you configured (for example `npm install @qdrant/js-client-rest` for Qdrant). Installing `mem0ai` alone only pulls in the providers used by default; you do not need SDKs for providers you never select.
 
 <CardGroup cols={2}>
   <Card

--- a/mem0-ts/package.json
+++ b/mem0-ts/package.json
@@ -151,6 +151,42 @@
     "@aws-sdk/client-bedrock-runtime": ">=3.0.0 <3.968.0"
   },
   "peerDependenciesMeta": {
+    "@qdrant/js-client-rest": {
+      "optional": true
+    },
+    "redis": {
+      "optional": true
+    },
+    "@supabase/supabase-js": {
+      "optional": true
+    },
+    "cloudflare": {
+      "optional": true
+    },
+    "@azure/search-documents": {
+      "optional": true
+    },
+    "@azure/identity": {
+      "optional": true
+    },
+    "@langchain/core": {
+      "optional": true
+    },
+    "@anthropic-ai/sdk": {
+      "optional": true
+    },
+    "@google/genai": {
+      "optional": true
+    },
+    "groq-sdk": {
+      "optional": true
+    },
+    "@mistralai/mistralai": {
+      "optional": true
+    },
+    "ollama": {
+      "optional": true
+    },
     "mysql2": {
       "optional": true
     },

--- a/mem0-ts/src/oss/src/embeddings/fastembed.ts
+++ b/mem0-ts/src/oss/src/embeddings/fastembed.ts
@@ -1,6 +1,7 @@
 import type { FlagEmbedding } from "fastembed";
 import { Embedder } from "./base";
 import { EmbeddingConfig } from "../types";
+import { loadPeer } from "../utils/load_peer";
 
 // FastEmbed only ships a fixed set of ONNX models (fastembed's `EmbeddingModel`
 // enum, minus CUSTOM). Mirrored here as literals so an invalid model name can
@@ -54,14 +55,11 @@ export class FastEmbedEmbedder implements Embedder {
    * consumers that never touch FastEmbed don't need it installed.
    */
   private async initEmbeddingModel(): Promise<FlagEmbedding> {
-    let sdk: any;
-    try {
-      sdk = await import("fastembed");
-    } catch {
-      throw new Error(
-        "The 'fastembed' package is required to use the FastEmbed embedder. Install it with: npm install fastembed",
-      );
-    }
+    const sdk = await loadPeer(
+      "fastembed",
+      "FastEmbed embedder",
+      () => import("fastembed"),
+    );
 
     return sdk.FlagEmbedding.init({ model: this.modelName });
   }

--- a/mem0-ts/src/oss/src/embeddings/google.ts
+++ b/mem0-ts/src/oss/src/embeddings/google.ts
@@ -1,21 +1,34 @@
-import { GoogleGenAI } from "@google/genai";
+import type { GoogleGenAI } from "@google/genai";
 import { Embedder } from "./base";
 import { EmbeddingConfig } from "../types";
 
 export class GoogleEmbedder implements Embedder {
-  private google: GoogleGenAI;
+  private google!: GoogleGenAI;
   private model: string;
   private embeddingDims: number | undefined;
+  private readonly apiKey: string | undefined;
 
   constructor(config: EmbeddingConfig) {
-    this.google = new GoogleGenAI({
-      apiKey: config.apiKey || process.env.GOOGLE_API_KEY,
-    });
+    this.apiKey = config.apiKey || process.env.GOOGLE_API_KEY;
     this.model = config.model || "gemini-embedding-001";
     this.embeddingDims = config.embeddingDims;
   }
 
+  private async ensureClient(): Promise<void> {
+    if (this.google) return;
+    let sdk: any;
+    try {
+      sdk = await import("@google/genai");
+    } catch {
+      throw new Error(
+        "The '@google/genai' package is required to use the Google embedder. Install it with: npm install @google/genai",
+      );
+    }
+    this.google = new sdk.GoogleGenAI({ apiKey: this.apiKey });
+  }
+
   async embed(text: string): Promise<number[]> {
+    await this.ensureClient();
     const response = await this.google.models.embedContent({
       model: this.model,
       contents: text,
@@ -27,6 +40,7 @@ export class GoogleEmbedder implements Embedder {
   }
 
   async embedBatch(texts: string[]): Promise<number[][]> {
+    await this.ensureClient();
     const response = await this.google.models.embedContent({
       model: this.model,
       contents: texts,

--- a/mem0-ts/src/oss/src/embeddings/google.ts
+++ b/mem0-ts/src/oss/src/embeddings/google.ts
@@ -1,6 +1,7 @@
 import type { GoogleGenAI } from "@google/genai";
 import { Embedder } from "./base";
 import { EmbeddingConfig } from "../types";
+import { loadPeer } from "../utils/load_peer";
 
 export class GoogleEmbedder implements Embedder {
   private google!: GoogleGenAI;
@@ -16,14 +17,11 @@ export class GoogleEmbedder implements Embedder {
 
   private async ensureClient(): Promise<void> {
     if (this.google) return;
-    let sdk: any;
-    try {
-      sdk = await import("@google/genai");
-    } catch {
-      throw new Error(
-        "The '@google/genai' package is required to use the Google embedder. Install it with: npm install @google/genai",
-      );
-    }
+    const sdk = await loadPeer(
+      "@google/genai",
+      "Google embedder",
+      () => import("@google/genai"),
+    );
     this.google = new sdk.GoogleGenAI({ apiKey: this.apiKey });
   }
 

--- a/mem0-ts/src/oss/src/embeddings/langchain.ts
+++ b/mem0-ts/src/oss/src/embeddings/langchain.ts
@@ -1,4 +1,4 @@
-import { Embeddings } from "@langchain/core/embeddings";
+import type { Embeddings } from "@langchain/core/embeddings";
 import { Embedder } from "./base";
 import { EmbeddingConfig } from "../types";
 

--- a/mem0-ts/src/oss/src/embeddings/ollama.ts
+++ b/mem0-ts/src/oss/src/embeddings/ollama.ts
@@ -2,6 +2,7 @@ import type { Ollama } from "ollama";
 import { Embedder } from "./base";
 import { EmbeddingConfig } from "../types";
 import { logger } from "../utils/logger";
+import { loadPeer } from "../utils/load_peer";
 
 export class OllamaEmbedder implements Embedder {
   private ollama!: Ollama;
@@ -22,14 +23,11 @@ export class OllamaEmbedder implements Embedder {
 
   private async ensureClient(): Promise<void> {
     if (this.ollama) return;
-    let sdk: any;
-    try {
-      sdk = await import("ollama");
-    } catch {
-      throw new Error(
-        "The 'ollama' package is required to use the Ollama embedder. Install it with: npm install ollama",
-      );
-    }
+    const sdk = await loadPeer(
+      "ollama",
+      "Ollama embedder",
+      () => import("ollama"),
+    );
     this.ollama = new sdk.Ollama({ host: this.host });
   }
 

--- a/mem0-ts/src/oss/src/embeddings/ollama.ts
+++ b/mem0-ts/src/oss/src/embeddings/ollama.ts
@@ -1,19 +1,18 @@
-import { Ollama } from "ollama";
+import type { Ollama } from "ollama";
 import { Embedder } from "./base";
 import { EmbeddingConfig } from "../types";
 import { logger } from "../utils/logger";
 
 export class OllamaEmbedder implements Embedder {
-  private ollama: Ollama;
+  private ollama!: Ollama;
   private model: string;
   private embeddingDims?: number;
+  private readonly host: string;
   // Using this variable to avoid calling the Ollama server multiple times
   private initialized: boolean = false;
 
   constructor(config: EmbeddingConfig) {
-    this.ollama = new Ollama({
-      host: config.url || config.baseURL || "http://localhost:11434",
-    });
+    this.host = config.url || config.baseURL || "http://localhost:11434";
     this.model = config.model || "nomic-embed-text:latest";
     this.embeddingDims = config.embeddingDims || 768;
     this.ensureModelExists().catch((err) => {
@@ -21,7 +20,21 @@ export class OllamaEmbedder implements Embedder {
     });
   }
 
+  private async ensureClient(): Promise<void> {
+    if (this.ollama) return;
+    let sdk: any;
+    try {
+      sdk = await import("ollama");
+    } catch {
+      throw new Error(
+        "The 'ollama' package is required to use the Ollama embedder. Install it with: npm install ollama",
+      );
+    }
+    this.ollama = new sdk.Ollama({ host: this.host });
+  }
+
   async embed(text: string): Promise<number[]> {
+    await this.ensureClient();
     try {
       await this.ensureModelExists();
     } catch (err) {
@@ -54,6 +67,7 @@ export class OllamaEmbedder implements Embedder {
     if (this.initialized) {
       return true;
     }
+    await this.ensureClient();
     const local_models = await this.ollama.list();
     const target = OllamaEmbedder.normalizeModelName(this.model);
     if (

--- a/mem0-ts/src/oss/src/embeddings/vertexai.ts
+++ b/mem0-ts/src/oss/src/embeddings/vertexai.ts
@@ -1,6 +1,7 @@
 import type { PredictionServiceClient } from "@google-cloud/aiplatform";
 import { Embedder } from "./base";
 import { VertexAIConfig } from "../types";
+import { loadPeer } from "../utils/load_peer";
 
 type AIPlatform = typeof import("@google-cloud/aiplatform");
 type ClientOptions = NonNullable<
@@ -105,15 +106,11 @@ export class VertexAIEmbedder implements Embedder {
   }
 
   private async createClient(): Promise<void> {
-    let aiplatform: AIPlatform;
-    try {
-      aiplatform = await import("@google-cloud/aiplatform");
-    } catch (err) {
-      throw new Error(
-        "Failed to import '@google-cloud/aiplatform'. Please install it to use the Vertex AI embedding provider: " +
-          (err as Error).message,
-      );
-    }
+    const aiplatform: AIPlatform = await loadPeer(
+      "@google-cloud/aiplatform",
+      "Vertex AI embedding provider",
+      () => import("@google-cloud/aiplatform"),
+    );
 
     const client = new aiplatform.PredictionServiceClient(this.clientOptions);
 

--- a/mem0-ts/src/oss/src/llms/anthropic.ts
+++ b/mem0-ts/src/oss/src/llms/anthropic.ts
@@ -1,6 +1,7 @@
 import type Anthropic from "@anthropic-ai/sdk";
 import { LLM, LLMResponse } from "./base";
 import { LLMConfig, Message } from "../types";
+import { loadPeer } from "../utils/load_peer";
 
 export class AnthropicLLM implements LLM {
   private client!: Anthropic;
@@ -32,14 +33,11 @@ export class AnthropicLLM implements LLM {
 
   private async ensureClient(): Promise<void> {
     if (this.client) return;
-    let sdk: any;
-    try {
-      sdk = await import("@anthropic-ai/sdk");
-    } catch {
-      throw new Error(
-        "The '@anthropic-ai/sdk' package is required to use the Anthropic LLM. Install it with: npm install @anthropic-ai/sdk",
-      );
-    }
+    const sdk = await loadPeer(
+      "@anthropic-ai/sdk",
+      "Anthropic LLM",
+      () => import("@anthropic-ai/sdk"),
+    );
     this.client = new sdk.default(this.clientArgs);
   }
 

--- a/mem0-ts/src/oss/src/llms/anthropic.ts
+++ b/mem0-ts/src/oss/src/llms/anthropic.ts
@@ -1,9 +1,10 @@
-import Anthropic from "@anthropic-ai/sdk";
+import type Anthropic from "@anthropic-ai/sdk";
 import { LLM, LLMResponse } from "./base";
 import { LLMConfig, Message } from "../types";
 
 export class AnthropicLLM implements LLM {
-  private client: Anthropic;
+  private client!: Anthropic;
+  private readonly clientArgs: { apiKey: string; baseURL?: string };
   private model: string;
   private maxTokens: number;
   private temperature?: number;
@@ -20,7 +21,7 @@ export class AnthropicLLM implements LLM {
     if (config.baseURL) {
       clientArgs.baseURL = config.baseURL;
     }
-    this.client = new Anthropic(clientArgs);
+    this.clientArgs = clientArgs;
     this.model = config.model || "claude-sonnet-4-6";
     // Defaults mirror the Python provider's AnthropicConfig
     // (max_tokens=2000, temperature=0.1, top_p omitted).
@@ -29,11 +30,25 @@ export class AnthropicLLM implements LLM {
     this.topP = config.topP;
   }
 
+  private async ensureClient(): Promise<void> {
+    if (this.client) return;
+    let sdk: any;
+    try {
+      sdk = await import("@anthropic-ai/sdk");
+    } catch {
+      throw new Error(
+        "The '@anthropic-ai/sdk' package is required to use the Anthropic LLM. Install it with: npm install @anthropic-ai/sdk",
+      );
+    }
+    this.client = new sdk.default(this.clientArgs);
+  }
+
   async generateResponse(
     messages: Message[],
     responseFormat?: { type: string },
     tools?: any[],
   ): Promise<string | LLMResponse> {
+    await this.ensureClient();
     // Extract system message if present
     const systemMessage = messages.find((msg) => msg.role === "system");
     const otherMessages = messages.filter((msg) => msg.role !== "system");

--- a/mem0-ts/src/oss/src/llms/google.ts
+++ b/mem0-ts/src/oss/src/llms/google.ts
@@ -1,14 +1,28 @@
-import { GoogleGenAI } from "@google/genai";
+import type { GoogleGenAI } from "@google/genai";
 import { LLM, LLMResponse } from "./base";
 import { LLMConfig, Message } from "../types";
 
 export class GoogleLLM implements LLM {
-  private google: GoogleGenAI;
+  private google!: GoogleGenAI;
   private model: string;
+  private readonly apiKey: string | undefined;
 
   constructor(config: LLMConfig) {
-    this.google = new GoogleGenAI({ apiKey: config.apiKey });
+    this.apiKey = config.apiKey;
     this.model = config.model || "gemini-2.0-flash";
+  }
+
+  private async ensureClient(): Promise<void> {
+    if (this.google) return;
+    let sdk: any;
+    try {
+      sdk = await import("@google/genai");
+    } catch {
+      throw new Error(
+        "The '@google/genai' package is required to use the Google LLM. Install it with: npm install @google/genai",
+      );
+    }
+    this.google = new sdk.GoogleGenAI({ apiKey: this.apiKey });
   }
 
   private formatContents(messages: Message[]) {
@@ -30,6 +44,7 @@ export class GoogleLLM implements LLM {
     responseFormat?: { type: string },
     tools?: any[],
   ): Promise<string | LLMResponse> {
+    await this.ensureClient();
     const contents = this.formatContents(messages);
 
     // Build config with tools if provided
@@ -72,6 +87,7 @@ export class GoogleLLM implements LLM {
   }
 
   async generateChat(messages: Message[]): Promise<LLMResponse> {
+    await this.ensureClient();
     const completion = await this.google.models.generateContent({
       contents: this.formatContents(messages),
       model: this.model,

--- a/mem0-ts/src/oss/src/llms/google.ts
+++ b/mem0-ts/src/oss/src/llms/google.ts
@@ -1,6 +1,7 @@
 import type { GoogleGenAI } from "@google/genai";
 import { LLM, LLMResponse } from "./base";
 import { LLMConfig, Message } from "../types";
+import { loadPeer } from "../utils/load_peer";
 
 export class GoogleLLM implements LLM {
   private google!: GoogleGenAI;
@@ -14,14 +15,11 @@ export class GoogleLLM implements LLM {
 
   private async ensureClient(): Promise<void> {
     if (this.google) return;
-    let sdk: any;
-    try {
-      sdk = await import("@google/genai");
-    } catch {
-      throw new Error(
-        "The '@google/genai' package is required to use the Google LLM. Install it with: npm install @google/genai",
-      );
-    }
+    const sdk = await loadPeer(
+      "@google/genai",
+      "Google LLM",
+      () => import("@google/genai"),
+    );
     this.google = new sdk.GoogleGenAI({ apiKey: this.apiKey });
   }
 

--- a/mem0-ts/src/oss/src/llms/groq.ts
+++ b/mem0-ts/src/oss/src/llms/groq.ts
@@ -1,6 +1,7 @@
 import type { Groq } from "groq-sdk";
 import { LLM, LLMResponse } from "./base";
 import { LLMConfig, Message } from "../types";
+import { loadPeer } from "../utils/load_peer";
 
 export class GroqLLM implements LLM {
   private client!: Groq;
@@ -18,14 +19,11 @@ export class GroqLLM implements LLM {
 
   private async ensureClient(): Promise<void> {
     if (this.client) return;
-    let sdk: any;
-    try {
-      sdk = await import("groq-sdk");
-    } catch {
-      throw new Error(
-        "The 'groq-sdk' package is required to use the Groq LLM. Install it with: npm install groq-sdk",
-      );
-    }
+    const sdk = await loadPeer(
+      "groq-sdk",
+      "Groq LLM",
+      () => import("groq-sdk"),
+    );
     this.client = new sdk.Groq({ apiKey: this.apiKey });
   }
 

--- a/mem0-ts/src/oss/src/llms/groq.ts
+++ b/mem0-ts/src/oss/src/llms/groq.ts
@@ -1,24 +1,39 @@
-import { Groq } from "groq-sdk";
+import type { Groq } from "groq-sdk";
 import { LLM, LLMResponse } from "./base";
 import { LLMConfig, Message } from "../types";
 
 export class GroqLLM implements LLM {
-  private client: Groq;
+  private client!: Groq;
   private model: string;
+  private readonly apiKey: string;
 
   constructor(config: LLMConfig) {
     const apiKey = config.apiKey || process.env.GROQ_API_KEY;
     if (!apiKey) {
       throw new Error("Groq API key is required");
     }
-    this.client = new Groq({ apiKey });
+    this.apiKey = apiKey;
     this.model = config.model || "llama3-70b-8192";
+  }
+
+  private async ensureClient(): Promise<void> {
+    if (this.client) return;
+    let sdk: any;
+    try {
+      sdk = await import("groq-sdk");
+    } catch {
+      throw new Error(
+        "The 'groq-sdk' package is required to use the Groq LLM. Install it with: npm install groq-sdk",
+      );
+    }
+    this.client = new sdk.Groq({ apiKey: this.apiKey });
   }
 
   async generateResponse(
     messages: Message[],
     responseFormat?: { type: string },
   ): Promise<string> {
+    await this.ensureClient();
     const response = await this.client.chat.completions.create({
       model: this.model,
       messages: messages.map((msg) => ({
@@ -35,6 +50,7 @@ export class GroqLLM implements LLM {
   }
 
   async generateChat(messages: Message[]): Promise<LLMResponse> {
+    await this.ensureClient();
     const response = await this.client.chat.completions.create({
       model: this.model,
       messages: messages.map((msg) => ({

--- a/mem0-ts/src/oss/src/llms/langchain.ts
+++ b/mem0-ts/src/oss/src/llms/langchain.ts
@@ -1,17 +1,16 @@
-import { BaseLanguageModel } from "@langchain/core/language_models/base";
-import {
-  AIMessage,
-  HumanMessage,
-  SystemMessage,
-  BaseMessage,
-} from "@langchain/core/messages";
+import type { BaseLanguageModel } from "@langchain/core/language_models/base";
+import type { BaseMessage } from "@langchain/core/messages";
 import { z } from "zod";
 import { LLM, LLMResponse } from "./base";
 import { LLMConfig, Message } from "../types/index";
 // Import the schemas directly into LangchainLLM
 import { FactRetrievalSchema, MemoryUpdateSchema } from "../prompts";
 
-const convertToLangchainMessages = (messages: Message[]): BaseMessage[] => {
+const convertToLangchainMessages = async (
+  messages: Message[],
+): Promise<BaseMessage[]> => {
+  const { AIMessage, HumanMessage, SystemMessage } =
+    await import("@langchain/core/messages");
   return messages.map((msg) => {
     const content =
       typeof msg.content === "string"
@@ -62,7 +61,7 @@ export class LangchainLLM implements LLM {
     response_format?: { type: string },
     tools?: any[],
   ): Promise<string | LLMResponse> {
-    const langchainMessages = convertToLangchainMessages(messages);
+    const langchainMessages = await convertToLangchainMessages(messages);
     let runnable: any = this.llmInstance;
     const invokeOptions: Record<string, any> = {};
     let isStructuredOutput = false;
@@ -170,7 +169,7 @@ export class LangchainLLM implements LLM {
   }
 
   async generateChat(messages: Message[]): Promise<LLMResponse> {
-    const langchainMessages = convertToLangchainMessages(messages);
+    const langchainMessages = await convertToLangchainMessages(messages);
     try {
       const response = await this.llmInstance.invoke(langchainMessages);
       if (response && typeof response.content === "string") {

--- a/mem0-ts/src/oss/src/llms/mistral.ts
+++ b/mem0-ts/src/oss/src/llms/mistral.ts
@@ -1,6 +1,7 @@
 import type { Mistral } from "@mistralai/mistralai";
 import { LLM, LLMResponse } from "./base";
 import { LLMConfig, Message } from "../types";
+import { loadPeer } from "../utils/load_peer";
 
 export class MistralLLM implements LLM {
   private client!: Mistral;
@@ -17,14 +18,11 @@ export class MistralLLM implements LLM {
 
   private async ensureClient(): Promise<void> {
     if (this.client) return;
-    let sdk: any;
-    try {
-      sdk = await import("@mistralai/mistralai");
-    } catch {
-      throw new Error(
-        "The '@mistralai/mistralai' package is required to use the Mistral LLM. Install it with: npm install @mistralai/mistralai",
-      );
-    }
+    const sdk = await loadPeer(
+      "@mistralai/mistralai",
+      "Mistral LLM",
+      () => import("@mistralai/mistralai"),
+    );
     this.client = new sdk.Mistral({ apiKey: this.apiKey });
   }
 

--- a/mem0-ts/src/oss/src/llms/mistral.ts
+++ b/mem0-ts/src/oss/src/llms/mistral.ts
@@ -1,19 +1,31 @@
-import { Mistral } from "@mistralai/mistralai";
+import type { Mistral } from "@mistralai/mistralai";
 import { LLM, LLMResponse } from "./base";
 import { LLMConfig, Message } from "../types";
 
 export class MistralLLM implements LLM {
-  private client: Mistral;
+  private client!: Mistral;
   private model: string;
+  private readonly apiKey: string;
 
   constructor(config: LLMConfig) {
     if (!config.apiKey) {
       throw new Error("Mistral API key is required");
     }
-    this.client = new Mistral({
-      apiKey: config.apiKey,
-    });
+    this.apiKey = config.apiKey;
     this.model = config.model || "mistral-tiny-latest";
+  }
+
+  private async ensureClient(): Promise<void> {
+    if (this.client) return;
+    let sdk: any;
+    try {
+      sdk = await import("@mistralai/mistralai");
+    } catch {
+      throw new Error(
+        "The '@mistralai/mistralai' package is required to use the Mistral LLM. Install it with: npm install @mistralai/mistralai",
+      );
+    }
+    this.client = new sdk.Mistral({ apiKey: this.apiKey });
   }
 
   // Helper function to convert content to string
@@ -41,6 +53,7 @@ export class MistralLLM implements LLM {
     responseFormat?: { type: string },
     tools?: any[],
   ): Promise<string | LLMResponse> {
+    await this.ensureClient();
     const response = await this.client.chat.complete({
       model: this.model,
       messages: messages.map((msg) => ({
@@ -82,6 +95,7 @@ export class MistralLLM implements LLM {
   }
 
   async generateChat(messages: Message[]): Promise<LLMResponse> {
+    await this.ensureClient();
     const formattedMessages = messages.map((msg) => ({
       role: msg.role as "system" | "user" | "assistant",
       content:

--- a/mem0-ts/src/oss/src/llms/ollama.ts
+++ b/mem0-ts/src/oss/src/llms/ollama.ts
@@ -1,22 +1,34 @@
-import { Ollama } from "ollama";
+import type { Ollama } from "ollama";
 import { LLM, LLMResponse } from "./base";
 import { LLMConfig, Message } from "../types";
 import { logger } from "../utils/logger";
 
 export class OllamaLLM implements LLM {
-  private ollama: Ollama;
+  private ollama!: Ollama;
   private model: string;
+  private readonly host: string;
   // Using this variable to avoid calling the Ollama server multiple times
   private initialized: boolean = false;
 
   constructor(config: LLMConfig) {
-    this.ollama = new Ollama({
-      host: config.url || config.baseURL || "http://localhost:11434",
-    });
+    this.host = config.url || config.baseURL || "http://localhost:11434";
     this.model = config.model || "llama3.1:8b";
     this.ensureModelExists().catch((err) => {
       logger.error(`Error ensuring model exists: ${err}`);
     });
+  }
+
+  private async ensureClient(): Promise<void> {
+    if (this.ollama) return;
+    let sdk: any;
+    try {
+      sdk = await import("ollama");
+    } catch {
+      throw new Error(
+        "The 'ollama' package is required to use the Ollama LLM. Install it with: npm install ollama",
+      );
+    }
+    this.ollama = new sdk.Ollama({ host: this.host });
   }
 
   async generateResponse(
@@ -24,6 +36,7 @@ export class OllamaLLM implements LLM {
     responseFormat?: { type: string },
     tools?: any[],
   ): Promise<string | LLMResponse> {
+    await this.ensureClient();
     try {
       await this.ensureModelExists();
     } catch (err) {
@@ -63,6 +76,7 @@ export class OllamaLLM implements LLM {
   }
 
   async generateChat(messages: Message[]): Promise<LLMResponse> {
+    await this.ensureClient();
     try {
       await this.ensureModelExists();
     } catch (err) {
@@ -93,6 +107,7 @@ export class OllamaLLM implements LLM {
     if (this.initialized) {
       return true;
     }
+    await this.ensureClient();
     const local_models = await this.ollama.list();
     if (!local_models.models.find((m: any) => m.name === this.model)) {
       logger.info(`Pulling model ${this.model}...`);

--- a/mem0-ts/src/oss/src/llms/ollama.ts
+++ b/mem0-ts/src/oss/src/llms/ollama.ts
@@ -2,6 +2,7 @@ import type { Ollama } from "ollama";
 import { LLM, LLMResponse } from "./base";
 import { LLMConfig, Message } from "../types";
 import { logger } from "../utils/logger";
+import { loadPeer } from "../utils/load_peer";
 
 export class OllamaLLM implements LLM {
   private ollama!: Ollama;
@@ -20,14 +21,7 @@ export class OllamaLLM implements LLM {
 
   private async ensureClient(): Promise<void> {
     if (this.ollama) return;
-    let sdk: any;
-    try {
-      sdk = await import("ollama");
-    } catch {
-      throw new Error(
-        "The 'ollama' package is required to use the Ollama LLM. Install it with: npm install ollama",
-      );
-    }
+    const sdk = await loadPeer("ollama", "Ollama LLM", () => import("ollama"));
     this.ollama = new sdk.Ollama({ host: this.host });
   }
 

--- a/mem0-ts/src/oss/src/rerankers/cohere.ts
+++ b/mem0-ts/src/oss/src/rerankers/cohere.ts
@@ -1,5 +1,6 @@
 import { RerankerConfig } from "../types";
 import { Reranker, RerankResult } from "./base";
+import { loadPeer } from "../utils/load_peer";
 
 const DEFAULT_MODEL = "rerank-v3.5";
 
@@ -41,14 +42,11 @@ export class CohereReranker implements Reranker {
   }
 
   private async createClient(): Promise<any> {
-    let sdk: any;
-    try {
-      sdk = await import("cohere-ai");
-    } catch {
-      throw new Error(
-        "The 'cohere-ai' package is required to use the Cohere reranker. Install it with: npm install cohere-ai",
-      );
-    }
+    const sdk = await loadPeer(
+      "cohere-ai",
+      "Cohere reranker",
+      () => import("cohere-ai"),
+    );
     return new sdk.CohereClient({ token: this.apiKey });
   }
 

--- a/mem0-ts/src/oss/src/rerankers/zeroentropy.ts
+++ b/mem0-ts/src/oss/src/rerankers/zeroentropy.ts
@@ -1,5 +1,6 @@
 import { RerankerConfig } from "../types";
 import { Reranker, RerankResult } from "./base";
+import { loadPeer } from "../utils/load_peer";
 
 const DEFAULT_MODEL = "zerank-1";
 
@@ -37,14 +38,11 @@ export class ZeroEntropyReranker implements Reranker {
   }
 
   private async createClient(): Promise<any> {
-    let sdk: any;
-    try {
-      sdk = await import("zeroentropy");
-    } catch {
-      throw new Error(
-        "The 'zeroentropy' package is required to use the ZeroEntropy reranker. Install it with: npm install zeroentropy",
-      );
-    }
+    const sdk = await loadPeer(
+      "zeroentropy",
+      "ZeroEntropy reranker",
+      () => import("zeroentropy"),
+    );
     return new sdk.ZeroEntropy({ apiKey: this.apiKey });
   }
 

--- a/mem0-ts/src/oss/src/storage/SupabaseHistoryManager.ts
+++ b/mem0-ts/src/oss/src/storage/SupabaseHistoryManager.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { v4 as uuidv4 } from "uuid";
 import { HistoryManager } from "./base";
+import { loadPeer } from "../utils/load_peer";
 
 interface HistoryEntry {
   id: string;
@@ -36,14 +37,11 @@ export class SupabaseHistoryManager implements HistoryManager {
 
   private async ensureClient(): Promise<void> {
     if (this.supabase) return;
-    let sdk: any;
-    try {
-      sdk = await import("@supabase/supabase-js");
-    } catch {
-      throw new Error(
-        "The '@supabase/supabase-js' package is required to use the Supabase history manager. Install it with: npm install @supabase/supabase-js",
-      );
-    }
+    const sdk = await loadPeer(
+      "@supabase/supabase-js",
+      "Supabase history manager",
+      () => import("@supabase/supabase-js"),
+    );
     this.supabase = sdk.createClient(this.supabaseUrl, this.supabaseKey);
   }
 

--- a/mem0-ts/src/oss/src/storage/SupabaseHistoryManager.ts
+++ b/mem0-ts/src/oss/src/storage/SupabaseHistoryManager.ts
@@ -1,4 +1,4 @@
-import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import { v4 as uuidv4 } from "uuid";
 import { HistoryManager } from "./base";
 
@@ -20,16 +20,35 @@ interface SupabaseHistoryConfig {
 }
 
 export class SupabaseHistoryManager implements HistoryManager {
-  private supabase: SupabaseClient;
+  // ponytail: benign double-construct race — two concurrent first-calls may each
+  // build a client; createClient opens no connection, so last-write-wins is fine.
+  private supabase!: SupabaseClient;
+  private readonly supabaseUrl: string;
+  private readonly supabaseKey: string;
   private readonly tableName: string;
 
   constructor(config: SupabaseHistoryConfig) {
     this.tableName = config.tableName || "memory_history";
-    this.supabase = createClient(config.supabaseUrl, config.supabaseKey);
+    this.supabaseUrl = config.supabaseUrl;
+    this.supabaseKey = config.supabaseKey;
     this.initializeSupabase().catch(console.error);
   }
 
+  private async ensureClient(): Promise<void> {
+    if (this.supabase) return;
+    let sdk: any;
+    try {
+      sdk = await import("@supabase/supabase-js");
+    } catch {
+      throw new Error(
+        "The '@supabase/supabase-js' package is required to use the Supabase history manager. Install it with: npm install @supabase/supabase-js",
+      );
+    }
+    this.supabase = sdk.createClient(this.supabaseUrl, this.supabaseKey);
+  }
+
   private async initializeSupabase(): Promise<void> {
+    await this.ensureClient();
     // Check if table exists
     const { error } = await this.supabase
       .from(this.tableName)
@@ -65,6 +84,7 @@ create table ${this.tableName} (
     updatedAt?: string,
     isDeleted: number = 0,
   ): Promise<void> {
+    await this.ensureClient();
     const historyEntry: HistoryEntry = {
       id: uuidv4(),
       memory_id: memoryId,
@@ -87,6 +107,7 @@ create table ${this.tableName} (
   }
 
   async getHistory(memoryId: string): Promise<any[]> {
+    await this.ensureClient();
     const { data, error } = await this.supabase
       .from(this.tableName)
       .select("*")
@@ -103,6 +124,7 @@ create table ${this.tableName} (
   }
 
   async reset(): Promise<void> {
+    await this.ensureClient();
     const { error } = await this.supabase
       .from(this.tableName)
       .delete()

--- a/mem0-ts/src/oss/src/utils/load_peer.ts
+++ b/mem0-ts/src/oss/src/utils/load_peer.ts
@@ -1,0 +1,13 @@
+export async function loadPeer(
+  pkg: string,
+  label: string,
+  load: () => Promise<any>,
+): Promise<any> {
+  try {
+    return await load();
+  } catch {
+    throw new Error(
+      `The '${pkg}' package is required to use the ${label}. Install it with: npm install ${pkg}`,
+    );
+  }
+}

--- a/mem0-ts/src/oss/src/vector_stores/azure_ai_search.ts
+++ b/mem0-ts/src/oss/src/vector_stores/azure_ai_search.ts
@@ -1,7 +1,6 @@
-import {
+import type {
   SearchClient,
   SearchIndexClient,
-  AzureKeyCredential,
   SearchIndex,
   SearchField,
   SearchFieldDataType,
@@ -13,7 +12,6 @@ import {
   BinaryQuantizationCompression,
   VectorizedQuery,
 } from "@azure/search-documents";
-import { DefaultAzureCredential } from "@azure/identity";
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
 
@@ -71,8 +69,8 @@ interface AzureAISearchConfig extends VectorStoreConfig {
  * Supports vector search with hybrid search, compression, and filtering
  */
 export class AzureAISearch implements VectorStore {
-  private searchClient: SearchClient<any>;
-  private indexClient: SearchIndexClient;
+  private searchClient!: SearchClient<any>;
+  private indexClient!: SearchIndexClient;
   private readonly serviceName: string;
   private readonly indexName: string;
   private readonly embeddingModelDims: number;
@@ -93,25 +91,48 @@ export class AzureAISearch implements VectorStore {
     this.vectorFilterMode = config.vectorFilterMode || "preFilter";
     this.apiKey = config.apiKey;
 
+    // Initialize the index
+    this.initialize().catch(console.error);
+  }
+
+  private async ensureClient(): Promise<void> {
+    if (this.searchClient) return;
+    let searchSdk: any;
+    try {
+      searchSdk = await import("@azure/search-documents");
+    } catch {
+      throw new Error(
+        "The '@azure/search-documents' package is required to use the Azure AI Search vector store. Install it with: npm install @azure/search-documents",
+      );
+    }
+
     const serviceEndpoint = `https://${this.serviceName}.search.windows.net`;
 
     // Determine authentication: API key or DefaultAzureCredential
-    const credential =
-      this.apiKey && this.apiKey !== "" && this.apiKey !== "your-api-key"
-        ? new AzureKeyCredential(this.apiKey)
-        : new DefaultAzureCredential();
+    let credential: any;
+    if (this.apiKey && this.apiKey !== "" && this.apiKey !== "your-api-key") {
+      credential = new searchSdk.AzureKeyCredential(this.apiKey);
+    } else {
+      let identitySdk: any;
+      try {
+        identitySdk = await import("@azure/identity");
+      } catch {
+        throw new Error(
+          "The '@azure/identity' package is required for Azure AI Search when no apiKey is provided. Install it with: npm install @azure/identity",
+        );
+      }
+      credential = new identitySdk.DefaultAzureCredential();
+    }
 
-    // Initialize clients
-    this.searchClient = new SearchClient(
+    this.searchClient = new searchSdk.SearchClient(
       serviceEndpoint,
       this.indexName,
       credential,
     );
-
-    this.indexClient = new SearchIndexClient(serviceEndpoint, credential);
-
-    // Initialize the index
-    this.initialize().catch(console.error);
+    this.indexClient = new searchSdk.SearchIndexClient(
+      serviceEndpoint,
+      credential,
+    );
   }
 
   /**
@@ -125,6 +146,7 @@ export class AzureAISearch implements VectorStore {
   }
 
   private async _doInitialize(): Promise<void> {
+    await this.ensureClient();
     try {
       const collections = await this.listCols();
       if (!collections.includes(this.indexName)) {
@@ -262,6 +284,7 @@ export class AzureAISearch implements VectorStore {
     ids: string[],
     payloads: Record<string, any>[],
   ): Promise<void> {
+    await this.initialize();
     console.log(
       `Inserting ${vectors.length} vectors into index ${this.indexName}`,
     );
@@ -334,6 +357,7 @@ export class AzureAISearch implements VectorStore {
     topK: number = 5,
     filters?: SearchFilters,
   ): Promise<VectorStoreResult[] | null> {
+    await this.initialize();
     try {
       const filterExpression = filters
         ? this.buildFilterExpression(filters)
@@ -373,6 +397,7 @@ export class AzureAISearch implements VectorStore {
     topK: number = 5,
     filters?: SearchFilters,
   ): Promise<VectorStoreResult[]> {
+    await this.initialize();
     const filterExpression = filters
       ? this.buildFilterExpression(filters)
       : undefined;
@@ -429,6 +454,7 @@ export class AzureAISearch implements VectorStore {
    * Delete a vector by ID
    */
   async delete(vectorId: string): Promise<void> {
+    await this.initialize();
     const response = await this.searchClient.deleteDocuments([
       { id: vectorId },
     ]);
@@ -454,6 +480,7 @@ export class AzureAISearch implements VectorStore {
     vector: number[],
     payload: Record<string, any>,
   ): Promise<void> {
+    await this.initialize();
     const document: Record<string, any> = { id: vectorId };
 
     if (vector) {
@@ -486,6 +513,7 @@ export class AzureAISearch implements VectorStore {
    * Retrieve a vector by ID
    */
   async get(vectorId: string): Promise<VectorStoreResult | null> {
+    await this.initialize();
     try {
       const result = await this.searchClient.getDocument(vectorId);
       const payloadStr = result.payload as string;
@@ -521,6 +549,7 @@ export class AzureAISearch implements VectorStore {
    * Delete the index
    */
   async deleteCol(): Promise<void> {
+    await this.initialize();
     await this.indexClient.deleteIndex(this.indexName);
   }
 
@@ -542,6 +571,7 @@ export class AzureAISearch implements VectorStore {
     filters?: SearchFilters,
     topK: number = 100,
   ): Promise<[VectorStoreResult[], number]> {
+    await this.initialize();
     const filterExpression = filters
       ? this.buildFilterExpression(filters)
       : undefined;
@@ -586,6 +616,7 @@ export class AzureAISearch implements VectorStore {
    * Required by VectorStore interface
    */
   async getUserId(): Promise<string> {
+    await this.initialize();
     try {
       // Check if memory_migrations index exists
       const collections = await this.listCols();
@@ -648,6 +679,7 @@ export class AzureAISearch implements VectorStore {
    * Required by VectorStore interface
    */
   async setUserId(userId: string): Promise<void> {
+    await this.initialize();
     try {
       // Get existing point ID or generate new one
       const searchResults = await this.searchClient.search("*", {
@@ -677,6 +709,7 @@ export class AzureAISearch implements VectorStore {
    * Reset the index by deleting and recreating it
    */
   async reset(): Promise<void> {
+    await this.initialize();
     console.log(`Resetting index ${this.indexName}...`);
 
     try {

--- a/mem0-ts/src/oss/src/vector_stores/azure_ai_search.ts
+++ b/mem0-ts/src/oss/src/vector_stores/azure_ai_search.ts
@@ -14,6 +14,7 @@ import type {
 } from "@azure/search-documents";
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
+import { loadPeer } from "../utils/load_peer";
 
 /**
  * Configuration interface for Azure AI Search vector store
@@ -97,14 +98,11 @@ export class AzureAISearch implements VectorStore {
 
   private async ensureClient(): Promise<void> {
     if (this.searchClient) return;
-    let searchSdk: any;
-    try {
-      searchSdk = await import("@azure/search-documents");
-    } catch {
-      throw new Error(
-        "The '@azure/search-documents' package is required to use the Azure AI Search vector store. Install it with: npm install @azure/search-documents",
-      );
-    }
+    const searchSdk = await loadPeer(
+      "@azure/search-documents",
+      "Azure AI Search vector store",
+      () => import("@azure/search-documents"),
+    );
 
     const serviceEndpoint = `https://${this.serviceName}.search.windows.net`;
 
@@ -113,14 +111,11 @@ export class AzureAISearch implements VectorStore {
     if (this.apiKey && this.apiKey !== "" && this.apiKey !== "your-api-key") {
       credential = new searchSdk.AzureKeyCredential(this.apiKey);
     } else {
-      let identitySdk: any;
-      try {
-        identitySdk = await import("@azure/identity");
-      } catch {
-        throw new Error(
-          "The '@azure/identity' package is required for Azure AI Search when no apiKey is provided. Install it with: npm install @azure/identity",
-        );
-      }
+      const identitySdk = await loadPeer(
+        "@azure/identity",
+        "Azure AI Search without an apiKey",
+        () => import("@azure/identity"),
+      );
       credential = new identitySdk.DefaultAzureCredential();
     }
 

--- a/mem0-ts/src/oss/src/vector_stores/azure_mysql.ts
+++ b/mem0-ts/src/oss/src/vector_stores/azure_mysql.ts
@@ -1,6 +1,7 @@
 import type { Pool, RowDataPacket } from "mysql2/promise";
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
+import { loadPeer } from "../utils/load_peer";
 
 const SAFE_IDENTIFIER_RE = /^[a-zA-Z_][a-zA-Z0-9_]{0,127}$/;
 
@@ -94,14 +95,11 @@ export class AzureMySQLDB implements VectorStore {
 
     // Loaded dynamically: mysql2 is an optional peer dependency, so a static value import
     // would break `import { Memory } from "mem0ai/oss"` for everyone else.
-    let createPool: typeof import("mysql2/promise").createPool;
-    try {
-      ({ createPool } = await import("mysql2/promise"));
-    } catch {
-      throw new Error(
-        "The Azure MySQL vector store requires the 'mysql2' package. Install it with: npm install mysql2",
-      );
-    }
+    const { createPool }: typeof import("mysql2/promise") = await loadPeer(
+      "mysql2",
+      "Azure MySQL vector store",
+      () => import("mysql2/promise"),
+    );
 
     this.pool = createPool({
       host: this.config.host,

--- a/mem0-ts/src/oss/src/vector_stores/baidu.ts
+++ b/mem0-ts/src/oss/src/vector_stores/baidu.ts
@@ -12,6 +12,7 @@ import type {
 } from "@mochow/mochow-sdk-node";
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
+import { loadPeer } from "../utils/load_peer";
 
 type MochowSdk = typeof import("@mochow/mochow-sdk-node");
 
@@ -156,14 +157,11 @@ export class BaiduDB implements VectorStore {
   // value import would break `import { Memory } from "mem0ai/oss"` for everyone else.
   private async loadSdk(): Promise<MochowSdk> {
     if (!this.sdk) {
-      let module: MochowSdk & { default?: MochowSdk };
-      try {
-        module = await import("@mochow/mochow-sdk-node");
-      } catch {
-        throw new Error(
-          "The Baidu vector store requires the '@mochow/mochow-sdk-node' package. Install it with: npm install @mochow/mochow-sdk-node",
-        );
-      }
+      const module: MochowSdk & { default?: MochowSdk } = await loadPeer(
+        "@mochow/mochow-sdk-node",
+        "Baidu vector store",
+        () => import("@mochow/mochow-sdk-node"),
+      );
       this.sdk = module.default ?? module;
     }
     return this.sdk;

--- a/mem0-ts/src/oss/src/vector_stores/cassandra.ts
+++ b/mem0-ts/src/oss/src/vector_stores/cassandra.ts
@@ -1,5 +1,6 @@
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
+import { loadPeer } from "../utils/load_peer";
 
 const MIGRATION_ROW_ID = "mem0-user";
 const SAFE_IDENTIFIER_RE = /^[A-Za-z_][A-Za-z0-9_]{0,127}$/;
@@ -377,14 +378,11 @@ export class CassandraDB implements VectorStore {
   // Loaded dynamically: cassandra-driver is an optional peer dependency, so a static
   // value import would break `import { Memory } from "mem0ai/oss"` for everyone else.
   private async loadDriver(): Promise<any> {
-    let sdk: any;
-    try {
-      sdk = await import("cassandra-driver");
-    } catch {
-      throw new Error(
-        "The 'cassandra-driver' package is required to use the Cassandra vector store. Install it with: npm install cassandra-driver",
-      );
-    }
+    const sdk = await loadPeer(
+      "cassandra-driver",
+      "Cassandra vector store",
+      () => import("cassandra-driver"),
+    );
     return sdk.default ?? sdk;
   }
 

--- a/mem0-ts/src/oss/src/vector_stores/chroma.ts
+++ b/mem0-ts/src/oss/src/vector_stores/chroma.ts
@@ -1,6 +1,7 @@
 import type { ChromaClient, CloudClient } from "chromadb";
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
+import { loadPeer } from "../utils/load_peer";
 
 interface ChromaConfig extends VectorStoreConfig {
   /** Pre-configured ChromaDB client instance. */
@@ -65,14 +66,11 @@ export class ChromaDB implements VectorStore {
       return config.client;
     }
 
-    let sdk: any;
-    try {
-      sdk = await import("chromadb");
-    } catch {
-      throw new Error(
-        "The 'chromadb' package is required to use the Chroma vector store. Install it with: npm install chromadb",
-      );
-    }
+    const sdk = await loadPeer(
+      "chromadb",
+      "Chroma vector store",
+      () => import("chromadb"),
+    );
 
     if (config.apiKey && config.tenant) {
       return new sdk.CloudClient({

--- a/mem0-ts/src/oss/src/vector_stores/elasticsearch.ts
+++ b/mem0-ts/src/oss/src/vector_stores/elasticsearch.ts
@@ -1,6 +1,7 @@
 import type { Client } from "@elastic/elasticsearch";
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
+import { loadPeer } from "../utils/load_peer";
 
 interface ElasticsearchConfig extends VectorStoreConfig {
   /** Pre-configured Elasticsearch client instance (typed as `any` to keep the
@@ -100,14 +101,11 @@ export class ElasticsearchDB implements VectorStore {
         params.headers = config.headers;
       }
 
-      let sdk: any;
-      try {
-        sdk = await import("@elastic/elasticsearch");
-      } catch {
-        throw new Error(
-          "The '@elastic/elasticsearch' package is required to use the Elasticsearch vector store. Install it with: npm install @elastic/elasticsearch",
-        );
-      }
+      const sdk = await loadPeer(
+        "@elastic/elasticsearch",
+        "Elasticsearch vector store",
+        () => import("@elastic/elasticsearch"),
+      );
 
       this.client = new sdk.Client(params);
     }

--- a/mem0-ts/src/oss/src/vector_stores/langchain.ts
+++ b/mem0-ts/src/oss/src/vector_stores/langchain.ts
@@ -1,5 +1,4 @@
-import { VectorStore as LangchainVectorStoreInterface } from "@langchain/core/vectorstores";
-import { Document } from "@langchain/core/documents";
+import type { VectorStore as LangchainVectorStoreInterface } from "@langchain/core/vectorstores";
 import { VectorStore } from "./base"; // mem0's VectorStore interface
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
 
@@ -77,6 +76,7 @@ export class LangchainVectorStore implements VectorStore {
     }
 
     // Convert payloads to Langchain Document metadata format
+    const { Document } = await import("@langchain/core/documents");
     const documents = payloads.map((payload, i) => {
       // Provide empty pageContent, store mem0 id and other data in metadata
       return new Document({

--- a/mem0-ts/src/oss/src/vector_stores/mongodb.ts
+++ b/mem0-ts/src/oss/src/vector_stores/mongodb.ts
@@ -1,6 +1,7 @@
 import type { MongoClient, Collection, Db } from "mongodb";
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
+import { loadPeer } from "../utils/load_peer";
 
 export interface MongoDBConfig extends VectorStoreConfig {
   url?: string;
@@ -42,14 +43,11 @@ export class MongoDB implements VectorStore {
     if (config.client) {
       this.client = config.client;
     } else {
-      let sdk: any;
-      try {
-        sdk = await import("mongodb");
-      } catch {
-        throw new Error(
-          "The 'mongodb' package is required to use the MongoDB vector store. Install it with: npm install mongodb",
-        );
-      }
+      const sdk = await loadPeer(
+        "mongodb",
+        "MongoDB vector store",
+        () => import("mongodb"),
+      );
       const url = config.url || "mongodb://localhost:27017";
       this.client = new sdk.MongoClient(url, { appName: "Mem0" });
     }

--- a/mem0-ts/src/oss/src/vector_stores/opensearch.ts
+++ b/mem0-ts/src/oss/src/vector_stores/opensearch.ts
@@ -1,6 +1,7 @@
 import type { Client } from "@opensearch-project/opensearch";
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
+import { loadPeer } from "../utils/load_peer";
 
 type OpenSearchAuth =
   | {
@@ -98,14 +99,11 @@ export class OpenSearchDB implements VectorStore {
           ? { username: config.user, password: config.password }
           : undefined);
 
-      let sdk: any;
-      try {
-        sdk = await import("@opensearch-project/opensearch");
-      } catch {
-        throw new Error(
-          "The '@opensearch-project/opensearch' package is required to use the OpenSearch vector store. Install it with: npm install @opensearch-project/opensearch",
-        );
-      }
+      const sdk = await loadPeer(
+        "@opensearch-project/opensearch",
+        "OpenSearch vector store",
+        () => import("@opensearch-project/opensearch"),
+      );
 
       this.client = new sdk.Client({
         node: `${useSSL ? "https" : "http"}://${host}:${port}`,

--- a/mem0-ts/src/oss/src/vector_stores/pinecone.ts
+++ b/mem0-ts/src/oss/src/vector_stores/pinecone.ts
@@ -1,6 +1,7 @@
 import type { Pinecone, Index } from "@pinecone-database/pinecone";
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
+import { loadPeer } from "../utils/load_peer";
 
 const MIGRATIONS_NAMESPACE = "__mem0_migrations__";
 const MIGRATIONS_RECORD_ID = "mem0-user-id";
@@ -82,14 +83,11 @@ export class PineconeDB implements VectorStore {
       this.client = config.client;
     } else {
       const apiKey = config.apiKey || process.env.PINECONE_API_KEY;
-      let sdk: any;
-      try {
-        sdk = await import("@pinecone-database/pinecone");
-      } catch {
-        throw new Error(
-          "The '@pinecone-database/pinecone' package is required to use the Pinecone vector store. Install it with: npm install @pinecone-database/pinecone",
-        );
-      }
+      const sdk = await loadPeer(
+        "@pinecone-database/pinecone",
+        "Pinecone vector store",
+        () => import("@pinecone-database/pinecone"),
+      );
       this.client = new sdk.Pinecone({ apiKey });
     }
   }

--- a/mem0-ts/src/oss/src/vector_stores/qdrant.ts
+++ b/mem0-ts/src/oss/src/vector_stores/qdrant.ts
@@ -1,6 +1,7 @@
 import type { QdrantClient } from "@qdrant/js-client-rest";
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
+import { loadPeer } from "../utils/load_peer";
 import * as fs from "fs";
 
 interface QdrantConfig extends VectorStoreConfig {
@@ -105,14 +106,11 @@ export class Qdrant implements VectorStore {
       }
     }
 
-    let sdk: any;
-    try {
-      sdk = await import("@qdrant/js-client-rest");
-    } catch {
-      throw new Error(
-        "The '@qdrant/js-client-rest' package is required to use the Qdrant vector store. Install it with: npm install @qdrant/js-client-rest",
-      );
-    }
+    const sdk = await loadPeer(
+      "@qdrant/js-client-rest",
+      "Qdrant vector store",
+      () => import("@qdrant/js-client-rest"),
+    );
     this.client = new sdk.QdrantClient(params);
   }
 

--- a/mem0-ts/src/oss/src/vector_stores/qdrant.ts
+++ b/mem0-ts/src/oss/src/vector_stores/qdrant.ts
@@ -1,4 +1,4 @@
-import { QdrantClient } from "@qdrant/js-client-rest";
+import type { QdrantClient } from "@qdrant/js-client-rest";
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
 import * as fs from "fs";
@@ -55,51 +55,65 @@ const KEY_MAP: Record<string, string> = {
 };
 
 export class Qdrant implements VectorStore {
-  private client: QdrantClient;
+  private client!: QdrantClient;
+  private readonly config: QdrantConfig;
   private readonly collectionName: string;
   private dimension: number;
   private _initPromise?: Promise<void>;
 
   constructor(config: QdrantConfig) {
-    if (config.client) {
-      this.client = config.client;
-    } else {
-      const params: Record<string, any> = {};
-      if (config.apiKey) {
-        params.apiKey = config.apiKey;
-      }
-      if (config.url) {
-        params.url = config.url;
-        // Workaround for qdrant/qdrant-js#59: explicitly pass port to avoid "Illegal host" error
-        try {
-          const parsedUrl = new URL(config.url);
-          params.port = parsedUrl.port ? parseInt(parsedUrl.port, 10) : 6333;
-        } catch (_) {
-          params.port = 6333;
-        }
-      }
-      if (config.host && config.port) {
-        params.host = config.host;
-        params.port = config.port;
-      }
-      if (!Object.keys(params).length) {
-        params.path = config.path;
-        if (!config.onDisk && config.path) {
-          if (
-            fs.existsSync(config.path) &&
-            fs.statSync(config.path).isDirectory()
-          ) {
-            fs.rmSync(config.path, { recursive: true });
-          }
-        }
-      }
-
-      this.client = new QdrantClient(params);
-    }
-
+    this.config = config;
     this.collectionName = config.collectionName;
     this.dimension = config.dimension || 1536; // Default OpenAI dimension
     this.initialize().catch(console.error);
+  }
+
+  private async ensureClient(): Promise<void> {
+    if (this.client) return;
+    const config = this.config;
+    if (config.client) {
+      this.client = config.client;
+      return;
+    }
+    const params: Record<string, any> = {};
+    if (config.apiKey) {
+      params.apiKey = config.apiKey;
+    }
+    if (config.url) {
+      params.url = config.url;
+      // Workaround for qdrant/qdrant-js#59: explicitly pass port to avoid "Illegal host" error
+      try {
+        const parsedUrl = new URL(config.url);
+        params.port = parsedUrl.port ? parseInt(parsedUrl.port, 10) : 6333;
+      } catch (_) {
+        params.port = 6333;
+      }
+    }
+    if (config.host && config.port) {
+      params.host = config.host;
+      params.port = config.port;
+    }
+    if (!Object.keys(params).length) {
+      params.path = config.path;
+      if (!config.onDisk && config.path) {
+        if (
+          fs.existsSync(config.path) &&
+          fs.statSync(config.path).isDirectory()
+        ) {
+          fs.rmSync(config.path, { recursive: true });
+        }
+      }
+    }
+
+    let sdk: any;
+    try {
+      sdk = await import("@qdrant/js-client-rest");
+    } catch {
+      throw new Error(
+        "The '@qdrant/js-client-rest' package is required to use the Qdrant vector store. Install it with: npm install @qdrant/js-client-rest",
+      );
+    }
+    this.client = new sdk.QdrantClient(params);
   }
 
   /**
@@ -270,6 +284,7 @@ export class Qdrant implements VectorStore {
     ids: string[],
     payloads: Record<string, any>[],
   ): Promise<void> {
+    await this.initialize();
     const points = vectors.map((vector, idx) => ({
       id: ids[idx],
       vector: vector,
@@ -290,6 +305,7 @@ export class Qdrant implements VectorStore {
     topK: number = 5,
     filters?: SearchFilters,
   ): Promise<VectorStoreResult[]> {
+    await this.initialize();
     const queryFilter = this.createFilter(filters);
     const results = await this.client.search(this.collectionName, {
       vector: query,
@@ -305,6 +321,7 @@ export class Qdrant implements VectorStore {
   }
 
   async get(vectorId: string): Promise<VectorStoreResult | null> {
+    await this.initialize();
     const results = await this.client.retrieve(this.collectionName, {
       ids: [vectorId],
       with_payload: true,
@@ -323,6 +340,7 @@ export class Qdrant implements VectorStore {
     vector: number[],
     payload: Record<string, any>,
   ): Promise<void> {
+    await this.initialize();
     const point = {
       id: vectorId,
       vector: vector,
@@ -335,12 +353,14 @@ export class Qdrant implements VectorStore {
   }
 
   async delete(vectorId: string): Promise<void> {
+    await this.initialize();
     await this.client.delete(this.collectionName, {
       points: [vectorId],
     });
   }
 
   async deleteCol(): Promise<void> {
+    await this.initialize();
     await this.client.deleteCollection(this.collectionName);
   }
 
@@ -348,6 +368,7 @@ export class Qdrant implements VectorStore {
     filters?: SearchFilters,
     topK: number = 100,
   ): Promise<[VectorStoreResult[], number]> {
+    await this.initialize();
     const scrollRequest = {
       limit: topK,
       filter: this.createFilter(filters),
@@ -380,6 +401,7 @@ export class Qdrant implements VectorStore {
   }
 
   async getUserId(): Promise<string> {
+    await this.initialize();
     try {
       // Ensure collection exists (idempotent — handles race conditions)
       await this.ensureCollection("memory_migrations", 1);
@@ -417,6 +439,7 @@ export class Qdrant implements VectorStore {
   }
 
   async setUserId(userId: string): Promise<void> {
+    await this.initialize();
     try {
       // Get existing point ID
       const result = await this.client.scroll("memory_migrations", {
@@ -496,6 +519,7 @@ export class Qdrant implements VectorStore {
 
   private async _doInitialize(): Promise<void> {
     try {
+      await this.ensureClient();
       await this.ensureCollection(this.collectionName, this.dimension);
       await this.ensureCollection("memory_migrations", 1);
     } catch (error) {

--- a/mem0-ts/src/oss/src/vector_stores/redis.ts
+++ b/mem0-ts/src/oss/src/vector_stores/redis.ts
@@ -7,6 +7,7 @@ import type {
 } from "redis";
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
+import { loadPeer } from "../utils/load_peer";
 
 /**
  * Escape RediSearch TAG filter special characters. Any punctuation in the
@@ -189,14 +190,11 @@ export class RedisDB implements VectorStore {
 
   private async ensureClient(): Promise<void> {
     if (this.client) return;
-    let sdk: any;
-    try {
-      sdk = await import("redis");
-    } catch {
-      throw new Error(
-        "The 'redis' package is required to use the Redis vector store. Install it with: npm install redis",
-      );
-    }
+    const sdk = await loadPeer(
+      "redis",
+      "Redis vector store",
+      () => import("redis"),
+    );
     this.client = sdk.createClient({
       url: this.redisUrl,
       username: this.username,

--- a/mem0-ts/src/oss/src/vector_stores/redis.ts
+++ b/mem0-ts/src/oss/src/vector_stores/redis.ts
@@ -1,4 +1,3 @@
-import { createClient } from "redis";
 import type {
   RedisClientType,
   RedisDefaultModules,
@@ -146,15 +145,21 @@ function toCamelCase(obj: Record<string, any>): Record<string, any> {
 }
 
 export class RedisDB implements VectorStore {
-  private client: RedisClientType<
+  private client!: RedisClientType<
     RedisDefaultModules & RedisModules & RedisFunctions & RedisScripts
   >;
+  private readonly redisUrl: string;
+  private readonly username?: string;
+  private readonly password?: string;
   private readonly indexName: string;
   private readonly indexPrefix: string;
   private readonly schema: RedisSchema;
   private _initPromise?: Promise<void>;
 
   constructor(config: RedisConfig) {
+    this.redisUrl = config.redisUrl;
+    this.username = config.username;
+    this.password = config.password;
     this.indexName = config.collectionName;
     this.indexPrefix = `mem0:${config.collectionName}`;
 
@@ -177,12 +182,27 @@ export class RedisDB implements VectorStore {
       }),
     };
 
-    this.client = createClient({
-      url: config.redisUrl,
-      username: config.username,
-      password: config.password,
+    this.initialize().catch((err) => {
+      console.error("Failed to initialize Redis:", err);
+    });
+  }
+
+  private async ensureClient(): Promise<void> {
+    if (this.client) return;
+    let sdk: any;
+    try {
+      sdk = await import("redis");
+    } catch {
+      throw new Error(
+        "The 'redis' package is required to use the Redis vector store. Install it with: npm install redis",
+      );
+    }
+    this.client = sdk.createClient({
+      url: this.redisUrl,
+      username: this.username,
+      password: this.password,
       socket: {
-        reconnectStrategy: (retries) => {
+        reconnectStrategy: (retries: number) => {
           if (retries > 10) {
             console.error("Max reconnection attempts reached");
             return new Error("Max reconnection attempts reached");
@@ -194,10 +214,6 @@ export class RedisDB implements VectorStore {
 
     this.client.on("error", (err) => console.error("Redis Client Error:", err));
     this.client.on("connect", () => console.log("Redis Client Connected"));
-
-    this.initialize().catch((err) => {
-      console.error("Failed to initialize Redis:", err);
-    });
   }
 
   private async createIndex(): Promise<void> {
@@ -260,6 +276,7 @@ export class RedisDB implements VectorStore {
   }
 
   private async _doInitialize(): Promise<void> {
+    await this.ensureClient();
     try {
       await this.client.connect();
       console.log("Connected to Redis");
@@ -331,6 +348,7 @@ export class RedisDB implements VectorStore {
     ids: string[],
     payloads: Record<string, any>[],
   ): Promise<void> {
+    await this.initialize();
     const data = vectors.map((vector, idx) => {
       const payload = toSnakeCase(payloads[idx]);
       const id = ids[idx];
@@ -389,6 +407,7 @@ export class RedisDB implements VectorStore {
     topK: number = 5,
     filters?: SearchFilters,
   ): Promise<VectorStoreResult[]> {
+    await this.initialize();
     const snakeFilters = filters ? toSnakeCase(filters) : undefined;
     const filterExpr = snakeFilters
       ? Object.entries(snakeFilters)
@@ -456,6 +475,7 @@ export class RedisDB implements VectorStore {
   }
 
   async get(vectorId: string): Promise<VectorStoreResult | null> {
+    await this.initialize();
     try {
       // Check if the memory exists first
       const exists = await this.client.exists(
@@ -562,6 +582,7 @@ export class RedisDB implements VectorStore {
     vector: number[],
     payload: Record<string, any>,
   ): Promise<void> {
+    await this.initialize();
     const snakePayload = toSnakeCase(payload);
     const createdAt = snakePayload.created_at
       ? new Date(snakePayload.created_at).getTime()
@@ -601,6 +622,7 @@ export class RedisDB implements VectorStore {
   }
 
   async delete(vectorId: string): Promise<void> {
+    await this.initialize();
     try {
       // Check if memory exists first
       const key = `${this.indexPrefix}:${vectorId}`;
@@ -626,6 +648,7 @@ export class RedisDB implements VectorStore {
   }
 
   async deleteCol(): Promise<void> {
+    await this.initialize();
     await this.client.ft.dropIndex(this.indexName);
   }
 
@@ -633,6 +656,7 @@ export class RedisDB implements VectorStore {
     filters?: SearchFilters,
     topK: number = 100,
   ): Promise<[VectorStoreResult[], number]> {
+    await this.initialize();
     const snakeFilters = filters ? toSnakeCase(filters) : undefined;
     const filterExpr = snakeFilters
       ? Object.entries(snakeFilters)
@@ -676,10 +700,11 @@ export class RedisDB implements VectorStore {
   }
 
   async close(): Promise<void> {
-    await this.client.quit();
+    if (this.client) await this.client.quit();
   }
 
   async getUserId(): Promise<string> {
+    await this.initialize();
     try {
       // Check if the user ID exists in Redis
       const userId = await this.client.get("memory_migrations:1");
@@ -702,6 +727,7 @@ export class RedisDB implements VectorStore {
   }
 
   async setUserId(userId: string): Promise<void> {
+    await this.initialize();
     try {
       await this.client.set("memory_migrations:1", userId);
     } catch (error) {

--- a/mem0-ts/src/oss/src/vector_stores/supabase.ts
+++ b/mem0-ts/src/oss/src/vector_stores/supabase.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
+import { loadPeer } from "../utils/load_peer";
 
 interface VectorData {
   id: string;
@@ -104,14 +105,11 @@ export class SupabaseDB implements VectorStore {
 
   private async ensureClient(): Promise<void> {
     if (this.client) return;
-    let sdk: any;
-    try {
-      sdk = await import("@supabase/supabase-js");
-    } catch {
-      throw new Error(
-        "The '@supabase/supabase-js' package is required to use the Supabase vector store. Install it with: npm install @supabase/supabase-js",
-      );
-    }
+    const sdk = await loadPeer(
+      "@supabase/supabase-js",
+      "Supabase vector store",
+      () => import("@supabase/supabase-js"),
+    );
     this.client = sdk.createClient(this.supabaseUrl, this.supabaseKey);
   }
 

--- a/mem0-ts/src/oss/src/vector_stores/supabase.ts
+++ b/mem0-ts/src/oss/src/vector_stores/supabase.ts
@@ -1,4 +1,4 @@
-import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
 
@@ -82,14 +82,17 @@ $$;
 */
 
 export class SupabaseDB implements VectorStore {
-  private client: SupabaseClient;
+  private client!: SupabaseClient;
+  private readonly supabaseUrl: string;
+  private readonly supabaseKey: string;
   private readonly tableName: string;
   private readonly embeddingColumnName: string;
   private readonly metadataColumnName: string;
   private _initPromise?: Promise<void>;
 
   constructor(config: SupabaseConfig) {
-    this.client = createClient(config.supabaseUrl, config.supabaseKey);
+    this.supabaseUrl = config.supabaseUrl;
+    this.supabaseKey = config.supabaseKey;
     this.tableName = config.tableName;
     this.embeddingColumnName = config.embeddingColumnName || "embedding";
     this.metadataColumnName = config.metadataColumnName || "metadata";
@@ -97,6 +100,19 @@ export class SupabaseDB implements VectorStore {
     this.initialize().catch((err) => {
       console.error("Failed to initialize Supabase:", err);
     });
+  }
+
+  private async ensureClient(): Promise<void> {
+    if (this.client) return;
+    let sdk: any;
+    try {
+      sdk = await import("@supabase/supabase-js");
+    } catch {
+      throw new Error(
+        "The '@supabase/supabase-js' package is required to use the Supabase vector store. Install it with: npm install @supabase/supabase-js",
+      );
+    }
+    this.client = sdk.createClient(this.supabaseUrl, this.supabaseKey);
   }
 
   async initialize(): Promise<void> {
@@ -107,6 +123,7 @@ export class SupabaseDB implements VectorStore {
   }
 
   private async _doInitialize(): Promise<void> {
+    await this.ensureClient();
     try {
       // Verify table exists and vector operations work by attempting a test insert
       const testVector = Array(1536).fill(0);
@@ -209,6 +226,7 @@ See the SQL migration instructions in the code comments.`,
     ids: string[],
     payloads: Record<string, any>[],
   ): Promise<void> {
+    await this.initialize();
     try {
       const data = vectors.map((vector, idx) => ({
         id: ids[idx],
@@ -237,6 +255,7 @@ See the SQL migration instructions in the code comments.`,
     topK: number = 5,
     filters?: SearchFilters,
   ): Promise<VectorStoreResult[]> {
+    await this.initialize();
     try {
       const rpcQuery: VectorQueryParams = {
         query_embedding: query,
@@ -265,6 +284,7 @@ See the SQL migration instructions in the code comments.`,
   }
 
   async get(vectorId: string): Promise<VectorStoreResult | null> {
+    await this.initialize();
     try {
       const { data, error } = await this.client
         .from(this.tableName)
@@ -290,6 +310,7 @@ See the SQL migration instructions in the code comments.`,
     vector: number[],
     payload: Record<string, any>,
   ): Promise<void> {
+    await this.initialize();
     try {
       const { error } = await this.client
         .from(this.tableName)
@@ -310,6 +331,7 @@ See the SQL migration instructions in the code comments.`,
   }
 
   async delete(vectorId: string): Promise<void> {
+    await this.initialize();
     try {
       const { error } = await this.client
         .from(this.tableName)
@@ -324,6 +346,7 @@ See the SQL migration instructions in the code comments.`,
   }
 
   async deleteCol(): Promise<void> {
+    await this.initialize();
     try {
       const { error } = await this.client
         .from(this.tableName)
@@ -341,6 +364,7 @@ See the SQL migration instructions in the code comments.`,
     filters?: SearchFilters,
     topK: number = 100,
   ): Promise<[VectorStoreResult[], number]> {
+    await this.initialize();
     try {
       let query = this.client
         .from(this.tableName)
@@ -370,6 +394,7 @@ See the SQL migration instructions in the code comments.`,
   }
 
   async getUserId(): Promise<string> {
+    await this.initialize();
     try {
       // First check if the table exists
       const { data: tableExists } = await this.client
@@ -421,6 +446,7 @@ See the SQL migration instructions in the code comments.`,
   }
 
   async setUserId(userId: string): Promise<void> {
+    await this.initialize();
     try {
       const { error: deleteError } = await this.client
         .from("memory_migrations")

--- a/mem0-ts/src/oss/src/vector_stores/turbopuffer.ts
+++ b/mem0-ts/src/oss/src/vector_stores/turbopuffer.ts
@@ -1,5 +1,6 @@
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
+import { loadPeer } from "../utils/load_peer";
 
 interface TurbopufferConfig extends VectorStoreConfig {
   apiKey?: string;
@@ -48,14 +49,11 @@ export class TurbopufferDB implements VectorStore {
   }
 
   private async createClient(): Promise<any> {
-    let sdk: any;
-    try {
-      sdk = await import("@turbopuffer/turbopuffer");
-    } catch {
-      throw new Error(
-        "The '@turbopuffer/turbopuffer' package is required to use the Turbopuffer vector store. Install it with: npm install @turbopuffer/turbopuffer",
-      );
-    }
+    const sdk = await loadPeer(
+      "@turbopuffer/turbopuffer",
+      "Turbopuffer vector store",
+      () => import("@turbopuffer/turbopuffer"),
+    );
 
     // @turbopuffer/turbopuffer ships `Turbopuffer` as both the default export
     // and a named export pointing at the same class. Use `.default` since

--- a/mem0-ts/src/oss/src/vector_stores/upstash_vector.ts
+++ b/mem0-ts/src/oss/src/vector_stores/upstash_vector.ts
@@ -1,6 +1,7 @@
 import type { Index, QueryResult, Vector } from "@upstash/vector";
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
+import { loadPeer } from "../utils/load_peer";
 
 interface UpstashVectorConfig extends VectorStoreConfig {
   collectionName: string;
@@ -42,14 +43,11 @@ export class UpstashVector implements VectorStore {
     if (config.client) {
       this.client = config.client;
     } else {
-      let sdk: any;
-      try {
-        sdk = await import("@upstash/vector");
-      } catch {
-        throw new Error(
-          "The '@upstash/vector' package is required to use the Upstash Vector store. Install it with: npm install @upstash/vector",
-        );
-      }
+      const sdk = await loadPeer(
+        "@upstash/vector",
+        "Upstash Vector store",
+        () => import("@upstash/vector"),
+      );
       this.client = new sdk.Index({
         url: config.url,
         token: config.token,

--- a/mem0-ts/src/oss/src/vector_stores/valkey.ts
+++ b/mem0-ts/src/oss/src/vector_stores/valkey.ts
@@ -1,6 +1,7 @@
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreResult } from "../types";
 import { ValkeyConfig } from "../types/valkey";
+import { loadPeer } from "../utils/load_peer";
 
 interface ValkeyClient {
   call: (...args: (string | number | Buffer)[]) => Promise<unknown>;
@@ -142,14 +143,8 @@ function formatTimestamp(timestamp: number, timezone: string = "UTC"): string {
   return `${yyyy}-${MM}-${dd}T${HH}:${mm}:${ss}${sign}${offHH}:${offMM}`;
 }
 
-async function loadIovalkey(): Promise<typeof import("iovalkey")> {
-  try {
-    return await import("iovalkey");
-  } catch {
-    throw new Error(
-      "iovalkey is required for the Valkey vector store. Install it with: npm install iovalkey",
-    );
-  }
+function loadIovalkey(): Promise<typeof import("iovalkey")> {
+  return loadPeer("iovalkey", "Valkey vector store", () => import("iovalkey"));
 }
 
 export class ValkeyDB implements VectorStore {

--- a/mem0-ts/src/oss/src/vector_stores/vectorize.ts
+++ b/mem0-ts/src/oss/src/vector_stores/vectorize.ts
@@ -1,4 +1,4 @@
-import Cloudflare from "cloudflare";
+import type Cloudflare from "cloudflare";
 import type { Vectorize, VectorizeVector } from "@cloudflare/workers-types";
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
@@ -17,17 +17,31 @@ interface CloudflareVector {
 
 export class VectorizeDB implements VectorStore {
   private client: Cloudflare | null = null;
+  private apiKey?: string;
   private dimensions: number;
   private indexName: string;
   private accountId: string;
   private _initPromise?: Promise<void>;
 
   constructor(config: VectorizeConfig) {
-    this.client = new Cloudflare({ apiToken: config.apiKey });
+    this.apiKey = config.apiKey;
     this.dimensions = config.dimension || 1536;
     this.indexName = config.indexName;
     this.accountId = config.accountId;
     this.initialize().catch(console.error);
+  }
+
+  private async ensureClient(): Promise<void> {
+    if (this.client) return;
+    let sdk: any;
+    try {
+      sdk = await import("cloudflare");
+    } catch {
+      throw new Error(
+        "The 'cloudflare' package is required to use the Vectorize vector store. Install it with: npm install cloudflare",
+      );
+    }
+    this.client = new sdk.default({ apiToken: this.apiKey });
   }
 
   async insert(
@@ -35,6 +49,7 @@ export class VectorizeDB implements VectorStore {
     ids: string[],
     payloads: Record<string, any>[],
   ): Promise<void> {
+    await this.initialize();
     try {
       const vectorObjects: CloudflareVector[] = vectors.map(
         (vector, index) => ({
@@ -83,6 +98,7 @@ export class VectorizeDB implements VectorStore {
     topK: number = 5,
     filters?: SearchFilters,
   ): Promise<VectorStoreResult[]> {
+    await this.initialize();
     try {
       const result = await this.client?.vectorize.indexes.query(
         this.indexName,
@@ -111,6 +127,7 @@ export class VectorizeDB implements VectorStore {
   }
 
   async get(vectorId: string): Promise<VectorStoreResult | null> {
+    await this.initialize();
     try {
       const result = (await this.client?.vectorize.indexes.getByIds(
         this.indexName,
@@ -139,6 +156,7 @@ export class VectorizeDB implements VectorStore {
     vector: number[],
     payload: Record<string, any>,
   ): Promise<void> {
+    await this.initialize();
     try {
       const data: VectorizeVector = {
         id: vectorId,
@@ -173,6 +191,7 @@ export class VectorizeDB implements VectorStore {
   }
 
   async delete(vectorId: string): Promise<void> {
+    await this.initialize();
     try {
       await this.client?.vectorize.indexes.deleteByIds(this.indexName, {
         account_id: this.accountId,
@@ -187,6 +206,7 @@ export class VectorizeDB implements VectorStore {
   }
 
   async deleteCol(): Promise<void> {
+    await this.initialize();
     try {
       await this.client?.vectorize.indexes.delete(this.indexName, {
         account_id: this.accountId,
@@ -203,6 +223,7 @@ export class VectorizeDB implements VectorStore {
     filters?: SearchFilters,
     topK: number = 20,
   ): Promise<[VectorStoreResult[], number]> {
+    await this.initialize();
     try {
       const result = await this.client?.vectorize.indexes.query(
         this.indexName,
@@ -243,6 +264,7 @@ export class VectorizeDB implements VectorStore {
   }
 
   async getUserId(): Promise<string> {
+    await this.initialize();
     try {
       let found = false;
       for await (const index of this.client!.vectorize.indexes.list({
@@ -309,6 +331,7 @@ export class VectorizeDB implements VectorStore {
   }
 
   async setUserId(userId: string): Promise<void> {
+    await this.initialize();
     try {
       // Get existing point ID
       const result: any = await this.client?.vectorize.indexes.query(
@@ -355,6 +378,7 @@ export class VectorizeDB implements VectorStore {
   }
 
   private async _doInitialize(): Promise<void> {
+    await this.ensureClient();
     try {
       // Check if the index already exists
       let indexFound = false;

--- a/mem0-ts/src/oss/src/vector_stores/vectorize.ts
+++ b/mem0-ts/src/oss/src/vector_stores/vectorize.ts
@@ -2,6 +2,7 @@ import type Cloudflare from "cloudflare";
 import type { Vectorize, VectorizeVector } from "@cloudflare/workers-types";
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
+import { loadPeer } from "../utils/load_peer";
 
 interface VectorizeConfig extends VectorStoreConfig {
   apiKey?: string;
@@ -33,14 +34,11 @@ export class VectorizeDB implements VectorStore {
 
   private async ensureClient(): Promise<void> {
     if (this.client) return;
-    let sdk: any;
-    try {
-      sdk = await import("cloudflare");
-    } catch {
-      throw new Error(
-        "The 'cloudflare' package is required to use the Vectorize vector store. Install it with: npm install cloudflare",
-      );
-    }
+    const sdk = await loadPeer(
+      "cloudflare",
+      "Vectorize vector store",
+      () => import("cloudflare"),
+    );
     this.client = new sdk.default({ apiToken: this.apiKey });
   }
 

--- a/mem0-ts/src/oss/src/vector_stores/weaviate.ts
+++ b/mem0-ts/src/oss/src/vector_stores/weaviate.ts
@@ -2,6 +2,7 @@ import type { WeaviateClient } from "weaviate-client";
 import { v4 as uuidv4 } from "uuid";
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
+import { loadPeer } from "../utils/load_peer";
 
 interface WeaviateConfig extends VectorStoreConfig {
   /** Pre-configured Weaviate client instance (typed as `any` to keep the
@@ -50,14 +51,11 @@ export class WeaviateDB implements VectorStore {
   private async ensureClient(): Promise<void> {
     if (this._client) return;
 
-    let sdk: any;
-    try {
-      sdk = await import("weaviate-client");
-    } catch {
-      throw new Error(
-        "The 'weaviate-client' package is required to use the Weaviate vector store. Install it with: npm install weaviate-client",
-      );
-    }
+    const sdk = await loadPeer(
+      "weaviate-client",
+      "Weaviate vector store",
+      () => import("weaviate-client"),
+    );
     this._sdk = sdk;
 
     const { client, clusterUrl, apiKey, additionalHeaders } = this._config;

--- a/mem0-ts/src/oss/tests/anthropic-llm.test.ts
+++ b/mem0-ts/src/oss/tests/anthropic-llm.test.ts
@@ -23,11 +23,16 @@ describe("AnthropicLLM (unit)", () => {
 
   // Regression #5665: a configured baseURL must reach the Anthropic client so
   // proxy/gateway users are not silently bypassed (TS parity with #5626).
-  it("forwards baseURL to the Anthropic client when set", () => {
-    new AnthropicLLM({
+  // The client is constructed lazily on first use, so drive generateResponse.
+  it("forwards baseURL to the Anthropic client when set", async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: "text", text: "ok" }],
+    });
+    const llm = new AnthropicLLM({
       apiKey: "test-key",
       baseURL: "https://proxy.example/v1",
     });
+    await llm.generateResponse([{ role: "user", content: "Hi" }]);
 
     expect(mockConstructor).toHaveBeenCalledTimes(1);
     const ctorArgs = mockConstructor.mock.calls[0][0];
@@ -37,8 +42,12 @@ describe("AnthropicLLM (unit)", () => {
 
   // When no baseURL is configured the client must not receive a baseURL key
   // (so the SDK default endpoint is used).
-  it("does NOT set baseURL when none is configured", () => {
-    new AnthropicLLM({ apiKey: "test-key" });
+  it("does NOT set baseURL when none is configured", async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: "text", text: "ok" }],
+    });
+    const llm = new AnthropicLLM({ apiKey: "test-key" });
+    await llm.generateResponse([{ role: "user", content: "Hi" }]);
 
     expect(mockConstructor).toHaveBeenCalledTimes(1);
     const ctorArgs = mockConstructor.mock.calls[0][0];

--- a/mem0-ts/src/oss/tests/optional-peers.test.ts
+++ b/mem0-ts/src/oss/tests/optional-peers.test.ts
@@ -22,7 +22,16 @@ function sourceFiles(dir: string, acc: string[] = []): string[] {
   for (const entry of readdirSync(dir)) {
     const full = join(dir, entry);
     if (statSync(full).isDirectory()) {
-      if (entry !== "tests" && entry !== "__tests__") sourceFiles(full, acc);
+      // examples/ are dev scripts and community/ is the separate @mem0/community
+      // package — neither ships in files:["dist"] nor is reachable via the mem0ai/oss
+      // barrel, so a static import there cannot crash a Memory() consumer.
+      if (
+        entry !== "tests" &&
+        entry !== "__tests__" &&
+        entry !== "examples" &&
+        entry !== "community"
+      )
+        sourceFiles(full, acc);
     } else if (entry.endsWith(".ts") && !entry.endsWith(".test.ts")) {
       acc.push(full);
     }

--- a/mem0-ts/src/oss/tests/qdrant-url-port.test.ts
+++ b/mem0-ts/src/oss/tests/qdrant-url-port.test.ts
@@ -40,14 +40,15 @@ beforeEach(() => {
 });
 
 describe("Qdrant URL port extraction (qdrant/qdrant-js#59 workaround)", () => {
-  it("extracts port from HTTPS URL with explicit port", () => {
-    new Qdrant({
+  it("extracts port from HTTPS URL with explicit port", async () => {
+    const store = new Qdrant({
       url: "https://my-cluster.us-west-1-0.aws.cloud.qdrant.io:6333",
       apiKey: "test-key",
       collectionName: "test",
       embeddingModelDims: 768,
       dimension: 768,
     });
+    await store.initialize();
 
     expect(capturedParams).toBeDefined();
     expect(capturedParams!.url).toBe(
@@ -57,47 +58,50 @@ describe("Qdrant URL port extraction (qdrant/qdrant-js#59 workaround)", () => {
     expect(capturedParams!.apiKey).toBe("test-key");
   });
 
-  it("extracts port from HTTP URL with explicit port", () => {
-    new Qdrant({
+  it("extracts port from HTTP URL with explicit port", async () => {
+    const store = new Qdrant({
       url: "http://localhost:6333",
       collectionName: "test",
       embeddingModelDims: 768,
       dimension: 768,
     });
+    await store.initialize();
 
     expect(capturedParams).toBeDefined();
     expect(capturedParams!.url).toBe("http://localhost:6333");
     expect(capturedParams!.port).toBe(6333);
   });
 
-  it("defaults to port 6333 when HTTPS URL has no explicit port", () => {
-    new Qdrant({
+  it("defaults to port 6333 when HTTPS URL has no explicit port", async () => {
+    const store = new Qdrant({
       url: "https://my-cluster.cloud.qdrant.io",
       apiKey: "test-key",
       collectionName: "test",
       embeddingModelDims: 768,
       dimension: 768,
     });
+    await store.initialize();
 
     expect(capturedParams).toBeDefined();
     expect(capturedParams!.url).toBe("https://my-cluster.cloud.qdrant.io");
     expect(capturedParams!.port).toBe(6333);
   });
 
-  it("defaults to port 6333 when HTTP URL has no explicit port", () => {
-    new Qdrant({
+  it("defaults to port 6333 when HTTP URL has no explicit port", async () => {
+    const store = new Qdrant({
       url: "http://localhost",
       collectionName: "test",
       embeddingModelDims: 768,
       dimension: 768,
     });
+    await store.initialize();
 
     expect(capturedParams).toBeDefined();
     expect(capturedParams!.port).toBe(6333);
   });
 
-  it("host+port config overrides URL-extracted port", () => {
-    new Qdrant({
+  it("host+port config overrides URL-extracted port", async () => {
+    const store = new Qdrant({
       url: "https://my-cluster.cloud.qdrant.io:6333",
       host: "custom-host",
       port: 9999,
@@ -106,28 +110,28 @@ describe("Qdrant URL port extraction (qdrant/qdrant-js#59 workaround)", () => {
       embeddingModelDims: 768,
       dimension: 768,
     });
+    await store.initialize();
 
     expect(capturedParams).toBeDefined();
     expect(capturedParams!.host).toBe("custom-host");
     expect(capturedParams!.port).toBe(9999);
   });
 
-  it("handles invalid URL gracefully without crashing", () => {
-    expect(() => {
-      new Qdrant({
-        url: "not-a-valid-url",
-        collectionName: "test",
-        embeddingModelDims: 768,
-        dimension: 768,
-      });
-    }).not.toThrow();
+  it("handles invalid URL gracefully without crashing", async () => {
+    const store = new Qdrant({
+      url: "not-a-valid-url",
+      collectionName: "test",
+      embeddingModelDims: 768,
+      dimension: 768,
+    });
+    await expect(store.initialize()).resolves.not.toThrow();
 
     expect(capturedParams).toBeDefined();
     expect(capturedParams!.url).toBe("not-a-valid-url");
     expect(capturedParams!.port).toBe(6333);
   });
 
-  it("does not pass port when using pre-configured client", () => {
+  it("does not pass port when using pre-configured client", async () => {
     const mockClient: any = {
       createCollection: jest.fn().mockResolvedValue(undefined),
       getCollection: jest.fn().mockResolvedValue({
@@ -141,12 +145,13 @@ describe("Qdrant URL port extraction (qdrant/qdrant-js#59 workaround)", () => {
       deleteCollection: jest.fn().mockResolvedValue(undefined),
     };
 
-    new Qdrant({
+    const store = new Qdrant({
       client: mockClient,
       collectionName: "test",
       embeddingModelDims: 768,
       dimension: 768,
     });
+    await store.initialize();
 
     // QdrantClient constructor should NOT have been called
     expect(
@@ -154,14 +159,15 @@ describe("Qdrant URL port extraction (qdrant/qdrant-js#59 workaround)", () => {
     ).not.toHaveBeenCalled();
   });
 
-  it("defaults to 6333 when HTTPS URL uses default port 443", () => {
-    new Qdrant({
+  it("defaults to 6333 when HTTPS URL uses default port 443", async () => {
+    const store = new Qdrant({
       url: "https://my-cluster.cloud.qdrant.io:443",
       apiKey: "test-key",
       collectionName: "test",
       embeddingModelDims: 768,
       dimension: 768,
     });
+    await store.initialize();
 
     // 443 is default for HTTPS, so URL.port returns empty string — we default to 6333
     expect(capturedParams).toBeDefined();


### PR DESCRIPTION
## Linked Issue

Closes #6388

Related: #3291 (SQLite / `disableHistory` half of the same class of problem, handled by #5720) · leaner alternative to the stalled #4444 (see note below).

## Description

Importing `Memory` from `mem0ai/oss` crashes at **load time** whenever an optional provider SDK is absent, even for a user who configured only pgvector + OpenAI.

**Root cause:** the OSS entry barrel `mem0-ts/src/oss/src/index.ts` uses `export *` to re-export every provider, so ESM/CJS eagerly evaluates each provider module's top level on any import from `mem0ai/oss`. Twelve provider modules value-imported their SDK at module top (`import Anthropic from "@anthropic-ai/sdk"`, `import { Ollama } from "ollama"`, …), so Node runs `require("ollama")` (and 11 siblings) the instant the barrel loads — before any user config is read. A pgvector + OpenAI user still crashed with `MODULE_NOT_FOUND: Cannot find module 'ollama'` at `new Memory()` and had to install 10+ unused peers just to boot (plus npm peer-dependency warnings).

**Fix:** switch those 12 SDKs from top-level value `import` to `import type` (erased at compile) and load each lazily via `await import()` inside the code path that needs a client — the exact pattern already used by `pinecone.ts` and the 16 previously-migrated providers. Vector stores route every public method through a memoized `initialize()`, with the private `ensureClient()` called only inside `_doInitialize()` (race-free); LLMs, embedders, and the Supabase history manager call `ensureClient()` at each public entry (idempotent; these clients open no connection on construction). Each lazy import throws a friendly `"...is required to use the <X>. Install it with: npm install <pkg>"` if the peer is genuinely missing.

This also marks those 12 SDKs `optional` in `package.json` `peerDependenciesMeta` — silencing the peer-warning half of the report and **activating the repo's existing static-import guard** (`tests/optional-peers.test.ts`), which now fails CI if any provider regresses to a static import. Excludes `pg` + `better-sqlite3` (default/required backends; SQLite lazification is #5720).

> **Note on #4444:** @kgarg2468's open PR #4444 targets the same root cause more broadly (centralized loader util + pack-smoke gate + README + npm scripts, 26 files / +976−76). This PR is a deliberately leaner take scoped to the minimal lazification + activating the guard that already exists in the repo. Credit to @kgarg2468 for surfacing the approach.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A — no public API signature change. `Memory`, all provider class names, and constructor signatures are unchanged; the `config.client` pass-in branch is preserved everywhere it existed. The only behavioral change for a correctly-configured user is that client construction moves from the constructor to first use (async). A user missing a peer they *actually* configured now gets a clear "install it with: npm install <pkg>" error at first use instead of a barrel-load crash.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

**Regression guard (ships in CI):** `tests/optional-peers.test.ts` scans `peerDependenciesMeta.optional` and asserts no optional peer is statically value-imported by `src`. Marking the 12 SDKs optional activates it for them.

**Red → green at the reporter's exact layer** (require-hook hides every optional peer, then `require("dist/oss/index.js")`):

```
# BEFORE (origin/main dist), all optional peers hidden:
CRASH: MODULE_NOT_FOUND Cannot find module 'ollama'   (exit 1)

# AFTER (this branch dist), all 34 optional peers hidden:
OK: required dist/oss/index.js with all optional peers hidden.
    Exports: AWSBedrockEmbedder, AWSBedrockLLM, AnthropicLLM, AzureAISearch, ...   (exit 0)
```

**Targeted gate (local):**
```
npx jest optional-peers vector-stores-compat tsup-externals  → 3 suites, 125 passed
npx tsup   → build success (CJS + ESM + DTS; all `import type` changes typecheck)
npx prettier --check <18 changed files>  → all clean
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed