### PR TITLE
feat(embeddings): honor memory_action task_type in Gemini embedder

### DIFF
--- a/docs/components/embedders/config.mdx
+++ b/docs/components/embedders/config.mdx
@@ -81,9 +81,9 @@ Here's a comprehensive list of all parameters that can be used across different 
 | `azure_kwargs` | Key-Value arguments for the AzureOpenAI embedding model | Azure OpenAI |
 | `openai_base_url`    | Base URL for OpenAI API                       | OpenAI            |
 | `vertex_credentials_json` | Path to the Google Cloud credentials JSON file for VertexAI                       | VertexAI            |
-| `memory_add_embedding_type` | The type of embedding to use for the add memory action                       | VertexAI            |
-| `memory_update_embedding_type` | The type of embedding to use for the update memory action                       | VertexAI            |
-| `memory_search_embedding_type` | The type of embedding to use for the search memory action                       | VertexAI            |
+| `memory_add_embedding_type` | The type of embedding to use for the add memory action                       | VertexAI, Gemini            |
+| `memory_update_embedding_type` | The type of embedding to use for the update memory action                       | VertexAI, Gemini            |
+| `memory_search_embedding_type` | The type of embedding to use for the search memory action                       | VertexAI, Gemini            |
 | `lmstudio_base_url` | Base URL for LM Studio API                    | LM Studio         |
 </Tab>
 <Tab title="TypeScript">

--- a/docs/components/embedders/models/google_AI.mdx
+++ b/docs/components/embedders/models/google_AI.mdx
@@ -59,6 +59,17 @@ await memory.add(messages, { userId: "john" });
 ```
 </CodeGroup>
 
+### Embedding types
+
+Gemini embeds the same text differently depending on the task you declare via `task_type`. The Python SDK maps the add, update, and search memory actions to these types, so stored memories use a document-oriented type and searches use a query-oriented one. Supported types include:
+- SEMANTIC_SIMILARITY
+- CLASSIFICATION
+- CLUSTERING
+- RETRIEVAL_DOCUMENT, RETRIEVAL_QUERY, QUESTION_ANSWERING, FACT_VERIFICATION
+- CODE_RETRIEVAL_QUERY
+
+Check out the [Gemini embeddings documentation](https://ai.google.dev/gemini-api/docs/embeddings#task-types) for more information. Override the defaults with `memory_add_embedding_type`, `memory_update_embedding_type`, and `memory_search_embedding_type`.
+
 ### Config
 
 Here are the parameters available for configuring Gemini embedder:
@@ -70,6 +81,9 @@ Here are the parameters available for configuring Gemini embedder:
 | `embedding_dims` | Dimensions of the embedding model     | `768`                   |
 | `api_key`        | The Google API key                   | `None`                  |
 | `output_dimensionality` | Output dimensionality for the embedding model (Gemini-specific; used when `embedding_dims` is not set) | `None` |
+| `memory_add_embedding_type`    | The `task_type` to use for the add memory action    | `RETRIEVAL_DOCUMENT` |
+| `memory_update_embedding_type` | The `task_type` to use for the update memory action | `RETRIEVAL_DOCUMENT` |
+| `memory_search_embedding_type` | The `task_type` to use for the search memory action | `RETRIEVAL_QUERY`    |
 </Tab>
 <Tab title="TypeScript">
 | Parameter         | Description                                   | Default Value              |

--- a/mem0/embeddings/gemini.py
+++ b/mem0/embeddings/gemini.py
@@ -19,6 +19,12 @@ class GoogleGenAIEmbedding(EmbeddingBase):
 
         self.client = genai.Client(api_key=api_key)
 
+        self.embedding_types = {
+            "add": self.config.memory_add_embedding_type or "RETRIEVAL_DOCUMENT",
+            "update": self.config.memory_update_embedding_type or "RETRIEVAL_DOCUMENT",
+            "search": self.config.memory_search_embedding_type or "RETRIEVAL_QUERY",
+        }
+
     def embed(self, text, memory_action: Optional[Literal["add", "search", "update"]] = None):
         """
         Get the embedding for the given text using Google Generative AI.
@@ -30,10 +36,14 @@ class GoogleGenAIEmbedding(EmbeddingBase):
         """
         text = text.replace("\n", " ")
 
-        # Create config for embedding parameters
-        config = types.EmbedContentConfig(output_dimensionality=self.config.embedding_dims)
+        embedding_type = "SEMANTIC_SIMILARITY"
+        if memory_action is not None:
+            if memory_action not in self.embedding_types:
+                raise ValueError(f"Invalid memory action: {memory_action}")
+            embedding_type = self.embedding_types[memory_action]
 
-        # Call the embed_content method with the correct parameters
+        config = types.EmbedContentConfig(output_dimensionality=self.config.embedding_dims, task_type=embedding_type)
+
         response = self.client.models.embed_content(model=self.config.model, contents=text, config=config)
 
         return response.embeddings[0].values
@@ -41,7 +51,14 @@ class GoogleGenAIEmbedding(EmbeddingBase):
     def embed_batch(self, texts, memory_action="add"):
         if not texts:
             return []
-        config = types.EmbedContentConfig(output_dimensionality=self.config.embedding_dims)
+
+        embedding_type = "SEMANTIC_SIMILARITY"
+        if memory_action is not None:
+            if memory_action not in self.embedding_types:
+                raise ValueError(f"Invalid memory action: {memory_action}")
+            embedding_type = self.embedding_types[memory_action]
+
+        config = types.EmbedContentConfig(output_dimensionality=self.config.embedding_dims, task_type=embedding_type)
         MAX_BATCH = 100
         all_embeddings = []
         for i in range(0, len(texts), MAX_BATCH):

--- a/tests/embeddings/test_gemini_emeddings.py
+++ b/tests/embeddings/test_gemini_emeddings.py
@@ -117,3 +117,89 @@ def test_embed_batch_strips_newlines(mock_genai, config):
     embedder.embed_batch(["line one\nline two"])
 
     mock_genai.assert_called_once_with(model="test_model", contents=["line one line two"], config=ANY)
+
+
+def _single_embedding_response():
+    emb = type("Embedding", (), {"values": [0.1, 0.2, 0.3]})()
+    return type("Response", (), {"embeddings": [emb]})()
+
+
+def _task_type_of(mock_genai):
+    return mock_genai.call_args.kwargs["config"].task_type
+
+
+def test_embed_defaults_to_semantic_similarity(mock_genai, config):
+    mock_genai.return_value = _single_embedding_response()
+
+    GoogleGenAIEmbedding(config).embed("hello")
+
+    assert _task_type_of(mock_genai) == "SEMANTIC_SIMILARITY"
+
+
+def test_embed_search_uses_retrieval_query(mock_genai, config):
+    mock_genai.return_value = _single_embedding_response()
+
+    GoogleGenAIEmbedding(config).embed("hello", "search")
+
+    assert _task_type_of(mock_genai) == "RETRIEVAL_QUERY"
+
+
+@pytest.mark.parametrize("action", ["add", "update"])
+def test_embed_add_and_update_use_retrieval_document(mock_genai, config, action):
+    mock_genai.return_value = _single_embedding_response()
+
+    GoogleGenAIEmbedding(config).embed("hello", action)
+
+    assert _task_type_of(mock_genai) == "RETRIEVAL_DOCUMENT"
+
+
+def test_embed_respects_config_task_type_override(mock_genai):
+    cfg = BaseEmbedderConfig(
+        api_key="dummy_api_key",
+        model="test_model",
+        embedding_dims=786,
+        memory_search_embedding_type="CODE_RETRIEVAL_QUERY",
+    )
+    mock_genai.return_value = _single_embedding_response()
+
+    GoogleGenAIEmbedding(cfg).embed("hello", "search")
+
+    assert _task_type_of(mock_genai) == "CODE_RETRIEVAL_QUERY"
+
+
+def test_embed_invalid_memory_action_raises(mock_genai, config):
+    embedder = GoogleGenAIEmbedding(config)
+
+    with pytest.raises(ValueError, match="Invalid memory action: bogus"):
+        embedder.embed("hello", "bogus")
+
+
+def test_embed_batch_defaults_to_retrieval_document(mock_genai, config):
+    mock_genai.return_value = _single_embedding_response()
+
+    GoogleGenAIEmbedding(config).embed_batch(["hello"])
+
+    assert _task_type_of(mock_genai) == "RETRIEVAL_DOCUMENT"
+
+
+def test_embed_batch_search_uses_retrieval_query(mock_genai, config):
+    mock_genai.return_value = _single_embedding_response()
+
+    GoogleGenAIEmbedding(config).embed_batch(["hello"], "search")
+
+    assert _task_type_of(mock_genai) == "RETRIEVAL_QUERY"
+
+
+def test_embed_batch_update_uses_retrieval_document(mock_genai, config):
+    mock_genai.return_value = _single_embedding_response()
+
+    GoogleGenAIEmbedding(config).embed_batch(["hello"], "update")
+
+    assert _task_type_of(mock_genai) == "RETRIEVAL_DOCUMENT"
+
+
+def test_embed_batch_invalid_memory_action_raises(mock_genai, config):
+    embedder = GoogleGenAIEmbedding(config)
+
+    with pytest.raises(ValueError, match="Invalid memory action: bogus"):
+        embedder.embed_batch(["hello"], "bogus")


### PR DESCRIPTION
## Linked Issue

Closes #6436

## Description

The Gemini embedder accepted a `memory_action` argument on `embed()` / `embed_batch()` but ignored it, so stored text and search queries were embedded with the same `task_type`. This threads `memory_action` through to the request `task_type`, mirroring the existing `mem0/embeddings/vertexai.py` embedder, so `gemini-embedding-001` can use asymmetric retrieval (`RETRIEVAL_DOCUMENT` for stored memories, `RETRIEVAL_QUERY` for searches).

The wiring already existed: `mem0/memory/main.py` passes `"search"` / `"add"` / `"update"` at every embed call site, and the three `memory_*_embedding_type` config fields were already defined in `BaseEmbedderConfig`. Only the Gemini provider was dropping the signal.

Defaults match Vertex: add/update -> `RETRIEVAL_DOCUMENT`, search -> `RETRIEVAL_QUERY`, no action -> `SEMANTIC_SIMILARITY`, each overridable via config.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Breaking Changes

No API change. One behavioral note: existing Gemini stores were embedded without a `task_type`, so after upgrading, new writes/searches use the asymmetric types (stored vectors are not rewritten). This is the same trade-off `vertexai.py` already ships; users who want the previous behavior can pin all three `memory_*_embedding_type` fields to `SEMANTIC_SIMILARITY`.

## Test Coverage

- [x] I added/updated unit tests

Added task_type assertions to `tests/embeddings/test_gemini_emeddings.py` covering the default, per-action mapping (search/add/update), config override, invalid-action error, and batch behavior. The new tests fail on the current code and pass with this change. `tests/embeddings/` 89/89, ruff clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed