### PR TITLE
fix(llms/gemini): map assistant role to model in message formatting

### DIFF
--- a/mem0/llms/gemini.py
+++ b/mem0/llms/gemini.py
@@ -106,9 +106,11 @@ class GeminiLLM(LLMBase):
             if message["role"] == "system":
                 system_instruction = message["content"]
             else:
+                # Gemini only accepts "user" and "model" roles
+                role = "model" if message["role"] == "assistant" else message["role"]
                 content = types.Content(
                     parts=[types.Part(text=message["content"])],
-                    role=message["role"],
+                    role=role,
                 )
                 contents.append(content)
 

--- a/tests/llms/test_gemini.py
+++ b/tests/llms/test_gemini.py
@@ -120,6 +120,30 @@ def test_generate_response_with_tools(mock_gemini_client: Mock):
     assert response["tool_calls"][0]["arguments"] == {"data": "Today is a sunny day."}
 
 
+def test_assistant_role_mapped_to_model(mock_gemini_client: Mock):
+    """Gemini only accepts "user" and "model" roles; the OpenAI-style "assistant"
+    role must be mapped to "model" instead of passed through (issue #6393)."""
+    config = BaseLlmConfig(model="gemini-2.0-flash", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = GeminiLLM(config)
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hi, I prefer window seats."},
+        {"role": "assistant", "content": "Noted, window seats it is."},
+        {"role": "user", "content": "Create procedural memory of the above conversation."},
+    ]
+
+    mock_part = Mock(text="ok")
+    mock_content = Mock(parts=[mock_part])
+    mock_candidate = Mock(content=mock_content)
+    mock_response = Mock(candidates=[mock_candidate])
+    mock_gemini_client.models.generate_content.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    contents = mock_gemini_client.models.generate_content.call_args.kwargs["contents"]
+    assert [c.role for c in contents] == ["user", "model", "user"]
+
+
 def test_parse_response_none_content_no_tools(mock_gemini_client: Mock):
     """Gemini can return content=None when response is blocked by safety filters."""
     config = BaseLlmConfig(model="gemini-2.0-flash", temperature=0.7, max_tokens=100, top_p=1.0)


### PR DESCRIPTION
## Linked Issue

Closes #6393

## Description

Gemini (`google-genai`) only accepts the roles `user` and `model`, but the provider passed the OpenAI-style `assistant` role straight through when building `types.Content`. Any multi-turn conversation that includes an assistant turn (e.g. `add(..., memory_type="procedural_memory")`) then fails with a 400. This maps `assistant` -> `model`, matching how the other providers handle role translation.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

Added `test_assistant_role_mapped_to_model` (asserts the assistant turn is sent to Gemini as `model`, never `assistant`). `test_gemini.py` 18/18, `ruff check` clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
