### PR TITLE
fix(ts-sdk): preserve metadata in batch updates

### DIFF
--- a/mem0-ts/src/client/mem0.ts
+++ b/mem0-ts/src/client/mem0.ts
@@ -542,6 +542,7 @@ export default class MemoryClient {
     const memoriesBody = memories.map((memory) => ({
       memory_id: memory.memoryId,
       text: memory.text,
+      ...(memory.metadata !== undefined && { metadata: memory.metadata }),
     }));
     const response = await this._fetchWithErrorHandling(
       `${this.host}/v1/batch/`,

--- a/mem0-ts/src/client/mem0.types.ts
+++ b/mem0-ts/src/client/mem0.types.ts
@@ -144,6 +144,7 @@ export interface MemoryHistory {
 export interface MemoryUpdateBody {
   memoryId: string;
   text: string;
+  metadata?: Record<string, any>;
 }
 
 export interface User {

--- a/mem0-ts/src/client/tests/memoryClient.batch.test.ts
+++ b/mem0-ts/src/client/tests/memoryClient.batch.test.ts
@@ -46,6 +46,33 @@ describe("MemoryClient - batchUpdate()", () => {
     ]);
   });
 
+  test("preserves metadata in request body", async () => {
+    const extra = new Map<string, { status: number; body: unknown }>();
+    extra.set("/v1/batch/", { status: 200, body: { message: "OK" } });
+    const mock = setupMockFetch(extra);
+
+    const client = new MemoryClient({ apiKey: TEST_API_KEY });
+    await client.batchUpdate([
+      {
+        memoryId: "mem_1",
+        text: "updated 1",
+        metadata: { category: "profile", source: "batch-import" },
+      },
+      { memoryId: "mem_2", text: "updated 2" },
+    ]);
+
+    const call = findFetchCall(mock, "/v1/batch/", "PUT");
+    const body = getFetchBody(call!);
+    expect(body.memories).toEqual([
+      {
+        memory_id: "mem_1",
+        text: "updated 1",
+        metadata: { category: "profile", source: "batch-import" },
+      },
+      { memory_id: "mem_2", text: "updated 2" },
+    ]);
+  });
+
   test("handles empty array without crashing", async () => {
     const extra = new Map<string, { status: number; body: unknown }>();
     extra.set("/v1/batch/", { status: 200, body: { message: "OK" } });


### PR DESCRIPTION
## Linked Issue

Closes #6392

## Description

`MemoryClient.batchUpdate()` accepted update items but only serialized `memoryId` and `text` into the `PUT /v1/batch/` request body. That meant callers could pass `metadata` in TypeScript, but the SDK dropped it before the request was sent.

This PR aligns the TypeScript SDK with the documented batch update item contract by preserving `metadata` when it is explicitly provided, while keeping existing text-only batch update payloads unchanged.

### What Problem This Solves

Before this change, this input:

```ts
await client.batchUpdate([
  {
    memoryId: "mem_1",
    text: "updated 1",
    metadata: { category: "profile", source: "batch-import" },
  },
]);
```

serialized to:

```json
{"memories":[{"memory_id":"mem_1","text":"updated 1"}]}
```

The `metadata` field was silently lost even though the OpenAPI schema documents it as a supported batch update item field.

### Change

- Adds `metadata?: Record<string, any>` to `MemoryUpdateBody`.
- Includes `metadata` in each batch update item only when it is not `undefined`.
- Adds a unit test that covers a mixed batch with one metadata update and one text-only update, proving the SDK preserves metadata without adding `metadata: undefined` to other items.

### Possible call chain / impact

```text
TypeScript caller
  -> MemoryClient.batchUpdate([{ memoryId, text, metadata }])
  -> memories.map(...)
  -> PUT /v1/batch/ body
```

The change is scoped to TypeScript SDK batch update serialization. It does not change single-memory update behavior, batch delete behavior, or backend API behavior.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Validation run from `mem0-ts`:

- `pnpm exec prettier --check src/client/mem0.ts src/client/mem0.types.ts src/client/tests/memoryClient.batch.test.ts`
- `pnpm exec jest src/client/tests/memoryClient.batch.test.ts --runInBand`
- `pnpm exec jest src/client/tests --runInBand`
- `pnpm exec tsup`
- `node -e "const m = require('./dist/index.js'); console.log('Client exports:', Object.keys(m).length)"`
- `node -e "const m = require('./dist/oss/index.js'); console.log('OSS exports:', Object.keys(m).length)"`

Notes:

- `git diff --check` passes with only Windows line-ending warnings.
- I did not use repo-wide `pnpm run build` as final validation because it fails before bundle compilation on this Windows checkout at the repository-wide Prettier check with existing unrelated formatting/line-ending findings. The changed files pass targeted Prettier, and `pnpm exec tsup` passes.
- `pnpm run test:unit` is not used as final validation here because local OSS SQLite tests fail with `better-sqlite3.node is not a valid Win32 application`, unrelated to this TypeScript hosted client serialization change.

Remote CI after opening the PR:

- GitHub Actions CI Gate passed.
- TypeScript SDK build passed on Node 20 and Node 22.
- TypeScript SDK integration tests passed on Node 20 and Node 22.
- CLA passed.
- Vercel reports `Authorization required to deploy`; this is an external deployment authorization status, not a failing TypeScript SDK check.
## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed

