### PR TITLE
fix(ts-sdk): forward metadata in batchUpdate requests

### DIFF
--- a/mem0-ts/src/client/mem0.ts
+++ b/mem0-ts/src/client/mem0.ts
@@ -542,6 +542,7 @@ export default class MemoryClient {
     const memoriesBody = memories.map((memory) => ({
       memory_id: memory.memoryId,
       text: memory.text,
+      ...(memory.metadata !== undefined ? { metadata: memory.metadata } : {}),
     }));
     const response = await this._fetchWithErrorHandling(
       `${this.host}/v1/batch/`,

--- a/mem0-ts/src/client/mem0.types.ts
+++ b/mem0-ts/src/client/mem0.types.ts
@@ -144,6 +144,7 @@ export interface MemoryHistory {
 export interface MemoryUpdateBody {
   memoryId: string;
   text: string;
+  metadata?: Record<string, any>;
 }
 
 export interface User {

--- a/mem0-ts/src/client/tests/memoryClient.batch.test.ts
+++ b/mem0-ts/src/client/tests/memoryClient.batch.test.ts
@@ -46,6 +46,33 @@ describe("MemoryClient - batchUpdate()", () => {
     ]);
   });
 
+  test("forwards metadata and preserves metadata-free item shapes", async () => {
+    const extra = new Map<string, { status: number; body: unknown }>();
+    extra.set("/v1/batch/", { status: 200, body: { message: "OK" } });
+    const mock = setupMockFetch(extra);
+
+    const client = new MemoryClient({ apiKey: TEST_API_KEY });
+    await client.batchUpdate([
+      {
+        memoryId: "mem_1",
+        text: "updated 1",
+        metadata: { SourceId: "A_1", nested: { Camel: 1 } },
+      },
+      { memoryId: "mem_2", text: "updated 2", metadata: undefined },
+    ]);
+
+    const call = findFetchCall(mock, "/v1/batch/", "PUT");
+    expect(getFetchBody(call!).memories).toEqual([
+      {
+        memory_id: "mem_1",
+        text: "updated 1",
+        metadata: { SourceId: "A_1", nested: { Camel: 1 } },
+      },
+      { memory_id: "mem_2", text: "updated 2" },
+    ]);
+    expect(getFetchBody(call!).memories[1]).not.toHaveProperty("metadata");
+  });
+
   test("handles empty array without crashing", async () => {
     const extra = new Map<string, { status: number; body: unknown }>();
     extra.set("/v1/batch/", { status: 200, body: { message: "OK" } });


### PR DESCRIPTION
## Linked Issue

Closes #6392

## Description

`MemoryClient.batchUpdate()` in the TypeScript SDK drops per-item `metadata` before the request reaches `PUT /v1/batch/`, so bulk updates cannot change memory metadata from the TS client. This change adds optional metadata to the batch-update item type and forwards it in each request item when present, while leaving items that omit metadata on the current payload shape.

## Root cause

The batch-update mapper rebuilds each item with only `memory_id` and `text`, and `MemoryUpdateBody` omits the optional metadata field entirely. Single-memory `update()` and the Python batch clients already support per-item metadata against the same endpoint, so the gap is specific to the TypeScript batch client surface.

## Scope

Items without metadata still serialize to exactly `{ memory_id, text }`. This change does not redesign the wider batch API, make `text` optional, alter `batchDelete`, touch Python code or endpoints, add dependencies, or change versions or docs.

## Attribution

The issue report from [@VectorPeak](https://github.com/VectorPeak) in [#6392](https://github.com/mem0ai/mem0/issues/6392) pinned the failing request shape and the expected metadata-preserving payload that this regression now targets.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed

Verification:
- [x] `cd mem0-ts && pnpm exec jest --runTestsByPath src/client/tests/memoryClient.batch.test.ts`
- [x] `cd mem0-ts && pnpm exec prettier --check src/client/mem0.ts src/client/mem0.types.ts src/client/tests/memoryClient.batch.test.ts`
- [ ] `cd mem0-ts && pnpm install --frozen-lockfile && pnpm run build && pnpm run test:unit`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [ ] New and existing tests pass locally
- [ ] I have updated documentation if needed
