### PR TITLE
fix(ts-sdk): normalize batchDelete memory inputs

### DIFF
--- a/mem0-ts/src/client/mem0.ts
+++ b/mem0-ts/src/client/mem0.ts
@@ -554,11 +554,16 @@ export default class MemoryClient {
     return response;
   }
 
-  async batchDelete(memories: Array<string>): Promise<string> {
+  async batchDelete(
+    memories: Array<string | { memoryId?: string; memory_id?: string }>,
+  ): Promise<string> {
     if (this.telemetryId === "") await this.ping();
     this._captureEvent("batch_delete", []);
     const memoriesBody = memories.map((memory) => ({
-      memory_id: memory,
+      memory_id:
+        typeof memory === "string"
+          ? memory
+          : (memory.memoryId ?? memory.memory_id),
     }));
     const response = await this._fetchWithErrorHandling(
       `${this.host}/v1/batch/`,

--- a/mem0-ts/src/client/tests/memoryClient.batch.test.ts
+++ b/mem0-ts/src/client/tests/memoryClient.batch.test.ts
@@ -89,6 +89,36 @@ describe("MemoryClient - batchDelete()", () => {
     ]);
   });
 
+  test("preserves OpenAPI memory_id object inputs", async () => {
+    const extra = new Map<string, { status: number; body: unknown }>();
+    extra.set("/v1/batch/", { status: 200, body: { message: "OK" } });
+    const mock = setupMockFetch(extra);
+
+    const client = new MemoryClient({ apiKey: TEST_API_KEY });
+    await client.batchDelete([{ memory_id: "mem_1" }, { memory_id: "mem_2" }]);
+
+    const call = findFetchCall(mock, "/v1/batch/", "DELETE");
+    expect(getFetchBody(call!).memories).toEqual([
+      { memory_id: "mem_1" },
+      { memory_id: "mem_2" },
+    ]);
+  });
+
+  test("normalizes camelCase memoryId object inputs", async () => {
+    const extra = new Map<string, { status: number; body: unknown }>();
+    extra.set("/v1/batch/", { status: 200, body: { message: "OK" } });
+    const mock = setupMockFetch(extra);
+
+    const client = new MemoryClient({ apiKey: TEST_API_KEY });
+    await client.batchDelete([{ memoryId: "mem_1" }, { memoryId: "mem_2" }]);
+
+    const call = findFetchCall(mock, "/v1/batch/", "DELETE");
+    expect(getFetchBody(call!).memories).toEqual([
+      { memory_id: "mem_1" },
+      { memory_id: "mem_2" },
+    ]);
+  });
+
   test("handles empty array without crashing", async () => {
     const extra = new Map<string, { status: number; body: unknown }>();
     extra.set("/v1/batch/", { status: 200, body: { message: "OK" } });


### PR DESCRIPTION
﻿## Linked Issue

N/A

## Description

This PR fixes a TypeScript SDK/API contract mismatch in `MemoryClient.batchDelete()`.

The OpenAPI contract for `DELETE /v1/batch/` defines `memories` as an array of objects shaped like `{ memory_id: string }`, and the JavaScript OpenAPI sample calls `client.batchDelete([{ memory_id: "..." }])`. The TS SDK method currently accepts only `string[]` and wraps each item as `{ memory_id: memory }`, so users following the OpenAPI JS example send a nested payload like:

```json
{"memories":[{"memory_id":{"memory_id":"mem_1"}}]}
```

This change keeps the existing string ID convenience form working, and also accepts OpenAPI/Python-style `{ memory_id }` objects plus TS SDK-style `{ memoryId }` objects. All inputs normalize to the API payload shape `{ memory_id: string }`.

Possible call chain / impact:

```text
JS user follows OpenAPI sample
  -> client.batchDelete([{ memory_id: "mem_1" }])
  -> TS SDK batchDelete maps each item into { memory_id: memory }
  -> request body sends { memory_id: { memory_id: "mem_1" } }
  -> API receives an object where it expects a memory_id string
```

Unaffected behavior: existing `batchDelete(["mem_1", "mem_2"])` calls still serialize to the same request body as before.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Validation performed locally:

- `pnpm --dir mem0-ts test -- memoryClient.batch.test.ts` - passed, 8 tests
- `pnpm --dir mem0-ts exec prettier --check src/client/mem0.ts src/client/tests/memoryClient.batch.test.ts` - passed
- `pnpm --dir mem0-ts exec tsup` - passed, including d.ts generation
- `git diff --check` - passed

Additional local note: `pnpm --dir mem0-ts run build` was blocked on this Windows checkout by full-repo Prettier/line-ending differences in pre-existing files. `pnpm --dir mem0-ts run test:unit` was blocked by the local native `better-sqlite3.node is not a valid Win32 application` environment issue in OSS tests; the targeted TS SDK batch test above passes.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] I have updated documentation if needed
