### PR TITLE
fix(vector_stores/vertex_ai): use configured embedding dimension in list() instead of hardcoded 768

### DIFF
--- a/mem0/configs/vector_stores/vertex_ai_vector_search.py
+++ b/mem0/configs/vector_stores/vertex_ai_vector_search.py
@@ -14,6 +14,7 @@ class GoogleMatchingEngineConfig(BaseModel):
     credentials_path: Optional[str] = Field(None, description="Path to service account credentials JSON file")
     service_account_json: Optional[Dict] = Field(None, description="Service account credentials as dictionary (alternative to credentials_path)")
     vector_search_api_endpoint: Optional[str] = Field(None, description="Vector search API endpoint")
+    embedding_model_dims: Optional[int] = Field(768, description="Dimension of the embedding vector")
 
     model_config = ConfigDict(extra="forbid")
 

--- a/mem0/vector_stores/vertex_ai_vector_search.py
+++ b/mem0/vector_stores/vertex_ai_vector_search.py
@@ -61,6 +61,7 @@ class GoogleMatchingEngine(VectorStoreBase):
         self.deployment_index_id = config.deployment_index_id  # The deployment-specific ID
         self.collection_name = config.collection_name
         self.vector_search_api_endpoint = config.vector_search_api_endpoint
+        self.embedding_model_dims = config.embedding_model_dims
 
         logger.debug("Using project=%s, location=%s", self.project_id, self.region)
 
@@ -481,7 +482,7 @@ class GoogleMatchingEngine(VectorStoreBase):
 
         try:
             # Use a zero vector for the search
-            dimension = 768  # This should be configurable based on the model
+            dimension = self.embedding_model_dims
             zero_vector = [0.0] * dimension
 
             # Use a large top_k if none specified

--- a/tests/vector_stores/test_vertex_ai_vector_search.py
+++ b/tests/vector_stores/test_vertex_ai_vector_search.py
@@ -128,6 +128,21 @@ def test_list_does_not_raise_type_error(vector_store, mock_vertex_ai):
     assert results == [[]]
 
 
+def test_list_uses_configured_embedding_dims(config, mock_vertex_ai):
+    """list() must build the zero query vector using the configured embedding dims."""
+    mock_vertex_ai["index_class"].return_value = mock_vertex_ai["index"]
+    mock_vertex_ai["endpoint_class"].return_value = mock_vertex_ai["endpoint"]
+    kwargs = config.model_dump()
+    kwargs["embedding_model_dims"] = 1536
+    store = GoogleMatchingEngine(**kwargs)
+    mock_vertex_ai["endpoint"].find_neighbors.return_value = [[]]
+
+    store.list(filters={"user_id": "test_user"}, top_k=5)
+
+    queries = mock_vertex_ai["endpoint"].find_neighbors.call_args[1]["queries"]
+    assert queries == [[0.0] * 1536]
+
+
 def test_similarity_search_with_score_passes_embedding(vector_store, mock_vertex_ai):
     """similarity_search_with_score() must pass the embedding as `vectors`."""
     embedding = [0.1, 0.2, 0.3]


### PR DESCRIPTION
## Linked Issue

Closes #6419

## Description

`list()` built the zero query vector with a hardcoded `dimension = 768`, and the config had no dimension field, so any index whose embedding dimension is not 768 (e.g. OpenAI 1536/3072) rejected the query and `list`/`get_all`/`delete_all` failed. This adds a configurable `embedding_model_dims` (default 768) and uses it.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

Added `test_list_uses_configured_embedding_dims` (list() uses a configured 1536-length vector). `test_vertex_ai_vector_search.py` 8/8, ruff clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed