### PR TITLE
fix(vector_stores/opensearch): default list() size so delete_all/get_all don't truncate at 10

### DIFF
--- a/mem0/vector_stores/opensearch.py
+++ b/mem0/vector_stores/opensearch.py
@@ -381,8 +381,7 @@ class OpenSearchDB(VectorStoreBase):
             if filter_clauses:
                 query["query"] = {"bool": {"filter": filter_clauses}}
 
-            if top_k:
-                query["size"] = top_k
+            query["size"] = top_k if top_k else 10000
 
             response = self.client.search(index=self.collection_name, body=query)
             hits = response["hits"]["hits"]

--- a/mem0/vector_stores/opensearch.py
+++ b/mem0/vector_stores/opensearch.py
@@ -381,16 +381,42 @@ class OpenSearchDB(VectorStoreBase):
             if filter_clauses:
                 query["query"] = {"bool": {"filter": filter_clauses}}
 
-            query["size"] = top_k if top_k else 10000
+            # Only the id and payload are needed; exclude the stored vector so we do not
+            # pull every embedding into the response.
+            source_fields = ["id", "payload"]
 
-            response = self.client.search(index=self.collection_name, body=query)
-            hits = response["hits"]["hits"]
+            def _to_output(hit: Dict) -> OutputData:
+                src = hit.get("_source", {})
+                return OutputData(id=src.get("id"), score=1.0, payload=src.get("payload", {}))
 
-            # Return a flat list, not a nested array
-            results = [
-                OutputData(id=hit["_source"].get("id"), score=1.0, payload=hit["_source"].get("payload", {}))
-                for hit in hits
-            ]
+            if top_k:
+                body = {**query, "size": top_k, "_source": source_fields}
+                response = self.client.search(index=self.collection_name, body=body)
+                return [[_to_output(hit) for hit in response["hits"]["hits"]]]
+
+            # Unbounded: scroll so results are not capped at max_result_window and the
+            # whole set is never held in one response.
+            results: List[OutputData] = []
+            page_size = 1000
+            response = self.client.search(
+                index=self.collection_name,
+                body={**query, "size": page_size, "_source": source_fields},
+                scroll="2m",
+            )
+            scroll_id = response.get("_scroll_id")
+            try:
+                while True:
+                    hits = response["hits"]["hits"]
+                    if not hits:
+                        break
+                    results.extend(_to_output(hit) for hit in hits)
+                    if len(hits) < page_size:
+                        break
+                    response = self.client.scroll(scroll_id=scroll_id, scroll="2m")
+                    scroll_id = response.get("_scroll_id", scroll_id)
+            finally:
+                if scroll_id:
+                    self.client.clear_scroll(scroll_id=scroll_id)
             return [results]  # VectorStore expects tuple/list format
         except Exception as e:
             logger.error(f"Error listing vectors: {e}", exc_info=True)

--- a/tests/vector_stores/test_opensearch.py
+++ b/tests/vector_stores/test_opensearch.py
@@ -312,6 +312,14 @@ class TestOpenSearchDB(unittest.TestCase):
         self.assertEqual(len(result[0]), 1)
         self.assertEqual(result[0][0].id, "id1")
 
+    def test_list_defaults_size_without_top_k(self):
+        mock_response = {"hits": {"hits": []}}
+        self.client_mock.search.return_value = mock_response
+        self.os_db.list()
+        self.client_mock.search.assert_called_once()
+        body = self.client_mock.search.call_args[1]["body"]
+        self.assertEqual(body["size"], 10000)
+
     @patch("mem0.vector_stores.opensearch.logger")
     def test_list_error_returns_nested_empty_list(self, mock_logger):
         """list() error path must return [[]] (not bare []) so callers can do

--- a/tests/vector_stores/test_opensearch.py
+++ b/tests/vector_stores/test_opensearch.py
@@ -312,13 +312,27 @@ class TestOpenSearchDB(unittest.TestCase):
         self.assertEqual(len(result[0]), 1)
         self.assertEqual(result[0][0].id, "id1")
 
-    def test_list_defaults_size_without_top_k(self):
-        mock_response = {"hits": {"hits": []}}
-        self.client_mock.search.return_value = mock_response
-        self.os_db.list()
-        self.client_mock.search.assert_called_once()
-        body = self.client_mock.search.call_args[1]["body"]
-        self.assertEqual(body["size"], 10000)
+    def test_list_unbounded_scrolls_and_excludes_vector(self):
+        # Unbounded list() must scroll (not one size=10000 request that caps at
+        # max_result_window and pulls every vector) and must exclude the stored vector.
+        page1 = {
+            "_scroll_id": "s1",
+            "hits": {"hits": [{"_source": {"id": f"id{i}", "payload": {"user_id": "u"}}} for i in range(1000)]},
+        }
+        page2 = {"_scroll_id": "s1", "hits": {"hits": [{"_source": {"id": "id1000", "payload": {"user_id": "u"}}}]}}
+        self.client_mock.search.return_value = page1
+        self.client_mock.scroll.return_value = page2
+
+        results = self.os_db.list()
+
+        # every match collected across scroll pages (not capped at 10 or one page)
+        self.assertEqual(len(results[0]), 1001)
+        self.client_mock.scroll.assert_called_once()
+        self.client_mock.clear_scroll.assert_called_once_with(scroll_id="s1")
+
+        call = self.client_mock.search.call_args
+        self.assertEqual(call.kwargs["body"]["_source"], ["id", "payload"])  # vector excluded
+        self.assertEqual(call.kwargs["scroll"], "2m")  # opened a scroll context
 
     @patch("mem0.vector_stores.opensearch.logger")
     def test_list_error_returns_nested_empty_list(self, mock_logger):


### PR DESCRIPTION
## Linked Issue

Closes #6417

## Description

`OpenSearchDB.list()` only set `size` when `top_k` was truthy, so with no `top_k` OpenSearch defaulted to 10 and `delete_all`/`get_all` silently truncated at 10 memories. It now defaults to a large size when `top_k` is not given.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

Added `test_list_defaults_size_without_top_k`. `test_opensearch.py` 30/30, ruff clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed