### PR TITLE
fix: avoid mutating LLM factory config dictionaries

### DIFF
--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -86,8 +86,7 @@ class LlmFactory:
             config = config_class(**kwargs)
         elif isinstance(config, dict):
             # Merge dict config with kwargs
-            config.update(kwargs)
-            config = config_class(**config)
+            config = config_class(**{**config, **kwargs})
         elif isinstance(config, BaseLlmConfig):
             # Convert base config to provider-specific config if needed
             if config_class != BaseLlmConfig:

--- a/tests/utils/test_factory.py
+++ b/tests/utils/test_factory.py
@@ -51,3 +51,13 @@ def test_base_to_provider_without_reasoning_fields_still_builds():
 
     assert isinstance(built, AnthropicConfig)
     assert built.model == "claude-3-5-sonnet-20240620"
+
+
+def test_dict_config_is_not_mutated_by_keyword_overrides():
+    config = {"model": "gpt-4o-mini"}
+
+    with patch("mem0.utils.factory.load_class", return_value=lambda built_config: built_config):
+        built = LlmFactory.create("openai", config, api_key="temporary-key")
+
+    assert config == {"model": "gpt-4o-mini"}
+    assert built.api_key == "temporary-key"


### PR DESCRIPTION
## Linked Issue

Closes #6428

## Description

`LlmFactory.create()` now merges keyword overrides into a new dictionary instead of calling `update()` on the caller-owned config. Provider precedence is unchanged, while shared configuration dictionaries remain reusable after factory construction.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] Added/updated unit tests
- [ ] Added/updated integration tests
- [x] Tested manually
- [ ] No tests needed

`hatch run dev_py_3_11:pytest tests/utils/test_factory.py -q`: 4 passed.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review performed
- [x] Tests prove the fix
- [x] New and existing targeted tests pass locally
- [x] Documentation is not required for this internal behavior fix