### PR TITLE
fix: preserve latest SQLite messages on timestamp ties

### DIFF
--- a/mem0/memory/storage.py
+++ b/mem0/memory/storage.py
@@ -283,7 +283,11 @@ class SQLiteManager:
                     """
                     DELETE FROM messages WHERE session_scope = ? AND id NOT IN (
                         SELECT id FROM (
-                            SELECT id FROM messages WHERE session_scope = ? ORDER BY created_at DESC LIMIT 10
+                            SELECT id
+                            FROM messages
+                            WHERE session_scope = ?
+                            ORDER BY created_at DESC, rowid DESC
+                            LIMIT 10
                         )
                     )
                 """,
@@ -302,12 +306,12 @@ class SQLiteManager:
             cur = self.connection.execute(
                 """
                 SELECT role, content, name, created_at FROM (
-                    SELECT role, content, name, created_at
+                    SELECT role, content, name, created_at, rowid AS insertion_order
                     FROM messages
                     WHERE session_scope = ?
-                    ORDER BY created_at DESC
+                    ORDER BY created_at DESC, rowid DESC
                     LIMIT ?
-                ) ORDER BY created_at ASC
+                ) ORDER BY created_at ASC, insertion_order ASC
             """,
                 (session_scope, limit),
             )

--- a/tests/memory/test_storage.py
+++ b/tests/memory/test_storage.py
@@ -198,7 +198,7 @@ class TestSQLiteManager:
             sqlite_manager.add_history(
                 memory_id=sample_data["memory_id"],
                 old_memory=f"Memory {i}",
-                new_memory=f"Memory {i+1}",
+                new_memory=f"Memory {i + 1}",
                 event="ADD" if i == 0 else "UPDATE",
                 created_at=ts,
                 updated_at=ts if i > 0 else None,
@@ -299,3 +299,19 @@ class TestSQLiteManager:
         assert msg_count == 0
         assert hist_count == 0
         mgr2.close()
+
+    def test_save_messages_keeps_latest_ten_when_batch_timestamps_match(self, memory_manager):
+        messages = [{"role": "user", "content": str(index)} for index in range(11)]
+
+        memory_manager.save_messages(messages, "session")
+
+        stored = memory_manager.get_last_messages("session")
+        assert [message["content"] for message in stored] == [str(index) for index in range(1, 11)]
+
+    def test_get_last_messages_uses_insertion_order_when_timestamps_match(self, memory_manager):
+        messages = [{"role": "user", "content": str(index)} for index in range(3)]
+        memory_manager.save_messages(messages, "session")
+
+        stored = memory_manager.get_last_messages("session", limit=2)
+
+        assert [message["content"] for message in stored] == ["1", "2"]


### PR DESCRIPTION
## Linked Issue

Closes #6429

## Description

Messages saved in one batch share a timestamp. SQLite retention and retrieval now use `rowid` as a deterministic insertion-order tie-breaker, so batches over ten entries discard the oldest messages and `get_last_messages()` returns the latest entries chronologically.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] Added/updated unit tests
- [ ] Added/updated integration tests
- [x] Tested manually
- [ ] No tests needed

`hatch run dev_py_3_11:pytest tests/memory/test_storage.py -q`: 17 passed.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review performed
- [x] Tests prove the fix
- [x] New and existing targeted tests pass locally
- [x] Documentation is not required for this internal storage fix