### PR TITLE
fix(vector_stores/elasticsearch): default list() size so delete_all/get_all don't truncate at 10

### DIFF
--- a/mem0/vector_stores/elasticsearch.py
+++ b/mem0/vector_stores/elasticsearch.py
@@ -282,8 +282,7 @@ class ElasticsearchDB(VectorStoreBase):
                 filter_conditions.append({"term": {f"metadata.{key}": value}})
             query["query"] = {"bool": {"must": filter_conditions}}
 
-        if top_k:
-            query["size"] = top_k
+        query["size"] = top_k if top_k else 10000
 
         response = self.client.search(index=self.collection_name, body=query)
 

--- a/mem0/vector_stores/elasticsearch.py
+++ b/mem0/vector_stores/elasticsearch.py
@@ -272,7 +272,14 @@ class ElasticsearchDB(VectorStoreBase):
         return self.client.indices.get(index=name)
 
     def list(self, filters: Optional[Dict] = None, top_k: Optional[int] = None) -> List[List[OutputData]]:
-        """List all memories."""
+        """List memories.
+
+        With ``top_k`` a single bounded page is returned. Without it, every match is
+        returned by paging with a point-in-time + ``search_after`` so results are not
+        capped at ``index.max_result_window`` and the whole set is never loaded in one
+        response. Only the id and metadata are needed, so the stored vector is excluded
+        from ``_source``.
+        """
         query: Dict[str, Any] = {"query": {"match_all": {}}}
 
         if filters:
@@ -282,19 +289,40 @@ class ElasticsearchDB(VectorStoreBase):
                 filter_conditions.append({"term": {f"metadata.{key}": value}})
             query["query"] = {"bool": {"must": filter_conditions}}
 
-        query["size"] = top_k if top_k else 10000
+        def _to_output(hit: Dict[str, Any]) -> OutputData:
+            return OutputData(id=hit["_id"], score=1.0, payload=hit.get("_source", {}).get("metadata", {}))
 
-        response = self.client.search(index=self.collection_name, body=query)
+        if top_k:
+            body = {**query, "size": top_k, "_source": ["metadata"]}
+            response = self.client.search(index=self.collection_name, body=body)
+            return [[_to_output(hit) for hit in response["hits"]["hits"]]]
 
-        results = []
-        for hit in response["hits"]["hits"]:
-            results.append(
-                OutputData(
-                    id=hit["_id"],
-                    score=1.0,  # Default score for list operation
-                    payload=hit.get("_source", {}).get("metadata", {}),
-                )
-            )
+        results: List[OutputData] = []
+        page_size = 1000
+        pit_id = self.client.open_point_in_time(index=self.collection_name, keep_alive="2m")["id"]
+        search_after: Optional[List[Any]] = None
+        try:
+            while True:
+                body: Dict[str, Any] = {
+                    **query,
+                    "size": page_size,
+                    "_source": ["metadata"],
+                    "pit": {"id": pit_id, "keep_alive": "2m"},
+                    "sort": [{"_shard_doc": "asc"}],
+                }
+                if search_after is not None:
+                    body["search_after"] = search_after
+                response = self.client.search(body=body)
+                hits = response["hits"]["hits"]
+                if not hits:
+                    break
+                results.extend(_to_output(hit) for hit in hits)
+                if len(hits) < page_size:
+                    break
+                search_after = hits[-1]["sort"]
+                pit_id = response.get("pit_id", pit_id)
+        finally:
+            self.client.close_point_in_time(id=pit_id)
 
         return [results]
 

--- a/tests/vector_stores/test_elasticsearch.py
+++ b/tests/vector_stores/test_elasticsearch.py
@@ -290,17 +290,34 @@ class TestElasticsearchDB(unittest.TestCase):
         self.assertEqual(results[0][1].id, "id2")
         self.assertEqual(results[0][1].payload, {"key2": "value2"})
 
-    def test_list_default_size(self):
-        # Mock search response
-        mock_response = {"hits": {"hits": []}}
-        self.client_mock.search.return_value = mock_response
+    def test_list_unbounded_paginates_and_excludes_vector(self):
+        # Unbounded list() must page with a point-in-time + search_after (not one
+        # size=10000 request that caps at max_result_window and pulls every vector),
+        # and must exclude the stored vector from _source.
+        self.client_mock.open_point_in_time.return_value = {"id": "pit-123"}
+        page1 = {
+            "hits": {
+                "hits": [
+                    {"_id": f"id{i}", "_source": {"metadata": {"user_id": "u"}}, "sort": [i]} for i in range(1000)
+                ]
+            }
+        }
+        page2 = {"hits": {"hits": [{"_id": "id1000", "_source": {"metadata": {"user_id": "u"}}, "sort": [1000]}]}}
+        self.client_mock.search.side_effect = [page1, page2]
 
-        # List without top_k should request a large size, not fall back to ES default of 10
-        self.es_db.list()
+        results = self.es_db.list()
 
-        self.client_mock.search.assert_called_once()
-        body = self.client_mock.search.call_args[1]["body"]
-        self.assertEqual(body["size"], 10000)
+        # every match collected across pages (not capped at 10 or a single page)
+        self.assertEqual(len(results[0]), 1001)
+        self.assertEqual(self.client_mock.search.call_count, 2)
+        self.client_mock.open_point_in_time.assert_called_once()
+        self.client_mock.close_point_in_time.assert_called_once_with(id="pit-123")
+
+        first_body = self.client_mock.search.call_args_list[0].kwargs["body"]
+        second_body = self.client_mock.search.call_args_list[1].kwargs["body"]
+        self.assertEqual(first_body["_source"], ["metadata"])  # vector excluded
+        self.assertNotIn("search_after", first_body)
+        self.assertEqual(second_body["search_after"], [999])  # paged via search_after
 
     def test_delete(self):
         # Perform delete

--- a/tests/vector_stores/test_elasticsearch.py
+++ b/tests/vector_stores/test_elasticsearch.py
@@ -290,6 +290,18 @@ class TestElasticsearchDB(unittest.TestCase):
         self.assertEqual(results[0][1].id, "id2")
         self.assertEqual(results[0][1].payload, {"key2": "value2"})
 
+    def test_list_default_size(self):
+        # Mock search response
+        mock_response = {"hits": {"hits": []}}
+        self.client_mock.search.return_value = mock_response
+
+        # List without top_k should request a large size, not fall back to ES default of 10
+        self.es_db.list()
+
+        self.client_mock.search.assert_called_once()
+        body = self.client_mock.search.call_args[1]["body"]
+        self.assertEqual(body["size"], 10000)
+
     def test_delete(self):
         # Perform delete
         self.es_db.delete(vector_id="id1")


### PR DESCRIPTION
## Linked Issue

Closes #6416

## Description

`ElasticsearchDB.list()` only set the query `size` when `top_k` was truthy. With no `top_k` (the path `delete_all`/`get_all` use), Elasticsearch applies its default `size` of 10, so listing and deleting silently stopped at 10 memories per scope. It now defaults to a large size when `top_k` is not given.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

Added `test_list_default_size` (list() with no top_k sends size=10000). `test_elasticsearch.py` 21/21, ruff clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed