### PR TITLE
feat(memory): add page/page_size pagination to OSS get_all

### DIFF
--- a/docs/open-source/features/async-memory.mdx
+++ b/docs/open-source/features/async-memory.mdx
@@ -220,6 +220,11 @@ specific_memories = await memory.get_all(
     filters={"user_id": "alice", "agent_id": "diet-assistant", "run_id": "consultation-001"}
 )
 
+# Page through large memory sets with page / page_size (also available on the sync Memory).
+# page is 1-based and must be passed together with page_size.
+page_1 = await memory.get_all(filters={"user_id": "alice"}, page=1, page_size=50)
+page_2 = await memory.get_all(filters={"user_id": "alice"}, page=2, page_size=50)
+
 history = await memory.history(memory_id="memory-id-here")
 ```
 

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -10,7 +10,7 @@ import uuid
 import warnings
 from copy import deepcopy
 from datetime import date, datetime, timezone
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 from pydantic import ValidationError
 
@@ -207,6 +207,27 @@ def _validate_search_params(threshold: Optional[float] = None, top_k: Optional[i
             raise ValueError(
                 f"Invalid top_k: {top_k}. Must be a non-negative integer."
             )
+
+
+def _resolve_pagination_window(page: Optional[int], page_size: Optional[int], top_k: int) -> Tuple[int, int]:
+    """
+    Resolve optional page/page_size into an (offset, limit) window over the result list.
+
+    When neither is provided, returns the unpaginated window (offset 0, top_k), so callers
+    that omit pagination behave exactly as before. page and page_size must be provided together.
+
+    Raises:
+        ValueError: If only one of page/page_size is provided, or either is not an integer >= 1.
+    """
+    if page is None and page_size is None:
+        return 0, top_k
+    if page is None or page_size is None:
+        raise ValueError("page and page_size must be provided together.")
+    if not isinstance(page, int) or isinstance(page, bool) or page < 1:
+        raise ValueError(f"Invalid page: {page}. Must be an integer >= 1.")
+    if not isinstance(page_size, int) or isinstance(page_size, bool) or page_size < 1:
+        raise ValueError(f"Invalid page_size: {page_size}. Must be an integer >= 1.")
+    return (page - 1) * page_size, page_size
 
 
 def _validate_and_trim_search_query(query: str) -> str:
@@ -1213,6 +1234,8 @@ class Memory(MemoryBase):
         *,
         filters: Optional[Dict[str, Any]] = None,
         top_k: int = 20,
+        page: Optional[int] = None,
+        page_size: Optional[int] = None,
         show_expired: bool = False,
         **kwargs,
     ):
@@ -1224,6 +1247,12 @@ class Memory(MemoryBase):
                 Must contain at least one of: user_id, agent_id, run_id.
                 Example: filters={"user_id": "u1", "agent_id": "a1"}
             top_k (int, optional): The maximum number of memories to return. Defaults to 20.
+            page (int, optional): 1-based page number. Must be provided together with page_size.
+                When set, page_size defines the window and top_k is ignored. Defaults to None.
+            page_size (int, optional): Number of memories per page. Must be provided together
+                with page. Defaults to None. Pages are fetched then sliced in memory, so deep
+                pages get progressively more expensive and a page may be short if a large
+                fraction of the matched memories are expired.
             show_expired (bool, optional): Include expired memories. Defaults to False.
 
         Returns:
@@ -1232,13 +1261,16 @@ class Memory(MemoryBase):
 
         Raises:
             ValueError: If filters doesn't contain at least one of user_id, agent_id, run_id,
-                or if top_k is invalid.
+                if top_k is invalid, or if only one of page/page_size is provided.
         """
         # Reject top-level entity params - must use filters instead
         _reject_top_level_entity_params(kwargs, "get_all")
 
         # Validate top_k
         _validate_search_params(top_k=top_k)
+
+        # Resolve pagination window (offset 0, top_k when page/page_size are omitted)
+        offset, window = _resolve_pagination_window(page, page_size, top_k)
 
         # Validate and trim entity IDs in filters
         effective_filters = dict(filters) if filters else {}
@@ -1262,7 +1294,7 @@ class Memory(MemoryBase):
                 "Example: filters={'user_id': 'u1'}"
             )
 
-        limit = top_k
+        limit = offset + window
         fetch_limit = limit if show_expired else max(limit * 4, 60)
         scale_threshold_notice = detect_scale_threshold_from_top_k(top_k)
 
@@ -1272,6 +1304,7 @@ class Memory(MemoryBase):
         )
 
         all_memories_result = self._get_all_from_vector_store(effective_filters, fetch_limit, show_expired, limit)
+        all_memories_result = all_memories_result[offset:]
 
         if scale_threshold_notice:
             display_scale_threshold_notice(self, "sync", "get_all", *scale_threshold_notice)
@@ -2847,6 +2880,8 @@ class AsyncMemory(MemoryBase):
         *,
         filters: Optional[Dict[str, Any]] = None,
         top_k: int = 20,
+        page: Optional[int] = None,
+        page_size: Optional[int] = None,
         show_expired: bool = False,
         **kwargs,
     ):
@@ -2858,6 +2893,12 @@ class AsyncMemory(MemoryBase):
                 Must contain at least one of: user_id, agent_id, run_id.
                 Example: filters={"user_id": "u1", "agent_id": "a1"}
             top_k (int, optional): The maximum number of memories to return. Defaults to 20.
+            page (int, optional): 1-based page number. Must be provided together with page_size.
+                When set, page_size defines the window and top_k is ignored. Defaults to None.
+            page_size (int, optional): Number of memories per page. Must be provided together
+                with page. Defaults to None. Pages are fetched then sliced in memory, so deep
+                pages get progressively more expensive and a page may be short if a large
+                fraction of the matched memories are expired.
             show_expired (bool, optional): Include expired memories. Defaults to False.
 
         Returns:
@@ -2866,13 +2907,16 @@ class AsyncMemory(MemoryBase):
 
         Raises:
             ValueError: If filters doesn't contain at least one of user_id, agent_id, run_id,
-                or if top_k is invalid.
+                if top_k is invalid, or if only one of page/page_size is provided.
         """
         # Reject top-level entity params - must use filters instead
         _reject_top_level_entity_params(kwargs, "get_all")
 
         # Validate top_k
         _validate_search_params(top_k=top_k)
+
+        # Resolve pagination window (offset 0, top_k when page/page_size are omitted)
+        offset, window = _resolve_pagination_window(page, page_size, top_k)
 
         # Validate and trim entity IDs in filters
         effective_filters = dict(filters) if filters else {}
@@ -2896,7 +2940,7 @@ class AsyncMemory(MemoryBase):
                 "Example: filters={'user_id': 'u1'}"
             )
 
-        limit = top_k
+        limit = offset + window
         fetch_limit = limit if show_expired else max(limit * 4, 60)
         scale_threshold_notice = detect_scale_threshold_from_top_k(top_k)
 
@@ -2906,6 +2950,7 @@ class AsyncMemory(MemoryBase):
         )
 
         all_memories_result = await self._get_all_from_vector_store(effective_filters, fetch_limit, show_expired, limit)
+        all_memories_result = all_memories_result[offset:]
 
         if scale_threshold_notice:
             await display_scale_threshold_notice_async(self, "async", "get_all", *scale_threshold_notice)

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -1083,3 +1083,154 @@ class TestAddPipelineEntityEmbeddingCountGuard:
         assert any("padding/truncating" in r.message for r in caplog.records), (
             "expected count-mismatch warning was not emitted"
         )
+
+
+def _silence_get_all_notices(mocker):
+    mocker.patch("mem0.memory.main.capture_event")
+    mocker.patch("mem0.memory.main.display_first_run_notice")
+    mocker.patch("mem0.memory.main.display_first_run_notice_async")
+
+
+def _mock_memory_rows(n):
+    rows = []
+    for i in range(n):
+        row = MagicMock()
+        row.id = f"id-{i}"
+        row.payload = {
+            "data": f"mem {i}",
+            "user_id": "u",
+            "hash": f"h{i}",
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "updated_at": "2026-01-01T00:00:00+00:00",
+        }
+        rows.append(row)
+    return rows
+
+
+def test_get_all_without_pagination_is_unchanged(mocker):
+    memory = _build_memory_instance(mocker, Memory)
+    _silence_get_all_notices(mocker)
+    memory.vector_store.list.return_value = [_mock_memory_rows(5)]
+
+    result = memory.get_all(filters={"user_id": "u"})
+
+    assert [r["id"] for r in result["results"]] == [f"id-{i}" for i in range(5)]
+    # default top_k=20 -> fetch window max(20*4, 60) = 80, offset 0 (no slicing)
+    assert memory.vector_store.list.call_args.kwargs["top_k"] == 80
+
+
+def test_get_all_first_page(mocker):
+    memory = _build_memory_instance(mocker, Memory)
+    _silence_get_all_notices(mocker)
+    memory.vector_store.list.return_value = [_mock_memory_rows(10)]
+
+    result = memory.get_all(filters={"user_id": "u"}, page=1, page_size=3)
+
+    assert [r["id"] for r in result["results"]] == ["id-0", "id-1", "id-2"]
+
+
+def test_get_all_second_page(mocker):
+    memory = _build_memory_instance(mocker, Memory)
+    _silence_get_all_notices(mocker)
+    memory.vector_store.list.return_value = [_mock_memory_rows(10)]
+
+    result = memory.get_all(filters={"user_id": "u"}, page=2, page_size=3)
+
+    assert [r["id"] for r in result["results"]] == ["id-3", "id-4", "id-5"]
+
+
+def test_get_all_page_beyond_data_is_empty(mocker):
+    memory = _build_memory_instance(mocker, Memory)
+    _silence_get_all_notices(mocker)
+    memory.vector_store.list.return_value = [_mock_memory_rows(4)]
+
+    result = memory.get_all(filters={"user_id": "u"}, page=3, page_size=3)
+
+    assert result["results"] == []
+
+
+def test_get_all_pagination_scales_fetch_window(mocker):
+    memory = _build_memory_instance(mocker, Memory)
+    _silence_get_all_notices(mocker)
+    memory.vector_store.list.return_value = [_mock_memory_rows(0)]
+
+    memory.get_all(filters={"user_id": "u"}, page=3, page_size=10)
+
+    # offset=20, window=10 -> limit=30 -> fetch window max(30*4, 60) = 120
+    assert memory.vector_store.list.call_args.kwargs["top_k"] == 120
+
+
+def test_get_all_partial_pagination_raises(mocker):
+    memory = _build_memory_instance(mocker, Memory)
+    _silence_get_all_notices(mocker)
+
+    with pytest.raises(ValueError, match="page and page_size must be provided together"):
+        memory.get_all(filters={"user_id": "u"}, page=1)
+    with pytest.raises(ValueError, match="page and page_size must be provided together"):
+        memory.get_all(filters={"user_id": "u"}, page_size=5)
+
+
+def test_get_all_invalid_pagination_raises(mocker):
+    memory = _build_memory_instance(mocker, Memory)
+    _silence_get_all_notices(mocker)
+
+    with pytest.raises(ValueError, match="Invalid page"):
+        memory.get_all(filters={"user_id": "u"}, page=0, page_size=5)
+    with pytest.raises(ValueError, match="Invalid page_size"):
+        memory.get_all(filters={"user_id": "u"}, page=1, page_size=0)
+
+
+def test_get_all_pagination_skips_expired_rows(mocker):
+    memory = _build_memory_instance(mocker, Memory)
+    _silence_get_all_notices(mocker)
+    rows = _mock_memory_rows(6)
+    # Mark id-1 and id-3 expired -> live order is id-0, id-2, id-4, id-5
+    for i in (1, 3):
+        rows[i].payload["expiration_date"] = "2000-01-01"
+    memory.vector_store.list.return_value = [rows]
+
+    page_1 = memory.get_all(filters={"user_id": "u"}, page=1, page_size=2)
+    page_2 = memory.get_all(filters={"user_id": "u"}, page=2, page_size=2)
+
+    assert [r["id"] for r in page_1["results"]] == ["id-0", "id-2"]
+    assert [r["id"] for r in page_2["results"]] == ["id-4", "id-5"]
+
+
+def test_get_all_pagination_ignores_top_k(mocker):
+    memory = _build_memory_instance(mocker, Memory)
+    _silence_get_all_notices(mocker)
+    memory.vector_store.list.return_value = [_mock_memory_rows(10)]
+
+    # top_k=1 would cap output to 1 without pagination; page_size must win.
+    result = memory.get_all(filters={"user_id": "u"}, top_k=1, page=1, page_size=4)
+
+    assert [r["id"] for r in result["results"]] == ["id-0", "id-1", "id-2", "id-3"]
+
+
+@pytest.mark.asyncio
+async def test_async_get_all_second_page(mocker):
+    memory = _build_memory_instance(mocker, AsyncMemory)
+    _silence_get_all_notices(mocker)
+    memory.vector_store.list.return_value = [_mock_memory_rows(10)]
+
+    result = await memory.get_all(filters={"user_id": "u"}, page=2, page_size=3)
+
+    assert [r["id"] for r in result["results"]] == ["id-3", "id-4", "id-5"]
+
+
+@pytest.mark.asyncio
+async def test_async_get_all_invalid_pagination_raises(mocker):
+    memory = _build_memory_instance(mocker, AsyncMemory)
+    _silence_get_all_notices(mocker)
+
+    with pytest.raises(ValueError, match="Invalid page"):
+        await memory.get_all(filters={"user_id": "u"}, page=0, page_size=5)
+
+
+@pytest.mark.asyncio
+async def test_async_get_all_partial_pagination_raises(mocker):
+    memory = _build_memory_instance(mocker, AsyncMemory)
+    _silence_get_all_notices(mocker)
+
+    with pytest.raises(ValueError, match="page and page_size must be provided together"):
+        await memory.get_all(filters={"user_id": "u"}, page_size=5)


### PR DESCRIPTION
## Linked Issue

Closes #6438

## Description

Adds optional `page` / `page_size` pagination to the OSS `Memory.get_all` and `AsyncMemory.get_all`, matching the parameter names the hosted `MemoryClient` already uses. Today OSS `get_all` only takes `top_k`, so there's no way to page a large memory set beyond the first N - this closes that OSS-vs-platform gap.

- `page` is 1-based and must be passed together with `page_size`. When set, `page_size` defines the window and `top_k` is ignored for the page.
- When both are omitted, behavior is byte-identical to before.
- Implemented entirely at the Memory layer: a small `_resolve_pagination_window` helper returns `(offset, limit)`, and `_get_all_from_vector_store` (which already accepts an output cap) fetches `offset + page_size` formatted memories, then the result is sliced `[offset:]`. No vector-store changes - the base `list(filters, top_k)` has no `offset`, so app-level slicing is the portable option across all providers.

```python
page_1 = memory.get_all(filters={"user_id": "alice"}, page=1, page_size=50)
page_2 = memory.get_all(filters={"user_id": "alice"}, page=2, page_size=50)
```

Known tradeoffs (documented in the docstring): pages are fetched then sliced in memory, so deep pages get progressively more expensive, and a page can be short if a large fraction of the matched memories are expired (this inherits the existing `max(limit*4, 60)` over-fetch used for expired filtering). The return shape stays the current bare `{"results": [...]}` to preserve the existing OSS contract; happy to add a `total`/`next` envelope if preferred, though that needs an extra count query.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Breaking Changes

N/A - `get_all` behaves identically when `page`/`page_size` are omitted.

## Test Coverage

- [x] I added/updated unit tests

Added pagination tests to `tests/memory/test_main.py`: first/second page, page beyond data, fetch-window scaling, expired rows still paginate correctly, `top_k` ignored when paginating, partial/invalid-arg validation, and async coverage. The new tests fail on `main` and pass here. `tests/memory/test_main.py` 60/60, ruff clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed