### PR TITLE
fix(vector_stores/faiss): support operator and $or/$not filters in _apply_filters

### DIFF
--- a/mem0/vector_stores/faiss.py
+++ b/mem0/vector_stores/faiss.py
@@ -427,19 +427,74 @@ class FAISS(VectorStoreBase):
         Returns:
             bool: True if payload passes filters, False otherwise.
         """
-        if not filters or not payload:
+        if not filters:
             return True
+        payload = payload or {}
 
         for key, value in filters.items():
-            if key not in payload:
-                return False
-
-            if isinstance(value, list):
-                if payload[key] not in value:
+            if key == "$or":
+                if not any(self._apply_filters(payload, sub) for sub in value):
                     return False
-            elif payload[key] != value:
+                continue
+            if key == "$not":
+                if any(self._apply_filters(payload, sub) for sub in value):
+                    return False
+                continue
+
+            present = key in payload
+            actual = payload.get(key)
+
+            if value == "*":
+                if not present:
+                    return False
+            elif isinstance(value, dict):
+                if not self._match_operators(actual, present, value):
+                    return False
+            elif isinstance(value, list):
+                if not present or actual not in value:
+                    return False
+            elif not present or actual != value:
                 return False
 
+        return True
+
+    def _match_operators(self, actual, present: bool, operators: Dict) -> bool:
+        """Match a payload value against a universal-filter operator dict (eq/ne/gt/gte/lt/lte/in/nin/contains/icontains)."""
+        for op, expected in operators.items():
+            if not present:
+                return False
+            if op == "eq":
+                if actual != expected:
+                    return False
+            elif op == "ne":
+                if actual == expected:
+                    return False
+            elif op in ("gt", "gte", "lt", "lte"):
+                try:
+                    a, e = float(actual), float(expected)
+                except (TypeError, ValueError):
+                    return False
+                if (
+                    (op == "gt" and not a > e)
+                    or (op == "gte" and not a >= e)
+                    or (op == "lt" and not a < e)
+                    or (op == "lte" and not a <= e)
+                ):
+                    return False
+            elif op == "in":
+                if actual not in expected:
+                    return False
+            elif op == "nin":
+                if actual in expected:
+                    return False
+            elif op == "contains":
+                if str(expected) not in str(actual):
+                    return False
+            elif op == "icontains":
+                if str(expected).lower() not in str(actual).lower():
+                    return False
+            else:
+                raise ValueError(f"Unsupported filter operator: {op}")
         return True
 
     def delete(self, vector_id: str):

--- a/tests/vector_stores/test_faiss.py
+++ b/tests/vector_stores/test_faiss.py
@@ -754,3 +754,32 @@ class TestCosineNormalization:
 
             assert results[0].id == "x"
             assert results[0].score == pytest.approx(1.0, abs=1e-5)
+
+
+def test_apply_filters_operators_and_logical(faiss_instance):
+    store = faiss_instance
+    payload = {"user_id": "u1", "category": "work", "priority": 5}
+
+    # scalar equality and list membership (unchanged behavior)
+    assert store._apply_filters(payload, {"user_id": "u1"}) is True
+    assert store._apply_filters(payload, {"user_id": "u2"}) is False
+    assert store._apply_filters(payload, {"category": ["work", "home"]}) is True
+    assert store._apply_filters(payload, {"category": ["home"]}) is False
+
+    # operator dicts: previously always dropped (returned False) -> empty results
+    assert store._apply_filters(payload, {"category": {"eq": "work"}}) is True
+    assert store._apply_filters(payload, {"category": {"ne": "home"}}) is True
+    assert store._apply_filters(payload, {"priority": {"gte": 5}}) is True
+    assert store._apply_filters(payload, {"priority": {"lt": 5}}) is False
+    assert store._apply_filters(payload, {"category": {"in": ["work", "home"]}}) is True
+    assert store._apply_filters(payload, {"category": {"nin": ["home"]}}) is True
+
+    # logical $or / $not: previously returned empty
+    assert store._apply_filters(payload, {"$or": [{"category": "home"}, {"category": "work"}]}) is True
+    assert store._apply_filters(payload, {"$or": [{"category": "home"}]}) is False
+    assert store._apply_filters(payload, {"$not": [{"category": "home"}]}) is True
+    assert store._apply_filters(payload, {"$not": [{"category": "work"}]}) is False
+
+    # absent key never matches
+    assert store._apply_filters(payload, {"missing": {"eq": "x"}}) is False
+    assert store._apply_filters(payload, {"missing": "x"}) is False


### PR DESCRIPTION
## Linked Issue

Closes #6424

## Description

`_apply_filters` only handled scalar equality and list membership, so operator-dict filters (e.g. `{"category": {"eq": "work"}}`) and logical `$or`/`$not` matched nothing and returned empty results. It now interprets the universal filter operators (eq/ne/gt/gte/lt/lte/in/nin/contains/icontains) and `$or`/`$not`, matching the pgvector store.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

Added `test_apply_filters_operators_and_logical` (operators + $or/$not + scalar/list). `test_faiss.py` 34/34, ruff clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed