### PR TITLE
fix(llms/openai_structured): return tool calls instead of dropping them

### DIFF
--- a/mem0/llms/openai_structured.py
+++ b/mem0/llms/openai_structured.py
@@ -1,3 +1,4 @@
+import json
 import os
 from typing import Dict, List, Optional
 
@@ -5,6 +6,7 @@ from openai import OpenAI
 
 from mem0.configs.llms.base import BaseLlmConfig
 from mem0.llms.base import LLMBase
+from mem0.memory.utils import extract_json
 
 
 class OpenAIStructuredLLM(LLMBase):
@@ -46,4 +48,34 @@ class OpenAIStructuredLLM(LLMBase):
             params["tool_choice"] = tool_choice
 
         response = self.client.beta.chat.completions.parse(**params)
-        return response.choices[0].message.content
+        return self._parse_response(response, tools)
+
+    def _parse_response(self, response, tools):
+        """
+        Process the response based on whether tools are used or not.
+
+        Args:
+            response: The raw response from API.
+            tools: The list of tools provided in the request.
+
+        Returns:
+            str or dict: The processed response.
+        """
+        if tools:
+            processed_response = {
+                "content": response.choices[0].message.content,
+                "tool_calls": [],
+            }
+
+            if response.choices[0].message.tool_calls:
+                for tool_call in response.choices[0].message.tool_calls:
+                    processed_response["tool_calls"].append(
+                        {
+                            "name": tool_call.function.name,
+                            "arguments": json.loads(extract_json(tool_call.function.arguments)),
+                        }
+                    )
+
+            return processed_response
+        else:
+            return response.choices[0].message.content

--- a/tests/llms/test_openai_structured.py
+++ b/tests/llms/test_openai_structured.py
@@ -51,6 +51,32 @@ def test_regular_model_sends_sampling_params(mock_openai_client):
     assert call_kwargs["model"] == "gpt-4o"
 
 
+def test_generate_response_with_tools_returns_tool_calls(mock_openai_client):
+    """When the model returns a tool call, `content` is None; tool calls must not be dropped."""
+    config = OpenAIConfig(model="gpt-4o")
+    llm = OpenAIStructuredLLM(config)
+
+    mock_tool_call = Mock()
+    mock_tool_call.function.name = "add_memory"
+    mock_tool_call.function.arguments = '{"data": "sunny day"}'
+
+    mock_message = Mock()
+    mock_message.content = None
+    mock_message.tool_calls = [mock_tool_call]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=mock_message)]
+    mock_openai_client.beta.chat.completions.parse.return_value = mock_response
+
+    tools = [{"type": "function", "function": {"name": "add_memory"}}]
+    response = llm.generate_response([{"role": "user", "content": "Remember sunny day"}], tools=tools)
+
+    assert response["content"] is None
+    assert len(response["tool_calls"]) == 1
+    assert response["tool_calls"][0]["name"] == "add_memory"
+    assert response["tool_calls"][0]["arguments"] == {"data": "sunny day"}
+
+
 def test_uses_openai_base_url_environment_variable(monkeypatch):
     base_url = "https://gateway.example/v1"
     monkeypatch.setenv("OPENAI_API_BASE", "https://legacy.example/v1")


### PR DESCRIPTION
## Linked Issue

Closes #6420

## Description

`OpenAIStructuredLLM.generate_response` forwards `tools`/`tool_choice` but always returned `response.choices[0].message.content`, which is `None` on a tool call, so tool calls were dropped. It now returns them via a `_parse_response(response, tools)` helper that mirrors `AzureOpenAIStructuredLLM`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

Added `test_generate_response_with_tools_returns_tool_calls`. `test_openai_structured.py` 4/4, ruff clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed