### PR TITLE
fix(qdrant): actually clear points on reset() for local Qdrant

### DIFF
--- a/mem0/vector_stores/qdrant.py
+++ b/mem0/vector_stores/qdrant.py
@@ -594,15 +594,13 @@ class Qdrant(VectorStoreBase):
     def reset(self):
         """Reset the index by deleting and recreating it."""
         logger.warning(f"Resetting index {self.collection_name}...")
+        self.delete_col()
+        self.create_col(self.embedding_model_dims, self.on_disk)
         if self.is_local:
-            # Local (path-based) Qdrant keeps a collection's storage.sqlite on
-            # disk after delete_collection(). Recreating a collection with the
-            # same name re-adopts that file, so drop/recreate leaves every point
-            # intact. Delete the points explicitly instead.
+            # Local delete_collection() rmtree's with ignore_errors=True and leaves its
+            # sqlite handle open, so where an open file blocks unlink (Windows, NFS) the
+            # recreated collection re-adopts the old storage.sqlite. Drop what survived.
             self.client.delete(
                 collection_name=self.collection_name,
                 points_selector=models.FilterSelector(filter=models.Filter(must=[])),
             )
-            return
-        self.delete_col()
-        self.create_col(self.embedding_model_dims, self.on_disk)

--- a/mem0/vector_stores/qdrant.py
+++ b/mem0/vector_stores/qdrant.py
@@ -594,5 +594,15 @@ class Qdrant(VectorStoreBase):
     def reset(self):
         """Reset the index by deleting and recreating it."""
         logger.warning(f"Resetting index {self.collection_name}...")
+        if self.is_local:
+            # Local (path-based) Qdrant keeps a collection's storage.sqlite on
+            # disk after delete_collection(). Recreating a collection with the
+            # same name re-adopts that file, so drop/recreate leaves every point
+            # intact. Delete the points explicitly instead.
+            self.client.delete(
+                collection_name=self.collection_name,
+                points_selector=models.FilterSelector(filter=models.Filter(must=[])),
+            )
+            return
         self.delete_col()
         self.create_col(self.embedding_model_dims, self.on_disk)

--- a/tests/vector_stores/test_qdrant.py
+++ b/tests/vector_stores/test_qdrant.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import tempfile
 import unittest
 import uuid
@@ -53,6 +54,36 @@ class TestQdrant(unittest.TestCase):
                     on_disk=False,
                 )
             self.assertTrue(os.path.isfile(sentinel))
+
+    def test_reset_clears_points_on_local_qdrant(self):
+        """reset() must actually drop the data on a local (path-based) Qdrant.
+
+        Local Qdrant keeps a collection's storage.sqlite on disk after
+        delete_collection(); recreating the same collection name re-adopts that
+        file, so a drop/recreate reset leaves every point in place. This uses a
+        real local client rather than a mock because the bug only reproduces
+        against the on-disk storage.
+        """
+        tmp = tempfile.mkdtemp()
+        store = Qdrant(collection_name="reset_me", embedding_model_dims=4, path=os.path.join(tmp, "qdrant"))
+        try:
+            self.assertTrue(store.is_local)
+
+            store.insert(
+                vectors=[[0.1, 0.2, 0.3, 0.4]],
+                payloads=[{"data": "remember me"}],
+                ids=[str(uuid.uuid4())],
+            )
+            self.assertEqual(len(store.list(top_k=10)[0]), 1)
+
+            store.reset()
+
+            self.assertEqual(len(store.list(top_k=10)[0]), 0)
+        finally:
+            # Local Qdrant holds the storage file open; release it before cleanup
+            # so the temp dir can be removed on Windows.
+            store.client.close()
+            shutil.rmtree(tmp, ignore_errors=True)
 
     def test_create_col(self):
         self.client_mock.get_collections.return_value = MagicMock(collections=[])

--- a/tests/vector_stores/test_qdrant.py
+++ b/tests/vector_stores/test_qdrant.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import tempfile
 import unittest
 import uuid
@@ -56,34 +55,28 @@ class TestQdrant(unittest.TestCase):
             self.assertTrue(os.path.isfile(sentinel))
 
     def test_reset_clears_points_on_local_qdrant(self):
-        """reset() must actually drop the data on a local (path-based) Qdrant.
+        """#6411: reset() must drop points even when the collection dir survives delete_col()."""
+        with tempfile.TemporaryDirectory() as tmp:
+            store = Qdrant(collection_name="reset_me", embedding_model_dims=4, path=os.path.join(tmp, "qdrant"))
+            try:
+                self.assertTrue(store.is_local)
+                store.insert(
+                    vectors=[[0.1, 0.2, 0.3, 0.4]],
+                    payloads=[{"data": "remember me"}],
+                    ids=[str(uuid.uuid4())],
+                )
+                self.assertEqual(len(store.list(top_k=10)[0]), 1)
 
-        Local Qdrant keeps a collection's storage.sqlite on disk after
-        delete_collection(); recreating the same collection name re-adopts that
-        file, so a drop/recreate reset leaves every point in place. This uses a
-        real local client rather than a mock because the bug only reproduces
-        against the on-disk storage.
-        """
-        tmp = tempfile.mkdtemp()
-        store = Qdrant(collection_name="reset_me", embedding_model_dims=4, path=os.path.join(tmp, "qdrant"))
-        try:
-            self.assertTrue(store.is_local)
+                # Simulate Windows/NFS, where rmtree(ignore_errors=True) silently fails
+                # on the open sqlite handle and the collection dir survives delete_col().
+                with patch("qdrant_client.local.qdrant_local.shutil.rmtree"):
+                    store.reset()
 
-            store.insert(
-                vectors=[[0.1, 0.2, 0.3, 0.4]],
-                payloads=[{"data": "remember me"}],
-                ids=[str(uuid.uuid4())],
-            )
-            self.assertEqual(len(store.list(top_k=10)[0]), 1)
-
-            store.reset()
-
-            self.assertEqual(len(store.list(top_k=10)[0]), 0)
-        finally:
-            # Local Qdrant holds the storage file open; release it before cleanup
-            # so the temp dir can be removed on Windows.
-            store.client.close()
-            shutil.rmtree(tmp, ignore_errors=True)
+                self.assertEqual(len(store.list(top_k=10)[0]), 0)
+                sparse = store.client.get_collection("reset_me").config.params.sparse_vectors
+                self.assertIn("bm25", sparse or {})
+            finally:
+                store.client.close()
 
     def test_create_col(self):
         self.client_mock.get_collections.return_value = MagicMock(collections=[])


### PR DESCRIPTION
Closes #6411

## Problem

`Memory.reset()` reports success but keeps every memory when the vector store is a local (path-based) Qdrant — mem0's default OSS configuration.

> **Correction (added post-merge, per [@kartik-mem0's review](https://github.com/mem0ai/mem0/pull/6412#issuecomment-5031282810)):** this is platform-conditional, not universal. `QdrantLocal.delete_collection()` relies on refcounting to release the sqlite handle and swallows failures with `ignore_errors=True`; on POSIX filesystems (Linux, macOS) an unlink on an open file still succeeds, so drop/recreate correctly clears the data there. The no-op only reproduces where an open handle blocks unlink: **Windows, NFS, or a Docker bind mount from a Windows host.**

Local Qdrant leaves a collection's `storage.sqlite` on disk after `delete_collection()` on those affected filesystems, and recreating a collection with the same name re-adopts that file. `Qdrant.reset()` was exactly that drop-and-recreate pair, so it never actually dropped the data there.

`Memory.reset()` *does* clear the history DB, so the surviving memories were left with zero history rows — the vector store and the history DB ended up disagreeing after a reset that looked like it worked.

## Fix

Delete the points explicitly when running against a local client. Remote mode keeps drop/recreate, which is correct there and is what the existing mocked tests cover.

```python
if self.is_local:
    self.client.delete(
        collection_name=self.collection_name,
        points_selector=models.FilterSelector(filter=models.Filter(must=[])),
    )
    return
```

> **Note:** the version above was the initial proposal. The merged version differs — see [@kartik-mem0's review comment](https://github.com/mem0ai/mem0/pull/6412#issuecomment-5031282810) for the final approach (drop/recreate first to preserve the v3 hybrid-search `bm25` schema slot, then a no-op-safe sweep) and the deterministic mock-based regression test that replaced the original filesystem-dependent one.

## Test

`test_reset_clears_points_on_local_qdrant` drives a real local `Qdrant` against a temp directory rather than a mock, because the bug only reproduces against the on-disk storage — the existing suite passes a `MagicMock` client, so `is_local` is `False` there and this path was never exercised.

The test closes the client in a `finally` before removing the temp dir, since local Qdrant holds the storage file open and Windows will not delete it otherwise.

Verified it fails without the fix and passes with it:

```
# without the source change
>           self.assertEqual(len(store.list(top_k=10)[0]), 0)
E           AssertionError: 1 != 0

# with the source change
96 passed in 1.40s
```

Wider suite is unchanged: `442 passed, 48 errors` both before and after, where the 48 collection errors are pre-existing and come from optional vector-store dependencies not being installed in my environment.

`ruff check` passes on both touched files. I deliberately did not run `ruff format` — both files already fail `ruff format --check` on a clean `main`, so formatting them would have buried this change in unrelated diff noise.

## Notes

Verified against `qdrant-client` 1.18.0 on Python 3.12.13.

Previous `reset()` fixes covered other backends and other code paths, so this does not overlap them: #5584 (mongodb), #5585 (weaviate), #6279 (pinecone namespace), #5915 (AsyncMemory).