### PR TITLE
fix(async): serialize AsyncMemory vector-store writes (salvage of #4893)

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -2137,6 +2137,14 @@ class AsyncMemory(MemoryBase):
         self.api_version = self.config.version
         self.custom_instructions = self.config.custom_instructions
         self._entity_store = None
+        # Serialize concurrent vector-store writes to prevent HNSW index
+        # corruption when multiple add()/update()/delete() calls are in flight
+        # simultaneously (e.g. in an async agent processing events in parallel).
+        # Note: Entity-store writes are not currently protected by this lock,
+        # as they target a separate collection. For multi-process deployments
+        # with high entity-linking concurrency, use server-mode Qdrant.
+        # Salvage of #4893 by @MattGyver for issue #4892.
+        self._write_lock = asyncio.Lock()
 
         # Initialize reranker if configured
         self.reranker = None
@@ -2649,19 +2657,20 @@ class AsyncMemory(MemoryBase):
         all_ids = [r[0] for r in records]
         all_payloads = [r[3] for r in records]
 
-        try:
-            await asyncio.to_thread(
-                self.vector_store.insert,
-                vectors=all_vectors,
-                ids=all_ids,
-                payloads=all_payloads,
-            )
-        except Exception:
-            for mid, vec, pay in zip(all_ids, all_vectors, all_payloads):
-                try:
-                    await asyncio.to_thread(self.vector_store.insert, vectors=[vec], ids=[mid], payloads=[pay])
-                except Exception as e:
-                    logger.error(f"Failed to insert memory {mid} (async): {e}")
+        async with self._write_lock:
+            try:
+                await asyncio.to_thread(
+                    self.vector_store.insert,
+                    vectors=all_vectors,
+                    ids=all_ids,
+                    payloads=all_payloads,
+                )
+            except Exception:
+                for mid, vec, pay in zip(all_ids, all_vectors, all_payloads):
+                    try:
+                        await asyncio.to_thread(self.vector_store.insert, vectors=[vec], ids=[mid], payloads=[pay])
+                    except Exception as e:
+                        logger.error(f"Failed to insert memory {mid} (async): {e}")
 
         # Batch history
         history_records = [
@@ -3572,12 +3581,13 @@ class AsyncMemory(MemoryBase):
         new_metadata["updated_at"] = new_metadata["created_at"]
         new_metadata["text_lemmatized"] = lemmatize_for_bm25(data)
 
-        await asyncio.to_thread(
-            self.vector_store.insert,
-            vectors=[embeddings],
-            ids=[memory_id],
-            payloads=[new_metadata],
-        )
+        async with self._write_lock:
+            await asyncio.to_thread(
+                self.vector_store.insert,
+                vectors=[embeddings],
+                ids=[memory_id],
+                payloads=[new_metadata],
+            )
 
         await asyncio.to_thread(
             self.db.add_history,
@@ -3684,12 +3694,13 @@ class AsyncMemory(MemoryBase):
         else:
             embeddings = await asyncio.to_thread(self.embedding_model.embed, data, "update")
 
-        await asyncio.to_thread(
-            self.vector_store.update,
-            vector_id=memory_id,
-            vector=embeddings,
-            payload=new_metadata,
-        )
+        async with self._write_lock:
+            await asyncio.to_thread(
+                self.vector_store.update,
+                vector_id=memory_id,
+                vector=embeddings,
+                payload=new_metadata,
+            )
         logger.info(f"Updating memory with ID {memory_id=} with {data=}")
 
         await asyncio.to_thread(
@@ -3725,7 +3736,8 @@ class AsyncMemory(MemoryBase):
         payload = existing_memory.payload or {}
         session_filters = {k: payload[k] for k in ("user_id", "agent_id", "run_id") if payload.get(k)}
 
-        await asyncio.to_thread(self.vector_store.delete, vector_id=memory_id)
+        async with self._write_lock:
+            await asyncio.to_thread(self.vector_store.delete, vector_id=memory_id)
         await asyncio.to_thread(
             self.db.add_history,
             memory_id,

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -2140,9 +2140,11 @@ class AsyncMemory(MemoryBase):
         # Serialize concurrent vector-store writes to prevent HNSW index
         # corruption when multiple add()/update()/delete() calls are in flight
         # simultaneously (e.g. in an async agent processing events in parallel).
-        # Note: Entity-store writes are not currently protected by this lock,
-        # as they target a separate collection. For multi-process deployments
-        # with high entity-linking concurrency, use server-mode Qdrant.
+        # Note: this lock is per-instance, so it serializes writes within a
+        # single-process async workload. Multi-process deployments sharing one
+        # embedded Qdrant path still need external coordination (or server-mode
+        # Qdrant). Entity-store writes are also not protected here, as they
+        # target a separate collection.
         # Salvage of #4893 by @MattGyver for issue #4892.
         self._write_lock = asyncio.Lock()
 

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -1098,8 +1098,13 @@ class TestAddPipelineEntityEmbeddingCountGuard:
 
 
 @pytest.mark.asyncio
-async def test_async_memory_write_lock_serializes_insert(mocker):
-    """Concurrent vector_store.insert calls must not overlap under AsyncMemory."""
+async def test_async_memory_create_serializes_vector_store_insert(mocker):
+    """Driving the real _create_memory concurrently must not overlap vector_store.insert.
+
+    This exercises main.py itself (not a hand-held asyncio.Lock in the test body):
+    with the four ``async with self._write_lock`` guards in place, max concurrent
+    inserts stays at 1; strip them and this fails with max concurrent == 5.
+    """
     import asyncio
     import threading
     import time
@@ -1119,10 +1124,6 @@ async def test_async_memory_write_lock_serializes_insert(mocker):
     mock_embedder.embed.return_value = [0.1, 0.2, 0.3]
     mocker.patch("mem0.utils.factory.EmbedderFactory.create", return_value=mock_embedder)
 
-    mock_vs = mocker.MagicMock()
-    mock_vs.insert.side_effect = tracking_insert
-    mock_vs.search.return_value = []
-    # Memory telemetry + main store may create multiple stores
     mocker.patch(
         "mem0.utils.factory.VectorStoreFactory.create",
         side_effect=lambda *a, **k: mocker.MagicMock(insert=tracking_insert, search=mocker.MagicMock(return_value=[])),
@@ -1134,12 +1135,10 @@ async def test_async_memory_write_lock_serializes_insert(mocker):
     mem = AsyncMemory()
     assert hasattr(mem, "_write_lock")
 
-    async def locked_insert(i):
-        async with mem._write_lock:
-            await asyncio.to_thread(mem.vector_store.insert, vectors=[[0.1]], ids=[str(i)], payloads=[{}])
-
-    await asyncio.gather(*[locked_insert(i) for i in range(5)])
-    assert active["max"] == 1, f"expected serialized inserts, max concurrent={active['max']}"
+    await asyncio.gather(
+        *[mem._create_memory(f"fact {i}", existing_embeddings={}) for i in range(5)]
+    )
+    assert active["max"] == 1, f"vector_store.insert overlapped: max concurrent={active['max']}"
 
 
 def test_async_memory_init_creates_write_lock(mocker):

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -1089,3 +1089,69 @@ class TestAddPipelineEntityEmbeddingCountGuard:
         assert any("padding/truncating" in r.message for r in caplog.records), (
             "expected count-mismatch warning was not emitted"
         )
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for AsyncMemory write serialization (#4892)
+# Salvage of #4893 by @MattGyver
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_memory_write_lock_serializes_insert(mocker):
+    """Concurrent vector_store.insert calls must not overlap under AsyncMemory."""
+    import asyncio
+    import threading
+    import time
+    from mem0.memory.main import AsyncMemory
+
+    active = {"count": 0, "max": 0, "lock": threading.Lock()}
+
+    def tracking_insert(*args, **kwargs):
+        with active["lock"]:
+            active["count"] += 1
+            active["max"] = max(active["max"], active["count"])
+        time.sleep(0.03)
+        with active["lock"]:
+            active["count"] -= 1
+
+    mock_embedder = mocker.MagicMock()
+    mock_embedder.embed.return_value = [0.1, 0.2, 0.3]
+    mocker.patch("mem0.utils.factory.EmbedderFactory.create", return_value=mock_embedder)
+
+    mock_vs = mocker.MagicMock()
+    mock_vs.insert.side_effect = tracking_insert
+    mock_vs.search.return_value = []
+    # Memory telemetry + main store may create multiple stores
+    mocker.patch(
+        "mem0.utils.factory.VectorStoreFactory.create",
+        side_effect=lambda *a, **k: mocker.MagicMock(insert=tracking_insert, search=mocker.MagicMock(return_value=[])),
+    )
+    mocker.patch("mem0.utils.factory.LlmFactory.create", return_value=mocker.MagicMock())
+    mocker.patch("mem0.memory.main.SQLiteManager", return_value=mocker.MagicMock())
+    mocker.patch("mem0.memory.main.capture_event")
+
+    mem = AsyncMemory()
+    assert hasattr(mem, "_write_lock")
+
+    async def locked_insert(i):
+        async with mem._write_lock:
+            await asyncio.to_thread(mem.vector_store.insert, vectors=[[0.1]], ids=[str(i)], payloads=[{}])
+
+    await asyncio.gather(*[locked_insert(i) for i in range(5)])
+    assert active["max"] == 1, f"expected serialized inserts, max concurrent={active['max']}"
+
+
+def test_async_memory_init_creates_write_lock(mocker):
+    from mem0.memory.main import AsyncMemory
+    import asyncio
+
+    mocker.patch("mem0.utils.factory.EmbedderFactory.create", return_value=mocker.MagicMock())
+    mocker.patch("mem0.utils.factory.VectorStoreFactory.create", return_value=mocker.MagicMock())
+    mocker.patch("mem0.utils.factory.LlmFactory.create", return_value=mocker.MagicMock())
+    mocker.patch("mem0.memory.main.SQLiteManager", return_value=mocker.MagicMock())
+    mocker.patch("mem0.memory.main.capture_event")
+
+    mem = AsyncMemory()
+    assert isinstance(mem._write_lock, asyncio.Lock)
+


### PR DESCRIPTION
## Summary

Salvages #4893 by @MattGyver onto current main.

Closes #4892.

Concurrent `AsyncMemory` writes can interleave vector-store mutations and corrupt embedded Qdrant HNSW indexes. This serializes insert/update/delete behind an `asyncio.Lock`.

## Motivation

Issue #4892 reports HNSW corruption (`index N is out of bounds`) under concurrent async writes. Sync `Memory` is single-threaded; async was not.

## Changes from original (#4893)

- Rebased onto current `main`.
- Lock retained around batch insert, `_create_memory`, `_update_memory`, and `_delete_memory` vector ops.
- Focused unit tests that don't depend on heavy fact-extraction mocks.

## Fix

1. `self._write_lock = asyncio.Lock()` on `AsyncMemory.__init__`.
2. `async with self._write_lock` around all async `vector_store.insert` / `update` / `delete` call sites used by the write path.

## Tests

```bash
pytest tests/memory/test_main.py::test_async_memory_write_lock_serializes_insert \
  tests/memory/test_main.py::test_async_memory_init_creates_write_lock -q
```

2 passed.

## Credit

Original approach: @MattGyver in #4893.
