### PR TITLE
fix(vector-stores/baidu): convert L2 distance to similarity score in search()

### DIFF
--- a/mem0/vector_stores/baidu.py
+++ b/mem0/vector_stores/baidu.py
@@ -224,8 +224,15 @@ class BaiduDB(VectorStoreBase):
         output = []
         for row in res.rows:
             row_data = row.get("row", {})
+            # Mochow returns the raw L2 distance (lower = closer). Convert it to a
+            # similarity score (higher = better) to satisfy the VectorStoreBase
+            # contract, mirroring the milvus provider. Non-L2 metrics already
+            # return a higher-is-better score.
+            raw_score = row.get("score", 0.0)
+            if self.metric_type in (MetricType.L2, "L2"):
+                raw_score = 1.0 / (1.0 + raw_score)
             output_data = OutputData(
-                id=row_data.get("id"), score=row.get("score", 0.0), payload=row_data.get("metadata", {})
+                id=row_data.get("id"), score=raw_score, payload=row_data.get("metadata", {})
             )
             output.append(output_data)
 

--- a/tests/vector_stores/test_baidu.py
+++ b/tests/vector_stores/test_baidu.py
@@ -137,6 +137,27 @@ def test_search(mochow_instance, mock_mochow_client):
     assert results[1].payload == {"name": "vector2"}
 
 
+def test_search_converts_l2_distance_to_similarity(mochow_instance):
+    # On the L2 metric, Mochow returns raw distances (lower = closer). search()
+    # must convert them to similarity scores (higher = better) to satisfy the
+    # VectorStoreBase contract, mirroring the milvus provider.
+    mochow_instance.metric_type = "L2"
+
+    mock_search_results = Mock()
+    mock_search_results.rows = [
+        {"row": {"id": "id1", "metadata": {"name": "vector1"}}, "score": 0.5},
+        {"row": {"id": "id2", "metadata": {"name": "vector2"}}, "score": 2.0},
+    ]
+    mochow_instance._table.vector_search.return_value = mock_search_results
+
+    results = mochow_instance.search(query="test", vectors=[0.1, 0.2, 0.3], top_k=2)
+
+    # 1.0 / (1.0 + distance): the closer memory must score higher than the far one.
+    assert results[0].score == pytest.approx(1.0 / 1.5)
+    assert results[1].score == pytest.approx(1.0 / 3.0)
+    assert results[0].score > results[1].score
+
+
 def test_search_with_filters(mochow_instance, mock_mochow_client):
     mochow_instance._table.vector_search.return_value = Mock(rows=[])
 


### PR DESCRIPTION
## Linked Issue

Closes #6434

## Description

The Baidu VectorDB (Mochow) provider returned the raw distance from `search()` as the similarity score, without converting it. On its default `L2` metric this inverts search ranking (least similar memories sort first) and breaks threshold filtering.

`VectorStoreBase` mandates that distance-based stores convert to a similarity score before returning (`L2 distance: score = 1.0 / (1.0 + distance)`), so higher = better. The default metric is `L2` (`mem0/configs/vector_stores/baidu.py:13`), and the sibling milvus provider does exactly this conversion (`mem0/vector_stores/milvus.py:195-198`). Baidu was the one distance store that skipped it — it was missed by #5391 ("normalize scores to similarity across all backends"), which updated base/milvus/pgvector/chroma/faiss/cassandra/azure/redis/s3_vectors but not `baidu.py`.

Downstream, `search()` scores feed `score_and_rank`, which sorts by score descending and filters on `score < threshold` (default 0.1). With raw L2 distances the ordering was inverted and threshold filtering was meaningless.

This PR converts the raw L2 distance to a similarity score in `search()`, mirroring milvus. Non-L2 metrics (which already return higher-is-better scores) are unchanged.

```python
raw_score = row.get("score", 0.0)
if self.metric_type in (MetricType.L2, "L2"):
    raw_score = 1.0 / (1.0 + raw_score)
```

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A — the raw L2 distances previously returned were already unusable for ranking/thresholding (higher = *less* similar). This aligns Baidu with the base-class contract and every other provider.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added `test_search_converts_l2_distance_to_similarity` in `tests/vector_stores/test_baidu.py`: with the `L2` metric and raw distances `0.5` / `2.0`, it asserts the returned scores are `1/1.5` / `1/3` and that the closer memory scores higher. It fails on `main` (raw distances pass through) and passes with this change. The existing `test_search` (which uses the `COSINE` metric) is unaffected, since non-L2 scores are left as-is. Full `tests/vector_stores/test_baidu.py` suite (16 tests) passes; `ruff check` is clean on the changed source.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
