### PR TITLE
fix(llm+storage): avoid mutating caller dict; fix SQLite batch eviction tie-breaker

### DIFF
--- a/mem0/memory/storage.py
+++ b/mem0/memory/storage.py
@@ -283,7 +283,7 @@ class SQLiteManager:
                     """
                     DELETE FROM messages WHERE session_scope = ? AND id NOT IN (
                         SELECT id FROM (
-                            SELECT id FROM messages WHERE session_scope = ? ORDER BY created_at DESC LIMIT 10
+                            SELECT id FROM messages WHERE session_scope = ? ORDER BY created_at DESC, rowid DESC LIMIT 10
                         )
                     )
                 """,
@@ -302,12 +302,12 @@ class SQLiteManager:
             cur = self.connection.execute(
                 """
                 SELECT role, content, name, created_at FROM (
-                    SELECT role, content, name, created_at
+                    SELECT role, content, name, created_at, rowid
                     FROM messages
                     WHERE session_scope = ?
-                    ORDER BY created_at DESC
+                    ORDER BY created_at DESC, rowid DESC
                     LIMIT ?
-                ) ORDER BY created_at ASC
+                ) ORDER BY created_at ASC, rowid ASC
             """,
                 (session_scope, limit),
             )

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -85,9 +85,8 @@ class LlmFactory:
             # Create default config with kwargs
             config = config_class(**kwargs)
         elif isinstance(config, dict):
-            # Merge dict config with kwargs
-            config.update(kwargs)
-            config = config_class(**config)
+            # Merge into a new dict to avoid mutating the caller-owned dictionary
+            config = config_class(**{**config, **kwargs})
         elif isinstance(config, BaseLlmConfig):
             # Convert base config to provider-specific config if needed
             if config_class != BaseLlmConfig:


### PR DESCRIPTION
## Summary

Two independent but easy-to-miss bugs, both reported by @lntutor:

### 1.  mutates caller-owned dict (#6428)

 accepted a plain `dict` config and called `config.update(kwargs)` directly, mutating the caller's dictionary as a side-effect of constructing an LLM. A shared base configuration could therefore retain one call's overrides and leak them into later construction.

**Fix:** merge kwargs into a new dict so the caller's input is unchanged:

```python
# before
config.update(kwargs)
config = config_class(**config)

# after
config = config_class(**{**config, **kwargs})
```

### 2. SQLite message eviction drops the newest message when a batch ties on `created_at` (#6429)

All messages in a `save_messages()` batch share the same `datetime.now()` timestamp. When the batch has more than 10 entries the eviction sub-select uses `ORDER BY created_at DESC LIMIT 10`, which is non-deterministic on ties — SQLite tends to return the first-inserted rows, so the DELETE keeps the oldest messages and removes the newest ones (exactly the wrong behaviour).

**Fix:** add `rowid DESC` as a secondary sort key, which is monotonically increasing within a single `INSERT` transaction:

```sql
-- before
ORDER BY created_at DESC LIMIT 10

-- after  
ORDER BY created_at DESC, rowid DESC LIMIT 10
```

The same secondary sort is applied in `get_last_messages()` so that messages sharing a timestamp always appear in insertion order.

## Test plan

- [ ] Verify `LlmFactory.create("openai", config, api_key="k")` does not mutate `config`
- [ ] Verify `save_messages` with 11 messages retains indices 1–10 (the newest), not 0–9

🤖 Generated with [Claude Code](https://claude.ai/claude-code)