### PR TITLE
fix(ts-sdk): accept snake case memory export id

### DIFF
--- a/mem0-ts/src/client/mem0.ts
+++ b/mem0-ts/src/client/mem0.ts
@@ -737,7 +737,7 @@ export default class MemoryClient {
     if (this.telemetryId === "") await this.ping();
     this._captureEvent("get_memory_export", []);
 
-    if (!data.memoryExportId && !data.filters) {
+    if (!data.memoryExportId && !data.memory_export_id && !data.filters) {
       throw new Error("Missing memoryExportId or filters");
     }
 

--- a/mem0-ts/src/client/mem0.types.ts
+++ b/mem0-ts/src/client/mem0.types.ts
@@ -230,4 +230,5 @@ export interface CreateMemoryExportPayload {
 export interface GetMemoryExportPayload {
   filters?: Record<string, any>;
   memoryExportId?: string;
+  memory_export_id?: string;
 }

--- a/mem0-ts/src/client/tests/memoryClient.exports.test.ts
+++ b/mem0-ts/src/client/tests/memoryClient.exports.test.ts
@@ -1,5 +1,5 @@
 /**
- * MemoryClient unit tests — createMemoryExport.
+ * MemoryClient unit tests — memory exports.
  * Verifies request construction, not mock response echo.
  */
 import { MemoryClient } from "../mem0";
@@ -43,5 +43,23 @@ describe("MemoryClient - createMemoryExport()", () => {
     expect(body.filters).toEqual({ user_id: "u1" });
     // SDK param is still snake_cased.
     expect(body.export_instructions).toBe("export it");
+  });
+});
+
+describe("MemoryClient - getMemoryExport()", () => {
+  test("accepts OpenAPI snake_case memory_export_id", async () => {
+    const extra = new Map<string, { status: number; body: unknown }>();
+    extra.set("/v1/exports/get/", {
+      status: 200,
+      body: { message: "ok", id: "exp_1" },
+    });
+    const mock = setupMockFetch(extra);
+
+    const client = new MemoryClient({ apiKey: TEST_API_KEY });
+    await client.getMemoryExport({ memory_export_id: "exp_1" });
+
+    const call = findFetchCall(mock, "/v1/exports/get/", "POST");
+    expect(call).toBeDefined();
+    expect(getFetchBody(call!)).toEqual({ memory_export_id: "exp_1" });
   });
 });


### PR DESCRIPTION
﻿## Linked Issue

Closes #6390

## Description

`MemoryClient.getMemoryExport()` now accepts the OpenAPI request-body key `memory_export_id` in addition to the existing SDK-style `memoryExportId` and `filters` inputs.

The generated OpenAPI JavaScript sample calls:

```ts
client.getMemoryExport({ memory_export_id })
```

Before this change, that shape failed the local SDK guard because `getMemoryExport()` only checked `data.memoryExportId` or `data.filters` before sending the request. The request body conversion path already preserves/sends `memory_export_id`, so the fix is limited to the input type and validation guard.

Added a regression test that exercises the OpenAPI sample shape and asserts the outgoing body remains:

```json
{ "memory_export_id": "exp_1" }
```

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Local validation run from `mem0-ts/`:

- `pnpm exec jest src/client/tests/memoryClient.exports.test.ts --runInBand --testEnvironment=node --forceExit` — passed, 2 tests.
- `pnpm exec jest src/client/tests --runInBand --testEnvironment=node --forceExit` — passed, 10 suites / 127 tests, 5 suites / 42 tests skipped by existing config.
- `pnpm exec prettier --check src/client/mem0.ts src/client/mem0.types.ts src/client/tests/memoryClient.exports.test.ts` — passed.
- `git diff --check` — passed.

Remote CI:

- `CI Gate` — passed.
- `TypeScript SDK / build_ts_sdk (20)` — passed.
- `TypeScript SDK / build_ts_sdk (22)` — passed.
- `TypeScript SDK / integration_ts_sdk (20)` — passed.
- `TypeScript SDK / integration_ts_sdk (22)` — passed.
- `TypeScript SDK / changelog_check` — passed.
- `license/cla` — passed.
- `Vercel` — failed with "Authorization required to deploy" for fork deployment authorization; this is unrelated to the TS SDK code path.

Local limitations:

- This Windows machine has Node `v24.15.0`; the repo CI tests the TypeScript SDK on Node 20/22.
- `pnpm install --frozen-lockfile` hit a local `better-sqlite3` native postinstall/build failure under Node 24, so I completed dependency linking with `pnpm install --frozen-lockfile --ignore-scripts` for the client-only Jest validation above.
- `pnpm run build` did not reach `tsup` locally because its full-repo `prettier --check .` step reports existing formatting differences across many untouched files on this Windows checkout. The three touched files pass targeted Prettier check, and the remote TypeScript SDK build passed on Node 20/22.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [x] I have updated documentation if needed
