### PR TITLE
fix(vector_stores/supabase): persist metadata-only updates instead of silently dropping them

### DIFF
--- a/mem0/vector_stores/supabase.py
+++ b/mem0/vector_stores/supabase.py
@@ -156,12 +156,12 @@ class Supabase(VectorStoreBase):
             payload (Dict, optional): Updated payload
         """
         if vector is None:
-            # If only updating metadata, we need to get the existing vector
-            existing = self.get(vector_id)
-            if existing and existing.payload:
-                vector = existing.payload.get("vector", [])
+            # If only updating metadata, recover the stored embedding from the collection.
+            existing = self.collection.fetch([(vector_id,)])
+            if existing:
+                vector = existing[0][1]
 
-        if vector:
+        if vector is not None:
             self.collection.upsert([(vector_id, vector, payload or {})])
 
     def get(self, vector_id: str) -> Optional[OutputData]:

--- a/tests/vector_stores/test_supabase.py
+++ b/tests/vector_stores/test_supabase.py
@@ -94,6 +94,21 @@ def test_update_vector(supabase_instance, mock_collection):
     mock_collection.upsert.assert_called_once_with([("id1", new_vector, new_payload)])
 
 
+def test_update_metadata_only_persists(supabase_instance, mock_collection):
+    # vector=None must recover the stored embedding and still upsert, not silently no-op.
+    # A vecs fetch record supports both attribute (.id/.metadata) and index ([1]) access.
+    record = Mock()
+    record.id = "id1"
+    record.metadata = {"name": "old"}
+    record.__getitem__ = lambda _self, i: ("id1", [0.1, 0.2, 0.3], {"name": "old"})[i]
+    mock_collection.fetch.return_value = [record]
+    new_payload = {"name": "updated_vector"}
+
+    supabase_instance.update(vector_id="id1", payload=new_payload)
+
+    mock_collection.upsert.assert_called_once_with([("id1", [0.1, 0.2, 0.3], new_payload)])
+
+
 def test_get_vector(supabase_instance, mock_collection):
     # Create a Mock object to represent the record
     mock_record = Mock()


### PR DESCRIPTION
## Linked Issue

Closes #6418

## Description

A metadata-only `update()` (called with `vector=None`) tried to recover the embedding from `existing.payload.get("vector")`, but the vector is never stored in the payload/metadata, so it resolved to empty, the `if vector:` guard was skipped, and the update was silently dropped. It now fetches the real stored vector from the collection and persists the new payload.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

Added `test_update_metadata_only_persists` (the upsert runs on a metadata-only update). `test_supabase.py` 11/11, ruff clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed