### PR TITLE
fix(opencode-plugin): recover MEM0_API_KEY from shell profiles

### DIFF
--- a/integrations/mem0-plugin/.opencode-plugin/api-key.test.ts
+++ b/integrations/mem0-plugin/.opencode-plugin/api-key.test.ts
@@ -1,0 +1,135 @@
+import {afterEach, describe, expect, test} from "bun:test";
+import {mkdtempSync, mkdirSync, writeFileSync} from "fs";
+import {tmpdir} from "os";
+import {join} from "path";
+import {parseApiKeyLine, resolveApiKey} from "./api-key";
+import Mem0Plugin from "./opencode-mem0";
+
+const originalKey = process.env.MEM0_API_KEY;
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
+const originalTelemetry = process.env.MEM0_TELEMETRY;
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  if (originalKey === undefined) delete process.env.MEM0_API_KEY;
+  else process.env.MEM0_API_KEY = originalKey;
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+  else process.env.USERPROFILE = originalUserProfile;
+  if (originalTelemetry === undefined) delete process.env.MEM0_TELEMETRY;
+  else process.env.MEM0_TELEMETRY = originalTelemetry;
+  globalThis.fetch = originalFetch;
+});
+
+function home(): string {
+  return mkdtempSync(join(tmpdir(), "mem0-api-key-"));
+}
+
+function pluginContext(logs: unknown[]) {
+  return {
+    client: {app: {log: async (entry: unknown) => logs.push(entry)}},
+    $: () => ({quiet: async () => ({stdout: ""})}),
+  } as any;
+}
+
+function stubFetch(): void {
+  globalThis.fetch = (async (input) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const body =
+      url.includes("/v1/ping/")
+        ? {status: "ok", userEmail: "plugin-test@mem0.dev"}
+        : url.includes("/v1/projects/")
+          ? {customCategories: []}
+          : {};
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: {"content-type": "application/json"},
+    });
+  }) as typeof fetch;
+}
+
+describe("parseApiKeyLine", () => {
+  test("accepts literal export and assignment forms", () => {
+    expect(parseApiKeyLine('export MEM0_API_KEY="m0-quoted" # comment')).toBe("m0-quoted");
+    expect(parseApiKeyLine("MEM0_API_KEY=m0-literal")).toBe("m0-literal");
+  });
+
+  test("rejects unrelated, empty, and executable-looking values", () => {
+    expect(parseApiKeyLine("OTHER_KEY=value")).toBeUndefined();
+    expect(parseApiKeyLine("MEM0_API_KEY=")).toBeUndefined();
+    expect(parseApiKeyLine("MEM0_API_KEY=$MEM0_API_KEY")).toBeUndefined();
+    expect(parseApiKeyLine("MEM0_API_KEY=$(cat secret)")).toBeUndefined();
+  });
+});
+
+describe("resolveApiKey", () => {
+  test("explicit environment value wins over profiles", () => {
+    const dir = home();
+    writeFileSync(join(dir, ".zshrc"), "MEM0_API_KEY=profile\n");
+    expect(resolveApiKey({MEM0_API_KEY: " explicit "}, dir)).toBe("explicit");
+  });
+
+  test("uses the first valid allowlisted profile", () => {
+    const dir = home();
+    writeFileSync(join(dir, ".zshrc"), "MEM0_API_KEY=$UNSET\n");
+    writeFileSync(join(dir, ".bashrc"), "export MEM0_API_KEY='m0-from-bashrc'\n");
+    writeFileSync(join(dir, ".profile"), "MEM0_API_KEY=late\n");
+    expect(resolveApiKey({}, dir)).toBe("m0-from-bashrc");
+  });
+
+  test("continues after an unreadable or absent earlier profile", () => {
+    const dir = home();
+    mkdirSync(join(dir, ".zshrc"));
+    writeFileSync(join(dir, ".profile"), "MEM0_API_KEY=m0-later\n");
+    expect(resolveApiKey({}, dir)).toBe("m0-later");
+  });
+
+  test("ignores unsupported files and invalid assignments", () => {
+    const dir = home();
+    writeFileSync(join(dir, ".env"), "MEM0_API_KEY=unsupported\n");
+    writeFileSync(join(dir, ".zshrc"), "MEM0_API_KEY= # empty\nMEM0_API_KEY=$(unsafe)\n");
+    expect(resolveApiKey({}, dir)).toBe("");
+  });
+
+  test("keeps the missing-key guard when no source yields a key", async () => {
+    const dir = home();
+    writeFileSync(join(dir, ".zshrc"), "MEM0_API_KEY= # empty\nMEM0_API_KEY=$UNSET\n");
+    delete process.env.MEM0_API_KEY;
+    process.env.HOME = dir;
+    process.env.USERPROFILE = dir;
+    process.env.MEM0_TELEMETRY = "false";
+    stubFetch();
+
+    const logs: unknown[] = [];
+    const plugin = await Mem0Plugin(pluginContext(logs));
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toMatchObject({
+      body: {
+        level: "error",
+        message: "MEM0_API_KEY environment variable not set. Get one at https://app.mem0.ai/dashboard/api-keys",
+      },
+    });
+    expect(plugin).toEqual({});
+  });
+
+  test("recovers the issue's shell-profile startup path", async () => {
+    const dir = home();
+    // Problem 2 in issue #6003: Desktop has no process key, but .zshrc does.
+    writeFileSync(join(dir, ".zshrc"), 'export MEM0_API_KEY="m0-from-profile"\n');
+    delete process.env.MEM0_API_KEY;
+    process.env.HOME = dir;
+    process.env.USERPROFILE = dir;
+    process.env.MEM0_TELEMETRY = "false";
+    stubFetch();
+
+    const logs: unknown[] = [];
+    const plugin = await Mem0Plugin(pluginContext(logs));
+
+    expect(logs).toHaveLength(0);
+    expect(Object.keys(plugin)).toContain("chat.message");
+    expect(plugin).toHaveProperty("tool");
+  });
+});

--- a/integrations/mem0-plugin/.opencode-plugin/api-key.test.ts
+++ b/integrations/mem0-plugin/.opencode-plugin/api-key.test.ts
@@ -10,8 +10,12 @@ const originalHome = process.env.HOME;
 const originalUserProfile = process.env.USERPROFILE;
 const originalTelemetry = process.env.MEM0_TELEMETRY;
 const originalFetch = globalThis.fetch;
+const testCleanups: Array<() => Promise<void> | void> = [];
 
-afterEach(() => {
+afterEach(async () => {
+  while (testCleanups.length > 0) {
+    await testCleanups.pop()?.();
+  }
   if (originalKey === undefined) delete process.env.MEM0_API_KEY;
   else process.env.MEM0_API_KEY = originalKey;
   if (originalHome === undefined) delete process.env.HOME;
@@ -48,6 +52,18 @@ function stubFetch(): void {
       headers: {"content-type": "application/json"},
     });
   }) as typeof fetch;
+}
+
+function captureDeferredPluginCleanup(): () => Promise<void> {
+  const baseline = new Set(process.listeners("beforeExit"));
+  return async () => {
+    await Promise.resolve();
+    for (const listener of process.listeners("beforeExit")) {
+      if (!baseline.has(listener)) {
+        process.off("beforeExit", listener as (...args: any[]) => void);
+      }
+    }
+  };
 }
 
 describe("parseApiKeyLine", () => {
@@ -101,6 +117,7 @@ describe("resolveApiKey", () => {
     process.env.USERPROFILE = dir;
     process.env.MEM0_TELEMETRY = "false";
     stubFetch();
+    testCleanups.push(captureDeferredPluginCleanup());
 
     const logs: unknown[] = [];
     const plugin = await Mem0Plugin(pluginContext(logs));
@@ -124,6 +141,7 @@ describe("resolveApiKey", () => {
     process.env.USERPROFILE = dir;
     process.env.MEM0_TELEMETRY = "false";
     stubFetch();
+    testCleanups.push(captureDeferredPluginCleanup());
 
     const logs: unknown[] = [];
     const plugin = await Mem0Plugin(pluginContext(logs));

--- a/integrations/mem0-plugin/.opencode-plugin/api-key.ts
+++ b/integrations/mem0-plugin/.opencode-plugin/api-key.ts
@@ -1,0 +1,30 @@
+import {readFileSync} from "fs";
+import {homedir} from "os";
+import {join} from "path";
+
+const PROFILE_FILES = [".zshrc", ".bashrc", ".zprofile", ".bash_profile", ".profile"];
+
+export function parseApiKeyLine(line: string): string | undefined {
+  const match = line.match(/^\s*(?:export\s+)?MEM0_API_KEY=(.*)$/);
+  if (!match) return undefined;
+
+  const value = match[1].replace(/#.*$/, "").trim().replace(/^("|')(.*)\1$/, "$2").trim();
+  return value && !value.startsWith("$") ? value : undefined;
+}
+
+export function resolveApiKey(env: NodeJS.ProcessEnv = process.env, homeDir = homedir()): string {
+  const explicit = env.MEM0_API_KEY?.trim();
+  if (explicit) return explicit;
+
+  for (const profile of PROFILE_FILES) {
+    try {
+      for (const line of readFileSync(join(homeDir, profile), "utf8").split(/\r?\n/)) {
+        const key = parseApiKeyLine(line);
+        if (key) return key;
+      }
+    } catch {
+    }
+  }
+
+  return "";
+}

--- a/integrations/mem0-plugin/.opencode-plugin/opencode-mem0.ts
+++ b/integrations/mem0-plugin/.opencode-plugin/opencode-mem0.ts
@@ -25,6 +25,7 @@ import {
 } from "./dream";
 import {asScope, scopeSearchFilters, scopeWriteParams, resolveDefaultScope, SCOPE_GUIDANCE, type Scope} from "./scope";
 import {parseProjectFromRemote} from "./project";
+import {resolveApiKey} from "./api-key";
 
 async function getUserId(): Promise<string> {
   if (process.env.MEM0_USER_ID) return process.env.MEM0_USER_ID;
@@ -258,7 +259,7 @@ function extractUserText(input: any, output: any): string {
 const Mem0Plugin: Plugin = async (ctx) => {
   const {$, client} = ctx;
 
-  const apiKey = process.env.MEM0_API_KEY;
+  const apiKey = resolveApiKey();
 
   if (!apiKey) {
     try {


### PR DESCRIPTION
## Linked Issue

Refs #6003

Companion to [#6012](https://github.com/mem0ai/mem0/pull/6012), which covers the separate OpenCode Desktop load-failure and project-identity slices from the same issue.

Attribution: this follows the scoped fix direction in [maintainer triage](https://github.com/mem0ai/mem0/issues/6003#issuecomment-4862984497) and mirrors the repo's existing plugin-family resolver behavior in `integrations/mem0-plugin/scripts/_identity.py`.

## Description

OpenCode Desktop can load `@mem0/opencode-plugin` without exposing any memory tools when `MEM0_API_KEY` exists in a supported shell profile but is absent from the Desktop process environment. The plugin currently treats that missing process env var as a missing credential, logs `MEM0_API_KEY environment variable not set...`, and returns before it registers hooks or tools.

This PR adds a package-local resolver in `.opencode-plugin` that keeps explicit `MEM0_API_KEY` env precedence, then falls back to the same allowlisted shell-profile assignment pattern the Mem0 plugin family already uses elsewhere in the repo. Startup now uses the resolved key through the existing guard instead of reading `process.env.MEM0_API_KEY` directly.

## Root cause

`integrations/mem0-plugin/.opencode-plugin/opencode-mem0.ts` reads only `process.env.MEM0_API_KEY` before startup. The repo's existing Desktop-safe resolver lives in `integrations/mem0-plugin/scripts/_identity.py`, but the OpenCode TypeScript package never received an equivalent local path, so Desktop startup exits early even when a valid literal `MEM0_API_KEY` is already present in `.zshrc`, `.bashrc`, or the other supported profile files.

## Scope

This change is limited to the OpenCode plugin package and the API-key fallback slice of #6003.

- Explicit `MEM0_API_KEY` env precedence stays unchanged.
- The current missing-key log and empty-plugin return stay unchanged when no source yields a key.
- The resolver reads only the fixed allowlist of shell-profile files and only literal `MEM0_API_KEY=` assignments. It does not source profiles or execute shell code.
- Build/runtime packaging, `app_id`, project context, docs wording, package versions, and other plugin hosts stay out of scope.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Test Coverage

- [x] I added/updated unit tests
- [x] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed

Verification from `integrations/mem0-plugin/.opencode-plugin`:

- [x] `bun install --frozen-lockfile` (`Checked 353 installs across 358 packages (no changes)`)
- [x] `bun test api-key.test.ts` (`8 pass`, `0 fail`, `16 expect() calls`)
- [x] `bun run type-check` (`tsc --noEmit`)
- [x] `bun run build` (`Bundled 204 modules`, `index.js  0.96 MB`)
- [x] `bun test` (`40 pass`, `0 fail`, `86 expect() calls`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed

