### PR TITLE
fix(vector_stores/milvus): guard text field in update() for legacy collections

### DIFF
--- a/mem0/vector_stores/milvus.py
+++ b/mem0/vector_stores/milvus.py
@@ -298,10 +298,12 @@ class MilvusDB(VectorStoreBase):
             if payload is None:
                 payload = existing[0].get("metadata")
 
-        text = ""
-        if payload:
-            text = (payload.get("text_lemmatized") or payload.get("data", ""))[:65535]
-        schema = {"id": vector_id, "vectors": vector, "metadata": payload, "text": text}
+        schema = {"id": vector_id, "vectors": vector, "metadata": payload}
+        if self._has_bm25_schema:
+            text = ""
+            if payload:
+                text = (payload.get("text_lemmatized") or payload.get("data", ""))[:65535]
+            schema["text"] = text
         self.client.upsert(collection_name=self.collection_name, data=schema)
 
     def get(self, vector_id) -> Optional[OutputData]:

--- a/tests/vector_stores/test_milvus.py
+++ b/tests/vector_stores/test_milvus.py
@@ -179,6 +179,32 @@ class TestMilvusDB:
         assert call_args[1]['data']['vectors'] == vector
         assert call_args[1]['data']['metadata'] == payload
 
+    def test_update_omits_text_on_legacy_collection(self, milvus_db, mock_milvus_client):
+        """Legacy collections lack a `text` field, so update must not upsert one (else it's rejected)."""
+        milvus_db._has_bm25_schema = False
+
+        milvus_db.update(
+            vector_id="test_id",
+            vector=[0.1] * 1536,
+            payload={"user_id": "alice", "data": "Updated memory"},
+        )
+
+        data = mock_milvus_client.upsert.call_args[1]['data']
+        assert "text" not in data
+
+    def test_update_includes_text_on_bm25_collection(self, milvus_db, mock_milvus_client):
+        """BM25-capable collections keep the `text` field for full-text search."""
+        milvus_db._has_bm25_schema = True
+
+        milvus_db.update(
+            vector_id="test_id",
+            vector=[0.1] * 1536,
+            payload={"user_id": "alice", "data": "Updated memory"},
+        )
+
+        data = mock_milvus_client.upsert.call_args[1]['data']
+        assert data["text"] == "Updated memory"
+
     def test_delete(self, milvus_db, mock_milvus_client):
         """Test vector deletion."""
         vector_id = "test_id"


### PR DESCRIPTION
## Linked Issue

Closes #6422

## Description

`insert()` guards the top-level `text` field behind `self._has_bm25_schema` because legacy pre-v3 collections have no `text` field and reject unknown fields, but `update()` added `text` unconditionally, so every update on a legacy collection was rejected. `update()` now guards `text` the same way `insert()` does.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

Added `test_update_omits_text_on_legacy_collection` and `test_update_includes_text_on_bm25_collection`. `test_milvus.py` 28/28, ruff clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed