### PR TITLE
fix(memory): extract_json must not treat a code fence inside a JSON value as an enclosing block

### DIFF
--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -135,7 +135,13 @@ def extract_json(text):
     If that also fails, returns the text as-is.
     """
     text = text.strip()
-    match = re.search(r"```(?:json)?\s*(.*?)\s*```", text, re.DOTALL)
+    # A response that already begins with '{' is a JSON object, so skip the
+    # code-fence heuristic. Otherwise a ``` sequence occurring inside a string
+    # value (e.g. a stored code snippet) would be mistaken for an enclosing
+    # code block and only its interior extracted, corrupting valid JSON.
+    match = None
+    if not text.startswith("{"):
+        match = re.search(r"```(?:json)?\s*(.*?)\s*```", text, re.DOTALL)
     if match:
         json_str = match.group(1)
     else:

--- a/tests/test_chatty_llm_parsing.py
+++ b/tests/test_chatty_llm_parsing.py
@@ -23,6 +23,14 @@ class TestExtractJson:
         parsed = json.loads(result)
         assert parsed["memory"][0]["text"] == "likes basketball"
 
+    def test_json_value_containing_code_fence_roundtrips(self):
+        # A stored payload whose value contains a ``` code fence must survive
+        # json.dumps -> extract_json -> json.loads unchanged; the fence inside
+        # the value must not be mistaken for an enclosing code block.
+        original = {"snippet": "```python\nx = 1\n```", "user_id": "u1"}
+        stored = json.dumps(original)
+        assert json.loads(extract_json(stored)) == original
+
     def test_json_in_markdown_code_block(self):
         text = '```json\n{"memory": [{"id": "0", "text": "likes basketball", "event": "ADD"}]}\n```'
         result = extract_json(text)


### PR DESCRIPTION
## Linked Issue

Closes #6427

## Description

`extract_json` used an unanchored code-fence regex before brace detection, so a fence inside a valid JSON string value was mistaken for an enclosing response fence. This skips the fence heuristic when the input already begins with a JSON object, preserving metadata that contains code snippets.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] Added/updated unit tests
- [ ] Added/updated integration tests
- [x] Tested manually
- [ ] No tests needed

`tests/test_chatty_llm_parsing.py` and `tests/memory/test_memory_utils.py`: 41 passed.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review performed
- [x] Tests prove the fix
- [x] New and existing targeted tests pass locally
- [x] Documentation is not required for this internal parsing fix