### PR TITLE
fix(memory): honor vector store reset() in AsyncMemory.reset() to match sync

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -3742,20 +3742,25 @@ class AsyncMemory(MemoryBase):
             Recreates the vector store with a new client
         """
         logger.warning("Resetting all memories")
-        await asyncio.to_thread(self.vector_store.delete_col)
-
-        gc.collect()
-
-        if hasattr(self.vector_store, "client") and hasattr(self.vector_store.client, "close"):
-            await asyncio.to_thread(self.vector_store.client.close)
 
         await asyncio.to_thread(self.db.reset)
         await asyncio.to_thread(self.db.close)
         self.db = SQLiteManager(self.config.history_db_path)
 
-        self.vector_store = VectorStoreFactory.create(
-            self.config.vector_store.provider, self.config.vector_store.config
-        )
+        if hasattr(self.vector_store, "reset"):
+            self.vector_store = await asyncio.to_thread(VectorStoreFactory.reset, self.vector_store)
+        else:
+            logger.warning("Vector store does not support reset. Skipping.")
+            await asyncio.to_thread(self.vector_store.delete_col)
+
+            gc.collect()
+
+            if hasattr(self.vector_store, "client") and hasattr(self.vector_store.client, "close"):
+                await asyncio.to_thread(self.vector_store.client.close)
+
+            self.vector_store = VectorStoreFactory.create(
+                self.config.vector_store.provider, self.config.vector_store.config
+            )
 
         if self._entity_store is not None:
             try:

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -407,6 +407,23 @@ async def test_async_create_memory_preserves_existing_created_at(mocker):
 
 
 @pytest.mark.asyncio
+async def test_async_reset_prefers_vector_store_reset(mocker):
+    memory = _build_memory_instance(mocker, AsyncMemory)
+    mocker.patch("mem0.memory.main.capture_event")
+    mocker.patch("mem0.memory.main.display_first_run_notice_async")
+    reset_factory = mocker.patch("mem0.memory.main.VectorStoreFactory.reset")
+    create_factory = mocker.patch("mem0.memory.main.VectorStoreFactory.create")
+    original_store = memory.vector_store
+
+    await memory.reset()
+
+    reset_factory.assert_called_once_with(original_store)
+    original_store.delete_col.assert_not_called()
+    create_factory.assert_not_called()
+    assert memory.vector_store is reset_factory.return_value
+
+
+@pytest.mark.asyncio
 async def test_async_update_memory_uses_utc_timestamps(mocker):
     memory = _build_memory_instance(mocker, AsyncMemory)
     memory.vector_store.get.return_value = MagicMock(


### PR DESCRIPTION
## Linked Issue

Closes #6421

## Description

`AsyncMemory.reset()` always did `delete_col` + recreate and never honored a vector store that implements its own `reset()`, diverging from sync `Memory.reset()`. It now prefers `VectorStoreFactory.reset()` when available (wrapped in `asyncio.to_thread`), falling back to the existing delete/recreate path, matching the sync behavior.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

Added `test_async_reset_prefers_vector_store_reset`. `test_main.py` 49/49, ruff clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed