### PR TITLE
fix(memory): prevent silent data loss on pgvector embedding dim mismatch (salvage of #4990)

### DIFF
--- a/docs/components/vectordbs/dbs/pgvector.mdx
+++ b/docs/components/vectordbs/dbs/pgvector.mdx
@@ -91,6 +91,11 @@ Here are the parameters available for configuring pgvector:
 
 **Python:** The Python SDK uses snake_case keys such as `connection_string`, `sslmode`, `collection_name`, and `embedding_model_dims`.
 
+<Warning>
+**Breaking (Python):** `embedding_model_dims` default changed from `1536` to `None`. When unset, Mem0 infers dimensions from the **resolved** embedder after factory construction. Set `embedding_model_dims` explicitly if you need a fixed table width, and recreate or rename the collection when switching embedder widths.
+</Warning>
+
+
 **Python connection priority**:
 
 1. `connection_pool` (highest priority)

--- a/mem0/configs/vector_stores/pgvector.py
+++ b/mem0/configs/vector_stores/pgvector.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 class PGVectorConfig(BaseModel):
     dbname: str = Field("postgres", description="Default name for the database")
     collection_name: str = Field("mem0", description="Default name for the collection")
-    embedding_model_dims: Optional[int] = Field(1536, description="Dimensions of the embedding model")
+    embedding_model_dims: Optional[int] = Field(None, description="Dimensions of the embedding model. When None, inferred from the configured embedder at Memory init time.")
     user: Optional[str] = Field(None, description="Database user")
     password: Optional[str] = Field(None, description="Database password")
     host: Optional[str] = Field(None, description="Database host. Default is localhost")

--- a/mem0/configs/vector_stores/pgvector.py
+++ b/mem0/configs/vector_stores/pgvector.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 class PGVectorConfig(BaseModel):
     dbname: str = Field("postgres", description="Default name for the database")
     collection_name: str = Field("mem0", description="Default name for the collection")
-    embedding_model_dims: Optional[int] = Field(None, description="Dimensions of the embedding model. When None, inferred from the configured embedder at Memory init time.")
+    embedding_model_dims: Optional[int] = Field(None, description="Dimensions of the embedding model. BREAKING: default changed from 1536 to None; when unset, inferred from the resolved embedder at Memory init. Set explicitly if you rely on a fixed width.")
     user: Optional[str] = Field(None, description="Database user")
     password: Optional[str] = Field(None, description="Database password")
     host: Optional[str] = Field(None, description="Database host. Default is localhost")

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -82,6 +82,61 @@ warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*swigva
 logger = logging.getLogger(__name__)
 
 
+def _embedder_embedding_dims(embedder_config) -> Optional[int]:
+    """Best-effort read of embedding_dims from an EmbedderConfig, BaseEmbedderConfig, or dict."""
+    if embedder_config is None:
+        return None
+    if isinstance(embedder_config, dict):
+        dims = embedder_config.get("embedding_dims")
+        return int(dims) if dims is not None else None
+    dims = getattr(embedder_config, "embedding_dims", None)
+    return int(dims) if dims is not None else None
+
+
+def _sync_pgvector_dims(config: "MemoryConfig") -> None:
+    """Align pgvector's embedding_model_dims with the configured embedder.
+
+    Rules (applied when provider == "pgvector"):
+    - If embedding_model_dims is None → infer it from the embedder's embedding_dims.
+    - If embedding_model_dims is explicitly set and differs from the embedder's
+      embedding_dims → raise ValueError so the mismatch is caught at construction
+      time rather than silently at write time.
+    - If embedding_dims cannot be determined from the embedder, do nothing (pgvector
+      itself will raise a clear error when it tries to create/use the table).
+    """
+    if getattr(config.vector_store, "provider", None) != "pgvector":
+        return
+
+    embed_dims = _embedder_embedding_dims(config.embedder.config)
+    if embed_dims is None:
+        return
+
+    vs_config = config.vector_store.config
+    configured_dims = getattr(vs_config, "embedding_model_dims", None)
+    if isinstance(vs_config, dict):
+        configured_dims = vs_config.get("embedding_model_dims")
+
+    if configured_dims is None:
+        if hasattr(vs_config, "embedding_model_dims"):
+            vs_config.embedding_model_dims = embed_dims
+        elif isinstance(vs_config, dict):
+            vs_config["embedding_model_dims"] = embed_dims
+    elif int(configured_dims) != int(embed_dims):
+        collection = getattr(vs_config, "collection_name", None)
+        if isinstance(vs_config, dict):
+            collection = vs_config.get("collection_name")
+        raise ValueError(
+            f"Embedding dimension mismatch: the configured embedder "
+            f"({config.embedder.provider}) produces {embed_dims}-dimensional vectors, "
+            f"but pgvector collection '{collection}' is configured with "
+            f"embedding_model_dims={configured_dims}. "
+            f"Either remove the explicit embedding_model_dims setting to auto-infer from "
+            f"the embedder, or set it to {embed_dims} to match the current embedder."
+        )
+
+
+
+
 def _vector_store_list_rows(listed):
     if isinstance(listed, (list, tuple)) and listed and isinstance(listed[0], list):
         return listed[0]
@@ -488,6 +543,10 @@ class Memory(MemoryBase):
             self.config.embedder.config,
             self.config.vector_store.config,
         )
+
+        if self.config.vector_store.provider == "pgvector":
+            _sync_pgvector_dims(self.config)
+
         self.vector_store = VectorStoreFactory.create(
             self.config.vector_store.provider, self.config.vector_store.config
         )
@@ -1044,12 +1103,21 @@ class Memory(MemoryBase):
                 payloads=all_payloads,
             )
         except Exception:
-            # Fallback: insert one by one
+            # Batch failed — retry individually so partial failures are surfaced
+            failures = []
             for mid, vec, pay in zip(all_ids, all_vectors, all_payloads):
                 try:
                     self.vector_store.insert(vectors=[vec], ids=[mid], payloads=[pay])
                 except Exception as e:
                     logger.error(f"Failed to insert memory {mid}: {e}")
+                    failures.append((mid, e))
+            if failures:
+                first_id, first_err = failures[0]
+                raise RuntimeError(
+                    f"{len(failures)} of {len(all_ids)} memor{'y' if len(failures) == 1 else 'ies'} "
+                    f"failed to persist to the vector store. "
+                    f"First failure (memory_id={first_id}): {first_err}"
+                ) from first_err
 
         # Batch history
         history_records = [
@@ -2162,6 +2230,10 @@ class AsyncMemory(MemoryBase):
             self.config.embedder.config,
             self.config.vector_store.config,
         )
+
+        if self.config.vector_store.provider == "pgvector":
+            _sync_pgvector_dims(self.config)
+
         self.vector_store = VectorStoreFactory.create(
             self.config.vector_store.provider, self.config.vector_store.config
         )
@@ -2691,11 +2763,21 @@ class AsyncMemory(MemoryBase):
                 payloads=all_payloads,
             )
         except Exception:
+            # Batch failed — retry individually so partial failures are surfaced
+            failures = []
             for mid, vec, pay in zip(all_ids, all_vectors, all_payloads):
                 try:
                     await asyncio.to_thread(self.vector_store.insert, vectors=[vec], ids=[mid], payloads=[pay])
                 except Exception as e:
                     logger.error(f"Failed to insert memory {mid} (async): {e}")
+                    failures.append((mid, e))
+            if failures:
+                first_id, first_err = failures[0]
+                raise RuntimeError(
+                    f"{len(failures)} of {len(all_ids)} memor{'y' if len(failures) == 1 else 'ies'} "
+                    f"failed to persist to the vector store. "
+                    f"First failure (memory_id={first_id}): {first_err}"
+                ) from first_err
 
         # Batch history
         history_records = [

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -109,9 +109,8 @@ def _sync_pgvector_dims(config: "MemoryConfig", embedder=None) -> None:
     Rules (applied when provider == "pgvector"):
     - If embedding_model_dims is None → infer it from the resolved embedder's
       embedding_dims (post EmbedderFactory.create defaults).
-    - If embedding_model_dims is explicitly set and differs from the embedder's
-      embedding_dims → raise ValueError so the mismatch is caught at construction
-      time rather than silently at write time.
+    - If embedding_model_dims is explicitly set, keep it (declared embedder dims
+      are advisory for some providers). Live enforcement is schema validation.
     - If embedding_dims cannot be determined from the embedder, do nothing (pgvector
       itself will raise a clear error when it tries to create/use the table).
     """
@@ -134,17 +133,22 @@ def _sync_pgvector_dims(config: "MemoryConfig", embedder=None) -> None:
         elif isinstance(vs_config, dict):
             vs_config["embedding_model_dims"] = embed_dims
     elif int(configured_dims) != int(embed_dims):
+        # Declared embedder dims are advisory for several providers
+        # (azure_openai/ollama/lmstudio). Do not hard-fail — keep the explicit
+        # config (documented workaround) and let schema validation enforce
+        # live table width.
         collection = getattr(vs_config, "collection_name", None)
         if isinstance(vs_config, dict):
             collection = vs_config.get("collection_name")
         provider = getattr(config.embedder, "provider", None)
-        raise ValueError(
-            f"Embedding dimension mismatch: the configured embedder "
-            f"({provider}) produces {embed_dims}-dimensional vectors, "
-            f"but pgvector collection '{collection}' is configured with "
-            f"embedding_model_dims={configured_dims}. "
-            f"Either remove the explicit embedding_model_dims setting to auto-infer from "
-            f"the embedder, or set it to {embed_dims} to match the current embedder."
+        logger.warning(
+            "pgvector embedding_model_dims=%s differs from embedder (%s) "
+            "declared embedding_dims=%s for collection '%s'. Keeping the explicit "
+            "config value; schema validation will enforce the live table width.",
+            configured_dims,
+            provider,
+            embed_dims,
+            collection,
         )
 
 
@@ -1263,6 +1267,10 @@ class Memory(MemoryBase):
         except Exception as e:
             logger.warning(f"Batch entity linking failed: {e}")
 
+        # Persist message history before raising on partial insert failure so
+        # last_messages context is not silently dropped for this turn.
+        self.db.save_messages(messages, session_scope)
+
         if _partial_insert_failures:
             first_id, first_err = _partial_insert_failures[0]
             raise VectorStoreError(
@@ -1282,8 +1290,6 @@ class Memory(MemoryBase):
                 suggestion="Check vector store dimensions/schema and retry failed memories",
             ) from first_err
 
-        # Phase 8: Save messages + return
-        self.db.save_messages(messages, session_scope)
 
         returned_memories = [
             {"id": r[0], "memory": r[1], "event": "ADD"}
@@ -2944,6 +2950,10 @@ class AsyncMemory(MemoryBase):
         except Exception as e:
             logger.warning(f"Batch entity linking failed (async): {e}")
 
+        # Persist message history before raising on partial insert failure so
+        # last_messages context is not silently dropped for this turn.
+        await asyncio.to_thread(self.db.save_messages, messages, session_scope)
+
         if _partial_insert_failures:
             first_id, first_err = _partial_insert_failures[0]
             raise VectorStoreError(
@@ -2963,8 +2973,6 @@ class AsyncMemory(MemoryBase):
                 suggestion="Check vector store dimensions/schema and retry failed memories",
             ) from first_err
 
-        # Phase 8: Save messages + return
-        await asyncio.to_thread(self.db.save_messages, messages, session_scope)
 
         returned_memories = [
             {"id": r[0], "memory": r[1], "event": "ADD"}

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -22,7 +22,7 @@ from mem0.configs.prompts import (
     PROCEDURAL_MEMORY_SYSTEM_PROMPT,
     generate_additive_extraction_prompt,
 )
-from mem0.exceptions import LLMError
+from mem0.exceptions import LLMError, VectorStoreError
 from mem0.exceptions import ValidationError as Mem0ValidationError
 from mem0.memory.base import MemoryBase
 from mem0.memory.notices import (
@@ -82,22 +82,33 @@ warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*swigva
 logger = logging.getLogger(__name__)
 
 
-def _embedder_embedding_dims(embedder_config) -> Optional[int]:
-    """Best-effort read of embedding_dims from an EmbedderConfig, BaseEmbedderConfig, or dict."""
-    if embedder_config is None:
+def _embedder_embedding_dims(embedder) -> Optional[int]:
+    """Best-effort read of embedding_dims from a resolved embedder or its config."""
+    if embedder is None:
         return None
-    if isinstance(embedder_config, dict):
-        dims = embedder_config.get("embedding_dims")
+    # Prefer the resolved embedder instance (EmbedderFactory output).
+    cfg = getattr(embedder, "config", None)
+    if cfg is not None:
+        if isinstance(cfg, dict):
+            dims = cfg.get("embedding_dims")
+        else:
+            dims = getattr(cfg, "embedding_dims", None)
+        if dims is not None:
+            return int(dims)
+    # Fallback: raw config / dict passed directly.
+    if isinstance(embedder, dict):
+        dims = embedder.get("embedding_dims")
         return int(dims) if dims is not None else None
-    dims = getattr(embedder_config, "embedding_dims", None)
+    dims = getattr(embedder, "embedding_dims", None)
     return int(dims) if dims is not None else None
 
 
-def _sync_pgvector_dims(config: "MemoryConfig") -> None:
-    """Align pgvector's embedding_model_dims with the configured embedder.
+def _sync_pgvector_dims(config: "MemoryConfig", embedder=None) -> None:
+    """Align pgvector's embedding_model_dims with the resolved embedder.
 
     Rules (applied when provider == "pgvector"):
-    - If embedding_model_dims is None → infer it from the embedder's embedding_dims.
+    - If embedding_model_dims is None → infer it from the resolved embedder's
+      embedding_dims (post EmbedderFactory.create defaults).
     - If embedding_model_dims is explicitly set and differs from the embedder's
       embedding_dims → raise ValueError so the mismatch is caught at construction
       time rather than silently at write time.
@@ -107,7 +118,8 @@ def _sync_pgvector_dims(config: "MemoryConfig") -> None:
     if getattr(config.vector_store, "provider", None) != "pgvector":
         return
 
-    embed_dims = _embedder_embedding_dims(config.embedder.config)
+    source = embedder if embedder is not None else getattr(config.embedder, "config", None)
+    embed_dims = _embedder_embedding_dims(source)
     if embed_dims is None:
         return
 
@@ -125,9 +137,10 @@ def _sync_pgvector_dims(config: "MemoryConfig") -> None:
         collection = getattr(vs_config, "collection_name", None)
         if isinstance(vs_config, dict):
             collection = vs_config.get("collection_name")
+        provider = getattr(config.embedder, "provider", None)
         raise ValueError(
             f"Embedding dimension mismatch: the configured embedder "
-            f"({config.embedder.provider}) produces {embed_dims}-dimensional vectors, "
+            f"({provider}) produces {embed_dims}-dimensional vectors, "
             f"but pgvector collection '{collection}' is configured with "
             f"embedding_model_dims={configured_dims}. "
             f"Either remove the explicit embedding_model_dims setting to auto-infer from "
@@ -545,7 +558,7 @@ class Memory(MemoryBase):
         )
 
         if self.config.vector_store.provider == "pgvector":
-            _sync_pgvector_dims(self.config)
+            _sync_pgvector_dims(self.config, self.embedding_model)
 
         self.vector_store = VectorStoreFactory.create(
             self.config.vector_store.provider, self.config.vector_store.config
@@ -1112,12 +1125,14 @@ class Memory(MemoryBase):
                     logger.error(f"Failed to insert memory {mid}: {e}")
                     failures.append((mid, e))
             if failures:
-                first_id, first_err = failures[0]
-                raise RuntimeError(
-                    f"{len(failures)} of {len(all_ids)} memor{'y' if len(failures) == 1 else 'ies'} "
-                    f"failed to persist to the vector store. "
-                    f"First failure (memory_id={first_id}): {first_err}"
-                ) from first_err
+                failed_ids = {mid for mid, _ in failures}
+                records = [r for r in records if r[0] not in failed_ids]
+                # Defer raise until after history/entity linking for the successful subset.
+                _partial_insert_failures = failures
+            else:
+                _partial_insert_failures = None
+        else:
+            _partial_insert_failures = None
 
         # Batch history
         history_records = [
@@ -1131,15 +1146,16 @@ class Memory(MemoryBase):
             }
             for r in records
         ]
-        try:
-            self.db.batch_add_history(history_records)
-        except Exception:
-            # Fallback: add one by one
-            for hr in history_records:
-                try:
-                    self.db.add_history(hr["memory_id"], None, hr["new_memory"], "ADD", created_at=hr.get("created_at"))
-                except Exception as e:
-                    logger.error(f"Failed to add history for {hr['memory_id']}: {e}")
+        if history_records:
+            try:
+                self.db.batch_add_history(history_records)
+            except Exception:
+                # Fallback: add one by one
+                for hr in history_records:
+                    try:
+                        self.db.add_history(hr["memory_id"], None, hr["new_memory"], "ADD", created_at=hr.get("created_at"))
+                    except Exception as e:
+                        logger.error(f"Failed to add history for {hr['memory_id']}: {e}")
 
         # Phase 7: Batch entity linking
         try:
@@ -1246,6 +1262,25 @@ class Memory(MemoryBase):
                             logger.warning(f"Batch entity insert failed: {e}")
         except Exception as e:
             logger.warning(f"Batch entity linking failed: {e}")
+
+        if _partial_insert_failures:
+            first_id, first_err = _partial_insert_failures[0]
+            raise VectorStoreError(
+                message=(
+                    f"{len(_partial_insert_failures)} of {len(all_ids)} "
+                    f"memor{'y' if len(_partial_insert_failures) == 1 else 'ies'} "
+                    f"failed to persist to the vector store. "
+                    f"First failure (memory_id={first_id}): {first_err}"
+                ),
+                error_code="VECTOR_001",
+                details={
+                    "operation": "insert",
+                    "failed_count": len(_partial_insert_failures),
+                    "total_count": len(all_ids),
+                    "first_memory_id": first_id,
+                },
+                suggestion="Check vector store dimensions/schema and retry failed memories",
+            ) from first_err
 
         # Phase 8: Save messages + return
         self.db.save_messages(messages, session_scope)
@@ -2232,7 +2267,7 @@ class AsyncMemory(MemoryBase):
         )
 
         if self.config.vector_store.provider == "pgvector":
-            _sync_pgvector_dims(self.config)
+            _sync_pgvector_dims(self.config, self.embedding_model)
 
         self.vector_store = VectorStoreFactory.create(
             self.config.vector_store.provider, self.config.vector_store.config
@@ -2772,12 +2807,13 @@ class AsyncMemory(MemoryBase):
                     logger.error(f"Failed to insert memory {mid} (async): {e}")
                     failures.append((mid, e))
             if failures:
-                first_id, first_err = failures[0]
-                raise RuntimeError(
-                    f"{len(failures)} of {len(all_ids)} memor{'y' if len(failures) == 1 else 'ies'} "
-                    f"failed to persist to the vector store. "
-                    f"First failure (memory_id={first_id}): {first_err}"
-                ) from first_err
+                failed_ids = {mid for mid, _ in failures}
+                records = [r for r in records if r[0] not in failed_ids]
+                _partial_insert_failures = failures
+            else:
+                _partial_insert_failures = None
+        else:
+            _partial_insert_failures = None
 
         # Batch history
         history_records = [
@@ -2791,17 +2827,18 @@ class AsyncMemory(MemoryBase):
             }
             for r in records
         ]
-        try:
-            await asyncio.to_thread(self.db.batch_add_history, history_records)
-        except Exception:
-            for hr in history_records:
-                try:
-                    await asyncio.to_thread(
-                        self.db.add_history, hr["memory_id"], None, hr["new_memory"], "ADD",
-                        created_at=hr.get("created_at")
-                    )
-                except Exception as e:
-                    logger.error(f"Failed to add history for {hr['memory_id']} (async): {e}")
+        if history_records:
+            try:
+                await asyncio.to_thread(self.db.batch_add_history, history_records)
+            except Exception:
+                for hr in history_records:
+                    try:
+                        await asyncio.to_thread(
+                            self.db.add_history, hr["memory_id"], None, hr["new_memory"], "ADD",
+                            created_at=hr.get("created_at")
+                        )
+                    except Exception as e:
+                        logger.error(f"Failed to add history for {hr['memory_id']} (async): {e}")
 
         # Phase 7: Batch entity linking
         try:
@@ -2906,6 +2943,25 @@ class AsyncMemory(MemoryBase):
                             logger.warning(f"Batch entity insert failed (async): {e}")
         except Exception as e:
             logger.warning(f"Batch entity linking failed (async): {e}")
+
+        if _partial_insert_failures:
+            first_id, first_err = _partial_insert_failures[0]
+            raise VectorStoreError(
+                message=(
+                    f"{len(_partial_insert_failures)} of {len(all_ids)} "
+                    f"memor{'y' if len(_partial_insert_failures) == 1 else 'ies'} "
+                    f"failed to persist to the vector store. "
+                    f"First failure (memory_id={first_id}): {first_err}"
+                ),
+                error_code="VECTOR_001",
+                details={
+                    "operation": "insert",
+                    "failed_count": len(_partial_insert_failures),
+                    "total_count": len(all_ids),
+                    "first_memory_id": first_id,
+                },
+                suggestion="Check vector store dimensions/schema and retry failed memories",
+            ) from first_err
 
         # Phase 8: Save messages + return
         await asyncio.to_thread(self.db.save_messages, messages, session_scope)

--- a/mem0/vector_stores/pgvector.py
+++ b/mem0/vector_stores/pgvector.py
@@ -212,10 +212,48 @@ class PGVector(VectorStoreBase):
     def _ensure_collection(self):
         if self._collection_ensured:
             return
+        if self.embedding_model_dims is None:
+            raise ValueError(
+                "PGVector requires 'embedding_model_dims' to be set. "
+                "Either pass it explicitly in the vector store config or configure an "
+                "embedder provider so that mem0 can infer the dimension automatically."
+            )
         collections = self.list_cols()
         if self.collection_name not in collections:
             self.create_col()
+        else:
+            self._validate_schema_dims()
         self._collection_ensured = True
+
+    def _get_table_vector_dim(self):
+        """Return the declared dimension of the 'vector' column for this table, or None."""
+        with self._get_cursor() as cur:
+            cur.execute(
+                """
+                SELECT a.atttypmod
+                FROM pg_attribute a
+                JOIN pg_class c ON a.attrelid = c.oid
+                WHERE c.relname = %s
+                  AND a.attname = 'vector'
+                  AND a.atttypmod > 0
+                """,
+                (self.collection_name,),
+            )
+            row = cur.fetchone()
+            return row[0] if row else None
+
+    def _validate_schema_dims(self) -> None:
+        """Raise if the existing table's vector dimension differs from the configured one."""
+        actual_dims = self._get_table_vector_dim()
+        if actual_dims is not None and actual_dims != self.embedding_model_dims:
+            raise ValueError(
+                f"Vector dimension mismatch for collection '{self.collection_name}': "
+                f"the existing table was created with {actual_dims}-dimensional vectors, "
+                f"but the current configuration expects {self.embedding_model_dims} dimensions. "
+                f"To resolve: use a different collection_name for the new embedder, drop the "
+                f"existing table and let mem0 recreate it, or reconfigure the embedder to "
+                f"produce {actual_dims}-dimensional vectors."
+            )
 
     @contextmanager
     def _get_cursor(self, commit: bool = False):

--- a/mem0/vector_stores/pgvector.py
+++ b/mem0/vector_stores/pgvector.py
@@ -233,7 +233,9 @@ class PGVector(VectorStoreBase):
                 SELECT a.atttypmod
                 FROM pg_attribute a
                 JOIN pg_class c ON a.attrelid = c.oid
+                JOIN pg_namespace n ON c.relnamespace = n.oid
                 WHERE c.relname = %s
+                  AND n.nspname = current_schema()
                   AND a.attname = 'vector'
                   AND a.atttypmod > 0
                 """,

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -1192,10 +1192,12 @@ def test_sync_pgvector_dims_infers_from_embedder():
 
     vs_config = SimpleNamespace(embedding_model_dims=None, collection_name="mem0")
     config = SimpleNamespace(
-        embedder=SimpleNamespace(provider="gemini", config=SimpleNamespace(embedding_dims=768)),
+        embedder=SimpleNamespace(provider="gemini", config=SimpleNamespace(embedding_dims=None)),
         vector_store=SimpleNamespace(provider="pgvector", config=vs_config),
     )
-    _sync_pgvector_dims(config)
+    # Resolved embedder carries defaults after EmbedderFactory.create().
+    resolved = SimpleNamespace(config=SimpleNamespace(embedding_dims=768))
+    _sync_pgvector_dims(config, resolved)
     assert vs_config.embedding_model_dims == 768
 
 
@@ -1206,11 +1208,12 @@ def test_sync_pgvector_dims_raises_on_explicit_mismatch():
 
     vs_config = SimpleNamespace(embedding_model_dims=1536, collection_name="mem0")
     config = SimpleNamespace(
-        embedder=SimpleNamespace(provider="gemini", config=SimpleNamespace(embedding_dims=768)),
+        embedder=SimpleNamespace(provider="gemini", config=SimpleNamespace(embedding_dims=None)),
         vector_store=SimpleNamespace(provider="pgvector", config=vs_config),
     )
+    resolved = SimpleNamespace(config=SimpleNamespace(embedding_dims=768))
     with pytest.raises(ValueError, match="Embedding dimension mismatch"):
-        _sync_pgvector_dims(config)
+        _sync_pgvector_dims(config, resolved)
 
 
 def test_sync_pgvector_dims_noop_for_other_providers():
@@ -1222,7 +1225,8 @@ def test_sync_pgvector_dims_noop_for_other_providers():
         embedder=SimpleNamespace(provider="openai", config=SimpleNamespace(embedding_dims=1536)),
         vector_store=SimpleNamespace(provider="qdrant", config=vs_config),
     )
-    _sync_pgvector_dims(config)
+    resolved = SimpleNamespace(config=SimpleNamespace(embedding_dims=1536))
+    _sync_pgvector_dims(config, resolved)
     assert vs_config.embedding_model_dims is None
 
 

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -1201,19 +1201,22 @@ def test_sync_pgvector_dims_infers_from_embedder():
     assert vs_config.embedding_model_dims == 768
 
 
-def test_sync_pgvector_dims_raises_on_explicit_mismatch():
+def test_sync_pgvector_dims_keeps_explicit_on_declared_mismatch(caplog):
     from mem0.memory.main import _sync_pgvector_dims
     from types import SimpleNamespace
-    import pytest
+    import logging
 
     vs_config = SimpleNamespace(embedding_model_dims=1536, collection_name="mem0")
     config = SimpleNamespace(
-        embedder=SimpleNamespace(provider="gemini", config=SimpleNamespace(embedding_dims=None)),
+        embedder=SimpleNamespace(provider="azure_openai", config=SimpleNamespace(embedding_dims=None)),
         vector_store=SimpleNamespace(provider="pgvector", config=vs_config),
     )
-    resolved = SimpleNamespace(config=SimpleNamespace(embedding_dims=768))
-    with pytest.raises(ValueError, match="Embedding dimension mismatch"):
+    # Declared dims understate real output; explicit pgvector dims must win.
+    resolved = SimpleNamespace(config=SimpleNamespace(embedding_dims=512))
+    with caplog.at_level(logging.WARNING):
         _sync_pgvector_dims(config, resolved)
+    assert vs_config.embedding_model_dims == 1536
+    assert any("embedding_model_dims" in r.message for r in caplog.records)
 
 
 def test_sync_pgvector_dims_noop_for_other_providers():

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -1178,3 +1178,86 @@ class TestAddPipelineEntityEmbeddingCountGuard:
         assert any("padding/truncating" in r.message for r in caplog.records), (
             "expected count-mismatch warning was not emitted"
         )
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for pgvector dimension sync + insert failure propagation (#4985)
+# Salvage of #4990 by @lost-particles
+# ---------------------------------------------------------------------------
+
+
+def test_sync_pgvector_dims_infers_from_embedder():
+    from mem0.memory.main import _sync_pgvector_dims
+    from types import SimpleNamespace
+
+    vs_config = SimpleNamespace(embedding_model_dims=None, collection_name="mem0")
+    config = SimpleNamespace(
+        embedder=SimpleNamespace(provider="gemini", config=SimpleNamespace(embedding_dims=768)),
+        vector_store=SimpleNamespace(provider="pgvector", config=vs_config),
+    )
+    _sync_pgvector_dims(config)
+    assert vs_config.embedding_model_dims == 768
+
+
+def test_sync_pgvector_dims_raises_on_explicit_mismatch():
+    from mem0.memory.main import _sync_pgvector_dims
+    from types import SimpleNamespace
+    import pytest
+
+    vs_config = SimpleNamespace(embedding_model_dims=1536, collection_name="mem0")
+    config = SimpleNamespace(
+        embedder=SimpleNamespace(provider="gemini", config=SimpleNamespace(embedding_dims=768)),
+        vector_store=SimpleNamespace(provider="pgvector", config=vs_config),
+    )
+    with pytest.raises(ValueError, match="Embedding dimension mismatch"):
+        _sync_pgvector_dims(config)
+
+
+def test_sync_pgvector_dims_noop_for_other_providers():
+    from mem0.memory.main import _sync_pgvector_dims
+    from types import SimpleNamespace
+
+    vs_config = SimpleNamespace(embedding_model_dims=None, collection_name="x")
+    config = SimpleNamespace(
+        embedder=SimpleNamespace(provider="openai", config=SimpleNamespace(embedding_dims=1536)),
+        vector_store=SimpleNamespace(provider="qdrant", config=vs_config),
+    )
+    _sync_pgvector_dims(config)
+    assert vs_config.embedding_model_dims is None
+
+
+def test_pgvector_validate_schema_dims_mismatch():
+    from mem0.vector_stores.pgvector import PGVector
+    from unittest.mock import MagicMock
+    import pytest
+
+    store = PGVector.__new__(PGVector)
+    store.collection_name = "memories"
+    store.embedding_model_dims = 768
+    store._get_table_vector_dim = MagicMock(return_value=1536)
+    with pytest.raises(ValueError, match="Vector dimension mismatch"):
+        store._validate_schema_dims()
+
+
+def test_pgvector_validate_schema_dims_match():
+    from mem0.vector_stores.pgvector import PGVector
+    from unittest.mock import MagicMock
+
+    store = PGVector.__new__(PGVector)
+    store.collection_name = "memories"
+    store.embedding_model_dims = 768
+    store._get_table_vector_dim = MagicMock(return_value=768)
+    store._validate_schema_dims()  # no raise
+
+
+def test_pgvector_ensure_collection_requires_dims():
+    from mem0.vector_stores.pgvector import PGVector
+    import pytest
+
+    store = PGVector.__new__(PGVector)
+    store._collection_ensured = False
+    store.embedding_model_dims = None
+    store.collection_name = "memories"
+    with pytest.raises(ValueError, match="embedding_model_dims"):
+        store._ensure_collection()
+


### PR DESCRIPTION
## Summary

Salvages #4990 by @lost-particles onto current main.

Closes #4985.

When the embedder is switched (or never matches the hard-coded 1536 default), pgvector tables and configs diverge. Writes can appear to succeed while nothing is stored. This makes dimension handling fail loud and auto-infers dims from the embedder.

## Motivation

- `PGVectorConfig.embedding_model_dims` defaulted to `1536` even for non-OpenAI embedders.
- `Memory` / `AsyncMemory` never copied embedder `embedding_dims` into the vector store config.
- Existing tables were not checked for vector dimension mismatch.
- V3 batch `insert` failures were logged only, so apps lost memory silently.

## Changes from original (#4990)

- Rebased onto current `main`.
- Schema validation lives in `_ensure_collection()` (current lazy ensure path) rather than a removed eager `__init__` list/create block.
- Shared `_sync_pgvector_dims` helper + lean unit tests.

## Fix

1. Default `embedding_model_dims` to `None`; infer from embedder config at init for `provider == "pgvector"`.
2. Raise `ValueError` on explicit config mismatch with embedder dims.
3. Validate existing table `vector` atttypmod against configured dims.
4. After per-row insert fallback, raise `RuntimeError` if any IDs still failed.

## Tests

```bash
pytest tests/memory/test_main.py::test_sync_pgvector_dims_infers_from_embedder \
  tests/memory/test_main.py::test_sync_pgvector_dims_raises_on_explicit_mismatch \
  tests/memory/test_main.py::test_sync_pgvector_dims_noop_for_other_providers \
  tests/memory/test_main.py::test_pgvector_validate_schema_dims_mismatch \
  tests/memory/test_main.py::test_pgvector_validate_schema_dims_match \
  tests/memory/test_main.py::test_pgvector_ensure_collection_requires_dims -q
```

6 passed.

## Credit

Original approach and analysis: @lost-particles in #4990. This salvage rebases and adapts for `_ensure_collection`.
