### PR TITLE
fix(vector_stores/weaviate): apply custom metadata filters, not just user/agent/run ids

### DIFF
--- a/mem0/vector_stores/weaviate.py
+++ b/mem0/vector_stores/weaviate.py
@@ -188,7 +188,7 @@ class Weaviate(VectorStoreBase):
         filter_conditions = []
         if filters:
             for key, value in filters.items():
-                if value and key in ["user_id", "agent_id", "run_id"]:
+                if value is not None and not isinstance(value, (dict, list)):
                     filter_conditions.append(Filter.by_property(key).equal(value))
         combined_filter = Filter.all_of(filter_conditions) if filter_conditions else None
         response = collection.query.hybrid(
@@ -239,7 +239,7 @@ class Weaviate(VectorStoreBase):
         filter_conditions = []
         if filters:
             for key, value in filters.items():
-                if value and key in ["user_id", "agent_id", "run_id"]:
+                if value is not None and not isinstance(value, (dict, list)):
                     filter_conditions.append(Filter.by_property(key).equal(value))
         combined_filter = Filter.all_of(filter_conditions) if filter_conditions else None
         response = collection.query.bm25(
@@ -362,7 +362,7 @@ class Weaviate(VectorStoreBase):
         filter_conditions = []
         if filters:
             for key, value in filters.items():
-                if value and key in ["user_id", "agent_id", "run_id"]:
+                if value is not None and not isinstance(value, (dict, list)):
                     filter_conditions.append(Filter.by_property(key).equal(value))
         combined_filter = Filter.all_of(filter_conditions) if filter_conditions else None
         response = collection.query.fetch_objects(

--- a/tests/vector_stores/test_weaviate.py
+++ b/tests/vector_stores/test_weaviate.py
@@ -264,6 +264,24 @@ class TestWeaviateDB(unittest.TestCase):
         self.assertEqual(len(vector_updates), 1)
         self.assertNotIn("properties", vector_updates[0].kwargs)
 
+    def test_search_builds_conditions_for_custom_metadata_filters(self):
+        mock_response = MagicMock()
+        mock_response.objects = []
+        mock_hybrid = MagicMock(return_value=mock_response)
+        self.client_mock.collections.get.return_value.query.hybrid = mock_hybrid
+
+        with patch("mem0.vector_stores.weaviate.Filter") as mock_filter:
+            self.weaviate_db.search(
+                query="",
+                vectors=[0.1] * 1536,
+                top_k=5,
+                filters={"user_id": "u1", "category": "work"},
+            )
+
+        called_keys = {call.args[0] for call in mock_filter.by_property.call_args_list}
+        self.assertIn("user_id", called_keys)
+        self.assertIn("category", called_keys)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Linked Issue

Closes #6423

## Description

`search()`/`list()` only built filter conditions for `user_id`/`agent_id`/`run_id`, silently dropping every other metadata filter (e.g. `{"category": "work"}`) and returning results from other scopes. They now build an equality condition for every scalar filter key. (Operator-dict and list filters remain a follow-up.)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

Added `test_search_builds_conditions_for_custom_metadata_filters`. `test_weaviate.py` 13/13, ruff clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed