### PR TITLE
fix(llms/anthropic): send sampling params for legacy claude-3-x models

### DIFF
--- a/mem0/llms/anthropic.py
+++ b/mem0/llms/anthropic.py
@@ -52,6 +52,14 @@ class AnthropicLLM(LLMBase):
 
         model_name = self.config.model.lower()
         model_name_parts = model_name.rsplit("[", 1)[0].split("-")
+
+        # Legacy "claude-3-*" ids (e.g. claude-3-5-sonnet, claude-3-opus) put the
+        # version numbers before the family name, so the family-position parsing
+        # below misreads them. They all support sampling parameters; the new
+        # "claude-<family>-<major>-<minor>" naming is handled after this.
+        if len(model_name_parts) > 1 and model_name_parts[1].isdigit():
+            return True
+
         _, family, major, minor, *_ = (*model_name_parts, "", "", "", "")
 
         # Use model_name if only provided a family name, e.g., opus

--- a/tests/llms/test_anthropic.py
+++ b/tests/llms/test_anthropic.py
@@ -149,6 +149,13 @@ def test_base_config_conversion_does_not_send_both(mock_anthropic_client):
         ("claude-fable-5", False),
         ("claude-mythos-5", False),
         ("claude-mythos-preview", False),
+        # Legacy "claude-3-*" naming puts the version before the family; all of
+        # these models support sampling params and must not be disabled.
+        ("claude-3-5-sonnet-20240620", True),
+        ("claude-3-7-sonnet-20250219", True),
+        ("claude-3-5-haiku-20241022", True),
+        ("claude-3-opus-20240229", True),
+        ("claude-3-haiku-20240307", True),
     ],
 )
 def test_enable_sampling_parameters_for_current_models(mock_anthropic_client, model, expected):


### PR DESCRIPTION
## Linked Issue

Closes #6432

## Description

`AnthropicLLM._enable_sampling_parameters()` parses the model family from position `[1]` of the `-`-split model id. That works for the current `claude-<family>-<major>-<minor>` naming (`claude-sonnet-4-6` → `family="sonnet"`), but every legacy `claude-3-x` id puts the version numbers **before** the family:

- `claude-3-5-sonnet-20240620` → `family="3"`
- `claude-3-7-sonnet-20250219` → `family="3"`
- `claude-3-5-haiku-20241022` → `family="3"`
- `claude-3-opus-20240229` → `family="3"`

`family` never matches `haiku`/`sonnet`/`opus`, so the method falls through to `return False` and `temperature`/`top_p` are silently dropped from the request — even though all Claude 3.x models support them. Anthropic then applies its server-side default (`temperature=1.0`), so mem0's fact-extraction / memory-update prompts run far less deterministically than the user configured, with no error raised. Claude 3.5 / 3.7 Sonnet and 3.5 Haiku are among the most commonly pinned Anthropic models.

This PR detects the legacy `claude-3-*` naming (version digits before the family) and returns `True` for those models before the family-position parsing runs. The existing behavior for the newer naming — disabling sampling params on the models that reject them (`claude-opus-4-7`+, `claude-sonnet-5`, etc.) — is unchanged.

```python
# Legacy "claude-3-*" ids (e.g. claude-3-5-sonnet, claude-3-opus) put the
# version numbers before the family name, so the family-position parsing
# below misreads them. They all support sampling parameters; the new
# "claude-<family>-<major>-<minor>" naming is handled after this.
if len(model_name_parts) > 1 and model_name_parts[1].isdigit():
    return True
```

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A — restores sending `temperature`/`top_p` for Claude 3.x models, which they support; behavior for the newer models is unchanged.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Extended the existing `test_enable_sampling_parameters_for_current_models` parametrized table in `tests/llms/test_anthropic.py` with five legacy `claude-3-x` cases (`claude-3-5-sonnet-20240620`, `claude-3-7-sonnet-20250219`, `claude-3-5-haiku-20241022`, `claude-3-opus-20240229`, `claude-3-haiku-20240307`), all expecting `temperature` to be sent. Those five fail on `main` (the params are dropped) and pass with this change. Full `tests/llms/test_anthropic.py` suite (27 tests) passes; `ruff check` is clean on the changed source.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
