### PR TITLE
fix(server): preserve interior markers in generate-instructions parse

### DIFF
--- a/server/instruction_parse.py
+++ b/server/instruction_parse.py
@@ -1,0 +1,67 @@
+"""Parse LLM responses for the /generate-instructions endpoint."""
+
+import re
+from typing import Dict, Optional
+
+# Match a TEST_MESSAGE label that starts a line (optional BOM/whitespace).
+_TEST_MESSAGE_LINE = re.compile(r"(?m)^\s*TEST_MESSAGE:\s*")
+# Match an INSTRUCTIONS label that starts a line.
+_INSTRUCTIONS_LINE = re.compile(r"(?m)^\s*INSTRUCTIONS:\s*")
+
+
+def parse_generate_instructions_response(
+    response: Optional[str], *, default_test_message: str = "I like to hike on weekends."
+) -> Dict[str, str]:
+    """Split an LLM response into custom_instructions + test_message.
+
+    The model is prompted to emit::
+
+        INSTRUCTIONS: ...
+        TEST_MESSAGE: ...
+
+    Naively calling ``str.replace("INSTRUCTIONS:", "")`` and
+    ``str.split("TEST_MESSAGE:")`` destroys or truncates payloads that
+    legitimately contain those marker strings inside the prose (e.g.
+    "prioritize recent INSTRUCTIONS: updates"). Split only on
+    line-anchored labels so interior markers survive.
+    """
+    if not isinstance(response, str):
+        response = "" if response is None else str(response)
+
+    text = response.strip()
+    if not _INSTRUCTIONS_LINE.search(text) or not _TEST_MESSAGE_LINE.search(text):
+        # Also accept non-line-anchored legacy lumped markers if both appear.
+        if "INSTRUCTIONS:" not in text or "TEST_MESSAGE:" not in text:
+            return {
+                "custom_instructions": text or response,
+                "test_message": default_test_message,
+            }
+
+    # Prefer line-anchored TEST_MESSAGE (last section of a well-formed reply).
+    line_split = _TEST_MESSAGE_LINE.split(text, maxsplit=1)
+    if len(line_split) == 2:
+        instructions_part, test_message = line_split
+    else:
+        # Fallback: final bare marker (model ignored newlines).
+        instructions_part, test_message = text.rsplit("TEST_MESSAGE:", 1)
+
+    instructions_part = instructions_part.strip()
+    test_message = test_message.strip()
+
+    line_instr = _INSTRUCTIONS_LINE.split(instructions_part, maxsplit=1)
+    if len(line_instr) == 2:
+        # Drop any preamble before the INSTRUCTIONS line; keep rest intact.
+        instructions = line_instr[1].strip()
+    elif instructions_part.startswith("INSTRUCTIONS:"):
+        instructions = instructions_part[len("INSTRUCTIONS:") :].strip()
+    else:
+        marker = "INSTRUCTIONS:"
+        idx = instructions_part.find(marker)
+        instructions = (
+            instructions_part[idx + len(marker) :].strip() if idx != -1 else instructions_part
+        )
+
+    return {
+        "custom_instructions": instructions,
+        "test_message": test_message,
+    }

--- a/server/main.py
+++ b/server/main.py
@@ -28,6 +28,7 @@ from routers import auth as auth_router
 from routers import entities as entities_router
 from routers import requests as requests_router
 from schemas import MessageResponse
+from instruction_parse import parse_generate_instructions_response
 from server_state import (
     get_current_config,
     get_memory_instance,
@@ -342,25 +343,28 @@ def generate_instructions(req: GenerateInstructionsRequest, _auth=Depends(verify
     try:
         llm = get_memory_instance().llm
         prompt = (
-            "You are configuring a memory system. Given the use case below, produce two things:\n"
+            "You are configuring a memory system. Given the use case below, produce two things:
+"
             "1. INSTRUCTIONS: A short paragraph of custom instructions telling the memory extraction system "
-            "what kinds of facts, preferences, and context to prioritize. Be specific to the use case.\n"
+            "what kinds of facts, preferences, and context to prioritize. Be specific to the use case.
+"
             "2. TEST_MESSAGE: A single realistic sentence a user in this use case would say, suitable for "
-            "testing that the memory system works.\n\n"
-            "Respond in exactly this format (no markdown, no extra text):\n"
-            "INSTRUCTIONS: <your instructions>\n"
-            f"TEST_MESSAGE: <your test message>\n\nUse case: {req.use_case}"
+            "testing that the memory system works.
+
+"
+            "Respond in exactly this format (no markdown, no extra text):
+"
+            "INSTRUCTIONS: <your instructions>
+"
+            f"TEST_MESSAGE: <your test message>
+
+Use case: {req.use_case}"
         )
         response = llm.generate_response([{"role": "user", "content": prompt}])
-        instructions = response
-        test_message = "I like to hike on weekends."
-        if "INSTRUCTIONS:" in response and "TEST_MESSAGE:" in response:
-            parts = response.split("TEST_MESSAGE:")
-            instructions = parts[0].replace("INSTRUCTIONS:", "").strip()
-            test_message = parts[1].strip()
-        return {"custom_instructions": instructions, "test_message": test_message}
+        return parse_generate_instructions_response(response)
     except Exception:
         raise upstream_error()
+
 
 
 @app.post("/memories", summary="Create memories")

--- a/server/main.py
+++ b/server/main.py
@@ -343,22 +343,15 @@ def generate_instructions(req: GenerateInstructionsRequest, _auth=Depends(verify
     try:
         llm = get_memory_instance().llm
         prompt = (
-            "You are configuring a memory system. Given the use case below, produce two things:
-"
+            "You are configuring a memory system. Given the use case below, produce two things:\n"
             "1. INSTRUCTIONS: A short paragraph of custom instructions telling the memory extraction system "
-            "what kinds of facts, preferences, and context to prioritize. Be specific to the use case.
-"
+            "what kinds of facts, preferences, and context to prioritize. Be specific to the use case.\n"
             "2. TEST_MESSAGE: A single realistic sentence a user in this use case would say, suitable for "
-            "testing that the memory system works.
-
-"
-            "Respond in exactly this format (no markdown, no extra text):
-"
-            "INSTRUCTIONS: <your instructions>
-"
-            f"TEST_MESSAGE: <your test message>
-
-Use case: {req.use_case}"
+            "testing that the memory system works.\n\n"
+            "Respond in exactly this format (no markdown, no extra text):\n"
+            "INSTRUCTIONS: <your instructions>\n"
+            "TEST_MESSAGE: <your test message>\n\n"
+            f"Use case: {req.use_case}"
         )
         response = llm.generate_response([{"role": "user", "content": prompt}])
         return parse_generate_instructions_response(response)

--- a/tests/server/test_generate_instructions_parse.py
+++ b/tests/server/test_generate_instructions_parse.py
@@ -1,0 +1,69 @@
+"""Unit tests for /generate-instructions response parsing (#5993)."""
+
+import sys
+from pathlib import Path
+
+# Allow importing the lightweight helper without loading the FastAPI app.
+SERVER_DIR = Path(__file__).resolve().parents[2] / "server"
+sys.path.insert(0, str(SERVER_DIR))
+
+from instruction_parse import parse_generate_instructions_response  # noqa: E402
+
+
+class TestParseGenerateInstructionsResponse:
+    def test_happy_path(self):
+        raw = (
+            "INSTRUCTIONS: Capture hiking preferences and gear notes.\n"
+            "TEST_MESSAGE: I want a lighter backpack for weekend hikes."
+        )
+        out = parse_generate_instructions_response(raw)
+        assert out["custom_instructions"] == "Capture hiking preferences and gear notes."
+        assert out["test_message"] == "I want a lighter backpack for weekend hikes."
+
+    def test_interior_instructions_marker_preserved(self):
+        # Global .replace("INSTRUCTIONS:", "") would destroy the interior marker.
+        raw = (
+            "INSTRUCTIONS: Please follow these INSTRUCTIONS: prioritize recent events.\n"
+            "TEST_MESSAGE: Remember this TEST_MESSAGE: hello."
+        )
+        out = parse_generate_instructions_response(raw)
+        assert out["custom_instructions"] == (
+            "Please follow these INSTRUCTIONS: prioritize recent events."
+        )
+        assert out["test_message"] == "Remember this TEST_MESSAGE: hello."
+
+    def test_interior_test_message_marker_in_instructions(self):
+        raw = (
+            "INSTRUCTIONS: Never echo TEST_MESSAGE: labels back to the user.\n"
+            "TEST_MESSAGE: I book flights every March."
+        )
+        out = parse_generate_instructions_response(raw)
+        assert "TEST_MESSAGE: labels" in out["custom_instructions"]
+        assert out["test_message"] == "I book flights every March."
+
+    def test_preamble_before_instructions(self):
+        raw = (
+            "Sure — here you go:\n"
+            "INSTRUCTIONS: Track dietary restrictions narrowly.\n"
+            "TEST_MESSAGE: I am allergic to peanuts."
+        )
+        out = parse_generate_instructions_response(raw)
+        assert out["custom_instructions"] == "Track dietary restrictions narrowly."
+        assert out["test_message"] == "I am allergic to peanuts."
+
+    def test_missing_markers_returns_raw_with_default_test(self):
+        raw = "unstructured blob with no labels"
+        out = parse_generate_instructions_response(raw)
+        assert out["custom_instructions"] == raw
+        assert out["test_message"] == "I like to hike on weekends."
+
+    def test_custom_default_test_message(self):
+        out = parse_generate_instructions_response(
+            "no labels here", default_test_message="fallback"
+        )
+        assert out["test_message"] == "fallback"
+
+    def test_none_response(self):
+        out = parse_generate_instructions_response(None)
+        assert out["custom_instructions"] == ""
+        assert out["test_message"] == "I like to hike on weekends."


### PR DESCRIPTION
## Summary

Closes #5993.

`/generate-instructions` used `response.split("TEST_MESSAGE:")` and a global `.replace("INSTRUCTIONS:", "")`. When the LLM put those labels inside the generated prose (or ignored newlines), the endpoint destroyed instruction text and truncated the test message.

## Motivation

Self-hosted dashboards call this endpoint to bootstrap extraction instructions. Corrupted parsing produces silent wrong config, with no error signal.

Differential vs #5994: that PR only switches to `rsplit` + leading-prefix strip and has no tests. This PR:
- extracts a pure `parse_generate_instructions_response` helper (`server/instruction_parse.py`) so the logic is unit-testable without booting FastAPI / JWT
- splits on **line-anchored** `INSTRUCTIONS:` / `TEST_MESSAGE:` labels (regex), with `rsplit` fallback for single-line replies
- keeps interior occurrences of both markers intact
- tolerates a short preamble before `INSTRUCTIONS:`
- adds 7 unit tests covering the issue repro + edge cases

## Root cause

String-global replace/split treated instructional *content* the same as protocol *delimiters*.

## Fix

Line-anchored delimiter parse + single prefix strip; endpoint delegates to the helper.

## Verification

```bash
python -m pytest tests/server/test_generate_instructions_parse.py -q
# 7 passed
```

## Files

- `server/instruction_parse.py` (new)
- `server/main.py`
- `tests/server/test_generate_instructions_parse.py` (new)